### PR TITLE
feat(platform): add timezone selector to schedule dialogs

### DIFF
--- a/turbo/apps/platform/src/signals/agent-detail/cron.ts
+++ b/turbo/apps/platform/src/signals/agent-detail/cron.ts
@@ -70,6 +70,40 @@ export function getTodayDateLocal(): string {
   return `${y}-${mo}-${day}`;
 }
 
+// ---------------------------------------------------------------------------
+// Common timezones for schedule selectors
+// ---------------------------------------------------------------------------
+
+export const COMMON_TIMEZONES = [
+  "UTC",
+  "America/New_York",
+  "America/Chicago",
+  "America/Denver",
+  "America/Los_Angeles",
+  "America/Anchorage",
+  "Pacific/Honolulu",
+  "America/Toronto",
+  "America/Vancouver",
+  "America/Sao_Paulo",
+  "Europe/London",
+  "Europe/Berlin",
+  "Europe/Paris",
+  "Europe/Moscow",
+  "Asia/Dubai",
+  "Asia/Kolkata",
+  "Asia/Shanghai",
+  "Asia/Tokyo",
+  "Asia/Seoul",
+  "Asia/Singapore",
+  "Australia/Sydney",
+  "Pacific/Auckland",
+] as const;
+
+/** Return the browser-detected timezone. */
+export function getBrowserTimezone(): string {
+  return new Intl.DateTimeFormat().resolvedOptions().timeZone;
+}
+
 export function buildCronExpression(opts: {
   timeOption: CronTimeOption;
   hour: string;

--- a/turbo/apps/platform/src/signals/agent-detail/run-dialog.ts
+++ b/turbo/apps/platform/src/signals/agent-detail/run-dialog.ts
@@ -17,7 +17,9 @@ import {
   buildAtTime,
   isAtTimePast,
   getTomorrowDateLocal,
+  getBrowserTimezone,
 } from "./cron.ts";
+import { notificationPreferences$ } from "../settings-page/notification-settings.ts";
 import { closeChatPanel$ } from "./chat.ts";
 
 const L = logger("RunDialog");
@@ -102,6 +104,14 @@ export const setRunDialogDayOfMonth$ = command(({ set }, value: string) => {
   set(internalDayOfMonth$, value);
 });
 
+// Timezone
+const internalTimezone$ = state(getBrowserTimezone());
+export const runDialogTimezone$ = computed((get) => get(internalTimezone$));
+
+export const setRunDialogTimezone$ = command(({ set }, value: string) => {
+  set(internalTimezone$, value);
+});
+
 // ---------------------------------------------------------------------------
 // Saving state
 // ---------------------------------------------------------------------------
@@ -120,7 +130,7 @@ export const runDialogSaveError$ = computed((get) => get(internalSaveError$));
 // Open / close
 // ---------------------------------------------------------------------------
 
-export const openRunDialog$ = command(({ set }) => {
+export const openRunDialog$ = command(async ({ get, set }) => {
   set(internalPrompt$, "");
   set(internalTimeOption$, "now");
   set(internalFrequency$, "9");
@@ -129,6 +139,16 @@ export const openRunDialog$ = command(({ set }) => {
   set(internalDayOfMonth$, "1");
   set(internalDate$, getTomorrowDateLocal());
   set(internalSaveError$, null);
+
+  // Default timezone from user preferences, fallback to browser
+  try {
+    const prefs = await get(notificationPreferences$);
+    set(internalTimezone$, prefs.timezone ?? getBrowserTimezone());
+  } catch (error) {
+    throwIfAbort(error);
+    set(internalTimezone$, getBrowserTimezone());
+  }
+
   set(internalOpen$, true);
 });
 
@@ -201,7 +221,7 @@ export const submitRunDialog$ = command(async ({ get, set }) => {
     }
 
     // Schedule creation (recurring or one-time)
-    const timezone = new Intl.DateTimeFormat().resolvedOptions().timeZone;
+    const timezone = get(internalTimezone$);
     let scheduleBody: ScheduleBody;
 
     if (timeOption === "once") {

--- a/turbo/apps/platform/src/signals/agent-detail/schedule.ts
+++ b/turbo/apps/platform/src/signals/agent-detail/schedule.ts
@@ -9,6 +9,7 @@ import {
   buildAtTime,
   isAtTimePast,
   getTomorrowDateLocal,
+  getBrowserTimezone,
   type CronTimeOption,
   type ScheduleTimeOption,
   type ScheduleBody,
@@ -337,6 +338,15 @@ export const setScheduleDialogDayOfMonth$ = command(
   },
 );
 
+const internalDialogTimezone$ = state(getBrowserTimezone());
+export const scheduleDialogTimezone$ = computed((get) =>
+  get(internalDialogTimezone$),
+);
+
+export const setScheduleDialogTimezone$ = command(({ set }, value: string) => {
+  set(internalDialogTimezone$, value);
+});
+
 const internalDialogSaving$ = state(false);
 export const scheduleDialogSaving$ = computed((get) =>
   get(internalDialogSaving$),
@@ -358,6 +368,7 @@ export const openScheduleDialog$ = command(({ get, set }) => {
   }
 
   set(internalDialogPrompt$, schedule.prompt);
+  set(internalDialogTimezone$, schedule.timezone || getBrowserTimezone());
   set(internalDialogSaveError$, null);
 
   if (schedule.triggerType === "loop" && schedule.intervalSeconds !== null) {
@@ -422,7 +433,7 @@ export const submitScheduleDialog$ = command(async ({ get, set }) => {
   try {
     const fetchFn = get(fetch$);
     const date = get(internalDialogDate$);
-    const timezone = new Intl.DateTimeFormat().resolvedOptions().timeZone;
+    const timezone = get(internalDialogTimezone$);
 
     // Use existing schedule name if editing, otherwise default to "default"
     const existingSchedule = get(internalAgentSchedule$);

--- a/turbo/apps/platform/src/views/agent-detail-page/__tests__/run-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/agent-detail-page/__tests__/run-dialog.test.tsx
@@ -302,12 +302,13 @@ describe("run dialog", () => {
       ).not.toBeInTheDocument();
     });
 
-    // Verify schedule API was called with cron expression
+    // Verify schedule API was called with cron expression and timezone
     const body = capturedBody as Record<string, unknown>;
     expect(body.composeId).toBe("compose_1");
     expect(body.cronExpression).toBe("0 9 * * 1-5");
     expect(body.prompt).toBe("Daily review");
     expect(body.name).toBe("default");
+    expect(body.timezone).toBeDefined();
   });
 
   it("should show error in inline run panel when run fails with error", async () => {

--- a/turbo/apps/platform/src/views/agent-detail-page/__tests__/schedule-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/agent-detail-page/__tests__/schedule-dialog.test.tsx
@@ -189,6 +189,34 @@ describe("schedule dialog", () => {
     const body = capturedBody as Record<string, unknown>;
     expect(body.composeId).toBe("compose_1");
     expect(body.prompt).toBe("Updated standup summary");
+    expect(body.timezone).toBeDefined();
+  });
+
+  it("should restore saved timezone in edit dialog", async () => {
+    mockAgentDetailAPI({
+      withSchedule: true,
+      schedule: { timezone: "Asia/Tokyo" },
+    });
+
+    await setupPage({
+      context,
+      path: "/agents/my-agent",
+    });
+
+    await vi.waitFor(() => {
+      expect(screen.getByText("Scheduled")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit schedule" }));
+
+    await vi.waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "Edit this schedule" }),
+      ).toBeInTheDocument();
+    });
+
+    // The timezone select should show the saved timezone
+    expect(screen.getByText("Asia/Tokyo")).toBeInTheDocument();
   });
 
   it("should show Scheduled badge for one-time schedule", async () => {

--- a/turbo/apps/platform/src/views/agent-detail-page/agent-header.tsx
+++ b/turbo/apps/platform/src/views/agent-detail-page/agent-header.tsx
@@ -30,6 +30,7 @@ import { openChatPanel$ } from "../../signals/agent-detail/chat.ts";
 import { AgentAvatar } from "./agent-avatar.tsx";
 import type { AgentDetail } from "../../signals/agent-detail/types.ts";
 import { Link } from "../router/link.tsx";
+import { detach, Reason } from "../../signals/utils.ts";
 
 interface AgentHeaderProps {
   detail: AgentDetail;
@@ -112,7 +113,7 @@ export function AgentHeader({ detail, isOwner }: AgentHeaderProps) {
               <Button
                 variant="default"
                 size="sm"
-                onClick={() => openRun()}
+                onClick={() => detach(openRun(), Reason.DomCallback)}
                 disabled={isBusy}
               >
                 {isBusy ? (

--- a/turbo/apps/platform/src/views/agent-detail-page/run-dialog/run-dialog.tsx
+++ b/turbo/apps/platform/src/views/agent-detail-page/run-dialog/run-dialog.tsx
@@ -37,9 +37,14 @@ import {
   runDialogSaving$,
   runDialogSaveError$,
   submitRunDialog$,
+  runDialogTimezone$,
+  setRunDialogTimezone$,
 } from "../../../signals/agent-detail/run-dialog.ts";
 import { agentSchedule$ } from "../../../signals/agent-detail/schedule.ts";
-import { getTodayDateLocal } from "../../../signals/agent-detail/cron.ts";
+import {
+  getTodayDateLocal,
+  COMMON_TIMEZONES,
+} from "../../../signals/agent-detail/cron.ts";
 import { detach, Reason } from "../../../signals/utils.ts";
 
 // ---------------------------------------------------------------------------
@@ -66,6 +71,8 @@ export function RunDialog() {
   const setDayOfMonth = useSet(setRunDialogDayOfMonth$);
   const setDate = useSet(setRunDialogDate$);
   const submit = useSet(submitRunDialog$);
+  const timezone = useGet(runDialogTimezone$);
+  const setTimezone = useSet(setRunDialogTimezone$);
   const schedule = useGet(agentSchedule$);
 
   const weekdays = [
@@ -234,6 +241,26 @@ export function RunDialog() {
                   </SelectContent>
                 </Select>
               </div>
+            </div>
+          )}
+
+          {isSchedule && (
+            <div className="flex flex-col gap-3">
+              <label className="text-sm font-medium text-foreground px-1">
+                Timezone
+              </label>
+              <Select value={timezone} onValueChange={setTimezone}>
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {COMMON_TIMEZONES.map((tz) => (
+                    <SelectItem key={tz} value={tz}>
+                      {tz.replace(/_/g, " ")}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
             </div>
           )}
         </div>

--- a/turbo/apps/platform/src/views/agent-detail-page/schedule-dialog.tsx
+++ b/turbo/apps/platform/src/views/agent-detail-page/schedule-dialog.tsx
@@ -39,8 +39,13 @@ import {
   scheduleDialogSaveError$,
   submitScheduleDialog$,
   deleteScheduleFromDialog$,
+  scheduleDialogTimezone$,
+  setScheduleDialogTimezone$,
 } from "../../signals/agent-detail/schedule.ts";
-import { getTodayDateLocal } from "../../signals/agent-detail/cron.ts";
+import {
+  getTodayDateLocal,
+  COMMON_TIMEZONES,
+} from "../../signals/agent-detail/cron.ts";
 import { detach, Reason } from "../../signals/utils.ts";
 
 // ---------------------------------------------------------------------------
@@ -89,6 +94,8 @@ export function ScheduleDialog() {
   const setDate = useSet(setScheduleDialogDate$);
   const submit = useSet(submitScheduleDialog$);
   const deleteSchedule = useSet(deleteScheduleFromDialog$);
+  const timezone = useGet(scheduleDialogTimezone$);
+  const setTimezone = useSet(setScheduleDialogTimezone$);
 
   const dayOfMonthOptions = Array.from({ length: 31 }, (_, i) => ({
     value: String(i + 1),
@@ -252,6 +259,24 @@ export function ScheduleDialog() {
               </div>
             </div>
           )}
+
+          <div className="flex flex-col gap-3">
+            <label className="text-sm font-medium text-foreground px-1">
+              Timezone
+            </label>
+            <Select value={timezone} onValueChange={setTimezone}>
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {COMMON_TIMEZONES.map((tz) => (
+                  <SelectItem key={tz} value={tz}>
+                    {tz.replace(/_/g, " ")}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
         </div>
 
         {saveError && <p className="text-sm text-destructive">{saveError}</p>}


### PR DESCRIPTION
## Summary
- Add timezone `<Select>` dropdown to both run-dialog (create schedule) and schedule-dialog (edit schedule)
- New schedules default to user's preferred timezone from Settings, falling back to browser detection
- Editing a schedule now correctly restores the saved timezone instead of silently overwriting it
- Shared `COMMON_TIMEZONES` list and `getBrowserTimezone()` utility added to `cron.ts`

## Test plan
- [x] All 18 existing tests pass (9 schedule-dialog + 9 run-dialog)
- [x] New test: verifies edit dialog restores saved timezone (Asia/Tokyo)
- [x] Updated test: verifies timezone is included in schedule creation API request
- [x] Type-check passes, lint clean (only pre-existing agent-header.tsx error), knip clean

Closes #3600

🤖 Generated with [Claude Code](https://claude.com/claude-code)