### PR TITLE
docs: add oauth app creation guide and normalize env template key casing

### DIFF
--- a/docs/create-oauth-app.md
+++ b/docs/create-oauth-app.md
@@ -1,0 +1,72 @@
+## Create OAuth App
+
+When integrating a new OAuth provider, create **two separate apps** per provider to achieve hard isolation of client ID and secret between environments.
+
+### Naming & Slug
+
+| Environment | App Name (preferred) | Fallback (if name too short) |
+|-------------|----------------------|------------------------------|
+| Production  | VM0                  | VM0 AI                       |
+| Development | VM0 TEST             | VM0 AI TEST                  |
+
+- Prefer **VM0** over VM0 AI whenever the platform allows it.
+- The URL slug should match the app name: prefer `vm0`, fall back to `vm0-ai`.
+- Some platforms enforce a minimum name length. Use the fallback names in that case.
+
+### Common Fields
+
+| Field       | Value                          |
+|-------------|--------------------------------|
+| Developer / Company | Max & Zoe, Inc.        |
+| Contact Email       | contact@vm0.ai         |
+| Support Email       | support@vm0.ai         |
+| Website             | https://www.vm0.ai     |
+| Documentation URL   | https://docs.vm0.ai    |
+
+### Product Description
+
+Use the following when the OAuth provider asks for an app description:
+
+> VM0 is a cloud platform for building and deploying AI agents using natural language. Developers describe agent behavior conversationally, and agents run 24/7 in managed cloud sandboxes with full observability, session persistence, and 50+ pre-built integrations.
+
+### Logo
+
+Upload the VM0 logo manually when the platform requires one.
+
+### Callback URIs
+
+| Environment | Callback URI |
+|-------------|-------------|
+| Production  | `https://www.vm0.ai/api/connectors/{provider}/callback` |
+| Development | `https://www.vm7.ai:8443/api/connectors/{provider}/callback` |
+
+Replace `{provider}` with the lowercase provider name. Examples:
+
+| Provider     | Production Callback | Development Callback |
+|-------------|--------------------|--------------------|
+| Deel         | `https://www.vm0.ai/api/connectors/deel/callback` | `https://www.vm7.ai:8443/api/connectors/deel/callback` |
+| Gmail        | `https://www.vm0.ai/api/connectors/gmail/callback` | `https://www.vm7.ai:8443/api/connectors/gmail/callback` |
+| Google Sheet | `https://www.vm0.ai/api/connectors/google-sheet/callback` | `https://www.vm7.ai:8443/api/connectors/google-sheet/callback` |
+| Strava       | `https://www.vm0.ai/api/connectors/strava/callback` | `https://www.vm7.ai:8443/api/connectors/strava/callback` |
+
+### Webhook URIs
+
+If the OAuth provider requires a webhook URL:
+
+| Environment | Webhook URI |
+|-------------|-------------|
+| Production  | `https://www.vm0.ai/api/webhooks/{provider}` |
+| Development | `https://tunnel-{provider}-dev.vm7.ai/api/webhooks/{provider}` |
+
+Examples:
+
+| Provider | Production Webhook | Development Webhook |
+|----------|-------------------|-------------------|
+| Vercel   | `https://www.vm0.ai/api/webhooks/vercel` | `https://tunnel-vercel-dev.vm7.ai/api/webhooks/vercel` |
+| Neon     | `https://www.vm0.ai/api/webhooks/neon` | `https://tunnel-neon-dev.vm7.ai/api/webhooks/neon` |
+
+### Why Two Apps?
+
+- **Hard isolation** — Production and development credentials never mix. A leaked dev secret cannot compromise production.
+- **Safe testing** — Development callbacks point to `vm7.ai:8443`, so OAuth flows can be tested locally without affecting production users.
+- **Independent rotation** — Credentials can be rotated per environment without cross-impact.

--- a/turbo/apps/web/.env.local.tpl
+++ b/turbo/apps/web/.env.local.tpl
@@ -103,7 +103,7 @@ NGROK_API_KEY=op://Development/vm0-env-local/NGROK_API_KEY
 NGROK_COMPUTER_CONNECTOR_DOMAIN=computer.vm7.io
 
 # Required: Platform UI URL (for settings page links in error messages)
-PLATFORM_URL=op://Development/vm0-env-local/next_public_platform_url
+PLATFORM_URL=op://Development/vm0-env-local/NEXT_PUBLIC_PLATFORM_URL
 
 # Optional: Blog Configuration
 BLOG_BASE_URL=

--- a/turbo/apps/web/.env.local.tpl
+++ b/turbo/apps/web/.env.local.tpl
@@ -10,37 +10,37 @@ E2B_API_KEY=op://Development/vm0-env-local/E2B_API_KEY
 E2B_TEMPLATE_NAME=vm0-claude-code-dev
 
 # Required: Object Storage (Cloudflare R2)
-R2_ACCOUNT_ID=op://Development/vm0-env-local/r2_account_id
-R2_ACCESS_KEY_ID=op://Development/vm0-env-local/r2_access_key_id
-R2_SECRET_ACCESS_KEY=op://Development/vm0-env-local/r2_secret_access_key
-R2_USER_STORAGES_BUCKET_NAME=op://Development/vm0-env-local/r2_user_storages_bucket_name
+R2_ACCOUNT_ID=op://Development/vm0-env-local/R2_ACCOUNT_ID
+R2_ACCESS_KEY_ID=op://Development/vm0-env-local/R2_ACCESS_KEY_ID
+R2_SECRET_ACCESS_KEY=op://Development/vm0-env-local/R2_SECRET_ACCESS_KEY
+R2_USER_STORAGES_BUCKET_NAME=op://Development/vm0-env-local/R2_USER_STORAGES_BUCKET_NAME
 
 # Optional: Observability (Axiom)
-AXIOM_TOKEN_SESSIONS=op://Development/vm0-env-local/axiom_token_sessions
-AXIOM_TOKEN_TELEMETRY=op://Development/vm0-env-local/axiom_token_telemetry
+AXIOM_TOKEN_SESSIONS=op://Development/vm0-env-local/AXIOM_TOKEN_SESSIONS
+AXIOM_TOKEN_TELEMETRY=op://Development/vm0-env-local/AXIOM_TOKEN_TELEMETRY
 AXIOM_DATASET_SUFFIX=dev
 
 SECRETS_ENCRYPTION_KEY=op://Development/vm0-env-local/SECRETS_ENCRYPTION_KEY
 
 # Optional: Slack Integration
-SLACK_CLIENT_ID=op://Development/vm0-env-local/slack_client_id
-SLACK_CLIENT_SECRET=op://Development/vm0-env-local/slack_client_secret
-SLACK_SIGNING_SECRET=op://Development/vm0-env-local/slack_signing_secret
-SLACK_DEFAULT_AGENT=op://Development/vm0-env-local/slack_default_agent
+SLACK_CLIENT_ID=op://Development/vm0-env-local/SLACK_CLIENT_ID
+SLACK_CLIENT_SECRET=op://Development/vm0-env-local/SLACK_CLIENT_SECRET
+SLACK_SIGNING_SECRET=op://Development/vm0-env-local/SLACK_SIGNING_SECRET
+SLACK_DEFAULT_AGENT=op://Development/vm0-env-local/SLACK_DEFAULT_AGENT
 
 # Required: Claude Code Version URL
 CLAUDE_CODE_VERSION_URL=https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/latest
 
 # Optional: LLM API (OpenRouter)
-OPENROUTER_API_KEY=op://Development/vm0-env-local/openrouter_api_key
+OPENROUTER_API_KEY=op://Development/vm0-env-local/OPENROUTER_API_KEY
 
 # Optional: GitHub OAuth Connector
-GH_OAUTH_CLIENT_ID=op://Development/vm0-env-local/gh_oauth_client_id
-GH_OAUTH_CLIENT_SECRET=op://Development/vm0-env-local/gh_oauth_client_secret
+GH_OAUTH_CLIENT_ID=op://Development/vm0-env-local/GH_OAUTH_CLIENT_ID
+GH_OAUTH_CLIENT_SECRET=op://Development/vm0-env-local/GH_OAUTH_CLIENT_SECRET
 
 # Optional: Notion OAuth Connector
-NOTION_OAUTH_CLIENT_ID=op://Development/vm0-env-local/notion_oauth_client_id
-NOTION_OAUTH_CLIENT_SECRET=op://Development/vm0-env-local/notion_oauth_client_secret
+NOTION_OAUTH_CLIENT_ID=op://Development/vm0-env-local/NOTION_OAUTH_CLIENT_ID
+NOTION_OAUTH_CLIENT_SECRET=op://Development/vm0-env-local/NOTION_OAUTH_CLIENT_SECRET
 
 # Optional: Google OAuth Connector (Gmail, Calendar, Drive, etc.)
 GOOGLE_OAUTH_CLIENT_ID=op://Development/vm0-env-local/GOOGLE_OAUTH_CLIENT_ID


### PR DESCRIPTION
## Summary

- Add `docs/create-oauth-app.md` with standardized instructions for creating OAuth apps across production and development environments (naming conventions, callback/webhook URIs, common fields, and rationale for two-app isolation)
- Normalize 1Password reference keys in `turbo/apps/web/.env.local.tpl` from mixed-case (`r2_account_id`, `slack_client_id`, etc.) to uppercase (`R2_ACCOUNT_ID`, `SLACK_CLIENT_ID`, etc.) for consistency with existing uppercase entries like `GOOGLE_OAUTH_CLIENT_ID` and `SECRETS_ENCRYPTION_KEY`

## Test plan

- [ ] Verify `script/sync-env.sh` still resolves all 1Password references correctly with the updated key casing
- [ ] Confirm the new doc renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)