### PR TITLE
feat(telegram): add agent completion callback handler

### DIFF
--- a/turbo/apps/web/app/api/internal/callbacks/telegram/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/telegram/__tests__/route.test.ts
@@ -119,7 +119,7 @@ async function setupTelegramCallback() {
   const { secret } = await createTestCallback({
     runId,
     url: "http://localhost/api/internal/callbacks/telegram",
-    payload,
+    payload: { ...payload },
   });
 
   return {

--- a/turbo/apps/web/app/api/internal/callbacks/telegram/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/telegram/__tests__/route.test.ts
@@ -1,0 +1,400 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { HttpResponse } from "msw";
+import { POST } from "../route";
+import {
+  testContext,
+  uniqueId,
+} from "../../../../../../src/__tests__/test-helpers";
+import {
+  createTestRun,
+  createTestCallback,
+  createTestAgentSession,
+  createTestRequest,
+  createTestScope,
+  createTestCompose,
+} from "../../../../../../src/__tests__/api-test-helpers";
+import { computeHmacSignature } from "../../../../../../src/lib/callback/hmac";
+import { createTelegramCallbackInstallation } from "../../../../../../src/lib/telegram/__tests__/helpers";
+import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
+import { server } from "../../../../../../src/mocks/server";
+import { http } from "../../../../../../src/__tests__/msw";
+
+const context = testContext();
+
+const TEST_BOT_TOKEN = "123456:ABC-test-telegram-callback";
+
+interface TelegramCallbackPayload {
+  installationId: string;
+  chatId: string;
+  messageId: string;
+  userLinkId: string;
+  agentName: string;
+  composeId: string;
+  existingSessionId: string | null;
+}
+
+function telegramSendMessage() {
+  return http.post(
+    `https://api.telegram.org/bot${TEST_BOT_TOKEN}/sendMessage`,
+    () =>
+      HttpResponse.json({
+        ok: true,
+        result: { message_id: 999, chat: { id: 123 }, text: "response" },
+      }),
+  );
+}
+
+function telegramSendChatAction() {
+  return http.post(
+    `https://api.telegram.org/bot${TEST_BOT_TOKEN}/sendChatAction`,
+    () => HttpResponse.json({ ok: true, result: true }),
+  );
+}
+
+/**
+ * Create a signed callback request for the Telegram callback endpoint
+ */
+function createCallbackRequest(
+  body: {
+    runId: string;
+    status: "completed" | "failed";
+    result?: Record<string, unknown>;
+    error?: string;
+    payload: TelegramCallbackPayload;
+  },
+  secret: string,
+  options?: { invalidSignature?: boolean; expiredTimestamp?: boolean },
+) {
+  const bodyString = JSON.stringify(body);
+  const timestamp = options?.expiredTimestamp
+    ? Math.floor(Date.now() / 1000) - 600
+    : Math.floor(Date.now() / 1000);
+
+  const signature = options?.invalidSignature
+    ? "invalid-signature"
+    : computeHmacSignature(bodyString, secret, timestamp);
+
+  return createTestRequest("http://localhost/api/internal/callbacks/telegram", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-VM0-Signature": signature,
+      "X-VM0-Timestamp": timestamp.toString(),
+    },
+    body: bodyString,
+  });
+}
+
+/**
+ * Set up a full Telegram test context: scope, compose (with version),
+ * installation (encrypted token), user link, run, callback.
+ */
+async function setupTelegramCallback() {
+  const userId = uniqueId("user");
+  mockClerk({ userId });
+
+  // Create scope + compose (with version) through API
+  await createTestScope(uniqueId("scope"));
+  const { composeId } = await createTestCompose("test-agent");
+
+  // Create installation with encrypted bot token + user link via helper
+  const { installationId, userLinkId } =
+    await createTelegramCallbackInstallation(composeId, userId, TEST_BOT_TOKEN);
+
+  // Create run and callback
+  const { runId } = await createTestRun(composeId, "Test prompt");
+  const chatId = `chat-${Date.now()}`;
+  const messageId = "42";
+
+  const payload: TelegramCallbackPayload = {
+    installationId,
+    chatId,
+    messageId,
+    userLinkId,
+    agentName: "test-agent",
+    composeId,
+    existingSessionId: null,
+  };
+
+  const { secret } = await createTestCallback({
+    runId,
+    url: "http://localhost/api/internal/callbacks/telegram",
+    payload,
+  });
+
+  return {
+    installationId,
+    composeId,
+    userId,
+    userLinkId,
+    runId,
+    chatId,
+    messageId,
+    payload,
+    secret,
+  };
+}
+
+describe("POST /api/internal/callbacks/telegram", () => {
+  beforeEach(() => {
+    context.setupMocks();
+  });
+
+  describe("Signature Verification", () => {
+    it("should reject request with invalid signature", async () => {
+      const { runId, payload, secret } = await setupTelegramCallback();
+
+      const request = createCallbackRequest(
+        { runId, status: "completed", payload },
+        secret,
+        { invalidSignature: true },
+      );
+      const response = await POST(request);
+
+      expect(response.status).toBe(401);
+      const data = await response.json();
+      expect(data.error).toContain("signature");
+    });
+
+    it("should reject request with expired timestamp", async () => {
+      const { runId, payload, secret } = await setupTelegramCallback();
+
+      const request = createCallbackRequest(
+        { runId, status: "completed", payload },
+        secret,
+        { expiredTimestamp: true },
+      );
+      const response = await POST(request);
+
+      expect(response.status).toBe(401);
+      const data = await response.json();
+      expect(data.error).toContain("expired");
+    });
+
+    it("should reject request for non-existent callback", async () => {
+      const request = createTestRequest(
+        "http://localhost/api/internal/callbacks/telegram",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "X-VM0-Signature": "any-signature",
+            "X-VM0-Timestamp": Math.floor(Date.now() / 1000).toString(),
+          },
+          body: JSON.stringify({
+            runId: "00000000-0000-0000-0000-000000000000",
+            status: "completed",
+            payload: {
+              installationId: "inst-123",
+              chatId: "123",
+              messageId: "1",
+              userLinkId: "link-123",
+              agentName: "test-agent",
+              composeId: "compose-123",
+              existingSessionId: null,
+            },
+          }),
+        },
+      );
+      const response = await POST(request);
+
+      expect(response.status).toBe(404);
+      const data = await response.json();
+      expect(data.error).toContain("not found");
+    });
+  });
+
+  describe("Successful Callback", () => {
+    it("should return 200 and send message on completed run", async () => {
+      const { runId, payload, secret } = await setupTelegramCallback();
+
+      const sendChatActionHandler = telegramSendChatAction();
+      const sendMessageHandler = telegramSendMessage();
+      server.use(sendChatActionHandler.handler, sendMessageHandler.handler);
+
+      const request = createCallbackRequest(
+        { runId, status: "completed", payload },
+        secret,
+      );
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.success).toBe(true);
+
+      // Telegram API was called
+      expect(sendChatActionHandler.mocked).toHaveBeenCalledTimes(1);
+      expect(sendMessageHandler.mocked).toHaveBeenCalledTimes(1);
+    });
+
+    it("should return 200 and send error message on failed run", async () => {
+      const { runId, payload, secret } = await setupTelegramCallback();
+
+      const sendChatActionHandler = telegramSendChatAction();
+      const sendMessageHandler = telegramSendMessage();
+      server.use(sendChatActionHandler.handler, sendMessageHandler.handler);
+
+      const request = createCallbackRequest(
+        {
+          runId,
+          status: "failed",
+          error: "Agent crashed unexpectedly",
+          payload,
+        },
+        secret,
+      );
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.success).toBe(true);
+
+      expect(sendMessageHandler.mocked).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("Thread Session", () => {
+    it("should process new thread callback without error", async () => {
+      const { runId, payload, secret, userId, composeId } =
+        await setupTelegramCallback();
+
+      const sendChatActionHandler = telegramSendChatAction();
+      const sendMessageHandler = telegramSendMessage();
+      server.use(sendChatActionHandler.handler, sendMessageHandler.handler);
+
+      // Create an agent session for findNewSessionId
+      await createTestAgentSession(userId, composeId);
+
+      const request = createCallbackRequest(
+        { runId, status: "completed", payload },
+        secret,
+      );
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+    });
+
+    it("should process existing session callback without error", async () => {
+      const { runId, payload, secret } = await setupTelegramCallback();
+
+      const sendChatActionHandler = telegramSendChatAction();
+      const sendMessageHandler = telegramSendMessage();
+      server.use(sendChatActionHandler.handler, sendMessageHandler.handler);
+
+      const request = createCallbackRequest(
+        {
+          runId,
+          status: "completed",
+          payload: { ...payload, existingSessionId: "existing-session-id" },
+        },
+        secret,
+      );
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+    });
+  });
+
+  describe("Validation", () => {
+    it("should reject request with missing runId", async () => {
+      const request = createTestRequest(
+        "http://localhost/api/internal/callbacks/telegram",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "X-VM0-Signature": "any-signature",
+            "X-VM0-Timestamp": Math.floor(Date.now() / 1000).toString(),
+          },
+          body: JSON.stringify({
+            status: "completed",
+            payload: {
+              installationId: "inst-123",
+              chatId: "123",
+              messageId: "1",
+              userLinkId: "link-123",
+              agentName: "test-agent",
+              composeId: "compose-123",
+              existingSessionId: null,
+            },
+          }),
+        },
+      );
+      const response = await POST(request);
+
+      expect(response.status).toBe(400);
+      const data = await response.json();
+      expect(data.error).toContain("runId");
+    });
+
+    it("should reject request with invalid payload", async () => {
+      const { runId, secret } = await setupTelegramCallback();
+
+      const body = JSON.stringify({
+        runId,
+        status: "completed",
+        payload: {
+          installationId: "inst-123",
+          // Missing required fields
+        },
+      });
+      const timestamp = Math.floor(Date.now() / 1000);
+      const signature = computeHmacSignature(body, secret, timestamp);
+
+      const request = createTestRequest(
+        "http://localhost/api/internal/callbacks/telegram",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "X-VM0-Signature": signature,
+            "X-VM0-Timestamp": timestamp.toString(),
+          },
+          body,
+        },
+      );
+      const response = await POST(request);
+
+      expect(response.status).toBe(400);
+      const data = await response.json();
+      expect(data.error).toContain("payload");
+    });
+
+    it("should return success for missing installation", async () => {
+      const { runId, secret } = await setupTelegramCallback();
+
+      const payload: TelegramCallbackPayload = {
+        installationId: "00000000-0000-0000-0000-000000000000",
+        chatId: "123",
+        messageId: "1",
+        userLinkId: "link-123",
+        agentName: "test-agent",
+        composeId: "compose-123",
+        existingSessionId: null,
+      };
+
+      const body = JSON.stringify({ runId, status: "completed", payload });
+      const timestamp = Math.floor(Date.now() / 1000);
+      const signature = computeHmacSignature(body, secret, timestamp);
+
+      const request = createTestRequest(
+        "http://localhost/api/internal/callbacks/telegram",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "X-VM0-Signature": signature,
+            "X-VM0-Timestamp": timestamp.toString(),
+          },
+          body,
+        },
+      );
+      const response = await POST(request);
+
+      // Missing installation returns 200 (graceful, don't retry)
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.success).toBe(true);
+    });
+  });
+});

--- a/turbo/apps/web/app/api/internal/callbacks/telegram/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/telegram/route.ts
@@ -1,0 +1,257 @@
+import { NextRequest, NextResponse } from "next/server";
+import { eq, and, gte, desc } from "drizzle-orm";
+import { initServices } from "../../../../../src/lib/init-services";
+import { verifyCallbackRequest } from "../../../../../src/lib/callback";
+import { decryptCredentialValue } from "../../../../../src/lib/crypto/secrets-encryption";
+import { telegramInstallations } from "../../../../../src/db/schema/telegram-installation";
+import { agentSessions } from "../../../../../src/db/schema/agent-session";
+import { agentRuns } from "../../../../../src/db/schema/agent-run";
+import { agentRunCallbacks } from "../../../../../src/db/schema/agent-run-callback";
+import {
+  createTelegramClient,
+  sendMessage,
+  sendChatAction,
+} from "../../../../../src/lib/telegram/client";
+import {
+  markdownToTelegramHtml,
+  splitMessage,
+} from "../../../../../src/lib/telegram/format";
+import { getRunOutput } from "../../../../../src/lib/slack/handlers/run-agent";
+import {
+  saveTelegramThreadSession,
+  storeTelegramMessage,
+  buildLogsUrl,
+} from "../../../../../src/lib/telegram/handlers/shared";
+import { env } from "../../../../../src/env";
+import { logger } from "../../../../../src/lib/logger";
+
+const log = logger("callback:telegram");
+
+interface CallbackPayload {
+  installationId: string;
+  chatId: string;
+  messageId: string;
+  userLinkId: string;
+  agentName: string;
+  composeId: string;
+  existingSessionId: string | null;
+}
+
+interface CallbackBody {
+  runId: string;
+  status: "completed" | "failed";
+  result?: Record<string, unknown>;
+  error?: string;
+  payload: CallbackPayload;
+}
+
+function parsePayload(body: CallbackBody): CallbackPayload | null {
+  if (!body.payload) return null;
+  const p = body.payload;
+  if (
+    typeof p.installationId !== "string" ||
+    typeof p.chatId !== "string" ||
+    typeof p.messageId !== "string" ||
+    typeof p.userLinkId !== "string" ||
+    typeof p.agentName !== "string" ||
+    typeof p.composeId !== "string"
+  ) {
+    return null;
+  }
+  return p;
+}
+
+function errorResponse(message: string, status: number): NextResponse {
+  return NextResponse.json({ error: message }, { status });
+}
+
+async function findNewSessionId(
+  userId: string,
+  composeId: string,
+  runCreatedAt: Date,
+): Promise<string | undefined> {
+  const [newSession] = await globalThis.services.db
+    .select({ id: agentSessions.id })
+    .from(agentSessions)
+    .where(
+      and(
+        eq(agentSessions.userId, userId),
+        eq(agentSessions.agentComposeId, composeId),
+        gte(agentSessions.updatedAt, runCreatedAt),
+      ),
+    )
+    .orderBy(desc(agentSessions.updatedAt))
+    .limit(1);
+  return newSession?.id;
+}
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  initServices();
+  const { SECRETS_ENCRYPTION_KEY } = env();
+
+  // Read raw body for signature verification
+  const rawBody = await request.text();
+
+  // Parse body first to get runId for callback lookup
+  let body: CallbackBody;
+  try {
+    body = JSON.parse(rawBody);
+  } catch {
+    return errorResponse("Invalid JSON body", 400);
+  }
+
+  const { runId, status, error } = body;
+
+  if (!runId) {
+    return errorResponse("Missing runId", 400);
+  }
+
+  // Query callback record to get the per-callback secret
+  const [callback] = await globalThis.services.db
+    .select({ encryptedSecret: agentRunCallbacks.encryptedSecret })
+    .from(agentRunCallbacks)
+    .where(eq(agentRunCallbacks.runId, runId))
+    .limit(1);
+
+  if (!callback) {
+    log.warn("Callback record not found", { runId });
+    return errorResponse("Callback not found", 404);
+  }
+
+  // Decrypt the per-callback secret
+  const callbackSecret = decryptCredentialValue(
+    callback.encryptedSecret,
+    SECRETS_ENCRYPTION_KEY,
+  );
+
+  // Verify signature using the per-callback secret
+  const signature = request.headers.get("X-VM0-Signature");
+  const timestamp = request.headers.get("X-VM0-Timestamp");
+
+  const verification = verifyCallbackRequest(
+    rawBody,
+    callbackSecret,
+    signature,
+    timestamp,
+  );
+
+  if (!verification.valid) {
+    log.warn("Callback signature verification failed", {
+      runId,
+      error: verification.error,
+    });
+    return errorResponse(verification.error ?? "Invalid signature", 401);
+  }
+
+  const payload = parsePayload(body);
+
+  if (!payload) {
+    return errorResponse("Invalid or missing payload", 400);
+  }
+
+  const {
+    installationId,
+    chatId,
+    messageId,
+    userLinkId,
+    agentName,
+    composeId,
+    existingSessionId,
+  } = payload;
+
+  log.debug("Processing Telegram callback", { runId, status, chatId });
+
+  // Get Telegram installation for bot token
+  const [installation] = await globalThis.services.db
+    .select({
+      id: telegramInstallations.id,
+      encryptedBotToken: telegramInstallations.encryptedBotToken,
+    })
+    .from(telegramInstallations)
+    .where(eq(telegramInstallations.id, installationId))
+    .limit(1);
+
+  if (!installation) {
+    log.warn("Telegram installation not found", { installationId });
+    return NextResponse.json({ success: true });
+  }
+
+  const botToken = decryptCredentialValue(
+    installation.encryptedBotToken,
+    SECRETS_ENCRYPTION_KEY,
+  );
+  const client = createTelegramClient(botToken);
+
+  // Send typing indicator before posting
+  await sendChatAction(client, chatId, "typing");
+
+  // Query Axiom for the agent's output
+  const output = status === "completed" ? await getRunOutput(runId) : undefined;
+
+  // Build response text
+  const logsUrl = buildLogsUrl(runId);
+  const responseText =
+    status === "completed"
+      ? (output ?? "Task completed successfully.")
+      : `Error: ${error ?? "Agent execution failed."}`;
+
+  const footer = `\n\n<a href="${logsUrl}">View logs</a> · ${agentName}`;
+
+  // Convert markdown to Telegram HTML and split if needed
+  const htmlOutput = markdownToTelegramHtml(responseText) + footer;
+  const chunks = splitMessage(htmlOutput);
+
+  // Send response message(s) as reply to user's original message
+  let botReplyMessageId: number | undefined;
+  for (const chunk of chunks) {
+    const sent = await sendMessage(client, chatId, chunk, {
+      replyToMessageId: Number(messageId),
+    });
+    // Capture first reply message_id as thread anchor
+    if (botReplyMessageId === undefined) {
+      botReplyMessageId = sent.message_id;
+    }
+  }
+
+  // Store bot's response in telegram_messages for context
+  if (botReplyMessageId !== undefined) {
+    await storeTelegramMessage(installationId, chatId, {
+      message_id: botReplyMessageId,
+      from: { id: 0, is_bot: true },
+      text: responseText,
+    });
+  }
+
+  // Get run to find userId for session lookup
+  const [run] = await globalThis.services.db
+    .select({ userId: agentRuns.userId, createdAt: agentRuns.createdAt })
+    .from(agentRuns)
+    .where(eq(agentRuns.id, runId))
+    .limit(1);
+
+  // Save thread session mapping
+  if (run && botReplyMessageId !== undefined) {
+    const newSessionId = !existingSessionId
+      ? await findNewSessionId(run.userId, composeId, run.createdAt)
+      : undefined;
+
+    // For new threads, use bot's reply as rootMessageId (thread anchor)
+    const rootMessageId = existingSessionId
+      ? messageId // Existing thread — use original anchor
+      : String(botReplyMessageId); // New thread — bot's reply is the anchor
+
+    await saveTelegramThreadSession({
+      userLinkId,
+      chatId,
+      rootMessageId,
+      existingSessionId: existingSessionId ?? undefined,
+      newSessionId,
+      messageId,
+      runStatus: status,
+    });
+  }
+
+  log.debug("Telegram callback processed successfully", { runId });
+
+  return NextResponse.json({ success: true });
+}

--- a/turbo/apps/web/src/lib/telegram/__tests__/helpers.ts
+++ b/turbo/apps/web/src/lib/telegram/__tests__/helpers.ts
@@ -1,8 +1,10 @@
 import { initServices } from "../../init-services";
 import { telegramInstallations } from "../../../db/schema/telegram-installation";
+import { telegramUserLinks } from "../../../db/schema/telegram-user-link";
 import { telegramMessages } from "../../../db/schema/telegram-message";
 import { agentComposes } from "../../../db/schema/agent-compose";
 import { scopes } from "../../../db/schema/scope";
+import { encryptCredentialValue } from "../../crypto/secrets-encryption";
 import { uniqueId } from "../../../__tests__/test-helpers";
 
 /**
@@ -76,4 +78,53 @@ export async function insertTelegramMessage(
     isBot: options.isBot ?? false,
     createdAt: options.createdAt ?? new Date(),
   });
+}
+
+interface CallbackInstallationResult {
+  installationId: string;
+  userLinkId: string;
+}
+
+/**
+ * Create a Telegram installation with properly encrypted bot token and a user link.
+ * Use this for callback endpoint tests that need to decrypt the bot token.
+ */
+export async function createTelegramCallbackInstallation(
+  composeId: string,
+  userId: string,
+  botToken: string,
+): Promise<CallbackInstallationResult> {
+  initServices();
+
+  const { SECRETS_ENCRYPTION_KEY } = globalThis.services.env;
+  const encryptedBotToken = encryptCredentialValue(
+    botToken,
+    SECRETS_ENCRYPTION_KEY,
+  );
+
+  const [installation] = await globalThis.services.db
+    .insert(telegramInstallations)
+    .values({
+      telegramBotId: uniqueId("bot"),
+      botUsername: "test_bot",
+      encryptedBotToken,
+      webhookSecret: "webhook-secret",
+      defaultComposeId: composeId,
+      adminUserId: userId,
+    })
+    .returning();
+
+  const [userLink] = await globalThis.services.db
+    .insert(telegramUserLinks)
+    .values({
+      telegramUserId: uniqueId("tg"),
+      installationId: installation!.id,
+      vm0UserId: userId,
+    })
+    .returning();
+
+  return {
+    installationId: installation!.id,
+    userLinkId: userLink!.id,
+  };
 }


### PR DESCRIPTION
## Summary

- Add callback endpoint at `/api/internal/callbacks/telegram` that receives agent completion notifications
- Verify HMAC signatures using per-callback secrets (same pattern as Slack callback)
- Convert agent output to Telegram HTML format, split long messages at paragraph boundaries
- Send typing indicator before posting response, reply to user's original message
- Create/update thread sessions based on run status (new session, completed, failed)
- Store bot's response in `telegram_messages` for future context retrieval
- 10 integration tests with MSW-mocked Telegram API

## Test plan

- [x] Reject invalid HMAC signature (401)
- [x] Reject expired timestamp (401)
- [x] Reject non-existent callback (404)
- [x] Return 200 and send message on completed run
- [x] Return 200 and send error message on failed run
- [x] Process new thread callback (session creation)
- [x] Process existing session callback (session update)
- [x] Reject missing runId (400)
- [x] Reject invalid payload (400)
- [x] Return 200 for missing installation (graceful)

Closes #3537

🤖 Generated with [Claude Code](https://claude.com/claude-code)