### PR TITLE
feat(platform): add telegram integration platform ui

### DIFF
--- a/turbo/apps/platform/src/mocks/handlers/api-integrations-telegram.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-integrations-telegram.ts
@@ -1,0 +1,84 @@
+/**
+ * Telegram Integration API Handlers
+ *
+ * Mock handlers for /api/integrations/telegram and /api/telegram/register endpoints.
+ * Default behavior: user has a linked Telegram bot with an agent configured.
+ */
+
+import { http, HttpResponse } from "msw";
+
+interface MockTelegramIntegrationData {
+  bot: { id: string; username: string };
+  agent: { id: string; name: string; scopeSlug: string } | null;
+  isAdmin: boolean;
+  environment: {
+    requiredSecrets: string[];
+    requiredVars: string[];
+    missingSecrets: string[];
+    missingVars: string[];
+  };
+}
+
+let mockTelegramData: MockTelegramIntegrationData = {
+  bot: { id: "bot_123", username: "test_bot" },
+  agent: { id: "compose_1", name: "default-agent", scopeSlug: "test-scope" },
+  isAdmin: true,
+  environment: {
+    requiredSecrets: ["ANTHROPIC_API_KEY"],
+    requiredVars: [],
+    missingSecrets: [],
+    missingVars: [],
+  },
+};
+
+export function resetMockTelegramIntegration(): void {
+  mockTelegramData = {
+    bot: { id: "bot_123", username: "test_bot" },
+    agent: {
+      id: "compose_1",
+      name: "default-agent",
+      scopeSlug: "test-scope",
+    },
+    isAdmin: true,
+    environment: {
+      requiredSecrets: ["ANTHROPIC_API_KEY"],
+      requiredVars: [],
+      missingSecrets: [],
+      missingVars: [],
+    },
+  };
+}
+
+export const apiIntegrationsTelegramHandlers = [
+  // GET /api/integrations/telegram
+  http.get("/api/integrations/telegram", () => {
+    return HttpResponse.json(mockTelegramData);
+  }),
+
+  // PATCH /api/integrations/telegram
+  http.patch("/api/integrations/telegram", async ({ request }) => {
+    const body = (await request.json()) as { agentName?: string };
+    if (body.agentName && mockTelegramData.agent) {
+      mockTelegramData.agent.name = body.agentName;
+    }
+    return HttpResponse.json({ ok: true });
+  }),
+
+  // DELETE /api/integrations/telegram
+  http.delete("/api/integrations/telegram", () => {
+    return HttpResponse.json({ ok: true });
+  }),
+
+  // GET /api/integrations/telegram/link
+  http.get("/api/integrations/telegram/link", () => {
+    return HttpResponse.json({ linked: false });
+  }),
+
+  // POST /api/telegram/register
+  http.post("/api/telegram/register", () => {
+    return HttpResponse.json({
+      id: "installation_1",
+      botUsername: "test_bot",
+    });
+  }),
+];

--- a/turbo/apps/platform/src/mocks/handlers/index.ts
+++ b/turbo/apps/platform/src/mocks/handlers/index.ts
@@ -22,6 +22,10 @@ import {
   apiIntegrationsSlackHandlers,
   resetMockSlackIntegration,
 } from "./api-integrations-slack.ts";
+import {
+  apiIntegrationsTelegramHandlers,
+  resetMockTelegramIntegration,
+} from "./api-integrations-telegram.ts";
 import { apiAgentsHandlers } from "./api-agents.ts";
 import {
   apiUserPreferencesHandlers,
@@ -37,6 +41,7 @@ export const handlers = [
   ...exampleHandlers,
   ...platformLogsHandlers,
   ...apiIntegrationsSlackHandlers,
+  ...apiIntegrationsTelegramHandlers,
   ...apiAgentsHandlers,
   ...apiUserPreferencesHandlers,
 ];
@@ -47,5 +52,6 @@ export function resetAllMockHandlers(): void {
   resetMockSecrets();
   resetMockVariables();
   resetMockSlackIntegration();
+  resetMockTelegramIntegration();
   resetMockUserPreferences();
 }

--- a/turbo/apps/platform/src/signals/bootstrap.ts
+++ b/turbo/apps/platform/src/signals/bootstrap.ts
@@ -28,6 +28,9 @@ import { setupGitHubSettingsPage$ } from "./integrations-page/github-settings-pa
 import { setupProviderSetupPage$ } from "./provider-setup/provider-setup-page.ts";
 import { setupSlackConnectPage$ } from "./slack-connect/slack-connect-page.ts";
 import { setupSlackConnectSuccessPage$ } from "./slack-connect/slack-connect-success-page.ts";
+import { setupTelegramSettingsPage$ } from "./integrations-page/telegram-settings-page.ts";
+import { setupTelegramConnectPage$ } from "./telegram-connect/telegram-connect-page.ts";
+import { setupTelegramConnectSuccessPage$ } from "./telegram-connect/telegram-connect-success-page.ts";
 
 const L = logger("Bootstrap");
 
@@ -95,6 +98,18 @@ const ROUTE_CONFIG = [
   {
     path: "/slack/connect/success",
     setup: setupAuthPageWrapper(setupSlackConnectSuccessPage$),
+  },
+  {
+    path: "/settings/telegram",
+    setup: setupScopeRequiredPageWrapper(setupTelegramSettingsPage$),
+  },
+  {
+    path: "/telegram/connect",
+    setup: setupAuthPageWrapper(setupTelegramConnectPage$),
+  },
+  {
+    path: "/telegram/connect/success",
+    setup: setupAuthPageWrapper(setupTelegramConnectSuccessPage$),
   },
   {
     path: "/_playground",

--- a/turbo/apps/platform/src/signals/integrations-page/telegram-integration.ts
+++ b/turbo/apps/platform/src/signals/integrations-page/telegram-integration.ts
@@ -1,0 +1,167 @@
+import { command, computed, state } from "ccstate";
+import { toast } from "@vm0/ui/components/ui/sonner";
+import { fetch$ } from "../fetch.ts";
+import { throwIfAbort } from "../utils.ts";
+import { logger } from "../log.ts";
+
+const L = logger("TelegramIntegration");
+
+interface TelegramIntegrationData {
+  bot: { id: string; username: string };
+  agent: { id: string; name: string; scopeSlug: string } | null;
+  isAdmin: boolean;
+  environment: {
+    requiredSecrets: string[];
+    requiredVars: string[];
+    missingSecrets: string[];
+    missingVars: string[];
+  };
+}
+
+interface TelegramIntegrationState {
+  data: TelegramIntegrationData | null;
+  loading: boolean;
+  error: string | null;
+  notLinked: boolean;
+}
+
+const telegramIntegrationState$ = state<TelegramIntegrationState>({
+  data: null,
+  loading: false,
+  error: null,
+  notLinked: false,
+});
+
+export const telegramIntegrationData$ = computed(
+  (get) => get(telegramIntegrationState$).data,
+);
+export const telegramIntegrationLoading$ = computed(
+  (get) => get(telegramIntegrationState$).loading,
+);
+export const telegramIntegrationNotLinked$ = computed(
+  (get) => get(telegramIntegrationState$).notLinked,
+);
+
+export const fetchTelegramIntegration$ = command(async ({ get, set }) => {
+  set(telegramIntegrationState$, (prev) => ({
+    ...prev,
+    loading: true,
+    error: null,
+  }));
+
+  try {
+    const fetchFn = get(fetch$);
+    const response = await fetchFn("/api/integrations/telegram");
+
+    if (response.status === 404) {
+      set(telegramIntegrationState$, {
+        data: null,
+        loading: false,
+        error: null,
+        notLinked: true,
+      });
+      return;
+    }
+
+    if (!response.ok) {
+      throw new Error(
+        `Failed to fetch Telegram integration: ${response.statusText}`,
+      );
+    }
+
+    const data = (await response.json()) as TelegramIntegrationData;
+    set(telegramIntegrationState$, {
+      data,
+      loading: false,
+      error: null,
+      notLinked: false,
+    });
+  } catch (error) {
+    throwIfAbort(error);
+    L.error("Failed to fetch Telegram integration:", error);
+    set(telegramIntegrationState$, (prev) => ({
+      ...prev,
+      loading: false,
+      error: error instanceof Error ? error.message : "Unknown error",
+    }));
+  }
+});
+
+const telegramDisconnectDialogState$ = state(false);
+
+export const telegramDisconnectDialogOpen$ = computed((get) =>
+  get(telegramDisconnectDialogState$),
+);
+
+export const openTelegramDisconnectDialog$ = command(({ set }) => {
+  set(telegramDisconnectDialogState$, true);
+});
+
+export const closeTelegramDisconnectDialog$ = command(({ set }) => {
+  set(telegramDisconnectDialogState$, false);
+});
+
+export const updateTelegramDefaultAgent$ = command(
+  async ({ get, set }, agentName: string) => {
+    // Optimistically update agent name so the UI doesn't flash a loading state
+    set(telegramIntegrationState$, (prev) => {
+      if (!prev.data) {
+        return prev;
+      }
+      return {
+        ...prev,
+        data: {
+          ...prev.data,
+          agent: prev.data.agent
+            ? { ...prev.data.agent, name: agentName }
+            : { id: "", name: agentName, scopeSlug: "" },
+        },
+      };
+    });
+
+    const fetchFn = get(fetch$);
+    const response = await fetchFn("/api/integrations/telegram", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ agentName }),
+    });
+
+    if (!response.ok) {
+      toast.error("Failed to update default agent");
+      // Re-fetch to revert optimistic update
+      await set(fetchTelegramIntegration$);
+      return;
+    }
+
+    toast.success(`Default agent updated to ${agentName}`);
+
+    // Silently refresh to pick up updated environment status without loading spinner
+    try {
+      const refreshResponse = await fetchFn("/api/integrations/telegram");
+      if (refreshResponse.ok) {
+        const data = (await refreshResponse.json()) as TelegramIntegrationData;
+        set(telegramIntegrationState$, (prev) => ({
+          ...prev,
+          data,
+        }));
+      }
+    } catch (error) {
+      throwIfAbort(error);
+      L.error("Failed to refresh after agent update:", error);
+    }
+  },
+);
+
+export const disconnectTelegram$ = command(async ({ get, set }) => {
+  const fetchFn = get(fetch$);
+  const response = await fetchFn("/api/integrations/telegram", {
+    method: "DELETE",
+  });
+
+  if (!response.ok) {
+    throw new Error("Failed to disconnect Telegram");
+  }
+
+  // Re-fetch to get the updated state
+  await set(fetchTelegramIntegration$);
+});

--- a/turbo/apps/platform/src/signals/integrations-page/telegram-settings-page.ts
+++ b/turbo/apps/platform/src/signals/integrations-page/telegram-settings-page.ts
@@ -1,0 +1,14 @@
+import { command } from "ccstate";
+import { createElement } from "react";
+import { updatePage$ } from "../react-router";
+import { TelegramSettingsPage } from "../../views/integrations-page/telegram-settings-page";
+import { fetchTelegramIntegration$ } from "./telegram-integration.ts";
+import { fetchAgentsList$ } from "../agents-page/agents-list.ts";
+
+/**
+ * Setup the Telegram settings detail page.
+ */
+export const setupTelegramSettingsPage$ = command(async ({ set }) => {
+  set(updatePage$, createElement(TelegramSettingsPage));
+  await Promise.all([set(fetchTelegramIntegration$), set(fetchAgentsList$)]);
+});

--- a/turbo/apps/platform/src/signals/settings-page/settings-page.ts
+++ b/turbo/apps/platform/src/signals/settings-page/settings-page.ts
@@ -7,6 +7,7 @@ import { initSettingsTabs$ } from "./settings-tabs.ts";
 import { featureSwitch$ } from "../external/feature-switch.ts";
 import { fetchSlackIntegration$ } from "../integrations-page/slack-integration.ts";
 import { fetchGitHubIntegration$ } from "../integrations-page/github-integration.ts";
+import { fetchTelegramIntegration$ } from "../integrations-page/telegram-integration.ts";
 
 /**
  * Setup the settings page.
@@ -19,6 +20,9 @@ export const setupSettingsPage$ = command(async ({ set, get }) => {
     set(fetchSlackIntegration$),
     features?.[FeatureSwitchKey.GitHubIntegration]
       ? set(fetchGitHubIntegration$)
+      : Promise.resolve(),
+    features?.[FeatureSwitchKey.TelegramIntegration]
+      ? set(fetchTelegramIntegration$)
       : Promise.resolve(),
   ]);
 });

--- a/turbo/apps/platform/src/signals/telegram-connect/telegram-connect-page.ts
+++ b/turbo/apps/platform/src/signals/telegram-connect/telegram-connect-page.ts
@@ -1,0 +1,39 @@
+import { command } from "ccstate";
+import { createElement } from "react";
+import { updatePage$ } from "../react-router.ts";
+import { navigate$ } from "../route.ts";
+import { hasAnyModelProvider$ } from "../external/model-providers.ts";
+import { throwIfAbort } from "../utils.ts";
+import { initTelegramConnect$ } from "./telegram-connect.ts";
+import { TelegramConnectPage } from "../../views/telegram-connect/telegram-connect-page.tsx";
+
+export const setupTelegramConnectPage$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    // Render page first so the user sees the loading spinner
+    set(updatePage$, createElement(TelegramConnectPage));
+
+    // Check provider — redirect to setup if none configured
+    let hasProvider = false;
+    try {
+      hasProvider = await get(hasAnyModelProvider$);
+    } catch (error) {
+      throwIfAbort(error);
+    }
+    signal.throwIfAborted();
+
+    if (!hasProvider) {
+      const setupParams = new URLSearchParams();
+      setupParams.set("return", "/telegram/connect");
+      await set(
+        navigate$,
+        "/provider-setup",
+        { searchParams: setupParams },
+        signal,
+      );
+      signal.throwIfAborted();
+      return;
+    }
+
+    await set(initTelegramConnect$);
+  },
+);

--- a/turbo/apps/platform/src/signals/telegram-connect/telegram-connect-success-page.ts
+++ b/turbo/apps/platform/src/signals/telegram-connect/telegram-connect-success-page.ts
@@ -1,0 +1,16 @@
+import { command } from "ccstate";
+import { createElement } from "react";
+import { updatePage$ } from "../react-router.ts";
+import { searchParams$ } from "../route.ts";
+import { TelegramConnectSuccessPage } from "../../views/telegram-connect/telegram-connect-success-page.tsx";
+
+export const setupTelegramConnectSuccessPage$ = command(({ get, set }) => {
+  set(updatePage$, createElement(TelegramConnectSuccessPage));
+
+  // Auto-open Telegram on page load
+  const params = get(searchParams$);
+  const botUsername = params.get("bot");
+  if (botUsername) {
+    window.location.href = `https://t.me/${botUsername}`;
+  }
+});

--- a/turbo/apps/platform/src/signals/telegram-connect/telegram-connect.ts
+++ b/turbo/apps/platform/src/signals/telegram-connect/telegram-connect.ts
@@ -1,0 +1,133 @@
+import { command, computed, state } from "ccstate";
+import { fetch$ } from "../fetch.ts";
+import { throwIfAbort } from "../utils.ts";
+import { logger } from "../log.ts";
+
+const L = logger("TelegramConnect");
+
+interface TelegramConnectState {
+  status: "checking" | "ready" | "registering" | "success" | "error";
+  isLinked: boolean;
+  error: string | null;
+}
+
+const telegramConnectState$ = state<TelegramConnectState>({
+  status: "checking",
+  isLinked: false,
+  error: null,
+});
+
+export const telegramConnectStatus$ = computed(
+  (get) => get(telegramConnectState$).status,
+);
+export const telegramConnectIsLinked$ = computed(
+  (get) => get(telegramConnectState$).isLinked,
+);
+export const telegramConnectError$ = computed(
+  (get) => get(telegramConnectState$).error,
+);
+
+const telegramBotTokenInput$ = state("");
+
+export const telegramBotToken$ = computed((get) => get(telegramBotTokenInput$));
+
+export const setTelegramBotToken$ = command(({ set }, value: string) => {
+  set(telegramBotTokenInput$, value);
+});
+
+/**
+ * Check if the user is already linked to a Telegram bot.
+ */
+export const initTelegramConnect$ = command(async ({ get, set }) => {
+  set(telegramConnectState$, {
+    status: "checking",
+    isLinked: false,
+    error: null,
+  });
+
+  try {
+    const fetchFn = get(fetch$);
+    const response = await fetchFn("/api/integrations/telegram/link");
+
+    if (!response.ok) {
+      throw new Error("Failed to check link status");
+    }
+
+    const data = (await response.json()) as {
+      linked: boolean;
+      telegramUserId?: string;
+    };
+
+    set(telegramConnectState$, {
+      status: "ready",
+      isLinked: data.linked,
+      error: null,
+    });
+  } catch (error) {
+    throwIfAbort(error);
+    L.error("Failed to check link status:", error);
+    set(telegramConnectState$, {
+      status: "error",
+      isLinked: false,
+      error: "Failed to check connection status. Please try again.",
+    });
+  }
+});
+
+/**
+ * Register a new Telegram bot (admin flow).
+ */
+export const registerTelegramBot$ = command(
+  async (
+    { get, set },
+    params: { botToken: string; defaultAgentId?: string },
+  ) => {
+    set(telegramConnectState$, (prev) => ({
+      ...prev,
+      status: "registering" as const,
+      error: null,
+    }));
+
+    try {
+      const fetchFn = get(fetch$);
+      const response = await fetchFn("/api/telegram/register", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(params),
+      });
+
+      if (!response.ok) {
+        const data = (await response.json()) as {
+          error?: { message?: string };
+        };
+        throw new Error(data.error?.message ?? "Failed to register bot");
+      }
+
+      const result = (await response.json()) as {
+        id: string;
+        botUsername: string;
+      };
+
+      set(telegramConnectState$, (prev) => ({
+        ...prev,
+        status: "success" as const,
+      }));
+
+      return {
+        success: true,
+        installationId: result.id,
+        botUsername: result.botUsername,
+      };
+    } catch (error) {
+      throwIfAbort(error);
+      L.error("Failed to register Telegram bot:", error);
+      set(telegramConnectState$, (prev) => ({
+        ...prev,
+        status: "ready" as const,
+        error:
+          error instanceof Error ? error.message : "Failed to register bot",
+      }));
+      return { success: false };
+    }
+  },
+);

--- a/turbo/apps/platform/src/signals/telegram-connect/telegram-connect.ts
+++ b/turbo/apps/platform/src/signals/telegram-connect/telegram-connect.ts
@@ -11,6 +11,10 @@ interface TelegramConnectState {
   error: string | null;
 }
 
+type RegisterTelegramBotResult =
+  | { success: true; installationId: string; botUsername: string }
+  | { success: false };
+
 const telegramConnectState$ = state<TelegramConnectState>({
   status: "checking",
   isLinked: false,
@@ -81,7 +85,7 @@ export const registerTelegramBot$ = command(
   async (
     { get, set },
     params: { botToken: string; defaultAgentId?: string },
-  ) => {
+  ): Promise<RegisterTelegramBotResult> => {
     set(telegramConnectState$, (prev) => ({
       ...prev,
       status: "registering" as const,

--- a/turbo/apps/platform/src/types/route.ts
+++ b/turbo/apps/platform/src/types/route.ts
@@ -15,4 +15,7 @@ export type RoutePath =
   | "/provider-setup"
   | "/slack/connect"
   | "/slack/connect/success"
+  | "/settings/telegram"
+  | "/telegram/connect"
+  | "/telegram/connect/success"
   | `/projects/${string}`;

--- a/turbo/apps/platform/src/views/integrations-page/__tests__/telegram-settings-page.test.tsx
+++ b/turbo/apps/platform/src/views/integrations-page/__tests__/telegram-settings-page.test.tsx
@@ -1,0 +1,215 @@
+import { describe, expect, it } from "vitest";
+import { server } from "../../../mocks/server.ts";
+import { http, HttpResponse } from "msw";
+import { setupPage } from "../../../__tests__/page-helper.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { pathname$ } from "../../../signals/route.ts";
+import { screen, within } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+
+const context = testContext();
+const user = userEvent.setup();
+
+describe("telegram settings page", () => {
+  it("renders bot info and default agent for admin user", async () => {
+    await setupPage({ context, path: "/settings/telegram" });
+
+    expect(context.store.get(pathname$)).toBe("/settings/telegram");
+
+    // Page title (h1 heading)
+    expect(
+      screen.getByRole("heading", { name: "VM0 in Telegram" }),
+    ).toBeInTheDocument();
+
+    // Bot info section
+    expect(screen.getByText("@test_bot")).toBeInTheDocument();
+    expect(screen.getByText("bot_123")).toBeInTheDocument();
+
+    // Default agent section (admin view)
+    expect(screen.getByText("Default agent")).toBeInTheDocument();
+    expect(
+      screen.getByText("Default agent you would like to use in Telegram"),
+    ).toBeInTheDocument();
+
+    // Agent select should show the default agent name
+    expect(screen.getByText("default-agent")).toBeInTheDocument();
+
+    // Available commands section
+    expect(screen.getByText("Your available commands")).toBeInTheDocument();
+    expect(screen.getByText("/start")).toBeInTheDocument();
+    expect(screen.getByText("/help")).toBeInTheDocument();
+
+    // Disconnect section (heading + button)
+    expect(
+      screen.getByRole("heading", { name: "Disconnect Telegram" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /disconnect/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders read-only view for non-admin user", async () => {
+    server.use(
+      http.get("/api/integrations/telegram", () => {
+        return HttpResponse.json({
+          bot: { id: "bot_123", username: "test_bot" },
+          agent: {
+            id: "compose_1",
+            name: "default-agent",
+            scopeSlug: "test-scope",
+          },
+          isAdmin: false,
+          environment: {
+            requiredSecrets: ["ANTHROPIC_API_KEY"],
+            requiredVars: [],
+            missingSecrets: [],
+            missingVars: [],
+          },
+        });
+      }),
+    );
+
+    await setupPage({ context, path: "/settings/telegram" });
+
+    // Non-admin text
+    expect(
+      screen.getByText("Default agent you use in Telegram"),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/managed by the bot admin/)).toBeInTheDocument();
+
+    // Agent name should still be displayed but not in a select
+    expect(screen.getByText("default-agent")).toBeInTheDocument();
+  });
+
+  it("shows missing environment banner when secrets are missing", async () => {
+    server.use(
+      http.get("/api/integrations/telegram", () => {
+        return HttpResponse.json({
+          bot: { id: "bot_123", username: "test_bot" },
+          agent: {
+            id: "compose_1",
+            name: "default-agent",
+            scopeSlug: "test-scope",
+          },
+          isAdmin: true,
+          environment: {
+            requiredSecrets: ["ANTHROPIC_API_KEY"],
+            requiredVars: [],
+            missingSecrets: ["ANTHROPIC_API_KEY"],
+            missingVars: [],
+          },
+        });
+      }),
+    );
+
+    await setupPage({ context, path: "/settings/telegram" });
+
+    // Should show the missing env warning banner
+    expect(screen.getByText(/missing some/)).toBeInTheDocument();
+
+    // Should show a link to secrets or variables settings
+    expect(
+      screen.getByRole("link", { name: /secrets or variables/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("opens disconnect confirmation dialog", async () => {
+    await setupPage({ context, path: "/settings/telegram" });
+
+    // Click the disconnect button
+    const disconnectButton = screen.getByRole("button", {
+      name: /disconnect/i,
+    });
+    await user.click(disconnectButton);
+
+    // Confirm dialog should appear
+    const dialog = await screen.findByRole("dialog");
+    expect(within(dialog).getByText("Disconnect Telegram")).toBeInTheDocument();
+    expect(
+      within(dialog).getByText(/remove the Telegram bot connection/),
+    ).toBeInTheDocument();
+
+    // Should have Cancel and Disconnect buttons
+    expect(
+      within(dialog).getByRole("button", { name: /cancel/i }),
+    ).toBeInTheDocument();
+    expect(
+      within(dialog).getByRole("button", { name: /disconnect/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("closes disconnect dialog on cancel", async () => {
+    await setupPage({ context, path: "/settings/telegram" });
+
+    // Open the dialog
+    const disconnectButton = screen.getByRole("button", {
+      name: /disconnect/i,
+    });
+    await user.click(disconnectButton);
+
+    const dialog = await screen.findByRole("dialog");
+    const cancelButton = within(dialog).getByRole("button", {
+      name: /cancel/i,
+    });
+    await user.click(cancelButton);
+
+    // Dialog should close
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+});
+
+describe("settings integrations tab with telegram", () => {
+  it("shows Telegram integration card with Settings button when feature enabled", async () => {
+    await setupPage({
+      context,
+      path: "/settings?tab=integrations",
+      featureSwitches: { telegramIntegration: true },
+    });
+
+    expect(context.store.get(pathname$)).toBe("/settings");
+
+    // The Telegram card should be visible
+    expect(screen.getByText("VM0 in Telegram")).toBeInTheDocument();
+    expect(
+      screen.getByText("Use your VM0 agent in Telegram"),
+    ).toBeInTheDocument();
+
+    // Should show a Settings link inside the Telegram card
+    const telegramCard = screen
+      .getByText("Use your VM0 agent in Telegram")
+      .closest("div.rounded-xl") as HTMLElement;
+    expect(
+      within(telegramCard).getByRole("link", { name: /settings/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows Connect link when bot is not linked", async () => {
+    server.use(
+      http.get("/api/integrations/telegram", () => {
+        return HttpResponse.json(
+          {
+            error: { code: "NOT_FOUND", message: "Not linked" },
+          },
+          { status: 404 },
+        );
+      }),
+    );
+
+    await setupPage({
+      context,
+      path: "/settings?tab=integrations",
+      featureSwitches: { telegramIntegration: true },
+    });
+
+    // Should show the Telegram card
+    expect(screen.getByText("VM0 in Telegram")).toBeInTheDocument();
+
+    // Should show Connect link (not Settings)
+    const telegramCard = screen
+      .getByText("Use your VM0 agent in Telegram")
+      .closest("div.rounded-xl") as HTMLElement;
+    expect(
+      within(telegramCard).getByRole("link", { name: /connect/i }),
+    ).toBeInTheDocument();
+  });
+});

--- a/turbo/apps/platform/src/views/integrations-page/integrations-page.tsx
+++ b/turbo/apps/platform/src/views/integrations-page/integrations-page.tsx
@@ -11,6 +11,10 @@ import {
   githubIntegrationNotLinked$,
   githubInstallUrl$,
 } from "../../signals/integrations-page/github-integration.ts";
+import {
+  telegramIntegrationLoading$,
+  telegramIntegrationNotLinked$,
+} from "../../signals/integrations-page/telegram-integration.ts";
 import githubIcon from "../settings-page/icons/github.svg";
 import { Link } from "../router/link.tsx";
 
@@ -100,6 +104,49 @@ export function GitHubIntegrationCard() {
         ) : (
           <Button variant="outline" size="sm" disabled>
             Installed
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function TelegramIntegrationCard() {
+  const loading = useGet(telegramIntegrationLoading$);
+  const notLinked = useGet(telegramIntegrationNotLinked$);
+
+  if (loading) {
+    return <IntegrationCardSkeleton />;
+  }
+
+  return (
+    <div className="flex items-center gap-4 rounded-xl border border-border bg-card p-4 transition-colors hover:bg-muted/50">
+      <div className="shrink-0">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
+          className="h-7 w-7"
+          fill="currentColor"
+        >
+          <path d="M11.944 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12 12 12 0 0 0 12-12A12 12 0 0 0 12 0a12 12 0 0 0-.056 0zm4.962 7.224c.1-.002.321.023.465.14a.506.506 0 0 1 .171.325c.016.093.036.306.02.472-.18 1.898-.962 6.502-1.36 8.627-.168.9-.499 1.201-.82 1.23-.696.065-1.225-.46-1.9-.902-1.056-.693-1.653-1.124-2.678-1.8-1.185-.78-.417-1.21.258-1.91.177-.184 3.247-2.977 3.307-3.23.007-.032.014-.15-.056-.212s-.174-.041-.249-.024c-.106.024-1.793 1.14-5.061 3.345-.479.33-.913.49-1.302.48-.428-.008-1.252-.241-1.865-.44-.752-.245-1.349-.374-1.297-.789.027-.216.325-.437.893-.663 3.498-1.524 5.83-2.529 6.998-3.014 3.332-1.386 4.025-1.627 4.476-1.635z" />
+        </svg>
+      </div>
+      <div className="flex flex-1 flex-col gap-1 min-w-0">
+        <div className="text-sm font-medium text-foreground">
+          VM0 in Telegram
+        </div>
+        <div className="text-sm text-muted-foreground">
+          Use your VM0 agent in Telegram
+        </div>
+      </div>
+      <div className="shrink-0">
+        {notLinked ? (
+          <Button variant="outline" size="sm" asChild>
+            <Link pathname="/telegram/connect">Connect</Link>
+          </Button>
+        ) : (
+          <Button variant="outline" size="sm" asChild>
+            <Link pathname="/settings/telegram">Settings</Link>
           </Button>
         )}
       </div>

--- a/turbo/apps/platform/src/views/integrations-page/telegram-settings-page.tsx
+++ b/turbo/apps/platform/src/views/integrations-page/telegram-settings-page.tsx
@@ -1,0 +1,388 @@
+import { useGet, useSet } from "ccstate-react";
+import { IconAlertTriangle, IconChevronDown } from "@tabler/icons-react";
+import {
+  CONNECTOR_TYPES,
+  getConnectorProvidedSecretNames,
+  type ConnectorType,
+} from "@vm0/core";
+import { Button } from "@vm0/ui/components/ui/button";
+import { Skeleton } from "@vm0/ui/components/ui/skeleton";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@vm0/ui/components/ui/select";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@vm0/ui/components/ui/dialog";
+import { detach, Reason } from "../../signals/utils.ts";
+import {
+  telegramIntegrationData$,
+  telegramIntegrationLoading$,
+  disconnectTelegram$,
+  updateTelegramDefaultAgent$,
+  telegramDisconnectDialogOpen$,
+  openTelegramDisconnectDialog$,
+  closeTelegramDisconnectDialog$,
+} from "../../signals/integrations-page/telegram-integration.ts";
+import { agentsList$ } from "../../signals/agents-page/agents-list.ts";
+import { navigateInReact$ } from "../../signals/route.ts";
+import { AppShell } from "../layout/app-shell.tsx";
+import { Link } from "../router/link.tsx";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function getAllConnectorEnvVars(): Set<string> {
+  return getConnectorProvidedSecretNames(
+    Object.keys(CONNECTOR_TYPES) as ConnectorType[],
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Missing env banner
+// ---------------------------------------------------------------------------
+
+function MissingEnvBanner({
+  agentName,
+  missingSecrets,
+  missingVars,
+}: {
+  agentName: string | undefined;
+  missingSecrets: string[];
+  missingVars: string[];
+}) {
+  const envVars = getAllConnectorEnvVars();
+
+  const hasMissingConnectors = missingSecrets.some((s) => envVars.has(s));
+  const hasMissingSecretsOrVars =
+    missingSecrets.some((s) => !envVars.has(s)) || missingVars.length > 0;
+
+  if (!hasMissingConnectors && !hasMissingSecretsOrVars) {
+    return null;
+  }
+
+  return (
+    <div className="flex items-center gap-3 rounded-lg border border-amber-500 bg-amber-50 px-4 py-3 dark:border-amber-700 dark:bg-amber-950/30">
+      <IconAlertTriangle
+        size={20}
+        className="shrink-0 text-amber-500"
+        stroke={1.5}
+      />
+      <p className="text-sm">
+        {"Looks like this agent is missing some "}
+        {hasMissingConnectors && agentName && (
+          <Link
+            pathname="/agents/:name/connections"
+            options={{
+              pathParams: { name: agentName },
+              searchParams: new URLSearchParams({ tab: "connectors" }),
+            }}
+            className="font-medium text-amber-600 hover:underline dark:text-amber-500"
+          >
+            connectors
+          </Link>
+        )}
+        {hasMissingConnectors && hasMissingSecretsOrVars && ", "}
+        {hasMissingSecretsOrVars && agentName && (
+          <Link
+            pathname="/agents/:name/connections"
+            options={{
+              pathParams: { name: agentName },
+              searchParams: new URLSearchParams({ tab: "secrets" }),
+            }}
+            className="font-medium text-amber-600 hover:underline dark:text-amber-500"
+          >
+            secrets or variables
+          </Link>
+        )}
+        {". Add them now so it can run without stopping."}
+      </p>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Default agent section
+// ---------------------------------------------------------------------------
+
+function DefaultAgentSection({
+  isAdmin,
+  agentName,
+  agentOptions,
+  onAgentChange,
+}: {
+  isAdmin: boolean;
+  agentName: string | undefined;
+  agentOptions: { name: string }[];
+  onAgentChange: (name: string) => void;
+}) {
+  return (
+    <div className="flex flex-col gap-4">
+      <h3 className="text-base font-medium">Default agent</h3>
+      <div className="flex flex-col gap-4 rounded-xl border border-border bg-card p-4 sm:flex-row sm:items-center">
+        <div className="flex flex-1 flex-col gap-1">
+          {isAdmin ? (
+            <>
+              <p className="text-sm font-medium">
+                Default agent you would like to use in Telegram
+              </p>
+              <p className="text-sm text-muted-foreground">
+                {
+                  "If you want to manage your agent's model provider, secrets, or connectors, go to "
+                }
+                <Link
+                  pathname="/settings"
+                  options={{
+                    searchParams: new URLSearchParams({
+                      tab: "providers",
+                    }),
+                  }}
+                  className="text-primary hover:underline"
+                >
+                  Settings
+                </Link>
+                .
+              </p>
+            </>
+          ) : (
+            <>
+              <p className="text-sm font-medium">
+                Default agent you use in Telegram
+              </p>
+              <p className="text-sm text-muted-foreground">
+                This agent is managed by the bot admin. To make changes, please
+                contact the bot admin.
+              </p>
+            </>
+          )}
+        </div>
+        {isAdmin ? (
+          <Select value={agentName ?? ""} onValueChange={onAgentChange}>
+            <SelectTrigger className="w-full sm:w-[280px] sm:shrink-0">
+              <SelectValue placeholder="Select an agent" />
+            </SelectTrigger>
+            <SelectContent>
+              {agentOptions.map((agent) => (
+                <SelectItem key={agent.name} value={agent.name}>
+                  {agent.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        ) : (
+          <div className="flex h-9 w-full items-center justify-between rounded-lg border border-border bg-muted px-3 py-2 sm:w-[280px] sm:shrink-0">
+            <span className="truncate text-sm">{agentName ?? "No agent"}</span>
+            <IconChevronDown size={16} className="shrink-0 opacity-50" />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main page
+// ---------------------------------------------------------------------------
+
+export function TelegramSettingsPage() {
+  const data = useGet(telegramIntegrationData$);
+  const loading = useGet(telegramIntegrationLoading$);
+  const agents = useGet(agentsList$);
+  const navigate = useSet(navigateInReact$);
+  const disconnect = useSet(disconnectTelegram$);
+  const updateAgent = useSet(updateTelegramDefaultAgent$);
+  const confirmOpen = useGet(telegramDisconnectDialogOpen$);
+  const openConfirm = useSet(openTelegramDisconnectDialog$);
+  const closeConfirm = useSet(closeTelegramDisconnectDialog$);
+
+  // Construct scoped agent name that matches the format used in agentsList$
+  const scopedAgentName = (() => {
+    if (!data?.agent) {
+      return undefined;
+    }
+    const fullName = `${data.agent.scopeSlug}/${data.agent.name}`;
+    if (agents.some((a) => a.name === fullName)) {
+      return fullName;
+    }
+    return data.agent.name;
+  })();
+
+  // Ensure the current agent appears in the dropdown
+  const agentOptions = (() => {
+    if (!scopedAgentName) {
+      return agents;
+    }
+    const hasCurrentAgent = agents.some((a) => a.name === scopedAgentName);
+    if (hasCurrentAgent) {
+      return agents;
+    }
+    return [
+      { name: scopedAgentName, headVersionId: null, updatedAt: "" },
+      ...agents,
+    ];
+  })();
+
+  const handleDisconnect = () => {
+    detach(
+      (async () => {
+        await disconnect();
+        closeConfirm();
+        navigate("/settings", {
+          searchParams: new URLSearchParams({ tab: "integrations" }),
+        });
+      })(),
+      Reason.DomCallback,
+    );
+  };
+
+  const handleAgentChange = (agentName: string) => {
+    detach(updateAgent(agentName), Reason.DomCallback);
+  };
+
+  const breadcrumb = [
+    { label: "Settings", path: "/settings" as const },
+    "VM0 in Telegram",
+  ];
+
+  return (
+    <AppShell
+      breadcrumb={breadcrumb}
+      title="VM0 in Telegram"
+      subtitle="Configure your settings for running VM0 in Telegram."
+      contentClassName="mx-auto w-full max-w-[1200px]"
+    >
+      <div className="flex flex-col gap-6 px-6 pb-8">
+        {loading ? (
+          <div className="flex flex-col gap-6">
+            <Skeleton className="h-24 w-full rounded-xl" />
+            <Skeleton className="h-14 w-full rounded-lg" />
+            <Skeleton className="h-32 w-full rounded-xl" />
+            <Skeleton className="h-20 w-full rounded-xl" />
+          </div>
+        ) : (
+          <>
+            {/* Bot info */}
+            {data?.bot && (
+              <div className="flex flex-col gap-4">
+                <h3 className="text-base font-medium">Bot info</h3>
+                <div className="flex flex-col gap-2 rounded-xl border border-border bg-card p-4">
+                  <div className="flex items-center gap-2 text-sm">
+                    <span className="font-medium text-muted-foreground">
+                      Username:
+                    </span>
+                    <span>@{data.bot.username}</span>
+                  </div>
+                  <div className="flex items-center gap-2 text-sm">
+                    <span className="font-medium text-muted-foreground">
+                      Bot ID:
+                    </span>
+                    <span>{data.bot.id}</span>
+                  </div>
+                </div>
+              </div>
+            )}
+
+            <DefaultAgentSection
+              isAdmin={data?.isAdmin ?? false}
+              agentName={scopedAgentName}
+              agentOptions={agentOptions}
+              onAgentChange={handleAgentChange}
+            />
+
+            <MissingEnvBanner
+              agentName={scopedAgentName}
+              missingSecrets={data?.environment.missingSecrets ?? []}
+              missingVars={data?.environment.missingVars ?? []}
+            />
+
+            {/* Available commands section */}
+            <div className="flex flex-col gap-4">
+              <div>
+                <h3 className="text-base font-medium">
+                  Your available commands
+                </h3>
+                <p className="text-sm text-muted-foreground">
+                  Commands you can use directly with the bot in Telegram
+                </p>
+              </div>
+              <div className="rounded-xl border border-border bg-card p-4">
+                <div className="font-mono text-sm leading-6">
+                  <p>
+                    <span className="font-medium">/start</span>
+                    <span className="text-muted-foreground">
+                      {" // link your account"}
+                    </span>
+                  </p>
+                  <p>
+                    <span className="font-medium">/help</span>
+                    <span className="text-muted-foreground">
+                      {" // show help"}
+                    </span>
+                  </p>
+                </div>
+              </div>
+            </div>
+
+            {/* Disconnect section */}
+            <div className="flex flex-col gap-4">
+              <h3 className="text-base font-medium">Disconnect Telegram</h3>
+              <div className="flex flex-col gap-4 rounded-xl border border-border bg-card p-4 sm:flex-row sm:items-center">
+                <div className="flex flex-1 flex-col gap-1">
+                  <p className="text-sm font-medium">Disconnect bot</p>
+                  <p className="text-sm text-muted-foreground">
+                    Your VM0 agent will be disconnected from this Telegram bot.
+                    All linked accounts and message history will be removed.
+                  </p>
+                </div>
+                <Button
+                  variant="destructive"
+                  size="sm"
+                  onClick={() => openConfirm()}
+                >
+                  Disconnect
+                </Button>
+              </div>
+            </div>
+          </>
+        )}
+      </div>
+
+      <Dialog
+        open={confirmOpen}
+        onOpenChange={(open) => {
+          if (!open) {
+            closeConfirm();
+          }
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Disconnect Telegram</DialogTitle>
+            <DialogDescription>
+              This will remove the Telegram bot connection, delete all linked
+              accounts, and clear message history. You can reconnect at any
+              time.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => closeConfirm()}>
+              Cancel
+            </Button>
+            <Button variant="destructive" onClick={handleDisconnect}>
+              Disconnect
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </AppShell>
+  );
+}

--- a/turbo/apps/platform/src/views/settings-page/settings-page.tsx
+++ b/turbo/apps/platform/src/views/settings-page/settings-page.tsx
@@ -21,6 +21,7 @@ import { DeleteVariableDialog } from "./delete-variable-dialog.tsx";
 import {
   SlackIntegrationCard,
   GitHubIntegrationCard,
+  TelegramIntegrationCard,
 } from "../integrations-page/integrations-page.tsx";
 import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
 import { mergedItems$ } from "../../signals/settings-page/secrets-and-variables.ts";
@@ -85,6 +86,9 @@ export function SettingsPage() {
             <SlackIntegrationCard />
             {featureSwitches?.[FeatureSwitchKey.GitHubIntegration] && (
               <GitHubIntegrationCard />
+            )}
+            {featureSwitches?.[FeatureSwitchKey.TelegramIntegration] && (
+              <TelegramIntegrationCard />
             )}
           </div>
         )}

--- a/turbo/apps/platform/src/views/telegram-connect/__tests__/telegram-connect-page.test.tsx
+++ b/turbo/apps/platform/src/views/telegram-connect/__tests__/telegram-connect-page.test.tsx
@@ -1,0 +1,165 @@
+import { describe, expect, it, vi } from "vitest";
+import { server } from "../../../mocks/server.ts";
+import { http, HttpResponse } from "msw";
+import { setupPage } from "../../../__tests__/page-helper.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { pathname$, searchParams$ } from "../../../signals/route.ts";
+import { screen } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+
+const context = testContext();
+const user = userEvent.setup();
+
+describe("telegram connect page", () => {
+  it("redirects to provider-setup when no provider configured", async () => {
+    server.use(
+      http.get("/api/model-providers", () => {
+        return HttpResponse.json({ modelProviders: [] });
+      }),
+    );
+
+    // The redirect during setup causes an AbortError which is expected
+    await setupPage({
+      context,
+      path: "/telegram/connect",
+    }).catch(() => {});
+
+    await vi.waitFor(() => {
+      expect(context.store.get(pathname$)).toBe("/provider-setup");
+    });
+    const params = context.store.get(searchParams$);
+    const returnUrl = params.get("return");
+    expect(returnUrl).toContain("/telegram/connect");
+  });
+
+  it("shows registration form when provider exists and user is not linked", async () => {
+    server.use(
+      http.get("*/api/integrations/telegram/link", () => {
+        return HttpResponse.json({ linked: false });
+      }),
+    );
+
+    await setupPage({
+      context,
+      path: "/telegram/connect",
+    });
+
+    await vi.waitFor(() => {
+      expect(screen.getByText("Connect a Telegram Bot")).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByPlaceholderText("123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Connect Bot" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
+  });
+
+  it("shows already-connected state when user is linked", async () => {
+    server.use(
+      http.get("*/api/integrations/telegram/link", () => {
+        return HttpResponse.json({ linked: true });
+      }),
+    );
+
+    await setupPage({
+      context,
+      path: "/telegram/connect",
+    });
+
+    await vi.waitFor(() => {
+      expect(screen.getByText("Already Connected")).toBeInTheDocument();
+    });
+    expect(
+      screen.getByText("Your account is already linked to a Telegram bot."),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Go to Settings" }),
+    ).toBeInTheDocument();
+  });
+
+  it("calls register API and navigates to success page on Connect Bot", async () => {
+    let capturedBody: Record<string, unknown> | null = null;
+
+    server.use(
+      http.get("*/api/integrations/telegram/link", () => {
+        return HttpResponse.json({ linked: false });
+      }),
+      http.post("*/api/telegram/register", async ({ request }) => {
+        capturedBody = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json({
+          id: "installation_1",
+          botUsername: "my_test_bot",
+        });
+      }),
+    );
+
+    await setupPage({
+      context,
+      path: "/telegram/connect",
+    });
+
+    await vi.waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "Connect Bot" }),
+      ).toBeInTheDocument();
+    });
+
+    // Type a bot token
+    const tokenInput = screen.getByPlaceholderText(
+      "123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11",
+    );
+    await user.type(tokenInput, "123456:ABC-token");
+
+    await user.click(screen.getByRole("button", { name: "Connect Bot" }));
+
+    await vi.waitFor(() => {
+      expect(capturedBody).toBeTruthy();
+    });
+    expect(capturedBody!.botToken).toBe("123456:ABC-token");
+
+    await vi.waitFor(() => {
+      expect(context.store.get(pathname$)).toBe("/telegram/connect/success");
+    });
+    const params = context.store.get(searchParams$);
+    expect(params.get("bot")).toBe("my_test_bot");
+  });
+
+  it("shows error message when registration fails", async () => {
+    server.use(
+      http.get("*/api/integrations/telegram/link", () => {
+        return HttpResponse.json({ linked: false });
+      }),
+      http.post("*/api/telegram/register", () => {
+        return HttpResponse.json(
+          { error: { message: "Invalid bot token" } },
+          { status: 400 },
+        );
+      }),
+    );
+
+    await setupPage({
+      context,
+      path: "/telegram/connect",
+    });
+
+    await vi.waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "Connect Bot" }),
+      ).toBeInTheDocument();
+    });
+
+    const tokenInput = screen.getByPlaceholderText(
+      "123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11",
+    );
+    await user.type(tokenInput, "bad-token");
+
+    await user.click(screen.getByRole("button", { name: "Connect Bot" }));
+
+    await vi.waitFor(() => {
+      expect(screen.getByText("Invalid bot token")).toBeInTheDocument();
+    });
+  });
+});

--- a/turbo/apps/platform/src/views/telegram-connect/__tests__/telegram-connect-success-page.test.tsx
+++ b/turbo/apps/platform/src/views/telegram-connect/__tests__/telegram-connect-success-page.test.tsx
@@ -1,0 +1,96 @@
+import { describe, expect, it, vi } from "vitest";
+import { setupPage } from "../../../__tests__/page-helper.ts";
+import { mockedClerk } from "../../../__tests__/mock-auth.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { pathname$ } from "../../../signals/route.ts";
+import { screen } from "@testing-library/react";
+
+const context = testContext();
+
+describe("telegram connect success page", () => {
+  it("renders success message and bot link when bot param is present", async () => {
+    await setupPage({
+      context,
+      path: "/telegram/connect/success?bot=my_test_bot",
+    });
+
+    expect(context.store.get(pathname$)).toBe("/telegram/connect/success");
+
+    expect(screen.getByText("Telegram bot connected")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Your Telegram bot is now connected to VM0. You can start using it right away.",
+      ),
+    ).toBeInTheDocument();
+
+    // Should show Telegram deep link
+    const telegramLink = screen.getByRole("link", {
+      name: "Open in Telegram",
+    });
+    expect(telegramLink).toBeInTheDocument();
+    expect(telegramLink.getAttribute("href")).toBe("https://t.me/my_test_bot");
+
+    // Should show platform link
+    const platformLink = screen.getByRole("link", {
+      name: "Go to VM0 Platform",
+    });
+    expect(platformLink).toBeInTheDocument();
+    expect(platformLink.getAttribute("href")).toBe("/");
+  });
+
+  it("renders without telegram link when no bot param", async () => {
+    await setupPage({
+      context,
+      path: "/telegram/connect/success",
+    });
+
+    expect(screen.getByText("Telegram bot connected")).toBeInTheDocument();
+
+    // Should NOT show "Open in Telegram" link
+    expect(
+      screen.queryByRole("link", { name: "Open in Telegram" }),
+    ).not.toBeInTheDocument();
+
+    // Should still show platform link
+    const platformLink = screen.getByRole("link", {
+      name: "Go to VM0 Platform",
+    });
+    expect(platformLink).toBeInTheDocument();
+  });
+
+  it("redirects to login when not authenticated", async () => {
+    await setupPage({
+      context,
+      path: "/telegram/connect/success",
+      user: null,
+    });
+
+    expect(mockedClerk.redirectToSignIn).toHaveBeenCalledWith();
+  });
+
+  it("auto-opens Telegram deep link on load", async () => {
+    const locationSpy = vi.spyOn(window, "location", "get");
+    const mockLocation = {
+      ...window.location,
+      href: "",
+    };
+    let capturedHref = "";
+    Object.defineProperty(mockLocation, "href", {
+      get: () => capturedHref,
+      set: (val: string) => {
+        capturedHref = val;
+      },
+    });
+    locationSpy.mockReturnValue(mockLocation as Location);
+
+    await setupPage({
+      context,
+      path: "/telegram/connect/success?bot=my_test_bot",
+    });
+
+    // The setupTelegramConnectSuccessPage$ sets window.location.href
+    expect(capturedHref).toBe("https://t.me/my_test_bot");
+
+    locationSpy.mockRestore();
+  });
+});

--- a/turbo/apps/platform/src/views/telegram-connect/telegram-connect-page.tsx
+++ b/turbo/apps/platform/src/views/telegram-connect/telegram-connect-page.tsx
@@ -29,15 +29,10 @@ export function TelegramConnectPage() {
     }
     detach(
       (async () => {
-        const result = (await registerBot({ botToken: botToken.trim() })) as {
-          success: boolean;
-          botUsername?: string;
-        };
+        const result = await registerBot({ botToken: botToken.trim() });
         if (result.success) {
           const successParams = new URLSearchParams();
-          if (result.botUsername) {
-            successParams.set("bot", result.botUsername);
-          }
+          successParams.set("bot", result.botUsername);
           navigate("/telegram/connect/success", {
             searchParams: successParams,
           });

--- a/turbo/apps/platform/src/views/telegram-connect/telegram-connect-page.tsx
+++ b/turbo/apps/platform/src/views/telegram-connect/telegram-connect-page.tsx
@@ -1,0 +1,183 @@
+import { useGet, useSet } from "ccstate-react";
+import { Button } from "@vm0/ui/components/ui/button";
+import { Input } from "@vm0/ui/components/ui/input";
+import { theme$ } from "../../signals/theme.ts";
+import { navigateInReact$ } from "../../signals/route.ts";
+import {
+  telegramConnectStatus$,
+  telegramConnectIsLinked$,
+  telegramConnectError$,
+  telegramBotToken$,
+  setTelegramBotToken$,
+  registerTelegramBot$,
+} from "../../signals/telegram-connect/telegram-connect.ts";
+import { detach, Reason } from "../../signals/utils.ts";
+
+export function TelegramConnectPage() {
+  const status = useGet(telegramConnectStatus$);
+  const isLinked = useGet(telegramConnectIsLinked$);
+  const error = useGet(telegramConnectError$);
+  const theme = useGet(theme$);
+  const registerBot = useSet(registerTelegramBot$);
+  const navigate = useSet(navigateInReact$);
+  const botToken = useGet(telegramBotToken$);
+  const setBotToken = useSet(setTelegramBotToken$);
+
+  const handleRegister = () => {
+    if (!botToken.trim()) {
+      return;
+    }
+    detach(
+      (async () => {
+        const result = (await registerBot({ botToken: botToken.trim() })) as {
+          success: boolean;
+          botUsername?: string;
+        };
+        if (result.success) {
+          const successParams = new URLSearchParams();
+          if (result.botUsername) {
+            successParams.set("bot", result.botUsername);
+          }
+          navigate("/telegram/connect/success", {
+            searchParams: successParams,
+          });
+        }
+      })(),
+      Reason.DomCallback,
+    );
+  };
+
+  const backgroundGradient =
+    theme === "dark"
+      ? "linear-gradient(91deg, rgba(255, 200, 176, 0.15) 0%, rgba(166, 222, 255, 0.15) 51%, rgba(255, 231, 162, 0.15) 100%), linear-gradient(90deg, hsl(var(--background)) 0%, hsl(var(--background)) 100%)"
+      : "linear-gradient(91deg, rgba(255, 200, 176, 0.26) 0%, rgba(166, 222, 255, 0.26) 51%, rgba(255, 231, 162, 0.26) 100%), linear-gradient(90deg, hsl(var(--background)) 0%, hsl(var(--background)) 100%)";
+
+  return (
+    <div
+      className="flex min-h-screen items-center justify-center p-6"
+      style={{ backgroundImage: backgroundGradient }}
+    >
+      <div className="w-full max-w-[400px] overflow-hidden rounded-xl border border-border bg-popover p-10">
+        <div className="flex flex-col items-center gap-8">
+          {/* Logo */}
+          <div className="flex items-center gap-2.5 p-1.5">
+            <img
+              src={theme === "dark" ? "/logo_dark.svg" : "/logo_light.svg"}
+              alt="VM0"
+              className="h-5 w-auto"
+            />
+            <span className="text-2xl font-normal leading-8 text-foreground">
+              Platform
+            </span>
+          </div>
+
+          {/* Content */}
+          <div className="flex w-full flex-col gap-6">
+            {status === "checking" ? (
+              <div className="flex flex-col items-center gap-2">
+                <div className="h-8 w-8 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+                <p className="text-sm text-muted-foreground">
+                  Checking connection status...
+                </p>
+              </div>
+            ) : isLinked ? (
+              /* Already linked */
+              <div className="flex flex-col items-center gap-4">
+                <div className="flex flex-col gap-1 text-center text-foreground">
+                  <h1 className="text-lg font-medium leading-7">
+                    Already Connected
+                  </h1>
+                  <p className="text-sm leading-5 text-muted-foreground">
+                    Your account is already linked to a Telegram bot.
+                  </p>
+                </div>
+                <Button
+                  variant="outline"
+                  className="w-full"
+                  onClick={() =>
+                    navigate("/settings", {
+                      searchParams: new URLSearchParams({
+                        tab: "integrations",
+                      }),
+                    })
+                  }
+                >
+                  Go to Settings
+                </Button>
+              </div>
+            ) : (
+              /* Registration form */
+              <>
+                <div className="flex flex-col gap-1 text-center text-foreground">
+                  <h1 className="text-lg font-medium leading-7">
+                    Connect a Telegram Bot
+                  </h1>
+                  <p className="text-sm leading-5 text-muted-foreground">
+                    Enter your bot token from{" "}
+                    <a
+                      href="https://t.me/BotFather"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-primary hover:underline"
+                    >
+                      @BotFather
+                    </a>{" "}
+                    to connect your Telegram bot to VM0.
+                  </p>
+                </div>
+
+                <div className="flex flex-col gap-2">
+                  <Input
+                    type="password"
+                    placeholder="123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11"
+                    value={botToken}
+                    onChange={(e) => setBotToken(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter") {
+                        handleRegister();
+                      }
+                    }}
+                  />
+                </div>
+
+                {/* Error Message */}
+                {error && (
+                  <div className="w-full rounded-md bg-destructive/10 p-2 text-center text-xs text-destructive">
+                    {error}
+                  </div>
+                )}
+
+                {/* Action Buttons */}
+                <div className="flex flex-col gap-4">
+                  <Button
+                    onClick={handleRegister}
+                    disabled={!botToken.trim() || status === "registering"}
+                    className="w-full"
+                  >
+                    {status === "registering"
+                      ? "Registering..."
+                      : "Connect Bot"}
+                  </Button>
+                  <Button
+                    className="w-full"
+                    variant="outline"
+                    onClick={() =>
+                      navigate("/settings", {
+                        searchParams: new URLSearchParams({
+                          tab: "integrations",
+                        }),
+                      })
+                    }
+                    disabled={status === "registering"}
+                  >
+                    Cancel
+                  </Button>
+                </div>
+              </>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/turbo/apps/platform/src/views/telegram-connect/telegram-connect-success-page.tsx
+++ b/turbo/apps/platform/src/views/telegram-connect/telegram-connect-success-page.tsx
@@ -1,0 +1,89 @@
+import { useGet } from "ccstate-react";
+import { Button } from "@vm0/ui/components/ui/button";
+import { Check } from "lucide-react";
+import { theme$ } from "../../signals/theme.ts";
+import { searchParams$ } from "../../signals/route.ts";
+
+export function TelegramConnectSuccessPage() {
+  const theme = useGet(theme$);
+  const params = useGet(searchParams$);
+
+  const botUsername = params.get("bot");
+  const telegramLink = botUsername ? `https://t.me/${botUsername}` : null;
+
+  const backgroundGradient =
+    theme === "dark"
+      ? "linear-gradient(91deg, rgba(255, 200, 176, 0.15) 0%, rgba(166, 222, 255, 0.15) 51%, rgba(255, 231, 162, 0.15) 100%), linear-gradient(90deg, hsl(var(--background)) 0%, hsl(var(--background)) 100%)"
+      : "linear-gradient(91deg, rgba(255, 200, 176, 0.26) 0%, rgba(166, 222, 255, 0.26) 51%, rgba(255, 231, 162, 0.26) 100%), linear-gradient(90deg, hsl(var(--background)) 0%, hsl(var(--background)) 100%)";
+
+  return (
+    <div
+      className="flex min-h-screen items-center justify-center p-6"
+      style={{ backgroundImage: backgroundGradient }}
+    >
+      <div className="w-full max-w-[400px] overflow-hidden rounded-xl border border-border bg-popover p-10">
+        <div className="flex flex-col items-center gap-8">
+          {/* Logo */}
+          <div className="flex items-center gap-2.5 p-1.5">
+            <img
+              src={theme === "dark" ? "/logo_dark.svg" : "/logo_light.svg"}
+              alt="VM0"
+              className="h-5 w-auto"
+            />
+            <span className="text-2xl font-normal leading-8 text-foreground">
+              Platform
+            </span>
+          </div>
+
+          {/* Content */}
+          <div className="flex w-full flex-col items-center gap-6">
+            <div className="flex flex-col items-center gap-4">
+              <Check size={24} className="text-lime-600" strokeWidth={2} />
+
+              <div className="flex flex-col gap-1 text-center text-foreground">
+                <h1 className="text-lg font-medium leading-7">
+                  Telegram bot connected
+                </h1>
+                <p className="text-sm leading-5 text-muted-foreground">
+                  Your Telegram bot is now connected to VM0. You can start using
+                  it right away.
+                </p>
+              </div>
+            </div>
+
+            {/* Tip */}
+            <p className="text-center text-xs leading-5 text-muted-foreground">
+              Tip: The agent you&apos;re using may require authorization for
+              certain apps or APIs. You can configure this in{" "}
+              <a
+                href="/settings/telegram"
+                className="text-primary hover:underline"
+              >
+                VM0 Platform &gt; Settings
+              </a>
+              .
+            </p>
+
+            {/* Action Buttons */}
+            <div className="flex w-full flex-col gap-4">
+              {telegramLink && (
+                <Button asChild variant="outline" className="w-full">
+                  <a
+                    href={telegramLink}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    Open in Telegram
+                  </a>
+                </Button>
+              )}
+              <Button asChild variant="outline" className="w-full">
+                <a href="/">Go to VM0 Platform</a>
+              </Button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -31,4 +31,5 @@ export enum FeatureSwitchKey {
   IntervalsIcuConnector = "intervalsIcuConnector",
   XeroConnector = "xeroConnector",
   GitHubIntegration = "githubIntegration",
+  TelegramIntegration = "telegramIntegration",
 }

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -170,6 +170,11 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledUserHashes: STAFF_USER_HASHES,
   },
+  [FeatureSwitchKey.TelegramIntegration]: {
+    maintainer: "ethan@vm0.ai",
+    enabled: false,
+    enabledUserHashes: STAFF_USER_HASHES,
+  },
 };
 
 /**


### PR DESCRIPTION
## Summary

Implements Phase 6 of the Telegram integration (issue #3540):

- **Feature switch**: `TelegramIntegration` key added to `FeatureSwitchKey` enum, gating all Telegram UI behind a toggle (matching the GitHub integration pattern)
- **Integration card**: Telegram card on Settings > Integrations page showing "Connect" when not linked, "Settings" when connected
- **Settings page**: Bot info display, admin-only default agent selector, missing env warning banner, disconnect with confirmation dialog
- **Connect page**: Bot token registration form (enter @BotFather token to register bot with VM0)
- **Success page**: Confirmation with "Open in Telegram" deep link

## Test plan

- [x] All pre-commit checks pass (lint, types, format, knip)
- [x] Feature switch controls visibility — card hidden when `TelegramIntegration` is `false`
- [x] Routes added: `/settings/telegram`, `/telegram/connect`, `/telegram/connect/success`
- [x] Settings page mirrors Slack settings pattern (agent selector, disconnect, env banner)
- [x] Connect page validates empty token, shows loading/error states
- [x] Signals follow ccstate patterns (no React useState)

Closes #3540

🤖 Generated with [Claude Code](https://claude.com/claude-code)