### PR TITLE
chore: remove x connector feature flag and improve oauth connector docs

### DIFF
--- a/docs/add-oauth-connector.md
+++ b/docs/add-oauth-connector.md
@@ -9,8 +9,15 @@
 1. Ensure that `.env.tpl` references the correct secrets/vars and that the secret/var names in 1Password match the environment variable names. Ask the user to create the secrets/vars in 1Password, then have them run `sync-env.sh`.
 1. Make sure the local `.env.local` contains the correct secret/var values.
 1. Ask the user to start the project locally with `pnpm dev` and verify that it can successfully connect to the OAuth provider and obtain user information.
-1. Check the `vm0-ai/vm0-skills` repository for a related skill. If one exists, ensure the skill's `vm0_secret` uses the environment variable injected by this connector. If it does not, modify the skill and open a PR for the skill repository.
-1. Help the user create a local agent example, for instance:
+1. Check the `vm0-ai/vm0-skills` repository for a related skill.
+   - If one exists, ensure the skill's `vm0_secrets` matches the environment variable key from the connector's `environmentMapping` (e.g., connector maps `X_ACCESS_TOKEN: "$secrets.X_ACCESS_TOKEN"` → skill declares `vm0_secrets: [X_ACCESS_TOKEN]`).
+   - If it does not match, modify the skill and open a PR for the skill repository.
+   - If no skill exists, create one following `docs/skill-template.md` in `vm0-ai/vm0-skills`, then open a PR.
+1. Create a test directory and set up a local agent to test the skill end-to-end:
+
+```bash
+mkdir test-<connector-name>-connector && cd test-<connector-name>-connector
+```
 
 vm0.yaml
 
@@ -22,19 +29,31 @@ agents:
     framework: claude-code
     instructions: AGENTS.md
     skills:
-      - gmail
+      - <skill-name>
 ```
 
 AGENTS.md
 
 ```text
-test every example in skill gmail
+test every example in skill <skill-name>
 ```
 
 Then run:
 
 ```bash
-vm0 cook "let's do it"
+vm0 cook --yes "let's do it"
 ```
 
-11. If everything works, the connector is ready to be merged.
+> **Note:** The `--yes` flag is required to auto-approve new secrets detected from the skill. Without it, compose will fail in non-interactive mode.
+
+12. Review the test results. The agent will execute every curl example from the skill and report which ones succeed or fail. Common issues:
+    - **Authentication errors (401/403):** Check that the connector's `environmentMapping` key matches the env var used in the skill's curl commands.
+    - **Credits/quota depleted:** The OAuth provider's API has usage limits. The connector itself is working if at least one endpoint succeeds (e.g., `/users/me` for X).
+    - **Variable not injected:** Ensure `vm0_secrets` in the skill matches the key (not the value) of the connector's `environmentMapping`.
+1. Clean up the test directory after verification:
+
+```bash
+cd .. && rm -rf test-<connector-name>-connector
+```
+
+14. If everything works, the connector is ready to be merged.

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -24,7 +24,6 @@ export enum FeatureSwitchKey {
   StravaConnector = "stravaConnector",
   NeonConnector = "neonConnector",
   GarminConnectConnector = "garminConnectConnector",
-  XConnector = "xConnector",
   RedditConnector = "redditConnector",
   VercelConnector = "vercelConnector",
   SentryConnector = "sentryConnector",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -135,11 +135,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledUserHashes: STAFF_USER_HASHES,
   },
-  [FeatureSwitchKey.XConnector]: {
-    maintainer: "ethan@vm0.ai",
-    enabled: false,
-    enabledUserHashes: STAFF_USER_HASHES,
-  },
+
   [FeatureSwitchKey.RedditConnector]: {
     maintainer: "ethan@vm0.ai",
     enabled: false,
@@ -193,7 +189,7 @@ export const CONNECTOR_FEATURE_FLAGS: Partial<
   neon: FeatureSwitchKey.NeonConnector,
   strava: FeatureSwitchKey.StravaConnector,
   "garmin-connect": FeatureSwitchKey.GarminConnectConnector,
-  x: FeatureSwitchKey.XConnector,
+
   reddit: FeatureSwitchKey.RedditConnector,
   vercel: FeatureSwitchKey.VercelConnector,
   sentry: FeatureSwitchKey.SentryConnector,


### PR DESCRIPTION
## Summary
- Remove the `XConnector` feature flag from `feature-switch-key.ts` and `feature-switch.ts` since the X connector integration is complete and no longer needs gating
- Remove the `x` entry from `CONNECTOR_FEATURE_FLAGS` mapping so the connector is visible to all users
- Improve the `add-oauth-connector.md` checklist with detailed skill verification steps, end-to-end testing instructions with `vm0 cook --yes`, troubleshooting guidance for common issues, and cleanup steps

## Test plan
- [ ] Verify `pnpm check-types` passes with the removed enum member
- [ ] Verify no remaining references to `XConnector` in the codebase
- [ ] Confirm X connector is no longer gated behind a feature flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)