### PR TITLE
ci: optimize rust-cache config for better hit rate

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -73,6 +73,8 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: crates -> target
+          shared-key: check
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Check formatting
         run: |
@@ -123,7 +125,9 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: crates -> target
-          key: aarch64-musl
+          shared-key: aarch64-musl
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+          cache-targets: false
 
       - name: Cross-compile guest binaries for ARM64
         run: |

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1249,7 +1249,9 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: crates -> target
-          key: aarch64-musl
+          shared-key: aarch64-musl
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+          cache-targets: false
 
       - name: Cross-compile guest binaries for ARM64
         run: |


### PR DESCRIPTION
## Summary

- Use `shared-key` so all branches share the same cache (avoids cold miss on every new PR)
- Only save cache on `main` push via `save-if` (PRs read-only, reduces upload time)
- Disable `cache-targets` for cross-compile jobs (final binaries change every build, not worth caching)

Affects 3 cache steps across `crates.yml` and `turbo.yml`.

## Test plan

- [ ] Verify main push saves cache successfully
- [ ] Verify PR run restores cache from main (no save)
- [ ] Compare CI build times before/after

🤖 Generated with [Claude Code](https://claude.com/claude-code)