### PR TITLE
refactor(github): restructure to org-level installation model

### DIFF
--- a/turbo/apps/platform/src/signals/integrations-page/github-integration.ts
+++ b/turbo/apps/platform/src/signals/integrations-page/github-integration.ts
@@ -7,7 +7,14 @@ import { logger } from "../log.ts";
 const L = logger("GitHubIntegration");
 
 interface GitHubIntegrationData {
-  installation: { id: string; installationId: string | null; status: string };
+  installation: {
+    id: string;
+    installationId: string | null;
+    status: string;
+    targetName: string | null;
+    targetType: string | null;
+    isAdmin: boolean;
+  };
   agent: { id: string; name: string; scopeSlug: string } | null;
   environment: {
     requiredSecrets: string[];
@@ -49,6 +56,9 @@ export const githubInstallUrl$ = computed(
 );
 export const githubIntegrationPendingApproval$ = computed(
   (get) => get(githubIntegrationState$).pendingApproval,
+);
+export const githubIntegrationIsAdmin$ = computed(
+  (get) => get(githubIntegrationState$).data?.installation.isAdmin ?? false,
 );
 
 export const fetchGitHubIntegration$ = command(async ({ get, set }) => {

--- a/turbo/apps/platform/src/views/integrations-page/github-settings-page.tsx
+++ b/turbo/apps/platform/src/views/integrations-page/github-settings-page.tsx
@@ -27,6 +27,7 @@ import {
   githubIntegrationData$,
   githubIntegrationLoading$,
   githubIntegrationPendingApproval$,
+  githubIntegrationIsAdmin$,
   disconnectGithub$,
   updateGithubDefaultAgent$,
   githubDisconnectDialogOpen$,
@@ -129,6 +130,7 @@ export function GitHubSettingsPage() {
   const data = useGet(githubIntegrationData$);
   const loading = useGet(githubIntegrationLoading$);
   const pendingApproval = useGet(githubIntegrationPendingApproval$);
+  const isAdmin = useGet(githubIntegrationIsAdmin$);
   const agents = useGet(agentsList$);
   const navigate = useSet(navigateInReact$);
   const disconnect = useSet(disconnectGithub$);
@@ -194,7 +196,11 @@ export function GitHubSettingsPage() {
     <AppShell
       breadcrumb={breadcrumb}
       title="VM0 in GitHub"
-      subtitle="Configure your settings how to run VM0 in GitHub."
+      subtitle={
+        data?.installation.targetName
+          ? `Connected to ${data.installation.targetName}`
+          : "Configure your settings how to run VM0 in GitHub."
+      }
     >
       <div className="flex flex-col gap-6 px-6 pb-8">
         {loading ? (
@@ -231,6 +237,7 @@ export function GitHubSettingsPage() {
                 <Select
                   value={scopedAgentName ?? ""}
                   onValueChange={handleAgentChange}
+                  disabled={!isAdmin}
                 >
                   <SelectTrigger className="w-full sm:w-[280px] sm:shrink-0">
                     <SelectValue placeholder="Select an agent" />
@@ -267,6 +274,7 @@ export function GitHubSettingsPage() {
                   variant="destructive"
                   size="sm"
                   onClick={() => openConfirm()}
+                  disabled={!isAdmin}
                 >
                   Uninstall
                 </Button>

--- a/turbo/apps/web/app/api/github/oauth/callback/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/github/oauth/callback/__tests__/route.test.ts
@@ -8,7 +8,7 @@ import {
   createTestScope,
   createTestCompose,
   findTestGitHubInstallations,
-  findTestGitHubInstallationsByUserId,
+  findTestGitHubInstallationsByTargetId,
 } from "../../../../../../src/__tests__/api-test-helpers";
 import {
   testContext,
@@ -19,8 +19,27 @@ import { env } from "../../../../../../src/env";
 
 const context = testContext();
 
-function setupGitHubTokenMock(installationId: string) {
+const TEST_TARGET_ID = "99887766";
+const TEST_TARGET_LOGIN = "test-org";
+const TEST_TARGET_TYPE = "Organization";
+
+function setupGitHubMocks(installationId: string) {
   server.use(
+    // Mock GET /app/installations/{id} for installation info
+    http.get(
+      `https://api.github.com/app/installations/${installationId}`,
+      () => {
+        return HttpResponse.json({
+          id: Number(installationId),
+          account: {
+            id: Number(TEST_TARGET_ID),
+            login: TEST_TARGET_LOGIN,
+            type: TEST_TARGET_TYPE,
+          },
+        });
+      },
+    ),
+    // Mock POST /app/installations/{id}/access_tokens
     http.post(
       `https://api.github.com/app/installations/${installationId}/access_tokens`,
       () => {
@@ -69,31 +88,6 @@ describe("/api/github/oauth/callback", () => {
     expect(location).toContain("Missing%20installation%20ID");
   });
 
-  it("should redirect with error when state has no vm0UserId", async () => {
-    const request = createTestRequest(
-      "http://localhost:3000/api/github/oauth/callback?installation_id=12345&setup_action=install",
-    );
-    const response = await GET(request);
-
-    expect(response.status).toBe(307);
-    const location = response.headers.get("Location");
-    expect(location).toContain("error=");
-    expect(location).toContain("Missing%20user%20context");
-  });
-
-  it("should redirect with error when state has no composeId and no signature", async () => {
-    const state = JSON.stringify({ vm0UserId: "user-123" });
-    const request = createTestRequest(
-      `http://localhost:3000/api/github/oauth/callback?installation_id=12345&setup_action=install&state=${encodeURIComponent(state)}`,
-    );
-    const response = await GET(request);
-
-    expect(response.status).toBe(307);
-    const location = response.headers.get("Location");
-    expect(location).toContain("error=");
-    expect(location).toContain("Invalid%20state%20signature");
-  });
-
   it("should redirect with error when state signature is invalid", async () => {
     const state = JSON.stringify({
       vm0UserId: "user-123",
@@ -131,8 +125,8 @@ describe("/api/github/oauth/callback", () => {
 
     const installationId = uniqueId("install");
     server.use(
-      http.post(
-        `https://api.github.com/app/installations/${installationId}/access_tokens`,
+      http.get(
+        `https://api.github.com/app/installations/${installationId}`,
         () => {
           return HttpResponse.json(
             { message: "Bad credentials" },
@@ -148,7 +142,7 @@ describe("/api/github/oauth/callback", () => {
     );
 
     await expect(GET(request)).rejects.toThrow(
-      "Failed to get installation access token: 401",
+      "Failed to get installation info: 401",
     );
   });
 
@@ -159,7 +153,7 @@ describe("/api/github/oauth/callback", () => {
     const { composeId } = await createTestCompose("gh-test-agent");
 
     const installationId = uniqueId("install");
-    setupGitHubTokenMock(installationId);
+    setupGitHubMocks(installationId);
 
     const state = buildSignedState(userId, composeId);
     const request = createTestRequest(
@@ -176,9 +170,11 @@ describe("/api/github/oauth/callback", () => {
     const installations = await findTestGitHubInstallations(installationId);
     expect(installations).toHaveLength(1);
     const installation = installations[0]!;
-    expect(installation.userId).toBe(userId);
     expect(installation.defaultComposeId).toBe(composeId);
     expect(installation.encryptedAccessToken).toBeTruthy();
+    expect(installation.targetType).toBe(TEST_TARGET_TYPE);
+    expect(installation.targetId).toBe(TEST_TARGET_ID);
+    expect(installation.targetName).toBe(TEST_TARGET_LOGIN);
   });
 
   it("should create pending record when setup_action is request", async () => {
@@ -188,7 +184,7 @@ describe("/api/github/oauth/callback", () => {
     const { composeId } = await createTestCompose("gh-test-agent");
 
     const state = buildSignedState(userId, composeId);
-    const targetId = "12345678";
+    const targetId = uniqueId("target");
     const request = createTestRequest(
       `http://localhost:3000/api/github/oauth/callback?setup_action=request&target_id=${targetId}&target_type=Organization&state=${encodeURIComponent(state)}`,
     );
@@ -201,10 +197,9 @@ describe("/api/github/oauth/callback", () => {
     expect(location).not.toContain("error=");
 
     // Verify pending installation was created in DB
-    const installations = await findTestGitHubInstallationsByUserId(userId);
+    const installations = await findTestGitHubInstallationsByTargetId(targetId);
     expect(installations).toHaveLength(1);
     const installation = installations[0]!;
-    expect(installation.userId).toBe(userId);
     expect(installation.status).toBe("pending");
     expect(installation.installationId).toBeNull();
     expect(installation.encryptedAccessToken).toBeNull();
@@ -220,7 +215,7 @@ describe("/api/github/oauth/callback", () => {
     const { composeId } = await createTestCompose("gh-test-agent");
 
     const installationId = uniqueId("install");
-    setupGitHubTokenMock(installationId);
+    setupGitHubMocks(installationId);
 
     // First callback — creates installation
     const state = buildSignedState(userId, composeId);

--- a/turbo/apps/web/app/api/github/oauth/callback/route.ts
+++ b/turbo/apps/web/app/api/github/oauth/callback/route.ts
@@ -1,11 +1,17 @@
 import { createHmac, timingSafeEqual } from "node:crypto";
 import { NextResponse } from "next/server";
-import { eq } from "drizzle-orm";
+import { eq, and } from "drizzle-orm";
 import { initServices } from "../../../../../src/lib/init-services";
 import { env } from "../../../../../src/env";
 import { encryptCredentialValue } from "../../../../../src/lib/crypto/secrets-encryption";
 import { githubInstallations } from "../../../../../src/db/schema/github-installation";
-import { getInstallationAccessToken } from "../../../../../src/lib/github/github-app";
+import { githubUserLinks } from "../../../../../src/db/schema/github-user-link";
+import { connectors } from "../../../../../src/db/schema/connector";
+import { scopes } from "../../../../../src/db/schema/scope";
+import {
+  getInstallationAccessToken,
+  getInstallationInfo,
+} from "../../../../../src/lib/github/github-app";
 import { getPlatformUrl } from "../../../../../src/lib/url";
 import { resolveDefaultAgentComposeId } from "../../../../../src/lib/agent-compose/resolve-default";
 
@@ -20,8 +26,8 @@ import { resolveDefaultAgentComposeId } from "../../../../../src/lib/agent-compo
  * Flow:
  * 1. Parse installation_id from query params
  * 2. Verify HMAC signature on state to prevent userId spoofing
- * 3. Generate an installation access token via JWT
- * 4. Encrypt and store the token in the database
+ * 3. Create/reuse installation record (org-level, not per-user)
+ * 4. Create github_user_links record if vm0UserId is present
  * 5. Redirect to Platform settings page
  */
 
@@ -73,16 +79,8 @@ export async function GET(request: Request) {
 
   const state = parseOAuthState(url.searchParams.get("state"));
 
-  if (!state.vm0UserId) {
-    return NextResponse.redirect(
-      `${platformUrl}/settings?tab=integrations&error=${encodeURIComponent("Missing user context. Please try installing again from the Platform.")}`,
-    );
-  }
-
-  // Verify HMAC signature to prevent userId spoofing.
-  // The install route always signs the state when vm0UserId is present,
-  // so we always verify when vm0UserId is present.
-  {
+  // Verify HMAC signature when vm0UserId is present
+  if (state.vm0UserId) {
     const expectedPayload = `${state.vm0UserId}:${state.composeId ?? ""}`;
     const expectedSig = createHmac("sha256", SECRETS_ENCRYPTION_KEY)
       .update(expectedPayload)
@@ -119,7 +117,6 @@ export async function GET(request: Request) {
     const targetType = url.searchParams.get("target_type") ?? "Organization";
 
     await globalThis.services.db.insert(githubInstallations).values({
-      userId: state.vm0UserId,
       installationId: null,
       encryptedAccessToken: null,
       status: "pending",
@@ -140,17 +137,29 @@ export async function GET(request: Request) {
     );
   }
 
+  const db = globalThis.services.db;
+
   // Check if installation already exists
-  const [existing] = await globalThis.services.db
+  const [existing] = await db
     .select({ id: githubInstallations.id })
     .from(githubInstallations)
     .where(eq(githubInstallations.installationId, installationId))
     .limit(1);
 
   if (existing) {
-    // Already installed — redirect to settings
+    // Installation exists — create user link if vm0UserId present and not already linked
+    if (state.vm0UserId) {
+      await linkVm0User(db, existing.id, state.vm0UserId);
+    }
     return NextResponse.redirect(`${platformUrl}/settings?tab=integrations`);
   }
+
+  // Get installation info from GitHub API (target type, ID, name)
+  const installInfo = await getInstallationInfo(
+    GITHUB_APP_ID,
+    GITHUB_APP_PRIVATE_KEY,
+    installationId,
+  );
 
   // Get installation access token from GitHub
   const { token } = await getInstallationAccessToken(
@@ -165,14 +174,97 @@ export async function GET(request: Request) {
     SECRETS_ENCRYPTION_KEY,
   );
 
-  // Create installation record
-  await globalThis.services.db.insert(githubInstallations).values({
-    userId: state.vm0UserId,
-    installationId,
-    encryptedAccessToken,
-    status: "active",
-    defaultComposeId: composeId,
-  });
+  // For User-type installations, the account IS the admin
+  const adminGithubUserId =
+    installInfo.targetType === "User" ? installInfo.targetId : null;
+
+  // Create installation record (org-level, no userId)
+  // Check for a pending record for this target first
+  const [pendingRecord] = await db
+    .select({ id: githubInstallations.id })
+    .from(githubInstallations)
+    .where(
+      and(
+        eq(githubInstallations.targetId, installInfo.targetId),
+        eq(githubInstallations.status, "pending"),
+      ),
+    )
+    .limit(1);
+
+  let installRecordId: string;
+
+  if (pendingRecord) {
+    // Activate pending record
+    await db
+      .update(githubInstallations)
+      .set({
+        status: "active",
+        installationId,
+        encryptedAccessToken,
+        targetType: installInfo.targetType,
+        targetName: installInfo.targetName,
+        adminGithubUserId,
+        updatedAt: new Date(),
+      })
+      .where(eq(githubInstallations.id, pendingRecord.id));
+    installRecordId = pendingRecord.id;
+  } else {
+    // Create new installation record
+    const [newInstall] = await db
+      .insert(githubInstallations)
+      .values({
+        installationId,
+        encryptedAccessToken,
+        status: "active",
+        targetType: installInfo.targetType,
+        targetId: installInfo.targetId,
+        targetName: installInfo.targetName,
+        adminGithubUserId,
+        defaultComposeId: composeId,
+      })
+      .returning({ id: githubInstallations.id });
+    installRecordId = newInstall!.id;
+  }
+
+  // Create user link if vm0UserId is present
+  if (state.vm0UserId) {
+    await linkVm0User(db, installRecordId, state.vm0UserId);
+  }
 
   return NextResponse.redirect(`${platformUrl}/settings?tab=integrations`);
+}
+
+/**
+ * Link a VM0 user to a GitHub installation via github_user_links.
+ *
+ * Looks up the user's GitHub connector to find their GitHub user ID.
+ * If no connector exists, the link is skipped (user can link later).
+ */
+async function linkVm0User(
+  db: typeof globalThis.services.db,
+  installRecordId: string,
+  vm0UserId: string,
+): Promise<void> {
+  // Find user's GitHub OAuth connector to get their GitHub user ID
+  const [connector] = await db
+    .select({ externalId: connectors.externalId })
+    .from(connectors)
+    .innerJoin(scopes, eq(scopes.id, connectors.scopeId))
+    .where(and(eq(scopes.ownerId, vm0UserId), eq(connectors.type, "github")))
+    .limit(1);
+
+  if (!connector?.externalId) {
+    // No GitHub connector — user needs to link via /github/connect later
+    return;
+  }
+
+  // Create user link (ignore conflict if already linked)
+  await db
+    .insert(githubUserLinks)
+    .values({
+      githubUserId: connector.externalId,
+      installationId: installRecordId,
+      vm0UserId,
+    })
+    .onConflictDoNothing();
 }

--- a/turbo/apps/web/app/api/integrations/github/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/integrations/github/__tests__/route.test.ts
@@ -5,6 +5,7 @@ import {
   createTestScope,
   createTestCompose,
   insertTestGitHubInstallationWithAdmin,
+  insertTestGitHubUserLink,
   findTestGitHubInstallationById,
   findTestComposeWithScope,
 } from "../../../../../src/__tests__/api-test-helpers";
@@ -154,6 +155,45 @@ describe("/api/integrations/github", () => {
       const row = await findTestGitHubInstallationById(installation.id);
       expect(row).toBeUndefined();
     });
+
+    it("should return 403 when non-admin attempts to delete", async () => {
+      // Create installation with admin user
+      const adminUserId = uniqueId("admin-user");
+      mockClerk({ userId: adminUserId });
+      await createTestScope(uniqueId("gh-scope"));
+      const { composeId } = await createTestCompose("gh-agent");
+      const { installation } = await insertTestGitHubInstallationWithAdmin(
+        composeId,
+        adminUserId,
+      );
+
+      // Create a non-admin user linked to the same installation
+      const nonAdminUserId = uniqueId("nonadmin-user");
+      mockClerk({ userId: nonAdminUserId });
+      await createTestScope(uniqueId("gh-scope"));
+      await insertTestGitHubUserLink(
+        uniqueId("gh-other-uid"),
+        installation.id,
+        nonAdminUserId,
+      );
+
+      const request = createTestRequest(
+        "http://localhost:3000/api/integrations/github",
+        {
+          method: "DELETE",
+          headers: { Authorization: "Bearer test-token" },
+        },
+      );
+      const response = await DELETE(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(403);
+      expect(data.error.code).toBe("FORBIDDEN");
+
+      // Verify installation was NOT deleted
+      const row = await findTestGitHubInstallationById(installation.id);
+      expect(row).toBeDefined();
+    });
   });
 
   describe("PATCH /api/integrations/github", () => {
@@ -217,6 +257,45 @@ describe("/api/integrations/github", () => {
       const response = await PATCH(request);
 
       expect(response.status).toBe(404);
+    });
+
+    it("should return 403 when non-admin attempts to update", async () => {
+      // Create installation with admin user
+      const adminUserId = uniqueId("admin-user");
+      mockClerk({ userId: adminUserId });
+      await createTestScope(uniqueId("gh-scope"));
+      const { composeId } = await createTestCompose("gh-agent");
+      const { installation } = await insertTestGitHubInstallationWithAdmin(
+        composeId,
+        adminUserId,
+      );
+
+      // Create a non-admin user linked to the same installation
+      const nonAdminUserId = uniqueId("nonadmin-user");
+      mockClerk({ userId: nonAdminUserId });
+      await createTestScope(uniqueId("gh-scope"));
+      await insertTestGitHubUserLink(
+        uniqueId("gh-other-uid"),
+        installation.id,
+        nonAdminUserId,
+      );
+
+      const request = createTestRequest(
+        "http://localhost:3000/api/integrations/github",
+        {
+          method: "PATCH",
+          headers: {
+            Authorization: "Bearer test-token",
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ agentName: "some-agent" }),
+        },
+      );
+      const response = await PATCH(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(403);
+      expect(data.error.code).toBe("FORBIDDEN");
     });
 
     it("should return 404 when agent does not exist", async () => {

--- a/turbo/apps/web/app/api/integrations/github/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/integrations/github/__tests__/route.test.ts
@@ -4,7 +4,7 @@ import {
   createTestRequest,
   createTestScope,
   createTestCompose,
-  insertTestGitHubInstallation,
+  insertTestGitHubInstallationWithAdmin,
   findTestGitHubInstallationById,
   findTestComposeWithScope,
 } from "../../../../../src/__tests__/api-test-helpers";
@@ -56,7 +56,7 @@ describe("/api/integrations/github", () => {
       await createTestScope(uniqueId("gh-scope"));
       const { composeId } = await createTestCompose("gh-agent");
 
-      await insertTestGitHubInstallation(userId, composeId);
+      await insertTestGitHubInstallationWithAdmin(composeId, userId);
 
       const request = createTestRequest(
         "http://localhost:3000/api/integrations/github",
@@ -78,7 +78,7 @@ describe("/api/integrations/github", () => {
       await createTestScope(uniqueId("gh-scope"));
       const { composeId } = await createTestCompose("gh-agent");
 
-      await insertTestGitHubInstallation(userId, composeId);
+      await insertTestGitHubInstallationWithAdmin(composeId, userId);
 
       const request = createTestRequest(
         "http://localhost:3000/api/integrations/github",
@@ -132,9 +132,9 @@ describe("/api/integrations/github", () => {
       await createTestScope(uniqueId("gh-scope"));
       const { composeId } = await createTestCompose("gh-agent");
 
-      const installation = await insertTestGitHubInstallation(
-        userId,
+      const { installation } = await insertTestGitHubInstallationWithAdmin(
         composeId,
+        userId,
       );
 
       const request = createTestRequest(
@@ -178,7 +178,7 @@ describe("/api/integrations/github", () => {
       mockClerk({ userId });
       await createTestScope(uniqueId("gh-scope"));
       const { composeId } = await createTestCompose("gh-agent");
-      await insertTestGitHubInstallation(userId, composeId);
+      await insertTestGitHubInstallationWithAdmin(composeId, userId);
 
       const request = createTestRequest(
         "http://localhost:3000/api/integrations/github",
@@ -224,7 +224,7 @@ describe("/api/integrations/github", () => {
       mockClerk({ userId });
       await createTestScope(uniqueId("gh-scope"));
       const { composeId } = await createTestCompose("gh-agent");
-      await insertTestGitHubInstallation(userId, composeId);
+      await insertTestGitHubInstallationWithAdmin(composeId, userId);
 
       const request = createTestRequest(
         "http://localhost:3000/api/integrations/github",
@@ -249,7 +249,7 @@ describe("/api/integrations/github", () => {
       mockClerk({ userId });
       await createTestScope(uniqueId("gh-scope"));
       const { composeId } = await createTestCompose("gh-agent");
-      await insertTestGitHubInstallation(userId, composeId);
+      await insertTestGitHubInstallationWithAdmin(composeId, userId);
 
       // Create a new agent to switch to
       await createTestCompose("new-agent");
@@ -287,7 +287,7 @@ describe("/api/integrations/github", () => {
       mockClerk({ userId });
       await createTestScope(uniqueId("gh-scope"));
       const { composeId } = await createTestCompose("gh-agent");
-      await insertTestGitHubInstallation(userId, composeId);
+      await insertTestGitHubInstallationWithAdmin(composeId, userId);
 
       // Create a compose in a different scope (simulating a shared agent)
       const otherUserId = uniqueId("other-user");

--- a/turbo/apps/web/app/api/integrations/github/route.ts
+++ b/turbo/apps/web/app/api/integrations/github/route.ts
@@ -10,6 +10,7 @@ import { env } from "../../../../src/env";
 import { getUserId } from "../../../../src/lib/auth/get-user-id";
 import { getApiUrl } from "../../../../src/lib/callback";
 import { githubInstallations } from "../../../../src/db/schema/github-installation";
+import { githubUserLinks } from "../../../../src/db/schema/github-user-link";
 import {
   agentComposes,
   agentComposeVersions,
@@ -27,8 +28,8 @@ import {
 /**
  * GET /api/integrations/github
  *
- * Returns GitHub App installation info for the authenticated user,
- * including current agent and environment variable status.
+ * Returns GitHub App installation info for the authenticated user.
+ * Finds installations via github_user_links join.
  * If no installation exists, returns 404 with an install URL.
  */
 export async function GET(request: Request) {
@@ -46,14 +47,21 @@ export async function GET(request: Request) {
 
   const db = globalThis.services.db;
 
-  // Find user's GitHub App installation
-  const [installation] = await db
-    .select()
-    .from(githubInstallations)
-    .where(eq(githubInstallations.userId, userId))
+  // Find user's GitHub App installation via user link
+  const [result] = await db
+    .select({
+      installation: githubInstallations,
+      link: githubUserLinks,
+    })
+    .from(githubUserLinks)
+    .innerJoin(
+      githubInstallations,
+      eq(githubInstallations.id, githubUserLinks.installationId),
+    )
+    .where(eq(githubUserLinks.vm0UserId, userId))
     .limit(1);
 
-  if (!installation) {
+  if (!result) {
     const { GITHUB_APP_SLUG } = env();
     const baseUrl = getApiUrl();
     const installUrl = GITHUB_APP_SLUG
@@ -68,6 +76,11 @@ export async function GET(request: Request) {
       { status: 404 },
     );
   }
+
+  const { installation } = result;
+
+  // Determine if current user is the admin
+  const isAdmin = result.link.githubUserId === installation.adminGithubUserId;
 
   // Get default agent info with headVersionId for environment extraction
   const [compose] = await db
@@ -133,6 +146,9 @@ export async function GET(request: Request) {
       id: installation.id,
       installationId: installation.installationId,
       status: installation.status,
+      targetName: installation.targetName,
+      targetType: installation.targetType,
+      isAdmin,
     },
     agent: compose
       ? { id: compose.id, name: compose.name, scopeSlug: compose.scopeSlug }
@@ -149,8 +165,8 @@ export async function GET(request: Request) {
 /**
  * DELETE /api/integrations/github
  *
- * Removes the authenticated user's GitHub App installation.
- * Cascades to delete all associated issue sessions.
+ * Removes the GitHub App installation. Only the admin can uninstall.
+ * Cascades to delete all associated issue sessions and user links.
  */
 export async function DELETE(request: Request) {
   initServices();
@@ -167,24 +183,45 @@ export async function DELETE(request: Request) {
 
   const db = globalThis.services.db;
 
-  // Find user's GitHub App installation
-  const [installation] = await db
-    .select({ id: githubInstallations.id })
-    .from(githubInstallations)
-    .where(eq(githubInstallations.userId, userId))
+  // Find user's GitHub App installation via user link
+  const [result] = await db
+    .select({
+      installationId: githubInstallations.id,
+      adminGithubUserId: githubInstallations.adminGithubUserId,
+      githubUserId: githubUserLinks.githubUserId,
+    })
+    .from(githubUserLinks)
+    .innerJoin(
+      githubInstallations,
+      eq(githubInstallations.id, githubUserLinks.installationId),
+    )
+    .where(eq(githubUserLinks.vm0UserId, userId))
     .limit(1);
 
-  if (!installation) {
+  if (!result) {
     return NextResponse.json(
       { error: { message: "No GitHub installation found", code: "NOT_FOUND" } },
       { status: 404 },
     );
   }
 
-  // Delete installation (cascades to github_issue_sessions)
+  // Only admin can delete
+  if (result.githubUserId !== result.adminGithubUserId) {
+    return NextResponse.json(
+      {
+        error: {
+          message: "Only the installation admin can uninstall",
+          code: "FORBIDDEN",
+        },
+      },
+      { status: 403 },
+    );
+  }
+
+  // Delete installation (cascades to github_issue_sessions and github_user_links)
   await db
     .delete(githubInstallations)
-    .where(eq(githubInstallations.id, installation.id));
+    .where(eq(githubInstallations.id, result.installationId));
 
   return NextResponse.json({ ok: true });
 }
@@ -192,7 +229,8 @@ export async function DELETE(request: Request) {
 /**
  * PATCH /api/integrations/github
  *
- * Updates the default agent for the authenticated user's GitHub installation.
+ * Updates the default agent for the GitHub installation.
+ * Only the admin can change the default agent.
  * Body: { agentName: string }
  */
 export async function PATCH(request: Request) {
@@ -218,17 +256,38 @@ export async function PATCH(request: Request) {
 
   const db = globalThis.services.db;
 
-  // Find user's GitHub App installation
-  const [installation] = await db
-    .select({ id: githubInstallations.id })
-    .from(githubInstallations)
-    .where(eq(githubInstallations.userId, userId))
+  // Find user's GitHub App installation via user link
+  const [result] = await db
+    .select({
+      installationId: githubInstallations.id,
+      adminGithubUserId: githubInstallations.adminGithubUserId,
+      githubUserId: githubUserLinks.githubUserId,
+    })
+    .from(githubUserLinks)
+    .innerJoin(
+      githubInstallations,
+      eq(githubInstallations.id, githubUserLinks.installationId),
+    )
+    .where(eq(githubUserLinks.vm0UserId, userId))
     .limit(1);
 
-  if (!installation) {
+  if (!result) {
     return NextResponse.json(
       { error: { message: "No GitHub installation found", code: "NOT_FOUND" } },
       { status: 404 },
+    );
+  }
+
+  // Only admin can change default agent
+  if (result.githubUserId !== result.adminGithubUserId) {
+    return NextResponse.json(
+      {
+        error: {
+          message: "Only the installation admin can change the default agent",
+          code: "FORBIDDEN",
+        },
+      },
+      { status: 403 },
     );
   }
 
@@ -274,7 +333,7 @@ export async function PATCH(request: Request) {
   await db
     .update(githubInstallations)
     .set({ defaultComposeId: compose.id, updatedAt: new Date() })
-    .where(eq(githubInstallations.id, installation.id));
+    .where(eq(githubInstallations.id, result.installationId));
 
   return NextResponse.json({ ok: true });
 }

--- a/turbo/apps/web/app/api/internal/callbacks/github/issues/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/github/issues/__tests__/route.test.ts
@@ -120,7 +120,7 @@ async function givenGitHubCallbackSetup(overrides?: {
   const { composeId } = await createTestCompose("gh-callback-agent");
 
   const { runId } = await createTestRun(composeId, "Test GitHub prompt");
-  const installation = await insertTestGitHubInstallation(userId, composeId);
+  const installation = await insertTestGitHubInstallation(composeId);
 
   const { capturedComments } = setupGitHubApiMocks(
     installation.installationId!,

--- a/turbo/apps/web/app/api/webhooks/github/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/github/__tests__/route.test.ts
@@ -11,7 +11,7 @@ import {
   createTestScope,
   createTestCompose,
   insertTestPendingGitHubInstallation,
-  findTestGitHubInstallationsByUserId,
+  findTestGitHubInstallationsByTargetId,
 } from "../../../../../src/__tests__/api-test-helpers";
 import { mockClerk } from "../../../../../src/__tests__/clerk-mock";
 import { POST } from "../route";
@@ -90,10 +90,12 @@ interface IssuesPayloadOverrides {
   installationId?: number;
   repo?: string;
   issueBody?: string | null;
+  senderId?: number;
 }
 
 /** Build a GitHub issues event payload */
 function buildIssuesPayload(overrides?: IssuesPayloadOverrides) {
+  const senderId = overrides?.senderId ?? 100;
   return {
     action: overrides?.action ?? "opened",
     issue: {
@@ -104,12 +106,12 @@ function buildIssuesPayload(overrides?: IssuesPayloadOverrides) {
           ? overrides.issueBody
           : "This is a test issue body",
       labels: overrides?.labels ?? [{ id: 1, name: "vm0-agent" }],
-      user: { id: 100, login: "testuser", type: "User" },
+      user: { id: senderId, login: "testuser", type: "User" },
     },
     ...(overrides?.label && { label: overrides.label }),
     repository: { full_name: overrides?.repo ?? "owner/repo" },
     installation: { id: overrides?.installationId ?? 12345 },
-    sender: { id: 100, login: "testuser", type: "User" },
+    sender: { id: senderId, login: "testuser", type: "User" },
   };
 }
 
@@ -122,10 +124,12 @@ interface CommentPayloadOverrides {
   repo?: string;
   senderType?: string;
   senderLogin?: string;
+  senderId?: number;
 }
 
 /** Build a GitHub issue_comment event payload */
 function buildIssueCommentPayload(overrides?: CommentPayloadOverrides) {
+  const senderId = overrides?.senderId ?? 100;
   const senderLogin = overrides?.senderLogin ?? "testuser";
   const senderType = overrides?.senderType ?? "User";
 
@@ -136,16 +140,16 @@ function buildIssueCommentPayload(overrides?: CommentPayloadOverrides) {
       title: "Test Issue",
       body: "This is a test issue body",
       labels: overrides?.labels ?? [{ id: 1, name: "vm0-agent" }],
-      user: { id: 100, login: "testuser", type: "User" },
+      user: { id: senderId, login: "testuser", type: "User" },
     },
     comment: {
       id: overrides?.commentId ?? 999,
       body: overrides?.commentBody ?? "Please help with this",
-      user: { id: 100, login: senderLogin, type: senderType },
+      user: { id: senderId, login: senderLogin, type: senderType },
     },
     repository: { full_name: overrides?.repo ?? "owner/repo" },
     installation: { id: overrides?.installationId ?? 12345 },
-    sender: { id: 100, login: senderLogin, type: senderType },
+    sender: { id: senderId, login: senderLogin, type: senderType },
   };
 }
 
@@ -222,7 +226,8 @@ describe("POST /api/webhooks/github", () => {
   describe("Issues Event", () => {
     it("should trigger agent for opened issue with vm0-agent label", async () => {
       // Given a GitHub installation exists
-      const { ghInstallationId } = await givenGitHubInstallation();
+      const { ghInstallationId, githubUserId } =
+        await givenGitHubInstallation();
 
       // When a webhook arrives for an opened issue with the vm0-agent label
       const request = createGitHubWebhookRequest(
@@ -231,6 +236,7 @@ describe("POST /api/webhooks/github", () => {
           action: "opened",
           labels: [{ id: 1, name: "vm0-agent" }],
           installationId: ghInstallationId,
+          senderId: Number(githubUserId),
         }),
       );
       const response = await POST(request);
@@ -250,7 +256,8 @@ describe("POST /api/webhooks/github", () => {
     });
 
     it("should trigger agent when vm0-agent label is added", async () => {
-      const { ghInstallationId } = await givenGitHubInstallation();
+      const { ghInstallationId, githubUserId } =
+        await givenGitHubInstallation();
 
       const request = createGitHubWebhookRequest(
         "issues",
@@ -259,6 +266,7 @@ describe("POST /api/webhooks/github", () => {
           labels: [{ id: 1, name: "vm0-agent" }],
           label: { id: 1, name: "vm0-agent" },
           installationId: ghInstallationId,
+          senderId: Number(githubUserId),
         }),
       );
       const response = await POST(request);
@@ -270,7 +278,8 @@ describe("POST /api/webhooks/github", () => {
     });
 
     it("should NOT trigger agent for opened issue without vm0-agent label", async () => {
-      const { ghInstallationId } = await givenGitHubInstallation();
+      const { ghInstallationId, githubUserId } =
+        await givenGitHubInstallation();
 
       const request = createGitHubWebhookRequest(
         "issues",
@@ -278,6 +287,7 @@ describe("POST /api/webhooks/github", () => {
           action: "opened",
           labels: [{ id: 2, name: "bug" }],
           installationId: ghInstallationId,
+          senderId: Number(githubUserId),
         }),
       );
       const response = await POST(request);
@@ -289,7 +299,8 @@ describe("POST /api/webhooks/github", () => {
     });
 
     it("should NOT trigger agent when a non-vm0-agent label is added", async () => {
-      const { ghInstallationId } = await givenGitHubInstallation();
+      const { ghInstallationId, githubUserId } =
+        await givenGitHubInstallation();
 
       const request = createGitHubWebhookRequest(
         "issues",
@@ -301,6 +312,7 @@ describe("POST /api/webhooks/github", () => {
           ],
           label: { id: 2, name: "enhancement" },
           installationId: ghInstallationId,
+          senderId: Number(githubUserId),
         }),
       );
       const response = await POST(request);
@@ -312,7 +324,8 @@ describe("POST /api/webhooks/github", () => {
     });
 
     it("should ignore closed/edited/other issue actions", async () => {
-      const { ghInstallationId } = await givenGitHubInstallation();
+      const { ghInstallationId, githubUserId } =
+        await givenGitHubInstallation();
 
       for (const action of ["closed", "edited", "reopened", "deleted"]) {
         createRunSpy.mockClear();
@@ -323,6 +336,7 @@ describe("POST /api/webhooks/github", () => {
             action,
             labels: [{ id: 1, name: "vm0-agent" }],
             installationId: ghInstallationId,
+            senderId: Number(githubUserId),
           }),
         );
         const response = await POST(request);
@@ -335,7 +349,8 @@ describe("POST /api/webhooks/github", () => {
     });
 
     it("should handle issue with null body", async () => {
-      const { ghInstallationId } = await givenGitHubInstallation();
+      const { ghInstallationId, githubUserId } =
+        await givenGitHubInstallation();
 
       const request = createGitHubWebhookRequest(
         "issues",
@@ -344,6 +359,7 @@ describe("POST /api/webhooks/github", () => {
           labels: [{ id: 1, name: "vm0-agent" }],
           installationId: ghInstallationId,
           issueBody: null,
+          senderId: Number(githubUserId),
         }),
       );
       const response = await POST(request);
@@ -359,7 +375,8 @@ describe("POST /api/webhooks/github", () => {
 
   describe("Issue Comment Event", () => {
     it("should trigger agent for comment on issue with vm0-agent label", async () => {
-      const { ghInstallationId } = await givenGitHubInstallation();
+      const { ghInstallationId, githubUserId } =
+        await givenGitHubInstallation();
 
       const request = createGitHubWebhookRequest(
         "issue_comment",
@@ -367,6 +384,7 @@ describe("POST /api/webhooks/github", () => {
           labels: [{ id: 1, name: "vm0-agent" }],
           commentBody: "Can you help me fix this?",
           installationId: ghInstallationId,
+          senderId: Number(githubUserId),
         }),
       );
       const response = await POST(request);
@@ -381,7 +399,8 @@ describe("POST /api/webhooks/github", () => {
     });
 
     it("should trigger agent for comment mentioning @bot", async () => {
-      const { ghInstallationId } = await givenGitHubInstallation();
+      const { ghInstallationId, githubUserId } =
+        await givenGitHubInstallation();
 
       const request = createGitHubWebhookRequest(
         "issue_comment",
@@ -389,6 +408,7 @@ describe("POST /api/webhooks/github", () => {
           labels: [], // No vm0-agent label
           commentBody: `@${TEST_APP_SLUG}[bot] please review this`,
           installationId: ghInstallationId,
+          senderId: Number(githubUserId),
         }),
       );
       const response = await POST(request);
@@ -400,7 +420,8 @@ describe("POST /api/webhooks/github", () => {
     });
 
     it("should NOT trigger for comment without label or mention", async () => {
-      const { ghInstallationId } = await givenGitHubInstallation();
+      const { ghInstallationId, githubUserId } =
+        await givenGitHubInstallation();
 
       const request = createGitHubWebhookRequest(
         "issue_comment",
@@ -408,6 +429,7 @@ describe("POST /api/webhooks/github", () => {
           labels: [{ id: 2, name: "bug" }],
           commentBody: "Just a regular comment",
           installationId: ghInstallationId,
+          senderId: Number(githubUserId),
         }),
       );
       const response = await POST(request);
@@ -419,7 +441,8 @@ describe("POST /api/webhooks/github", () => {
     });
 
     it("should prevent self-triggering from bot comments", async () => {
-      const { ghInstallationId } = await givenGitHubInstallation();
+      const { ghInstallationId, githubUserId } =
+        await givenGitHubInstallation();
 
       const request = createGitHubWebhookRequest(
         "issue_comment",
@@ -429,6 +452,7 @@ describe("POST /api/webhooks/github", () => {
           senderType: "Bot",
           senderLogin: `${TEST_APP_SLUG}[bot]`,
           installationId: ghInstallationId,
+          senderId: Number(githubUserId),
         }),
       );
       const response = await POST(request);
@@ -440,7 +464,8 @@ describe("POST /api/webhooks/github", () => {
     });
 
     it("should ignore non-created comment actions", async () => {
-      const { ghInstallationId } = await givenGitHubInstallation();
+      const { ghInstallationId, githubUserId } =
+        await givenGitHubInstallation();
 
       for (const action of ["edited", "deleted"]) {
         createRunSpy.mockClear();
@@ -451,6 +476,7 @@ describe("POST /api/webhooks/github", () => {
             action,
             labels: [{ id: 1, name: "vm0-agent" }],
             installationId: ghInstallationId,
+            senderId: Number(githubUserId),
           }),
         );
         const response = await POST(request);
@@ -500,6 +526,8 @@ describe("POST /api/webhooks/github", () => {
       installationId?: number;
       accountId?: number;
       accountType?: string;
+      accountLogin?: string;
+      senderId?: number;
     }) {
       return {
         action: overrides?.action ?? "created",
@@ -507,8 +535,13 @@ describe("POST /api/webhooks/github", () => {
           id: overrides?.installationId ?? 99999,
           account: {
             id: overrides?.accountId ?? 55555,
+            login: overrides?.accountLogin ?? "test-org",
             type: overrides?.accountType ?? "Organization",
           },
+        },
+        sender: {
+          id: overrides?.senderId ?? 12345,
+          login: "installer-user",
         },
       };
     }
@@ -537,7 +570,7 @@ describe("POST /api/webhooks/github", () => {
       const ghInstallationId = Math.floor(Math.random() * 1_000_000_000);
 
       // Create a pending installation record
-      await insertTestPendingGitHubInstallation(userId, composeId, targetId);
+      await insertTestPendingGitHubInstallation(composeId, targetId);
 
       // Set up MSW mock for GitHub token API
       setupInstallationTokenMock(ghInstallationId);
@@ -556,7 +589,8 @@ describe("POST /api/webhooks/github", () => {
       await flushAfterCallbacks();
 
       // Verify the pending installation was activated
-      const installations = await findTestGitHubInstallationsByUserId(userId);
+      const installations =
+        await findTestGitHubInstallationsByTargetId(targetId);
       expect(installations).toHaveLength(1);
       const installation = installations[0]!;
       expect(installation.status).toBe("active");
@@ -615,7 +649,8 @@ describe("POST /api/webhooks/github", () => {
 
   describe("Session Continuity", () => {
     it("should include callback context with session info", async () => {
-      const { ghInstallationId } = await givenGitHubInstallation();
+      const { ghInstallationId, githubUserId } =
+        await givenGitHubInstallation();
 
       const request = createGitHubWebhookRequest(
         "issue_comment",
@@ -623,6 +658,7 @@ describe("POST /api/webhooks/github", () => {
           labels: [{ id: 1, name: "vm0-agent" }],
           commentBody: "Follow-up question",
           installationId: ghInstallationId,
+          senderId: Number(githubUserId),
         }),
       );
       const response = await POST(request);

--- a/turbo/apps/web/src/__tests__/api-test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers.ts
@@ -2182,9 +2182,36 @@ export async function insertTestGitHubInstallationWithAdmin(
     .set({ adminGithubUserId: githubUserId })
     .where(eq(githubInstallations.id, installation.id));
 
-  await insertTestGitHubUserLink(githubUserId, installation.id, vm0UserId);
+  // Create user link inline (maps GitHub user to VM0 user for this installation)
+  await globalThis.services.db
+    .insert(githubUserLinks)
+    .values({
+      githubUserId,
+      installationId: installation.id,
+      vm0UserId,
+    })
+    .onConflictDoNothing();
 
   return { installation, githubUserId };
+}
+
+/**
+ * Insert a GitHub user link record directly in the database.
+ *
+ * Direct DB insert is required because user links are created by the
+ * GitHub OAuth callback which requires real GitHub API interaction.
+ * This helper creates a link between a GitHub user and a VM0 user
+ * for a given installation, used to test non-admin authorization paths.
+ */
+export async function insertTestGitHubUserLink(
+  githubUserId: string,
+  installationId: string,
+  vm0UserId: string,
+) {
+  await globalThis.services.db
+    .insert(githubUserLinks)
+    .values({ githubUserId, installationId, vm0UserId })
+    .onConflictDoNothing();
 }
 
 /**

--- a/turbo/apps/web/src/__tests__/api-test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers.ts
@@ -21,6 +21,7 @@ import { usageDaily } from "../db/schema/usage-daily";
 import { slackComposeRequests } from "../db/schema/slack-compose-request";
 import { slackInstallations } from "../db/schema/slack-installation";
 import { githubInstallations } from "../db/schema/github-installation";
+import { githubUserLinks } from "../db/schema/github-user-link";
 import { githubIssueSessions } from "../db/schema/github-issue-session";
 import { slackThreadSessions } from "../db/schema/slack-thread-session";
 import { emailThreadSessions } from "../db/schema/email-thread-session";
@@ -2086,7 +2087,6 @@ export async function findTestScheduleById(scheduleId: string) {
  * GitHub OAuth callback route, which requires real GitHub API interaction.
  */
 export async function insertTestGitHubInstallation(
-  userId: string,
   composeId: string,
   installationId?: string,
 ) {
@@ -2099,7 +2099,6 @@ export async function insertTestGitHubInstallation(
   const [row] = await globalThis.services.db
     .insert(githubInstallations)
     .values({
-      userId,
       installationId: id,
       encryptedAccessToken: encryptedToken,
       defaultComposeId: composeId,
@@ -2117,7 +2116,6 @@ export async function insertTestGitHubInstallation(
  * OAuth redirect flow.
  */
 export async function insertTestPendingGitHubInstallation(
-  userId: string,
   composeId: string,
   targetId: string,
   targetType: string = "Organization",
@@ -2125,7 +2123,6 @@ export async function insertTestPendingGitHubInstallation(
   const [row] = await globalThis.services.db
     .insert(githubInstallations)
     .values({
-      userId,
       installationId: null,
       encryptedAccessToken: null,
       status: "pending",
@@ -2167,16 +2164,40 @@ export async function findTestGitHubInstallationById(id: string) {
 }
 
 /**
- * Find GitHub installations by user ID.
+ * Create a GitHub installation with a user link and admin role.
+ *
+ * Combines insertTestGitHubInstallation + insertTestGitHubUserLink
+ * and sets adminGithubUserId so the linked user is the admin.
+ */
+export async function insertTestGitHubInstallationWithAdmin(
+  composeId: string,
+  vm0UserId: string,
+) {
+  const githubUserId = uniqueId("gh-uid");
+  const installation = await insertTestGitHubInstallation(composeId);
+
+  // Set admin to the github user
+  await globalThis.services.db
+    .update(githubInstallations)
+    .set({ adminGithubUserId: githubUserId })
+    .where(eq(githubInstallations.id, installation.id));
+
+  await insertTestGitHubUserLink(githubUserId, installation.id, vm0UserId);
+
+  return { installation, githubUserId };
+}
+
+/**
+ * Find GitHub installations by target ID.
  *
  * Direct DB read is required because pending installations have no
  * installation_id to query by, and the GET endpoint requires auth context.
  */
-export async function findTestGitHubInstallationsByUserId(userId: string) {
+export async function findTestGitHubInstallationsByTargetId(targetId: string) {
   return globalThis.services.db
     .select()
     .from(githubInstallations)
-    .where(eq(githubInstallations.userId, userId));
+    .where(eq(githubInstallations.targetId, targetId));
 }
 
 /**

--- a/turbo/apps/web/src/__tests__/github/api-helpers.ts
+++ b/turbo/apps/web/src/__tests__/github/api-helpers.ts
@@ -17,11 +17,11 @@ import {
   agentComposeVersions,
 } from "../../db/schema/agent-compose";
 import { githubInstallations } from "../../db/schema/github-installation";
+import { githubUserLinks } from "../../db/schema/github-user-link";
 
 interface GitHubInstallationResult {
   installation: {
     id: string;
-    userId: string;
     installationId: string;
     defaultComposeId: string;
   };
@@ -29,12 +29,13 @@ interface GitHubInstallationResult {
   compose: { id: string; name: string };
   versionId: string;
   userId: string;
+  githubUserId: string;
 }
 
 /**
  * Given a GitHub App installation exists in the database.
  *
- * Creates all prerequisite records (scope, compose, version, installation)
+ * Creates all prerequisite records (scope, compose, version, installation, user link)
  * needed for webhook handler tests.
  */
 export async function givenGitHubInstallation(
@@ -47,6 +48,7 @@ export async function givenGitHubInstallation(
   const { SECRETS_ENCRYPTION_KEY } = env();
 
   const userId = uniqueId("gh-user");
+  const githubUserId = String(Math.floor(Math.random() * 1_000_000_000));
   const scopeSlug = uniqueId("scope");
 
   // Create scope
@@ -87,7 +89,7 @@ export async function givenGitHubInstallation(
     .set({ headVersionId: versionId })
     .where(eq(agentComposes.id, compose!.id));
 
-  // Create installation
+  // Create installation (org-level, no userId)
   const encryptedToken = encryptCredentialValue(
     "ghs_test_token",
     SECRETS_ENCRYPTION_KEY,
@@ -96,17 +98,26 @@ export async function givenGitHubInstallation(
   const [installation] = await globalThis.services.db
     .insert(githubInstallations)
     .values({
-      userId,
       installationId: String(ghInstallationId),
       encryptedAccessToken: encryptedToken,
       defaultComposeId: compose!.id,
+      targetType: "Organization",
+      targetId: String(Math.floor(Math.random() * 1_000_000_000)),
+      targetName: "test-org",
+      adminGithubUserId: githubUserId,
     })
     .returning();
+
+  // Create user link
+  await globalThis.services.db.insert(githubUserLinks).values({
+    githubUserId,
+    installationId: installation!.id,
+    vm0UserId: userId,
+  });
 
   return {
     installation: {
       id: installation!.id,
-      userId: installation!.userId,
       installationId: installation!.installationId!,
       defaultComposeId: installation!.defaultComposeId,
     },
@@ -114,5 +125,6 @@ export async function givenGitHubInstallation(
     compose: { id: compose!.id, name: compose!.name },
     versionId,
     userId,
+    githubUserId,
   };
 }

--- a/turbo/apps/web/src/db/db.ts
+++ b/turbo/apps/web/src/db/db.ts
@@ -30,6 +30,7 @@ import * as emailThreadSessionSchema from "./schema/email-thread-session";
 import * as emailReplyRequestSchema from "./schema/email-reply-request";
 import * as orgAccessTokenSchema from "./schema/org-access-token";
 import * as githubInstallationSchema from "./schema/github-installation";
+import * as githubUserLinkSchema from "./schema/github-user-link";
 import * as githubIssueSessionSchema from "./schema/github-issue-session";
 import * as telegramInstallationSchema from "./schema/telegram-installation";
 import * as telegramUserLinkSchema from "./schema/telegram-user-link";
@@ -69,6 +70,7 @@ export const schema = {
   ...emailReplyRequestSchema,
   ...orgAccessTokenSchema,
   ...githubInstallationSchema,
+  ...githubUserLinkSchema,
   ...githubIssueSessionSchema,
   ...telegramInstallationSchema,
   ...telegramUserLinkSchema,

--- a/turbo/apps/web/src/db/migrations/0102_github_user_links.sql
+++ b/turbo/apps/web/src/db/migrations/0102_github_user_links.sql
@@ -1,0 +1,26 @@
+CREATE TABLE "github_user_links" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"github_user_id" varchar(255) NOT NULL,
+	"installation_id" uuid NOT NULL,
+	"vm0_user_id" text NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "github_installations" ADD COLUMN "target_name" varchar(255);--> statement-breakpoint
+ALTER TABLE "github_installations" ADD COLUMN "admin_github_user_id" varchar(255);--> statement-breakpoint
+ALTER TABLE "github_user_links" ADD CONSTRAINT "github_user_links_installation_id_github_installations_id_fk" FOREIGN KEY ("installation_id") REFERENCES "public"."github_installations"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "idx_github_user_links_user_installation" ON "github_user_links" USING btree ("github_user_id","installation_id");--> statement-breakpoint
+-- Data migration: for each existing installation with a user_id,
+-- create a github_user_link record. We use target_id as github_user_id
+-- for User-type installations since that's the GitHub user's numeric ID.
+-- For Org installations, admin_github_user_id will be set via the OAuth flow.
+INSERT INTO "github_user_links" ("installation_id", "github_user_id", "vm0_user_id", "created_at")
+SELECT
+  gi."id",
+  COALESCE(gi."target_id", gi."installation_id", gi."id"::text),
+  gi."user_id",
+  gi."created_at"
+FROM "github_installations" gi
+WHERE gi."user_id" IS NOT NULL;
+--> statement-breakpoint
+ALTER TABLE "github_installations" DROP COLUMN "user_id";

--- a/turbo/apps/web/src/db/migrations/meta/0102_snapshot.json
+++ b/turbo/apps/web/src/db/migrations/meta/0102_snapshot.json
@@ -1,0 +1,4658 @@
+{
+  "id": "f30aa8fb-c74b-4d40-ba1f-60ed09998c68",
+  "prevId": "cd27e9e9-b660-4f44-a476-8f3fed8998e4",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.agent_compose_versions": {
+      "name": "agent_compose_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "compose_id": {
+          "name": "compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_compose_versions_compose_id": {
+          "name": "idx_agent_compose_versions_compose_id",
+          "columns": [
+            {
+              "expression": "compose_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_compose_versions_compose_id_agent_composes_id_fk": {
+          "name": "agent_compose_versions_compose_id_agent_composes_id_fk",
+          "tableFrom": "agent_compose_versions",
+          "tableTo": "agent_composes",
+          "columnsFrom": [
+            "compose_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_composes": {
+      "name": "agent_composes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "head_version_id": {
+          "name": "head_version_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_composes_scope_name": {
+          "name": "idx_agent_composes_scope_name",
+          "columns": [
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_composes_scope": {
+          "name": "idx_agent_composes_scope",
+          "columns": [
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_composes_scope_id_scopes_id_fk": {
+          "name": "agent_composes_scope_id_scopes_id_fk",
+          "tableFrom": "agent_composes",
+          "tableTo": "scopes",
+          "columnsFrom": [
+            "scope_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_permissions": {
+      "name": "agent_permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "agent_compose_id": {
+          "name": "agent_compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grantee_type": {
+          "name": "grantee_type",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grantee_email": {
+          "name": "grantee_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "permission": {
+          "name": "permission",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'run_view'"
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_permissions_compose": {
+          "name": "idx_agent_permissions_compose",
+          "columns": [
+            {
+              "expression": "agent_compose_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_permissions_email": {
+          "name": "idx_agent_permissions_email",
+          "columns": [
+            {
+              "expression": "grantee_email",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "grantee_email IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_permissions_agent_compose_id_agent_composes_id_fk": {
+          "name": "agent_permissions_agent_compose_id_agent_composes_id_fk",
+          "tableFrom": "agent_permissions",
+          "tableTo": "agent_composes",
+          "columnsFrom": [
+            "agent_compose_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "agent_permissions_compose_type_email_unique": {
+          "name": "agent_permissions_compose_type_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "agent_compose_id",
+            "grantee_type",
+            "grantee_email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_run_callbacks": {
+      "name": "agent_run_callbacks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_secret": {
+          "name": "encrypted_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_attempt_at": {
+          "name": "last_attempt_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_run_callbacks_run_id": {
+          "name": "idx_agent_run_callbacks_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_run_callbacks_pending": {
+          "name": "idx_agent_run_callbacks_pending",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "status = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_run_callbacks_run_id_agent_runs_id_fk": {
+          "name": "agent_run_callbacks_run_id_agent_runs_id_fk",
+          "tableFrom": "agent_run_callbacks",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_run_events": {
+      "name": "agent_run_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence_number": {
+          "name": "sequence_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_data": {
+          "name": "event_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_run_events_run_id_agent_runs_id_fk": {
+          "name": "agent_run_events_run_id_agent_runs_id_fk",
+          "tableFrom": "agent_run_events",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_run_events_local": {
+      "name": "agent_run_events_local",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence_number": {
+          "name": "sequence_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_data": {
+          "name": "event_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_run_events_local_run_id": {
+          "name": "idx_agent_run_events_local_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_run_events_local_run_seq": {
+          "name": "idx_agent_run_events_local_run_seq",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sequence_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_run_events_local_run_id_agent_runs_id_fk": {
+          "name": "agent_run_events_local_run_id_agent_runs_id_fk",
+          "tableFrom": "agent_run_events_local",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_runs": {
+      "name": "agent_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_compose_version_id": {
+          "name": "agent_compose_version_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resumed_from_checkpoint_id": {
+          "name": "resumed_from_checkpoint_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "continued_from_session_id": {
+          "name": "continued_from_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vars": {
+          "name": "vars",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "secret_names": {
+          "name": "secret_names",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_heartbeat_at": {
+          "name": "last_heartbeat_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_agent_runs_user_created": {
+          "name": "idx_agent_runs_user_created",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_runs_status_heartbeat": {
+          "name": "idx_agent_runs_status_heartbeat",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_heartbeat_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_runs_running_heartbeat": {
+          "name": "idx_agent_runs_running_heartbeat",
+          "columns": [
+            {
+              "expression": "last_heartbeat_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "status = 'running'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_runs_schedule_created": {
+          "name": "idx_agent_runs_schedule_created",
+          "columns": [
+            {
+              "expression": "schedule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "schedule_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_runs_agent_compose_version_id_agent_compose_versions_id_fk": {
+          "name": "agent_runs_agent_compose_version_id_agent_compose_versions_id_fk",
+          "tableFrom": "agent_runs",
+          "tableTo": "agent_compose_versions",
+          "columnsFrom": [
+            "agent_compose_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "agent_runs_schedule_id_agent_schedules_id_fk": {
+          "name": "agent_runs_schedule_id_agent_schedules_id_fk",
+          "tableFrom": "agent_runs",
+          "tableTo": "agent_schedules",
+          "columnsFrom": [
+            "schedule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_schedules": {
+      "name": "agent_schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "compose_id": {
+          "name": "compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_type": {
+          "name": "trigger_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'cron'"
+        },
+        "cron_expression": {
+          "name": "cron_expression",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "at_time": {
+          "name": "at_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "interval_seconds": {
+          "name": "interval_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vars": {
+          "name": "vars",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_secrets": {
+          "name": "encrypted_secrets",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artifact_name": {
+          "name": "artifact_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artifact_version": {
+          "name": "artifact_version",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "volume_versions": {
+          "name": "volume_versions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_run_id": {
+          "name": "last_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retry_started_at": {
+          "name": "retry_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consecutive_failures": {
+          "name": "consecutive_failures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_schedules_compose_name": {
+          "name": "idx_agent_schedules_compose_name",
+          "columns": [
+            {
+              "expression": "compose_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_schedules_compose": {
+          "name": "idx_agent_schedules_compose",
+          "columns": [
+            {
+              "expression": "compose_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_schedules_next_run": {
+          "name": "idx_agent_schedules_next_run",
+          "columns": [
+            {
+              "expression": "next_run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "enabled = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_schedules_compose_id_agent_composes_id_fk": {
+          "name": "agent_schedules_compose_id_agent_composes_id_fk",
+          "tableFrom": "agent_schedules",
+          "tableTo": "agent_composes",
+          "columnsFrom": [
+            "compose_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_schedules_last_run_id_agent_runs_id_fk": {
+          "name": "agent_schedules_last_run_id_agent_runs_id_fk",
+          "tableFrom": "agent_schedules",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "last_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_sessions": {
+      "name": "agent_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_compose_id": {
+          "name": "agent_compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artifact_name": {
+          "name": "artifact_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chat_messages": {
+          "name": "chat_messages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_sessions_user_compose_artifact": {
+          "name": "idx_agent_sessions_user_compose_artifact",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_compose_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "artifact_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_sessions_agent_compose_id_agent_composes_id_fk": {
+          "name": "agent_sessions_agent_compose_id_agent_composes_id_fk",
+          "tableFrom": "agent_sessions",
+          "tableTo": "agent_composes",
+          "columnsFrom": [
+            "agent_compose_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_sessions_conversation_id_conversations_id_fk": {
+          "name": "agent_sessions_conversation_id_conversations_id_fk",
+          "tableFrom": "agent_sessions",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blobs": {
+      "name": "blobs",
+      "schema": "",
+      "columns": {
+        "hash": {
+          "name": "hash",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref_count": {
+          "name": "ref_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_blobs_ref_count": {
+          "name": "idx_blobs_ref_count",
+          "columns": [
+            {
+              "expression": "ref_count",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.checkpoints": {
+      "name": "checkpoints",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_compose_snapshot": {
+          "name": "agent_compose_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_snapshot": {
+          "name": "artifact_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "volume_versions_snapshot": {
+          "name": "volume_versions_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "checkpoints_run_id_agent_runs_id_fk": {
+          "name": "checkpoints_run_id_agent_runs_id_fk",
+          "tableFrom": "checkpoints",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "checkpoints_conversation_id_conversations_id_fk": {
+          "name": "checkpoints_conversation_id_conversations_id_fk",
+          "tableFrom": "checkpoints",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "checkpoints_run_id_unique": {
+          "name": "checkpoints_run_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "run_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cli_tokens": {
+      "name": "cli_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cli_tokens_token_unique": {
+          "name": "cli_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.compose_jobs": {
+      "name": "compose_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_url": {
+          "name": "github_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "overwrite": {
+          "name": "overwrite",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'github'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_compose_jobs_user_status": {
+          "name": "idx_compose_jobs_user_status",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_compose_jobs_created": {
+          "name": "idx_compose_jobs_created",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.connector_sessions": {
+      "name": "connector_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(9)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "connector_session_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_connector_sessions_code": {
+          "name": "idx_connector_sessions_code",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_connector_sessions_user_status": {
+          "name": "idx_connector_sessions_user_status",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.connectors": {
+      "name": "connectors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_method": {
+          "name": "auth_method",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_username": {
+          "name": "external_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_email": {
+          "name": "external_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_scopes": {
+          "name": "oauth_scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_connectors_scope_type": {
+          "name": "idx_connectors_scope_type",
+          "columns": [
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_connectors_scope": {
+          "name": "idx_connectors_scope",
+          "columns": [
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "connectors_scope_id_scopes_id_fk": {
+          "name": "connectors_scope_id_scopes_id_fk",
+          "tableFrom": "connectors",
+          "tableTo": "scopes",
+          "columnsFrom": [
+            "scope_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversations": {
+      "name": "conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cli_agent_type": {
+          "name": "cli_agent_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cli_agent_session_id": {
+          "name": "cli_agent_session_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cli_agent_session_history": {
+          "name": "cli_agent_session_history",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cli_agent_session_history_hash": {
+          "name": "cli_agent_session_history_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "conversations_run_id_agent_runs_id_fk": {
+          "name": "conversations_run_id_agent_runs_id_fk",
+          "tableFrom": "conversations",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "conversations_run_id_unique": {
+          "name": "conversations_run_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "run_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.device_codes": {
+      "name": "device_codes",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "varchar(9)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "device_code_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_reply_requests": {
+      "name": "email_reply_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_thread_session_id": {
+          "name": "email_thread_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inbound_email_id": {
+          "name": "inbound_email_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inbound_message_id": {
+          "name": "inbound_message_id",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_email_reply_requests_run": {
+          "name": "idx_email_reply_requests_run",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_reply_requests_run_id_agent_runs_id_fk": {
+          "name": "email_reply_requests_run_id_agent_runs_id_fk",
+          "tableFrom": "email_reply_requests",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "email_reply_requests_email_thread_session_id_email_thread_sessions_id_fk": {
+          "name": "email_reply_requests_email_thread_session_id_email_thread_sessions_id_fk",
+          "tableFrom": "email_reply_requests",
+          "tableTo": "email_thread_sessions",
+          "columnsFrom": [
+            "email_thread_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_thread_sessions": {
+      "name": "email_thread_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "compose_id": {
+          "name": "compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_session_id": {
+          "name": "agent_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_email_message_id": {
+          "name": "last_email_message_id",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_to_token": {
+          "name": "reply_to_token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_email_thread_sessions_reply_token": {
+          "name": "idx_email_thread_sessions_reply_token",
+          "columns": [
+            {
+              "expression": "reply_to_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_email_thread_sessions_user": {
+          "name": "idx_email_thread_sessions_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_thread_sessions_compose_id_agent_composes_id_fk": {
+          "name": "email_thread_sessions_compose_id_agent_composes_id_fk",
+          "tableFrom": "email_thread_sessions",
+          "tableTo": "agent_composes",
+          "columnsFrom": [
+            "compose_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "email_thread_sessions_agent_session_id_agent_sessions_id_fk": {
+          "name": "email_thread_sessions_agent_session_id_agent_sessions_id_fk",
+          "tableFrom": "email_thread_sessions",
+          "tableTo": "agent_sessions",
+          "columnsFrom": [
+            "agent_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_installations": {
+      "name": "github_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_access_token": {
+          "name": "encrypted_access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_compose_id": {
+          "name": "default_compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_configs": {
+          "name": "repo_configs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "target_name": {
+          "name": "target_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "admin_github_user_id": {
+          "name": "admin_github_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "github_installations_installation_id_unique": {
+          "name": "github_installations_installation_id_unique",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "installation_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_installations_default_compose_id_agent_composes_id_fk": {
+          "name": "github_installations_default_compose_id_agent_composes_id_fk",
+          "tableFrom": "github_installations",
+          "tableTo": "agent_composes",
+          "columnsFrom": [
+            "default_compose_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_issue_sessions": {
+      "name": "github_issue_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo": {
+          "name": "repo",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_number": {
+          "name": "issue_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_session_id": {
+          "name": "agent_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_comment_id": {
+          "name": "last_comment_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_github_issue_sessions_installation_repo_issue": {
+          "name": "idx_github_issue_sessions_installation_repo_issue",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "repo",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "issue_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_github_issue_sessions_installation": {
+          "name": "idx_github_issue_sessions_installation",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_issue_sessions_installation_id_github_installations_id_fk": {
+          "name": "github_issue_sessions_installation_id_github_installations_id_fk",
+          "tableFrom": "github_issue_sessions",
+          "tableTo": "github_installations",
+          "columnsFrom": [
+            "installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_issue_sessions_agent_session_id_agent_sessions_id_fk": {
+          "name": "github_issue_sessions_agent_session_id_agent_sessions_id_fk",
+          "tableFrom": "github_issue_sessions",
+          "tableTo": "agent_sessions",
+          "columnsFrom": [
+            "agent_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_providers": {
+      "name": "model_providers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_id": {
+          "name": "secret_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_method": {
+          "name": "auth_method",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "selected_model": {
+          "name": "selected_model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_model_providers_scope_type": {
+          "name": "idx_model_providers_scope_type",
+          "columns": [
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_model_providers_scope": {
+          "name": "idx_model_providers_scope",
+          "columns": [
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_model_providers_secret": {
+          "name": "idx_model_providers_secret",
+          "columns": [
+            {
+              "expression": "secret_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "model_providers_scope_id_scopes_id_fk": {
+          "name": "model_providers_scope_id_scopes_id_fk",
+          "tableFrom": "model_providers",
+          "tableTo": "scopes",
+          "columnsFrom": [
+            "scope_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "model_providers_secret_id_secrets_id_fk": {
+          "name": "model_providers_secret_id_secrets_id_fk",
+          "tableFrom": "model_providers",
+          "tableTo": "secrets",
+          "columnsFrom": [
+            "secret_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_access_tokens": {
+      "name": "org_access_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_org_access_tokens_user_scope": {
+          "name": "idx_org_access_tokens_user_scope",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_access_tokens_scope_id_scopes_id_fk": {
+          "name": "org_access_tokens_scope_id_scopes_id_fk",
+          "tableFrom": "org_access_tokens",
+          "tableTo": "scopes",
+          "columnsFrom": [
+            "scope_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "org_access_tokens_token_unique": {
+          "name": "org_access_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runner_job_queue": {
+      "name": "runner_job_queue",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "runner_group": {
+          "name": "runner_group",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_context": {
+          "name": "execution_context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "runner_job_queue_group_unclaimed_idx": {
+          "name": "runner_job_queue_group_unclaimed_idx",
+          "columns": [
+            {
+              "expression": "runner_group",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "claimed_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runner_job_queue_expires_at_idx": {
+          "name": "runner_job_queue_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "runner_job_queue_run_id_agent_runs_id_fk": {
+          "name": "runner_job_queue_run_id_agent_runs_id_fk",
+          "tableFrom": "runner_job_queue",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sandbox_telemetry": {
+      "name": "sandbox_telemetry",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_sandbox_telemetry_run_id": {
+          "name": "idx_sandbox_telemetry_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sandbox_telemetry_run_id_agent_runs_id_fk": {
+          "name": "sandbox_telemetry_run_id_agent_runs_id_fk",
+          "tableFrom": "sandbox_telemetry",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scopes": {
+      "name": "scopes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "scope_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'personal'"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clerk_org_id": {
+          "name": "clerk_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notify_email": {
+          "name": "notify_email",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "notify_slack": {
+          "name": "notify_slack",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_scopes_owner": {
+          "name": "idx_scopes_owner",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_scopes_type": {
+          "name": "idx_scopes_type",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_scopes_clerk_org": {
+          "name": "idx_scopes_clerk_org",
+          "columns": [
+            {
+              "expression": "clerk_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "scopes_slug_unique": {
+          "name": "scopes_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.secrets": {
+      "name": "secrets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_value": {
+          "name": "encrypted_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_secrets_scope_name_type": {
+          "name": "idx_secrets_scope_name_type",
+          "columns": [
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_secrets_scope": {
+          "name": "idx_secrets_scope",
+          "columns": [
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_secrets_type": {
+          "name": "idx_secrets_type",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "secrets_scope_id_scopes_id_fk": {
+          "name": "secrets_scope_id_scopes_id_fk",
+          "tableFrom": "secrets",
+          "tableTo": "scopes",
+          "columnsFrom": [
+            "scope_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_compose_requests": {
+      "name": "slack_compose_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "compose_job_id": {
+          "name": "compose_job_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_workspace_id": {
+          "name": "slack_workspace_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_user_id": {
+          "name": "slack_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_channel_id": {
+          "name": "slack_channel_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_slack_compose_requests_job": {
+          "name": "idx_slack_compose_requests_job",
+          "columns": [
+            {
+              "expression": "compose_job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "slack_compose_requests_compose_job_id_compose_jobs_id_fk": {
+          "name": "slack_compose_requests_compose_job_id_compose_jobs_id_fk",
+          "tableFrom": "slack_compose_requests",
+          "tableTo": "compose_jobs",
+          "columnsFrom": [
+            "compose_job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_installations": {
+      "name": "slack_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slack_workspace_id": {
+          "name": "slack_workspace_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_workspace_name": {
+          "name": "slack_workspace_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_bot_token": {
+          "name": "encrypted_bot_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bot_user_id": {
+          "name": "bot_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_compose_id": {
+          "name": "default_compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "admin_slack_user_id": {
+          "name": "admin_slack_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "slack_installations_default_compose_id_agent_composes_id_fk": {
+          "name": "slack_installations_default_compose_id_agent_composes_id_fk",
+          "tableFrom": "slack_installations",
+          "tableTo": "agent_composes",
+          "columnsFrom": [
+            "default_compose_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "slack_installations_slack_workspace_id_unique": {
+          "name": "slack_installations_slack_workspace_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slack_workspace_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_pending_questions": {
+      "name": "slack_pending_questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_workspace_id": {
+          "name": "slack_workspace_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_channel_id": {
+          "name": "slack_channel_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_thread_ts": {
+          "name": "slack_thread_ts",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_message_ts": {
+          "name": "slack_message_ts",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_link_id": {
+          "name": "user_link_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "compose_id": {
+          "name": "compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "questions": {
+          "name": "questions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "answered_at": {
+          "name": "answered_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_slack_pending_questions_run_id": {
+          "name": "idx_slack_pending_questions_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_thread_sessions": {
+      "name": "slack_thread_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slack_user_link_id": {
+          "name": "slack_user_link_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_channel_id": {
+          "name": "slack_channel_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_thread_ts": {
+          "name": "slack_thread_ts",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_session_id": {
+          "name": "agent_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_processed_message_ts": {
+          "name": "last_processed_message_ts",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_slack_thread_sessions_thread_user_link": {
+          "name": "idx_slack_thread_sessions_thread_user_link",
+          "columns": [
+            {
+              "expression": "slack_user_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slack_channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slack_thread_ts",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_slack_thread_sessions_user_link": {
+          "name": "idx_slack_thread_sessions_user_link",
+          "columns": [
+            {
+              "expression": "slack_user_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "slack_thread_sessions_slack_user_link_id_slack_user_links_id_fk": {
+          "name": "slack_thread_sessions_slack_user_link_id_slack_user_links_id_fk",
+          "tableFrom": "slack_thread_sessions",
+          "tableTo": "slack_user_links",
+          "columnsFrom": [
+            "slack_user_link_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "slack_thread_sessions_agent_session_id_agent_sessions_id_fk": {
+          "name": "slack_thread_sessions_agent_session_id_agent_sessions_id_fk",
+          "tableFrom": "slack_thread_sessions",
+          "tableTo": "agent_sessions",
+          "columnsFrom": [
+            "agent_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_user_links": {
+      "name": "slack_user_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slack_user_id": {
+          "name": "slack_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_workspace_id": {
+          "name": "slack_workspace_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vm0_user_id": {
+          "name": "vm0_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dm_welcome_sent": {
+          "name": "dm_welcome_sent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_slack_user_links_user_workspace": {
+          "name": "idx_slack_user_links_user_workspace",
+          "columns": [
+            {
+              "expression": "slack_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slack_workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.storage_versions": {
+      "name": "storage_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "storage_id": {
+          "name": "storage_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "file_count": {
+          "name": "file_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "storage_versions_storage_id_storages_id_fk": {
+          "name": "storage_versions_storage_id_storages_id_fk",
+          "tableFrom": "storage_versions",
+          "tableTo": "storages",
+          "columnsFrom": [
+            "storage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.storages": {
+      "name": "storages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'volume'"
+        },
+        "s3_prefix": {
+          "name": "s3_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "file_count": {
+          "name": "file_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "head_version_id": {
+          "name": "head_version_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_storages_scope_name_type": {
+          "name": "idx_storages_scope_name_type",
+          "columns": [
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_storages_scope": {
+          "name": "idx_storages_scope",
+          "columns": [
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "storages_scope_id_scopes_id_fk": {
+          "name": "storages_scope_id_scopes_id_fk",
+          "tableFrom": "storages",
+          "tableTo": "scopes",
+          "columnsFrom": [
+            "scope_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "storages_head_version_id_storage_versions_id_fk": {
+          "name": "storages_head_version_id_storage_versions_id_fk",
+          "tableFrom": "storages",
+          "tableTo": "storage_versions",
+          "columnsFrom": [
+            "head_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_installations": {
+      "name": "telegram_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "telegram_bot_id": {
+          "name": "telegram_bot_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bot_username": {
+          "name": "bot_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_bot_token": {
+          "name": "encrypted_bot_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhook_secret": {
+          "name": "webhook_secret",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_compose_id": {
+          "name": "default_compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "admin_user_id": {
+          "name": "admin_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "telegram_installations_default_compose_id_agent_composes_id_fk": {
+          "name": "telegram_installations_default_compose_id_agent_composes_id_fk",
+          "tableFrom": "telegram_installations",
+          "tableTo": "agent_composes",
+          "columnsFrom": [
+            "default_compose_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "telegram_installations_telegram_bot_id_unique": {
+          "name": "telegram_installations_telegram_bot_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "telegram_bot_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_messages": {
+      "name": "telegram_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_user_id": {
+          "name": "from_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_username": {
+          "name": "from_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_bot": {
+          "name": "is_bot",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_telegram_messages_unique": {
+          "name": "idx_telegram_messages_unique",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_telegram_messages_chat": {
+          "name": "idx_telegram_messages_chat",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_telegram_messages_created_at": {
+          "name": "idx_telegram_messages_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "telegram_messages_installation_id_telegram_installations_id_fk": {
+          "name": "telegram_messages_installation_id_telegram_installations_id_fk",
+          "tableFrom": "telegram_messages",
+          "tableTo": "telegram_installations",
+          "columnsFrom": [
+            "installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_thread_sessions": {
+      "name": "telegram_thread_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "telegram_user_link_id": {
+          "name": "telegram_user_link_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "root_message_id": {
+          "name": "root_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_session_id": {
+          "name": "agent_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_processed_message_id": {
+          "name": "last_processed_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_telegram_thread_sessions_chat_user_link": {
+          "name": "idx_telegram_thread_sessions_chat_user_link",
+          "columns": [
+            {
+              "expression": "telegram_user_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "root_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_telegram_thread_sessions_user_link": {
+          "name": "idx_telegram_thread_sessions_user_link",
+          "columns": [
+            {
+              "expression": "telegram_user_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "telegram_thread_sessions_telegram_user_link_id_telegram_user_links_id_fk": {
+          "name": "telegram_thread_sessions_telegram_user_link_id_telegram_user_links_id_fk",
+          "tableFrom": "telegram_thread_sessions",
+          "tableTo": "telegram_user_links",
+          "columnsFrom": [
+            "telegram_user_link_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "telegram_thread_sessions_agent_session_id_agent_sessions_id_fk": {
+          "name": "telegram_thread_sessions_agent_session_id_agent_sessions_id_fk",
+          "tableFrom": "telegram_thread_sessions",
+          "tableTo": "agent_sessions",
+          "columnsFrom": [
+            "agent_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_user_links": {
+      "name": "telegram_user_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "telegram_user_id": {
+          "name": "telegram_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vm0_user_id": {
+          "name": "vm0_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dm_welcome_sent": {
+          "name": "dm_welcome_sent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_telegram_user_links_user_installation": {
+          "name": "idx_telegram_user_links_user_installation",
+          "columns": [
+            {
+              "expression": "telegram_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "telegram_user_links_installation_id_telegram_installations_id_fk": {
+          "name": "telegram_user_links_installation_id_telegram_installations_id_fk",
+          "tableFrom": "telegram_user_links",
+          "tableTo": "telegram_installations",
+          "columnsFrom": [
+            "installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.usage_daily": {
+      "name": "usage_daily",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_count": {
+          "name": "run_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "run_time_ms": {
+          "name": "run_time_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_usage_daily_user_date": {
+          "name": "uq_usage_daily_user_date",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_users_scope": {
+          "name": "idx_users_scope",
+          "columns": [
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_scope_id_scopes_id_fk": {
+          "name": "users_scope_id_scopes_id_fk",
+          "tableFrom": "users",
+          "tableTo": "scopes",
+          "columnsFrom": [
+            "scope_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.variables": {
+      "name": "variables",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_variables_scope_name": {
+          "name": "idx_variables_scope_name",
+          "columns": [
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_variables_scope": {
+          "name": "idx_variables_scope",
+          "columns": [
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "variables_scope_id_scopes_id_fk": {
+          "name": "variables_scope_id_scopes_id_fk",
+          "tableFrom": "variables",
+          "tableTo": "scopes",
+          "columnsFrom": [
+            "scope_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_user_links": {
+      "name": "github_user_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "github_user_id": {
+          "name": "github_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vm0_user_id": {
+          "name": "vm0_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_github_user_links_user_installation": {
+          "name": "idx_github_user_links_user_installation",
+          "columns": [
+            {
+              "expression": "github_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_user_links_installation_id_github_installations_id_fk": {
+          "name": "github_user_links_installation_id_github_installations_id_fk",
+          "tableFrom": "github_user_links",
+          "tableTo": "github_installations",
+          "columnsFrom": [
+            "installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.connector_session_status": {
+      "name": "connector_session_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "complete",
+        "expired",
+        "error"
+      ]
+    },
+    "public.device_code_status": {
+      "name": "device_code_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "authenticated",
+        "expired",
+        "denied"
+      ]
+    },
+    "public.scope_type": {
+      "name": "scope_type",
+      "schema": "public",
+      "values": [
+        "personal",
+        "organization"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/turbo/apps/web/src/db/migrations/meta/0102_snapshot.json
+++ b/turbo/apps/web/src/db/migrations/meta/0102_snapshot.json
@@ -62,12 +62,8 @@
           "name": "agent_compose_versions_compose_id_agent_composes_id_fk",
           "tableFrom": "agent_compose_versions",
           "tableTo": "agent_composes",
-          "columnsFrom": [
-            "compose_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["compose_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -172,12 +168,8 @@
           "name": "agent_composes_scope_id_scopes_id_fk",
           "tableFrom": "agent_composes",
           "tableTo": "scopes",
-          "columnsFrom": [
-            "scope_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["scope_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -282,12 +274,8 @@
           "name": "agent_permissions_agent_compose_id_agent_composes_id_fk",
           "tableFrom": "agent_permissions",
           "tableTo": "agent_composes",
-          "columnsFrom": [
-            "agent_compose_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_compose_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -297,11 +285,7 @@
         "agent_permissions_compose_type_email_unique": {
           "name": "agent_permissions_compose_type_email_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "agent_compose_id",
-            "grantee_type",
-            "grantee_email"
-          ]
+          "columns": ["agent_compose_id", "grantee_type", "grantee_email"]
         }
       },
       "policies": {},
@@ -421,12 +405,8 @@
           "name": "agent_run_callbacks_run_id_agent_runs_id_fk",
           "tableFrom": "agent_run_callbacks",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -486,12 +466,8 @@
           "name": "agent_run_events_run_id_agent_runs_id_fk",
           "tableFrom": "agent_run_events",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -588,12 +564,8 @@
           "name": "agent_run_events_local_run_id_agent_runs_id_fk",
           "tableFrom": "agent_run_events_local",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -800,12 +772,8 @@
           "name": "agent_runs_agent_compose_version_id_agent_compose_versions_id_fk",
           "tableFrom": "agent_runs",
           "tableTo": "agent_compose_versions",
-          "columnsFrom": [
-            "agent_compose_version_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_compose_version_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         },
@@ -813,12 +781,8 @@
           "name": "agent_runs_schedule_id_agent_schedules_id_fk",
           "tableFrom": "agent_runs",
           "tableTo": "agent_schedules",
-          "columnsFrom": [
-            "schedule_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["schedule_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -1032,12 +996,8 @@
           "name": "agent_schedules_compose_id_agent_composes_id_fk",
           "tableFrom": "agent_schedules",
           "tableTo": "agent_composes",
-          "columnsFrom": [
-            "compose_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["compose_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -1045,12 +1005,8 @@
           "name": "agent_schedules_last_run_id_agent_runs_id_fk",
           "tableFrom": "agent_schedules",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "last_run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["last_run_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -1152,12 +1108,8 @@
           "name": "agent_sessions_agent_compose_id_agent_composes_id_fk",
           "tableFrom": "agent_sessions",
           "tableTo": "agent_composes",
-          "columnsFrom": [
-            "agent_compose_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_compose_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -1165,12 +1117,8 @@
           "name": "agent_sessions_conversation_id_conversations_id_fk",
           "tableFrom": "agent_sessions",
           "tableTo": "conversations",
-          "columnsFrom": [
-            "conversation_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -1291,12 +1239,8 @@
           "name": "checkpoints_run_id_agent_runs_id_fk",
           "tableFrom": "checkpoints",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -1304,12 +1248,8 @@
           "name": "checkpoints_conversation_id_conversations_id_fk",
           "tableFrom": "checkpoints",
           "tableTo": "conversations",
-          "columnsFrom": [
-            "conversation_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -1319,9 +1259,7 @@
         "checkpoints_run_id_unique": {
           "name": "checkpoints_run_id_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "run_id"
-          ]
+          "columns": ["run_id"]
         }
       },
       "policies": {},
@@ -1384,9 +1322,7 @@
         "cli_tokens_token_unique": {
           "name": "cli_tokens_token_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "token"
-          ]
+          "columns": ["token"]
         }
       },
       "policies": {},
@@ -1756,12 +1692,8 @@
           "name": "connectors_scope_id_scopes_id_fk",
           "tableFrom": "connectors",
           "tableTo": "scopes",
-          "columnsFrom": [
-            "scope_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["scope_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -1827,12 +1759,8 @@
           "name": "conversations_run_id_agent_runs_id_fk",
           "tableFrom": "conversations",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -1842,9 +1770,7 @@
         "conversations_run_id_unique": {
           "name": "conversations_run_id_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "run_id"
-          ]
+          "columns": ["run_id"]
         }
       },
       "policies": {},
@@ -1969,12 +1895,8 @@
           "name": "email_reply_requests_run_id_agent_runs_id_fk",
           "tableFrom": "email_reply_requests",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -1982,12 +1904,8 @@
           "name": "email_reply_requests_email_thread_session_id_email_thread_sessions_id_fk",
           "tableFrom": "email_reply_requests",
           "tableTo": "email_thread_sessions",
-          "columnsFrom": [
-            "email_thread_session_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["email_thread_session_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -2091,12 +2009,8 @@
           "name": "email_thread_sessions_compose_id_agent_composes_id_fk",
           "tableFrom": "email_thread_sessions",
           "tableTo": "agent_composes",
-          "columnsFrom": [
-            "compose_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["compose_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -2104,12 +2018,8 @@
           "name": "email_thread_sessions_agent_session_id_agent_sessions_id_fk",
           "tableFrom": "email_thread_sessions",
           "tableTo": "agent_sessions",
-          "columnsFrom": [
-            "agent_session_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_session_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -2224,12 +2134,8 @@
           "name": "github_installations_default_compose_id_agent_composes_id_fk",
           "tableFrom": "github_installations",
           "tableTo": "agent_composes",
-          "columnsFrom": [
-            "default_compose_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["default_compose_id"],
+          "columnsTo": ["id"],
           "onDelete": "restrict",
           "onUpdate": "no action"
         }
@@ -2351,12 +2257,8 @@
           "name": "github_issue_sessions_installation_id_github_installations_id_fk",
           "tableFrom": "github_issue_sessions",
           "tableTo": "github_installations",
-          "columnsFrom": [
-            "installation_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["installation_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -2364,12 +2266,8 @@
           "name": "github_issue_sessions_agent_session_id_agent_sessions_id_fk",
           "tableFrom": "github_issue_sessions",
           "tableTo": "agent_sessions",
-          "columnsFrom": [
-            "agent_session_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_session_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -2501,12 +2399,8 @@
           "name": "model_providers_scope_id_scopes_id_fk",
           "tableFrom": "model_providers",
           "tableTo": "scopes",
-          "columnsFrom": [
-            "scope_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["scope_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -2514,12 +2408,8 @@
           "name": "model_providers_secret_id_secrets_id_fk",
           "tableFrom": "model_providers",
           "tableTo": "secrets",
-          "columnsFrom": [
-            "secret_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["secret_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -2614,12 +2504,8 @@
           "name": "org_access_tokens_scope_id_scopes_id_fk",
           "tableFrom": "org_access_tokens",
           "tableTo": "scopes",
-          "columnsFrom": [
-            "scope_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["scope_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -2629,9 +2515,7 @@
         "org_access_tokens_token_unique": {
           "name": "org_access_tokens_token_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "token"
-          ]
+          "columns": ["token"]
         }
       },
       "policies": {},
@@ -2718,12 +2602,8 @@
           "name": "runner_job_queue_run_id_agent_runs_id_fk",
           "tableFrom": "runner_job_queue",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -2787,12 +2667,8 @@
           "name": "sandbox_telemetry_run_id_agent_runs_id_fk",
           "tableFrom": "sandbox_telemetry",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -2928,9 +2804,7 @@
         "scopes_slug_unique": {
           "name": "scopes_slug_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "slug"
-          ]
+          "columns": ["slug"]
         }
       },
       "policies": {},
@@ -3058,12 +2932,8 @@
           "name": "secrets_scope_id_scopes_id_fk",
           "tableFrom": "secrets",
           "tableTo": "scopes",
-          "columnsFrom": [
-            "scope_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["scope_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -3139,12 +3009,8 @@
           "name": "slack_compose_requests_compose_job_id_compose_jobs_id_fk",
           "tableFrom": "slack_compose_requests",
           "tableTo": "compose_jobs",
-          "columnsFrom": [
-            "compose_job_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["compose_job_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -3223,12 +3089,8 @@
           "name": "slack_installations_default_compose_id_agent_composes_id_fk",
           "tableFrom": "slack_installations",
           "tableTo": "agent_composes",
-          "columnsFrom": [
-            "default_compose_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["default_compose_id"],
+          "columnsTo": ["id"],
           "onDelete": "restrict",
           "onUpdate": "no action"
         }
@@ -3238,9 +3100,7 @@
         "slack_installations_slack_workspace_id_unique": {
           "name": "slack_installations_slack_workspace_id_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "slack_workspace_id"
-          ]
+          "columns": ["slack_workspace_id"]
         }
       },
       "policies": {},
@@ -3467,12 +3327,8 @@
           "name": "slack_thread_sessions_slack_user_link_id_slack_user_links_id_fk",
           "tableFrom": "slack_thread_sessions",
           "tableTo": "slack_user_links",
-          "columnsFrom": [
-            "slack_user_link_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["slack_user_link_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -3480,12 +3336,8 @@
           "name": "slack_thread_sessions_agent_session_id_agent_sessions_id_fk",
           "tableFrom": "slack_thread_sessions",
           "tableTo": "agent_sessions",
-          "columnsFrom": [
-            "agent_session_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_session_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -3632,12 +3484,8 @@
           "name": "storage_versions_storage_id_storages_id_fk",
           "tableFrom": "storage_versions",
           "tableTo": "storages",
-          "columnsFrom": [
-            "storage_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["storage_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -3774,12 +3622,8 @@
           "name": "storages_scope_id_scopes_id_fk",
           "tableFrom": "storages",
           "tableTo": "scopes",
-          "columnsFrom": [
-            "scope_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["scope_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -3787,12 +3631,8 @@
           "name": "storages_head_version_id_storage_versions_id_fk",
           "tableFrom": "storages",
           "tableTo": "storage_versions",
-          "columnsFrom": [
-            "head_version_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["head_version_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -3871,12 +3711,8 @@
           "name": "telegram_installations_default_compose_id_agent_composes_id_fk",
           "tableFrom": "telegram_installations",
           "tableTo": "agent_composes",
-          "columnsFrom": [
-            "default_compose_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["default_compose_id"],
+          "columnsTo": ["id"],
           "onDelete": "restrict",
           "onUpdate": "no action"
         }
@@ -3886,9 +3722,7 @@
         "telegram_installations_telegram_bot_id_unique": {
           "name": "telegram_installations_telegram_bot_id_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "telegram_bot_id"
-          ]
+          "columns": ["telegram_bot_id"]
         }
       },
       "policies": {},
@@ -4027,12 +3861,8 @@
           "name": "telegram_messages_installation_id_telegram_installations_id_fk",
           "tableFrom": "telegram_messages",
           "tableTo": "telegram_installations",
-          "columnsFrom": [
-            "installation_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["installation_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -4148,12 +3978,8 @@
           "name": "telegram_thread_sessions_telegram_user_link_id_telegram_user_links_id_fk",
           "tableFrom": "telegram_thread_sessions",
           "tableTo": "telegram_user_links",
-          "columnsFrom": [
-            "telegram_user_link_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["telegram_user_link_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -4161,12 +3987,8 @@
           "name": "telegram_thread_sessions_agent_session_id_agent_sessions_id_fk",
           "tableFrom": "telegram_thread_sessions",
           "tableTo": "agent_sessions",
-          "columnsFrom": [
-            "agent_session_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_session_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -4256,12 +4078,8 @@
           "name": "telegram_user_links_installation_id_telegram_installations_id_fk",
           "tableFrom": "telegram_user_links",
           "tableTo": "telegram_installations",
-          "columnsFrom": [
-            "installation_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["installation_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -4408,12 +4226,8 @@
           "name": "users_scope_id_scopes_id_fk",
           "tableFrom": "users",
           "tableTo": "scopes",
-          "columnsFrom": [
-            "scope_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["scope_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -4517,12 +4331,8 @@
           "name": "variables_scope_id_scopes_id_fk",
           "tableFrom": "variables",
           "tableTo": "scopes",
-          "columnsFrom": [
-            "scope_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["scope_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -4598,12 +4408,8 @@
           "name": "github_user_links_installation_id_github_installations_id_fk",
           "tableFrom": "github_user_links",
           "tableTo": "github_installations",
-          "columnsFrom": [
-            "installation_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["installation_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -4619,30 +4425,17 @@
     "public.connector_session_status": {
       "name": "connector_session_status",
       "schema": "public",
-      "values": [
-        "pending",
-        "complete",
-        "expired",
-        "error"
-      ]
+      "values": ["pending", "complete", "expired", "error"]
     },
     "public.device_code_status": {
       "name": "device_code_status",
       "schema": "public",
-      "values": [
-        "pending",
-        "authenticated",
-        "expired",
-        "denied"
-      ]
+      "values": ["pending", "authenticated", "expired", "denied"]
     },
     "public.scope_type": {
       "name": "scope_type",
       "schema": "public",
-      "values": [
-        "personal",
-        "organization"
-      ]
+      "values": ["personal", "organization"]
     }
   },
   "schemas": {},

--- a/turbo/apps/web/src/db/migrations/meta/_journal.json
+++ b/turbo/apps/web/src/db/migrations/meta/_journal.json
@@ -715,6 +715,13 @@
       "when": 1772601676707,
       "tag": "0101_chemical_terror",
       "breakpoints": true
+    },
+    {
+      "idx": 102,
+      "version": "7",
+      "when": 1772606887912,
+      "tag": "0102_github_user_links",
+      "breakpoints": true
     }
   ]
 }

--- a/turbo/apps/web/src/db/schema/github-installation.ts
+++ b/turbo/apps/web/src/db/schema/github-installation.ts
@@ -13,18 +13,20 @@ import { agentComposes } from "./agent-compose";
 /**
  * GitHub Installations table
  * Stores GitHub App installation data and default agent configuration.
- * One record per GitHub App installation (user or org level).
+ * One record per GitHub App installation (org or user account level).
+ * User association is managed via the github_user_links table.
  */
 export const githubInstallations = pgTable(
   "github_installations",
   {
     id: uuid("id").defaultRandom().primaryKey(),
-    userId: text("user_id").notNull(),
     installationId: varchar("installation_id", { length: 255 }),
     encryptedAccessToken: text("encrypted_access_token"),
     status: varchar("status", { length: 20 }).notNull().default("active"),
     targetType: varchar("target_type", { length: 20 }),
     targetId: varchar("target_id", { length: 255 }),
+    targetName: varchar("target_name", { length: 255 }),
+    adminGithubUserId: varchar("admin_github_user_id", { length: 255 }),
     defaultComposeId: uuid("default_compose_id")
       .notNull()
       .references(() => agentComposes.id, { onDelete: "restrict" }),

--- a/turbo/apps/web/src/db/schema/github-user-link.ts
+++ b/turbo/apps/web/src/db/schema/github-user-link.ts
@@ -1,0 +1,35 @@
+import {
+  pgTable,
+  uuid,
+  varchar,
+  text,
+  timestamp,
+  uniqueIndex,
+} from "drizzle-orm/pg-core";
+import { githubInstallations } from "./github-installation";
+
+/**
+ * GitHub User Links table
+ * Maps GitHub users to VM0 users for account linking.
+ * Allows multiple VM0 users to link to the same GitHub org installation.
+ */
+export const githubUserLinks = pgTable(
+  "github_user_links",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    githubUserId: varchar("github_user_id", { length: 255 }).notNull(),
+    installationId: uuid("installation_id")
+      .notNull()
+      .references(() => githubInstallations.id, { onDelete: "cascade" }),
+    // VM0 user ID (Clerk user ID)
+    vm0UserId: text("vm0_user_id").notNull(),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+  },
+  (table) => [
+    // Each GitHub user can only link to one VM0 user per installation
+    uniqueIndex("idx_github_user_links_user_installation").on(
+      table.githubUserId,
+      table.installationId,
+    ),
+  ],
+);

--- a/turbo/apps/web/src/lib/github/github-app.ts
+++ b/turbo/apps/web/src/lib/github/github-app.ts
@@ -74,6 +74,50 @@ export async function getInstallationAccessToken(
   return { token: data.token, expiresAt: data.expires_at };
 }
 
+/**
+ * Get installation details from the GitHub API.
+ *
+ * Uses the App JWT to fetch the installation's account info
+ * (target type, ID, and display name).
+ */
+export async function getInstallationInfo(
+  appId: string,
+  privateKeyBase64: string,
+  installationId: string,
+): Promise<{
+  targetType: string;
+  targetId: string;
+  targetName: string;
+}> {
+  const jwt = createAppJWT(appId, privateKeyBase64);
+
+  const res = await fetch(
+    `https://api.github.com/app/installations/${installationId}`,
+    {
+      headers: {
+        Authorization: `Bearer ${jwt}`,
+        Accept: "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+    },
+  );
+
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`Failed to get installation info: ${res.status} ${body}`);
+  }
+
+  const data = (await res.json()) as {
+    account: { id: number; login: string; type: string };
+  };
+
+  return {
+    targetType: data.account.type,
+    targetId: String(data.account.id),
+    targetName: data.account.login,
+  };
+}
+
 function base64url(str: string): string {
   return Buffer.from(str)
     .toString("base64")

--- a/turbo/apps/web/src/lib/github/handlers/installation-event.ts
+++ b/turbo/apps/web/src/lib/github/handlers/installation-event.ts
@@ -12,6 +12,7 @@ const log = logger("github:installation-event");
 
 const gitHubInstallationAccountSchema = z.object({
   id: z.number(),
+  login: z.string(),
   type: z.string(),
 });
 
@@ -20,9 +21,15 @@ const gitHubInstallationSchema = z.object({
   account: gitHubInstallationAccountSchema,
 });
 
+const gitHubSenderSchema = z.object({
+  id: z.number(),
+  login: z.string(),
+});
+
 export const gitHubInstallationEventSchema = z.object({
   action: z.string(),
   installation: gitHubInstallationSchema,
+  sender: gitHubSenderSchema.optional(),
 });
 
 type GitHubInstallationEvent = z.infer<typeof gitHubInstallationEventSchema>;
@@ -85,6 +92,9 @@ export async function handleInstallationCreatedEvent(
     SECRETS_ENCRYPTION_KEY,
   );
 
+  // Set adminGithubUserId from webhook sender if available
+  const adminGithubUserId = payload.sender ? String(payload.sender.id) : null;
+
   // Activate the pending record
   await globalThis.services.db
     .update(githubInstallations)
@@ -92,6 +102,8 @@ export async function handleInstallationCreatedEvent(
       status: "active",
       installationId: ghInstallationId,
       encryptedAccessToken,
+      targetName: account.login,
+      adminGithubUserId,
       updatedAt: new Date(),
     })
     .where(eq(githubInstallations.id, pending.id));

--- a/turbo/apps/web/src/lib/github/handlers/issue-event.ts
+++ b/turbo/apps/web/src/lib/github/handlers/issue-event.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { eq, and, desc } from "drizzle-orm";
 import { githubInstallations } from "../../../db/schema/github-installation";
+import { githubUserLinks } from "../../../db/schema/github-user-link";
 import { githubIssueSessions } from "../../../db/schema/github-issue-session";
 import {
   agentComposes,
@@ -100,7 +101,7 @@ export async function handleIssuesEvent(
   payload: GitHubIssuesEvent,
   appSlug: string | undefined,
 ): Promise<void> {
-  const { action, issue, label, repository, installation } = payload;
+  const { action, issue, label, repository, installation, sender } = payload;
 
   // Only handle opened and labeled actions
   if (action !== "opened" && action !== "labeled") {
@@ -130,6 +131,7 @@ export async function handleIssuesEvent(
     ghInstallationId: String(installation.id),
     repo: repository.full_name,
     issueNumber: issue.number,
+    senderGithubUserId: String(sender.id),
     prompt,
     appSlug,
   });
@@ -179,6 +181,7 @@ export async function handleIssueCommentEvent(
     ghInstallationId: String(installation.id),
     repo: repository.full_name,
     issueNumber: issue.number,
+    senderGithubUserId: String(sender.id),
     prompt,
     commentId: String(comment.id),
     appSlug,
@@ -191,6 +194,7 @@ interface DispatchParams {
   ghInstallationId: string;
   repo: string;
   issueNumber: number;
+  senderGithubUserId: string;
   prompt: string;
   commentId?: string;
   appSlug: string | undefined;
@@ -200,13 +204,21 @@ interface DispatchParams {
  * Core dispatch logic shared by issue and comment handlers.
  *
  * 1. Resolve installation from GitHub installation ID
- * 2. Get agent compose and latest version
- * 3. Look up existing session for multi-turn
- * 4. Create agent run with callback
- * 5. Update/create issue session mapping
+ * 2. Resolve VM0 user via github_user_links
+ * 3. Get agent compose and latest version
+ * 4. Look up existing session for multi-turn
+ * 5. Create agent run with callback
+ * 6. Update/create issue session mapping
  */
 async function dispatchAgentRun(params: DispatchParams): Promise<void> {
-  const { ghInstallationId, repo, issueNumber, prompt, commentId } = params;
+  const {
+    ghInstallationId,
+    repo,
+    issueNumber,
+    senderGithubUserId,
+    prompt,
+    commentId,
+  } = params;
 
   // 1. Resolve installation (only active installations can trigger runs)
   const [installation] = await globalThis.services.db
@@ -226,7 +238,30 @@ async function dispatchAgentRun(params: DispatchParams): Promise<void> {
     );
   }
 
-  // 2. Resolve agent compose and version
+  // 2. Resolve VM0 user via github_user_links
+  const [userLink] = await globalThis.services.db
+    .select({ vm0UserId: githubUserLinks.vm0UserId })
+    .from(githubUserLinks)
+    .where(
+      and(
+        eq(githubUserLinks.githubUserId, senderGithubUserId),
+        eq(githubUserLinks.installationId, installation.id),
+      ),
+    )
+    .limit(1);
+
+  if (!userLink) {
+    log.warn("No VM0 user linked for GitHub user", {
+      githubUserId: senderGithubUserId,
+      installationId: installation.id,
+    });
+    // TODO: Post comment asking user to link their VM0 account
+    return;
+  }
+
+  const vm0UserId = userLink.vm0UserId;
+
+  // 3. Resolve agent compose and version
   const [compose] = await globalThis.services.db
     .select()
     .from(agentComposes)
@@ -254,7 +289,7 @@ async function dispatchAgentRun(params: DispatchParams): Promise<void> {
     versionId = latestVersion.id;
   }
 
-  // 3. Look up existing session for multi-turn
+  // 4. Look up existing session for multi-turn
   let existingSessionId: string | undefined;
   const [existingSession] = await globalThis.services.db
     .select({
@@ -281,14 +316,14 @@ async function dispatchAgentRun(params: DispatchParams): Promise<void> {
     }
   }
 
-  // 4. Create agent run with callback
+  // 5. Create agent run with callback
   const callbackUrl = `${getApiUrl()}/api/internal/callbacks/github`;
   const callbackSecret = generateCallbackSecret();
   const callbackContext: GitHubCallbackContext = {
     installationId: installation.id,
     repo,
     issueNumber,
-    userId: installation.userId,
+    userId: vm0UserId,
     agentName: compose.name,
     composeId: compose.id,
     existingSessionId,
@@ -296,7 +331,7 @@ async function dispatchAgentRun(params: DispatchParams): Promise<void> {
 
   try {
     const result = await createRun({
-      userId: installation.userId,
+      userId: vm0UserId,
       agentComposeVersionId: versionId,
       prompt,
       composeId: compose.id,
@@ -318,7 +353,7 @@ async function dispatchAgentRun(params: DispatchParams): Promise<void> {
       issueNumber,
     });
 
-    // 5. Update or create issue session mapping
+    // 6. Update or create issue session mapping
     if (existingSession) {
       // Update lastCommentId for deduplication
       if (commentId) {


### PR DESCRIPTION
## Summary

- Introduces `github_user_links` table to decouple GitHub App installations from individual users (matching the Slack/Telegram integration pattern)
- Removes `userId` from `github_installations`, adds `adminGithubUserId` and `targetName` for org-level tracking
- Updates OAuth callback, integrations API, webhook handlers, and Platform UI to work with the new org-level model
- Adds admin role checks so only installation admins can change default agent or uninstall

## Changes

### Schema & Migration
- New `github_user_links` table mapping GitHub users to VM0 users per installation
- Migration 0101 includes data migration from old `user_id` column

### OAuth Callback
- Creates org-level installation records (no `userId`)
- Calls `getInstallationInfo` API to populate `targetType`/`targetId`/`targetName`
- Creates `github_user_links` records via connector lookup

### Integrations API
- GET/PATCH/DELETE now query via `github_user_links` join
- PATCH/DELETE restricted to admin users (403 for non-admins)
- Response includes `isAdmin`, `targetName`, `targetType`

### Issue Event Handler
- Resolves VM0 user from `github_user_links` using sender's GitHub user ID
- Returns early with warning if sender has no link

### Platform UI
- Shows org/account name in settings subtitle
- Disables agent selection and uninstall for non-admin users

## Test plan
- [x] All 54 GitHub-related tests pass (webhook, integrations, OAuth callback, issues callback)
- [x] Full test suite passes (3221/3222 — 1 pre-existing date-mocking failure in usage tests)
- [x] Lint, type check, format, and knip all pass
- [x] Migration tested locally with data migration path

Closes #3604

🤖 Generated with [Claude Code](https://claude.com/claude-code)