### PR TITLE
fix: correct 1password reference key for platform url in env template

### DIFF
--- a/turbo/apps/web/.env.local.tpl
+++ b/turbo/apps/web/.env.local.tpl
@@ -111,7 +111,7 @@ NGROK_API_KEY=op://Development/vm0-env-local/NGROK_API_KEY
 NGROK_COMPUTER_CONNECTOR_DOMAIN=computer.vm7.io
 
 # Required: Platform UI URL (for settings page links in error messages)
-PLATFORM_URL=op://Development/vm0-env-local/NEXT_PUBLIC_PLATFORM_URL
+PLATFORM_URL=op://Development/vm0-env-local/PLATFORM_URL
 
 # Optional: Blog Configuration
 BLOG_BASE_URL=


### PR DESCRIPTION
## Summary
- Fix the 1Password reference key for `PLATFORM_URL` in `.env.local.tpl` from `NEXT_PUBLIC_PLATFORM_URL` to `PLATFORM_URL`
- The env variable was renamed but the 1Password reference key was not updated to match, causing `sync-env.sh` to pull the wrong value

## Test plan
- [ ] Run `script/sync-env.sh` and verify `PLATFORM_URL` is correctly resolved from 1Password

🤖 Generated with [Claude Code](https://claude.com/claude-code)