### PR TITLE
fix(slack): restrict ask-user question submission to initiator only

### DIFF
--- a/turbo/apps/web/app/api/slack/interactive/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/slack/interactive/__tests__/route.test.ts
@@ -2,8 +2,14 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 import { createHmac } from "crypto";
 import { WebClient } from "@slack/web-api";
 import { POST } from "../route";
-import { testContext } from "../../../../../src/__tests__/test-helpers";
-import { givenLinkedSlackUser } from "../../../../../src/__tests__/slack/api-helpers";
+import {
+  testContext,
+  uniqueId,
+} from "../../../../../src/__tests__/test-helpers";
+import {
+  givenLinkedSlackUser,
+  givenPendingQuestion,
+} from "../../../../../src/__tests__/slack/api-helpers";
 
 // Mock only external dependencies (third-party packages)
 
@@ -218,6 +224,132 @@ describe("POST /api/slack/interactive", () => {
       const response = await POST(request);
 
       expect(response.status).toBe(200);
+    });
+  });
+
+  describe("Ask User - Authorization", () => {
+    it("rejects direct-pick from unauthorized user and rolls back answeredAt", async () => {
+      const { userLink, installation } = await givenLinkedSlackUser();
+      const { pendingId, channelId } = await givenPendingQuestion(
+        userLink,
+        installation,
+      );
+
+      const mockClient = vi.mocked(new WebClient(), true);
+      mockClient.chat.postEphemeral.mockClear();
+
+      const unauthorizedUserId = uniqueId("U-intruder");
+
+      // Unauthorized user clicks a direct-pick button
+      const body = buildInteractiveBody({
+        type: "block_actions",
+        user: {
+          id: unauthorizedUserId,
+          username: "intruder",
+          team_id: installation.slackWorkspaceId,
+        },
+        team: { id: installation.slackWorkspaceId, domain: "test" },
+        channel: { id: channelId },
+        actions: [
+          {
+            action_id: "ask_user_pick_q0_o0",
+            block_id: "ask_user_block_q0",
+            value: pendingId,
+          },
+        ],
+      });
+      const request = createSignedSlackRequest(body);
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+
+      // Wait for background handler to complete
+      await vi.waitFor(
+        () => {
+          expect(mockClient.chat.postEphemeral).toHaveBeenCalledWith(
+            expect.objectContaining({
+              channel: channelId,
+              user: unauthorizedUserId,
+              text: expect.stringContaining("Only the person who started"),
+            }),
+          );
+        },
+        { timeout: 5000 },
+      );
+
+      // Card should NOT have been updated (no updateMessage call for answered state)
+      expect(mockClient.chat.update).not.toHaveBeenCalled();
+    });
+
+    it("allows authorized user to submit after unauthorized attempt", async () => {
+      const { userLink, installation } = await givenLinkedSlackUser();
+      const { pendingId, channelId } = await givenPendingQuestion(
+        userLink,
+        installation,
+      );
+
+      const mockClient = vi.mocked(new WebClient(), true);
+      mockClient.chat.postEphemeral.mockClear();
+      mockClient.chat.update.mockClear();
+
+      // 1. Unauthorized user tries first
+      const intruderId = uniqueId("U-intruder");
+      const intruderBody = buildInteractiveBody({
+        type: "block_actions",
+        user: {
+          id: intruderId,
+          username: "intruder",
+          team_id: installation.slackWorkspaceId,
+        },
+        team: { id: installation.slackWorkspaceId, domain: "test" },
+        channel: { id: channelId },
+        actions: [
+          {
+            action_id: "ask_user_pick_q0_o0",
+            block_id: "ask_user_block_q0",
+            value: pendingId,
+          },
+        ],
+      });
+      await POST(createSignedSlackRequest(intruderBody));
+
+      // Wait for rejection to complete
+      await vi.waitFor(
+        () => {
+          expect(mockClient.chat.postEphemeral).toHaveBeenCalled();
+        },
+        { timeout: 5000 },
+      );
+
+      mockClient.chat.update.mockClear();
+
+      // 2. Authorized user submits — should still work (answeredAt was rolled back)
+      const authorizedBody = buildInteractiveBody({
+        type: "block_actions",
+        user: {
+          id: userLink.slackUserId,
+          username: "realuser",
+          team_id: installation.slackWorkspaceId,
+        },
+        team: { id: installation.slackWorkspaceId, domain: "test" },
+        channel: { id: channelId },
+        actions: [
+          {
+            action_id: "ask_user_pick_q0_o0",
+            block_id: "ask_user_block_q0",
+            value: pendingId,
+          },
+        ],
+      });
+      await POST(createSignedSlackRequest(authorizedBody));
+
+      // Wait for card update (answered state)
+      await vi.waitFor(
+        () => {
+          expect(mockClient.chat.update).toHaveBeenCalled();
+        },
+        { timeout: 5000 },
+      );
     });
   });
 });

--- a/turbo/apps/web/app/api/slack/interactive/route.ts
+++ b/turbo/apps/web/app/api/slack/interactive/route.ts
@@ -206,6 +206,61 @@ async function handleHomeDisconnect(
 type SlackAction = NonNullable<SlackInteractivePayload["actions"]>[number];
 
 /**
+ * Verify the submitting user is the initiator of the pending question.
+ * If not, roll back `answeredAt` so the real user can still answer,
+ * and post an ephemeral rejection to the unauthorized user.
+ */
+async function validateSubmitter(
+  claimed: typeof slackPendingQuestions.$inferSelect,
+  slackUserId: string,
+): Promise<boolean> {
+  const [userLink] = await globalThis.services.db
+    .select({ slackUserId: slackUserLinks.slackUserId })
+    .from(slackUserLinks)
+    .where(eq(slackUserLinks.id, claimed.userLinkId))
+    .limit(1);
+
+  if (userLink && userLink.slackUserId === slackUserId) {
+    return true;
+  }
+
+  // Roll back answeredAt so the real user can still answer
+  await globalThis.services.db
+    .update(slackPendingQuestions)
+    .set({ answeredAt: null })
+    .where(eq(slackPendingQuestions.id, claimed.id));
+
+  // Post ephemeral rejection to the unauthorized user
+  const { SECRETS_ENCRYPTION_KEY } = env();
+  const [installation] = await globalThis.services.db
+    .select()
+    .from(slackInstallations)
+    .where(eq(slackInstallations.slackWorkspaceId, claimed.slackWorkspaceId))
+    .limit(1);
+
+  if (installation) {
+    const botToken = decryptCredentialValue(
+      installation.encryptedBotToken,
+      SECRETS_ENCRYPTION_KEY,
+    );
+    const client = createSlackClient(botToken);
+    await client.chat.postEphemeral({
+      channel: claimed.slackChannelId,
+      user: slackUserId,
+      text: "Only the person who started this conversation can answer this question.",
+    });
+  }
+
+  log.warn("Unauthorized ask-user submit attempt", {
+    pendingId: claimed.id,
+    expectedUserLinkId: claimed.userLinkId,
+    actualSlackUserId: slackUserId,
+  });
+
+  return false;
+}
+
+/**
  * Handle direct-submit button click (single question, single-select).
  * The button click IS the answer — no separate Submit step.
  */
@@ -238,6 +293,10 @@ async function handleDirectPick(
     .returning();
 
   if (!claimed) return;
+
+  // Verify the submitting user is the initiator
+  const authorized = await validateSubmitter(claimed, payload.user.id);
+  if (!authorized) return;
 
   const parsed = askUserQuestionSchema.safeParse(claimed.questions);
   if (!parsed.success) return;
@@ -397,6 +456,10 @@ async function handleAskUserSubmit(
     });
     return;
   }
+
+  // Verify the submitting user is the initiator
+  const authorized = await validateSubmitter(claimed, payload.user.id);
+  if (!authorized) return;
 
   // Validate JSONB questions data at runtime
   const parsed = askUserQuestionSchema.safeParse(claimed.questions);

--- a/turbo/apps/web/src/__tests__/slack/api-helpers.ts
+++ b/turbo/apps/web/src/__tests__/slack/api-helpers.ts
@@ -17,6 +17,7 @@ import { uniqueId } from "../test-helpers";
 import { initServices } from "../../lib/init-services";
 import { slackUserLinks } from "../../db/schema/slack-user-link";
 import { slackInstallations } from "../../db/schema/slack-installation";
+import { slackPendingQuestions } from "../../db/schema/slack-pending-question";
 
 // Import route handlers
 import { GET as oauthCallbackRoute } from "../../../app/api/slack/oauth/callback/route";
@@ -276,9 +277,6 @@ export async function givenPendingQuestion(
   channelId: string;
 }> {
   initServices();
-  const { slackPendingQuestions } = await import(
-    "../../db/schema/slack-pending-question"
-  );
 
   const channelId = options.channelId ?? "C-test-channel";
   const questions = options.questions ?? [

--- a/turbo/apps/web/src/__tests__/slack/api-helpers.ts
+++ b/turbo/apps/web/src/__tests__/slack/api-helpers.ts
@@ -255,6 +255,64 @@ export async function givenUserHasAgent(
 }
 
 /**
+ * Create a pending ask-user question for testing interactive handlers.
+ */
+export async function givenPendingQuestion(
+  userLink: LinkedUserResult["userLink"],
+  installation: WorkspaceInstallationResult["installation"],
+  options: {
+    channelId?: string;
+    threadTs?: string;
+    messageTs?: string;
+    questions?: Array<{
+      question: string;
+      header: string;
+      options: Array<{ label: string; description: string }>;
+      multiSelect: boolean;
+    }>;
+  } = {},
+): Promise<{
+  pendingId: string;
+  channelId: string;
+}> {
+  initServices();
+  const { slackPendingQuestions } = await import(
+    "../../db/schema/slack-pending-question"
+  );
+
+  const channelId = options.channelId ?? "C-test-channel";
+  const questions = options.questions ?? [
+    {
+      question: "Which option?",
+      header: "Choice",
+      options: [
+        { label: "Option A", description: "First option" },
+        { label: "Option B", description: "Second option" },
+      ],
+      multiSelect: false,
+    },
+  ];
+
+  const [pending] = await globalThis.services.db
+    .insert(slackPendingQuestions)
+    .values({
+      runId: uniqueId("run"),
+      slackWorkspaceId: installation.slackWorkspaceId,
+      slackChannelId: channelId,
+      slackThreadTs: options.threadTs ?? "thread.ts",
+      slackMessageTs: options.messageTs ?? "card.ts",
+      userLinkId: userLink.id,
+      composeId: installation.defaultComposeId,
+      agentName: "test-agent",
+      questions,
+      expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+    })
+    .returning({ id: slackPendingQuestions.id });
+
+  return { pendingId: pending!.id, channelId };
+}
+
+/**
  * Given the workspace agent has been removed (compose no longer exists).
  * Points defaultComposeId to a non-existent UUID so getWorkspaceAgent
  * naturally returns undefined. Uses session_replication_role to bypass


### PR DESCRIPTION
## Summary

- Add server-side user identity validation to `handleAskUserSubmit` and `handleDirectPick` in the Slack interactive handler
- After atomically claiming a pending question, verify `payload.user.id` matches the `slackUserId` from `claimed.userLinkId`
- If unauthorized: roll back `answeredAt` (so the real user can still answer) and post ephemeral error
- Add `givenPendingQuestion` test helper and integration tests covering authorized/unauthorized/retry scenarios

Closes #3630

## Test plan

- [x] Unauthorized user clicks direct-pick → rejected with ephemeral error, `answeredAt` rolled back
- [x] Authorized user submits after unauthorized attempt → succeeds (rollback preserved the pending question)
- [x] All existing tests still pass (10/10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)