### PR TITLE
revert(slack): restore permission denial detection for ask-user

### DIFF
--- a/turbo/apps/web/app/api/internal/callbacks/slack/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/slack/route.ts
@@ -18,7 +18,7 @@ import {
 } from "../../../../../src/lib/slack";
 import {
   getRunResultData,
-  formatAskUserQuestions,
+  formatAskUserDenials,
 } from "../../../../../src/lib/slack/handlers/run-agent";
 import { buildLogsUrl } from "../../../../../src/lib/slack/handlers/shared";
 import { getPlatformUrl } from "../../../../../src/lib/url";
@@ -27,7 +27,7 @@ import { env } from "../../../../../src/env";
 import { logger } from "../../../../../src/lib/logger";
 import type { AskUserQuestion } from "../../../../../src/lib/slack";
 import type { WebClient } from "@slack/web-api";
-import type { RunResultData } from "../../../../../src/lib/slack/handlers/run-agent";
+import type { PermissionDenial } from "../../../../../src/lib/slack/handlers/run-agent";
 
 const log = logger("callback:slack");
 
@@ -93,16 +93,24 @@ async function findNewSessionId(
 }
 
 /**
- * Post an interactive Block Kit card for ask-user questions.
+ * Post an interactive Block Kit card for askUserQuestion denials.
  * Creates a pending question record and sends the card to Slack.
  */
 async function postAskUserInteractiveCard(
   client: WebClient,
-  questions: AskUserQuestion[],
+  resultData: { askUserDenials: PermissionDenial[] },
   payload: CallbackPayload,
   runId: string,
 ): Promise<void> {
-  if (questions.length === 0) {
+  const allQuestions: AskUserQuestion[] = [];
+  for (const denial of resultData.askUserDenials) {
+    const questions = denial.tool_input?.questions;
+    if (questions) {
+      allQuestions.push(...questions);
+    }
+  }
+
+  if (allQuestions.length === 0) {
     return;
   }
 
@@ -118,7 +126,7 @@ async function postAskUserInteractiveCard(
       composeId: payload.composeId,
       agentName: payload.agentName,
       sessionId: payload.existingSessionId ?? undefined,
-      questions,
+      questions: allQuestions,
       expiresAt,
     })
     .returning({ id: slackPendingQuestions.id });
@@ -127,13 +135,13 @@ async function postAskUserInteractiveCard(
     return;
   }
 
-  const fallbackText = formatAskUserQuestions(questions);
-  const cardBlocks = buildAskUserQuestionBlocks(questions, pending.id);
+  const fallbackText = formatAskUserDenials(resultData.askUserDenials);
+  const cardBlocks = buildAskUserQuestionBlocks(allQuestions, pending.id);
 
   const cardResult = await postMessage(
     client,
     payload.channelId,
-    fallbackText,
+    fallbackText ?? "The agent needs your input.",
     { threadTs: payload.threadTs, blocks: cardBlocks },
   );
 
@@ -147,20 +155,19 @@ async function postAskUserInteractiveCard(
 
 /**
  * Build the text response based on run status and result data.
- * Uses cleanResult (with ask_user block stripped) when questions are present.
  */
 function buildResponseText(
   status: string,
   error: string | undefined,
-  resultData: RunResultData | undefined,
+  resultData: Awaited<ReturnType<typeof getRunResultData>>,
 ): string {
   if (status !== "completed") {
     return `Error: ${error ?? "Agent execution failed."}`;
   }
-  if (resultData && resultData.askUserQuestions.length > 0) {
-    return resultData.cleanResult ?? "";
+  if (resultData && resultData.askUserDenials.length > 0) {
+    return resultData.result ?? "";
   }
-  return resultData?.cleanResult ?? "Task completed successfully.";
+  return resultData?.result ?? "Task completed successfully.";
 }
 
 /**
@@ -311,8 +318,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 
   const resultData =
     status === "completed" ? await getRunResultData(runId) : undefined;
-  const hasAskUserQuestions =
-    resultData && resultData.askUserQuestions.length > 0;
+  const hasAskUserDenials = resultData && resultData.askUserDenials.length > 0;
   const responseText = buildResponseText(status, error, resultData);
 
   // Post text response (if any content)
@@ -330,14 +336,9 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     });
   }
 
-  // Post interactive card for ask-user questions
-  if (hasAskUserQuestions) {
-    await postAskUserInteractiveCard(
-      client,
-      resultData.askUserQuestions,
-      payload,
-      runId,
-    );
+  // Post interactive card for askUserQuestion denials
+  if (hasAskUserDenials) {
+    await postAskUserInteractiveCard(client, resultData, payload, runId);
   }
 
   await saveThreadSession(payload, runId, status);

--- a/turbo/apps/web/app/api/internal/callbacks/slack/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/slack/route.ts
@@ -101,6 +101,7 @@ async function postAskUserInteractiveCard(
   resultData: { askUserDenials: PermissionDenial[] },
   payload: CallbackPayload,
   runId: string,
+  resolvedSessionId: string | undefined,
 ): Promise<void> {
   const allQuestions: AskUserQuestion[] = [];
   for (const denial of resultData.askUserDenials) {
@@ -125,7 +126,7 @@ async function postAskUserInteractiveCard(
       userLinkId: payload.userLinkId,
       composeId: payload.composeId,
       agentName: payload.agentName,
-      sessionId: payload.existingSessionId ?? undefined,
+      sessionId: resolvedSessionId,
       questions: allQuestions,
       expiresAt,
     })
@@ -172,12 +173,13 @@ function buildResponseText(
 
 /**
  * Save or update the Slack thread → agent session mapping.
+ * Returns the resolved session ID (existing or newly discovered).
  */
 async function saveThreadSession(
   payload: CallbackPayload,
   runId: string,
   status: string,
-): Promise<void> {
+): Promise<string | undefined> {
   const {
     channelId,
     threadTs,
@@ -194,7 +196,7 @@ async function saveThreadSession(
     .limit(1);
 
   if (!run) {
-    return;
+    return existingSessionId;
   }
 
   if (!existingSessionId) {
@@ -215,7 +217,10 @@ async function saveThreadSession(
         })
         .onConflictDoNothing();
     }
-  } else if (status === "completed") {
+    return newSessionId;
+  }
+
+  if (status === "completed") {
     await globalThis.services.db
       .update(slackThreadSessions)
       .set({
@@ -230,6 +235,7 @@ async function saveThreadSession(
         ),
       );
   }
+  return existingSessionId;
 }
 
 export async function POST(request: NextRequest): Promise<NextResponse> {
@@ -321,6 +327,11 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   const hasAskUserDenials = resultData && resultData.askUserDenials.length > 0;
   const responseText = buildResponseText(status, error, resultData);
 
+  // Resolve session before posting interactive card so the pending question
+  // gets the correct sessionId (on first run, the session doesn't exist yet
+  // when the callback payload was constructed).
+  const resolvedSessionId = await saveThreadSession(payload, runId, status);
+
   // Post text response (if any content)
   if (responseText) {
     const logsUrl = buildLogsUrl(runId);
@@ -338,10 +349,14 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 
   // Post interactive card for askUserQuestion denials
   if (hasAskUserDenials) {
-    await postAskUserInteractiveCard(client, resultData, payload, runId);
+    await postAskUserInteractiveCard(
+      client,
+      resultData,
+      payload,
+      runId,
+      resolvedSessionId,
+    );
   }
-
-  await saveThreadSession(payload, runId, status);
 
   // Clear assistant thinking status
   try {

--- a/turbo/apps/web/app/api/slack/interactive/route.ts
+++ b/turbo/apps/web/app/api/slack/interactive/route.ts
@@ -331,7 +331,7 @@ function buildAnswerPrompt(
     }
   }
   return items.length > 0
-    ? items.join("\n")
+    ? `User selected:\n${items.join("\n")}`
     : "The user submitted the form without making a selection.";
 }
 

--- a/turbo/apps/web/app/api/slack/interactive/route.ts
+++ b/turbo/apps/web/app/api/slack/interactive/route.ts
@@ -321,15 +321,17 @@ function buildAnswerPrompt(
   questions: AskUserQuestion[],
   answers: Map<number, string[]>,
 ): string {
-  const parts: string[] = [];
+  const items: string[] = [];
   for (let qIdx = 0; qIdx < questions.length; qIdx++) {
     const selected = answers.get(qIdx);
-    if (selected && selected.length > 0) {
-      parts.push(`The user selected: "${selected.join(", ")}"`);
+    if (selected) {
+      for (const label of selected) {
+        items.push(`- ${label}`);
+      }
     }
   }
-  return parts.length > 0
-    ? parts.join("\n")
+  return items.length > 0
+    ? items.join("\n")
     : "The user submitted the form without making a selection.";
 }
 

--- a/turbo/apps/web/app/api/slack/interactive/route.ts
+++ b/turbo/apps/web/app/api/slack/interactive/route.ts
@@ -314,7 +314,8 @@ function collectAnswersFromState(
 }
 
 /**
- * Build a human-readable answer prompt from questions and selected answers.
+ * Build a human-readable answer prompt from selected answers.
+ * The agent already has session context, so we only include what the user chose.
  */
 function buildAnswerPrompt(
   questions: AskUserQuestion[],
@@ -324,9 +325,7 @@ function buildAnswerPrompt(
   for (let qIdx = 0; qIdx < questions.length; qIdx++) {
     const selected = answers.get(qIdx);
     if (selected && selected.length > 0) {
-      parts.push(
-        `The user was asked: "${questions[qIdx]!.question}" and selected: "${selected.join(", ")}"`,
-      );
+      parts.push(`The user selected: "${selected.join(", ")}"`);
     }
   }
   return parts.length > 0

--- a/turbo/apps/web/app/api/slack/interactive/route.ts
+++ b/turbo/apps/web/app/api/slack/interactive/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { eq, and, isNull, gte } from "drizzle-orm";
+import { z } from "zod";
 import { initServices } from "../../../../src/lib/init-services";
 import { env } from "../../../../src/env";
 import {
@@ -19,12 +20,25 @@ import {
   buildErrorMessage,
 } from "../../../../src/lib/slack";
 import type { AskUserQuestion } from "../../../../src/lib/slack";
-import {
-  runAgentForSlack,
-  askUserQuestionSchema,
-} from "../../../../src/lib/slack/handlers/run-agent";
+import { runAgentForSlack } from "../../../../src/lib/slack/handlers/run-agent";
 import type { SlackCallbackContext } from "../../../../src/lib/slack/handlers/run-agent";
 import { logger } from "../../../../src/lib/logger";
+
+const askUserQuestionSchema = z.array(
+  z.object({
+    question: z.string(),
+    header: z.string().optional(),
+    options: z
+      .array(
+        z.object({
+          label: z.string(),
+          description: z.string().optional(),
+        }),
+      )
+      .optional(),
+    multiSelect: z.boolean().optional(),
+  }),
+);
 
 const log = logger("slack:interactive");
 

--- a/turbo/apps/web/src/lib/slack/handlers/__tests__/format-ask-user-denials.test.ts
+++ b/turbo/apps/web/src/lib/slack/handlers/__tests__/format-ask-user-denials.test.ts
@@ -1,98 +1,14 @@
 import { describe, it, expect } from "vitest";
-import { parseAskUserFromResponse, formatAskUserQuestions } from "../run-agent";
+import { formatAskUserDenials } from "../run-agent";
 
-describe("parseAskUserFromResponse", () => {
-  it("should parse a valid ask_user block", () => {
-    const text = `Some response text.
-
-\`\`\`ask_user
-{"questions":[{"question":"Which framework?","header":"Framework","options":[{"label":"React","description":"UI library"},{"label":"Vue"}],"multiSelect":false}]}
-\`\`\``;
-
-    const result = parseAskUserFromResponse(text);
-
-    expect(result).not.toBeNull();
-    expect(result!.questions).toHaveLength(1);
-    expect(result!.questions[0]!.question).toBe("Which framework?");
-    expect(result!.questions[0]!.header).toBe("Framework");
-    expect(result!.questions[0]!.options).toHaveLength(2);
-    expect(result!.cleanText).toBe("Some response text.");
-  });
-
-  it("should return null when no ask_user block is present", () => {
-    const result = parseAskUserFromResponse("Just some plain text.");
-    expect(result).toBeNull();
-  });
-
-  it("should return null for invalid JSON in ask_user block", () => {
-    const text = `Text.
-
-\`\`\`ask_user
-{invalid json}
-\`\`\``;
-
-    const result = parseAskUserFromResponse(text);
-    expect(result).toBeNull();
-  });
-
-  it("should return null when JSON does not match schema", () => {
-    const text = `Text.
-
-\`\`\`ask_user
-{"questions":[{"invalid":"field"}]}
-\`\`\``;
-
-    const result = parseAskUserFromResponse(text);
-    expect(result).toBeNull();
-  });
-
-  it("should strip the ask_user block from cleanText", () => {
-    const text = `Here is my analysis.\n\nI need some input.\n\n\`\`\`ask_user\n{"questions":[{"question":"Pick one?"}]}\n\`\`\``;
-
-    const result = parseAskUserFromResponse(text);
-
-    expect(result).not.toBeNull();
-    expect(result!.cleanText).toBe(
-      "Here is my analysis.\n\nI need some input.",
-    );
-  });
-
-  it("should handle ask_user block with no preceding text", () => {
-    const text = `\`\`\`ask_user\n{"questions":[{"question":"Pick one?"}]}\n\`\`\``;
-
-    const result = parseAskUserFromResponse(text);
-
-    expect(result).not.toBeNull();
-    expect(result!.cleanText).toBe("");
-    expect(result!.questions).toHaveLength(1);
-  });
-
-  it("should parse multiple questions", () => {
-    const text = `Response.\n\n\`\`\`ask_user\n{"questions":[{"question":"Q1?"},{"question":"Q2?","multiSelect":true}]}\n\`\`\``;
-
-    const result = parseAskUserFromResponse(text);
-
-    expect(result).not.toBeNull();
-    expect(result!.questions).toHaveLength(2);
-    expect(result!.questions[1]!.multiSelect).toBe(true);
-  });
-
-  it("should handle questions with optional fields omitted", () => {
-    const text = `Text.\n\n\`\`\`ask_user\n{"questions":[{"question":"Simple question?"}]}\n\`\`\``;
-
-    const result = parseAskUserFromResponse(text);
-
-    expect(result).not.toBeNull();
-    expect(result!.questions[0]!.header).toBeUndefined();
-    expect(result!.questions[0]!.options).toBeUndefined();
-    expect(result!.questions[0]!.multiSelect).toBeUndefined();
-  });
-});
-
-describe("formatAskUserQuestions", () => {
+describe("formatAskUserDenials", () => {
   it("should format a single question without options", () => {
-    const result = formatAskUserQuestions([
-      { question: "Which database should I use?" },
+    const result = formatAskUserDenials([
+      {
+        tool_input: {
+          questions: [{ question: "Which database should I use?" }],
+        },
+      },
     ]);
 
     expect(result).toBe(
@@ -101,13 +17,19 @@ describe("formatAskUserQuestions", () => {
   });
 
   it("should format a question with options", () => {
-    const result = formatAskUserQuestions([
+    const result = formatAskUserDenials([
       {
-        question: "Which framework do you prefer?",
-        options: [
-          { label: "React", description: "A UI library" },
-          { label: "Vue", description: "A progressive framework" },
-        ],
+        tool_input: {
+          questions: [
+            {
+              question: "Which framework do you prefer?",
+              options: [
+                { label: "React", description: "A UI library" },
+                { label: "Vue", description: "A progressive framework" },
+              ],
+            },
+          ],
+        },
       },
     ]);
 
@@ -117,10 +39,16 @@ describe("formatAskUserQuestions", () => {
   });
 
   it("should format options without descriptions", () => {
-    const result = formatAskUserQuestions([
+    const result = formatAskUserDenials([
       {
-        question: "Pick one:",
-        options: [{ label: "Option A" }, { label: "Option B" }],
+        tool_input: {
+          questions: [
+            {
+              question: "Pick one:",
+              options: [{ label: "Option A" }, { label: "Option B" }],
+            },
+          ],
+        },
       },
     ]);
 
@@ -129,18 +57,65 @@ describe("formatAskUserQuestions", () => {
     expect(result).not.toContain("\u2014");
   });
 
-  it("should format multiple questions", () => {
-    const result = formatAskUserQuestions([
-      { question: "First question?" },
-      { question: "Second question?" },
+  it("should format multiple questions from a single denial", () => {
+    const result = formatAskUserDenials([
+      {
+        tool_input: {
+          questions: [
+            { question: "First question?" },
+            { question: "Second question?" },
+          ],
+        },
+      },
     ]);
 
     expect(result).toContain("First question?");
     expect(result).toContain("Second question?");
   });
 
-  it("should return fallback for empty questions array", () => {
-    const result = formatAskUserQuestions([]);
-    expect(result).toBe("The agent needs your input to proceed.");
+  it("should format multiple denials", () => {
+    const result = formatAskUserDenials([
+      {
+        tool_input: {
+          questions: [{ question: "Question from denial 1" }],
+        },
+      },
+      {
+        tool_input: {
+          questions: [{ question: "Question from denial 2" }],
+        },
+      },
+    ]);
+
+    expect(result).toContain("Question from denial 1");
+    expect(result).toContain("Question from denial 2");
+  });
+
+  it("should return undefined for empty denials array", () => {
+    const result = formatAskUserDenials([]);
+    expect(result).toBeUndefined();
+  });
+
+  it("should return undefined when denials have no questions", () => {
+    const result = formatAskUserDenials([
+      { tool_input: { questions: [] } },
+      { tool_input: undefined },
+      {},
+    ]);
+
+    expect(result).toBeUndefined();
+  });
+
+  it("should skip denials without tool_input and include ones with questions", () => {
+    const result = formatAskUserDenials([
+      {},
+      {
+        tool_input: {
+          questions: [{ question: "Valid question" }],
+        },
+      },
+    ]);
+
+    expect(result).toContain("Valid question");
   });
 });

--- a/turbo/apps/web/src/lib/slack/handlers/run-agent.ts
+++ b/turbo/apps/web/src/lib/slack/handlers/run-agent.ts
@@ -1,5 +1,4 @@
 import { eq, desc } from "drizzle-orm";
-import { z } from "zod";
 import {
   agentComposes,
   agentComposeVersions,
@@ -9,48 +8,8 @@ import { isConcurrentRunLimit } from "../../errors";
 import { queryAxiom, getDatasetName, DATASETS } from "../../axiom";
 import { logger } from "../../logger";
 import { generateCallbackSecret, getApiUrl } from "../../callback";
-import type { AskUserQuestion } from "../blocks";
 
 const log = logger("slack:run-agent");
-
-// ---------------------------------------------------------------------------
-// Prompt instructions for ask-user questions
-// ---------------------------------------------------------------------------
-
-export const ASK_USER_PROMPT_INSTRUCTIONS = `# Ask User Questions
-
-When you need user input with a choice of options, output a fenced code block with the \`ask_user\` language tag at the END of your response. Do NOT use the AskUserQuestion CLI tool.
-
-Format:
-\`\`\`ask_user
-{"questions":[{"question":"Your question?","header":"Short Label","options":[{"label":"Option 1","description":"Details"},{"label":"Option 2"}],"multiSelect":false}]}
-\`\`\`
-
-Rules:
-- "question" is required. "header", "options", "multiSelect" are optional.
-- Each option must have "label"; "description" is optional.
-- Set "multiSelect" to true only when the user can pick more than one option.
-- Place the block at the very end of your message, after any explanatory text.`;
-
-// ---------------------------------------------------------------------------
-// Zod schema for ask-user questions (shared with interactive/route.ts)
-// ---------------------------------------------------------------------------
-
-export const askUserQuestionSchema = z.array(
-  z.object({
-    question: z.string(),
-    header: z.string().optional(),
-    options: z
-      .array(
-        z.object({
-          label: z.string(),
-          description: z.string().optional(),
-        }),
-      )
-      .optional(),
-    multiSelect: z.boolean().optional(),
-  }),
-);
 
 /**
  * Slack-specific context to include in the callback payload
@@ -137,14 +96,10 @@ export async function runAgentForSlack(
       versionId = latestVersion.id;
     }
 
-    // Build the full prompt with ask-user instructions and thread context
-    const fullPrompt = [
-      ASK_USER_PROMPT_INSTRUCTIONS,
-      threadContext ? `# Thread Context\n\n${threadContext}` : "",
-      `# User Prompt\n\n${prompt}`,
-    ]
-      .filter(Boolean)
-      .join("\n\n");
+    // Build the full prompt with thread context
+    const fullPrompt = threadContext
+      ? `${threadContext}\n\n# User Prompt\n\n${prompt}`
+      : prompt;
 
     // Build callback for run completion notification
     const callbackUrl = `${getApiUrl()}/api/internal/callbacks/slack`;
@@ -194,53 +149,29 @@ export async function runAgentForSlack(
 }
 
 // ---------------------------------------------------------------------------
-// Ask-user response parser
-// ---------------------------------------------------------------------------
-
-const ASK_USER_BLOCK_RE = /```ask_user\n([\s\S]*?)\n```/;
-
-interface ParsedAskUser {
-  questions: AskUserQuestion[];
-  cleanText: string;
-}
-
-/**
- * Parse an `ask_user` fenced code block from agent text output.
- * Returns the validated questions and the text with the block stripped,
- * or `null` if no valid block is found.
- */
-export function parseAskUserFromResponse(text: string): ParsedAskUser | null {
-  const match = ASK_USER_BLOCK_RE.exec(text);
-  if (!match?.[1]) return null;
-
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(match[1]);
-  } catch {
-    return null;
-  }
-
-  const questionsSchema = z.object({ questions: askUserQuestionSchema });
-  const result = questionsSchema.safeParse(parsed);
-  if (!result.success) return null;
-
-  const cleanText = text.slice(0, match.index).trimEnd();
-  return { questions: result.data.questions, cleanText };
-}
-
-// ---------------------------------------------------------------------------
 // Axiom result querying
 // ---------------------------------------------------------------------------
 
-export interface RunResultData {
+export interface PermissionDenial {
+  tool_name: string;
+  tool_input?: {
+    questions?: Array<{
+      question: string;
+      header?: string;
+      options?: Array<{ label: string; description?: string }>;
+      multiSelect?: boolean;
+    }>;
+  };
+}
+
+interface RunResultData {
   result?: string;
-  cleanResult?: string;
-  askUserQuestions: AskUserQuestion[];
+  askUserDenials: PermissionDenial[];
 }
 
 /**
- * Query Axiom for the result event data (text output + ask-user questions).
- * Parses ask_user blocks from the agent's text output.
+ * Query Axiom for the result event data (text output + permission denials).
+ * Shared by getRunOutput (text formatting) and the callback handler (raw denials).
  */
 export async function getRunResultData(
   runId: string,
@@ -255,6 +186,7 @@ export async function getRunResultData(
   interface ResultEvent {
     eventData: {
       result?: string;
+      permission_denials?: PermissionDenial[];
     };
   }
 
@@ -264,27 +196,20 @@ export async function getRunResultData(
   }
 
   const event = events[0];
-  const resultText = event?.eventData?.result;
+  const denials = event?.eventData?.permission_denials ?? [];
+  const askUserDenials = denials.filter(
+    (d) => d.tool_name === "AskUserQuestion",
+  );
 
-  if (!resultText) {
-    return { result: undefined, cleanResult: undefined, askUserQuestions: [] };
-  }
-
-  const parsed = parseAskUserFromResponse(resultText);
-  if (parsed) {
-    return {
-      result: resultText,
-      cleanResult: parsed.cleanText,
-      askUserQuestions: parsed.questions,
-    };
-  }
-
-  return { result: resultText, cleanResult: resultText, askUserQuestions: [] };
+  return {
+    result: event?.eventData?.result,
+    askUserDenials,
+  };
 }
 
 /**
  * Query Axiom for the result event to get the agent's output text.
- * Formats ask-user questions as plain text (fallback for non-interactive contexts).
+ * Formats AskUserQuestion denials as plain text (fallback for non-interactive contexts).
  */
 export async function getRunOutput(runId: string): Promise<string | undefined> {
   const data = await getRunResultData(runId);
@@ -292,31 +217,46 @@ export async function getRunOutput(runId: string): Promise<string | undefined> {
     return undefined;
   }
 
-  if (data.askUserQuestions.length > 0) {
-    const formatted = formatAskUserQuestions(data.askUserQuestions);
-    return data.cleanResult ? `${data.cleanResult}\n\n${formatted}` : formatted;
+  if (data.askUserDenials.length > 0) {
+    const formatted = formatAskUserDenials(data.askUserDenials);
+    if (formatted) {
+      return data.result ? `${data.result}\n\n${formatted}` : formatted;
+    }
   }
 
   return data.result;
 }
 
-/**
- * Format ask-user questions as plain text for non-interactive contexts.
- */
-export function formatAskUserQuestions(questions: AskUserQuestion[]): string {
+export function formatAskUserDenials(
+  denials: Array<{
+    tool_input?: {
+      questions?: Array<{
+        question: string;
+        header?: string;
+        options?: Array<{ label: string; description?: string }>;
+        multiSelect?: boolean;
+      }>;
+    };
+  }>,
+): string | undefined {
   const parts: string[] = [];
 
-  for (const q of questions) {
-    parts.push(q.question);
-    if (q.options) {
-      for (const opt of q.options) {
-        const desc = opt.description ? ` — ${opt.description}` : "";
-        parts.push(`  • ${opt.label}${desc}`);
+  for (const denial of denials) {
+    const questions = denial.tool_input?.questions;
+    if (!questions || questions.length === 0) continue;
+
+    for (const q of questions) {
+      parts.push(q.question);
+      if (q.options) {
+        for (const opt of q.options) {
+          const desc = opt.description ? ` — ${opt.description}` : "";
+          parts.push(`  • ${opt.label}${desc}`);
+        }
       }
     }
   }
 
-  return parts.length > 0
-    ? `The agent needs your input to proceed:\n\n${parts.join("\n")}`
-    : "The agent needs your input to proceed.";
+  if (parts.length === 0) return undefined;
+
+  return `The agent needs your input to proceed:\n\n${parts.join("\n")}`;
 }


### PR DESCRIPTION
## Summary

- Reverts the prompt-based ask-user approach (#3602 commit `48ca9fc3`) which injected `ASK_USER_PROMPT_INSTRUCTIONS` into agent prompts
- Restores the original `AskUserQuestion` permission denial detection from Axiom result events
- Prompt injection caused agents to generate questions too eagerly — permission denial detection is more reliable since it only triggers when the agent genuinely calls the `AskUserQuestion` tool

### What changed

- **`run-agent.ts`**: Restore `PermissionDenial` interface, `formatAskUserDenials()`, permission_denials Axiom query; remove `ASK_USER_PROMPT_INSTRUCTIONS`, `parseAskUserFromResponse()`, `askUserQuestionSchema`, prompt injection
- **`callbacks/slack/route.ts`**: Restore `postAskUserInteractiveCard()` accepting `PermissionDenial[]`; remove `RunResultData`/`formatAskUserQuestions` imports
- **`interactive/route.ts`**: Restore inline `askUserQuestionSchema` zod definition; remove import from `run-agent.ts`
- **Tests**: Restore `formatAskUserDenials` tests

## Test plan

- [x] All Slack tests pass (76 total)
- [x] Lint, knip, pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)