### PR TITLE
fix(callback): use callback id for signature verification to fix multi-callback runs

### DIFF
--- a/turbo/apps/web/app/api/internal/callbacks/email/reply/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/email/reply/route.ts
@@ -1,9 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { eq } from "drizzle-orm";
 import { initServices } from "../../../../../../src/lib/init-services";
-import { verifyCallbackRequest } from "../../../../../../src/lib/callback";
-import { decryptCredentialValue } from "../../../../../../src/lib/crypto/secrets-encryption";
-import { agentRunCallbacks } from "../../../../../../src/db/schema/agent-run-callback";
+import { verifyCallback } from "../../../../../../src/lib/callback";
 import { agentRuns } from "../../../../../../src/db/schema/agent-run";
 import { agentComposes } from "../../../../../../src/db/schema/agent-compose";
 import { emailThreadSessions } from "../../../../../../src/db/schema/email-thread-session";
@@ -17,7 +15,6 @@ import {
   buildLogsUrl,
 } from "../../../../../../src/lib/email/handlers/shared";
 import { AgentReplyEmail } from "../../../../../../src/lib/email/templates/agent-reply";
-import { env } from "../../../../../../src/env";
 import { logger } from "../../../../../../src/lib/logger";
 
 const log = logger("callback:email:reply");
@@ -29,24 +26,16 @@ interface CallbackPayload {
   inboundReferences?: string;
 }
 
-interface CallbackBody {
-  runId: string;
-  status: "completed" | "failed";
-  result?: Record<string, unknown>;
-  error?: string;
-  payload: CallbackPayload;
-}
-
-function parsePayload(body: CallbackBody): CallbackPayload | null {
-  if (!body.payload) return null;
-  const p = body.payload;
+function parsePayload(payload: unknown): CallbackPayload | null {
+  if (!payload || typeof payload !== "object") return null;
+  const p = payload as Record<string, unknown>;
   if (
     typeof p.emailThreadSessionId !== "string" ||
     typeof p.inboundEmailId !== "string"
   ) {
     return null;
   }
-  return p;
+  return p as unknown as CallbackPayload;
 }
 
 function errorResponse(message: string, status: number): NextResponse {
@@ -79,61 +68,13 @@ function formatOutput(
 
 export async function POST(request: NextRequest): Promise<NextResponse> {
   initServices();
-  const { SECRETS_ENCRYPTION_KEY } = env();
 
-  // Read raw body for signature verification
-  const rawBody = await request.text();
+  const result = await verifyCallback<CallbackPayload>(request, log);
+  if (!result.ok) return result.response;
 
-  let body: CallbackBody;
-  try {
-    body = JSON.parse(rawBody);
-  } catch {
-    return errorResponse("Invalid JSON body", 400);
-  }
+  const { runId, status, error } = result.data;
 
-  const { runId, status, error } = body;
-
-  if (!runId) {
-    return errorResponse("Missing runId", 400);
-  }
-
-  // Query callback record to get the per-callback secret
-  const [callback] = await globalThis.services.db
-    .select({ encryptedSecret: agentRunCallbacks.encryptedSecret })
-    .from(agentRunCallbacks)
-    .where(eq(agentRunCallbacks.runId, runId))
-    .limit(1);
-
-  if (!callback) {
-    log.warn("Callback record not found", { runId });
-    return errorResponse("Callback not found", 404);
-  }
-
-  // Decrypt the per-callback secret and verify signature
-  const callbackSecret = decryptCredentialValue(
-    callback.encryptedSecret,
-    SECRETS_ENCRYPTION_KEY,
-  );
-
-  const signature = request.headers.get("X-VM0-Signature");
-  const timestamp = request.headers.get("X-VM0-Timestamp");
-
-  const verification = verifyCallbackRequest(
-    rawBody,
-    callbackSecret,
-    signature,
-    timestamp,
-  );
-
-  if (!verification.valid) {
-    log.warn("Callback signature verification failed", {
-      runId,
-      error: verification.error,
-    });
-    return errorResponse(verification.error ?? "Invalid signature", 401);
-  }
-
-  const payload = parsePayload(body);
+  const payload = parsePayload(result.data.payload);
   if (!payload) {
     return errorResponse("Invalid or missing payload", 400);
   }

--- a/turbo/apps/web/app/api/internal/callbacks/email/schedule/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/email/schedule/route.ts
@@ -1,9 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { eq } from "drizzle-orm";
 import { initServices } from "../../../../../../src/lib/init-services";
-import { verifyCallbackRequest } from "../../../../../../src/lib/callback";
-import { decryptCredentialValue } from "../../../../../../src/lib/crypto/secrets-encryption";
-import { agentRunCallbacks } from "../../../../../../src/db/schema/agent-run-callback";
+import { verifyCallback } from "../../../../../../src/lib/callback";
 import { agentRuns } from "../../../../../../src/db/schema/agent-run";
 import { getUserEmail } from "../../../../../../src/lib/auth/get-user-email";
 import { getRunOutput } from "../../../../../../src/lib/slack/handlers/run-agent";
@@ -29,17 +27,9 @@ interface CallbackPayload {
   userId: string;
 }
 
-interface CallbackBody {
-  runId: string;
-  status: "completed" | "failed";
-  result?: Record<string, unknown>;
-  error?: string;
-  payload: CallbackPayload;
-}
-
-function parsePayload(body: CallbackBody): CallbackPayload | null {
-  if (!body.payload) return null;
-  const p = body.payload;
+function parsePayload(payload: unknown): CallbackPayload | null {
+  if (!payload || typeof payload !== "object") return null;
+  const p = payload as Record<string, unknown>;
   if (
     typeof p.scheduleId !== "string" ||
     typeof p.composeId !== "string" ||
@@ -48,7 +38,7 @@ function parsePayload(body: CallbackBody): CallbackPayload | null {
   ) {
     return null;
   }
-  return p;
+  return p as unknown as CallbackPayload;
 }
 
 function errorResponse(message: string, status: number): NextResponse {
@@ -63,61 +53,12 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     return NextResponse.json({ success: true, skipped: true });
   }
 
-  const { SECRETS_ENCRYPTION_KEY } = env();
+  const result = await verifyCallback<CallbackPayload>(request, log);
+  if (!result.ok) return result.response;
 
-  // Read raw body for signature verification
-  const rawBody = await request.text();
+  const { runId, status, error } = result.data;
 
-  let body: CallbackBody;
-  try {
-    body = JSON.parse(rawBody);
-  } catch {
-    return errorResponse("Invalid JSON body", 400);
-  }
-
-  const { runId, status, error } = body;
-
-  if (!runId) {
-    return errorResponse("Missing runId", 400);
-  }
-
-  // Query callback record to get the per-callback secret
-  const [callback] = await globalThis.services.db
-    .select({ encryptedSecret: agentRunCallbacks.encryptedSecret })
-    .from(agentRunCallbacks)
-    .where(eq(agentRunCallbacks.runId, runId))
-    .limit(1);
-
-  if (!callback) {
-    log.warn("Callback record not found", { runId });
-    return errorResponse("Callback not found", 404);
-  }
-
-  // Decrypt the per-callback secret and verify signature
-  const callbackSecret = decryptCredentialValue(
-    callback.encryptedSecret,
-    SECRETS_ENCRYPTION_KEY,
-  );
-
-  const signature = request.headers.get("X-VM0-Signature");
-  const timestamp = request.headers.get("X-VM0-Timestamp");
-
-  const verification = verifyCallbackRequest(
-    rawBody,
-    callbackSecret,
-    signature,
-    timestamp,
-  );
-
-  if (!verification.valid) {
-    log.warn("Callback signature verification failed", {
-      runId,
-      error: verification.error,
-    });
-    return errorResponse(verification.error ?? "Invalid signature", 401);
-  }
-
-  const payload = parsePayload(body);
+  const payload = parsePayload(result.data.payload);
   if (!payload) {
     return errorResponse("Invalid or missing payload", 400);
   }
@@ -151,13 +92,13 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       .where(eq(agentRuns.id, runId))
       .limit(1);
 
-    const result = run?.result;
+    const runResult = run?.result;
     const agentSessionId =
-      result &&
-      typeof result === "object" &&
-      "agentSessionId" in result &&
-      typeof result.agentSessionId === "string"
-        ? result.agentSessionId
+      runResult &&
+      typeof runResult === "object" &&
+      "agentSessionId" in runResult &&
+      typeof runResult.agentSessionId === "string"
+        ? runResult.agentSessionId
         : undefined;
 
     // Generate reply token and send email

--- a/turbo/apps/web/app/api/internal/callbacks/email/trigger/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/email/trigger/route.ts
@@ -1,9 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { eq } from "drizzle-orm";
 import { initServices } from "../../../../../../src/lib/init-services";
-import { verifyCallbackRequest } from "../../../../../../src/lib/callback";
-import { decryptCredentialValue } from "../../../../../../src/lib/crypto/secrets-encryption";
-import { agentRunCallbacks } from "../../../../../../src/db/schema/agent-run-callback";
+import { verifyCallback } from "../../../../../../src/lib/callback";
 import { agentRuns } from "../../../../../../src/db/schema/agent-run";
 import { agentComposes } from "../../../../../../src/db/schema/agent-compose";
 import { getRunOutput } from "../../../../../../src/lib/slack/handlers/run-agent";
@@ -32,17 +30,9 @@ interface CallbackPayload {
   triggerLocalPart?: string;
 }
 
-interface CallbackBody {
-  runId: string;
-  status: "completed" | "failed";
-  result?: Record<string, unknown>;
-  error?: string;
-  payload: CallbackPayload;
-}
-
-function parsePayload(body: CallbackBody): CallbackPayload | null {
-  const p = body.payload;
-  if (!p) return null;
+function parsePayload(payload: unknown): CallbackPayload | null {
+  if (!payload || typeof payload !== "object") return null;
+  const p = payload as Record<string, unknown>;
   if (
     typeof p.senderEmail !== "string" ||
     typeof p.composeId !== "string" ||
@@ -52,7 +42,7 @@ function parsePayload(body: CallbackBody): CallbackPayload | null {
   ) {
     return null;
   }
-  return p;
+  return p as unknown as CallbackPayload;
 }
 
 function errorResponse(message: string, status: number): NextResponse {
@@ -127,59 +117,12 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     return NextResponse.json({ success: true, skipped: true });
   }
 
-  const { SECRETS_ENCRYPTION_KEY } = env();
+  const result = await verifyCallback<CallbackPayload>(request, log);
+  if (!result.ok) return result.response;
 
-  const rawBody = await request.text();
+  const { runId, status, error } = result.data;
 
-  let body: CallbackBody;
-  try {
-    body = JSON.parse(rawBody);
-  } catch {
-    return errorResponse("Invalid JSON body", 400);
-  }
-
-  const { runId, status, error } = body;
-
-  if (!runId) {
-    return errorResponse("Missing runId", 400);
-  }
-
-  // Verify callback signature
-  const [callback] = await globalThis.services.db
-    .select({ encryptedSecret: agentRunCallbacks.encryptedSecret })
-    .from(agentRunCallbacks)
-    .where(eq(agentRunCallbacks.runId, runId))
-    .limit(1);
-
-  if (!callback) {
-    log.warn("Callback record not found", { runId });
-    return errorResponse("Callback not found", 404);
-  }
-
-  const callbackSecret = decryptCredentialValue(
-    callback.encryptedSecret,
-    SECRETS_ENCRYPTION_KEY,
-  );
-
-  const signature = request.headers.get("X-VM0-Signature");
-  const timestamp = request.headers.get("X-VM0-Timestamp");
-
-  const verification = verifyCallbackRequest(
-    rawBody,
-    callbackSecret,
-    signature,
-    timestamp,
-  );
-
-  if (!verification.valid) {
-    log.warn("Callback signature verification failed", {
-      runId,
-      error: verification.error,
-    });
-    return errorResponse(verification.error ?? "Invalid signature", 401);
-  }
-
-  const payload = parsePayload(body);
+  const payload = parsePayload(result.data.payload);
   if (!payload) {
     return errorResponse("Invalid or missing payload", 400);
   }

--- a/turbo/apps/web/app/api/internal/callbacks/github/issues/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/github/issues/route.ts
@@ -1,13 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
 import { eq, and, gte, desc } from "drizzle-orm";
 import { initServices } from "../../../../../../src/lib/init-services";
-import { verifyCallbackRequest } from "../../../../../../src/lib/callback";
-import { decryptCredentialValue } from "../../../../../../src/lib/crypto/secrets-encryption";
+import { verifyCallback } from "../../../../../../src/lib/callback";
 import { githubInstallations } from "../../../../../../src/db/schema/github-installation";
 import { githubIssueSessions } from "../../../../../../src/db/schema/github-issue-session";
 import { agentSessions } from "../../../../../../src/db/schema/agent-session";
 import { agentRuns } from "../../../../../../src/db/schema/agent-run";
-import { agentRunCallbacks } from "../../../../../../src/db/schema/agent-run-callback";
 import { getInstallationAccessToken } from "../../../../../../src/lib/github/github-app";
 import { getRunOutput } from "../../../../../../src/lib/slack/handlers/run-agent";
 import { env } from "../../../../../../src/env";
@@ -23,17 +21,9 @@ interface CallbackPayload {
   existingSessionId?: string;
 }
 
-interface CallbackBody {
-  runId: string;
-  status: "completed" | "failed";
-  result?: Record<string, unknown>;
-  error?: string;
-  payload: CallbackPayload;
-}
-
-function parsePayload(body: CallbackBody): CallbackPayload | null {
-  if (!body.payload) return null;
-  const p = body.payload;
+function parsePayload(payload: unknown): CallbackPayload | null {
+  if (!payload || typeof payload !== "object") return null;
+  const p = payload as Record<string, unknown>;
   if (
     typeof p.installationId !== "string" ||
     typeof p.repo !== "string" ||
@@ -42,7 +32,7 @@ function parsePayload(body: CallbackBody): CallbackPayload | null {
   ) {
     return null;
   }
-  return p;
+  return p as unknown as CallbackPayload;
 }
 
 function errorResponse(message: string, status: number): NextResponse {
@@ -118,65 +108,13 @@ async function postIssueComment(
 
 export async function POST(request: NextRequest): Promise<NextResponse> {
   initServices();
-  const { SECRETS_ENCRYPTION_KEY, GITHUB_APP_ID, GITHUB_APP_PRIVATE_KEY } =
-    env();
 
-  // Read raw body for signature verification
-  const rawBody = await request.text();
+  const result = await verifyCallback<CallbackPayload>(request, log);
+  if (!result.ok) return result.response;
 
-  // Parse body first to get runId for callback lookup
-  let body: CallbackBody;
-  try {
-    body = JSON.parse(rawBody);
-  } catch {
-    return errorResponse("Invalid JSON body", 400);
-  }
+  const { runId, status, error } = result.data;
 
-  const { runId, status, error } = body;
-
-  if (!runId) {
-    return errorResponse("Missing runId", 400);
-  }
-
-  // Query callback record to get the per-callback secret
-  const [callback] = await globalThis.services.db
-    .select({ encryptedSecret: agentRunCallbacks.encryptedSecret })
-    .from(agentRunCallbacks)
-    .where(eq(agentRunCallbacks.runId, runId))
-    .limit(1);
-
-  if (!callback) {
-    log.warn("Callback record not found", { runId });
-    return errorResponse("Callback not found", 404);
-  }
-
-  // Decrypt the per-callback secret
-  const callbackSecret = decryptCredentialValue(
-    callback.encryptedSecret,
-    SECRETS_ENCRYPTION_KEY,
-  );
-
-  // Verify signature using the per-callback secret
-  const signature = request.headers.get("X-VM0-Signature");
-  const timestamp = request.headers.get("X-VM0-Timestamp");
-
-  const verification = verifyCallbackRequest(
-    rawBody,
-    callbackSecret,
-    signature,
-    timestamp,
-  );
-
-  if (!verification.valid) {
-    log.warn("Callback signature verification failed", {
-      runId,
-      error: verification.error,
-    });
-    return errorResponse(verification.error ?? "Invalid signature", 401);
-  }
-
-  const payload = parsePayload(body);
-
+  const payload = parsePayload(result.data.payload);
   if (!payload) {
     return errorResponse("Invalid or missing payload", 400);
   }
@@ -190,6 +128,8 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     repo,
     issueNumber,
   });
+
+  const { GITHUB_APP_ID, GITHUB_APP_PRIVATE_KEY } = env();
 
   // Get GitHub installation for access token
   const [installation] = await globalThis.services.db

--- a/turbo/apps/web/app/api/internal/callbacks/schedule/loop/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/schedule/loop/__tests__/route.test.ts
@@ -28,6 +28,7 @@ interface LoopCallbackPayload {
 
 function createCallbackRequest(
   body: {
+    callbackId?: string;
     runId: string;
     status: "completed" | "failed";
     error?: string;
@@ -72,7 +73,7 @@ describe("POST /api/internal/callbacks/schedule/loop", () => {
     });
     await enableTestSchedule(composeId, schedule.name);
     const { runId } = await createTestRun(composeId, "Loop task");
-    const { secret } = await createTestCallback({
+    const { callbackId, secret } = await createTestCallback({
       runId,
       url: "http://localhost/api/internal/callbacks/schedule/loop",
       payload: {
@@ -80,7 +81,7 @@ describe("POST /api/internal/callbacks/schedule/loop", () => {
         intervalSeconds: 300,
       },
     });
-    return { schedule, runId, secret };
+    return { schedule, runId, callbackId, secret };
   }
 
   describe("Signature Verification", () => {
@@ -116,6 +117,60 @@ describe("POST /api/internal/callbacks/schedule/loop", () => {
       const response = await POST(request);
 
       expect(response.status).toBe(404);
+    });
+
+    it("should verify using callbackId for PK-based secret lookup", async () => {
+      const { schedule, runId, callbackId, secret } = await setupLoopSchedule();
+
+      const request = createCallbackRequest(
+        {
+          callbackId,
+          runId,
+          status: "completed",
+          payload: { scheduleId: schedule.id, intervalSeconds: 300 },
+        },
+        secret,
+      );
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.success).toBe(true);
+    });
+
+    it("should verify correct callback when multiple callbacks exist for same run", async () => {
+      const { schedule, runId, callbackId, secret } = await setupLoopSchedule();
+
+      // Create additional callbacks for the same run (simulates email + slack)
+      await createTestCallback({
+        runId,
+        url: "http://localhost/api/internal/callbacks/slack",
+        payload: { workspaceId: "W1" },
+      });
+      await createTestCallback({
+        runId,
+        url: "http://localhost/api/internal/callbacks/email/reply",
+        payload: { emailId: "E1" },
+      });
+
+      // With callbackId, the loop callback should still verify with its own secret
+      const request = createCallbackRequest(
+        {
+          callbackId,
+          runId,
+          status: "completed",
+          payload: { scheduleId: schedule.id, intervalSeconds: 300 },
+        },
+        secret,
+      );
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.success).toBe(true);
+
+      const updated = await findTestScheduleById(schedule.id);
+      expect(updated!.nextRunAt).not.toBeNull();
     });
   });
 

--- a/turbo/apps/web/app/api/internal/callbacks/schedule/loop/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/schedule/loop/route.ts
@@ -1,11 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 import { eq } from "drizzle-orm";
 import { initServices } from "../../../../../../src/lib/init-services";
-import { verifyCallbackRequest } from "../../../../../../src/lib/callback";
-import { decryptCredentialValue } from "../../../../../../src/lib/crypto/secrets-encryption";
-import { agentRunCallbacks } from "../../../../../../src/db/schema/agent-run-callback";
+import { verifyCallback } from "../../../../../../src/lib/callback";
 import { agentSchedules } from "../../../../../../src/db/schema/agent-schedule";
-import { env } from "../../../../../../src/env";
 import { logger } from "../../../../../../src/lib/logger";
 
 const log = logger("callback:schedule:loop");
@@ -18,24 +15,16 @@ interface CallbackPayload {
   intervalSeconds: number;
 }
 
-interface CallbackBody {
-  runId: string;
-  status: "completed" | "failed";
-  result?: Record<string, unknown>;
-  error?: string;
-  payload: CallbackPayload;
-}
-
-function parsePayload(body: CallbackBody): CallbackPayload | null {
-  if (!body.payload) return null;
-  const p = body.payload;
+function parsePayload(payload: unknown): CallbackPayload | null {
+  if (!payload || typeof payload !== "object") return null;
+  const p = payload as Record<string, unknown>;
   if (
     typeof p.scheduleId !== "string" ||
     typeof p.intervalSeconds !== "number"
   ) {
     return null;
   }
-  return p;
+  return p as unknown as CallbackPayload;
 }
 
 function errorResponse(message: string, status: number): NextResponse {
@@ -44,68 +33,24 @@ function errorResponse(message: string, status: number): NextResponse {
 
 export async function POST(request: NextRequest): Promise<NextResponse> {
   initServices();
-  const { SECRETS_ENCRYPTION_KEY } = env();
 
-  // Read raw body for signature verification
-  const rawBody = await request.text();
+  const result = await verifyCallback<CallbackPayload>(request, log);
+  if (!result.ok) return result.response;
 
-  let body: CallbackBody;
-  try {
-    body = JSON.parse(rawBody);
-  } catch {
-    return errorResponse("Invalid JSON body", 400);
-  }
+  const { status, payload: rawPayload } = result.data;
 
-  const { runId, status } = body;
-
-  if (!runId) {
-    return errorResponse("Missing runId", 400);
-  }
-
-  // Query callback record to get the per-callback secret
-  const [callback] = await globalThis.services.db
-    .select({ encryptedSecret: agentRunCallbacks.encryptedSecret })
-    .from(agentRunCallbacks)
-    .where(eq(agentRunCallbacks.runId, runId))
-    .limit(1);
-
-  if (!callback) {
-    log.warn("Callback record not found", { runId });
-    return errorResponse("Callback not found", 404);
-  }
-
-  // Decrypt the per-callback secret and verify signature
-  const callbackSecret = decryptCredentialValue(
-    callback.encryptedSecret,
-    SECRETS_ENCRYPTION_KEY,
-  );
-
-  const signature = request.headers.get("X-VM0-Signature");
-  const timestamp = request.headers.get("X-VM0-Timestamp");
-
-  const verification = verifyCallbackRequest(
-    rawBody,
-    callbackSecret,
-    signature,
-    timestamp,
-  );
-
-  if (!verification.valid) {
-    log.warn("Callback signature verification failed", {
-      runId,
-      error: verification.error,
-    });
-    return errorResponse(verification.error ?? "Invalid signature", 401);
-  }
-
-  const payload = parsePayload(body);
+  const payload = parsePayload(rawPayload);
   if (!payload) {
     return errorResponse("Invalid or missing payload", 400);
   }
 
   const { scheduleId, intervalSeconds } = payload;
 
-  log.debug("Processing loop schedule callback", { runId, status, scheduleId });
+  log.debug("Processing loop schedule callback", {
+    runId: result.data.runId,
+    status,
+    scheduleId,
+  });
 
   // Load schedule
   const [schedule] = await globalThis.services.db

--- a/turbo/apps/web/app/api/internal/callbacks/slack/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/slack/route.ts
@@ -1,13 +1,12 @@
 import { NextRequest, NextResponse } from "next/server";
 import { eq, and, gte, desc } from "drizzle-orm";
 import { initServices } from "../../../../../src/lib/init-services";
-import { verifyCallbackRequest } from "../../../../../src/lib/callback";
+import { verifyCallback } from "../../../../../src/lib/callback";
 import { decryptCredentialValue } from "../../../../../src/lib/crypto/secrets-encryption";
 import { slackInstallations } from "../../../../../src/db/schema/slack-installation";
 import { slackThreadSessions } from "../../../../../src/db/schema/slack-thread-session";
 import { agentSessions } from "../../../../../src/db/schema/agent-session";
 import { agentRuns } from "../../../../../src/db/schema/agent-run";
-import { agentRunCallbacks } from "../../../../../src/db/schema/agent-run-callback";
 import {
   createSlackClient,
   postMessage,
@@ -43,17 +42,9 @@ interface CallbackPayload {
   existingSessionId?: string;
 }
 
-interface CallbackBody {
-  runId: string;
-  status: "completed" | "failed";
-  result?: Record<string, unknown>;
-  error?: string;
-  payload: CallbackPayload;
-}
-
-function parsePayload(body: CallbackBody): CallbackPayload | null {
-  if (!body.payload) return null;
-  const p = body.payload;
+function parsePayload(payload: unknown): CallbackPayload | null {
+  if (!payload || typeof payload !== "object") return null;
+  const p = payload as Record<string, unknown>;
   if (
     typeof p.workspaceId !== "string" ||
     typeof p.channelId !== "string" ||
@@ -65,7 +56,7 @@ function parsePayload(body: CallbackBody): CallbackPayload | null {
   ) {
     return null;
   }
-  return p;
+  return p as unknown as CallbackPayload;
 }
 
 function errorResponse(message: string, status: number): NextResponse {
@@ -227,58 +218,13 @@ async function saveThreadSession(
 
 export async function POST(request: NextRequest): Promise<NextResponse> {
   initServices();
-  const { SECRETS_ENCRYPTION_KEY } = env();
 
-  const rawBody = await request.text();
+  const result = await verifyCallback<CallbackPayload>(request, log);
+  if (!result.ok) return result.response;
 
-  let body: CallbackBody;
-  try {
-    body = JSON.parse(rawBody);
-  } catch {
-    return errorResponse("Invalid JSON body", 400);
-  }
+  const { runId, status, error } = result.data;
 
-  const { runId, status, error } = body;
-
-  if (!runId) {
-    return errorResponse("Missing runId", 400);
-  }
-
-  // Query callback record to get the per-callback secret
-  const [callback] = await globalThis.services.db
-    .select({ encryptedSecret: agentRunCallbacks.encryptedSecret })
-    .from(agentRunCallbacks)
-    .where(eq(agentRunCallbacks.runId, runId))
-    .limit(1);
-
-  if (!callback) {
-    log.warn("Callback record not found", { runId });
-    return errorResponse("Callback not found", 404);
-  }
-
-  const callbackSecret = decryptCredentialValue(
-    callback.encryptedSecret,
-    SECRETS_ENCRYPTION_KEY,
-  );
-
-  const signature = request.headers.get("X-VM0-Signature");
-  const timestamp = request.headers.get("X-VM0-Timestamp");
-  const verification = verifyCallbackRequest(
-    rawBody,
-    callbackSecret,
-    signature,
-    timestamp,
-  );
-
-  if (!verification.valid) {
-    log.warn("Callback signature verification failed", {
-      runId,
-      error: verification.error,
-    });
-    return errorResponse(verification.error ?? "Invalid signature", 401);
-  }
-
-  const payload = parsePayload(body);
+  const payload = parsePayload(result.data.payload);
   if (!payload) {
     return errorResponse("Invalid or missing payload", 400);
   }
@@ -288,6 +234,8 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     status,
     channelId: payload.channelId,
   });
+
+  const { SECRETS_ENCRYPTION_KEY } = env();
 
   // Get Slack installation for bot token
   const [installation] = await globalThis.services.db

--- a/turbo/apps/web/app/api/internal/callbacks/slack/schedule/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/slack/schedule/route.ts
@@ -1,9 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 import { eq } from "drizzle-orm";
 import { initServices } from "../../../../../../src/lib/init-services";
-import { verifyCallbackRequest } from "../../../../../../src/lib/callback";
+import { verifyCallback } from "../../../../../../src/lib/callback";
 import { decryptCredentialValue } from "../../../../../../src/lib/crypto/secrets-encryption";
-import { agentRunCallbacks } from "../../../../../../src/db/schema/agent-run-callback";
 import { agentRuns } from "../../../../../../src/db/schema/agent-run";
 import { slackUserLinks } from "../../../../../../src/db/schema/slack-user-link";
 import { slackInstallations } from "../../../../../../src/db/schema/slack-installation";
@@ -28,17 +27,9 @@ interface CallbackPayload {
   userId: string;
 }
 
-interface CallbackBody {
-  runId: string;
-  status: "completed" | "failed";
-  result?: Record<string, unknown>;
-  error?: string;
-  payload: CallbackPayload;
-}
-
-function parsePayload(body: CallbackBody): CallbackPayload | null {
-  if (!body.payload) return null;
-  const p = body.payload;
+function parsePayload(payload: unknown): CallbackPayload | null {
+  if (!payload || typeof payload !== "object") return null;
+  const p = payload as Record<string, unknown>;
   if (
     typeof p.scheduleId !== "string" ||
     typeof p.composeId !== "string" ||
@@ -47,7 +38,7 @@ function parsePayload(body: CallbackBody): CallbackPayload | null {
   ) {
     return null;
   }
-  return p;
+  return p as unknown as CallbackPayload;
 }
 
 function errorResponse(message: string, status: number): NextResponse {
@@ -68,61 +59,13 @@ function extractAgentSessionId(result: unknown): string | undefined {
 
 export async function POST(request: NextRequest): Promise<NextResponse> {
   initServices();
-  const { SECRETS_ENCRYPTION_KEY } = env();
 
-  // Read raw body for signature verification
-  const rawBody = await request.text();
+  const result = await verifyCallback<CallbackPayload>(request, log);
+  if (!result.ok) return result.response;
 
-  let body: CallbackBody;
-  try {
-    body = JSON.parse(rawBody);
-  } catch {
-    return errorResponse("Invalid JSON body", 400);
-  }
+  const { runId, status, error } = result.data;
 
-  const { runId, status, error } = body;
-
-  if (!runId) {
-    return errorResponse("Missing runId", 400);
-  }
-
-  // Query callback record to get the per-callback secret
-  const [callback] = await globalThis.services.db
-    .select({ encryptedSecret: agentRunCallbacks.encryptedSecret })
-    .from(agentRunCallbacks)
-    .where(eq(agentRunCallbacks.runId, runId))
-    .limit(1);
-
-  if (!callback) {
-    log.warn("Callback record not found", { runId });
-    return errorResponse("Callback not found", 404);
-  }
-
-  // Decrypt the per-callback secret and verify signature
-  const callbackSecret = decryptCredentialValue(
-    callback.encryptedSecret,
-    SECRETS_ENCRYPTION_KEY,
-  );
-
-  const signature = request.headers.get("X-VM0-Signature");
-  const timestamp = request.headers.get("X-VM0-Timestamp");
-
-  const verification = verifyCallbackRequest(
-    rawBody,
-    callbackSecret,
-    signature,
-    timestamp,
-  );
-
-  if (!verification.valid) {
-    log.warn("Callback signature verification failed", {
-      runId,
-      error: verification.error,
-    });
-    return errorResponse(verification.error ?? "Invalid signature", 401);
-  }
-
-  const payload = parsePayload(body);
+  const payload = parsePayload(result.data.payload);
   if (!payload) {
     return errorResponse("Invalid or missing payload", 400);
   }
@@ -130,6 +73,8 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   const { composeName, userId } = payload;
 
   log.debug("Processing Slack schedule callback", { runId, status });
+
+  const { SECRETS_ENCRYPTION_KEY } = env();
 
   // Find slack user link for this VM0 user
   const [userLink] = await globalThis.services.db

--- a/turbo/apps/web/app/api/internal/callbacks/telegram/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/telegram/route.ts
@@ -1,12 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
 import { eq, and, gte, desc } from "drizzle-orm";
 import { initServices } from "../../../../../src/lib/init-services";
-import { verifyCallbackRequest } from "../../../../../src/lib/callback";
+import { verifyCallback } from "../../../../../src/lib/callback";
 import { decryptCredentialValue } from "../../../../../src/lib/crypto/secrets-encryption";
 import { telegramInstallations } from "../../../../../src/db/schema/telegram-installation";
 import { agentSessions } from "../../../../../src/db/schema/agent-session";
 import { agentRuns } from "../../../../../src/db/schema/agent-run";
-import { agentRunCallbacks } from "../../../../../src/db/schema/agent-run-callback";
 import {
   createTelegramClient,
   sendMessage,
@@ -37,17 +36,9 @@ interface CallbackPayload {
   existingSessionId: string | null;
 }
 
-interface CallbackBody {
-  runId: string;
-  status: "completed" | "failed";
-  result?: Record<string, unknown>;
-  error?: string;
-  payload: CallbackPayload;
-}
-
-function parsePayload(body: CallbackBody): CallbackPayload | null {
-  if (!body.payload) return null;
-  const p = body.payload;
+function parsePayload(payload: unknown): CallbackPayload | null {
+  if (!payload || typeof payload !== "object") return null;
+  const p = payload as Record<string, unknown>;
   if (
     typeof p.installationId !== "string" ||
     typeof p.chatId !== "string" ||
@@ -58,7 +49,7 @@ function parsePayload(body: CallbackBody): CallbackPayload | null {
   ) {
     return null;
   }
-  return p;
+  return p as unknown as CallbackPayload;
 }
 
 function errorResponse(message: string, status: number): NextResponse {
@@ -87,64 +78,13 @@ async function findNewSessionId(
 
 export async function POST(request: NextRequest): Promise<NextResponse> {
   initServices();
-  const { SECRETS_ENCRYPTION_KEY } = env();
 
-  // Read raw body for signature verification
-  const rawBody = await request.text();
+  const result = await verifyCallback<CallbackPayload>(request, log);
+  if (!result.ok) return result.response;
 
-  // Parse body first to get runId for callback lookup
-  let body: CallbackBody;
-  try {
-    body = JSON.parse(rawBody);
-  } catch {
-    return errorResponse("Invalid JSON body", 400);
-  }
+  const { runId, status, error } = result.data;
 
-  const { runId, status, error } = body;
-
-  if (!runId) {
-    return errorResponse("Missing runId", 400);
-  }
-
-  // Query callback record to get the per-callback secret
-  const [callback] = await globalThis.services.db
-    .select({ encryptedSecret: agentRunCallbacks.encryptedSecret })
-    .from(agentRunCallbacks)
-    .where(eq(agentRunCallbacks.runId, runId))
-    .limit(1);
-
-  if (!callback) {
-    log.warn("Callback record not found", { runId });
-    return errorResponse("Callback not found", 404);
-  }
-
-  // Decrypt the per-callback secret
-  const callbackSecret = decryptCredentialValue(
-    callback.encryptedSecret,
-    SECRETS_ENCRYPTION_KEY,
-  );
-
-  // Verify signature using the per-callback secret
-  const signature = request.headers.get("X-VM0-Signature");
-  const timestamp = request.headers.get("X-VM0-Timestamp");
-
-  const verification = verifyCallbackRequest(
-    rawBody,
-    callbackSecret,
-    signature,
-    timestamp,
-  );
-
-  if (!verification.valid) {
-    log.warn("Callback signature verification failed", {
-      runId,
-      error: verification.error,
-    });
-    return errorResponse(verification.error ?? "Invalid signature", 401);
-  }
-
-  const payload = parsePayload(body);
-
+  const payload = parsePayload(result.data.payload);
   if (!payload) {
     return errorResponse("Invalid or missing payload", 400);
   }
@@ -160,6 +100,8 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   } = payload;
 
   log.debug("Processing Telegram callback", { runId, status, chatId });
+
+  const { SECRETS_ENCRYPTION_KEY } = env();
 
   // Get Telegram installation for bot token
   const [installation] = await globalThis.services.db

--- a/turbo/apps/web/src/lib/callback/dispatcher.ts
+++ b/turbo/apps/web/src/lib/callback/dispatcher.ts
@@ -100,8 +100,9 @@ async function dispatchSingleCallback(
   // Decrypt the callback secret
   const secret = decryptCredentialValue(encryptedSecret, encryptionKey);
 
-  // Build callback body
+  // Build callback body (callbackId enables PK-based secret lookup on receivers)
   const body = JSON.stringify({
+    callbackId: id,
     runId,
     status,
     result,

--- a/turbo/apps/web/src/lib/callback/index.ts
+++ b/turbo/apps/web/src/lib/callback/index.ts
@@ -1,3 +1,3 @@
 export { generateCallbackSecret } from "./hmac";
 export { dispatchCallbacks, getApiUrl } from "./dispatcher";
-export { verifyCallbackRequest } from "./verify-signature";
+export { verifyCallback } from "./verify-callback";

--- a/turbo/apps/web/src/lib/callback/verify-callback.ts
+++ b/turbo/apps/web/src/lib/callback/verify-callback.ts
@@ -1,0 +1,133 @@
+import { eq } from "drizzle-orm";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+import { agentRunCallbacks } from "../../db/schema/agent-run-callback";
+import { decryptCredentialValue } from "../crypto/secrets-encryption";
+import { env } from "../../env";
+import { verifyCallbackRequest } from "./verify-signature";
+
+interface Logger {
+  warn: (...args: unknown[]) => void;
+}
+
+/**
+ * Parsed and verified callback request data.
+ * Generic over the payload type so each endpoint can narrow its own payload shape.
+ */
+interface VerifiedCallback<P = unknown> {
+  callbackId: string;
+  runId: string;
+  status: "completed" | "failed";
+  result?: Record<string, unknown>;
+  error?: string;
+  payload: P;
+}
+
+type VerifyCallbackResult<P> =
+  | { ok: true; data: VerifiedCallback<P> }
+  | { ok: false; response: NextResponse };
+
+function errorResponse(message: string, status: number): NextResponse {
+  return NextResponse.json({ error: message }, { status });
+}
+
+/**
+ * Verify an incoming callback request: parse body, look up callback record by
+ * primary key (`callbackId`), decrypt the per-callback secret, and verify the
+ * HMAC signature.
+ *
+ * Replaces the duplicated verification pattern previously copy-pasted across
+ * all callback endpoints. When verification fails the returned `response` can
+ * be returned directly from the route handler.
+ */
+export async function verifyCallback<P = unknown>(
+  request: NextRequest,
+  log: Logger,
+): Promise<VerifyCallbackResult<P>> {
+  const { SECRETS_ENCRYPTION_KEY } = env();
+
+  const rawBody = await request.text();
+
+  let body: {
+    callbackId?: string;
+    runId?: string;
+    status: "completed" | "failed";
+    result?: Record<string, unknown>;
+    error?: string;
+    payload: P;
+  };
+  try {
+    body = JSON.parse(rawBody);
+  } catch {
+    return { ok: false, response: errorResponse("Invalid JSON body", 400) };
+  }
+
+  const { callbackId, runId } = body;
+
+  if (!callbackId && !runId) {
+    return {
+      ok: false,
+      response: errorResponse("Missing callbackId and runId", 400),
+    };
+  }
+
+  // Look up the callback record — prefer callbackId (PK) for unambiguous lookup
+  const [callback] = callbackId
+    ? await globalThis.services.db
+        .select({ encryptedSecret: agentRunCallbacks.encryptedSecret })
+        .from(agentRunCallbacks)
+        .where(eq(agentRunCallbacks.id, callbackId))
+        .limit(1)
+    : await globalThis.services.db
+        .select({ encryptedSecret: agentRunCallbacks.encryptedSecret })
+        .from(agentRunCallbacks)
+        .where(eq(agentRunCallbacks.runId, runId!))
+        .limit(1);
+
+  if (!callback) {
+    log.warn("Callback record not found", { callbackId, runId });
+    return {
+      ok: false,
+      response: errorResponse("Callback not found", 404),
+    };
+  }
+
+  const callbackSecret = decryptCredentialValue(
+    callback.encryptedSecret,
+    SECRETS_ENCRYPTION_KEY,
+  );
+
+  const signature = request.headers.get("X-VM0-Signature");
+  const timestamp = request.headers.get("X-VM0-Timestamp");
+
+  const verification = verifyCallbackRequest(
+    rawBody,
+    callbackSecret,
+    signature,
+    timestamp,
+  );
+
+  if (!verification.valid) {
+    log.warn("Callback signature verification failed", {
+      callbackId,
+      runId,
+      error: verification.error,
+    });
+    return {
+      ok: false,
+      response: errorResponse(verification.error ?? "Invalid signature", 401),
+    };
+  }
+
+  return {
+    ok: true,
+    data: {
+      callbackId: callbackId ?? runId!,
+      runId: runId ?? callbackId!,
+      status: body.status,
+      result: body.result,
+      error: body.error,
+      payload: body.payload,
+    },
+  };
+}

--- a/turbo/apps/web/src/lib/callback/verify-callback.ts
+++ b/turbo/apps/web/src/lib/callback/verify-callback.ts
@@ -15,7 +15,8 @@ interface Logger {
  * Generic over the payload type so each endpoint can narrow its own payload shape.
  */
 interface VerifiedCallback<P = unknown> {
-  callbackId: string;
+  /** Present only when the dispatcher includes callbackId (new behavior). */
+  callbackId?: string;
   runId: string;
   status: "completed" | "failed";
   result?: Record<string, unknown>;
@@ -62,16 +63,19 @@ export async function verifyCallback<P = unknown>(
     return { ok: false, response: errorResponse("Invalid JSON body", 400) };
   }
 
-  const { callbackId, runId } = body;
+  const { callbackId } = body;
 
-  if (!callbackId && !runId) {
+  if (!body.runId) {
     return {
       ok: false,
-      response: errorResponse("Missing callbackId and runId", 400),
+      response: errorResponse("Missing runId", 400),
     };
   }
 
-  // Look up the callback record — prefer callbackId (PK) for unambiguous lookup
+  const runId = body.runId;
+
+  // Look up the callback record — prefer callbackId (PK) for unambiguous lookup.
+  // TODO: remove runId-only fallback once all deployed dispatchers include callbackId
   const [callback] = callbackId
     ? await globalThis.services.db
         .select({ encryptedSecret: agentRunCallbacks.encryptedSecret })
@@ -81,7 +85,7 @@ export async function verifyCallback<P = unknown>(
     : await globalThis.services.db
         .select({ encryptedSecret: agentRunCallbacks.encryptedSecret })
         .from(agentRunCallbacks)
-        .where(eq(agentRunCallbacks.runId, runId!))
+        .where(eq(agentRunCallbacks.runId, runId))
         .limit(1);
 
   if (!callback) {
@@ -122,8 +126,8 @@ export async function verifyCallback<P = unknown>(
   return {
     ok: true,
     data: {
-      callbackId: callbackId ?? runId!,
-      runId: runId ?? callbackId!,
+      callbackId,
+      runId,
       status: body.status,
       result: body.result,
       error: body.error,


### PR DESCRIPTION
## Summary

- **Root cause**: When a run has multiple callbacks (e.g. email + slack + loop), all 8 callback endpoints queried by `runId` with `LIMIT 1`, returning an arbitrary callback record — potentially with the wrong HMAC secret. This caused signature verification failures ~67% of the time with 3 callbacks.
- **Fix**: Include `callbackId` in the dispatcher request body so endpoints can do a PK-based lookup for the exact callback secret.
- **Bonus**: Extract shared `verifyCallback()` utility, eliminating ~45 lines of duplicated verification code across all 8 endpoints (net -321 lines).

## Changes

| File | Change |
|------|--------|
| `src/lib/callback/dispatcher.ts` | Add `callbackId` to request body |
| `src/lib/callback/verify-callback.ts` | **New** shared verification utility |
| `src/lib/callback/index.ts` | Update exports |
| 8 callback `route.ts` files | Replace inline verification with `verifyCallback()` |

## Test plan

- [ ] Deploy to preview and run a loop schedule with email + Slack notifications enabled
- [ ] Verify all 3 callbacks (email, Slack, loop) succeed without signature errors
- [ ] Verify loop schedule advances to next run after completion
- [ ] Check backward compatibility: endpoints still accept requests without `callbackId` (falls back to `runId` query)

Closes #3628

🤖 Generated with [Claude Code](https://claude.com/claude-code)