### PR TITLE
chore: remove sentry connector feature flag

### DIFF
--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -26,7 +26,6 @@ export enum FeatureSwitchKey {
   GarminConnectConnector = "garminConnectConnector",
   RedditConnector = "redditConnector",
   VercelConnector = "vercelConnector",
-  SentryConnector = "sentryConnector",
   IntervalsIcuConnector = "intervalsIcuConnector",
   XeroConnector = "xeroConnector",
   GitHubIntegration = "githubIntegration",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -146,11 +146,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledUserHashes: STAFF_USER_HASHES,
   },
-  [FeatureSwitchKey.SentryConnector]: {
-    maintainer: "ethan@vm0.ai",
-    enabled: false,
-    enabledUserHashes: STAFF_USER_HASHES,
-  },
   [FeatureSwitchKey.IntervalsIcuConnector]: {
     maintainer: "ethan@vm0.ai",
     enabled: false,
@@ -197,7 +192,6 @@ export const CONNECTOR_FEATURE_FLAGS: Partial<
 
   reddit: FeatureSwitchKey.RedditConnector,
   vercel: FeatureSwitchKey.VercelConnector,
-  sentry: FeatureSwitchKey.SentryConnector,
   "intervals-icu": FeatureSwitchKey.IntervalsIcuConnector,
   xero: FeatureSwitchKey.XeroConnector,
 };


### PR DESCRIPTION
## Summary
- Remove Sentry connector from feature switch system, making it publicly visible to all users
- Remove `SentryConnector` from `FeatureSwitchKey` enum
- Remove sentry entry from `CONNECTOR_FEATURE_FLAGS` map

Connectors not listed in `CONNECTOR_FEATURE_FLAGS` are always visible (same as notion, slack, linear, x, etc.)

## Test plan
- [x] Sentry connector tested end-to-end via `vm0 cook` — 16/16 API endpoints passed
- [ ] Verify sentry connector appears in Settings > Connectors for non-staff users
- [ ] Verify OAuth flow works for new users

🤖 Generated with [Claude Code](https://claude.com/claude-code)