### PR TITLE
fix(ci): use grep instead of wc to count metal hosts

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -163,7 +163,7 @@ jobs:
           METAL_HOSTS: ${{ secrets.AWS_METAL_RUNNER_HOSTS }}
           JOB_REF: ${{ github.event_name == 'pull_request' && format('pr-{0}-test', github.event.pull_request.number) || 'main-test' }}
         run: |
-          NUM_HOSTS=$(echo "$METAL_HOSTS" | tr ',' '\n' | wc -l)
+          NUM_HOSTS=$(echo "$METAL_HOSTS" | tr ',' '\n' | grep -c .)
           HASH=$(echo -n "$JOB_REF" | md5sum | cut -c1-8)
           HOST_INDEX=$(( 0x$HASH % NUM_HOSTS ))
           HOST=$(echo "$METAL_HOSTS" | tr ',' '\n' | sed -n "$((HOST_INDEX + 1))p")

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -163,15 +163,15 @@ jobs:
           METAL_HOSTS: ${{ secrets.AWS_METAL_RUNNER_HOSTS }}
           JOB_REF: ${{ github.event_name == 'pull_request' && format('pr-{0}-test', github.event.pull_request.number) || 'main-test' }}
         run: |
-          HOSTS=($(echo "$METAL_HOSTS" | tr ',' '\n' | grep .))
-          NUM_HOSTS=${#HOSTS[@]}
+          HOSTS=$(echo "$METAL_HOSTS" | tr ',' '\n' | grep .)
+          NUM_HOSTS=$(echo "$HOSTS" | grep -c .)
           if [ "$NUM_HOSTS" -lt 1 ]; then
             echo "::error::AWS_METAL_RUNNER_HOSTS is empty"
             exit 1
           fi
           HASH=$(echo -n "$JOB_REF" | md5sum | cut -c1-8)
           HOST_INDEX=$(( 0x$HASH % NUM_HOSTS ))
-          HOST=${HOSTS[$HOST_INDEX]}
+          HOST=$(echo "$HOSTS" | sed -n "$((HOST_INDEX + 1))p")
           echo "host=${HOST}" >> "$GITHUB_OUTPUT"
           echo "job-ref=${JOB_REF}" >> "$GITHUB_OUTPUT"
           echo "Selected metal host: ${HOST} (index ${HOST_INDEX}/${NUM_HOSTS})"

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -163,10 +163,15 @@ jobs:
           METAL_HOSTS: ${{ secrets.AWS_METAL_RUNNER_HOSTS }}
           JOB_REF: ${{ github.event_name == 'pull_request' && format('pr-{0}-test', github.event.pull_request.number) || 'main-test' }}
         run: |
-          NUM_HOSTS=$(echo "$METAL_HOSTS" | tr ',' '\n' | grep -c .)
+          HOSTS=($(echo "$METAL_HOSTS" | tr ',' '\n' | grep .))
+          NUM_HOSTS=${#HOSTS[@]}
+          if [ "$NUM_HOSTS" -lt 1 ]; then
+            echo "::error::AWS_METAL_RUNNER_HOSTS is empty"
+            exit 1
+          fi
           HASH=$(echo -n "$JOB_REF" | md5sum | cut -c1-8)
           HOST_INDEX=$(( 0x$HASH % NUM_HOSTS ))
-          HOST=$(echo "$METAL_HOSTS" | tr ',' '\n' | sed -n "$((HOST_INDEX + 1))p")
+          HOST=${HOSTS[$HOST_INDEX]}
           echo "host=${HOST}" >> "$GITHUB_OUTPUT"
           echo "job-ref=${JOB_REF}" >> "$GITHUB_OUTPUT"
           echo "Selected metal host: ${HOST} (index ${HOST_INDEX}/${NUM_HOSTS})"


### PR DESCRIPTION
## Summary

- Replace `wc -l` with `grep -c .` when counting metal hosts in `crates.yml`
- `wc -l` counts empty lines from trailing commas in `METAL_HOSTS` secret, causing 50% chance of selecting an empty host string
- `grep -c .` filters empty lines, matching the pattern already used in `turbo.yml`

## Test plan

- [ ] Verify host selection works with trailing comma in secret (e.g. `dev-5.aws.vm3.ai,`)
- [ ] Verify host selection works without trailing comma (e.g. `dev-5.aws.vm3.ai`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)