### PR TITLE
feat(telegram): auto-link admin on bot install

### DIFF
--- a/turbo/apps/platform/src/signals/integrations-page/telegram-integration.ts
+++ b/turbo/apps/platform/src/signals/integrations-page/telegram-integration.ts
@@ -10,6 +10,7 @@ interface TelegramIntegrationData {
   bot: { id: string; username: string };
   agent: { id: string; name: string; scopeSlug: string } | null;
   isAdmin: boolean;
+  needsLink: boolean;
   environment: {
     requiredSecrets: string[];
     requiredVars: string[];

--- a/turbo/apps/platform/src/signals/telegram-connect/telegram-connect-success-page.ts
+++ b/turbo/apps/platform/src/signals/telegram-connect/telegram-connect-success-page.ts
@@ -7,10 +7,12 @@ import { TelegramConnectSuccessPage } from "../../views/telegram-connect/telegra
 export const setupTelegramConnectSuccessPage$ = command(({ get, set }) => {
   set(updatePage$, createElement(TelegramConnectSuccessPage));
 
-  // Auto-open Telegram app on page load (uses tg:// protocol for system prompt)
+  // Auto-open Telegram app with deep link to trigger /start with link token
   const params = get(searchParams$);
   const botUsername = params.get("bot");
+  const linkToken = params.get("token");
   if (botUsername) {
-    window.location.href = `tg://resolve?domain=${botUsername}`;
+    const startParam = linkToken ? `&start=${linkToken}` : "";
+    window.location.href = `tg://resolve?domain=${botUsername}${startParam}`;
   }
 });

--- a/turbo/apps/platform/src/signals/telegram-connect/telegram-connect-success-page.ts
+++ b/turbo/apps/platform/src/signals/telegram-connect/telegram-connect-success-page.ts
@@ -7,16 +7,10 @@ import { TelegramConnectSuccessPage } from "../../views/telegram-connect/telegra
 export const setupTelegramConnectSuccessPage$ = command(({ get, set }) => {
   set(updatePage$, createElement(TelegramConnectSuccessPage));
 
-  // Auto-open Telegram with deep link to trigger /start with link token
+  // Auto-open Telegram so the user can send their first message
   const params = get(searchParams$);
   const botUsername = params.get("bot");
-  const linkToken = params.get("token");
   if (botUsername) {
-    const startParam = linkToken ? `?start=${linkToken}` : "";
-    window.open(
-      `https://t.me/${botUsername}${startParam}`,
-      "_blank",
-      "noopener,noreferrer",
-    );
+    window.open(`https://t.me/${botUsername}`, "_blank", "noopener,noreferrer");
   }
 });

--- a/turbo/apps/platform/src/signals/telegram-connect/telegram-connect-success-page.ts
+++ b/turbo/apps/platform/src/signals/telegram-connect/telegram-connect-success-page.ts
@@ -7,12 +7,16 @@ import { TelegramConnectSuccessPage } from "../../views/telegram-connect/telegra
 export const setupTelegramConnectSuccessPage$ = command(({ get, set }) => {
   set(updatePage$, createElement(TelegramConnectSuccessPage));
 
-  // Auto-open Telegram app with deep link to trigger /start with link token
+  // Auto-open Telegram with deep link to trigger /start with link token
   const params = get(searchParams$);
   const botUsername = params.get("bot");
   const linkToken = params.get("token");
   if (botUsername) {
-    const startParam = linkToken ? `&start=${linkToken}` : "";
-    window.location.href = `tg://resolve?domain=${botUsername}${startParam}`;
+    const startParam = linkToken ? `?start=${linkToken}` : "";
+    window.open(
+      `https://t.me/${botUsername}${startParam}`,
+      "_blank",
+      "noopener,noreferrer",
+    );
   }
 });

--- a/turbo/apps/platform/src/signals/telegram-connect/telegram-connect.ts
+++ b/turbo/apps/platform/src/signals/telegram-connect/telegram-connect.ts
@@ -12,7 +12,12 @@ interface TelegramConnectState {
 }
 
 type RegisterTelegramBotResult =
-  | { success: true; installationId: string; botUsername: string }
+  | {
+      success: true;
+      installationId: string;
+      botUsername: string;
+      linkToken?: string;
+    }
   | { success: false };
 
 const telegramConnectState$ = state<TelegramConnectState>({
@@ -110,6 +115,7 @@ export const registerTelegramBot$ = command(
       const result = (await response.json()) as {
         id: string;
         botUsername: string;
+        linkToken?: string;
       };
 
       set(telegramConnectState$, (prev) => ({
@@ -121,6 +127,7 @@ export const registerTelegramBot$ = command(
         success: true,
         installationId: result.id,
         botUsername: result.botUsername,
+        linkToken: result.linkToken,
       };
     } catch (error) {
       throwIfAbort(error);

--- a/turbo/apps/platform/src/signals/telegram-connect/telegram-connect.ts
+++ b/turbo/apps/platform/src/signals/telegram-connect/telegram-connect.ts
@@ -16,7 +16,6 @@ type RegisterTelegramBotResult =
       success: true;
       installationId: string;
       botUsername: string;
-      linkToken?: string;
     }
   | { success: false };
 
@@ -115,7 +114,6 @@ export const registerTelegramBot$ = command(
       const result = (await response.json()) as {
         id: string;
         botUsername: string;
-        linkToken?: string;
       };
 
       set(telegramConnectState$, (prev) => ({
@@ -127,7 +125,6 @@ export const registerTelegramBot$ = command(
         success: true,
         installationId: result.id,
         botUsername: result.botUsername,
-        linkToken: result.linkToken,
       };
     } catch (error) {
       throwIfAbort(error);

--- a/turbo/apps/platform/src/views/integrations-page/telegram-settings-page.tsx
+++ b/turbo/apps/platform/src/views/integrations-page/telegram-settings-page.tsx
@@ -1,5 +1,9 @@
 import { useGet, useSet } from "ccstate-react";
-import { IconAlertTriangle, IconChevronDown } from "@tabler/icons-react";
+import {
+  IconAlertTriangle,
+  IconChevronDown,
+  IconLink,
+} from "@tabler/icons-react";
 import {
   CONNECTOR_TYPES,
   getConnectorProvidedSecretNames,
@@ -44,6 +48,38 @@ import { Link } from "../router/link.tsx";
 function getAllConnectorEnvVars(): Set<string> {
   return getConnectorProvidedSecretNames(
     Object.keys(CONNECTOR_TYPES) as ConnectorType[],
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Link account banner
+// ---------------------------------------------------------------------------
+
+function LinkAccountBanner({ botUsername }: { botUsername: string }) {
+  return (
+    <div className="flex items-center gap-3 rounded-lg border border-blue-500 bg-blue-50 px-4 py-3 dark:border-blue-700 dark:bg-blue-950/30">
+      <IconLink size={20} className="shrink-0 text-blue-500" stroke={1.5} />
+      <div className="flex flex-1 flex-col gap-1">
+        <p className="text-sm font-medium">Link your Telegram account</p>
+        <p className="text-sm text-muted-foreground">
+          Open the bot in Telegram and press Start to link your account. This
+          lets you chat with the agent directly.
+        </p>
+      </div>
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={() =>
+          window.open(
+            `https://t.me/${botUsername}`,
+            "_blank",
+            "noopener,noreferrer",
+          )
+        }
+      >
+        Open in Telegram
+      </Button>
+    </div>
   );
 }
 
@@ -251,6 +287,11 @@ export function TelegramSettingsPage() {
           </div>
         ) : (
           <>
+            {/* Link account banner */}
+            {data?.needsLink && data.bot && (
+              <LinkAccountBanner botUsername={data.bot.username} />
+            )}
+
             {/* Bot info */}
             {data?.bot && (
               <div className="flex flex-col gap-4">

--- a/turbo/apps/platform/src/views/telegram-connect/__tests__/telegram-connect-page.test.tsx
+++ b/turbo/apps/platform/src/views/telegram-connect/__tests__/telegram-connect-page.test.tsx
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { server } from "../../../mocks/server.ts";
 import { http, HttpResponse } from "msw";
 import { setupPage } from "../../../__tests__/page-helper.ts";
@@ -11,12 +11,16 @@ const context = testContext();
 const user = userEvent.setup();
 
 describe("telegram connect page", () => {
+  let openSpy: ReturnType<typeof vi.spyOn>;
+
   beforeEach(() => {
-    // Reset window.location if a previous test changed it to a non-http protocol
-    // (e.g., tg:// from the success page signal during navigate$)
-    if (!window.location.href.startsWith("http")) {
-      window.location.href = "http://localhost/";
-    }
+    // Mock window.open to prevent the success page signal from triggering
+    // real navigation to https://t.me/... which would hit MSW
+    openSpy = vi.spyOn(window, "open").mockImplementation(() => null);
+  });
+
+  afterEach(() => {
+    openSpy.mockRestore();
   });
 
   it("redirects to provider-setup when no provider configured", async () => {

--- a/turbo/apps/platform/src/views/telegram-connect/__tests__/telegram-connect-page.test.tsx
+++ b/turbo/apps/platform/src/views/telegram-connect/__tests__/telegram-connect-page.test.tsx
@@ -100,6 +100,7 @@ describe("telegram connect page", () => {
         return HttpResponse.json({
           id: "installation_1",
           botUsername: "my_test_bot",
+          linkToken: "test-link-token",
         });
       }),
     );
@@ -133,6 +134,7 @@ describe("telegram connect page", () => {
     });
     const params = context.store.get(searchParams$);
     expect(params.get("bot")).toBe("my_test_bot");
+    expect(params.get("token")).toBe("test-link-token");
   });
 
   it("shows error message when registration fails", async () => {

--- a/turbo/apps/platform/src/views/telegram-connect/__tests__/telegram-connect-page.test.tsx
+++ b/turbo/apps/platform/src/views/telegram-connect/__tests__/telegram-connect-page.test.tsx
@@ -104,7 +104,6 @@ describe("telegram connect page", () => {
         return HttpResponse.json({
           id: "installation_1",
           botUsername: "my_test_bot",
-          linkToken: "test-link-token",
         });
       }),
     );
@@ -138,7 +137,7 @@ describe("telegram connect page", () => {
     });
     const params = context.store.get(searchParams$);
     expect(params.get("bot")).toBe("my_test_bot");
-    expect(params.get("token")).toBe("test-link-token");
+    expect(params.get("token")).toBeNull();
   });
 
   it("shows error message when registration fails", async () => {

--- a/turbo/apps/platform/src/views/telegram-connect/__tests__/telegram-connect-success-page.test.tsx
+++ b/turbo/apps/platform/src/views/telegram-connect/__tests__/telegram-connect-success-page.test.tsx
@@ -79,11 +79,11 @@ describe("telegram connect success page", () => {
   it("auto-opens Telegram deep link on load", async () => {
     await setupPage({
       context,
-      path: "/telegram/connect/success?bot=my_test_bot&token=abc123",
+      path: "/telegram/connect/success?bot=my_test_bot",
     });
 
     expect(openSpy).toHaveBeenCalledWith(
-      "https://t.me/my_test_bot?start=abc123",
+      "https://t.me/my_test_bot",
       "_blank",
       "noopener,noreferrer",
     );

--- a/turbo/apps/platform/src/views/telegram-connect/__tests__/telegram-connect-success-page.test.tsx
+++ b/turbo/apps/platform/src/views/telegram-connect/__tests__/telegram-connect-success-page.test.tsx
@@ -84,11 +84,11 @@ describe("telegram connect success page", () => {
 
     await setupPage({
       context,
-      path: "/telegram/connect/success?bot=my_test_bot",
+      path: "/telegram/connect/success?bot=my_test_bot&token=abc123",
     });
 
-    // The setupTelegramConnectSuccessPage$ sets window.location.href with tg:// protocol
-    expect(capturedHref).toBe("tg://resolve?domain=my_test_bot");
+    // The setupTelegramConnectSuccessPage$ sets window.location.href with tg:// protocol and link token
+    expect(capturedHref).toBe("tg://resolve?domain=my_test_bot&start=abc123");
 
     locationSpy.mockRestore();
   });

--- a/turbo/apps/platform/src/views/telegram-connect/__tests__/telegram-connect-success-page.test.tsx
+++ b/turbo/apps/platform/src/views/telegram-connect/__tests__/telegram-connect-success-page.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { setupPage } from "../../../__tests__/page-helper.ts";
 import { mockedClerk } from "../../../__tests__/mock-auth.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
@@ -8,6 +8,15 @@ import { screen } from "@testing-library/react";
 const context = testContext();
 
 describe("telegram connect success page", () => {
+  let openSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    openSpy = vi.spyOn(window, "open").mockImplementation(() => null);
+  });
+
+  afterEach(() => {
+    openSpy.mockRestore();
+  });
   it("renders success message and bot link when bot param is present", async () => {
     await setupPage({
       context,
@@ -68,28 +77,15 @@ describe("telegram connect success page", () => {
   });
 
   it("auto-opens Telegram deep link on load", async () => {
-    const locationSpy = vi.spyOn(window, "location", "get");
-    const mockLocation = {
-      ...window.location,
-      href: "",
-    };
-    let capturedHref = "";
-    Object.defineProperty(mockLocation, "href", {
-      get: () => capturedHref,
-      set: (val: string) => {
-        capturedHref = val;
-      },
-    });
-    locationSpy.mockReturnValue(mockLocation as Location);
-
     await setupPage({
       context,
       path: "/telegram/connect/success?bot=my_test_bot&token=abc123",
     });
 
-    // The setupTelegramConnectSuccessPage$ sets window.location.href with tg:// protocol and link token
-    expect(capturedHref).toBe("tg://resolve?domain=my_test_bot&start=abc123");
-
-    locationSpy.mockRestore();
+    expect(openSpy).toHaveBeenCalledWith(
+      "https://t.me/my_test_bot?start=abc123",
+      "_blank",
+      "noopener,noreferrer",
+    );
   });
 });

--- a/turbo/apps/platform/src/views/telegram-connect/telegram-connect-page.tsx
+++ b/turbo/apps/platform/src/views/telegram-connect/telegram-connect-page.tsx
@@ -33,9 +33,6 @@ export function TelegramConnectPage() {
         if (result.success) {
           const successParams = new URLSearchParams();
           successParams.set("bot", result.botUsername);
-          if (result.linkToken) {
-            successParams.set("token", result.linkToken);
-          }
           navigate("/telegram/connect/success", {
             searchParams: successParams,
           });

--- a/turbo/apps/platform/src/views/telegram-connect/telegram-connect-page.tsx
+++ b/turbo/apps/platform/src/views/telegram-connect/telegram-connect-page.tsx
@@ -33,6 +33,9 @@ export function TelegramConnectPage() {
         if (result.success) {
           const successParams = new URLSearchParams();
           successParams.set("bot", result.botUsername);
+          if (result.linkToken) {
+            successParams.set("token", result.linkToken);
+          }
           navigate("/telegram/connect/success", {
             searchParams: successParams,
           });

--- a/turbo/apps/platform/src/views/telegram-connect/telegram-connect-success-page.tsx
+++ b/turbo/apps/platform/src/views/telegram-connect/telegram-connect-success-page.tsx
@@ -9,8 +9,9 @@ export function TelegramConnectSuccessPage() {
   const params = useGet(searchParams$);
 
   const botUsername = params.get("bot");
+  const linkToken = params.get("token");
   const telegramLink = botUsername
-    ? `tg://resolve?domain=${botUsername}`
+    ? `tg://resolve?domain=${botUsername}${linkToken ? `&start=${linkToken}` : ""}`
     : null;
 
   const backgroundGradient =

--- a/turbo/apps/platform/src/views/telegram-connect/telegram-connect-success-page.tsx
+++ b/turbo/apps/platform/src/views/telegram-connect/telegram-connect-success-page.tsx
@@ -9,10 +9,7 @@ export function TelegramConnectSuccessPage() {
   const params = useGet(searchParams$);
 
   const botUsername = params.get("bot");
-  const linkToken = params.get("token");
-  const telegramLink = botUsername
-    ? `https://t.me/${botUsername}${linkToken ? `?start=${linkToken}` : ""}`
-    : null;
+  const telegramLink = botUsername ? `https://t.me/${botUsername}` : null;
 
   const backgroundGradient =
     theme === "dark"

--- a/turbo/apps/platform/src/views/telegram-connect/telegram-connect-success-page.tsx
+++ b/turbo/apps/platform/src/views/telegram-connect/telegram-connect-success-page.tsx
@@ -11,7 +11,7 @@ export function TelegramConnectSuccessPage() {
   const botUsername = params.get("bot");
   const linkToken = params.get("token");
   const telegramLink = botUsername
-    ? `tg://resolve?domain=${botUsername}${linkToken ? `&start=${linkToken}` : ""}`
+    ? `https://t.me/${botUsername}${linkToken ? `?start=${linkToken}` : ""}`
     : null;
 
   const backgroundGradient =

--- a/turbo/apps/web/app/api/integrations/telegram/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/integrations/telegram/__tests__/route.test.ts
@@ -71,7 +71,28 @@ describe("/api/integrations/telegram", () => {
       expect(data.bot.username).toBeDefined();
       expect(data.agent).toBeDefined();
       expect(data.isAdmin).toBe(true);
+      expect(data.needsLink).toBe(false);
       expect(data.environment).toBeDefined();
+    });
+
+    it("returns bot info with needsLink when admin has no user link", async () => {
+      const user = await context.setupUser();
+      // Create installation with admin but no user link (omit vm0UserId)
+      await createTestTelegramInstallation({
+        adminUserId: user.userId,
+      });
+
+      const request = new Request(
+        "http://localhost:3000/api/integrations/telegram",
+      );
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.bot.id).toBeDefined();
+      expect(data.bot.username).toBeDefined();
+      expect(data.isAdmin).toBe(true);
+      expect(data.needsLink).toBe(true);
     });
   });
 

--- a/turbo/apps/web/app/api/integrations/telegram/link/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/integrations/telegram/link/__tests__/route.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { GET, POST } from "../route";
-import { verifyLinkToken } from "../route";
+import { verifyLinkToken } from "../../../../../../src/lib/telegram/handlers/start";
 import { testContext } from "../../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
 import { createTestTelegramInstallation } from "../../../../../../src/__tests__/api-test-helpers";

--- a/turbo/apps/web/app/api/integrations/telegram/link/route.ts
+++ b/turbo/apps/web/app/api/integrations/telegram/link/route.ts
@@ -1,4 +1,3 @@
-import { createHmac, timingSafeEqual } from "crypto";
 import { NextResponse } from "next/server";
 import { eq, desc } from "drizzle-orm";
 import { z } from "zod";
@@ -7,63 +6,11 @@ import { env } from "../../../../../src/env";
 import { getUserId } from "../../../../../src/lib/auth/get-user-id";
 import { telegramUserLinks } from "../../../../../src/db/schema/telegram-user-link";
 import { telegramInstallations } from "../../../../../src/db/schema/telegram-installation";
+import { createLinkToken } from "../../../../../src/lib/telegram/handlers/start";
 
 const linkBodySchema = z.object({
   installationId: z.string().min(1),
 });
-
-/** Link token expiry: 10 minutes */
-const LINK_TOKEN_TTL_MS = 10 * 60 * 1000;
-
-const linkTokenPayloadSchema = z.object({
-  vm0UserId: z.string(),
-  installationId: z.string(),
-  exp: z.number(),
-});
-
-type LinkTokenPayload = z.infer<typeof linkTokenPayloadSchema>;
-
-/**
- * Create a signed link token (base64url-encoded payload + HMAC signature).
- */
-function createLinkToken(payload: LinkTokenPayload, secret: string): string {
-  const data = Buffer.from(JSON.stringify(payload)).toString("base64url");
-  const sig = createHmac("sha256", secret).update(data).digest("base64url");
-  return `${data}.${sig}`;
-}
-
-/**
- * Verify and decode a link token. Returns null if invalid or expired.
- */
-export function verifyLinkToken(
-  token: string,
-  secret: string,
-): LinkTokenPayload | null {
-  const parts = token.split(".");
-  if (parts.length !== 2) return null;
-
-  const [data, sig] = parts;
-  if (!data || !sig) return null;
-
-  const expectedSig = createHmac("sha256", secret)
-    .update(data)
-    .digest("base64url");
-
-  // Timing-safe comparison
-  const expectedBuf = Buffer.from(expectedSig);
-  const sigBuf = Buffer.from(sig);
-  if (expectedBuf.length !== sigBuf.length) return null;
-  if (!timingSafeEqual(expectedBuf, sigBuf)) return null;
-
-  const parsed = linkTokenPayloadSchema.safeParse(
-    JSON.parse(Buffer.from(data, "base64url").toString()),
-  );
-  if (!parsed.success) return null;
-
-  if (Date.now() > parsed.data.exp) return null;
-
-  return parsed.data;
-}
 
 /**
  * GET /api/integrations/telegram/link
@@ -157,11 +104,8 @@ export async function POST(request: Request) {
   const { SECRETS_ENCRYPTION_KEY } = env();
 
   const token = createLinkToken(
-    {
-      vm0UserId: userId,
-      installationId: installation.id,
-      exp: Date.now() + LINK_TOKEN_TTL_MS,
-    },
+    userId,
+    installation.id,
     SECRETS_ENCRYPTION_KEY,
   );
 

--- a/turbo/apps/web/app/api/integrations/telegram/route.ts
+++ b/turbo/apps/web/app/api/integrations/telegram/route.ts
@@ -62,25 +62,34 @@ export async function GET(request: Request) {
     .orderBy(desc(telegramUserLinks.createdAt))
     .limit(1);
 
-  if (!userLink) {
+  let installation;
+  let needsLink = false;
+
+  if (userLink) {
+    // Get bot installation via user link
+    const [linked] = await db
+      .select()
+      .from(telegramInstallations)
+      .where(eq(telegramInstallations.id, userLink.installationId))
+      .limit(1);
+    installation = linked;
+  } else {
+    // Fallback: check if user is admin of any installation
+    const [adminInstallation] = await db
+      .select()
+      .from(telegramInstallations)
+      .where(eq(telegramInstallations.adminUserId, userId))
+      .orderBy(desc(telegramInstallations.createdAt))
+      .limit(1);
+    installation = adminInstallation;
+    needsLink = !!adminInstallation;
+  }
+
+  if (!installation) {
     return NextResponse.json(
       {
         error: { message: "No linked Telegram bot", code: "NOT_FOUND" },
       },
-      { status: 404 },
-    );
-  }
-
-  // Get bot installation
-  const [installation] = await db
-    .select()
-    .from(telegramInstallations)
-    .where(eq(telegramInstallations.id, userLink.installationId))
-    .limit(1);
-
-  if (!installation) {
-    return NextResponse.json(
-      { error: { message: "Telegram bot not found", code: "NOT_FOUND" } },
       { status: 404 },
     );
   }
@@ -156,6 +165,7 @@ export async function GET(request: Request) {
       ? { id: compose.id, name: compose.name, scopeSlug: compose.scopeSlug }
       : null,
     isAdmin,
+    needsLink,
     environment: {
       requiredSecrets,
       requiredVars,

--- a/turbo/apps/web/app/api/telegram/register/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/telegram/register/__tests__/route.test.ts
@@ -1,14 +1,13 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { HttpResponse } from "msw";
 import { POST } from "../route";
-import { eq, and } from "drizzle-orm";
 import {
   testContext,
   uniqueId,
 } from "../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../src/__tests__/clerk-mock";
 import { createTestCompose } from "../../../../../src/__tests__/api-test-helpers";
-import { telegramUserLinks } from "../../../../../src/db/schema/telegram-user-link";
+import { GET as linkGET } from "../../../../api/integrations/telegram/link/route";
 import { server } from "../../../../../src/mocks/server";
 import { http } from "../../../../../src/__tests__/msw";
 
@@ -133,19 +132,14 @@ describe("POST /api/telegram/register", () => {
     expect(body.id).toBeDefined();
     expect(body.linkToken).toBeUndefined();
 
-    // Verify pending user link was created
-    const [pendingLink] = await globalThis.services.db
-      .select()
-      .from(telegramUserLinks)
-      .where(
-        and(
-          eq(telegramUserLinks.installationId, body.id),
-          eq(telegramUserLinks.telegramUserId, "pending"),
-        ),
-      )
-      .limit(1);
-    expect(pendingLink).toBeDefined();
-    expect(pendingLink!.vm0UserId).toBeDefined();
+    // Verify pending user link was created via the link API
+    const linkResponse = await linkGET(
+      new Request("http://localhost:3000/api/integrations/telegram/link"),
+    );
+    const linkData = await linkResponse.json();
+    expect(linkResponse.status).toBe(200);
+    expect(linkData.linked).toBe(true);
+    expect(linkData.telegramUserId).toBe("pending");
 
     expect(getMeHandler.mocked).toHaveBeenCalledTimes(1);
     expect(setWebhookHandler.mocked).toHaveBeenCalledTimes(1);

--- a/turbo/apps/web/app/api/telegram/register/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/telegram/register/__tests__/route.test.ts
@@ -129,6 +129,7 @@ describe("POST /api/telegram/register", () => {
     expect(body.botUsername).toBe(`bot_${botId}`);
     expect(body.webhookUrl).toContain("/api/telegram/webhook/");
     expect(body.id).toBeDefined();
+    expect(body.linkToken).toBeDefined();
 
     expect(getMeHandler.mocked).toHaveBeenCalledTimes(1);
     expect(setWebhookHandler.mocked).toHaveBeenCalledTimes(1);

--- a/turbo/apps/web/app/api/telegram/register/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/telegram/register/__tests__/route.test.ts
@@ -8,6 +8,7 @@ import {
 import { mockClerk } from "../../../../../src/__tests__/clerk-mock";
 import { createTestCompose } from "../../../../../src/__tests__/api-test-helpers";
 import { GET as linkGET } from "../../../../api/integrations/telegram/link/route";
+import { PENDING_TELEGRAM_USER_ID } from "../../../../../src/lib/telegram/handlers/shared";
 import { server } from "../../../../../src/mocks/server";
 import { http } from "../../../../../src/__tests__/msw";
 
@@ -139,7 +140,7 @@ describe("POST /api/telegram/register", () => {
     const linkData = await linkResponse.json();
     expect(linkResponse.status).toBe(200);
     expect(linkData.linked).toBe(true);
-    expect(linkData.telegramUserId).toBe("pending");
+    expect(linkData.telegramUserId).toBe(PENDING_TELEGRAM_USER_ID);
 
     expect(getMeHandler.mocked).toHaveBeenCalledTimes(1);
     expect(setWebhookHandler.mocked).toHaveBeenCalledTimes(1);

--- a/turbo/apps/web/app/api/telegram/register/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/telegram/register/__tests__/route.test.ts
@@ -1,12 +1,14 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { HttpResponse } from "msw";
 import { POST } from "../route";
+import { eq, and } from "drizzle-orm";
 import {
   testContext,
   uniqueId,
 } from "../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../src/__tests__/clerk-mock";
 import { createTestCompose } from "../../../../../src/__tests__/api-test-helpers";
+import { telegramUserLinks } from "../../../../../src/db/schema/telegram-user-link";
 import { server } from "../../../../../src/mocks/server";
 import { http } from "../../../../../src/__tests__/msw";
 
@@ -129,7 +131,21 @@ describe("POST /api/telegram/register", () => {
     expect(body.botUsername).toBe(`bot_${botId}`);
     expect(body.webhookUrl).toContain("/api/telegram/webhook/");
     expect(body.id).toBeDefined();
-    expect(body.linkToken).toBeDefined();
+    expect(body.linkToken).toBeUndefined();
+
+    // Verify pending user link was created
+    const [pendingLink] = await globalThis.services.db
+      .select()
+      .from(telegramUserLinks)
+      .where(
+        and(
+          eq(telegramUserLinks.installationId, body.id),
+          eq(telegramUserLinks.telegramUserId, "pending"),
+        ),
+      )
+      .limit(1);
+    expect(pendingLink).toBeDefined();
+    expect(pendingLink!.vm0UserId).toBeDefined();
 
     expect(getMeHandler.mocked).toHaveBeenCalledTimes(1);
     expect(setWebhookHandler.mocked).toHaveBeenCalledTimes(1);

--- a/turbo/apps/web/app/api/telegram/register/route.ts
+++ b/turbo/apps/web/app/api/telegram/register/route.ts
@@ -5,7 +5,6 @@ import { initServices } from "../../../../src/lib/init-services";
 import { env } from "../../../../src/env";
 import { getUserId } from "../../../../src/lib/auth/get-user-id";
 import { telegramInstallations } from "../../../../src/db/schema/telegram-installation";
-import { telegramUserLinks } from "../../../../src/db/schema/telegram-user-link";
 import { agentComposes } from "../../../../src/db/schema/agent-compose";
 import {
   getMe,
@@ -15,6 +14,7 @@ import {
 import { encryptCredentialValue } from "../../../../src/lib/crypto/secrets-encryption";
 import { generateCallbackSecret } from "../../../../src/lib/callback/hmac";
 import { resolveDefaultAgentComposeId } from "../../../../src/lib/agent-compose/resolve-default";
+import { createLinkToken } from "../../../../src/lib/telegram/handlers/start";
 import { logger } from "../../../../src/lib/logger";
 
 const registerBodySchema = z.object({
@@ -195,15 +195,12 @@ export async function POST(request: Request) {
     log.warn("Failed to register bot commands", { error });
   });
 
-  // 8. Auto-create user link for the registering admin
-  await globalThis.services.db
-    .insert(telegramUserLinks)
-    .values({
-      telegramUserId: telegramBotId,
-      installationId: installation.id,
-      vm0UserId: userId,
-    })
-    .onConflictDoNothing();
+  // 8. Generate link token so the admin can link their Telegram account
+  const linkToken = createLinkToken(
+    userId,
+    installation.id,
+    SECRETS_ENCRYPTION_KEY,
+  );
 
   return NextResponse.json(
     {
@@ -211,6 +208,7 @@ export async function POST(request: Request) {
       botId: telegramBotId,
       botUsername: botInfoResult.username,
       webhookUrl,
+      linkToken,
     },
     { status: 201 },
   );

--- a/turbo/apps/web/app/api/telegram/register/route.ts
+++ b/turbo/apps/web/app/api/telegram/register/route.ts
@@ -14,7 +14,8 @@ import {
 import { encryptCredentialValue } from "../../../../src/lib/crypto/secrets-encryption";
 import { generateCallbackSecret } from "../../../../src/lib/callback/hmac";
 import { resolveDefaultAgentComposeId } from "../../../../src/lib/agent-compose/resolve-default";
-import { createLinkToken } from "../../../../src/lib/telegram/handlers/start";
+import { telegramUserLinks } from "../../../../src/db/schema/telegram-user-link";
+import { ensureScopeAndArtifact } from "../../../../src/lib/telegram/handlers/shared";
 import { logger } from "../../../../src/lib/logger";
 
 const registerBodySchema = z.object({
@@ -195,12 +196,13 @@ export async function POST(request: Request) {
     log.warn("Failed to register bot commands", { error });
   });
 
-  // 8. Generate link token so the admin can link their Telegram account
-  const linkToken = createLinkToken(
-    userId,
-    installation.id,
-    SECRETS_ENCRYPTION_KEY,
-  );
+  // 8. Create pending user link so the admin is auto-linked on first message
+  await globalThis.services.db.insert(telegramUserLinks).values({
+    telegramUserId: "pending",
+    installationId: installation.id,
+    vm0UserId: userId,
+  });
+  await ensureScopeAndArtifact(userId);
 
   return NextResponse.json(
     {
@@ -208,7 +210,6 @@ export async function POST(request: Request) {
       botId: telegramBotId,
       botUsername: botInfoResult.username,
       webhookUrl,
-      linkToken,
     },
     { status: 201 },
   );

--- a/turbo/apps/web/app/api/telegram/register/route.ts
+++ b/turbo/apps/web/app/api/telegram/register/route.ts
@@ -15,7 +15,10 @@ import { encryptCredentialValue } from "../../../../src/lib/crypto/secrets-encry
 import { generateCallbackSecret } from "../../../../src/lib/callback/hmac";
 import { resolveDefaultAgentComposeId } from "../../../../src/lib/agent-compose/resolve-default";
 import { telegramUserLinks } from "../../../../src/db/schema/telegram-user-link";
-import { ensureScopeAndArtifact } from "../../../../src/lib/telegram/handlers/shared";
+import {
+  ensureScopeAndArtifact,
+  PENDING_TELEGRAM_USER_ID,
+} from "../../../../src/lib/telegram/handlers/shared";
 import { logger } from "../../../../src/lib/logger";
 
 const registerBodySchema = z.object({
@@ -198,7 +201,7 @@ export async function POST(request: Request) {
 
   // 8. Create pending user link so the admin is auto-linked on first message
   await globalThis.services.db.insert(telegramUserLinks).values({
-    telegramUserId: "pending",
+    telegramUserId: PENDING_TELEGRAM_USER_ID,
     installationId: installation.id,
     vm0UserId: userId,
   });

--- a/turbo/apps/web/app/api/telegram/webhook/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/telegram/webhook/__tests__/route.test.ts
@@ -10,6 +10,7 @@ import {
   createTelegramPendingLinkInstallation,
 } from "../../../../../src/lib/telegram/__tests__/helpers";
 import { GET as linkGET } from "../../../../api/integrations/telegram/link/route";
+import { PENDING_TELEGRAM_USER_ID } from "../../../../../src/lib/telegram/handlers/shared";
 import { server } from "../../../../../src/mocks/server";
 import { http } from "../../../../../src/__tests__/msw";
 import { POST } from "../[installationId]/route";
@@ -228,7 +229,7 @@ describe("POST /api/telegram/webhook/[installationId]", () => {
       );
       const beforeData = await beforeResponse.json();
       expect(beforeData.linked).toBe(true);
-      expect(beforeData.telegramUserId).toBe("pending");
+      expect(beforeData.telegramUserId).toBe(PENDING_TELEGRAM_USER_ID);
 
       // Send a DM as the admin (telegramUserId = "789")
       const telegramUserId = 789;

--- a/turbo/apps/web/app/api/telegram/webhook/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/telegram/webhook/__tests__/route.test.ts
@@ -1,6 +1,17 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { testContext } from "../../../../../src/__tests__/test-helpers";
-import { createTelegramInstallation } from "../../../../../src/lib/telegram/__tests__/helpers";
+import { HttpResponse } from "msw";
+import {
+  testContext,
+  uniqueId,
+} from "../../../../../src/__tests__/test-helpers";
+import { createTestCompose } from "../../../../../src/__tests__/api-test-helpers";
+import {
+  createTelegramInstallation,
+  createTelegramPendingLinkInstallation,
+} from "../../../../../src/lib/telegram/__tests__/helpers";
+import { GET as linkGET } from "../../../../api/integrations/telegram/link/route";
+import { server } from "../../../../../src/mocks/server";
+import { http } from "../../../../../src/__tests__/msw";
 import { POST } from "../[installationId]/route";
 
 // Mock Next.js after() to execute synchronously
@@ -20,9 +31,10 @@ async function flushAfterCallbacks() {
   afterPromises.length = 0;
 }
 
-testContext();
+const context = testContext();
 
 const WEBHOOK_SECRET = "webhook-secret";
+const TEST_BOT_TOKEN = "123456:ABC-pending-test";
 
 function createWebhookRequest(
   body: Record<string, unknown>,
@@ -181,5 +193,72 @@ describe("POST /api/telegram/webhook/[installationId]", () => {
       params: Promise.resolve({ installationId }),
     });
     expect(response.status).toBe(400);
+  });
+
+  describe("auto-complete pending link", () => {
+    it("should complete pending link on first DM from admin", async () => {
+      context.setupMocks();
+      const user = await context.setupUser();
+      const { composeId } = await createTestCompose(uniqueId("agent"));
+
+      const pending = await createTelegramPendingLinkInstallation(
+        composeId,
+        user.userId,
+        TEST_BOT_TOKEN,
+      );
+
+      // Set up MSW handlers for Telegram API calls the DM handler makes
+      const sendChatActionHandler = http.post(
+        `https://api.telegram.org/bot${TEST_BOT_TOKEN}/sendChatAction`,
+        () => HttpResponse.json({ ok: true, result: true }),
+      );
+      const sendMessageHandler = http.post(
+        `https://api.telegram.org/bot${TEST_BOT_TOKEN}/sendMessage`,
+        () =>
+          HttpResponse.json({
+            ok: true,
+            result: { message_id: 99, chat: { id: 789 } },
+          }),
+      );
+      server.use(sendChatActionHandler.handler, sendMessageHandler.handler);
+
+      // Verify the link is pending before the webhook
+      const beforeResponse = await linkGET(
+        new Request("http://localhost:3000/api/integrations/telegram/link"),
+      );
+      const beforeData = await beforeResponse.json();
+      expect(beforeData.linked).toBe(true);
+      expect(beforeData.telegramUserId).toBe("pending");
+
+      // Send a DM as the admin (telegramUserId = "789")
+      const telegramUserId = 789;
+      const request = createWebhookRequest({
+        update_id: 100,
+        message: {
+          message_id: 1,
+          chat: { id: telegramUserId, type: "private" },
+          from: { id: telegramUserId, username: "admin_user" },
+          text: "hello bot",
+        },
+      });
+
+      const response = await POST(request, {
+        params: Promise.resolve({
+          installationId: pending.installationId,
+        }),
+      });
+      expect(response.status).toBe(200);
+
+      // Flush the after() callback so the DM handler runs
+      await flushAfterCallbacks();
+
+      // Verify the pending link was completed with the real Telegram user ID
+      const afterResponse = await linkGET(
+        new Request("http://localhost:3000/api/integrations/telegram/link"),
+      );
+      const afterData = await afterResponse.json();
+      expect(afterData.linked).toBe(true);
+      expect(afterData.telegramUserId).toBe(String(telegramUserId));
+    });
   });
 });

--- a/turbo/apps/web/src/lib/telegram/__tests__/helpers.ts
+++ b/turbo/apps/web/src/lib/telegram/__tests__/helpers.ts
@@ -5,6 +5,7 @@ import { telegramMessages } from "../../../db/schema/telegram-message";
 import { agentComposes } from "../../../db/schema/agent-compose";
 import { scopes } from "../../../db/schema/scope";
 import { encryptCredentialValue } from "../../crypto/secrets-encryption";
+import { PENDING_TELEGRAM_USER_ID } from "../handlers/shared";
 import { uniqueId } from "../../../__tests__/test-helpers";
 
 /**
@@ -119,7 +120,7 @@ export async function createTelegramPendingLinkInstallation(
   const [userLink] = await globalThis.services.db
     .insert(telegramUserLinks)
     .values({
-      telegramUserId: "pending",
+      telegramUserId: PENDING_TELEGRAM_USER_ID,
       installationId: installation!.id,
       vm0UserId,
     })

--- a/turbo/apps/web/src/lib/telegram/__tests__/helpers.ts
+++ b/turbo/apps/web/src/lib/telegram/__tests__/helpers.ts
@@ -80,6 +80,58 @@ export async function insertTelegramMessage(
   });
 }
 
+interface PendingLinkInstallationResult {
+  installationId: string;
+  userLinkId: string;
+  vm0UserId: string;
+}
+
+/**
+ * Create a Telegram installation with a properly encrypted bot token
+ * and a pending user link (telegramUserId='pending').
+ * Use this for testing the auto-complete pending link flow.
+ */
+export async function createTelegramPendingLinkInstallation(
+  composeId: string,
+  vm0UserId: string,
+  botToken: string,
+): Promise<PendingLinkInstallationResult> {
+  initServices();
+
+  const { SECRETS_ENCRYPTION_KEY } = globalThis.services.env;
+  const encryptedBotToken = encryptCredentialValue(
+    botToken,
+    SECRETS_ENCRYPTION_KEY,
+  );
+
+  const [installation] = await globalThis.services.db
+    .insert(telegramInstallations)
+    .values({
+      telegramBotId: uniqueId("bot"),
+      botUsername: "test_bot",
+      encryptedBotToken,
+      webhookSecret: "webhook-secret",
+      defaultComposeId: composeId,
+      adminUserId: vm0UserId,
+    })
+    .returning();
+
+  const [userLink] = await globalThis.services.db
+    .insert(telegramUserLinks)
+    .values({
+      telegramUserId: "pending",
+      installationId: installation!.id,
+      vm0UserId,
+    })
+    .returning();
+
+  return {
+    installationId: installation!.id,
+    userLinkId: userLink!.id,
+    vm0UserId,
+  };
+}
+
 interface CallbackInstallationResult {
   installationId: string;
   userLinkId: string;

--- a/turbo/apps/web/src/lib/telegram/handlers/direct-message.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/direct-message.ts
@@ -11,6 +11,7 @@ import {
   storeTelegramMessage,
   getWorkspaceAgent,
   resolveSessionCompose,
+  completePendingLink,
 } from "./shared";
 import { logger } from "../../logger";
 
@@ -60,7 +61,7 @@ export async function handleTelegramDirectMessage(
   const client = createTelegramClient(botToken);
 
   // 2. Check user link
-  const [userLink] = await globalThis.services.db
+  let [userLink] = await globalThis.services.db
     .select()
     .from(telegramUserLinks)
     .where(
@@ -70,6 +71,18 @@ export async function handleTelegramDirectMessage(
       ),
     )
     .limit(1);
+
+  // 2b. Auto-complete pending link if no direct match
+  if (!userLink) {
+    const completed = await completePendingLink(installationId, fromUserId);
+    if (completed) {
+      userLink = completed;
+      log.info("Auto-completed pending link", {
+        installationId,
+        telegramUserId: fromUserId,
+      });
+    }
+  }
 
   if (!userLink) {
     await sendMessage(

--- a/turbo/apps/web/src/lib/telegram/handlers/direct-message.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/direct-message.ts
@@ -1,6 +1,5 @@
-import { eq, and } from "drizzle-orm";
+import { eq } from "drizzle-orm";
 import { telegramInstallations } from "../../../db/schema/telegram-installation";
-import { telegramUserLinks } from "../../../db/schema/telegram-user-link";
 import { decryptCredentialValue } from "../../crypto/secrets-encryption";
 import { env } from "../../../env";
 import { createTelegramClient, sendMessage, sendChatAction } from "../client";
@@ -11,7 +10,7 @@ import {
   storeTelegramMessage,
   getWorkspaceAgent,
   resolveSessionCompose,
-  completePendingLink,
+  resolveUserLink,
 } from "./shared";
 import { logger } from "../../logger";
 
@@ -60,29 +59,8 @@ export async function handleTelegramDirectMessage(
   );
   const client = createTelegramClient(botToken);
 
-  // 2. Check user link
-  let [userLink] = await globalThis.services.db
-    .select()
-    .from(telegramUserLinks)
-    .where(
-      and(
-        eq(telegramUserLinks.telegramUserId, fromUserId),
-        eq(telegramUserLinks.installationId, installationId),
-      ),
-    )
-    .limit(1);
-
-  // 2b. Auto-complete pending link if no direct match
-  if (!userLink) {
-    const completed = await completePendingLink(installationId, fromUserId);
-    if (completed) {
-      userLink = completed;
-      log.info("Auto-completed pending link", {
-        installationId,
-        telegramUserId: fromUserId,
-      });
-    }
-  }
+  // 2. Check user link (auto-completes pending link if needed)
+  const userLink = await resolveUserLink(installationId, fromUserId);
 
   if (!userLink) {
     await sendMessage(

--- a/turbo/apps/web/src/lib/telegram/handlers/mention.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/mention.ts
@@ -11,6 +11,7 @@ import {
   storeTelegramMessage,
   getWorkspaceAgent,
   resolveSessionCompose,
+  completePendingLink,
 } from "./shared";
 import { logger } from "../../logger";
 
@@ -70,7 +71,7 @@ export async function handleTelegramMention(
   const client = createTelegramClient(botToken);
 
   // 2. Check user link
-  const [userLink] = await globalThis.services.db
+  let [userLink] = await globalThis.services.db
     .select()
     .from(telegramUserLinks)
     .where(
@@ -80,6 +81,18 @@ export async function handleTelegramMention(
       ),
     )
     .limit(1);
+
+  // 2b. Auto-complete pending link if no direct match
+  if (!userLink) {
+    const completed = await completePendingLink(installationId, fromUserId);
+    if (completed) {
+      userLink = completed;
+      log.info("Auto-completed pending link", {
+        installationId,
+        telegramUserId: fromUserId,
+      });
+    }
+  }
 
   if (!userLink) {
     await sendMessage(

--- a/turbo/apps/web/src/lib/telegram/handlers/mention.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/mention.ts
@@ -1,6 +1,5 @@
-import { eq, and } from "drizzle-orm";
+import { eq } from "drizzle-orm";
 import { telegramInstallations } from "../../../db/schema/telegram-installation";
-import { telegramUserLinks } from "../../../db/schema/telegram-user-link";
 import { decryptCredentialValue } from "../../crypto/secrets-encryption";
 import { env } from "../../../env";
 import { createTelegramClient, sendMessage, sendChatAction } from "../client";
@@ -11,7 +10,7 @@ import {
   storeTelegramMessage,
   getWorkspaceAgent,
   resolveSessionCompose,
-  completePendingLink,
+  resolveUserLink,
 } from "./shared";
 import { logger } from "../../logger";
 
@@ -70,29 +69,8 @@ export async function handleTelegramMention(
   );
   const client = createTelegramClient(botToken);
 
-  // 2. Check user link
-  let [userLink] = await globalThis.services.db
-    .select()
-    .from(telegramUserLinks)
-    .where(
-      and(
-        eq(telegramUserLinks.telegramUserId, fromUserId),
-        eq(telegramUserLinks.installationId, installationId),
-      ),
-    )
-    .limit(1);
-
-  // 2b. Auto-complete pending link if no direct match
-  if (!userLink) {
-    const completed = await completePendingLink(installationId, fromUserId);
-    if (completed) {
-      userLink = completed;
-      log.info("Auto-completed pending link", {
-        installationId,
-        telegramUserId: fromUserId,
-      });
-    }
-  }
+  // 2. Check user link (auto-completes pending link if needed)
+  const userLink = await resolveUserLink(installationId, fromUserId);
 
   if (!userLink) {
     await sendMessage(

--- a/turbo/apps/web/src/lib/telegram/handlers/shared.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/shared.ts
@@ -132,13 +132,6 @@ export async function storeTelegramMessage(
 }
 
 /**
- * Build the deep link URL for account linking
- */
-export function buildLoginUrl(botUsername: string, linkToken: string): string {
-  return `https://t.me/${botUsername}?start=${linkToken}`;
-}
-
-/**
  * Build the logs URL for a run
  */
 export function buildLogsUrl(runId: string): string {

--- a/turbo/apps/web/src/lib/telegram/handlers/shared.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/shared.ts
@@ -1,6 +1,7 @@
 import { eq, and } from "drizzle-orm";
 import { telegramThreadSessions } from "../../../db/schema/telegram-thread-session";
 import { telegramMessages } from "../../../db/schema/telegram-message";
+import { telegramUserLinks } from "../../../db/schema/telegram-user-link";
 import { agentComposes } from "../../../db/schema/agent-compose";
 import { getPlatformUrl } from "../../url";
 import {
@@ -142,6 +143,30 @@ export function buildLoginUrl(botUsername: string, linkToken: string): string {
  */
 export function buildLogsUrl(runId: string): string {
   return `${getPlatformUrl()}/logs/${runId}`;
+}
+
+/**
+ * Complete a pending user link by replacing the placeholder telegramUserId
+ * with the real one. Returns the updated row or null if no pending link exists.
+ */
+export async function completePendingLink(
+  installationId: string,
+  realTelegramUserId: string,
+): Promise<typeof telegramUserLinks.$inferSelect | null> {
+  const [updated] = await globalThis.services.db
+    .update(telegramUserLinks)
+    .set({
+      telegramUserId: realTelegramUserId,
+      updatedAt: new Date(),
+    })
+    .where(
+      and(
+        eq(telegramUserLinks.installationId, installationId),
+        eq(telegramUserLinks.telegramUserId, "pending"),
+      ),
+    )
+    .returning();
+  return updated ?? null;
 }
 
 /**

--- a/turbo/apps/web/src/lib/telegram/handlers/shared.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/shared.ts
@@ -15,6 +15,13 @@ import { logger } from "../../logger";
 
 const log = logger("telegram:shared");
 
+/**
+ * Sentinel value for a pending user link that hasn't been claimed yet.
+ * Set as telegramUserId at registration time, replaced with the real
+ * Telegram user ID when the admin sends their first message.
+ */
+export const PENDING_TELEGRAM_USER_ID = "pending";
+
 interface ThreadSessionLookup {
   existingSessionId: string | undefined;
   lastProcessedMessageId: string | undefined;
@@ -139,10 +146,46 @@ export function buildLogsUrl(runId: string): string {
 }
 
 /**
+ * Look up a user link by telegramUserId and installationId.
+ * If no direct match, try to auto-complete a pending link.
+ * Returns the user link row or null.
+ */
+export async function resolveUserLink(
+  installationId: string,
+  telegramUserId: string,
+): Promise<typeof telegramUserLinks.$inferSelect | null> {
+  const [userLink] = await globalThis.services.db
+    .select()
+    .from(telegramUserLinks)
+    .where(
+      and(
+        eq(telegramUserLinks.telegramUserId, telegramUserId),
+        eq(telegramUserLinks.installationId, installationId),
+      ),
+    )
+    .limit(1);
+
+  if (userLink) {
+    return userLink;
+  }
+
+  const completed = await completePendingLink(installationId, telegramUserId);
+  if (completed) {
+    log.info("Auto-completed pending link", {
+      installationId,
+      telegramUserId,
+    });
+    return completed;
+  }
+
+  return null;
+}
+
+/**
  * Complete a pending user link by replacing the placeholder telegramUserId
  * with the real one. Returns the updated row or null if no pending link exists.
  */
-export async function completePendingLink(
+async function completePendingLink(
   installationId: string,
   realTelegramUserId: string,
 ): Promise<typeof telegramUserLinks.$inferSelect | null> {
@@ -155,7 +198,7 @@ export async function completePendingLink(
     .where(
       and(
         eq(telegramUserLinks.installationId, installationId),
-        eq(telegramUserLinks.telegramUserId, "pending"),
+        eq(telegramUserLinks.telegramUserId, PENDING_TELEGRAM_USER_ID),
       ),
     )
     .returning();

--- a/turbo/apps/web/src/lib/telegram/handlers/start.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/start.ts
@@ -124,9 +124,17 @@ export async function handleStartCommand(
   });
 }
 
+/** HMAC-SHA256 produces 32 bytes = 43 base64url characters (no padding) */
+const SIGNATURE_LENGTH = 43;
+
 /**
  * Create a signed link token for account linking.
  * Uses HMAC-SHA256 with a simple JSON payload + expiry.
+ *
+ * Token format: base64url(payload) + base64url(hmac) concatenated without
+ * separator. Telegram deep link start parameters only allow A-Za-z0-9_-
+ * so we cannot use '.' or any other special character as a delimiter.
+ * The signature is always 43 chars (SHA-256), so we split from the end.
  */
 export function createLinkToken(
   vm0UserId: string,
@@ -145,7 +153,7 @@ export function createLinkToken(
     .update(data)
     .digest("base64url");
 
-  return `${data}.${signature}`;
+  return `${data}${signature}`;
 }
 
 /**
@@ -156,10 +164,10 @@ export function verifyLinkToken(
   token: string,
   secretKey: string,
 ): LinkTokenPayload | null {
-  const parts = token.split(".");
-  if (parts.length !== 2) return null;
+  if (token.length <= SIGNATURE_LENGTH) return null;
 
-  const [data, signature] = parts as [string, string];
+  const data = token.slice(0, -SIGNATURE_LENGTH);
+  const signature = token.slice(-SIGNATURE_LENGTH);
 
   const expectedSignature = crypto
     .createHmac("sha256", secretKey)


### PR DESCRIPTION
## Summary
- Create a pending user link (`telegramUserId='pending'`) at bot registration time instead of generating a link token
- Auto-complete pending link with real Telegram user ID when admin sends their first message to the bot
- Remove `linkToken` from API response, signals, views, and success page deep links
- Matches the Slack installation flow where the user link is created at install time

## Test plan
- [x] Register route test verifies pending link creation and no `linkToken` in response
- [x] Platform connect page test verifies no `token` param in success URL
- [x] Success page test verifies deep link opens `https://t.me/bot` without `?start=` param
- [x] All 79 tests pass, lint/types/knip clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)