### PR TITLE
ci: add binary existence check to deploy-runner-start

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1436,6 +1436,12 @@ jobs:
             local REMOTE="${METAL_USER}@${HOST}"
             echo "=== Starting runner ${RUNNER_NAME} on ${HOST} ==="
 
+            # Guard: ensure binary exists (fails fast on "Re-run failed jobs" without prepare)
+            if ! ssh $SSH_OPTS "$REMOTE" "test -x ${BIN_DIR}/runner"; then
+              echo "::error::Runner binary not found on ${HOST}. Use 'Re-run all jobs' to redeploy the runner first."
+              return 1
+            fi
+
             # Generate runner.yaml with real preview URL (no build needed, uses cached hashes)
             ssh $SSH_OPTS $REMOTE "${BIN_DIR}/runner config \
               --rootfs-hash ${ROOTFS_HASH} \


### PR DESCRIPTION
## Summary
- Add `test -x` guard in `deploy-runner-start`'s `start_on_host()` to fail fast if the runner binary doesn't exist
- Prevents confusing "No such file or directory" errors when someone uses "Re-run failed jobs" which skips the `deploy-runner-prepare` step
- Matches the existing guard pattern already used in `cli-e2e-03-runner` verify step

## Test plan
- [ ] Verify CI passes
- [ ] Confirm error message appears when binary is missing (manual "Re-run failed jobs" scenario)

🤖 Generated with [Claude Code](https://claude.com/claude-code)