### PR TITLE
fix(runner): remove trigger comment and bump for release

### DIFF
--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -1,4 +1,3 @@
-// trigger ci
 mod cmd;
 mod config;
 mod deps;


### PR DESCRIPTION
Remove leftover `// trigger ci` comment from main.rs. Using `fix:` type to trigger release-please runner version bump, which will deploy the claude code v2.1.68 upgrade to metal machines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)