### PR TITLE
fix(compose): generate server-side cli token for sandbox auth

### DIFF
--- a/turbo/apps/web/app/api/compose/jobs/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/compose/jobs/__tests__/route.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import { POST } from "../route";
 import { GET } from "../[jobId]/route";
 import { POST as webhookComplete } from "../../../webhooks/compose/complete/route";
@@ -10,6 +10,7 @@ import {
 import { testContext } from "../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../src/__tests__/clerk-mock";
 import { randomUUID } from "crypto";
+import { Sandbox } from "@e2b/code-interpreter";
 
 const context = testContext();
 
@@ -669,5 +670,153 @@ describe("GET /api/compose/jobs/:jobId", () => {
 
       expect(response.status).toBe(400);
     });
+  });
+});
+
+describe("Platform session auth (no CLI token)", () => {
+  const context = testContext();
+
+  const testContent = {
+    version: "1",
+    agents: {
+      "my-agent": {
+        framework: "claude-code",
+        description: "A test agent",
+      },
+    },
+  };
+
+  beforeEach(async () => {
+    context.setupMocks();
+  });
+
+  it("should create a job via Clerk session without Authorization header", async () => {
+    await context.setupUser();
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/compose/jobs",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ content: testContent }),
+      },
+    );
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(201);
+    const data = await response.json();
+    expect(data.jobId).toBeDefined();
+    expect(data.status).toBe("pending");
+    expect(data.source).toBe("platform");
+  });
+
+  it("should pass a generated vm0_live_ token to sandbox", async () => {
+    await context.setupUser();
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/compose/jobs",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          githubUrl: "https://github.com/owner/repo",
+        }),
+      },
+    );
+
+    const response = await POST(request);
+    expect(response.status).toBe(201);
+
+    // Verify E2B sandbox was created with a generated vm0_live_ token
+    const createCall = vi.mocked(Sandbox.create).mock.calls[0];
+    expect(createCall).toBeDefined();
+    const sandboxEnvs = createCall![1]?.envs as Record<string, string>;
+    expect(sandboxEnvs.VM0_TOKEN).toMatch(/^vm0_live_/);
+  });
+
+  it("should create a job with Clerk JWT in Authorization header", async () => {
+    // Platform SaaS sends a Clerk JWT as Bearer token — this should still work
+    // because getUserId() resolves auth via Clerk session cookies first
+    await context.setupUser();
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/compose/jobs",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: "Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.fake",
+        },
+        body: JSON.stringify({ content: testContent }),
+      },
+    );
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(201);
+    const data = await response.json();
+    expect(data.jobId).toBeDefined();
+    expect(data.source).toBe("platform");
+  });
+
+  it("should complete full lifecycle: session auth → webhook → poll", async () => {
+    const user = await context.setupUser();
+
+    // 1. Create job via session auth (no CLI token)
+    const createRequest = createTestRequest(
+      "http://localhost:3000/api/compose/jobs",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ content: testContent }),
+      },
+    );
+
+    const createResponse = await POST(createRequest);
+    expect(createResponse.status).toBe(201);
+    const { jobId } = await createResponse.json();
+
+    // 2. Complete via webhook
+    const sandboxToken = await createTestComposeJobToken(user.userId, jobId);
+    const webhookRequest = createTestRequest(
+      "http://localhost:3000/api/webhooks/compose/complete",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${sandboxToken}`,
+        },
+        body: JSON.stringify({
+          jobId,
+          success: true,
+          result: {
+            composeId: "session-compose-id",
+            composeName: "my-agent",
+            versionId: "session-version-id",
+            warnings: [],
+          },
+        }),
+      },
+    );
+
+    await webhookComplete(webhookRequest);
+
+    // 3. Poll for completed status (use CLI token for GET — platform would use session)
+    const userCliToken = await createTestCliToken(user.userId);
+    const getRequest = createTestRequest(
+      `http://localhost:3000/api/compose/jobs/${jobId}`,
+      {
+        method: "GET",
+        headers: { Authorization: `Bearer ${userCliToken}` },
+      },
+    );
+
+    const getResponse = await GET(getRequest);
+    expect(getResponse.status).toBe(200);
+    const data = await getResponse.json();
+    expect(data.status).toBe("completed");
+    expect(data.result.composeId).toBe("session-compose-id");
+    expect(data.completedAt).toBeDefined();
   });
 });

--- a/turbo/apps/web/app/api/compose/jobs/route.ts
+++ b/turbo/apps/web/app/api/compose/jobs/route.ts
@@ -55,34 +55,18 @@ const router = tsr.router(composeJobsMainContract, {
       };
     }
 
-    // Extract user token from Authorization header
-    const userToken = headers.authorization?.substring(7); // Remove "Bearer "
-    if (!userToken) {
-      return {
-        status: 401 as const,
-        body: {
-          error: {
-            message: "Missing authorization token",
-            code: "UNAUTHORIZED",
-          },
-        },
-      };
-    }
-
     // Dispatch based on input type: GitHub URL or platform content
     const isGitHubInput = "githubUrl" in body;
 
     const result = isGitHubInput
       ? await triggerComposeJob({
           userId,
-          userToken,
           source: "github",
           githubUrl: body.githubUrl,
           overwrite: body.overwrite,
         })
       : await triggerComposeJob({
           userId,
-          userToken,
           source: "platform",
           content: body.content,
           instructions: body.instructions,

--- a/turbo/apps/web/app/api/webhooks/compose/complete/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/compose/complete/__tests__/route.test.ts
@@ -587,7 +587,6 @@ describe("POST /api/webhooks/compose/complete", () => {
         userId: userLink.vm0UserId,
         source: "github",
         githubUrl: "https://github.com/owner/failing-repo",
-        userToken: "test-token",
       });
 
       // Insert slack_compose_requests record (simulating what Slack handler does)

--- a/turbo/apps/web/src/lib/compose/trigger-compose-job.ts
+++ b/turbo/apps/web/src/lib/compose/trigger-compose-job.ts
@@ -231,7 +231,7 @@ type SandboxComposeParams =
 async function spawnComposeJobSandbox(
   jobId: string,
   params: SandboxComposeParams,
-  userToken: string,
+  cliToken: string,
   webhookToken: string,
 ): Promise<void> {
   const apiUrl = getApiUrl();
@@ -243,7 +243,7 @@ async function spawnComposeJobSandbox(
   const sandboxEnvs: Record<string, string> = {
     VM0_JOB_ID: jobId,
     VM0_COMPOSE_MODE: params.mode,
-    VM0_TOKEN: userToken,
+    VM0_TOKEN: cliToken,
     VM0_API_URL: apiUrl,
     VM0_WEBHOOK_URL: webhookUrl,
     VM0_WEBHOOK_TOKEN: webhookToken,

--- a/turbo/apps/web/src/lib/compose/trigger-compose-job.ts
+++ b/turbo/apps/web/src/lib/compose/trigger-compose-job.ts
@@ -1,6 +1,8 @@
+import crypto from "crypto";
 import { and, eq, inArray } from "drizzle-orm";
 import { composeJobs } from "../../db/schema/compose-job";
 import type { ComposeJobSource } from "../../db/schema/compose-job";
+import { cliTokens } from "../../db/schema/cli-tokens";
 import { generateComposeJobToken } from "../auth/sandbox-token";
 import { Sandbox } from "@e2b/code-interpreter";
 import { env } from "../../env";
@@ -342,22 +344,43 @@ interface TriggerComposeJobResult {
 }
 
 /**
+ * Generate a short-lived CLI token for sandbox use.
+ * The token is stored in the cli_tokens table with a 10-minute TTL,
+ * matching the compose-job webhook token lifetime.
+ */
+async function generateComposeCliToken(
+  userId: string,
+  jobId: string,
+): Promise<string> {
+  const token = `vm0_live_${crypto.randomBytes(32).toString("base64url")}`;
+  const expiresAt = new Date(Date.now() + 10 * 60 * 1000); // 10 minutes
+
+  await globalThis.services.db.insert(cliTokens).values({
+    token,
+    userId,
+    name: `Compose Job ${jobId}`,
+    expiresAt,
+  });
+
+  return token;
+}
+
+/**
  * Trigger a compose job from any source.
  * Reusable internal function callable from both the HTTP endpoint and Slack handler.
  *
- * No Slack-specific parameters — pure compose domain.
+ * Generates a short-lived CLI token server-side for sandbox authentication,
+ * so callers don't need to provide a token.
  */
 type TriggerComposeJobParams =
   | {
       userId: string;
-      userToken: string;
       source: "github";
       githubUrl: string;
       overwrite?: boolean;
     }
   | {
       userId: string;
-      userToken: string;
       source: "platform";
       content: Record<string, unknown>;
       instructions?: string;
@@ -366,7 +389,7 @@ type TriggerComposeJobParams =
 export async function triggerComposeJob(
   params: TriggerComposeJobParams,
 ): Promise<TriggerComposeJobResult> {
-  const { userId, userToken, source } = params;
+  const { userId, source } = params;
 
   // Idempotency: Check for existing active job for this user
   const [existingJob] = await globalThis.services.db
@@ -409,7 +432,8 @@ export async function triggerComposeJob(
 
   log.debug(`Created new job ${jobId} for user ${userId}`);
 
-  // Generate webhook token
+  // Generate tokens for sandbox
+  const cliToken = await generateComposeCliToken(userId, jobId);
   const webhookToken = await generateComposeJobToken(userId, jobId);
 
   // Build sandbox params
@@ -423,7 +447,7 @@ export async function triggerComposeJob(
         };
 
   // Fire-and-forget: Spawn sandbox asynchronously
-  spawnComposeJobSandbox(jobId, sandboxParams, userToken, webhookToken).catch(
+  spawnComposeJobSandbox(jobId, sandboxParams, cliToken, webhookToken).catch(
     async (error) => {
       log.error(`Failed to spawn sandbox for job ${jobId}:`, error);
       const errorMessage =


### PR DESCRIPTION
## Summary

- Generate a short-lived (10min) `vm0_live_*` CLI token server-side for each compose job instead of forwarding the caller's Authorization header token
- Remove `userToken` from `TriggerComposeJobParams` — `triggerComposeJob()` now generates its own token internally
- Simplify compose jobs route by removing the token extraction logic that blocked platform UI requests

## Root Cause

The compose jobs route was the **only** API route that extracted the raw Authorization header token to pass to the E2B sandbox. Platform UI authenticates via Clerk session cookies, not CLI tokens. The sandbox received either a Clerk JWT (SaaS) or no token (self-hosted), both causing "Not authenticated" errors.

## Changes

| File | Change |
|------|--------|
| `trigger-compose-job.ts` | Added `generateComposeCliToken()` that creates a 10min `vm0_live_*` token in `cli_tokens` table |
| `trigger-compose-job.ts` | Removed `userToken` from params; function generates token internally |
| `route.ts` | Removed token extraction block (was blocking platform auth) |
| `route.test.ts` | Added 4 platform session auth tests |
| `webhook route.test.ts` | Removed obsolete `userToken` from test call |

## Test plan

- [x] Clerk session auth without Authorization header creates job (201)
- [x] Generated `vm0_live_*` token is passed to E2B sandbox
- [x] Clerk JWT in Authorization header still works (session auth takes priority)
- [x] Full lifecycle: session auth → webhook complete → poll completed
- [x] All 22 compose job tests pass
- [x] All 14 webhook tests pass
- [x] Lint, format, knip all clean

Closes #3656

🤖 Generated with [Claude Code](https://claude.com/claude-code)