### PR TITLE
fix(email): add sender verification to email reply handler

### DIFF
--- a/turbo/apps/web/app/api/webhooks/email/inbound/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/email/inbound/__tests__/route.test.ts
@@ -80,7 +80,9 @@ function createWebhookRequest(body: string, headers?: Record<string, string>) {
 /** Extract the first emails.send call args (error reply email) */
 function getErrorReplyArgs() {
   const call = mockResend.emails.send.mock.calls[0];
-  return call?.[0] as { from: string; to: string; subject: string } | undefined;
+  return call?.[0] as
+    | { from: string; to: string; subject: string; react: unknown }
+    | undefined;
 }
 
 describe("POST /api/webhooks/email/inbound", () => {
@@ -381,7 +383,12 @@ describe("POST /api/webhooks/email/inbound", () => {
 
     // Error reply should have been sent
     expect(mockResend.emails.send).toHaveBeenCalledTimes(1);
-    expect(getErrorReplyArgs()?.to).toBe(unregisteredSender);
+    const args = getErrorReplyArgs();
+    expect(args?.to).toBe(unregisteredSender);
+    expect(args?.subject).toBe("Re: test");
+    expect(JSON.stringify(args?.react)).toContain(
+      "not associated with a VM0 account",
+    );
   });
 
   it("should send error reply when reply sender is a different user than session owner", async () => {
@@ -430,7 +437,12 @@ describe("POST /api/webhooks/email/inbound", () => {
 
     // Error reply should have been sent
     expect(mockResend.emails.send).toHaveBeenCalledTimes(1);
-    expect(getErrorReplyArgs()?.to).toBe(userBEmail);
+    const args = getErrorReplyArgs();
+    expect(args?.to).toBe(userBEmail);
+    expect(args?.subject).toBe("Re: test");
+    expect(JSON.stringify(args?.react)).toContain(
+      "Only the original sender can continue",
+    );
   });
 
   it("should send error reply when reply email fails DMARC verification", async () => {
@@ -496,7 +508,10 @@ describe("POST /api/webhooks/email/inbound", () => {
 
     // Error reply should have been sent
     expect(mockResend.emails.send).toHaveBeenCalledTimes(1);
-    expect(getErrorReplyArgs()?.to).toBe(senderEmail);
+    const args = getErrorReplyArgs();
+    expect(args?.to).toBe(senderEmail);
+    expect(args?.subject).toBe("Re: test");
+    expect(JSON.stringify(args?.react)).toContain("DMARC verification failed");
   });
 
   describe("Email Trigger (scope+agent@domain)", () => {

--- a/turbo/apps/web/app/api/webhooks/email/inbound/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/email/inbound/__tests__/route.test.ts
@@ -152,8 +152,9 @@ describe("POST /api/webhooks/email/inbound", () => {
       replyToToken: replyToken,
     });
 
-    // Switch to webhook auth (no Clerk)
-    mockClerk({ userId: null });
+    // Mock Clerk to return the session owner when looking up by email
+    const senderEmail = "user@example.com";
+    mockClerk({ userId: user.userId, email: senderEmail });
 
     // Build inbound email webhook payload
     const payload = JSON.stringify({
@@ -161,7 +162,7 @@ describe("POST /api/webhooks/email/inbound", () => {
       data: {
         email_id: "inbound-email-123",
         to: [`reply+${replyToken}@vm7.bot`],
-        from: "user@example.com",
+        from: senderEmail,
         subject: "Re: test",
         created_at: new Date().toISOString(),
       },
@@ -251,9 +252,9 @@ describe("POST /api/webhooks/email/inbound", () => {
       replyToToken: replyToken,
     });
 
-    mockClerk({ userId: null });
-
+    // Mock Clerk to return the session owner when looking up by email
     const senderEmail = "user@example.com";
+    mockClerk({ userId: user.userId, email: senderEmail });
 
     // Mock Resend to return empty text (e.g., email with only quoted content)
     mockReceivedEmailGet({
@@ -262,7 +263,10 @@ describe("POST /api/webhooks/email/inbound", () => {
       subject: "Re: test",
       text: "   ",
       html: "<p></p>",
-      headers: {},
+      headers: {
+        "authentication-results":
+          "mx.resend.com; dkim=pass; spf=pass; dmarc=pass",
+      },
     });
 
     const payload = JSON.stringify({
@@ -323,6 +327,172 @@ describe("POST /api/webhooks/email/inbound", () => {
 
     // The handler should have returned early — Resend receiving.get not called
     expect(mockResend.emails.receiving.get).not.toHaveBeenCalled();
+
+    // Error reply should have been sent
+    expect(mockResend.emails.send).toHaveBeenCalledTimes(1);
+    expect(getErrorReplyArgs()?.to).toBe(senderEmail);
+  });
+
+  it("should send error reply when reply sender is not a registered user", async () => {
+    mockResend.emails.receiving.get.mockClear();
+
+    // Given a user with a compose and email thread session
+    const user = await context.setupUser({ prefix: "reply-unreg" });
+    const { composeId } = await createTestCompose(
+      uniqueId("reply-unreg-agent"),
+    );
+    const agentSession = await createTestSessionWithConversation(
+      user.userId,
+      composeId,
+    );
+
+    const replyToken = generateReplyToken(agentSession.id);
+    await createTestEmailThreadSession({
+      userId: user.userId,
+      composeId,
+      agentSessionId: agentSession.id,
+      replyToToken: replyToken,
+    });
+
+    // Mock Clerk to return the session owner only for their email
+    mockClerk({ userId: user.userId, email: "owner@example.com" });
+
+    // Send reply from an unregistered email address
+    const unregisteredSender = "stranger@example.com";
+    const payload = JSON.stringify({
+      type: "email.received",
+      data: {
+        email_id: "unreg-reply-email",
+        to: [`reply+${replyToken}@vm7.bot`],
+        from: unregisteredSender,
+        subject: "Re: test",
+        created_at: new Date().toISOString(),
+      },
+    });
+
+    const request = createWebhookRequest(payload);
+    const response = await POST(request);
+
+    expect(response.status).toBe(200);
+    await context.mocks.flushAfter();
+
+    // No email should have been fetched (early return before Resend call)
+    expect(mockResend.emails.receiving.get).not.toHaveBeenCalled();
+
+    // Error reply should have been sent
+    expect(mockResend.emails.send).toHaveBeenCalledTimes(1);
+    expect(getErrorReplyArgs()?.to).toBe(unregisteredSender);
+  });
+
+  it("should send error reply when reply sender is a different user than session owner", async () => {
+    mockResend.emails.receiving.get.mockClear();
+
+    // Given user A owns the session
+    const userA = await context.setupUser({ prefix: "reply-owner" });
+    const { composeId } = await createTestCompose(uniqueId("reply-diff-agent"));
+    const agentSession = await createTestSessionWithConversation(
+      userA.userId,
+      composeId,
+    );
+
+    const replyToken = generateReplyToken(agentSession.id);
+    await createTestEmailThreadSession({
+      userId: userA.userId,
+      composeId,
+      agentSessionId: agentSession.id,
+      replyToToken: replyToken,
+    });
+
+    // Mock Clerk to return a DIFFERENT user (user B) when looking up by email
+    const userBEmail = "user-b@example.com";
+    mockClerk({ userId: "different-user-id", email: userBEmail });
+
+    // User B replies to the thread (they were CC'd on the original email)
+    const payload = JSON.stringify({
+      type: "email.received",
+      data: {
+        email_id: "diff-user-reply-email",
+        to: [`reply+${replyToken}@vm7.bot`],
+        from: userBEmail,
+        subject: "Re: test",
+        created_at: new Date().toISOString(),
+      },
+    });
+
+    const request = createWebhookRequest(payload);
+    const response = await POST(request);
+
+    expect(response.status).toBe(200);
+    await context.mocks.flushAfter();
+
+    // No email should have been fetched (early return before Resend call)
+    expect(mockResend.emails.receiving.get).not.toHaveBeenCalled();
+
+    // Error reply should have been sent
+    expect(mockResend.emails.send).toHaveBeenCalledTimes(1);
+    expect(getErrorReplyArgs()?.to).toBe(userBEmail);
+  });
+
+  it("should send error reply when reply email fails DMARC verification", async () => {
+    // Given a user with a compose and email thread session
+    const user = await context.setupUser({ prefix: "reply-dmarc" });
+    const { composeId } = await createTestCompose(
+      uniqueId("reply-dmarc-agent"),
+    );
+    const agentSession = await createTestSessionWithConversation(
+      user.userId,
+      composeId,
+    );
+
+    const replyToken = generateReplyToken(agentSession.id);
+    await createTestEmailThreadSession({
+      userId: user.userId,
+      composeId,
+      agentSessionId: agentSession.id,
+      replyToToken: replyToken,
+    });
+
+    // Mock Clerk to return the session owner
+    const senderEmail = "owner@example.com";
+    mockClerk({ userId: user.userId, email: senderEmail });
+
+    // Override Resend mock to return dmarc=fail
+    mockReceivedEmailGet({
+      from: senderEmail,
+      to: [`reply+${replyToken}@vm7.bot`],
+      subject: "Re: test",
+      text: "Reply with failed DMARC",
+      html: "<p>Reply with failed DMARC</p>",
+      headers: {
+        "Message-ID": "<dmarc-fail-reply@example.com>",
+        "Authentication-Results":
+          "mx.google.com; dkim=pass; spf=pass; dmarc=fail",
+      },
+    });
+
+    const payload = JSON.stringify({
+      type: "email.received",
+      data: {
+        email_id: "dmarc-fail-reply-email",
+        to: [`reply+${replyToken}@vm7.bot`],
+        from: senderEmail,
+        subject: "Re: test",
+        created_at: new Date().toISOString(),
+      },
+    });
+
+    const request = createWebhookRequest(payload);
+    const response = await POST(request);
+
+    expect(response.status).toBe(200);
+    await context.mocks.flushAfter();
+
+    // No run should have been created
+    const runs = await findTestRunsByUserAndPrompt(
+      user.userId,
+      "Reply with failed DMARC",
+    );
+    expect(runs).toHaveLength(0);
 
     // Error reply should have been sent
     expect(mockResend.emails.send).toHaveBeenCalledTimes(1);
@@ -830,11 +1000,13 @@ describe("POST /api/webhooks/email/inbound", () => {
       replyToToken: replyToken,
     });
 
-    mockClerk({ userId: null });
+    // Mock Clerk to return the session owner when looking up by email
+    const senderEmail = "user@example.com";
+    mockClerk({ userId: user.userId, email: senderEmail });
 
     // Override Resend mock to return HTML-only content
     mockReceivedEmailGet({
-      from: "user@example.com",
+      from: senderEmail,
       to: [`reply+${replyToken}@vm7.bot`],
       subject: "Re: test",
       text: "",
@@ -850,7 +1022,7 @@ describe("POST /api/webhooks/email/inbound", () => {
       data: {
         email_id: "html-only-reply",
         to: [`reply+${replyToken}@vm7.bot`],
-        from: "user@example.com",
+        from: senderEmail,
         subject: "Re: test",
         created_at: new Date().toISOString(),
       },
@@ -1380,11 +1552,13 @@ describe("POST /api/webhooks/email/inbound", () => {
         replyToToken: replyToken,
       });
 
-      mockClerk({ userId: null });
+      // Mock Clerk to return the session owner when looking up by email
+      const senderEmail = "user@example.com";
+      mockClerk({ userId: user.userId, email: senderEmail });
 
       // Mock Resend to return reply email
       mockReceivedEmailGet({
-        from: "user@example.com",
+        from: senderEmail,
         to: [`reply+${replyToken}@vm7.bot`],
         subject: "Re: test",
         text: "Here is the file you requested",
@@ -1433,7 +1607,7 @@ describe("POST /api/webhooks/email/inbound", () => {
         data: {
           email_id: "reply-att-email",
           to: [`reply+${replyToken}@vm7.bot`],
-          from: "user@example.com",
+          from: senderEmail,
           subject: "Re: test",
           created_at: new Date().toISOString(),
         },

--- a/turbo/apps/web/src/lib/email/handlers/inbound-reply.ts
+++ b/turbo/apps/web/src/lib/email/handlers/inbound-reply.ts
@@ -3,6 +3,7 @@ import { agentComposes } from "../../../db/schema/agent-compose";
 import { getReceivedEmail } from "../client";
 import { processEmailAttachments } from "../attachment";
 import { extractEmailBody } from "../content-extract";
+import { verifySenderAuthenticity } from "../sender-auth";
 import {
   verifyReplyToken,
   lookupEmailThreadSession,
@@ -12,6 +13,7 @@ import {
 } from "./shared";
 import { createRun } from "../../run";
 import { generateCallbackSecret, getApiUrl } from "../../callback";
+import { getUserIdByEmail } from "../../auth/get-user-id-by-email";
 import { logger } from "../../logger";
 
 const log = logger("email:inbound-reply");
@@ -80,10 +82,49 @@ export async function handleInboundEmailReply(
     };
   }
 
-  // 4. Fetch full email body from Resend
+  // 4. Verify sender is the session owner
+  const senderEmail = event.data.from;
+  const senderUserId = await getUserIdByEmail(senderEmail);
+  if (!senderUserId) {
+    log.debug("Reply sender email not registered", { from: senderEmail });
+    return {
+      ok: false,
+      errorMessage: "Your email address is not associated with a VM0 account.",
+    };
+  }
+
+  if (senderUserId !== session.userId) {
+    log.warn("Reply sender does not match session owner", {
+      from: senderEmail,
+      senderUserId,
+      sessionUserId: session.userId,
+    });
+    return {
+      ok: false,
+      errorMessage:
+        "Only the original sender can continue this email conversation.",
+    };
+  }
+
+  // 5. Fetch full email body from Resend
   const email = await getReceivedEmail(emailId);
 
-  // 5. Compute reply recipients based on bot position in To/CC
+  // 6. Verify sender authenticity via DMARC
+  const verification = verifySenderAuthenticity(email.headers);
+  if (!verification.verified) {
+    log.warn("Reply sender authentication failed", {
+      from: senderEmail,
+      reason: verification.reason,
+      emailId,
+    });
+    return {
+      ok: false,
+      errorMessage:
+        "Your email could not be authenticated (DMARC verification failed).",
+    };
+  }
+
+  // 7. Compute reply recipients based on bot position in To/CC
   const replyRecipients = computeReplyRecipients({
     from: event.data.from,
     to: email.to,
@@ -92,7 +133,7 @@ export async function handleInboundEmailReply(
     botDomain: getFromDomain(),
   });
 
-  // 6. Extract inbound Message-ID and References for threading (case-insensitive lookup)
+  // 8. Extract inbound Message-ID and References for threading (case-insensitive lookup)
   const headers = email.headers ?? {};
   const messageIdKey = Object.keys(headers).find(
     (k) => k.toLowerCase() === "message-id",
@@ -103,7 +144,7 @@ export async function handleInboundEmailReply(
   );
   const inboundReferences = referencesKey ? headers[referencesKey] : undefined;
 
-  // 7. Extract email body (prefer HTML, fallback to text, strip quotes)
+  // 9. Extract email body (prefer HTML, fallback to text, strip quotes)
   let replyContent = extractEmailBody(email.html, email.text);
   if (!replyContent.trim()) {
     log.debug("Empty reply content after stripping", { emailId });
@@ -113,13 +154,13 @@ export async function handleInboundEmailReply(
     };
   }
 
-  // 7b. Process attachments and append to reply content
+  // 9b. Process attachments and append to reply content
   const attachmentText = await processEmailAttachments(emailId);
   if (attachmentText) {
     replyContent = `${replyContent}\n\n${attachmentText}`;
   }
 
-  // 8. Get compose to find agent name and version
+  // 10. Get compose to find agent name and version
   const [compose] = await globalThis.services.db
     .select({
       name: agentComposes.name,
@@ -139,7 +180,7 @@ export async function handleInboundEmailReply(
     };
   }
 
-  // 9. Build callbacks for email reply notification
+  // 11. Build callbacks for email reply notification
   const callbacks = [
     {
       url: `${getApiUrl()}/api/internal/callbacks/email/reply`,
@@ -155,7 +196,7 @@ export async function handleInboundEmailReply(
     },
   ];
 
-  // 10. Create and dispatch run via unified pipeline
+  // 12. Create and dispatch run via unified pipeline
   const result = await createRun({
     userId: session.userId,
     agentComposeVersionId: compose.headVersionId ?? "",


### PR DESCRIPTION
## Summary

- Add sender identity verification to the email reply handler (`inbound-reply.ts`) to prevent authorization bypass via CC'd recipients
- Verify reply sender is a registered VM0 user, matches the session owner, and passes DMARC authentication
- Add 3 security test cases: unregistered sender, different user, DMARC failure

## Problem

The email reply handler only validated the HMAC reply token without checking who sent the reply. When a user emails the bot and CCs someone, the CC'd person receives the `reply+{token}` address and can reply to interact with the agent under the original sender's identity — no VM0 account or permission needed.

## Solution

Add three authorization checks to `handleInboundEmailReply` (mirroring the trigger handler):
1. `getUserIdByEmail(senderEmail)` — sender must be a registered VM0 user
2. `senderUserId !== session.userId` — sender must match the session owner
3. `verifySenderAuthenticity(email.headers)` — DMARC verification

## Test plan

- [x] Existing happy path test updated to mock Clerk correctly for sender verification
- [x] New test: reply from unregistered sender → rejected
- [x] New test: reply from different registered user → rejected  
- [x] New test: reply with DMARC failure → rejected
- [x] All 35 tests pass
- [x] Lint passes, knip passes, format passes

Closes #3662

🤖 Generated with [Claude Code](https://claude.com/claude-code)