### PR TITLE
feat(runner): add concurrency-factor parameter for cpu overcommit

### DIFF
--- a/crates/runner/src/cmd/config.rs
+++ b/crates/runner/src/cmd/config.rs
@@ -38,7 +38,7 @@ pub struct ConfigArgs {
     /// Maximum concurrent VMs (0 = auto-detect from host CPU/memory)
     #[arg(long, default_value_t = DEFAULT_MAX_CONCURRENT)]
     max_concurrent: usize,
-    /// CPU overcommit factor for auto-detected concurrency (default: 1.0)
+    /// CPU overcommit factor for auto-detected concurrency (must be > 0)
     #[arg(long, default_value_t = DEFAULT_CONCURRENCY_FACTOR)]
     concurrency_factor: f64,
 

--- a/crates/runner/src/cmd/config.rs
+++ b/crates/runner/src/cmd/config.rs
@@ -3,8 +3,8 @@ use clap::Args;
 use sandbox_fc::SnapshotOutputPaths;
 
 use crate::config::{
-    self, DEFAULT_MAX_CONCURRENT, DEFAULT_MEMORY_MB, DEFAULT_VCPU, FirecrackerConfig, RunnerConfig,
-    SandboxConfig, ServerConfig,
+    self, DEFAULT_CONCURRENCY_FACTOR, DEFAULT_MAX_CONCURRENT, DEFAULT_MEMORY_MB, DEFAULT_VCPU,
+    FirecrackerConfig, RunnerConfig, SandboxConfig, ServerConfig,
 };
 use crate::deps::{FIRECRACKER_VERSION, KERNEL_VERSION};
 use crate::error::{RunnerError, RunnerResult};
@@ -38,6 +38,9 @@ pub struct ConfigArgs {
     /// Maximum concurrent VMs (0 = auto-detect from host CPU/memory)
     #[arg(long, default_value_t = DEFAULT_MAX_CONCURRENT)]
     max_concurrent: usize,
+    /// CPU overcommit factor for auto-detected concurrency (default: 1.0)
+    #[arg(long, default_value_t = DEFAULT_CONCURRENCY_FACTOR)]
+    concurrency_factor: f64,
 
     /// vm0 API URL
     #[arg(long, env = "VM0_API_URL")]
@@ -93,6 +96,7 @@ pub async fn run_config(args: ConfigArgs) -> RunnerResult<()> {
             vcpu: args.vcpu,
             memory_mb: args.memory_mb,
             max_concurrent: args.max_concurrent,
+            concurrency_factor: args.concurrency_factor,
         },
         server: Some(ServerConfig {
             url: args.api_url,

--- a/crates/runner/src/cmd/start.rs
+++ b/crates/runner/src/cmd/start.rs
@@ -162,15 +162,26 @@ pub async fn run_start(args: StartArgs) -> RunnerResult<()> {
         max_concurrent,
         vcpu,
         memory_mb,
+        concurrency_factor,
     } = sandbox;
     let max_concurrent = if max_concurrent == 0 {
         let host_cpus = crate::host::cpu_count()?;
         let host_memory_mb = crate::host::memory_mb()?;
-        let computed =
-            crate::host::compute_max_concurrent(host_cpus, host_memory_mb, vcpu, memory_mb);
+        let computed = crate::host::compute_max_concurrent(
+            host_cpus,
+            host_memory_mb,
+            vcpu,
+            memory_mb,
+            concurrency_factor,
+        );
         info!(
             host_cpus,
-            host_memory_mb, vcpu, memory_mb, computed, "auto-detected max_concurrent"
+            host_memory_mb,
+            vcpu,
+            memory_mb,
+            concurrency_factor,
+            computed,
+            "auto-detected max_concurrent"
         );
         computed
     } else {

--- a/crates/runner/src/config.rs
+++ b/crates/runner/src/config.rs
@@ -97,6 +97,11 @@ pub async fn load(path: &Path) -> RunnerResult<RunnerConfig> {
             "sandbox.vcpu and sandbox.memory_mb must be non-zero".into(),
         ));
     }
+    if !config.sandbox.concurrency_factor.is_finite() || config.sandbox.concurrency_factor <= 0.0 {
+        return Err(RunnerError::Config(
+            "sandbox.concurrency_factor must be a positive finite number".into(),
+        ));
+    }
     Ok(config)
 }
 
@@ -396,6 +401,48 @@ sandbox:
             err.to_string().contains("non-zero"),
             "expected non-zero error, got: {err}"
         );
+    }
+
+    #[tokio::test]
+    async fn load_rejects_invalid_concurrency_factor() {
+        let dir = tempfile::tempdir().unwrap();
+        let fc = dir.path().join("firecracker");
+        let kernel = dir.path().join("vmlinux");
+        let rootfs = dir.path().join("rootfs.squashfs");
+        for f in [&fc, &kernel, &rootfs] {
+            tokio::fs::write(f, b"").await.unwrap();
+        }
+
+        for bad_value in ["0.0", "-1.0", ".nan", ".inf"] {
+            let yaml = format!(
+                r#"
+name: test
+group: test/group
+base_dir: {base_dir}
+ca_dir: {ca_dir}
+firecracker:
+  binary: {fc}
+  kernel: {kernel}
+  rootfs: {rootfs}
+sandbox:
+  concurrency_factor: {bad_value}
+"#,
+                base_dir = dir.path().display(),
+                ca_dir = dir.path().display(),
+                fc = fc.display(),
+                kernel = kernel.display(),
+                rootfs = rootfs.display(),
+            );
+
+            let config_path = dir.path().join("runner.yaml");
+            tokio::fs::write(&config_path, &yaml).await.unwrap();
+
+            let err = load(&config_path).await.unwrap_err();
+            assert!(
+                err.to_string().contains("concurrency_factor"),
+                "expected concurrency_factor error for {bad_value}, got: {err}"
+            );
+        }
     }
 
     #[tokio::test]

--- a/crates/runner/src/config.rs
+++ b/crates/runner/src/config.rs
@@ -413,7 +413,7 @@ sandbox:
             tokio::fs::write(f, b"").await.unwrap();
         }
 
-        for bad_value in ["0.0", "-1.0", ".nan", ".inf"] {
+        for bad_value in ["0.0", "-1.0", ".nan", ".inf", "-.inf"] {
             let yaml = format!(
                 r#"
 name: test

--- a/crates/runner/src/config.rs
+++ b/crates/runner/src/config.rs
@@ -8,6 +8,7 @@ pub(crate) const DEFAULT_VCPU: u32 = 2;
 pub(crate) const DEFAULT_MEMORY_MB: u32 = 2048;
 /// 0 means auto-detect from host CPU and memory at startup.
 pub(crate) const DEFAULT_MAX_CONCURRENT: usize = 0;
+pub(crate) const DEFAULT_CONCURRENCY_FACTOR: f64 = 1.0;
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct RunnerConfig {
@@ -56,6 +57,9 @@ pub struct SandboxConfig {
     pub vcpu: u32,
     pub memory_mb: u32,
     pub max_concurrent: usize,
+    /// CPU overcommit factor for auto-detected concurrency (default: 1.0).
+    /// Only used when max_concurrent is 0 (auto mode).
+    pub concurrency_factor: f64,
 }
 
 impl Default for SandboxConfig {
@@ -64,6 +68,7 @@ impl Default for SandboxConfig {
             vcpu: DEFAULT_VCPU,
             memory_mb: DEFAULT_MEMORY_MB,
             max_concurrent: DEFAULT_MAX_CONCURRENT,
+            concurrency_factor: DEFAULT_CONCURRENCY_FACTOR,
         }
     }
 }
@@ -219,6 +224,7 @@ sandbox:
   vcpu: 4
   memory_mb: 4096
   max_concurrent: 8
+  concurrency_factor: 2.0
 server:
   url: https://api.example.com
   token: secret
@@ -239,6 +245,7 @@ server:
         assert_eq!(config.sandbox.vcpu, 4);
         assert_eq!(config.sandbox.memory_mb, 4096);
         assert_eq!(config.sandbox.max_concurrent, 8);
+        assert!((config.sandbox.concurrency_factor - 2.0).abs() < f64::EPSILON);
         let server = config.server.unwrap();
         assert_eq!(server.url, "https://api.example.com");
         assert_eq!(server.token, "secret");
@@ -279,6 +286,9 @@ firecracker:
         assert_eq!(config.sandbox.vcpu, DEFAULT_VCPU);
         assert_eq!(config.sandbox.memory_mb, DEFAULT_MEMORY_MB);
         assert_eq!(config.sandbox.max_concurrent, DEFAULT_MAX_CONCURRENT);
+        assert!(
+            (config.sandbox.concurrency_factor - DEFAULT_CONCURRENCY_FACTOR).abs() < f64::EPSILON
+        );
         assert!(config.server.is_none());
     }
 
@@ -470,6 +480,7 @@ firecracker:
                 vcpu: 4,
                 memory_mb: 4096,
                 max_concurrent: 8,
+                concurrency_factor: 2.0,
             },
             server: Some(ServerConfig {
                 url: "https://api.example.com".into(),

--- a/crates/runner/src/host.rs
+++ b/crates/runner/src/host.rs
@@ -43,6 +43,10 @@ pub fn compute_max_concurrent(
     memory_mb: u32,
     cpu_factor: f64,
 ) -> usize {
+    assert!(
+        cpu_factor.is_finite() && cpu_factor > 0.0,
+        "cpu_factor must be a positive finite number, got {cpu_factor}"
+    );
     let effective = (host_cpus as f64 * cpu_factor).floor();
     let effective_cpus = (effective.clamp(0.0, usize::MAX as f64)) as usize;
     std::cmp::min(

--- a/crates/runner/src/host.rs
+++ b/crates/runner/src/host.rs
@@ -32,14 +32,21 @@ pub fn memory_mb() -> RunnerResult<usize> {
 ///
 /// Uses integer division because we need whole sandboxes — a host with 5 CPUs
 /// and vcpu=2 can run 2 sandboxes, not 2.5.
+///
+/// `cpu_factor` is a multiplier applied to host CPU count before division,
+/// enabling CPU overcommit for I/O-bound workloads (e.g. 2.0 = 2x overcommit).
+/// Memory side is always 1:1 since Firecracker pre-allocates `mem_size_mib`.
+#[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
 pub fn compute_max_concurrent(
     host_cpus: usize,
     host_memory_mb: usize,
     vcpu: u32,
     memory_mb: u32,
+    cpu_factor: f64,
 ) -> usize {
+    let effective_cpus = (host_cpus as f64 * cpu_factor).floor() as usize;
     std::cmp::min(
-        host_cpus / vcpu as usize,
+        effective_cpus / vcpu as usize,
         host_memory_mb / memory_mb as usize,
     )
     .max(1)
@@ -65,24 +72,45 @@ mod tests {
     #[test]
     fn compute_max_concurrent_cpu_limited() {
         // 8 CPUs, 32 GB, 2 vcpu, 4 GB per VM → min(4, 8) = 4
-        assert_eq!(compute_max_concurrent(8, 32768, 2, 4096), 4);
+        assert_eq!(compute_max_concurrent(8, 32768, 2, 4096, 1.0), 4);
     }
 
     #[test]
     fn compute_max_concurrent_memory_limited() {
         // 16 CPUs, 8 GB, 2 vcpu, 4 GB per VM → min(8, 2) = 2
-        assert_eq!(compute_max_concurrent(16, 8192, 2, 4096), 2);
+        assert_eq!(compute_max_concurrent(16, 8192, 2, 4096, 1.0), 2);
     }
 
     #[test]
     fn compute_max_concurrent_minimum_one() {
         // 1 CPU, 1 GB, 2 vcpu, 4 GB → min(0, 0) → max(1) = 1
-        assert_eq!(compute_max_concurrent(1, 1024, 2, 4096), 1);
+        assert_eq!(compute_max_concurrent(1, 1024, 2, 4096, 1.0), 1);
     }
 
     #[test]
     fn compute_max_concurrent_exact_fit() {
         // 4 CPUs, 8 GB, 2 vcpu, 2 GB → min(2, 4) = 2
-        assert_eq!(compute_max_concurrent(4, 8192, 2, 2048), 2);
+        assert_eq!(compute_max_concurrent(4, 8192, 2, 2048, 1.0), 2);
+    }
+
+    #[test]
+    fn compute_max_concurrent_factor_doubles_cpu() {
+        // 8 CPUs * 2.0 = 16 effective, 32 GB, vcpu=2, mem=4096
+        // min(16/2, 32768/4096) = min(8, 8) = 8
+        assert_eq!(compute_max_concurrent(8, 32768, 2, 4096, 2.0), 8);
+    }
+
+    #[test]
+    fn compute_max_concurrent_factor_hits_memory_limit() {
+        // 8 CPUs * 4.0 = 32 effective, 32 GB, vcpu=2, mem=4096
+        // min(32/2, 32768/4096) = min(16, 8) = 8 (memory-limited)
+        assert_eq!(compute_max_concurrent(8, 32768, 2, 4096, 4.0), 8);
+    }
+
+    #[test]
+    fn compute_max_concurrent_factor_fractional() {
+        // 8 CPUs * 1.5 = 12.0 effective, 32 GB, vcpu=2, mem=4096
+        // min(12/2, 32768/4096) = min(6, 8) = 6
+        assert_eq!(compute_max_concurrent(8, 32768, 2, 4096, 1.5), 6);
     }
 }

--- a/crates/runner/src/host.rs
+++ b/crates/runner/src/host.rs
@@ -36,7 +36,6 @@ pub fn memory_mb() -> RunnerResult<usize> {
 /// `cpu_factor` is a multiplier applied to host CPU count before division,
 /// enabling CPU overcommit for I/O-bound workloads (e.g. 2.0 = 2x overcommit).
 /// Memory side is always 1:1 since Firecracker pre-allocates `mem_size_mib`.
-#[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
 pub fn compute_max_concurrent(
     host_cpus: usize,
     host_memory_mb: usize,
@@ -44,7 +43,8 @@ pub fn compute_max_concurrent(
     memory_mb: u32,
     cpu_factor: f64,
 ) -> usize {
-    let effective_cpus = (host_cpus as f64 * cpu_factor).floor() as usize;
+    let effective = (host_cpus as f64 * cpu_factor).floor();
+    let effective_cpus = (effective.clamp(0.0, usize::MAX as f64)) as usize;
     std::cmp::min(
         effective_cpus / vcpu as usize,
         host_memory_mb / memory_mb as usize,


### PR DESCRIPTION
## Summary

- Add `concurrency_factor` (f64, default 1.0) to `SandboxConfig`
- When `max_concurrent` is auto-detected (0), factor multiplies host CPU count before computing VM slots
- Memory side stays 1:1 (Firecracker pre-allocates `mem_size_mib`)
- CLI: `runner config --concurrency-factor 2.0`
- Backward compatible: existing YAML configs without the field default to 1.0

Closes #3665

## Test plan

- [x] Existing 4 `compute_max_concurrent` tests updated (pass `1.0`)
- [x] 3 new tests: factor doubles CPU, factor hits memory limit, factor fractional
- [x] Config serialization round-trip test updated
- [x] Config defaults test verifies `concurrency_factor` defaults to 1.0
- [x] Clippy clean (`-D warnings`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)