### PR TITLE
fix(guest-init): configure aggressive tcp keepalive to detect dead connections

### DIFF
--- a/crates/guest-init/src/init.rs
+++ b/crates/guest-init/src/init.rs
@@ -146,6 +146,20 @@ pub fn init_filesystem() -> Result<(), InitError> {
         source: e,
     })?;
 
+    // Configure aggressive TCP keepalive for faster dead connection detection.
+    // Default values (7200s/75s/9 probes = ~2h11m) exceed JOB_TIMEOUT (2h),
+    // so dead connections are never detected. These values reduce detection to ~2min.
+    for (param, value) in [
+        ("tcp_keepalive_time", "60"),
+        ("tcp_keepalive_intvl", "10"),
+        ("tcp_keepalive_probes", "6"),
+    ] {
+        let path = format!("/proc/sys/net/ipv4/{param}");
+        if let Err(e) = fs::write(&path, value) {
+            eprintln!("[guest-init] Warning: failed to set {param}: {e}");
+        }
+    }
+
     mount(
         Some("sys"),
         "/sys",


### PR DESCRIPTION
## Summary

- Configure aggressive TCP keepalive sysctl values in guest-init after `/proc` mount
- Reduces dead TCP connection detection from ~2h11m to ~2min (60s idle + 6 probes × 10s)
- Non-fatal: logs warning on failure, does not block VM boot

Closes #3670

## Test plan

- [ ] Deploy new guest-init to dev machine
- [ ] `runner exec <run-id> -- cat /proc/sys/net/ipv4/tcp_keepalive_time` → expect `60`
- [ ] `runner exec <run-id> -- cat /proc/sys/net/ipv4/tcp_keepalive_intvl` → expect `10`
- [ ] `runner exec <run-id> -- cat /proc/sys/net/ipv4/tcp_keepalive_probes` → expect `6`

🤖 Generated with [Claude Code](https://claude.com/claude-code)