### PR TITLE
fix(email): preserve cc recipients when bot is sole to recipient

### DIFF
--- a/turbo/apps/web/src/lib/email/handlers/__tests__/shared.test.ts
+++ b/turbo/apps/web/src/lib/email/handlers/__tests__/shared.test.ts
@@ -251,6 +251,58 @@ describe("computeReplyRecipients", () => {
     expect(result.cc).toEqual([]);
   });
 
+  it("should preserve CC when bot is sole To recipient", () => {
+    const result = computeReplyRecipients({
+      from: "user@example.com",
+      to: ["my-agent@vm0.bot"],
+      cc: ["colleague@example.com"],
+      replyTo: [],
+      botDomain,
+    });
+    expect(result.to).toEqual(["user@example.com"]);
+    expect(result.cc).toEqual(["colleague@example.com"]);
+  });
+
+  it("should preserve multiple CC recipients", () => {
+    const result = computeReplyRecipients({
+      from: "user@example.com",
+      to: ["my-agent@vm0.bot"],
+      cc: ["cc1@example.com", "cc2@example.com", "cc3@example.com"],
+      replyTo: [],
+      botDomain,
+    });
+    expect(result.to).toEqual(["user@example.com"]);
+    expect(result.cc).toEqual([
+      "cc1@example.com",
+      "cc2@example.com",
+      "cc3@example.com",
+    ]);
+  });
+
+  it("should preserve non-bot CC when bot is CC'd with others", () => {
+    const result = computeReplyRecipients({
+      from: "user-a@example.com",
+      to: ["user-b@example.com"],
+      cc: ["my-agent@vm0.bot", "user-c@example.com"],
+      replyTo: [],
+      botDomain,
+    });
+    expect(result.to).toEqual(["user-a@example.com"]);
+    expect(result.cc).toEqual(["user-c@example.com"]);
+  });
+
+  it("should filter bot addresses from CC", () => {
+    const result = computeReplyRecipients({
+      from: "user@example.com",
+      to: ["my-agent@vm0.bot"],
+      cc: ["reply+token@vm0.bot", "colleague@example.com"],
+      replyTo: [],
+      botDomain,
+    });
+    expect(result.to).toEqual(["user@example.com"]);
+    expect(result.cc).toEqual(["colleague@example.com"]);
+  });
+
   it("should handle empty to and cc arrays", () => {
     const result = computeReplyRecipients({
       from: "user@example.com",

--- a/turbo/apps/web/src/lib/email/handlers/shared.ts
+++ b/turbo/apps/web/src/lib/email/handlers/shared.ts
@@ -99,9 +99,9 @@ function emailDomain(address: string): string {
  * Compute reply recipients based on the bot's position in the original email.
  *
  * Strategy:
- * - Bot in To (sole recipient): reply to sender only
- * - Bot in To (with others):    reply-all (sender + other To → to, CC preserved)
- * - Bot only in CC:             reply to sender only
+ * - Bot in To (sole recipient): reply to sender, preserve CC
+ * - Bot in To (with others):    reply-all (sender + other To → to), preserve CC
+ * - Bot only in CC:             reply to sender, preserve CC
  *
  * Also handles Reply-To honoring, self-loop prevention, and deduplication.
  */
@@ -132,12 +132,13 @@ export function computeReplyRecipients(opts: {
   if (botInTo && otherToRecipients.length > 0) {
     // Reply-All: bot was in To with others
     replyToList = [primaryTarget, ...otherToRecipients];
-    replyCcList = [...cc];
   } else {
     // Simple reply: bot was sole To recipient or only CC'd
     replyToList = [primaryTarget];
-    replyCcList = [];
   }
+
+  // Always preserve CC (bot-filtering and dedup happens below)
+  replyCcList = [...cc];
 
   // Remove bot's own addresses
   replyToList = replyToList.filter((addr) => !isBotAddress(addr));


### PR DESCRIPTION
## Summary

- Fix `computeReplyRecipients()` to always preserve CC recipients instead of dropping them when the bot is the sole To recipient
- Add 4 new test cases covering CC preservation scenarios (sole bot + CC, multiple CCs, bot in CC with others, bot addresses filtered from CC)

Closes #3675

## Test plan

- [x] New test: bot sole To recipient with CC → CC preserved
- [x] New test: multiple CC recipients preserved
- [x] New test: bot in CC with non-bot CC → non-bot CC preserved
- [x] New test: bot addresses filtered from CC
- [x] All 39 existing tests pass (no regressions)
- [ ] Manual test: send email To: agent@vm0.bot CC: someone → verify CC'd user receives reply

🤖 Generated with [Claude Code](https://claude.com/claude-code)