### PR TITLE
feat(telegram): add emoji branding, deep links, session reuse, and /new_session command

### DIFF
--- a/turbo/apps/web/app/api/internal/callbacks/slack/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/slack/route.ts
@@ -283,7 +283,11 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   // Post text response (if any content)
   if (responseText) {
     const logsUrl = buildLogsUrl(runId);
-    const deepLinks = detectDeepLinks(responseText, getPlatformUrl());
+    const deepLinks = detectDeepLinks(
+      responseText,
+      getPlatformUrl(),
+      payload.agentName,
+    );
     await postMessage(client, payload.channelId, responseText, {
       threadTs: payload.threadTs,
       blocks: buildAgentResponseMessage(

--- a/turbo/apps/web/app/api/internal/callbacks/telegram/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/telegram/__tests__/route.test.ts
@@ -46,6 +46,13 @@ function telegramSendMessage() {
   );
 }
 
+function telegramSendChatAction() {
+  return http.post(
+    `https://api.telegram.org/bot${TEST_BOT_TOKEN}/sendChatAction`,
+    () => HttpResponse.json({ ok: true, result: true }),
+  );
+}
+
 function telegramDeleteMessage() {
   return http.post(
     `https://api.telegram.org/bot${TEST_BOT_TOKEN}/deleteMessage`,
@@ -212,9 +219,14 @@ describe("POST /api/internal/callbacks/telegram", () => {
     it("should return 200 and send message on completed run", async () => {
       const { runId, payload, secret } = await setupTelegramCallback();
 
+      const chatActionHandler = telegramSendChatAction();
       const deleteMessageHandler = telegramDeleteMessage();
       const sendMessageHandler = telegramSendMessage();
-      server.use(deleteMessageHandler.handler, sendMessageHandler.handler);
+      server.use(
+        chatActionHandler.handler,
+        deleteMessageHandler.handler,
+        sendMessageHandler.handler,
+      );
 
       const request = createCallbackRequest(
         { runId, status: "completed", payload },
@@ -234,9 +246,14 @@ describe("POST /api/internal/callbacks/telegram", () => {
     it("should return 200 and send error message on failed run", async () => {
       const { runId, payload, secret } = await setupTelegramCallback();
 
+      const chatActionHandler = telegramSendChatAction();
       const deleteMessageHandler = telegramDeleteMessage();
       const sendMessageHandler = telegramSendMessage();
-      server.use(deleteMessageHandler.handler, sendMessageHandler.handler);
+      server.use(
+        chatActionHandler.handler,
+        deleteMessageHandler.handler,
+        sendMessageHandler.handler,
+      );
 
       const request = createCallbackRequest(
         {
@@ -262,9 +279,14 @@ describe("POST /api/internal/callbacks/telegram", () => {
       const { runId, payload, secret, userId, composeId } =
         await setupTelegramCallback();
 
+      const chatActionHandler = telegramSendChatAction();
       const deleteMessageHandler = telegramDeleteMessage();
       const sendMessageHandler = telegramSendMessage();
-      server.use(deleteMessageHandler.handler, sendMessageHandler.handler);
+      server.use(
+        chatActionHandler.handler,
+        deleteMessageHandler.handler,
+        sendMessageHandler.handler,
+      );
 
       // Create an agent session for findNewSessionId
       await createTestAgentSession(userId, composeId);
@@ -281,9 +303,14 @@ describe("POST /api/internal/callbacks/telegram", () => {
     it("should process existing session callback without error", async () => {
       const { runId, payload, secret } = await setupTelegramCallback();
 
+      const chatActionHandler = telegramSendChatAction();
       const deleteMessageHandler = telegramDeleteMessage();
       const sendMessageHandler = telegramSendMessage();
-      server.use(deleteMessageHandler.handler, sendMessageHandler.handler);
+      server.use(
+        chatActionHandler.handler,
+        deleteMessageHandler.handler,
+        sendMessageHandler.handler,
+      );
 
       const request = createCallbackRequest(
         {

--- a/turbo/apps/web/app/api/internal/callbacks/telegram/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/telegram/route.ts
@@ -162,7 +162,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   const output = status === "completed" ? await getRunOutput(runId) : undefined;
 
   // Build response text
-  const logsUrl = buildLogsUrl(runId);
+  const logsUrl = buildLogsUrl(runId, agentName);
   const responseText =
     status === "completed"
       ? (output ?? "Task completed successfully.")

--- a/turbo/apps/web/app/api/internal/callbacks/telegram/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/telegram/route.ts
@@ -9,12 +9,15 @@ import { agentRuns } from "../../../../../src/db/schema/agent-run";
 import {
   createTelegramClient,
   sendMessage,
+  sendChatAction,
   deleteMessage,
 } from "../../../../../src/lib/telegram/client";
 import {
   splitMessage,
   buildTelegramResponse,
 } from "../../../../../src/lib/telegram/format";
+import { detectDeepLinks } from "../../../../../src/lib/deep-links";
+import { getPlatformUrl } from "../../../../../src/lib/url";
 import { getRunOutput } from "../../../../../src/lib/slack/handlers/run-agent";
 import {
   saveTelegramThreadSession,
@@ -152,6 +155,9 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     }
   }
 
+  // Send typing indicator while building response
+  await sendChatAction(client, chatId, "typing");
+
   // Query Axiom for the agent's output
   const output = status === "completed" ? await getRunOutput(runId) : undefined;
 
@@ -162,8 +168,16 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       ? (output ?? "Task completed successfully.")
       : `Error: ${error ?? "Agent execution failed."}`;
 
+  // Detect deep links for configuration hints
+  const deepLinks = detectDeepLinks(responseText, getPlatformUrl(), agentName);
+
   // Build structured response with bot header and footer
-  const htmlOutput = buildTelegramResponse(responseText, agentName, logsUrl);
+  const htmlOutput = buildTelegramResponse(
+    responseText,
+    agentName,
+    logsUrl,
+    deepLinks,
+  );
   const chunks = splitMessage(htmlOutput);
 
   // In DMs, don't reply-to (no quote noise); in groups, reply for threading
@@ -203,10 +217,12 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       ? await findNewSessionId(run.userId, composeId, run.createdAt)
       : undefined;
 
-    // For new threads, use bot's reply as rootMessageId (thread anchor)
-    const rootMessageId = existingSessionId
-      ? messageId // Existing thread — use original anchor
-      : String(botReplyMessageId); // New thread — bot's reply is the anchor
+    // For DMs, always use "dm" sentinel; for groups, use message-based anchors
+    const rootMessageId = isDM
+      ? "dm"
+      : existingSessionId
+        ? messageId // Existing thread — use original anchor
+        : String(botReplyMessageId); // New thread — bot's reply is the anchor
 
     await saveTelegramThreadSession({
       userLinkId,

--- a/turbo/apps/web/app/api/telegram/register/route.ts
+++ b/turbo/apps/web/app/api/telegram/register/route.ts
@@ -193,9 +193,11 @@ export async function POST(request: Request) {
 
   // 7. Register bot commands (non-blocking)
   await setMyCommands(body.botToken, [
-    { command: "start", description: "Link your account" },
     { command: "new_session", description: "Start a new conversation" },
-    { command: "help", description: "Show help" },
+    { command: "connect", description: "Connect your VM0 account" },
+    { command: "disconnect", description: "Disconnect your account" },
+    { command: "settings", description: "Open platform settings" },
+    { command: "help", description: "Show available commands" },
   ]).catch((error) => {
     log.warn("Failed to register bot commands", { error });
   });

--- a/turbo/apps/web/app/api/telegram/register/route.ts
+++ b/turbo/apps/web/app/api/telegram/register/route.ts
@@ -194,6 +194,7 @@ export async function POST(request: Request) {
   // 7. Register bot commands (non-blocking)
   await setMyCommands(body.botToken, [
     { command: "start", description: "Link your account" },
+    { command: "new_session", description: "Start a new conversation" },
     { command: "help", description: "Show help" },
   ]).catch((error) => {
     log.warn("Failed to register bot commands", { error });

--- a/turbo/apps/web/app/api/telegram/webhook/[installationId]/route.ts
+++ b/turbo/apps/web/app/api/telegram/webhook/[installationId]/route.ts
@@ -6,6 +6,7 @@ import { verifyTelegramWebhook } from "../../../../../src/lib/telegram/verify";
 import { handleTelegramMention } from "../../../../../src/lib/telegram/handlers/mention";
 import { handleTelegramDirectMessage } from "../../../../../src/lib/telegram/handlers/direct-message";
 import { handleStartCommand } from "../../../../../src/lib/telegram/handlers/start";
+import { handleNewSessionCommand } from "../../../../../src/lib/telegram/handlers/new-session";
 import { storeTelegramMessage } from "../../../../../src/lib/telegram/handlers/shared";
 import { logger } from "../../../../../src/lib/logger";
 
@@ -33,6 +34,7 @@ interface TelegramUpdate {
  *
  * Routing:
  * - /start command → handleStartCommand
+ * - /new_session command → handleNewSessionCommand
  * - Private chat (DM) → handleTelegramDirectMessage
  * - Bot @mention in group → handleTelegramMention
  * - Reply to bot message → handleTelegramMention (continuation)
@@ -88,6 +90,12 @@ export async function POST(
       // /start command
       if (message.text?.startsWith("/start")) {
         await handleStartCommand({ message }, installationId);
+        return;
+      }
+
+      // /new_session command
+      if (message.text?.startsWith("/new_session")) {
+        await handleNewSessionCommand({ message }, installationId);
         return;
       }
 

--- a/turbo/apps/web/app/api/telegram/webhook/[installationId]/route.ts
+++ b/turbo/apps/web/app/api/telegram/webhook/[installationId]/route.ts
@@ -7,6 +7,12 @@ import { handleTelegramMention } from "../../../../../src/lib/telegram/handlers/
 import { handleTelegramDirectMessage } from "../../../../../src/lib/telegram/handlers/direct-message";
 import { handleStartCommand } from "../../../../../src/lib/telegram/handlers/start";
 import { handleNewSessionCommand } from "../../../../../src/lib/telegram/handlers/new-session";
+import {
+  handleConnectCommand,
+  handleDisconnectCommand,
+  handleSettingsCommand,
+  handleHelpCommand,
+} from "../../../../../src/lib/telegram/handlers/commands";
 import { storeTelegramMessage } from "../../../../../src/lib/telegram/handlers/shared";
 import { logger } from "../../../../../src/lib/logger";
 
@@ -35,6 +41,10 @@ interface TelegramUpdate {
  * Routing:
  * - /start command → handleStartCommand
  * - /new_session command → handleNewSessionCommand
+ * - /connect command → handleConnectCommand
+ * - /disconnect command → handleDisconnectCommand
+ * - /settings command → handleSettingsCommand
+ * - /help command → handleHelpCommand
  * - Private chat (DM) → handleTelegramDirectMessage
  * - Bot @mention in group → handleTelegramMention
  * - Reply to bot message → handleTelegramMention (continuation)
@@ -96,6 +106,30 @@ export async function POST(
       // /new_session command
       if (message.text?.startsWith("/new_session")) {
         await handleNewSessionCommand({ message }, installationId);
+        return;
+      }
+
+      // /connect command
+      if (message.text?.startsWith("/connect")) {
+        await handleConnectCommand({ message }, installationId);
+        return;
+      }
+
+      // /disconnect command
+      if (message.text?.startsWith("/disconnect")) {
+        await handleDisconnectCommand({ message }, installationId);
+        return;
+      }
+
+      // /settings command
+      if (message.text?.startsWith("/settings")) {
+        await handleSettingsCommand({ message }, installationId);
+        return;
+      }
+
+      // /help command
+      if (message.text?.startsWith("/help")) {
+        await handleHelpCommand({ message }, installationId);
         return;
       }
 

--- a/turbo/apps/web/app/api/telegram/webhook/[installationId]/route.ts
+++ b/turbo/apps/web/app/api/telegram/webhook/[installationId]/route.ts
@@ -15,22 +15,13 @@ import {
 } from "../../../../../src/lib/telegram/handlers/commands";
 import { storeTelegramMessage } from "../../../../../src/lib/telegram/handlers/shared";
 import { logger } from "../../../../../src/lib/logger";
+import type { TelegramHandlerUpdate } from "../../../../../src/lib/telegram/handlers/types";
 
 const log = logger("telegram:webhook");
 
-interface TelegramUpdate {
+interface TelegramWebhookUpdate {
   update_id: number;
-  message?: {
-    message_id: number;
-    chat: { id: number; type: string };
-    from?: { id: number; username?: string; is_bot?: boolean };
-    text?: string;
-    entities?: Array<{ type: string; offset: number; length: number }>;
-    reply_to_message?: {
-      message_id: number;
-      from?: { id: number; is_bot?: boolean };
-    };
-  };
+  message?: TelegramHandlerUpdate["message"];
 }
 
 /**
@@ -79,9 +70,9 @@ export async function POST(
   }
 
   // Parse update
-  let update: TelegramUpdate;
+  let update: TelegramWebhookUpdate;
   try {
-    update = (await request.json()) as TelegramUpdate;
+    update = (await request.json()) as TelegramWebhookUpdate;
   } catch {
     return new Response("Bad Request", { status: 400 });
   }

--- a/turbo/apps/web/app/api/telegram/webhook/__tests__/commands.test.ts
+++ b/turbo/apps/web/app/api/telegram/webhook/__tests__/commands.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { eq, and } from "drizzle-orm";
 import { HttpResponse } from "msw";
 import {
   testContext,
@@ -13,6 +14,8 @@ import { mockClerk } from "../../../../../src/__tests__/clerk-mock";
 import { server } from "../../../../../src/mocks/server";
 import { http } from "../../../../../src/__tests__/msw";
 import { POST } from "../[installationId]/route";
+import { telegramThreadSessions } from "../../../../../src/db/schema/telegram-thread-session";
+import { agentSessions } from "../../../../../src/db/schema/agent-session";
 
 // Mock Next.js after() to execute synchronously
 const afterPromises: Promise<unknown>[] = [];
@@ -69,12 +72,17 @@ function telegramSendMessage() {
 
 describe("Telegram bot commands", () => {
   let installationId: string;
+  let composeId: string;
+  let userLinkId: string;
+  let userId: string;
 
   beforeEach(async () => {
     afterPromises.length = 0;
     context.setupMocks();
     const user = await context.setupUser();
-    const { composeId } = await createTestCompose(uniqueId("agent"));
+    userId = user.userId;
+    const compose = await createTestCompose(uniqueId("agent"));
+    composeId = compose.composeId;
 
     const result = await createTelegramCallbackInstallation(
       composeId,
@@ -83,6 +91,7 @@ describe("Telegram bot commands", () => {
       { telegramUserId: String(TELEGRAM_USER_ID) },
     );
     installationId = result.installationId;
+    userLinkId = result.userLinkId;
 
     mockClerk({ userId: user.userId });
   });
@@ -273,6 +282,111 @@ describe("Telegram bot commands", () => {
 
       expect(sendMsg.mocked).toHaveBeenCalled();
       expect(sendMsg.calls[0]?.text).toContain("admin");
+    });
+  });
+
+  describe("/new_session command", () => {
+    it("should clear DM session and send confirmation", async () => {
+      // Create an agent session and thread session to be deleted
+      const [agentSession] = await globalThis.services.db
+        .insert(agentSessions)
+        .values({
+          userId,
+          agentComposeId: composeId,
+        })
+        .returning();
+
+      await globalThis.services.db.insert(telegramThreadSessions).values({
+        telegramUserLinkId: userLinkId,
+        chatId: String(TELEGRAM_USER_ID),
+        rootMessageId: "dm",
+        agentSessionId: agentSession!.id,
+      });
+
+      const sendMsg = telegramSendMessage();
+      server.use(sendMsg.handler);
+
+      const request = createWebhookRequest({
+        update_id: 1,
+        message: {
+          message_id: 1,
+          chat: { id: TELEGRAM_USER_ID, type: "private" },
+          from: { id: TELEGRAM_USER_ID, username: "testuser" },
+          text: "/new_session",
+        },
+      });
+
+      const response = await POST(request, {
+        params: Promise.resolve({ installationId }),
+      });
+      expect(response.status).toBe(200);
+      await flushAfterCallbacks();
+
+      // Verify confirmation message
+      expect(sendMsg.mocked).toHaveBeenCalled();
+      expect(sendMsg.calls[0]?.text).toContain("New session started");
+
+      // Verify thread session was deleted
+      const [remaining] = await globalThis.services.db
+        .select({ id: telegramThreadSessions.id })
+        .from(telegramThreadSessions)
+        .where(
+          and(
+            eq(telegramThreadSessions.telegramUserLinkId, userLinkId),
+            eq(telegramThreadSessions.chatId, String(TELEGRAM_USER_ID)),
+            eq(telegramThreadSessions.rootMessageId, "dm"),
+          ),
+        )
+        .limit(1);
+      expect(remaining).toBeUndefined();
+    });
+
+    it("should prompt linking when user is not connected", async () => {
+      const sendMsg = telegramSendMessage();
+      server.use(sendMsg.handler);
+
+      const request = createWebhookRequest({
+        update_id: 1,
+        message: {
+          message_id: 1,
+          chat: { id: 99999, type: "private" },
+          from: { id: 99999, username: "unknown_user" },
+          text: "/new_session",
+        },
+      });
+
+      const response = await POST(request, {
+        params: Promise.resolve({ installationId }),
+      });
+      expect(response.status).toBe(200);
+      await flushAfterCallbacks();
+
+      expect(sendMsg.mocked).toHaveBeenCalled();
+      expect(sendMsg.calls[0]?.text).toContain("link your account");
+    });
+
+    it("should be ignored in group chats", async () => {
+      const sendMsg = telegramSendMessage();
+      server.use(sendMsg.handler);
+
+      const request = createWebhookRequest({
+        update_id: 1,
+        message: {
+          message_id: 1,
+          chat: { id: TELEGRAM_USER_ID, type: "group" },
+          from: { id: TELEGRAM_USER_ID, username: "testuser" },
+          text: "/new_session",
+        },
+      });
+
+      const response = await POST(request, {
+        params: Promise.resolve({ installationId }),
+      });
+      expect(response.status).toBe(200);
+      await flushAfterCallbacks();
+
+      // No message sent in group chat
+      expect(sendMsg.mocked).not.toHaveBeenCalled();
     });
   });
 });

--- a/turbo/apps/web/app/api/telegram/webhook/__tests__/commands.test.ts
+++ b/turbo/apps/web/app/api/telegram/webhook/__tests__/commands.test.ts
@@ -1,0 +1,278 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { HttpResponse } from "msw";
+import {
+  testContext,
+  uniqueId,
+} from "../../../../../src/__tests__/test-helpers";
+import { createTestCompose } from "../../../../../src/__tests__/api-test-helpers";
+import {
+  createTelegramCallbackInstallation,
+  telegramUserLinkExists,
+} from "../../../../../src/lib/telegram/__tests__/helpers";
+import { mockClerk } from "../../../../../src/__tests__/clerk-mock";
+import { server } from "../../../../../src/mocks/server";
+import { http } from "../../../../../src/__tests__/msw";
+import { POST } from "../[installationId]/route";
+
+// Mock Next.js after() to execute synchronously
+const afterPromises: Promise<unknown>[] = [];
+vi.mock("next/server", async (importOriginal) => {
+  const original = await importOriginal<typeof import("next/server")>();
+  return {
+    ...original,
+    after: (promise: Promise<unknown>) => {
+      afterPromises.push(promise);
+    },
+  };
+});
+
+async function flushAfterCallbacks() {
+  await Promise.all(afterPromises);
+  afterPromises.length = 0;
+}
+
+const context = testContext();
+
+const TEST_BOT_TOKEN = "123456:ABC-commands-test";
+const WEBHOOK_SECRET = "webhook-secret";
+const TELEGRAM_USER_ID = 12345;
+
+function createWebhookRequest(body: Record<string, unknown>): Request {
+  return new Request("http://localhost/api/telegram/webhook/test", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "x-telegram-bot-api-secret-token": WEBHOOK_SECRET,
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+function telegramSendMessage() {
+  const calls: Array<{ chat_id: string; text: string }> = [];
+  const handler = http.post(
+    `https://api.telegram.org/bot${TEST_BOT_TOKEN}/sendMessage`,
+    async ({ request }) => {
+      const body = (await request.json()) as {
+        chat_id: string;
+        text: string;
+      };
+      calls.push(body);
+      return HttpResponse.json({
+        ok: true,
+        result: { message_id: 999, chat: { id: TELEGRAM_USER_ID } },
+      });
+    },
+  );
+  return { ...handler, calls };
+}
+
+describe("Telegram bot commands", () => {
+  let installationId: string;
+
+  beforeEach(async () => {
+    afterPromises.length = 0;
+    context.setupMocks();
+    const user = await context.setupUser();
+    const { composeId } = await createTestCompose(uniqueId("agent"));
+
+    const result = await createTelegramCallbackInstallation(
+      composeId,
+      user.userId,
+      TEST_BOT_TOKEN,
+      { telegramUserId: String(TELEGRAM_USER_ID) },
+    );
+    installationId = result.installationId;
+
+    mockClerk({ userId: user.userId });
+  });
+
+  describe("/connect command", () => {
+    it("should confirm when user is already connected", async () => {
+      const sendMsg = telegramSendMessage();
+      server.use(sendMsg.handler);
+
+      const request = createWebhookRequest({
+        update_id: 1,
+        message: {
+          message_id: 1,
+          chat: { id: TELEGRAM_USER_ID, type: "private" },
+          from: { id: TELEGRAM_USER_ID, username: "testuser" },
+          text: "/connect",
+        },
+      });
+
+      const response = await POST(request, {
+        params: Promise.resolve({ installationId }),
+      });
+      expect(response.status).toBe(200);
+      await flushAfterCallbacks();
+
+      expect(sendMsg.mocked).toHaveBeenCalled();
+      expect(sendMsg.calls[0]?.text).toContain("already connected");
+    });
+
+    it("should send platform link when user is not connected", async () => {
+      const sendMsg = telegramSendMessage();
+      server.use(sendMsg.handler);
+
+      const request = createWebhookRequest({
+        update_id: 1,
+        message: {
+          message_id: 1,
+          chat: { id: 99999, type: "private" },
+          from: { id: 99999, username: "unknown_user" },
+          text: "/connect",
+        },
+      });
+
+      const response = await POST(request, {
+        params: Promise.resolve({ installationId }),
+      });
+      expect(response.status).toBe(200);
+      await flushAfterCallbacks();
+
+      expect(sendMsg.mocked).toHaveBeenCalled();
+      expect(sendMsg.calls[0]?.text).toContain("settings/telegram");
+    });
+  });
+
+  describe("/disconnect command", () => {
+    it("should disconnect linked user and remove user link", async () => {
+      const sendMsg = telegramSendMessage();
+      server.use(sendMsg.handler);
+
+      const request = createWebhookRequest({
+        update_id: 1,
+        message: {
+          message_id: 1,
+          chat: { id: TELEGRAM_USER_ID, type: "private" },
+          from: { id: TELEGRAM_USER_ID, username: "testuser" },
+          text: "/disconnect",
+        },
+      });
+
+      const response = await POST(request, {
+        params: Promise.resolve({ installationId }),
+      });
+      expect(response.status).toBe(200);
+      await flushAfterCallbacks();
+
+      expect(sendMsg.mocked).toHaveBeenCalled();
+      expect(sendMsg.calls[0]?.text).toContain("disconnected");
+
+      // Verify user link was deleted
+      const exists = await telegramUserLinkExists(
+        installationId,
+        String(TELEGRAM_USER_ID),
+      );
+      expect(exists).toBe(false);
+    });
+
+    it("should inform user when not connected", async () => {
+      const sendMsg = telegramSendMessage();
+      server.use(sendMsg.handler);
+
+      const request = createWebhookRequest({
+        update_id: 1,
+        message: {
+          message_id: 1,
+          chat: { id: 99999, type: "private" },
+          from: { id: 99999, username: "unknown_user" },
+          text: "/disconnect",
+        },
+      });
+
+      const response = await POST(request, {
+        params: Promise.resolve({ installationId }),
+      });
+      expect(response.status).toBe(200);
+      await flushAfterCallbacks();
+
+      expect(sendMsg.mocked).toHaveBeenCalled();
+      expect(sendMsg.calls[0]?.text).toContain("not connected");
+    });
+  });
+
+  describe("/settings command", () => {
+    it("should send settings link with admin context", async () => {
+      const sendMsg = telegramSendMessage();
+      server.use(sendMsg.handler);
+
+      const request = createWebhookRequest({
+        update_id: 1,
+        message: {
+          message_id: 1,
+          chat: { id: TELEGRAM_USER_ID, type: "private" },
+          from: { id: TELEGRAM_USER_ID, username: "testuser" },
+          text: "/settings",
+        },
+      });
+
+      const response = await POST(request, {
+        params: Promise.resolve({ installationId }),
+      });
+      expect(response.status).toBe(200);
+      await flushAfterCallbacks();
+
+      expect(sendMsg.mocked).toHaveBeenCalled();
+      expect(sendMsg.calls[0]?.text).toContain("Settings");
+      expect(sendMsg.calls[0]?.text).toContain("settings/telegram");
+    });
+  });
+
+  describe("/help command", () => {
+    it("should list available commands", async () => {
+      const sendMsg = telegramSendMessage();
+      server.use(sendMsg.handler);
+
+      const request = createWebhookRequest({
+        update_id: 1,
+        message: {
+          message_id: 1,
+          chat: { id: TELEGRAM_USER_ID, type: "private" },
+          from: { id: TELEGRAM_USER_ID, username: "testuser" },
+          text: "/help",
+        },
+      });
+
+      const response = await POST(request, {
+        params: Promise.resolve({ installationId }),
+      });
+      expect(response.status).toBe(200);
+      await flushAfterCallbacks();
+
+      expect(sendMsg.mocked).toHaveBeenCalled();
+      const text = sendMsg.calls[0]?.text ?? "";
+      expect(text).toContain("/new_session");
+      expect(text).toContain("/connect");
+      expect(text).toContain("/disconnect");
+      expect(text).toContain("/settings");
+      expect(text).toContain("/help");
+    });
+
+    it("should include admin notice for admin user", async () => {
+      const sendMsg = telegramSendMessage();
+      server.use(sendMsg.handler);
+
+      const request = createWebhookRequest({
+        update_id: 1,
+        message: {
+          message_id: 1,
+          chat: { id: TELEGRAM_USER_ID, type: "private" },
+          from: { id: TELEGRAM_USER_ID, username: "testuser" },
+          text: "/help",
+        },
+      });
+
+      const response = await POST(request, {
+        params: Promise.resolve({ installationId }),
+      });
+      expect(response.status).toBe(200);
+      await flushAfterCallbacks();
+
+      expect(sendMsg.mocked).toHaveBeenCalled();
+      expect(sendMsg.calls[0]?.text).toContain("admin");
+    });
+  });
+});

--- a/turbo/apps/web/app/api/telegram/webhook/__tests__/commands.test.ts
+++ b/turbo/apps/web/app/api/telegram/webhook/__tests__/commands.test.ts
@@ -1,21 +1,23 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { eq, and } from "drizzle-orm";
 import { HttpResponse } from "msw";
 import {
   testContext,
   uniqueId,
 } from "../../../../../src/__tests__/test-helpers";
-import { createTestCompose } from "../../../../../src/__tests__/api-test-helpers";
+import {
+  createTestCompose,
+  createTestAgentSession,
+} from "../../../../../src/__tests__/api-test-helpers";
 import {
   createTelegramCallbackInstallation,
   telegramUserLinkExists,
+  createTelegramThreadSession,
+  telegramThreadSessionExists,
 } from "../../../../../src/lib/telegram/__tests__/helpers";
 import { mockClerk } from "../../../../../src/__tests__/clerk-mock";
 import { server } from "../../../../../src/mocks/server";
 import { http } from "../../../../../src/__tests__/msw";
 import { POST } from "../[installationId]/route";
-import { telegramThreadSessions } from "../../../../../src/db/schema/telegram-thread-session";
-import { agentSessions } from "../../../../../src/db/schema/agent-session";
 
 // Mock Next.js after() to execute synchronously
 const afterPromises: Promise<unknown>[] = [];
@@ -288,19 +290,13 @@ describe("Telegram bot commands", () => {
   describe("/new_session command", () => {
     it("should clear DM session and send confirmation", async () => {
       // Create an agent session and thread session to be deleted
-      const [agentSession] = await globalThis.services.db
-        .insert(agentSessions)
-        .values({
-          userId,
-          agentComposeId: composeId,
-        })
-        .returning();
+      const agentSession = await createTestAgentSession(userId, composeId);
 
-      await globalThis.services.db.insert(telegramThreadSessions).values({
+      await createTelegramThreadSession({
         telegramUserLinkId: userLinkId,
         chatId: String(TELEGRAM_USER_ID),
         rootMessageId: "dm",
-        agentSessionId: agentSession!.id,
+        agentSessionId: agentSession.id,
       });
 
       const sendMsg = telegramSendMessage();
@@ -327,18 +323,12 @@ describe("Telegram bot commands", () => {
       expect(sendMsg.calls[0]?.text).toContain("New session started");
 
       // Verify thread session was deleted
-      const [remaining] = await globalThis.services.db
-        .select({ id: telegramThreadSessions.id })
-        .from(telegramThreadSessions)
-        .where(
-          and(
-            eq(telegramThreadSessions.telegramUserLinkId, userLinkId),
-            eq(telegramThreadSessions.chatId, String(TELEGRAM_USER_ID)),
-            eq(telegramThreadSessions.rootMessageId, "dm"),
-          ),
-        )
-        .limit(1);
-      expect(remaining).toBeUndefined();
+      const exists = await telegramThreadSessionExists({
+        telegramUserLinkId: userLinkId,
+        chatId: String(TELEGRAM_USER_ID),
+        rootMessageId: "dm",
+      });
+      expect(exists).toBe(false);
     });
 
     it("should prompt linking when user is not connected", async () => {

--- a/turbo/apps/web/src/lib/deep-links.ts
+++ b/turbo/apps/web/src/lib/deep-links.ts
@@ -1,0 +1,110 @@
+// ---------------------------------------------------------------------------
+// Keyword detection for deep links (shared across Slack and Telegram)
+// ---------------------------------------------------------------------------
+
+interface KeywordLinkMapping {
+  keywords: string[];
+  label: string;
+  path: string;
+  /** When set, use this path instead when agentName is provided */
+  agentPath?: string;
+  emoji: string;
+}
+
+export interface DeepLink {
+  emoji: string;
+  label: string;
+  url: string;
+}
+
+const KEYWORD_LINK_MAPPINGS: readonly KeywordLinkMapping[] = Object.freeze([
+  {
+    keywords: ["model provider", "provider not configured"],
+    label: "Configure model providers",
+    path: "/settings",
+    emoji: "🔑",
+  },
+  {
+    keywords: [
+      "secret",
+      "missing variable",
+      "env var",
+      "environment variable",
+      "api key",
+      "api_key",
+      "apikey",
+      "not set",
+      "未设置",
+      "未配置",
+      "环境变量",
+    ],
+    label: "Manage secrets & variables",
+    path: "/settings?tab=secrets-and-variables",
+    agentPath: "/agents/:name/connections",
+    emoji: "🔒",
+  },
+  {
+    keywords: [
+      "slack token",
+      "slack_bot_token",
+      "bot token",
+      "slack not connected",
+    ],
+    label: "Slack settings",
+    path: "/settings/slack",
+    emoji: "⚙️",
+  },
+  {
+    keywords: [
+      "connector",
+      "mcp server",
+      "tool not available",
+      "tool not found",
+    ],
+    label: "Configure connectors",
+    path: "/settings?tab=connectors",
+    agentPath: "/agents/:name/connections",
+    emoji: "🔌",
+  },
+]);
+
+/**
+ * Detect deep links based on keywords in the response text.
+ *
+ * Scans the text for known configuration-related keywords and returns
+ * matching platform deep links (deduplicated by destination path).
+ *
+ * When agentName is provided, agent-specific paths (e.g. connections page)
+ * are used instead of global settings paths where applicable.
+ */
+export function detectDeepLinks(
+  responseText: string,
+  platformUrl: string,
+  agentName?: string,
+): DeepLink[] {
+  const lowerText = responseText.toLowerCase();
+  const seen = new Set<string>();
+  const links: DeepLink[] = [];
+
+  for (const mapping of KEYWORD_LINK_MAPPINGS) {
+    const path =
+      agentName && mapping.agentPath
+        ? mapping.agentPath.replace(":name", encodeURIComponent(agentName))
+        : mapping.path;
+
+    if (seen.has(path)) {
+      continue;
+    }
+    const matched = mapping.keywords.some((kw) => lowerText.includes(kw));
+    if (matched) {
+      seen.add(path);
+      links.push({
+        emoji: mapping.emoji,
+        label: mapping.label,
+        url: `${platformUrl}${path}`,
+      });
+    }
+  }
+
+  return links;
+}

--- a/turbo/apps/web/src/lib/slack/__tests__/blocks.test.ts
+++ b/turbo/apps/web/src/lib/slack/__tests__/blocks.test.ts
@@ -202,4 +202,40 @@ describe("detectDeepLinks", () => {
     expect(urls).toContain(`${platformUrl}/settings/slack`);
     expect(urls).toContain(`${platformUrl}/settings?tab=connectors`);
   });
+
+  it("should use agent-specific paths when agentName is provided", () => {
+    const links = detectDeepLinks(
+      "Error: missing variable DATABASE_URL",
+      platformUrl,
+      "my-agent",
+    );
+    expect(links).toHaveLength(1);
+    expect(links[0]).toEqual({
+      emoji: "🔒",
+      label: "Manage secrets & variables",
+      url: `${platformUrl}/agents/my-agent/connections`,
+    });
+  });
+
+  it("should encode agentName in agent-specific paths", () => {
+    const links = detectDeepLinks(
+      "The MCP server is not available",
+      platformUrl,
+      "agent with spaces",
+    );
+    expect(links).toHaveLength(1);
+    expect(links[0]?.url).toBe(
+      `${platformUrl}/agents/agent%20with%20spaces/connections`,
+    );
+  });
+
+  it("should not use agent paths for categories without agentPath", () => {
+    const links = detectDeepLinks(
+      "The model provider is not configured",
+      platformUrl,
+      "my-agent",
+    );
+    expect(links).toHaveLength(1);
+    expect(links[0]?.url).toBe(`${platformUrl}/settings`);
+  });
 });

--- a/turbo/apps/web/src/lib/slack/__tests__/blocks.test.ts
+++ b/turbo/apps/web/src/lib/slack/__tests__/blocks.test.ts
@@ -123,12 +123,12 @@ describe("detectDeepLinks", () => {
 
   it("should detect provider-related keywords", () => {
     const links = detectDeepLinks(
-      "The api key is missing for the model provider",
+      "The model provider is not configured",
       platformUrl,
     );
     expect(links).toHaveLength(1);
     expect(links[0]).toEqual({
-      emoji: ":key:",
+      emoji: "🔑",
       label: "Configure model providers",
       url: `${platformUrl}/settings`,
     });
@@ -141,17 +141,20 @@ describe("detectDeepLinks", () => {
     );
     expect(links).toHaveLength(1);
     expect(links[0]).toEqual({
-      emoji: ":lock:",
+      emoji: "🔒",
       label: "Manage secrets & variables",
       url: `${platformUrl}/settings?tab=secrets-and-variables`,
     });
   });
 
   it("should detect Slack token keywords", () => {
-    const links = detectDeepLinks("SLACK_BOT_TOKEN is not set", platformUrl);
+    const links = detectDeepLinks(
+      "Slack not connected to workspace",
+      platformUrl,
+    );
     expect(links).toHaveLength(1);
     expect(links[0]).toEqual({
-      emoji: ":gear:",
+      emoji: "⚙️",
       label: "Slack settings",
       url: `${platformUrl}/settings/slack`,
     });
@@ -164,7 +167,7 @@ describe("detectDeepLinks", () => {
     );
     expect(links).toHaveLength(1);
     expect(links[0]).toEqual({
-      emoji: ":electric_plug:",
+      emoji: "🔌",
       label: "Configure connectors",
       url: `${platformUrl}/settings?tab=connectors`,
     });
@@ -173,26 +176,29 @@ describe("detectDeepLinks", () => {
   it("should match case-insensitively", () => {
     const links = detectDeepLinks("API_KEY is not configured", platformUrl);
     expect(links).toHaveLength(1);
-    expect(links[0]?.label).toBe("Configure model providers");
+    expect(links[0]?.label).toBe("Manage secrets & variables");
   });
 
   it("should deduplicate by path", () => {
     const links = detectDeepLinks(
-      "The api key for the model provider is not configured and the apikey is invalid",
+      "The api key is missing and the secret is not configured and the apikey is invalid",
       platformUrl,
     );
     expect(links).toHaveLength(1);
-    expect(links[0]?.url).toBe(`${platformUrl}/settings`);
+    expect(links[0]?.url).toBe(
+      `${platformUrl}/settings?tab=secrets-and-variables`,
+    );
   });
 
   it("should return multiple links for different destinations", () => {
     const links = detectDeepLinks(
-      "The api key is missing. Also SLACK_BOT_TOKEN is not set and the MCP server is down.",
+      "The model provider is missing. Also SLACK_BOT_TOKEN is not set and the MCP server is down.",
       platformUrl,
     );
-    expect(links).toHaveLength(3);
+    expect(links).toHaveLength(4);
     const urls = links.map((l) => l.url);
     expect(urls).toContain(`${platformUrl}/settings`);
+    expect(urls).toContain(`${platformUrl}/settings?tab=secrets-and-variables`);
     expect(urls).toContain(`${platformUrl}/settings/slack`);
     expect(urls).toContain(`${platformUrl}/settings?tab=connectors`);
   });

--- a/turbo/apps/web/src/lib/slack/blocks.ts
+++ b/turbo/apps/web/src/lib/slack/blocks.ts
@@ -9,6 +9,7 @@ import type {
   Option,
 } from "@slack/web-api";
 import { getPlatformUrl } from "../url";
+import type { DeepLink } from "../deep-links";
 
 const SLACK_DOCS_URL = "https://docs.vm0.ai/docs/integrations/slack";
 
@@ -443,96 +444,10 @@ export function buildMarkdownMessage(content: string): (Block | KnownBlock)[] {
 }
 
 // ---------------------------------------------------------------------------
-// Keyword detection for deep links
+// Keyword detection for deep links (re-exported from shared module)
 // ---------------------------------------------------------------------------
 
-interface KeywordLinkMapping {
-  keywords: string[];
-  label: string;
-  path: string;
-  emoji: string;
-}
-
-export interface DeepLink {
-  emoji: string;
-  label: string;
-  url: string;
-}
-
-const KEYWORD_LINK_MAPPINGS: readonly KeywordLinkMapping[] = Object.freeze([
-  {
-    keywords: [
-      "api key",
-      "api_key",
-      "apikey",
-      "model provider",
-      "provider not configured",
-    ],
-    label: "Configure model providers",
-    path: "/settings",
-    emoji: ":key:",
-  },
-  {
-    keywords: ["secret", "missing variable", "env var", "environment variable"],
-    label: "Manage secrets & variables",
-    path: "/settings?tab=secrets-and-variables",
-    emoji: ":lock:",
-  },
-  {
-    keywords: [
-      "slack token",
-      "slack_bot_token",
-      "bot token",
-      "slack not connected",
-    ],
-    label: "Slack settings",
-    path: "/settings/slack",
-    emoji: ":gear:",
-  },
-  {
-    keywords: [
-      "connector",
-      "mcp server",
-      "tool not available",
-      "tool not found",
-    ],
-    label: "Configure connectors",
-    path: "/settings?tab=connectors",
-    emoji: ":electric_plug:",
-  },
-]);
-
-/**
- * Detect deep links based on keywords in the response text.
- *
- * Scans the text for known configuration-related keywords and returns
- * matching platform deep links (deduplicated by destination path).
- */
-export function detectDeepLinks(
-  responseText: string,
-  platformUrl: string,
-): DeepLink[] {
-  const lowerText = responseText.toLowerCase();
-  const seen = new Set<string>();
-  const links: DeepLink[] = [];
-
-  for (const mapping of KEYWORD_LINK_MAPPINGS) {
-    if (seen.has(mapping.path)) {
-      continue;
-    }
-    const matched = mapping.keywords.some((kw) => lowerText.includes(kw));
-    if (matched) {
-      seen.add(mapping.path);
-      links.push({
-        emoji: mapping.emoji,
-        label: mapping.label,
-        url: `${platformUrl}${mapping.path}`,
-      });
-    }
-  }
-
-  return links;
-}
+export { detectDeepLinks, type DeepLink } from "../deep-links";
 
 /**
  * Build an agent response message with agent name context and optional logs link

--- a/turbo/apps/web/src/lib/telegram/__tests__/format.test.ts
+++ b/turbo/apps/web/src/lib/telegram/__tests__/format.test.ts
@@ -67,12 +67,11 @@ describe("buildTelegramResponse", () => {
       "https://example.com/logs/123",
     );
 
-    expect(result).toContain("<b>TestBot</b>");
+    expect(result).toContain("🤖 <b>TestBot</b>");
     expect(result).toContain("Hello world");
     expect(result).toContain(
-      '<a href="https://example.com/logs/123">View logs</a>',
+      '<a href="https://example.com/logs/123">📋 View logs</a>',
     );
-    expect(result).toContain("· TestBot");
   });
 
   it("should separate header, content, and footer with line breaks", () => {
@@ -82,8 +81,8 @@ describe("buildTelegramResponse", () => {
       "https://example.com/logs",
     );
 
-    // Header + blank line + content + blank line + separator + footer
-    expect(result).toMatch(/^<b>Bot<\/b>\n\ncontent\n\n─\n/);
+    // Header + blank line + content + blank line + footer
+    expect(result).toMatch(/^🤖 <b>Bot<\/b>\n\ncontent\n\n/);
   });
 
   it("should escape HTML in agent name", () => {
@@ -93,7 +92,7 @@ describe("buildTelegramResponse", () => {
       "https://example.com/logs",
     );
 
-    expect(result).toContain("<b>Bot &lt;script&gt;</b>");
+    expect(result).toContain("🤖 <b>Bot &lt;script&gt;</b>");
   });
 
   it("should convert markdown content to Telegram HTML", () => {
@@ -104,6 +103,38 @@ describe("buildTelegramResponse", () => {
     );
 
     expect(result).toContain("<b>bold</b> and <code>code</code>");
+  });
+
+  it("should include deep links when provided", () => {
+    const result = buildTelegramResponse(
+      "content",
+      "Bot",
+      "https://example.com/logs",
+      [
+        {
+          emoji: "🔑",
+          label: "Configure model providers",
+          url: "https://example.com/settings",
+        },
+      ],
+    );
+
+    expect(result).toContain(
+      '🔑 <a href="https://example.com/settings">Configure model providers</a>',
+    );
+    expect(result).toContain("📋 View logs</a>");
+  });
+
+  it("should not include deep links section when empty", () => {
+    const result = buildTelegramResponse(
+      "content",
+      "Bot",
+      "https://example.com/logs",
+      [],
+    );
+
+    expect(result).not.toContain("🔑");
+    expect(result).toContain("📋 View logs</a>");
   });
 });
 

--- a/turbo/apps/web/src/lib/telegram/__tests__/helpers.ts
+++ b/turbo/apps/web/src/lib/telegram/__tests__/helpers.ts
@@ -1,3 +1,4 @@
+import { eq, and } from "drizzle-orm";
 import { initServices } from "../../init-services";
 import { telegramInstallations } from "../../../db/schema/telegram-installation";
 import { telegramUserLinks } from "../../../db/schema/telegram-user-link";
@@ -146,6 +147,7 @@ export async function createTelegramCallbackInstallation(
   composeId: string,
   userId: string,
   botToken: string,
+  options?: { telegramUserId?: string },
 ): Promise<CallbackInstallationResult> {
   initServices();
 
@@ -170,7 +172,7 @@ export async function createTelegramCallbackInstallation(
   const [userLink] = await globalThis.services.db
     .insert(telegramUserLinks)
     .values({
-      telegramUserId: uniqueId("tg"),
+      telegramUserId: options?.telegramUserId ?? uniqueId("tg"),
       installationId: installation!.id,
       vm0UserId: userId,
     })
@@ -180,4 +182,27 @@ export async function createTelegramCallbackInstallation(
     installationId: installation!.id,
     userLinkId: userLink!.id,
   };
+}
+
+/**
+ * Check whether a user link exists for a given installation and telegram user ID.
+ * Returns true if the link exists, false otherwise.
+ */
+export async function telegramUserLinkExists(
+  installationId: string,
+  telegramUserId: string,
+): Promise<boolean> {
+  initServices();
+
+  const [row] = await globalThis.services.db
+    .select({ id: telegramUserLinks.id })
+    .from(telegramUserLinks)
+    .where(
+      and(
+        eq(telegramUserLinks.installationId, installationId),
+        eq(telegramUserLinks.telegramUserId, telegramUserId),
+      ),
+    )
+    .limit(1);
+  return row !== undefined;
 }

--- a/turbo/apps/web/src/lib/telegram/__tests__/helpers.ts
+++ b/turbo/apps/web/src/lib/telegram/__tests__/helpers.ts
@@ -3,6 +3,7 @@ import { initServices } from "../../init-services";
 import { telegramInstallations } from "../../../db/schema/telegram-installation";
 import { telegramUserLinks } from "../../../db/schema/telegram-user-link";
 import { telegramMessages } from "../../../db/schema/telegram-message";
+import { telegramThreadSessions } from "../../../db/schema/telegram-thread-session";
 import { agentComposes } from "../../../db/schema/agent-compose";
 import { scopes } from "../../../db/schema/scope";
 import { encryptCredentialValue } from "../../crypto/secrets-encryption";
@@ -201,6 +202,52 @@ export async function telegramUserLinkExists(
       and(
         eq(telegramUserLinks.installationId, installationId),
         eq(telegramUserLinks.telegramUserId, telegramUserId),
+      ),
+    )
+    .limit(1);
+  return row !== undefined;
+}
+
+/**
+ * Create a telegram thread session for testing.
+ */
+export async function createTelegramThreadSession(params: {
+  telegramUserLinkId: string;
+  chatId: string;
+  rootMessageId: string;
+  agentSessionId: string;
+}): Promise<void> {
+  initServices();
+
+  await globalThis.services.db.insert(telegramThreadSessions).values({
+    telegramUserLinkId: params.telegramUserLinkId,
+    chatId: params.chatId,
+    rootMessageId: params.rootMessageId,
+    agentSessionId: params.agentSessionId,
+  });
+}
+
+/**
+ * Check whether a telegram thread session exists for the given parameters.
+ */
+export async function telegramThreadSessionExists(params: {
+  telegramUserLinkId: string;
+  chatId: string;
+  rootMessageId: string;
+}): Promise<boolean> {
+  initServices();
+
+  const [row] = await globalThis.services.db
+    .select({ id: telegramThreadSessions.id })
+    .from(telegramThreadSessions)
+    .where(
+      and(
+        eq(
+          telegramThreadSessions.telegramUserLinkId,
+          params.telegramUserLinkId,
+        ),
+        eq(telegramThreadSessions.chatId, params.chatId),
+        eq(telegramThreadSessions.rootMessageId, params.rootMessageId),
       ),
     )
     .limit(1);

--- a/turbo/apps/web/src/lib/telegram/format.ts
+++ b/turbo/apps/web/src/lib/telegram/format.ts
@@ -1,3 +1,5 @@
+import type { DeepLink } from "../deep-links";
+
 /** Maximum message length allowed by Telegram */
 const MAX_MESSAGE_LENGTH = 4096;
 
@@ -87,18 +89,31 @@ export function markdownToTelegramHtml(markdown: string): string {
  * Layout:
  * 1. Bot header: bold agent name
  * 2. Content: markdown converted to Telegram HTML
- * 3. Footer: logs link + agent name, visually separated
+ * 3. Deep links (optional): configuration hints when keywords detected
+ * 4. Footer: logs link, visually separated
  */
 export function buildTelegramResponse(
   markdown: string,
   agentName: string,
   logsUrl: string,
+  deepLinks?: DeepLink[],
 ): string {
-  const header = `<b>${escapeHtml(agentName)}</b>`;
+  const header = `🤖 <b>${escapeHtml(agentName)}</b>`;
   const content = markdownToTelegramHtml(markdown);
-  const footer = `<a href="${escapeHtml(logsUrl)}">View logs</a> · ${escapeHtml(agentName)}`;
 
-  return `${header}\n\n${content}\n\n─\n${footer}`;
+  const footerParts: string[] = [];
+  if (deepLinks && deepLinks.length > 0) {
+    const linkText = deepLinks
+      .map(
+        (link) =>
+          `${link.emoji} <a href="${escapeHtml(link.url)}">${escapeHtml(link.label)}</a>`,
+      )
+      .join("  ·  ");
+    footerParts.push(linkText);
+  }
+  footerParts.push(`<a href="${escapeHtml(logsUrl)}">📋 View logs</a>`);
+
+  return `${header}\n\n${content}\n\n${footerParts.join("\n")}`;
 }
 
 /**

--- a/turbo/apps/web/src/lib/telegram/handlers/commands.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/commands.ts
@@ -1,0 +1,230 @@
+import { eq } from "drizzle-orm";
+import { telegramInstallations } from "../../../db/schema/telegram-installation";
+import { telegramUserLinks } from "../../../db/schema/telegram-user-link";
+import { decryptCredentialValue } from "../../crypto/secrets-encryption";
+import { env } from "../../../env";
+import { createTelegramClient, sendMessage } from "../client";
+import { resolveUserLink, getWorkspaceAgent } from "./shared";
+import { escapeHtml } from "../format";
+import { getPlatformUrl } from "../../url";
+import { getUserEmail } from "../../auth/get-user-email";
+import { removePermission } from "../../agent/permission-service";
+import { logger } from "../../logger";
+
+const log = logger("telegram:commands");
+
+interface TelegramUpdate {
+  message: {
+    message_id: number;
+    chat: { id: number; type: string };
+    from?: { id: number; username?: string; is_bot?: boolean };
+    text?: string;
+  };
+}
+
+/**
+ * Handle /connect command
+ *
+ * If user is already linked, confirms the connection.
+ * If not, directs them to the platform to connect their account.
+ */
+export async function handleConnectCommand(
+  update: TelegramUpdate,
+  installationId: string,
+): Promise<void> {
+  const { SECRETS_ENCRYPTION_KEY } = env();
+  const message = update.message;
+  const chatId = String(message.chat.id);
+  const fromUserId = String(message.from?.id ?? 0);
+
+  const [installation] = await globalThis.services.db
+    .select()
+    .from(telegramInstallations)
+    .where(eq(telegramInstallations.id, installationId))
+    .limit(1);
+
+  if (!installation) {
+    return;
+  }
+
+  const botToken = decryptCredentialValue(
+    installation.encryptedBotToken,
+    SECRETS_ENCRYPTION_KEY,
+  );
+  const client = createTelegramClient(botToken);
+
+  const userLink = await resolveUserLink(installationId, fromUserId);
+
+  if (userLink) {
+    const agent = await getWorkspaceAgent(installation.defaultComposeId);
+    const agentName = agent?.name ?? "Agent";
+    await sendMessage(
+      client,
+      chatId,
+      `You are already connected. 🤖 ${escapeHtml(agentName)} is ready.`,
+    );
+    return;
+  }
+
+  const platformUrl = getPlatformUrl();
+  await sendMessage(
+    client,
+    chatId,
+    `Visit the platform to connect your account:\n<a href="${escapeHtml(platformUrl)}/settings/telegram">Open Platform</a>`,
+  );
+}
+
+/**
+ * Handle /disconnect command
+ *
+ * Removes the user link and revokes agent permission.
+ */
+export async function handleDisconnectCommand(
+  update: TelegramUpdate,
+  installationId: string,
+): Promise<void> {
+  const { SECRETS_ENCRYPTION_KEY } = env();
+  const message = update.message;
+  const chatId = String(message.chat.id);
+  const fromUserId = String(message.from?.id ?? 0);
+
+  const [installation] = await globalThis.services.db
+    .select()
+    .from(telegramInstallations)
+    .where(eq(telegramInstallations.id, installationId))
+    .limit(1);
+
+  if (!installation) {
+    return;
+  }
+
+  const botToken = decryptCredentialValue(
+    installation.encryptedBotToken,
+    SECRETS_ENCRYPTION_KEY,
+  );
+  const client = createTelegramClient(botToken);
+
+  const userLink = await resolveUserLink(installationId, fromUserId);
+
+  if (!userLink) {
+    await sendMessage(client, chatId, "You are not connected.");
+    return;
+  }
+
+  // Revoke agent permission
+  const email = await getUserEmail(userLink.vm0UserId);
+  if (email) {
+    await removePermission(installation.defaultComposeId, "email", email);
+  }
+
+  // Delete user link
+  await globalThis.services.db
+    .delete(telegramUserLinks)
+    .where(eq(telegramUserLinks.id, userLink.id));
+
+  await sendMessage(
+    client,
+    chatId,
+    "You have been disconnected and your agent access has been revoked.",
+  );
+
+  log.info("User disconnected", {
+    chatId,
+    installationId,
+    telegramUserId: fromUserId,
+  });
+}
+
+/**
+ * Handle /settings command
+ *
+ * Sends a link to the platform settings page with admin-aware description.
+ */
+export async function handleSettingsCommand(
+  update: TelegramUpdate,
+  installationId: string,
+): Promise<void> {
+  const { SECRETS_ENCRYPTION_KEY } = env();
+  const message = update.message;
+  const chatId = String(message.chat.id);
+  const fromUserId = String(message.from?.id ?? 0);
+
+  const [installation] = await globalThis.services.db
+    .select()
+    .from(telegramInstallations)
+    .where(eq(telegramInstallations.id, installationId))
+    .limit(1);
+
+  if (!installation) {
+    return;
+  }
+
+  const botToken = decryptCredentialValue(
+    installation.encryptedBotToken,
+    SECRETS_ENCRYPTION_KEY,
+  );
+  const client = createTelegramClient(botToken);
+
+  const userLink = await resolveUserLink(installationId, fromUserId);
+  const isAdmin = userLink?.vm0UserId === installation.adminUserId;
+
+  const platformUrl = getPlatformUrl();
+  const desc = isAdmin
+    ? "Configure secrets, variables, and select the workspace agent on the VM0 platform."
+    : "Configure your environment variables and secrets on the VM0 platform.";
+
+  await sendMessage(
+    client,
+    chatId,
+    `⚙️ <b>Settings</b>\n${escapeHtml(desc)}\n\n<a href="${escapeHtml(platformUrl)}/settings/telegram">Open Platform</a>`,
+  );
+}
+
+/**
+ * Handle /help command
+ *
+ * Lists available commands and usage info.
+ */
+export async function handleHelpCommand(
+  update: TelegramUpdate,
+  installationId: string,
+): Promise<void> {
+  const { SECRETS_ENCRYPTION_KEY } = env();
+  const message = update.message;
+  const chatId = String(message.chat.id);
+  const fromUserId = String(message.from?.id ?? 0);
+
+  const [installation] = await globalThis.services.db
+    .select()
+    .from(telegramInstallations)
+    .where(eq(telegramInstallations.id, installationId))
+    .limit(1);
+
+  if (!installation) {
+    return;
+  }
+
+  const botToken = decryptCredentialValue(
+    installation.encryptedBotToken,
+    SECRETS_ENCRYPTION_KEY,
+  );
+  const client = createTelegramClient(botToken);
+
+  const userLink = await resolveUserLink(installationId, fromUserId);
+  const isAdmin = userLink?.vm0UserId === installation.adminUserId;
+  const botUsername = installation.botUsername ?? "bot";
+
+  let helpText = `<b>Available commands:</b>\n\n`;
+  helpText += `/new_session - Start a new conversation\n`;
+  helpText += `/connect - Connect your VM0 account\n`;
+  helpText += `/disconnect - Disconnect your account\n`;
+  helpText += `/settings - Open platform settings\n`;
+  helpText += `/help - Show this help message\n`;
+  helpText += `\nMention @${escapeHtml(botUsername)} in a group or send a DM to chat with the agent.`;
+
+  if (isAdmin) {
+    helpText += `\n\nYou are the admin of this bot installation.`;
+  }
+
+  await sendMessage(client, chatId, helpText);
+}

--- a/turbo/apps/web/src/lib/telegram/handlers/commands.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/commands.ts
@@ -10,17 +10,9 @@ import { getPlatformUrl } from "../../url";
 import { getUserEmail } from "../../auth/get-user-email";
 import { removePermission } from "../../agent/permission-service";
 import { logger } from "../../logger";
+import type { TelegramHandlerUpdate } from "./types";
 
 const log = logger("telegram:commands");
-
-interface TelegramUpdate {
-  message: {
-    message_id: number;
-    chat: { id: number; type: string };
-    from?: { id: number; username?: string; is_bot?: boolean };
-    text?: string;
-  };
-}
 
 /**
  * Handle /connect command
@@ -29,7 +21,7 @@ interface TelegramUpdate {
  * If not, directs them to the platform to connect their account.
  */
 export async function handleConnectCommand(
-  update: TelegramUpdate,
+  update: TelegramHandlerUpdate,
   installationId: string,
 ): Promise<void> {
   const { SECRETS_ENCRYPTION_KEY } = env();
@@ -80,7 +72,7 @@ export async function handleConnectCommand(
  * Removes the user link and revokes agent permission.
  */
 export async function handleDisconnectCommand(
-  update: TelegramUpdate,
+  update: TelegramHandlerUpdate,
   installationId: string,
 ): Promise<void> {
   const { SECRETS_ENCRYPTION_KEY } = env();
@@ -141,7 +133,7 @@ export async function handleDisconnectCommand(
  * Sends a link to the platform settings page with admin-aware description.
  */
 export async function handleSettingsCommand(
-  update: TelegramUpdate,
+  update: TelegramHandlerUpdate,
   installationId: string,
 ): Promise<void> {
   const { SECRETS_ENCRYPTION_KEY } = env();
@@ -186,7 +178,7 @@ export async function handleSettingsCommand(
  * Lists available commands and usage info.
  */
 export async function handleHelpCommand(
-  update: TelegramUpdate,
+  update: TelegramHandlerUpdate,
   installationId: string,
 ): Promise<void> {
   const { SECRETS_ENCRYPTION_KEY } = env();

--- a/turbo/apps/web/src/lib/telegram/handlers/direct-message.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/direct-message.ts
@@ -14,17 +14,9 @@ import {
   resolveUserLink,
 } from "./shared";
 import { logger } from "../../logger";
+import type { TelegramHandlerUpdate } from "./types";
 
 const log = logger("telegram:dm");
-
-interface TelegramUpdate {
-  message: {
-    message_id: number;
-    chat: { id: number; type: string };
-    from?: { id: number; username?: string; is_bot?: boolean };
-    text?: string;
-  };
-}
 
 /**
  * Handle a direct message to the bot
@@ -34,7 +26,7 @@ interface TelegramUpdate {
  * - Use rootMessageId = "dm" sentinel for single ongoing DM session
  */
 export async function handleTelegramDirectMessage(
-  update: TelegramUpdate,
+  update: TelegramHandlerUpdate,
   installationId: string,
 ): Promise<void> {
   const { SECRETS_ENCRYPTION_KEY } = env();

--- a/turbo/apps/web/src/lib/telegram/handlers/direct-message.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/direct-message.ts
@@ -115,12 +115,16 @@ export async function handleTelegramDirectMessage(
     }
   }
 
-  // 8. Fetch context
-  const { executionContext } = await fetchTelegramContext(
-    installationId,
-    chatId,
-    lastProcessedMessageId,
-  );
+  // 8. Fetch context (skip when continuing an existing session — it already has history)
+  let executionContext = "";
+  if (!existingSessionId) {
+    const ctx = await fetchTelegramContext(
+      installationId,
+      chatId,
+      lastProcessedMessageId,
+    );
+    executionContext = ctx.executionContext;
+  }
 
   // 9. Dispatch agent run
   const { status, response } = await runAgentForTelegram({

--- a/turbo/apps/web/src/lib/telegram/handlers/mention.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/mention.ts
@@ -14,19 +14,9 @@ import {
   resolveUserLink,
 } from "./shared";
 import { logger } from "../../logger";
+import type { TelegramHandlerUpdate } from "./types";
 
 const log = logger("telegram:mention");
-
-interface TelegramUpdate {
-  message: {
-    message_id: number;
-    chat: { id: number; type: string };
-    from?: { id: number; username?: string; is_bot?: boolean };
-    text?: string;
-    entities?: Array<{ type: string; offset: number; length: number }>;
-    reply_to_message?: { message_id: number; from?: { is_bot?: boolean } };
-  };
-}
 
 /**
  * Handle a group @mention of the bot
@@ -44,7 +34,7 @@ interface TelegramUpdate {
  * 10. Dispatch agent run
  */
 export async function handleTelegramMention(
-  update: TelegramUpdate,
+  update: TelegramHandlerUpdate,
   installationId: string,
 ): Promise<void> {
   const { SECRETS_ENCRYPTION_KEY } = env();

--- a/turbo/apps/web/src/lib/telegram/handlers/new-session.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/new-session.ts
@@ -7,17 +7,9 @@ import { createTelegramClient, sendMessage } from "../client";
 import { resolveUserLink, getWorkspaceAgent } from "./shared";
 import { escapeHtml } from "../format";
 import { logger } from "../../logger";
+import type { TelegramHandlerUpdate } from "./types";
 
 const log = logger("telegram:new-session");
-
-interface TelegramUpdate {
-  message: {
-    message_id: number;
-    chat: { id: number; type: string };
-    from?: { id: number; username?: string; is_bot?: boolean };
-    text?: string;
-  };
-}
 
 /**
  * Handle /new_session command
@@ -26,7 +18,7 @@ interface TelegramUpdate {
  * Only works in private chats (DMs).
  */
 export async function handleNewSessionCommand(
-  update: TelegramUpdate,
+  update: TelegramHandlerUpdate,
   installationId: string,
 ): Promise<void> {
   const { SECRETS_ENCRYPTION_KEY } = env();

--- a/turbo/apps/web/src/lib/telegram/handlers/new-session.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/new-session.ts
@@ -1,0 +1,89 @@
+import { eq, and } from "drizzle-orm";
+import { telegramInstallations } from "../../../db/schema/telegram-installation";
+import { telegramThreadSessions } from "../../../db/schema/telegram-thread-session";
+import { decryptCredentialValue } from "../../crypto/secrets-encryption";
+import { env } from "../../../env";
+import { createTelegramClient, sendMessage } from "../client";
+import { resolveUserLink, getWorkspaceAgent } from "./shared";
+import { escapeHtml } from "../format";
+import { logger } from "../../logger";
+
+const log = logger("telegram:new-session");
+
+interface TelegramUpdate {
+  message: {
+    message_id: number;
+    chat: { id: number; type: string };
+    from?: { id: number; username?: string; is_bot?: boolean };
+    text?: string;
+  };
+}
+
+/**
+ * Handle /new_session command
+ *
+ * Clears the DM session mapping so the next message creates a fresh agent session.
+ * Only works in private chats (DMs).
+ */
+export async function handleNewSessionCommand(
+  update: TelegramUpdate,
+  installationId: string,
+): Promise<void> {
+  const { SECRETS_ENCRYPTION_KEY } = env();
+  const message = update.message;
+  const chatId = String(message.chat.id);
+  const fromUserId = String(message.from?.id ?? 0);
+
+  // Only works in DMs
+  if (message.chat.type !== "private") {
+    return;
+  }
+
+  const [installation] = await globalThis.services.db
+    .select()
+    .from(telegramInstallations)
+    .where(eq(telegramInstallations.id, installationId))
+    .limit(1);
+
+  if (!installation) {
+    return;
+  }
+
+  const botToken = decryptCredentialValue(
+    installation.encryptedBotToken,
+    SECRETS_ENCRYPTION_KEY,
+  );
+  const client = createTelegramClient(botToken);
+
+  const userLink = await resolveUserLink(installationId, fromUserId);
+  if (!userLink) {
+    await sendMessage(
+      client,
+      chatId,
+      "Please link your account first. Send /start to begin.",
+    );
+    return;
+  }
+
+  // Delete the DM session mapping
+  await globalThis.services.db
+    .delete(telegramThreadSessions)
+    .where(
+      and(
+        eq(telegramThreadSessions.telegramUserLinkId, userLink.id),
+        eq(telegramThreadSessions.chatId, chatId),
+        eq(telegramThreadSessions.rootMessageId, "dm"),
+      ),
+    );
+
+  const agent = await getWorkspaceAgent(installation.defaultComposeId);
+  const agentName = agent?.name ?? "Agent";
+
+  await sendMessage(
+    client,
+    chatId,
+    `New session started. 🤖 ${escapeHtml(agentName)} is ready.`,
+  );
+
+  log.info("DM session reset", { chatId, installationId });
+}

--- a/turbo/apps/web/src/lib/telegram/handlers/shared.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/shared.ts
@@ -269,7 +269,7 @@ export async function sendThinkingMessage(
   agentName: string,
   options?: { replyToMessageId?: number },
 ): Promise<TelegramSentMessage | undefined> {
-  const text = `<i>${escapeHtml(agentName)} is thinking...</i>`;
+  const text = `<i>🤖 ${escapeHtml(agentName)} is thinking...</i>`;
   try {
     return await sendMessage(client, chatId, text, options);
   } catch (err) {

--- a/turbo/apps/web/src/lib/telegram/handlers/shared.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/shared.ts
@@ -145,10 +145,10 @@ export async function storeTelegramMessage(
 }
 
 /**
- * Build the logs URL for a run
+ * Build the logs URL for a run, linking to the agent detail logs page.
  */
-export function buildLogsUrl(runId: string): string {
-  return `${getPlatformUrl()}/logs/${runId}`;
+export function buildLogsUrl(runId: string, agentName: string): string {
+  return `${getPlatformUrl()}/agents/${encodeURIComponent(agentName)}/logs/${encodeURIComponent(runId)}`;
 }
 
 /**

--- a/turbo/apps/web/src/lib/telegram/handlers/start.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/start.ts
@@ -6,21 +6,13 @@ import { env } from "../../../env";
 import { createTelegramClient, sendMessage } from "../client";
 import { ensureScopeAndArtifact } from "./shared";
 import { logger } from "../../logger";
+import type { TelegramHandlerUpdate } from "./types";
 import crypto from "crypto";
 
 const log = logger("telegram:start");
 
 /** Token expiry in seconds (10 minutes) */
 const TOKEN_EXPIRY_SECONDS = 600;
-
-interface TelegramUpdate {
-  message: {
-    message_id: number;
-    chat: { id: number; type: string };
-    from?: { id: number; username?: string; is_bot?: boolean };
-    text?: string;
-  };
-}
 
 interface LinkTokenPayload {
   vm0UserId: string;
@@ -37,7 +29,7 @@ interface LinkTokenPayload {
  * 3. Token present → validate, create user link, send confirmation
  */
 export async function handleStartCommand(
-  update: TelegramUpdate,
+  update: TelegramHandlerUpdate,
   installationId: string,
 ): Promise<void> {
   const { SECRETS_ENCRYPTION_KEY } = env();

--- a/turbo/apps/web/src/lib/telegram/handlers/types.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/types.ts
@@ -1,0 +1,22 @@
+/**
+ * Shared Telegram update type for handler functions.
+ *
+ * This represents the subset of a Telegram Update that is passed to
+ * individual command/message handlers (i.e. the `{ message }` wrapper).
+ * The webhook route parses the raw update and passes this shape down.
+ */
+export interface TelegramHandlerUpdate {
+  message: {
+    message_id: number;
+    chat: { id: number; type: string };
+    from?: { id: number; username?: string; is_bot?: boolean };
+    text?: string;
+    /** Present on group messages with @mentions or bot commands */
+    entities?: Array<{ type: string; offset: number; length: number }>;
+    /** Present when the user replies to another message */
+    reply_to_message?: {
+      message_id: number;
+      from?: { id: number; is_bot?: boolean };
+    };
+  };
+}


### PR DESCRIPTION
## Summary

- Add 🤖 emoji to agent name in response header, thinking message, and footer (matching Slack's `:robot_face:`)
- Add typing indicator (`sendChatAction`) in callback while building response
- Extract `detectDeepLinks` to shared `src/lib/deep-links.ts` module, used by both Slack and Telegram
- Reclassify `api_key`/`api key` keywords from model providers to secrets & variables category; add Chinese keyword support (`未设置`, `未配置`, `环境变量`)
- Deep links for secrets/connectors now point to agent connections page (`/agents/:name/connections`) when agent name is available
- Build Telegram response with deep link hints and clipboard emoji on View logs link
- Remove horizontal separator (`─`) from Telegram response layout
- Fix DM session reuse bug: callback now uses `"dm"` sentinel as `rootMessageId` for DMs (was incorrectly using numeric message IDs, causing every DM to create a new session)
- Skip context fetch for existing DM sessions (session already has conversation history)
- Add `/new_session` command to reset DM session and start a fresh conversation

## Test plan

- [x] `pnpm vitest run apps/web/src/lib/telegram/` — all 64 tests pass
- [x] `pnpm vitest run apps/web/app/api/internal/callbacks/telegram/` — all 10 tests pass
- [x] `pnpm vitest run apps/web/src/lib/slack/__tests__/blocks.test.ts` — all 13 tests pass
- [x] `pnpm turbo run lint check-types --filter=web` — clean
- [x] `pnpm knip` — no issues
- [ ] Manual: send DM to bot, verify 🤖 emoji in thinking + response
- [ ] Manual: send `/new_session`, verify session resets
- [ ] Manual: trigger missing secret response, verify 🔒 deep link points to agent connections page

🤖 Generated with [Claude Code](https://claude.com/claude-code)