### PR TITLE
feat(sandbox-fc): enable virtio-balloon with deflate_on_oom as safety net

### DIFF
--- a/crates/runner/src/cmd/snapshot.rs
+++ b/crates/runner/src/cmd/snapshot.rs
@@ -200,7 +200,7 @@ mod tests {
         // Changing this assertion means ALL existing cached snapshots are
         // invalidated.  Only update deliberately.
         assert_eq!(
-            hash, "8f1709d611d8120311e2d51dc4d4f630604b93dc0a24757197d20bc86042e826",
+            hash, "613b56fa4b60a815a6cb2584d6376907eb3ed5b338b8e828858c05a2477f0b68",
             "snapshot hash changed — this invalidates all cached snapshots"
         );
     }

--- a/crates/sandbox-fc/src/api.rs
+++ b/crates/sandbox-fc/src/api.rs
@@ -210,6 +210,28 @@ impl<'a> ApiClient<'a> {
         .await
     }
 
+    /// Configure the balloon device via PUT /balloon.
+    ///
+    /// Must be called before starting the instance. With `deflate_on_oom` enabled,
+    /// the balloon automatically deflates to return memory to the guest when it
+    /// faces OOM pressure, preventing the OOM killer from terminating processes.
+    pub async fn configure_balloon(
+        &self,
+        amount_mib: u32,
+        deflate_on_oom: bool,
+        stats_polling_interval_s: u32,
+    ) -> Result<(), ApiError> {
+        self.put_json(
+            "/balloon",
+            &serde_json::json!({
+                "amount_mib": amount_mib,
+                "deflate_on_oom": deflate_on_oom,
+                "stats_polling_interval_s": stats_polling_interval_s,
+            }),
+        )
+        .await
+    }
+
     /// Start the VM instance via PUT /actions.
     pub async fn start_instance(&self) -> Result<(), ApiError> {
         self.request_with_timeout(
@@ -926,6 +948,43 @@ mod tests {
 
         let client = ApiClient::new(&sock_path);
         let result = client.start_instance().await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn configure_balloon_succeeds_on_204() {
+        let dir = tempfile::tempdir().unwrap_or_else(|e| panic!("tempdir: {e}"));
+        let sock_path = dir.path().join("test-balloon.sock");
+
+        let listener = UnixListener::bind(&sock_path).unwrap_or_else(|e| {
+            panic!("bind {}: {e}", sock_path.display());
+        });
+
+        tokio::spawn(async move {
+            let Ok((mut stream, _)) = listener.accept().await else {
+                return;
+            };
+            let mut buf = vec![0u8; 4096];
+            let _ = stream.read(&mut buf).await;
+
+            let req = String::from_utf8_lossy(&buf);
+            assert!(req.starts_with("PUT /balloon"), "got: {req}");
+            assert!(req.contains("amount_mib"), "missing amount_mib in: {req}");
+            assert!(
+                req.contains("deflate_on_oom"),
+                "missing deflate_on_oom in: {req}"
+            );
+            assert!(
+                req.contains("stats_polling_interval_s"),
+                "missing stats_polling_interval_s in: {req}"
+            );
+
+            let response = "HTTP/1.1 204 No Content\r\nContent-Length: 0\r\n\r\n";
+            let _ = stream.write_all(response.as_bytes()).await;
+        });
+
+        let client = ApiClient::new(&sock_path);
+        let result = client.configure_balloon(0, true, 0).await;
         assert!(result.is_ok());
     }
 

--- a/crates/sandbox-fc/src/factory.rs
+++ b/crates/sandbox-fc/src/factory.rs
@@ -55,6 +55,7 @@ pub fn config_hash() -> String {
     hasher.update(GUEST_NETWORK.tap_mac.as_bytes());
     hasher.update(b"prewarm:");
     hasher.update(PREWARM_SCRIPT.as_bytes());
+    hasher.update(b"balloon:deflate_on_oom:true");
     format!("{:x}", hasher.finalize())
 }
 

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -166,6 +166,11 @@ impl FirecrackerSandbox {
                 "guest_cid": 3,
                 "uds_path": vsock_path,
             },
+            "balloon": {
+                "amount_mib": 0,
+                "deflate_on_oom": true,
+                "stats_polling_interval_s": 0,
+            },
         })
     }
 

--- a/crates/sandbox-fc/src/snapshot.rs
+++ b/crates/sandbox-fc/src/snapshot.rs
@@ -238,7 +238,7 @@ async fn run_with_firecracker(
 
     info!("firecracker API ready");
 
-    // 6. Configure VM via API (6 parallel PUT calls).
+    // 6. Configure VM via API (7 parallel PUT calls).
     let kernel_path = config.kernel_path.display().to_string();
     let rootfs_path = config.rootfs_path.display().to_string();
     let overlay_path = paths.overlay().display().to_string();
@@ -254,6 +254,7 @@ async fn run_with_firecracker(
         client.configure_drive("overlay", &overlay_path, false, false),
         client.configure_network_interface("eth0", GUEST_NETWORK.guest_mac, GUEST_NETWORK.tap_name),
         client.configure_vsock(3, &vsock_uds_str),
+        client.configure_balloon(0, true, 0),
     )?;
 
     info!("VM configured");


### PR DESCRIPTION
## Summary

Enable virtio-balloon device on every Firecracker VM with `amount_mib=0` and `deflate_on_oom=true`. This is a transparent safety net — balloon driver loads but does nothing until guest faces OOM pressure, at which point it automatically deflates to return memory instead of killing processes.

## Changes

- **`api.rs`**: Add `configure_balloon()` method (PUT /balloon) + test
- **`sandbox.rs`**: Add `"balloon"` to `build_config()` JSON (fresh boot path)
- **`snapshot.rs`**: Add `configure_balloon()` to parallel `try_join!` block (snapshot creation path)
- **`factory.rs`**: Add balloon to `config_hash()` (invalidates existing snapshots for rebuild)
- **`runner/cmd/snapshot.rs`**: Update expected hash in stability test

## Notes

- Kernel already has `CONFIG_VIRTIO_BALLOON=y` built-in (Firecracker CI kernel 6.1.155)
- Snapshot restore doesn't need changes — balloon state is captured in the snapshot
- Config hash change triggers automatic snapshot rebuild in CI/deploy
- No runner config or CLI changes — balloon is an internal sandbox-fc detail

Closes #3666