### PR TITLE
fix(ci): remove runner doctor check before e2e tests

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1612,12 +1612,8 @@ jobs:
               echo "::error::Runner binary not found on ${HOST}. The cleanup job may have already run. Use 'Re-run all jobs' to redeploy the runner first."
               exit 1
             fi
-            if ! ssh $SSH_OPTS "$REMOTE" "${BIN_DIR}/runner doctor --name ${RUNNER_NAME}"; then
-              echo "::error::Runner ${RUNNER_NAME} not healthy on ${HOST}. Use 'Re-run all jobs' to redeploy the runner first."
-              exit 1
-            fi
           done
-          echo "All runners healthy"
+          echo "All runners reachable"
 
       - name: Run Runner E2E Tests (Chunk ${{ matrix.index }})
         run: |


### PR DESCRIPTION
Parallel PR runners on the same host cause transient doctor failures. The binary reachability check is sufficient. Deploy-time health check retained.