### PR TITLE
chore: trigger ci

### DIFF
--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -1,3 +1,4 @@
+// trigger ci
 mod cmd;
 mod config;
 mod deps;


### PR DESCRIPTION
Trigger CI to verify runner e2e without doctor check.