### PR TITLE
refactor(sandbox-fc): unify config_hash and build_config via shared struct

### DIFF
--- a/crates/runner/src/cmd/snapshot.rs
+++ b/crates/runner/src/cmd/snapshot.rs
@@ -200,7 +200,7 @@ mod tests {
         // Changing this assertion means ALL existing cached snapshots are
         // invalidated.  Only update deliberately.
         assert_eq!(
-            hash, "613b56fa4b60a815a6cb2584d6376907eb3ed5b338b8e828858c05a2477f0b68",
+            hash, "ea32dbfd0e3254334e9498893888061099634d22160ba3e64c8fff29369af8ed",
             "snapshot hash changed — this invalidates all cached snapshots"
         );
     }

--- a/crates/sandbox-fc/src/factory.rs
+++ b/crates/sandbox-fc/src/factory.rs
@@ -50,11 +50,16 @@ pub struct BalloonConfig {
 ///
 /// Adding a field here automatically changes the config hash (via `Serialize`)
 /// and makes it available to all consumers.
+///
+/// **Important:** `serde_json` serializes struct fields in declaration order.
+/// Reordering fields changes the hash and invalidates all cached snapshots.
 #[derive(serde::Serialize)]
 pub struct InvariantConfig {
     pub boot_args: String,
     pub guest_mac: &'static str,
     pub tap_name: &'static str,
+    /// TAP MAC used in netns setup for ARP. Not in the Firecracker config JSON,
+    /// but affects snapshot behavior (guest ARP cache is baked into the snapshot).
     pub tap_mac: &'static str,
     pub iface_id: &'static str,
     pub guest_cid: u32,

--- a/crates/sandbox-fc/src/factory.rs
+++ b/crates/sandbox-fc/src/factory.rs
@@ -33,30 +33,70 @@ pub const PREWARM_SCRIPT: &str = "\
     (claude --print --verbose --output-format stream-json hi 2>/dev/null || true) && \
     (codex --help >/dev/null 2>&1 || true)";
 
+/// Balloon device configuration (invariant across all sandboxes).
+#[derive(serde::Serialize)]
+pub struct BalloonConfig {
+    pub amount_mib: u32,
+    pub deflate_on_oom: bool,
+    pub stats_polling_interval_s: u32,
+}
+
+/// Invariant configuration shared by all sandboxes.
+///
+/// These parameters affect snapshot output and are used by:
+/// - [`config_hash`] — deterministic fingerprint for snapshot cache invalidation
+/// - [`super::sandbox::FirecrackerSandbox::build_config`] — fresh boot JSON configuration
+/// - Snapshot creation API calls in `snapshot.rs`
+///
+/// Adding a field here automatically changes the config hash (via `Serialize`)
+/// and makes it available to all consumers.
+#[derive(serde::Serialize)]
+pub struct InvariantConfig {
+    pub boot_args: String,
+    pub guest_mac: &'static str,
+    pub tap_name: &'static str,
+    pub tap_mac: &'static str,
+    pub iface_id: &'static str,
+    pub guest_cid: u32,
+    pub balloon: BalloonConfig,
+    pub prewarm_script: &'static str,
+}
+
+impl InvariantConfig {
+    pub fn new() -> Self {
+        Self {
+            boot_args: generate_boot_args(),
+            guest_mac: GUEST_NETWORK.guest_mac,
+            tap_name: GUEST_NETWORK.tap_name,
+            tap_mac: GUEST_NETWORK.tap_mac,
+            iface_id: "eth0",
+            guest_cid: 3,
+            balloon: BalloonConfig {
+                amount_mib: 0,
+                deflate_on_oom: true,
+                stats_polling_interval_s: 0,
+            },
+            prewarm_script: PREWARM_SCRIPT,
+        }
+    }
+}
+
 /// SHA-256 fingerprint of all sandbox-fc internal configuration that affects
-/// snapshot output (boot args, guest network, pre-warm script, etc.).
+/// snapshot output.
+///
+/// Derived from [`InvariantConfig`] serialization — adding a field to that
+/// struct automatically changes this hash.
 ///
 /// This is the backing implementation for [`SandboxFactory::config_hash`].
 /// It is also available as a free function so callers that don't have a
 /// factory instance (e.g. the snapshot subcommand) can compute the hash.
+/// # Panics
+/// Cannot panic — `InvariantConfig` contains only primitives and `String`.
+#[allow(clippy::expect_used)]
 pub fn config_hash() -> String {
-    let boot_args = generate_boot_args();
-    let mut hasher = Sha256::new();
-    // boot_args already contains guest_ip, gateway_ip, netmask via
-    // generate_guest_network_boot_args(). Only guest_mac and tap_name
-    // need to be hashed separately (used by configure_network_interface).
-    hasher.update(b"boot_args:");
-    hasher.update(boot_args.as_bytes());
-    hasher.update(b"guest_mac:");
-    hasher.update(GUEST_NETWORK.guest_mac.as_bytes());
-    hasher.update(b"tap_name:");
-    hasher.update(GUEST_NETWORK.tap_name.as_bytes());
-    hasher.update(b"tap_mac:");
-    hasher.update(GUEST_NETWORK.tap_mac.as_bytes());
-    hasher.update(b"prewarm:");
-    hasher.update(PREWARM_SCRIPT.as_bytes());
-    hasher.update(b"balloon:deflate_on_oom:true");
-    format!("{:x}", hasher.finalize())
+    let config = InvariantConfig::new();
+    let json = serde_json::to_string(&config).expect("serialize invariant config");
+    format!("{:x}", Sha256::digest(json.as_bytes()))
 }
 
 pub struct FirecrackerFactory {

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -13,7 +13,7 @@ use tracing::{info, warn};
 use vsock_host::VsockHost;
 
 use crate::config::FirecrackerConfig;
-use crate::network::{GUEST_NETWORK, PooledNetns, generate_boot_args};
+use crate::network::PooledNetns;
 use crate::paths::{SandboxPaths, SockPaths};
 
 /// Timeout for waiting for the guest to connect via vsock after start.
@@ -125,17 +125,16 @@ impl FirecrackerSandbox {
 
     /// Build the Firecracker JSON configuration for fresh boot.
     fn build_config(&self) -> serde_json::Value {
+        let inv = crate::factory::InvariantConfig::new();
         let kernel_path = self.factory_config.kernel_path.display().to_string();
         let rootfs_path = self.factory_config.rootfs_path.display().to_string();
         let overlay_path = self.overlay.display().to_string();
         let vsock_path = self.sock_paths.vsock().display().to_string();
 
-        let boot_args = generate_boot_args();
-
         serde_json::json!({
             "boot-source": {
                 "kernel_image_path": kernel_path,
-                "boot_args": boot_args,
+                "boot_args": inv.boot_args,
             },
             "drives": [
                 {
@@ -157,19 +156,19 @@ impl FirecrackerSandbox {
             },
             "network-interfaces": [
                 {
-                    "iface_id": "eth0",
-                    "guest_mac": GUEST_NETWORK.guest_mac,
-                    "host_dev_name": GUEST_NETWORK.tap_name,
+                    "iface_id": inv.iface_id,
+                    "guest_mac": inv.guest_mac,
+                    "host_dev_name": inv.tap_name,
                 },
             ],
             "vsock": {
-                "guest_cid": 3,
+                "guest_cid": inv.guest_cid,
                 "uds_path": vsock_path,
             },
             "balloon": {
-                "amount_mib": 0,
-                "deflate_on_oom": true,
-                "stats_polling_interval_s": 0,
+                "amount_mib": inv.balloon.amount_mib,
+                "deflate_on_oom": inv.balloon.deflate_on_oom,
+                "stats_polling_interval_s": inv.balloon.stats_polling_interval_s,
             },
         })
     }

--- a/crates/sandbox-fc/src/snapshot.rs
+++ b/crates/sandbox-fc/src/snapshot.rs
@@ -6,7 +6,7 @@ use tracing::info;
 
 use crate::api::ApiClient;
 use crate::config::SnapshotConfig;
-use crate::network::{GUEST_NETWORK, NetnsPool, NetnsPoolConfig, generate_boot_args};
+use crate::network::{NetnsPool, NetnsPoolConfig};
 use crate::overlay::{Ext4Creator, OverlayCreator as _};
 use crate::paths::{RuntimePaths, SandboxPaths, SnapshotOutputPaths, SockPaths};
 use crate::process;
@@ -239,22 +239,25 @@ async fn run_with_firecracker(
     info!("firecracker API ready");
 
     // 6. Configure VM via API (7 parallel PUT calls).
+    let inv = crate::factory::InvariantConfig::new();
     let kernel_path = config.kernel_path.display().to_string();
     let rootfs_path = config.rootfs_path.display().to_string();
     let overlay_path = paths.overlay().display().to_string();
     tokio::fs::create_dir_all(&sock_paths.vsock_dir()).await?;
     let vsock_uds_str = sock_paths.vsock().display().to_string();
 
-    let boot_args = generate_boot_args();
-
     tokio::try_join!(
         client.configure_machine(config.vcpu_count, config.memory_mb),
-        client.configure_boot_source(&kernel_path, &boot_args),
+        client.configure_boot_source(&kernel_path, &inv.boot_args),
         client.configure_drive("rootfs", &rootfs_path, true, true),
         client.configure_drive("overlay", &overlay_path, false, false),
-        client.configure_network_interface("eth0", GUEST_NETWORK.guest_mac, GUEST_NETWORK.tap_name),
-        client.configure_vsock(3, &vsock_uds_str),
-        client.configure_balloon(0, true, 0),
+        client.configure_network_interface(inv.iface_id, inv.guest_mac, inv.tap_name),
+        client.configure_vsock(inv.guest_cid, &vsock_uds_str),
+        client.configure_balloon(
+            inv.balloon.amount_mib,
+            inv.balloon.deflate_on_oom,
+            inv.balloon.stats_polling_interval_s
+        ),
     )?;
 
     info!("VM configured");
@@ -288,7 +291,7 @@ async fn run_with_firecracker(
     //      are fast. The snapshot captures memory + overlay state, so caches
     //      populated here persist across restores.
     let prewarm_result = guest
-        .exec(crate::factory::PREWARM_SCRIPT, 30_000, &[], false)
+        .exec(inv.prewarm_script, 30_000, &[], false)
         .await
         .map_err(|e| SnapshotError::Setup(format!("pre-warm exec: {e}")))?;
     if prewarm_result.exit_code != 0 {


### PR DESCRIPTION
## Summary

Extract all invariant device parameters (boot args, network config, vsock, balloon, prewarm script) into a single `InvariantConfig` struct with `Serialize`. This eliminates the need to manually maintain two separate parameter lists that must stay in sync.

## Problem

Previously, `config_hash()`, `build_config()`, and `snapshot.rs` each independently specified the same device parameters. Adding a new device (like balloon in #3666) required updating all three in lockstep — forgetting one meant stale snapshots or missing devices.

## Solution

- **`InvariantConfig` struct** — single source of truth for all shared parameters
- **`config_hash()`** — serialize the struct to JSON, then SHA-256 hash it
- **`build_config()`** — read from `InvariantConfig` fields instead of `GUEST_NETWORK` / `generate_boot_args()` directly
- **`snapshot.rs`** — same, use `inv.guest_mac`, `inv.balloon.deflate_on_oom`, etc.

Adding a new field to `InvariantConfig` automatically changes the hash (via Serialize) and is immediately available to all consumers.

## Also fixes

`guest_cid` (vsock CID=3) and `iface_id` ("eth0") were missing from `config_hash()` — now included via the struct.

## Changes

| File | Change |
|---|---|
| `sandbox-fc/src/factory.rs` | Add `InvariantConfig` + `BalloonConfig` structs; rewrite `config_hash()` |
| `sandbox-fc/src/sandbox.rs` | Use `InvariantConfig` in `build_config()` |
| `sandbox-fc/src/snapshot.rs` | Use `InvariantConfig` in `try_join!` and prewarm |
| `runner/src/cmd/snapshot.rs` | Update hash stability test |

Closes #3674