### PR TITLE
chore(ci): increase runner gc --keep-latest from 2 to 3

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -206,8 +206,8 @@ jobs:
           ssh $SSH_OPTS $REMOTE "rm -rf ${BIN_DIR} ~/.vm0-runner/runners/${JOB_REF}-bench ~/.vm0-runner/runners/${JOB_REF}-local && mkdir -p ${BIN_DIR}"
           scp $SSH_OPTS "${TARGET_DIR}/runner" "${REMOTE}:${BIN_DIR}/"
 
-          # Clean up old rootfs/snapshots, keep the 2 most recent
-          ssh $SSH_OPTS $REMOTE "${BIN_DIR}/runner gc --keep-latest 2"
+          # Clean up old rootfs/snapshots, keep the 3 most recent
+          ssh $SSH_OPTS $REMOTE "${BIN_DIR}/runner gc --keep-latest 3"
 
           # Run setup (downloads firecracker/kernel/mitmdump, cached + idempotent)
           echo "=== Running setup ==="

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1338,8 +1338,8 @@ jobs:
             ssh $SSH_OPTS $REMOTE "rm -rf ${BIN_DIR} ${RUNNER_DIR} && mkdir -p ${BIN_DIR}"
             scp $SSH_OPTS "${TARGET_DIR}/runner" "${REMOTE}:${BIN_DIR}/"
 
-            # Clean up old rootfs/snapshots, keep the 2 most recent
-            ssh $SSH_OPTS $REMOTE "${BIN_DIR}/runner gc --keep-latest 2"
+            # Clean up old rootfs/snapshots, keep the 3 most recent
+            ssh $SSH_OPTS $REMOTE "${BIN_DIR}/runner gc --keep-latest 3"
 
             # Run setup (downloads firecracker/kernel/mitmdump, cached + idempotent)
             ssh $SSH_OPTS $REMOTE "${BIN_DIR}/runner setup"


### PR DESCRIPTION
Keep 3 most recent rootfs/snapshots instead of 2 in both crates.yml and turbo.yml CI workflows.