### PR TITLE
fix(slack): extract rich text content from blocks instead of lossy text fallback

### DIFF
--- a/turbo/apps/web/src/lib/slack/__tests__/context.test.ts
+++ b/turbo/apps/web/src/lib/slack/__tests__/context.test.ts
@@ -4,6 +4,7 @@ import {
   formatContextForAgent,
   formatContextForAgentWithImages,
   extractMessageContent,
+  extractTextFromBlocks,
 } from "../context";
 import { testContext } from "../../../__tests__/test-helpers";
 import { server } from "../../../mocks/server";
@@ -914,6 +915,517 @@ describe("Feature: Format Context With Image Upload", () => {
       expect(result).toContain("- RELATIVE_INDEX: -1");
       expect(result).toContain("- MSG_ID: 1234567890.002");
       expect(result).toContain("- SENDER_ID: U456");
+    });
+  });
+});
+
+describe("Feature: Extract Text From Rich Text Blocks", () => {
+  describe("Scenario: Return undefined for missing or empty blocks", () => {
+    it("should return undefined when blocks is undefined", () => {
+      expect(extractTextFromBlocks(undefined)).toBeUndefined();
+    });
+
+    it("should return undefined when blocks array is empty", () => {
+      expect(extractTextFromBlocks([])).toBeUndefined();
+    });
+
+    it("should return undefined when no rich_text blocks present", () => {
+      expect(extractTextFromBlocks([{ type: "section" }])).toBeUndefined();
+    });
+  });
+
+  describe("Scenario: Extract plain text from rich_text_section", () => {
+    it("should extract simple text", () => {
+      const blocks = [
+        {
+          type: "rich_text",
+          elements: [
+            {
+              type: "rich_text_section",
+              elements: [{ type: "text", text: "Hello world" }],
+            },
+          ],
+        },
+      ];
+
+      expect(extractTextFromBlocks(blocks)).toBe("Hello world");
+    });
+
+    it("should preserve bold formatting", () => {
+      const blocks = [
+        {
+          type: "rich_text",
+          elements: [
+            {
+              type: "rich_text_section",
+              elements: [
+                { type: "text", text: "Hello " },
+                { type: "text", text: "world", style: { bold: true } },
+              ],
+            },
+          ],
+        },
+      ];
+
+      expect(extractTextFromBlocks(blocks)).toBe("Hello **world**");
+    });
+
+    it("should preserve italic formatting", () => {
+      const blocks = [
+        {
+          type: "rich_text",
+          elements: [
+            {
+              type: "rich_text_section",
+              elements: [
+                { type: "text", text: "emphasis", style: { italic: true } },
+              ],
+            },
+          ],
+        },
+      ];
+
+      expect(extractTextFromBlocks(blocks)).toBe("_emphasis_");
+    });
+
+    it("should preserve inline code formatting", () => {
+      const blocks = [
+        {
+          type: "rich_text",
+          elements: [
+            {
+              type: "rich_text_section",
+              elements: [
+                { type: "text", text: "use " },
+                { type: "text", text: "npm install", style: { code: true } },
+              ],
+            },
+          ],
+        },
+      ];
+
+      expect(extractTextFromBlocks(blocks)).toBe("use `npm install`");
+    });
+
+    it("should preserve strikethrough formatting", () => {
+      const blocks = [
+        {
+          type: "rich_text",
+          elements: [
+            {
+              type: "rich_text_section",
+              elements: [
+                { type: "text", text: "removed", style: { strike: true } },
+              ],
+            },
+          ],
+        },
+      ];
+
+      expect(extractTextFromBlocks(blocks)).toBe("~removed~");
+    });
+  });
+
+  describe("Scenario: Handle links", () => {
+    it("should format link with display text", () => {
+      const blocks = [
+        {
+          type: "rich_text",
+          elements: [
+            {
+              type: "rich_text_section",
+              elements: [
+                { type: "link", url: "https://example.com", text: "Example" },
+              ],
+            },
+          ],
+        },
+      ];
+
+      expect(extractTextFromBlocks(blocks)).toBe(
+        "[Example](https://example.com)",
+      );
+    });
+
+    it("should format link without display text", () => {
+      const blocks = [
+        {
+          type: "rich_text",
+          elements: [
+            {
+              type: "rich_text_section",
+              elements: [{ type: "link", url: "https://example.com" }],
+            },
+          ],
+        },
+      ];
+
+      expect(extractTextFromBlocks(blocks)).toBe(
+        "[https://example.com](https://example.com)",
+      );
+    });
+  });
+
+  describe("Scenario: Handle emoji", () => {
+    it("should convert unicode emoji", () => {
+      const blocks = [
+        {
+          type: "rich_text",
+          elements: [
+            {
+              type: "rich_text_section",
+              elements: [{ type: "emoji", name: "wave", unicode: "1f44b" }],
+            },
+          ],
+        },
+      ];
+
+      expect(extractTextFromBlocks(blocks)).toBe("\u{1f44b}");
+    });
+
+    it("should use colon notation for custom emoji", () => {
+      const blocks = [
+        {
+          type: "rich_text",
+          elements: [
+            {
+              type: "rich_text_section",
+              elements: [{ type: "emoji", name: "partyparrot" }],
+            },
+          ],
+        },
+      ];
+
+      expect(extractTextFromBlocks(blocks)).toBe(":partyparrot:");
+    });
+  });
+
+  describe("Scenario: Handle mentions", () => {
+    it("should format user mention", () => {
+      const blocks = [
+        {
+          type: "rich_text",
+          elements: [
+            {
+              type: "rich_text_section",
+              elements: [{ type: "user", user_id: "U12345" }],
+            },
+          ],
+        },
+      ];
+
+      expect(extractTextFromBlocks(blocks)).toBe("<@U12345>");
+    });
+
+    it("should format channel mention", () => {
+      const blocks = [
+        {
+          type: "rich_text",
+          elements: [
+            {
+              type: "rich_text_section",
+              elements: [{ type: "channel", channel_id: "C12345" }],
+            },
+          ],
+        },
+      ];
+
+      expect(extractTextFromBlocks(blocks)).toBe("<#C12345>");
+    });
+
+    it("should format broadcast", () => {
+      const blocks = [
+        {
+          type: "rich_text",
+          elements: [
+            {
+              type: "rich_text_section",
+              elements: [{ type: "broadcast", range: "channel" }],
+            },
+          ],
+        },
+      ];
+
+      expect(extractTextFromBlocks(blocks)).toBe("@channel");
+    });
+  });
+
+  describe("Scenario: Handle rich_text_list", () => {
+    it("should format bullet list", () => {
+      const blocks = [
+        {
+          type: "rich_text",
+          elements: [
+            {
+              type: "rich_text_list",
+              style: "bullet",
+              elements: [
+                {
+                  type: "rich_text_section",
+                  elements: [{ type: "text", text: "Item 1" }],
+                },
+                {
+                  type: "rich_text_section",
+                  elements: [{ type: "text", text: "Item 2" }],
+                },
+              ],
+            },
+          ],
+        },
+      ];
+
+      expect(extractTextFromBlocks(blocks)).toBe("- Item 1\n- Item 2");
+    });
+
+    it("should format ordered list", () => {
+      const blocks = [
+        {
+          type: "rich_text",
+          elements: [
+            {
+              type: "rich_text_list",
+              style: "ordered",
+              elements: [
+                {
+                  type: "rich_text_section",
+                  elements: [{ type: "text", text: "First" }],
+                },
+                {
+                  type: "rich_text_section",
+                  elements: [{ type: "text", text: "Second" }],
+                },
+              ],
+            },
+          ],
+        },
+      ];
+
+      expect(extractTextFromBlocks(blocks)).toBe("1. First\n2. Second");
+    });
+
+    it("should handle indented lists", () => {
+      const blocks = [
+        {
+          type: "rich_text",
+          elements: [
+            {
+              type: "rich_text_list",
+              style: "bullet",
+              indent: 1,
+              elements: [
+                {
+                  type: "rich_text_section",
+                  elements: [{ type: "text", text: "Sub-item" }],
+                },
+              ],
+            },
+          ],
+        },
+      ];
+
+      expect(extractTextFromBlocks(blocks)).toBe("  - Sub-item");
+    });
+
+    it("should handle ordered list with offset", () => {
+      const blocks = [
+        {
+          type: "rich_text",
+          elements: [
+            {
+              type: "rich_text_list",
+              style: "ordered",
+              offset: 3,
+              elements: [
+                {
+                  type: "rich_text_section",
+                  elements: [{ type: "text", text: "Continued" }],
+                },
+              ],
+            },
+          ],
+        },
+      ];
+
+      expect(extractTextFromBlocks(blocks)).toBe("4. Continued");
+    });
+  });
+
+  describe("Scenario: Handle rich_text_preformatted", () => {
+    it("should format code block", () => {
+      const blocks = [
+        {
+          type: "rich_text",
+          elements: [
+            {
+              type: "rich_text_preformatted",
+              elements: [{ type: "text", text: "const x = 1;" }],
+            },
+          ],
+        },
+      ];
+
+      expect(extractTextFromBlocks(blocks)).toBe("```\nconst x = 1;\n```");
+    });
+
+    it("should include language annotation", () => {
+      const blocks = [
+        {
+          type: "rich_text",
+          elements: [
+            {
+              type: "rich_text_preformatted",
+              language: "typescript",
+              elements: [{ type: "text", text: "const x: number = 1;" }],
+            },
+          ],
+        },
+      ];
+
+      expect(extractTextFromBlocks(blocks)).toBe(
+        "```typescript\nconst x: number = 1;\n```",
+      );
+    });
+  });
+
+  describe("Scenario: Handle rich_text_quote", () => {
+    it("should format blockquote", () => {
+      const blocks = [
+        {
+          type: "rich_text",
+          elements: [
+            {
+              type: "rich_text_quote",
+              elements: [{ type: "text", text: "Quoted text" }],
+            },
+          ],
+        },
+      ];
+
+      expect(extractTextFromBlocks(blocks)).toBe("> Quoted text");
+    });
+
+    it("should handle multi-line quotes", () => {
+      const blocks = [
+        {
+          type: "rich_text",
+          elements: [
+            {
+              type: "rich_text_quote",
+              elements: [{ type: "text", text: "Line 1\nLine 2" }],
+            },
+          ],
+        },
+      ];
+
+      expect(extractTextFromBlocks(blocks)).toBe("> Line 1\n> Line 2");
+    });
+  });
+
+  describe("Scenario: Complex multi-section messages", () => {
+    it("should combine multiple sections", () => {
+      const blocks = [
+        {
+          type: "rich_text",
+          elements: [
+            {
+              type: "rich_text_section",
+              elements: [
+                {
+                  type: "text",
+                  text: "Project Summary",
+                  style: { bold: true },
+                },
+              ],
+            },
+            {
+              type: "rich_text_section",
+              elements: [{ type: "text", text: "Here are the key points:" }],
+            },
+            {
+              type: "rich_text_list",
+              style: "bullet",
+              elements: [
+                {
+                  type: "rich_text_section",
+                  elements: [{ type: "text", text: "Point A" }],
+                },
+                {
+                  type: "rich_text_section",
+                  elements: [{ type: "text", text: "Point B" }],
+                },
+              ],
+            },
+          ],
+        },
+      ];
+
+      expect(extractTextFromBlocks(blocks)).toBe(
+        "**Project Summary**\nHere are the key points:\n- Point A\n- Point B",
+      );
+    });
+  });
+
+  describe("Scenario: Integration with formatContextForAgent", () => {
+    it("should prefer blocks content over text fallback", () => {
+      const messages = [
+        {
+          user: "U123",
+          text: "Short fallback",
+          ts: "1234567890.001",
+          blocks: [
+            {
+              type: "rich_text",
+              elements: [
+                {
+                  type: "rich_text_section",
+                  elements: [
+                    {
+                      type: "text",
+                      text: "Full rich text content with all details preserved",
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ];
+
+      const result = formatContextForAgent(messages);
+
+      expect(result).toContain(
+        "Full rich text content with all details preserved",
+      );
+      expect(result).not.toContain("Short fallback");
+    });
+
+    it("should fall back to text when no rich_text blocks", () => {
+      const messages = [
+        {
+          user: "U123",
+          text: "Plain text message",
+          ts: "1234567890.001",
+          blocks: [{ type: "section" }],
+        },
+      ];
+
+      const result = formatContextForAgent(messages);
+
+      expect(result).toContain("Plain text message");
+    });
+
+    it("should fall back to text when blocks is undefined", () => {
+      const messages = [
+        {
+          user: "U123",
+          text: "Plain text message",
+          ts: "1234567890.001",
+        },
+      ];
+
+      const result = formatContextForAgent(messages);
+
+      expect(result).toContain("Plain text message");
     });
   });
 });

--- a/turbo/apps/web/src/lib/slack/context.ts
+++ b/turbo/apps/web/src/lib/slack/context.ts
@@ -60,17 +60,16 @@ interface RichTextElement {
   usergroup_id?: string;
   channel_id?: string;
   range?: string;
-  style?: RichTextStyle;
+  style?: RichTextStyle | string;
+  indent?: number;
+  offset?: number;
+  language?: string;
   elements?: RichTextElement[];
 }
 
 interface SlackBlock {
   type: string;
   elements?: RichTextElement[];
-  style?: string;
-  indent?: number;
-  offset?: number;
-  language?: string;
 }
 
 interface SlackMessage {
@@ -144,9 +143,10 @@ function isSupportedImageType(file: SlackFile): boolean {
  */
 function applyTextStyle(
   text: string,
-  style: RichTextStyle | undefined,
+  style: RichTextStyle | string | undefined,
 ): string {
-  if (style?.code) return `\`${text}\``;
+  if (typeof style === "string" || !style) return text;
+  if (style.code) return `\`${text}\``;
   let result = text;
   if (style?.bold) result = `**${result}**`;
   if (style?.italic) result = `_${result}_`;
@@ -214,8 +214,9 @@ export function extractTextFromBlocks(
           const items = section.elements ?? [];
           const indent = "  ".repeat(section.indent ?? 0);
           items.forEach((item, i) => {
+            const listStyle = section.style as string | undefined;
             const bullet =
-              section.style === "ordered"
+              listStyle === "ordered"
                 ? `${(section.offset ?? 0) + i + 1}.`
                 : "-";
             const text = inlineElementsToText(item.elements ?? []);

--- a/turbo/apps/web/src/lib/slack/context.ts
+++ b/turbo/apps/web/src/lib/slack/context.ts
@@ -214,7 +214,8 @@ export function extractTextFromBlocks(
           const items = section.elements ?? [];
           const indent = "  ".repeat(section.indent ?? 0);
           items.forEach((item, i) => {
-            const listStyle = section.style as string | undefined;
+            const listStyle =
+              typeof section.style === "string" ? section.style : undefined;
             const bullet =
               listStyle === "ordered"
                 ? `${(section.offset ?? 0) + i + 1}.`

--- a/turbo/apps/web/src/lib/slack/context.ts
+++ b/turbo/apps/web/src/lib/slack/context.ts
@@ -43,6 +43,36 @@ interface SlackAttachment {
   fallback?: string;
 }
 
+interface RichTextStyle {
+  bold?: boolean;
+  italic?: boolean;
+  strike?: boolean;
+  code?: boolean;
+}
+
+interface RichTextElement {
+  type: string;
+  text?: string;
+  url?: string;
+  name?: string;
+  unicode?: string;
+  user_id?: string;
+  usergroup_id?: string;
+  channel_id?: string;
+  range?: string;
+  style?: RichTextStyle;
+  elements?: RichTextElement[];
+}
+
+interface SlackBlock {
+  type: string;
+  elements?: RichTextElement[];
+  style?: string;
+  indent?: number;
+  offset?: number;
+  language?: string;
+}
+
 interface SlackMessage {
   user?: string;
   text?: string;
@@ -50,6 +80,7 @@ interface SlackMessage {
   bot_id?: string;
   files?: SlackFile[];
   attachments?: SlackAttachment[];
+  blocks?: SlackBlock[];
 }
 
 /**
@@ -106,6 +137,116 @@ export async function fetchChannelContext(
 function isSupportedImageType(file: SlackFile): boolean {
   const mimetype = file.mimetype?.toLowerCase();
   return mimetype !== undefined && SUPPORTED_IMAGE_TYPES.includes(mimetype);
+}
+
+/**
+ * Apply markdown-like style wrappers to a text element.
+ */
+function applyTextStyle(
+  text: string,
+  style: RichTextStyle | undefined,
+): string {
+  if (style?.code) return `\`${text}\``;
+  let result = text;
+  if (style?.bold) result = `**${result}**`;
+  if (style?.italic) result = `_${result}_`;
+  if (style?.strike) result = `~${result}~`;
+  return result;
+}
+
+/**
+ * Convert an inline rich text element to plain text with markdown-like formatting.
+ */
+function formatInlineElement(el: RichTextElement): string {
+  switch (el.type) {
+    case "text":
+      return applyTextStyle(el.text ?? "", el.style);
+    case "link":
+      return el.url ? `[${el.text ?? el.url}](${el.url})` : (el.text ?? "");
+    case "emoji":
+      return el.unicode
+        ? String.fromCodePoint(
+            ...el.unicode.split("-").map((h) => parseInt(h, 16)),
+          )
+        : `:${el.name ?? "emoji"}:`;
+    case "user":
+      return `<@${el.user_id ?? "unknown"}>`;
+    case "usergroup":
+      return `<!subteam^${el.usergroup_id ?? "unknown"}>`;
+    case "channel":
+      return `<#${el.channel_id ?? "unknown"}>`;
+    case "broadcast":
+      return `@${el.range ?? "here"}`;
+    default:
+      return el.text ?? "";
+  }
+}
+
+/**
+ * Convert an array of inline elements to a single text string.
+ */
+function inlineElementsToText(elements: RichTextElement[]): string {
+  return elements.map(formatInlineElement).join("");
+}
+
+/**
+ * Extract plain text content from Slack rich_text blocks.
+ * Returns undefined when no rich_text blocks are present so callers
+ * can fall back to msg.text.
+ */
+export function extractTextFromBlocks(
+  blocks: SlackBlock[] | undefined,
+): string | undefined {
+  if (!blocks || blocks.length === 0) return undefined;
+
+  const richTextBlocks = blocks.filter((b) => b.type === "rich_text");
+  if (richTextBlocks.length === 0) return undefined;
+
+  const parts: string[] = [];
+
+  for (const block of richTextBlocks) {
+    for (const section of block.elements ?? []) {
+      switch (section.type) {
+        case "rich_text_section":
+          parts.push(inlineElementsToText(section.elements ?? []));
+          break;
+        case "rich_text_list": {
+          const items = section.elements ?? [];
+          const indent = "  ".repeat(section.indent ?? 0);
+          items.forEach((item, i) => {
+            const bullet =
+              section.style === "ordered"
+                ? `${(section.offset ?? 0) + i + 1}.`
+                : "-";
+            const text = inlineElementsToText(item.elements ?? []);
+            parts.push(`${indent}${bullet} ${text}`);
+          });
+          break;
+        }
+        case "rich_text_preformatted": {
+          const code = inlineElementsToText(section.elements ?? []);
+          const lang = section.language ?? "";
+          parts.push(`\`\`\`${lang}\n${code}\n\`\`\``);
+          break;
+        }
+        case "rich_text_quote":
+          parts.push(
+            (section.elements ?? [])
+              .map((el) => formatInlineElement(el))
+              .join("")
+              .split("\n")
+              .map((line) => `> ${line}`)
+              .join("\n"),
+          );
+          break;
+        default:
+          break;
+      }
+    }
+  }
+
+  const result = parts.join("\n");
+  return result.length > 0 ? result : undefined;
 }
 
 /**
@@ -324,7 +465,7 @@ function formatMessageWithMetadata(
 ): string {
   const senderId = msg.bot_id ? "BOT" : (msg.user ?? "unknown");
   const msgId = msg.ts ?? "unknown";
-  const text = msg.text ?? "";
+  const text = extractTextFromBlocks(msg.blocks) ?? msg.text ?? "";
 
   const parts: string[] = [
     "---",


### PR DESCRIPTION
## Summary

- Slack WYSIWYG messages store full content in `blocks` (rich_text type), but the context builder only read `msg.text` which is a lossy plain-text fallback
- Added `extractTextFromBlocks()` converter that parses `rich_text` blocks into markdown-like text, preserving formatting (bold, italic, code, lists, quotes, code blocks, links, mentions, emoji)
- `formatMessageWithMetadata` now prefers blocks content over text fallback
- 27 new tests covering all rich_text element types and integration with existing formatters

Closes #3672

## Test plan

- [x] All 62 context tests pass (35 existing + 27 new)
- [x] Lint clean (0 errors, 0 warnings)
- [x] Type check clean
- [x] Knip clean
- [x] Format clean
- [ ] CI pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)