### PR TITLE
fix(platform): add user- prefix to default scope slug generation

### DIFF
--- a/turbo/apps/platform/src/signals/__tests__/onboarding.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/onboarding.test.ts
@@ -79,6 +79,34 @@ describe("needsOnboarding$", () => {
 });
 
 describe("saveOnboardingConfig$", () => {
+  it("should send slug with user- prefix when creating scope", async () => {
+    let scopeSlug: string | undefined;
+
+    server.use(
+      http.get("/api/scope", () => {
+        return new HttpResponse(null, { status: 404 });
+      }),
+      http.post("/api/scope", async ({ request }) => {
+        const body = (await request.json()) as { slug: string };
+        scopeSlug = body.slug;
+        return HttpResponse.json({}, { status: 201 });
+      }),
+    );
+
+    await setupPage({ context, path: "/", withoutRender: true });
+
+    act(() => {
+      context.store.set(setOnboardingSecret$, "test-oauth-token");
+    });
+
+    await act(async () => {
+      await context.store.set(saveOnboardingConfig$, context.signal);
+    });
+
+    expect(scopeSlug).toBeDefined();
+    expect(scopeSlug).toMatch(/^user-[0-9a-f]{8}$/);
+  });
+
   it("should create scope and model provider when saving with oauth token", async () => {
     let scopeCreated = false;
     let providerCreated = false;

--- a/turbo/apps/platform/src/signals/scope.ts
+++ b/turbo/apps/platform/src/signals/scope.ts
@@ -67,7 +67,7 @@ async function generateDefaultSlug(userId: string): Promise<string> {
   const hashHex = hashArray
     .map((b) => b.toString(16).padStart(2, "0"))
     .join("");
-  return hashHex.slice(0, 8);
+  return `user-${hashHex.slice(0, 8)}`;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Fix `generateDefaultSlug` in Platform to prepend `user-` prefix to scope slugs, matching the backend `generateDefaultScopeSlug` format
- Add integration test verifying the slug format sent to `POST /api/scope`
- Only affects new scope creation; existing bare-hex slugs remain unchanged

Closes #3691

## Test plan

- [x] New test asserts scope slug matches `/^user-[0-9a-f]{8}$/`
- [x] All 11 existing onboarding tests pass
- [x] Lint, format, and knip checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)