### PR TITLE
feat(telegram): improve UX with bot commands and deep links

### DIFF
--- a/turbo/apps/platform/src/views/integrations-page/__tests__/telegram-settings-page.test.tsx
+++ b/turbo/apps/platform/src/views/integrations-page/__tests__/telegram-settings-page.test.tsx
@@ -36,7 +36,10 @@ describe("telegram settings page", () => {
 
     // Available commands section
     expect(screen.getByText("Your available commands")).toBeInTheDocument();
-    expect(screen.getByText("/start")).toBeInTheDocument();
+    expect(screen.getByText("/new_session")).toBeInTheDocument();
+    expect(screen.getByText("/connect")).toBeInTheDocument();
+    expect(screen.getByText("/disconnect")).toBeInTheDocument();
+    expect(screen.getByText("/settings")).toBeInTheDocument();
     expect(screen.getByText("/help")).toBeInTheDocument();
 
     // Disconnect section (heading + button)

--- a/turbo/apps/platform/src/views/integrations-page/telegram-settings-page.tsx
+++ b/turbo/apps/platform/src/views/integrations-page/telegram-settings-page.tsx
@@ -339,15 +339,33 @@ export function TelegramSettingsPage() {
               <div className="rounded-xl border border-border bg-card p-4">
                 <div className="font-mono text-sm leading-6">
                   <p>
-                    <span className="font-medium">/start</span>
+                    <span className="font-medium">/new_session</span>
                     <span className="text-muted-foreground">
-                      {" // link your account"}
+                      {" // start a new conversation"}
+                    </span>
+                  </p>
+                  <p>
+                    <span className="font-medium">/connect</span>
+                    <span className="text-muted-foreground">
+                      {" // connect your VM0 account"}
+                    </span>
+                  </p>
+                  <p>
+                    <span className="font-medium">/disconnect</span>
+                    <span className="text-muted-foreground">
+                      {" // disconnect your account"}
+                    </span>
+                  </p>
+                  <p>
+                    <span className="font-medium">/settings</span>
+                    <span className="text-muted-foreground">
+                      {" // open platform settings"}
                     </span>
                   </p>
                   <p>
                     <span className="font-medium">/help</span>
                     <span className="text-muted-foreground">
-                      {" // show help"}
+                      {" // show available commands"}
                     </span>
                   </p>
                 </div>

--- a/turbo/apps/web/src/lib/telegram/handlers/commands.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/commands.ts
@@ -14,6 +14,7 @@ import type { TelegramHandlerUpdate } from "./types";
 
 const log = logger("telegram:commands");
 
+
 /**
  * Handle /connect command
  *

--- a/turbo/apps/web/src/lib/telegram/handlers/commands.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/commands.ts
@@ -14,7 +14,6 @@ import type { TelegramHandlerUpdate } from "./types";
 
 const log = logger("telegram:commands");
 
-
 /**
  * Handle /connect command
  *

--- a/turbo/apps/web/src/lib/telegram/handlers/direct-message.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/direct-message.ts
@@ -59,7 +59,7 @@ export async function handleTelegramDirectMessage(
     await sendMessage(
       client,
       chatId,
-      "Please link your account first. Send /start to begin.",
+      "Please link your account first. Use /connect to get started.",
     );
     return;
   }

--- a/turbo/apps/web/src/lib/telegram/handlers/mention.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/mention.ts
@@ -67,7 +67,7 @@ export async function handleTelegramMention(
     await sendMessage(
       client,
       chatId,
-      "Please link your account first. Send /start to the bot in a direct message.",
+      "Please link your account first. Use /connect to get started.",
       { replyToMessageId: message.message_id },
     );
     return;

--- a/turbo/apps/web/src/lib/telegram/handlers/new-session.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/new-session.ts
@@ -52,7 +52,7 @@ export async function handleNewSessionCommand(
     await sendMessage(
       client,
       chatId,
-      "Please link your account first. Send /start to begin.",
+      "Please link your account first. Use /connect to get started.",
     );
     return;
   }

--- a/turbo/apps/web/src/lib/telegram/handlers/new-session.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/new-session.ts
@@ -11,6 +11,7 @@ import type { TelegramHandlerUpdate } from "./types";
 
 const log = logger("telegram:new-session");
 
+
 /**
  * Handle /new_session command
  *

--- a/turbo/apps/web/src/lib/telegram/handlers/new-session.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/new-session.ts
@@ -11,7 +11,6 @@ import type { TelegramHandlerUpdate } from "./types";
 
 const log = logger("telegram:new-session");
 
-
 /**
  * Handle /new_session command
  *


### PR DESCRIPTION
## Summary

- Add bot commands (`/new_session`, `/connect`, `/disconnect`, `/settings`, `/help`) with Telegram menu integration
- Add deep link support for agent selection and account linking
- Improve session reuse logic and emoji branding in messages
- Update settings page to display all available commands
- Unify "link your account" prompts to reference `/connect` instead of `/start`
- Add agent detail logs URL in conversation responses
- Add integration tests for commands and `/new_session`

## Test plan

- [ ] Verify bot commands appear in Telegram command menu
- [ ] Test `/new_session` creates a fresh session
- [ ] Test `/connect` and `/disconnect` account linking flow
- [ ] Test deep link with agent name parameter
- [ ] Verify settings page shows updated command list
- [ ] CI passes (lint, type-check, tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)