### PR TITLE
refactor: stop passing slug when creating clerk organizations

### DIFF
--- a/turbo/apps/web/app/api/cli/auth/test-token/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/cli/auth/test-token/__tests__/route.test.ts
@@ -14,8 +14,8 @@ vi.mock("@clerk/nextjs/server", () => ({
     organizations: {
       createOrganization: vi
         .fn()
-        .mockImplementation(({ slug }: { slug: string }) =>
-          Promise.resolve({ id: `org_mock_${slug}` }),
+        .mockImplementation(({ name }: { name: string }) =>
+          Promise.resolve({ id: `org_mock_${name}` }),
         ),
     },
   })),

--- a/turbo/apps/web/src/__tests__/clerk-mock.ts
+++ b/turbo/apps/web/src/__tests__/clerk-mock.ts
@@ -63,8 +63,8 @@ export function mockClerk(options: { userId: string | null; email?: string }) {
     organizations: {
       createOrganization: vi
         .fn()
-        .mockImplementation(({ slug }: { slug: string }) =>
-          Promise.resolve({ id: `org_mock_${slug}` }),
+        .mockImplementation(({ name }: { name: string }) =>
+          Promise.resolve({ id: `org_mock_${name}` }),
         ),
     },
   } as unknown as Awaited<ReturnType<typeof clerkClient>>);

--- a/turbo/apps/web/src/__tests__/org-test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/org-test-helpers.ts
@@ -33,7 +33,6 @@ export function setupClerkOrgMock(options: {
     createOrganization: vi.fn().mockResolvedValue({
       id: orgId,
       name: "test-org",
-      slug: "test-org",
     }),
     getOrganizationMembershipList: vi.fn().mockResolvedValue({
       data: memberships.map((m) => ({

--- a/turbo/apps/web/src/lib/org/org-service.ts
+++ b/turbo/apps/web/src/lib/org/org-service.ts
@@ -77,7 +77,6 @@ export async function createOrganization(clerkUserId: string, slug: string) {
   const client = await clerkClient();
   const clerkOrg = await client.organizations.createOrganization({
     name: slug,
-    slug,
     createdBy: clerkUserId,
   });
 

--- a/turbo/apps/web/src/lib/scope/scope-service.ts
+++ b/turbo/apps/web/src/lib/scope/scope-service.ts
@@ -122,7 +122,6 @@ export async function createUserScope(clerkUserId: string, slug: string) {
       const client = await clerkClient();
       const clerkOrg = await client.organizations.createOrganization({
         name: slug,
-        slug,
         createdBy: clerkUserId,
       });
       clerkOrgId = clerkOrg.id;


### PR DESCRIPTION
## Summary

- Remove `slug` parameter from all `createOrganization` calls to Clerk SDK — let Clerk auto-generate its own slug
- Update test mocks to reflect the new API shape (`name` instead of `slug`)
- No code reads `clerkOrg.slug` anywhere — only `clerkOrg.id` is used, so this is a safe removal

This eliminates:
1. **Slug conflicts** (HTTP 422) when creating Clerk orgs with duplicate slugs
2. **Slug drift** between local DB and Clerk (e.g., after `vm0 scope set`)
3. **Unnecessary complexity** in the backfill script's retry logic

## Test plan

- [x] All 2871 existing tests pass
- [x] Lint, format, and knip checks pass
- [x] Verified no remaining `slug` references in `createOrganization` calls via grep

Closes #3692

🤖 Generated with [Claude Code](https://claude.com/claude-code)