### PR TITLE
chore(ci): test mold linker + ci profile for faster cross-compilation

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -119,6 +119,10 @@ jobs:
       needs.detect.outputs.guest-agent-changed == 'true' ||
       needs.detect.outputs.guest-mock-claude-changed == 'true'
     timeout-minutes: 20
+    env:
+      CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_RUSTFLAGS: "-C target-feature=+crt-static -C link-arg=-fuse-ld=mold"
+      CARGO_PROFILE: ci
+      TARGET_TRIPLE: aarch64-unknown-linux-musl
     outputs:
       host: ${{ steps.host.outputs.host }}
       job-ref: ${{ steps.host.outputs.job-ref }}
@@ -127,27 +131,31 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Install mold linker
+        run: |
+          apt-get update && apt-get install -y mold
+
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: crates -> target
-          shared-key: aarch64-musl
+          shared-key: aarch64-musl-ci
           save-if: ${{ github.ref == 'refs/heads/main' }}
           cache-targets: false
 
       - name: Cross-compile guest binaries for ARM64
         run: |
           cd crates
-          cargo build --release --target aarch64-unknown-linux-musl \
+          cargo build --profile $CARGO_PROFILE --target $TARGET_TRIPLE \
             -p guest-agent -p guest-download -p guest-init -p guest-mock-claude
 
       - name: Cross-compile runner with embedded guests for ARM64
         run: |
           cd crates
-          GUEST_AGENT_PATH=target/aarch64-unknown-linux-musl/release/guest-agent \
-          GUEST_DOWNLOAD_PATH=target/aarch64-unknown-linux-musl/release/guest-download \
-          GUEST_INIT_PATH=target/aarch64-unknown-linux-musl/release/guest-init \
-          GUEST_MOCK_CLAUDE_PATH=target/aarch64-unknown-linux-musl/release/guest-mock-claude \
-          cargo build --release --target aarch64-unknown-linux-musl -p runner
+          GUEST_AGENT_PATH=target/$TARGET_TRIPLE/$CARGO_PROFILE/guest-agent \
+          GUEST_DOWNLOAD_PATH=target/$TARGET_TRIPLE/$CARGO_PROFILE/guest-download \
+          GUEST_INIT_PATH=target/$TARGET_TRIPLE/$CARGO_PROFILE/guest-init \
+          GUEST_MOCK_CLAUDE_PATH=target/$TARGET_TRIPLE/$CARGO_PROFILE/guest-mock-claude \
+          cargo build --profile $CARGO_PROFILE --target $TARGET_TRIPLE -p runner
 
       - name: Setup SSH
         env:
@@ -186,7 +194,7 @@ jobs:
           SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10 -i $HOME/.ssh/runner.pem"
           REMOTE="${METAL_USER}@${HOST}"
           BIN_DIR="~/.vm0-runner/bin/${JOB_REF}"
-          TARGET_DIR="crates/target/aarch64-unknown-linux-musl/release"
+          TARGET_DIR="crates/target/${TARGET_TRIPLE}/${CARGO_PROFILE}"
 
           # Provision system dependencies (idempotent)
           echo "=== Provisioning system dependencies ==="

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -132,8 +132,13 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install mold linker
+        env:
+          MOLD_VERSION: "2.40.4"
         run: |
-          apt-get update && apt-get install -y mold
+          curl -fsSL "https://github.com/rui314/mold/releases/download/v${MOLD_VERSION}/mold-${MOLD_VERSION}-x86_64-linux.tar.gz" \
+            | tar xz --strip-components=2 -C /usr/local/bin "mold-${MOLD_VERSION}-x86_64-linux/bin/mold"
+          ln -sf /usr/local/bin/mold /usr/local/bin/ld.mold
+          ln -sf /usr/local/bin/mold /usr/local/bin/aarch64-linux-gnu-ld.mold
 
       - uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1221,8 +1221,13 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install mold linker
+        env:
+          MOLD_VERSION: "2.40.4"
         run: |
-          apt-get update && apt-get install -y mold
+          curl -fsSL "https://github.com/rui314/mold/releases/download/v${MOLD_VERSION}/mold-${MOLD_VERSION}-x86_64-linux.tar.gz" \
+            | tar xz --strip-components=2 -C /usr/local/bin "mold-${MOLD_VERSION}-x86_64-linux/bin/mold"
+          ln -sf /usr/local/bin/mold /usr/local/bin/ld.mold
+          ln -sf /usr/local/bin/mold /usr/local/bin/aarch64-linux-gnu-ld.mold
 
       - uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1197,6 +1197,10 @@ jobs:
       image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260203
     needs: [prepare]
     timeout-minutes: 10
+    env:
+      CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_RUSTFLAGS: "-C target-feature=+crt-static -C link-arg=-fuse-ld=mold"
+      CARGO_PROFILE: ci
+      TARGET_TRIPLE: aarch64-unknown-linux-musl
     if: |
       github.event_name != 'push' &&
       needs.prepare.outputs.job-ref != '' && (
@@ -1216,27 +1220,31 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Install mold linker
+        run: |
+          apt-get update && apt-get install -y mold
+
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: crates -> target
-          shared-key: aarch64-musl
+          shared-key: aarch64-musl-ci
           save-if: ${{ github.ref == 'refs/heads/main' }}
           cache-targets: false
 
       - name: Cross-compile guest binaries for ARM64
         run: |
           cd crates
-          cargo build --release --target aarch64-unknown-linux-musl \
+          cargo build --profile $CARGO_PROFILE --target $TARGET_TRIPLE \
             -p guest-agent -p guest-download -p guest-init -p guest-mock-claude
 
       - name: Cross-compile runner with embedded guests for ARM64
         run: |
           cd crates
-          GUEST_AGENT_PATH=target/aarch64-unknown-linux-musl/release/guest-agent \
-          GUEST_DOWNLOAD_PATH=target/aarch64-unknown-linux-musl/release/guest-download \
-          GUEST_INIT_PATH=target/aarch64-unknown-linux-musl/release/guest-init \
-          GUEST_MOCK_CLAUDE_PATH=target/aarch64-unknown-linux-musl/release/guest-mock-claude \
-          cargo build --release --target aarch64-unknown-linux-musl -p runner
+          GUEST_AGENT_PATH=target/$TARGET_TRIPLE/$CARGO_PROFILE/guest-agent \
+          GUEST_DOWNLOAD_PATH=target/$TARGET_TRIPLE/$CARGO_PROFILE/guest-download \
+          GUEST_INIT_PATH=target/$TARGET_TRIPLE/$CARGO_PROFILE/guest-init \
+          GUEST_MOCK_CLAUDE_PATH=target/$TARGET_TRIPLE/$CARGO_PROFILE/guest-mock-claude \
+          cargo build --profile $CARGO_PROFILE --target $TARGET_TRIPLE -p runner
 
       - name: Setup SSH
         env:
@@ -1312,7 +1320,7 @@ jobs:
           RUNNER_DIR: ${{ steps.host.outputs.runner-dir }}
         run: |
           SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10 -i $HOME/.ssh/runner.pem"
-          TARGET_DIR="crates/target/aarch64-unknown-linux-musl/release"
+          TARGET_DIR="crates/target/${TARGET_TRIPLE}/${CARGO_PROFILE}"
 
           # Provision system dependencies on all hosts (idempotent)
           echo "=== Provisioning system dependencies ==="

--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -74,6 +74,11 @@ lto = true
 strip = true
 codegen-units = 1
 
+[profile.ci]
+inherits = "release"
+lto = "thin"
+codegen-units = 4
+
 [workspace.lints.rust]
 warnings = "deny"
 


### PR DESCRIPTION
Test faster cross-compilation with:
- `[profile.ci]`: thin LTO + codegen-units=4 (vs full LTO + codegen-units=1)
- mold linker (vs default ld via gcc)

Baseline: 58s + 105s = 163s for cross-compile steps. Expecting ~50% reduction.