### PR TITLE
feat(telegram): streamline re-link flow after /disconnect

### DIFF
--- a/turbo/apps/platform/src/signals/telegram-connect/telegram-connect-page.ts
+++ b/turbo/apps/platform/src/signals/telegram-connect/telegram-connect-page.ts
@@ -1,7 +1,7 @@
 import { command } from "ccstate";
 import { createElement } from "react";
 import { updatePage$ } from "../react-router.ts";
-import { navigate$ } from "../route.ts";
+import { navigate$, searchParams$ } from "../route.ts";
 import { hasAnyModelProvider$ } from "../external/model-providers.ts";
 import { throwIfAbort } from "../utils.ts";
 import { initTelegramConnect$ } from "./telegram-connect.ts";
@@ -34,6 +34,9 @@ export const setupTelegramConnectPage$ = command(
       return;
     }
 
-    await set(initTelegramConnect$);
+    // Pass ?bot= param to init so it can look up existing installation
+    const params = get(searchParams$);
+    const botId = params.get("bot") ?? undefined;
+    await set(initTelegramConnect$, botId);
   },
 );

--- a/turbo/apps/platform/src/signals/telegram-connect/telegram-connect.ts
+++ b/turbo/apps/platform/src/signals/telegram-connect/telegram-connect.ts
@@ -28,6 +28,7 @@ type RegisterTelegramBotResult =
       success: true;
       installationId: string;
       botUsername: string;
+      deepLink?: string;
     }
   | { success: false };
 
@@ -141,8 +142,10 @@ export const linkTelegramBot$ = command(
         throw new Error(data.error?.message ?? "Failed to link account");
       }
 
-      // Consume response (token is used via Telegram deep link)
-      await response.json();
+      const data = (await response.json()) as {
+        token: string;
+        deepLink: string | null;
+      };
 
       set(telegramConnectState$, (prev) => ({
         ...prev,
@@ -153,6 +156,7 @@ export const linkTelegramBot$ = command(
         success: true,
         installationId,
         botUsername,
+        deepLink: data.deepLink ?? undefined,
       };
     } catch (error) {
       throwIfAbort(error);

--- a/turbo/apps/platform/src/signals/telegram-connect/telegram-connect.ts
+++ b/turbo/apps/platform/src/signals/telegram-connect/telegram-connect.ts
@@ -5,9 +5,21 @@ import { logger } from "../log.ts";
 
 const L = logger("TelegramConnect");
 
+interface TelegramInstallationInfo {
+  id: string;
+  botUsername: string;
+}
+
 interface TelegramConnectState {
-  status: "checking" | "ready" | "registering" | "success" | "error";
+  status:
+    | "checking"
+    | "ready"
+    | "registering"
+    | "linking"
+    | "success"
+    | "error";
   isLinked: boolean;
+  installation: TelegramInstallationInfo | null;
   error: string | null;
 }
 
@@ -22,6 +34,7 @@ type RegisterTelegramBotResult =
 const telegramConnectState$ = state<TelegramConnectState>({
   status: "checking",
   isLinked: false,
+  installation: null,
   error: null,
 });
 
@@ -34,6 +47,9 @@ export const telegramConnectIsLinked$ = computed(
 export const telegramConnectError$ = computed(
   (get) => get(telegramConnectState$).error,
 );
+export const telegramConnectInstallation$ = computed(
+  (get) => get(telegramConnectState$).installation,
+);
 
 const telegramBotTokenInput$ = state("");
 
@@ -45,42 +61,112 @@ export const setTelegramBotToken$ = command(({ set }, value: string) => {
 
 /**
  * Check if the user is already linked to a Telegram bot.
+ * When botId is provided, also checks for an existing installation to enable re-linking.
  */
-export const initTelegramConnect$ = command(async ({ get, set }) => {
-  set(telegramConnectState$, {
-    status: "checking",
-    isLinked: false,
-    error: null,
-  });
-
-  try {
-    const fetchFn = get(fetch$);
-    const response = await fetchFn("/api/integrations/telegram/link");
-
-    if (!response.ok) {
-      throw new Error("Failed to check link status");
-    }
-
-    const data = (await response.json()) as {
-      linked: boolean;
-      telegramUserId?: string;
-    };
-
+export const initTelegramConnect$ = command(
+  async ({ get, set }, botId?: string) => {
     set(telegramConnectState$, {
-      status: "ready",
-      isLinked: data.linked,
+      status: "checking",
+      isLinked: false,
+      installation: null,
       error: null,
     });
-  } catch (error) {
-    throwIfAbort(error);
-    L.error("Failed to check link status:", error);
-    set(telegramConnectState$, {
-      status: "error",
-      isLinked: false,
-      error: "Failed to check connection status. Please try again.",
-    });
-  }
-});
+
+    try {
+      const fetchFn = get(fetch$);
+      const url = botId
+        ? `/api/integrations/telegram/link?botId=${encodeURIComponent(botId)}`
+        : "/api/integrations/telegram/link";
+      const response = await fetchFn(url);
+
+      if (!response.ok) {
+        throw new Error("Failed to check link status");
+      }
+
+      const data = (await response.json()) as {
+        linked: boolean;
+        telegramUserId?: string;
+        installation?: TelegramInstallationInfo;
+      };
+
+      set(telegramConnectState$, {
+        status: "ready",
+        isLinked: data.linked,
+        installation: data.installation ?? null,
+        error: null,
+      });
+    } catch (error) {
+      throwIfAbort(error);
+      L.error("Failed to check link status:", error);
+      set(telegramConnectState$, {
+        status: "error",
+        isLinked: false,
+        installation: null,
+        error: "Failed to check connection status. Please try again.",
+      });
+    }
+  },
+);
+
+/**
+ * Link user to an existing Telegram bot installation.
+ * Generates a deep link token and returns the Telegram deep link URL.
+ */
+export const linkTelegramBot$ = command(
+  async (
+    { get, set },
+    installationId: string,
+  ): Promise<RegisterTelegramBotResult> => {
+    const botUsername =
+      get(telegramConnectState$).installation?.botUsername ?? "";
+
+    set(telegramConnectState$, (prev) => ({
+      ...prev,
+      status: "linking" as const,
+      error: null,
+    }));
+
+    try {
+      const fetchFn = get(fetch$);
+      const response = await fetchFn("/api/integrations/telegram/link", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ installationId }),
+      });
+
+      if (!response.ok) {
+        const data = (await response.json()) as {
+          error?: { message?: string };
+        };
+        throw new Error(data.error?.message ?? "Failed to link account");
+      }
+
+      // Consume response (token is used via Telegram deep link)
+      await response.json();
+
+      set(telegramConnectState$, (prev) => ({
+        ...prev,
+        status: "success" as const,
+      }));
+
+      return {
+        success: true,
+        installationId,
+        botUsername,
+      };
+    } catch (error) {
+      throwIfAbort(error);
+      L.error("Failed to link Telegram bot:", error);
+      set(telegramConnectState$, (prev) => ({
+        ...prev,
+        status: "ready" as const,
+        error:
+          error instanceof Error ? error.message : "Failed to link account",
+      }));
+      return { success: false };
+    }
+  },
+);
 
 /**
  * Register a new Telegram bot (admin flow).

--- a/turbo/apps/platform/src/views/telegram-connect/telegram-connect-page.tsx
+++ b/turbo/apps/platform/src/views/telegram-connect/telegram-connect-page.tsx
@@ -56,6 +56,9 @@ export function TelegramConnectPage() {
         if (result.success) {
           const successParams = new URLSearchParams();
           successParams.set("bot", result.botUsername);
+          if (result.deepLink) {
+            successParams.set("deepLink", result.deepLink);
+          }
           navigate("/telegram/connect/success", {
             searchParams: successParams,
           });

--- a/turbo/apps/platform/src/views/telegram-connect/telegram-connect-page.tsx
+++ b/turbo/apps/platform/src/views/telegram-connect/telegram-connect-page.tsx
@@ -7,18 +7,22 @@ import {
   telegramConnectStatus$,
   telegramConnectIsLinked$,
   telegramConnectError$,
+  telegramConnectInstallation$,
   telegramBotToken$,
   setTelegramBotToken$,
   registerTelegramBot$,
+  linkTelegramBot$,
 } from "../../signals/telegram-connect/telegram-connect.ts";
 import { detach, Reason } from "../../signals/utils.ts";
 
 export function TelegramConnectPage() {
   const status = useGet(telegramConnectStatus$);
   const isLinked = useGet(telegramConnectIsLinked$);
+  const installation = useGet(telegramConnectInstallation$);
   const error = useGet(telegramConnectError$);
   const theme = useGet(theme$);
   const registerBot = useSet(registerTelegramBot$);
+  const linkBot = useSet(linkTelegramBot$);
   const navigate = useSet(navigateInReact$);
   const botToken = useGet(telegramBotToken$);
   const setBotToken = useSet(setTelegramBotToken$);
@@ -42,10 +46,31 @@ export function TelegramConnectPage() {
     );
   };
 
+  const handleLink = () => {
+    if (!installation) {
+      return;
+    }
+    detach(
+      (async () => {
+        const result = await linkBot(installation.id);
+        if (result.success) {
+          const successParams = new URLSearchParams();
+          successParams.set("bot", result.botUsername);
+          navigate("/telegram/connect/success", {
+            searchParams: successParams,
+          });
+        }
+      })(),
+      Reason.DomCallback,
+    );
+  };
+
   const backgroundGradient =
     theme === "dark"
       ? "linear-gradient(91deg, rgba(255, 200, 176, 0.15) 0%, rgba(166, 222, 255, 0.15) 51%, rgba(255, 231, 162, 0.15) 100%), linear-gradient(90deg, hsl(var(--background)) 0%, hsl(var(--background)) 100%)"
       : "linear-gradient(91deg, rgba(255, 200, 176, 0.26) 0%, rgba(166, 222, 255, 0.26) 51%, rgba(255, 231, 162, 0.26) 100%), linear-gradient(90deg, hsl(var(--background)) 0%, hsl(var(--background)) 100%)";
+
+  const isLinking = status === "linking";
 
   return (
     <div
@@ -100,6 +125,54 @@ export function TelegramConnectPage() {
                   Go to Settings
                 </Button>
               </div>
+            ) : installation ? (
+              /* Re-link to existing bot */
+              <>
+                <div className="flex flex-col gap-1 text-center text-foreground">
+                  <h1 className="text-lg font-medium leading-7">
+                    Link Your Account
+                  </h1>
+                  <p className="text-sm leading-5 text-muted-foreground">
+                    A Telegram bot{" "}
+                    <span className="font-medium text-foreground">
+                      @{installation.botUsername}
+                    </span>{" "}
+                    is already installed. Link your account to start using it.
+                  </p>
+                </div>
+
+                {/* Error Message */}
+                {error && (
+                  <div className="w-full rounded-md bg-destructive/10 p-2 text-center text-xs text-destructive">
+                    {error}
+                  </div>
+                )}
+
+                {/* Action Buttons */}
+                <div className="flex flex-col gap-4">
+                  <Button
+                    onClick={handleLink}
+                    disabled={isLinking}
+                    className="w-full"
+                  >
+                    {isLinking ? "Linking..." : "Link Account"}
+                  </Button>
+                  <Button
+                    className="w-full"
+                    variant="outline"
+                    onClick={() =>
+                      navigate("/settings", {
+                        searchParams: new URLSearchParams({
+                          tab: "integrations",
+                        }),
+                      })
+                    }
+                    disabled={isLinking}
+                  >
+                    Cancel
+                  </Button>
+                </div>
+              </>
             ) : (
               /* Registration form */
               <>

--- a/turbo/apps/platform/src/views/telegram-connect/telegram-connect-success-page.tsx
+++ b/turbo/apps/platform/src/views/telegram-connect/telegram-connect-success-page.tsx
@@ -9,7 +9,9 @@ export function TelegramConnectSuccessPage() {
   const params = useGet(searchParams$);
 
   const botUsername = params.get("bot");
-  const telegramLink = botUsername ? `https://t.me/${botUsername}` : null;
+  const deepLink = params.get("deepLink");
+  const telegramLink =
+    deepLink ?? (botUsername ? `https://t.me/${botUsername}` : null);
 
   const backgroundGradient =
     theme === "dark"

--- a/turbo/apps/web/app/api/integrations/telegram/link/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/integrations/telegram/link/__tests__/route.test.ts
@@ -1,14 +1,27 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { GET, POST } from "../route";
 import { verifyLinkToken } from "../../../../../../src/lib/telegram/handlers/start";
-import { testContext } from "../../../../../../src/__tests__/test-helpers";
+import {
+  testContext,
+  uniqueId,
+} from "../../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
 import { createTestTelegramInstallation } from "../../../../../../src/__tests__/api-test-helpers";
 
 const context = testContext();
 
-function linkRequest(method: string, body?: Record<string, unknown>) {
-  return new Request("http://localhost:3000/api/integrations/telegram/link", {
+function linkRequest(
+  method: string,
+  body?: Record<string, unknown>,
+  queryParams?: Record<string, string>,
+) {
+  const url = new URL("http://localhost:3000/api/integrations/telegram/link");
+  if (queryParams) {
+    for (const [key, value] of Object.entries(queryParams)) {
+      url.searchParams.set(key, value);
+    }
+  }
+  return new Request(url.toString(), {
     method,
     ...(body
       ? {
@@ -58,6 +71,39 @@ describe("/api/integrations/telegram/link", () => {
       expect(response.status).toBe(200);
       expect(data.linked).toBe(true);
       expect(data.telegramUserId).toBeDefined();
+    });
+
+    it("returns installation info when botId matches an existing bot", async () => {
+      await context.setupUser();
+      const telegramBotId = uniqueId("bot");
+      const installationId = await createTestTelegramInstallation({
+        telegramBotId,
+      });
+
+      const response = await GET(
+        linkRequest("GET", undefined, { botId: telegramBotId }),
+      );
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.linked).toBe(false);
+      expect(data.installation).toEqual({
+        id: installationId,
+        botUsername: `bot_${telegramBotId}`,
+      });
+    });
+
+    it("returns linked: false without installation for unknown botId", async () => {
+      await context.setupUser();
+
+      const response = await GET(
+        linkRequest("GET", undefined, { botId: "nonexistent-bot-id" }),
+      );
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.linked).toBe(false);
+      expect(data.installation).toBeUndefined();
     });
   });
 

--- a/turbo/apps/web/app/api/integrations/telegram/link/route.ts
+++ b/turbo/apps/web/app/api/integrations/telegram/link/route.ts
@@ -48,7 +48,10 @@ export async function GET(request: Request) {
     });
   }
 
-  // If not linked, check if a specific bot was requested via ?botId= param
+  // If not linked, check if a specific bot was requested via ?botId= param.
+  // This returns the installation ID and botUsername so the frontend can show
+  // a re-link UI. Actual linking is gated by an HMAC-signed deep link token
+  // that must be activated via Telegram interaction (see /start handler).
   const url = new URL(request.url);
   const botId = url.searchParams.get("botId");
 

--- a/turbo/apps/web/app/api/integrations/telegram/link/route.ts
+++ b/turbo/apps/web/app/api/integrations/telegram/link/route.ts
@@ -41,14 +41,39 @@ export async function GET(request: Request) {
     .orderBy(desc(telegramUserLinks.createdAt))
     .limit(1);
 
-  if (!userLink) {
-    return NextResponse.json({ linked: false });
+  if (userLink) {
+    return NextResponse.json({
+      linked: true,
+      telegramUserId: userLink.telegramUserId,
+    });
   }
 
-  return NextResponse.json({
-    linked: true,
-    telegramUserId: userLink.telegramUserId,
-  });
+  // If not linked, check if a specific bot was requested via ?botId= param
+  const url = new URL(request.url);
+  const botId = url.searchParams.get("botId");
+
+  if (botId) {
+    const [installation] = await globalThis.services.db
+      .select({
+        id: telegramInstallations.id,
+        botUsername: telegramInstallations.botUsername,
+      })
+      .from(telegramInstallations)
+      .where(eq(telegramInstallations.telegramBotId, botId))
+      .limit(1);
+
+    if (installation) {
+      return NextResponse.json({
+        linked: false,
+        installation: {
+          id: installation.id,
+          botUsername: installation.botUsername,
+        },
+      });
+    }
+  }
+
+  return NextResponse.json({ linked: false });
 }
 
 /**

--- a/turbo/apps/web/app/api/telegram/register/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/telegram/register/__tests__/route.test.ts
@@ -147,7 +147,7 @@ describe("POST /api/telegram/register", () => {
     expect(setCommandsHandler.mocked).toHaveBeenCalledTimes(1);
   });
 
-  it("returns 409 when bot is already registered", async () => {
+  it("creates user link when bot is already registered", async () => {
     await context.setupUser();
 
     const botId = testBotId();
@@ -168,14 +168,14 @@ describe("POST /api/telegram/register", () => {
     );
     expect(first.status).toBe(201);
 
-    // Second registration with same bot fails
+    // Second registration with same bot creates a user link instead of 409
     const second = await POST(
       registerRequest({ botToken: TEST_BOT_TOKEN, defaultAgentId: composeId }),
     );
     const body = await second.json();
 
-    expect(second.status).toBe(409);
-    expect(body.error.code).toBe("CONFLICT");
+    expect(second.status).toBe(200);
+    expect(body.botUsername).toBeDefined();
   });
 
   it("returns 400 when no default agent is available", async () => {

--- a/turbo/apps/web/app/api/telegram/register/route.ts
+++ b/turbo/apps/web/app/api/telegram/register/route.ts
@@ -91,23 +91,34 @@ export async function POST(request: Request) {
 
   const telegramBotId = String(botInfoResult.id);
 
-  // 2. Check for duplicate
+  // 2. Check for duplicate — if bot already registered, link the user instead
   const [existing] = await globalThis.services.db
-    .select({ id: telegramInstallations.id })
+    .select({
+      id: telegramInstallations.id,
+      telegramBotId: telegramInstallations.telegramBotId,
+      botUsername: telegramInstallations.botUsername,
+    })
     .from(telegramInstallations)
     .where(eq(telegramInstallations.telegramBotId, telegramBotId))
     .limit(1);
 
   if (existing) {
-    return NextResponse.json(
-      {
-        error: {
-          message: "This bot is already registered",
-          code: "CONFLICT",
-        },
-      },
-      { status: 409 },
-    );
+    // Create a pending user link so the user is auto-linked on first message
+    await globalThis.services.db
+      .insert(telegramUserLinks)
+      .values({
+        telegramUserId: PENDING_TELEGRAM_USER_ID,
+        installationId: existing.id,
+        vm0UserId: userId,
+      })
+      .onConflictDoNothing();
+    await ensureScopeAndArtifact(userId);
+
+    return NextResponse.json({
+      id: existing.id,
+      botId: existing.telegramBotId,
+      botUsername: existing.botUsername,
+    });
   }
 
   // 3. Resolve default agent

--- a/turbo/apps/web/app/api/telegram/webhook/__tests__/commands.test.ts
+++ b/turbo/apps/web/app/api/telegram/webhook/__tests__/commands.test.ts
@@ -123,7 +123,7 @@ describe("Telegram bot commands", () => {
       expect(sendMsg.calls[0]?.text).toContain("already connected");
     });
 
-    it("should send platform link when user is not connected", async () => {
+    it("should send platform link with bot param when user is not connected", async () => {
       const sendMsg = telegramSendMessage();
       server.use(sendMsg.handler);
 
@@ -144,7 +144,7 @@ describe("Telegram bot commands", () => {
       await flushAfterCallbacks();
 
       expect(sendMsg.mocked).toHaveBeenCalled();
-      expect(sendMsg.calls[0]?.text).toContain("settings/telegram");
+      expect(sendMsg.calls[0]?.text).toContain("/telegram/connect?bot=");
     });
   });
 

--- a/turbo/apps/web/src/__tests__/api-test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers.ts
@@ -2255,6 +2255,7 @@ export async function findTestGitHubIssueSession(
 export async function createTestTelegramInstallation(options?: {
   adminUserId?: string;
   vm0UserId?: string;
+  telegramBotId?: string;
 }): Promise<string> {
   initServices();
   const { SECRETS_ENCRYPTION_KEY } = globalThis.services.env;
@@ -2283,8 +2284,8 @@ export async function createTestTelegramInstallation(options?: {
   const [installation] = await globalThis.services.db
     .insert(telegramInstallations)
     .values({
-      telegramBotId: suffix,
-      botUsername: `bot_${suffix}`,
+      telegramBotId: options?.telegramBotId ?? suffix,
+      botUsername: `bot_${options?.telegramBotId ?? suffix}`,
       encryptedBotToken: encryptCredentialValue(
         "test-bot-token",
         SECRETS_ENCRYPTION_KEY,

--- a/turbo/apps/web/src/lib/telegram/handlers/commands.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/commands.ts
@@ -59,10 +59,11 @@ export async function handleConnectCommand(
   }
 
   const platformUrl = getPlatformUrl();
+  const connectUrl = `${platformUrl}/telegram/connect?bot=${installation.telegramBotId}`;
   await sendMessage(
     client,
     chatId,
-    `Visit the platform to connect your account:\n<a href="${escapeHtml(platformUrl)}/settings/telegram">Open Platform</a>`,
+    `Visit the platform to connect your account:\n<a href="${escapeHtml(connectUrl)}">Open Platform</a>`,
   );
 }
 


### PR DESCRIPTION
## Summary

Closes #3699

After a user runs `/disconnect` in Telegram, they previously hit a dead end when trying to re-connect — the register endpoint returned 409 (conflict) and there was no way to re-link to an existing bot.

This PR implements the **Hybrid Smart Register + URL Parameter** approach:

- **Register endpoint**: Returns 200 with user link instead of 409 when bot already exists, allowing non-admin users to re-link seamlessly
- **Link API**: GET endpoint now supports `?botId=` query param to discover existing installations for re-linking
- **Connect page signals**: `initTelegramConnect$` accepts optional `botId` param, new `linkTelegramBot$` command for re-linking
- **Connect page UI**: New "Link Your Account" view when an existing installation is detected, showing bot username and one-click link button
- **`/connect` command**: URL changed from `/settings/telegram` to `/telegram/connect?bot={botId}` so users arriving from Telegram get the streamlined re-link flow

## Test plan

- [x] Register endpoint: "creates user link when bot is already registered" test (was 409, now 200)
- [x] `/connect` command: test verifies URL contains `/telegram/connect?bot=`
- [x] All 18 telegram-related tests pass
- [x] Full test suite passes locally (3301 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)