### PR TITLE
feat: add oauth scope mismatch detection in connector settings

### DIFF
--- a/turbo/apps/platform/src/signals/settings-page/connectors.ts
+++ b/turbo/apps/platform/src/signals/settings-page/connectors.ts
@@ -3,6 +3,7 @@ import { toast } from "@vm0/ui/components/ui/sonner";
 import {
   CONNECTOR_TYPES,
   FeatureSwitchKey,
+  hasRequiredScopes,
   type ConnectorType,
   type ConnectorResponse,
 } from "@vm0/core";
@@ -37,6 +38,8 @@ export interface ConnectorTypeWithStatus {
   connector: ConnectorResponse | null;
   /** True if at least one agent references this connector (env mapping). */
   usedByAgent?: boolean;
+  /** True if stored OAuth scopes don't cover all currently required scopes. */
+  scopeMismatch: boolean;
 }
 
 /**
@@ -89,6 +92,8 @@ export const allConnectorTypes$ = computed(async (get) => {
         helpText: config.helpText,
         connected: connector !== null,
         connector,
+        scopeMismatch:
+          connector !== null && !hasRequiredScopes(type, connector.oauthScopes),
       };
     });
 });

--- a/turbo/apps/platform/src/views/settings-page/connector-list.tsx
+++ b/turbo/apps/platform/src/views/settings-page/connector-list.tsx
@@ -4,6 +4,7 @@ import {
   IconCircleCheck,
   IconLoader,
   IconPlus,
+  IconAlertTriangle,
 } from "@tabler/icons-react";
 import { Button } from "@vm0/ui/components/ui/button";
 import {
@@ -70,6 +71,12 @@ function ConnectorRow({
             Connected
           </span>
         )}
+        {item.connected && item.scopeMismatch && (
+          <span className="inline-flex items-center gap-1.5 rounded-lg border border-yellow-300 bg-yellow-50 px-1.5 py-1 text-xs font-medium text-yellow-800 dark:border-yellow-700 dark:bg-yellow-950 dark:text-yellow-300">
+            <IconAlertTriangle className="h-3 w-3" />
+            Permissions outdated
+          </span>
+        )}
         {!item.connected && isPolling && (
           <span className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-background px-1.5 py-1 text-xs font-medium text-secondary-foreground">
             <IconLoader className="h-3 w-3 text-yellow-600 animate-spin" />
@@ -80,6 +87,18 @@ function ConnectorRow({
 
       {/* Actions */}
       <div className="shrink-0 flex items-center gap-2">
+        {item.connected && item.scopeMismatch && !isPolling && (
+          <button
+            onClick={() =>
+              detach(connect(item.type, pageSignal), Reason.DomCallback)
+            }
+            className="flex items-center shrink-0 rounded-lg border border-yellow-300 bg-yellow-50 overflow-hidden hover:bg-yellow-100 transition-colors dark:border-yellow-700 dark:bg-yellow-950 dark:hover:bg-yellow-900"
+          >
+            <span className="px-4 py-2 text-sm font-medium text-yellow-800 dark:text-yellow-300">
+              Reconnect
+            </span>
+          </button>
+        )}
         {!item.connected && !isPolling && (
           <button
             onClick={() =>

--- a/turbo/packages/core/src/contracts/__tests__/connectors.test.ts
+++ b/turbo/packages/core/src/contracts/__tests__/connectors.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { hasRequiredScopes } from "../connectors";
+
+describe("hasRequiredScopes", () => {
+  it("returns true for non-OAuth connector type", () => {
+    // computer connector has no oauth config
+    expect(hasRequiredScopes("computer", null)).toBe(true);
+  });
+
+  it("returns true when connector has empty required scopes", () => {
+    // notion has scopes: []
+    expect(hasRequiredScopes("notion", null)).toBe(true);
+    expect(hasRequiredScopes("notion", [])).toBe(true);
+    expect(hasRequiredScopes("notion", ["some-scope"])).toBe(true);
+  });
+
+  it("returns false when storedScopes is null", () => {
+    // github requires ["repo"]
+    expect(hasRequiredScopes("github", null)).toBe(false);
+  });
+
+  it("returns false when required scope is missing", () => {
+    expect(hasRequiredScopes("github", [])).toBe(false);
+    expect(hasRequiredScopes("github", ["read:org"])).toBe(false);
+  });
+
+  it("returns true when all required scopes are present", () => {
+    expect(hasRequiredScopes("github", ["repo"])).toBe(true);
+  });
+
+  it("returns true when stored scopes are a superset of required", () => {
+    expect(hasRequiredScopes("github", ["repo", "read:org", "user"])).toBe(
+      true,
+    );
+  });
+});

--- a/turbo/packages/core/src/contracts/connectors.ts
+++ b/turbo/packages/core/src/contracts/connectors.ts
@@ -968,6 +968,23 @@ export function getConnectorOAuthConfig(
 }
 
 /**
+ * Check if stored OAuth scopes cover all required scopes for a connector type.
+ * Returns true if no OAuth config exists (non-OAuth connector) or all required scopes are present.
+ * Returns false if storedScopes is null (legacy connector) or missing any required scope.
+ */
+export function hasRequiredScopes(
+  connectorType: ConnectorType,
+  storedScopes: string[] | null,
+): boolean {
+  const oauthConfig = getConnectorOAuthConfig(connectorType);
+  if (!oauthConfig) return true;
+  if (oauthConfig.scopes.length === 0) return true;
+  if (!storedScopes) return false;
+  const storedSet = new Set(storedScopes);
+  return oauthConfig.scopes.every((s) => storedSet.has(s));
+}
+
+/**
  * Connector response schema
  */
 export const connectorResponseSchema = z.object({

--- a/turbo/packages/core/src/contracts/index.ts
+++ b/turbo/packages/core/src/contracts/index.ts
@@ -407,6 +407,7 @@ export {
   getConnectorDerivedNames,
   getConnectorProvidedSecretNames,
   getConnectorOAuthConfig,
+  hasRequiredScopes,
   type ConnectorsMainContract,
   type ConnectorsByTypeContract,
   type ConnectorSessionsContract,


### PR DESCRIPTION
## Summary

- Add `hasRequiredScopes()` utility to `@vm0/core` that compares stored OAuth scopes against currently required scopes
- Extend `ConnectorTypeWithStatus` signal with `scopeMismatch` computed field
- Show "Permissions outdated" warning badge and "Reconnect" button in connector settings UI when scopes are stale
- Handle edge cases: non-OAuth connectors (skip), empty required scopes (skip), null stored scopes (mismatch), superset stored scopes (ok)

Closes #3648

## Test plan

- [x] Unit tests for `hasRequiredScopes()` (6 test cases covering all edge cases)
- [ ] Manual: connect a connector, verify no warning shown
- [ ] Manual: modify required scopes in code → verify "Permissions outdated" badge appears
- [ ] Manual: click "Reconnect" → verify OAuth flow completes and warning disappears

🤖 Generated with [Claude Code](https://claude.com/claude-code)