### PR TITLE
feat(github): add issue context, reactions, and session validation to handler

### DIFF
--- a/.claude/commands/dev-start-github.md
+++ b/.claude/commands/dev-start-github.md
@@ -1,0 +1,11 @@
+---
+command: dev-start-github
+description: Start the development server with a fixed GitHub tunnel URL
+---
+
+```typescript
+await Skill({
+  skill: "dev-server",
+  args: "start --tunnel-hostname=tunnel-github-dev.vm7.ai"
+});
+```

--- a/.claude/skills/dev-server/SKILL.md
+++ b/.claude/skills/dev-server/SKILL.md
@@ -10,7 +10,7 @@ You are a development server specialist for the vm0 project. Your role is to man
 
 Parse the `args` parameter to determine which operation to perform:
 
-- **start**: Start the development server in background mode (tunnel is automatic for web app)
+- **start**: Start the development server in background mode (tunnel is automatic for web app). Supports `--tunnel-hostname=<fqdn>` to use a fixed tunnel domain instead of the auto-generated one.
 - **stop**: Stop the background development server
 - **logs [pattern]**: View development server logs with optional filtering
 - **auth**: Authenticate with local development server and get CLI token
@@ -80,7 +80,16 @@ fi
 
 ### Step 3: Start Dev Server in Background
 
-Start the server with non-interactive output using Bash tool with `run_in_background: true` parameter:
+Start the server with non-interactive output using Bash tool with `run_in_background: true` parameter.
+
+**If `--tunnel-hostname=<fqdn>` was provided in args**, pass it as `TUNNEL_HOSTNAME` env var:
+
+```bash
+PROJECT_ROOT=$(git rev-parse --show-toplevel)
+cd "$PROJECT_ROOT/turbo" && TUNNEL_HOSTNAME=<fqdn> pnpm dev --ui=stream
+```
+
+**Otherwise** (default):
 
 ```bash
 PROJECT_ROOT=$(git rev-parse --show-toplevel)

--- a/scripts/tunnel.sh
+++ b/scripts/tunnel.sh
@@ -34,28 +34,36 @@ fi
 TUNNEL_LOG="/tmp/cloudflared-${PORT}.log"
 TUNNEL_PIDFILE="/tmp/cloudflared-${PORT}.pid"
 
-# --- Determine mode based on git email ---
-EMAIL=$(git config user.email 2>/dev/null || true)
-DOMAIN="${EMAIL##*@}"
-
-if [[ "$DOMAIN" == "vm0.ai" ]]; then
+# --- Determine mode based on git email or TUNNEL_HOSTNAME override ---
+if [[ -n "${TUNNEL_HOSTNAME:-}" ]]; then
   MODE="named"
-  USERNAME="${EMAIL%%@*}"
-  MACHINE_HOSTNAME=$(hostname)
-
-  # Map well-known ports to service names
-  case "$PORT" in
-    3000) SERVICE="www" ;;
-    3001) SERVICE="docs" ;;
-    3002) SERVICE="platform" ;;
-    *)    SERVICE="$PORT" ;;
-  esac
-
-  FQDN="tunnel-${USERNAME}-${MACHINE_HOSTNAME}-${SERVICE}.${TUNNEL_BASE_DOMAIN}"
-  TUNNEL_NAME="tunnel-${USERNAME}-${MACHINE_HOSTNAME}-${SERVICE}"
+  FQDN="$TUNNEL_HOSTNAME"
+  TUNNEL_NAME="${FQDN%%.*}"
   TUNNEL_URL="https://${FQDN}"
+  log "Using TUNNEL_HOSTNAME override: ${FQDN}"
 else
-  MODE="anonymous"
+  EMAIL=$(git config user.email 2>/dev/null || true)
+  DOMAIN="${EMAIL##*@}"
+
+  if [[ "$DOMAIN" == "vm0.ai" ]]; then
+    MODE="named"
+    USERNAME="${EMAIL%%@*}"
+    MACHINE_HOSTNAME=$(hostname)
+
+    # Map well-known ports to service names
+    case "$PORT" in
+      3000) SERVICE="www" ;;
+      3001) SERVICE="docs" ;;
+      3002) SERVICE="platform" ;;
+      *)    SERVICE="$PORT" ;;
+    esac
+
+    FQDN="tunnel-${USERNAME}-${MACHINE_HOSTNAME}-${SERVICE}.${TUNNEL_BASE_DOMAIN}"
+    TUNNEL_NAME="tunnel-${USERNAME}-${MACHINE_HOSTNAME}-${SERVICE}"
+    TUNNEL_URL="https://${FQDN}"
+  else
+    MODE="anonymous"
+  fi
 fi
 
 # --- Named tunnel setup ---

--- a/turbo/apps/web/app/api/internal/callbacks/email/reply/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/email/reply/route.ts
@@ -117,7 +117,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   }
 
   // Get run output
-  const logsUrl = buildLogsUrl(runId);
+  const logsUrl = buildLogsUrl(runId, compose.name);
   const rawOutput =
     status === "completed" ? ((await getRunOutput(runId)) ?? null) : null;
   const output = formatOutput(status, rawOutput, error);

--- a/turbo/apps/web/app/api/internal/callbacks/email/schedule/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/email/schedule/route.ts
@@ -74,7 +74,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     return NextResponse.json({ success: true, skipped: true });
   }
 
-  const logsUrl = buildLogsUrl(runId);
+  const logsUrl = buildLogsUrl(runId, composeName);
 
   if (status === "completed") {
     // Get agent output

--- a/turbo/apps/web/app/api/internal/callbacks/email/trigger/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/email/trigger/route.ts
@@ -145,7 +145,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   }
 
   // Get run output and session ID
-  const logsUrl = buildLogsUrl(runId);
+  const logsUrl = buildLogsUrl(runId, compose.name);
   const rawOutput = status === "completed" ? await getRunOutput(runId) : null;
   const output = formatOutput(status, rawOutput, error);
 

--- a/turbo/apps/web/app/api/internal/callbacks/github/issues/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/github/issues/__tests__/route.test.ts
@@ -29,6 +29,7 @@ interface CallbackPayload {
   repo: string;
   issueNumber: number;
   composeId: string;
+  agentName: string;
   existingSessionId?: string;
 }
 
@@ -131,6 +132,7 @@ async function givenGitHubCallbackSetup(overrides?: {
     repo: "test-org/test-repo",
     issueNumber: 42,
     composeId,
+    agentName: "gh-callback-agent",
     existingSessionId: overrides?.existingSessionId,
   };
 
@@ -292,8 +294,8 @@ describe("POST /api/internal/callbacks/github/issues", () => {
       expect(capturedComments[0]!.owner).toBe("test-org");
       expect(capturedComments[0]!.repo).toBe("test-repo");
       expect(capturedComments[0]!.issueNumber).toBe("42");
-      // Verify the comment body includes the VM0 attribution footer
-      expect(capturedComments[0]!.body).toContain("Powered by");
+      // Verify the comment body includes the logs footer
+      expect(capturedComments[0]!.body).toContain("View logs");
     });
 
     it("should post error comment on failed run", async () => {
@@ -338,6 +340,7 @@ describe("POST /api/internal/callbacks/github/issues", () => {
         repo: "org/repo",
         issueNumber: 1,
         composeId,
+        agentName: "gh-missing-agent",
       };
 
       const { secret } = await createTestCallback({

--- a/turbo/apps/web/app/api/internal/callbacks/github/issues/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/github/issues/route.ts
@@ -7,6 +7,10 @@ import { githubIssueSessions } from "../../../../../../src/db/schema/github-issu
 import { agentSessions } from "../../../../../../src/db/schema/agent-session";
 import { agentRuns } from "../../../../../../src/db/schema/agent-run";
 import { getInstallationAccessToken } from "../../../../../../src/lib/github/github-app";
+import {
+  postIssueComment,
+  removeCommentReaction,
+} from "../../../../../../src/lib/github/api";
 import { getRunResultData } from "../../../../../../src/lib/slack/handlers/run-agent";
 import { getPlatformUrl } from "../../../../../../src/lib/url";
 import { detectDeepLinks } from "../../../../../../src/lib/deep-links";
@@ -74,24 +78,11 @@ function formatGitHubComment(opts: {
   status: "completed" | "failed";
   agentName: string;
   runId: string;
-  repo: string;
-  issueNumber: number;
   output?: string;
   error?: string;
-  triggerCommentId?: string;
   triggerCommentBody?: string;
 }): string {
-  const {
-    status,
-    agentName,
-    runId,
-    repo,
-    issueNumber,
-    output,
-    error,
-    triggerCommentId,
-    triggerCommentBody,
-  } = opts;
+  const { status, agentName, runId, output, error, triggerCommentBody } = opts;
   const platformUrl = getPlatformUrl();
   const logsUrl = `${platformUrl}/agents/${encodeURIComponent(agentName)}/logs/${encodeURIComponent(runId)}`;
   const content =
@@ -124,66 +115,6 @@ function formatGitHubComment(opts: {
   parts.push(`<sub>📋 [View logs](${logsUrl})</sub>`);
 
   return parts.join("\n");
-}
-
-/**
- * Remove a reaction from a GitHub issue comment.
- */
-async function removeCommentReaction(
-  token: string,
-  repo: string,
-  commentId: string,
-  reactionId: string,
-): Promise<void> {
-  const res = await fetch(
-    `https://api.github.com/repos/${repo}/issues/comments/${commentId}/reactions/${reactionId}`,
-    {
-      method: "DELETE",
-      headers: {
-        Authorization: `Bearer ${token}`,
-        Accept: "application/vnd.github+json",
-        "X-GitHub-Api-Version": "2022-11-28",
-      },
-    },
-  );
-  if (!res.ok) {
-    log.warn("Failed to remove reaction", {
-      commentId,
-      reactionId,
-      status: res.status,
-    });
-  }
-}
-
-/**
- * Post a comment to a GitHub issue using the installation access token.
- */
-async function postIssueComment(
-  token: string,
-  repo: string,
-  issueNumber: number,
-  body: string,
-): Promise<string | undefined> {
-  const res = await fetch(
-    `https://api.github.com/repos/${repo}/issues/${issueNumber}/comments`,
-    {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${token}`,
-        Accept: "application/vnd.github+json",
-        "X-GitHub-Api-Version": "2022-11-28",
-      },
-      body: JSON.stringify({ body }),
-    },
-  );
-
-  if (!res.ok) {
-    const text = await res.text();
-    throw new Error(`Failed to post GitHub comment: ${res.status} ${text}`);
-  }
-
-  const data = (await res.json()) as { id: number };
-  return String(data.id);
 }
 
 export async function POST(request: NextRequest): Promise<NextResponse> {
@@ -251,11 +182,8 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     status,
     agentName: payload.agentName,
     runId,
-    repo,
-    issueNumber,
     output: resultData?.result,
     error,
-    triggerCommentId: payload.triggerCommentId,
     triggerCommentBody: payload.triggerCommentBody,
   });
   const commentId = await postIssueComment(

--- a/turbo/apps/web/app/api/internal/callbacks/github/issues/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/github/issues/route.ts
@@ -7,7 +7,9 @@ import { githubIssueSessions } from "../../../../../../src/db/schema/github-issu
 import { agentSessions } from "../../../../../../src/db/schema/agent-session";
 import { agentRuns } from "../../../../../../src/db/schema/agent-run";
 import { getInstallationAccessToken } from "../../../../../../src/lib/github/github-app";
-import { getRunOutput } from "../../../../../../src/lib/slack/handlers/run-agent";
+import { getRunResultData } from "../../../../../../src/lib/slack/handlers/run-agent";
+import { getPlatformUrl } from "../../../../../../src/lib/url";
+import { detectDeepLinks } from "../../../../../../src/lib/deep-links";
 import { env } from "../../../../../../src/env";
 import { logger } from "../../../../../../src/lib/logger";
 
@@ -18,7 +20,11 @@ interface CallbackPayload {
   repo: string; // "owner/repo"
   issueNumber: number;
   composeId: string;
+  agentName: string;
   existingSessionId?: string;
+  triggerCommentId?: string;
+  triggerCommentBody?: string;
+  triggerReactionId?: string;
 }
 
 function parsePayload(payload: unknown): CallbackPayload | null {
@@ -28,7 +34,8 @@ function parsePayload(payload: unknown): CallbackPayload | null {
     typeof p.installationId !== "string" ||
     typeof p.repo !== "string" ||
     typeof p.issueNumber !== "number" ||
-    typeof p.composeId !== "string"
+    typeof p.composeId !== "string" ||
+    typeof p.agentName !== "string"
   ) {
     return null;
   }
@@ -60,19 +67,92 @@ async function findNewSessionId(
 }
 
 /**
- * Format agent output as a GitHub issue comment with attribution footer.
+ * Format agent output as a GitHub issue comment.
+ * Mirrors Slack's block layout: agent name header, content, deep links, logs footer.
  */
-function formatGitHubComment(
-  output: string,
-  status: "completed" | "failed",
-  error?: string,
-): string {
-  const body =
+function formatGitHubComment(opts: {
+  status: "completed" | "failed";
+  agentName: string;
+  runId: string;
+  repo: string;
+  issueNumber: number;
+  output?: string;
+  error?: string;
+  triggerCommentId?: string;
+  triggerCommentBody?: string;
+}): string {
+  const {
+    status,
+    agentName,
+    runId,
+    repo,
+    issueNumber,
+    output,
+    error,
+    triggerCommentId,
+    triggerCommentBody,
+  } = opts;
+  const platformUrl = getPlatformUrl();
+  const logsUrl = `${platformUrl}/agents/${encodeURIComponent(agentName)}/logs/${encodeURIComponent(runId)}`;
+  const content =
     status === "completed"
-      ? output || "Task completed successfully."
+      ? (output ?? "Task completed successfully.")
       : `**Error:** ${error ?? "Agent execution failed."}`;
 
-  return `${body}\n\n---\n*🤖 Powered by [VM0](https://vm0.com)*`;
+  const parts: string[] = [];
+
+  // Quote the triggering comment when replying to an @mention
+  if (triggerCommentBody) {
+    const quoted = triggerCommentBody
+      .split("\n")
+      .map((line) => `> ${line}`)
+      .join("\n");
+    parts.push(quoted, "");
+  }
+
+  parts.push(`<sub>🤖 **${agentName}**</sub>`, "", content, "");
+
+  // Detect deep links for missing connectors, model providers, etc.
+  const deepLinks = detectDeepLinks(content, platformUrl, agentName);
+  if (deepLinks.length > 0) {
+    const linkText = deepLinks
+      .map((link) => `${link.emoji} [${link.label}](${link.url})`)
+      .join(" · ");
+    parts.push(`<sub>${linkText}</sub>`, "");
+  }
+
+  parts.push(`<sub>📋 [View logs](${logsUrl})</sub>`);
+
+  return parts.join("\n");
+}
+
+/**
+ * Remove a reaction from a GitHub issue comment.
+ */
+async function removeCommentReaction(
+  token: string,
+  repo: string,
+  commentId: string,
+  reactionId: string,
+): Promise<void> {
+  const res = await fetch(
+    `https://api.github.com/repos/${repo}/issues/comments/${commentId}/reactions/${reactionId}`,
+    {
+      method: "DELETE",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+    },
+  );
+  if (!res.ok) {
+    log.warn("Failed to remove reaction", {
+      commentId,
+      reactionId,
+      status: res.status,
+    });
+  }
 }
 
 /**
@@ -163,16 +243,37 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   );
 
   // Query Axiom for the agent's output
-  const output = status === "completed" ? await getRunOutput(runId) : undefined;
+  const resultData =
+    status === "completed" ? await getRunResultData(runId) : undefined;
 
   // Format and post comment to GitHub issue
-  const commentBody = formatGitHubComment(output ?? "", status, error);
+  const commentBody = formatGitHubComment({
+    status,
+    agentName: payload.agentName,
+    runId,
+    repo,
+    issueNumber,
+    output: resultData?.result,
+    error,
+    triggerCommentId: payload.triggerCommentId,
+    triggerCommentBody: payload.triggerCommentBody,
+  });
   const commentId = await postIssueComment(
     token,
     repo,
     issueNumber,
     commentBody,
   );
+
+  // Remove 👀 reaction now that the agent has responded
+  if (payload.triggerCommentId && payload.triggerReactionId) {
+    await removeCommentReaction(
+      token,
+      repo,
+      payload.triggerCommentId,
+      payload.triggerReactionId,
+    );
+  }
 
   // Get run to find userId for session lookup
   const [run] = await globalThis.services.db

--- a/turbo/apps/web/app/api/internal/callbacks/slack/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/slack/route.ts
@@ -282,7 +282,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 
   // Post text response (if any content)
   if (responseText) {
-    const logsUrl = buildLogsUrl(runId);
+    const logsUrl = buildLogsUrl(runId, payload.agentName);
     const deepLinks = detectDeepLinks(
       responseText,
       getPlatformUrl(),

--- a/turbo/apps/web/app/api/internal/callbacks/slack/schedule/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/slack/schedule/route.ts
@@ -113,7 +113,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   const client = createSlackClient(botToken);
 
   // Build and send notification
-  const logsUrl = buildLogsUrl(runId);
+  const logsUrl = buildLogsUrl(runId, composeName);
 
   if (status === "completed") {
     const rawOutput = await getRunOutput(runId);

--- a/turbo/apps/web/app/api/webhooks/github/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/github/__tests__/route.test.ts
@@ -167,6 +167,22 @@ describe("POST /api/webhooks/github", () => {
     // Reload env after stubbing
     reloadEnv();
 
+    // Mock GitHub API: installation token + issue comments (used by context fetching)
+    server.use(
+      http.post(
+        "https://api.github.com/app/installations/:id/access_tokens",
+        () =>
+          HttpResponse.json({
+            token: "ghs_test",
+            expires_at: "2099-01-01T00:00:00Z",
+          }),
+      ),
+      http.get(
+        "https://api.github.com/repos/:owner/:repo/issues/:num/comments",
+        () => HttpResponse.json([]),
+      ),
+    );
+
     // Mock createRun to prevent actual sandbox dispatch
     createRunSpy = vi.spyOn(runModule, "createRun").mockResolvedValue({
       runId: "test-run-id",
@@ -250,8 +266,7 @@ describe("POST /api/webhooks/github", () => {
         prompt: string;
         callbacks: Array<{ payload: { issueNumber: number } }>;
       };
-      expect(callArgs.prompt).toContain("Test Issue");
-      expect(callArgs.prompt).toContain("test issue body");
+      expect(callArgs.prompt).toContain("This is a test issue body");
       expect(callArgs.callbacks[0]!.payload.issueNumber).toBe(42);
     });
 
@@ -369,12 +384,13 @@ describe("POST /api/webhooks/github", () => {
 
       expect(createRunSpy).toHaveBeenCalledTimes(1);
       const callArgs = createRunSpy.mock.calls[0]![0] as { prompt: string };
-      expect(callArgs.prompt).toContain("No description provided");
+      // When body is null, falls back to issue title
+      expect(callArgs.prompt).toContain("Test Issue");
     });
   });
 
   describe("Issue Comment Event", () => {
-    it("should trigger agent for comment on issue with vm0-agent label", async () => {
+    it("should NOT trigger for comment on issue with vm0-agent label but no mention", async () => {
       const { ghInstallationId, githubUserId } =
         await givenGitHubInstallation();
 
@@ -392,10 +408,8 @@ describe("POST /api/webhooks/github", () => {
 
       await flushAfterCallbacks();
 
-      expect(createRunSpy).toHaveBeenCalledTimes(1);
-      const callArgs = createRunSpy.mock.calls[0]![0] as { prompt: string };
-      expect(callArgs.prompt).toContain("Can you help me fix this?");
-      expect(callArgs.prompt).toContain("Test Issue");
+      // Label alone should NOT trigger — bot mention is required
+      expect(createRunSpy).not.toHaveBeenCalled();
     });
 
     it("should trigger agent for comment mentioning @bot", async () => {
@@ -655,8 +669,8 @@ describe("POST /api/webhooks/github", () => {
       const request = createGitHubWebhookRequest(
         "issue_comment",
         buildIssueCommentPayload({
-          labels: [{ id: 1, name: "vm0-agent" }],
-          commentBody: "Follow-up question",
+          labels: [],
+          commentBody: `@${TEST_APP_SLUG}[bot] Follow-up question`,
           installationId: ghInstallationId,
           senderId: Number(githubUserId),
         }),

--- a/turbo/apps/web/app/api/webhooks/github/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/github/__tests__/route.test.ts
@@ -105,7 +105,7 @@ function buildIssuesPayload(overrides?: IssuesPayloadOverrides) {
         overrides?.issueBody !== undefined
           ? overrides.issueBody
           : "This is a test issue body",
-      labels: overrides?.labels ?? [{ id: 1, name: "vm0-agent" }],
+      labels: overrides?.labels ?? [{ id: 1, name: TEST_APP_SLUG }],
       user: { id: senderId, login: "testuser", type: "User" },
     },
     ...(overrides?.label && { label: overrides.label }),
@@ -139,7 +139,7 @@ function buildIssueCommentPayload(overrides?: CommentPayloadOverrides) {
       number: 42,
       title: "Test Issue",
       body: "This is a test issue body",
-      labels: overrides?.labels ?? [{ id: 1, name: "vm0-agent" }],
+      labels: overrides?.labels ?? [{ id: 1, name: TEST_APP_SLUG }],
       user: { id: senderId, login: "testuser", type: "User" },
     },
     comment: {
@@ -240,17 +240,17 @@ describe("POST /api/webhooks/github", () => {
   });
 
   describe("Issues Event", () => {
-    it("should trigger agent for opened issue with vm0-agent label", async () => {
+    it("should trigger agent for opened issue with app slug label", async () => {
       // Given a GitHub installation exists
       const { ghInstallationId, githubUserId } =
         await givenGitHubInstallation();
 
-      // When a webhook arrives for an opened issue with the vm0-agent label
+      // When a webhook arrives for an opened issue with the app slug label
       const request = createGitHubWebhookRequest(
         "issues",
         buildIssuesPayload({
           action: "opened",
-          labels: [{ id: 1, name: "vm0-agent" }],
+          labels: [{ id: 1, name: TEST_APP_SLUG }],
           installationId: ghInstallationId,
           senderId: Number(githubUserId),
         }),
@@ -270,7 +270,7 @@ describe("POST /api/webhooks/github", () => {
       expect(callArgs.callbacks[0]!.payload.issueNumber).toBe(42);
     });
 
-    it("should trigger agent when vm0-agent label is added", async () => {
+    it("should trigger agent when app slug label is added", async () => {
       const { ghInstallationId, githubUserId } =
         await givenGitHubInstallation();
 
@@ -278,8 +278,8 @@ describe("POST /api/webhooks/github", () => {
         "issues",
         buildIssuesPayload({
           action: "labeled",
-          labels: [{ id: 1, name: "vm0-agent" }],
-          label: { id: 1, name: "vm0-agent" },
+          labels: [{ id: 1, name: TEST_APP_SLUG }],
+          label: { id: 1, name: TEST_APP_SLUG },
           installationId: ghInstallationId,
           senderId: Number(githubUserId),
         }),
@@ -292,7 +292,7 @@ describe("POST /api/webhooks/github", () => {
       expect(createRunSpy).toHaveBeenCalledTimes(1);
     });
 
-    it("should NOT trigger agent for opened issue without vm0-agent label", async () => {
+    it("should NOT trigger agent for opened issue without app slug label", async () => {
       const { ghInstallationId, githubUserId } =
         await givenGitHubInstallation();
 
@@ -313,7 +313,7 @@ describe("POST /api/webhooks/github", () => {
       expect(createRunSpy).not.toHaveBeenCalled();
     });
 
-    it("should NOT trigger agent when a non-vm0-agent label is added", async () => {
+    it("should NOT trigger agent when a non-app slug label is added", async () => {
       const { ghInstallationId, githubUserId } =
         await givenGitHubInstallation();
 
@@ -322,7 +322,7 @@ describe("POST /api/webhooks/github", () => {
         buildIssuesPayload({
           action: "labeled",
           labels: [
-            { id: 1, name: "vm0-agent" },
+            { id: 1, name: TEST_APP_SLUG },
             { id: 2, name: "enhancement" },
           ],
           label: { id: 2, name: "enhancement" },
@@ -349,7 +349,7 @@ describe("POST /api/webhooks/github", () => {
           "issues",
           buildIssuesPayload({
             action,
-            labels: [{ id: 1, name: "vm0-agent" }],
+            labels: [{ id: 1, name: TEST_APP_SLUG }],
             installationId: ghInstallationId,
             senderId: Number(githubUserId),
           }),
@@ -371,7 +371,7 @@ describe("POST /api/webhooks/github", () => {
         "issues",
         buildIssuesPayload({
           action: "opened",
-          labels: [{ id: 1, name: "vm0-agent" }],
+          labels: [{ id: 1, name: TEST_APP_SLUG }],
           installationId: ghInstallationId,
           issueBody: null,
           senderId: Number(githubUserId),
@@ -390,14 +390,14 @@ describe("POST /api/webhooks/github", () => {
   });
 
   describe("Issue Comment Event", () => {
-    it("should NOT trigger for comment on issue with vm0-agent label but no mention", async () => {
+    it("should NOT trigger for comment on issue with app slug label but no mention", async () => {
       const { ghInstallationId, githubUserId } =
         await givenGitHubInstallation();
 
       const request = createGitHubWebhookRequest(
         "issue_comment",
         buildIssueCommentPayload({
-          labels: [{ id: 1, name: "vm0-agent" }],
+          labels: [{ id: 1, name: TEST_APP_SLUG }],
           commentBody: "Can you help me fix this?",
           installationId: ghInstallationId,
           senderId: Number(githubUserId),
@@ -419,7 +419,7 @@ describe("POST /api/webhooks/github", () => {
       const request = createGitHubWebhookRequest(
         "issue_comment",
         buildIssueCommentPayload({
-          labels: [], // No vm0-agent label
+          labels: [], // No app slug label
           commentBody: `@${TEST_APP_SLUG}[bot] please review this`,
           installationId: ghInstallationId,
           senderId: Number(githubUserId),
@@ -461,7 +461,7 @@ describe("POST /api/webhooks/github", () => {
       const request = createGitHubWebhookRequest(
         "issue_comment",
         buildIssueCommentPayload({
-          labels: [{ id: 1, name: "vm0-agent" }],
+          labels: [{ id: 1, name: TEST_APP_SLUG }],
           commentBody: "Here is the analysis...",
           senderType: "Bot",
           senderLogin: `${TEST_APP_SLUG}[bot]`,
@@ -488,7 +488,7 @@ describe("POST /api/webhooks/github", () => {
           "issue_comment",
           buildIssueCommentPayload({
             action,
-            labels: [{ id: 1, name: "vm0-agent" }],
+            labels: [{ id: 1, name: TEST_APP_SLUG }],
             installationId: ghInstallationId,
             senderId: Number(githubUserId),
           }),
@@ -510,7 +510,7 @@ describe("POST /api/webhooks/github", () => {
         "issues",
         buildIssuesPayload({
           installationId: 99999,
-          labels: [{ id: 1, name: "vm0-agent" }],
+          labels: [{ id: 1, name: TEST_APP_SLUG }],
         }),
       );
       const response = await POST(request);

--- a/turbo/apps/web/scripts/dev.sh
+++ b/turbo/apps/web/scripts/dev.sh
@@ -25,7 +25,7 @@ cleanup() {
 }
 trap cleanup EXIT INT TERM
 
-# Start tunnel and capture URL
+# Start tunnel and capture URL (TUNNEL_HOSTNAME is forwarded if set)
 TUNNEL_URL=$("$REPO_ROOT/scripts/tunnel.sh" "$PORT")
 
 echo ""

--- a/turbo/apps/web/src/lib/callback/dispatcher.ts
+++ b/turbo/apps/web/src/lib/callback/dispatcher.ts
@@ -95,7 +95,15 @@ async function dispatchSingleCallback(
   error: string | undefined,
   encryptionKey: string,
 ): Promise<DispatchResult> {
-  const { id, url, encryptedSecret, payload } = callback;
+  const { id, encryptedSecret, payload } = callback;
+
+  // In local dev, rewrite self-referencing tunnel URLs to localhost to avoid
+  // hairpin (server fetching its own tunnel URL times out via cloudflare).
+  const url =
+    process.env.NODE_ENV === "development" &&
+    callback.url.startsWith("https://tunnel-")
+      ? callback.url.replace(/^https:\/\/tunnel-[^/]+/, "http://localhost:3000")
+      : callback.url;
 
   // Decrypt the callback secret
   const secret = decryptCredentialValue(encryptedSecret, encryptionKey);

--- a/turbo/apps/web/src/lib/callback/dispatcher.ts
+++ b/turbo/apps/web/src/lib/callback/dispatcher.ts
@@ -99,9 +99,9 @@ async function dispatchSingleCallback(
 
   // In local dev, rewrite self-referencing tunnel URLs to localhost to avoid
   // hairpin (server fetching its own tunnel URL times out via cloudflare).
+  const { NODE_ENV } = env();
   const url =
-    process.env.NODE_ENV === "development" &&
-    callback.url.startsWith("https://tunnel-")
+    NODE_ENV === "development" && callback.url.startsWith("https://tunnel-")
       ? callback.url.replace(/^https:\/\/tunnel-[^/]+/, "http://localhost:3000")
       : callback.url;
 

--- a/turbo/apps/web/src/lib/email/handlers/shared.ts
+++ b/turbo/apps/web/src/lib/email/handlers/shared.ts
@@ -293,10 +293,10 @@ export function buildFromAddress(localPart: string): string {
 }
 
 /**
- * Build the logs URL for a run.
+ * Build the logs URL for a run, linking to the agent detail logs page.
  */
-export function buildLogsUrl(runId: string): string {
-  return `${getPlatformUrl()}/logs/${runId}`;
+export function buildLogsUrl(runId: string, agentName: string): string {
+  return `${getPlatformUrl()}/agents/${encodeURIComponent(agentName)}/logs/${encodeURIComponent(runId)}`;
 }
 
 // ============================================================================

--- a/turbo/apps/web/src/lib/github/api.ts
+++ b/turbo/apps/web/src/lib/github/api.ts
@@ -1,0 +1,181 @@
+import { logger } from "../logger";
+
+const log = logger("github:api");
+
+const GITHUB_API_BASE = "https://api.github.com";
+
+const GITHUB_HEADERS = {
+  Accept: "application/vnd.github+json",
+  "X-GitHub-Api-Version": "2022-11-28",
+} as const;
+
+function authHeaders(token: string): Record<string, string> {
+  return {
+    Authorization: `Bearer ${token}`,
+    ...GITHUB_HEADERS,
+  };
+}
+
+// ─── Issue Comments ──────────────────────────────────────────────────
+
+export interface IssueComment {
+  id: number;
+  user: { login: string; type: string };
+  body: string;
+  created_at: string;
+}
+
+/**
+ * Fetch issue comments from GitHub API.
+ * Returns up to 100 most recent comments.
+ * Returns empty array on failure (with warning logged).
+ */
+export async function fetchIssueComments(
+  token: string,
+  repo: string,
+  issueNumber: number,
+): Promise<IssueComment[]> {
+  const res = await fetch(
+    `${GITHUB_API_BASE}/repos/${repo}/issues/${issueNumber}/comments?per_page=100&direction=asc`,
+    { headers: authHeaders(token) },
+  );
+
+  if (!res.ok) {
+    log.warn("Failed to fetch issue comments", {
+      status: res.status,
+      repo,
+      issueNumber,
+    });
+    return [];
+  }
+
+  return (await res.json()) as IssueComment[];
+}
+
+/**
+ * Post a comment to a GitHub issue.
+ * Returns the comment ID on success, throws on failure.
+ */
+export async function postIssueComment(
+  token: string,
+  repo: string,
+  issueNumber: number,
+  body: string,
+): Promise<string> {
+  const res = await fetch(
+    `${GITHUB_API_BASE}/repos/${repo}/issues/${issueNumber}/comments`,
+    {
+      method: "POST",
+      headers: authHeaders(token),
+      body: JSON.stringify({ body }),
+    },
+  );
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Failed to post GitHub comment: ${res.status} ${text}`);
+  }
+
+  const data = (await res.json()) as { id: number };
+  return String(data.id);
+}
+
+/**
+ * Post a comment to a GitHub issue, swallowing errors.
+ * Use for best-effort feedback (e.g. error comments) where failure to post
+ * should not disrupt the calling flow.
+ */
+export async function postIssueCommentBestEffort(
+  token: string,
+  repo: string,
+  issueNumber: number,
+  body: string,
+): Promise<void> {
+  try {
+    await postIssueComment(token, repo, issueNumber, body);
+  } catch (error) {
+    log.warn("Best-effort comment failed", {
+      repo,
+      issueNumber,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+// ─── Reactions ───────────────────────────────────────────────────────
+
+/**
+ * Add a reaction to a GitHub issue comment.
+ * Best-effort: returns undefined on failure (network or API error).
+ */
+export async function addCommentReaction(
+  token: string,
+  repo: string,
+  commentId: string,
+  content: string,
+): Promise<string | undefined> {
+  try {
+    const res = await fetch(
+      `${GITHUB_API_BASE}/repos/${repo}/issues/comments/${commentId}/reactions`,
+      {
+        method: "POST",
+        headers: authHeaders(token),
+        body: JSON.stringify({ content }),
+      },
+    );
+
+    if (!res.ok) {
+      log.warn("Failed to add comment reaction", {
+        commentId,
+        content,
+        status: res.status,
+      });
+      return undefined;
+    }
+
+    const data = (await res.json()) as { id: number };
+    return String(data.id);
+  } catch (error) {
+    log.warn("Failed to add comment reaction", {
+      commentId,
+      content,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return undefined;
+  }
+}
+
+/**
+ * Remove a reaction from a GitHub issue comment.
+ * Best-effort: logs warning on failure (network or API error).
+ */
+export async function removeCommentReaction(
+  token: string,
+  repo: string,
+  commentId: string,
+  reactionId: string,
+): Promise<void> {
+  try {
+    const res = await fetch(
+      `${GITHUB_API_BASE}/repos/${repo}/issues/comments/${commentId}/reactions/${reactionId}`,
+      {
+        method: "DELETE",
+        headers: authHeaders(token),
+      },
+    );
+
+    if (!res.ok) {
+      log.warn("Failed to remove comment reaction", {
+        commentId,
+        reactionId,
+        status: res.status,
+      });
+    }
+  } catch (error) {
+    log.warn("Failed to remove comment reaction", {
+      commentId,
+      reactionId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}

--- a/turbo/apps/web/src/lib/github/handlers/issue-event.ts
+++ b/turbo/apps/web/src/lib/github/handlers/issue-event.ts
@@ -23,11 +23,6 @@ import { logger } from "../../logger";
 
 const log = logger("github:issue-event");
 
-function getAgentLabel(): string {
-  const { NODE_ENV } = env();
-  return NODE_ENV === "development" ? "vm0-agent-test" : "vm0-agent";
-}
-
 // ─── GitHub Webhook Payload Schemas ────────────────────────────────
 
 const gitHubUserSchema = z.object({
@@ -124,17 +119,27 @@ export async function handleIssuesEvent(
     return;
   }
 
-  // For "labeled" action, only trigger when the vm0-agent label is added
-  if (action === "labeled" && label?.name !== getAgentLabel()) {
-    log.debug("Ignoring label that is not vm0-agent", { label: label?.name });
+  if (!appSlug) {
+    log.debug("Ignoring issues event: app slug not configured");
     return;
   }
 
-  // For "opened" action, check if issue has the vm0-agent label
+  // For "labeled" action, only trigger when the app slug label is added
+  if (action === "labeled" && label?.name !== appSlug) {
+    log.debug("Ignoring label that is not app slug", {
+      label: label?.name,
+      expected: appSlug,
+    });
+    return;
+  }
+
+  // For "opened" action, check if issue has the app slug label
   if (action === "opened") {
-    const hasLabel = issue.labels.some((l) => l.name === getAgentLabel());
+    const hasLabel = issue.labels.some((l) => l.name === appSlug);
     if (!hasLabel) {
-      log.debug("Ignoring opened issue without vm0-agent label");
+      log.debug("Ignoring opened issue without app slug label", {
+        expected: appSlug,
+      });
       return;
     }
   }

--- a/turbo/apps/web/src/lib/github/handlers/issue-event.ts
+++ b/turbo/apps/web/src/lib/github/handlers/issue-event.ts
@@ -23,7 +23,10 @@ import { logger } from "../../logger";
 
 const log = logger("github:issue-event");
 
-const VM0_AGENT_LABEL = "vm0-agent";
+function getAgentLabel(): string {
+  const { NODE_ENV } = env();
+  return NODE_ENV === "development" ? "vm0-agent-test" : "vm0-agent";
+}
 
 // ─── GitHub Webhook Payload Schemas ────────────────────────────────
 
@@ -122,14 +125,14 @@ export async function handleIssuesEvent(
   }
 
   // For "labeled" action, only trigger when the vm0-agent label is added
-  if (action === "labeled" && label?.name !== VM0_AGENT_LABEL) {
+  if (action === "labeled" && label?.name !== getAgentLabel()) {
     log.debug("Ignoring label that is not vm0-agent", { label: label?.name });
     return;
   }
 
   // For "opened" action, check if issue has the vm0-agent label
   if (action === "opened") {
-    const hasLabel = issue.labels.some((l) => l.name === VM0_AGENT_LABEL);
+    const hasLabel = issue.labels.some((l) => l.name === getAgentLabel());
     if (!hasLabel) {
       log.debug("Ignoring opened issue without vm0-agent label");
       return;

--- a/turbo/apps/web/src/lib/github/handlers/issue-event.ts
+++ b/turbo/apps/web/src/lib/github/handlers/issue-event.ts
@@ -7,9 +7,11 @@ import {
   agentComposes,
   agentComposeVersions,
 } from "../../../db/schema/agent-compose";
-import { createRun } from "../../run";
+import { createRun, validateAgentSession } from "../../run";
 import { isConcurrentRunLimit } from "../../errors";
 import { generateCallbackSecret, getApiUrl } from "../../callback";
+import { getInstallationAccessToken } from "../github-app";
+import { env } from "../../../env";
 import { logger } from "../../logger";
 
 const log = logger("github:issue-event");
@@ -86,6 +88,9 @@ interface GitHubCallbackContext {
   agentName: string;
   composeId: string;
   existingSessionId?: string;
+  triggerCommentId?: string;
+  triggerCommentBody?: string;
+  triggerReactionId?: string;
 }
 
 // ─── Event Handlers ────────────────────────────────────────────────
@@ -130,9 +135,10 @@ export async function handleIssuesEvent(
   await dispatchAgentRun({
     ghInstallationId: String(installation.id),
     repo: repository.full_name,
-    issueNumber: issue.number,
+    issue,
     senderGithubUserId: String(sender.id),
     prompt,
+    forceNewSession: true,
     appSlug,
   });
 }
@@ -141,11 +147,11 @@ export async function handleIssuesEvent(
  * Handle `issue_comment` events (created).
  *
  * Triggers agent when:
- * - Issue has vm0-agent label, OR
  * - Comment mentions @{app-slug}[bot]
  *
  * Skips if:
  * - Comment is from a bot (prevents self-triggering)
+ * - App slug is not configured
  */
 export async function handleIssueCommentEvent(
   payload: GitHubIssueCommentEvent,
@@ -164,13 +170,15 @@ export async function handleIssueCommentEvent(
     return;
   }
 
-  // Check trigger conditions
-  const hasLabel = issue.labels.some((l) => l.name === VM0_AGENT_LABEL);
-  const botMention = appSlug ? `@${appSlug}[bot]` : null;
-  const hasMention = botMention ? comment.body.includes(botMention) : false;
+  // Only trigger when the comment explicitly mentions the bot
+  if (!appSlug) {
+    log.debug("Ignoring comment: app slug not configured");
+    return;
+  }
 
-  if (!hasLabel && !hasMention) {
-    log.debug("Ignoring comment: no vm0-agent label and no bot mention");
+  const botMention = `@${appSlug}[bot]`;
+  if (!comment.body.includes(botMention)) {
+    log.debug("Ignoring comment: no bot mention", { expected: botMention });
     return;
   }
 
@@ -180,10 +188,11 @@ export async function handleIssueCommentEvent(
   await dispatchAgentRun({
     ghInstallationId: String(installation.id),
     repo: repository.full_name,
-    issueNumber: issue.number,
+    issue,
     senderGithubUserId: String(sender.id),
     prompt,
     commentId: String(comment.id),
+    comment,
     appSlug,
   });
 }
@@ -193,10 +202,12 @@ export async function handleIssueCommentEvent(
 interface DispatchParams {
   ghInstallationId: string;
   repo: string;
-  issueNumber: number;
+  issue: GitHubIssue;
   senderGithubUserId: string;
   prompt: string;
   commentId?: string;
+  comment?: GitHubComment;
+  forceNewSession?: boolean;
   appSlug: string | undefined;
 }
 
@@ -214,11 +225,12 @@ async function dispatchAgentRun(params: DispatchParams): Promise<void> {
   const {
     ghInstallationId,
     repo,
-    issueNumber,
+    issue,
     senderGithubUserId,
     prompt,
     commentId,
   } = params;
+  const issueNumber = issue.number;
 
   // 1. Resolve installation (only active installations can trigger runs)
   const [installation] = await globalThis.services.db
@@ -236,6 +248,17 @@ async function dispatchAgentRun(params: DispatchParams): Promise<void> {
     throw new Error(
       `GitHub installation not found: installationId=${ghInstallationId}`,
     );
+  }
+
+  // Get GitHub token early for reactions and error comments
+  const token = installation.installationId
+    ? await getGitHubToken(installation.installationId)
+    : undefined;
+
+  // Add 👀 reaction to the triggering comment
+  let reactionId: string | undefined;
+  if (token && commentId) {
+    reactionId = await addCommentReaction(token, repo, commentId, "eyes");
   }
 
   // 2. Resolve VM0 user via github_user_links
@@ -289,35 +312,88 @@ async function dispatchAgentRun(params: DispatchParams): Promise<void> {
     versionId = latestVersion.id;
   }
 
-  // 4. Look up existing session for multi-turn
+  // 4. Look up existing session for multi-turn (skip for label triggers — always new session)
   let existingSessionId: string | undefined;
-  const [existingSession] = await globalThis.services.db
-    .select({
-      agentSessionId: githubIssueSessions.agentSessionId,
-      lastCommentId: githubIssueSessions.lastCommentId,
-    })
-    .from(githubIssueSessions)
-    .where(
-      and(
-        eq(githubIssueSessions.installationId, installation.id),
-        eq(githubIssueSessions.repo, repo),
-        eq(githubIssueSessions.issueNumber, issueNumber),
-      ),
-    )
-    .limit(1);
+  let existingSession:
+    | { agentSessionId: string; lastCommentId: string | null }
+    | undefined;
 
-  if (existingSession) {
-    existingSessionId = existingSession.agentSessionId;
+  if (!params.forceNewSession) {
+    const [found] = await globalThis.services.db
+      .select({
+        agentSessionId: githubIssueSessions.agentSessionId,
+        lastCommentId: githubIssueSessions.lastCommentId,
+      })
+      .from(githubIssueSessions)
+      .where(
+        and(
+          eq(githubIssueSessions.installationId, installation.id),
+          eq(githubIssueSessions.repo, repo),
+          eq(githubIssueSessions.issueNumber, issueNumber),
+        ),
+      )
+      .limit(1);
+    existingSession = found;
 
-    // Deduplicate: skip if we already processed this comment
-    if (commentId && existingSession.lastCommentId === commentId) {
-      log.debug("Skipping duplicate comment", { commentId });
-      return;
+    if (existingSession) {
+      // Deduplicate: skip if we already processed this comment
+      if (commentId && existingSession.lastCommentId === commentId) {
+        log.debug("Skipping duplicate comment", { commentId });
+        return;
+      }
+
+      // Validate session's agent matches current default — discard if changed
+      try {
+        const sessionData = await validateAgentSession(
+          existingSession.agentSessionId,
+          vm0UserId,
+        );
+        if (sessionData.agentComposeId === compose.id) {
+          existingSessionId = existingSession.agentSessionId;
+        } else {
+          log.debug("Agent changed, starting new session", {
+            sessionComposeId: sessionData.agentComposeId,
+            currentComposeId: compose.id,
+          });
+        }
+      } catch {
+        log.debug("Session validation failed, starting new session");
+      }
     }
   }
 
-  // 5. Create agent run with callback
-  const callbackUrl = `${getApiUrl()}/api/internal/callbacks/github`;
+  // 5. Fetch issue context (comments history)
+  const lastCommentId = existingSessionId
+    ? (existingSession?.lastCommentId ?? undefined)
+    : undefined;
+  let issueContext = "";
+  if (token) {
+    const comments = await fetchIssueComments(token, repo, issueNumber);
+    issueContext = formatIssueContext(
+      issue,
+      comments,
+      lastCommentId,
+      commentId,
+    );
+  }
+
+  // Build full prompt with context
+  let fullPrompt: string;
+  if (issueContext) {
+    if (commentId) {
+      // Comment trigger — context + comment body as user prompt
+      fullPrompt = `${issueContext}\n\n# User Prompt\n\n${prompt}`;
+    } else {
+      // Label trigger — context already includes issue body and comments.
+      // Instruct the agent to analyze the context and decide what to do.
+      fullPrompt = `${issueContext}\n\nBased on the GitHub issue above and its discussion, analyze the request and decide on the appropriate action.`;
+    }
+  } else {
+    fullPrompt = prompt;
+  }
+
+  // 6. Create agent run with callback
+  const callbackUrl = `${getApiUrl()}/api/internal/callbacks/github/issues`;
   const callbackSecret = generateCallbackSecret();
   const callbackContext: GitHubCallbackContext = {
     installationId: installation.id,
@@ -327,13 +403,16 @@ async function dispatchAgentRun(params: DispatchParams): Promise<void> {
     agentName: compose.name,
     composeId: compose.id,
     existingSessionId,
+    triggerCommentId: commentId,
+    triggerCommentBody: commentId ? params.comment?.body : undefined,
+    triggerReactionId: reactionId,
   };
 
   try {
     const result = await createRun({
       userId: vm0UserId,
       agentComposeVersionId: versionId,
-      prompt,
+      prompt: fullPrompt,
       composeId: compose.id,
       sessionId: existingSessionId,
       agentName: compose.name,
@@ -375,12 +454,46 @@ async function dispatchAgentRun(params: DispatchParams): Promise<void> {
     // Note: New session mapping will be created by the callback handler
     // once the run completes and we have the agentSessionId from the result
   } catch (error) {
+    // Remove 👀 reaction on failure
+    if (token && commentId && reactionId) {
+      await removeCommentReaction(token, repo, commentId, reactionId);
+    }
+
+    const commentBody = params.comment?.body;
+    const quotePrefix = commentBody
+      ? commentBody
+          .split("\n")
+          .map((line) => `> ${line}`)
+          .join("\n") + "\n\n"
+      : "";
+
     if (isConcurrentRunLimit(error)) {
       log.warn("Concurrent run limit reached for GitHub issue", {
         repo,
         issueNumber,
       });
+      if (token) {
+        await postIssueComment(
+          token,
+          repo,
+          issueNumber,
+          `${quotePrefix}⚠️ The agent is currently busy with another task. Please try again shortly.`,
+        );
+      }
       return;
+    }
+
+    if (token) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : "An unexpected error occurred.";
+      await postIssueComment(
+        token,
+        repo,
+        issueNumber,
+        `${quotePrefix}❌ Failed to start the agent: ${message}`,
+      );
     }
     throw error;
   }
@@ -388,39 +501,204 @@ async function dispatchAgentRun(params: DispatchParams): Promise<void> {
 
 /**
  * Build a prompt from an issue (for opened/labeled events).
+ * Sends only the issue body as the user prompt.
  */
 function buildIssuePrompt(issue: GitHubIssue): string {
-  const parts: string[] = [
-    `# GitHub Issue #${issue.number}: ${issue.title}`,
-    "",
-  ];
+  return issue.body ?? issue.title;
+}
 
-  if (issue.body) {
-    parts.push(issue.body);
-  } else {
-    parts.push("(No description provided)");
+/**
+ * Build a prompt from a comment.
+ * Sends only the comment body as the user prompt.
+ */
+function buildCommentPrompt(
+  _issue: GitHubIssue,
+  comment: GitHubComment,
+): string {
+  return comment.body;
+}
+
+// ─── Issue Context ──────────────────────────────────────────────────
+
+interface IssueComment {
+  id: number;
+  user: { login: string; type: string };
+  body: string;
+  created_at: string;
+}
+
+/**
+ * Fetch issue comments from GitHub API.
+ * Returns up to 100 most recent comments.
+ */
+async function fetchIssueComments(
+  token: string,
+  repo: string,
+  issueNumber: number,
+): Promise<IssueComment[]> {
+  const res = await fetch(
+    `https://api.github.com/repos/${repo}/issues/${issueNumber}/comments?per_page=100&direction=asc`,
+    {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+    },
+  );
+
+  if (!res.ok) {
+    log.warn("Failed to fetch issue comments", {
+      status: res.status,
+      repo,
+      issueNumber,
+    });
+    return [];
   }
 
+  return (await res.json()) as IssueComment[];
+}
+
+/**
+ * Format issue and comments as context for the agent prompt.
+ * When lastCommentId is provided, only includes comments after it (dedup for session continuity).
+ */
+function formatIssueContext(
+  issue: GitHubIssue,
+  comments: IssueComment[],
+  lastCommentId: string | undefined,
+  currentCommentId: string | undefined,
+): string {
+  // Filter to only new comments when continuing a session,
+  // and exclude the triggering comment (it's already in the user prompt)
+  let relevantComments = lastCommentId
+    ? comments.filter((c) => c.id > Number(lastCommentId))
+    : comments;
+  if (currentCommentId) {
+    relevantComments = relevantComments.filter(
+      (c) => String(c.id) !== currentCommentId,
+    );
+  }
+
+  if (relevantComments.length === 0 && lastCommentId) {
+    // Session continuation with no new comments — no context needed
+    return "";
+  }
+
+  const parts: string[] = ["# GitHub Issue Context"];
+
+  if (!lastCommentId) {
+    // New session — include issue body
+    parts.push(
+      "",
+      `**${issue.title}** (#${issue.number})`,
+      "",
+      issue.body ?? "_No description provided._",
+    );
+  }
+
+  if (relevantComments.length > 0) {
+    parts.push("", "## Comments", "");
+    for (const comment of relevantComments) {
+      const role = comment.user.type === "Bot" ? "bot" : "user";
+      parts.push(`**@${comment.user.login}** (${role}):`, comment.body, "");
+    }
+  }
+
+  parts.push("---");
   return parts.join("\n");
 }
 
 /**
- * Build a prompt from a comment, with issue context.
+ * Get a GitHub installation access token, returning undefined if credentials are not configured.
  */
-function buildCommentPrompt(
-  issue: GitHubIssue,
-  comment: GitHubComment,
-): string {
-  const parts: string[] = [
-    `# GitHub Issue #${issue.number}: ${issue.title}`,
-    "",
-  ];
-
-  if (issue.body) {
-    parts.push("## Issue Description", "", issue.body, "");
+async function getGitHubToken(
+  ghInstallationId: string,
+): Promise<string | undefined> {
+  const { GITHUB_APP_ID, GITHUB_APP_PRIVATE_KEY } = env();
+  if (!GITHUB_APP_ID || !GITHUB_APP_PRIVATE_KEY) {
+    return undefined;
   }
+  const { token } = await getInstallationAccessToken(
+    GITHUB_APP_ID,
+    GITHUB_APP_PRIVATE_KEY,
+    ghInstallationId,
+  );
+  return token;
+}
 
-  parts.push("## New Comment", "", `**@${comment.user.login}:**`, comment.body);
+// ─── GitHub API Helpers ─────────────────────────────────────────────
 
-  return parts.join("\n");
+async function addCommentReaction(
+  token: string,
+  repo: string,
+  commentId: string,
+  content: string,
+): Promise<string | undefined> {
+  try {
+    const res = await fetch(
+      `https://api.github.com/repos/${repo}/issues/comments/${commentId}/reactions`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          Accept: "application/vnd.github+json",
+          "X-GitHub-Api-Version": "2022-11-28",
+        },
+        body: JSON.stringify({ content }),
+      },
+    );
+    if (!res.ok) return undefined;
+    const data = (await res.json()) as { id: number };
+    return String(data.id);
+  } catch {
+    return undefined;
+  }
+}
+
+async function removeCommentReaction(
+  token: string,
+  repo: string,
+  commentId: string,
+  reactionId: string,
+): Promise<void> {
+  try {
+    await fetch(
+      `https://api.github.com/repos/${repo}/issues/comments/${commentId}/reactions/${reactionId}`,
+      {
+        method: "DELETE",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          Accept: "application/vnd.github+json",
+          "X-GitHub-Api-Version": "2022-11-28",
+        },
+      },
+    );
+  } catch {
+    // Best-effort
+  }
+}
+
+async function postIssueComment(
+  token: string,
+  repo: string,
+  issueNumber: number,
+  body: string,
+): Promise<void> {
+  try {
+    await fetch(
+      `https://api.github.com/repos/${repo}/issues/${issueNumber}/comments`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          Accept: "application/vnd.github+json",
+          "X-GitHub-Api-Version": "2022-11-28",
+        },
+        body: JSON.stringify({ body }),
+      },
+    );
+  } catch {
+    // Best-effort
+  }
 }

--- a/turbo/apps/web/src/lib/github/handlers/issue-event.ts
+++ b/turbo/apps/web/src/lib/github/handlers/issue-event.ts
@@ -11,6 +11,13 @@ import { createRun, validateAgentSession } from "../../run";
 import { isConcurrentRunLimit } from "../../errors";
 import { generateCallbackSecret, getApiUrl } from "../../callback";
 import { getInstallationAccessToken } from "../github-app";
+import {
+  type IssueComment,
+  addCommentReaction,
+  fetchIssueComments,
+  postIssueCommentBestEffort,
+  removeCommentReaction,
+} from "../api";
 import { env } from "../../../env";
 import { logger } from "../../logger";
 
@@ -183,7 +190,7 @@ export async function handleIssueCommentEvent(
   }
 
   // Build prompt with comment as the user message and issue as context
-  const prompt = buildCommentPrompt(issue, comment);
+  const prompt = buildCommentPrompt(comment);
 
   await dispatchAgentRun({
     ghInstallationId: String(installation.id),
@@ -212,14 +219,183 @@ interface DispatchParams {
 }
 
 /**
+ * Resolve the compose version ID, falling back to the latest version.
+ */
+async function resolveVersionId(compose: {
+  id: string;
+  headVersionId: string | null;
+}): Promise<string> {
+  if (compose.headVersionId) return compose.headVersionId;
+
+  const [latestVersion] = await globalThis.services.db
+    .select({ id: agentComposeVersions.id })
+    .from(agentComposeVersions)
+    .where(eq(agentComposeVersions.composeId, compose.id))
+    .orderBy(desc(agentComposeVersions.createdAt))
+    .limit(1);
+
+  if (!latestVersion) {
+    throw new Error(`Agent compose has no versions: composeId=${compose.id}`);
+  }
+  return latestVersion.id;
+}
+
+/**
+ * Look up and validate an existing issue session for multi-turn.
+ * Returns the validated session ID, or undefined to start a new session.
+ * Returns "duplicate" if the comment was already processed.
+ */
+async function resolveExistingSession(
+  installationDbId: string,
+  repo: string,
+  issueNumber: number,
+  composeId: string,
+  vm0UserId: string,
+  commentId: string | undefined,
+): Promise<
+  | { kind: "duplicate" }
+  | {
+      kind: "resolved";
+      sessionId: string | undefined;
+      lastCommentId: string | null | undefined;
+    }
+> {
+  const [found] = await globalThis.services.db
+    .select({
+      agentSessionId: githubIssueSessions.agentSessionId,
+      lastCommentId: githubIssueSessions.lastCommentId,
+    })
+    .from(githubIssueSessions)
+    .where(
+      and(
+        eq(githubIssueSessions.installationId, installationDbId),
+        eq(githubIssueSessions.repo, repo),
+        eq(githubIssueSessions.issueNumber, issueNumber),
+      ),
+    )
+    .limit(1);
+
+  if (!found) {
+    return { kind: "resolved", sessionId: undefined, lastCommentId: undefined };
+  }
+
+  // Deduplicate: skip if we already processed this comment
+  if (commentId && found.lastCommentId === commentId) {
+    log.debug("Skipping duplicate comment", { commentId });
+    return { kind: "duplicate" };
+  }
+
+  // Validate session's agent matches current default
+  const sessionId = await validateSessionAgent(
+    found.agentSessionId,
+    vm0UserId,
+    composeId,
+  );
+  return {
+    kind: "resolved",
+    sessionId,
+    lastCommentId: sessionId ? found.lastCommentId : undefined,
+  };
+}
+
+/**
+ * Validate that a session's agent matches the expected compose.
+ * Returns the session ID if valid, undefined otherwise.
+ */
+async function validateSessionAgent(
+  sessionId: string,
+  vm0UserId: string,
+  expectedComposeId: string,
+): Promise<string | undefined> {
+  try {
+    const sessionData = await validateAgentSession(sessionId, vm0UserId);
+    if (sessionData.agentComposeId === expectedComposeId) {
+      return sessionId;
+    }
+    log.debug("Agent changed, starting new session", {
+      sessionComposeId: sessionData.agentComposeId,
+      currentComposeId: expectedComposeId,
+    });
+    return undefined;
+  } catch (error) {
+    log.warn("Session validation failed, starting new session", {
+      sessionId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return undefined;
+  }
+}
+
+/**
+ * Build a full prompt with issue context.
+ */
+function buildFullPrompt(
+  prompt: string,
+  issueContext: string,
+  isCommentTrigger: boolean,
+): string {
+  if (!issueContext) return prompt;
+
+  if (isCommentTrigger) {
+    return `${issueContext}\n\n# User Prompt\n\n${prompt}`;
+  }
+  return `${issueContext}\n\nBased on the GitHub issue above and its discussion, analyze the request and decide on the appropriate action.`;
+}
+
+/**
+ * Handle error from createRun: remove reaction and post error feedback.
+ */
+async function handleDispatchError(
+  error: unknown,
+  token: string | undefined,
+  repo: string,
+  issueNumber: number,
+  commentId: string | undefined,
+  reactionId: string | undefined,
+  commentBody: string | undefined,
+): Promise<void> {
+  if (token && commentId && reactionId) {
+    await removeCommentReaction(token, repo, commentId, reactionId);
+  }
+
+  const quotePrefix = commentBody
+    ? commentBody
+        .split("\n")
+        .map((line) => `> ${line}`)
+        .join("\n") + "\n\n"
+    : "";
+
+  if (isConcurrentRunLimit(error)) {
+    log.warn("Concurrent run limit reached for GitHub issue", {
+      repo,
+      issueNumber,
+    });
+    if (token) {
+      await postIssueCommentBestEffort(
+        token,
+        repo,
+        issueNumber,
+        `${quotePrefix}⚠️ The agent is currently busy with another task. Please try again shortly.`,
+      );
+    }
+    return;
+  }
+
+  if (token) {
+    const message =
+      error instanceof Error ? error.message : "An unexpected error occurred.";
+    await postIssueCommentBestEffort(
+      token,
+      repo,
+      issueNumber,
+      `${quotePrefix}❌ Failed to start the agent: ${message}`,
+    );
+  }
+  throw error;
+}
+
+/**
  * Core dispatch logic shared by issue and comment handlers.
- *
- * 1. Resolve installation from GitHub installation ID
- * 2. Resolve VM0 user via github_user_links
- * 3. Get agent compose and latest version
- * 4. Look up existing session for multi-turn
- * 5. Create agent run with callback
- * 6. Update/create issue session mapping
  */
 async function dispatchAgentRun(params: DispatchParams): Promise<void> {
   const {
@@ -232,7 +408,7 @@ async function dispatchAgentRun(params: DispatchParams): Promise<void> {
   } = params;
   const issueNumber = issue.number;
 
-  // 1. Resolve installation (only active installations can trigger runs)
+  // 1. Resolve installation
   const [installation] = await globalThis.services.db
     .select()
     .from(githubInstallations)
@@ -255,13 +431,13 @@ async function dispatchAgentRun(params: DispatchParams): Promise<void> {
     ? await getGitHubToken(installation.installationId)
     : undefined;
 
-  // Add 👀 reaction to the triggering comment
-  let reactionId: string | undefined;
-  if (token && commentId) {
-    reactionId = await addCommentReaction(token, repo, commentId, "eyes");
-  }
+  // Add eyes reaction to the triggering comment
+  const reactionId =
+    token && commentId
+      ? await addCommentReaction(token, repo, commentId, "eyes")
+      : undefined;
 
-  // 2. Resolve VM0 user via github_user_links
+  // 2. Resolve VM0 user
   const [userLink] = await globalThis.services.db
     .select({ vm0UserId: githubUserLinks.vm0UserId })
     .from(githubUserLinks)
@@ -278,7 +454,6 @@ async function dispatchAgentRun(params: DispatchParams): Promise<void> {
       githubUserId: senderGithubUserId,
       installationId: installation.id,
     });
-    // TODO: Post comment asking user to link their VM0 account
     return;
   }
 
@@ -297,100 +472,38 @@ async function dispatchAgentRun(params: DispatchParams): Promise<void> {
     );
   }
 
-  let versionId = compose.headVersionId;
-  if (!versionId) {
-    const [latestVersion] = await globalThis.services.db
-      .select({ id: agentComposeVersions.id })
-      .from(agentComposeVersions)
-      .where(eq(agentComposeVersions.composeId, compose.id))
-      .orderBy(desc(agentComposeVersions.createdAt))
-      .limit(1);
+  const versionId = await resolveVersionId(compose);
 
-    if (!latestVersion) {
-      throw new Error(`Agent compose has no versions: composeId=${compose.id}`);
-    }
-    versionId = latestVersion.id;
-  }
-
-  // 4. Look up existing session for multi-turn (skip for label triggers — always new session)
+  // 4. Look up existing session
   let existingSessionId: string | undefined;
-  let existingSession:
-    | { agentSessionId: string; lastCommentId: string | null }
-    | undefined;
+  let lastCommentId: string | null | undefined;
 
   if (!params.forceNewSession) {
-    const [found] = await globalThis.services.db
-      .select({
-        agentSessionId: githubIssueSessions.agentSessionId,
-        lastCommentId: githubIssueSessions.lastCommentId,
-      })
-      .from(githubIssueSessions)
-      .where(
-        and(
-          eq(githubIssueSessions.installationId, installation.id),
-          eq(githubIssueSessions.repo, repo),
-          eq(githubIssueSessions.issueNumber, issueNumber),
-        ),
-      )
-      .limit(1);
-    existingSession = found;
-
-    if (existingSession) {
-      // Deduplicate: skip if we already processed this comment
-      if (commentId && existingSession.lastCommentId === commentId) {
-        log.debug("Skipping duplicate comment", { commentId });
-        return;
-      }
-
-      // Validate session's agent matches current default — discard if changed
-      try {
-        const sessionData = await validateAgentSession(
-          existingSession.agentSessionId,
-          vm0UserId,
-        );
-        if (sessionData.agentComposeId === compose.id) {
-          existingSessionId = existingSession.agentSessionId;
-        } else {
-          log.debug("Agent changed, starting new session", {
-            sessionComposeId: sessionData.agentComposeId,
-            currentComposeId: compose.id,
-          });
-        }
-      } catch {
-        log.debug("Session validation failed, starting new session");
-      }
-    }
+    const sessionResult = await resolveExistingSession(
+      installation.id,
+      repo,
+      issueNumber,
+      compose.id,
+      vm0UserId,
+      commentId,
+    );
+    if (sessionResult.kind === "duplicate") return;
+    existingSessionId = sessionResult.sessionId;
+    lastCommentId = sessionResult.lastCommentId;
   }
 
-  // 5. Fetch issue context (comments history)
-  const lastCommentId = existingSessionId
-    ? (existingSession?.lastCommentId ?? undefined)
-    : undefined;
+  // 5. Fetch issue context and build prompt
   let issueContext = "";
   if (token) {
     const comments = await fetchIssueComments(token, repo, issueNumber);
     issueContext = formatIssueContext(
       issue,
       comments,
-      lastCommentId,
+      existingSessionId ? (lastCommentId ?? undefined) : undefined,
       commentId,
     );
   }
-
-  // Build full prompt with context
-  let fullPrompt: string;
-  if (issueContext) {
-    if (commentId) {
-      // Comment trigger — context + comment body as user prompt
-      fullPrompt = `${issueContext}\n\n# User Prompt\n\n${prompt}`;
-    } else {
-      // Label trigger — context already includes issue body and comments.
-      // Instruct the agent to analyze the context and decide what to do.
-      fullPrompt = `${issueContext}\n\nBased on the GitHub issue above and its discussion, analyze the request and decide on the appropriate action.`;
-    }
-  } else {
-    fullPrompt = prompt;
-  }
+  const fullPrompt = buildFullPrompt(prompt, issueContext, !!commentId);
 
   // 6. Create agent run with callback
   const callbackUrl = `${getApiUrl()}/api/internal/callbacks/github/issues`;
@@ -432,70 +545,29 @@ async function dispatchAgentRun(params: DispatchParams): Promise<void> {
       issueNumber,
     });
 
-    // 6. Update or create issue session mapping
-    if (existingSession) {
-      // Update lastCommentId for deduplication
-      if (commentId) {
-        await globalThis.services.db
-          .update(githubIssueSessions)
-          .set({
-            lastCommentId: commentId,
-            updatedAt: new Date(),
-          })
-          .where(
-            and(
-              eq(githubIssueSessions.installationId, installation.id),
-              eq(githubIssueSessions.repo, repo),
-              eq(githubIssueSessions.issueNumber, issueNumber),
-            ),
-          );
-      }
-    }
-    // Note: New session mapping will be created by the callback handler
-    // once the run completes and we have the agentSessionId from the result
-  } catch (error) {
-    // Remove 👀 reaction on failure
-    if (token && commentId && reactionId) {
-      await removeCommentReaction(token, repo, commentId, reactionId);
-    }
-
-    const commentBody = params.comment?.body;
-    const quotePrefix = commentBody
-      ? commentBody
-          .split("\n")
-          .map((line) => `> ${line}`)
-          .join("\n") + "\n\n"
-      : "";
-
-    if (isConcurrentRunLimit(error)) {
-      log.warn("Concurrent run limit reached for GitHub issue", {
-        repo,
-        issueNumber,
-      });
-      if (token) {
-        await postIssueComment(
-          token,
-          repo,
-          issueNumber,
-          `${quotePrefix}⚠️ The agent is currently busy with another task. Please try again shortly.`,
+    // Update lastCommentId for deduplication on existing sessions
+    if (existingSessionId && commentId) {
+      await globalThis.services.db
+        .update(githubIssueSessions)
+        .set({ lastCommentId: commentId, updatedAt: new Date() })
+        .where(
+          and(
+            eq(githubIssueSessions.installationId, installation.id),
+            eq(githubIssueSessions.repo, repo),
+            eq(githubIssueSessions.issueNumber, issueNumber),
+          ),
         );
-      }
-      return;
     }
-
-    if (token) {
-      const message =
-        error instanceof Error
-          ? error.message
-          : "An unexpected error occurred.";
-      await postIssueComment(
-        token,
-        repo,
-        issueNumber,
-        `${quotePrefix}❌ Failed to start the agent: ${message}`,
-      );
-    }
-    throw error;
+  } catch (error) {
+    await handleDispatchError(
+      error,
+      token,
+      repo,
+      issueNumber,
+      commentId,
+      reactionId,
+      params.comment?.body,
+    );
   }
 }
 
@@ -511,53 +583,11 @@ function buildIssuePrompt(issue: GitHubIssue): string {
  * Build a prompt from a comment.
  * Sends only the comment body as the user prompt.
  */
-function buildCommentPrompt(
-  _issue: GitHubIssue,
-  comment: GitHubComment,
-): string {
+function buildCommentPrompt(comment: GitHubComment): string {
   return comment.body;
 }
 
 // ─── Issue Context ──────────────────────────────────────────────────
-
-interface IssueComment {
-  id: number;
-  user: { login: string; type: string };
-  body: string;
-  created_at: string;
-}
-
-/**
- * Fetch issue comments from GitHub API.
- * Returns up to 100 most recent comments.
- */
-async function fetchIssueComments(
-  token: string,
-  repo: string,
-  issueNumber: number,
-): Promise<IssueComment[]> {
-  const res = await fetch(
-    `https://api.github.com/repos/${repo}/issues/${issueNumber}/comments?per_page=100&direction=asc`,
-    {
-      headers: {
-        Authorization: `Bearer ${token}`,
-        Accept: "application/vnd.github+json",
-        "X-GitHub-Api-Version": "2022-11-28",
-      },
-    },
-  );
-
-  if (!res.ok) {
-    log.warn("Failed to fetch issue comments", {
-      status: res.status,
-      repo,
-      issueNumber,
-    });
-    return [];
-  }
-
-  return (await res.json()) as IssueComment[];
-}
 
 /**
  * Format issue and comments as context for the agent prompt.
@@ -625,80 +655,4 @@ async function getGitHubToken(
     ghInstallationId,
   );
   return token;
-}
-
-// ─── GitHub API Helpers ─────────────────────────────────────────────
-
-async function addCommentReaction(
-  token: string,
-  repo: string,
-  commentId: string,
-  content: string,
-): Promise<string | undefined> {
-  try {
-    const res = await fetch(
-      `https://api.github.com/repos/${repo}/issues/comments/${commentId}/reactions`,
-      {
-        method: "POST",
-        headers: {
-          Authorization: `Bearer ${token}`,
-          Accept: "application/vnd.github+json",
-          "X-GitHub-Api-Version": "2022-11-28",
-        },
-        body: JSON.stringify({ content }),
-      },
-    );
-    if (!res.ok) return undefined;
-    const data = (await res.json()) as { id: number };
-    return String(data.id);
-  } catch {
-    return undefined;
-  }
-}
-
-async function removeCommentReaction(
-  token: string,
-  repo: string,
-  commentId: string,
-  reactionId: string,
-): Promise<void> {
-  try {
-    await fetch(
-      `https://api.github.com/repos/${repo}/issues/comments/${commentId}/reactions/${reactionId}`,
-      {
-        method: "DELETE",
-        headers: {
-          Authorization: `Bearer ${token}`,
-          Accept: "application/vnd.github+json",
-          "X-GitHub-Api-Version": "2022-11-28",
-        },
-      },
-    );
-  } catch {
-    // Best-effort
-  }
-}
-
-async function postIssueComment(
-  token: string,
-  repo: string,
-  issueNumber: number,
-  body: string,
-): Promise<void> {
-  try {
-    await fetch(
-      `https://api.github.com/repos/${repo}/issues/${issueNumber}/comments`,
-      {
-        method: "POST",
-        headers: {
-          Authorization: `Bearer ${token}`,
-          Accept: "application/vnd.github+json",
-          "X-GitHub-Api-Version": "2022-11-28",
-        },
-        body: JSON.stringify({ body }),
-      },
-    );
-  } catch {
-    // Best-effort
-  }
 }

--- a/turbo/apps/web/src/lib/slack/handlers/direct-message.ts
+++ b/turbo/apps/web/src/lib/slack/handlers/direct-message.ts
@@ -130,17 +130,15 @@ export async function handleDirectMessage(
     });
   }
 
-  // 6b. Validate session's agent matches current default — discard if changed
+  // 6b. Validate session's agent matches current default — discard only on positive mismatch
   if (existingSessionId) {
     const sessionCompose = await resolveSessionCompose(
       existingSessionId,
       userLink.vm0UserId,
     );
-    if (sessionCompose && sessionCompose.composeId === composeId) {
-      log.debug("Continuing session with same agent", { composeId });
-    } else {
+    if (sessionCompose && sessionCompose.composeId !== composeId) {
       log.debug("Agent changed, starting new session", {
-        sessionComposeId: sessionCompose?.composeId,
+        sessionComposeId: sessionCompose.composeId,
         currentComposeId: composeId,
       });
       existingSessionId = undefined;

--- a/turbo/apps/web/src/lib/slack/handlers/direct-message.ts
+++ b/turbo/apps/web/src/lib/slack/handlers/direct-message.ts
@@ -130,16 +130,21 @@ export async function handleDirectMessage(
     });
   }
 
-  // 6b. If continuing session, use session's compose instead of workspace default
+  // 6b. Validate session's agent matches current default — discard if changed
   if (existingSessionId) {
     const sessionCompose = await resolveSessionCompose(
       existingSessionId,
       userLink.vm0UserId,
     );
-    if (sessionCompose) {
-      composeId = sessionCompose.composeId;
-      agentName = sessionCompose.agentName;
-      log.debug("Using session compose", { composeId, agentName });
+    if (sessionCompose && sessionCompose.composeId === composeId) {
+      log.debug("Continuing session with same agent", { composeId });
+    } else {
+      log.debug("Agent changed, starting new session", {
+        sessionComposeId: sessionCompose?.composeId,
+        currentComposeId: composeId,
+      });
+      existingSessionId = undefined;
+      lastProcessedMessageTs = undefined;
     }
   }
 

--- a/turbo/apps/web/src/lib/slack/handlers/direct-message.ts
+++ b/turbo/apps/web/src/lib/slack/handlers/direct-message.ts
@@ -93,8 +93,8 @@ export async function handleDirectMessage(
     return;
   }
 
-  // 4. Resolve workspace agent (may be overridden by session below)
-  let composeId = installation.defaultComposeId;
+  // 4. Resolve workspace agent
+  const composeId = installation.defaultComposeId;
   const defaultAgent = await getWorkspaceAgent(composeId);
   if (!defaultAgent) {
     await postMessage(
@@ -105,7 +105,7 @@ export async function handleDirectMessage(
     );
     return;
   }
-  let agentName = defaultAgent.name;
+  const agentName = defaultAgent.name;
 
   // 5. Show assistant thinking status
   await setThreadStatus(client, context.channelId, threadTs, "is thinking...");

--- a/turbo/apps/web/src/lib/slack/handlers/mention.ts
+++ b/turbo/apps/web/src/lib/slack/handlers/mention.ts
@@ -136,16 +136,21 @@ export async function handleAppMention(context: MentionContext): Promise<void> {
     });
   }
 
-  // 6b. If continuing session, use session's compose instead of workspace default
+  // 6b. Validate session's agent matches current default — discard if changed
   if (existingSessionId) {
     const sessionCompose = await resolveSessionCompose(
       existingSessionId,
       userLink.vm0UserId,
     );
-    if (sessionCompose) {
-      composeId = sessionCompose.composeId;
-      agentName = sessionCompose.agentName;
-      log.debug("Using session compose", { composeId, agentName });
+    if (sessionCompose && sessionCompose.composeId === composeId) {
+      log.debug("Continuing session with same agent", { composeId });
+    } else {
+      log.debug("Agent changed, starting new session", {
+        sessionComposeId: sessionCompose?.composeId,
+        currentComposeId: composeId,
+      });
+      existingSessionId = undefined;
+      lastProcessedMessageTs = undefined;
     }
   }
 

--- a/turbo/apps/web/src/lib/slack/handlers/mention.ts
+++ b/turbo/apps/web/src/lib/slack/handlers/mention.ts
@@ -136,17 +136,15 @@ export async function handleAppMention(context: MentionContext): Promise<void> {
     });
   }
 
-  // 6b. Validate session's agent matches current default — discard if changed
+  // 6b. Validate session's agent matches current default — discard only on positive mismatch
   if (existingSessionId) {
     const sessionCompose = await resolveSessionCompose(
       existingSessionId,
       userLink.vm0UserId,
     );
-    if (sessionCompose && sessionCompose.composeId === composeId) {
-      log.debug("Continuing session with same agent", { composeId });
-    } else {
+    if (sessionCompose && sessionCompose.composeId !== composeId) {
       log.debug("Agent changed, starting new session", {
-        sessionComposeId: sessionCompose?.composeId,
+        sessionComposeId: sessionCompose.composeId,
         currentComposeId: composeId,
       });
       existingSessionId = undefined;

--- a/turbo/apps/web/src/lib/slack/handlers/mention.ts
+++ b/turbo/apps/web/src/lib/slack/handlers/mention.ts
@@ -99,8 +99,8 @@ export async function handleAppMention(context: MentionContext): Promise<void> {
     return;
   }
 
-  // 4. Resolve workspace agent (may be overridden by session below)
-  let composeId = installation.defaultComposeId;
+  // 4. Resolve workspace agent
+  const composeId = installation.defaultComposeId;
   const defaultAgent = await getWorkspaceAgent(composeId);
   if (!defaultAgent) {
     await postMessage(
@@ -111,7 +111,7 @@ export async function handleAppMention(context: MentionContext): Promise<void> {
     );
     return;
   }
-  let agentName = defaultAgent.name;
+  const agentName = defaultAgent.name;
 
   // 5. Show assistant thinking status
   await setThreadStatus(client, context.channelId, threadTs, "is thinking...");

--- a/turbo/apps/web/src/lib/slack/handlers/shared.ts
+++ b/turbo/apps/web/src/lib/slack/handlers/shared.ts
@@ -205,10 +205,10 @@ export function buildLoginUrl(
 }
 
 /**
- * Build the logs URL for a run
+ * Build the logs URL for a run, linking to the agent detail logs page.
  */
-export function buildLogsUrl(runId: string): string {
-  return `${getPlatformUrl()}/logs/${runId}`;
+export function buildLogsUrl(runId: string, agentName: string): string {
+  return `${getPlatformUrl()}/agents/${encodeURIComponent(agentName)}/logs/${encodeURIComponent(runId)}`;
 }
 
 /**

--- a/turbo/apps/web/src/lib/telegram/handlers/direct-message.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/direct-message.ts
@@ -95,17 +95,15 @@ export async function handleTelegramDirectMessage(
   let existingSessionId = session.existingSessionId;
   const lastProcessedMessageId = session.lastProcessedMessageId;
 
-  // 7b. Validate session's agent matches current default — discard if changed
+  // 7b. Validate session's agent matches current default — discard only on positive mismatch
   if (existingSessionId) {
     const sessionCompose = await resolveSessionCompose(
       existingSessionId,
       userLink.vm0UserId,
     );
-    if (sessionCompose && sessionCompose.composeId === composeId) {
-      log.debug("Continuing session with same agent", { composeId });
-    } else {
+    if (sessionCompose && sessionCompose.composeId !== composeId) {
       log.debug("Agent changed, starting new session", {
-        sessionComposeId: sessionCompose?.composeId,
+        sessionComposeId: sessionCompose.composeId,
         currentComposeId: composeId,
       });
       existingSessionId = undefined;

--- a/turbo/apps/web/src/lib/telegram/handlers/direct-message.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/direct-message.ts
@@ -92,18 +92,23 @@ export async function handleTelegramDirectMessage(
     rootMessageId,
     userLink.id,
   );
-  const existingSessionId = session.existingSessionId;
+  let existingSessionId = session.existingSessionId;
   const lastProcessedMessageId = session.lastProcessedMessageId;
 
-  // 7b. If continuing session, use session's compose
+  // 7b. Validate session's agent matches current default — discard if changed
   if (existingSessionId) {
     const sessionCompose = await resolveSessionCompose(
       existingSessionId,
       userLink.vm0UserId,
     );
-    if (sessionCompose) {
-      composeId = sessionCompose.composeId;
-      agentName = sessionCompose.agentName;
+    if (sessionCompose && sessionCompose.composeId === composeId) {
+      log.debug("Continuing session with same agent", { composeId });
+    } else {
+      log.debug("Agent changed, starting new session", {
+        sessionComposeId: sessionCompose?.composeId,
+        currentComposeId: composeId,
+      });
+      existingSessionId = undefined;
     }
   }
 

--- a/turbo/apps/web/src/lib/telegram/handlers/direct-message.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/direct-message.ts
@@ -65,7 +65,7 @@ export async function handleTelegramDirectMessage(
   }
 
   // 3. Resolve workspace agent
-  let composeId = installation.defaultComposeId;
+  const composeId = installation.defaultComposeId;
   const defaultAgent = await getWorkspaceAgent(composeId);
   if (!defaultAgent) {
     await sendMessage(
@@ -75,7 +75,7 @@ export async function handleTelegramDirectMessage(
     );
     return;
   }
-  let agentName = defaultAgent.name;
+  const agentName = defaultAgent.name;
 
   // 4. Send thinking placeholder message
   const thinkingMessage = await sendThinkingMessage(client, chatId, agentName);

--- a/turbo/apps/web/src/lib/telegram/handlers/mention.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/mention.ts
@@ -74,7 +74,7 @@ export async function handleTelegramMention(
   }
 
   // 3. Resolve workspace agent
-  let composeId = installation.defaultComposeId;
+  const composeId = installation.defaultComposeId;
   const defaultAgent = await getWorkspaceAgent(composeId);
   if (!defaultAgent) {
     await sendMessage(
@@ -85,7 +85,7 @@ export async function handleTelegramMention(
     );
     return;
   }
-  let agentName = defaultAgent.name;
+  const agentName = defaultAgent.name;
 
   // 4. Send thinking placeholder message (reply to user's message in groups)
   const thinkingMessage = await sendThinkingMessage(client, chatId, agentName, {

--- a/turbo/apps/web/src/lib/telegram/handlers/mention.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/mention.ts
@@ -126,17 +126,15 @@ export async function handleTelegramMention(
     lastProcessedMessageId = session.lastProcessedMessageId;
   }
 
-  // 8b. Validate session's agent matches current default — discard if changed
+  // 8b. Validate session's agent matches current default — discard only on positive mismatch
   if (existingSessionId) {
     const sessionCompose = await resolveSessionCompose(
       existingSessionId,
       userLink.vm0UserId,
     );
-    if (sessionCompose && sessionCompose.composeId === composeId) {
-      log.debug("Continuing session with same agent", { composeId });
-    } else {
+    if (sessionCompose && sessionCompose.composeId !== composeId) {
       log.debug("Agent changed, starting new session", {
-        sessionComposeId: sessionCompose?.composeId,
+        sessionComposeId: sessionCompose.composeId,
         currentComposeId: composeId,
       });
       existingSessionId = undefined;

--- a/turbo/apps/web/src/lib/telegram/handlers/mention.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/mention.ts
@@ -126,15 +126,21 @@ export async function handleTelegramMention(
     lastProcessedMessageId = session.lastProcessedMessageId;
   }
 
-  // 8b. If continuing session, use session's compose
+  // 8b. Validate session's agent matches current default — discard if changed
   if (existingSessionId) {
     const sessionCompose = await resolveSessionCompose(
       existingSessionId,
       userLink.vm0UserId,
     );
-    if (sessionCompose) {
-      composeId = sessionCompose.composeId;
-      agentName = sessionCompose.agentName;
+    if (sessionCompose && sessionCompose.composeId === composeId) {
+      log.debug("Continuing session with same agent", { composeId });
+    } else {
+      log.debug("Agent changed, starting new session", {
+        sessionComposeId: sessionCompose?.composeId,
+        currentComposeId: composeId,
+      });
+      existingSessionId = undefined;
+      lastProcessedMessageId = undefined;
     }
   }
 


### PR DESCRIPTION
## Summary

- **GitHub issue handler overhaul**: Fetch issue comments as context for agent prompts, with deduplication for session continuity. Add eyes reaction to the triggering comment while agent processes, remove on completion. Format GitHub comments with agent name header, deep links, and logs footer. Post error feedback comments when agent dispatch fails.
- **Trigger behavior change**: Issue comments now only trigger on explicit `@bot` mention (removed label-only trigger), reducing noise from unrelated comments.
- **Cross-channel session validation**: All channels (Slack DM/mention, Telegram DM/mention, GitHub) now validate that the session's agent matches the current default agent, starting a new session if the agent has changed.
- **Logs URL improvement**: `buildLogsUrl` across Slack, email, and GitHub callbacks now links to agent-specific log pages (`/agents/{name}/logs/{runId}`).
- **Dev tunnel improvements**: Support `TUNNEL_HOSTNAME` env var override for fixed tunnel domains; rewrite self-referencing tunnel URLs to localhost in development to avoid hairpin routing timeouts.

## Test plan

- [ ] Verify GitHub issue opened event triggers agent with full issue context
- [ ] Verify GitHub comment with `@bot` mention triggers agent with comment history context
- [ ] Verify comments without `@bot` mention do NOT trigger agent
- [ ] Verify eyes reaction appears on triggering comment and is removed after agent responds
- [ ] Verify error feedback comment is posted when agent dispatch fails
- [ ] Verify session continuity works (multi-turn conversation on same issue)
- [ ] Verify session resets when default agent changes
- [ ] Verify Slack/Telegram session validation discards stale sessions
- [ ] Verify logs URLs link to correct agent-specific pages
- [ ] Run existing integration tests: `pnpm vitest` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)