### PR TITLE
ci: add github app env vars to ci workflows

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -259,6 +259,11 @@ jobs:
             RESEND_WEBHOOK_SECRET=${{ secrets.RESEND_WEBHOOK_SECRET }}
             RESEND_FROM_DOMAIN=${{ vars.RESEND_FROM_DOMAIN }}
             VM0_ADMIN_USERS=${{ vars.VM0_ADMIN_USERS }}
+            GITHUB_APP_SLUG=${{ vars.VM0_GITHUB_APP_SLUG }}
+            GITHUB_APP_CLIENT_ID=${{ vars.VM0_GITHUB_APP_CLIENT_ID }}
+            GITHUB_APP_CLIENT_SECRET=${{ secrets.VM0_GITHUB_APP_CLIENT_SECRET }}
+            GITHUB_APP_WEBHOOK_SECRET=${{ secrets.VM0_GITHUB_APP_WEBHOOK_SECRET }}
+            GITHUB_APP_PRIVATE_KEY=${{ secrets.VM0_GITHUB_APP_PRIVATE_KEY }}
 
       - name: Calculate duration
         id: duration

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -644,6 +644,11 @@ jobs:
           RESEND_FROM_DOMAIN: ${{ vars.RESEND_FROM_DOMAIN }}
           VM0_ADMIN_USERS: ${{ vars.VM0_ADMIN_USERS }}
           STRAPI_URL: ${{ vars.STRAPI_URL }}
+          GITHUB_APP_SLUG: ${{ vars.VM0_GITHUB_APP_SLUG }}
+          GITHUB_APP_CLIENT_ID: ${{ vars.VM0_GITHUB_APP_CLIENT_ID }}
+          GITHUB_APP_CLIENT_SECRET: ${{ secrets.VM0_GITHUB_APP_CLIENT_SECRET }}
+          GITHUB_APP_WEBHOOK_SECRET: ${{ secrets.VM0_GITHUB_APP_WEBHOOK_SECRET }}
+          GITHUB_APP_PRIVATE_KEY: ${{ secrets.VM0_GITHUB_APP_PRIVATE_KEY }}
         run: |
           # --- Start Neon branch creation in background ---
           (
@@ -797,6 +802,11 @@ jobs:
             RESEND_FROM_DOMAIN=${{ vars.RESEND_FROM_DOMAIN }}
             VM0_ADMIN_USERS=${{ vars.VM0_ADMIN_USERS }}
             STRAPI_URL=${{ vars.STRAPI_URL }}
+            GITHUB_APP_SLUG=${{ vars.VM0_GITHUB_APP_SLUG }}
+            GITHUB_APP_CLIENT_ID=${{ vars.VM0_GITHUB_APP_CLIENT_ID }}
+            GITHUB_APP_CLIENT_SECRET=${{ secrets.VM0_GITHUB_APP_CLIENT_SECRET }}
+            GITHUB_APP_WEBHOOK_SECRET=${{ secrets.VM0_GITHUB_APP_WEBHOOK_SECRET }}
+            GITHUB_APP_PRIVATE_KEY=${{ secrets.VM0_GITHUB_APP_PRIVATE_KEY }}
 
       - name: Finish deployment
         uses: bobheadxi/deployments@v1


### PR DESCRIPTION
## Summary
- Add GitHub App environment variables (slug, client ID, client secret, webhook secret, private key) to CI workflows
- Updates `turbo.yml` (deploy and production jobs) and `release-please.yml` (release deploy job)
- Maps repository variables/secrets with `VM0_GITHUB_APP_*` prefix to `GITHUB_APP_*` env vars

## Test plan
- [ ] Verify CI workflows pass with the new environment variables
- [ ] Confirm GitHub App integration works in deployed environments

🤖 Generated with [Claude Code](https://claude.com/claude-code)