### PR TITLE
refactor(telegram): use pending link instead of deep link token for re-link

### DIFF
--- a/turbo/apps/platform/src/signals/integrations-page/github-settings-page.ts
+++ b/turbo/apps/platform/src/signals/integrations-page/github-settings-page.ts
@@ -1,14 +1,31 @@
 import { command } from "ccstate";
 import { createElement } from "react";
 import { updatePage$ } from "../react-router";
+import { navigate$ } from "../route.ts";
 import { GitHubSettingsPage } from "../../views/integrations-page/github-settings-page";
-import { fetchGitHubIntegration$ } from "./github-integration.ts";
+import {
+  fetchGitHubIntegration$,
+  githubIntegrationNotLinked$,
+} from "./github-integration.ts";
 import { fetchAgentsList$ } from "../agents-page/agents-list.ts";
 
 /**
  * Setup the GitHub settings detail page.
+ * Redirects to integrations tab if not linked.
  */
-export const setupGitHubSettingsPage$ = command(async ({ set }) => {
-  set(updatePage$, createElement(GitHubSettingsPage));
-  await Promise.all([set(fetchGitHubIntegration$), set(fetchAgentsList$)]);
-});
+export const setupGitHubSettingsPage$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    set(updatePage$, createElement(GitHubSettingsPage));
+    await Promise.all([set(fetchGitHubIntegration$), set(fetchAgentsList$)]);
+    signal.throwIfAborted();
+
+    if (get(githubIntegrationNotLinked$)) {
+      await set(
+        navigate$,
+        "/settings",
+        { searchParams: new URLSearchParams({ tab: "integrations" }) },
+        signal,
+      );
+    }
+  },
+);

--- a/turbo/apps/platform/src/signals/integrations-page/slack-settings-page.ts
+++ b/turbo/apps/platform/src/signals/integrations-page/slack-settings-page.ts
@@ -1,14 +1,31 @@
 import { command } from "ccstate";
 import { createElement } from "react";
 import { updatePage$ } from "../react-router";
+import { navigate$ } from "../route.ts";
 import { SlackSettingsPage } from "../../views/integrations-page/slack-settings-page";
-import { fetchSlackIntegration$ } from "./slack-integration.ts";
+import {
+  fetchSlackIntegration$,
+  slackIntegrationNotLinked$,
+} from "./slack-integration.ts";
 import { fetchAgentsList$ } from "../agents-page/agents-list.ts";
 
 /**
  * Setup the Slack settings detail page.
+ * Redirects to integrations tab if not linked.
  */
-export const setupSlackSettingsPage$ = command(async ({ set }) => {
-  set(updatePage$, createElement(SlackSettingsPage));
-  await Promise.all([set(fetchSlackIntegration$), set(fetchAgentsList$)]);
-});
+export const setupSlackSettingsPage$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    set(updatePage$, createElement(SlackSettingsPage));
+    await Promise.all([set(fetchSlackIntegration$), set(fetchAgentsList$)]);
+    signal.throwIfAborted();
+
+    if (get(slackIntegrationNotLinked$)) {
+      await set(
+        navigate$,
+        "/settings",
+        { searchParams: new URLSearchParams({ tab: "integrations" }) },
+        signal,
+      );
+    }
+  },
+);

--- a/turbo/apps/platform/src/signals/integrations-page/telegram-integration.ts
+++ b/turbo/apps/platform/src/signals/integrations-page/telegram-integration.ts
@@ -7,6 +7,7 @@ import { logger } from "../log.ts";
 const L = logger("TelegramIntegration");
 
 interface TelegramIntegrationData {
+  installationId: string;
   bot: { id: string; username: string };
   agent: { id: string; name: string; scopeSlug: string } | null;
   isAdmin: boolean;
@@ -152,6 +153,31 @@ export const updateTelegramDefaultAgent$ = command(
     }
   },
 );
+
+export const linkTelegramAccount$ = command(async ({ get, set }) => {
+  const data = get(telegramIntegrationState$).data;
+  if (!data) {
+    return;
+  }
+
+  const fetchFn = get(fetch$);
+  const response = await fetchFn("/api/integrations/telegram/link", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ installationId: data.installationId }),
+  });
+
+  if (!response.ok) {
+    const err = (await response.json()) as { error?: { message?: string } };
+    toast.error(err.error?.message ?? "Failed to link account");
+    return;
+  }
+
+  toast.success("Account linked successfully");
+
+  // Refresh integration data to clear needsLink banner
+  await set(fetchTelegramIntegration$);
+});
 
 export const disconnectTelegram$ = command(async ({ get, set }) => {
   const fetchFn = get(fetch$);

--- a/turbo/apps/platform/src/signals/integrations-page/telegram-integration.ts
+++ b/turbo/apps/platform/src/signals/integrations-page/telegram-integration.ts
@@ -7,11 +7,9 @@ import { logger } from "../log.ts";
 const L = logger("TelegramIntegration");
 
 interface TelegramIntegrationData {
-  installationId: string;
   bot: { id: string; username: string };
   agent: { id: string; name: string; scopeSlug: string } | null;
   isAdmin: boolean;
-  needsLink: boolean;
   environment: {
     requiredSecrets: string[];
     requiredVars: string[];
@@ -153,31 +151,6 @@ export const updateTelegramDefaultAgent$ = command(
     }
   },
 );
-
-export const linkTelegramAccount$ = command(async ({ get, set }) => {
-  const data = get(telegramIntegrationState$).data;
-  if (!data) {
-    return;
-  }
-
-  const fetchFn = get(fetch$);
-  const response = await fetchFn("/api/integrations/telegram/link", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ installationId: data.installationId }),
-  });
-
-  if (!response.ok) {
-    const err = (await response.json()) as { error?: { message?: string } };
-    toast.error(err.error?.message ?? "Failed to link account");
-    return;
-  }
-
-  toast.success("Account linked successfully");
-
-  // Refresh integration data to clear needsLink banner
-  await set(fetchTelegramIntegration$);
-});
 
 export const disconnectTelegram$ = command(async ({ get, set }) => {
   const fetchFn = get(fetch$);

--- a/turbo/apps/platform/src/signals/integrations-page/telegram-settings-page.ts
+++ b/turbo/apps/platform/src/signals/integrations-page/telegram-settings-page.ts
@@ -1,14 +1,31 @@
 import { command } from "ccstate";
 import { createElement } from "react";
 import { updatePage$ } from "../react-router";
+import { navigate$ } from "../route.ts";
 import { TelegramSettingsPage } from "../../views/integrations-page/telegram-settings-page";
-import { fetchTelegramIntegration$ } from "./telegram-integration.ts";
+import {
+  fetchTelegramIntegration$,
+  telegramIntegrationNotLinked$,
+} from "./telegram-integration.ts";
 import { fetchAgentsList$ } from "../agents-page/agents-list.ts";
 
 /**
  * Setup the Telegram settings detail page.
+ * Redirects to integrations tab if not linked.
  */
-export const setupTelegramSettingsPage$ = command(async ({ set }) => {
-  set(updatePage$, createElement(TelegramSettingsPage));
-  await Promise.all([set(fetchTelegramIntegration$), set(fetchAgentsList$)]);
-});
+export const setupTelegramSettingsPage$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    set(updatePage$, createElement(TelegramSettingsPage));
+    await Promise.all([set(fetchTelegramIntegration$), set(fetchAgentsList$)]);
+    signal.throwIfAborted();
+
+    if (get(telegramIntegrationNotLinked$)) {
+      await set(
+        navigate$,
+        "/settings",
+        { searchParams: new URLSearchParams({ tab: "integrations" }) },
+        signal,
+      );
+    }
+  },
+);

--- a/turbo/apps/platform/src/signals/telegram-connect/telegram-connect-page.ts
+++ b/turbo/apps/platform/src/signals/telegram-connect/telegram-connect-page.ts
@@ -34,10 +34,9 @@ export const setupTelegramConnectPage$ = command(
       return;
     }
 
-    // Pass ?bot= and ?uid= params to init so it can look up existing installation
+    // Pass ?bot= param to init so it can look up existing installation
     const params = get(searchParams$);
     const botId = params.get("bot") ?? undefined;
-    const telegramUserId = params.get("uid") ?? undefined;
-    await set(initTelegramConnect$, botId, telegramUserId);
+    await set(initTelegramConnect$, botId);
   },
 );

--- a/turbo/apps/platform/src/signals/telegram-connect/telegram-connect-page.ts
+++ b/turbo/apps/platform/src/signals/telegram-connect/telegram-connect-page.ts
@@ -34,9 +34,10 @@ export const setupTelegramConnectPage$ = command(
       return;
     }
 
-    // Pass ?bot= param to init so it can look up existing installation
+    // Pass ?bot= and ?uid= params to init so it can look up existing installation
     const params = get(searchParams$);
     const botId = params.get("bot") ?? undefined;
-    await set(initTelegramConnect$, botId);
+    const telegramUserId = params.get("uid") ?? undefined;
+    await set(initTelegramConnect$, botId, telegramUserId);
   },
 );

--- a/turbo/apps/platform/src/signals/telegram-connect/telegram-connect.ts
+++ b/turbo/apps/platform/src/signals/telegram-connect/telegram-connect.ts
@@ -28,7 +28,6 @@ type RegisterTelegramBotResult =
       success: true;
       installationId: string;
       botUsername: string;
-      deepLink?: string;
     }
   | { success: false };
 
@@ -142,10 +141,7 @@ export const linkTelegramBot$ = command(
         throw new Error(data.error?.message ?? "Failed to link account");
       }
 
-      const data = (await response.json()) as {
-        token: string;
-        deepLink: string | null;
-      };
+      await response.json();
 
       set(telegramConnectState$, (prev) => ({
         ...prev,
@@ -156,7 +152,6 @@ export const linkTelegramBot$ = command(
         success: true,
         installationId,
         botUsername,
-        deepLink: data.deepLink ?? undefined,
       };
     } catch (error) {
       throwIfAbort(error);

--- a/turbo/apps/platform/src/signals/telegram-connect/telegram-connect.ts
+++ b/turbo/apps/platform/src/signals/telegram-connect/telegram-connect.ts
@@ -20,6 +20,7 @@ interface TelegramConnectState {
     | "error";
   isLinked: boolean;
   installation: TelegramInstallationInfo | null;
+  telegramUserId: string | null;
   error: string | null;
 }
 
@@ -35,6 +36,7 @@ const telegramConnectState$ = state<TelegramConnectState>({
   status: "checking",
   isLinked: false,
   installation: null,
+  telegramUserId: null,
   error: null,
 });
 
@@ -64,11 +66,12 @@ export const setTelegramBotToken$ = command(({ set }, value: string) => {
  * When botId is provided, also checks for an existing installation to enable re-linking.
  */
 export const initTelegramConnect$ = command(
-  async ({ get, set }, botId?: string) => {
+  async ({ get, set }, botId?: string, telegramUserId?: string) => {
     set(telegramConnectState$, {
       status: "checking",
       isLinked: false,
       installation: null,
+      telegramUserId: telegramUserId ?? null,
       error: null,
     });
 
@@ -93,6 +96,7 @@ export const initTelegramConnect$ = command(
         status: "ready",
         isLinked: data.linked,
         installation: data.installation ?? null,
+        telegramUserId: telegramUserId ?? null,
         error: null,
       });
     } catch (error) {
@@ -102,6 +106,7 @@ export const initTelegramConnect$ = command(
         status: "error",
         isLinked: false,
         installation: null,
+        telegramUserId: null,
         error: "Failed to check connection status. Please try again.",
       });
     }
@@ -128,10 +133,14 @@ export const linkTelegramBot$ = command(
 
     try {
       const fetchFn = get(fetch$);
+      const telegramUserId = get(telegramConnectState$).telegramUserId;
       const response = await fetchFn("/api/integrations/telegram/link", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ installationId }),
+        body: JSON.stringify({
+          installationId,
+          ...(telegramUserId ? { telegramUserId } : {}),
+        }),
       });
 
       if (!response.ok) {

--- a/turbo/apps/platform/src/signals/telegram-connect/telegram-connect.ts
+++ b/turbo/apps/platform/src/signals/telegram-connect/telegram-connect.ts
@@ -20,7 +20,6 @@ interface TelegramConnectState {
     | "error";
   isLinked: boolean;
   installation: TelegramInstallationInfo | null;
-  telegramUserId: string | null;
   error: string | null;
 }
 
@@ -36,7 +35,6 @@ const telegramConnectState$ = state<TelegramConnectState>({
   status: "checking",
   isLinked: false,
   installation: null,
-  telegramUserId: null,
   error: null,
 });
 
@@ -66,12 +64,11 @@ export const setTelegramBotToken$ = command(({ set }, value: string) => {
  * When botId is provided, also checks for an existing installation to enable re-linking.
  */
 export const initTelegramConnect$ = command(
-  async ({ get, set }, botId?: string, telegramUserId?: string) => {
+  async ({ get, set }, botId?: string) => {
     set(telegramConnectState$, {
       status: "checking",
       isLinked: false,
       installation: null,
-      telegramUserId: telegramUserId ?? null,
       error: null,
     });
 
@@ -96,7 +93,6 @@ export const initTelegramConnect$ = command(
         status: "ready",
         isLinked: data.linked,
         installation: data.installation ?? null,
-        telegramUserId: telegramUserId ?? null,
         error: null,
       });
     } catch (error) {
@@ -106,7 +102,6 @@ export const initTelegramConnect$ = command(
         status: "error",
         isLinked: false,
         installation: null,
-        telegramUserId: null,
         error: "Failed to check connection status. Please try again.",
       });
     }
@@ -133,14 +128,10 @@ export const linkTelegramBot$ = command(
 
     try {
       const fetchFn = get(fetch$);
-      const telegramUserId = get(telegramConnectState$).telegramUserId;
       const response = await fetchFn("/api/integrations/telegram/link", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          installationId,
-          ...(telegramUserId ? { telegramUserId } : {}),
-        }),
+        body: JSON.stringify({ installationId }),
       });
 
       if (!response.ok) {

--- a/turbo/apps/platform/src/views/integrations-page/telegram-settings-page.tsx
+++ b/turbo/apps/platform/src/views/integrations-page/telegram-settings-page.tsx
@@ -31,6 +31,7 @@ import {
   telegramIntegrationData$,
   telegramIntegrationLoading$,
   disconnectTelegram$,
+  linkTelegramAccount$,
   updateTelegramDefaultAgent$,
   telegramDisconnectDialogOpen$,
   openTelegramDisconnectDialog$,
@@ -55,29 +56,23 @@ function getAllConnectorEnvVars(): Set<string> {
 // Link account banner
 // ---------------------------------------------------------------------------
 
-function LinkAccountBanner({ botUsername }: { botUsername: string }) {
+function LinkAccountBanner() {
+  const linkAccount = useSet(linkTelegramAccount$);
+
   return (
     <div className="flex items-center gap-3 rounded-lg border border-blue-500 bg-blue-50 px-4 py-3 dark:border-blue-700 dark:bg-blue-950/30">
       <IconLink size={20} className="shrink-0 text-blue-500" stroke={1.5} />
       <div className="flex flex-1 flex-col gap-1">
         <p className="text-sm font-medium">Link your Telegram account</p>
         <p className="text-sm text-muted-foreground">
-          Open the bot in Telegram and press Start to link your account. This
-          lets you chat with the agent directly.
+          Link your account to chat with the agent in Telegram.
         </p>
       </div>
       <Button
-        variant="outline"
         size="sm"
-        onClick={() =>
-          window.open(
-            `https://t.me/${botUsername}`,
-            "_blank",
-            "noopener,noreferrer",
-          )
-        }
+        onClick={() => detach(linkAccount(), Reason.DomCallback)}
       >
-        Open in Telegram
+        Link Account
       </Button>
     </div>
   );
@@ -288,9 +283,7 @@ export function TelegramSettingsPage() {
         ) : (
           <>
             {/* Link account banner */}
-            {data?.needsLink && data.bot && (
-              <LinkAccountBanner botUsername={data.bot.username} />
-            )}
+            {data?.needsLink && data.bot && <LinkAccountBanner />}
 
             {/* Bot info */}
             {data?.bot && (

--- a/turbo/apps/platform/src/views/integrations-page/telegram-settings-page.tsx
+++ b/turbo/apps/platform/src/views/integrations-page/telegram-settings-page.tsx
@@ -1,9 +1,5 @@
 import { useGet, useSet } from "ccstate-react";
-import {
-  IconAlertTriangle,
-  IconChevronDown,
-  IconLink,
-} from "@tabler/icons-react";
+import { IconAlertTriangle, IconChevronDown } from "@tabler/icons-react";
 import {
   CONNECTOR_TYPES,
   getConnectorProvidedSecretNames,
@@ -31,7 +27,6 @@ import {
   telegramIntegrationData$,
   telegramIntegrationLoading$,
   disconnectTelegram$,
-  linkTelegramAccount$,
   updateTelegramDefaultAgent$,
   telegramDisconnectDialogOpen$,
   openTelegramDisconnectDialog$,
@@ -49,32 +44,6 @@ import { Link } from "../router/link.tsx";
 function getAllConnectorEnvVars(): Set<string> {
   return getConnectorProvidedSecretNames(
     Object.keys(CONNECTOR_TYPES) as ConnectorType[],
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Link account banner
-// ---------------------------------------------------------------------------
-
-function LinkAccountBanner() {
-  const linkAccount = useSet(linkTelegramAccount$);
-
-  return (
-    <div className="flex items-center gap-3 rounded-lg border border-blue-500 bg-blue-50 px-4 py-3 dark:border-blue-700 dark:bg-blue-950/30">
-      <IconLink size={20} className="shrink-0 text-blue-500" stroke={1.5} />
-      <div className="flex flex-1 flex-col gap-1">
-        <p className="text-sm font-medium">Link your Telegram account</p>
-        <p className="text-sm text-muted-foreground">
-          Link your account to chat with the agent in Telegram.
-        </p>
-      </div>
-      <Button
-        size="sm"
-        onClick={() => detach(linkAccount(), Reason.DomCallback)}
-      >
-        Link Account
-      </Button>
-    </div>
   );
 }
 
@@ -283,8 +252,6 @@ export function TelegramSettingsPage() {
         ) : (
           <>
             {/* Link account banner */}
-            {data?.needsLink && data.bot && <LinkAccountBanner />}
-
             {/* Bot info */}
             {data?.bot && (
               <div className="flex flex-col gap-4">

--- a/turbo/apps/platform/src/views/telegram-connect/__tests__/telegram-connect-success-page.test.tsx
+++ b/turbo/apps/platform/src/views/telegram-connect/__tests__/telegram-connect-success-page.test.tsx
@@ -25,12 +25,8 @@ describe("telegram connect success page", () => {
 
     expect(context.store.get(pathname$)).toBe("/telegram/connect/success");
 
-    expect(screen.getByText("Telegram bot installed")).toBeInTheDocument();
-    expect(
-      screen.getByText(
-        "Your Telegram bot is now installed on VM0. You can start using it right away.",
-      ),
-    ).toBeInTheDocument();
+    expect(screen.getByText("Telegram Bot Connected")).toBeInTheDocument();
+    expect(screen.getByText(/Your account is linked/)).toBeInTheDocument();
 
     // Should show Telegram button
     const telegramButton = screen.getByRole("button", {
@@ -52,7 +48,7 @@ describe("telegram connect success page", () => {
       path: "/telegram/connect/success",
     });
 
-    expect(screen.getByText("Telegram bot installed")).toBeInTheDocument();
+    expect(screen.getByText("Telegram Bot Connected")).toBeInTheDocument();
 
     // Should NOT show "Open in Telegram" button
     expect(

--- a/turbo/apps/platform/src/views/telegram-connect/telegram-connect-page.tsx
+++ b/turbo/apps/platform/src/views/telegram-connect/telegram-connect-page.tsx
@@ -56,9 +56,6 @@ export function TelegramConnectPage() {
         if (result.success) {
           const successParams = new URLSearchParams();
           successParams.set("bot", result.botUsername);
-          if (result.deepLink) {
-            successParams.set("deepLink", result.deepLink);
-          }
           navigate("/telegram/connect/success", {
             searchParams: successParams,
           });

--- a/turbo/apps/platform/src/views/telegram-connect/telegram-connect-success-page.tsx
+++ b/turbo/apps/platform/src/views/telegram-connect/telegram-connect-success-page.tsx
@@ -9,9 +9,7 @@ export function TelegramConnectSuccessPage() {
   const params = useGet(searchParams$);
 
   const botUsername = params.get("bot");
-  const deepLink = params.get("deepLink");
-  const telegramLink =
-    deepLink ?? (botUsername ? `https://t.me/${botUsername}` : null);
+  const telegramLink = botUsername ? `https://t.me/${botUsername}` : null;
 
   const backgroundGradient =
     theme === "dark"
@@ -44,11 +42,11 @@ export function TelegramConnectSuccessPage() {
 
               <div className="flex flex-col gap-1 text-center text-foreground">
                 <h1 className="text-lg font-medium leading-7">
-                  Telegram bot installed
+                  Telegram Bot Connected
                 </h1>
                 <p className="text-sm leading-5 text-muted-foreground">
-                  Your Telegram bot is now installed on VM0. You can start using
-                  it right away.
+                  Your account is linked. Open Telegram and send any message to
+                  the bot to start chatting with the agent.
                 </p>
               </div>
             </div>

--- a/turbo/apps/web/app/api/integrations/telegram/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/integrations/telegram/__tests__/route.test.ts
@@ -71,11 +71,10 @@ describe("/api/integrations/telegram", () => {
       expect(data.bot.username).toBeDefined();
       expect(data.agent).toBeDefined();
       expect(data.isAdmin).toBe(true);
-      expect(data.needsLink).toBe(false);
       expect(data.environment).toBeDefined();
     });
 
-    it("returns bot info with needsLink when admin has no user link", async () => {
+    it("returns 404 when admin has no user link", async () => {
       const user = await context.setupUser();
       // Create installation with admin but no user link (omit vm0UserId)
       await createTestTelegramInstallation({
@@ -86,13 +85,8 @@ describe("/api/integrations/telegram", () => {
         "http://localhost:3000/api/integrations/telegram",
       );
       const response = await GET(request);
-      const data = await response.json();
 
-      expect(response.status).toBe(200);
-      expect(data.bot.id).toBeDefined();
-      expect(data.bot.username).toBeDefined();
-      expect(data.isAdmin).toBe(true);
-      expect(data.needsLink).toBe(true);
+      expect(response.status).toBe(404);
     });
   });
 

--- a/turbo/apps/web/app/api/integrations/telegram/link/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/integrations/telegram/link/__tests__/route.test.ts
@@ -1,12 +1,13 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { GET, POST } from "../route";
-import { verifyLinkToken } from "../../../../../../src/lib/telegram/handlers/start";
 import {
   testContext,
   uniqueId,
 } from "../../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
 import { createTestTelegramInstallation } from "../../../../../../src/__tests__/api-test-helpers";
+import { PENDING_TELEGRAM_USER_ID } from "../../../../../../src/lib/telegram/handlers/shared";
+import { telegramUserLinkExists } from "../../../../../../src/lib/telegram/__tests__/helpers";
 
 const context = testContext();
 
@@ -144,30 +145,27 @@ describe("/api/integrations/telegram/link", () => {
       expect(data.error.code).toBe("NOT_FOUND");
     });
 
-    it("generates a valid deep link token", async () => {
+    it("creates a pending user link and returns bot info", async () => {
       const user = await context.setupUser();
+      const telegramBotId = uniqueId("bot");
       const installationId = await createTestTelegramInstallation({
         adminUserId: user.userId,
-        vm0UserId: user.userId,
+        telegramBotId,
       });
 
       const response = await POST(linkRequest("POST", { installationId }));
       const data = await response.json();
 
       expect(response.status).toBe(200);
-      expect(data.token).toBeDefined();
-      expect(data.deepLink).toContain("https://t.me/");
-      expect(data.deepLink).toContain(`?start=${data.token}`);
+      expect(data.botUsername).toBe(`bot_${telegramBotId}`);
+      expect(data.botLink).toContain("https://t.me/");
 
-      // Verify the token is valid using the exported verifier
-      const { SECRETS_ENCRYPTION_KEY } = globalThis.services.env;
-      const payload = verifyLinkToken(data.token, SECRETS_ENCRYPTION_KEY);
-      expect(payload).toEqual(
-        expect.objectContaining({
-          vm0UserId: user.userId,
-          installationId,
-        }),
+      // Verify pending user link was created
+      const exists = await telegramUserLinkExists(
+        installationId,
+        PENDING_TELEGRAM_USER_ID,
       );
+      expect(exists).toBe(true);
     });
   });
 });

--- a/turbo/apps/web/app/api/integrations/telegram/link/route.ts
+++ b/turbo/apps/web/app/api/integrations/telegram/link/route.ts
@@ -2,11 +2,13 @@ import { NextResponse } from "next/server";
 import { eq, desc } from "drizzle-orm";
 import { z } from "zod";
 import { initServices } from "../../../../../src/lib/init-services";
-import { env } from "../../../../../src/env";
 import { getUserId } from "../../../../../src/lib/auth/get-user-id";
 import { telegramUserLinks } from "../../../../../src/db/schema/telegram-user-link";
 import { telegramInstallations } from "../../../../../src/db/schema/telegram-installation";
-import { createLinkToken } from "../../../../../src/lib/telegram/handlers/start";
+import {
+  ensureScopeAndArtifact,
+  PENDING_TELEGRAM_USER_ID,
+} from "../../../../../src/lib/telegram/handlers/shared";
 
 const linkBodySchema = z.object({
   installationId: z.string().min(1),
@@ -49,9 +51,9 @@ export async function GET(request: Request) {
   }
 
   // If not linked, check if a specific bot was requested via ?botId= param.
-  // This returns the installation ID and botUsername so the frontend can show
-  // a re-link UI. Actual linking is gated by an HMAC-signed deep link token
-  // that must be activated via Telegram interaction (see /start handler).
+  // Returns installation info so the frontend can show a re-link UI.
+  // Actual linking creates a pending user link that auto-completes on first
+  // Telegram message (see resolveUserLink in shared.ts).
   const url = new URL(request.url);
   const botId = url.searchParams.get("botId");
 
@@ -82,7 +84,8 @@ export async function GET(request: Request) {
 /**
  * POST /api/integrations/telegram/link
  *
- * Generate a deep link token for account linking via Telegram.
+ * Create a pending user link for account linking via Telegram.
+ * The link auto-completes when the user sends their first message to the bot.
  * Body: { installationId: string }
  */
 export async function POST(request: Request) {
@@ -129,17 +132,20 @@ export async function POST(request: Request) {
     );
   }
 
-  const { SECRETS_ENCRYPTION_KEY } = env();
+  // Create pending user link (auto-completes on first Telegram message)
+  await globalThis.services.db
+    .insert(telegramUserLinks)
+    .values({
+      telegramUserId: PENDING_TELEGRAM_USER_ID,
+      installationId: installation.id,
+      vm0UserId: userId,
+    })
+    .onConflictDoNothing();
+  await ensureScopeAndArtifact(userId);
 
-  const token = createLinkToken(
-    userId,
-    installation.id,
-    SECRETS_ENCRYPTION_KEY,
-  );
-
-  const deepLink = installation.botUsername
-    ? `https://t.me/${installation.botUsername}?start=${token}`
+  const botLink = installation.botUsername
+    ? `https://t.me/${installation.botUsername}`
     : null;
 
-  return NextResponse.json({ token, deepLink });
+  return NextResponse.json({ botUsername: installation.botUsername, botLink });
 }

--- a/turbo/apps/web/app/api/integrations/telegram/link/route.ts
+++ b/turbo/apps/web/app/api/integrations/telegram/link/route.ts
@@ -7,23 +7,11 @@ import { telegramUserLinks } from "../../../../../src/db/schema/telegram-user-li
 import { telegramInstallations } from "../../../../../src/db/schema/telegram-installation";
 import {
   ensureScopeAndArtifact,
-  getWorkspaceAgent,
   PENDING_TELEGRAM_USER_ID,
 } from "../../../../../src/lib/telegram/handlers/shared";
-import { decryptCredentialValue } from "../../../../../src/lib/crypto/secrets-encryption";
-import { env } from "../../../../../src/env";
-import {
-  createTelegramClient,
-  sendMessage,
-} from "../../../../../src/lib/telegram/client";
-import { escapeHtml } from "../../../../../src/lib/telegram/format";
-import { logger } from "../../../../../src/lib/logger";
-
-const log = logger("telegram:link");
 
 const linkBodySchema = z.object({
   installationId: z.string().min(1),
-  telegramUserId: z.string().min(1).optional(),
 });
 
 /**
@@ -127,9 +115,12 @@ export async function POST(request: Request) {
   }
   const body = parseResult.data;
 
-  // Look up installation to get botUsername and bot token
+  // Look up installation to get botUsername
   const [installation] = await globalThis.services.db
-    .select()
+    .select({
+      id: telegramInstallations.id,
+      botUsername: telegramInstallations.botUsername,
+    })
     .from(telegramInstallations)
     .where(eq(telegramInstallations.id, body.installationId))
     .limit(1);
@@ -141,39 +132,17 @@ export async function POST(request: Request) {
     );
   }
 
-  const telegramUserId = body.telegramUserId ?? PENDING_TELEGRAM_USER_ID;
-
-  // Create user link (real if telegramUserId provided, pending otherwise)
+  // Create a pending user link — it auto-completes when the user sends
+  // their first message to the bot (see resolveUserLink in shared.ts).
   await globalThis.services.db
     .insert(telegramUserLinks)
     .values({
-      telegramUserId,
+      telegramUserId: PENDING_TELEGRAM_USER_ID,
       installationId: installation.id,
       vm0UserId: userId,
     })
     .onConflictDoNothing();
   await ensureScopeAndArtifact(userId);
-
-  // Send confirmation message via bot if we have a real telegramUserId
-  if (body.telegramUserId) {
-    try {
-      const { SECRETS_ENCRYPTION_KEY } = env();
-      const botToken = decryptCredentialValue(
-        installation.encryptedBotToken,
-        SECRETS_ENCRYPTION_KEY,
-      );
-      const client = createTelegramClient(botToken);
-      const agent = await getWorkspaceAgent(installation.defaultComposeId);
-      const agentName = agent?.name ?? "Agent";
-      await sendMessage(
-        client,
-        body.telegramUserId,
-        `🎉 Account connected! 🤖 ${escapeHtml(agentName)} is ready.\n\nSend a message to start chatting.`,
-      );
-    } catch (error) {
-      log.warn("Failed to send connect confirmation", { error });
-    }
-  }
 
   const botLink = installation.botUsername
     ? `https://t.me/${installation.botUsername}`

--- a/turbo/apps/web/app/api/integrations/telegram/link/route.ts
+++ b/turbo/apps/web/app/api/integrations/telegram/link/route.ts
@@ -7,11 +7,23 @@ import { telegramUserLinks } from "../../../../../src/db/schema/telegram-user-li
 import { telegramInstallations } from "../../../../../src/db/schema/telegram-installation";
 import {
   ensureScopeAndArtifact,
+  getWorkspaceAgent,
   PENDING_TELEGRAM_USER_ID,
 } from "../../../../../src/lib/telegram/handlers/shared";
+import { decryptCredentialValue } from "../../../../../src/lib/crypto/secrets-encryption";
+import { env } from "../../../../../src/env";
+import {
+  createTelegramClient,
+  sendMessage,
+} from "../../../../../src/lib/telegram/client";
+import { escapeHtml } from "../../../../../src/lib/telegram/format";
+import { logger } from "../../../../../src/lib/logger";
+
+const log = logger("telegram:link");
 
 const linkBodySchema = z.object({
   installationId: z.string().min(1),
+  telegramUserId: z.string().min(1).optional(),
 });
 
 /**
@@ -115,12 +127,9 @@ export async function POST(request: Request) {
   }
   const body = parseResult.data;
 
-  // Look up installation to get botUsername
+  // Look up installation to get botUsername and bot token
   const [installation] = await globalThis.services.db
-    .select({
-      id: telegramInstallations.id,
-      botUsername: telegramInstallations.botUsername,
-    })
+    .select()
     .from(telegramInstallations)
     .where(eq(telegramInstallations.id, body.installationId))
     .limit(1);
@@ -132,16 +141,39 @@ export async function POST(request: Request) {
     );
   }
 
-  // Create pending user link (auto-completes on first Telegram message)
+  const telegramUserId = body.telegramUserId ?? PENDING_TELEGRAM_USER_ID;
+
+  // Create user link (real if telegramUserId provided, pending otherwise)
   await globalThis.services.db
     .insert(telegramUserLinks)
     .values({
-      telegramUserId: PENDING_TELEGRAM_USER_ID,
+      telegramUserId,
       installationId: installation.id,
       vm0UserId: userId,
     })
     .onConflictDoNothing();
   await ensureScopeAndArtifact(userId);
+
+  // Send confirmation message via bot if we have a real telegramUserId
+  if (body.telegramUserId) {
+    try {
+      const { SECRETS_ENCRYPTION_KEY } = env();
+      const botToken = decryptCredentialValue(
+        installation.encryptedBotToken,
+        SECRETS_ENCRYPTION_KEY,
+      );
+      const client = createTelegramClient(botToken);
+      const agent = await getWorkspaceAgent(installation.defaultComposeId);
+      const agentName = agent?.name ?? "Agent";
+      await sendMessage(
+        client,
+        body.telegramUserId,
+        `🎉 Account connected! 🤖 ${escapeHtml(agentName)} is ready.\n\nSend a message to start chatting.`,
+      );
+    } catch (error) {
+      log.warn("Failed to send connect confirmation", { error });
+    }
+  }
 
   const botLink = installation.botUsername
     ? `https://t.me/${installation.botUsername}`

--- a/turbo/apps/web/app/api/integrations/telegram/route.ts
+++ b/turbo/apps/web/app/api/integrations/telegram/route.ts
@@ -62,34 +62,23 @@ export async function GET(request: Request) {
     .orderBy(desc(telegramUserLinks.createdAt))
     .limit(1);
 
-  let installation;
-  let needsLink = false;
-
-  if (userLink) {
-    // Get bot installation via user link
-    const [linked] = await db
-      .select()
-      .from(telegramInstallations)
-      .where(eq(telegramInstallations.id, userLink.installationId))
-      .limit(1);
-    installation = linked;
-  } else {
-    // Fallback: check if user is admin of any installation
-    const [adminInstallation] = await db
-      .select()
-      .from(telegramInstallations)
-      .where(eq(telegramInstallations.adminUserId, userId))
-      .orderBy(desc(telegramInstallations.createdAt))
-      .limit(1);
-    installation = adminInstallation;
-    needsLink = !!adminInstallation;
+  if (!userLink) {
+    return NextResponse.json(
+      { error: { message: "No linked Telegram bot", code: "NOT_FOUND" } },
+      { status: 404 },
+    );
   }
+
+  // Get bot installation via user link
+  const [installation] = await db
+    .select()
+    .from(telegramInstallations)
+    .where(eq(telegramInstallations.id, userLink.installationId))
+    .limit(1);
 
   if (!installation) {
     return NextResponse.json(
-      {
-        error: { message: "No linked Telegram bot", code: "NOT_FOUND" },
-      },
+      { error: { message: "No linked Telegram bot", code: "NOT_FOUND" } },
       { status: 404 },
     );
   }
@@ -157,7 +146,6 @@ export async function GET(request: Request) {
   const isAdmin = installation.adminUserId === userId;
 
   return NextResponse.json({
-    installationId: installation.id,
     bot: {
       id: installation.telegramBotId,
       username: installation.botUsername,
@@ -166,7 +154,6 @@ export async function GET(request: Request) {
       ? { id: compose.id, name: compose.name, scopeSlug: compose.scopeSlug }
       : null,
     isAdmin,
-    needsLink,
     environment: {
       requiredSecrets,
       requiredVars,

--- a/turbo/apps/web/app/api/integrations/telegram/route.ts
+++ b/turbo/apps/web/app/api/integrations/telegram/route.ts
@@ -157,6 +157,7 @@ export async function GET(request: Request) {
   const isAdmin = installation.adminUserId === userId;
 
   return NextResponse.json({
+    installationId: installation.id,
     bot: {
       id: installation.telegramBotId,
       username: installation.botUsername,

--- a/turbo/apps/web/app/api/internal/callbacks/telegram/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/telegram/route.ts
@@ -33,6 +33,7 @@ interface CallbackPayload {
   installationId: string;
   chatId: string;
   messageId: string;
+  rootMessageId: string | null;
   userLinkId: string;
   agentName: string;
   composeId: string;
@@ -58,6 +59,7 @@ function parsePayload(payload: unknown): CallbackPayload | null {
     installationId: p.installationId,
     chatId: p.chatId,
     messageId: p.messageId,
+    rootMessageId: typeof p.rootMessageId === "string" ? p.rootMessageId : null,
     userLinkId: p.userLinkId,
     agentName: p.agentName,
     composeId: p.composeId,
@@ -110,6 +112,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     installationId,
     chatId,
     messageId,
+    rootMessageId: payloadRootMessageId,
     userLinkId,
     agentName,
     composeId,
@@ -217,17 +220,15 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       ? await findNewSessionId(run.userId, composeId, run.createdAt)
       : undefined;
 
-    // For DMs, always use "dm" sentinel; for groups, use message-based anchors
-    const rootMessageId = isDM
-      ? "dm"
-      : existingSessionId
-        ? messageId // Existing thread — use original anchor
-        : String(botReplyMessageId); // New thread — bot's reply is the anchor
+    // Use bot's latest reply as rootMessageId so the user can continue
+    // the session by replying to any bot response.
+    const newRootMessageId = isDM ? "dm" : String(botReplyMessageId);
 
     await saveTelegramThreadSession({
       userLinkId,
       chatId,
-      rootMessageId,
+      rootMessageId: newRootMessageId,
+      previousRootMessageId: payloadRootMessageId ?? undefined,
       existingSessionId: existingSessionId ?? undefined,
       newSessionId,
       messageId,

--- a/turbo/apps/web/app/api/telegram/webhook/__tests__/commands.test.ts
+++ b/turbo/apps/web/app/api/telegram/webhook/__tests__/commands.test.ts
@@ -352,7 +352,7 @@ describe("Telegram bot commands", () => {
       await flushAfterCallbacks();
 
       expect(sendMsg.mocked).toHaveBeenCalled();
-      expect(sendMsg.calls[0]?.text).toContain("link your account");
+      expect(sendMsg.calls[0]?.text).toContain("connect your account");
     });
 
     it("should be ignored in group chats", async () => {

--- a/turbo/apps/web/app/api/telegram/webhook/__tests__/commands.test.ts
+++ b/turbo/apps/web/app/api/telegram/webhook/__tests__/commands.test.ts
@@ -352,7 +352,7 @@ describe("Telegram bot commands", () => {
       await flushAfterCallbacks();
 
       expect(sendMsg.mocked).toHaveBeenCalled();
-      expect(sendMsg.calls[0]?.text).toContain("connect your account");
+      expect(sendMsg.calls[0]?.text).toContain("Connect your account");
     });
 
     it("should be ignored in group chats", async () => {

--- a/turbo/apps/web/src/lib/telegram/context.ts
+++ b/turbo/apps/web/src/lib/telegram/context.ts
@@ -5,7 +5,7 @@ import { logger } from "../logger";
 const log = logger("telegram:context");
 
 /** Maximum number of recent messages to fetch for context */
-const MAX_CONTEXT_MESSAGES = 50;
+const MAX_CONTEXT_MESSAGES = 10;
 
 const CONTEXT_PREAMBLE = [
   "The messages below are from a Telegram conversation. When responding:",

--- a/turbo/apps/web/src/lib/telegram/handlers/commands.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/commands.ts
@@ -59,7 +59,7 @@ export async function handleConnectCommand(
   }
 
   const platformUrl = getPlatformUrl();
-  const connectUrl = `${platformUrl}/telegram/connect?bot=${installation.telegramBotId}`;
+  const connectUrl = `${platformUrl}/telegram/connect?bot=${installation.telegramBotId}&uid=${fromUserId}`;
   await sendMessage(
     client,
     chatId,

--- a/turbo/apps/web/src/lib/telegram/handlers/commands.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/commands.ts
@@ -169,7 +169,7 @@ export async function handleSettingsCommand(
   await sendMessage(
     client,
     chatId,
-    `⚙️ <b>Settings</b>\n${escapeHtml(desc)}\n\n<a href="${escapeHtml(platformUrl)}/settings/telegram">Open Platform</a>`,
+    `⚙️ <b>Settings</b>\n\n${escapeHtml(desc)}\n\n<a href="${escapeHtml(platformUrl)}/settings/telegram">Open Platform</a>`,
   );
 }
 

--- a/turbo/apps/web/src/lib/telegram/handlers/commands.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/commands.ts
@@ -63,7 +63,7 @@ export async function handleConnectCommand(
   await sendMessage(
     client,
     chatId,
-    `Visit the platform to connect your account:\n<a href="${escapeHtml(connectUrl)}">Open Platform</a>`,
+    `🔗 Connect your account to get started:\n\n<a href="${escapeHtml(connectUrl)}">Open Platform</a>`,
   );
 }
 

--- a/turbo/apps/web/src/lib/telegram/handlers/commands.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/commands.ts
@@ -65,7 +65,7 @@ export async function handleConnectCommand(
   }
 
   const platformUrl = getPlatformUrl();
-  const connectUrl = `${platformUrl}/telegram/connect?bot=${installation.telegramBotId}&uid=${fromUserId}`;
+  const connectUrl = `${platformUrl}/telegram/connect?bot=${installation.telegramBotId}`;
   await sendMessage(
     client,
     chatId,
@@ -180,7 +180,7 @@ export async function handleSettingsCommand(
 
   if (!userLink) {
     const platformUrl = getPlatformUrl();
-    const connectUrl = `${platformUrl}/telegram/connect?bot=${installation.telegramBotId}&uid=${fromUserId}`;
+    const connectUrl = `${platformUrl}/telegram/connect?bot=${installation.telegramBotId}`;
     await sendMessage(
       client,
       chatId,

--- a/turbo/apps/web/src/lib/telegram/handlers/commands.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/commands.ts
@@ -47,6 +47,11 @@ export async function handleConnectCommand(
 
   const userLink = await resolveUserLink(installationId, fromUserId);
 
+  const replyOptions =
+    message.chat.type !== "private"
+      ? { replyToMessageId: message.message_id }
+      : undefined;
+
   if (userLink) {
     const agent = await getWorkspaceAgent(installation.defaultComposeId);
     const agentName = agent?.name ?? "Agent";
@@ -54,6 +59,7 @@ export async function handleConnectCommand(
       client,
       chatId,
       `You are already connected. 🤖 ${escapeHtml(agentName)} is ready.`,
+      replyOptions,
     );
     return;
   }
@@ -64,6 +70,7 @@ export async function handleConnectCommand(
     client,
     chatId,
     `🔗 Connect your account to get started:\n\n<a href="${escapeHtml(connectUrl)}">Open Platform</a>`,
+    replyOptions,
   );
 }
 
@@ -99,8 +106,13 @@ export async function handleDisconnectCommand(
 
   const userLink = await resolveUserLink(installationId, fromUserId);
 
+  const replyOptions =
+    message.chat.type !== "private"
+      ? { replyToMessageId: message.message_id }
+      : undefined;
+
   if (!userLink) {
-    await sendMessage(client, chatId, "You are not connected.");
+    await sendMessage(client, chatId, "You are not connected.", replyOptions);
     return;
   }
 
@@ -119,6 +131,7 @@ export async function handleDisconnectCommand(
     client,
     chatId,
     "You have been disconnected and your agent access has been revoked.",
+    replyOptions,
   );
 
   log.info("User disconnected", {
@@ -159,8 +172,25 @@ export async function handleSettingsCommand(
   const client = createTelegramClient(botToken);
 
   const userLink = await resolveUserLink(installationId, fromUserId);
-  const isAdmin = userLink?.vm0UserId === installation.adminUserId;
 
+  const replyOptions =
+    message.chat.type !== "private"
+      ? { replyToMessageId: message.message_id }
+      : undefined;
+
+  if (!userLink) {
+    const platformUrl = getPlatformUrl();
+    const connectUrl = `${platformUrl}/telegram/connect?bot=${installation.telegramBotId}&uid=${fromUserId}`;
+    await sendMessage(
+      client,
+      chatId,
+      `🔗 Connect your account to get started:\n\n<a href="${escapeHtml(connectUrl)}">Open Platform</a>`,
+      replyOptions,
+    );
+    return;
+  }
+
+  const isAdmin = userLink.vm0UserId === installation.adminUserId;
   const platformUrl = getPlatformUrl();
   const desc = isAdmin
     ? "Configure secrets, variables, and select the workspace agent on the VM0 platform."
@@ -170,6 +200,7 @@ export async function handleSettingsCommand(
     client,
     chatId,
     `⚙️ <b>Settings</b>\n\n${escapeHtml(desc)}\n\n<a href="${escapeHtml(platformUrl)}/settings/telegram">Open Platform</a>`,
+    replyOptions,
   );
 }
 
@@ -207,6 +238,11 @@ export async function handleHelpCommand(
   const isAdmin = userLink?.vm0UserId === installation.adminUserId;
   const botUsername = installation.botUsername ?? "bot";
 
+  const replyOptions =
+    message.chat.type !== "private"
+      ? { replyToMessageId: message.message_id }
+      : undefined;
+
   let helpText = `<b>Available commands:</b>\n\n`;
   helpText += `/new_session - Start a new conversation\n`;
   helpText += `/connect - Connect your VM0 account\n`;
@@ -219,5 +255,5 @@ export async function handleHelpCommand(
     helpText += `\n\nYou are the admin of this bot installation.`;
   }
 
-  await sendMessage(client, chatId, helpText);
+  await sendMessage(client, chatId, helpText, replyOptions);
 }

--- a/turbo/apps/web/src/lib/telegram/handlers/direct-message.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/direct-message.ts
@@ -137,6 +137,7 @@ export async function handleTelegramDirectMessage(
       installationId,
       chatId,
       messageId: String(message.message_id),
+      rootMessageId: "dm",
       userLinkId: userLink.id,
       agentName,
       composeId,

--- a/turbo/apps/web/src/lib/telegram/handlers/direct-message.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/direct-message.ts
@@ -59,7 +59,7 @@ export async function handleTelegramDirectMessage(
 
   if (!userLink) {
     const platformUrl = getPlatformUrl();
-    const connectUrl = `${platformUrl}/telegram/connect?bot=${installation.telegramBotId}&uid=${fromUserId}`;
+    const connectUrl = `${platformUrl}/telegram/connect?bot=${installation.telegramBotId}`;
     await sendMessage(
       client,
       chatId,

--- a/turbo/apps/web/src/lib/telegram/handlers/direct-message.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/direct-message.ts
@@ -2,7 +2,7 @@ import { eq } from "drizzle-orm";
 import { telegramInstallations } from "../../../db/schema/telegram-installation";
 import { decryptCredentialValue } from "../../crypto/secrets-encryption";
 import { env } from "../../../env";
-import { createTelegramClient, sendMessage } from "../client";
+import { createTelegramClient, sendMessage, deleteMessage } from "../client";
 import { sendThinkingMessage } from "./shared";
 import { fetchTelegramContext } from "../context";
 import { runAgentForTelegram } from "./run-agent";
@@ -150,6 +150,9 @@ export async function handleTelegramDirectMessage(
 
   if (status === "failed") {
     log.error("Failed to dispatch agent run", { response });
+    if (thinkingMessage) {
+      await deleteMessage(client, chatId, thinkingMessage.message_id);
+    }
     await sendMessage(
       client,
       chatId,

--- a/turbo/apps/web/src/lib/telegram/handlers/direct-message.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/direct-message.ts
@@ -59,7 +59,7 @@ export async function handleTelegramDirectMessage(
 
   if (!userLink) {
     const platformUrl = getPlatformUrl();
-    const connectUrl = `${platformUrl}/telegram/connect?bot=${installation.telegramBotId}`;
+    const connectUrl = `${platformUrl}/telegram/connect?bot=${installation.telegramBotId}&uid=${fromUserId}`;
     await sendMessage(
       client,
       chatId,

--- a/turbo/apps/web/src/lib/telegram/handlers/direct-message.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/direct-message.ts
@@ -63,7 +63,7 @@ export async function handleTelegramDirectMessage(
     await sendMessage(
       client,
       chatId,
-      `Please connect your account first:\n<a href="${escapeHtml(connectUrl)}">Open Platform</a>`,
+      `🔗 Connect your account to get started:\n\n<a href="${escapeHtml(connectUrl)}">Open Platform</a>`,
     );
     return;
   }

--- a/turbo/apps/web/src/lib/telegram/handlers/direct-message.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/direct-message.ts
@@ -13,6 +13,8 @@ import {
   resolveSessionCompose,
   resolveUserLink,
 } from "./shared";
+import { escapeHtml } from "../format";
+import { getPlatformUrl } from "../../url";
 import { logger } from "../../logger";
 import type { TelegramHandlerUpdate } from "./types";
 
@@ -56,10 +58,12 @@ export async function handleTelegramDirectMessage(
   const userLink = await resolveUserLink(installationId, fromUserId);
 
   if (!userLink) {
+    const platformUrl = getPlatformUrl();
+    const connectUrl = `${platformUrl}/telegram/connect?bot=${installation.telegramBotId}`;
     await sendMessage(
       client,
       chatId,
-      "Please link your account first. Use /connect to get started.",
+      `Please connect your account first:\n<a href="${escapeHtml(connectUrl)}">Open Platform</a>`,
     );
     return;
   }

--- a/turbo/apps/web/src/lib/telegram/handlers/mention.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/mention.ts
@@ -2,7 +2,7 @@ import { eq } from "drizzle-orm";
 import { telegramInstallations } from "../../../db/schema/telegram-installation";
 import { decryptCredentialValue } from "../../crypto/secrets-encryption";
 import { env } from "../../../env";
-import { createTelegramClient, sendMessage } from "../client";
+import { createTelegramClient, sendMessage, deleteMessage } from "../client";
 import { sendThinkingMessage } from "./shared";
 import { fetchTelegramContext } from "../context";
 import { runAgentForTelegram } from "./run-agent";
@@ -178,6 +178,9 @@ export async function handleTelegramMention(
 
   if (status === "failed") {
     log.error("Failed to dispatch agent run", { response });
+    if (thinkingMessage) {
+      await deleteMessage(client, chatId, thinkingMessage.message_id);
+    }
     await sendMessage(
       client,
       chatId,

--- a/turbo/apps/web/src/lib/telegram/handlers/mention.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/mention.ts
@@ -67,7 +67,7 @@ export async function handleTelegramMention(
 
   if (!userLink) {
     const platformUrl = getPlatformUrl();
-    const connectUrl = `${platformUrl}/telegram/connect?bot=${installation.telegramBotId}`;
+    const connectUrl = `${platformUrl}/telegram/connect?bot=${installation.telegramBotId}&uid=${fromUserId}`;
     await sendMessage(
       client,
       chatId,

--- a/turbo/apps/web/src/lib/telegram/handlers/mention.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/mention.ts
@@ -106,45 +106,15 @@ export async function handleTelegramMention(
     message.entities,
   );
 
-  // 7. Determine thread anchor
-  let rootMessageId: string | undefined;
-  if (
-    message.reply_to_message?.from?.is_bot &&
-    message.reply_to_message.message_id
-  ) {
-    // Replying to bot's message — use that as thread anchor
-    rootMessageId = String(message.reply_to_message.message_id);
-  }
-  // New mention (not replying) — rootMessageId set after bot replies in callback
-
-  // 8. Look up existing session
-  let existingSessionId: string | undefined;
-  let lastProcessedMessageId: string | undefined;
-  if (rootMessageId) {
-    const session = await lookupTelegramThreadSession(
+  // 7. Determine thread anchor and resolve session
+  const { rootMessageId, existingSessionId, lastProcessedMessageId } =
+    await resolveThreadSession(
+      message,
       chatId,
-      rootMessageId,
       userLink.id,
-    );
-    existingSessionId = session.existingSessionId;
-    lastProcessedMessageId = session.lastProcessedMessageId;
-  }
-
-  // 8b. Validate session's agent matches current default — discard only on positive mismatch
-  if (existingSessionId) {
-    const sessionCompose = await resolveSessionCompose(
-      existingSessionId,
       userLink.vm0UserId,
+      composeId,
     );
-    if (sessionCompose && sessionCompose.composeId !== composeId) {
-      log.debug("Agent changed, starting new session", {
-        sessionComposeId: sessionCompose.composeId,
-        currentComposeId: composeId,
-      });
-      existingSessionId = undefined;
-      lastProcessedMessageId = undefined;
-    }
-  }
 
   // 9. Fetch context
   const { executionContext } = await fetchTelegramContext(
@@ -189,6 +159,55 @@ export async function handleTelegramMention(
       { replyToMessageId: message.message_id },
     );
   }
+}
+
+async function resolveThreadSession(
+  message: TelegramHandlerUpdate["message"],
+  chatId: string,
+  userLinkId: string,
+  vm0UserId: string,
+  composeId: string,
+): Promise<{
+  rootMessageId: string | undefined;
+  existingSessionId: string | undefined;
+  lastProcessedMessageId: string | undefined;
+}> {
+  let rootMessageId: string | undefined;
+  if (
+    message.reply_to_message?.from?.is_bot &&
+    message.reply_to_message.message_id
+  ) {
+    rootMessageId = String(message.reply_to_message.message_id);
+  }
+
+  let existingSessionId: string | undefined;
+  let lastProcessedMessageId: string | undefined;
+  if (rootMessageId) {
+    const session = await lookupTelegramThreadSession(
+      chatId,
+      rootMessageId,
+      userLinkId,
+    );
+    existingSessionId = session.existingSessionId;
+    lastProcessedMessageId = session.lastProcessedMessageId;
+  }
+
+  if (existingSessionId) {
+    const sessionCompose = await resolveSessionCompose(
+      existingSessionId,
+      vm0UserId,
+    );
+    if (sessionCompose && sessionCompose.composeId !== composeId) {
+      log.debug("Agent changed, starting new session", {
+        sessionComposeId: sessionCompose.composeId,
+        currentComposeId: composeId,
+      });
+      existingSessionId = undefined;
+      lastProcessedMessageId = undefined;
+    }
+  }
+
+  return { rootMessageId, existingSessionId, lastProcessedMessageId };
 }
 
 /**

--- a/turbo/apps/web/src/lib/telegram/handlers/mention.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/mention.ts
@@ -165,6 +165,7 @@ export async function handleTelegramMention(
       installationId,
       chatId,
       messageId: String(message.message_id),
+      rootMessageId: rootMessageId ?? null,
       userLinkId: userLink.id,
       agentName,
       composeId,

--- a/turbo/apps/web/src/lib/telegram/handlers/mention.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/mention.ts
@@ -67,7 +67,7 @@ export async function handleTelegramMention(
 
   if (!userLink) {
     const platformUrl = getPlatformUrl();
-    const connectUrl = `${platformUrl}/telegram/connect?bot=${installation.telegramBotId}&uid=${fromUserId}`;
+    const connectUrl = `${platformUrl}/telegram/connect?bot=${installation.telegramBotId}`;
     await sendMessage(
       client,
       chatId,

--- a/turbo/apps/web/src/lib/telegram/handlers/mention.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/mention.ts
@@ -13,6 +13,8 @@ import {
   resolveSessionCompose,
   resolveUserLink,
 } from "./shared";
+import { escapeHtml } from "../format";
+import { getPlatformUrl } from "../../url";
 import { logger } from "../../logger";
 import type { TelegramHandlerUpdate } from "./types";
 
@@ -64,10 +66,12 @@ export async function handleTelegramMention(
   const userLink = await resolveUserLink(installationId, fromUserId);
 
   if (!userLink) {
+    const platformUrl = getPlatformUrl();
+    const connectUrl = `${platformUrl}/telegram/connect?bot=${installation.telegramBotId}`;
     await sendMessage(
       client,
       chatId,
-      "Please link your account first. Use /connect to get started.",
+      `Please connect your account first:\n<a href="${escapeHtml(connectUrl)}">Open Platform</a>`,
       { replyToMessageId: message.message_id },
     );
     return;

--- a/turbo/apps/web/src/lib/telegram/handlers/mention.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/mention.ts
@@ -71,7 +71,7 @@ export async function handleTelegramMention(
     await sendMessage(
       client,
       chatId,
-      `Please connect your account first:\n<a href="${escapeHtml(connectUrl)}">Open Platform</a>`,
+      `🔗 Connect your account to get started:\n\n<a href="${escapeHtml(connectUrl)}">Open Platform</a>`,
       { replyToMessageId: message.message_id },
     );
     return;

--- a/turbo/apps/web/src/lib/telegram/handlers/new-session.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/new-session.ts
@@ -55,7 +55,7 @@ export async function handleNewSessionCommand(
     await sendMessage(
       client,
       chatId,
-      `Please connect your account first:\n<a href="${escapeHtml(connectUrl)}">Open Platform</a>`,
+      `🔗 Connect your account to get started:\n\n<a href="${escapeHtml(connectUrl)}">Open Platform</a>`,
     );
     return;
   }

--- a/turbo/apps/web/src/lib/telegram/handlers/new-session.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/new-session.ts
@@ -51,7 +51,7 @@ export async function handleNewSessionCommand(
   const userLink = await resolveUserLink(installationId, fromUserId);
   if (!userLink) {
     const platformUrl = getPlatformUrl();
-    const connectUrl = `${platformUrl}/telegram/connect?bot=${installation.telegramBotId}`;
+    const connectUrl = `${platformUrl}/telegram/connect?bot=${installation.telegramBotId}&uid=${fromUserId}`;
     await sendMessage(
       client,
       chatId,

--- a/turbo/apps/web/src/lib/telegram/handlers/new-session.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/new-session.ts
@@ -6,6 +6,7 @@ import { env } from "../../../env";
 import { createTelegramClient, sendMessage } from "../client";
 import { resolveUserLink, getWorkspaceAgent } from "./shared";
 import { escapeHtml } from "../format";
+import { getPlatformUrl } from "../../url";
 import { logger } from "../../logger";
 import type { TelegramHandlerUpdate } from "./types";
 
@@ -49,10 +50,12 @@ export async function handleNewSessionCommand(
 
   const userLink = await resolveUserLink(installationId, fromUserId);
   if (!userLink) {
+    const platformUrl = getPlatformUrl();
+    const connectUrl = `${platformUrl}/telegram/connect?bot=${installation.telegramBotId}`;
     await sendMessage(
       client,
       chatId,
-      "Please link your account first. Use /connect to get started.",
+      `Please connect your account first:\n<a href="${escapeHtml(connectUrl)}">Open Platform</a>`,
     );
     return;
   }

--- a/turbo/apps/web/src/lib/telegram/handlers/new-session.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/new-session.ts
@@ -51,7 +51,7 @@ export async function handleNewSessionCommand(
   const userLink = await resolveUserLink(installationId, fromUserId);
   if (!userLink) {
     const platformUrl = getPlatformUrl();
-    const connectUrl = `${platformUrl}/telegram/connect?bot=${installation.telegramBotId}&uid=${fromUserId}`;
+    const connectUrl = `${platformUrl}/telegram/connect?bot=${installation.telegramBotId}`;
     await sendMessage(
       client,
       chatId,

--- a/turbo/apps/web/src/lib/telegram/handlers/run-agent.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/run-agent.ts
@@ -17,6 +17,7 @@ export interface TelegramCallbackContext {
   installationId: string;
   chatId: string;
   messageId: string;
+  rootMessageId: string | null;
   userLinkId: string;
   agentName: string;
   composeId: string;

--- a/turbo/apps/web/src/lib/telegram/handlers/shared.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/shared.ts
@@ -69,6 +69,7 @@ export async function saveTelegramThreadSession(opts: {
   userLinkId: string;
   chatId: string;
   rootMessageId: string;
+  previousRootMessageId: string | undefined;
   existingSessionId: string | undefined;
   newSessionId: string | undefined;
   messageId: string;
@@ -78,6 +79,7 @@ export async function saveTelegramThreadSession(opts: {
     userLinkId,
     chatId,
     rootMessageId,
+    previousRootMessageId,
     existingSessionId,
     newSessionId,
     messageId,
@@ -100,10 +102,13 @@ export async function saveTelegramThreadSession(opts: {
     existingSessionId &&
     (runStatus === "completed" || runStatus === "timeout")
   ) {
-    // Existing thread, successful run — update lastProcessedMessageId
+    // Existing thread, successful run — update rootMessageId to bot's latest
+    // reply so the user can continue by replying to any bot response.
+    const matchRootMessageId = previousRootMessageId ?? rootMessageId;
     await globalThis.services.db
       .update(telegramThreadSessions)
       .set({
+        rootMessageId,
         lastProcessedMessageId: messageId,
         updatedAt: new Date(),
       })
@@ -111,7 +116,7 @@ export async function saveTelegramThreadSession(opts: {
         and(
           eq(telegramThreadSessions.telegramUserLinkId, userLinkId),
           eq(telegramThreadSessions.chatId, chatId),
-          eq(telegramThreadSessions.rootMessageId, rootMessageId),
+          eq(telegramThreadSessions.rootMessageId, matchRootMessageId),
         ),
       );
   }


### PR DESCRIPTION
## Summary

The previous re-link flow used HMAC-signed deep link tokens via `/start TOKEN`, which didn't work reliably because Telegram doesn't auto-send `/start` when the user already has a conversation with the bot.

This replaces the deep link token approach with a **pending user link** — the same mechanism used by the admin registration flow:

1. User clicks "Link Account" on platform
2. POST `/api/integrations/telegram/link` creates a pending user link (`telegramUserId = "pending"`)
3. Success page tells user to open Telegram and send any message
4. First message auto-completes the pending link via `resolveUserLink`

### Changes
- **POST link endpoint**: Creates pending user link instead of generating HMAC token
- **Signal**: Removed `deepLink` from result type (no longer needed)
- **Success page**: Updated copy to "send any message to the bot", removed `deepLink` URL param
- **Tests**: Updated to verify pending link creation instead of token generation

## Test plan

- [x] 46 telegram tests pass
- [x] Lint, knip, format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)