### PR TITLE
chore(e2b): upgrade claude code to v2.1.69

### DIFF
--- a/turbo/scripts/e2b/vm0-claude-code/template.ts
+++ b/turbo/scripts/e2b/vm0-claude-code/template.ts
@@ -12,7 +12,7 @@ import { Template } from "e2b";
 export const template = Template()
   .fromNodeImage("24")
   .aptInstall(["curl", "git", "ripgrep", "jq", "file", "tzdata"])
-  .npmInstall("@anthropic-ai/claude-code@2.1.68", { g: true })
+  .npmInstall("@anthropic-ai/claude-code@2.1.69", { g: true })
   // Install GitHub CLI
   // https://github.com/cli/cli/blob/trunk/docs/install_linux.md
   .runCmd(


### PR DESCRIPTION
## Summary
- Upgrade `@anthropic-ai/claude-code` from v2.1.68 to v2.1.69 in the `vm0-claude-code` E2B template

## Test plan
- [ ] CI passes (e2b template build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)