### PR TITLE
refactor(cli): enable vitest clear-mocks and remove manual calls

### DIFF
--- a/turbo/apps/cli/src/commands/agent/__tests__/clone.test.ts
+++ b/turbo/apps/cli/src/commands/agent/__tests__/clone.test.ts
@@ -27,7 +27,6 @@ describe("agent clone command", () => {
     .mockImplementation(() => {});
 
   beforeEach(() => {
-    vi.clearAllMocks();
     vi.stubEnv("VM0_API_URL", "http://localhost:3000");
     vi.stubEnv("VM0_TOKEN", "test-token");
     tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "vm0-clone-test-"));

--- a/turbo/apps/cli/src/commands/agent/__tests__/delete.test.ts
+++ b/turbo/apps/cli/src/commands/agent/__tests__/delete.test.ts
@@ -22,7 +22,6 @@ describe("agent delete command", () => {
     .mockImplementation(() => {});
 
   beforeEach(() => {
-    vi.clearAllMocks();
     vi.stubEnv("VM0_API_URL", "http://localhost:3000");
     vi.stubEnv("VM0_TOKEN", "test-token");
   });

--- a/turbo/apps/cli/src/commands/agent/__tests__/list.test.ts
+++ b/turbo/apps/cli/src/commands/agent/__tests__/list.test.ts
@@ -22,7 +22,6 @@ describe("agent list command", () => {
     .mockImplementation(() => {});
 
   beforeEach(() => {
-    vi.clearAllMocks();
     vi.stubEnv("VM0_API_URL", "http://localhost:3000");
     vi.stubEnv("VM0_TOKEN", "test-token");
   });

--- a/turbo/apps/cli/src/commands/agent/__tests__/sharing.test.ts
+++ b/turbo/apps/cli/src/commands/agent/__tests__/sharing.test.ts
@@ -31,7 +31,6 @@ describe("Agent Sharing Commands", () => {
   const testScopeSlug = "test-user";
 
   beforeEach(() => {
-    vi.clearAllMocks();
     chalk.level = 0;
     vi.stubEnv("VM0_API_URL", "http://localhost:3000");
     vi.stubEnv("VM0_TOKEN", "test-token");

--- a/turbo/apps/cli/src/commands/agent/__tests__/status.test.ts
+++ b/turbo/apps/cli/src/commands/agent/__tests__/status.test.ts
@@ -22,7 +22,6 @@ describe("agent status command", () => {
     .mockImplementation(() => {});
 
   beforeEach(() => {
-    vi.clearAllMocks();
     vi.stubEnv("VM0_API_URL", "http://localhost:3000");
     vi.stubEnv("VM0_TOKEN", "test-token");
   });

--- a/turbo/apps/cli/src/commands/artifact/__tests__/clone.test.ts
+++ b/turbo/apps/cli/src/commands/artifact/__tests__/clone.test.ts
@@ -29,7 +29,6 @@ describe("artifact clone", () => {
     .mockImplementation(() => {});
 
   beforeEach(() => {
-    vi.clearAllMocks();
     chalk.level = 0;
     vi.stubEnv("VM0_API_URL", "http://localhost:3000");
     vi.stubEnv("VM0_TOKEN", "test-token");

--- a/turbo/apps/cli/src/commands/artifact/__tests__/init.test.ts
+++ b/turbo/apps/cli/src/commands/artifact/__tests__/init.test.ts
@@ -28,7 +28,6 @@ describe("artifact init", () => {
     .mockImplementation(() => {});
 
   beforeEach(() => {
-    vi.clearAllMocks();
     chalk.level = 0;
 
     // Setup temp directory

--- a/turbo/apps/cli/src/commands/artifact/__tests__/list.test.ts
+++ b/turbo/apps/cli/src/commands/artifact/__tests__/list.test.ts
@@ -23,7 +23,6 @@ describe("artifact list", () => {
     .mockImplementation(() => {});
 
   beforeEach(() => {
-    vi.clearAllMocks();
     chalk.level = 0;
     vi.stubEnv("VM0_API_URL", "http://localhost:3000");
     vi.stubEnv("VM0_TOKEN", "test-token");

--- a/turbo/apps/cli/src/commands/artifact/__tests__/pull.test.ts
+++ b/turbo/apps/cli/src/commands/artifact/__tests__/pull.test.ts
@@ -34,7 +34,6 @@ describe("artifact pull", () => {
     .mockImplementation(() => {});
 
   beforeEach(() => {
-    vi.clearAllMocks();
     chalk.level = 0;
     vi.stubEnv("VM0_API_URL", "http://localhost:3000");
     vi.stubEnv("VM0_TOKEN", "test-token");

--- a/turbo/apps/cli/src/commands/artifact/__tests__/push.test.ts
+++ b/turbo/apps/cli/src/commands/artifact/__tests__/push.test.ts
@@ -30,7 +30,6 @@ describe("artifact push", () => {
     .mockImplementation(() => {});
 
   beforeEach(() => {
-    vi.clearAllMocks();
     chalk.level = 0;
     vi.stubEnv("VM0_API_URL", "http://localhost:3000");
     vi.stubEnv("VM0_TOKEN", "test-token");

--- a/turbo/apps/cli/src/commands/artifact/__tests__/status.test.ts
+++ b/turbo/apps/cli/src/commands/artifact/__tests__/status.test.ts
@@ -30,7 +30,6 @@ describe("artifact status", () => {
     .mockImplementation(() => {});
 
   beforeEach(() => {
-    vi.clearAllMocks();
     chalk.level = 0;
     vi.stubEnv("VM0_API_URL", "http://localhost:3000");
     vi.stubEnv("VM0_TOKEN", "test-token");

--- a/turbo/apps/cli/src/commands/auth/__tests__/login.test.ts
+++ b/turbo/apps/cli/src/commands/auth/__tests__/login.test.ts
@@ -40,7 +40,6 @@ describe("auth login", () => {
     .mockImplementation(() => true);
 
   beforeEach(async () => {
-    vi.clearAllMocks();
     chalk.level = 0;
     vi.stubEnv("VM0_API_URL", "http://localhost:3000");
 

--- a/turbo/apps/cli/src/commands/auth/__tests__/logout.test.ts
+++ b/turbo/apps/cli/src/commands/auth/__tests__/logout.test.ts
@@ -28,7 +28,6 @@ describe("auth logout", () => {
   const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
 
   beforeEach(async () => {
-    vi.clearAllMocks();
     chalk.level = 0;
 
     // Ensure clean config state

--- a/turbo/apps/cli/src/commands/auth/__tests__/setup-token.test.ts
+++ b/turbo/apps/cli/src/commands/auth/__tests__/setup-token.test.ts
@@ -37,7 +37,6 @@ describe("auth setup-token", () => {
     .mockImplementation(() => {});
 
   beforeEach(async () => {
-    vi.clearAllMocks();
     chalk.level = 0;
 
     // Ensure clean config state

--- a/turbo/apps/cli/src/commands/auth/__tests__/status.test.ts
+++ b/turbo/apps/cli/src/commands/auth/__tests__/status.test.ts
@@ -32,7 +32,6 @@ describe("auth status", () => {
     .mockImplementation(() => {});
 
   beforeEach(async () => {
-    vi.clearAllMocks();
     chalk.level = 0;
 
     // Ensure clean config state

--- a/turbo/apps/cli/src/commands/compose/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/compose/__tests__/index.test.ts
@@ -95,7 +95,6 @@ describe("compose command", () => {
   };
 
   beforeEach(() => {
-    vi.clearAllMocks();
     tempDir = mkdtempSync(path.join(os.tmpdir(), "test-compose-"));
     originalCwd = process.cwd();
     process.chdir(tempDir);
@@ -1809,7 +1808,6 @@ describe("GitHub URL compose", () => {
   }
 
   beforeEach(() => {
-    vi.clearAllMocks();
     tempDir = mkdtempSync(path.join(os.tmpdir(), "test-github-compose-"));
     originalCwd = process.cwd();
     process.chdir(tempDir);

--- a/turbo/apps/cli/src/commands/connector/__tests__/disconnect.test.ts
+++ b/turbo/apps/cli/src/commands/connector/__tests__/disconnect.test.ts
@@ -23,7 +23,6 @@ describe("connector disconnect command", () => {
     .mockImplementation(() => {});
 
   beforeEach(() => {
-    vi.clearAllMocks();
     chalk.level = 0;
     vi.stubEnv("VM0_API_URL", "http://localhost:3000");
     vi.stubEnv("VM0_TOKEN", "test-token");

--- a/turbo/apps/cli/src/commands/connector/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/connector/__tests__/index.test.ts
@@ -7,16 +7,10 @@
  * - Real (internal): All CLI code
  */
 
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { connectorCommand } from "../index";
 
 describe("connector command", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
-  afterEach(() => {});
-
   describe("help text", () => {
     it("should show command description and subcommands", async () => {
       const mockStdoutWrite = vi

--- a/turbo/apps/cli/src/commands/connector/__tests__/list.test.ts
+++ b/turbo/apps/cli/src/commands/connector/__tests__/list.test.ts
@@ -23,7 +23,6 @@ describe("connector list command", () => {
     .mockImplementation(() => {});
 
   beforeEach(() => {
-    vi.clearAllMocks();
     chalk.level = 0;
     vi.stubEnv("VM0_API_URL", "http://localhost:3000");
     vi.stubEnv("VM0_TOKEN", "test-token");

--- a/turbo/apps/cli/src/commands/connector/__tests__/status.test.ts
+++ b/turbo/apps/cli/src/commands/connector/__tests__/status.test.ts
@@ -23,7 +23,6 @@ describe("connector status command", () => {
     .mockImplementation(() => {});
 
   beforeEach(() => {
-    vi.clearAllMocks();
     chalk.level = 0;
     vi.stubEnv("VM0_API_URL", "http://localhost:3000");
     vi.stubEnv("VM0_TOKEN", "test-token");

--- a/turbo/apps/cli/src/commands/cook/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/cook/__tests__/index.test.ts
@@ -52,7 +52,6 @@ describe("cook command", () => {
     .mockImplementation(() => {});
 
   beforeEach(async () => {
-    vi.clearAllMocks();
     tempDir = mkdtempSync(path.join(os.tmpdir(), "test-cook-"));
     testHome = mkdtempSync(path.join(os.tmpdir(), "test-cook-home-"));
     originalCwd = process.cwd();

--- a/turbo/apps/cli/src/commands/dev-tool/__tests__/compose.test.ts
+++ b/turbo/apps/cli/src/commands/dev-tool/__tests__/compose.test.ts
@@ -14,7 +14,6 @@ const mockConsoleError = vi
 
 describe("dev-tool compose command", () => {
   beforeEach(() => {
-    vi.clearAllMocks();
     vi.stubEnv("VM0_API_URL", "http://localhost:3000");
     vi.stubEnv("VM0_TOKEN", "test-token");
   });

--- a/turbo/apps/cli/src/commands/info/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/info/__tests__/index.test.ts
@@ -31,7 +31,6 @@ describe("info command", () => {
   let tempDir: string;
 
   beforeEach(() => {
-    vi.clearAllMocks();
     chalk.level = 0;
     vi.stubEnv("VM0_API_URL", "https://www.vm0.ai");
 

--- a/turbo/apps/cli/src/commands/init/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/init/__tests__/index.test.ts
@@ -33,7 +33,6 @@ describe("init command", () => {
     .mockImplementation(() => {});
 
   beforeEach(() => {
-    vi.clearAllMocks();
     chalk.level = 0;
     tempDir = mkdtempSync(path.join(os.tmpdir(), "test-init-"));
     originalCwd = process.cwd();

--- a/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
@@ -22,7 +22,6 @@ describe("logs command", () => {
     .mockImplementation(() => {});
 
   beforeEach(() => {
-    vi.clearAllMocks();
     vi.stubEnv("VM0_API_URL", "http://localhost:3000");
     vi.stubEnv("VM0_TOKEN", "test-token");
   });

--- a/turbo/apps/cli/src/commands/model-provider/__tests__/delete.test.ts
+++ b/turbo/apps/cli/src/commands/model-provider/__tests__/delete.test.ts
@@ -13,7 +13,6 @@ describe("model-provider delete command", () => {
     .mockImplementation(() => {});
 
   beforeEach(() => {
-    vi.clearAllMocks();
     vi.stubEnv("VM0_API_URL", "http://localhost:3000");
     vi.stubEnv("VM0_TOKEN", "test-token");
   });

--- a/turbo/apps/cli/src/commands/model-provider/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/model-provider/__tests__/index.test.ts
@@ -7,16 +7,10 @@
  * - Real (internal): All CLI code
  */
 
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { modelProviderCommand } from "../index";
 
 describe("model-provider command", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
-  afterEach(() => {});
-
   describe("help text", () => {
     it("should show command description and subcommands", async () => {
       const mockStdoutWrite = vi

--- a/turbo/apps/cli/src/commands/model-provider/__tests__/list.test.ts
+++ b/turbo/apps/cli/src/commands/model-provider/__tests__/list.test.ts
@@ -23,7 +23,6 @@ describe("model-provider list command", () => {
     .mockImplementation(() => {});
 
   beforeEach(() => {
-    vi.clearAllMocks();
     chalk.level = 0;
     vi.stubEnv("VM0_API_URL", "http://localhost:3000");
     vi.stubEnv("VM0_TOKEN", "test-token");

--- a/turbo/apps/cli/src/commands/model-provider/__tests__/set-default.test.ts
+++ b/turbo/apps/cli/src/commands/model-provider/__tests__/set-default.test.ts
@@ -22,7 +22,6 @@ describe("model-provider set-default command", () => {
     .mockImplementation(() => {});
 
   beforeEach(() => {
-    vi.clearAllMocks();
     vi.stubEnv("VM0_API_URL", "http://localhost:3000");
     vi.stubEnv("VM0_TOKEN", "test-token");
   });

--- a/turbo/apps/cli/src/commands/model-provider/__tests__/setup.test.ts
+++ b/turbo/apps/cli/src/commands/model-provider/__tests__/setup.test.ts
@@ -26,7 +26,6 @@ describe("model-provider setup command", () => {
   let originalIsTTY: boolean | undefined;
 
   beforeEach(() => {
-    vi.clearAllMocks();
     vi.stubEnv("VM0_API_URL", "http://localhost:3000");
     vi.stubEnv("VM0_TOKEN", "test-token");
 

--- a/turbo/apps/cli/src/commands/onboard/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/onboard/__tests__/index.test.ts
@@ -45,8 +45,6 @@ describe("onboard command", () => {
   let mockExit: ReturnType<typeof vi.fn>;
 
   beforeEach(async () => {
-    vi.clearAllMocks();
-
     // Mock process.exit to throw (simulates process termination)
     mockExit = vi.fn().mockImplementation(() => {
       throw new Error("process.exit called");

--- a/turbo/apps/cli/src/commands/preference/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/preference/__tests__/index.test.ts
@@ -26,7 +26,6 @@ describe("preference command", () => {
   let originalIsTTY: boolean | undefined;
 
   beforeEach(() => {
-    vi.clearAllMocks();
     chalk.level = 0;
     vi.stubEnv("VM0_API_URL", "http://localhost:3000");
     vi.stubEnv("VM0_TOKEN", "test-token");

--- a/turbo/apps/cli/src/commands/run/__tests__/continue.test.ts
+++ b/turbo/apps/cli/src/commands/run/__tests__/continue.test.ts
@@ -62,7 +62,6 @@ describe("run continue command", () => {
   };
 
   beforeEach(() => {
-    vi.clearAllMocks();
     chalk.level = 0;
     vi.stubEnv("VM0_API_URL", "http://localhost:3000");
     vi.stubEnv("VM0_TOKEN", "test-token");

--- a/turbo/apps/cli/src/commands/run/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/run/__tests__/index.test.ts
@@ -81,7 +81,6 @@ describe("run command", () => {
   };
 
   beforeEach(() => {
-    vi.clearAllMocks();
     // Disable chalk colors for deterministic console output assertions
     chalk.level = 0;
     // Use environment variables for config instead of mocking the module
@@ -2170,28 +2169,26 @@ describe("run command", () => {
       expect(allErrors.some((log) => log.includes("Unknown error"))).toBe(true);
     });
 
-    it("should display various error patterns correctly", async () => {
-      const errorPatterns = [
-        {
-          error: "Error: Authentication failed: Invalid API key",
-          expected: "Authentication failed",
-        },
-        {
-          error: "Error: Network request failed: ECONNREFUSED",
-          expected: "Network request failed",
-        },
-        {
-          error: "Error: Permission denied: Cannot write to /etc/passwd",
-          expected: "Permission denied",
-        },
-        {
-          error: "Error: Operation timed out after 300000ms",
-          expected: "timed out",
-        },
-      ];
-
-      for (const { error, expected } of errorPatterns) {
-        vi.clearAllMocks();
+    it.each([
+      {
+        error: "Error: Authentication failed: Invalid API key",
+        expected: "Authentication failed",
+      },
+      {
+        error: "Error: Network request failed: ECONNREFUSED",
+        expected: "Network request failed",
+      },
+      {
+        error: "Error: Permission denied: Cannot write to /etc/passwd",
+        expected: "Permission denied",
+      },
+      {
+        error: "Error: Operation timed out after 300000ms",
+        expected: "timed out",
+      },
+    ])(
+      "should display error pattern: $expected",
+      async ({ error, expected }) => {
         server.use(
           http.post("http://localhost:3000/api/agent/runs", () => {
             return HttpResponse.json(errorTestRunResponse, { status: 201 });
@@ -2217,7 +2214,7 @@ describe("run command", () => {
           .filter((log): log is string => typeof log === "string");
 
         expect(allErrors.some((log) => log.includes(expected))).toBe(true);
-      }
-    });
+      },
+    );
   });
 });

--- a/turbo/apps/cli/src/commands/run/__tests__/kill.test.ts
+++ b/turbo/apps/cli/src/commands/run/__tests__/kill.test.ts
@@ -23,7 +23,6 @@ describe("run kill command", () => {
     .mockImplementation(() => {});
 
   beforeEach(() => {
-    vi.clearAllMocks();
     chalk.level = 0;
     vi.stubEnv("VM0_API_URL", "http://localhost:3000");
     vi.stubEnv("VM0_TOKEN", "test-token");

--- a/turbo/apps/cli/src/commands/run/__tests__/list.test.ts
+++ b/turbo/apps/cli/src/commands/run/__tests__/list.test.ts
@@ -23,7 +23,6 @@ describe("run list command", () => {
     .mockImplementation(() => {});
 
   beforeEach(() => {
-    vi.clearAllMocks();
     chalk.level = 0;
     vi.stubEnv("VM0_API_URL", "http://localhost:3000");
     vi.stubEnv("VM0_TOKEN", "test-token");

--- a/turbo/apps/cli/src/commands/run/__tests__/resume.test.ts
+++ b/turbo/apps/cli/src/commands/run/__tests__/resume.test.ts
@@ -63,7 +63,6 @@ describe("run resume command", () => {
   };
 
   beforeEach(() => {
-    vi.clearAllMocks();
     chalk.level = 0;
     vi.stubEnv("VM0_API_URL", "http://localhost:3000");
     vi.stubEnv("VM0_TOKEN", "test-token");

--- a/turbo/apps/cli/src/commands/run/__tests__/volume-version.test.ts
+++ b/turbo/apps/cli/src/commands/run/__tests__/volume-version.test.ts
@@ -106,7 +106,6 @@ describe("--volume-version option", () => {
   };
 
   beforeEach(() => {
-    vi.clearAllMocks();
     chalk.level = 0;
     vi.stubEnv("VM0_API_URL", "http://localhost:3000");
     vi.stubEnv("VM0_TOKEN", "test-token");

--- a/turbo/apps/cli/src/commands/schedule/__tests__/delete-command.test.ts
+++ b/turbo/apps/cli/src/commands/schedule/__tests__/delete-command.test.ts
@@ -51,7 +51,6 @@ describe("schedule delete command", () => {
   let originalIsTTY: boolean | undefined;
 
   beforeEach(() => {
-    vi.clearAllMocks();
     chalk.level = 0;
     vi.stubEnv("VM0_API_URL", "http://localhost:3000");
     vi.stubEnv("VM0_TOKEN", "test-token");

--- a/turbo/apps/cli/src/commands/schedule/__tests__/disable-command.test.ts
+++ b/turbo/apps/cli/src/commands/schedule/__tests__/disable-command.test.ts
@@ -48,7 +48,6 @@ describe("schedule disable command", () => {
     .mockImplementation(() => {});
 
   beforeEach(() => {
-    vi.clearAllMocks();
     chalk.level = 0;
     vi.stubEnv("VM0_API_URL", "http://localhost:3000");
     vi.stubEnv("VM0_TOKEN", "test-token");

--- a/turbo/apps/cli/src/commands/schedule/__tests__/enable-command.test.ts
+++ b/turbo/apps/cli/src/commands/schedule/__tests__/enable-command.test.ts
@@ -48,7 +48,6 @@ describe("schedule enable command", () => {
     .mockImplementation(() => {});
 
   beforeEach(() => {
-    vi.clearAllMocks();
     chalk.level = 0;
     vi.stubEnv("VM0_API_URL", "http://localhost:3000");
     vi.stubEnv("VM0_TOKEN", "test-token");

--- a/turbo/apps/cli/src/commands/schedule/__tests__/list-command.test.ts
+++ b/turbo/apps/cli/src/commands/schedule/__tests__/list-command.test.ts
@@ -23,7 +23,6 @@ describe("schedule list command", () => {
     .mockImplementation(() => {});
 
   beforeEach(() => {
-    vi.clearAllMocks();
     chalk.level = 0;
     vi.stubEnv("VM0_API_URL", "http://localhost:3000");
     vi.stubEnv("VM0_TOKEN", "test-token");

--- a/turbo/apps/cli/src/commands/schedule/__tests__/schedule-command.test.ts
+++ b/turbo/apps/cli/src/commands/schedule/__tests__/schedule-command.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { mkdtempSync, rmSync, writeFileSync, existsSync } from "fs";
 import * as path from "path";
 import * as os from "os";

--- a/turbo/apps/cli/src/commands/schedule/__tests__/schedule-command.test.ts
+++ b/turbo/apps/cli/src/commands/schedule/__tests__/schedule-command.test.ts
@@ -18,7 +18,6 @@ describe("schedule command validation", () => {
   let originalCwd: string;
 
   beforeEach(() => {
-    vi.clearAllMocks();
     tempDir = mkdtempSync(path.join(os.tmpdir(), "test-schedule-cmd-"));
     originalCwd = process.cwd();
     process.chdir(tempDir);

--- a/turbo/apps/cli/src/commands/schedule/__tests__/setup-command.test.ts
+++ b/turbo/apps/cli/src/commands/schedule/__tests__/setup-command.test.ts
@@ -78,7 +78,6 @@ describe("schedule setup command", () => {
     .mockImplementation(() => {});
 
   beforeEach(() => {
-    vi.clearAllMocks();
     chalk.level = 0;
     vi.stubEnv("VM0_API_URL", "http://localhost:3000");
     vi.stubEnv("VM0_TOKEN", "test-token");

--- a/turbo/apps/cli/src/commands/schedule/__tests__/setup.test.ts
+++ b/turbo/apps/cli/src/commands/schedule/__tests__/setup.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { mkdtempSync, rmSync, writeFileSync } from "fs";
 import * as path from "path";
 import * as os from "os";

--- a/turbo/apps/cli/src/commands/schedule/__tests__/setup.test.ts
+++ b/turbo/apps/cli/src/commands/schedule/__tests__/setup.test.ts
@@ -19,7 +19,6 @@ describe("schedule setup utilities", () => {
   let originalCwd: string;
 
   beforeEach(() => {
-    vi.clearAllMocks();
     tempDir = mkdtempSync(path.join(os.tmpdir(), "test-schedule-init-"));
     originalCwd = process.cwd();
     process.chdir(tempDir);

--- a/turbo/apps/cli/src/commands/schedule/__tests__/status-command.test.ts
+++ b/turbo/apps/cli/src/commands/schedule/__tests__/status-command.test.ts
@@ -48,7 +48,6 @@ describe("schedule status command", () => {
     .mockImplementation(() => {});
 
   beforeEach(() => {
-    vi.clearAllMocks();
     chalk.level = 0;
     vi.stubEnv("VM0_API_URL", "http://localhost:3000");
     vi.stubEnv("VM0_TOKEN", "test-token");

--- a/turbo/apps/cli/src/commands/scope/__tests__/list.test.ts
+++ b/turbo/apps/cli/src/commands/scope/__tests__/list.test.ts
@@ -32,7 +32,6 @@ describe("scope list command", () => {
     .mockImplementation(() => {});
 
   beforeEach(() => {
-    vi.clearAllMocks();
     chalk.level = 0;
     vi.stubEnv("VM0_API_URL", "http://localhost:3000");
     vi.stubEnv("VM0_TOKEN", "test-token");

--- a/turbo/apps/cli/src/commands/scope/__tests__/set.test.ts
+++ b/turbo/apps/cli/src/commands/scope/__tests__/set.test.ts
@@ -13,7 +13,6 @@ describe("scope set command", () => {
     .mockImplementation(() => {});
 
   beforeEach(() => {
-    vi.clearAllMocks();
     vi.stubEnv("VM0_API_URL", "http://localhost:3000");
     vi.stubEnv("VM0_TOKEN", "test-token");
   });

--- a/turbo/apps/cli/src/commands/scope/__tests__/status.test.ts
+++ b/turbo/apps/cli/src/commands/scope/__tests__/status.test.ts
@@ -13,7 +13,6 @@ describe("scope status command", () => {
     .mockImplementation(() => {});
 
   beforeEach(() => {
-    vi.clearAllMocks();
     vi.stubEnv("VM0_API_URL", "http://localhost:3000");
     vi.stubEnv("VM0_TOKEN", "test-token");
   });

--- a/turbo/apps/cli/src/commands/scope/__tests__/use.test.ts
+++ b/turbo/apps/cli/src/commands/scope/__tests__/use.test.ts
@@ -34,7 +34,6 @@ describe("scope use command", () => {
     .mockImplementation(() => {});
 
   beforeEach(() => {
-    vi.clearAllMocks();
     chalk.level = 0;
     vi.stubEnv("VM0_API_URL", "http://localhost:3000");
     vi.stubEnv("VM0_TOKEN", "test-token");

--- a/turbo/apps/cli/src/commands/scope/org/__tests__/create.test.ts
+++ b/turbo/apps/cli/src/commands/scope/org/__tests__/create.test.ts
@@ -34,7 +34,6 @@ describe("org create command", () => {
     .mockImplementation(() => {});
 
   beforeEach(() => {
-    vi.clearAllMocks();
     chalk.level = 0;
     vi.stubEnv("VM0_API_URL", "http://localhost:3000");
     vi.stubEnv("VM0_TOKEN", "test-token");

--- a/turbo/apps/cli/src/commands/scope/org/__tests__/invite.test.ts
+++ b/turbo/apps/cli/src/commands/scope/org/__tests__/invite.test.ts
@@ -23,7 +23,6 @@ describe("org invite command", () => {
     .mockImplementation(() => {});
 
   beforeEach(() => {
-    vi.clearAllMocks();
     chalk.level = 0;
     vi.stubEnv("VM0_API_URL", "http://localhost:3000");
     vi.stubEnv("VM0_TOKEN", "test-token");

--- a/turbo/apps/cli/src/commands/scope/org/__tests__/leave.test.ts
+++ b/turbo/apps/cli/src/commands/scope/org/__tests__/leave.test.ts
@@ -33,7 +33,6 @@ describe("org leave command", () => {
     .mockImplementation(() => {});
 
   beforeEach(() => {
-    vi.clearAllMocks();
     chalk.level = 0;
     vi.stubEnv("VM0_API_URL", "http://localhost:3000");
     vi.stubEnv("VM0_TOKEN", "test-token");

--- a/turbo/apps/cli/src/commands/scope/org/__tests__/remove.test.ts
+++ b/turbo/apps/cli/src/commands/scope/org/__tests__/remove.test.ts
@@ -23,7 +23,6 @@ describe("org remove command", () => {
     .mockImplementation(() => {});
 
   beforeEach(() => {
-    vi.clearAllMocks();
     chalk.level = 0;
     vi.stubEnv("VM0_API_URL", "http://localhost:3000");
     vi.stubEnv("VM0_TOKEN", "test-token");

--- a/turbo/apps/cli/src/commands/scope/org/__tests__/status.test.ts
+++ b/turbo/apps/cli/src/commands/scope/org/__tests__/status.test.ts
@@ -23,7 +23,6 @@ describe("org status command", () => {
     .mockImplementation(() => {});
 
   beforeEach(() => {
-    vi.clearAllMocks();
     chalk.level = 0;
     vi.stubEnv("VM0_API_URL", "http://localhost:3000");
     vi.stubEnv("VM0_TOKEN", "test-token");

--- a/turbo/apps/cli/src/commands/secret/__tests__/delete.test.ts
+++ b/turbo/apps/cli/src/commands/secret/__tests__/delete.test.ts
@@ -23,7 +23,6 @@ describe("secret delete command", () => {
     .mockImplementation(() => {});
 
   beforeEach(() => {
-    vi.clearAllMocks();
     chalk.level = 0;
     vi.stubEnv("VM0_API_URL", "http://localhost:3000");
     vi.stubEnv("VM0_TOKEN", "test-token");

--- a/turbo/apps/cli/src/commands/secret/__tests__/list.test.ts
+++ b/turbo/apps/cli/src/commands/secret/__tests__/list.test.ts
@@ -23,7 +23,6 @@ describe("secret list command", () => {
     .mockImplementation(() => {});
 
   beforeEach(() => {
-    vi.clearAllMocks();
     chalk.level = 0;
     vi.stubEnv("VM0_API_URL", "http://localhost:3000");
     vi.stubEnv("VM0_TOKEN", "test-token");

--- a/turbo/apps/cli/src/commands/secret/__tests__/set.test.ts
+++ b/turbo/apps/cli/src/commands/secret/__tests__/set.test.ts
@@ -26,7 +26,6 @@ describe("secret set command", () => {
   let originalIsTTY: boolean | undefined;
 
   beforeEach(() => {
-    vi.clearAllMocks();
     chalk.level = 0;
     vi.stubEnv("VM0_API_URL", "http://localhost:3000");
     vi.stubEnv("VM0_TOKEN", "test-token");

--- a/turbo/apps/cli/src/commands/setup-claude/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/setup-claude/__tests__/index.test.ts
@@ -20,7 +20,6 @@ describe("setup-claude command", () => {
   let mockExit: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
-    vi.clearAllMocks();
     tempDir = mkdtempSync(path.join(os.tmpdir(), "test-setup-claude-"));
     originalCwd = process.cwd();
     process.chdir(tempDir);

--- a/turbo/apps/cli/src/commands/upgrade/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/upgrade/__tests__/index.test.ts
@@ -32,7 +32,6 @@ describe("upgrade command", () => {
     .mockImplementation(() => {});
 
   beforeEach(() => {
-    vi.clearAllMocks();
     // Default: npm package manager
     process.argv = ["/usr/bin/node", "/usr/local/bin/vm0"];
   });

--- a/turbo/apps/cli/src/commands/usage/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/usage/__tests__/index.test.ts
@@ -13,7 +13,6 @@ describe("usage command", () => {
     .mockImplementation(() => {});
 
   beforeEach(() => {
-    vi.clearAllMocks();
     vi.useFakeTimers({ now: new Date("2026-01-19T12:00:00Z") });
     vi.stubEnv("VM0_API_URL", "http://localhost:3000");
     vi.stubEnv("VM0_TOKEN", "test-token");

--- a/turbo/apps/cli/src/commands/variable/__tests__/delete.test.ts
+++ b/turbo/apps/cli/src/commands/variable/__tests__/delete.test.ts
@@ -23,7 +23,6 @@ describe("variable delete command", () => {
     .mockImplementation(() => {});
 
   beforeEach(() => {
-    vi.clearAllMocks();
     chalk.level = 0;
     vi.stubEnv("VM0_API_URL", "http://localhost:3000");
     vi.stubEnv("VM0_TOKEN", "test-token");

--- a/turbo/apps/cli/src/commands/variable/__tests__/list.test.ts
+++ b/turbo/apps/cli/src/commands/variable/__tests__/list.test.ts
@@ -23,7 +23,6 @@ describe("variable list command", () => {
     .mockImplementation(() => {});
 
   beforeEach(() => {
-    vi.clearAllMocks();
     chalk.level = 0;
     vi.stubEnv("VM0_API_URL", "http://localhost:3000");
     vi.stubEnv("VM0_TOKEN", "test-token");

--- a/turbo/apps/cli/src/commands/variable/__tests__/set.test.ts
+++ b/turbo/apps/cli/src/commands/variable/__tests__/set.test.ts
@@ -23,7 +23,6 @@ describe("variable set command", () => {
     .mockImplementation(() => {});
 
   beforeEach(() => {
-    vi.clearAllMocks();
     chalk.level = 0;
     vi.stubEnv("VM0_API_URL", "http://localhost:3000");
     vi.stubEnv("VM0_TOKEN", "test-token");

--- a/turbo/apps/cli/src/commands/volume/__tests__/clone.test.ts
+++ b/turbo/apps/cli/src/commands/volume/__tests__/clone.test.ts
@@ -29,7 +29,6 @@ describe("volume clone", () => {
     .mockImplementation(() => {});
 
   beforeEach(() => {
-    vi.clearAllMocks();
     chalk.level = 0;
     vi.stubEnv("VM0_API_URL", "http://localhost:3000");
     vi.stubEnv("VM0_TOKEN", "test-token");

--- a/turbo/apps/cli/src/commands/volume/__tests__/init.test.ts
+++ b/turbo/apps/cli/src/commands/volume/__tests__/init.test.ts
@@ -28,7 +28,6 @@ describe("volume init", () => {
     .mockImplementation(() => {});
 
   beforeEach(() => {
-    vi.clearAllMocks();
     chalk.level = 0;
 
     // Setup temp directory

--- a/turbo/apps/cli/src/commands/volume/__tests__/list.test.ts
+++ b/turbo/apps/cli/src/commands/volume/__tests__/list.test.ts
@@ -23,7 +23,6 @@ describe("volume list", () => {
     .mockImplementation(() => {});
 
   beforeEach(() => {
-    vi.clearAllMocks();
     chalk.level = 0;
     vi.stubEnv("VM0_API_URL", "http://localhost:3000");
     vi.stubEnv("VM0_TOKEN", "test-token");

--- a/turbo/apps/cli/src/commands/volume/__tests__/pull.test.ts
+++ b/turbo/apps/cli/src/commands/volume/__tests__/pull.test.ts
@@ -31,7 +31,6 @@ describe("volume pull", () => {
     .mockImplementation(() => {});
 
   beforeEach(() => {
-    vi.clearAllMocks();
     chalk.level = 0;
     vi.stubEnv("VM0_API_URL", "http://localhost:3000");
     vi.stubEnv("VM0_TOKEN", "test-token");

--- a/turbo/apps/cli/src/commands/volume/__tests__/push.test.ts
+++ b/turbo/apps/cli/src/commands/volume/__tests__/push.test.ts
@@ -30,7 +30,6 @@ describe("volume push", () => {
     .mockImplementation(() => {});
 
   beforeEach(() => {
-    vi.clearAllMocks();
     chalk.level = 0;
     vi.stubEnv("VM0_API_URL", "http://localhost:3000");
     vi.stubEnv("VM0_TOKEN", "test-token");

--- a/turbo/apps/cli/src/commands/volume/__tests__/status.test.ts
+++ b/turbo/apps/cli/src/commands/volume/__tests__/status.test.ts
@@ -30,7 +30,6 @@ describe("volume status", () => {
     .mockImplementation(() => {});
 
   beforeEach(() => {
-    vi.clearAllMocks();
     chalk.level = 0;
     vi.stubEnv("VM0_API_URL", "http://localhost:3000");
     vi.stubEnv("VM0_TOKEN", "test-token");

--- a/turbo/apps/cli/src/lib/command/__tests__/with-error-handler.test.ts
+++ b/turbo/apps/cli/src/lib/command/__tests__/with-error-handler.test.ts
@@ -12,7 +12,6 @@ describe("withErrorHandler", () => {
     .mockImplementation(() => {});
 
   beforeEach(() => {
-    vi.clearAllMocks();
     chalk.level = 0;
   });
 

--- a/turbo/apps/cli/vitest.config.ts
+++ b/turbo/apps/cli/vitest.config.ts
@@ -9,5 +9,6 @@ export default defineConfig({
     globals: true,
     environment: "node",
     setupFiles: ["./src/test/setup.ts"],
+    clearMocks: true,
   },
 });


### PR DESCRIPTION
## Summary
- Add `clearMocks: true` to CLI `vitest.config.ts` so mocks are automatically cleared before each test
- Remove all 67+ manual `vi.clearAllMocks()` calls from `beforeEach()` blocks across 70+ test files
- Refactor the for-loop pattern in `run/__tests__/index.test.ts` to use `it.each()` for proper per-test mock clearing
- Clean up 2 empty `beforeEach`/`afterEach` blocks and unused imports left behind

## Test plan
- [x] All 75 CLI test files pass (883 tests)
- [x] Knip reports no unused exports/dependencies
- [x] Prettier formatting unchanged
- [x] Commitlint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)