### PR TITLE
docs(crates): replace cross with cargo in build instructions

### DIFF
--- a/crates/README.md
+++ b/crates/README.md
@@ -64,7 +64,7 @@ cargo build --release
 
 # Cross-compile for aarch64 (production target)
 # Step 1: build guest binaries
-cross build --target aarch64-unknown-linux-musl \
+cargo build --target aarch64-unknown-linux-musl \
   -p guest-agent -p guest-download -p guest-init -p guest-mock-claude \
   --release
 
@@ -73,7 +73,7 @@ GUEST_AGENT_PATH=target/aarch64-unknown-linux-musl/release/guest-agent \
 GUEST_DOWNLOAD_PATH=target/aarch64-unknown-linux-musl/release/guest-download \
 GUEST_INIT_PATH=target/aarch64-unknown-linux-musl/release/guest-init \
 GUEST_MOCK_CLAUDE_PATH=target/aarch64-unknown-linux-musl/release/guest-mock-claude \
-cross build --target aarch64-unknown-linux-musl -p runner --release
+cargo build --target aarch64-unknown-linux-musl -p runner --release
 ```
 
 ## Testing


### PR DESCRIPTION
## Summary
- Replace `cross build` with `cargo build` in crates/README.md cross-compilation instructions since we no longer use the `cross` tool

## Test plan
- Documentation only change

🤖 Generated with [Claude Code](https://claude.com/claude-code)