### PR TITLE
feat(platform): add loop schedule support to run dialog

### DIFF
--- a/turbo/apps/platform/src/signals/agent-detail/run-dialog.ts
+++ b/turbo/apps/platform/src/signals/agent-detail/run-dialog.ts
@@ -42,7 +42,7 @@ export const setRunDialogPrompt$ = command(({ set }, value: string) => {
   set(internalPrompt$, value);
 });
 
-type TimeOption = "now" | "once" | CronTimeOption;
+type TimeOption = "now" | "once" | "loop" | CronTimeOption;
 
 const internalTimeOption$ = state<TimeOption>("now");
 export const runDialogTimeOption$ = computed((get) => get(internalTimeOption$));
@@ -51,6 +51,7 @@ function isTimeOption(v: string): v is TimeOption {
   return (
     v === "now" ||
     v === "once" ||
+    v === "loop" ||
     v === "every-weekday" ||
     v === "every-day" ||
     v === "every-week" ||
@@ -112,6 +113,18 @@ export const setRunDialogTimezone$ = command(({ set }, value: string) => {
   set(internalTimezone$, value);
 });
 
+// Interval seconds for "loop" schedule
+const internalIntervalSeconds$ = state("300");
+export const runDialogIntervalSeconds$ = computed((get) =>
+  get(internalIntervalSeconds$),
+);
+
+export const setRunDialogIntervalSeconds$ = command(
+  ({ set }, value: string) => {
+    set(internalIntervalSeconds$, value);
+  },
+);
+
 // ---------------------------------------------------------------------------
 // Saving state
 // ---------------------------------------------------------------------------
@@ -138,6 +151,7 @@ export const openRunDialog$ = command(async ({ get, set }) => {
   set(internalDayOfWeek$, "1");
   set(internalDayOfMonth$, "1");
   set(internalDate$, getTomorrowDateLocal());
+  set(internalIntervalSeconds$, "300");
   set(internalSaveError$, null);
 
   // Default timezone from user preferences, fallback to browser
@@ -155,6 +169,63 @@ export const openRunDialog$ = command(async ({ get, set }) => {
 export const closeRunDialog$ = command(({ set }) => {
   set(internalOpen$, false);
 });
+
+// ---------------------------------------------------------------------------
+// Schedule body builder
+// ---------------------------------------------------------------------------
+
+interface ScheduleFields {
+  composeId: string;
+  prompt: string;
+  timeOption: Exclude<TimeOption, "now">;
+  timezone: string;
+  frequency: string;
+  minute: string;
+  dayOfWeek: string;
+  dayOfMonth: string;
+  date: string;
+  intervalSeconds: string;
+}
+
+function buildScheduleBody(
+  fields: ScheduleFields,
+): ScheduleBody | { error: string } {
+  const base = {
+    composeId: fields.composeId,
+    name: "default" as const,
+    timezone: fields.timezone,
+    prompt: fields.prompt,
+  };
+
+  if (fields.timeOption === "once") {
+    if (isAtTimePast(fields.date, fields.frequency, fields.minute)) {
+      return { error: "Scheduled time must be in the future" };
+    }
+    return {
+      ...base,
+      atTime: buildAtTime(fields.date, fields.frequency, fields.minute),
+    };
+  }
+
+  if (fields.timeOption === "loop") {
+    const seconds = Number.parseInt(fields.intervalSeconds, 10);
+    if (Number.isNaN(seconds) || seconds < 0) {
+      return { error: "Interval must be a non-negative number" };
+    }
+    return { ...base, intervalSeconds: seconds };
+  }
+
+  return {
+    ...base,
+    cronExpression: buildCronExpression({
+      timeOption: fields.timeOption,
+      hour: fields.frequency,
+      minute: fields.minute,
+      dayOfWeek: fields.dayOfWeek,
+      dayOfMonth: fields.dayOfMonth,
+    }),
+  };
+}
 
 // ---------------------------------------------------------------------------
 // Submit — immediate run or schedule creation
@@ -220,41 +291,27 @@ export const submitRunDialog$ = command(async ({ get, set }) => {
       return;
     }
 
-    // Schedule creation (recurring or one-time)
-    const timezone = get(internalTimezone$);
-    let scheduleBody: ScheduleBody;
+    // Schedule creation (recurring, loop, or one-time)
+    const result = buildScheduleBody({
+      composeId: detail.id,
+      prompt: prompt.trim(),
+      timeOption,
+      timezone: get(internalTimezone$),
+      frequency,
+      minute,
+      dayOfWeek,
+      dayOfMonth,
+      date: get(internalDate$),
+      intervalSeconds: get(internalIntervalSeconds$),
+    });
 
-    if (timeOption === "once") {
-      const date = get(internalDate$);
-      if (isAtTimePast(date, frequency, minute)) {
-        set(internalSaveError$, "Scheduled time must be in the future");
-        set(internalSaving$, false);
-        return;
-      }
-      const atTime = buildAtTime(date, frequency, minute);
-      scheduleBody = {
-        composeId: detail.id,
-        name: "default",
-        atTime,
-        timezone,
-        prompt: prompt.trim(),
-      };
-    } else {
-      const cronExpression = buildCronExpression({
-        timeOption,
-        hour: frequency,
-        minute,
-        dayOfWeek,
-        dayOfMonth,
-      });
-      scheduleBody = {
-        composeId: detail.id,
-        name: "default",
-        cronExpression,
-        timezone,
-        prompt: prompt.trim(),
-      };
+    if ("error" in result) {
+      set(internalSaveError$, result.error);
+      set(internalSaving$, false);
+      return;
     }
+
+    const scheduleBody = result;
 
     const response = await fetchFn("/api/agent/schedules", {
       method: "POST",

--- a/turbo/apps/platform/src/views/agent-detail-page/__tests__/run-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/agent-detail-page/__tests__/run-dialog.test.tsx
@@ -9,6 +9,7 @@ import {
   setRunDialogFrequency$,
   setRunDialogMinute$,
   setRunDialogDate$,
+  setRunDialogIntervalSeconds$,
 } from "../../../signals/agent-detail/run-dialog.ts";
 
 const context = testContext();
@@ -496,6 +497,92 @@ describe("run dialog", () => {
     expect(
       screen.getByRole("heading", { name: "Run this agent" }),
     ).toBeInTheDocument();
+  });
+
+  it("should create loop schedule with intervalSeconds", async () => {
+    mockAgentDetailAPI();
+
+    let capturedBody: unknown = null;
+    server.use(
+      http.post("/api/agent/schedules", async ({ request }) => {
+        capturedBody = await request.json();
+        return HttpResponse.json(
+          {
+            id: "schedule_loop",
+            composeId: "compose_1",
+            composeName: "my-agent",
+            scopeSlug: "test-user",
+            name: "default",
+            triggerType: "loop",
+            cronExpression: null,
+            atTime: null,
+            intervalSeconds: 600,
+            timezone: "UTC",
+            prompt: "Monitor dashboard",
+            vars: null,
+            secretNames: null,
+            artifactName: null,
+            artifactVersion: null,
+            volumeVersions: null,
+            enabled: true,
+            nextRunAt: null,
+            lastRunAt: null,
+            retryStartedAt: null,
+            consecutiveFailures: 0,
+            createdAt: "2024-01-01T00:00:00Z",
+            updatedAt: "2024-01-01T00:00:00Z",
+          },
+          { status: 201 },
+        );
+      }),
+    );
+
+    await setupPage({
+      context,
+      path: "/agents/my-agent",
+    });
+
+    await vi.waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "my-agent" }),
+      ).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /Run/ }));
+
+    await vi.waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "Run this agent" }),
+      ).toBeInTheDocument();
+    });
+
+    const textarea = screen.getByPlaceholderText(
+      "Describe your task in natural language.",
+    );
+    fireEvent.change(textarea, { target: { value: "Monitor dashboard" } });
+
+    // Set time option to "loop" and provide an interval
+    act(() => {
+      context.store.set(setRunDialogTimeOption$, "loop");
+      context.store.set(setRunDialogIntervalSeconds$, "600");
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await vi.waitFor(() => {
+      expect(
+        screen.queryByRole("heading", { name: "Run this agent" }),
+      ).not.toBeInTheDocument();
+    });
+
+    // Verify schedule API was called with intervalSeconds (no cronExpression, no atTime)
+    const body = capturedBody as Record<string, unknown>;
+    expect(body.composeId).toBe("compose_1");
+    expect(body.intervalSeconds).toBe(600);
+    expect(body.cronExpression).toBeUndefined();
+    expect(body.atTime).toBeUndefined();
+    expect(body.prompt).toBe("Monitor dashboard");
+    expect(body.name).toBe("default");
   });
 
   it("should close dialog on Cancel", async () => {

--- a/turbo/apps/platform/src/views/agent-detail-page/__tests__/schedule-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/agent-detail-page/__tests__/schedule-dialog.test.tsx
@@ -13,8 +13,10 @@ function makeSchedule(overrides?: Record<string, unknown>) {
     composeName: "my-agent",
     scopeSlug: "test-user",
     name: "default",
+    triggerType: "cron",
     cronExpression: "30 14 * * 1-5",
     atTime: null,
+    intervalSeconds: null,
     timezone: "UTC",
     prompt: "Daily standup summary",
     vars: null,
@@ -26,6 +28,7 @@ function makeSchedule(overrides?: Record<string, unknown>) {
     nextRunAt: null,
     lastRunAt: null,
     retryStartedAt: null,
+    consecutiveFailures: 0,
     createdAt: "2024-01-01T00:00:00Z",
     updatedAt: "2024-01-01T00:00:00Z",
     ...overrides,
@@ -375,5 +378,114 @@ describe("schedule dialog", () => {
     await vi.waitFor(() => {
       expect(screen.queryByText("Scheduled")).not.toBeInTheDocument();
     });
+  });
+
+  it("should show Scheduled badge for loop schedule", async () => {
+    mockAgentDetailAPI({
+      withSchedule: true,
+      schedule: {
+        triggerType: "loop",
+        cronExpression: null,
+        intervalSeconds: 300,
+        prompt: "Continuous monitoring",
+      },
+    });
+
+    await setupPage({ context, path: "/agents/my-agent" });
+
+    await vi.waitFor(() => {
+      expect(screen.getByText("Scheduled")).toBeInTheDocument();
+    });
+  });
+
+  it("should open edit dialog with loop fields for loop schedule", async () => {
+    mockAgentDetailAPI({
+      withSchedule: true,
+      schedule: {
+        triggerType: "loop",
+        cronExpression: null,
+        intervalSeconds: 300,
+        prompt: "Continuous monitoring",
+      },
+    });
+
+    await setupPage({ context, path: "/agents/my-agent" });
+
+    await vi.waitFor(() => {
+      expect(screen.getByText("Scheduled")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit schedule" }));
+
+    await vi.waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "Edit this schedule" }),
+      ).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByDisplayValue("Continuous monitoring"),
+    ).toBeInTheDocument();
+    expect(screen.getByDisplayValue("300")).toBeInTheDocument();
+  });
+
+  it("should save loop schedule with intervalSeconds", async () => {
+    mockAgentDetailAPI({
+      withSchedule: true,
+      schedule: {
+        triggerType: "loop",
+        cronExpression: null,
+        intervalSeconds: 300,
+        prompt: "Continuous monitoring",
+      },
+    });
+
+    let capturedBody: unknown = null;
+    server.use(
+      http.post("/api/agent/schedules", async ({ request }) => {
+        capturedBody = await request.json();
+        return HttpResponse.json(
+          makeSchedule({
+            triggerType: "loop",
+            cronExpression: null,
+            intervalSeconds: 300,
+            prompt: "Updated monitoring",
+          }),
+          { status: 200 },
+        );
+      }),
+    );
+
+    await setupPage({ context, path: "/agents/my-agent" });
+
+    await vi.waitFor(() => {
+      expect(screen.getByText("Scheduled")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit schedule" }));
+
+    await vi.waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "Edit this schedule" }),
+      ).toBeInTheDocument();
+    });
+
+    const textarea = screen.getByDisplayValue("Continuous monitoring");
+    fireEvent.change(textarea, { target: { value: "Updated monitoring" } });
+
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await vi.waitFor(() => {
+      expect(
+        screen.queryByRole("heading", { name: "Edit this schedule" }),
+      ).not.toBeInTheDocument();
+    });
+
+    const body = capturedBody as Record<string, unknown>;
+    expect(body.composeId).toBe("compose_1");
+    expect(body.intervalSeconds).toBe(300);
+    expect(body.cronExpression).toBeUndefined();
+    expect(body.atTime).toBeUndefined();
+    expect(body.prompt).toBe("Updated monitoring");
   });
 });

--- a/turbo/apps/platform/src/views/agent-detail-page/run-dialog/run-dialog.tsx
+++ b/turbo/apps/platform/src/views/agent-detail-page/run-dialog/run-dialog.tsx
@@ -39,6 +39,8 @@ import {
   submitRunDialog$,
   runDialogTimezone$,
   setRunDialogTimezone$,
+  runDialogIntervalSeconds$,
+  setRunDialogIntervalSeconds$,
 } from "../../../signals/agent-detail/run-dialog.ts";
 import { agentSchedule$ } from "../../../signals/agent-detail/schedule.ts";
 import {
@@ -73,6 +75,8 @@ export function RunDialog() {
   const submit = useSet(submitRunDialog$);
   const timezone = useGet(runDialogTimezone$);
   const setTimezone = useSet(setRunDialogTimezone$);
+  const intervalSeconds = useGet(runDialogIntervalSeconds$);
+  const setIntervalSeconds = useSet(setRunDialogIntervalSeconds$);
   const schedule = useGet(agentSchedule$);
 
   const weekdays = [
@@ -103,7 +107,8 @@ export function RunDialog() {
   const hasSchedule = schedule !== null;
   const isSchedule = timeOption !== "now";
   const isOnce = timeOption === "once";
-  const isRecurring = isSchedule && !isOnce;
+  const isLoop = timeOption === "loop";
+  const isRecurring = isSchedule && !isOnce && !isLoop;
 
   return (
     <Dialog open={open} onOpenChange={(v) => !v && close()}>
@@ -145,6 +150,7 @@ export function RunDialog() {
                     <SelectItem value="every-day">Every day</SelectItem>
                     <SelectItem value="every-week">Every week</SelectItem>
                     <SelectItem value="every-month">Every month</SelectItem>
+                    <SelectItem value="loop">Loop</SelectItem>
                   </>
                 )}
               </SelectContent>
@@ -205,7 +211,33 @@ export function RunDialog() {
             </div>
           )}
 
-          {isSchedule && (
+          {isLoop && (
+            <div className="flex flex-col gap-3">
+              <label className="text-sm font-medium text-foreground px-1">
+                Interval (seconds)
+              </label>
+              <div className="flex items-center gap-2">
+                <IconClock
+                  size={16}
+                  className="text-muted-foreground shrink-0"
+                />
+                <input
+                  type="number"
+                  min="0"
+                  value={intervalSeconds}
+                  onChange={(e) => setIntervalSeconds(e.target.value)}
+                  className="w-full rounded-md border border-border bg-input px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+                  placeholder="300"
+                />
+              </div>
+              <p className="text-xs text-muted-foreground px-1">
+                Time between the end of one run and the start of the next. Use 0
+                for immediate restart.
+              </p>
+            </div>
+          )}
+
+          {isSchedule && !isLoop && (
             <div className="flex flex-col gap-3">
               <label className="text-sm font-medium text-foreground px-1">
                 {isOnce ? "Time" : "Frequency"}


### PR DESCRIPTION
## Summary
- Add "Loop" time option to the run dialog, allowing users to create interval-based schedules (alongside the existing support in the schedule dialog)
- Add interval seconds input UI with validation and helper text
- Extract `buildScheduleBody()` helper to keep submit logic clean
- Add integration tests for loop schedule flows in schedule dialog (badge display, field population, API payload)

## Test plan
- [x] Existing schedule dialog tests pass (12/12)
- [x] Type check, lint, knip all pass
- [ ] Manual: open run dialog → select "Loop" → enter interval → verify schedule created with `intervalSeconds`

Closes #3714

🤖 Generated with [Claude Code](https://claude.com/claude-code)