### PR TITLE
feat(docs): fix broken internal links and add missing usage cards

### DIFF
--- a/turbo/apps/docs/content/docs/index.mdx
+++ b/turbo/apps/docs/content/docs/index.mdx
@@ -42,9 +42,9 @@ Welcome to VM0 documentation. Get started with building AI agents.
     description="Enhance your agent with Firecrawl and Tavily for better research"
   />
   <Card
-    title="Syncing Reports to GitHub"
-    href="/docs/tutorial/custom-image"
-    description="Enable your agent to automatically commit research reports to GitHub repositories"
+    title="Scheduling Your Agent"
+    href="/docs/tutorial/scheduling"
+    description="Run your research agent automatically on a schedule"
   />
 </Cards>
 
@@ -92,9 +92,24 @@ Welcome to VM0 documentation. Get started with building AI agents.
     description="Execute agents with vm0 run command"
   />
   <Card
+    title="Schedule Agent"
+    href="/docs/usage/schedule-agent"
+    description="Automate agent runs with VM0's built-in scheduling"
+  />
+  <Card
+    title="Using Skills"
+    href="/docs/usage/using-skills"
+    description="How to effectively use skills in your agent workflows"
+  />
+  <Card
     title="Debugging"
     href="/docs/usage/debugging"
     description="Debug agent runs with checkpoints and logs"
+  />
+  <Card
+    title="Self-Hosting"
+    href="/docs/usage/self-hosting"
+    description="Deploy VM0 on your own infrastructure with Docker Compose"
   />
 </Cards>
 

--- a/turbo/apps/docs/content/docs/quick-start.mdx
+++ b/turbo/apps/docs/content/docs/quick-start.mdx
@@ -49,7 +49,7 @@ vm0 init
 
 This creates two files:
 
-- **[vm0.yaml](/docs/reference/vm0-yaml)** - Agent configuration file that defines the agent's provider and environment settings
+- **[vm0.yaml](/docs/reference/configuration/vm0-yaml)** - Agent configuration file that defines the agent's provider and environment settings
 - **AGENTS.md** - Instructions file that describes what the agent should do and how it should behave
 
 ## Run Your Agent

--- a/turbo/apps/docs/content/docs/tutorial/research-capabilities.mdx
+++ b/turbo/apps/docs/content/docs/tutorial/research-capabilities.mdx
@@ -45,7 +45,7 @@ agents:
 The skills section tells VM0 to load these integrations when composing your agent.
 
 <Callout type="info">
-  Learn more about [vm0.yaml configuration](/docs/reference/vm0-yaml) and the [skills system](/docs/core-concept/skills).
+  Learn more about [vm0.yaml configuration](/docs/reference/configuration/vm0-yaml) and the [skills system](/docs/core-concept/skills).
 </Callout>
 
 ## Step 2: Update Agent Instructions


### PR DESCRIPTION
## Summary
- Replace dead `/docs/tutorial/custom-image` card link with `/docs/tutorial/scheduling` in the docs index page
- Fix incorrect `/docs/reference/vm0-yaml` links to `/docs/reference/configuration/vm0-yaml` in quick-start and research-capabilities tutorial pages
- Add missing "Schedule Agent", "Using Skills", and "Self-Hosting" cards to the Usage section of the docs index page

## Test plan
- [x] Run `pnpm --filter docs check-types` to verify MDX validity
- [ ] Verify all internal links resolve correctly in the deployed docs site

🤖 Generated with [Claude Code](https://claude.com/claude-code)