### PR TITLE
feat(docs): update Z.AI model list with glm-5 and fix casing

### DIFF
--- a/turbo/apps/docs/content/docs/model-selection/index.mdx
+++ b/turbo/apps/docs/content/docs/model-selection/index.mdx
@@ -31,7 +31,7 @@ Once configured, credentials are automatically injected when running agents.
 | [Moonshot](/docs/model-selection/moonshot) | `moonshot-api-key` | Kimi K2 models | [Moonshot Platform](https://platform.moonshot.ai/console/api-keys) |
 | [MiniMax](/docs/model-selection/minimax) | `minimax-api-key` | MiniMax-M2.1 | [MiniMax Platform](https://platform.minimax.io/user-center/basic-information/interface-key) |
 | [DeepSeek](/docs/model-selection/deepseek) | `deepseek-api-key` | deepseek-chat | [DeepSeek Platform](https://platform.deepseek.com/api_keys) |
-| [Z.AI](/docs/model-selection/zai) | `zai-api-key` | GLM-4.7, GLM-4.5-Air | [Z.AI Platform](https://z.ai/model-api) |
+| [Z.AI](/docs/model-selection/zai) | `zai-api-key` | glm-5, glm-4.7, glm-4.5-air | [Z.AI Platform](https://z.ai/model-api) |
 | [Azure Foundry](/docs/model-selection/azure-foundry) | `azure-foundry` | Custom | [Azure Portal](https://portal.azure.com) |
 | [AWS Bedrock](/docs/model-selection/aws-bedrock) | `aws-bedrock` | Custom | [AWS Console](https://console.aws.amazon.com) |
 
@@ -59,7 +59,7 @@ Some providers support choosing specific models. During setup, you'll be prompte
 |----------|-----------------|---------|
 | OpenRouter | `anthropic/claude-sonnet-4.5`, `anthropic/claude-opus-4.5`, `anthropic/claude-haiku-4.5` | auto |
 | Moonshot | `kimi-k2.5`, `kimi-k2-thinking-turbo`, `kimi-k2-thinking` | `kimi-k2.5` |
-| Z.AI | `GLM-4.7`, `GLM-4.5-Air` | `GLM-4.7` |
+| Z.AI | `glm-5`, `glm-4.7`, `glm-4.5-air` | `glm-4.7` |
 | MiniMax | `MiniMax-M2.1` | `MiniMax-M2.1` |
 | DeepSeek | `deepseek-chat` | `deepseek-chat` |
 | Azure Foundry | Custom input | - |

--- a/turbo/apps/docs/content/docs/model-selection/zai.mdx
+++ b/turbo/apps/docs/content/docs/model-selection/zai.mdx
@@ -21,8 +21,9 @@ Visit the [Z.AI Platform](https://z.ai/model-api) to create and obtain an API ke
 
 | Model | Description |
 |-------|-------------|
-| `GLM-4.7` | Latest GLM model (default) |
-| `GLM-4.5-Air` | Lighter, faster variant |
+| `glm-5` | Most capable GLM model |
+| `glm-4.7` | Latest GLM model (default) |
+| `glm-4.5-air` | Lighter, faster variant |
 
 ## Non-Interactive Setup
 
@@ -31,7 +32,7 @@ Visit the [Z.AI Platform](https://z.ai/model-api) to create and obtain an API ke
 vm0 model-provider setup --type zai-api-key --secret "xxx"
 
 # With specific model
-vm0 model-provider setup --type zai-api-key --secret "xxx" --model "GLM-4.5-Air"
+vm0 model-provider setup --type zai-api-key --secret "xxx" --model "glm-4.5-air"
 ```
 
 ## Run


### PR DESCRIPTION
## Summary
- Add missing `glm-5` model to Z.AI documentation (both `zai.mdx` and `index.mdx`)
- Fix model name casing from `GLM-4.7`/`GLM-4.5-Air` to lowercase `glm-4.7`/`glm-4.5-air` to match the source of truth in `model-providers.ts`
- Update example command in `zai.mdx` to use correct lowercase model name

## Test plan
- [x] Verified changes match `turbo/packages/core/src/contracts/model-providers.ts` line 160
- [x] Confirmed `check-types` errors are pre-existing on main (unrelated to MDX content changes)
- [x] Content-only MDX changes — no code logic affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)