### PR TITLE
feat(docs): add missing options to run-agent documentation

### DIFF
--- a/turbo/apps/docs/content/docs/usage/run-agent.mdx
+++ b/turbo/apps/docs/content/docs/usage/run-agent.mdx
@@ -23,12 +23,19 @@ vm0 run my-agent:abc123 "build a todo app"
 
 ## Options
 
-| Option                      | Description                           |
-| --------------------------- | ------------------------------------- |
-| `--vars <KEY=value>`        | Pass variables for `${{ vars.xxx }}`  |
-| `--secrets <KEY=value>`     | Pass secrets for `${{ secrets.xxx }}` |
-| `--artifact-name <name>`    | Use persistent artifact storage       |
-| `--artifact-version <hash>` | Use specific artifact version         |
+| Option                           | Description                                                          |
+| -------------------------------- | -------------------------------------------------------------------- |
+| `--vars <KEY=value>`             | Pass variables for `${{ vars.xxx }}`                                 |
+| `--secrets <KEY=value>`          | Pass secrets for `${{ secrets.xxx }}`                                |
+| `--artifact-name <name>`         | Use persistent artifact storage                                      |
+| `--artifact-version <hash>`      | Use specific artifact version                                        |
+| `--env-file <path>`              | Load environment variables from file (priority: CLI flags > file > env vars) |
+| `--volume-version <name=version>` | Volume version override (repeatable, format: volumeName=version)     |
+| `--conversation <id>`            | Resume from conversation ID (for fine-grained control)               |
+| `--model-provider <type>`        | Override model provider (e.g., anthropic-api-key)                    |
+| `--verbose`                      | Show full tool inputs and outputs                                    |
+| `--check-env`                    | Validate secrets and vars before running                             |
+| `--experimental-shared-agent`    | Allow running agents shared by other users                           |
 
 ### Passing Variables and Secrets
 


### PR DESCRIPTION
## Summary
- Add 7 missing CLI options to the `vm0 run` options table in `run-agent.mdx`
- New options: `--env-file`, `--volume-version`, `--conversation`, `--model-provider`, `--verbose`, `--check-env`, `--experimental-shared-agent`
- Options and descriptions match the actual CLI implementation in `turbo/apps/cli/src/commands/run/run.ts`

## Test plan
- [x] Verified options match source code in `run.ts`
- [x] Confirmed existing 4 options are preserved
- [x] MDX table formatting is consistent with existing style

🤖 Generated with [Claude Code](https://claude.com/claude-code)