### PR TITLE
feat(docs): update CLI reference with missing commands and options

### DIFF
--- a/turbo/apps/docs/content/docs/model-selection/index.mdx
+++ b/turbo/apps/docs/content/docs/model-selection/index.mdx
@@ -31,7 +31,7 @@ Once configured, credentials are automatically injected when running agents.
 | [Moonshot](/docs/model-selection/moonshot) | `moonshot-api-key` | Kimi K2 models | [Moonshot Platform](https://platform.moonshot.ai/console/api-keys) |
 | [MiniMax](/docs/model-selection/minimax) | `minimax-api-key` | MiniMax-M2.1 | [MiniMax Platform](https://platform.minimax.io/user-center/basic-information/interface-key) |
 | [DeepSeek](/docs/model-selection/deepseek) | `deepseek-api-key` | deepseek-chat | [DeepSeek Platform](https://platform.deepseek.com/api_keys) |
-| [Z.AI](/docs/model-selection/zai) | `zai-api-key` | GLM-4.7, GLM-4.5-Air | [Z.AI Platform](https://z.ai/model-api) |
+| [Z.AI](/docs/model-selection/zai) | `zai-api-key` | glm-5, glm-4.7, glm-4.5-air | [Z.AI Platform](https://z.ai/model-api) |
 | [Azure Foundry](/docs/model-selection/azure-foundry) | `azure-foundry` | Custom | [Azure Portal](https://portal.azure.com) |
 | [AWS Bedrock](/docs/model-selection/aws-bedrock) | `aws-bedrock` | Custom | [AWS Console](https://console.aws.amazon.com) |
 
@@ -59,7 +59,7 @@ Some providers support choosing specific models. During setup, you'll be prompte
 |----------|-----------------|---------|
 | OpenRouter | `anthropic/claude-sonnet-4.5`, `anthropic/claude-opus-4.5`, `anthropic/claude-haiku-4.5` | auto |
 | Moonshot | `kimi-k2.5`, `kimi-k2-thinking-turbo`, `kimi-k2-thinking` | `kimi-k2.5` |
-| Z.AI | `GLM-4.7`, `GLM-4.5-Air` | `GLM-4.7` |
+| Z.AI | `glm-5`, `glm-4.7`, `glm-4.5-air` | `glm-4.7` |
 | MiniMax | `MiniMax-M2.1` | `MiniMax-M2.1` |
 | DeepSeek | `deepseek-chat` | `deepseek-chat` |
 | Azure Foundry | Custom input | - |

--- a/turbo/apps/docs/content/docs/model-selection/zai.mdx
+++ b/turbo/apps/docs/content/docs/model-selection/zai.mdx
@@ -21,8 +21,9 @@ Visit the [Z.AI Platform](https://z.ai/model-api) to create and obtain an API ke
 
 | Model | Description |
 |-------|-------------|
-| `GLM-4.7` | Latest GLM model (default) |
-| `GLM-4.5-Air` | Lighter, faster variant |
+| `glm-5` | Most capable GLM model |
+| `glm-4.7` | Latest GLM model (default) |
+| `glm-4.5-air` | Lighter, faster variant |
 
 ## Non-Interactive Setup
 
@@ -31,7 +32,7 @@ Visit the [Z.AI Platform](https://z.ai/model-api) to create and obtain an API ke
 vm0 model-provider setup --type zai-api-key --secret "xxx"
 
 # With specific model
-vm0 model-provider setup --type zai-api-key --secret "xxx" --model "GLM-4.5-Air"
+vm0 model-provider setup --type zai-api-key --secret "xxx" --model "glm-4.5-air"
 ```
 
 ## Run

--- a/turbo/apps/docs/content/docs/reference/cli/index.mdx
+++ b/turbo/apps/docs/content/docs/reference/cli/index.mdx
@@ -7,10 +7,13 @@ description: Complete reference for all VM0 CLI commands
 
 | Command | Description | Options |
 | ------- | ----------- | ------- |
-| `vm0 info` | Display environment information | - |
+| `vm0 info` | Display environment and debug information | - |
 | `vm0 init` | Initialize a new VM0 project with `vm0.yaml` | `-f, --force`, `-n, --name <name>` |
 | `vm0 onboard` | Guided setup for new VM0 users | `-y, --yes`, `--name <name>` |
-| `vm0 setup-claude` | Install vm0-cli skill for Claude | - |
+| `vm0 setup-claude` | Install vm0-cli skill for Claude | `--agent-dir <dir>`, `--scope <scope>` (default: `project`) |
+| `vm0 dashboard` | Quick reference for common query commands | - |
+| `vm0 preference` | View or update your preferences | `--timezone <timezone>`, `--notify-email <on\|off>`, `--notify-slack <on\|off>` |
+| `vm0 upgrade` | Upgrade vm0 CLI to the latest version | - |
 
 ## Authentication
 
@@ -21,6 +24,17 @@ description: Complete reference for all VM0 CLI commands
 | `vm0 auth status` | Show authentication status | - |
 | `vm0 auth setup-token` | Output auth token for CI/CD environments | - |
 
+## Connector Management
+
+Manage third-party service connections.
+
+| Command | Description | Options |
+| ------- | ----------- | ------- |
+| `vm0 connector list` | List all connectors and their status | Alias: `ls` |
+| `vm0 connector connect <type>` | Connect a third-party service (e.g., GitHub) | - |
+| `vm0 connector disconnect <type>` | Disconnect a third-party service | - |
+| `vm0 connector status <type>` | Show detailed status of a connector | - |
+
 ## Model Provider Management
 
 Configure model providers for agent runs.
@@ -28,7 +42,7 @@ Configure model providers for agent runs.
 | Command | Description | Options |
 | ------- | ----------- | ------- |
 | `vm0 model-provider list` | List configured model providers | - |
-| `vm0 model-provider setup` | Configure a model provider | `-t, --type <type>`, `-s, --secret <value>`, `--convert` |
+| `vm0 model-provider setup` | Configure a model provider | `-t, --type <type>`, `-s, --secret <value>`, `-a, --auth-method <method>`, `-m, --model <model>` |
 | `vm0 model-provider delete <type>` | Delete a model provider | - |
 | `vm0 model-provider set-default <type>` | Set a model provider as default for its framework | - |
 
@@ -41,8 +55,8 @@ vm0 model-provider setup
 # Non-interactive setup
 vm0 model-provider setup --type anthropic-api-key --secret "sk-ant-xxx"
 
-# Convert existing credential to model provider
-vm0 model-provider setup --convert
+# Non-interactive with auth method and model
+vm0 model-provider setup --type aws-bedrock --auth-method iam --secret "AWS_ACCESS_KEY_ID=xxx" --secret "AWS_SECRET_ACCESS_KEY=yyy" --model claude-sonnet-4-20250514
 ```
 
 ## Secret Management
@@ -52,17 +66,20 @@ Store and manage secrets (sensitive data) for use in agent runs.
 | Command | Description | Options |
 | ------- | ----------- | ------- |
 | `vm0 secret list` | List all stored secrets | Alias: `ls` |
-| `vm0 secret set <name> <value>` | Store a secret | `-d, --description` |
-| `vm0 secret delete <name>` | Delete a secret | - |
+| `vm0 secret set <name>` | Store a secret | `-b, --body <value>` (required in non-interactive mode), `-d, --description <description>` |
+| `vm0 secret delete <name>` | Delete a secret | `-y, --yes` |
 
 ### Examples
 
 ```bash
-# Store a secret
-vm0 secret set MY_API_KEY sk-xxx
+# Store a secret (interactive — prompts for value)
+vm0 secret set MY_API_KEY
+
+# Store a secret (non-interactive)
+vm0 secret set MY_API_KEY --body "sk-xxx"
 
 # Store with description
-vm0 secret set MY_API_KEY sk-xxx -d "OpenAI API key"
+vm0 secret set MY_API_KEY --body "sk-xxx" -d "OpenAI API key"
 
 # List all secrets (values are hidden)
 vm0 secret list
@@ -104,24 +121,38 @@ Scopes are namespaces for organizing agents.
 | Command | Description | Options |
 | ------- | ----------- | ------- |
 | `vm0 scope status` | Show current scope | - |
-| `vm0 scope set <slug>` | Set the active scope | - |
+| `vm0 scope set <slug>` | Set the active scope | `--force` |
+| `vm0 scope list` | List all accessible scopes | - |
+| `vm0 scope use [slug]` | Switch to a different scope | `--personal` |
+| `vm0 scope create <slug>` | Create a new team scope | - |
+| `vm0 scope members` | View scope members | - |
+| `vm0 scope invite` | Invite a member to the current scope | `--email <email>` (required) |
+| `vm0 scope remove <email>` | Remove a member from the current scope | - |
+| `vm0 scope leave` | Leave the current scope | - |
 
 ## Agent Management
 
 | Command | Description | Options |
 | ------- | ----------- | ------- |
-| `vm0 compose <agent-yaml>` | Create or update agent compose | `-y, --yes` |
+| `vm0 compose [agent-yaml]` | Create or update agent compose (default: vm0.yaml) | `-y, --yes`, `--json` |
 | `vm0 run <agent-name> <prompt>` | Run an agent | See options table below |
-| `vm0 run continue <session-id> <prompt>` | Continue from session (uses latest artifact) | `--env-file`, `--vars`, `--secrets`, `--volume-version`, `--model-provider` |
-| `vm0 run resume <checkpoint-id> <prompt>` | Resume from checkpoint (uses snapshot data) | `--env-file`, `--vars`, `--secrets`, `--volume-version`, `--model-provider` |
-| `vm0 run list` | List active runs (pending and running) | Alias: `ls` |
+| `vm0 run continue <session-id> <prompt>` | Continue from session (uses latest artifact) | `--env-file <path>`, `--vars`, `--secrets`, `--model-provider <type>`, `--verbose`, `--check-env` |
+| `vm0 run resume <checkpoint-id> <prompt>` | Resume from checkpoint (uses snapshot data) | `--env-file <path>`, `--vars`, `--secrets`, `--volume-version <name=version>`, `--model-provider <type>`, `--verbose`, `--check-env` |
+| `vm0 run list` | List runs | Alias: `ls`. Options: `--status <status,...>`, `--all`, `--agent <name>`, `--since <date>`, `--until <date>`, `--limit <n>` |
 | `vm0 run kill <run-id>` | Kill (cancel) a pending or running run | - |
-| `vm0 cook [prompt]` | Prepare and execute agent from `vm0.yaml` | `--env-file <path>`, `-y, --yes` |
+| `vm0 cook [prompt]` | Prepare and execute agent from `vm0.yaml` | `--env-file <path>`, `-y, --yes`, `-v, --verbose` |
 | `vm0 cook logs` | View logs from the last cook run | Same as `vm0 logs` options |
-| `vm0 cook continue <prompt>` | Continue from last session | `--env-file <path>` |
-| `vm0 cook resume <prompt>` | Resume from last checkpoint | `--env-file <path>` |
-| `vm0 agent list` | List all agent composes | `--json` |
-| `vm0 agent status <name[:version]>` | Show agent compose status | `--json` |
+| `vm0 cook continue <prompt>` | Continue from last session | `--env-file <path>`, `-v, --verbose` |
+| `vm0 cook resume <prompt>` | Resume from last checkpoint | `--env-file <path>`, `-v, --verbose` |
+| `vm0 agent list` | List all agent composes | Alias: `ls` |
+| `vm0 agent status <name[:version]>` | Show agent compose status | `--no-sources` |
+| `vm0 agent clone <name> [destination]` | Clone agent compose to local directory (latest version) | - |
+| `vm0 agent delete <name>` | Delete an agent | Alias: `rm`. Options: `-y, --yes` |
+| `vm0 agent permission <name>` | List all permissions for an agent | `--experimental-shared-agent` |
+| `vm0 agent public <name>` | Make an agent public (accessible to all authenticated users) | `--experimental-shared-agent` |
+| `vm0 agent private <name>` | Make an agent private (remove public access) | `--experimental-shared-agent` |
+| `vm0 agent share <name>` | Share an agent with a user by email | `--email <email>` (required), `--experimental-shared-agent` |
+| `vm0 agent unshare <name>` | Remove sharing from a user | `--email <email>` (required), `--experimental-shared-agent` |
 
 ### `vm0 run` Options
 
@@ -135,6 +166,9 @@ Scopes are namespaces for organizing agents.
 | `--volume-version <name=version>` | Volume version override (repeatable) |
 | `--conversation <id>` | Resume from conversation ID |
 | `--model-provider <type>` | Override model provider |
+| `--verbose` | Show full tool inputs and outputs |
+| `--experimental-shared-agent` | Allow running agents shared by other users |
+| `--check-env` | Validate secrets and vars before running |
 
 ### `vm0 run` Examples
 
@@ -186,7 +220,7 @@ vm0 cook resume "try a different approach"
 
 | Command | Description | Options |
 | ------- | ----------- | ------- |
-| `vm0 schedule setup <agent>` | Create or edit a schedule | `-f`, `-t`, `-d`, `-z`, `-p`, `--var`, `--secret`, `--artifact-name`, `-e, --enable` |
+| `vm0 schedule setup <agent>` | Create or edit a schedule | `-f, --frequency <type>`, `-t, --time <HH:MM>`, `-d, --day <day>`, `-i, --interval <seconds>`, `-z, --timezone <tz>`, `-p, --prompt <text>`, `--artifact-name <name>`, `-e, --enable` |
 | `vm0 schedule list` | List all schedules | Alias: `ls` |
 | `vm0 schedule status <agent>` | Show schedule details | - |
 | `vm0 schedule enable <agent>` | Activate a schedule | - |
@@ -197,13 +231,12 @@ vm0 cook resume "try a different approach"
 
 | Option | Description |
 | ------ | ----------- |
-| `-f, --frequency <type>` | Schedule frequency: `daily`, `weekly`, `monthly`, `once` |
+| `-f, --frequency <type>` | Schedule frequency: `daily`, `weekly`, `monthly`, `once`, `loop` |
 | `-t, --time <HH:MM>` | Time to run (24-hour format) |
 | `-d, --day <day>` | Day of week (`mon`-`sun`) or month (`1`-`31`) |
+| `-i, --interval <seconds>` | Interval in seconds for loop mode |
 | `-z, --timezone <tz>` | IANA timezone |
 | `-p, --prompt <text>` | Prompt to run |
-| `--var <KEY=value>` | Pass variable (repeatable) |
-| `--secret <KEY=value>` | Pass secret (repeatable) |
 | `--artifact-name <name>` | Artifact name (default: `artifact`) |
 | `-e, --enable` | Enable schedule immediately after creation |
 
@@ -224,6 +257,13 @@ vm0 schedule setup my-agent \
   --frequency daily \
   --time 09:00 \
   --prompt "run daily tasks" \
+  --enable
+
+# Loop schedule (run every 5 minutes)
+vm0 schedule setup my-agent \
+  --frequency loop \
+  --interval 300 \
+  --prompt "check for updates" \
   --enable
 
 # List all schedules
@@ -270,7 +310,7 @@ Artifacts are work products generated by agents during execution. Unlike volumes
 
 | Command | Description | Options |
 | ------- | ----------- | ------- |
-| `vm0 logs <runId>` | View logs for an agent run | `-a/--agent`, `-s/--system`, `-m/--metrics`, `-n/--network`, `--since`, `--tail`, `--head` |
+| `vm0 logs <runId>` | View logs for an agent run | `-a/--agent`, `-s/--system`, `-m/--metrics`, `-n/--network`, `--since`, `--tail`, `--head`, `--all` |
 
 **Examples:**
 ```bash
@@ -285,6 +325,9 @@ vm0 logs 11007483-20b2-42b1-8f2a-b42a10186810 --tail 20
 
 # Show logs since 5 minutes ago
 vm0 logs 11007483-20b2-42b1-8f2a-b42a10186810 --since 5m
+
+# Fetch all log entries
+vm0 logs 11007483-20b2-42b1-8f2a-b42a10186810 --all
 ```
 
 ## Usage Statistics
@@ -348,8 +391,8 @@ Use `-y` flag to skip confirmation prompts.
 ```bash
 vm0 variable set ENV production
 vm0 variable set REGION us-west
-vm0 secret set API_KEY sk-xxx
-vm0 secret set DB_PASSWORD pwd123
+vm0 secret set API_KEY --body "sk-xxx"
+vm0 secret set DB_PASSWORD --body "pwd123"
 ```
 
 Then just run your agent - values are automatically loaded:


### PR DESCRIPTION
## Summary
- Add 4 undocumented top-level command groups: `connector`, `dashboard`, `preference`, `upgrade`
- Add 7 undocumented agent subcommands: `clone`, `delete`, `permission`, `public`, `private`, `share`, `unshare`
- Add 7 undocumented scope subcommands: `list`, `use`, `create`, `members`, `invite`, `remove`, `leave`
- Fix `vm0 secret set` signature to use `--body` option instead of positional `<value>` argument
- Fix `vm0 info` description to match actual implementation
- Mark `vm0 compose [agent-yaml]` argument as optional with default
- Remove non-existent options: `--convert` from model-provider setup, `--json` from agent list/status, `--volume-version` from run continue
- Add missing options to documented commands: run, run continue, run resume, run list, cook, logs, compose, setup-claude, scope set, secret delete, schedule setup, agent list, agent status
- Add `loop` frequency and `--interval` option to schedule setup
- Remove non-existent `--var` and `--secret` options from schedule setup
- Update FAQ examples to use new `vm0 secret set --body` syntax

## Test plan
- [x] Verified every change against the actual CLI source files in `turbo/apps/cli/src/commands/`
- [x] Confirmed type check errors are pre-existing (identical on main branch)
- [x] Content-only MDX change — no runtime code affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)