### PR TITLE
feat(docs): update configuration reference with missing fields and fixes

### DIFF
--- a/turbo/apps/docs/content/docs/reference/configuration/storage-yaml.mdx
+++ b/turbo/apps/docs/content/docs/reference/configuration/storage-yaml.mdx
@@ -14,7 +14,7 @@ type: volume
 
 ## Fields
 
-| Field  | Type   | Required | Description                                                                   |
-| ------ | ------ | -------- | ----------------------------------------------------------------------------- |
-| `name` | string | Yes      | Unique name for the storage (3-64 chars, lowercase letters, numbers, hyphens) |
-| `type` | string | Yes      | Storage type: `volume` or `artifact`                                          |
+| Field  | Type   | Required | Default  | Description                                                                   |
+| ------ | ------ | -------- | -------- | ----------------------------------------------------------------------------- |
+| `name` | string | Yes      | -        | Unique name for the storage. Must be 3-64 characters, lowercase letters, numbers, and hyphens only. Must start and end with an alphanumeric character. No consecutive hyphens (`--`) allowed |
+| `type` | string | No       | `volume` | Storage type: `volume` or `artifact`                                          |

--- a/turbo/apps/docs/content/docs/reference/configuration/vm0-yaml.mdx
+++ b/turbo/apps/docs/content/docs/reference/configuration/vm0-yaml.mdx
@@ -25,9 +25,11 @@ version: "1.0"
 
 agents:
   my-agent:
+    description: My production agent
     framework: claude-code
     instructions: AGENTS.md
     skills:
+      - slack
       - https://github.com/vm0-ai/vm0-skills/tree/main/hackernews
     volumes:
       - my-volume:/home/user/.config
@@ -45,6 +47,10 @@ volumes:
 Template values like `${{ secrets.X }}` and `${{ vars.X }}` are resolved from Platform-stored secrets and variables. Store them once with `vm0 secret set` or `vm0 variable set`, and they're automatically loaded on every run. See [Environment Variables](/docs/core-concept/environment-variable) for details.
 </Callout>
 
+<Callout type="warn">
+Currently only one agent per `vm0.yaml` file is supported. Defining multiple agents will result in a validation error.
+</Callout>
+
 ## Top-Level Fields
 
 | Field     | Type   | Required | Default | Description                              |
@@ -55,17 +61,23 @@ Template values like `${{ secrets.X }}` and `${{ vars.X }}` are resolved from Pl
 
 ## Agent Fields
 
-| Field          | Type   | Required | Default | Description                                                                                       |
-| -------------- | ------ | -------- | ------- | ------------------------------------------------------------------------------------------------- |
-| `framework`    | string | Yes      | -       | Agent framework: `claude-code` (default) or `codex` ([experimental](/docs/experimental/codex)). See [Model Selection](/docs/model-selection) |
-| `instructions` | string | No       | -       | Path to instruction file (e.g., `AGENTS.md`). See [Instructions](/docs/core-concept/instructions) |
-| `skills`       | array  | No       | `[]`    | List of skill URLs. See [Skills](/docs/core-concept/skills)                                       |
-| `volumes`      | array  | No       | `[]`    | Volume mounts in format `name:path`. See [Volume](/docs/core-concept/volume)                      |
-| `environment`  | object | No       | `{}`    | Environment variables. See [Environment Variables](/docs/core-concept/environment-variable)       |
+Each agent key must be a valid agent name: 3-64 characters, starting and ending with a letter or number, containing only letters, numbers, and hyphens.
+
+| Field                    | Type   | Required | Default        | Description                                                                                       |
+| ------------------------ | ------ | -------- | -------------- | ------------------------------------------------------------------------------------------------- |
+| `description`            | string | No       | -              | Optional description for the agent                                                                |
+| `framework`              | string | No       | `claude-code`  | Agent framework: `claude-code` or `codex` ([experimental](/docs/experimental/codex)). See [Model Selection](/docs/model-selection) |
+| `instructions`           | string | No       | -              | Path to instruction file (e.g., `AGENTS.md`). See [Instructions](/docs/core-concept/instructions) |
+| `skills`                 | array  | No       | `[]`           | List of skill references. Supports bare names (e.g., `"slack"`) which resolve to `https://github.com/vm0-ai/vm0-skills/tree/main/slack`, or full GitHub URLs. See [Skills](/docs/core-concept/skills) |
+| `volumes`                | array  | No       | `[]`           | Volume mounts in format `name:path`. See [Volume](/docs/core-concept/volume)                      |
+| `environment`            | object | No       | `{}`           | Environment variables. See [Environment Variables](/docs/core-concept/environment-variable)       |
+| `experimental_runner`    | object | No       | -              | Self-hosted runner configuration. Object with `group` field in `scope/name` format (e.g., `acme/production`) |
+| `experimental_firewall`  | object | No       | -              | Firewall configuration for network access control. See [Firewall](/docs/experimental/firewall) for details |
 
 ## Volume Fields
 
-| Field     | Type   | Required | Default  | Description                                  |
-| --------- | ------ | -------- | -------- | -------------------------------------------- |
-| `name`    | string | Yes      | -        | Volume name (must match `.vm0/storage.yaml`) |
-| `version` | string | Yes      | -        | Version to use (e.g., `latest` or version hash) |
+| Field      | Type    | Required | Default  | Description                                             |
+| ---------- | ------- | -------- | -------- | ------------------------------------------------------- |
+| `name`     | string  | Yes      | -        | Volume name (must match `.vm0/storage.yaml`)            |
+| `version`  | string  | Yes      | -        | Version to use (e.g., `latest` or version hash)         |
+| `optional` | boolean | No       | `false`  | When true, skip mounting without error if volume doesn't exist |


### PR DESCRIPTION
## Summary
- **vm0.yaml**: Add missing `description`, `experimental_runner`, `experimental_firewall` agent fields and `optional` volume field. Fix `framework` to show correct default (`claude-code`). Document bare skill name syntax, agent name validation rules, and single-agent limitation.
- **storage.yaml**: Add missing `name` validation rules (alphanumeric start/end, no consecutive hyphens). Fix `type` field to show it is optional with default `volume`.

## Test plan
- [x] Verify all added fields match source schemas in `composes.ts` and `storage-utils.ts`
- [x] Verify MDX renders correctly (content-only changes, no code)
- [x] Pre-commit hooks pass (prettier, commitlint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)