### PR TITLE
feat(docs): fix agent-skills index categorization and skill count

### DIFF
--- a/turbo/apps/docs/content/docs/agent-skills/index.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/index.mdx
@@ -3,7 +3,7 @@ title: Overview
 description: Pre-built integrations to extend your agent's capabilities
 ---
 
-Agent Skills are pre-built integrations that give your agent access to external services and APIs. Browse the available skills below and add them to your `vm0.yaml` configuration.
+Agent Skills are pre-built integrations that give your agent access to external services and APIs. With **68 documented skills** (and 80+ available in the repository), you can connect your agent to a wide range of services. Browse the available skills below and add them to your `vm0.yaml` configuration.
 
 ## Adding Skills
 
@@ -88,7 +88,6 @@ See [Skills Configuration](/docs/core-concept/skills) for URL format details and
 
 | Skill | Description |
 |-------|-------------|
-| [Supabase](/docs/agent-skills/supabase) | PostgreSQL database with REST API |
 | [Streak](/docs/agent-skills/streak) | CRM integrated with Gmail |
 | [Kommo](/docs/agent-skills/kommo) | Messenger-based CRM |
 | [Bitrix](/docs/agent-skills/bitrix) | Business collaboration and CRM |
@@ -105,7 +104,7 @@ See [Skills Configuration](/docs/core-concept/skills) for URL format details and
 | [HTML/CSS to Image](/docs/agent-skills/htmlcsstoimage) | Convert HTML to images |
 | [MiniMax](/docs/agent-skills/minimax) | Multimodal AI models |
 
-### Cloud Storage
+### Cloud & Storage
 
 | Skill | Description |
 |-------|-------------|
@@ -113,6 +112,7 @@ See [Skills Configuration](/docs/core-concept/skills) for URL format details and
 | [Cloudinary](/docs/agent-skills/cloudinary) | Media management platform |
 | [Qdrant](/docs/agent-skills/qdrant) | Vector database |
 | [Supadata](/docs/agent-skills/supadata) | Data infrastructure platform |
+| [Supabase](/docs/agent-skills/supabase) | PostgreSQL database with REST API |
 
 ### Documents
 


### PR DESCRIPTION
## Summary
- Move Supabase from "CRM & Sales" to "Cloud & Storage" category since it is a database/backend platform, not a CRM tool
- Rename "Cloud Storage" section to "Cloud & Storage" for consistency
- Add total skill count (68 documented, 80+ in repository) to the page introduction

## Test plan
- [x] Verified MDX content is valid (content-only change, no code logic)
- [x] Confirmed skill count matches 68 documented skills across all categories
- [x] Pre-commit hooks (prettier, commitlint) passed successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)