### PR TITLE
feat(docs): document bare skill names and fix env var resolution priority

### DIFF
--- a/turbo/apps/docs/content/docs/core-concept/environment-variable.mdx
+++ b/turbo/apps/docs/content/docs/core-concept/environment-variable.mdx
@@ -129,14 +129,16 @@ Environment files are **not** automatically loaded. You must explicitly specify 
 When the same value is defined in multiple places, VM0 uses this priority order:
 
 1. **CLI flags** (`--vars`, `--secrets`) - highest priority
-2. **Platform-stored values** - medium priority
-3. **`--env-file`** values - lowest priority
+2. **Platform-stored values** - set via `vm0 secret set` / `vm0 variable set`
+3. **`--env-file`** values - loaded from the file specified with `--env-file`
+4. **Process environment** (`process.env`) - lowest priority fallback
 
 Example:
 
 ```bash
 # Platform has: vm0 secret set API_KEY stored-value
 # .env file contains: API_KEY=from-env-file
+# Shell environment has: export API_KEY=from-shell-env
 
 # CLI value wins over everything
 vm0 run my-agent "prompt" --secrets API_KEY=from-cli --env-file .env
@@ -149,6 +151,10 @@ vm0 run my-agent "prompt" --env-file .env
 # Without Platform-stored value, --env-file is used
 vm0 run my-agent "prompt" --env-file .env
 # Result: API_KEY = "from-env-file"
+
+# Without any of the above, falls back to process environment
+vm0 run my-agent "prompt"
+# Result: API_KEY = "from-shell-env"
 ```
 
 ## Best Practices

--- a/turbo/apps/docs/content/docs/core-concept/skills.mdx
+++ b/turbo/apps/docs/content/docs/core-concept/skills.mdx
@@ -16,15 +16,27 @@ agents:
   my-agent:
     framework: claude-code
     skills: # [!code highlight]
+      - slack # [!code highlight]
       - https://github.com/anthropics/skills/tree/main/skills/pdf # [!code highlight]
-      - https://github.com/vm0-ai/vm0-skills/tree/main/slack # [!code highlight]
 ```
 
-Each skill is specified as a GitHub URL pointing to a directory containing the skill definition.
+Each skill can be specified as either a **bare name** or a **full GitHub URL**.
 
-## Skill URL Format
+## Bare Skill Name
 
-Skills must be GitHub tree URLs in the format:
+You can reference skills from the [vm0-ai/vm0-skills](https://github.com/vm0-ai/vm0-skills) repository by their bare name. The bare name is automatically resolved to a full GitHub URL on the `main` branch:
+
+```yaml title="vm0.yaml"
+skills:
+  - slack                    # Resolves to https://github.com/vm0-ai/vm0-skills/tree/main/slack
+  - firecrawl                # Resolves to https://github.com/vm0-ai/vm0-skills/tree/main/firecrawl
+```
+
+A bare name is any string that does not contain `/` or start with `https://`. This shorthand only works for skills hosted in the default `vm0-ai/vm0-skills` repository. For skills in other repositories, use the full GitHub URL.
+
+## Full GitHub URL
+
+For skills outside the default repository, or to pin to a specific branch, tag, or commit, use the full GitHub tree URL format:
 
 ```
 https://github.com/{owner}/{repo}/tree/{ref}/{path}
@@ -38,9 +50,10 @@ The `{ref}` can be:
 
 **Examples:**
 
-| Skill                 | URL                                                                |
+| Skill                 | Syntax                                                             |
 | --------------------- | ------------------------------------------------------------------ |
-| PDF (main branch)     | `https://github.com/anthropics/skills/tree/main/skills/pdf`        |
+| Slack (bare name)     | `slack`                                                             |
+| PDF (full URL)        | `https://github.com/anthropics/skills/tree/main/skills/pdf`        |
 | Slack (pinned to tag) | `https://github.com/vm0-ai/vm0-skills/tree/v1.0/slack`             |
 | GitHub CLI            | `https://github.com/vm0-ai/vm0-skills/tree/main/skills/github-cli` |
 
@@ -65,4 +78,4 @@ See the [Agent Skills](/docs/agent-skills) section for detailed documentation on
 - [Hacker News](/docs/agent-skills/hackernews) - Tech news
 - [Runway](/docs/agent-skills/runway) - Video generation
 
-Browse all 60+ skills at [vm0-ai/vm0-skills](https://github.com/vm0-ai/vm0-skills).
+Browse all 80+ skills at [vm0-ai/vm0-skills](https://github.com/vm0-ai/vm0-skills).


### PR DESCRIPTION
## Summary
- **Skills docs**: Added documentation for bare skill name syntax (e.g., `slack` auto-resolves to `https://github.com/vm0-ai/vm0-skills/tree/main/slack`), matching the `resolveSkillRef` function in `@vm0/core`. Updated examples table and skill count from 60+ to 80+.
- **Environment variable docs**: Added `process.env` as the lowest-priority fallback in the value resolution priority list, matching the actual `loadValues` implementation in the CLI.

## Test plan
- [x] `pnpm --filter docs check-types` passes
- [ ] Verify rendered MDX displays correctly on the docs site

🤖 Generated with [Claude Code](https://claude.com/claude-code)