### PR TITLE
ci: use random round-robin for runner e2e chunk distribution

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1288,37 +1288,26 @@ jobs:
         id: runner-matrix
         shell: bash
         run: |
-          # Split test files into fixed chunks for parallel bats execution
-          NUM_FILES=$(ls e2e/tests/03-experimental-runner/*.bats 2>/dev/null | wc -l)
+          # Split test files into chunks via random round-robin for balanced runtime
+          mapfile -t FILES < <(ls e2e/tests/03-experimental-runner/*.bats | shuf)
+          NUM_FILES=${#FILES[@]}
           NUM_CHUNKS=4
           [ "$NUM_CHUNKS" -gt "$NUM_FILES" ] && NUM_CHUNKS=$NUM_FILES
+          echo "Runner E2E: $NUM_FILES files, $NUM_CHUNKS chunks"
 
-          # Count tests per file, sort heaviest first
-          mapfile -t SORTED < <(
-            for f in e2e/tests/03-experimental-runner/*.bats; do
-              echo "$(grep -c "^@test" "$f" 2>/dev/null || echo 0) $f"
-            done | sort -rn
-          )
-          echo "Runner E2E: ${#SORTED[@]} files, $NUM_CHUNKS chunks"
-
-          # Greedy bin-packing: assign each file to the lightest chunk
-          declare -a CHUNK_FILES CHUNK_COUNTS
-          for ((i=0; i<NUM_CHUNKS; i++)); do CHUNK_FILES[$i]=""; CHUNK_COUNTS[$i]=0; done
-          for entry in "${SORTED[@]}"; do
-            tests=${entry%% *}; f=${entry#* }
-            min=0
-            for ((i=1; i<NUM_CHUNKS; i++)); do
-              [ ${CHUNK_COUNTS[$i]} -lt ${CHUNK_COUNTS[$min]} ] && min=$i
-            done
-            CHUNK_FILES[$min]="${CHUNK_FILES[$min]:+${CHUNK_FILES[$min]} }$f"
-            CHUNK_COUNTS[$min]=$((CHUNK_COUNTS[$min] + tests))
+          declare -a CHUNK_FILES
+          for ((i=0; i<NUM_CHUNKS; i++)); do CHUNK_FILES[$i]=""; done
+          for ((i=0; i<NUM_FILES; i++)); do
+            idx=$((i % NUM_CHUNKS))
+            CHUNK_FILES[$idx]="${CHUNK_FILES[$idx]:+${CHUNK_FILES[$idx]} }${FILES[$i]}"
           done
 
           CHUNKS="["
           for ((i=0; i<NUM_CHUNKS; i++)); do
             [ $i -gt 0 ] && CHUNKS="$CHUNKS,"
+            file_count=$(echo ${CHUNK_FILES[$i]} | wc -w)
             CHUNKS="$CHUNKS{\"index\":$((i+1)),\"files\":\"${CHUNK_FILES[$i]}\"}"
-            echo "Chunk $((i+1)): ${CHUNK_COUNTS[$i]} tests"
+            echo "Chunk $((i+1)): $file_count files"
           done
           echo "matrix=${CHUNKS}]" >> $GITHUB_OUTPUT
           echo "chunk-count=${NUM_CHUNKS}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary
- Replace greedy bin-packing (by test count) with shuffle + round-robin for runner E2E test chunks
- Test count is a poor proxy for actual runtime — VM-based tests are much slower than CLI tests, causing unbalanced chunks (51s vs 96s observed)
- Random distribution averages out over time and is simpler code

## Test plan
- CI will validate the new chunking strategy
- Compare chunk runtimes across a few runs to verify better balance

🤖 Generated with [Claude Code](https://claude.com/claude-code)