### PR TITLE
ci: remove redundant python install on ubuntu-latest jobs

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -29,9 +29,7 @@ jobs:
 
       - name: Install Ansible
         if: steps.check.outputs.should-cleanup == 'true'
-        run: |
-          apt-get update && apt-get install -y python3 python3-pip
-          pip3 install ansible
+        run: pip3 install ansible
 
       - name: Setup SSH key
         if: steps.check.outputs.should-cleanup == 'true'

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -507,9 +507,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install Ansible
-        run: |
-          apt-get update && apt-get install -y python3 python3-pip
-          pip3 install ansible
+        run: pip3 install ansible
 
       - name: Setup SSH key
         env:

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1793,9 +1793,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install Ansible
-        run: |
-          apt-get update && apt-get install -y python3 python3-pip
-          pip3 install ansible
+        run: pip3 install ansible
 
       - name: Setup SSH key
         env:


### PR DESCRIPTION
## Summary
- Remove `apt-get update && apt-get install -y python3 python3-pip` from jobs running on `ubuntu-latest` (cleanup.yml, crates.yml, turbo.yml)
- `ubuntu-latest` already has Python 3 and pip pre-installed
- Jobs in custom containers (`vm0-toolchain-rust`) are unchanged since they need the install

🤖 Generated with [Claude Code](https://claude.com/claude-code)