### PR TITLE
ci: enable balloon reclaim in all ci runner tests

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -339,7 +339,8 @@ jobs:
           # Start transient runner service
           echo "--- Starting runner ---"
           "$BIN_DIR/runner" service start --name "$SVC" \
-            --config "$RUNNER_DIR/runner.yaml" --local --env USE_MOCK_CLAUDE=true
+            --config "$RUNNER_DIR/runner.yaml" --local --env USE_MOCK_CLAUDE=true \
+            --balloon-reclaim
 
           # Submit a long-running job in background (keeps sandbox alive during tests)
           echo "--- Submitting long-running job ---"
@@ -632,7 +633,8 @@ jobs:
           # 1. Install runner A
           echo "--- Installing runner A ---"
           "$BIN_DIR/runner" service install --name "$SVC_A" \
-            --config "$RUNNER_DIR_A/runner.yaml" --local --env USE_MOCK_CLAUDE=true
+            --config "$RUNNER_DIR_A/runner.yaml" --local --env USE_MOCK_CLAUDE=true \
+            --balloon-reclaim
 
           # 2. Submit job 1 (background, long-running) → only A running
           echo "--- Submit job 1 (only A, long-running) ---"
@@ -642,7 +644,8 @@ jobs:
           # 3. Install runner B while job 1 still in-flight on A
           echo "--- Installing runner B ---"
           "$BIN_DIR/runner" service install --name "$SVC_B" \
-            --config "$RUNNER_DIR_B/runner.yaml" --local --env USE_MOCK_CLAUDE=true
+            --config "$RUNNER_DIR_B/runner.yaml" --local --env USE_MOCK_CLAUDE=true \
+            --balloon-reclaim
 
           # 4. Submit job 2 (background, long-running) → A and B compete
           echo "--- Submit job 2 (A and B compete, long-running) ---"

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1473,7 +1473,8 @@ jobs:
               --name ${RUNNER_NAME} \
               --config ${RUNNER_DIR}/runner.yaml \
               --env VERCEL_AUTOMATION_BYPASS_SECRET=${VERCEL_BYPASS} \
-              --env USE_MOCK_CLAUDE=true"
+              --env USE_MOCK_CLAUDE=true \
+              --balloon-reclaim"
 
             # Health check — filter by name so other PR runners don't cause false positives
             sleep 5


### PR DESCRIPTION
## Summary
- Add `--balloon-reclaim` to runner exec, upgrade, and E2E preview runner starts
- Balloon controller now runs alongside all CI tests, providing broader integration coverage
- Production deploy (`ansible/playbooks/deploy-runner.yml`) is unchanged

## Test plan
- [ ] `runner-exec` passes with balloon controller active
- [ ] `runner-balloon` continues to pass (already had the flag)
- [ ] `runner-upgrade-local` passes with balloon controller on both A and B
- [ ] E2E runner tests pass with balloon controller active

🤖 Generated with [Claude Code](https://claude.com/claude-code)