### PR TITLE
feat(docs): sync docs with current cli and platform behavior

### DIFF
--- a/turbo/apps/docs/content/docs/core-concept/environment-variable.mdx
+++ b/turbo/apps/docs/content/docs/core-concept/environment-variable.mdx
@@ -129,14 +129,16 @@ Environment files are **not** automatically loaded. You must explicitly specify 
 When the same value is defined in multiple places, VM0 uses this priority order:
 
 1. **CLI flags** (`--vars`, `--secrets`) - highest priority
-2. **Platform-stored values** - medium priority
-3. **`--env-file`** values - lowest priority
+2. **Platform-stored values** - set via `vm0 secret set` / `vm0 variable set`
+3. **`--env-file`** values - loaded from the file specified with `--env-file`
+4. **Process environment** (`process.env`) - lowest priority fallback
 
 Example:
 
 ```bash
 # Platform has: vm0 secret set API_KEY stored-value
 # .env file contains: API_KEY=from-env-file
+# Shell environment has: export API_KEY=from-shell-env
 
 # CLI value wins over everything
 vm0 run my-agent "prompt" --secrets API_KEY=from-cli --env-file .env
@@ -149,6 +151,10 @@ vm0 run my-agent "prompt" --env-file .env
 # Without Platform-stored value, --env-file is used
 vm0 run my-agent "prompt" --env-file .env
 # Result: API_KEY = "from-env-file"
+
+# Without any of the above, falls back to process environment
+vm0 run my-agent "prompt"
+# Result: API_KEY = "from-shell-env"
 ```
 
 ## Best Practices

--- a/turbo/apps/docs/content/docs/core-concept/skills.mdx
+++ b/turbo/apps/docs/content/docs/core-concept/skills.mdx
@@ -16,15 +16,27 @@ agents:
   my-agent:
     framework: claude-code
     skills: # [!code highlight]
+      - slack # [!code highlight]
       - https://github.com/anthropics/skills/tree/main/skills/pdf # [!code highlight]
-      - https://github.com/vm0-ai/vm0-skills/tree/main/slack # [!code highlight]
 ```
 
-Each skill is specified as a GitHub URL pointing to a directory containing the skill definition.
+Each skill can be specified as either a **bare name** or a **full GitHub URL**.
 
-## Skill URL Format
+## Bare Skill Name
 
-Skills must be GitHub tree URLs in the format:
+You can reference skills from the [vm0-ai/vm0-skills](https://github.com/vm0-ai/vm0-skills) repository by their bare name. The bare name is automatically resolved to a full GitHub URL on the `main` branch:
+
+```yaml title="vm0.yaml"
+skills:
+  - slack                    # Resolves to https://github.com/vm0-ai/vm0-skills/tree/main/slack
+  - firecrawl                # Resolves to https://github.com/vm0-ai/vm0-skills/tree/main/firecrawl
+```
+
+A bare name is any string that does not contain `/` or start with `https://`. This shorthand only works for skills hosted in the default `vm0-ai/vm0-skills` repository. For skills in other repositories, use the full GitHub URL.
+
+## Full GitHub URL
+
+For skills outside the default repository, or to pin to a specific branch, tag, or commit, use the full GitHub tree URL format:
 
 ```
 https://github.com/{owner}/{repo}/tree/{ref}/{path}
@@ -38,9 +50,10 @@ The `{ref}` can be:
 
 **Examples:**
 
-| Skill                 | URL                                                                |
+| Skill                 | Syntax                                                             |
 | --------------------- | ------------------------------------------------------------------ |
-| PDF (main branch)     | `https://github.com/anthropics/skills/tree/main/skills/pdf`        |
+| Slack (bare name)     | `slack`                                                             |
+| PDF (full URL)        | `https://github.com/anthropics/skills/tree/main/skills/pdf`        |
 | Slack (pinned to tag) | `https://github.com/vm0-ai/vm0-skills/tree/v1.0/slack`             |
 | GitHub CLI            | `https://github.com/vm0-ai/vm0-skills/tree/main/skills/github-cli` |
 
@@ -65,4 +78,4 @@ See the [Agent Skills](/docs/agent-skills) section for detailed documentation on
 - [Hacker News](/docs/agent-skills/hackernews) - Tech news
 - [Runway](/docs/agent-skills/runway) - Video generation
 
-Browse all 60+ skills at [vm0-ai/vm0-skills](https://github.com/vm0-ai/vm0-skills).
+Browse all 80+ skills at [vm0-ai/vm0-skills](https://github.com/vm0-ai/vm0-skills).

--- a/turbo/apps/docs/content/docs/reference/configuration/storage-yaml.mdx
+++ b/turbo/apps/docs/content/docs/reference/configuration/storage-yaml.mdx
@@ -14,7 +14,7 @@ type: volume
 
 ## Fields
 
-| Field  | Type   | Required | Description                                                                   |
-| ------ | ------ | -------- | ----------------------------------------------------------------------------- |
-| `name` | string | Yes      | Unique name for the storage (3-64 chars, lowercase letters, numbers, hyphens) |
-| `type` | string | Yes      | Storage type: `volume` or `artifact`                                          |
+| Field  | Type   | Required | Default  | Description                                                                   |
+| ------ | ------ | -------- | -------- | ----------------------------------------------------------------------------- |
+| `name` | string | Yes      | -        | Unique name for the storage. Must be 3-64 characters, lowercase letters, numbers, and hyphens only. Must start and end with an alphanumeric character. No consecutive hyphens (`--`) allowed |
+| `type` | string | No       | `volume` | Storage type: `volume` or `artifact`                                          |

--- a/turbo/apps/docs/content/docs/reference/configuration/vm0-yaml.mdx
+++ b/turbo/apps/docs/content/docs/reference/configuration/vm0-yaml.mdx
@@ -25,9 +25,11 @@ version: "1.0"
 
 agents:
   my-agent:
+    description: My production agent
     framework: claude-code
     instructions: AGENTS.md
     skills:
+      - slack
       - https://github.com/vm0-ai/vm0-skills/tree/main/hackernews
     volumes:
       - my-volume:/home/user/.config
@@ -45,6 +47,10 @@ volumes:
 Template values like `${{ secrets.X }}` and `${{ vars.X }}` are resolved from Platform-stored secrets and variables. Store them once with `vm0 secret set` or `vm0 variable set`, and they're automatically loaded on every run. See [Environment Variables](/docs/core-concept/environment-variable) for details.
 </Callout>
 
+<Callout type="warn">
+Currently only one agent per `vm0.yaml` file is supported. Defining multiple agents will result in a validation error.
+</Callout>
+
 ## Top-Level Fields
 
 | Field     | Type   | Required | Default | Description                              |
@@ -55,17 +61,23 @@ Template values like `${{ secrets.X }}` and `${{ vars.X }}` are resolved from Pl
 
 ## Agent Fields
 
-| Field          | Type   | Required | Default | Description                                                                                       |
-| -------------- | ------ | -------- | ------- | ------------------------------------------------------------------------------------------------- |
-| `framework`    | string | Yes      | -       | Agent framework: `claude-code` (default) or `codex` ([experimental](/docs/experimental/codex)). See [Model Selection](/docs/model-selection) |
-| `instructions` | string | No       | -       | Path to instruction file (e.g., `AGENTS.md`). See [Instructions](/docs/core-concept/instructions) |
-| `skills`       | array  | No       | `[]`    | List of skill URLs. See [Skills](/docs/core-concept/skills)                                       |
-| `volumes`      | array  | No       | `[]`    | Volume mounts in format `name:path`. See [Volume](/docs/core-concept/volume)                      |
-| `environment`  | object | No       | `{}`    | Environment variables. See [Environment Variables](/docs/core-concept/environment-variable)       |
+Each agent key must be a valid agent name: 3-64 characters, starting and ending with a letter or number, containing only letters, numbers, and hyphens.
+
+| Field                    | Type   | Required | Default        | Description                                                                                       |
+| ------------------------ | ------ | -------- | -------------- | ------------------------------------------------------------------------------------------------- |
+| `description`            | string | No       | -              | Optional description for the agent                                                                |
+| `framework`              | string | No       | `claude-code`  | Agent framework: `claude-code` or `codex` ([experimental](/docs/experimental/codex)). See [Model Selection](/docs/model-selection) |
+| `instructions`           | string | No       | -              | Path to instruction file (e.g., `AGENTS.md`). See [Instructions](/docs/core-concept/instructions) |
+| `skills`                 | array  | No       | `[]`           | List of skill references. Supports bare names (e.g., `"slack"`) which resolve to `https://github.com/vm0-ai/vm0-skills/tree/main/slack`, or full GitHub URLs. See [Skills](/docs/core-concept/skills) |
+| `volumes`                | array  | No       | `[]`           | Volume mounts in format `name:path`. See [Volume](/docs/core-concept/volume)                      |
+| `environment`            | object | No       | `{}`           | Environment variables. See [Environment Variables](/docs/core-concept/environment-variable)       |
+| `experimental_runner`    | object | No       | -              | Self-hosted runner configuration. Object with `group` field in `scope/name` format (e.g., `acme/production`) |
+| `experimental_firewall`  | object | No       | -              | Firewall configuration for network access control. See [Firewall](/docs/experimental/firewall) for details |
 
 ## Volume Fields
 
-| Field     | Type   | Required | Default  | Description                                  |
-| --------- | ------ | -------- | -------- | -------------------------------------------- |
-| `name`    | string | Yes      | -        | Volume name (must match `.vm0/storage.yaml`) |
-| `version` | string | Yes      | -        | Version to use (e.g., `latest` or version hash) |
+| Field      | Type    | Required | Default  | Description                                             |
+| ---------- | ------- | -------- | -------- | ------------------------------------------------------- |
+| `name`     | string  | Yes      | -        | Volume name (must match `.vm0/storage.yaml`)            |
+| `version`  | string  | Yes      | -        | Version to use (e.g., `latest` or version hash)         |
+| `optional` | boolean | No       | `false`  | When true, skip mounting without error if volume doesn't exist |

--- a/turbo/apps/docs/content/docs/self-hosting.mdx
+++ b/turbo/apps/docs/content/docs/self-hosting.mdx
@@ -117,34 +117,66 @@ The `caddy` reverse proxy exposes the web app on port `8080` (configurable via `
 | `DB_PASSWORD`    | PostgreSQL password          | -       |
 | `MINIO_PASSWORD` | MinIO (object storage) password | -    |
 
-### Optional Variables
+### Optional — General
 
 | Variable                 | Description                                     | Default      |
 | ------------------------ | ----------------------------------------------- | ------------ |
 | `DOMAIN`                 | Domain for Caddy reverse proxy                  | `localhost`  |
-| `DB_USER`                | PostgreSQL username                              | `vm0`        |
-| `DB_NAME`                | PostgreSQL database name                         | `vm0`        |
 | `HTTP_PORT`              | HTTP port for Caddy                              | `8080`       |
+| `HTTPS_PORT`             | HTTPS port for Caddy                             | `8443`       |
 | `PLATFORM_PORT`          | Platform console port                            | `3001`       |
 | `SECRETS_ENCRYPTION_KEY` | 64-char hex key (auto-generated if empty)        | auto         |
 | `CONCURRENT_RUN_LIMIT`   | Max concurrent agent runs (0 = unlimited)        | `0`          |
 | `DOCKER_SANDBOX_MEMORY`  | Memory limit per sandbox container               | `2g`         |
 | `DOCKER_SANDBOX_CPUS`    | CPU limit per sandbox container                  | `2`          |
 
-### External Services (Optional)
+### Optional — Built-in PostgreSQL
 
-You can replace the built-in PostgreSQL and MinIO with external services:
+| Variable       | Description              | Default |
+| -------------- | ------------------------ | ------- |
+| `DB_USER`      | PostgreSQL username      | `vm0`   |
+| `DB_NAME`      | PostgreSQL database name | `vm0`   |
+| `DB_POOL_MAX`  | Connection pool size     | `10`    |
 
-```bash
-# External database
-DATABASE_URL=postgresql://user:pass@host:5432/dbname
+### Optional — Built-in MinIO
 
-# External S3-compatible storage
-S3_ENDPOINT=https://s3.amazonaws.com
-R2_ACCESS_KEY_ID=your_key
-R2_SECRET_ACCESS_KEY=your_secret
-R2_USER_STORAGES_BUCKET_NAME=your_bucket
-```
+| Variable             | Description             | Default          |
+| -------------------- | ----------------------- | ---------------- |
+| `MINIO_USER`         | MinIO admin username    | `minioadmin`     |
+| `MINIO_BUCKET`       | Default bucket name     | `vm0-storages`   |
+| `MINIO_API_PORT`     | MinIO API port          | `9000`           |
+| `MINIO_CONSOLE_PORT` | MinIO console port      | `9001`           |
+
+### Optional — External Database
+
+Use an external PostgreSQL database instead of the built-in one:
+
+| Variable       | Description                                      | Default |
+| -------------- | ------------------------------------------------ | ------- |
+| `DATABASE_URL` | PostgreSQL connection string (overrides built-in) | -       |
+
+### Optional — External S3-Compatible Storage
+
+Use an external S3-compatible storage instead of the built-in MinIO:
+
+| Variable                       | Description                          | Default |
+| ------------------------------ | ------------------------------------ | ------- |
+| `S3_ENDPOINT`                  | S3 endpoint URL                      | -       |
+| `S3_REGION`                    | S3 region                            | -       |
+| `S3_FORCE_PATH_STYLE`          | Use path-style S3 URLs               | `false` |
+| `R2_ACCESS_KEY_ID`             | S3 access key ID                     | -       |
+| `R2_SECRET_ACCESS_KEY`         | S3 secret access key                 | -       |
+| `R2_USER_STORAGES_BUCKET_NAME` | S3 bucket name for user storages     | -       |
+
+### Optional — Slack Integration
+
+| Variable                   | Description                      | Default    |
+| -------------------------- | -------------------------------- | ---------- |
+| `SLACK_INTEGRATION_ENABLED`| Enable Slack integration         | `false`    |
+| `SLACK_CLIENT_ID`          | Slack OAuth client ID            | -          |
+| `SLACK_CLIENT_SECRET`      | Slack OAuth client secret        | -          |
+| `SLACK_SIGNING_SECRET`     | Slack signing secret             | -          |
+| `SLACK_REDIRECT_BASE_URL`  | Base URL for Slack OAuth redirect| -          |
 
 ## Troubleshooting
 

--- a/turbo/apps/docs/content/docs/usage/debugging.mdx
+++ b/turbo/apps/docs/content/docs/usage/debugging.mdx
@@ -63,20 +63,68 @@ This approach lets you:
 
 ## Viewing Logs
 
-View full logs from a completed run:
+View logs from a completed run:
 
 ```bash
 vm0 logs <run-id>
 ```
 
-View the last N lines:
+By default, this shows the last 5 agent event entries.
+
+### Log Types
+
+The `vm0 logs` command supports four log types. These flags are mutually exclusive — you can only use one at a time:
+
+| Flag | Description |
+|------|-------------|
+| `-a`, `--agent` | Show agent events (default) |
+| `-s`, `--system` | Show system log |
+| `-m`, `--metrics` | Show metrics (CPU, memory, disk) |
+| `-n`, `--network` | Show network logs (proxy traffic) |
 
 ```bash
-vm0 logs <run-id> --tail 100
+# View system log
+vm0 logs <run-id> --system
+
+# View metrics
+vm0 logs <run-id> --metrics
+
+# View network traffic
+vm0 logs <run-id> --network
 ```
 
-View the first N lines:
+### Pagination
+
+Control how many entries are displayed with `--tail`, `--head`, or `--all`. These flags are mutually exclusive:
+
+| Flag | Description |
+|------|-------------|
+| `--tail <n>` | Show last N entries (default: 5) |
+| `--head <n>` | Show first N entries |
+| `--all` | Fetch all log entries |
 
 ```bash
+# Show last 100 entries
+vm0 logs <run-id> --tail 100
+
+# Show first 50 entries
 vm0 logs <run-id> --head 50
+
+# Show all entries
+vm0 logs <run-id> --all
+```
+
+### Filtering by Time
+
+Use `--since` to filter logs by timestamp. Accepts relative durations, ISO 8601 timestamps, or Unix timestamps:
+
+```bash
+# Logs from the last 5 minutes
+vm0 logs <run-id> --since 5m
+
+# Logs from the last 2 hours
+vm0 logs <run-id> --since 2h
+
+# Logs since a specific time
+vm0 logs <run-id> --since 2024-01-15T10:30:00Z
 ```

--- a/turbo/apps/docs/content/docs/usage/run-agent.mdx
+++ b/turbo/apps/docs/content/docs/usage/run-agent.mdx
@@ -23,12 +23,19 @@ vm0 run my-agent:abc123 "build a todo app"
 
 ## Options
 
-| Option                      | Description                           |
-| --------------------------- | ------------------------------------- |
-| `--vars <KEY=value>`        | Pass variables for `${{ vars.xxx }}`  |
-| `--secrets <KEY=value>`     | Pass secrets for `${{ secrets.xxx }}` |
-| `--artifact-name <name>`    | Use persistent artifact storage       |
-| `--artifact-version <hash>` | Use specific artifact version         |
+| Option                           | Description                                                          |
+| -------------------------------- | -------------------------------------------------------------------- |
+| `--vars <KEY=value>`             | Pass variables for `${{ vars.xxx }}`                                 |
+| `--secrets <KEY=value>`          | Pass secrets for `${{ secrets.xxx }}`                                |
+| `--artifact-name <name>`         | Use persistent artifact storage                                      |
+| `--artifact-version <hash>`      | Use specific artifact version                                        |
+| `--env-file <path>`              | Load environment variables from file (priority: CLI flags > file > env vars) |
+| `--volume-version <name=version>` | Volume version override (repeatable, format: volumeName=version)     |
+| `--conversation <id>`            | Resume from conversation ID (for fine-grained control)               |
+| `--model-provider <type>`        | Override model provider (e.g., anthropic-api-key)                    |
+| `--verbose`                      | Show full tool inputs and outputs                                    |
+| `--check-env`                    | Validate secrets and vars before running                             |
+| `--experimental-shared-agent`    | Allow running agents shared by other users                           |
 
 ### Passing Variables and Secrets
 

--- a/turbo/apps/docs/content/docs/usage/schedule-agent.mdx
+++ b/turbo/apps/docs/content/docs/usage/schedule-agent.mdx
@@ -37,9 +37,10 @@ vm0 schedule setup my-agent
 ```
 
 The CLI will prompt for:
-- **Frequency**: daily, weekly, monthly, or one-time
-- **Time**: When to run (HH:MM format)
+- **Frequency**: daily, weekly, monthly, one-time, or loop
+- **Time**: When to run (HH:MM format, for daily/weekly/monthly)
 - **Day**: Day of week or month (for weekly/monthly)
+- **Interval**: Seconds between runs (for loop)
 - **Timezone**: Your local timezone (auto-detected)
 - **Prompt**: The prompt to send to the agent
 
@@ -59,14 +60,14 @@ vm0 schedule setup my-agent \
 
 | Option | Description |
 | ------ | ----------- |
-| `-f, --frequency <type>` | Schedule frequency: `daily`, `weekly`, `monthly`, `once` |
+| `-f, --frequency <type>` | Schedule frequency: `daily`, `weekly`, `monthly`, `once`, `loop` |
 | `-t, --time <HH:MM>` | Time to run (24-hour format) |
 | `-d, --day <day>` | Day of week (`mon`-`sun`) or month (`1`-`31`) |
+| `-i, --interval <seconds>` | Interval in seconds for loop mode |
 | `-z, --timezone <tz>` | IANA timezone (e.g., `America/New_York`) |
 | `-p, --prompt <text>` | Prompt to run |
-| `--var <KEY=value>` | Pass variable (repeatable) |
-| `--secret <KEY=value>` | Pass secret (repeatable) |
 | `--artifact-name <name>` | Artifact name (default: `artifact`) |
+| `-e, --enable` | Enable schedule immediately after creation |
 
 ## Schedule Frequencies
 
@@ -89,6 +90,13 @@ vm0 schedule setup my-agent --frequency monthly --day 1 --time 09:00
 ```bash
 vm0 schedule setup my-agent --frequency once --day 2024-12-25 --time 09:00
 ```
+
+### Loop
+```bash
+vm0 schedule setup my-agent --frequency loop --interval 300 --prompt "check for updates"
+```
+
+Runs repeatedly at a fixed interval. The `--interval` flag specifies the number of seconds between runs.
 
 ## Managing Schedules
 
@@ -131,16 +139,14 @@ vm0 schedule delete my-agent
 
 ## Passing Variables and Secrets
 
-**Recommended: Use Platform Storage**
-
-Store secrets on the platform once, and they're automatically available for all scheduled runs:
+Variables and secrets for scheduled runs are inherited from the agent's platform-stored values. Store them once, and they are automatically available for all scheduled runs:
 
 ```bash
 vm0 variable set ENV production
 vm0 secret set API_KEY sk-xxx
 ```
 
-Then set up your schedule without passing secrets:
+Then set up your schedule:
 
 ```bash
 vm0 schedule setup my-agent \
@@ -148,23 +154,6 @@ vm0 schedule setup my-agent \
   --time 09:00 \
   --prompt "deploy to production"
 ```
-
-**Alternative: Schedule-Specific Values**
-
-For schedule-specific overrides, pass values in the setup command:
-
-```bash
-vm0 schedule setup my-agent \
-  --frequency daily \
-  --time 09:00 \
-  --prompt "deploy to production" \
-  --var ENV=production \
-  --secret API_KEY=sk-xxx
-```
-
-<Callout type="info">
-Schedule-specific values (`--var`, `--secret`) override Platform-stored values for that schedule only. Other schedules and manual runs still use Platform-stored values.
-</Callout>
 
 The agent can access these via `${{ vars.ENV }}` and `${{ secrets.API_KEY }}`.
 
@@ -176,7 +165,13 @@ See [Environment Variables](/docs/core-concept/environment-variable) for more de
 
 <Accordion title="When are schedules created vs enabled?">
 
-Schedules are created in a **disabled** state by default. This is a safety measure to let you review the configuration before activating. After setup, run:
+In **interactive mode**, `vm0 schedule setup` prompts you to enable the schedule after creation (default: yes). In **non-interactive mode**, schedules are created in a disabled state unless you pass the `--enable` flag:
+
+```bash
+vm0 schedule setup my-agent --frequency daily --time 09:00 --prompt "daily report" --enable
+```
+
+You can also enable a schedule at any time with:
 
 ```bash
 vm0 schedule enable my-agent

--- a/turbo/apps/docs/content/docs/usage/self-hosting.mdx
+++ b/turbo/apps/docs/content/docs/usage/self-hosting.mdx
@@ -162,34 +162,66 @@ The `caddy` reverse proxy exposes the web app on port `8080` (configurable via `
 | `DB_PASSWORD`    | PostgreSQL password          | -       |
 | `MINIO_PASSWORD` | MinIO (object storage) password | -    |
 
-### Optional Variables
+### Optional — General
 
 | Variable                 | Description                                     | Default      |
 | ------------------------ | ----------------------------------------------- | ------------ |
 | `DOMAIN`                 | Domain for Caddy reverse proxy                  | `localhost`  |
-| `DB_USER`                | PostgreSQL username                              | `vm0`        |
-| `DB_NAME`                | PostgreSQL database name                         | `vm0`        |
 | `HTTP_PORT`              | HTTP port for Caddy                              | `8080`       |
+| `HTTPS_PORT`             | HTTPS port for Caddy                             | `8443`       |
 | `PLATFORM_PORT`          | Platform console port                            | `3001`       |
 | `SECRETS_ENCRYPTION_KEY` | 64-char hex key (auto-generated if empty)        | auto         |
 | `CONCURRENT_RUN_LIMIT`   | Max concurrent agent runs (0 = unlimited)        | `0`          |
 | `DOCKER_SANDBOX_MEMORY`  | Memory limit per sandbox container               | `2g`         |
 | `DOCKER_SANDBOX_CPUS`    | CPU limit per sandbox container                  | `2`          |
 
-### External Services (Optional)
+### Optional — Built-in PostgreSQL
 
-You can replace the built-in PostgreSQL and MinIO with external services:
+| Variable       | Description              | Default |
+| -------------- | ------------------------ | ------- |
+| `DB_USER`      | PostgreSQL username      | `vm0`   |
+| `DB_NAME`      | PostgreSQL database name | `vm0`   |
+| `DB_POOL_MAX`  | Connection pool size     | `10`    |
 
-```bash
-# External database
-DATABASE_URL=postgresql://user:pass@host:5432/dbname
+### Optional — Built-in MinIO
 
-# External S3-compatible storage
-S3_ENDPOINT=https://s3.amazonaws.com
-R2_ACCESS_KEY_ID=your_key
-R2_SECRET_ACCESS_KEY=your_secret
-R2_USER_STORAGES_BUCKET_NAME=your_bucket
-```
+| Variable             | Description             | Default          |
+| -------------------- | ----------------------- | ---------------- |
+| `MINIO_USER`         | MinIO admin username    | `minioadmin`     |
+| `MINIO_BUCKET`       | Default bucket name     | `vm0-storages`   |
+| `MINIO_API_PORT`     | MinIO API port          | `9000`           |
+| `MINIO_CONSOLE_PORT` | MinIO console port      | `9001`           |
+
+### Optional — External Database
+
+Use an external PostgreSQL database instead of the built-in one:
+
+| Variable       | Description                                      | Default |
+| -------------- | ------------------------------------------------ | ------- |
+| `DATABASE_URL` | PostgreSQL connection string (overrides built-in) | -       |
+
+### Optional — External S3-Compatible Storage
+
+Use an external S3-compatible storage instead of the built-in MinIO:
+
+| Variable                       | Description                          | Default |
+| ------------------------------ | ------------------------------------ | ------- |
+| `S3_ENDPOINT`                  | S3 endpoint URL                      | -       |
+| `S3_REGION`                    | S3 region                            | -       |
+| `S3_FORCE_PATH_STYLE`          | Use path-style S3 URLs               | `false` |
+| `R2_ACCESS_KEY_ID`             | S3 access key ID                     | -       |
+| `R2_SECRET_ACCESS_KEY`         | S3 secret access key                 | -       |
+| `R2_USER_STORAGES_BUCKET_NAME` | S3 bucket name for user storages     | -       |
+
+### Optional — Slack Integration
+
+| Variable                   | Description                      | Default    |
+| -------------------------- | -------------------------------- | ---------- |
+| `SLACK_INTEGRATION_ENABLED`| Enable Slack integration         | `false`    |
+| `SLACK_CLIENT_ID`          | Slack OAuth client ID            | -          |
+| `SLACK_CLIENT_SECRET`      | Slack OAuth client secret        | -          |
+| `SLACK_SIGNING_SECRET`     | Slack signing secret             | -          |
+| `SLACK_REDIRECT_BASE_URL`  | Base URL for Slack OAuth redirect| -          |
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary

- **environment-variable.mdx**: add `process.env` as priority 4 fallback in precedence chain
- **skills.mdx**: document bare skill name syntax (e.g., `slack` instead of full GitHub URL), update skill count to 80+
- **storage-yaml.mdx**: add Default column, make `type` field optional (defaults to `volume`)
- **vm0-yaml.mdx**: add `description`, `experimental_runner`, `experimental_firewall`, `optional` volume field; document single-agent-per-file limit; update skills to mention bare names
- **self-hosting.mdx** (×2): reorganize env vars into subcategories, add HTTPS_PORT, DB_POOL_MAX, MinIO, S3, and Slack integration settings
- **debugging.mdx**: expand log types (agent/system/metrics/network), add pagination and time filtering
- **run-agent.mdx**: add missing CLI options (`--env-file`, `--volume-version`, `--conversation`, `--model-provider`, `--verbose`, `--check-env`, `--experimental-shared-agent`)
- **schedule-agent.mdx**: add `loop` frequency and `--interval` flag, add `--enable` flag, remove deprecated `--var`/`--secret` flags (now inherited from platform)

## Test plan

- [ ] Verify docs build succeeds
- [ ] Spot-check rendered pages for formatting correctness
- [ ] Verify CLI option descriptions match `vm0 run --help` and `vm0 schedule setup --help`

🤖 Generated with [Claude Code](https://claude.com/claude-code)