### PR TITLE
feat(docs): add process.env fallback and bare skill name syntax

### DIFF
--- a/turbo/apps/docs/content/docs/core-concept/environment-variable.mdx
+++ b/turbo/apps/docs/content/docs/core-concept/environment-variable.mdx
@@ -129,26 +129,39 @@ Environment files are **not** automatically loaded. You must explicitly specify 
 When the same value is defined in multiple places, VM0 uses this priority order:
 
 1. **CLI flags** (`--vars`, `--secrets`) - highest priority
-2. **Platform-stored values** - medium priority
-3. **`--env-file`** values - lowest priority
+2. **`--env-file`** values - loaded from the file specified with `--env-file`
+3. **Process environment** (`process.env`) - inherited from the current shell
+4. **Platform-stored values** - set via `vm0 secret set` / `vm0 variable set` (lowest priority)
+
+The CLI resolves values locally (steps 1-3), then sends them to the server where they override any platform-stored values (step 4).
+
+<Callout type="info">
+`process.env` and `--env-file` only resolve values for variable names explicitly referenced in your `vm0.yaml` environment configuration — they do not pass your entire shell environment to the agent.
+</Callout>
 
 Example:
 
 ```bash
 # Platform has: vm0 secret set API_KEY stored-value
 # .env file contains: API_KEY=from-env-file
+# Shell environment has: export API_KEY=from-shell-env
 
 # CLI value wins over everything
 vm0 run my-agent "prompt" --secrets API_KEY=from-cli --env-file .env
 # Result: API_KEY = "from-cli"
 
-# Without CLI flag, Platform-stored value wins
-vm0 run my-agent "prompt" --env-file .env
-# Result: API_KEY = "stored-value"
-
-# Without Platform-stored value, --env-file is used
+# Without CLI flag, --env-file wins
 vm0 run my-agent "prompt" --env-file .env
 # Result: API_KEY = "from-env-file"
+
+# Without --env-file, process environment wins
+vm0 run my-agent "prompt"
+# Result: API_KEY = "from-shell-env"
+
+# Without any local values, Platform-stored value is used
+# (unset API_KEY from shell, no --env-file, no --secrets)
+vm0 run my-agent "prompt"
+# Result: API_KEY = "stored-value"
 ```
 
 ## Best Practices

--- a/turbo/apps/docs/content/docs/core-concept/skills.mdx
+++ b/turbo/apps/docs/content/docs/core-concept/skills.mdx
@@ -16,15 +16,27 @@ agents:
   my-agent:
     framework: claude-code
     skills: # [!code highlight]
+      - slack # [!code highlight]
       - https://github.com/anthropics/skills/tree/main/skills/pdf # [!code highlight]
-      - https://github.com/vm0-ai/vm0-skills/tree/main/slack # [!code highlight]
 ```
 
-Each skill is specified as a GitHub URL pointing to a directory containing the skill definition.
+Each skill can be specified as either a **bare name** or a **full GitHub URL**.
 
-## Skill URL Format
+## Bare Skill Name
 
-Skills must be GitHub tree URLs in the format:
+You can reference skills from the [vm0-ai/vm0-skills](https://github.com/vm0-ai/vm0-skills) repository by their bare name. The bare name is automatically resolved to a full GitHub URL on the `main` branch:
+
+```yaml title="vm0.yaml"
+skills:
+  - slack                    # Resolves to https://github.com/vm0-ai/vm0-skills/tree/main/slack
+  - firecrawl                # Resolves to https://github.com/vm0-ai/vm0-skills/tree/main/firecrawl
+```
+
+A bare name is any string that does not contain `/` or start with `https://`. This shorthand only works for skills hosted in the default `vm0-ai/vm0-skills` repository. For skills in other repositories, use the full GitHub URL.
+
+## Full GitHub URL
+
+For skills outside the default repository, or to pin to a specific branch, tag, or commit, use the full GitHub tree URL format:
 
 ```
 https://github.com/{owner}/{repo}/tree/{ref}/{path}
@@ -38,9 +50,10 @@ The `{ref}` can be:
 
 **Examples:**
 
-| Skill                 | URL                                                                |
+| Skill                 | Syntax                                                             |
 | --------------------- | ------------------------------------------------------------------ |
-| PDF (main branch)     | `https://github.com/anthropics/skills/tree/main/skills/pdf`        |
+| Slack (bare name)     | `slack`                                                             |
+| PDF (full URL)        | `https://github.com/anthropics/skills/tree/main/skills/pdf`        |
 | Slack (pinned to tag) | `https://github.com/vm0-ai/vm0-skills/tree/v1.0/slack`             |
 | GitHub CLI            | `https://github.com/vm0-ai/vm0-skills/tree/main/skills/github-cli` |
 
@@ -65,4 +78,4 @@ See the [Agent Skills](/docs/agent-skills) section for detailed documentation on
 - [Hacker News](/docs/agent-skills/hackernews) - Tech news
 - [Runway](/docs/agent-skills/runway) - Video generation
 
-Browse all 60+ skills at [vm0-ai/vm0-skills](https://github.com/vm0-ai/vm0-skills).
+Browse all 80+ skills at [vm0-ai/vm0-skills](https://github.com/vm0-ai/vm0-skills).


### PR DESCRIPTION
## Summary

- **environment-variable.mdx**:
  - **Fix incorrect priority order**: the existing docs claimed `Platform-stored > --env-file > process.env`, but the actual code (`loadValues` in `shared.ts` + `mergeSecrets`/`fetchAndMergeVariables` in `build-context.ts`) shows `CLI flags > --env-file > process.env > Platform-stored`
  - Add `process.env` as a documented fallback source
  - Add callout explaining that only variables referenced in `vm0.yaml` are resolved from env-file/process.env
- **skills.mdx**: document bare skill name syntax (e.g., `slack` instead of full GitHub URL), update skill count from 60+ to 80+

## Code evidence for priority fix

CLI side (`cli/src/commands/run/shared.ts:loadValues`):
```
Priority: CLI flags > env-file > process.env
Result sent to server as `cliVars`/`cliSecrets`
```

Server side (`web/src/lib/run/build-context.ts`):
```typescript
// fetchAndMergeVariables (line 612)
const merged = { ...storedVars, ...cliVars };  // CLI overrides stored

// mergeSecrets (line 501)
return { ...dbSecrets, ...cliSecrets };  // CLI overrides stored
```

## Test plan

- [ ] Verify docs build succeeds
- [ ] Spot-check rendered pages for formatting
- [ ] Cross-reference priority order with `loadValues` in `shared.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)