### PR TITLE
fix: handle invalid json in github oauth callback state parameter

### DIFF
--- a/turbo/apps/web/app/api/github/oauth/callback/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/github/oauth/callback/__tests__/route.test.ts
@@ -208,6 +208,23 @@ describe("/api/github/oauth/callback", () => {
     expect(installation.defaultComposeId).toBe(composeId);
   });
 
+  it("should handle invalid JSON state without crashing", async () => {
+    mockClerk({ userId: uniqueId("gh-user") });
+    await createTestScope(uniqueId("gh-scope"));
+    await createTestCompose("gh-test-agent");
+
+    const request = createTestRequest(
+      `http://localhost:3000/api/github/oauth/callback?installation_id=12345&setup_action=install&state=not-json`,
+    );
+    const response = await GET(request);
+
+    // Should not crash - proceeds with null state values (no vm0UserId means no sig check)
+    // With null composeId, it falls back to resolveDefaultAgentComposeId
+    expect(response.status).toBe(307);
+    const location = response.headers.get("Location");
+    expect(location).toContain("settings?tab=integrations");
+  });
+
   it("should skip creation when installation already exists", async () => {
     const userId = uniqueId("gh-user");
     mockClerk({ userId });

--- a/turbo/apps/web/app/api/github/oauth/callback/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/github/oauth/callback/__tests__/route.test.ts
@@ -25,7 +25,6 @@ const TEST_TARGET_TYPE = "Organization";
 
 function setupGitHubMocks(installationId: string) {
   server.use(
-    // Mock GET /app/installations/{id} for installation info
     http.get(
       `https://api.github.com/app/installations/${installationId}`,
       () => {
@@ -39,7 +38,6 @@ function setupGitHubMocks(installationId: string) {
         });
       },
     ),
-    // Mock POST /app/installations/{id}/access_tokens
     http.post(
       `https://api.github.com/app/installations/${installationId}/access_tokens`,
       () => {
@@ -52,9 +50,6 @@ function setupGitHubMocks(installationId: string) {
   );
 }
 
-/**
- * Build a signed OAuth state string matching the install route's HMAC format.
- */
 function buildSignedState(vm0UserId: string, composeId: string): string {
   const { SECRETS_ENCRYPTION_KEY } = env();
   const payload = `${vm0UserId}:${composeId}`;
@@ -166,7 +161,6 @@ describe("/api/github/oauth/callback", () => {
     expect(location).toContain("settings?tab=integrations");
     expect(location).not.toContain("error=");
 
-    // Verify installation was created in DB
     const installations = await findTestGitHubInstallations(installationId);
     expect(installations).toHaveLength(1);
     const installation = installations[0]!;
@@ -196,7 +190,6 @@ describe("/api/github/oauth/callback", () => {
     expect(location).toContain("pending=true");
     expect(location).not.toContain("error=");
 
-    // Verify pending installation was created in DB
     const installations = await findTestGitHubInstallationsByTargetId(targetId);
     expect(installations).toHaveLength(1);
     const installation = installations[0]!;
@@ -208,21 +201,17 @@ describe("/api/github/oauth/callback", () => {
     expect(installation.defaultComposeId).toBe(composeId);
   });
 
-  it("should handle invalid JSON state without crashing", async () => {
-    mockClerk({ userId: uniqueId("gh-user") });
-    await createTestScope(uniqueId("gh-scope"));
-    await createTestCompose("gh-test-agent");
-
+  it("should redirect with error when state contains invalid JSON", async () => {
     const request = createTestRequest(
       `http://localhost:3000/api/github/oauth/callback?installation_id=12345&setup_action=install&state=not-json`,
     );
     const response = await GET(request);
 
-    // Should not crash - proceeds with null state values (no vm0UserId means no sig check)
-    // With null composeId, it falls back to resolveDefaultAgentComposeId
     expect(response.status).toBe(307);
     const location = response.headers.get("Location");
     expect(location).toContain("settings?tab=integrations");
+    expect(location).toContain("error=");
+    expect(location).toContain("Invalid%20OAuth%20state");
   });
 
   it("should skip creation when installation already exists", async () => {
@@ -234,14 +223,12 @@ describe("/api/github/oauth/callback", () => {
     const installationId = uniqueId("install");
     setupGitHubMocks(installationId);
 
-    // First callback — creates installation
     const state = buildSignedState(userId, composeId);
     const request1 = createTestRequest(
       `http://localhost:3000/api/github/oauth/callback?installation_id=${installationId}&setup_action=install&state=${encodeURIComponent(state)}`,
     );
     await GET(request1);
 
-    // Second callback — should skip, not error
     const request2 = createTestRequest(
       `http://localhost:3000/api/github/oauth/callback?installation_id=${installationId}&setup_action=install&state=${encodeURIComponent(state)}`,
     );
@@ -252,7 +239,6 @@ describe("/api/github/oauth/callback", () => {
     expect(location).toContain("settings?tab=integrations");
     expect(location).not.toContain("error=");
 
-    // Verify only one installation record exists
     const installations = await findTestGitHubInstallations(installationId);
     expect(installations).toHaveLength(1);
   });

--- a/turbo/apps/web/app/api/github/oauth/callback/route.ts
+++ b/turbo/apps/web/app/api/github/oauth/callback/route.ts
@@ -38,23 +38,20 @@ interface OAuthState {
 }
 
 function parseOAuthState(state: string | null): OAuthState {
-  const result: OAuthState = { vm0UserId: null, composeId: null, sig: null };
   if (!state) {
-    return result;
+    return { vm0UserId: null, composeId: null, sig: null };
   }
-  try {
-    const parsed = JSON.parse(state) as {
-      vm0UserId?: string;
-      composeId?: string;
-      sig?: string;
-    };
-    result.vm0UserId = parsed.vm0UserId ?? null;
-    result.composeId = parsed.composeId ?? null;
-    result.sig = parsed.sig ?? null;
-  } catch {
-    // Ignore parse errors - return default empty state
-  }
-  return result;
+
+  const parsed = JSON.parse(state) as {
+    vm0UserId?: string;
+    composeId?: string;
+    sig?: string;
+  };
+  return {
+    vm0UserId: parsed.vm0UserId ?? null,
+    composeId: parsed.composeId ?? null,
+    sig: parsed.sig ?? null,
+  };
 }
 
 export async function GET(request: Request) {
@@ -80,7 +77,14 @@ export async function GET(request: Request) {
     return NextResponse.redirect(`${platformUrl}/settings?tab=integrations`);
   }
 
-  const state = parseOAuthState(url.searchParams.get("state"));
+  let state: OAuthState;
+  try {
+    state = parseOAuthState(url.searchParams.get("state"));
+  } catch {
+    return NextResponse.redirect(
+      `${platformUrl}/settings?tab=integrations&error=${encodeURIComponent("Invalid OAuth state. Please try installing again from the Platform.")}`,
+    );
+  }
 
   // Verify HMAC signature when vm0UserId is present
   if (state.vm0UserId) {

--- a/turbo/apps/web/app/api/github/oauth/callback/route.ts
+++ b/turbo/apps/web/app/api/github/oauth/callback/route.ts
@@ -38,20 +38,23 @@ interface OAuthState {
 }
 
 function parseOAuthState(state: string | null): OAuthState {
+  const result: OAuthState = { vm0UserId: null, composeId: null, sig: null };
   if (!state) {
-    return { vm0UserId: null, composeId: null, sig: null };
+    return result;
   }
-
-  const parsed = JSON.parse(state) as {
-    vm0UserId?: string;
-    composeId?: string;
-    sig?: string;
-  };
-  return {
-    vm0UserId: parsed.vm0UserId ?? null,
-    composeId: parsed.composeId ?? null,
-    sig: parsed.sig ?? null,
-  };
+  try {
+    const parsed = JSON.parse(state) as {
+      vm0UserId?: string;
+      composeId?: string;
+      sig?: string;
+    };
+    result.vm0UserId = parsed.vm0UserId ?? null;
+    result.composeId = parsed.composeId ?? null;
+    result.sig = parsed.sig ?? null;
+  } catch {
+    // Ignore parse errors - return default empty state
+  }
+  return result;
 }
 
 export async function GET(request: Request) {


### PR DESCRIPTION
## Summary
- Wrap `JSON.parse(state)` in try/catch in the GitHub OAuth callback to prevent uncaught `SyntaxError` when the state parameter contains invalid JSON
- Matches the defensive pattern already used in the Slack OAuth callback
- Invalid state gracefully falls back to null values instead of crashing the endpoint

## Test plan
- [x] Added test for invalid JSON state (`?state=not-json`) - verifies no crash, returns redirect
- [x] All 3344 tests pass
- [x] Lint, type check, format, and knip all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)