### PR TITLE
fix: remove unused refresh_token from cli auth token response

### DIFF
--- a/turbo/apps/web/app/api/cli/auth/token/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/cli/auth/token/__tests__/route.test.ts
@@ -95,7 +95,6 @@ describe("POST /api/cli/auth/token", () => {
     expect(body.access_token).toMatch(/^vm0_live_/);
     expect(body.token_type).toBe("Bearer");
     expect(body.expires_in).toBe(90 * 24 * 60 * 60);
-    expect(body.refresh_token).toEqual(expect.any(String));
 
     // Verify the CLI token was persisted
     const tokenRow = await findTestCliToken(body.access_token);

--- a/turbo/apps/web/app/api/cli/auth/token/route.ts
+++ b/turbo/apps/web/app/api/cli/auth/token/route.ts
@@ -133,7 +133,6 @@ const router = tsr.router(cliAuthTokenContract, {
           status: 200 as const,
           body: {
             access_token: cliToken,
-            refresh_token: `refresh_${crypto.randomBytes(16).toString("hex")}`,
             token_type: "Bearer" as const,
             expires_in: 90 * 24 * 60 * 60, // 90 days in seconds
           },

--- a/turbo/packages/core/src/contracts/cli-auth.ts
+++ b/turbo/packages/core/src/contracts/cli-auth.ts
@@ -56,7 +56,6 @@ export const cliAuthTokenContract = c.router({
       // Success - token issued
       200: z.object({
         access_token: z.string(),
-        refresh_token: z.string(),
         token_type: z.literal("Bearer"),
         expires_in: z.number(),
       }),


### PR DESCRIPTION
## Summary
- Remove `refresh_token` field from CLI auth token endpoint - it was generated but never consumed by any client
- Removed from: contract schema, route handler response, and test assertions

## Files changed
- `packages/core/src/contracts/cli-auth.ts` - Remove from response schema
- `apps/web/app/api/cli/auth/token/route.ts` - Remove from response body
- `apps/web/app/api/cli/auth/token/__tests__/route.test.ts` - Remove assertion

## Test plan
- [x] All 6 CLI auth token tests pass
- [x] All 3344 tests pass
- [x] Lint, type check, format, and knip all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)