### PR TITLE
feat: support multiple schedules per agent

### DIFF
--- a/turbo/apps/cli/src/commands/schedule/__tests__/delete-command.test.ts
+++ b/turbo/apps/cli/src/commands/schedule/__tests__/delete-command.test.ts
@@ -158,6 +158,71 @@ describe("schedule delete command", () => {
     });
   });
 
+  describe("--name option (multi-schedule disambiguation)", () => {
+    it("should require --name when agent has multiple schedules", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/agent/schedules", () => {
+          return HttpResponse.json({
+            schedules: [
+              createMockSchedule({ name: "daily-report" }),
+              createMockSchedule({ name: "weekly-cleanup" }),
+            ],
+          });
+        }),
+      );
+
+      await expect(async () => {
+        await deleteCommand.parseAsync([
+          "node",
+          "cli",
+          "test-agent",
+          "--force",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("multiple schedules"),
+      );
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("--name"),
+      );
+    });
+
+    it("should delete specific schedule with --name", async () => {
+      const schedule1 = createMockSchedule({ name: "daily-report" });
+      const schedule2 = createMockSchedule({ name: "weekly-cleanup" });
+      let deletedName: string | undefined;
+
+      server.use(
+        http.get("http://localhost:3000/api/agent/schedules", () => {
+          return HttpResponse.json({
+            schedules: [schedule1, schedule2],
+          });
+        }),
+        http.delete(
+          "http://localhost:3000/api/agent/schedules/:name",
+          ({ params }) => {
+            deletedName = params.name as string;
+            return new HttpResponse(null, { status: 204 });
+          },
+        ),
+      );
+
+      await deleteCommand.parseAsync([
+        "node",
+        "cli",
+        "test-agent",
+        "--name",
+        "weekly-cleanup",
+        "--force",
+      ]);
+
+      expect(deletedName).toBe("weekly-cleanup");
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("Deleted schedule");
+    });
+  });
+
   describe("confirmation", () => {
     it("should require --force in non-interactive mode", async () => {
       const schedule = createMockSchedule();

--- a/turbo/apps/cli/src/commands/schedule/__tests__/disable-command.test.ts
+++ b/turbo/apps/cli/src/commands/schedule/__tests__/disable-command.test.ts
@@ -140,6 +140,65 @@ describe("schedule disable command", () => {
     });
   });
 
+  describe("--name option (multi-schedule disambiguation)", () => {
+    it("should require --name when agent has multiple schedules", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/agent/schedules", () => {
+          return HttpResponse.json({
+            schedules: [
+              createMockSchedule({ name: "daily-report" }),
+              createMockSchedule({ name: "weekly-cleanup" }),
+            ],
+          });
+        }),
+      );
+
+      await expect(async () => {
+        await disableCommand.parseAsync(["node", "cli", "test-agent"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("multiple schedules"),
+      );
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("--name"),
+      );
+    });
+
+    it("should disable specific schedule with --name", async () => {
+      const schedule1 = createMockSchedule({ name: "daily-report" });
+      const schedule2 = createMockSchedule({ name: "weekly-cleanup" });
+      let disabledName: string | undefined;
+
+      server.use(
+        http.get("http://localhost:3000/api/agent/schedules", () => {
+          return HttpResponse.json({
+            schedules: [schedule1, schedule2],
+          });
+        }),
+        http.post(
+          "http://localhost:3000/api/agent/schedules/:name/disable",
+          ({ params }) => {
+            disabledName = params.name as string;
+            return HttpResponse.json({ ...schedule1, enabled: false });
+          },
+        ),
+      );
+
+      await disableCommand.parseAsync([
+        "node",
+        "cli",
+        "test-agent",
+        "--name",
+        "daily-report",
+      ]);
+
+      expect(disabledName).toBe("daily-report");
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("Disabled schedule");
+    });
+  });
+
   describe("error handling", () => {
     it("should handle schedule not found", async () => {
       server.use(

--- a/turbo/apps/cli/src/commands/schedule/__tests__/enable-command.test.ts
+++ b/turbo/apps/cli/src/commands/schedule/__tests__/enable-command.test.ts
@@ -183,6 +183,63 @@ describe("schedule enable command", () => {
       expect(mockExit).toHaveBeenCalledWith(1);
     });
 
+    it("should require --name when agent has multiple schedules", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/agent/schedules", () => {
+          return HttpResponse.json({
+            schedules: [
+              createMockSchedule({ name: "daily-report" }),
+              createMockSchedule({ name: "weekly-cleanup" }),
+            ],
+          });
+        }),
+      );
+
+      await expect(async () => {
+        await enableCommand.parseAsync(["node", "cli", "test-agent"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("multiple schedules"),
+      );
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("--name"),
+      );
+    });
+
+    it("should enable specific schedule with --name", async () => {
+      const schedule1 = createMockSchedule({ name: "daily-report" });
+      const schedule2 = createMockSchedule({ name: "weekly-cleanup" });
+      let enabledName: string | undefined;
+
+      server.use(
+        http.get("http://localhost:3000/api/agent/schedules", () => {
+          return HttpResponse.json({
+            schedules: [schedule1, schedule2],
+          });
+        }),
+        http.post(
+          "http://localhost:3000/api/agent/schedules/:name/enable",
+          ({ params }) => {
+            enabledName = params.name as string;
+            return HttpResponse.json({ ...schedule2, enabled: true });
+          },
+        ),
+      );
+
+      await enableCommand.parseAsync([
+        "node",
+        "cli",
+        "test-agent",
+        "--name",
+        "weekly-cleanup",
+      ]);
+
+      expect(enabledName).toBe("weekly-cleanup");
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("Enabled schedule");
+    });
+
     it("should handle schedule past error", async () => {
       const schedule = createMockSchedule({
         atTime: new Date(Date.now() - 86400000).toISOString(), // yesterday

--- a/turbo/apps/cli/src/commands/schedule/__tests__/list-command.test.ts
+++ b/turbo/apps/cli/src/commands/schedule/__tests__/list-command.test.ts
@@ -110,7 +110,9 @@ describe("schedule list command", () => {
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("my-agent");
+      expect(logCalls).toContain("my-agent-schedule");
       expect(logCalls).toContain("other-agent");
+      expect(logCalls).toContain("other-agent-schedule");
       expect(logCalls).toContain("0 9 * * *");
       expect(logCalls).toContain("UTC");
     });
@@ -186,6 +188,76 @@ describe("schedule list command", () => {
       expect(logCalls).toContain("vm0 schedule setup");
     });
 
+    it("should display multiple schedules for same agent", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/agent/schedules", () => {
+          return HttpResponse.json({
+            schedules: [
+              {
+                id: "schedule-1",
+                composeId: "compose-1",
+                composeName: "my-agent",
+                scopeSlug: "user-test",
+                name: "daily-report",
+                triggerType: "cron",
+                cronExpression: "0 9 * * *",
+                atTime: null,
+                intervalSeconds: null,
+                timezone: "UTC",
+                prompt: "Daily report",
+                vars: null,
+                secretNames: null,
+                artifactName: null,
+                artifactVersion: null,
+                volumeVersions: null,
+                enabled: true,
+                nextRunAt: new Date(Date.now() + 86400000).toISOString(),
+                lastRunAt: null,
+                retryStartedAt: null,
+                consecutiveFailures: 0,
+                createdAt: new Date().toISOString(),
+                updatedAt: new Date().toISOString(),
+              },
+              {
+                id: "schedule-2",
+                composeId: "compose-1",
+                composeName: "my-agent",
+                scopeSlug: "user-test",
+                name: "weekly-cleanup",
+                triggerType: "cron",
+                cronExpression: "0 10 * * 1",
+                atTime: null,
+                intervalSeconds: null,
+                timezone: "UTC",
+                prompt: "Weekly cleanup",
+                vars: null,
+                secretNames: null,
+                artifactName: null,
+                artifactVersion: null,
+                volumeVersions: null,
+                enabled: true,
+                nextRunAt: new Date(Date.now() + 86400000).toISOString(),
+                lastRunAt: null,
+                retryStartedAt: null,
+                consecutiveFailures: 0,
+                createdAt: new Date().toISOString(),
+                updatedAt: new Date().toISOString(),
+              },
+            ],
+          });
+        }),
+      );
+
+      await listCommand.parseAsync(["node", "cli"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      // Both schedules for same agent should be shown
+      expect(logCalls).toContain("daily-report");
+      expect(logCalls).toContain("weekly-cleanup");
+      expect(logCalls).toContain("0 9 * * *");
+      expect(logCalls).toContain("0 10 * * 1");
+    });
+
     it("should show table header with correct columns", async () => {
       server.use(
         http.get("http://localhost:3000/api/agent/schedules", () => {
@@ -220,6 +292,7 @@ describe("schedule list command", () => {
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("AGENT");
+      expect(logCalls).toContain("SCHEDULE");
       expect(logCalls).toContain("TRIGGER");
       expect(logCalls).toContain("STATUS");
       expect(logCalls).toContain("NEXT RUN");

--- a/turbo/apps/cli/src/commands/schedule/__tests__/setup-command.test.ts
+++ b/turbo/apps/cli/src/commands/schedule/__tests__/setup-command.test.ts
@@ -304,8 +304,54 @@ describe("schedule setup command", () => {
       expect(logCalls).toContain("Updated schedule");
     });
 
-    // Test removed: --var option no longer supported
-    // vars are now managed via platform tables (vm0 var set)
+    it("should create schedule with custom --name", async () => {
+      const compose = createMockCompose();
+      const schedule = createMockSchedule({
+        name: "daily-report",
+        cronExpression: "0 9 * * *",
+      });
+      let deployPayload: Record<string, unknown> | undefined;
+
+      server.use(
+        http.get("http://localhost:3000/api/agent/composes", () => {
+          return HttpResponse.json(compose);
+        }),
+        http.get("http://localhost:3000/api/agent/schedules", () => {
+          return HttpResponse.json({ schedules: [] });
+        }),
+        http.post(
+          "http://localhost:3000/api/agent/schedules",
+          async ({ request }) => {
+            deployPayload = (await request.json()) as Record<string, unknown>;
+            return HttpResponse.json(
+              { created: true, schedule },
+              { status: 201 },
+            );
+          },
+        ),
+      );
+
+      await setupCommand.parseAsync([
+        "node",
+        "cli",
+        "test-agent",
+        "--name",
+        "daily-report",
+        "--frequency",
+        "daily",
+        "--time",
+        "09:00",
+        "--prompt",
+        "Daily report",
+      ]);
+
+      expect(deployPayload).toBeDefined();
+      expect(deployPayload!.name).toBe("daily-report");
+      expect(deployPayload!.cronExpression).toBe("0 9 * * *");
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("Created schedule");
+    });
 
     it("should enable schedule with --enable flag", async () => {
       const compose = createMockCompose();

--- a/turbo/apps/cli/src/commands/schedule/__tests__/status-command.test.ts
+++ b/turbo/apps/cli/src/commands/schedule/__tests__/status-command.test.ts
@@ -218,6 +218,68 @@ describe("schedule status command", () => {
     });
   });
 
+  describe("--name option (multi-schedule disambiguation)", () => {
+    it("should require --name when agent has multiple schedules", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/agent/schedules", () => {
+          return HttpResponse.json({
+            schedules: [
+              createMockSchedule({ name: "daily-report" }),
+              createMockSchedule({ name: "weekly-cleanup" }),
+            ],
+          });
+        }),
+      );
+
+      await expect(async () => {
+        await statusCommand.parseAsync(["node", "cli", "test-agent"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("multiple schedules"),
+      );
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("--name"),
+      );
+    });
+
+    it("should show status for specific schedule with --name", async () => {
+      const schedule1 = createMockSchedule({ name: "daily-report" });
+      const schedule2 = createMockSchedule({ name: "weekly-cleanup" });
+      let fetchedName: string | undefined;
+
+      server.use(
+        http.get("http://localhost:3000/api/agent/schedules", () => {
+          return HttpResponse.json({
+            schedules: [schedule1, schedule2],
+          });
+        }),
+        http.get(
+          "http://localhost:3000/api/agent/schedules/:name",
+          ({ params }) => {
+            fetchedName = params.name as string;
+            return HttpResponse.json(schedule1);
+          },
+        ),
+        http.get("http://localhost:3000/api/agent/schedules/:name/runs", () => {
+          return HttpResponse.json({ runs: [] });
+        }),
+      );
+
+      await statusCommand.parseAsync([
+        "node",
+        "cli",
+        "test-agent",
+        "--name",
+        "daily-report",
+      ]);
+
+      expect(fetchedName).toBe("daily-report");
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("test-agent");
+    });
+  });
+
   describe("--limit option", () => {
     it("should respect --limit option", async () => {
       const schedule = createMockSchedule();

--- a/turbo/apps/cli/src/commands/schedule/delete.ts
+++ b/turbo/apps/cli/src/commands/schedule/delete.ts
@@ -9,56 +9,62 @@ export const deleteCommand = new Command()
   .alias("rm")
   .description("Delete a schedule")
   .argument("<agent-name>", "Agent name")
+  .option(
+    "-n, --name <schedule-name>",
+    "Schedule name (required when agent has multiple schedules)",
+  )
   .option("-f, --force", "Skip confirmation prompt")
-  .action(async (agentName: string, options: { force?: boolean }) => {
-    try {
-      // Resolve schedule by agent name
-      const resolved = await resolveScheduleByAgent(agentName);
+  .action(
+    async (agentName: string, options: { name?: string; force?: boolean }) => {
+      try {
+        // Resolve schedule by agent name
+        const resolved = await resolveScheduleByAgent(agentName, options.name);
 
-      // Confirm deletion
-      if (!options.force) {
-        if (!isInteractive()) {
-          console.error(
-            chalk.red("✗ --force required in non-interactive mode"),
+        // Confirm deletion
+        if (!options.force) {
+          if (!isInteractive()) {
+            console.error(
+              chalk.red("✗ --force required in non-interactive mode"),
+            );
+            process.exit(1);
+          }
+          const confirmed = await promptConfirm(
+            `Delete schedule for agent ${chalk.cyan(agentName)}?`,
+            false,
           );
-          process.exit(1);
+          if (!confirmed) {
+            console.log(chalk.dim("Cancelled"));
+            return;
+          }
         }
-        const confirmed = await promptConfirm(
-          `Delete schedule for agent ${chalk.cyan(agentName)}?`,
-          false,
+
+        // Call API
+        await deleteSchedule({
+          name: resolved.name,
+          composeId: resolved.composeId,
+        });
+
+        console.log(
+          chalk.green(`✓ Deleted schedule for agent ${chalk.cyan(agentName)}`),
         );
-        if (!confirmed) {
-          console.log(chalk.dim("Cancelled"));
-          return;
+      } catch (error) {
+        console.error(chalk.red("✗ Failed to delete schedule"));
+        if (error instanceof Error) {
+          if (error.message.includes("Not authenticated")) {
+            console.error(chalk.dim("  Run: vm0 auth login"));
+          } else if (
+            error.message.toLowerCase().includes("not found") ||
+            error.message.includes("No schedule found")
+          ) {
+            console.error(
+              chalk.dim(`  No schedule found for agent "${agentName}"`),
+            );
+            console.error(chalk.dim("  Run: vm0 schedule list"));
+          } else {
+            console.error(chalk.dim(`  ${error.message}`));
+          }
         }
+        process.exit(1);
       }
-
-      // Call API
-      await deleteSchedule({
-        name: resolved.name,
-        composeId: resolved.composeId,
-      });
-
-      console.log(
-        chalk.green(`✓ Deleted schedule for agent ${chalk.cyan(agentName)}`),
-      );
-    } catch (error) {
-      console.error(chalk.red("✗ Failed to delete schedule"));
-      if (error instanceof Error) {
-        if (error.message.includes("Not authenticated")) {
-          console.error(chalk.dim("  Run: vm0 auth login"));
-        } else if (
-          error.message.toLowerCase().includes("not found") ||
-          error.message.includes("No schedule found")
-        ) {
-          console.error(
-            chalk.dim(`  No schedule found for agent "${agentName}"`),
-          );
-          console.error(chalk.dim("  Run: vm0 schedule list"));
-        } else {
-          console.error(chalk.dim(`  ${error.message}`));
-        }
-      }
-      process.exit(1);
-    }
-  });
+    },
+  );

--- a/turbo/apps/cli/src/commands/schedule/disable.ts
+++ b/turbo/apps/cli/src/commands/schedule/disable.ts
@@ -7,10 +7,14 @@ export const disableCommand = new Command()
   .name("disable")
   .description("Disable a schedule")
   .argument("<agent-name>", "Agent name")
-  .action(async (agentName: string) => {
+  .option(
+    "-n, --name <schedule-name>",
+    "Schedule name (required when agent has multiple schedules)",
+  )
+  .action(async (agentName: string, options: { name?: string }) => {
     try {
       // Resolve schedule by agent name
-      const resolved = await resolveScheduleByAgent(agentName);
+      const resolved = await resolveScheduleByAgent(agentName, options.name);
 
       // Call API
       await disableSchedule({

--- a/turbo/apps/cli/src/commands/schedule/enable.ts
+++ b/turbo/apps/cli/src/commands/schedule/enable.ts
@@ -7,10 +7,14 @@ export const enableCommand = new Command()
   .name("enable")
   .description("Enable a schedule")
   .argument("<agent-name>", "Agent name")
-  .action(async (agentName: string) => {
+  .option(
+    "-n, --name <schedule-name>",
+    "Schedule name (required when agent has multiple schedules)",
+  )
+  .action(async (agentName: string, options: { name?: string }) => {
     try {
       // Resolve schedule by agent name
-      const resolved = await resolveScheduleByAgent(agentName);
+      const resolved = await resolveScheduleByAgent(agentName, options.name);
 
       // Call API
       await enableSchedule({

--- a/turbo/apps/cli/src/commands/schedule/list.ts
+++ b/turbo/apps/cli/src/commands/schedule/list.ts
@@ -25,6 +25,10 @@ export const listCommand = new Command()
         5,
         ...result.schedules.map((s) => s.composeName.length),
       );
+      const scheduleWidth = Math.max(
+        8,
+        ...result.schedules.map((s) => s.name.length),
+      );
       const triggerWidth = Math.max(
         7,
         ...result.schedules.map((s) =>
@@ -37,6 +41,7 @@ export const listCommand = new Command()
       // Print header
       const header = [
         "AGENT".padEnd(agentWidth),
+        "SCHEDULE".padEnd(scheduleWidth),
         "TRIGGER".padEnd(triggerWidth),
         "STATUS".padEnd(8),
         "NEXT RUN",
@@ -59,6 +64,7 @@ export const listCommand = new Command()
 
         const row = [
           schedule.composeName.padEnd(agentWidth),
+          schedule.name.padEnd(scheduleWidth),
           trigger.padEnd(triggerWidth),
           status.padEnd(8 + (schedule.enabled ? 0 : 2)), // Account for chalk chars
           nextRun,

--- a/turbo/apps/cli/src/commands/schedule/setup.ts
+++ b/turbo/apps/cli/src/commands/schedule/setup.ts
@@ -130,6 +130,7 @@ function parseFrequencyFromCron(
 }
 
 interface SetupOptions {
+  name?: string;
   frequency?: string;
   time?: string;
   day?: string;
@@ -148,6 +149,7 @@ interface ExistingScheduleDefaults {
 }
 
 interface ScheduleListItem {
+  name: string;
   composeName: string;
   triggerType?: "cron" | "once" | "loop";
   cronExpression?: string | null;
@@ -411,7 +413,10 @@ async function gatherPromptText(
 /**
  * Resolve agent and get composeId with content
  */
-async function resolveAgent(agentName: string): Promise<{
+async function resolveAgent(
+  agentName: string,
+  scheduleName?: string,
+): Promise<{
   composeId: string;
   scheduleName: string;
   composeContent: unknown;
@@ -424,7 +429,7 @@ async function resolveAgent(agentName: string): Promise<{
   }
   return {
     composeId: compose.id,
-    scheduleName: `${agentName}-schedule`,
+    scheduleName: scheduleName || `${agentName}-schedule`,
     composeContent: compose.content,
   };
 }
@@ -526,13 +531,16 @@ async function gatherTiming(
 }
 
 /**
- * Find existing schedule for agent
+ * Find existing schedule for agent by schedule name
  */
 async function findExistingSchedule(
   agentName: string,
+  scheduleName: string,
 ): Promise<ScheduleListItem | undefined> {
   const { schedules } = await listSchedules();
-  return schedules.find((s) => s.composeName === agentName);
+  return schedules.find(
+    (s) => s.composeName === agentName && s.name === scheduleName,
+  );
 }
 
 interface DeployResult {
@@ -722,6 +730,10 @@ export const setupCommand = new Command()
   .name("setup")
   .description("Create or edit a schedule for an agent")
   .argument("<agent-name>", "Agent name to configure schedule for")
+  .option(
+    "-n, --name <schedule-name>",
+    "Schedule name (default: <agent>-schedule)",
+  )
   .option("-f, --frequency <type>", "Frequency: daily|weekly|monthly|once|loop")
   .option("-t, --time <HH:MM>", "Time to run (24-hour format)")
   .option("-d, --day <day>", "Day of week (mon-sun) or day of month (1-31)")
@@ -735,10 +747,16 @@ export const setupCommand = new Command()
       // 1. Resolve agent to composeId and get content
       // Note: composeContent is resolved but validation of required secrets/vars
       // is now done server-side against platform tables
-      const { composeId, scheduleName } = await resolveAgent(agentName);
+      const { composeId, scheduleName } = await resolveAgent(
+        agentName,
+        options.name,
+      );
 
       // 2. Check for existing schedule
-      const existingSchedule = await findExistingSchedule(agentName);
+      const existingSchedule = await findExistingSchedule(
+        agentName,
+        scheduleName,
+      );
 
       console.log(
         chalk.dim(

--- a/turbo/apps/cli/src/commands/schedule/status.ts
+++ b/turbo/apps/cli/src/commands/schedule/status.ts
@@ -182,33 +182,39 @@ export const statusCommand = new Command()
   .description("Show detailed status of a schedule")
   .argument("<agent-name>", "Agent name")
   .option(
+    "-n, --name <schedule-name>",
+    "Schedule name (required when agent has multiple schedules)",
+  )
+  .option(
     "-l, --limit <number>",
     "Number of recent runs to show (0 to hide)",
     "5",
   )
-  .action(async (agentName: string, options: { limit: string }) => {
-    try {
-      const resolved = await resolveScheduleByAgent(agentName);
-      const { name, composeId } = resolved;
+  .action(
+    async (agentName: string, options: { name?: string; limit: string }) => {
+      try {
+        const resolved = await resolveScheduleByAgent(agentName, options.name);
+        const { name, composeId } = resolved;
 
-      const schedule = await getScheduleByName({ name, composeId });
+        const schedule = await getScheduleByName({ name, composeId });
 
-      console.log();
-      console.log(`Schedule for agent: ${chalk.cyan(agentName)}`);
-      console.log(chalk.dim("━".repeat(50)));
+        console.log();
+        console.log(`Schedule for agent: ${chalk.cyan(agentName)}`);
+        console.log(chalk.dim("━".repeat(50)));
 
-      printRunConfiguration(schedule);
-      printTimeSchedule(schedule);
+        printRunConfiguration(schedule);
+        printTimeSchedule(schedule);
 
-      const parsed = parseInt(options.limit, 10);
-      const limit = Math.min(
-        Math.max(0, Number.isNaN(parsed) ? 5 : parsed),
-        100,
-      );
-      await printRecentRuns(name, composeId, limit);
+        const parsed = parseInt(options.limit, 10);
+        const limit = Math.min(
+          Math.max(0, Number.isNaN(parsed) ? 5 : parsed),
+          100,
+        );
+        await printRecentRuns(name, composeId, limit);
 
-      console.log();
-    } catch (error) {
-      handleStatusError(error, agentName);
-    }
-  });
+        console.log();
+      } catch (error) {
+        handleStatusError(error, agentName);
+      }
+    },
+  );

--- a/turbo/apps/cli/src/lib/domain/schedule-utils.ts
+++ b/turbo/apps/cli/src/lib/domain/schedule-utils.ts
@@ -357,22 +357,52 @@ interface ResolveScheduleResult {
 /**
  * Resolve a schedule by agent name using the list API.
  * Searches across all user's schedules and finds by composeName (agent name).
- * @throws Error if agent has no schedule
+ *
+ * When an agent has multiple schedules, scheduleName is required for disambiguation.
+ * When an agent has exactly one schedule, scheduleName is optional.
+ *
+ * @throws Error if agent has no schedule or disambiguation is needed
  */
 export async function resolveScheduleByAgent(
   agentName: string,
+  scheduleName?: string,
 ): Promise<ResolveScheduleResult> {
   const { schedules } = await listSchedules();
 
-  const schedule = schedules.find((s) => s.composeName === agentName);
+  const agentSchedules = schedules.filter((s) => s.composeName === agentName);
 
-  if (!schedule) {
+  if (agentSchedules.length === 0) {
     throw new Error(`No schedule found for agent "${agentName}"`);
   }
 
-  return {
-    name: schedule.name,
-    composeId: schedule.composeId,
-    composeName: schedule.composeName,
-  };
+  // If scheduleName is provided, filter by name
+  if (scheduleName) {
+    const match = agentSchedules.find((s) => s.name === scheduleName);
+    if (!match) {
+      const available = agentSchedules.map((s) => s.name).join(", ");
+      throw new Error(
+        `Schedule "${scheduleName}" not found for agent "${agentName}". Available schedules: ${available}`,
+      );
+    }
+    return {
+      name: match.name,
+      composeId: match.composeId,
+      composeName: match.composeName,
+    };
+  }
+
+  // Single schedule — return it directly (backward compatible)
+  if (agentSchedules.length === 1) {
+    return {
+      name: agentSchedules[0]!.name,
+      composeId: agentSchedules[0]!.composeId,
+      composeName: agentSchedules[0]!.composeName,
+    };
+  }
+
+  // Multiple schedules without --name — require disambiguation
+  const available = agentSchedules.map((s) => s.name).join(", ");
+  throw new Error(
+    `Agent "${agentName}" has multiple schedules. Use --name to specify which one: ${available}`,
+  );
 }

--- a/turbo/apps/web/app/api/agent/schedules/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/schedules/__tests__/route.test.ts
@@ -344,15 +344,15 @@ describe("POST /api/agent/schedules - Deploy Schedule", () => {
     });
   });
 
-  describe("Schedule Limit", () => {
-    it("should reject creating second schedule for same agent (1:1 constraint)", async () => {
+  describe("Multiple Schedules (1:N)", () => {
+    it("should allow creating multiple schedules for same agent with different names", async () => {
       // Create first schedule
       await createTestSchedule(testComposeId, "first-schedule", {
         cronExpression: "0 8 * * *",
         prompt: "First",
       });
 
-      // Try to create second schedule with different name
+      // Create second schedule with different name
       const request = createTestRequest(
         "http://localhost:3000/api/agent/schedules",
         {
@@ -371,8 +371,16 @@ describe("POST /api/agent/schedules - Deploy Schedule", () => {
       const response = await POST(request);
       const data = await response.json();
 
-      expect(response.status).toBe(400);
-      expect(data.error.message).toContain("already has a schedule");
+      expect(response.status).toBe(201);
+      expect(data.created).toBe(true);
+      expect(data.schedule.name).toBe("second-schedule");
+
+      // Verify both schedules exist
+      const schedules = await listTestSchedules();
+      const agentSchedules = schedules.filter(
+        (s) => s.composeId === testComposeId,
+      );
+      expect(agentSchedules.length).toBe(2);
     });
   });
 

--- a/turbo/apps/web/src/db/schema/agent-schedule.ts
+++ b/turbo/apps/web/src/db/schema/agent-schedule.ts
@@ -17,8 +17,7 @@ import { agentRuns } from "./agent-run";
 /**
  * Agent Schedules table
  * Stores schedule configurations for automated agent runs
- * Database supports 1:N (one agent can have multiple schedules)
- * API enforces 1:1 in initial version (single schedule per agent)
+ * Supports 1:N (one agent can have multiple named schedules)
  *
  * Note: The migration includes a CHECK constraint (trigger_check) ensuring
  * exactly one trigger type is set, matching the trigger_type column:

--- a/turbo/apps/web/src/lib/schedule/schedule-service.ts
+++ b/turbo/apps/web/src/lib/schedule/schedule-service.ts
@@ -369,21 +369,6 @@ export async function deploySchedule(
     )
     .limit(1);
 
-  // Initial version: enforce 1:1 constraint (one schedule per agent)
-  if (!existing) {
-    const existingSchedules = await globalThis.services.db
-      .select()
-      .from(agentSchedules)
-      .where(eq(agentSchedules.composeId, request.composeId))
-      .limit(1);
-
-    if (existingSchedules.length > 0) {
-      throw badRequest(
-        "This agent already has a schedule. Please edit the existing schedule or delete it first.",
-      );
-    }
-  }
-
   // Validate required secrets/vars against platform tables
   await validateRequiredConfig(compose);
 


### PR DESCRIPTION
## Summary

- Remove 1:1 schedule-per-agent enforcement in `schedule-service.ts` (delete ~13 lines)
- Update `resolveScheduleByAgent()` to support disambiguation when agent has multiple schedules
- Add `--name` option to `setup`, `enable`, `disable`, `delete`, `status` CLI commands
- Add SCHEDULE column to `list` command output

## How it works

- **Single schedule (backward compatible)**: All commands work exactly as before — no `--name` needed
- **Multiple schedules**: When an agent has multiple schedules, `--name` is required to specify which one
- **Setup with custom name**: `vm0 schedule setup my-agent --name daily-report ...`
- **Default name**: Without `--name`, setup defaults to `{agentName}-schedule` (backward compat)

## Test plan

- [x] API tests: 26 passed (replaced 1:1 rejection test with 1:N creation test)
- [x] CLI tests: 103 passed (added disambiguation, multi-schedule list, --name option tests)
- [x] Lint: 0 warnings, 0 errors
- [x] Knip: no issues
- [ ] CI pipeline passes

Closes #3762

🤖 Generated with [Claude Code](https://claude.com/claude-code)