### PR TITLE
fix(e2e): bypass clerk org creation in test-token endpoint

### DIFF
--- a/e2e/scripts/generate-test-token.sh
+++ b/e2e/scripts/generate-test-token.sh
@@ -38,13 +38,23 @@ if [[ -n "${VERCEL_AUTOMATION_BYPASS_SECRET:-}" ]]; then
   CURL_HEADERS+=(-H "x-vercel-protection-bypass: $VERCEL_AUTOMATION_BYPASS_SECRET")
 fi
 
-# Check if error is retryable (Vercel alias propagation delay)
+# Check if error is retryable (deployment propagation / cold start)
 is_retryable_error() {
   local http_code="$1"
   local body="$2"
 
   # Retry on 404 with DEPLOYMENT_NOT_FOUND (Vercel alias not yet propagated)
   if [[ "$http_code" == "404" ]] && [[ "$body" == *"DEPLOYMENT_NOT_FOUND"* ]]; then
+    return 0
+  fi
+
+  # Retry on 5xx server errors (cold start, transient failures)
+  if [[ "$http_code" =~ ^5[0-9][0-9]$ ]]; then
+    return 0
+  fi
+
+  # Retry on empty response (connection refused or DNS not ready)
+  if [[ -z "$http_code" ]] || [[ "$http_code" == "000" ]]; then
     return 0
   fi
 
@@ -59,7 +69,7 @@ call_test_token_endpoint() {
   local response http_code body
 
   while [[ $attempt -le $MAX_RETRIES ]]; do
-    echo "Calling test-token endpoint (attempt $attempt/$MAX_RETRIES)..."
+    echo "Calling test-token endpoint (attempt $attempt/$MAX_RETRIES)..." >&2
 
     response=$(curl -s -w "\n%{http_code}" \
       "${CURL_HEADERS[@]}" \
@@ -72,7 +82,7 @@ call_test_token_endpoint() {
     # Success
     if [[ "$http_code" == "200" ]]; then
       if [[ $attempt -gt 1 ]]; then
-        echo "Attempt $attempt/$MAX_RETRIES succeeded"
+        echo "Attempt $attempt/$MAX_RETRIES succeeded" >&2
       fi
       echo "$body"
       return 0
@@ -81,7 +91,7 @@ call_test_token_endpoint() {
     # Check if error is retryable
     if is_retryable_error "$http_code" "$body"; then
       if [[ $attempt -lt $MAX_RETRIES ]]; then
-        echo "Attempt $attempt/$MAX_RETRIES failed (DEPLOYMENT_NOT_FOUND), retrying in ${delay}s..."
+        echo "Attempt $attempt/$MAX_RETRIES failed (HTTP $http_code), retrying in ${delay}s..." >&2
         sleep "$delay"
         delay=$((delay * 2))
         attempt=$((attempt + 1))
@@ -90,8 +100,8 @@ call_test_token_endpoint() {
     fi
 
     # Non-retryable error or max retries exhausted
-    echo "Error: test-token endpoint returned $http_code"
-    echo "Response: $body"
+    echo "Error: test-token endpoint returned $http_code" >&2
+    echo "Response: $body" >&2
     return 1
   done
 

--- a/turbo/apps/web/app/api/cli/auth/test-token/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/cli/auth/test-token/__tests__/route.test.ts
@@ -11,13 +11,6 @@ vi.mock("@clerk/nextjs/server", () => ({
     users: {
       getUserList: mockGetUserList,
     },
-    organizations: {
-      createOrganization: vi
-        .fn()
-        .mockImplementation(({ name }: { name: string }) =>
-          Promise.resolve({ id: `org_mock_${name}` }),
-        ),
-    },
   })),
   auth: vi.fn(),
 }));

--- a/turbo/apps/web/app/api/cli/auth/test-token/route.ts
+++ b/turbo/apps/web/app/api/cli/auth/test-token/route.ts
@@ -70,8 +70,11 @@ async function ensureTestScope(userId: string): Promise<void> {
         .insert(scopes)
         .values({ slug: fallbackSlug, clerkOrgId: TEST_CLERK_ORG_ID })
         .returning();
+      if (!fallback) {
+        throw new Error("Failed to create test scope with fallback slug");
+      }
       await tx.insert(scopeMembers).values({
-        scopeId: fallback!.id,
+        scopeId: fallback.id,
         userId,
         role: "admin",
       });

--- a/turbo/apps/web/app/api/cli/auth/test-token/route.ts
+++ b/turbo/apps/web/app/api/cli/auth/test-token/route.ts
@@ -2,17 +2,20 @@ import { NextResponse } from "next/server";
 import crypto from "crypto";
 import { initServices } from "../../../../../src/lib/init-services";
 import { cliTokens } from "../../../../../src/db/schema/cli-tokens";
+import { scopes } from "../../../../../src/db/schema/scope";
+import { scopeMembers } from "../../../../../src/db/schema/scope-member";
 import {
   getUserScopeByClerkId,
-  createUserScope,
   generateDefaultScopeSlug,
 } from "../../../../../src/lib/scope/scope-service";
-import { isBadRequest } from "../../../../../src/lib/errors";
 import {
   resolveTestUserId,
   isTestVariant,
 } from "../../../../../src/lib/auth/test-user";
 import { env } from "../../../../../src/env";
+
+/** Sentinel Clerk org ID for test-created scopes (never hits Clerk API) */
+const TEST_CLERK_ORG_ID = "org_test_e2e";
 
 /**
  * Check if test-token endpoint is allowed based on environment.
@@ -38,6 +41,49 @@ function isTestTokenAllowed(request: Request): boolean {
   }
 
   return false;
+}
+
+/**
+ * Ensure the test user has a scope, creating one directly in the database
+ * if necessary. Unlike the normal createUserScope flow, this bypasses
+ * Clerk Organization creation entirely — test scopes don't need a real
+ * Clerk org, and the Clerk Backend API rejects org creation for
+ * e2e test users (403 Forbidden).
+ */
+async function ensureTestScope(userId: string): Promise<void> {
+  const existing = await getUserScopeByClerkId(userId);
+  if (existing) return;
+
+  const slug = generateDefaultScopeSlug(userId);
+
+  await globalThis.services.db.transaction(async (tx) => {
+    const [newScope] = await tx
+      .insert(scopes)
+      .values({ slug, clerkOrgId: TEST_CLERK_ORG_ID })
+      .onConflictDoNothing({ target: scopes.slug })
+      .returning();
+
+    if (!newScope) {
+      // Slug conflict — use a random fallback
+      const fallbackSlug = `user-${crypto.randomBytes(4).toString("hex")}`;
+      const [fallback] = await tx
+        .insert(scopes)
+        .values({ slug: fallbackSlug, clerkOrgId: TEST_CLERK_ORG_ID })
+        .returning();
+      await tx.insert(scopeMembers).values({
+        scopeId: fallback!.id,
+        userId,
+        role: "admin",
+      });
+      return;
+    }
+
+    await tx.insert(scopeMembers).values({
+      scopeId: newScope.id,
+      userId,
+      role: "admin",
+    });
+  });
 }
 
 /**
@@ -67,21 +113,8 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "Test user not found" }, { status: 500 });
   }
 
-  // Auto-create scope if user doesn't have one
-  const existingScope = await getUserScopeByClerkId(userId);
-  if (!existingScope) {
-    const defaultSlug = generateDefaultScopeSlug(userId);
-    try {
-      await createUserScope(userId, defaultSlug);
-    } catch (error) {
-      if (isBadRequest(error) && error.message.includes("already exists")) {
-        const fallbackSlug = `user-${crypto.randomBytes(4).toString("hex")}`;
-        await createUserScope(userId, fallbackSlug);
-      } else {
-        throw error;
-      }
-    }
-  }
+  // Auto-create scope if user doesn't have one (bypasses Clerk org creation)
+  await ensureTestScope(userId);
 
   // Generate CLI token
   const randomBytes = crypto.randomBytes(32);


### PR DESCRIPTION
## Summary

- Replace `createUserScope()` with local `ensureTestScope()` in test-token endpoint to bypass Clerk Organization creation that fails with 403 for e2e test users
- Fix `generate-test-token.sh` error visibility: restore stderr for status messages, restore 5xx retry, show HTTP status in retry messages

## Context

After scope unification Phase 3 enforced `clerk_org_id NOT NULL`, the test-token endpoint calls `createUserScope()` which calls Clerk's `createOrganization()`. Clerk returns **403 Forbidden** for e2e test users, causing HTTP 500 on every CI run where the Neon DB branch is reset (clearing test user scopes).

This affects **all PRs** — confirmed failures on `feature/run-queue-clean`, `feature/issue-3762-multiple-schedules-per-agent`, `feat/balloon-observability-3751`.

The shell script also had a visibility bug: echo statements went to stdout instead of stderr, getting swallowed by `$()` capture — making CI logs show no useful error info.

## Test plan

- [x] Existing test-token route tests pass (10/10)
- [x] Lint, type-check, knip all pass
- [ ] CI pipeline should now succeed for the `Generate E2E test tokens` step

🤖 Generated with [Claude Code](https://claude.com/claude-code)