### PR TITLE
feat(ci): add otel-collector monitoring for metal machines

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -195,6 +195,8 @@ jobs:
           METAL_USER: ${{ vars.AWS_METAL_RUNNER_USER }}
           HOST: ${{ steps.host.outputs.host }}
           JOB_REF: ${{ steps.host.outputs.job-ref }}
+          AXIOM_TOKEN_HOST_METRICS: ${{ secrets.AXIOM_TOKEN_HOST_METRICS }}
+          AXIOM_DATASET_HOST_METRICS: ${{ vars.AXIOM_DATASET_HOST_METRICS }}
         run: |
           SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10 -i $HOME/.ssh/runner.pem"
           REMOTE="${METAL_USER}@${HOST}"
@@ -208,10 +210,20 @@ jobs:
           cd ansible
           ansible-playbook \
             -i "${HOST}," \
-            playbooks/provision-metal.yml \
+            playbooks/provision-runner.yml \
             --private-key $HOME/.ssh/runner.pem \
             -e "ansible_user=${METAL_USER}" \
             -v
+          if [ -n "${AXIOM_TOKEN_HOST_METRICS}" ]; then
+            ansible-playbook \
+              -i "${HOST}," \
+              playbooks/provision-monitoring.yml \
+              --private-key $HOME/.ssh/runner.pem \
+              -e "ansible_user=${METAL_USER}" \
+              -e "axiom_token=${AXIOM_TOKEN_HOST_METRICS}" \
+              -e "axiom_dataset=${AXIOM_DATASET_HOST_METRICS}" \
+              -v
+          fi
           cd ..
 
           # Clean previous run artifacts and upload runner (guests are embedded)

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -686,6 +686,8 @@ jobs:
           AWS_METAL_RUNNER_SSH_KEY: ${{ secrets.AWS_METAL_RUNNER_SSH_KEY }}
           OFFICIAL_RUNNER_SECRET: ${{ secrets.OFFICIAL_RUNNER_SECRET }}
           RUNNER_VERSION: ${{ needs.release-please.outputs.runner_rs_version }}
+          AXIOM_TOKEN_HOST_METRICS: ${{ secrets.AXIOM_TOKEN_HOST_METRICS }}
+          AXIOM_DATASET_HOST_METRICS: ${{ vars.AXIOM_DATASET_HOST_METRICS }}
         run: |
           mkdir -p ~/.ssh
           echo "$AWS_METAL_RUNNER_SSH_KEY" > ~/.ssh/prod-runner.pem
@@ -693,10 +695,20 @@ jobs:
           cd ansible
           ansible-playbook \
             -i "${AWS_METAL_RUNNER_HOSTS}," \
-            playbooks/provision-metal.yml \
+            playbooks/provision-runner.yml \
             --private-key ~/.ssh/prod-runner.pem \
             -e "ansible_user=${AWS_METAL_RUNNER_USER}" \
             -v
+          if [ -n "${AXIOM_TOKEN_HOST_METRICS}" ]; then
+            ansible-playbook \
+              -i "${AWS_METAL_RUNNER_HOSTS}," \
+              playbooks/provision-monitoring.yml \
+              --private-key ~/.ssh/prod-runner.pem \
+              -e "ansible_user=${AWS_METAL_RUNNER_USER}" \
+              -e "axiom_token=${AXIOM_TOKEN_HOST_METRICS}" \
+              -e "axiom_dataset=${AXIOM_DATASET_HOST_METRICS}" \
+              -v
+          fi
           ansible-playbook \
             -i "${AWS_METAL_RUNNER_HOSTS}," \
             playbooks/deploy-runner.yml \

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1326,6 +1326,8 @@ jobs:
           JOB_REF: ${{ needs.prepare.outputs.job-ref }}
           BIN_DIR: ${{ steps.host.outputs.bin-dir }}
           RUNNER_DIR: ${{ steps.host.outputs.runner-dir }}
+          AXIOM_TOKEN_HOST_METRICS: ${{ secrets.AXIOM_TOKEN_HOST_METRICS }}
+          AXIOM_DATASET_HOST_METRICS: ${{ vars.AXIOM_DATASET_HOST_METRICS }}
         run: |
           SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10 -i $HOME/.ssh/runner.pem"
           TARGET_DIR="crates/target/${TARGET_TRIPLE}/${CARGO_PROFILE}"
@@ -1337,10 +1339,20 @@ jobs:
           cd ansible
           ansible-playbook \
             -i "${METAL_HOSTS}," \
-            playbooks/provision-metal.yml \
+            playbooks/provision-runner.yml \
             --private-key $HOME/.ssh/runner.pem \
             -e "ansible_user=${METAL_USER}" \
             -v
+          if [ -n "${AXIOM_TOKEN_HOST_METRICS}" ]; then
+            ansible-playbook \
+              -i "${METAL_HOSTS}," \
+              playbooks/provision-monitoring.yml \
+              --private-key $HOME/.ssh/runner.pem \
+              -e "ansible_user=${METAL_USER}" \
+              -e "axiom_token=${AXIOM_TOKEN_HOST_METRICS}" \
+              -e "axiom_dataset=${AXIOM_DATASET_HOST_METRICS}" \
+              -v
+          fi
           cd ..
 
           deploy_to_host() {

--- a/ansible/playbooks/provision-monitoring.yml
+++ b/ansible/playbooks/provision-monitoring.yml
@@ -1,0 +1,152 @@
+# Provision OpenTelemetry Collector for Host Metrics
+#
+# Idempotent playbook that installs otel-collector-contrib on bare-metal hosts
+# to collect system metrics (CPU, memory, disk, network, load) and push them
+# to Axiom via OTLP.
+#
+# Usage:
+#   ansible-playbook -i "host1,host2," playbooks/provision-monitoring.yml \
+#     -e "ansible_user=ubuntu" \
+#     -e "axiom_token=xaat-..." \
+#     -e "axiom_dataset=vm0-host-metrics-dev"
+#
+# Required variables:
+#   axiom_token   - Axiom API token with ingest permission
+#   axiom_dataset - Axiom dataset name (e.g. vm0-host-metrics-dev)
+
+- name: Provision OpenTelemetry Collector
+  hosts: all
+
+  vars:
+    otelcol_version: "0.147.0"
+    otelcol_arch_map:
+      aarch64: "arm64"
+      x86_64: "amd64"
+    otelcol_arch: "{{ otelcol_arch_map[ansible_architecture] }}"
+    otelcol_bin: "/usr/local/bin/otelcol-contrib"
+    otelcol_config_dir: "/etc/otelcol"
+    otelcol_config: "/etc/otelcol/config.yaml"
+    otelcol_env_file: "/etc/otelcol/env"
+    otelcol_service: "otelcol"
+
+  tasks:
+    - name: Check if otelcol-contrib is installed
+      command: "{{ otelcol_bin }} --version"
+      register: otelcol_check
+      changed_when: false
+      failed_when: false
+
+    - name: Download and extract otelcol-contrib
+      when: otelcol_check.rc != 0 or otelcol_version not in (otelcol_check.stdout | default(''))
+      become: true
+      block:
+        - name: Download otelcol-contrib tarball
+          get_url:
+            url: "https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v{{ otelcol_version }}/otelcol-contrib_{{ otelcol_version }}_linux_{{ otelcol_arch }}.tar.gz"
+            dest: "/tmp/otelcol-contrib.tar.gz"
+            mode: '0644'
+
+        - name: Extract otelcol-contrib binary
+          shell: tar -xzf /tmp/otelcol-contrib.tar.gz -C /usr/local/bin/ otelcol-contrib
+          changed_when: true
+
+        - name: Clean up tarball
+          file:
+            path: /tmp/otelcol-contrib.tar.gz
+            state: absent
+
+    - name: Create config directory
+      file:
+        path: "{{ otelcol_config_dir }}"
+        state: directory
+        mode: '0755'
+      become: true
+
+    - name: Write otelcol config
+      copy:
+        dest: "{{ otelcol_config }}"
+        mode: '0644'
+        content: |
+          receivers:
+            hostmetrics:
+              collection_interval: 15s
+              scrapers:
+                cpu:
+                disk:
+                filesystem:
+                load:
+                memory:
+                network:
+                processes:
+
+          processors:
+            batch:
+              timeout: 30s
+            resourcedetection:
+              detectors: [env, system]
+              system:
+                hostname_sources: [os]
+
+          exporters:
+            otlphttp:
+              endpoint: https://api.axiom.co
+              headers:
+                authorization: "Bearer ${AXIOM_TOKEN}"
+                x-axiom-dataset: "${AXIOM_DATASET}"
+
+          service:
+            pipelines:
+              metrics:
+                receivers: [hostmetrics]
+                processors: [batch, resourcedetection]
+                exporters: [otlphttp]
+      become: true
+      notify: restart otelcol
+
+    - name: Write environment file
+      copy:
+        dest: "{{ otelcol_env_file }}"
+        mode: '0600'
+        content: |
+          AXIOM_TOKEN={{ axiom_token }}
+          AXIOM_DATASET={{ axiom_dataset }}
+      become: true
+      notify: restart otelcol
+
+    - name: Write systemd unit
+      copy:
+        dest: "/etc/systemd/system/{{ otelcol_service }}.service"
+        mode: '0644'
+        content: |
+          [Unit]
+          Description=OpenTelemetry Collector
+          After=network-online.target
+
+          [Service]
+          Type=simple
+          ExecStart={{ otelcol_bin }} --config {{ otelcol_config }}
+          Restart=on-failure
+          RestartSec=5
+          MemoryMax=128M
+          EnvironmentFile={{ otelcol_env_file }}
+
+          [Install]
+          WantedBy=multi-user.target
+      become: true
+      notify: restart otelcol
+
+    - name: Enable and start otelcol
+      systemd:
+        name: "{{ otelcol_service }}"
+        enabled: true
+        state: started
+        daemon_reload: true
+      become: true
+
+  handlers:
+    - name: restart otelcol
+      systemd:
+        name: "{{ otelcol_service }}"
+        state: restarted
+        daemon_reload: true
+      become: true

--- a/ansible/playbooks/provision-runner.yml
+++ b/ansible/playbooks/provision-runner.yml
@@ -1,14 +1,14 @@
-# Provision Metal Host Dependencies
+# Provision Runner Dependencies
 #
 # Idempotent playbook that installs all system-level dependencies required by
 # the VM0 runner on bare-metal hosts. Safe to run repeatedly — all tasks use
 # idempotent operations (apt state=present, group append, chmod).
 #
 # Usage:
-#   ansible-playbook -i "host1,host2," playbooks/provision-metal.yml \
+#   ansible-playbook -i "host1,host2," playbooks/provision-runner.yml \
 #     -e "ansible_user=ubuntu"
 
-- name: Provision metal host dependencies
+- name: Provision runner dependencies
   hosts: all
 
   tasks:


### PR DESCRIPTION
## Summary
- New Ansible playbook `provision-monitoring.yml` deploys otel-collector-contrib on metal machines
- Collects system metrics (CPU, memory, disk, network, load, processes) via `hostmetrics` receiver
- Pushes to Axiom via OTLP (`vm0-host-metrics-{dev|prod}` dataset)
- Integrated into `crates.yml`, `turbo.yml`, and `release-please.yml` provisioning steps
- Guarded by `AXIOM_TOKEN_HOST_METRICS` — skipped if secret not set
- Rename `provision-metal.yml` to `provision-runner.yml`

## Setup Required
1. Create Axiom API token with ingest permission → add as secret `AXIOM_TOKEN_HOST_METRICS`
2. Set `AXIOM_DATASET_HOST_METRICS` var (e.g. `vm0-host-metrics-dev` for repo, `vm0-host-metrics-prod` for production env)
3. Create the dataset in Axiom dashboard

## Test plan
- [ ] Set secrets in GitHub, trigger CI, verify otel-collector is installed on metal host
- [ ] Check Axiom dataset for incoming metrics
- [ ] Verify playbook is idempotent (re-run doesn't break anything)

Closes #3763

🤖 Generated with [Claude Code](https://claude.com/claude-code)