### PR TITLE
fix(vsock-guest): prevent secret leakage in exec/spawn_watch logs

### DIFF
--- a/crates/vsock-guest/src/lib.rs
+++ b/crates/vsock-guest/src/lib.rs
@@ -223,16 +223,17 @@ fn handle_exec(
     env: &[(&str, &str)],
     sudo: bool,
 ) -> (i32, Vec<u8>, Vec<u8>) {
-    let command = prepend_env(command, env);
     log(
         "INFO",
         &format!(
-            "exec: {} (timeout={}ms, sudo={})",
-            truncate_preview(&command),
+            "exec: {} (timeout={}ms, sudo={}, env_count={})",
+            truncate_preview(command),
             timeout_ms,
             sudo,
+            env.len(),
         ),
     );
+    let command = prepend_env(command, env);
 
     // Create new process group so we can kill the entire tree on timeout
     #[cfg(unix)]
@@ -364,16 +365,17 @@ fn handle_spawn_watch(
     seq: u32,
     writer: Arc<Mutex<UnixStream>>,
 ) -> io::Result<Vec<u8>> {
-    let command = prepend_env(command, env);
     log(
         "INFO",
         &format!(
-            "spawn_watch: {} (timeout={}ms, sudo={})",
-            truncate_preview(&command),
+            "spawn_watch: {} (timeout={}ms, sudo={}, env_count={})",
+            truncate_preview(command),
             timeout_ms,
             sudo,
+            env.len(),
         ),
     );
+    let command = prepend_env(command, env);
 
     // Create new process group so we can kill the entire tree on timeout
     #[cfg(unix)]


### PR DESCRIPTION
## Summary
- Move `log()` before `prepend_env()` in `handle_exec` and `handle_spawn_watch` so environment variables (API keys, user secrets) are never included in log output
- Log only the raw command and `env_count` instead of the full command with exported secrets

## Test plan
- [x] `cargo check -p vsock-guest` passes
- [x] `cargo test -p vsock-guest` — all 9 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)