### PR TITLE
fix(slack): keep spinner alive during long agent runs via progress callbacks

### DIFF
--- a/turbo/apps/web/app/api/internal/callbacks/email/reply/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/email/reply/route.ts
@@ -68,6 +68,60 @@ function formatOutput(
   return error ?? "The agent run failed.";
 }
 
+async function sendReplyEmail(
+  session: { replyToToken: string; lastEmailMessageId: string | null },
+  payload: CallbackPayload,
+  composeName: string,
+  userEmail: string | string[],
+  output: string,
+  logsUrl: string,
+): Promise<{ messageId: string }> {
+  const replyToAddress = buildReplyToAddress(session.replyToToken);
+  const headers: Record<string, string> = {};
+
+  const replyToMessageId =
+    payload.inboundMessageId ?? session.lastEmailMessageId;
+  if (replyToMessageId) {
+    headers["In-Reply-To"] = replyToMessageId;
+  }
+
+  const referencesParts: string[] = [];
+  if (payload.inboundReferences) {
+    referencesParts.push(payload.inboundReferences);
+  } else if (session.lastEmailMessageId) {
+    referencesParts.push(session.lastEmailMessageId);
+  }
+  if (payload.inboundMessageId) {
+    referencesParts.push(payload.inboundMessageId);
+  }
+  if (referencesParts.length > 0) {
+    headers["References"] = referencesParts.join(" ");
+  }
+
+  const emailTo =
+    payload.replyRecipientTo && payload.replyRecipientTo.length > 0
+      ? payload.replyRecipientTo
+      : userEmail;
+  const emailCc =
+    payload.replyRecipientCc && payload.replyRecipientCc.length > 0
+      ? payload.replyRecipientCc
+      : undefined;
+
+  return sendEmail({
+    from: buildFromAddress(composeName),
+    to: emailTo,
+    subject: `Re: VM0 - Scheduled run for "${composeName}" completed`,
+    react: AgentReplyEmail({
+      agentName: composeName,
+      output,
+      logsUrl,
+    }),
+    cc: emailCc,
+    replyTo: replyToAddress,
+    headers,
+  });
+}
+
 export async function POST(request: NextRequest): Promise<NextResponse> {
   initServices();
 
@@ -137,55 +191,14 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   const newAgentSessionId = extractAgentSessionId(run?.result);
 
   // Send response email with threading headers
-  const replyToAddress = buildReplyToAddress(session.replyToToken);
-  const headers: Record<string, string> = {};
-
-  // In-Reply-To: the inbound message we are replying to (RFC 2822)
-  // Falls back to session.lastEmailMessageId for backwards compatibility
-  const replyToMessageId =
-    payload.inboundMessageId ?? session.lastEmailMessageId;
-  if (replyToMessageId) {
-    headers["In-Reply-To"] = replyToMessageId;
-  }
-
-  // References: inbound References chain + inbound Message-ID (RFC 2822)
-  // Falls back to session.lastEmailMessageId if no inbound data
-  const referencesParts: string[] = [];
-  if (payload.inboundReferences) {
-    referencesParts.push(payload.inboundReferences);
-  } else if (session.lastEmailMessageId) {
-    referencesParts.push(session.lastEmailMessageId);
-  }
-  if (payload.inboundMessageId) {
-    referencesParts.push(payload.inboundMessageId);
-  }
-  if (referencesParts.length > 0) {
-    headers["References"] = referencesParts.join(" ");
-  }
-
-  // Use computed recipients if available, fall back to session owner
-  const emailTo =
-    payload.replyRecipientTo && payload.replyRecipientTo.length > 0
-      ? payload.replyRecipientTo
-      : userEmail;
-  const emailCc =
-    payload.replyRecipientCc && payload.replyRecipientCc.length > 0
-      ? payload.replyRecipientCc
-      : undefined;
-
-  const { messageId } = await sendEmail({
-    from: buildFromAddress(compose.name),
-    to: emailTo,
-    subject: `Re: VM0 - Scheduled run for "${compose.name}" completed`,
-    react: AgentReplyEmail({
-      agentName: compose.name,
-      output,
-      logsUrl,
-    }),
-    cc: emailCc,
-    replyTo: replyToAddress,
-    headers,
-  });
+  const { messageId } = await sendReplyEmail(
+    session,
+    payload,
+    compose.name,
+    userEmail,
+    output,
+    logsUrl,
+  );
 
   // Update email thread session with new message ID and session
   await updateEmailThreadSession(session.id, {

--- a/turbo/apps/web/app/api/internal/callbacks/email/reply/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/email/reply/route.ts
@@ -85,6 +85,11 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 
   log.debug("Processing email reply callback", { runId, status });
 
+  // Progress notifications are not applicable for email — no-op.
+  if (status === "progress") {
+    return NextResponse.json({ success: true });
+  }
+
   // Look up the email thread session
   const [session] = await globalThis.services.db
     .select()

--- a/turbo/apps/web/app/api/internal/callbacks/email/reply/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/email/reply/route.ts
@@ -75,7 +75,7 @@ async function sendReplyEmail(
   userEmail: string | string[],
   output: string,
   logsUrl: string,
-): Promise<{ messageId: string }> {
+): ReturnType<typeof sendEmail> {
   const replyToAddress = buildReplyToAddress(session.replyToToken);
   const headers: Record<string, string> = {};
 

--- a/turbo/apps/web/app/api/internal/callbacks/github/issues/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/github/issues/route.ts
@@ -140,6 +140,11 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     issueNumber,
   });
 
+  // Progress notifications are not applicable for GitHub issues — no-op.
+  if (status === "progress") {
+    return NextResponse.json({ success: true });
+  }
+
   const { GITHUB_APP_ID, GITHUB_APP_PRIVATE_KEY } = env();
 
   // Get GitHub installation for access token

--- a/turbo/apps/web/app/api/internal/callbacks/slack/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/slack/__tests__/route.test.ts
@@ -38,7 +38,7 @@ interface CallbackPayload {
 function createCallbackRequest(
   body: {
     runId: string;
-    status: "completed" | "failed";
+    status: "completed" | "failed" | "progress";
     result?: Record<string, unknown>;
     error?: string;
     payload: CallbackPayload;
@@ -572,6 +572,126 @@ describe("POST /api/internal/callbacks/slack", () => {
       expect(response.status).toBe(400);
       const data = await response.json();
       expect(data.error).toContain("payload");
+    });
+  });
+
+  describe("Progress Callback", () => {
+    it("should refresh thread status on progress and not post messages", async () => {
+      // Given a linked Slack user with an agent
+      const { userLink, installation } = await givenLinkedSlackUser();
+      const { binding } = await givenUserHasAgent(userLink, {
+        agentName: "test-agent",
+      });
+
+      // And a run with a registered callback
+      mockClerk({ userId: userLink.vm0UserId });
+      const { runId } = await createTestRun(binding.composeId, "Test prompt");
+      const channelId = `C-progress-${Date.now()}`;
+      const threadTs = `${Date.now()}.000000`;
+      const { secret } = await createTestCallback({
+        runId,
+        url: "http://localhost/api/internal/callbacks/slack",
+        payload: {
+          workspaceId: installation.slackWorkspaceId,
+          channelId,
+          threadTs,
+          messageTs: `${Date.now()}.123456`,
+          userLinkId: userLink.id,
+          agentName: "test-agent",
+          composeId: binding.composeId,
+        },
+      });
+
+      // When a progress callback is received
+      const request = createCallbackRequest(
+        {
+          runId,
+          status: "progress",
+          payload: {
+            workspaceId: installation.slackWorkspaceId,
+            channelId,
+            threadTs,
+            messageTs: `${Date.now()}.123456`,
+            userLinkId: userLink.id,
+            agentName: "test-agent",
+            composeId: binding.composeId,
+          },
+        },
+        secret,
+      );
+      const response = await POST(request);
+
+      // Then the request should succeed
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.success).toBe(true);
+
+      // And the thread status should be refreshed with "is thinking..."
+      expect(mockClient.assistant.threads.setStatus).toHaveBeenCalledTimes(1);
+      const statusCall = mockClient.assistant.threads.setStatus.mock
+        .calls[0]![0] as {
+        channel_id: string;
+        thread_ts: string;
+        status: string;
+      };
+      expect(statusCall.status).toBe("is thinking...");
+      expect(statusCall.channel_id).toBe(channelId);
+      expect(statusCall.thread_ts).toBe(threadTs);
+
+      // And NO messages should be posted (progress is status-only)
+      expect(mockClient.chat.postMessage).not.toHaveBeenCalled();
+    });
+
+    it("should return success even if setThreadStatus fails", async () => {
+      // Given a linked Slack user with an agent
+      const { userLink, installation } = await givenLinkedSlackUser();
+      const { binding } = await givenUserHasAgent(userLink, {
+        agentName: "test-agent",
+      });
+
+      // And setThreadStatus will fail
+      mockClient.assistant.threads.setStatus.mockRejectedValueOnce(
+        new Error("Slack API error"),
+      );
+
+      // And a run with a registered callback
+      mockClerk({ userId: userLink.vm0UserId });
+      const { runId } = await createTestRun(binding.composeId, "Test prompt");
+      const { secret } = await createTestCallback({
+        runId,
+        url: "http://localhost/api/internal/callbacks/slack",
+        payload: {
+          workspaceId: installation.slackWorkspaceId,
+          channelId: "C-fail",
+          threadTs: "123.456",
+          messageTs: "123.789",
+          userLinkId: userLink.id,
+          agentName: "test-agent",
+          composeId: binding.composeId,
+        },
+      });
+
+      // When a progress callback is received
+      const request = createCallbackRequest(
+        {
+          runId,
+          status: "progress",
+          payload: {
+            workspaceId: installation.slackWorkspaceId,
+            channelId: "C-fail",
+            threadTs: "123.456",
+            messageTs: "123.789",
+            userLinkId: userLink.id,
+            agentName: "test-agent",
+            composeId: binding.composeId,
+          },
+        },
+        secret,
+      );
+      const response = await POST(request);
+
+      // Then it should still succeed (error is caught)
+      expect(response.status).toBe(200);
     });
   });
 });

--- a/turbo/apps/web/app/api/internal/callbacks/slack/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/slack/route.ts
@@ -250,6 +250,36 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 
   const { SECRETS_ENCRYPTION_KEY } = env();
 
+  // Handle progress notifications: refresh the Slack typing indicator
+  // to prevent the 2-minute auto-expiry on assistant.threads.setStatus.
+  if (status === "progress") {
+    const [inst] = await globalThis.services.db
+      .select()
+      .from(slackInstallations)
+      .where(eq(slackInstallations.slackWorkspaceId, payload.workspaceId))
+      .limit(1);
+
+    if (inst) {
+      const token = decryptCredentialValue(
+        inst.encryptedBotToken,
+        SECRETS_ENCRYPTION_KEY,
+      );
+      const slackClient = createSlackClient(token);
+      try {
+        await setThreadStatus(
+          slackClient,
+          payload.channelId,
+          payload.threadTs,
+          "is thinking...",
+        );
+      } catch (err) {
+        log.debug("Failed to refresh thread status", { runId, error: err });
+      }
+    }
+
+    return NextResponse.json({ success: true });
+  }
+
   // Get Slack installation for bot token
   const [installation] = await globalThis.services.db
     .select()

--- a/turbo/apps/web/app/api/webhooks/agent/heartbeat/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/heartbeat/__tests__/route.test.ts
@@ -209,5 +209,28 @@ describe("POST /api/webhooks/agent/heartbeat", () => {
       expect(data1.ok).toBe(true);
       expect(data2.ok).toBe(true);
     });
+
+    it("should register an after() callback for progress dispatch", async () => {
+      const request = createTestRequest(
+        "http://localhost:3000/api/webhooks/agent/heartbeat",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${testToken}`,
+          },
+          body: JSON.stringify({ runId: testRunId }),
+        },
+      );
+
+      const response = await POST(request);
+      expect(response.status).toBe(200);
+
+      // The heartbeat handler should have registered an after() callback
+      expect(globalThis.nextAfterCallbacks).toHaveLength(1);
+
+      // Flush and verify it doesn't throw (no callbacks registered for this run)
+      await context.mocks.flushAfter();
+    });
   });
 });

--- a/turbo/apps/web/app/api/webhooks/agent/heartbeat/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/heartbeat/route.ts
@@ -8,7 +8,9 @@ import { initServices } from "../../../../../src/lib/init-services";
 import { agentRuns } from "../../../../../src/db/schema/agent-run";
 import { eq, and } from "drizzle-orm";
 import { getSandboxAuthForRun } from "../../../../../src/lib/auth/get-sandbox-auth";
+import { dispatchProgressCallbacks } from "../../../../../src/lib/callback";
 import { logger } from "../../../../../src/lib/logger";
+import { after } from "next/server";
 
 const log = logger("webhooks:heartbeat");
 
@@ -48,6 +50,14 @@ const router = tsr.router(webhookHeartbeatContract, {
     }
 
     log.debug(`Updated heartbeat for run ${body.runId}`);
+
+    // Dispatch progress notifications to integration callbacks (non-blocking).
+    // Keeps status indicators alive (e.g. Slack's assistant typing indicator).
+    after(() => {
+      dispatchProgressCallbacks(body.runId).catch((err) =>
+        log.debug("Failed to dispatch progress callbacks", { err }),
+      );
+    });
 
     return {
       status: 200 as const,

--- a/turbo/apps/web/src/lib/callback/__tests__/dispatcher.test.ts
+++ b/turbo/apps/web/src/lib/callback/__tests__/dispatcher.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { dispatchProgressCallbacks } from "../dispatcher";
+import { testContext, type UserContext } from "../../../__tests__/test-helpers";
+import { mockClerk } from "../../../__tests__/clerk-mock";
+import {
+  createTestCompose,
+  createTestRun,
+  createTestCallback,
+} from "../../../__tests__/api-test-helpers";
+
+const context = testContext();
+
+describe("dispatchProgressCallbacks", () => {
+  let user: UserContext;
+  let testRunId: string;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    context.setupMocks();
+    user = await context.setupUser();
+    mockClerk({ userId: user.userId });
+
+    const { composeId } = await createTestCompose(
+      `agent-progress-${Date.now()}`,
+    );
+    const { runId } = await createTestRun(composeId, "Test prompt");
+    testRunId = runId;
+  });
+
+  it("should send progress notification to pending callbacks", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(
+        new Response(JSON.stringify({ success: true }), { status: 200 }),
+      );
+
+    await createTestCallback({
+      runId: testRunId,
+      url: "http://localhost/api/internal/callbacks/slack",
+      payload: { workspaceId: "T123", channelId: "C123", threadTs: "123.456" },
+    });
+
+    await dispatchProgressCallbacks(testRunId);
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [url, options] = fetchSpy.mock.calls[0]!;
+    expect(url).toBe("http://localhost/api/internal/callbacks/slack");
+    const body = JSON.parse(options!.body as string);
+    expect(body.status).toBe("progress");
+    expect(body.runId).toBe(testRunId);
+    expect(body.payload).toEqual({
+      workspaceId: "T123",
+      channelId: "C123",
+      threadTs: "123.456",
+    });
+
+    fetchSpy.mockRestore();
+  });
+
+  it("should not update callback status (subsequent calls still work)", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(
+        new Response(JSON.stringify({ success: true }), { status: 200 }),
+      );
+
+    await createTestCallback({
+      runId: testRunId,
+      url: "http://localhost/api/internal/callbacks/slack",
+      payload: { workspaceId: "T123" },
+    });
+
+    // First progress call
+    await dispatchProgressCallbacks(testRunId);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+    // Second progress call should also work (callback still pending)
+    await dispatchProgressCallbacks(testRunId);
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+
+    fetchSpy.mockRestore();
+  });
+
+  it("should do nothing when no callbacks exist", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(
+        new Response(JSON.stringify({ success: true }), { status: 200 }),
+      );
+
+    await dispatchProgressCallbacks(testRunId);
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+
+    fetchSpy.mockRestore();
+  });
+
+  it("should silently ignore fetch failures", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("Network error"));
+
+    await createTestCallback({
+      runId: testRunId,
+      url: "http://localhost/api/internal/callbacks/slack",
+      payload: { workspaceId: "T123" },
+    });
+
+    // Should not throw
+    await dispatchProgressCallbacks(testRunId);
+
+    vi.restoreAllMocks();
+  });
+});

--- a/turbo/apps/web/src/lib/callback/__tests__/dispatcher.test.ts
+++ b/turbo/apps/web/src/lib/callback/__tests__/dispatcher.test.ts
@@ -1,4 +1,6 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../mocks/server";
 import { dispatchProgressCallbacks } from "../dispatcher";
 import { testContext, type UserContext } from "../../../__tests__/test-helpers";
 import { mockClerk } from "../../../__tests__/clerk-mock";
@@ -15,7 +17,6 @@ describe("dispatchProgressCallbacks", () => {
   let testRunId: string;
 
   beforeEach(async () => {
-    vi.clearAllMocks();
     context.setupMocks();
     user = await context.setupUser();
     mockClerk({ userId: user.userId });
@@ -28,11 +29,19 @@ describe("dispatchProgressCallbacks", () => {
   });
 
   it("should send progress notification to pending callbacks", async () => {
-    const fetchSpy = vi
-      .spyOn(globalThis, "fetch")
-      .mockResolvedValue(
-        new Response(JSON.stringify({ success: true }), { status: 200 }),
-      );
+    const capturedRequests: { url: string; body: Record<string, unknown> }[] =
+      [];
+
+    server.use(
+      http.post(
+        "http://localhost/api/internal/callbacks/slack",
+        async ({ request }) => {
+          const body = (await request.json()) as Record<string, unknown>;
+          capturedRequests.push({ url: request.url, body });
+          return HttpResponse.json({ success: true });
+        },
+      ),
+    );
 
     await createTestCallback({
       runId: testRunId,
@@ -42,27 +51,27 @@ describe("dispatchProgressCallbacks", () => {
 
     await dispatchProgressCallbacks(testRunId);
 
-    expect(fetchSpy).toHaveBeenCalledTimes(1);
-    const [url, options] = fetchSpy.mock.calls[0]!;
-    expect(url).toBe("http://localhost/api/internal/callbacks/slack");
-    const body = JSON.parse(options!.body as string);
-    expect(body.status).toBe("progress");
-    expect(body.runId).toBe(testRunId);
-    expect(body.payload).toEqual({
+    expect(capturedRequests).toHaveLength(1);
+    const captured = capturedRequests[0]!;
+    expect(captured.url).toBe("http://localhost/api/internal/callbacks/slack");
+    expect(captured.body.status).toBe("progress");
+    expect(captured.body.runId).toBe(testRunId);
+    expect(captured.body.payload).toEqual({
       workspaceId: "T123",
       channelId: "C123",
       threadTs: "123.456",
     });
-
-    fetchSpy.mockRestore();
   });
 
   it("should not update callback status (subsequent calls still work)", async () => {
-    const fetchSpy = vi
-      .spyOn(globalThis, "fetch")
-      .mockResolvedValue(
-        new Response(JSON.stringify({ success: true }), { status: 200 }),
-      );
+    let callCount = 0;
+
+    server.use(
+      http.post("http://localhost/api/internal/callbacks/slack", () => {
+        callCount++;
+        return HttpResponse.json({ success: true });
+      }),
+    );
 
     await createTestCallback({
       runId: testRunId,
@@ -72,31 +81,34 @@ describe("dispatchProgressCallbacks", () => {
 
     // First progress call
     await dispatchProgressCallbacks(testRunId);
-    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(callCount).toBe(1);
 
     // Second progress call should also work (callback still pending)
     await dispatchProgressCallbacks(testRunId);
-    expect(fetchSpy).toHaveBeenCalledTimes(2);
-
-    fetchSpy.mockRestore();
+    expect(callCount).toBe(2);
   });
 
   it("should do nothing when no callbacks exist", async () => {
-    const fetchSpy = vi
-      .spyOn(globalThis, "fetch")
-      .mockResolvedValue(
-        new Response(JSON.stringify({ success: true }), { status: 200 }),
-      );
+    let callCount = 0;
+
+    server.use(
+      http.post("http://localhost/api/internal/callbacks/slack", () => {
+        callCount++;
+        return HttpResponse.json({ success: true });
+      }),
+    );
 
     await dispatchProgressCallbacks(testRunId);
 
-    expect(fetchSpy).not.toHaveBeenCalled();
-
-    fetchSpy.mockRestore();
+    expect(callCount).toBe(0);
   });
 
   it("should silently ignore fetch failures", async () => {
-    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("Network error"));
+    server.use(
+      http.post("http://localhost/api/internal/callbacks/slack", () => {
+        return HttpResponse.error();
+      }),
+    );
 
     await createTestCallback({
       runId: testRunId,
@@ -106,7 +118,5 @@ describe("dispatchProgressCallbacks", () => {
 
     // Should not throw
     await dispatchProgressCallbacks(testRunId);
-
-    vi.restoreAllMocks();
   });
 });

--- a/turbo/apps/web/src/lib/callback/dispatcher.ts
+++ b/turbo/apps/web/src/lib/callback/dispatcher.ts
@@ -1,4 +1,4 @@
-import { eq } from "drizzle-orm";
+import { eq, and } from "drizzle-orm";
 import { agentRunCallbacks } from "../../db/schema/agent-run-callback";
 import { decryptCredentialValue } from "../crypto/secrets-encryption";
 import { env } from "../../env";
@@ -87,6 +87,17 @@ export async function dispatchCallbacks(
   return results;
 }
 
+/**
+ * In local dev, rewrite self-referencing tunnel URLs to localhost to avoid
+ * hairpin (server fetching its own tunnel URL times out via cloudflare).
+ */
+function resolveCallbackUrl(url: string): string {
+  const { NODE_ENV } = env();
+  return NODE_ENV === "development" && url.startsWith("https://tunnel-")
+    ? url.replace(/^https:\/\/tunnel-[^/]+/, "http://localhost:3000")
+    : url;
+}
+
 async function dispatchSingleCallback(
   callback: CallbackRecord,
   runId: string,
@@ -97,13 +108,7 @@ async function dispatchSingleCallback(
 ): Promise<DispatchResult> {
   const { id, encryptedSecret, payload } = callback;
 
-  // In local dev, rewrite self-referencing tunnel URLs to localhost to avoid
-  // hairpin (server fetching its own tunnel URL times out via cloudflare).
-  const { NODE_ENV } = env();
-  const url =
-    NODE_ENV === "development" && callback.url.startsWith("https://tunnel-")
-      ? callback.url.replace(/^https:\/\/tunnel-[^/]+/, "http://localhost:3000")
-      : callback.url;
+  const url = resolveCallbackUrl(callback.url);
 
   // Decrypt the callback secret
   const secret = decryptCredentialValue(encryptedSecret, encryptionKey);
@@ -180,4 +185,66 @@ async function dispatchSingleCallback(
     log.error(`Callback ${id} failed with exception`, { error: err });
     return { callbackId: id, success: false, error: errorMessage };
   }
+}
+
+/**
+ * Send lightweight progress notifications to all pending callbacks for a run.
+ *
+ * Used by the heartbeat webhook to keep integration status indicators alive
+ * (e.g. Slack's assistant typing indicator which auto-expires after 2 minutes).
+ *
+ * Unlike dispatchCallbacks, this does NOT update callback status or attempt count.
+ * Failures are silently ignored — a missed progress notification is non-critical.
+ */
+export async function dispatchProgressCallbacks(runId: string): Promise<void> {
+  const { SECRETS_ENCRYPTION_KEY } = env();
+
+  const callbacks = await globalThis.services.db
+    .select({
+      id: agentRunCallbacks.id,
+      url: agentRunCallbacks.url,
+      encryptedSecret: agentRunCallbacks.encryptedSecret,
+      payload: agentRunCallbacks.payload,
+    })
+    .from(agentRunCallbacks)
+    .where(
+      and(
+        eq(agentRunCallbacks.runId, runId),
+        eq(agentRunCallbacks.status, "pending"),
+      ),
+    );
+
+  if (callbacks.length === 0) {
+    return;
+  }
+
+  await Promise.allSettled(
+    callbacks.map((callback) => {
+      const url = resolveCallbackUrl(callback.url);
+      const secret = decryptCredentialValue(
+        callback.encryptedSecret,
+        SECRETS_ENCRYPTION_KEY,
+      );
+
+      const body = JSON.stringify({
+        callbackId: callback.id,
+        runId,
+        status: "progress",
+        payload: callback.payload,
+      });
+
+      const timestamp = Math.floor(Date.now() / 1000);
+      const signature = computeHmacSignature(body, secret, timestamp);
+
+      return fetch(url, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-VM0-Signature": signature,
+          "X-VM0-Timestamp": timestamp.toString(),
+        },
+        body,
+      });
+    }),
+  );
 }

--- a/turbo/apps/web/src/lib/callback/index.ts
+++ b/turbo/apps/web/src/lib/callback/index.ts
@@ -1,3 +1,7 @@
 export { generateCallbackSecret } from "./hmac";
-export { dispatchCallbacks, getApiUrl } from "./dispatcher";
+export {
+  dispatchCallbacks,
+  dispatchProgressCallbacks,
+  getApiUrl,
+} from "./dispatcher";
 export { verifyCallback } from "./verify-callback";

--- a/turbo/apps/web/src/lib/callback/verify-callback.ts
+++ b/turbo/apps/web/src/lib/callback/verify-callback.ts
@@ -18,7 +18,7 @@ interface VerifiedCallback<P = unknown> {
   /** Present only when the dispatcher includes callbackId (new behavior). */
   callbackId?: string;
   runId: string;
-  status: "completed" | "failed";
+  status: "completed" | "failed" | "progress";
   result?: Record<string, unknown>;
   error?: string;
   payload: P;
@@ -52,7 +52,7 @@ export async function verifyCallback<P = unknown>(
   let body: {
     callbackId?: string;
     runId?: string;
-    status: "completed" | "failed";
+    status: "completed" | "failed" | "progress";
     result?: Record<string, unknown>;
     error?: string;
     payload: P;


### PR DESCRIPTION
## Summary

- Extends callback dispatcher with `"progress"` status type for heartbeat-driven status refresh
- Heartbeat webhook (every 60s) now dispatches progress notifications to pending callbacks via `after()`
- Slack callback endpoint refreshes `assistant.threads.setThreadStatus("is thinking...")` on progress events
- Fully decoupled: heartbeat handler has no integration knowledge; each callback endpoint decides independently

## Root Cause

Slack's `assistant.threads.setStatus` auto-expires after 2 minutes. For agent runs exceeding this, the spinner disappeared while the agent was still running, causing user confusion and duplicate retriggers.

## Changes

| File | Change |
|------|--------|
| `src/lib/callback/dispatcher.ts` | New `dispatchProgressCallbacks()`, extracted `resolveCallbackUrl()` |
| `src/lib/callback/verify-callback.ts` | Added `"progress"` to status union |
| `src/lib/callback/index.ts` | Export `dispatchProgressCallbacks` |
| `app/api/webhooks/agent/heartbeat/route.ts` | Call `dispatchProgressCallbacks` in `after()` |
| `app/api/internal/callbacks/slack/route.ts` | Handle progress → refresh spinner |

## Test plan

- [x] Dispatcher: progress sends POST with `status: "progress"`, doesn't update callback record
- [x] Dispatcher: skips when no pending callbacks, ignores fetch failures
- [x] Heartbeat: registers `after()` callback for progress dispatch
- [x] Slack callback: refreshes thread status on progress, no messages posted
- [x] Slack callback: graceful handling when setThreadStatus fails
- [x] All existing tests continue to pass (24 total across 3 files)

Closes #3750

🤖 Generated with [Claude Code](https://claude.com/claude-code)