### PR TITLE
chore: remove api_to_init_complete and api_to_cli_spawn timing points

### DIFF
--- a/crates/guest-agent/src/cli.rs
+++ b/crates/guest-agent/src/cli.rs
@@ -183,7 +183,6 @@ pub async fn execute_cli(
     }
 
     let mut child = cmd.spawn()?;
-    crate::timing::record_e2e_from_api("api_to_cli_spawn");
 
     let stdout = child
         .stdout

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -146,8 +146,6 @@ async fn execute(
         init_elapsed.as_secs()
     );
 
-    guest_agent::timing::record_e2e_from_api("api_to_init_complete");
-
     // Execution phase
     log_info!(LOG_TAG, "▷ Execution");
     let cli_start = Instant::now();

--- a/turbo/packages/sandbox-scripts/src/scripts/run-agent.ts
+++ b/turbo/packages/sandbox-scripts/src/scripts/run-agent.ts
@@ -367,8 +367,6 @@ async function run(): Promise<[number, string]> {
   recordSandboxOp("init_total", initDurationMs, true);
   logInfo(`✓ Initialization complete (${Math.floor(initDurationMs / 1000)}s)`);
 
-  recordE2eFromApi("api_to_init_complete");
-
   // Lifecycle: Execution
   logInfo("▷ Execution");
   const execStartTime = Date.now();
@@ -400,8 +398,6 @@ async function run(): Promise<[number, string]> {
     const proc = spawn(cmdExe, cmd.slice(1), {
       stdio: ["ignore", "pipe", "pipe"],
     });
-
-    recordE2eFromApi("api_to_cli_spawn");
 
     // Create promise to track process exit - register handlers BEFORE reading streams
     // This prevents race condition where process exits before handlers are registered


### PR DESCRIPTION
## Summary
- Remove `api_to_init_complete` and `api_to_cli_spawn` telemetry timing points from guest-agent (Rust) and sandbox-scripts (TS)

## Test plan
- CI validates compilation and lint

🤖 Generated with [Claude Code](https://claude.com/claude-code)