### PR TITLE
feat: add vnc support to devcontainer

### DIFF
--- a/.claude/skills/agent-browser/SKILL.md
+++ b/.claude/skills/agent-browser/SKILL.md
@@ -15,7 +15,7 @@ This project runs in a headless devcontainer. **Always start the noVNC stack bef
 x11vnc and novnc are not baked into the dev image. Install them if missing:
 
 ```bash
-which x11vnc || sudo apt-get update -qq && sudo apt-get install -y -qq x11vnc novnc
+which x11vnc || sudo apt-get update -qq && sudo apt-get install -y -qq x11vnc novnc openbox
 ```
 
 ### Start the VNC Stack
@@ -23,8 +23,10 @@ which x11vnc || sudo apt-get update -qq && sudo apt-get install -y -qq x11vnc no
 Run these before any agent-browser command:
 
 ```bash
-# Start Xvfb, x11vnc, and noVNC (idempotent - skips if already running)
-pgrep -x Xvfb > /dev/null || Xvfb :99 -screen 0 3008x1692x24 > /dev/null 2>&1 &
+# Start Xvfb, openbox, x11vnc, and noVNC (idempotent - skips if already running)
+pgrep -x Xvfb > /dev/null || Xvfb :99 -screen 0 1344x840x24 > /dev/null 2>&1 &
+sleep 1
+pgrep -x openbox > /dev/null || DISPLAY=:99 openbox > /dev/null 2>&1 &
 sleep 1
 pgrep -x x11vnc > /dev/null || x11vnc -display :99 -nopw -forever -shared -rfbport 5900 > /dev/null 2>&1 &
 sleep 1
@@ -34,12 +36,10 @@ sleep 1
 
 ### Always Use Headed Mode
 
-All agent-browser commands must set `DISPLAY=:99` and use `--headed`. After the first `open`, maximize the browser window to fill the virtual screen:
+All agent-browser commands must set `DISPLAY=:99` and use `--headed`. For local HTTPS dev servers, use `--ignore-https-errors` (Playwright flag, NOT Chrome's `--ignore-certificate-errors` which breaks stealth):
 
 ```bash
-DISPLAY=:99 agent-browser --headed open <url>
-DISPLAY=:99 xdotool search --class chromium windowmove 0 0 windowsize 3008 1692
-agent-browser set viewport 3008 1602
+DISPLAY=:99 agent-browser --headed --ignore-https-errors open <url>
 ```
 
 ### Tell the User How to Connect
@@ -60,8 +60,7 @@ Every browser automation follows this pattern:
 
 1. **Start noVNC stack** (see above)
 2. **Navigate**: `DISPLAY=:99 agent-browser --headed open <url>`
-3. **Maximize window**: `DISPLAY=:99 xdotool search --class chromium windowmove 0 0 windowsize 3008 1692`
-4. **Snapshot**: `DISPLAY=:99 agent-browser snapshot -i` (get element refs like `@e1`, `@e2`)
+3. **Snapshot**: `DISPLAY=:99 agent-browser snapshot -i` (get element refs like `@e1`, `@e2`)
 4. **Interact**: Use refs to click, fill, select
 5. **Re-snapshot**: After navigation or DOM changes, get fresh refs
 

--- a/.claude/skills/agent-browser/SKILL.md
+++ b/.claude/skills/agent-browser/SKILL.md
@@ -24,7 +24,7 @@ Run these before any agent-browser command:
 
 ```bash
 # Start Xvfb, x11vnc, and noVNC (idempotent - skips if already running)
-pgrep -x Xvfb > /dev/null || Xvfb :99 -screen 0 1280x720x24 > /dev/null 2>&1 &
+pgrep -x Xvfb > /dev/null || Xvfb :99 -screen 0 3008x1692x24 > /dev/null 2>&1 &
 sleep 1
 pgrep -x x11vnc > /dev/null || x11vnc -display :99 -nopw -forever -shared -rfbport 5900 > /dev/null 2>&1 &
 sleep 1
@@ -34,10 +34,12 @@ sleep 1
 
 ### Always Use Headed Mode
 
-All agent-browser commands must set `DISPLAY=:99` and use `--headed`:
+All agent-browser commands must set `DISPLAY=:99` and use `--headed`. After the first `open`, maximize the browser window to fill the virtual screen:
 
 ```bash
 DISPLAY=:99 agent-browser --headed open <url>
+DISPLAY=:99 xdotool search --class chromium windowmove 0 0 windowsize 3008 1692
+agent-browser set viewport 3008 1602
 ```
 
 ### Tell the User How to Connect
@@ -58,7 +60,8 @@ Every browser automation follows this pattern:
 
 1. **Start noVNC stack** (see above)
 2. **Navigate**: `DISPLAY=:99 agent-browser --headed open <url>`
-3. **Snapshot**: `DISPLAY=:99 agent-browser snapshot -i` (get element refs like `@e1`, `@e2`)
+3. **Maximize window**: `DISPLAY=:99 xdotool search --class chromium windowmove 0 0 windowsize 3008 1692`
+4. **Snapshot**: `DISPLAY=:99 agent-browser snapshot -i` (get element refs like `@e1`, `@e2`)
 4. **Interact**: Use refs to click, fill, select
 5. **Re-snapshot**: After navigation or DOM changes, get fresh refs
 

--- a/.claude/skills/agent-browser/SKILL.md
+++ b/.claude/skills/agent-browser/SKILL.md
@@ -6,17 +6,64 @@ allowed-tools: Bash(npx agent-browser:*), Bash(agent-browser:*)
 
 # Browser Automation with agent-browser
 
+## noVNC Setup (Required)
+
+This project runs in a headless devcontainer. **Always start the noVNC stack before using agent-browser** so the user can see and interact with the browser from their macOS host.
+
+### Prerequisites
+
+x11vnc and novnc are not baked into the dev image. Install them if missing:
+
+```bash
+which x11vnc || sudo apt-get update -qq && sudo apt-get install -y -qq x11vnc novnc
+```
+
+### Start the VNC Stack
+
+Run these before any agent-browser command:
+
+```bash
+# Start Xvfb, x11vnc, and noVNC (idempotent - skips if already running)
+pgrep -x Xvfb > /dev/null || Xvfb :99 -screen 0 1280x720x24 > /dev/null 2>&1 &
+sleep 1
+pgrep -x x11vnc > /dev/null || x11vnc -display :99 -nopw -forever -shared -rfbport 5900 > /dev/null 2>&1 &
+sleep 1
+pgrep -f websockify > /dev/null || websockify --web /usr/share/novnc/ 6080 localhost:5900 > /dev/null 2>&1 &
+sleep 1
+```
+
+### Always Use Headed Mode
+
+All agent-browser commands must set `DISPLAY=:99` and use `--headed`:
+
+```bash
+DISPLAY=:99 agent-browser --headed open <url>
+```
+
+### Tell the User How to Connect
+
+After starting the VNC stack, tell the user:
+
+> The browser is running in headed mode with noVNC. To view and interact with it from macOS, run:
+>
+> ```
+> dcvnc <vm_name>
+> ```
+>
+> (e.g., `dcvnc vm01`). This opens the noVNC viewer in your default browser.
+
 ## Core Workflow
 
 Every browser automation follows this pattern:
 
-1. **Navigate**: `agent-browser open <url>`
-2. **Snapshot**: `agent-browser snapshot -i` (get element refs like `@e1`, `@e2`)
-3. **Interact**: Use refs to click, fill, select
-4. **Re-snapshot**: After navigation or DOM changes, get fresh refs
+1. **Start noVNC stack** (see above)
+2. **Navigate**: `DISPLAY=:99 agent-browser --headed open <url>`
+3. **Snapshot**: `DISPLAY=:99 agent-browser snapshot -i` (get element refs like `@e1`, `@e2`)
+4. **Interact**: Use refs to click, fill, select
+5. **Re-snapshot**: After navigation or DOM changes, get fresh refs
 
 ```bash
-agent-browser open https://example.com/form
+DISPLAY=:99 agent-browser --headed open https://example.com/form
 agent-browser snapshot -i
 # Output: @e1 [input type="email"], @e2 [input type="password"], @e3 [button] "Submit"
 
@@ -219,17 +266,16 @@ AGENT_BROWSER_COLOR_SCHEME=dark agent-browser open https://example.com
 agent-browser set media dark
 ```
 
-### Visual Browser (Debugging)
+### Visual Browser (via noVNC)
+
+In this project, headed mode is the default (see noVNC Setup above). Additional debugging tools:
 
 ```bash
-agent-browser --headed open https://example.com
 agent-browser highlight @e1          # Highlight element
 agent-browser record start demo.webm # Record session
 agent-browser profiler start         # Start Chrome DevTools profiling
 agent-browser profiler stop trace.json # Stop and save profile (path optional)
 ```
-
-Use `AGENT_BROWSER_HEADED=1` to enable headed mode via environment variable. Browser extensions work in both headed and headless mode.
 
 ### Local Files (PDFs, HTML)
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,7 +17,8 @@
     "NODE_EXTRA_CA_CERTS": "${containerWorkspaceFolder}/.certs/rootCA.pem",
     "CARGO_HOME": "/home/vscode/.cache/cargo",
     "PATH": "/home/vscode/.cache/cargo/bin:/home/vscode/.local/bin:${containerWorkspaceFolder}/bin:${containerEnv:PATH}",
-    "VM0_API_URL": "https://www.vm7.ai:8443"
+    "VM0_API_URL": "https://www.vm7.ai:8443",
+    "AGENT_BROWSER_PROFILE": "/home/vscode/.local/share/agent-browser/profile"
   },
   "mounts": [
     "source=config,target=/home/vscode/.config",
@@ -28,7 +29,8 @@
     "source=claude,target=/home/vscode/.local/share/claude",
     "source=codex,target=/home/vscode/.codex",
     "source=pki,target=/home/vscode/.pki",
-    "source=cloudflared,target=/home/vscode/.cloudflared"
+    "source=cloudflared,target=/home/vscode/.cloudflared",
+    "source=agent-browser,target=/home/vscode/.local/share/agent-browser"
   ],
   "postCreateCommand": "bash .devcontainer/setup.sh",
   "postStartCommand": "gh auth setup-git",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,7 @@
     }
   },
   "remoteUser": "vscode",
-  "forwardPorts": [8443],
+  "forwardPorts": [6080, 8443],
   "runArgs": ["-p", "8443", "--hostname", "${localWorkspaceFolderBasename}"],
   "remoteEnv": {
     "CLAUDE_CONFIG_DIR": "/home/vscode/.config/claude",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,7 +8,7 @@
   },
   "remoteUser": "vscode",
   "forwardPorts": [6080, 8443],
-  "runArgs": ["-p", "8443", "--hostname", "${localWorkspaceFolderBasename}"],
+  "runArgs": ["-p", "6080", "-p", "8443", "--hostname", "${localWorkspaceFolderBasename}"],
   "remoteEnv": {
     "CLAUDE_CONFIG_DIR": "/home/vscode/.config/claude",
     "CRUSH_GLOBAL_CONFIG": "/home/vscode/.config/crush",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -18,7 +18,8 @@
     "CARGO_HOME": "/home/vscode/.cache/cargo",
     "PATH": "/home/vscode/.cache/cargo/bin:/home/vscode/.local/bin:${containerWorkspaceFolder}/bin:${containerEnv:PATH}",
     "VM0_API_URL": "https://www.vm7.ai:8443",
-    "AGENT_BROWSER_PROFILE": "/home/vscode/.local/share/agent-browser/profile"
+    "AGENT_BROWSER_PROFILE": "/home/vscode/.local/share/agent-browser/profile",
+    "AGENT_BROWSER_ARGS": "--disable-blink-features=AutomationControlled"
   },
   "mounts": [
     "source=config,target=/home/vscode/.config",

--- a/bin/dcvnc
+++ b/bin/dcvnc
@@ -35,6 +35,6 @@ if [ -z "$port" ]; then
     exit 1
 fi
 
-url="http://127.0.0.1:${port}/vnc.html"
+url="http://127.0.0.1:${port}/vnc.html?resize=scale&autoconnect=true"
 echo "Opening noVNC: ${url}"
 open "${url}"

--- a/bin/dcvnc
+++ b/bin/dcvnc
@@ -35,6 +35,6 @@ if [ -z "$port" ]; then
     exit 1
 fi
 
-url="http://127.0.0.1:${port}/vnc.html?resize=scale&autoconnect=true"
+url="http://127.0.0.1:${port}/vnc.html"
 echo "Opening noVNC: ${url}"
 open "${url}"

--- a/bin/dcvnc
+++ b/bin/dcvnc
@@ -10,13 +10,28 @@ fi
 
 vm_name="$1"
 
-# Find the container and extract the host port mapped to container port 6080
-port=$(docker ps | grep "vsc-${vm_name}" | ggrep -oP '0\.0\.0\.0:\K[0-9]+(?=->6080)' | head -n1)
+# Find container by hostname (set via --hostname in devcontainer.json)
+container_id=$(docker ps -q --filter "name=." | while read -r cid; do
+    if [ "$(docker inspect -f '{{.Config.Hostname}}' "$cid")" = "$vm_name" ]; then
+        echo "$cid"
+        break
+    fi
+done)
+
+if [ -z "$container_id" ]; then
+    echo "Error: No running container with hostname '${vm_name}'"
+    echo "Available containers:"
+    docker ps --format "table {{.Names}}\t{{.Config.Hostname}}\t{{.Ports}}" 2>/dev/null \
+        || docker ps --format "table {{.Names}}\t{{.Ports}}"
+    exit 1
+fi
+
+# Extract the host port mapped to container port 6080
+port=$(docker port "$container_id" 6080 2>/dev/null | head -n1 | sed 's/.*://')
 
 if [ -z "$port" ]; then
-    echo "Error: Container for '${vm_name}' not found or no port 6080 mapping"
-    echo "Available containers:"
-    docker ps --format "table {{.Names}}\t{{.Ports}}" | grep vsc- || echo "No devcontainers running"
+    echo "Error: Container '${vm_name}' has no port 6080 mapping"
+    echo "Add \"-p\", \"6080\" to runArgs in devcontainer.json and rebuild"
     exit 1
 fi
 

--- a/bin/dcvnc
+++ b/bin/dcvnc
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+set -eu
+
+if [ $# -eq 0 ]; then
+    echo "Usage: dcvnc <vm_name>"
+    echo "Example: dcvnc vm01"
+    exit 1
+fi
+
+vm_name="$1"
+
+# Find the container and extract the host port mapped to container port 6080
+port=$(docker ps | grep "vsc-${vm_name}" | ggrep -oP '0\.0\.0\.0:\K[0-9]+(?=->6080)' | head -n1)
+
+if [ -z "$port" ]; then
+    echo "Error: Container for '${vm_name}' not found or no port 6080 mapping"
+    echo "Available containers:"
+    docker ps --format "table {{.Names}}\t{{.Ports}}" | grep vsc- || echo "No devcontainers running"
+    exit 1
+fi
+
+url="http://127.0.0.1:${port}/vnc.html"
+echo "Opening noVNC: ${url}"
+open "${url}"

--- a/docker/toolchain/Dockerfile
+++ b/docker/toolchain/Dockerfile
@@ -128,12 +128,6 @@ RUN curl -fsSL https://downloads.1password.com/linux/keys/1password.asc | gpg --
 RUN npm install -g agent-browser \
     && agent-browser install --with-deps
 
-# Install noVNC stack for remote browser viewing
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    x11vnc \
-    novnc \
-    && rm -rf /var/lib/apt/lists/*
-
 # Install AWS CLI v2
 RUN apt-get update && apt-get install -y unzip \
     && ARCH=$(dpkg --print-architecture) \
@@ -174,6 +168,12 @@ RUN mkdir -p /usr/share/keyrings \
     && echo "deb [signed-by=/usr/share/keyrings/cloudflare-main.gpg] https://pkg.cloudflare.com/cloudflared $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/cloudflared.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends cloudflared \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install noVNC stack for remote browser viewing
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    x11vnc \
+    novnc \
     && rm -rf /var/lib/apt/lists/*
 
 # Default command

--- a/docker/toolchain/Dockerfile
+++ b/docker/toolchain/Dockerfile
@@ -128,6 +128,12 @@ RUN curl -fsSL https://downloads.1password.com/linux/keys/1password.asc | gpg --
 RUN npm install -g agent-browser \
     && agent-browser install --with-deps
 
+# Install noVNC stack for remote browser viewing
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    x11vnc \
+    novnc \
+    && rm -rf /var/lib/apt/lists/*
+
 # Install AWS CLI v2
 RUN apt-get update && apt-get install -y unzip \
     && ARCH=$(dpkg --print-architecture) \
@@ -148,7 +154,7 @@ RUN groupadd -f --gid 1000 vscode \
     && useradd --uid 1000 --gid vscode --shell /usr/bin/zsh --create-home vscode \
     && echo "vscode ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/vscode \
     && chmod 0440 /etc/sudoers.d/vscode \
-    && mkdir -p /home/vscode/.local/share /home/vscode/.cache /home/vscode/.config \
+    && mkdir -p /home/vscode/.local/share /home/vscode/.local/share/agent-browser /home/vscode/.cache /home/vscode/.config \
     && chown -R vscode:vscode /home/vscode
 
 # Install rust-src for rust-analyzer (IDE support for standard library)


### PR DESCRIPTION
## Summary
- Forward port 6080 (noVNC) in devcontainer configuration
- Add `bin/dcvnc` helper script to open noVNC sessions for devcontainers from the host

## Test plan
- [ ] Verify devcontainer starts with port 6080 forwarded
- [ ] Run `dcvnc <vm_name>` from host and confirm noVNC opens in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)