### PR TITLE
perf: add per-step timing metrics to run creation flow

### DIFF
--- a/turbo/apps/web/src/lib/run/executors/docker-executor.ts
+++ b/turbo/apps/web/src/lib/run/executors/docker-executor.ts
@@ -183,6 +183,7 @@ export async function executeDockerRun(
       status: "running",
       sandboxId: sandbox.sandboxId,
       createdAt: new Date(startTime).toISOString(),
+      sandboxType: "docker",
     };
   } catch (error) {
     let errorMessage = error instanceof Error ? error.message : "Unknown error";

--- a/turbo/apps/web/src/lib/run/executors/e2b-executor.ts
+++ b/turbo/apps/web/src/lib/run/executors/e2b-executor.ts
@@ -183,6 +183,7 @@ export async function executeE2bRun(
       status: "running",
       sandboxId: sandbox.sandboxId,
       createdAt: new Date(startTime).toISOString(),
+      sandboxType: "e2b",
     };
   } catch (error) {
     // Extract error message

--- a/turbo/apps/web/src/lib/run/executors/runner-executor.ts
+++ b/turbo/apps/web/src/lib/run/executors/runner-executor.ts
@@ -91,5 +91,6 @@ export async function executeRunnerJob(
     runId: context.runId,
     status: "pending",
     createdAt: new Date().toISOString(),
+    sandboxType: "runner",
   };
 }

--- a/turbo/apps/web/src/lib/run/executors/types.ts
+++ b/turbo/apps/web/src/lib/run/executors/types.ts
@@ -71,4 +71,5 @@ export interface ExecutorResult {
   sandboxId?: string;
   createdAt: string;
   error?: string;
+  sandboxType: "runner" | "e2b" | "docker";
 }

--- a/turbo/apps/web/src/lib/run/run-service.ts
+++ b/turbo/apps/web/src/lib/run/run-service.ts
@@ -16,7 +16,6 @@ import {
 } from "../errors";
 import { logger } from "../logger";
 import type { Database } from "../../types/global";
-import type { ExecutionContext } from "./types";
 import type { AgentComposeSnapshot } from "../checkpoint/types";
 import type { AgentComposeYaml } from "../../types/agent-compose";
 import { getAgentSessionWithConversation } from "../agent-session";
@@ -27,6 +26,7 @@ import { executeDockerRun } from "./executors/docker-executor";
 import type { ExecutorResult, PreparedContext } from "./executors/types";
 import { buildExecutionContext as buildContext } from "./build-context";
 import { generateSandboxToken } from "../auth/sandbox-token";
+import { recordSandboxOperation } from "../metrics";
 import { canAccessCompose } from "../agent/permission-service";
 import { getUserEmail } from "../auth/get-user-email";
 import { extractTemplateVars } from "../config-validator";
@@ -214,28 +214,6 @@ export async function validateAgentSession(
   return {
     agentComposeId: session.agentComposeId,
   };
-}
-
-/**
- * Prepare execution context and dispatch to appropriate executor
- *
- * This is the unified entry point that handles both E2B and runner paths:
- * 1. Prepares the execution context (storage manifest, working dir, etc.)
- * 2. Routes to the appropriate executor based on runner group config
- *
- * @param context ExecutionContext built by buildExecutionContext()
- * @returns ExecutorResult with status and optional sandboxId
- */
-async function prepareAndDispatchRun(
-  context: ExecutionContext,
-): Promise<ExecutorResult> {
-  log.debug(`Preparing and dispatching run ${context.runId}...`);
-
-  // Layer 1: Prepare context (storage manifest, working dir, etc.)
-  const preparedContext = await prepareForExecution(context);
-
-  // Layer 2: Dispatch to appropriate executor
-  return await dispatchRun(preparedContext);
 }
 
 /**
@@ -521,6 +499,7 @@ export async function createRun(
     agentComposeVersionId,
     params.composeId,
   );
+  const authorizeTime = Date.now();
 
   // Step 3: Validate template vars and image access (for new runs only)
   if (!params.checkpointId && !params.sessionId) {
@@ -578,6 +557,7 @@ export async function createRun(
     return newRun;
   });
 
+  const transactionTime = Date.now();
   log.debug(`Created run ${run.id} for user ${userId}`);
 
   // From this point on, errors must mark the run as "failed"
@@ -589,6 +569,7 @@ export async function createRun(
 
     // Step 7: Generate sandbox token
     const sandboxToken = await generateSandboxToken(userId, run.id);
+    const tokenTime = Date.now();
 
     // Step 8: Build execution context (pass pre-loaded compose to avoid double fetch)
     const context = await buildContext({
@@ -616,8 +597,33 @@ export async function createRun(
       scopeId,
     });
 
-    // Step 9: Dispatch to executor
-    const result = await prepareAndDispatchRun(context);
+    const buildContextTime = Date.now();
+
+    // Step 9: Prepare execution context (storage manifest, working dir, etc.)
+    const preparedContext = await prepareForExecution(context);
+    const prepareTime = Date.now();
+
+    // Step 10: Dispatch to executor
+    const result = await dispatchRun(preparedContext);
+    const dispatchTime = Date.now();
+
+    // Record per-step timing metrics for latency diagnosis
+    const steps = [
+      { op: "api_step_authorize", ms: authorizeTime - apiStartTime },
+      { op: "api_step_transaction", ms: transactionTime - authorizeTime },
+      { op: "api_step_token", ms: tokenTime - transactionTime },
+      { op: "api_step_build_context", ms: buildContextTime - tokenTime },
+      { op: "api_step_prepare", ms: prepareTime - buildContextTime },
+      { op: "api_step_dispatch", ms: dispatchTime - prepareTime },
+    ];
+    for (const step of steps) {
+      recordSandboxOperation({
+        sandboxType: result.sandboxType,
+        actionType: step.op,
+        durationMs: step.ms,
+        success: true,
+      });
+    }
 
     log.debug(`Run ${run.id} dispatched with status: ${result.status}`);
 

--- a/turbo/apps/web/src/lib/run/run-service.ts
+++ b/turbo/apps/web/src/lib/run/run-service.ts
@@ -610,8 +610,11 @@ export async function createRun(
     // Record per-step timing metrics for latency diagnosis
     const steps = [
       { op: "api_step_authorize", ms: authorizeTime - apiStartTime },
-      { op: "api_step_transaction", ms: transactionTime - authorizeTime },
-      { op: "api_step_token", ms: tokenTime - transactionTime },
+      {
+        op: "api_step_validate_and_insert",
+        ms: transactionTime - authorizeTime,
+      },
+      { op: "api_step_callbacks_and_token", ms: tokenTime - transactionTime },
       { op: "api_step_build_context", ms: buildContextTime - tokenTime },
       { op: "api_step_prepare", ms: prepareTime - buildContextTime },
       { op: "api_step_dispatch", ms: dispatchTime - prepareTime },


### PR DESCRIPTION
## Summary

- Break down the coarse `api_to_executor` metric (avg 4,036ms in production) into 6 fine-grained steps: `api_step_authorize`, `api_step_transaction`, `api_step_token`, `api_step_build_context`, `api_step_prepare`, `api_step_dispatch`
- Add `sandboxType` to `ExecutorResult` so metrics are accurately attributed to runner/e2b/docker
- Inline `prepareAndDispatchRun` into `createRun` to enable per-step measurement

## Test plan

- [ ] Type check passes (`npx tsc --noEmit`)
- [ ] Knip passes (no unused exports)
- [ ] Deploy to preview, trigger a run, verify `api_step_*` metrics appear in Axiom
- [ ] Verify existing `api_to_executor` metric still works unchanged

Refs #3790

🤖 Generated with [Claude Code](https://claude.com/claude-code)