### PR TITLE
fix(cli): align schedule cli consistency with platform ui

### DIFF
--- a/e2e/tests/02-parallel/t20-vm0-schedule.bats
+++ b/e2e/tests/02-parallel/t20-vm0-schedule.bats
@@ -47,7 +47,7 @@ teardown_file() {
 
     # Clean up schedule and temp directory
     if [ -n "$AGENT_NAME" ]; then
-        $CLI_COMMAND schedule delete "$AGENT_NAME" --force 2>/dev/null || true
+        $CLI_COMMAND schedule delete "$AGENT_NAME" --yes 2>/dev/null || true
     fi
     if [ -n "$TEST_DIR" ] && [ -d "$TEST_DIR" ]; then
         rm -rf "$TEST_DIR"
@@ -141,8 +141,8 @@ setup() {
         --prompt "To be deleted"
     assert_success
 
-    # Delete with force flag
-    run $CLI_COMMAND schedule delete "$AGENT_NAME" --force
+    # Delete with yes flag
+    run $CLI_COMMAND schedule delete "$AGENT_NAME" --yes
     assert_success
     assert_output --partial "Deleted"
 }
@@ -221,7 +221,7 @@ EOF
     local LOOP_AGENT_NAME=$(cat "$BATS_FILE_TMPDIR/loop_agent_name")
     local LOOP_TEST_DIR=$(cat "$BATS_FILE_TMPDIR/loop_test_dir")
 
-    run $CLI_COMMAND schedule delete "$LOOP_AGENT_NAME" --force
+    run $CLI_COMMAND schedule delete "$LOOP_AGENT_NAME" --yes
     assert_success
     assert_output --partial "Deleted"
 
@@ -286,7 +286,7 @@ EOF
     assert_success
 
     # Clean up
-    $CLI_COMMAND schedule delete "$CONFIG_AGENT_NAME" --force 2>/dev/null || true
+    $CLI_COMMAND schedule delete "$CONFIG_AGENT_NAME" --yes 2>/dev/null || true
     $CLI_COMMAND secret delete "$SECRET_NAME" -y 2>/dev/null || true
     $CLI_COMMAND variable delete "$VAR_URL_NAME" -y 2>/dev/null || true
     $CLI_COMMAND variable delete "$VAR_DEBUG_NAME" -y 2>/dev/null || true

--- a/e2e/tests/03-experimental-runner/t20-vm0-schedule.bats
+++ b/e2e/tests/03-experimental-runner/t20-vm0-schedule.bats
@@ -48,7 +48,7 @@ teardown_file() {
 
     # Clean up schedule and temp directory
     if [ -n "$AGENT_NAME" ]; then
-        $CLI_COMMAND schedule delete "$AGENT_NAME" --force 2>/dev/null || true
+        $CLI_COMMAND schedule delete "$AGENT_NAME" --yes 2>/dev/null || true
     fi
     if [ -n "$TEST_DIR" ] && [ -d "$TEST_DIR" ]; then
         rm -rf "$TEST_DIR"
@@ -142,8 +142,8 @@ setup() {
         --prompt "To be deleted"
     assert_success
 
-    # Delete with force flag
-    run $CLI_COMMAND schedule delete "$AGENT_NAME" --force
+    # Delete with yes flag
+    run $CLI_COMMAND schedule delete "$AGENT_NAME" --yes
     assert_success
     assert_output --partial "Deleted"
 }
@@ -223,7 +223,7 @@ EOF
     local LOOP_AGENT_NAME=$(cat "$BATS_FILE_TMPDIR/loop_agent_name")
     local LOOP_TEST_DIR=$(cat "$BATS_FILE_TMPDIR/loop_test_dir")
 
-    run $CLI_COMMAND schedule delete "$LOOP_AGENT_NAME" --force
+    run $CLI_COMMAND schedule delete "$LOOP_AGENT_NAME" --yes
     assert_success
     assert_output --partial "Deleted"
 
@@ -289,7 +289,7 @@ EOF
     assert_success
 
     # Clean up
-    $CLI_COMMAND schedule delete "$CONFIG_AGENT_NAME" --force 2>/dev/null || true
+    $CLI_COMMAND schedule delete "$CONFIG_AGENT_NAME" --yes 2>/dev/null || true
     $CLI_COMMAND secret delete "$SECRET_NAME" -y 2>/dev/null || true
     $CLI_COMMAND variable delete "$VAR_URL_NAME" -y 2>/dev/null || true
     $CLI_COMMAND variable delete "$VAR_DEBUG_NAME" -y 2>/dev/null || true

--- a/turbo/apps/cli/src/commands/schedule/__tests__/delete-command.test.ts
+++ b/turbo/apps/cli/src/commands/schedule/__tests__/delete-command.test.ts
@@ -88,7 +88,7 @@ describe("schedule delete command", () => {
 
       expect(output).toContain("Delete a schedule");
       expect(output).toContain("<agent-name>");
-      expect(output).toContain("--force");
+      expect(output).toContain("--yes");
       expect(output).toContain("rm");
 
       mockStdoutWrite.mockRestore();
@@ -96,7 +96,7 @@ describe("schedule delete command", () => {
   });
 
   describe("successful delete", () => {
-    it("should delete schedule with --force", async () => {
+    it("should delete schedule with --yes", async () => {
       const schedule = createMockSchedule();
       let deletedName: string | undefined;
 
@@ -115,7 +115,7 @@ describe("schedule delete command", () => {
         ),
       );
 
-      await deleteCommand.parseAsync(["node", "cli", "test-agent", "--force"]);
+      await deleteCommand.parseAsync(["node", "cli", "test-agent", "--yes"]);
 
       expect(deletedName).toBe("test-agent-schedule");
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
@@ -149,7 +149,7 @@ describe("schedule delete command", () => {
         "node",
         "cli",
         "my-special-agent",
-        "--force",
+        "--yes",
       ]);
 
       expect(deletedName).toBe("my-special-agent-schedule");
@@ -172,12 +172,7 @@ describe("schedule delete command", () => {
       );
 
       await expect(async () => {
-        await deleteCommand.parseAsync([
-          "node",
-          "cli",
-          "test-agent",
-          "--force",
-        ]);
+        await deleteCommand.parseAsync(["node", "cli", "test-agent", "--yes"]);
       }).rejects.toThrow("process.exit called");
 
       expect(mockConsoleError).toHaveBeenCalledWith(
@@ -214,7 +209,7 @@ describe("schedule delete command", () => {
         "test-agent",
         "--name",
         "weekly-cleanup",
-        "--force",
+        "--yes",
       ]);
 
       expect(deletedName).toBe("weekly-cleanup");
@@ -224,7 +219,7 @@ describe("schedule delete command", () => {
   });
 
   describe("confirmation", () => {
-    it("should require --force in non-interactive mode", async () => {
+    it("should require --yes in non-interactive mode", async () => {
       const schedule = createMockSchedule();
 
       server.use(
@@ -241,7 +236,7 @@ describe("schedule delete command", () => {
       }).rejects.toThrow("process.exit called");
 
       expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining("--force required"),
+        expect.stringContaining("--yes"),
       );
       expect(mockExit).toHaveBeenCalledWith(1);
     });
@@ -326,13 +321,10 @@ describe("schedule delete command", () => {
           "node",
           "cli",
           "nonexistent-agent",
-          "--force",
+          "--yes",
         ]);
       }).rejects.toThrow("process.exit called");
 
-      expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining("Failed to delete schedule"),
-      );
       expect(mockConsoleError).toHaveBeenCalledWith(
         expect.stringContaining("No schedule found"),
       );
@@ -355,12 +347,7 @@ describe("schedule delete command", () => {
       );
 
       await expect(async () => {
-        await deleteCommand.parseAsync([
-          "node",
-          "cli",
-          "test-agent",
-          "--force",
-        ]);
+        await deleteCommand.parseAsync(["node", "cli", "test-agent", "--yes"]);
       }).rejects.toThrow("process.exit called");
 
       expect(mockConsoleError).toHaveBeenCalledWith(

--- a/turbo/apps/cli/src/commands/schedule/__tests__/disable-command.test.ts
+++ b/turbo/apps/cli/src/commands/schedule/__tests__/disable-command.test.ts
@@ -212,9 +212,6 @@ describe("schedule disable command", () => {
       }).rejects.toThrow("process.exit called");
 
       expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining("Failed to disable schedule"),
-      );
-      expect(mockConsoleError).toHaveBeenCalledWith(
         expect.stringContaining("No schedule found"),
       );
       expect(mockExit).toHaveBeenCalledWith(1);

--- a/turbo/apps/cli/src/commands/schedule/__tests__/enable-command.test.ts
+++ b/turbo/apps/cli/src/commands/schedule/__tests__/enable-command.test.ts
@@ -150,9 +150,6 @@ describe("schedule enable command", () => {
       }).rejects.toThrow("process.exit called");
 
       expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining("Failed to enable schedule"),
-      );
-      expect(mockConsoleError).toHaveBeenCalledWith(
         expect.stringContaining("No schedule found"),
       );
       expect(mockExit).toHaveBeenCalledWith(1);
@@ -269,9 +266,6 @@ describe("schedule enable command", () => {
         await enableCommand.parseAsync(["node", "cli", "test-agent"]);
       }).rejects.toThrow("process.exit called");
 
-      expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining("Failed to enable schedule"),
-      );
       expect(mockConsoleError).toHaveBeenCalledWith(
         expect.stringContaining("Scheduled time has already passed"),
       );

--- a/turbo/apps/cli/src/commands/schedule/__tests__/setup-command.test.ts
+++ b/turbo/apps/cli/src/commands/schedule/__tests__/setup-command.test.ts
@@ -171,6 +171,7 @@ describe("schedule setup command", () => {
       ]);
 
       expect(deployPayload).toBeDefined();
+      expect(deployPayload!.name).toBe("default");
       expect(deployPayload!.cronExpression).toBe("0 14 * * *");
       expect(deployPayload!.timezone).toBe("America/New_York");
       expect(deployPayload!.prompt).toBe("Run daily task");
@@ -266,8 +267,9 @@ describe("schedule setup command", () => {
 
     it("should update existing schedule", async () => {
       const compose = createMockCompose();
-      const existingSchedule = createMockSchedule();
+      const existingSchedule = createMockSchedule({ name: "default" });
       const updatedSchedule = createMockSchedule({
+        name: "default",
         cronExpression: "0 10 * * *",
         prompt: "Updated task",
       });

--- a/turbo/apps/cli/src/commands/schedule/__tests__/status-command.test.ts
+++ b/turbo/apps/cli/src/commands/schedule/__tests__/status-command.test.ts
@@ -383,9 +383,6 @@ describe("schedule status command", () => {
       }).rejects.toThrow("process.exit called");
 
       expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining("Failed to get schedule status"),
-      );
-      expect(mockConsoleError).toHaveBeenCalledWith(
         expect.stringContaining("No schedule found"),
       );
       expect(mockExit).toHaveBeenCalledWith(1);

--- a/turbo/apps/cli/src/commands/schedule/delete.ts
+++ b/turbo/apps/cli/src/commands/schedule/delete.ts
@@ -3,6 +3,7 @@ import chalk from "chalk";
 import { deleteSchedule } from "../../lib/api";
 import { resolveScheduleByAgent } from "../../lib/domain/schedule-utils";
 import { isInteractive, promptConfirm } from "../../lib/utils/prompt-utils";
+import { withErrorHandler } from "../../lib/command";
 
 export const deleteCommand = new Command()
   .name("delete")
@@ -13,20 +14,17 @@ export const deleteCommand = new Command()
     "-n, --name <schedule-name>",
     "Schedule name (required when agent has multiple schedules)",
   )
-  .option("-f, --force", "Skip confirmation prompt")
+  .option("-y, --yes", "Skip confirmation prompt")
   .action(
-    async (agentName: string, options: { name?: string; force?: boolean }) => {
-      try {
+    withErrorHandler(
+      async (agentName: string, options: { name?: string; yes?: boolean }) => {
         // Resolve schedule by agent name
         const resolved = await resolveScheduleByAgent(agentName, options.name);
 
         // Confirm deletion
-        if (!options.force) {
+        if (!options.yes) {
           if (!isInteractive()) {
-            console.error(
-              chalk.red("✗ --force required in non-interactive mode"),
-            );
-            process.exit(1);
+            throw new Error("--yes flag is required in non-interactive mode");
           }
           const confirmed = await promptConfirm(
             `Delete schedule for agent ${chalk.cyan(agentName)}?`,
@@ -47,24 +45,6 @@ export const deleteCommand = new Command()
         console.log(
           chalk.green(`✓ Deleted schedule for agent ${chalk.cyan(agentName)}`),
         );
-      } catch (error) {
-        console.error(chalk.red("✗ Failed to delete schedule"));
-        if (error instanceof Error) {
-          if (error.message.includes("Not authenticated")) {
-            console.error(chalk.dim("  Run: vm0 auth login"));
-          } else if (
-            error.message.toLowerCase().includes("not found") ||
-            error.message.includes("No schedule found")
-          ) {
-            console.error(
-              chalk.dim(`  No schedule found for agent "${agentName}"`),
-            );
-            console.error(chalk.dim("  Run: vm0 schedule list"));
-          } else {
-            console.error(chalk.dim(`  ${error.message}`));
-          }
-        }
-        process.exit(1);
-      }
-    },
+      },
+    ),
   );

--- a/turbo/apps/cli/src/commands/schedule/disable.ts
+++ b/turbo/apps/cli/src/commands/schedule/disable.ts
@@ -2,6 +2,7 @@ import { Command } from "commander";
 import chalk from "chalk";
 import { disableSchedule } from "../../lib/api";
 import { resolveScheduleByAgent } from "../../lib/domain/schedule-utils";
+import { withErrorHandler } from "../../lib/command";
 
 export const disableCommand = new Command()
   .name("disable")
@@ -11,8 +12,8 @@ export const disableCommand = new Command()
     "-n, --name <schedule-name>",
     "Schedule name (required when agent has multiple schedules)",
   )
-  .action(async (agentName: string, options: { name?: string }) => {
-    try {
+  .action(
+    withErrorHandler(async (agentName: string, options: { name?: string }) => {
       // Resolve schedule by agent name
       const resolved = await resolveScheduleByAgent(agentName, options.name);
 
@@ -25,23 +26,5 @@ export const disableCommand = new Command()
       console.log(
         chalk.green(`✓ Disabled schedule for agent ${chalk.cyan(agentName)}`),
       );
-    } catch (error) {
-      console.error(chalk.red("✗ Failed to disable schedule"));
-      if (error instanceof Error) {
-        if (error.message.includes("Not authenticated")) {
-          console.error(chalk.dim("  Run: vm0 auth login"));
-        } else if (
-          error.message.toLowerCase().includes("not found") ||
-          error.message.includes("No schedule found")
-        ) {
-          console.error(
-            chalk.dim(`  No schedule found for agent "${agentName}"`),
-          );
-          console.error(chalk.dim("  Run: vm0 schedule list"));
-        } else {
-          console.error(chalk.dim(`  ${error.message}`));
-        }
-      }
-      process.exit(1);
-    }
-  });
+    }),
+  );

--- a/turbo/apps/cli/src/commands/schedule/enable.ts
+++ b/turbo/apps/cli/src/commands/schedule/enable.ts
@@ -1,7 +1,8 @@
 import { Command } from "commander";
 import chalk from "chalk";
-import { enableSchedule, ApiRequestError } from "../../lib/api";
+import { enableSchedule } from "../../lib/api";
 import { resolveScheduleByAgent } from "../../lib/domain/schedule-utils";
+import { withErrorHandler } from "../../lib/command";
 
 export const enableCommand = new Command()
   .name("enable")
@@ -11,8 +12,8 @@ export const enableCommand = new Command()
     "-n, --name <schedule-name>",
     "Schedule name (required when agent has multiple schedules)",
   )
-  .action(async (agentName: string, options: { name?: string }) => {
-    try {
+  .action(
+    withErrorHandler(async (agentName: string, options: { name?: string }) => {
       // Resolve schedule by agent name
       const resolved = await resolveScheduleByAgent(agentName, options.name);
 
@@ -25,34 +26,5 @@ export const enableCommand = new Command()
       console.log(
         chalk.green(`✓ Enabled schedule for agent ${chalk.cyan(agentName)}`),
       );
-    } catch (error) {
-      console.error(chalk.red("✗ Failed to enable schedule"));
-      if (error instanceof ApiRequestError) {
-        if (error.code === "SCHEDULE_PAST") {
-          console.error(chalk.dim("  Scheduled time has already passed"));
-          console.error(chalk.dim(`  Run: vm0 schedule setup ${agentName}`));
-        } else if (error.code === "NOT_FOUND") {
-          console.error(
-            chalk.dim(`  No schedule found for agent "${agentName}"`),
-          );
-          console.error(chalk.dim("  Run: vm0 schedule list"));
-        } else if (error.code === "UNAUTHORIZED") {
-          console.error(chalk.dim("  Run: vm0 auth login"));
-        } else {
-          console.error(chalk.dim(`  ${error.message}`));
-        }
-      } else if (error instanceof Error) {
-        if (error.message.includes("Not authenticated")) {
-          console.error(chalk.dim("  Run: vm0 auth login"));
-        } else if (error.message.includes("No schedule found")) {
-          console.error(
-            chalk.dim(`  No schedule found for agent "${agentName}"`),
-          );
-          console.error(chalk.dim("  Run: vm0 schedule list"));
-        } else {
-          console.error(chalk.dim(`  ${error.message}`));
-        }
-      }
-      process.exit(1);
-    }
-  });
+    }),
+  );

--- a/turbo/apps/cli/src/commands/schedule/setup.ts
+++ b/turbo/apps/cli/src/commands/schedule/setup.ts
@@ -429,7 +429,7 @@ async function resolveAgent(
   }
   return {
     composeId: compose.id,
-    scheduleName: scheduleName || `${agentName}-schedule`,
+    scheduleName: scheduleName || "default",
     composeContent: compose.content,
   };
 }
@@ -730,10 +730,7 @@ export const setupCommand = new Command()
   .name("setup")
   .description("Create or edit a schedule for an agent")
   .argument("<agent-name>", "Agent name to configure schedule for")
-  .option(
-    "-n, --name <schedule-name>",
-    "Schedule name (default: <agent>-schedule)",
-  )
+  .option("-n, --name <schedule-name>", 'Schedule name (default: "default")')
   .option("-f, --frequency <type>", "Frequency: daily|weekly|monthly|once|loop")
   .option("-t, --time <HH:MM>", "Time to run (24-hour format)")
   .option("-d, --day <day>", "Day of week (mon-sun) or day of month (1-31)")

--- a/turbo/apps/cli/src/commands/schedule/status.ts
+++ b/turbo/apps/cli/src/commands/schedule/status.ts
@@ -6,6 +6,7 @@ import {
   detectTimezone,
   resolveScheduleByAgent,
 } from "../../lib/domain/schedule-utils";
+import { withErrorHandler } from "../../lib/command";
 import type { ScheduleResponse, RunSummary } from "@vm0/core";
 
 type RunStatus = RunSummary["status"];
@@ -155,28 +156,6 @@ async function printRecentRuns(
   }
 }
 
-/**
- * Handle status command errors
- */
-function handleStatusError(error: unknown, agentName: string): never {
-  console.error(chalk.red("✗ Failed to get schedule status"));
-  if (error instanceof Error) {
-    if (error.message.includes("Not authenticated")) {
-      console.error(chalk.dim("  Run: vm0 auth login"));
-    } else if (
-      error.message.includes("not found") ||
-      error.message.includes("Not found") ||
-      error.message.includes("No schedule found")
-    ) {
-      console.error(chalk.dim(`  No schedule found for agent "${agentName}"`));
-      console.error(chalk.dim("  Run: vm0 schedule list"));
-    } else {
-      console.error(chalk.dim(`  ${error.message}`));
-    }
-  }
-  process.exit(1);
-}
-
 export const statusCommand = new Command()
   .name("status")
   .description("Show detailed status of a schedule")
@@ -191,8 +170,8 @@ export const statusCommand = new Command()
     "5",
   )
   .action(
-    async (agentName: string, options: { name?: string; limit: string }) => {
-      try {
+    withErrorHandler(
+      async (agentName: string, options: { name?: string; limit: string }) => {
         const resolved = await resolveScheduleByAgent(agentName, options.name);
         const { name, composeId } = resolved;
 
@@ -213,8 +192,6 @@ export const statusCommand = new Command()
         await printRecentRuns(name, composeId, limit);
 
         console.log();
-      } catch (error) {
-        handleStatusError(error, agentName);
-      }
-    },
+      },
+    ),
   );


### PR DESCRIPTION
## Summary

- Default schedule name changed from `${agentName}-schedule` to `"default"` to align with Platform UI behavior
- Renamed `--force` to `--yes` in `schedule delete` for consistency with other delete commands
- Migrated `enable`, `disable`, `delete`, `status` commands to use `withErrorHandler` wrapper (already used by `setup` and `list`), removing ~114 lines of duplicated error handling code

## Test plan

- [x] All 110 schedule command tests pass (`pnpm vitest run apps/cli/src/commands/schedule`)
- [x] Lint passes with 0 warnings/errors
- [x] Knip finds no unused code
- [x] Code formatted correctly
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)