### PR TITLE
chore(guest-agent): suppress unnecessary claude cli features in sandbox

### DIFF
--- a/crates/guest-agent/src/cli.rs
+++ b/crates/guest-agent/src/cli.rs
@@ -177,9 +177,12 @@ pub async fn execute_cli(
         // update check, GitHub) add ~2s latency, telemetry has no receiver,
         // and the CLI version is baked into the rootfs image.
         cmd.env("CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC", "1");
-        cmd.env("DISABLE_TELEMETRY", "1");
+        cmd.env("CLAUDE_CODE_DISABLE_FEEDBACK_SURVEY", "1");
+        cmd.env("CLAUDE_CODE_DISABLE_TERMINAL_TITLE", "1");
         cmd.env("DISABLE_AUTOUPDATER", "1");
+        cmd.env("DISABLE_ERROR_REPORTING", "1");
         cmd.env("DISABLE_INSTALLATION_CHECKS", "1");
+        cmd.env("DISABLE_TELEMETRY", "1");
     }
 
     let mut child = cmd.spawn()?;


### PR DESCRIPTION
## Summary
- Add `DISABLE_ERROR_REPORTING` — error reporting has no receiver in sandbox
- Add `CLAUDE_CODE_DISABLE_FEEDBACK_SURVEY` — no interactive survey in sandbox
- Add `CLAUDE_CODE_DISABLE_TERMINAL_TITLE` — no terminal title escape sequences needed
- Reorder env vars by prefix group + alphabetical for readability

## Test plan
- [x] `cargo check -p guest-agent` passes
- CI will verify full build

🤖 Generated with [Claude Code](https://claude.com/claude-code)