### PR TITLE
ci: add github app id env variable to workflows

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -262,6 +262,7 @@ jobs:
             RESEND_FROM_DOMAIN=${{ vars.RESEND_FROM_DOMAIN }}
             VM0_ADMIN_USERS=${{ vars.VM0_ADMIN_USERS }}
             GITHUB_APP_SLUG=${{ vars.VM0_GITHUB_APP_SLUG }}
+            GITHUB_APP_ID=${{ vars.VM0_GITHUB_APP_ID }}
             GITHUB_APP_CLIENT_ID=${{ vars.VM0_GITHUB_APP_CLIENT_ID }}
             GITHUB_APP_CLIENT_SECRET=${{ secrets.VM0_GITHUB_APP_CLIENT_SECRET }}
             GITHUB_APP_WEBHOOK_SECRET=${{ secrets.VM0_GITHUB_APP_WEBHOOK_SECRET }}

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -647,6 +647,7 @@ jobs:
           VM0_ADMIN_USERS: ${{ vars.VM0_ADMIN_USERS }}
           STRAPI_URL: ${{ vars.STRAPI_URL }}
           GITHUB_APP_SLUG: ${{ vars.VM0_GITHUB_APP_SLUG }}
+          GITHUB_APP_ID: ${{ vars.VM0_GITHUB_APP_ID }}
           GITHUB_APP_CLIENT_ID: ${{ vars.VM0_GITHUB_APP_CLIENT_ID }}
           GITHUB_APP_CLIENT_SECRET: ${{ secrets.VM0_GITHUB_APP_CLIENT_SECRET }}
           GITHUB_APP_WEBHOOK_SECRET: ${{ secrets.VM0_GITHUB_APP_WEBHOOK_SECRET }}
@@ -807,6 +808,7 @@ jobs:
             VM0_ADMIN_USERS=${{ vars.VM0_ADMIN_USERS }}
             STRAPI_URL=${{ vars.STRAPI_URL }}
             GITHUB_APP_SLUG=${{ vars.VM0_GITHUB_APP_SLUG }}
+            GITHUB_APP_ID=${{ vars.VM0_GITHUB_APP_ID }}
             GITHUB_APP_CLIENT_ID=${{ vars.VM0_GITHUB_APP_CLIENT_ID }}
             GITHUB_APP_CLIENT_SECRET=${{ secrets.VM0_GITHUB_APP_CLIENT_SECRET }}
             GITHUB_APP_WEBHOOK_SECRET=${{ secrets.VM0_GITHUB_APP_WEBHOOK_SECRET }}


### PR DESCRIPTION
## Summary
- Add `GITHUB_APP_ID` environment variable to `release-please.yml` and `turbo.yml` workflows
- Ensures the GitHub App ID is available in CI/CD build and deploy environments

## Test plan
- [ ] Verify `release-please.yml` workflow passes with the new env variable
- [ ] Verify `turbo.yml` workflow passes with the new env variable

🤖 Generated with [Claude Code](https://claude.com/claude-code)