### PR TITLE
test(run-queue): add cancel drain queue integration test

### DIFF
--- a/turbo/apps/web/app/api/agent/runs/[id]/cancel/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/cancel/__tests__/route.test.ts
@@ -6,6 +6,7 @@ import {
   createTestCompose,
   createTestRun,
   findTestQueueEntry,
+  findTestRunRecord,
 } from "../../../../../../../src/__tests__/api-test-helpers";
 import {
   testContext,
@@ -96,6 +97,38 @@ describe("POST /api/agent/runs/:id/cancel - Cancel Run", () => {
       // Queue entry should be removed (encrypted secrets deleted)
       const queueAfter = await findTestQueueEntry(queued.runId);
       expect(queueAfter).toBeUndefined();
+    });
+
+    it("should drain queue after cancelling a running run", async () => {
+      vi.stubEnv("CONCURRENT_RUN_LIMIT", "1");
+      reloadEnv();
+
+      // Create a running run (claims the slot)
+      const running = await createTestRun(testComposeId, "Running run");
+      expect(running.status).toBe("running");
+
+      // Create a second run that gets queued
+      const queued = await createTestRun(testComposeId, "Queued run");
+      expect(queued.status).toBe("queued");
+
+      // Cancel the running run (frees the concurrency slot)
+      const request = createTestRequest(
+        `http://localhost:3000/api/agent/runs/${running.runId}/cancel`,
+        { method: "POST" },
+      );
+      const response = await POST(request);
+      expect(response.status).toBe(200);
+
+      // Flush the after() callback which triggers drainUserQueue
+      await context.mocks.flushAfter();
+
+      // Queued run should now be dispatched (running)
+      const run = await findTestRunRecord(queued.runId);
+      expect(run!.status).toBe("running");
+
+      // Queue entry should be deleted
+      const queueEntry = await findTestQueueEntry(queued.runId);
+      expect(queueEntry).toBeUndefined();
     });
   });
 


### PR DESCRIPTION
## Summary
- Add integration test verifying that cancelling a running run triggers `drainUserQueue` via `after()` callback, automatically dispatching the next queued run
- This covers the cancel-drain path added in #3764 that was missing test coverage

## Test plan
- [x] New test passes locally (8/8 in cancel route test suite)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)