### PR TITLE
ci: add vm0 default agent env variable to workflows

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -262,6 +262,7 @@ jobs:
             RESEND_WEBHOOK_SECRET=${{ secrets.RESEND_WEBHOOK_SECRET }}
             RESEND_FROM_DOMAIN=${{ vars.RESEND_FROM_DOMAIN }}
             VM0_ADMIN_USERS=${{ vars.VM0_ADMIN_USERS }}
+            VM0_DEFAULT_AGENT=${{ vars.VM0_DEFAULT_AGENT }}
             GITHUB_APP_SLUG=${{ vars.VM0_GITHUB_APP_SLUG }}
             GITHUB_APP_ID=${{ vars.VM0_GITHUB_APP_ID }}
             GITHUB_APP_CLIENT_ID=${{ vars.VM0_GITHUB_APP_CLIENT_ID }}

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -646,6 +646,7 @@ jobs:
           RESEND_WEBHOOK_SECRET: ${{ secrets.RESEND_WEBHOOK_SECRET }}
           RESEND_FROM_DOMAIN: ${{ vars.RESEND_FROM_DOMAIN }}
           VM0_ADMIN_USERS: ${{ vars.VM0_ADMIN_USERS }}
+          VM0_DEFAULT_AGENT: ${{ vars.VM0_DEFAULT_AGENT }}
           STRAPI_URL: ${{ vars.STRAPI_URL }}
           GITHUB_APP_SLUG: ${{ vars.VM0_GITHUB_APP_SLUG }}
           GITHUB_APP_ID: ${{ vars.VM0_GITHUB_APP_ID }}
@@ -808,6 +809,7 @@ jobs:
             RESEND_WEBHOOK_SECRET=${{ secrets.RESEND_WEBHOOK_SECRET }}
             RESEND_FROM_DOMAIN=${{ vars.RESEND_FROM_DOMAIN }}
             VM0_ADMIN_USERS=${{ vars.VM0_ADMIN_USERS }}
+            VM0_DEFAULT_AGENT=${{ vars.VM0_DEFAULT_AGENT }}
             STRAPI_URL=${{ vars.STRAPI_URL }}
             GITHUB_APP_SLUG=${{ vars.VM0_GITHUB_APP_SLUG }}
             GITHUB_APP_ID=${{ vars.VM0_GITHUB_APP_ID }}


### PR DESCRIPTION
## Summary
- Add `VM0_DEFAULT_AGENT` environment variable to CI deploy workflows
- Without this, GitHub/Slack/Telegram integrations fail to resolve the default agent on production

## Changes
- `release-please.yml`: production web deploy (1 location)
- `turbo.yml`: build env + preview deploy (2 locations)

## Required
Add `VM0_DEFAULT_AGENT` variable in GitHub repo Settings → Variables (format: `scope/agent-name`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)