### PR TITLE
chore: update docker image tags to 20260306

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "VM0 Development",
-  "image": "ghcr.io/vm0-ai/vm0-dev:20260202",
+  "image": "ghcr.io/vm0-ai/vm0-dev:20260306",
   "features": {
     "ghcr.io/itsmechlark/features/postgresql:1": {
       "version": "17"

--- a/.github/workflows/cleanup-stale.yml
+++ b/.github/workflows/cleanup-stale.yml
@@ -17,7 +17,7 @@ jobs:
   cleanup-neon-branches:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260203
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260306
     steps:
       - name: Install neonctl
         run: npm install -g neonctl@2.15.0

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -75,7 +75,7 @@ jobs:
   cleanup-database:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260203
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260306
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -21,7 +21,7 @@ jobs:
   detect:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260203
+      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260306
     outputs:
       workflow-changed: ${{ steps.detect.outputs.workflow-changed }}
       ably-subscriber-changed: ${{ steps.detect.outputs.ably-subscriber-changed }}
@@ -70,7 +70,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260203
+      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260306
     needs: [detect]
     steps:
       - uses: actions/checkout@v6
@@ -109,7 +109,7 @@ jobs:
   runner-build:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260203
+      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260306
     needs: [detect]
     if: |
       needs.detect.outputs.workflow-changed == 'true' ||

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -47,7 +47,7 @@ jobs:
     if: ${{ needs.release-please.outputs.web_release_created == 'true' }}
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260203
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260306
     permissions:
       contents: read
     environment: production
@@ -144,7 +144,7 @@ jobs:
     if: ${{ needs.release-please.outputs.web_release_created == 'true' }}
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260203
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260306
     permissions:
       contents: read
       deployments: write
@@ -318,7 +318,7 @@ jobs:
     if: ${{ needs.release-please.outputs.docs_release_created == 'true' }}
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260203
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260306
     permissions:
       contents: read
       deployments: write
@@ -406,7 +406,7 @@ jobs:
     if: ${{ needs.release-please.outputs.platform_release_created == 'true' }}
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260203
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260306
     permissions:
       contents: read
       deployments: write
@@ -597,7 +597,7 @@ jobs:
     if: ${{ needs.release-please.outputs.runner_rs_release_created == 'true' }}
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260203
+      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260306
     permissions:
       contents: write
     environment: production
@@ -760,7 +760,7 @@ jobs:
     if: ${{ needs.release-please.outputs.releases_created == 'true' }}
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260203
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260306
     permissions:
       contents: read
     environment: production

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -21,7 +21,7 @@ jobs:
   prepare:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260203
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260306
     outputs:
       job-ref: ${{ steps.set-job-ref.outputs.job-ref }}
       web-preview-url: ${{ steps.preview-urls.outputs.web-url }}
@@ -380,7 +380,7 @@ jobs:
     # Skip for release-please commits (only version bumps and changelogs)
     if: "${{ github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore: release') }}"
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260203
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260306
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/toolchain-init
@@ -394,7 +394,7 @@ jobs:
   lint-types:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260203
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260306
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/toolchain-init
@@ -408,7 +408,7 @@ jobs:
   lint-format:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260203
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260306
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/toolchain-init
@@ -419,7 +419,7 @@ jobs:
   lint-knip:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260203
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260306
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/toolchain-init
@@ -437,7 +437,7 @@ jobs:
     # Skip for release-please commits (only version bumps and changelogs)
     if: "${{ github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore: release') }}"
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260203
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260306
     services:
       postgres:
         image: postgres:17-alpine
@@ -471,7 +471,7 @@ jobs:
     # Only run when migration or schema files changed
     if: needs.prepare.outputs.migration-changed == 'true'
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260203
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260306
     services:
       postgres:
         image: postgres:17-alpine
@@ -494,7 +494,7 @@ jobs:
   test-cli:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260203
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260306
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/toolchain-init
@@ -508,7 +508,7 @@ jobs:
   test-platform:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260203
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260306
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/toolchain-init
@@ -522,7 +522,7 @@ jobs:
   test-other:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260203
+      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260306
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/toolchain-init
@@ -537,7 +537,7 @@ jobs:
   deploy-web:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260203
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260306
     needs: [prepare]
     # Deploy if job-ref is set (PR or main), not a release-please commit, and web, CLI, runner, or platform changed
     if: |
@@ -878,7 +878,7 @@ jobs:
   deploy-docs:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260203
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260306
     needs: [prepare]
     # Deploy if job-ref is set (PR or main), not a release-please commit, and docs changed
     if: "${{ (github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore: release')) && needs.prepare.outputs.job-ref != '' && needs.prepare.outputs.docs-changed == 'true' }}"
@@ -920,7 +920,7 @@ jobs:
   deploy-platform:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260203
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260306
     needs: [prepare]
     # Deploy if job-ref is set (PR or main), not a release-please commit, and platform changed
     if: "${{ (github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore: release')) && needs.prepare.outputs.job-ref != '' && needs.prepare.outputs.platform-changed == 'true' }}"
@@ -971,7 +971,7 @@ jobs:
   e2e-auth:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260203
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260306
     needs: [prepare, deploy-web]
     if: |
       (github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore: release')) &&
@@ -1031,7 +1031,7 @@ jobs:
   cli-e2e-01-serial:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260203
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260306
     needs:
       [
         prepare,
@@ -1120,7 +1120,7 @@ jobs:
   cli-e2e-02-parallel:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260203
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260306
     needs: [prepare, deploy-web]
     if: |
       (github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore: release')) &&
@@ -1212,7 +1212,7 @@ jobs:
   deploy-runner-prepare:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260203
+      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260306
     needs: [prepare]
     timeout-minutes: 10
     env:
@@ -1534,7 +1534,7 @@ jobs:
   cli-e2e-03-runner:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260203
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260306
     needs:
       [
         prepare,
@@ -1671,7 +1671,7 @@ jobs:
   runner-stress-test:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260203
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260306
     needs:
       [
         prepare,
@@ -1821,7 +1821,7 @@ jobs:
   build-e2b-template:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260203
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260306
     needs: [prepare]
     # Build on PR or main push when E2B templates changed, skip release-please commits
     if: |


### PR DESCRIPTION
## Summary
- Update `vm0-dev` image tag from `20260202` to `20260306` in devcontainer
- Update `vm0-toolchain` image tag from `20260203` to `20260306` in all GitHub Actions workflows
- Update `vm0-toolchain-rust` image tag from `20260203` to `20260306` in all GitHub Actions workflows

Built from https://github.com/vm0-ai/vm0/actions/runs/22750777400

## Test plan
- [ ] CI passes with the new image tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)