### PR TITLE
fix: skip progress callbacks for completed or failed runs

### DIFF
--- a/turbo/apps/web/src/__tests__/api-test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers.ts
@@ -703,6 +703,41 @@ export async function completeTestRun(
   return checkpoint;
 }
 
+/**
+ * Fail a test run via the complete webhook (exitCode=1).
+ *
+ * Unlike completeTestRun, no checkpoint is needed for a failed run.
+ */
+export async function failTestRun(
+  userId: string,
+  runId: string,
+  error?: string,
+): Promise<void> {
+  const sandboxToken = await generateSandboxToken(userId, runId);
+  const request = createTestRequest(
+    "http://localhost:3000/api/webhooks/agent/complete",
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${sandboxToken}`,
+      },
+      body: JSON.stringify({
+        runId,
+        exitCode: 1,
+        error: error ?? "test failure",
+      }),
+    },
+  );
+  const response = await completeWebhook(request);
+  if (!response.ok) {
+    const errorBody = await response.json();
+    throw new Error(
+      `Failed to fail run: ${(errorBody as { error?: { message?: string } }).error?.message || response.status}`,
+    );
+  }
+}
+
 // ============================================================================
 // Schedule Test Helpers
 // ============================================================================

--- a/turbo/apps/web/src/lib/callback/__tests__/dispatcher.test.ts
+++ b/turbo/apps/web/src/lib/callback/__tests__/dispatcher.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect, beforeEach } from "vitest";
+import { eq } from "drizzle-orm";
 import { http, HttpResponse } from "msw";
 import { server } from "../../../mocks/server";
 import { dispatchProgressCallbacks } from "../dispatcher";
+import { agentRuns } from "../../../db/schema/agent-run";
 import { testContext, type UserContext } from "../../../__tests__/test-helpers";
 import { mockClerk } from "../../../__tests__/clerk-mock";
 import {
@@ -118,5 +120,59 @@ describe("dispatchProgressCallbacks", () => {
 
     // Should not throw
     await dispatchProgressCallbacks(testRunId);
+  });
+
+  it("should skip when run is already completed", async () => {
+    let callCount = 0;
+
+    server.use(
+      http.post("http://localhost/api/internal/callbacks/slack", () => {
+        callCount++;
+        return HttpResponse.json({ success: true });
+      }),
+    );
+
+    await createTestCallback({
+      runId: testRunId,
+      url: "http://localhost/api/internal/callbacks/slack",
+      payload: { workspaceId: "T123" },
+    });
+
+    // Mark run as completed
+    await globalThis.services.db
+      .update(agentRuns)
+      .set({ status: "completed", completedAt: new Date() })
+      .where(eq(agentRuns.id, testRunId));
+
+    await dispatchProgressCallbacks(testRunId);
+
+    expect(callCount).toBe(0);
+  });
+
+  it("should skip when run is already failed", async () => {
+    let callCount = 0;
+
+    server.use(
+      http.post("http://localhost/api/internal/callbacks/slack", () => {
+        callCount++;
+        return HttpResponse.json({ success: true });
+      }),
+    );
+
+    await createTestCallback({
+      runId: testRunId,
+      url: "http://localhost/api/internal/callbacks/slack",
+      payload: { workspaceId: "T123" },
+    });
+
+    // Mark run as failed
+    await globalThis.services.db
+      .update(agentRuns)
+      .set({ status: "failed", completedAt: new Date(), error: "test error" })
+      .where(eq(agentRuns.id, testRunId));
+
+    await dispatchProgressCallbacks(testRunId);
+
+    expect(callCount).toBe(0);
   });
 });

--- a/turbo/apps/web/src/lib/callback/__tests__/dispatcher.test.ts
+++ b/turbo/apps/web/src/lib/callback/__tests__/dispatcher.test.ts
@@ -1,15 +1,15 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { eq } from "drizzle-orm";
 import { http, HttpResponse } from "msw";
 import { server } from "../../../mocks/server";
 import { dispatchProgressCallbacks } from "../dispatcher";
-import { agentRuns } from "../../../db/schema/agent-run";
 import { testContext, type UserContext } from "../../../__tests__/test-helpers";
 import { mockClerk } from "../../../__tests__/clerk-mock";
 import {
   createTestCompose,
   createTestRun,
   createTestCallback,
+  completeTestRun,
+  failTestRun,
 } from "../../../__tests__/api-test-helpers";
 
 const context = testContext();
@@ -138,11 +138,7 @@ describe("dispatchProgressCallbacks", () => {
       payload: { workspaceId: "T123" },
     });
 
-    // Mark run as completed
-    await globalThis.services.db
-      .update(agentRuns)
-      .set({ status: "completed", completedAt: new Date() })
-      .where(eq(agentRuns.id, testRunId));
+    await completeTestRun(user.userId, testRunId);
 
     await dispatchProgressCallbacks(testRunId);
 
@@ -165,11 +161,7 @@ describe("dispatchProgressCallbacks", () => {
       payload: { workspaceId: "T123" },
     });
 
-    // Mark run as failed
-    await globalThis.services.db
-      .update(agentRuns)
-      .set({ status: "failed", completedAt: new Date(), error: "test error" })
-      .where(eq(agentRuns.id, testRunId));
+    await failTestRun(user.userId, testRunId);
 
     await dispatchProgressCallbacks(testRunId);
 

--- a/turbo/apps/web/src/lib/callback/dispatcher.ts
+++ b/turbo/apps/web/src/lib/callback/dispatcher.ts
@@ -1,5 +1,6 @@
 import { eq, and } from "drizzle-orm";
 import { agentRunCallbacks } from "../../db/schema/agent-run-callback";
+import { agentRuns } from "../../db/schema/agent-run";
 import { decryptCredentialValue } from "../crypto/secrets-encryption";
 import { env } from "../../env";
 import { computeHmacSignature } from "./hmac";
@@ -197,6 +198,20 @@ async function dispatchSingleCallback(
  * Failures are silently ignored — a missed progress notification is non-critical.
  */
 export async function dispatchProgressCallbacks(runId: string): Promise<void> {
+  // Skip if run is already completed/failed to avoid race with completion
+  // callbacks that clear status indicators (e.g. Slack spinner).
+  // The complete webhook updates agentRuns.status synchronously before its
+  // after() callback dispatches completion, so this check is effective.
+  const [run] = await globalThis.services.db
+    .select({ status: agentRuns.status })
+    .from(agentRuns)
+    .where(eq(agentRuns.id, runId))
+    .limit(1);
+
+  if (!run || run.status === "completed" || run.status === "failed") {
+    return;
+  }
+
   const { SECRETS_ENCRYPTION_KEY } = env();
 
   const callbacks = await globalThis.services.db


### PR DESCRIPTION
## Summary

- Adds an early-exit check in `dispatchProgressCallbacks` to skip dispatching when the agent run is already completed or failed
- Prevents a race condition where progress callbacks (e.g., Slack spinner updates) fire after the completion callback has already cleared status indicators
- The fix works because the completion webhook updates `agentRuns.status` synchronously before its `after()` callback dispatches completion

## Test plan

- [x] Added test: skip dispatch when run status is `completed`
- [x] Added test: skip dispatch when run status is `failed`
- [ ] Existing dispatcher tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)