### PR TITLE
feat(connectors): add project oauth scope to github connector

### DIFF
--- a/turbo/packages/core/src/contracts/__tests__/connectors.test.ts
+++ b/turbo/packages/core/src/contracts/__tests__/connectors.test.ts
@@ -22,15 +22,16 @@ describe("hasRequiredScopes", () => {
   it("returns false when required scope is missing", () => {
     expect(hasRequiredScopes("github", [])).toBe(false);
     expect(hasRequiredScopes("github", ["read:org"])).toBe(false);
+    expect(hasRequiredScopes("github", ["repo"])).toBe(false);
   });
 
   it("returns true when all required scopes are present", () => {
-    expect(hasRequiredScopes("github", ["repo"])).toBe(true);
+    expect(hasRequiredScopes("github", ["repo", "project"])).toBe(true);
   });
 
   it("returns true when stored scopes are a superset of required", () => {
-    expect(hasRequiredScopes("github", ["repo", "read:org", "user"])).toBe(
-      true,
-    );
+    expect(
+      hasRequiredScopes("github", ["repo", "project", "read:org", "user"]),
+    ).toBe(true);
   });
 });

--- a/turbo/packages/core/src/contracts/connectors.ts
+++ b/turbo/packages/core/src/contracts/connectors.ts
@@ -65,7 +65,7 @@ export const CONNECTOR_TYPES = {
     oauth: {
       authorizationUrl: "https://github.com/login/oauth/authorize",
       tokenUrl: "https://github.com/login/oauth/access_token",
-      scopes: ["repo"],
+      scopes: ["repo", "project"],
     } as ConnectorOAuthConfig,
   },
   notion: {


### PR DESCRIPTION
## Summary

- Add the `project` OAuth scope to the GitHub connector configuration to enable GitHub Projects V2 API access
- Update `hasRequiredScopes` tests to reflect the new required scopes `["repo", "project"]`
- Existing users will see a "Permissions outdated" badge and can re-authorize to gain the new scope

## Test plan

- [x] `hasRequiredScopes` tests updated and passing (6/6)
- [ ] Verify new OAuth flow requests `repo project` scopes on GitHub consent screen
- [ ] Verify existing connectors show "Permissions outdated" badge in settings UI
- [ ] Verify re-authorization grants the new `project` scope

> **Note**: The GitHub OAuth App on github.com may also need the `project` scope added to its allowed scopes (infrastructure/ops follow-up).

Closes #3761

🤖 Generated with [Claude Code](https://claude.com/claude-code)