### PR TITLE
perf: add sub-step timing to prepare-for-execution

### DIFF
--- a/turbo/apps/web/src/lib/run/context/execution-preparer.ts
+++ b/turbo/apps/web/src/lib/run/context/execution-preparer.ts
@@ -171,9 +171,20 @@ function resolveRunnerGroup(agentCompose: unknown): string | null {
  * @param context ExecutionContext built by run-service
  * @returns PreparedContext ready for executor dispatch
  */
+interface PrepareTimings {
+  resolveScopes: number;
+  ensureArtifact: number;
+  storageManifest: number;
+}
+
+interface PrepareResult {
+  context: PreparedContext;
+  timings: PrepareTimings;
+}
+
 export async function prepareForExecution(
   context: ExecutionContext,
-): Promise<PreparedContext> {
+): Promise<PrepareResult> {
   log.debug(`Preparing execution context for run ${context.runId}...`);
 
   // Extract configuration from agent compose
@@ -190,6 +201,7 @@ export async function prepareForExecution(
 
   // Resolve runner's scope and owner's scope in parallel (independent DB queries)
   const userId = context.userId || "";
+  const scopeStart = Date.now();
   const [runnerScope, [composeInfo]] = await Promise.all([
     getUserScopeByClerkId(userId),
     globalThis.services.db
@@ -206,6 +218,7 @@ export async function prepareForExecution(
       .where(eq(agentComposeVersions.id, context.agentComposeVersionId))
       .limit(1),
   ]);
+  const scopeEnd = Date.now();
 
   if (!runnerScope) {
     throw badRequest("Runner scope not found");
@@ -215,6 +228,7 @@ export async function prepareForExecution(
   }
 
   // Auto-create artifact if it doesn't exist yet
+  const artifactStart = Date.now();
   if (context.artifactName) {
     await ensureArtifactExists(
       runnerScope.id,
@@ -223,10 +237,12 @@ export async function prepareForExecution(
       runnerScope.slug,
     );
   }
+  const artifactEnd = Date.now();
 
   // Prepare storage manifest with dual scopes
   // - Volumes: resolved from agent owner's scope
   // - Artifacts: resolved from runner's scope
+  const storageStart = Date.now();
   const storageManifest = await prepareStorageManifest(
     context.agentCompose as AgentComposeYaml,
     context.vars || {},
@@ -238,6 +254,7 @@ export async function prepareForExecution(
     context.resumeArtifact,
     workingDir,
   );
+  const storageEnd = Date.now();
 
   log.debug(
     `Storage manifest prepared with dual scopes: owner=${composeInfo.scopeId}, runner=${runnerScope.id}, ${storageManifest.storages.length} storages, ${storageManifest.artifact ? "1 artifact" : "no artifact"}`,
@@ -254,9 +271,17 @@ export async function prepareForExecution(
     composeInfo.scopeSlug,
   );
 
-  log.debug(`PreparedContext built for run ${context.runId}`);
+  const timings: PrepareTimings = {
+    resolveScopes: scopeEnd - scopeStart,
+    ensureArtifact: artifactEnd - artifactStart,
+    storageManifest: storageEnd - storageStart,
+  };
 
-  return preparedContext;
+  log.debug(
+    `PreparedContext built for run ${context.runId} (scopes=${timings.resolveScopes}ms, artifact=${timings.ensureArtifact}ms, storage=${timings.storageManifest}ms)`,
+  );
+
+  return { context: preparedContext, timings };
 }
 
 /**

--- a/turbo/apps/web/src/lib/run/run-service.ts
+++ b/turbo/apps/web/src/lib/run/run-service.ts
@@ -547,11 +547,11 @@ async function buildAndDispatchRun(opts: {
     const buildContextTime = Date.now();
 
     // Prepare execution context (storage manifest, working dir, etc.)
-    const preparedContext = await prepareForExecution(context);
+    const prepareResult = await prepareForExecution(context);
     const prepareTime = Date.now();
 
     // Dispatch to executor
-    const result = await dispatchRun(preparedContext, userEmail);
+    const result = await dispatchRun(prepareResult.context, userEmail);
     const dispatchTime = Date.now();
 
     // Record per-step timing metrics for latency diagnosis
@@ -565,6 +565,19 @@ async function buildAndDispatchRun(opts: {
       { op: "api_step_build_context", ms: buildContextTime - tokenTime },
       { op: "api_step_prepare", ms: prepareTime - buildContextTime },
       { op: "api_step_dispatch", ms: dispatchTime - prepareTime },
+      // Sub-step timings within prepareForExecution
+      {
+        op: "api_prepare_resolve_scopes",
+        ms: prepareResult.timings.resolveScopes,
+      },
+      {
+        op: "api_prepare_ensure_artifact",
+        ms: prepareResult.timings.ensureArtifact,
+      },
+      {
+        op: "api_prepare_storage_manifest",
+        ms: prepareResult.timings.storageManifest,
+      },
     ];
     for (const step of steps) {
       recordSandboxOperation({


### PR DESCRIPTION
## Summary

- Add fine-grained timing within `prepareForExecution` to identify bottlenecks in the ~1,046ms avg latency
- Emits 3 new metrics via `recordSandboxOperation`:
  - `api_prepare_resolve_scopes` — parallel scope queries (`getUserScopeByClerkId` + compose scope join)
  - `api_prepare_ensure_artifact` — conditional artifact creation
  - `api_prepare_storage_manifest` — volume/artifact resolution
- Returns `PrepareResult` (context + timings) so metrics are emitted with correct `sandboxType`

## Test plan

- [ ] Deploy to preview, trigger runs, verify new `api_prepare_*` metrics appear in Axiom
- [ ] Confirm existing `api_step_prepare` metric still reports total time correctly

Closes #3807

🤖 Generated with [Claude Code](https://claude.com/claude-code)