### PR TITLE
docs: switch agent-browser from remote cdp to headed novnc mode

### DIFF
--- a/docs/add-oauth-connector.md
+++ b/docs/add-oauth-connector.md
@@ -28,7 +28,7 @@ Register two separate OAuth apps for each provider — one for development/testi
 
 ### Registration Workflow
 
-Use `agent-browser` to navigate the provider's developer portal, filling in each field above. Stop and ask the user to confirm before submitting any form that creates or modifies an app registration. For logo upload, always stop and let the user handle it manually.
+Use `agent-browser` (in headed mode via noVNC — the user watches and can intervene) to navigate the provider's developer portal, filling in each field above. Stop and ask the user to confirm before submitting any form that creates or modifies an app registration. For logo upload, always stop and let the user handle it manually via the noVNC viewer.
 
 **As you register each app**, write the credentials you see (client ID, client secret, slug) into `/tmp/oauth-credentials/<PROVIDER>` immediately — don't wait until both apps are done:
 
@@ -75,29 +75,41 @@ After both apps are registered and the credentials file is populated:
 1. Commit all changes and create a PR using `/pull-request`. This lets CI validate the implementation in parallel while you do local testing.
 1. Start the project locally using `/dev-tunnel` (starts the dev server, creates a Cloudflare tunnel, and sets up the proxy). Verify the server is running and accessible before proceeding.
 
-1. **Connect `agent-browser` to the user's local Chrome.** All subsequent `agent-browser` commands in this guide require this connection.
+1. **Start the noVNC stack for `agent-browser`.** All subsequent `agent-browser` commands in this guide run in headed mode inside the devcontainer, with the user connecting via noVNC to observe and assist.
 
-   **Prerequisites:** The user must have Chrome running on macOS with remote debugging enabled:
+   **Install prerequisites (if missing):**
    ```bash
-   # macOS (user runs this once)
-   /Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome \
-     --remote-debugging-port=9222 \
-     --user-data-dir=$HOME/.local/agent-browser \
-     --remote-allow-origins='*'
+   which x11vnc || sudo apt-get update -qq && sudo apt-get install -y -qq x11vnc novnc openbox
    ```
 
-   **Discover the CDP WebSocket URL** (run once per session — reuse `$CDP_URL` everywhere):
+   **Start the VNC stack (idempotent — safe to run multiple times):**
    ```bash
-   CDP_URL=$(curl -s http://0.250.250.254:9222/json/version | python3 -c "import sys,json; print(json.load(sys.stdin)['webSocketDebuggerUrl'])")
+   pgrep -x Xvfb > /dev/null || Xvfb :99 -screen 0 1344x840x24 > /dev/null 2>&1 &
+   sleep 1
+   pgrep -x openbox > /dev/null || DISPLAY=:99 openbox > /dev/null 2>&1 &
+   sleep 1
+   pgrep -x x11vnc > /dev/null || x11vnc -display :99 -nopw -forever -shared -rfbport 5900 > /dev/null 2>&1 &
+   sleep 1
+   pgrep -f websockify > /dev/null || websockify --web /usr/share/novnc/ 6080 localhost:5900 > /dev/null 2>&1 &
+   sleep 1
    ```
 
-   All `agent-browser` commands below should include `--cdp "$CDP_URL"` to target the user's real browser. Refs (`@e1`, `@e2`, etc.) are dynamic — always run `snapshot -i` to get fresh refs before interacting.
+   **Tell the user to connect via noVNC:**
+   > The browser is running in headed mode with noVNC. To view and interact with it, run:
+   >
+   > ```
+   > dcvnc <vm_name>
+   > ```
+   >
+   > (e.g., `dcvnc vm01`). This opens the noVNC viewer in your default browser. You can watch the OAuth flow and intervene when credentials are needed.
+
+   All `agent-browser` commands below must use `DISPLAY=:99` and `--headed`. For local HTTPS dev servers, add `--ignore-https-errors`. Refs (`@e1`, `@e2`, etc.) are dynamic — always run `snapshot -i` to get fresh refs before interacting.
 
 1. **Set up CLI authentication, scope, and model provider.** These are required before the OAuth flow and skill validation will work.
 
    **Step A: CLI authentication**
 
-   Run `vm0 auth login` in the background — it will print a device code and wait for browser confirmation. Then use `agent-browser` to complete the login flow:
+   Run `vm0 auth login` in the background — it will print a device code and wait for browser confirmation. Then use `agent-browser` (headed, via noVNC) to complete the login flow:
 
    ```bash
    # Start auth login in background (captures the device code URL)
@@ -105,7 +117,7 @@ After both apps are registered and the credentials file is populated:
    AUTH_PID=$!
 
    # Open the CLI auth page and complete sign-in
-   agent-browser --cdp "$CDP_URL" open "https://www.vm7.ai:8443/cli-auth"
+   DISPLAY=:99 agent-browser --headed --ignore-https-errors open "https://www.vm7.ai:8443/cli-auth"
    agent-browser wait 3000 && agent-browser snapshot -i
 
    # Sign up (first time) or sign in with Clerk test credentials
@@ -180,15 +192,15 @@ After both apps are registered and the credentials file is populated:
    vm0 model-provider list  # Shows default provider for claude-code
    ```
 
-1. **Connect the OAuth provider.** Use `agent-browser` with the `$CDP_URL` established earlier:
+1. **Connect the OAuth provider.** Use `agent-browser` in headed mode (the user watches via noVNC):
 
    ```bash
-   agent-browser --cdp "$CDP_URL" open "https://www.vm7.ai:8443/api/connectors/<connector-name>/authorize"
+   DISPLAY=:99 agent-browser --headed --ignore-https-errors open "https://www.vm7.ai:8443/api/connectors/<connector-name>/authorize"
    agent-browser wait 5000 && agent-browser snapshot -i
    ```
 
    > **Important:** The OAuth flow has two distinct stages:
-   > 1. **Provider login page** (if not already logged in) — requires the user's real account credentials. Stop and ask the user to log in manually, then continue.
+   > 1. **Provider login page** (if not already logged in) — requires the user's real account credentials. Stop and ask the user to log in via the noVNC viewer, then continue.
    > 2. **Authorization/consent page** — the page asking to grant permissions to our app. This can be clicked directly with `agent-browser click @<authorize-button-ref>` without human confirmation.
 
    **If the callback returns an error page**, check the dev server logs and the error message in the URL. Before diving into code, **search the web for the error** — provider-specific quirks (e.g., OAuth scopes appended to the callback URL, non-standard token response shapes) are often documented in community forums or the provider's own changelog. Use `WebSearch` with the provider name and the error message to see if others have encountered the same issue.
@@ -260,10 +272,10 @@ Review the test results. The agent will execute every curl example from the skil
 
 **Issues that require human intervention:**
 
-- **Missing OAuth scopes (401/403):** The connector requested insufficient scopes. Fix the scopes in the connector code, then reconnect using `agent-browser`:
+- **Missing OAuth scopes (401/403):** The connector requested insufficient scopes. Fix the scopes in the connector code, then reconnect using `agent-browser` (the user watches and assists via noVNC):
   ```bash
   # Navigate to connections settings
-  agent-browser open "https://www.vm7.ai:8443/settings?tab=connections"
+  DISPLAY=:99 agent-browser --headed --ignore-https-errors open "https://www.vm7.ai:8443/settings?tab=connections"
   agent-browser wait 3000 && agent-browser snapshot -i
 
   # Disconnect the existing connector
@@ -271,12 +283,12 @@ Review the test results. The agent will execute every curl example from the skil
   agent-browser wait 2000 && agent-browser snapshot -i
 
   # Reconnect — hit authorize directly or click Connect, then authorize
-  agent-browser open "https://www.vm7.ai:8443/api/connectors/<connector-name>/authorize"
+  DISPLAY=:99 agent-browser --headed --ignore-https-errors open "https://www.vm7.ai:8443/api/connectors/<connector-name>/authorize"
   agent-browser wait 5000 && agent-browser snapshot -i
   # If already logged into the provider, the consent page appears — click Authorize directly
   agent-browser click @<authorize-button-ref>
   agent-browser wait 5000 && agent-browser snapshot -i
-  # If provider login is required, stop and ask the user to log in first
+  # If provider login is required, stop and ask the user to log in via the noVNC viewer
   ```
 - **Credits/quota depleted:** The OAuth provider's API has usage limits. The connector itself is working if at least one endpoint succeeds (e.g., `/users/me`).
 
@@ -286,7 +298,7 @@ After fixes:
 
 - **Skill-only changes** (jq fields, example tweaks, documentation): Push to `vm0-skills` main, re-run `vm0 cook`. No human needed.
 - **Connector code changes** (response parsing, error handling): Re-run `vm0 cook`. No human needed — the dev server hot-reloads.
-- **Scope changes**: Disconnect and reconnect the connector via `agent-browser` (see Step 3 scope fix above), then re-run `vm0 cook`.
+- **Scope changes**: Disconnect and reconnect the connector via `agent-browser` with noVNC (see Step 3 scope fix above), then re-run `vm0 cook`.
 
 Repeat Steps 2–4 until all examples pass.
 


### PR DESCRIPTION
## Summary

- Replace remote Chrome CDP (`--cdp` flag) approach with local headed browser + noVNC stack (`DISPLAY=:99 --headed`)
- Add instructions for installing Xvfb, openbox, x11vnc, and novnc in the devcontainer
- Update all `agent-browser` commands to use `--headed --ignore-https-errors` with `DISPLAY=:99`
- Direct users to connect via `dcvnc` to observe and intervene during OAuth flows

🤖 Generated with [Claude Code](https://claude.com/claude-code)