### PR TITLE
fix(skills): resolve vnc stack startup in agent-browser skill

### DIFF
--- a/.claude/skills/agent-browser/SKILL.md
+++ b/.claude/skills/agent-browser/SKILL.md
@@ -22,15 +22,17 @@ which x11vnc || sudo apt-get update -qq && sudo apt-get install -y -qq x11vnc no
 
 Run these before any agent-browser command:
 
+**Important:** Each process must be started in a separate shell command to avoid `||` and `&` operator precedence issues that can silently prevent later processes (especially websockify) from launching.
+
 ```bash
-# Start Xvfb, openbox, x11vnc, and noVNC (idempotent - skips if already running)
-pgrep -x Xvfb > /dev/null || Xvfb :99 -screen 0 1344x840x24 > /dev/null 2>&1 &
+# Start each process individually (idempotent - skips if already running)
+pgrep -x Xvfb > /dev/null || (Xvfb :99 -screen 0 1344x840x24 > /dev/null 2>&1 &)
 sleep 1
-pgrep -x openbox > /dev/null || DISPLAY=:99 openbox > /dev/null 2>&1 &
+pgrep -x openbox > /dev/null || (DISPLAY=:99 openbox > /dev/null 2>&1 &)
 sleep 1
-pgrep -x x11vnc > /dev/null || x11vnc -display :99 -nopw -forever -shared -rfbport 5900 > /dev/null 2>&1 &
+pgrep -x x11vnc > /dev/null || (x11vnc -display :99 -nopw -forever -shared -rfbport 5900 > /dev/null 2>&1 &)
 sleep 1
-pgrep -f websockify > /dev/null || websockify --web /usr/share/novnc/ 6080 localhost:5900 > /dev/null 2>&1 &
+pgrep -f websockify > /dev/null || (websockify --web /usr/share/novnc/ 0.0.0.0:6080 localhost:5900 > /dev/null 2>&1 &)
 sleep 1
 ```
 


### PR DESCRIPTION
## Summary

- Wrap VNC background process launches in subshells `(cmd &)` to fix shell `||` and `&` operator precedence issues that silently prevented websockify from starting
- Bind websockify to `0.0.0.0:6080` instead of localhost so noVNC is reachable from outside the container
- Add a note explaining why each process must be started individually

## Test plan

- [ ] Run the VNC startup script in a fresh devcontainer and verify all 4 processes (Xvfb, openbox, x11vnc, websockify) are running
- [ ] Confirm websockify listens on `0.0.0.0:6080` via `netstat -tlnp | grep 6080`
- [ ] Access noVNC from outside the container via the mapped port

🤖 Generated with [Claude Code](https://claude.com/claude-code)