### PR TITLE
fix: use server-computed connector-provided secret names in compose warning

### DIFF
--- a/turbo/apps/cli/src/commands/compose/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/compose/__tests__/index.test.ts
@@ -3056,6 +3056,63 @@ agents:
       expect(result.setupUrl).not.toContain("JIRA_TOKEN");
     });
 
+    it("should not show warning when all secrets are connector-provided", async () => {
+      await fs.writeFile(
+        path.join(tempDir, "vm0.yaml"),
+        yaml.stringify({
+          version: "1.0",
+          agents: {
+            test: {
+              framework: "claude-code",
+              working_dir: "/",
+              environment: {
+                GH_TOKEN: "${{ secrets.GH_TOKEN }}",
+                SLACK_TOKEN: "${{ secrets.SLACK_TOKEN }}",
+              },
+            },
+          },
+        }),
+      );
+
+      server.use(
+        composeApiHandler,
+        scopeApiHandler,
+        http.get("http://localhost:3000/api/secrets", () => {
+          return HttpResponse.json({ secrets: [] });
+        }),
+        http.get("http://localhost:3000/api/variables", () => {
+          return HttpResponse.json({ variables: [] });
+        }),
+        http.get("http://localhost:3000/api/connectors", () => {
+          return HttpResponse.json({
+            connectors: [],
+            connectorProvidedSecretNames: [
+              "GH_TOKEN",
+              "GITHUB_TOKEN",
+              "SLACK_TOKEN",
+            ],
+          });
+        }),
+      );
+
+      await composeCommand.parseAsync(["node", "cli", "--json"]);
+
+      const jsonOutputCall = mockConsoleLog.mock.calls.find((call) => {
+        try {
+          const parsed = JSON.parse(call[0] as string);
+          return parsed.composeId !== undefined;
+        } catch {
+          return false;
+        }
+      });
+
+      expect(jsonOutputCall).toBeDefined();
+      const result = JSON.parse(jsonOutputCall![0] as string);
+      // All secrets covered by connectors — no missing, no setupUrl
+      expect(result.missingSecrets).toBeUndefined();
+      expect(result.setupUrl).toBeUndefined();
+    });
+
     it("should show all secrets as missing when no connectors are connected", async () => {
       await fs.writeFile(
         path.join(tempDir, "vm0.yaml"),

--- a/turbo/apps/cli/src/commands/compose/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/compose/__tests__/index.test.ts
@@ -2978,6 +2978,7 @@ agents:
                 updatedAt: new Date().toISOString(),
               },
             ],
+            connectorProvidedSecretNames: ["GH_TOKEN", "GITHUB_TOKEN"],
           });
         }),
       );
@@ -2999,6 +3000,60 @@ agents:
       expect(result.missingSecrets).toEqual(["OTHER_KEY"]);
       expect(result.setupUrl).toContain("secrets=OTHER_KEY");
       expect(result.setupUrl).not.toContain("GH_TOKEN");
+    });
+
+    it("should use server-provided secret names for unknown connector types", async () => {
+      await fs.writeFile(
+        path.join(tempDir, "vm0.yaml"),
+        yaml.stringify({
+          version: "1.0",
+          agents: {
+            test: {
+              framework: "claude-code",
+              working_dir: "/",
+              environment: {
+                JIRA_TOKEN: "${{ secrets.JIRA_TOKEN }}",
+                OTHER_KEY: "${{ secrets.OTHER_KEY }}",
+              },
+            },
+          },
+        }),
+      );
+
+      server.use(
+        composeApiHandler,
+        scopeApiHandler,
+        http.get("http://localhost:3000/api/secrets", () => {
+          return HttpResponse.json({ secrets: [] });
+        }),
+        http.get("http://localhost:3000/api/variables", () => {
+          return HttpResponse.json({ variables: [] });
+        }),
+        http.get("http://localhost:3000/api/connectors", () => {
+          // Server knows about "jira" even if CLI schema doesn't
+          return HttpResponse.json({
+            connectors: [],
+            connectorProvidedSecretNames: ["JIRA_TOKEN"],
+          });
+        }),
+      );
+
+      await composeCommand.parseAsync(["node", "cli", "--json"]);
+
+      const jsonOutputCall = mockConsoleLog.mock.calls.find((call) => {
+        try {
+          const parsed = JSON.parse(call[0] as string);
+          return parsed.composeId !== undefined;
+        } catch {
+          return false;
+        }
+      });
+
+      expect(jsonOutputCall).toBeDefined();
+      const result = JSON.parse(jsonOutputCall![0] as string);
+      // JIRA_TOKEN is server-reported as connector-provided, should not be missing
+      expect(result.missingSecrets).toEqual(["OTHER_KEY"]);
+      expect(result.setupUrl).not.toContain("JIRA_TOKEN");
     });
 
     it("should show all secrets as missing when no connectors are connected", async () => {
@@ -3028,7 +3083,10 @@ agents:
           return HttpResponse.json({ variables: [] });
         }),
         http.get("http://localhost:3000/api/connectors", () => {
-          return HttpResponse.json({ connectors: [] });
+          return HttpResponse.json({
+            connectors: [],
+            connectorProvidedSecretNames: [],
+          });
         }),
       );
 

--- a/turbo/apps/cli/src/commands/compose/index.ts
+++ b/turbo/apps/cli/src/commands/compose/index.ts
@@ -8,7 +8,6 @@ import {
   getLegacySystemTemplateWarning,
   extractVariableReferences,
   groupVariablesBySource,
-  getConnectorProvidedSecretNames,
   resolveSkillRef,
 } from "@vm0/core";
 import {
@@ -435,8 +434,9 @@ async function checkAndPromptMissingItems(
   );
 
   // Connector-provided secrets (e.g., GH_TOKEN from GitHub connector)
-  const connectorProvided = getConnectorProvidedSecretNames(
-    connectorsResponse.connectors.map((c) => c.type),
+  // Use server-computed list to avoid CLI/server version skew issues
+  const connectorProvided = new Set(
+    connectorsResponse.connectorProvidedSecretNames,
   );
 
   const missingSecrets = [...requiredSecrets].filter(

--- a/turbo/apps/cli/src/mocks/handlers/api-handlers.ts
+++ b/turbo/apps/cli/src/mocks/handlers/api-handlers.ts
@@ -55,7 +55,7 @@ export const apiHandlers = [
   // GET /api/connectors - listConnectors
   http.get("http://localhost:3000/api/connectors", () => {
     return HttpResponse.json(
-      { connectors: [], configuredTypes: [] },
+      { connectors: [], configuredTypes: [], connectorProvidedSecretNames: [] },
       { status: 200 },
     );
   }),

--- a/turbo/apps/platform/src/mocks/handlers/api-connectors.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-connectors.ts
@@ -30,6 +30,7 @@ export const apiConnectorsHandlers = [
     const response: ConnectorListResponse = {
       connectors: mockConnectors,
       configuredTypes: ALL_CONNECTOR_TYPES,
+      connectorProvidedSecretNames: [],
     };
     return HttpResponse.json(response);
   }),

--- a/turbo/apps/web/app/api/connectors/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/connectors/__tests__/route.test.ts
@@ -38,6 +38,7 @@ describe("GET /api/connectors - List Connectors", () => {
 
     expect(response.status).toBe(200);
     expect(data.connectors).toEqual([]);
+    expect(data.connectorProvidedSecretNames).toEqual([]);
   });
 
   it("should list all connectors for user", async () => {
@@ -53,6 +54,21 @@ describe("GET /api/connectors - List Connectors", () => {
     expect(data.connectors[0].type).toBe("github");
     expect(data.connectors[0].authMethod).toBe("oauth");
     expect(data.connectors[0].externalUsername).toBe("testuser");
+  });
+
+  it("should return connector-provided secret names", async () => {
+    const user = await context.setupUser();
+    await createTestConnector(user.scopeId, { type: "github" });
+
+    const request = createTestRequest("http://localhost:3000/api/connectors");
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.connectorProvidedSecretNames).toEqual(
+      expect.arrayContaining(["GH_TOKEN", "GITHUB_TOKEN"]),
+    );
+    expect(data.connectorProvidedSecretNames).toHaveLength(2);
   });
 
   it("should not return connectors from other users", async () => {

--- a/turbo/apps/web/app/api/connectors/route.ts
+++ b/turbo/apps/web/app/api/connectors/route.ts
@@ -1,5 +1,9 @@
 import { createHandler, tsr } from "../../../src/lib/ts-rest-handler";
-import { connectorsMainContract, createErrorResponse } from "@vm0/core";
+import {
+  connectorsMainContract,
+  createErrorResponse,
+  getConnectorProvidedSecretNames,
+} from "@vm0/core";
 import { initServices } from "../../../src/lib/init-services";
 import { getUserId } from "../../../src/lib/auth/get-user-id";
 import { resolveScope } from "../../../src/lib/scope/resolve-scope";
@@ -24,12 +28,16 @@ const router = tsr.router(connectorsMainContract, {
     const configuredTypes = getConfiguredConnectorTypes(
       globalThis.services.env,
     );
+    const connectorProvidedSecretNames = [
+      ...getConnectorProvidedSecretNames(connectorList.map((c) => c.type)),
+    ];
 
     return {
       status: 200 as const,
       body: {
         connectors: connectorList,
         configuredTypes,
+        connectorProvidedSecretNames,
       },
     };
   },

--- a/turbo/packages/core/src/contracts/connectors.ts
+++ b/turbo/packages/core/src/contracts/connectors.ts
@@ -1068,6 +1068,7 @@ export type ConnectorResponse = z.infer<typeof connectorResponseSchema>;
 export const connectorListResponseSchema = z.object({
   connectors: z.array(connectorResponseSchema),
   configuredTypes: z.array(connectorTypeSchema),
+  connectorProvidedSecretNames: z.array(z.string()),
 });
 
 export type ConnectorListResponse = z.infer<typeof connectorListResponseSchema>;


### PR DESCRIPTION
## Summary

- Add `connectorProvidedSecretNames` field to the connector list API response, computed server-side
- CLI compose now uses this server-provided data instead of client-side `connectorTypeSchema` validation
- Eliminates false "missing secret" warnings caused by CLI/server version skew when new connector types are added

## Root Cause

`getConnectorProvidedSecretNames()` used a client-side Zod enum (`connectorTypeSchema`) to validate connector types. Unknown types were silently skipped, so whenever a new connector type was deployed to the server before the CLI was updated, its secrets were incorrectly reported as missing.

## Changes

| File | Change |
|------|--------|
| `packages/core/src/contracts/connectors.ts` | Add `connectorProvidedSecretNames` to `connectorListResponseSchema` |
| `apps/web/app/api/connectors/route.ts` | Compute and return the new field |
| `apps/cli/src/commands/compose/index.ts` | Use server data; remove local computation |
| `apps/web/app/api/connectors/__tests__/route.test.ts` | Add tests for new field |
| `apps/cli/src/commands/compose/__tests__/index.test.ts` | Update mocks; add version-skew test |
| `apps/cli/src/mocks/handlers/api-handlers.ts` | Update default mock |

## Test plan

- [x] Server route test: verify `connectorProvidedSecretNames` returns correct secret names for connected GitHub connector
- [x] Server route test: verify empty array when no connectors exist
- [x] CLI compose test: verify connector-provided secrets excluded from missing list
- [x] CLI compose test: verify server-reported secrets for unknown connector types are trusted (version-skew scenario)
- [x] CLI compose test: verify all secrets shown as missing when no connectors connected
- [x] All pre-commit checks pass (lint, format, knip, commitlint)

Closes #3758

🤖 Generated with [Claude Code](https://claude.com/claude-code)