### PR TITLE
feat(telegram): handle progress callback to refresh typing indicator

### DIFF
--- a/turbo/apps/web/app/api/internal/callbacks/telegram/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/telegram/__tests__/route.test.ts
@@ -66,7 +66,7 @@ function telegramDeleteMessage() {
 function createCallbackRequest(
   body: {
     runId: string;
-    status: "completed" | "failed";
+    status: "completed" | "failed" | "progress";
     result?: Record<string, unknown>;
     error?: string;
     payload: TelegramCallbackPayload;
@@ -271,6 +271,31 @@ describe("POST /api/internal/callbacks/telegram", () => {
       expect(data.success).toBe(true);
 
       expect(sendMessageHandler.mocked).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("Progress Callback", () => {
+    it("should refresh typing indicator and return early without sending a message", async () => {
+      const { runId, payload, secret } = await setupTelegramCallback();
+
+      const chatActionHandler = telegramSendChatAction();
+      const sendMessageHandler = telegramSendMessage();
+      server.use(chatActionHandler.handler, sendMessageHandler.handler);
+
+      const request = createCallbackRequest(
+        { runId, status: "progress", payload },
+        secret,
+      );
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.success).toBe(true);
+
+      // Should refresh typing indicator
+      expect(chatActionHandler.mocked).toHaveBeenCalledTimes(1);
+      // Should NOT send a message (no error, no completion text)
+      expect(sendMessageHandler.mocked).not.toHaveBeenCalled();
     });
   });
 

--- a/turbo/apps/web/app/api/internal/callbacks/telegram/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/telegram/route.ts
@@ -123,6 +123,33 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 
   log.debug("Processing Telegram callback", { runId, status, chatId });
 
+  // Handle progress notifications: refresh the typing indicator
+  if (status === "progress") {
+    const { SECRETS_ENCRYPTION_KEY } = env();
+    const [inst] = await globalThis.services.db
+      .select({
+        encryptedBotToken: telegramInstallations.encryptedBotToken,
+      })
+      .from(telegramInstallations)
+      .where(eq(telegramInstallations.id, installationId))
+      .limit(1);
+
+    if (inst) {
+      const token = decryptCredentialValue(
+        inst.encryptedBotToken,
+        SECRETS_ENCRYPTION_KEY,
+      );
+      const progressClient = createTelegramClient(token);
+      try {
+        await sendChatAction(progressClient, chatId, "typing");
+      } catch (err) {
+        log.debug("Failed to refresh typing indicator", { runId, error: err });
+      }
+    }
+
+    return NextResponse.json({ success: true });
+  }
+
   const { SECRETS_ENCRYPTION_KEY } = env();
 
   // Get Telegram installation for bot token

--- a/turbo/apps/web/app/api/internal/callbacks/telegram/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/telegram/route.ts
@@ -95,19 +95,16 @@ async function findNewSessionId(
   return newSession?.id;
 }
 
-export async function POST(request: NextRequest): Promise<NextResponse> {
-  initServices();
+interface CompletionContext {
+  client: ReturnType<typeof createTelegramClient>;
+  runId: string;
+  status: "completed" | "failed";
+  error: string | undefined;
+  payload: CallbackPayload;
+}
 
-  const result = await verifyCallback<CallbackPayload>(request, log);
-  if (!result.ok) return result.response;
-
-  const { runId, status, error } = result.data;
-
-  const payload = parsePayload(result.data.payload);
-  if (!payload) {
-    return errorResponse("Invalid or missing payload", 400);
-  }
-
+async function handleCompletion(ctx: CompletionContext): Promise<void> {
+  const { client, runId, status, error, payload } = ctx;
   const {
     installationId,
     chatId,
@@ -120,58 +117,6 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     isDM,
     thinkingMessageId,
   } = payload;
-
-  log.debug("Processing Telegram callback", { runId, status, chatId });
-
-  // Handle progress notifications: refresh the typing indicator
-  if (status === "progress") {
-    const { SECRETS_ENCRYPTION_KEY } = env();
-    const [inst] = await globalThis.services.db
-      .select({
-        encryptedBotToken: telegramInstallations.encryptedBotToken,
-      })
-      .from(telegramInstallations)
-      .where(eq(telegramInstallations.id, installationId))
-      .limit(1);
-
-    if (inst) {
-      const token = decryptCredentialValue(
-        inst.encryptedBotToken,
-        SECRETS_ENCRYPTION_KEY,
-      );
-      const progressClient = createTelegramClient(token);
-      try {
-        await sendChatAction(progressClient, chatId, "typing");
-      } catch (err) {
-        log.debug("Failed to refresh typing indicator", { runId, error: err });
-      }
-    }
-
-    return NextResponse.json({ success: true });
-  }
-
-  const { SECRETS_ENCRYPTION_KEY } = env();
-
-  // Get Telegram installation for bot token
-  const [installation] = await globalThis.services.db
-    .select({
-      id: telegramInstallations.id,
-      encryptedBotToken: telegramInstallations.encryptedBotToken,
-    })
-    .from(telegramInstallations)
-    .where(eq(telegramInstallations.id, installationId))
-    .limit(1);
-
-  if (!installation) {
-    log.warn("Telegram installation not found", { installationId });
-    return NextResponse.json({ success: true });
-  }
-
-  const botToken = decryptCredentialValue(
-    installation.encryptedBotToken,
-    SECRETS_ENCRYPTION_KEY,
-  );
-  const client = createTelegramClient(botToken);
 
   // Delete thinking placeholder message
   if (thinkingMessageId) {
@@ -219,7 +164,6 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   let botReplyMessageId: number | undefined;
   for (const chunk of chunks) {
     const sent = await sendMessage(client, chatId, chunk, replyOptions);
-    // Capture first reply message_id as thread anchor
     if (botReplyMessageId === undefined) {
       botReplyMessageId = sent.message_id;
     }
@@ -247,8 +191,6 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       ? await findNewSessionId(run.userId, composeId, run.createdAt)
       : undefined;
 
-    // Use bot's latest reply as rootMessageId so the user can continue
-    // the session by replying to any bot response.
     const newRootMessageId = isDM ? "dm" : String(botReplyMessageId);
 
     await saveTelegramThreadSession({
@@ -262,8 +204,64 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       runStatus: status,
     });
   }
+}
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  initServices();
+
+  const result = await verifyCallback<CallbackPayload>(request, log);
+  if (!result.ok) return result.response;
+
+  const { runId, status, error } = result.data;
+
+  const payload = parsePayload(result.data.payload);
+  if (!payload) {
+    return errorResponse("Invalid or missing payload", 400);
+  }
+
+  log.debug("Processing Telegram callback", {
+    runId,
+    status,
+    chatId: payload.chatId,
+  });
+
+  const { SECRETS_ENCRYPTION_KEY } = env();
+
+  // Get Telegram installation for bot token
+  const [installation] = await globalThis.services.db
+    .select({
+      id: telegramInstallations.id,
+      encryptedBotToken: telegramInstallations.encryptedBotToken,
+    })
+    .from(telegramInstallations)
+    .where(eq(telegramInstallations.id, payload.installationId))
+    .limit(1);
+
+  if (!installation) {
+    log.warn("Telegram installation not found", {
+      installationId: payload.installationId,
+    });
+    return NextResponse.json({ success: true });
+  }
+
+  const botToken = decryptCredentialValue(
+    installation.encryptedBotToken,
+    SECRETS_ENCRYPTION_KEY,
+  );
+  const client = createTelegramClient(botToken);
+
+  // Handle progress notifications: refresh the typing indicator
+  if (status === "progress") {
+    try {
+      await sendChatAction(client, payload.chatId, "typing");
+    } catch (err) {
+      log.debug("Failed to refresh typing indicator", { runId, error: err });
+    }
+    return NextResponse.json({ success: true });
+  }
+
+  await handleCompletion({ client, runId, status, error, payload });
 
   log.debug("Telegram callback processed successfully", { runId });
-
   return NextResponse.json({ success: true });
 }


### PR DESCRIPTION
## Summary
- Add a `progress` status handler to the Telegram callback route that refreshes the typing indicator without sending a message
- Extend the test suite with a new test case verifying the progress callback sends a chat action but no message

## Test plan
- [ ] Verify progress callback returns 200 with `{ success: true }`
- [ ] Verify typing indicator is refreshed via `sendChatAction`
- [ ] Verify no message is sent on progress callbacks
- [ ] Run existing Telegram callback tests to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)