### PR TITLE
docs: fix vnc startup commands and add troubleshooting guide

### DIFF
--- a/.claude/skills/agent-browser/SKILL.md
+++ b/.claude/skills/agent-browser/SKILL.md
@@ -36,6 +36,31 @@ pgrep -f websockify > /dev/null || (websockify --web /usr/share/novnc/ 0.0.0.0:6
 sleep 1
 ```
 
+### Troubleshooting noVNC
+
+If the user can't connect to noVNC (`dcvnc` fails or the page doesn't load):
+
+1. **websockify not listening** — The most common issue. Verify with `netstat -tlnp 2>/dev/null | grep 6080`. If not listening:
+   - Kill any stale process: `pkill -9 -f websockify`
+   - Restart with correct bind address (must be `0.0.0.0`, not `localhost`):
+     ```bash
+     (websockify --web /usr/share/novnc/ 0.0.0.0:6080 localhost:5900 > /dev/null 2>&1 &)
+     ```
+   - Verify: `sleep 2 && netstat -tlnp 2>/dev/null | grep 6080`
+
+2. **`||` and `&` precedence bug** — Running `pgrep ... || websockify ... &` without subshells causes `&` to background the entire pipeline, not just websockify. The `pgrep` succeeds (exit 0) and websockify never starts. Always wrap in `(...)`:
+   ```bash
+   # WRONG — websockify may silently not start
+   pgrep -f websockify > /dev/null || websockify ... &
+   # CORRECT — subshell ensures only websockify is backgrounded
+   pgrep -f websockify > /dev/null || (websockify ... &)
+   ```
+
+3. **Chrome profile lock from another VM** — If agent-browser fails with "profile appears to be in use by another Chromium process", remove the stale lock:
+   ```bash
+   rm -f ~/.local/share/agent-browser/profile/Singleton{Lock,Cookie,Socket}
+   ```
+
 ### Always Use Headed Mode
 
 All agent-browser commands must set `DISPLAY=:99` and use `--headed`. For local HTTPS dev servers, use `--ignore-https-errors` (Playwright flag, NOT Chrome's `--ignore-certificate-errors` which breaks stealth):

--- a/docs/add-oauth-connector.md
+++ b/docs/add-oauth-connector.md
@@ -83,14 +83,17 @@ After both apps are registered and the credentials file is populated:
    ```
 
    **Start the VNC stack (idempotent — safe to run multiple times):**
+
+   **Important:** Each process must be wrapped in subshell `()` to avoid `||` and `&` operator precedence issues that can silently prevent later processes (especially websockify) from launching. Also, websockify must bind to `0.0.0.0:6080` (not just `6080`) so it's accessible from the host.
+
    ```bash
-   pgrep -x Xvfb > /dev/null || Xvfb :99 -screen 0 1344x840x24 > /dev/null 2>&1 &
+   pgrep -x Xvfb > /dev/null || (Xvfb :99 -screen 0 1344x840x24 > /dev/null 2>&1 &)
    sleep 1
-   pgrep -x openbox > /dev/null || DISPLAY=:99 openbox > /dev/null 2>&1 &
+   pgrep -x openbox > /dev/null || (DISPLAY=:99 openbox > /dev/null 2>&1 &)
    sleep 1
-   pgrep -x x11vnc > /dev/null || x11vnc -display :99 -nopw -forever -shared -rfbport 5900 > /dev/null 2>&1 &
+   pgrep -x x11vnc > /dev/null || (x11vnc -display :99 -nopw -forever -shared -rfbport 5900 > /dev/null 2>&1 &)
    sleep 1
-   pgrep -f websockify > /dev/null || websockify --web /usr/share/novnc/ 6080 localhost:5900 > /dev/null 2>&1 &
+   pgrep -f websockify > /dev/null || (websockify --web /usr/share/novnc/ 0.0.0.0:6080 localhost:5900 > /dev/null 2>&1 &)
    sleep 1
    ```
 


### PR DESCRIPTION
## Summary
- Fix `docs/add-oauth-connector.md`: wrap backgrounded VNC processes in subshells to avoid `||` and `&` operator precedence bug, use `0.0.0.0:6080` instead of bare `6080` for websockify
- Add troubleshooting section to `agent-browser` skill covering the three most common noVNC issues agents hit: websockify not listening, operator precedence bug, Chrome profile lock from another VM

## Test plan
- [ ] Verify noVNC is accessible after following the updated startup commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)