### PR TITLE
fix(connectors): add missing redirect_uri to todoist oauth flow

### DIFF
--- a/turbo/apps/web/src/lib/connector/providers/todoist-handler.ts
+++ b/turbo/apps/web/src/lib/connector/providers/todoist-handler.ts
@@ -7,8 +7,13 @@ import {
 
 export const todoistHandler: ProviderHandler = {
   buildAuthUrl: buildTodoistAuthorizationUrl,
-  async exchangeCode(clientId, clientSecret, code) {
-    const result = await exchangeTodoistCode(clientId, clientSecret, code);
+  async exchangeCode(clientId, clientSecret, code, redirectUri) {
+    const result = await exchangeTodoistCode(
+      clientId,
+      clientSecret,
+      code,
+      redirectUri,
+    );
     return {
       accessToken: result.accessToken,
       refreshToken: null,

--- a/turbo/apps/web/src/lib/connector/providers/todoist.ts
+++ b/turbo/apps/web/src/lib/connector/providers/todoist.ts
@@ -31,6 +31,7 @@ export function buildTodoistAuthorizationUrl(
     client_id: clientId,
     scope: oauthConfig.scopes.join(","),
     state,
+    redirect_uri: redirectUri,
   });
 
   return `${oauthConfig.authorizationUrl}?${params.toString()}`;
@@ -45,6 +46,7 @@ export async function exchangeTodoistCode(
   clientId: string,
   clientSecret: string,
   code: string,
+  redirectUri: string,
 ): Promise<TodoistTokenResult> {
   const oauthConfig = getConnectorOAuthConfig("todoist");
   if (!oauthConfig) {
@@ -60,6 +62,7 @@ export async function exchangeTodoistCode(
       client_id: clientId,
       client_secret: clientSecret,
       code,
+      redirect_uri: redirectUri,
     }),
   });
 


### PR DESCRIPTION
## Summary
- Adds `redirect_uri` parameter to Todoist OAuth authorization URL construction
- Adds `redirect_uri` parameter to Todoist token exchange request body
- Without these, Todoist returns `invalid_request` / `redirect_uri_not_configured` errors

## Test plan
- [x] Verified authorize endpoint redirects to Todoist OAuth with correct params (client_id, scope, state, redirect_uri)
- [x] Confirmed redirect_uri is derived from request origin (works with both localhost and proxy)
- [ ] Full end-to-end OAuth flow (requires Todoist account login on consent page)

🤖 Generated with [Claude Code](https://claude.com/claude-code)