### PR TITLE
perf(storage): remove unused archive size from storage manifest

### DIFF
--- a/turbo/apps/web/src/lib/storage/storage-service.ts
+++ b/turbo/apps/web/src/lib/storage/storage-service.ts
@@ -1,9 +1,5 @@
 import { resolveVolumes } from "./storage-resolver";
-import {
-  generatePresignedUrl,
-  listS3Objects,
-  putS3Object,
-} from "../s3/s3-client";
+import { generatePresignedUrl, putS3Object } from "../s3/s3-client";
 import { logger } from "../logger";
 import { badRequest } from "../errors";
 import type {
@@ -308,17 +304,12 @@ export async function prepareStorageManifest(
         const archiveKey = `${s3Key}/archive.tar.gz`;
         const archiveUrl = await generatePresignedUrl(bucketName, archiveKey);
 
-        // Get archive size from S3
-        const archiveObjects = await listS3Objects(bucketName, archiveKey);
-        const archiveSize = archiveObjects[0]?.size ?? 0;
-
         const manifestStorage: ManifestStorage = {
           name: volume.name,
           mountPath: volume.mountPath,
           vasStorageName: volume.vasStorageName,
           vasVersionId: versionId,
           archiveUrl,
-          archiveSize,
         };
 
         log.debug(`Generated archive URL for volume "${volume.name}"`);
@@ -373,16 +364,11 @@ export async function prepareStorageManifest(
         const manifestKey = `${s3Key}/manifest.json`;
         const manifestUrl = await generatePresignedUrl(bucketName, manifestKey);
 
-        // Get archive size from S3
-        const archiveObjects = await listS3Objects(bucketName, archiveKey);
-        const archiveSize = archiveObjects[0]?.size ?? 0;
-
         const manifestArtifact: ManifestArtifact = {
           mountPath: artifactSource.mountPath,
           vasStorageName: artifactSource.vasStorageName,
           vasVersionId: versionId,
           archiveUrl,
-          archiveSize,
           manifestUrl,
         };
 

--- a/turbo/apps/web/src/lib/storage/types.ts
+++ b/turbo/apps/web/src/lib/storage/types.ts
@@ -95,8 +95,6 @@ export interface ManifestStorage {
   vasVersionId: string;
   /** Presigned URL for downloading archive.tar.gz */
   archiveUrl: string;
-  /** Size of archive.tar.gz in bytes */
-  archiveSize: number;
 }
 
 /**
@@ -108,8 +106,6 @@ export interface ManifestArtifact {
   vasVersionId: string;
   /** Presigned URL for downloading archive.tar.gz */
   archiveUrl: string;
-  /** Size of archive.tar.gz in bytes */
-  archiveSize: number;
   /** Presigned URL for downloading manifest.json (for incremental upload) */
   manifestUrl?: string;
 }


### PR DESCRIPTION
## Summary

- Remove `listS3Objects()` calls from `prepareStorageManifest()` that fetched `archiveSize` for each volume/artifact (~100-200ms per S3 network call)
- Remove `archiveSize` field from `ManifestStorage` and `ManifestArtifact` interfaces
- No consumer reads this field — Runner (Rust serde ignores unknown fields), E2B, and Docker all discard it

## Impact

Expected ~700ms reduction in `api_prepare_storage_manifest` latency (755ms → ~50ms).

Closes #3861

🤖 Generated with [Claude Code](https://claude.com/claude-code)