### PR TITLE
feat(connectors): gate airtable connector behind internal feature switch

### DIFF
--- a/turbo/apps/platform/src/signals/settings-page/connectors.ts
+++ b/turbo/apps/platform/src/signals/settings-page/connectors.ts
@@ -50,6 +50,7 @@ export interface ConnectorTypeWithStatus {
 const CONNECTOR_FEATURE_FLAGS = Object.freeze<
   Partial<Record<ConnectorType, FeatureSwitchKey>>
 >({
+  airtable: FeatureSwitchKey.AirtableConnector,
   computer: FeatureSwitchKey.ComputerConnector,
   deel: FeatureSwitchKey.DeelConnector,
   docusign: FeatureSwitchKey.DocuSignConnector,

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -10,6 +10,7 @@ export enum FeatureSwitchKey {
   PlatformSecrets = "platformSecrets",
   PlatformArtifacts = "platformArtifacts",
   PlatformApiKeys = "platformApiKeys",
+  AirtableConnector = "airtableConnector",
   CanvaConnector = "canvaConnector",
   ComputerConnector = "computerConnector",
   DeelConnector = "deelConnector",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -65,6 +65,11 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     maintainer: "ethan@vm0.ai",
     enabled: false,
   },
+  [FeatureSwitchKey.AirtableConnector]: {
+    maintainer: "ethan@vm0.ai",
+    enabled: false,
+    enabledUserHashes: STAFF_USER_HASHES,
+  },
   [FeatureSwitchKey.CanvaConnector]: {
     maintainer: "ethan@vm0.ai",
     enabled: false,
@@ -185,6 +190,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
 export const CONNECTOR_FEATURE_FLAGS: Partial<
   Record<ConnectorType, FeatureSwitchKey>
 > = {
+  airtable: FeatureSwitchKey.AirtableConnector,
   canva: FeatureSwitchKey.CanvaConnector,
   computer: FeatureSwitchKey.ComputerConnector,
   deel: FeatureSwitchKey.DeelConnector,


### PR DESCRIPTION
## Summary

- Add `AirtableConnector` feature switch key to `FeatureSwitchKey` enum
- Register the switch in `FEATURE_SWITCHES` with `enabled: false` and `enabledUserHashes: STAFF_USER_HASHES` (staff-only visibility)
- Map `airtable` connector type to the new key in `CONNECTOR_FEATURE_FLAGS` (both `@vm0/core` and `@vm0/platform`)

The Airtable connector will now only be visible to internal staff users until the feature switch is broadly enabled.

## Test plan

- [ ] Verify Airtable connector does not appear in the connectors list for a regular user
- [ ] Verify Airtable connector appears for a staff user (hash in `STAFF_USER_HASHES`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)