### PR TITLE
fix: rewrite nodename label to inventory hostname

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -195,6 +195,9 @@ jobs:
           METAL_USER: ${{ vars.AWS_METAL_RUNNER_USER }}
           HOST: ${{ steps.host.outputs.host }}
           JOB_REF: ${{ steps.host.outputs.job-ref }}
+          GRAFANA_CLOUD_PROMETHEUS_URL: ${{ secrets.GRAFANA_CLOUD_PROMETHEUS_URL }}
+          GRAFANA_CLOUD_PROMETHEUS_USER: ${{ secrets.GRAFANA_CLOUD_PROMETHEUS_USER }}
+          GRAFANA_CLOUD_API_KEY: ${{ secrets.GRAFANA_CLOUD_API_KEY }}
         run: |
           SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10 -i $HOME/.ssh/runner.pem"
           REMOTE="${METAL_USER}@${HOST}"
@@ -212,6 +215,18 @@ jobs:
             --private-key $HOME/.ssh/runner.pem \
             -e "ansible_user=${METAL_USER}" \
             -v
+          if [ -n "${GRAFANA_CLOUD_API_KEY}" ]; then
+            ansible-playbook \
+              -i "${HOST}," \
+              playbooks/provision-monitoring.yml \
+              --private-key $HOME/.ssh/runner.pem \
+              -e "ansible_user=${METAL_USER}" \
+              -e "grafana_cloud_prometheus_url=${GRAFANA_CLOUD_PROMETHEUS_URL}" \
+              -e "grafana_cloud_prometheus_user=${GRAFANA_CLOUD_PROMETHEUS_USER}" \
+              -e "grafana_cloud_api_key=${GRAFANA_CLOUD_API_KEY}" \
+              -e "env_label=dev" \
+              -v
+          fi
           cd ..
 
           # Clean previous run artifacts and upload runner (guests are embedded)

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -697,6 +697,9 @@ jobs:
           AWS_METAL_RUNNER_SSH_KEY: ${{ secrets.AWS_METAL_RUNNER_SSH_KEY }}
           OFFICIAL_RUNNER_SECRET: ${{ secrets.OFFICIAL_RUNNER_SECRET }}
           RUNNER_VERSION: ${{ needs.release-please.outputs.runner_rs_version }}
+          GRAFANA_CLOUD_PROMETHEUS_URL: ${{ secrets.GRAFANA_CLOUD_PROMETHEUS_URL }}
+          GRAFANA_CLOUD_PROMETHEUS_USER: ${{ secrets.GRAFANA_CLOUD_PROMETHEUS_USER }}
+          GRAFANA_CLOUD_API_KEY: ${{ secrets.GRAFANA_CLOUD_API_KEY }}
         run: |
           mkdir -p ~/.ssh
           echo "$AWS_METAL_RUNNER_SSH_KEY" > ~/.ssh/prod-runner.pem
@@ -708,6 +711,18 @@ jobs:
             --private-key ~/.ssh/prod-runner.pem \
             -e "ansible_user=${AWS_METAL_RUNNER_USER}" \
             -v
+          if [ -n "${GRAFANA_CLOUD_API_KEY}" ]; then
+            ansible-playbook \
+              -i "${AWS_METAL_RUNNER_HOSTS}," \
+              playbooks/provision-monitoring.yml \
+              --private-key ~/.ssh/prod-runner.pem \
+              -e "ansible_user=${AWS_METAL_RUNNER_USER}" \
+              -e "grafana_cloud_prometheus_url=${GRAFANA_CLOUD_PROMETHEUS_URL}" \
+              -e "grafana_cloud_prometheus_user=${GRAFANA_CLOUD_PROMETHEUS_USER}" \
+              -e "grafana_cloud_api_key=${GRAFANA_CLOUD_API_KEY}" \
+              -e "env_label=prod" \
+              -v
+          fi
           ansible-playbook \
             -i "${AWS_METAL_RUNNER_HOSTS}," \
             playbooks/deploy-runner.yml \

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1348,6 +1348,9 @@ jobs:
           JOB_REF: ${{ needs.prepare.outputs.job-ref }}
           BIN_DIR: ${{ steps.host.outputs.bin-dir }}
           RUNNER_DIR: ${{ steps.host.outputs.runner-dir }}
+          GRAFANA_CLOUD_PROMETHEUS_URL: ${{ secrets.GRAFANA_CLOUD_PROMETHEUS_URL }}
+          GRAFANA_CLOUD_PROMETHEUS_USER: ${{ secrets.GRAFANA_CLOUD_PROMETHEUS_USER }}
+          GRAFANA_CLOUD_API_KEY: ${{ secrets.GRAFANA_CLOUD_API_KEY }}
         run: |
           SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10 -i $HOME/.ssh/runner.pem"
           TARGET_DIR="crates/target/${TARGET_TRIPLE}/${CARGO_PROFILE}"
@@ -1363,6 +1366,18 @@ jobs:
             --private-key $HOME/.ssh/runner.pem \
             -e "ansible_user=${METAL_USER}" \
             -v
+          if [ -n "${GRAFANA_CLOUD_API_KEY}" ]; then
+            ansible-playbook \
+              -i "${METAL_HOSTS}," \
+              playbooks/provision-monitoring.yml \
+              --private-key $HOME/.ssh/runner.pem \
+              -e "ansible_user=${METAL_USER}" \
+              -e "grafana_cloud_prometheus_url=${GRAFANA_CLOUD_PROMETHEUS_URL}" \
+              -e "grafana_cloud_prometheus_user=${GRAFANA_CLOUD_PROMETHEUS_USER}" \
+              -e "grafana_cloud_api_key=${GRAFANA_CLOUD_API_KEY}" \
+              -e "env_label=dev" \
+              -v
+          fi
           cd ..
 
           deploy_to_host() {

--- a/ansible/playbooks/provision-metal.yml
+++ b/ansible/playbooks/provision-metal.yml
@@ -12,6 +12,11 @@
   hosts: all
 
   tasks:
+    - name: Wait for apt lock to be released
+      shell: while fuser /var/lib/dpkg/lock-frontend >/dev/null 2>&1; do sleep 2; done
+      become: true
+      changed_when: false
+
     - name: Install system packages
       apt:
         name:

--- a/ansible/playbooks/provision-monitoring.yml
+++ b/ansible/playbooks/provision-monitoring.yml
@@ -63,11 +63,10 @@
         content: |
           // Collect system metrics (equivalent to node_exporter)
           prometheus.exporter.unix "default" {
-            enable_collectors = ["systemd"]
-            disable_collectors = [
-              "arp", "cooling", "dmi", "edac", "entropy", "hwmon",
-              "netstat", "nvme", "schedstat", "selinux", "sockstat",
-              "softnet", "textfile", "timex",
+            set_collectors = [
+              "cpu", "disk", "filesystem", "loadavg", "meminfo",
+              "netdev", "os", "pressure", "processes", "systemd",
+              "uname", "vmstat",
             ]
             netdev {
               device_include = "^(en|eth|bond).*"

--- a/ansible/playbooks/provision-monitoring.yml
+++ b/ansible/playbooks/provision-monitoring.yml
@@ -16,6 +16,11 @@
   hosts: all
 
   tasks:
+    - name: Wait for apt lock to be released
+      shell: while fuser /var/lib/dpkg/lock-frontend >/dev/null 2>&1; do sleep 2; done
+      become: true
+      changed_when: false
+
     - name: Install dependencies
       apt:
         name:

--- a/ansible/playbooks/provision-monitoring.yml
+++ b/ansible/playbooks/provision-monitoring.yml
@@ -86,9 +86,21 @@
             }
           }
 
+          // Rewrite nodename label to inventory hostname
+          prometheus.relabel "default" {
+            forward_to = [prometheus.remote_write.grafana_cloud.receiver]
+
+            rule {
+              source_labels = ["nodename"]
+              regex         = ".+"
+              target_label  = "nodename"
+              replacement   = "{{ inventory_hostname }}"
+            }
+          }
+
           prometheus.scrape "default" {
             targets         = discovery.relabel.default.output
-            forward_to      = [prometheus.remote_write.grafana_cloud.receiver]
+            forward_to      = [prometheus.relabel.default.receiver]
             scrape_interval = "15s"
           }
 

--- a/ansible/playbooks/provision-monitoring.yml
+++ b/ansible/playbooks/provision-monitoring.yml
@@ -64,8 +64,18 @@
           // Collect system metrics (equivalent to node_exporter)
           prometheus.exporter.unix "default" {}
 
+          // Override instance label with inventory hostname
+          discovery.relabel "default" {
+            targets = prometheus.exporter.unix.default.targets
+
+            rule {
+              target_label = "instance"
+              replacement  = "{{ inventory_hostname }}"
+            }
+          }
+
           prometheus.scrape "default" {
-            targets         = prometheus.exporter.unix.default.targets
+            targets         = discovery.relabel.default.output
             forward_to      = [prometheus.remote_write.grafana_cloud.receiver]
             scrape_interval = "15s"
           }
@@ -79,8 +89,7 @@
               }
             }
             external_labels = {
-              instance = "{{ inventory_hostname }}",
-              env      = "{{ env_label }}",
+              env = "{{ env_label }}",
             }
           }
         dest: /etc/alloy/config.alloy

--- a/ansible/playbooks/provision-monitoring.yml
+++ b/ansible/playbooks/provision-monitoring.yml
@@ -1,0 +1,101 @@
+# Provision Monitoring with Grafana Alloy
+#
+# Installs Grafana Alloy on bare metal hosts to collect system metrics
+# (via built-in prometheus.exporter.unix) and remote-write to Grafana Cloud.
+#
+# Usage:
+#   ansible-playbook -i "host1,host2," playbooks/provision-monitoring.yml \
+#     --private-key ~/.ssh/runner.pem \
+#     -e "ansible_user=ubuntu" \
+#     -e "grafana_cloud_prometheus_url=https://..." \
+#     -e "grafana_cloud_prometheus_user=123456" \
+#     -e "grafana_cloud_api_key=glc_..." \
+#     -e "env_label=prod"
+
+- name: Provision monitoring with Grafana Alloy
+  hosts: all
+
+  tasks:
+    - name: Install dependencies
+      apt:
+        name:
+          - gpg
+          - apt-transport-https
+          - software-properties-common
+        state: present
+        update_cache: true
+      become: true
+
+    - name: Ensure keyrings directory exists
+      file:
+        path: /etc/apt/keyrings
+        state: directory
+        mode: "0755"
+      become: true
+
+    - name: Add Grafana GPG key
+      shell: |
+        curl -fsSL https://apt.grafana.com/gpg.key | gpg --dearmor -o /etc/apt/keyrings/grafana.gpg
+      args:
+        creates: /etc/apt/keyrings/grafana.gpg
+      become: true
+
+    - name: Add Grafana APT repository
+      copy:
+        content: "deb [signed-by=/etc/apt/keyrings/grafana.gpg] https://apt.grafana.com stable main"
+        dest: /etc/apt/sources.list.d/grafana.list
+      become: true
+
+    - name: Install Grafana Alloy
+      apt:
+        name: alloy
+        state: present
+        update_cache: true
+      become: true
+
+    - name: Configure Grafana Alloy
+      copy:
+        content: |
+          // Collect system metrics (equivalent to node_exporter)
+          prometheus.exporter.unix "default" {}
+
+          prometheus.scrape "default" {
+            targets         = prometheus.exporter.unix.default.targets
+            forward_to      = [prometheus.remote_write.grafana_cloud.receiver]
+            scrape_interval = "15s"
+          }
+
+          prometheus.remote_write "grafana_cloud" {
+            endpoint {
+              url = "{{ grafana_cloud_prometheus_url }}"
+              basic_auth {
+                username = "{{ grafana_cloud_prometheus_user }}"
+                password = "{{ grafana_cloud_api_key }}"
+              }
+            }
+            external_labels = {
+              instance = "{{ inventory_hostname }}",
+              env      = "{{ env_label }}",
+            }
+          }
+        dest: /etc/alloy/config.alloy
+        owner: root
+        group: alloy
+        mode: "0640"
+      become: true
+      notify: Restart Alloy
+
+    - name: Enable and start Alloy
+      systemd:
+        name: alloy
+        state: started
+        enabled: true
+        daemon_reload: true
+      become: true
+
+  handlers:
+    - name: Restart Alloy
+      systemd:
+        name: alloy
+        state: restarted
+      become: true

--- a/ansible/playbooks/provision-monitoring.yml
+++ b/ansible/playbooks/provision-monitoring.yml
@@ -62,7 +62,12 @@
       copy:
         content: |
           // Collect system metrics (equivalent to node_exporter)
-          prometheus.exporter.unix "default" {}
+          prometheus.exporter.unix "default" {
+            enable_collectors = ["systemd"]
+            systemd {
+              unit_include = "vm0-runner-v.+\\.service|alloy\\.service|docker\\.service"
+            }
+          }
 
           // Override instance label with inventory hostname
           discovery.relabel "default" {

--- a/ansible/playbooks/provision-monitoring.yml
+++ b/ansible/playbooks/provision-monitoring.yml
@@ -64,7 +64,7 @@
           // Collect system metrics (equivalent to node_exporter)
           prometheus.exporter.unix "default" {
             set_collectors = [
-              "cpu", "disk", "filesystem", "loadavg", "meminfo",
+              "cpu", "diskstats", "filesystem", "loadavg", "meminfo",
               "netdev", "os", "pressure", "processes", "systemd",
               "uname", "vmstat",
             ]

--- a/ansible/playbooks/provision-monitoring.yml
+++ b/ansible/playbooks/provision-monitoring.yml
@@ -53,7 +53,7 @@
 
     - name: Install Grafana Alloy
       apt:
-        name: alloy
+        name: alloy=1.13.2-1
         state: present
         update_cache: true
       become: true

--- a/ansible/playbooks/provision-monitoring.yml
+++ b/ansible/playbooks/provision-monitoring.yml
@@ -64,6 +64,7 @@
           // Collect system metrics (equivalent to node_exporter)
           prometheus.exporter.unix "default" {
             enable_collectors = ["systemd"]
+            disable_collectors = ["schedstat", "softnet", "cooling"]
             systemd {
               unit_include = "vm0-runner-v.+\\.service|alloy\\.service|docker\\.service"
             }

--- a/ansible/playbooks/provision-monitoring.yml
+++ b/ansible/playbooks/provision-monitoring.yml
@@ -64,7 +64,14 @@
           // Collect system metrics (equivalent to node_exporter)
           prometheus.exporter.unix "default" {
             enable_collectors = ["systemd"]
-            disable_collectors = ["schedstat", "softnet", "cooling"]
+            disable_collectors = [
+              "arp", "cooling", "dmi", "edac", "entropy", "hwmon",
+              "netstat", "nvme", "schedstat", "selinux", "sockstat",
+              "softnet", "textfile", "timex",
+            ]
+            netdev {
+              device_include = "^(en|eth|bond).*"
+            }
             systemd {
               unit_include = "vm0-runner-v.+\\.service|alloy\\.service|docker\\.service"
             }


### PR DESCRIPTION
## Summary
- Add `prometheus.relabel` to rewrite `nodename` label from AWS internal hostname (`ip-172-31-33-219`) to inventory hostname (`dev-1.aws.vm3.ai`)
- Scrape pipeline: `exporter.unix → discovery.relabel (instance) → scrape → prometheus.relabel (nodename) → remote_write`

Closes #3803

## Test plan
- [ ] Verify on dev-1 that `nodename` in `node_uname_info` shows `dev-1.aws.vm3.ai`
- [ ] Verify Grafana dashboard Nodename dropdown shows friendly hostnames

🤖 Generated with [Claude Code](https://claude.com/claude-code)