### PR TITLE
fix: replace any type with proper interface in rebuild-snapshots script

### DIFF
--- a/turbo/scripts/rebuild-snapshots-from-db.ts
+++ b/turbo/scripts/rebuild-snapshots-from-db.ts
@@ -184,12 +184,27 @@ async function generateSnapshotFromDb(
 
     // Update _journal.json to ensure this migration entry exists
     const journalPath = path.join(META_DIR, "_journal.json");
-    const journal = JSON.parse(fs.readFileSync(journalPath, "utf-8"));
+
+    interface MigrationJournalEntry {
+      idx: number;
+      version: string;
+      when: number;
+      tag: string;
+      breakpoints: boolean;
+    }
+
+    interface MigrationJournal {
+      version: string;
+      dialect: string;
+      entries: MigrationJournalEntry[];
+    }
+
+    const journal = JSON.parse(
+      fs.readFileSync(journalPath, "utf-8"),
+    ) as MigrationJournal;
 
     // Check if entry already exists
-    const existingEntry = journal.entries.find(
-      (e: any) => e.idx === migration.idx,
-    );
+    const existingEntry = journal.entries.find((e) => e.idx === migration.idx);
     if (!existingEntry) {
       console.log(
         `⚠️  Migration ${migration.idx} not in journal - this shouldn't happen`,


### PR DESCRIPTION
## Summary
- Replace `any` type with properly defined `MigrationJournalEntry` and `MigrationJournal` interfaces in `scripts/rebuild-snapshots-from-db.ts`
- Maintains zero-tolerance policy for `any` types per `docs/bad-smell.md`

## Test plan
- [x] Pre-commit hooks pass (prettier, knip, commitlint)
- [ ] CI type-check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)