### PR TITLE
fix: remove defensive try-catch in skill-frontmatter

### DIFF
--- a/turbo/packages/core/src/skill-frontmatter.ts
+++ b/turbo/packages/core/src/skill-frontmatter.ts
@@ -29,12 +29,7 @@ export function parseSkillFrontmatter(content: string): SkillFrontmatter {
     return {};
   }
 
-  let parsed: unknown;
-  try {
-    parsed = parseYaml(yamlContent);
-  } catch {
-    return {};
-  }
+  const parsed: unknown = parseYaml(yamlContent);
 
   if (!parsed || typeof parsed !== "object") {
     return {};
@@ -133,12 +128,7 @@ async function collectSkillDeclaredVars(
  * Accepts bare skill names (e.g. "slack") or full GitHub tree URLs.
  */
 function buildSkillMdUrl(url: string): string | null {
-  let resolved: string;
-  try {
-    resolved = resolveSkillRef(url);
-  } catch {
-    return null;
-  }
+  const resolved = resolveSkillRef(url);
 
   const parsed = parseGitHubTreeUrl(resolved);
   if (!parsed) {


### PR DESCRIPTION
## Summary
- Remove unnecessary try/catch around `parseYaml()` — let exceptions propagate to `Promise.allSettled()` caller
- Remove unnecessary try/catch around `resolveSkillRef()` — same pattern
- Per `docs/bad-smell.md`: avoid defensive try/catch that silently swallows errors

## Test plan
- [x] Pre-commit hooks pass (prettier, knip, commitlint)
- [ ] CI type-check and tests pass
- [ ] Verify `collectSkillDeclaredVars()` still handles failures gracefully via `Promise.allSettled()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)