### PR TITLE
fix(cli): add warning for missing sentry environment config

### DIFF
--- a/turbo/apps/cli/src/instrument.ts
+++ b/turbo/apps/cli/src/instrument.ts
@@ -60,9 +60,14 @@ function isOperationalError(error: unknown): boolean {
 }
 
 if (DSN) {
+  const sentryEnvironment = process.env.SENTRY_ENVIRONMENT;
+  if (!sentryEnvironment) {
+    console.warn("SENTRY_ENVIRONMENT not set, defaulting to 'production'");
+  }
+
   Sentry.init({
     dsn: DSN,
-    environment: process.env.SENTRY_ENVIRONMENT ?? "production",
+    environment: sentryEnvironment ?? "production",
     release: __CLI_VERSION__,
     sendDefaultPii: false,
     tracesSampleRate: 0,


### PR DESCRIPTION
## Summary
- Add `console.warn` when Sentry initializes without `SENTRY_ENVIRONMENT` set
- Makes the silent fallback to "production" visible instead of hiding config gaps
- Per `docs/bad-smell.md`: configuration errors should be caught, not hidden

## Test plan
- [x] Pre-commit hooks pass (prettier, knip, commitlint)
- [ ] CI type-check and tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)