### PR TITLE
refactor(cli): improve scope create and scope set commands

### DIFF
--- a/turbo/apps/cli/src/commands/scope/__tests__/create-scope.test.ts
+++ b/turbo/apps/cli/src/commands/scope/__tests__/create-scope.test.ts
@@ -1,5 +1,5 @@
 /**
- * Tests for org create command
+ * Tests for scope create command
  *
  * Tests command-level behavior via parseAsync() following CLI testing principles:
  * - Entry point: command.parseAsync()
@@ -22,7 +22,7 @@ vi.mock("../../../lib/api/config", async (importOriginal) => {
   };
 });
 
-describe("org create command", () => {
+describe("scope create command", () => {
   const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
     throw new Error("process.exit called");
   }) as never);
@@ -37,22 +37,45 @@ describe("org create command", () => {
     vi.stubEnv("VM0_TOKEN", "test-token");
   });
 
-  it("should create org and auto-switch scope, show success", async () => {
+  it("should show friendly error when user already has a scope", async () => {
     server.use(
+      http.get("http://localhost:3000/api/scope", () => {
+        return HttpResponse.json({
+          id: "test-id",
+          slug: "user-a1b2c3d4",
+          tier: "free",
+          createdAt: "2025-01-01T00:00:00Z",
+          updatedAt: "2025-01-01T00:00:00Z",
+        });
+      }),
+    );
+
+    await expect(async () => {
+      await createCommand.parseAsync(["node", "cli", "my-team"]);
+    }).rejects.toThrow("process.exit called");
+
+    const errorCalls = mockConsoleError.mock.calls.flat().join("\n");
+    expect(errorCalls).toContain("already have a scope: user-a1b2c3d4");
+    expect(errorCalls).toContain("vm0 scope set my-team --force");
+    expect(mockExit).toHaveBeenCalledWith(1);
+  });
+
+  it("should create scope and auto-activate when user has none", async () => {
+    server.use(
+      http.get("http://localhost:3000/api/scope", () => {
+        return HttpResponse.json(
+          { error: { message: "No scope configured", code: "NOT_FOUND" } },
+          { status: 404 },
+        );
+      }),
       http.post("http://localhost:3000/api/scope", () => {
         return HttpResponse.json(
           {
+            id: "new-id",
             slug: "my-team",
-            role: "admin",
-            members: [
-              {
-                userId: "user-1",
-                email: "",
-                role: "admin",
-                joinedAt: "2025-01-01T00:00:00Z",
-              },
-            ],
+            tier: "free",
             createdAt: "2025-01-01T00:00:00Z",
+            updatedAt: "2025-01-01T00:00:00Z",
           },
           { status: 201 },
         );
@@ -63,31 +86,21 @@ describe("org create command", () => {
 
     const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
     expect(logCalls).toContain("my-team");
-    expect(logCalls).toContain("created");
+    expect(logCalls).toContain("created and activated");
   });
 
-  it("should handle 'already own an organization' error", async () => {
+  it("should propagate non-scope errors from pre-check", async () => {
     server.use(
-      http.post("http://localhost:3000/api/scope", () => {
+      http.get("http://localhost:3000/api/scope", () => {
         return HttpResponse.json(
-          {
-            error: {
-              message: "You already have a scope",
-              code: "BAD_REQUEST",
-            },
-          },
-          { status: 400 },
+          { error: { message: "Not authenticated", code: "UNAUTHORIZED" } },
+          { status: 401 },
         );
       }),
     );
 
     await expect(async () => {
-      await createCommand.parseAsync(["node", "cli", "new-org"]);
-    }).rejects.toThrow("process.exit called");
-
-    expect(mockConsoleError).toHaveBeenCalledWith(
-      expect.stringContaining("already have a scope"),
-    );
-    expect(mockExit).toHaveBeenCalledWith(1);
+      await createCommand.parseAsync(["node", "cli", "my-team"]);
+    }).rejects.toThrow("Not authenticated");
   });
 });

--- a/turbo/apps/cli/src/commands/scope/__tests__/create-scope.test.ts
+++ b/turbo/apps/cli/src/commands/scope/__tests__/create-scope.test.ts
@@ -32,6 +32,9 @@ describe("scope create command", () => {
     .mockImplementation(() => {});
 
   beforeEach(() => {
+    mockExit.mockClear();
+    mockConsoleLog.mockClear();
+    mockConsoleError.mockClear();
     chalk.level = 0;
     vi.stubEnv("VM0_API_URL", "http://localhost:3000");
     vi.stubEnv("VM0_TOKEN", "test-token");

--- a/turbo/apps/cli/src/commands/scope/__tests__/set.test.ts
+++ b/turbo/apps/cli/src/commands/scope/__tests__/set.test.ts
@@ -23,248 +23,97 @@ describe("scope set command", () => {
     mockConsoleError.mockClear();
   });
 
-  describe("authentication", () => {
-    it("should exit with error if not authenticated", async () => {
-      vi.stubEnv("VM0_TOKEN", "");
-      vi.stubEnv("HOME", "/tmp/test-no-config");
+  it("should exit with error if not authenticated", async () => {
+    vi.stubEnv("VM0_TOKEN", "");
+    vi.stubEnv("HOME", "/tmp/test-no-config");
 
-      await expect(async () => {
-        await setCommand.parseAsync(["node", "cli", "testslug"]);
-      }).rejects.toThrow("process.exit called");
-
-      expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining("Not authenticated"),
-      );
-      expect(mockExit).toHaveBeenCalledWith(1);
-    });
-  });
-
-  describe("create new scope", () => {
-    it("should create scope successfully", async () => {
-      server.use(
-        http.get("http://localhost:3000/api/scope", () => {
-          return HttpResponse.json(
-            { error: { message: "No scope configured", code: "NOT_FOUND" } },
-            { status: 404 },
-          );
-        }),
-        http.post("http://localhost:3000/api/scope", () => {
-          return HttpResponse.json(
-            {
-              id: "test-id",
-              slug: "testslug",
-              createdAt: "2024-01-01T00:00:00Z",
-              updatedAt: "2024-01-01T00:00:00Z",
-            },
-            { status: 201 },
-          );
-        }),
-      );
-
+    await expect(async () => {
       await setCommand.parseAsync(["node", "cli", "testslug"]);
+    }).rejects.toThrow("process.exit called");
 
-      expect(mockConsoleLog).toHaveBeenCalledWith(
-        expect.stringContaining("Scope created: testslug"),
-      );
-      expect(mockConsoleLog).toHaveBeenCalledWith(
-        expect.stringContaining("testslug/<agent-name>"),
-      );
-    });
+    expect(mockConsoleError).toHaveBeenCalledWith(
+      expect.stringContaining("Not authenticated"),
+    );
+    expect(mockExit).toHaveBeenCalledWith(1);
   });
 
-  describe("update existing scope", () => {
-    it("should require --force to update existing scope", async () => {
-      server.use(
-        http.get("http://localhost:3000/api/scope", () => {
-          return HttpResponse.json({
-            id: "test-id",
-            slug: "oldslug",
-            createdAt: "2024-01-01T00:00:00Z",
-            updatedAt: "2024-01-01T00:00:00Z",
-          });
-        }),
-      );
+  it("should require --force to update existing scope", async () => {
+    server.use(
+      http.get("http://localhost:3000/api/scope", () => {
+        return HttpResponse.json({
+          id: "test-id",
+          slug: "oldslug",
+          createdAt: "2024-01-01T00:00:00Z",
+          updatedAt: "2024-01-01T00:00:00Z",
+        });
+      }),
+    );
 
-      await expect(async () => {
-        await setCommand.parseAsync(["node", "cli", "newslug"]);
-      }).rejects.toThrow("process.exit called");
+    await expect(async () => {
+      await setCommand.parseAsync(["node", "cli", "newslug"]);
+    }).rejects.toThrow("process.exit called");
 
-      expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining("already have a scope: oldslug"),
-      );
-      expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining("--force"),
-      );
-      expect(mockExit).toHaveBeenCalledWith(1);
-    });
-
-    it("should update scope with --force", async () => {
-      server.use(
-        http.get("http://localhost:3000/api/scope", () => {
-          return HttpResponse.json({
-            id: "test-id",
-            slug: "oldslug",
-            createdAt: "2024-01-01T00:00:00Z",
-            updatedAt: "2024-01-01T00:00:00Z",
-          });
-        }),
-        http.put("http://localhost:3000/api/scope", () => {
-          return HttpResponse.json({
-            id: "test-id",
-            slug: "newslug",
-            createdAt: "2024-01-01T00:00:00Z",
-            updatedAt: "2024-01-01T00:00:00Z",
-          });
-        }),
-      );
-
-      await setCommand.parseAsync(["node", "cli", "newslug", "--force"]);
-
-      expect(mockConsoleLog).toHaveBeenCalledWith(
-        expect.stringContaining("Scope updated to newslug"),
-      );
-    });
+    expect(mockConsoleError).toHaveBeenCalledWith(
+      expect.stringContaining("already have a scope: oldslug"),
+    );
+    expect(mockConsoleError).toHaveBeenCalledWith(
+      expect.stringContaining("--force"),
+    );
+    expect(mockExit).toHaveBeenCalledWith(1);
   });
 
-  describe("error handling", () => {
-    it("should handle slug already taken", async () => {
-      server.use(
-        http.get("http://localhost:3000/api/scope", () => {
-          return HttpResponse.json(
-            { error: { message: "No scope configured", code: "NOT_FOUND" } },
-            { status: 404 },
-          );
-        }),
-        http.post("http://localhost:3000/api/scope", () => {
-          return HttpResponse.json(
-            { error: { message: "Scope already exists", code: "CONFLICT" } },
-            { status: 409 },
-          );
-        }),
-      );
+  it("should update scope with --force", async () => {
+    server.use(
+      http.get("http://localhost:3000/api/scope", () => {
+        return HttpResponse.json({
+          id: "test-id",
+          slug: "oldslug",
+          createdAt: "2024-01-01T00:00:00Z",
+          updatedAt: "2024-01-01T00:00:00Z",
+        });
+      }),
+      http.put("http://localhost:3000/api/scope", () => {
+        return HttpResponse.json({
+          id: "test-id",
+          slug: "newslug",
+          createdAt: "2024-01-01T00:00:00Z",
+          updatedAt: "2024-01-01T00:00:00Z",
+        });
+      }),
+    );
 
-      await expect(async () => {
-        await setCommand.parseAsync(["node", "cli", "takenslug"]);
-      }).rejects.toThrow("process.exit called");
+    await setCommand.parseAsync(["node", "cli", "newslug", "--force"]);
 
-      expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining("already taken"),
-      );
-      expect(mockExit).toHaveBeenCalledWith(1);
-    });
+    expect(mockConsoleLog).toHaveBeenCalledWith(
+      expect.stringContaining("Scope updated to newslug"),
+    );
+  });
 
-    it("should handle reserved slug", async () => {
-      server.use(
-        http.get("http://localhost:3000/api/scope", () => {
-          return HttpResponse.json(
-            { error: { message: "No scope configured", code: "NOT_FOUND" } },
-            { status: 404 },
-          );
-        }),
-        http.post("http://localhost:3000/api/scope", () => {
-          return HttpResponse.json(
-            {
-              error: {
-                message: 'Scope slug "vm0" is reserved',
-                code: "FORBIDDEN",
-              },
-            },
-            { status: 403 },
-          );
-        }),
-      );
+  it("should handle slug already taken", async () => {
+    server.use(
+      http.get("http://localhost:3000/api/scope", () => {
+        return HttpResponse.json({
+          id: "test-id",
+          slug: "oldslug",
+          createdAt: "2024-01-01T00:00:00Z",
+          updatedAt: "2024-01-01T00:00:00Z",
+        });
+      }),
+      http.put("http://localhost:3000/api/scope", () => {
+        return HttpResponse.json(
+          { error: { message: "Scope already exists", code: "CONFLICT" } },
+          { status: 409 },
+        );
+      }),
+    );
 
-      await expect(async () => {
-        await setCommand.parseAsync(["node", "cli", "vm0"]);
-      }).rejects.toThrow("process.exit called");
+    await expect(async () => {
+      await setCommand.parseAsync(["node", "cli", "takenslug", "--force"]);
+    }).rejects.toThrow("process.exit called");
 
-      expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining("reserved"),
-      );
-      expect(mockExit).toHaveBeenCalledWith(1);
-    });
-
-    it("should handle vm0 prefix rejection", async () => {
-      server.use(
-        http.get("http://localhost:3000/api/scope", () => {
-          return HttpResponse.json(
-            { error: { message: "No scope configured", code: "NOT_FOUND" } },
-            { status: 404 },
-          );
-        }),
-        http.post("http://localhost:3000/api/scope", () => {
-          return HttpResponse.json(
-            {
-              error: {
-                message: 'Scope slug "vm0test" is reserved',
-                code: "FORBIDDEN",
-              },
-            },
-            { status: 403 },
-          );
-        }),
-      );
-
-      await expect(async () => {
-        await setCommand.parseAsync(["node", "cli", "vm0test"]);
-      }).rejects.toThrow("process.exit called");
-
-      expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining("reserved"),
-      );
-      expect(mockExit).toHaveBeenCalledWith(1);
-    });
-
-    it("should handle unexpected errors", async () => {
-      server.use(
-        http.get("http://localhost:3000/api/scope", () => {
-          return HttpResponse.json(
-            { error: { message: "No scope configured", code: "NOT_FOUND" } },
-            { status: 404 },
-          );
-        }),
-        http.post("http://localhost:3000/api/scope", () => {
-          return HttpResponse.json(
-            {
-              error: { message: "Unexpected error", code: "SERVER_ERROR" },
-            },
-            { status: 500 },
-          );
-        }),
-      );
-
-      await expect(async () => {
-        await setCommand.parseAsync(["node", "cli", "testslug"]);
-      }).rejects.toThrow("process.exit called");
-
-      expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining("Unexpected error"),
-      );
-      expect(mockExit).toHaveBeenCalledWith(1);
-    });
-
-    it("should handle non-Error exceptions", async () => {
-      server.use(
-        http.get("http://localhost:3000/api/scope", () => {
-          return HttpResponse.json(
-            { error: { message: "No scope configured", code: "NOT_FOUND" } },
-            { status: 404 },
-          );
-        }),
-        http.post("http://localhost:3000/api/scope", () => {
-          return HttpResponse.error();
-        }),
-      );
-
-      await expect(async () => {
-        await setCommand.parseAsync(["node", "cli", "testslug"]);
-      }).rejects.toThrow("process.exit called");
-
-      // Network error from HttpResponse.error() manifests as "Failed to fetch"
-      expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining("Failed to fetch"),
-      );
-      expect(mockExit).toHaveBeenCalledWith(1);
-    });
+    expect(mockConsoleError).toHaveBeenCalledWith(
+      expect.stringContaining("already taken"),
+    );
+    expect(mockExit).toHaveBeenCalledWith(1);
   });
 });

--- a/turbo/apps/cli/src/commands/scope/__tests__/set.test.ts
+++ b/turbo/apps/cli/src/commands/scope/__tests__/set.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { http, HttpResponse } from "msw";
 import { server } from "../../../mocks/server";
 import { setCommand } from "../set";
@@ -13,14 +13,9 @@ describe("scope set command", () => {
     .mockImplementation(() => {});
 
   beforeEach(() => {
+    vi.clearAllMocks();
     vi.stubEnv("VM0_API_URL", "http://localhost:3000");
     vi.stubEnv("VM0_TOKEN", "test-token");
-  });
-
-  afterEach(() => {
-    mockExit.mockClear();
-    mockConsoleLog.mockClear();
-    mockConsoleError.mockClear();
   });
 
   it("should exit with error if not authenticated", async () => {

--- a/turbo/apps/cli/src/commands/scope/create-scope.ts
+++ b/turbo/apps/cli/src/commands/scope/create-scope.ts
@@ -1,26 +1,40 @@
 import { Command } from "commander";
 import chalk from "chalk";
-import { createScope } from "../../lib/api";
+import { createScope, getScope } from "../../lib/api";
 import { saveConfig } from "../../lib/api/config";
 
 export const createCommand = new Command()
   .name("create")
-  .description("Create a new team scope")
+  .description("Create a new scope")
   .argument("<slug>", "Scope slug (e.g., myteam)")
   .action(async (slug: string) => {
+    // Check if user already has a scope
     try {
-      await createScope({ slug });
-
-      // Auto-switch to the new org scope
-      await saveConfig({ activeScope: slug });
-
-      console.log(chalk.green(`✓ Scope '${slug}' created and activated.`));
-    } catch (error) {
-      if (error instanceof Error) {
-        console.error(chalk.red(`✗ ${error.message}`));
-      } else {
-        console.error(chalk.red("✗ An unexpected error occurred"));
-      }
+      const existingScope = await getScope();
+      console.error(
+        chalk.yellow(`✗ You already have a scope: ${existingScope.slug}`),
+      );
+      console.error();
+      console.error("To rename your scope, use:");
+      console.error(chalk.cyan(`  vm0 scope set ${slug} --force`));
       process.exit(1);
+    } catch (error) {
+      // "No scope configured" means user has no scope — proceed with creation
+      if (
+        !(error instanceof Error) ||
+        !error.message.includes("No scope configured")
+      ) {
+        throw error;
+      }
     }
+
+    const scope = await createScope({ slug });
+
+    // Auto-switch to the new scope
+    await saveConfig({ activeScope: scope.slug });
+
+    console.log(chalk.green(`✓ Scope '${scope.slug}' created and activated.`));
+    console.log();
+    console.log("Your agents will now be namespaced as:");
+    console.log(chalk.cyan(`  ${scope.slug}/<agent-name>`));
   });

--- a/turbo/apps/cli/src/commands/scope/create-scope.ts
+++ b/turbo/apps/cli/src/commands/scope/create-scope.ts
@@ -1,6 +1,6 @@
 import { Command } from "commander";
 import chalk from "chalk";
-import { createScope, getScope } from "../../lib/api";
+import { createScope, getScope, ApiRequestError } from "../../lib/api";
 import { saveConfig } from "../../lib/api/config";
 
 export const createCommand = new Command()
@@ -19,11 +19,8 @@ export const createCommand = new Command()
       console.error(chalk.cyan(`  vm0 scope set ${slug} --force`));
       process.exit(1);
     } catch (error) {
-      // "No scope configured" means user has no scope — proceed with creation
-      if (
-        !(error instanceof Error) ||
-        !error.message.includes("No scope configured")
-      ) {
+      // 404 means user has no scope — proceed with creation
+      if (!(error instanceof ApiRequestError) || error.status !== 404) {
         throw error;
       }
     }

--- a/turbo/apps/cli/src/commands/scope/set.ts
+++ b/turbo/apps/cli/src/commands/scope/set.ts
@@ -1,56 +1,34 @@
 import { Command } from "commander";
 import chalk from "chalk";
-import { getScope, createScope, updateScope } from "../../lib/api";
+import { getScope, updateScope } from "../../lib/api";
 
 export const setCommand = new Command()
   .name("set")
-  .description("Set your scope slug")
-  .argument("<slug>", "The scope slug (e.g., your username)")
+  .description("Rename your scope slug")
+  .argument("<slug>", "The new scope slug")
   .option("--force", "Force change existing scope (may break references)")
   .action(async (slug: string, options: { force?: boolean }) => {
     try {
-      // First check if user already has a scope
-      let existingScope;
-      try {
-        existingScope = await getScope();
-      } catch (error) {
-        // Only swallow "No scope configured" errors - that's the expected case for new users
-        // All other errors (network, auth, etc.) should propagate to the outer handler
-        if (
-          !(error instanceof Error) ||
-          !error.message.includes("No scope configured")
-        ) {
-          throw error;
-        }
+      const existingScope = await getScope();
+
+      if (!options.force) {
+        console.error(
+          chalk.yellow(`You already have a scope: ${existingScope.slug}`),
+        );
+        console.error();
+        console.error("To change your scope, use --force:");
+        console.error(chalk.cyan(`  vm0 scope set ${slug} --force`));
+        console.error();
+        console.error(
+          chalk.yellow(
+            "Warning: Changing your scope may break existing agent references.",
+          ),
+        );
+        process.exit(1);
       }
 
-      let scope;
-      if (existingScope) {
-        // User already has a scope - update it
-        if (!options.force) {
-          console.error(
-            chalk.yellow(`You already have a scope: ${existingScope.slug}`),
-          );
-          console.error();
-          console.error("To change your scope, use --force:");
-          console.error(chalk.cyan(`  vm0 scope set ${slug} --force`));
-          console.error();
-          console.error(
-            chalk.yellow(
-              "Warning: Changing your scope may break existing agent references.",
-            ),
-          );
-          process.exit(1);
-        }
-
-        scope = await updateScope({ slug, force: true });
-        console.log(chalk.green(`✓ Scope updated to ${scope.slug}`));
-      } else {
-        // Create new scope
-        scope = await createScope({ slug });
-        console.log(chalk.green(`✓ Scope created: ${scope.slug}`));
-      }
-
+      const scope = await updateScope({ slug, force: true });
+      console.log(chalk.green(`✓ Scope updated to ${scope.slug}`));
       console.log();
       console.log("Your agents will now be namespaced as:");
       console.log(chalk.cyan(`  ${scope.slug}/<agent-name>`));
@@ -62,14 +40,6 @@ export const setCommand = new Command()
           console.error(
             chalk.red(
               `✗ Scope "${slug}" is already taken. Please choose a different slug.`,
-            ),
-          );
-        } else if (error.message.includes("reserved")) {
-          console.error(chalk.red(`✗ ${error.message}`));
-        } else if (error.message.includes("vm0")) {
-          console.error(
-            chalk.red(
-              "✗ Scope slugs cannot start with 'vm0' (reserved for system use)",
             ),
           );
         } else {


### PR DESCRIPTION
## Summary

Closes #3873

- **`scope create`**: Add `getScope()` pre-check — when user already has a scope, show friendly error guiding them to `scope set --force` instead of raw backend error
- **`scope set`**: Remove dead code (unreachable create path due to auto-provisioning), update description to "Rename your scope slug"
- Update tests to match new behavior

## Test plan

- [x] `scope create` shows friendly error when user already has a scope
- [x] `scope create` still works for users without a scope (future multi-scope support)
- [x] `scope create` propagates auth errors properly
- [x] `scope set` requires `--force` to rename
- [x] `scope set --force` renames successfully
- [x] `scope set` handles slug-taken errors
- [x] All pre-commit checks pass (lint, knip, format, commitlint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)