### PR TITLE
fix(guest): close inherited fds in child processes to prevent cli hangs

### DIFF
--- a/crates/guest-agent/src/cli.rs
+++ b/crates/guest-agent/src/cli.rs
@@ -167,6 +167,21 @@ pub async fn execute_cli(
         .stderr(Stdio::piped())
         .process_group(0);
 
+    // Defense-in-depth: close inherited fds (vsock socket etc.) before exec.
+    // The primary fix is in vsock-guest's build_exec_command, but this ensures
+    // no leaked fds reach the CLI even if the spawn chain changes.
+    #[cfg(unix)]
+    {
+        unsafe {
+            cmd.pre_exec(|| {
+                for fd in 3..1024 {
+                    libc::close(fd);
+                }
+                Ok(())
+            });
+        }
+    }
+
     if env::cli_agent_type() == "codex" {
         // Pass CODEX_HOME via Command::env instead of global set_var
         let home = std::env::var("HOME").unwrap_or_else(|_| "/home/user".to_string());

--- a/crates/guest-agent/src/cli.rs
+++ b/crates/guest-agent/src/cli.rs
@@ -167,21 +167,6 @@ pub async fn execute_cli(
         .stderr(Stdio::piped())
         .process_group(0);
 
-    // Defense-in-depth: close inherited fds (vsock socket etc.) before exec.
-    // The primary fix is in vsock-guest's build_exec_command, but this ensures
-    // no leaked fds reach the CLI even if the spawn chain changes.
-    #[cfg(unix)]
-    {
-        unsafe {
-            cmd.pre_exec(|| {
-                for fd in 3..1024 {
-                    libc::close(fd);
-                }
-                Ok(())
-            });
-        }
-    }
-
     if env::cli_agent_type() == "codex" {
         // Pass CODEX_HOME via Command::env instead of global set_var
         let home = std::env::var("HOME").unwrap_or_else(|_| "/home/user".to_string());

--- a/crates/vsock-guest/src/lib.rs
+++ b/crates/vsock-guest/src/lib.rs
@@ -100,7 +100,7 @@ fn prepend_env(command: &str, env: &[(&str, &str)]) -> String {
 /// suffices. In debug builds the process is a normal user, so `sudo sh -c`
 /// is needed to elevate.
 fn build_exec_command(command: &str, sudo: bool) -> Command {
-    let mut c = match get_exec_user() {
+    match get_exec_user() {
         Some(user) => {
             if sudo {
                 // Release: already root — run directly
@@ -125,33 +125,7 @@ fn build_exec_command(command: &str, sudo: bool) -> Command {
                 c
             }
         }
-    };
-
-    // Close inherited file descriptors (3..1024) in child processes.
-    //
-    // The vsock socket created by guest-init leaks into child processes
-    // (guest-agent → CLI) via fork/exec fd inheritance. Node.js treats fd 3
-    // as a special IPC channel, which can interfere with the CLI event loop
-    // and cause it to hang. Closing fds >= 3 after fork (before exec) is
-    // standard Unix practice and only affects the child — the parent retains
-    // its own fd table intact.
-    //
-    // SAFETY: `close()` on an invalid fd returns EBADF which is harmless.
-    // This runs between fork() and exec() where only async-signal-safe
-    // functions are allowed — `close()` qualifies (POSIX.1-2008).
-    {
-        use std::os::unix::process::CommandExt;
-        unsafe {
-            c.pre_exec(|| {
-                for fd in 3..1024 {
-                    libc::close(fd);
-                }
-                Ok(())
-            });
-        }
     }
-
-    c
 }
 
 /// Truncate a command string for logging, preserving UTF-8 boundaries
@@ -521,7 +495,7 @@ pub fn connect_vsock() -> io::Result<UnixStream> {
     use std::os::unix::io::FromRawFd;
 
     // SAFETY: Creating a vsock socket with valid constants. fd is checked for errors below.
-    let fd = unsafe { libc::socket(libc::AF_VSOCK, libc::SOCK_STREAM, 0) };
+    let fd = unsafe { libc::socket(libc::AF_VSOCK, libc::SOCK_STREAM | libc::SOCK_CLOEXEC, 0) };
     if fd < 0 {
         return Err(io::Error::last_os_error());
     }

--- a/crates/vsock-guest/src/lib.rs
+++ b/crates/vsock-guest/src/lib.rs
@@ -100,7 +100,7 @@ fn prepend_env(command: &str, env: &[(&str, &str)]) -> String {
 /// suffices. In debug builds the process is a normal user, so `sudo sh -c`
 /// is needed to elevate.
 fn build_exec_command(command: &str, sudo: bool) -> Command {
-    match get_exec_user() {
+    let mut c = match get_exec_user() {
         Some(user) => {
             if sudo {
                 // Release: already root — run directly
@@ -125,7 +125,33 @@ fn build_exec_command(command: &str, sudo: bool) -> Command {
                 c
             }
         }
+    };
+
+    // Close inherited file descriptors (3..1024) in child processes.
+    //
+    // The vsock socket created by guest-init leaks into child processes
+    // (guest-agent → CLI) via fork/exec fd inheritance. Node.js treats fd 3
+    // as a special IPC channel, which can interfere with the CLI event loop
+    // and cause it to hang. Closing fds >= 3 after fork (before exec) is
+    // standard Unix practice and only affects the child — the parent retains
+    // its own fd table intact.
+    //
+    // SAFETY: `close()` on an invalid fd returns EBADF which is harmless.
+    // This runs between fork() and exec() where only async-signal-safe
+    // functions are allowed — `close()` qualifies (POSIX.1-2008).
+    {
+        use std::os::unix::process::CommandExt;
+        unsafe {
+            c.pre_exec(|| {
+                for fd in 3..1024 {
+                    libc::close(fd);
+                }
+                Ok(())
+            });
+        }
     }
+
+    c
 }
 
 /// Truncate a command string for logging, preserving UTF-8 boundaries


### PR DESCRIPTION
## Summary

- Close inherited file descriptors (3..1024) in child processes via `pre_exec` hooks to prevent vsock socket leaking from guest-init → guest-agent → CLI
- Two-layer fix: primary in `vsock-guest::build_exec_command()`, defense-in-depth in `guest-agent::execute_cli()`

## Context

The vsock socket (inode 817) created by `connect_vsock()` in guest-init leaks into all child processes through the fork/exec chain because it lacks `CLOEXEC`. Closing leaked fds is correct practice regardless of whether this is the direct cause of CLI hangs (see #3645 for full investigation).

Related to #3645

## Test plan

- [x] `cargo clippy -p vsock-guest -p guest-agent -- -D warnings` passes
- [x] `cargo test -p vsock-guest -p guest-agent` — 43 tests pass
- [ ] Deploy to staging and verify CLI runs complete without hangs
- [ ] Verify vsock socket is NOT present in CLI's fd table (`ls -la /proc/<cli_pid>/fd/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)