### PR TITLE
fix: rewrite nodename label and pin alloy version

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -4,12 +4,14 @@ on:
   pull_request:
     paths:
       - 'crates/**'
+      - 'ansible/**'
       - '.github/workflows/crates.yml'
   push:
     branches:
       - main
     paths:
       - 'crates/**'
+      - 'ansible/**'
       - '.github/workflows/crates.yml'
   merge_group:
 
@@ -23,7 +25,7 @@ jobs:
     container:
       image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260306
     outputs:
-      workflow-changed: ${{ steps.detect.outputs.workflow-changed }}
+      ci-changed: ${{ steps.detect.outputs.ci-changed }}
       ably-subscriber-changed: ${{ steps.detect.outputs.ably-subscriber-changed }}
       runner-changed: ${{ steps.detect.outputs.runner-changed }}
       guest-init-changed: ${{ steps.detect.outputs.guest-init-changed }}
@@ -47,11 +49,11 @@ jobs:
           # Git 2.35.2+ rejects such repos unless marked as safe.
           git config --global --add safe.directory "$GITHUB_WORKSPACE" 2>/dev/null || true
 
-          # Check if the workflow file itself changed
-          if git diff --name-only "$BASE_REF" HEAD | grep -q "^\.github/workflows/crates\.yml$"; then
-            echo "workflow-changed=true" >> "$GITHUB_OUTPUT"
+          # Check if the workflow file or ansible playbooks changed
+          if git diff --name-only "$BASE_REF" HEAD | grep -qE "^\.github/workflows/crates\.yml$|^ansible/"; then
+            echo "ci-changed=true" >> "$GITHUB_OUTPUT"
           else
-            echo "workflow-changed=false" >> "$GITHUB_OUTPUT"
+            echo "ci-changed=false" >> "$GITHUB_OUTPUT"
           fi
 
           # scripts/crate-changed.sh: exit 0=changed, 1=not changed, 2+=error
@@ -99,7 +101,7 @@ jobs:
       - name: Run ably-subscriber smoke test
         if: |
           needs.detect.outputs.ably-subscriber-changed == 'true' ||
-          needs.detect.outputs.workflow-changed == 'true'
+          needs.detect.outputs.ci-changed == 'true'
         env:
           ABLY_API_KEY: ${{ secrets.ABLY_API_KEY }}
         run: |
@@ -112,7 +114,7 @@ jobs:
       image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260306
     needs: [detect]
     if: |
-      needs.detect.outputs.workflow-changed == 'true' ||
+      needs.detect.outputs.ci-changed == 'true' ||
       needs.detect.outputs.runner-changed == 'true' ||
       needs.detect.outputs.guest-init-changed == 'true' ||
       needs.detect.outputs.guest-download-changed == 'true' ||

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -201,7 +201,7 @@ jobs:
             BASE_REF="HEAD^"
           fi
 
-          if git diff --name-only "$BASE_REF" HEAD | grep -q "^\.github/workflows/turbo\.yml$"; then
+          if git diff --name-only "$BASE_REF" HEAD | grep -qE "^\.github/workflows/turbo\.yml$|^ansible/"; then
             echo "CI workflow changes detected"
             echo "ci-changed=true" >> $GITHUB_OUTPUT
           else

--- a/ansible/playbooks/provision-monitoring.yml
+++ b/ansible/playbooks/provision-monitoring.yml
@@ -53,7 +53,7 @@
 
     - name: Install Grafana Alloy
       apt:
-        name: alloy
+        name: alloy=1.13.2-1
         state: present
         update_cache: true
       become: true
@@ -86,9 +86,21 @@
             }
           }
 
+          // Rewrite nodename label to inventory hostname
+          prometheus.relabel "default" {
+            forward_to = [prometheus.remote_write.grafana_cloud.receiver]
+
+            rule {
+              source_labels = ["nodename"]
+              regex         = ".+"
+              target_label  = "nodename"
+              replacement   = "{{ inventory_hostname }}"
+            }
+          }
+
           prometheus.scrape "default" {
             targets         = discovery.relabel.default.output
-            forward_to      = [prometheus.remote_write.grafana_cloud.receiver]
+            forward_to      = [prometheus.relabel.default.receiver]
             scrape_interval = "15s"
           }
 


### PR DESCRIPTION
## Summary
- Add `prometheus.relabel` to rewrite `nodename` label from AWS internal hostname (`ip-172-31-33-219`) to inventory hostname (`dev-1.aws.vm3.ai`)
- Pin alloy package to version `1.13.2-1`
- Scrape pipeline: `exporter.unix → discovery.relabel (instance) → scrape → prometheus.relabel (nodename) → remote_write`

## Test plan
- [ ] Verify on dev-1 that `nodename` in `node_uname_info` shows `dev-1.aws.vm3.ai`
- [ ] Verify Grafana dashboard Nodename dropdown shows friendly hostnames

🤖 Generated with [Claude Code](https://claude.com/claude-code)