### PR TITLE
fix(guest-agent): decouple event sending from stdout reading loop

### DIFF
--- a/crates/guest-agent/src/cli.rs
+++ b/crates/guest-agent/src/cli.rs
@@ -264,8 +264,10 @@ pub async fn execute_cli(
                             }
                             // Prepare event (fast: mask secrets, add seq) and enqueue
                             // for background sending.  Never blocks the reading loop.
-                            if let Some(payload) = events::prepare_event(&mut event, seq, masker) {
-                                let _ = event_tx.send(payload);
+                            if let Some(payload) = events::prepare_event(&mut event, seq, masker)
+                                && event_tx.send(payload).is_err()
+                            {
+                                log_warn!(LOG_TAG, "Event channel closed, dropping event seq={seq}");
                             }
                             seq += 1;
                         }
@@ -309,7 +311,9 @@ pub async fn execute_cli(
     // so we drop unsent events to avoid stalling on retries.
     drop(event_tx);
     if event_result.is_ok() {
-        let _ = event_sender.await;
+        if let Err(e) = event_sender.await {
+            log_warn!(LOG_TAG, "Event sender task failed: {e}");
+        }
     } else {
         event_sender.abort();
     }

--- a/crates/guest-agent/src/cli.rs
+++ b/crates/guest-agent/src/cli.rs
@@ -211,11 +211,11 @@ pub async fn execute_cli(
 
     // Stream stdout JSONL, racing against heartbeat and process exit.
     //
-    // When `child.wait()` fires we do NOT break — we keep reading events
-    // so buffered lines (including the final `result` event) are not lost.
-    // Events read after the CLI exits are buffered in memory (not sent via
-    // HTTP inline) so that slow HTTP POSTs don't prevent the pipe from
-    // draining.  Buffered events are sent after the pipe reaches EOF.
+    // Event sending is decoupled from stdout reading via an mpsc channel
+    // to prevent a deadlock: Bun (Claude CLI runtime) uses blocking stdout
+    // writes, so if the agent's HTTP POSTs are slow and the pipe buffer
+    // fills, the CLI's entire event loop blocks — including TCP I/O.
+    // See: https://github.com/vm0-ai/vm0/issues/3645
     let mut reader = tokio::io::BufReader::new(stdout).lines();
     let mut seq = 0u32;
 
@@ -224,10 +224,18 @@ pub async fn execute_cli(
     let pgid = child.id().map(|pid| pid as i32);
 
     let mut cli_status: Option<std::process::ExitStatus> = None;
-    // Events buffered during drain phase (after CLI exits).  Sent after
-    // the pipe reaches EOF so that slow HTTP POSTs don't block the loop
-    // while it drains remaining pipe data.
-    let mut deferred_events: Vec<(serde_json::Value, u32)> = Vec::new();
+
+    // Background event sender: HTTP POSTs happen here, never in the
+    // stdout reading loop.  Unbounded channel because events are small
+    // and CLI lifetime is bounded by JOB_TIMEOUT.
+    let (event_tx, mut event_rx) = tokio::sync::mpsc::unbounded_channel::<serde_json::Value>();
+    let event_sender = tokio::spawn(async move {
+        while let Some(payload) = event_rx.recv().await {
+            if let Err(e) = events::post_event(&payload).await {
+                log_warn!(LOG_TAG, "Event send failed: {e}");
+            }
+        }
+    });
 
     let event_result: Result<(), AgentError> = loop {
         tokio::select! {
@@ -254,11 +262,10 @@ pub async fn execute_cli(
                             {
                                 println!("{result}");
                             }
-                            if cli_status.is_some() {
-                                // CLI already exited — buffer for post-loop send.
-                                deferred_events.push((event, seq));
-                            } else if let Err(e) = events::send_event(&mut event, seq, masker).await {
-                                log_warn!(LOG_TAG, "Event send failed: {e}");
+                            // Prepare event (fast: mask secrets, add seq) and enqueue
+                            // for background sending.  Never blocks the reading loop.
+                            if let Some(payload) = events::prepare_event(&mut event, seq, masker) {
+                                let _ = event_tx.send(payload);
                             }
                             seq += 1;
                         }
@@ -297,16 +304,14 @@ pub async fn execute_cli(
         }
     };
 
-    // Send events that were buffered during the drain phase.
-    // Skip if the event loop exited with an error (e.g. heartbeat failure)
-    // because the server is likely unreachable and each retry would stall.
-    if event_result.is_ok() && !deferred_events.is_empty() {
-        log_info!(LOG_TAG, "Sending {} deferred events", deferred_events.len());
-        for (mut event, event_seq) in deferred_events {
-            if let Err(e) = events::send_event(&mut event, event_seq, masker).await {
-                log_warn!(LOG_TAG, "Deferred event send failed: {e}");
-            }
-        }
+    // Close the channel so the background sender can finish.
+    // On error (e.g. heartbeat failure) the server is likely unreachable,
+    // so we drop unsent events to avoid stalling on retries.
+    drop(event_tx);
+    if event_result.is_ok() {
+        let _ = event_sender.await;
+    } else {
+        event_sender.abort();
     }
 
     let status = match cli_status {

--- a/crates/guest-agent/src/events.rs
+++ b/crates/guest-agent/src/events.rs
@@ -23,12 +23,25 @@ pub async fn send_event(
     seq: u32,
     masker: &SecretMasker,
 ) -> Result<(), AgentError> {
+    let Some(payload) = prepare_event(event, seq, masker) else {
+        return Ok(());
+    };
+    post_event(&payload).await
+}
+
+/// Prepare an event for sending: extract session ID, add sequence number,
+/// mask secrets, and build the HTTP payload.
+///
+/// Returns `None` if there is no API token (local/test mode) or the event
+/// should not be posted.  This function is fast (no I/O) and safe to call
+/// inline in the stdout reading loop.
+pub fn prepare_event(event: &mut Value, seq: u32, masker: &SecretMasker) -> Option<Value> {
     // Extract session ID from init event (must happen before masking)
     extract_session_id(event);
 
     // No API token → local/test mode; skip posting events.
     if !env::has_api() {
-        return Ok(());
+        return None;
     }
 
     // Add sequence number
@@ -39,15 +52,18 @@ pub async fn send_event(
     // Mask secrets
     masker.mask_value(event);
 
-    // POST to events endpoint
-    let payload = json!({
+    // Build payload
+    Some(json!({
         "runId": env::run_id(),
         "events": [event],
-    });
+    }))
+}
 
+/// POST a prepared event payload to the webhook endpoint.
+pub async fn post_event(payload: &Value) -> Result<(), AgentError> {
     match http::post_json(
         urls::events_url(),
-        &payload,
+        payload,
         crate::constants::HTTP_MAX_RETRIES,
     )
     .await


### PR DESCRIPTION
## Summary

- Move event HTTP POSTs from the stdout reading `select!` loop to a background task via unbounded mpsc channel
- The reading loop now only does fast event preparation (extract session ID, mask secrets, add sequence number) and enqueues the payload — never blocks on network I/O
- Removes the `deferred_events` mechanism which was a partial fix for the same problem

## Root Cause

Bun (Claude CLI's runtime) uses **blocking stdout writes** on POSIX — unlike Node.js which uses async I/O for piped stdout. When the agent's inline `events::send_event()` HTTP POST is slow (up to 93s with 3 retries × 30s timeout), the `select!` loop stops polling `reader.next_line()`. The CLI's stdout pipe buffer (1MB on Linux) fills, and Bun's `write()` blocks the entire event loop — including TCP I/O. TCP connections eventually time out via keepalive, leaving the CLI stuck in `epoll_wait` with zero connections.

Evidence from Bun source code (`src/bun.js/bindings/BunProcess.cpp`):
```cpp
// On POSIX: force stdout to be synchronous
forceSync = true;
```

This matches all observed symptoms:
- CLI runs normally for ~44s then hangs
- Zero TCP connections when stuck
- `epoll_wait` (waiting for stdout pipe to become writable)
- Only happens in VMs (network latency makes HTTP POSTs slower)

## Design

```
Before:  select! { read line → send_event().await (up to 93s) }
After:   select! { read line → prepare_event() + tx.send() (microseconds) }
         Background task: rx.recv() → post_event().await
```

- **Unbounded channel**: Events are small JSON values (~500 bytes), CLI lifetime is bounded by JOB_TIMEOUT (2h), so memory is not a concern
- **Sequential sending**: Background task sends events one at a time, preserving order
- **Graceful shutdown**: On normal exit, sender is dropped → background task drains remaining events. On error (heartbeat failure), background task is aborted to avoid stalling on unreachable server

## Test plan

- [x] `cargo clippy -p guest-agent -- -D warnings` passes
- [x] `cargo test -p guest-agent` — 34 tests pass (17 unit + 17 integration)
- [ ] Deploy to staging and run workloads with varying network latency
- [ ] Monitor for CLI hang recurrence

Ref #3645

🤖 Generated with [Claude Code](https://claude.com/claude-code)