### PR TITLE
fix(connectors): fix wix token exchange to use form-encoded body

### DIFF
--- a/turbo/apps/web/src/lib/connector/providers/wix.ts
+++ b/turbo/apps/web/src/lib/connector/providers/wix.ts
@@ -95,14 +95,14 @@ export async function exchangeWixCode(
   const response = await fetch(WIX_TOKEN_URL, {
     method: "POST",
     headers: {
-      "Content-Type": "application/json",
+      "Content-Type": "application/x-www-form-urlencoded",
     },
-    body: JSON.stringify({
+    body: new URLSearchParams({
       grant_type: "client_credentials",
       client_id: clientId,
       client_secret: clientSecret,
       instance_id: instanceId,
-    }),
+    }).toString(),
   });
 
   if (!response.ok) {
@@ -146,14 +146,14 @@ export async function refreshWixToken(
   const response = await fetch(WIX_TOKEN_URL, {
     method: "POST",
     headers: {
-      "Content-Type": "application/json",
+      "Content-Type": "application/x-www-form-urlencoded",
     },
-    body: JSON.stringify({
+    body: new URLSearchParams({
       grant_type: "client_credentials",
       client_id: clientId,
       client_secret: clientSecret,
       instance_id: instanceId,
-    }),
+    }).toString(),
   });
 
   if (!response.ok) {
@@ -182,7 +182,7 @@ export async function refreshWixToken(
 async function fetchWixUserInfo(accessToken: string): Promise<WixUserInfo> {
   const response = await fetch("https://www.wixapis.com/apps/v1/instance", {
     headers: {
-      Authorization: accessToken,
+      Authorization: `Bearer ${accessToken}`,
     },
   });
 


### PR DESCRIPTION
## Summary

- Fix Wix OAuth2 token exchange to use `Content-Type: application/x-www-form-urlencoded` instead of `application/json` — the Wix token endpoint only accepts form-encoded bodies
- Fix `Authorization` header in `fetchWixUserInfo` to include `Bearer` prefix as required by Wix REST APIs

## Root Cause

The Wix `oauth2/token` endpoint returns `invalid_request` when the body is JSON. Form-encoded requests work correctly.

## Test plan

- [x] Token exchange confirmed working locally: `client_credentials` flow with instanceId returns a valid access token
- [x] Wix connector connected successfully on dev site ("Dev site 1 (Blank)")

🤖 Generated with [Claude Code](https://claude.com/claude-code)