### PR TITLE
fix(sandbox-fc): flush conntrack entries on namespace release

### DIFF
--- a/crates/sandbox-fc/src/network/pool.rs
+++ b/crates/sandbox-fc/src/network/pool.rs
@@ -472,6 +472,21 @@ async fn delete_namespace_resources(ns_name: &str, host_device: &str) {
     info!(name = %ns_name, "namespace deleted");
 }
 
+/// Flush conntrack entries for a given IP address.
+///
+/// Namespaces are reused between VMs with the same peer IP. Without
+/// flushing, stale conntrack entries from a previous VM can cause the
+/// stateful iptables rule (`-m state --state RELATED,ESTABLISHED`) to
+/// misroute or silently drop return packets for a new VM.
+async fn flush_conntrack(peer_ip: &str) {
+    let src_args = ["-D", "-s", peer_ip];
+    let dst_args = ["-D", "-d", peer_ip];
+    tokio::join!(
+        exec_ignore_errors("conntrack", &src_args, Privilege::Sudo),
+        exec_ignore_errors("conntrack", &dst_args, Privilege::Sudo),
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Pool index lock
 // ---------------------------------------------------------------------------
@@ -719,6 +734,11 @@ impl NetnsPool {
             info!(name = %ns.name, "namespace already in pool, ignoring");
             return Ok(());
         }
+
+        // Flush stale conntrack entries so the next VM using this namespace
+        // does not inherit connection tracking state from the previous VM.
+        flush_conntrack(&ns.peer_ip).await;
+
         info!(
             name = %ns.name,
             available = target_queue.len() + 1,


### PR DESCRIPTION
## Summary

- Flush conntrack entries (by source and destination IP) when a network namespace is released back to the pool
- Prevents stale connection tracking state from a previous VM from affecting a new VM that reuses the same namespace

## Problem

Network namespaces are reused between VMs with fixed peer IPs. When a VM exits:
1. iptables rules are deleted
2. veth interface is deleted  
3. Namespace is deleted or returned to pool
4. **Conntrack entries are NOT flushed** (default timeout: 5 days)

The inbound iptables rule depends on conntrack:
```
-A FORWARD -i {ext_iface} -o {veth_host} -m state --state RELATED,ESTABLISHED -j ACCEPT
```

If a new VM reuses the same namespace + IP, stale conntrack entries from the previous VM can cause return packets to be silently dropped or misrouted.

## Fix

Call `conntrack -D -s {peer_ip}` and `conntrack -D -d {peer_ip}` in the `release()` path before pushing the namespace back to the pool queue. Uses `exec_ignore_errors` since the conntrack command returns non-zero when there are no matching entries (which is fine).

## Test plan

- [x] `cargo clippy -p sandbox-fc -- -D warnings` passes
- [x] `cargo test -p sandbox-fc` — 97 tests pass
- [ ] Deploy and verify `conntrack -L` shows no stale entries after VM release

Ref #3645

🤖 Generated with [Claude Code](https://claude.com/claude-code)