### PR TITLE
fix: create missing 1password items in sync-oauth script

### DIFF
--- a/scripts/sync-oauth.sh
+++ b/scripts/sync-oauth.sh
@@ -35,7 +35,10 @@ op_safe_edit() {
   if err=$(op item edit "$item" --vault "$vault" "$@" 2>&1 >/dev/null); then
     return 0
   fi
-  if [[ "$err" == *"Password item requires ps value"* ]]; then
+  if [[ "$err" == *"isn't an item in"* ]] || [[ "$err" == *"not found"* ]]; then
+    # Item doesn't exist — create it
+    op item create --vault "$vault" --title "$item" --category Login "$@" >/dev/null
+  elif [[ "$err" == *"Password item requires ps value"* ]]; then
     op item edit "$item" --vault "$vault" "password[password]=placeholder" "$@" >/dev/null
   else
     echo "$err" >&2


### PR DESCRIPTION
## Summary

- Adds handling for the case when a 1Password item does not yet exist during `op item edit`
- When the error message indicates the item isn't found, the script now creates it with `op item create` instead of propagating the error
- Covers both `"isn't an item in"` and `"not found"` error variants from the 1Password CLI

## Test plan

- [ ] Run `scripts/sync-oauth.sh` against a vault that has a missing item and confirm it is created successfully
- [ ] Run against a vault with an existing item and confirm it is still edited correctly
- [ ] Confirm the `"Password item requires ps value"` fallback path still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)