### PR TITLE
fix(platform): deduplicate events by sequence number to prevent unknown blocks in log detail

### DIFF
--- a/turbo/apps/platform/src/views/logs-page/log-detail/__tests__/utils.test.ts
+++ b/turbo/apps/platform/src/views/logs-page/log-detail/__tests__/utils.test.ts
@@ -718,6 +718,125 @@ describe("log-detail utils", () => {
       expect(result[1].toolOperations).toBeUndefined();
     });
 
+    it("should not create unknown block when duplicate tool_result events arrive from consecutive log deliveries", () => {
+      // Simulates two consecutive API responses that overlap on the boundary event.
+      // First delivery:  seq 6 (thinking), seq 7 (tool_use Bash_1), seq 8 (tool_result Bash_1)
+      // Second delivery: seq 8 (duplicate!), seq 9 (thinking), seq 10 (text), seq 11 (tool_use Bash_2)
+      // The duplicate seq 8 must NOT produce an "Unknown" orphan block.
+      const events: AgentEvent[] = [
+        {
+          sequenceNumber: 6,
+          eventType: "assistant",
+          eventData: {
+            message: {
+              content: [{ type: "thinking" as "text", text: "Thinking..." }],
+            },
+          },
+          createdAt: "2024-01-01T00:00:01Z",
+        },
+        {
+          sequenceNumber: 7,
+          eventType: "assistant",
+          eventData: {
+            message: {
+              content: [
+                {
+                  type: "tool_use",
+                  id: "Bash_1",
+                  name: "Bash",
+                  input: { command: "echo hello" },
+                },
+              ],
+            },
+          },
+          createdAt: "2024-01-01T00:00:02Z",
+        },
+        // Event 8 appears in both deliveries
+        {
+          sequenceNumber: 8,
+          eventType: "user",
+          eventData: {
+            message: {
+              content: [
+                {
+                  type: "tool_result",
+                  tool_use_id: "Bash_1",
+                  content: "hello",
+                  is_error: false,
+                },
+              ],
+            },
+          },
+          createdAt: "2024-01-01T00:00:03Z",
+        },
+        // Duplicate of event 8 from the second delivery
+        {
+          sequenceNumber: 8,
+          eventType: "user",
+          eventData: {
+            message: {
+              content: [
+                {
+                  type: "tool_result",
+                  tool_use_id: "Bash_1",
+                  content: "hello",
+                  is_error: false,
+                },
+              ],
+            },
+          },
+          createdAt: "2024-01-01T00:00:03Z",
+        },
+        {
+          sequenceNumber: 9,
+          eventType: "assistant",
+          eventData: {
+            message: {
+              content: [
+                { type: "thinking" as "text", text: "More thinking..." },
+              ],
+            },
+          },
+          createdAt: "2024-01-01T00:00:04Z",
+        },
+        {
+          sequenceNumber: 10,
+          eventType: "assistant",
+          eventData: {
+            message: {
+              content: [{ type: "text", text: "Here is my response" }],
+            },
+          },
+          createdAt: "2024-01-01T00:00:05Z",
+        },
+        {
+          sequenceNumber: 11,
+          eventType: "assistant",
+          eventData: {
+            message: {
+              content: [
+                {
+                  type: "tool_use",
+                  id: "Bash_2",
+                  name: "Bash",
+                  input: { command: "ls" },
+                },
+              ],
+            },
+          },
+          createdAt: "2024-01-01T00:00:06Z",
+        },
+      ];
+
+      const result = groupEventsIntoMessages(events);
+
+      // Must not produce any "Unknown" orphan block from the duplicate tool_result
+      const unknownOps = result
+        .flatMap((m) => m.toolOperations ?? [])
+        .filter((op) => op.toolName === "Unknown");
+      expect(unknownOps).toHaveLength(0);
+    });
+
     it("should create standalone todo card for TodoWrite", () => {
       const events: AgentEvent[] = [
         {

--- a/turbo/apps/platform/src/views/logs-page/log-detail/utils.ts
+++ b/turbo/apps/platform/src/views/logs-page/log-detail/utils.ts
@@ -637,13 +637,22 @@ export function groupEventsIntoMessages(
     (a, b) => a.sequenceNumber - b.sequenceNumber,
   );
 
+  const seen = new Set<number>();
+  const deduped = sorted.filter((e) => {
+    if (seen.has(e.sequenceNumber)) {
+      return false;
+    }
+    seen.add(e.sequenceNumber);
+    return true;
+  });
+
   const ctx: GroupingContext = {
     grouped: [],
     pendingToolUses: new Map(),
     todoState: new Map(),
   };
 
-  for (const event of sorted) {
+  for (const event of deduped) {
     const eventData = event.eventData as GroupingEventData;
 
     if (event.eventType === "system") {


### PR DESCRIPTION
## Summary

- When the log detail page polls for new events, the last event of the previous page is returned again in the next response (inclusive `since` boundary semantics)
- `groupEventsIntoMessages` processed the duplicate `tool_result` twice: the second pass found no matching entry in `pendingToolUses` (already consumed) and fell into the orphan branch, producing a `GroupedMessage` with `toolName: "Unknown"`
- This "Unknown" orphan rendered as a mysterious unknown block in the log detail UI

**Fix:** deduplicate the sorted event array by `sequenceNumber` before processing — keeping only the first occurrence of each sequence number. 4-line change in `groupEventsIntoMessages`.

**Regression test added:** simulates two consecutive API deliveries with an overlapping boundary event (seq 8 appears in both), asserts no "Unknown" orphan blocks are produced.

## Test plan

- [x] New regression test in `utils.test.ts` that was failing before the fix, now passes
- [x] All 57 tests in `log-detail` pass
- [x] Lint and format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)