### PR TITLE
fix(guest-init): set correct env vars for sudo and user sessions

### DIFF
--- a/crates/guest-init/src/init.rs
+++ b/crates/guest-init/src/init.rs
@@ -13,6 +13,8 @@ use std::fs;
 use std::io;
 use std::path::Path;
 
+const DEFAULT_PATH: &str = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin";
+
 /// Initialize filesystem and perform pivot_root.
 ///
 /// This uses direct syscalls for filesystem initialization.
@@ -178,10 +180,7 @@ pub fn init_filesystem() -> Result<(), InitError> {
     // so these only affect root/sudo commands (e.g. clock fix).
     // SAFETY: We are the init process, no other threads are running yet
     unsafe {
-        std::env::set_var(
-            "PATH",
-            "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-        );
+        std::env::set_var("PATH", DEFAULT_PATH);
         std::env::set_var("HOME", "/root");
         std::env::set_var("USER", "root");
         std::env::set_var("SHELL", "/bin/bash");
@@ -201,7 +200,7 @@ pub fn init_filesystem() -> Result<(), InitError> {
     }
     if let Err(e) = fs::write(
         "/etc/profile.d/vm0-path.sh",
-        "export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\n",
+        format!("export PATH={DEFAULT_PATH}\n"),
     ) {
         eprintln!("[guest-init] Warning: failed to write /etc/profile.d/vm0-path.sh: {e}");
     }

--- a/crates/guest-init/src/init.rs
+++ b/crates/guest-init/src/init.rs
@@ -173,20 +173,42 @@ pub fn init_filesystem() -> Result<(), InitError> {
     })?;
     eprintln!("[guest-init] Virtual filesystems mounted");
 
-    // 10. Set environment variables
+    // 10. Set environment variables for the init process (root).
+    // User commands run via `su - user` which resets env from /etc/passwd,
+    // so these only affect root/sudo commands (e.g. clock fix).
     // SAFETY: We are the init process, no other threads are running yet
     unsafe {
         std::env::set_var(
             "PATH",
             "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
         );
-        std::env::set_var("HOME", "/home/user");
-        std::env::set_var("USER", "user");
+        std::env::set_var("HOME", "/root");
+        std::env::set_var("USER", "root");
         std::env::set_var("SHELL", "/bin/bash");
+        std::env::set_var("LANG", "C.UTF-8");
     }
 
-    // 11. Change to home directory
-    let _ = std::env::set_current_dir("/home/user");
+    // Write environment for `su - user` (login shell). Docker ENV is lost
+    // during `docker export`, and `std::env::set_var` only affects the
+    // current process — `su -` resets the environment.
+    //
+    // LANG goes in /etc/environment (read by PAM, not overridden later).
+    // PATH goes in /etc/profile.d/ because Debian's /etc/profile overrides
+    // PATH from /etc/environment, omitting sbin dirs for non-root users.
+    // Scripts in /etc/profile.d/ run after /etc/profile, so our PATH wins.
+    if let Err(e) = fs::write("/etc/environment", "LANG=C.UTF-8\n") {
+        eprintln!("[guest-init] Warning: failed to write /etc/environment: {e}");
+    }
+    if let Err(e) = fs::write(
+        "/etc/profile.d/vm0-path.sh",
+        "export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\n",
+    ) {
+        eprintln!("[guest-init] Warning: failed to write /etc/profile.d/vm0-path.sh: {e}");
+    }
+
+    // 11. Change to root home directory (init runs as root;
+    // `su - user` will cd to /home/user automatically)
+    let _ = std::env::set_current_dir("/root");
 
     eprintln!("[guest-init] Filesystem initialization complete");
     Ok(())

--- a/crates/runner/src/cmd/benchmark.rs
+++ b/crates/runner/src/cmd/benchmark.rs
@@ -34,6 +34,9 @@ pub struct BenchmarkArgs {
     /// Environment variables to pass (KEY=VALUE), can be repeated
     #[arg(long, short)]
     env: Vec<String>,
+    /// Run the command as root (sudo)
+    #[arg(long)]
+    sudo: bool,
 }
 
 pub async fn run_benchmark(args: BenchmarkArgs) -> RunnerResult<ExitCode> {
@@ -242,7 +245,7 @@ async fn run_in_sandbox(
             cmd: &args.command,
             timeout: Duration::from_secs(args.timeout_secs),
             env: &env_refs,
-            sudo: false,
+            sudo: args.sudo,
         })
         .await
         .map_err(Into::into);


### PR DESCRIPTION
## Summary

- Set correct root identity (`USER=root`, `HOME=/root`, `LANG=C.UTF-8`) in guest-init since it runs as PID 1; user env is handled by `su - user` login shell
- Write `LANG=C.UTF-8` to `/etc/environment` for login shells (PAM)
- Write PATH to `/etc/profile.d/vm0-path.sh` instead of `/etc/environment` — Debian's `/etc/profile` overrides PATH from `/etc/environment`, omitting sbin dirs for non-root
- Add `--sudo` flag to `runner benchmark` for testing root command environments

## Test plan

- [x] Verified on dev-1 with `runner benchmark` — all 5 env vars (LANG, PATH, HOME, USER, SHELL) correct for both sudo and non-sudo
- [ ] CI passes

Closes #3891

🤖 Generated with [Claude Code](https://claude.com/claude-code)