### PR TITLE
feat(runner): enable balloon reclaim in production deployment

### DIFF
--- a/ansible/playbooks/deploy-runner.yml
+++ b/ansible/playbooks/deploy-runner.yml
@@ -84,6 +84,7 @@
         {{ bin_dir }}/runner service install
         --name {{ runner_name }}
         --config {{ runner_dir }}/runner.yaml
+        --balloon-reclaim
 
     # ========================================
     # Phase 4: Health check


### PR DESCRIPTION
## Summary

- Add `--balloon-reclaim` flag to `runner service install` in `ansible/playbooks/deploy-runner.yml`

This enables virtio-balloon memory reclaim for production runners, allowing the host to reclaim unused guest memory.

Closes #3749

## Rollout plan

Per the issue, gray deploy to prod-1 first, monitor 24-48h, then full rollout.

## Test plan

- [ ] CI passes (no functional code change)
- [ ] Gray deploy on prod-1 with 24h observation
- [ ] No regression in job success rate or runner stability

🤖 Generated with [Claude Code](https://claude.com/claude-code)