### PR TITLE
chore(deps): upgrade zod from ^4.1.12 to ^4.3.6

### DIFF
--- a/turbo/apps/cli/package.json
+++ b/turbo/apps/cli/package.json
@@ -36,7 +36,7 @@
     "tar": "^7.5.2",
     "undici": "^6.23.0",
     "yaml": "^2.3.4",
-    "zod": "^4.1.12"
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@types/node": "^24.3.0",

--- a/turbo/apps/web/package.json
+++ b/turbo/apps/web/package.json
@@ -58,7 +58,7 @@
     "resend": "^6.9.2",
     "server-only": "^0.0.1",
     "svix": "^1.84.1",
-    "zod": "^4.1.12"
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.1.18",

--- a/turbo/packages/core/package.json
+++ b/turbo/packages/core/package.json
@@ -26,6 +26,6 @@
   "dependencies": {
     "@ts-rest/core": "3.53.0-rc.1",
     "yaml": "^2.8.1",
-    "zod": "^4.1.12"
+    "zod": "^4.3.6"
   }
 }

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -81,8 +81,8 @@ importers:
         specifier: ^2.3.4
         version: 2.8.1
       zod:
-        specifier: ^4.1.12
-        version: 4.1.12
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       '@types/node':
         specifier: ^24.3.0
@@ -352,7 +352,7 @@ importers:
         version: 7.13.0
       '@t3-oss/env-nextjs':
         specifier: ^0.13.8
-        version: 0.13.8(typescript@5.9.3)(zod@4.1.12)
+        version: 0.13.8(typescript@5.9.3)(zod@4.3.6)
       '@tabler/icons-react':
         specifier: ^3.36.1
         version: 3.36.1(react@19.2.1)
@@ -435,8 +435,8 @@ importers:
         specifier: ^1.84.1
         version: 1.84.1
       zod:
-        specifier: ^4.1.12
-        version: 4.1.12
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       '@tailwindcss/postcss':
         specifier: ^4.1.18
@@ -517,8 +517,8 @@ importers:
         specifier: ^2.8.1
         version: 2.8.1
       zod:
-        specifier: ^4.1.12
-        version: 4.1.12
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       '@vm0/eslint-config':
         specifier: workspace:*
@@ -9161,9 +9161,6 @@ packages:
     resolution: {integrity: sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==}
     engines: {node: '>= 14'}
 
-  zod@4.1.12:
-    resolution: {integrity: sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ==}
-
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
 
@@ -13068,17 +13065,17 @@ snapshots:
     dependencies:
       defer-to-connect: 2.0.1
 
-  '@t3-oss/env-core@0.13.8(typescript@5.9.3)(zod@4.1.12)':
+  '@t3-oss/env-core@0.13.8(typescript@5.9.3)(zod@4.3.6)':
     optionalDependencies:
       typescript: 5.9.3
-      zod: 4.1.12
+      zod: 4.3.6
 
-  '@t3-oss/env-nextjs@0.13.8(typescript@5.9.3)(zod@4.1.12)':
+  '@t3-oss/env-nextjs@0.13.8(typescript@5.9.3)(zod@4.3.6)':
     dependencies:
-      '@t3-oss/env-core': 0.13.8(typescript@5.9.3)(zod@4.1.12)
+      '@t3-oss/env-core': 0.13.8(typescript@5.9.3)(zod@4.3.6)
     optionalDependencies:
       typescript: 5.9.3
-      zod: 4.1.12
+      zod: 4.3.6
 
   '@tabler/icons-react@3.36.1(react@19.2.1)':
     dependencies:
@@ -13729,7 +13726,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.3.0)(@vitest/ui@4.0.18)(happy-dom@20.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(msw@2.12.7(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.20.5)(yaml@2.8.1)
+      vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.3.0)(@vitest/ui@4.0.18)(happy-dom@20.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(msw@2.12.7(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.20.6)(yaml@2.8.1)
 
   '@vitest/utils@4.0.18':
     dependencies:
@@ -16157,7 +16154,7 @@ snapshots:
       smol-toml: 1.5.2
       strip-json-comments: 5.0.2
       typescript: 5.9.3
-      zod: 4.1.12
+      zod: 4.3.6
 
   langium@3.3.1:
     dependencies:
@@ -18937,8 +18934,6 @@ snapshots:
       archiver-utils: 5.0.2
       compress-commons: 6.0.2
       readable-stream: 4.7.0
-
-  zod@4.1.12: {}
 
   zod@4.3.6: {}
 


### PR DESCRIPTION
## Summary

- Unify zod to a single version (`4.3.6`) across all workspaces (`@vm0/cli`, `web`, `@vm0/core`)
- Removes dual-version conflict — previously both `4.1.12` and `4.3.6` were installed side-by-side
- Fixes TS2322 type errors in `@vm0/core` contracts: in zod `4.1.12`, `$ZodObjectInternals` does not extend `$ZodTypeInternals`, making `ZodObject` unassignable to `z.ZodSchema`. This is fixed in `4.3.6`

## Test plan

- [x] `pnpm check-types --filter=@vm0/core --force` — no errors
- [x] `pnpm check-types --force` (all packages) — 8/8 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)