### PR TITLE
feat: hardcode memory name convention in slack, telegram, and email handlers

### DIFF
--- a/turbo/apps/web/src/lib/email/handlers/inbound-trigger.ts
+++ b/turbo/apps/web/src/lib/email/handlers/inbound-trigger.ts
@@ -273,6 +273,7 @@ export async function handleInboundEmailTrigger(
     composeId: compose.composeId,
     agentName: triggerAddress.agent,
     artifactName: "artifact",
+    memoryName: "memory",
     callbacks,
   });
 

--- a/turbo/apps/web/src/lib/slack/handlers/__tests__/run-agent.test.ts
+++ b/turbo/apps/web/src/lib/slack/handlers/__tests__/run-agent.test.ts
@@ -16,7 +16,7 @@ describe("runAgentForSlack", () => {
     context.setupMocks();
   });
 
-  it("should pass artifactName 'artifact' to createRun", async () => {
+  it("should pass artifactName and memoryName conventions to createRun", async () => {
     // Given a user with an agent compose (created via API so it has a version)
     const userId = uniqueId("test-user");
     mockClerk({ userId });
@@ -58,6 +58,7 @@ describe("runAgentForSlack", () => {
     expect(createRunSpy).toHaveBeenCalledTimes(1);
     expect(createRunSpy.mock.calls[0]![0]).toMatchObject({
       artifactName: "artifact",
+      memoryName: "memory",
     });
   });
 });

--- a/turbo/apps/web/src/lib/slack/handlers/run-agent.ts
+++ b/turbo/apps/web/src/lib/slack/handlers/run-agent.ts
@@ -113,6 +113,7 @@ export async function runAgentForSlack(
       sessionId,
       agentName,
       artifactName: "artifact",
+      memoryName: "memory",
       callbacks: [
         {
           url: callbackUrl,

--- a/turbo/apps/web/src/lib/telegram/handlers/__tests__/run-agent.test.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/__tests__/run-agent.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { testContext, uniqueId } from "../../../../__tests__/test-helpers";
+import {
+  createTestCompose,
+  createTestScope,
+} from "../../../../__tests__/api-test-helpers";
+import { mockClerk } from "../../../../__tests__/clerk-mock";
+import * as runModule from "../../../run";
+import { runAgentForTelegram } from "../run-agent";
+import type { TelegramCallbackContext } from "../run-agent";
+
+const context = testContext();
+
+describe("runAgentForTelegram", () => {
+  beforeEach(() => {
+    context.setupMocks();
+  });
+
+  it("should pass artifactName and memoryName conventions to createRun", async () => {
+    // Given a user with an agent compose (created via API so it has a version)
+    const userId = uniqueId("test-user");
+    mockClerk({ userId });
+    await createTestScope(uniqueId("scope"));
+    const { composeId } = await createTestCompose("test-agent");
+
+    // And createRun is spied on to capture the call without executing
+    const createRunSpy = vi.spyOn(runModule, "createRun").mockResolvedValue({
+      runId: "mock-run-id",
+      status: "running",
+      createdAt: new Date(),
+    });
+
+    const callbackContext: TelegramCallbackContext = {
+      installationId: uniqueId("install"),
+      chatId: uniqueId("chat"),
+      messageId: uniqueId("msg"),
+      rootMessageId: null,
+      userLinkId: uniqueId("link"),
+      agentName: "test-agent",
+      composeId,
+      existingSessionId: null,
+      isDM: true,
+      thinkingMessageId: null,
+    };
+
+    // When runAgentForTelegram is called
+    const result = await runAgentForTelegram({
+      composeId,
+      agentName: "test-agent",
+      sessionId: undefined,
+      prompt: "help me",
+      threadContext: "",
+      userId,
+      callbackContext,
+    });
+
+    // Then the run should be dispatched
+    expect(result.status).toBe("dispatched");
+
+    // And createRun should receive artifactName and memoryName
+    expect(createRunSpy).toHaveBeenCalledTimes(1);
+    expect(createRunSpy.mock.calls[0]![0]).toMatchObject({
+      artifactName: "artifact",
+      memoryName: "memory",
+    });
+  });
+});

--- a/turbo/apps/web/src/lib/telegram/handlers/run-agent.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/run-agent.ts
@@ -110,6 +110,7 @@ export async function runAgentForTelegram(
       sessionId,
       agentName,
       artifactName: "artifact",
+      memoryName: "memory",
       callbacks: [
         {
           url: callbackUrl,


### PR DESCRIPTION
## Summary

- Add `memoryName: "memory"` to `createRun()` calls in Slack, Telegram, and Email handlers
- Matches the existing `artifactName: "artifact"` hardcoded convention
- Enables memory for agent runs triggered from non-CLI entry points

## Changes

| File | Change |
|------|--------|
| `slack/handlers/run-agent.ts` | Add `memoryName: "memory"` |
| `telegram/handlers/run-agent.ts` | Add `memoryName: "memory"` |
| `email/handlers/inbound-trigger.ts` | Add `memoryName: "memory"` |
| `slack/handlers/__tests__/run-agent.test.ts` | Update assertion |

## Test plan

- [x] Slack handler test updated to verify `memoryName: "memory"` is passed
- [x] Pre-commit hooks pass (prettier, knip, commitlint)
- [ ] CI pipeline validates all checks

Closes #3896

🤖 Generated with [Claude Code](https://claude.com/claude-code)