### PR TITLE
fix(runner): use proper shell escaping in executor guest commands

### DIFF
--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -322,7 +322,7 @@ async fn copy_guest_logs(sandbox: &dyn Sandbox, context: &ExecutionContext, log_
     ];
 
     for (guest_path, host_path) in &files {
-        let cat_cmd = format!("cat {guest_path}");
+        let cat_cmd = format!("cat '{guest_path}'");
         let result = sandbox
             .exec(&ExecRequest {
                 cmd: &cat_cmd,
@@ -424,9 +424,21 @@ async fn restore_session(
         .trim_start_matches('/')
         .replace('/', "-");
     let session_dir = format!("/home/user/.claude/projects/-{project_name}");
+
+    // Validate session_id to prevent path traversal (only allow alnum, dash, underscore)
+    if !session
+        .session_id
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+    {
+        return Err(crate::error::RunnerError::Internal(format!(
+            "invalid session_id: {}",
+            session.session_id
+        )));
+    }
     let session_path = format!("{session_dir}/{}.jsonl", session.session_id);
 
-    let mkdir_cmd = format!("mkdir -p \"{session_dir}\"");
+    let mkdir_cmd = format!("mkdir -p '{}'", session_dir.replace('\'', "'\\''"));
     sandbox
         .exec(&ExecRequest {
             cmd: &mkdir_cmd,

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -426,11 +426,7 @@ async fn restore_session(
     let session_dir = format!("/home/user/.claude/projects/-{project_name}");
 
     // Validate session_id to prevent path traversal (only allow alnum, dash, underscore)
-    if !session
-        .session_id
-        .chars()
-        .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
-    {
+    if !is_valid_session_id(&session.session_id) {
         return Err(crate::error::RunnerError::Internal(format!(
             "invalid session_id: {}",
             session.session_id
@@ -456,6 +452,14 @@ async fn restore_session(
 
 /// Proxy CA certificate path inside the guest rootfs (pre-baked at build time).
 const VM_PROXY_CA_PATH: &str = "/usr/local/share/ca-certificates/vm0-proxy-ca.crt";
+
+/// Returns true if the session ID contains only safe characters (alphanumeric, dash, underscore).
+fn is_valid_session_id(id: &str) -> bool {
+    !id.is_empty()
+        && id
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+}
 
 /// Build the environment variables JSON, matching the TS `buildEnvironmentVariables`.
 fn build_env_json(context: &ExecutionContext, api_url: &str) -> HashMap<String, String> {
@@ -920,13 +924,16 @@ mod tests {
 
     #[test]
     fn session_id_validation_rejects_path_traversal() {
-        let invalid_ids = ["../../etc/passwd", "foo/bar", "a b", "id;rm -rf /", "a\nb"];
+        let invalid_ids = [
+            "../../etc/passwd",
+            "foo/bar",
+            "a b",
+            "id;rm -rf /",
+            "a\nb",
+            "",
+        ];
         for id in invalid_ids {
-            assert!(
-                !id.chars()
-                    .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_'),
-                "expected rejection for: {id:?}"
-            );
+            assert!(!is_valid_session_id(id), "expected rejection for: {id:?}");
         }
     }
 
@@ -939,11 +946,7 @@ mod tests {
             "01961d3a-c0ab-7891-a6d3-9b52cd28716c",
         ];
         for id in valid_ids {
-            assert!(
-                id.chars()
-                    .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_'),
-                "expected acceptance for: {id:?}"
-            );
+            assert!(is_valid_session_id(id), "expected acceptance for: {id:?}");
         }
     }
 }

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -917,4 +917,33 @@ mod tests {
         assert!(dmesg_indicates_oom("Killed process 99 (agent)"));
         assert!(dmesg_indicates_oom("OOM-kill: constraint=MEMCG"));
     }
+
+    #[test]
+    fn session_id_validation_rejects_path_traversal() {
+        let invalid_ids = ["../../etc/passwd", "foo/bar", "a b", "id;rm -rf /", "a\nb"];
+        for id in invalid_ids {
+            assert!(
+                !id.chars()
+                    .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_'),
+                "expected rejection for: {id:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn session_id_validation_accepts_valid_ids() {
+        let valid_ids = [
+            "abc-123",
+            "sess_456",
+            "a1b2c3",
+            "01961d3a-c0ab-7891-a6d3-9b52cd28716c",
+        ];
+        for id in valid_ids {
+            assert!(
+                id.chars()
+                    .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_'),
+                "expected acceptance for: {id:?}"
+            );
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- Quote `guest_path` in `cat` command for consistency with vsock-guest escaping conventions
- Validate `session_id` allows only `[a-zA-Z0-9_-]` to prevent path traversal
- Use single-quote escaping for `mkdir` to prevent `$()` / backtick shell expansion

Closes #3897

## Test plan
- [x] `cargo test -p runner` — 180 tests pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)