### PR TITLE
fix: use correct storage type in memory dedup path and propagate checkpoint errors

### DIFF
--- a/crates/guest-agent/src/artifact.rs
+++ b/crates/guest-agent/src/artifact.rs
@@ -131,7 +131,7 @@ pub async fn create_snapshot(
         );
         let commit_payload = json!({
             "storageName": storage_name,
-            "storageType": "artifact",
+            "storageType": storage_type,
             "versionId": version_id,
             "files": files,
             "runId": run_id,

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -209,12 +209,14 @@ async fn execute(
                 );
             }
             Err(e) => {
-                log_error!(LOG_TAG, "Checkpoint failed: {e}");
+                let msg = format!("Checkpoint failed: {e}");
+                log_error!(LOG_TAG, "{msg}");
                 log_info!(
                     LOG_TAG,
                     "✗ Checkpoint failed ({}s)",
                     cp_start.elapsed().as_secs()
                 );
+                let _ = std::fs::write(paths::checkpoint_error_file(), &msg);
                 exit_code = 1;
             }
         }

--- a/crates/guest-agent/src/paths.rs
+++ b/crates/guest-agent/src/paths.rs
@@ -31,6 +31,8 @@ pub fn session_history_path_file() -> &'static str {
 
 static EVENT_ERROR_FLAG: LazyLock<String> =
     LazyLock::new(|| format!("/tmp/vm0-event-error-{}", env::run_id()));
+static CHECKPOINT_ERROR_FILE: LazyLock<String> =
+    LazyLock::new(|| format!("/tmp/vm0-checkpoint-error-{}", env::run_id()));
 static SYSTEM_LOG_FILE: LazyLock<String> =
     LazyLock::new(|| format!("/tmp/vm0-system-{}.log", env::run_id()));
 static AGENT_LOG_FILE: LazyLock<String> =
@@ -40,6 +42,9 @@ static METRICS_LOG_FILE: LazyLock<String> =
 
 pub fn event_error_flag() -> &'static str {
     &EVENT_ERROR_FLAG
+}
+pub fn checkpoint_error_file() -> &'static str {
+    &CHECKPOINT_ERROR_FILE
 }
 pub fn system_log_file() -> &'static str {
     &SYSTEM_LOG_FILE

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -3,6 +3,7 @@ use std::time::{Duration, Instant};
 
 use sandbox::{ExecRequest, Sandbox, SandboxConfig, SandboxFactory};
 use tracing::{error, info, warn};
+use uuid::Uuid;
 
 /// Maximum wall-clock time for a single job (2 hours).
 const JOB_TIMEOUT: Duration = Duration::from_secs(7200);
@@ -288,12 +289,43 @@ async fn run_in_sandbox(
 
     let error_msg = if exit.exit_code != 0 {
         let stderr = String::from_utf8_lossy(&exit.stderr).to_string();
-        Some(stderr).filter(|s| !s.is_empty())
+        if !stderr.is_empty() {
+            Some(stderr)
+        } else {
+            // Stderr is empty (redirected to log file). Check for a structured
+            // error file written by the guest-agent (e.g. checkpoint failures).
+            read_guest_error_file(sandbox, context.run_id).await
+        }
     } else {
         None
     };
 
     Ok((exit.exit_code, error_msg))
+}
+
+/// Read a structured error file from the guest filesystem.
+///
+/// The guest-agent writes checkpoint errors to `/tmp/vm0-checkpoint-error-{run_id}`
+/// so the runner can surface them even though stdout/stderr are redirected to the
+/// system log file.
+async fn read_guest_error_file(sandbox: &dyn Sandbox, run_id: Uuid) -> Option<String> {
+    let error_path = format!("/tmp/vm0-checkpoint-error-{run_id}");
+    let cat_cmd = format!("cat {error_path} 2>/dev/null");
+    match sandbox
+        .exec(&ExecRequest {
+            cmd: &cat_cmd,
+            timeout: Duration::from_secs(5),
+            env: &[],
+            sudo: false,
+        })
+        .await
+    {
+        Ok(result) if result.exit_code == 0 && !result.stdout.is_empty() => {
+            let msg = String::from_utf8_lossy(&result.stdout).trim().to_string();
+            Some(msg).filter(|s| !s.is_empty())
+        }
+        _ => None,
+    }
 }
 
 /// Returns true if dmesg output indicates an OOM kill.

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -308,7 +308,12 @@ async fn run_in_sandbox(
 /// The guest-agent writes checkpoint errors to `/tmp/vm0-checkpoint-error-{run_id}`
 /// so the runner can surface them even though stdout/stderr are redirected to the
 /// system log file.
+///
+/// NOTE: This path must match the convention in `crates/guest-agent/src/paths.rs`
+/// (`checkpoint_error_file()`). The runner and guest-agent are separate binaries
+/// running in different processes, so the path is duplicated by design.
 async fn read_guest_error_file(sandbox: &dyn Sandbox, run_id: Uuid) -> Option<String> {
+    // Mirror of guest-agent paths::checkpoint_error_file()
     let error_path = format!("/tmp/vm0-checkpoint-error-{run_id}");
     let cat_cmd = format!("cat {error_path} 2>/dev/null");
     match sandbox

--- a/e2e/tests/02-parallel/t34-vm0-memory.bats
+++ b/e2e/tests/02-parallel/t34-vm0-memory.bats
@@ -136,3 +136,19 @@ teardown_file() {
     assert_output --partial "● Bash("
     assert_output --partial "memory-marker-t34"
 }
+
+@test "t34-5: fresh run with --memory reads previously written marker (dedup path)" {
+    # This triggers the dedup path: memory content is unchanged since t34-2,
+    # so the prepare endpoint returns existing=true and the commit must use
+    # the correct storageType ("memory", not "artifact").
+    echo "# Running fresh agent with --memory $MEMORY_NAME (dedup path)..."
+    run $CLI_COMMAND run "$AGENT_NAME" \
+        --memory "$MEMORY_NAME" \
+        "cat /home/user/.vm0/memory/marker.txt"
+
+    assert_success
+    assert_output --partial "● Bash("
+    assert_output --partial "memory-marker-t34"
+    assert_output --partial "◆ Claude Code Completed"
+    assert_output --partial "Checkpoint:"
+}

--- a/e2e/tests/03-experimental-runner/t34-vm0-memory.bats
+++ b/e2e/tests/03-experimental-runner/t34-vm0-memory.bats
@@ -136,3 +136,19 @@ teardown_file() {
     assert_output --partial "● Bash("
     assert_output --partial "memory-marker-t34"
 }
+
+@test "t34-5: fresh run with --memory reads previously written marker (dedup path)" {
+    # This triggers the dedup path: memory content is unchanged since t34-2,
+    # so the prepare endpoint returns existing=true and the commit must use
+    # the correct storageType ("memory", not "artifact").
+    echo "# Running fresh agent with --memory $MEMORY_NAME (dedup path)..."
+    run $CLI_COMMAND run "$AGENT_NAME" \
+        --memory "$MEMORY_NAME" \
+        "cat /home/user/.vm0/memory/marker.txt"
+
+    assert_success
+    assert_output --partial "● Bash("
+    assert_output --partial "memory-marker-t34"
+    assert_output --partial "◆ Claude Code Completed"
+    assert_output --partial "Checkpoint:"
+}

--- a/turbo/apps/platform/src/views/logs-page/log-detail/components/log-detail-content.tsx
+++ b/turbo/apps/platform/src/views/logs-page/log-detail/components/log-detail-content.tsx
@@ -148,7 +148,11 @@ export function LogDetailContent() {
         <div className="px-4 sm:px-8">
           <Alert variant="destructive">
             <AlertTriangle className="h-4 w-4" />
-            <AlertTitle>Missing required secrets</AlertTitle>
+            <AlertTitle>
+              {missingSecrets.length > 0
+                ? "Missing required secrets"
+                : "Run failed"}
+            </AlertTitle>
             <AlertDescription>
               {missingSecrets.length > 0 ? (
                 <div className="flex flex-wrap items-center gap-x-3 gap-y-2">


### PR DESCRIPTION
## Summary

- **Root cause fix**: `artifact.rs` hardcoded `"artifact"` as `storageType` in the dedup commit path — when memory content was unchanged across runs, the commit endpoint couldn't find the storage entry because it queries by `(scopeId, name, type)` and the type was wrong. Now uses the actual `storage_type` parameter.
- **Error propagation**: Guest-agent now writes checkpoint errors to `/tmp/vm0-checkpoint-error-{run_id}` so the runner can read them when stderr is empty (redirected to log file). This surfaces real error messages in the complete webhook instead of generic "Agent exited with code 1".
- **UI fix**: Log detail error banner now shows "Run failed" for non-secret errors instead of always showing "Missing required secrets".
- **E2E coverage**: Added `t34-5` test covering the memory dedup path — a fresh run with `--memory` reads a previously written marker file, exercising the prepare→existing→commit flow.

## Test plan

- [ ] CI passes (lint, type-check, clippy, cargo test)
- [ ] E2E `t34-vm0-memory` tests pass (parallel + runner suites)
- [ ] Manual: run agent with `--memory`, write file, run again with same `--memory` — second run succeeds and reads the file

🤖 Generated with [Claude Code](https://claude.com/claude-code)