### PR TITLE
chore: bump claude code cli to 2.1.71

### DIFF
--- a/crates/runner/scripts/rootfs.Dockerfile
+++ b/crates/runner/scripts/rootfs.Dockerfile
@@ -49,7 +49,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Install Claude Code CLI as a standalone Bun-compiled binary.
 # The binary bundles Bun runtime (JSC) + application code into a single executable,
 # eliminating module resolution overhead and reducing CLI cold-start time.
-ARG CLAUDE_CODE_VERSION=2.1.70
+ARG CLAUDE_CODE_VERSION=2.1.71
 RUN ARCH=$(dpkg --print-architecture) \
     && case "$ARCH" in amd64) PLATFORM="linux-x64" ;; arm64) PLATFORM="linux-arm64" ;; *) echo "Unsupported architecture: $ARCH" >&2; exit 1 ;; esac \
     && GCS_BUCKET="https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases" \

--- a/turbo/scripts/e2b/vm0-claude-code/template.ts
+++ b/turbo/scripts/e2b/vm0-claude-code/template.ts
@@ -12,7 +12,7 @@ import { Template } from "e2b";
 export const template = Template()
   .fromNodeImage("24")
   .aptInstall(["curl", "git", "ripgrep", "jq", "file", "tzdata"])
-  .npmInstall("@anthropic-ai/claude-code@2.1.70", { g: true })
+  .npmInstall("@anthropic-ai/claude-code@2.1.71", { g: true })
   // Install GitHub CLI
   // https://github.com/cli/cli/blob/trunk/docs/install_linux.md
   .runCmd(


### PR DESCRIPTION
## Summary
- Bump Claude Code CLI from 2.1.70 to 2.1.71 in rootfs Dockerfile and e2b template

## Changed files
- `crates/runner/scripts/rootfs.Dockerfile` — GCS binary version
- `turbo/scripts/e2b/vm0-claude-code/template.ts` — npm install version

🤖 Generated with [Claude Code](https://claude.com/claude-code)