### PR TITLE
perf: parallelize credential resolution queries

### DIFF
--- a/turbo/apps/web/src/lib/run/build-context.ts
+++ b/turbo/apps/web/src/lib/run/build-context.ts
@@ -762,12 +762,17 @@ async function resolveCredentialsAndEnvironment(
       fetchAndMergeVariables(scopeId, userId, vars),
     ]);
 
-  // Merge credentials from all sources (connector > model-provider > user)
-  const credentials: Record<string, string> = {
-    ...dbSecrets,
-    ...modelProviderResult.credentials,
-    ...connectorResult.credentials,
-  };
+  // Merge credentials from all sources (connector > model-provider > user).
+  // Return undefined when no source contributed credentials (preserves original behavior).
+  const hasCredentials =
+    dbSecrets || modelProviderResult.credentials || connectorResult.credentials;
+  const credentials: Record<string, string> | undefined = hasCredentials
+    ? {
+        ...dbSecrets,
+        ...modelProviderResult.credentials,
+        ...connectorResult.credentials,
+      }
+    : undefined;
 
   // Merge secrets: DB user secrets + CLI secrets (CLI takes priority)
   let secrets = mergeSecrets(dbSecrets, cliSecrets);

--- a/turbo/apps/web/src/lib/run/build-context.ts
+++ b/turbo/apps/web/src/lib/run/build-context.ts
@@ -182,10 +182,9 @@ async function resolveModelProviderCredential(
   userId: string,
   framework: string,
   hasExplicitModelProviderConfig: boolean,
-  existingCredentials: Record<string, string> | undefined,
   explicitModelProvider?: string,
 ): Promise<ModelProviderCredentialResult> {
-  let credentials = existingCredentials;
+  let credentials: Record<string, string> | undefined;
 
   // Skip if explicit model provider config exists or framework doesn't use model providers
   if (
@@ -403,9 +402,8 @@ interface ConnectorCredentialResult {
 async function resolveConnectorCredentials(
   scopeId: string,
   userId: string,
-  existingCredentials: Record<string, string> | undefined,
 ): Promise<ConnectorCredentialResult> {
-  let credentials = existingCredentials;
+  let credentials: Record<string, string> | undefined;
 
   // Query connected connectors directly (only need the type for environmentMapping)
   const userConnectors = await globalThis.services.db
@@ -747,57 +745,42 @@ async function resolveCredentialsAndEnvironment(
   );
   const framework = firstAgent?.framework || "claude-code";
 
-  // Run credential resolution chain and variable fetching in parallel
-  const [credentialChainResult, mergedVars] = await Promise.all([
-    (async () => {
-      // Fetch secrets/credentials referenced in environment
-      const dbSecrets = await fetchReferencedCredentials(
-        scopeId,
-        userId,
-        firstAgent?.environment,
-      );
-
-      // Merge DB secrets with CLI secrets (CLI takes priority)
-      let secrets = mergeSecrets(dbSecrets, cliSecrets);
-
-      // credentials is used for backwards compatibility with credentials.* syntax
-      let credentials: Record<string, string> | undefined = dbSecrets;
-
-      const modelProviderResult = await resolveModelProviderCredential(
+  // Run all credential resolution and variable fetching in parallel.
+  // The three resolve functions have independent DB queries (different secret types),
+  // so there is no data dependency between them.
+  const [dbSecrets, modelProviderResult, connectorResult, mergedVars] =
+    await Promise.all([
+      fetchReferencedCredentials(scopeId, userId, firstAgent?.environment),
+      resolveModelProviderCredential(
         scopeId,
         userId,
         framework,
         hasExplicitModelProviderConfig,
-        credentials,
         modelProvider,
-      );
-      credentials = modelProviderResult.credentials;
-      const modelProviderEnvVars = modelProviderResult.injectedEnvVars;
+      ),
+      resolveConnectorCredentials(scopeId, userId),
+      fetchAndMergeVariables(scopeId, userId, vars),
+    ]);
 
-      // Resolve connector credentials (GH_TOKEN, GITHUB_TOKEN, etc.)
-      const connectorResult = await resolveConnectorCredentials(
-        scopeId,
-        userId,
-        credentials,
-      );
-      credentials = connectorResult.credentials;
-      const connectorEnvVars = connectorResult.injectedEnvVars;
+  // Merge credentials from all sources (connector > model-provider > user)
+  const credentials: Record<string, string> = {
+    ...dbSecrets,
+    ...modelProviderResult.credentials,
+    ...connectorResult.credentials,
+  };
 
-      // Merge connector secrets into secrets pool for explicit ${{ secrets.* }} references only.
-      // Connector secrets only fill gaps — user/CLI secrets take precedence.
-      secrets = mergeConnectorSecretsForReferences(
-        firstAgent?.environment,
-        secrets,
-        connectorEnvVars,
-      );
+  // Merge secrets: DB user secrets + CLI secrets (CLI takes priority)
+  let secrets = mergeSecrets(dbSecrets, cliSecrets);
 
-      return { secrets, credentials, modelProviderEnvVars };
-    })(),
-    fetchAndMergeVariables(scopeId, userId, vars),
-  ]);
+  // Merge connector secrets into secrets pool for explicit ${{ secrets.* }} references only.
+  // Connector secrets only fill gaps — user/CLI secrets take precedence.
+  secrets = mergeConnectorSecretsForReferences(
+    firstAgent?.environment,
+    secrets,
+    connectorResult.injectedEnvVars,
+  );
 
-  const { secrets, credentials } = credentialChainResult;
-  const { modelProviderEnvVars } = credentialChainResult;
+  const modelProviderEnvVars = modelProviderResult.injectedEnvVars;
 
   // Expand environment variables from compose config
   const { environment: expandedEnvironment } = expandEnvironmentFromCompose(


### PR DESCRIPTION
## Summary

- Parallelize `fetchReferencedCredentials`, `resolveModelProviderCredential`, `resolveConnectorCredentials`, and `fetchAndMergeVariables` in a single `Promise.all`
- Remove false `existingCredentials` dependency between the three resolve functions (only used for accumulative merging, not query conditions)
- Merge credentials after all results arrive, preserving the same precedence order (connector > model-provider > user)

## Motivation

`api_build_resolve_credentials` takes ~1,285ms due to 5 serial DB queries across the three resolve functions. Each queries independent tables/types, so they can safely run concurrently.

**Expected improvement:** ~500ms reduction (from ~1,285ms to ~500-700ms).

## Test plan

- [ ] Existing `create-run` tests pass (CI)
- [ ] CLI E2E tests pass (CI)
- [ ] Monitor `api_build_resolve_credentials` timing in production after deploy

Closes #3922

Generated with [Claude Code](https://claude.com/claude-code)