### PR TITLE
perf(run): parallelize user email fetch with compose loading

### DIFF
--- a/turbo/apps/web/src/lib/agent/permission-service.ts
+++ b/turbo/apps/web/src/lib/agent/permission-service.ts
@@ -18,26 +18,24 @@ const log = logger("agent:permission");
 export async function canAccessCompose(
   userId: string,
   userEmail: string,
-  compose: { id: string; userId: string; scopeId: string | null },
+  compose: { id: string; userId: string; scopeId: string },
 ): Promise<boolean> {
   // 1. Owner always has access
   if (compose.userId === userId) return true;
 
   // 2. Check scope membership (members of the scope can access its agents)
-  if (compose.scopeId) {
-    const [member] = await globalThis.services.db
-      .select({ id: scopeMembers.id })
-      .from(scopeMembers)
-      .where(
-        and(
-          eq(scopeMembers.scopeId, compose.scopeId),
-          eq(scopeMembers.userId, userId),
-        ),
-      )
-      .limit(1);
+  const [member] = await globalThis.services.db
+    .select({ id: scopeMembers.id })
+    .from(scopeMembers)
+    .where(
+      and(
+        eq(scopeMembers.scopeId, compose.scopeId),
+        eq(scopeMembers.userId, userId),
+      ),
+    )
+    .limit(1);
 
-    if (member) return true;
-  }
+  if (member) return true;
 
   // 3. Check ACL
   const permissionResult = await globalThis.services.db

--- a/turbo/apps/web/src/lib/agent/permission-service.ts
+++ b/turbo/apps/web/src/lib/agent/permission-service.ts
@@ -18,24 +18,26 @@ const log = logger("agent:permission");
 export async function canAccessCompose(
   userId: string,
   userEmail: string,
-  compose: { id: string; userId: string; scopeId: string },
+  compose: { id: string; userId: string; scopeId: string | null },
 ): Promise<boolean> {
   // 1. Owner always has access
   if (compose.userId === userId) return true;
 
   // 2. Check scope membership (members of the scope can access its agents)
-  const [member] = await globalThis.services.db
-    .select({ id: scopeMembers.id })
-    .from(scopeMembers)
-    .where(
-      and(
-        eq(scopeMembers.scopeId, compose.scopeId),
-        eq(scopeMembers.userId, userId),
-      ),
-    )
-    .limit(1);
+  if (compose.scopeId) {
+    const [member] = await globalThis.services.db
+      .select({ id: scopeMembers.id })
+      .from(scopeMembers)
+      .where(
+        and(
+          eq(scopeMembers.scopeId, compose.scopeId),
+          eq(scopeMembers.userId, userId),
+        ),
+      )
+      .limit(1);
 
-  if (member) return true;
+    if (member) return true;
+  }
 
   // 3. Check ACL
   const permissionResult = await globalThis.services.db

--- a/turbo/apps/web/src/lib/run/run-service.ts
+++ b/turbo/apps/web/src/lib/run/run-service.ts
@@ -345,7 +345,7 @@ async function loadCompose(
   callerComposeId?: string,
 ): Promise<{
   composeContent: AgentComposeYaml;
-  compose: { id: string; userId: string; scopeId: string | null };
+  compose: { id: string; userId: string; scopeId: string };
 }> {
   const [version] = await globalThis.services.db
     .select({
@@ -387,7 +387,7 @@ async function loadCompose(
 async function authorizeCompose(
   userId: string,
   userEmail: string,
-  compose: { id: string; userId: string; scopeId: string | null },
+  compose: { id: string; userId: string; scopeId: string },
 ): Promise<void> {
   const hasAccess = await canAccessCompose(userId, userEmail, compose);
   if (!hasAccess) {

--- a/turbo/apps/web/src/lib/run/run-service.ts
+++ b/turbo/apps/web/src/lib/run/run-service.ts
@@ -340,9 +340,7 @@ export interface CreateRunResult {
  * @throws NotFoundError - version or compose not found
  * @throws ForbiddenError - user cannot access compose
  */
-async function loadAndAuthorizeCompose(
-  userId: string,
-  userEmail: string,
+async function loadCompose(
   agentComposeVersionId: string,
   callerComposeId?: string,
 ): Promise<{
@@ -383,12 +381,18 @@ async function loadAndAuthorizeCompose(
     throw notFound("Agent compose not found");
   }
 
+  return { composeContent, compose };
+}
+
+async function authorizeCompose(
+  userId: string,
+  userEmail: string,
+  compose: { id: string; userId: string; scopeId: string | null },
+): Promise<void> {
   const hasAccess = await canAccessCompose(userId, userEmail, compose);
   if (!hasAccess) {
     throw forbidden("You do not have permission to access this agent");
   }
-
-  return { composeContent, compose };
 }
 
 /**
@@ -643,16 +647,12 @@ export async function createRun(
   const apiStartTime = Date.now();
   const { userId, agentComposeVersionId, prompt } = params;
 
-  // Fetch user email once, reused for authorization and dispatch routing
-  const userEmail = await getUserEmail(userId);
-
-  // Steps 1-2: Load compose version/metadata and verify access
-  const { composeContent } = await loadAndAuthorizeCompose(
-    userId,
-    userEmail,
-    agentComposeVersionId,
-    params.composeId,
-  );
+  // Steps 1-2: Load compose and fetch user email in parallel, then authorize
+  const [{ composeContent, compose }, userEmail] = await Promise.all([
+    loadCompose(agentComposeVersionId, params.composeId),
+    getUserEmail(userId),
+  ]);
+  await authorizeCompose(userId, userEmail, compose);
   const authorizeTime = Date.now();
 
   // Step 3: Validate template vars and image access (for new runs only)
@@ -785,16 +785,13 @@ export async function executeQueuedRun(
 
   log.debug(`Executing queued run ${runId} for user ${userId}`);
 
-  // Fetch user email once, reused for authorization and dispatch routing
-  const userEmail = await getUserEmail(userId);
-
-  // Steps 2-3: Load compose version/metadata and verify access
-  const { composeContent } = await loadAndAuthorizeCompose(
-    userId,
-    userEmail,
-    agentComposeVersionId,
-    params.composeId,
-  );
+  // Steps 2-3: Load compose and fetch user email in parallel, then authorize
+  const [{ composeContent, compose: queuedCompose }, userEmail] =
+    await Promise.all([
+      loadCompose(agentComposeVersionId, params.composeId),
+      getUserEmail(userId),
+    ]);
+  await authorizeCompose(userId, userEmail, queuedCompose);
   const authorizeTime = Date.now();
 
   // Step 4: Validate template vars and image access (for new runs only)

--- a/turbo/apps/web/src/lib/run/run-service.ts
+++ b/turbo/apps/web/src/lib/run/run-service.ts
@@ -334,11 +334,10 @@ export interface CreateRunResult {
 }
 
 /**
- * Load compose version and compose metadata, then verify access.
+ * Load compose version and compose metadata.
  *
  * @returns composeContent and compose record
  * @throws NotFoundError - version or compose not found
- * @throws ForbiddenError - user cannot access compose
  */
 async function loadCompose(
   agentComposeVersionId: string,


### PR DESCRIPTION
## Summary

- Split `loadAndAuthorizeCompose` into `loadCompose` + `authorizeCompose`
- Run `getUserEmail` (Clerk HTTP ~100ms) in parallel with compose DB queries (~200ms) via `Promise.all`
- Fix `canAccessCompose` to accept nullable `scopeId` and skip scope membership check when null

Expected savings: ~100ms on `api_step_authorize` (from ~330ms to ~230ms).

Closes #3925

## Test plan

- [ ] Type check passes
- [ ] Knip clean
- [ ] Existing create-run tests pass in CI
- [ ] Observe `api_step_authorize` timing reduction in Axiom

🤖 Generated with [Claude Code](https://claude.com/claude-code)