### PR TITLE
fix(storage): unify memory storage auto-creation with artifact pattern

### DIFF
--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -575,14 +575,6 @@ fn build_env_json(context: &ExecutionContext, api_url: &str) -> HashMap<String, 
             "VM0_MEMORY_VERSION_ID".into(),
             memory.vas_version_id.clone(),
         );
-    } else if let Some(name) = &context.memory_name {
-        // First run: memory doesn't exist yet, but we still need env vars for upload
-        env.insert("VM0_MEMORY_DRIVER".into(), "vas".into());
-        env.insert(
-            "VM0_MEMORY_MOUNT_PATH".into(),
-            "/home/user/.vm0/memory".into(),
-        );
-        env.insert("VM0_MEMORY_NAME".into(), name.clone());
     }
 
     // Resume session ID
@@ -646,7 +638,6 @@ mod tests {
             checkpoint_id: None,
             sandbox_token: "tok".into(),
             working_dir: "/workspace".into(),
-            memory_name: None,
             storage_manifest: None,
             environment: None,
             resume_session: None,

--- a/crates/runner/src/provider/local.rs
+++ b/crates/runner/src/provider/local.rs
@@ -146,7 +146,6 @@ impl JobProvider for LocalProvider {
             checkpoint_id: None,
             sandbox_token: String::new(),
             working_dir: req.working_dir,
-            memory_name: None,
             storage_manifest: None,
             environment: req.environment,
             resume_session: None,

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -61,8 +61,6 @@ pub struct ExecutionContext {
     pub api_start_time: Option<f64>,
     #[serde(default)]
     pub user_timezone: Option<String>,
-    #[serde(default)]
-    pub memory_name: Option<String>,
 }
 
 /// Firewall and proxy configuration attached to each execution.

--- a/turbo/apps/web/src/lib/run/__tests__/create-run.test.ts
+++ b/turbo/apps/web/src/lib/run/__tests__/create-run.test.ts
@@ -313,6 +313,41 @@ describe("createRun()", () => {
   });
 
   describe("Memory", () => {
+    it("should auto-create memory storage on first run", async () => {
+      const memoryName = uniqueId("new-mem");
+      const result = await createRun(baseParams({ memoryName }));
+
+      expect(result.runId).toBeDefined();
+      expect(result.status).toBe("running");
+
+      // Verify sandbox was called with full memory env vars including VERSION_ID
+      const createCall = vi.mocked(Sandbox.create).mock.calls[0];
+      expect(createCall).toBeDefined();
+      const sandboxOptions = createCall![1] as {
+        envs?: Record<string, string>;
+      };
+      expect(sandboxOptions.envs?.VM0_MEMORY_NAME).toBe(memoryName);
+      expect(sandboxOptions.envs?.VM0_MEMORY_VERSION_ID).toBeDefined();
+      expect(sandboxOptions.envs?.VM0_MEMORY_DRIVER).toBe("vas");
+    });
+
+    it("should succeed when memory already exists (idempotent)", async () => {
+      // Allow concurrent runs for this test
+      vi.stubEnv("CONCURRENT_RUN_LIMIT", "0");
+      reloadEnv();
+
+      const memoryName = uniqueId("existing-mem");
+      // First run creates the memory
+      await createRun(baseParams({ memoryName }));
+
+      // Second run should also succeed (idempotent)
+      const result = await createRun(
+        baseParams({ memoryName, prompt: "second run" }),
+      );
+      expect(result.runId).toBeDefined();
+      expect(result.status).toBe("running");
+    });
+
     it("should accept memoryName and dispatch successfully", async () => {
       const result = await createRun(baseParams({ memoryName: "my-memory" }));
 

--- a/turbo/apps/web/src/lib/run/context/execution-preparer.ts
+++ b/turbo/apps/web/src/lib/run/context/execution-preparer.ts
@@ -8,7 +8,7 @@ import type { ExecutionContext } from "../types";
 import type { PreparedContext } from "../executors/types";
 import {
   prepareStorageManifest,
-  ensureArtifactExists,
+  ensureStorageExists,
 } from "../../storage/storage-service";
 import type { StorageManifest } from "../../storage/types";
 import { badRequest } from "../../errors";
@@ -173,7 +173,7 @@ function resolveRunnerGroup(agentCompose: unknown): string | null {
  */
 interface PrepareTimings {
   resolveScopes: number;
-  ensureArtifact: number;
+  ensureStorage: number;
   storageManifest: number;
 }
 
@@ -227,17 +227,29 @@ export async function prepareForExecution(
     throw badRequest("Agent compose not found");
   }
 
-  // Auto-create artifact if it doesn't exist yet
-  const artifactStart = Date.now();
-  if (context.artifactName) {
-    await ensureArtifactExists(
-      runnerScope.id,
-      userId,
-      context.artifactName,
-      runnerScope.slug,
-    );
-  }
-  const artifactEnd = Date.now();
+  // Auto-create artifact and memory storages if they don't exist yet
+  const ensureStart = Date.now();
+  await Promise.all([
+    context.artifactName
+      ? ensureStorageExists(
+          runnerScope.id,
+          userId,
+          context.artifactName,
+          runnerScope.slug,
+          "artifact",
+        )
+      : null,
+    context.memoryName
+      ? ensureStorageExists(
+          runnerScope.id,
+          userId,
+          context.memoryName,
+          runnerScope.slug,
+          "memory",
+        )
+      : null,
+  ]);
+  const ensureEnd = Date.now();
 
   // Prepare storage manifest with dual scopes
   // - Volumes: resolved from agent owner's scope
@@ -274,12 +286,12 @@ export async function prepareForExecution(
 
   const timings: PrepareTimings = {
     resolveScopes: scopeEnd - scopeStart,
-    ensureArtifact: artifactEnd - artifactStart,
+    ensureStorage: ensureEnd - ensureStart,
     storageManifest: storageEnd - storageStart,
   };
 
   log.debug(
-    `PreparedContext built for run ${context.runId} (scopes=${timings.resolveScopes}ms, artifact=${timings.ensureArtifact}ms, storage=${timings.storageManifest}ms)`,
+    `PreparedContext built for run ${context.runId} (scopes=${timings.resolveScopes}ms, ensure=${timings.ensureStorage}ms, storage=${timings.storageManifest}ms)`,
   );
 
   return { context: preparedContext, timings };

--- a/turbo/apps/web/src/lib/run/executors/docker-executor.ts
+++ b/turbo/apps/web/src/lib/run/executors/docker-executor.ts
@@ -6,7 +6,6 @@ import { env } from "../../../env";
 import type { SandboxLike } from "../../docker/docker-sandbox";
 import type { AgentComposeYaml } from "../../../types/agent-compose";
 import {
-  DEFAULT_MEMORY_MOUNT_PATH,
   type PreparedArtifact,
   type StorageManifest,
 } from "../../storage/types";
@@ -283,11 +282,6 @@ async function buildSandboxEnvVars(
     sandboxEnvVars.VM0_MEMORY_MOUNT_PATH = memory.mountPath;
     sandboxEnvVars.VM0_MEMORY_NAME = memory.vasStorageName;
     sandboxEnvVars.VM0_MEMORY_VERSION_ID = memory.vasVersionId;
-  } else if (context.memoryName) {
-    // First run: memory doesn't exist yet, but we still need env vars for upload
-    sandboxEnvVars.VM0_MEMORY_DRIVER = "vas";
-    sandboxEnvVars.VM0_MEMORY_MOUNT_PATH = DEFAULT_MEMORY_MOUNT_PATH;
-    sandboxEnvVars.VM0_MEMORY_NAME = context.memoryName;
   }
 
   // Inject user timezone as TZ environment variable (if not already set in environment)

--- a/turbo/apps/web/src/lib/run/executors/e2b-executor.ts
+++ b/turbo/apps/web/src/lib/run/executors/e2b-executor.ts
@@ -5,7 +5,6 @@ import { badRequest } from "../../errors";
 import { resolveSystemImageToE2b } from "@vm0/core";
 import type { AgentComposeYaml } from "../../../types/agent-compose";
 import {
-  DEFAULT_MEMORY_MOUNT_PATH,
   type PreparedArtifact,
   type StorageManifest,
 } from "../../storage/types";
@@ -272,11 +271,6 @@ function addStorageEnvVars(
     envVars.VM0_MEMORY_MOUNT_PATH = memory.mountPath;
     envVars.VM0_MEMORY_NAME = memory.vasStorageName;
     envVars.VM0_MEMORY_VERSION_ID = memory.vasVersionId;
-  } else if (context.memoryName) {
-    // First run: memory doesn't exist yet, but we still need env vars for upload
-    envVars.VM0_MEMORY_DRIVER = "vas";
-    envVars.VM0_MEMORY_MOUNT_PATH = DEFAULT_MEMORY_MOUNT_PATH;
-    envVars.VM0_MEMORY_NAME = context.memoryName;
   }
 }
 

--- a/turbo/apps/web/src/lib/run/run-service.ts
+++ b/turbo/apps/web/src/lib/run/run-service.ts
@@ -590,8 +590,8 @@ async function buildAndDispatchRun(opts: {
         ms: prepareResult.timings.resolveScopes,
       },
       {
-        op: "api_prepare_ensure_artifact",
-        ms: prepareResult.timings.ensureArtifact,
+        op: "api_prepare_ensure_storage",
+        ms: prepareResult.timings.ensureStorage,
       },
       {
         op: "api_prepare_storage_manifest",

--- a/turbo/apps/web/src/lib/slack/handlers/shared.ts
+++ b/turbo/apps/web/src/lib/slack/handlers/shared.ts
@@ -15,7 +15,7 @@ import {
   generateDefaultScopeSlug,
 } from "../../scope/scope-service";
 import { validateAgentSession } from "../../run";
-import { ensureArtifactExists } from "../../storage/storage-service";
+import { ensureStorageExists } from "../../storage/storage-service";
 import { logger } from "../../logger";
 
 const log = logger("slack:shared");
@@ -229,7 +229,13 @@ export async function ensureScopeAndArtifact(vm0UserId: string): Promise<void> {
   // Preserve original Slack behavior: log but don't throw on artifact creation failure.
   // Slack callers (server actions, OAuth callback) don't have error handling for this.
   try {
-    await ensureArtifactExists(scope.id, vm0UserId, "artifact", scope.slug);
+    await ensureStorageExists(
+      scope.id,
+      vm0UserId,
+      "artifact",
+      scope.slug,
+      "artifact",
+    );
   } catch (err) {
     log.error("Failed to ensure artifact exists for Slack user", {
       userId: vm0UserId,

--- a/turbo/apps/web/src/lib/storage/storage-service.ts
+++ b/turbo/apps/web/src/lib/storage/storage-service.ts
@@ -1,3 +1,4 @@
+import { gzipSync } from "node:zlib";
 import { resolveVolumes } from "./storage-resolver";
 import { generatePresignedUrl, putS3Object } from "../s3/s3-client";
 import { logger } from "../logger";
@@ -17,22 +18,30 @@ import { computeContentHashFromHashes } from "./content-hash";
 
 const log = logger("storage");
 
+/** Create a minimal valid empty tar.gz (two 512-byte null end-of-archive blocks, gzipped) */
+function createEmptyTarGz(): Buffer {
+  return gzipSync(Buffer.alloc(1024, 0));
+}
+
 /**
- * Ensure an artifact storage exists with at least one version.
+ * Ensure a storage exists with at least one version.
  * If the storage record doesn't exist, creates it.
- * If it exists but has no HEAD version, creates an empty initial version.
+ * If it exists but has no HEAD version, creates an empty initial version
+ * (both manifest.json and archive.tar.gz so download.ts can create the mount directory).
  * If it already has a HEAD version, this is a no-op.
  *
  * @param scopeId - Scope ID for storage access
  * @param userId - User ID for storage record ownership
- * @param artifactName - Artifact storage name
+ * @param storageName - Storage name
  * @param scopeSlug - Scope slug for S3 prefix construction
+ * @param storageType - Storage type ("artifact" or "memory")
  */
-export async function ensureArtifactExists(
+export async function ensureStorageExists(
   scopeId: string,
   userId: string,
-  artifactName: string,
+  storageName: string,
   scopeSlug: string,
+  storageType: "artifact" | "memory",
 ): Promise<void> {
   // Find or create storage record
   let [storage] = await globalThis.services.db
@@ -41,8 +50,8 @@ export async function ensureArtifactExists(
     .where(
       and(
         eq(storages.scopeId, scopeId),
-        eq(storages.name, artifactName),
-        eq(storages.type, "artifact"),
+        eq(storages.name, storageName),
+        eq(storages.type, storageType),
       ),
     )
     .limit(1);
@@ -52,10 +61,10 @@ export async function ensureArtifactExists(
       .insert(storages)
       .values({
         scopeId,
-        name: artifactName,
-        type: "artifact",
+        name: storageName,
+        type: storageType,
         userId,
-        s3Prefix: `${scopeSlug}/artifact/${artifactName}`,
+        s3Prefix: `${scopeSlug}/${storageType}/${storageName}`,
         size: 0,
         fileCount: 0,
       })
@@ -70,8 +79,8 @@ export async function ensureArtifactExists(
         .where(
           and(
             eq(storages.scopeId, scopeId),
-            eq(storages.name, artifactName),
-            eq(storages.type, "artifact"),
+            eq(storages.name, storageName),
+            eq(storages.type, storageType),
           ),
         )
         .limit(1);
@@ -79,12 +88,12 @@ export async function ensureArtifactExists(
     } else {
       storage = newStorage;
     }
-    log.info("Auto-created artifact storage", { artifactName, scopeId });
+    log.info("Auto-created storage", { storageName, storageType, scopeId });
   }
 
   if (!storage) {
     throw new Error(
-      `Failed to create or fetch artifact storage "${artifactName}"`,
+      `Failed to create or fetch ${storageType} storage "${storageName}"`,
     );
   }
 
@@ -97,14 +106,23 @@ export async function ensureArtifactExists(
     const versionId = computeContentHashFromHashes(storageId, []);
     const s3Key = `${storage.s3Prefix}/${versionId}`;
     const manifestKey = `${s3Key}/manifest.json`;
+    const archiveKey = `${s3Key}/archive.tar.gz`;
     const bucketName = env().R2_USER_STORAGES_BUCKET_NAME;
 
-    await putS3Object(
-      bucketName,
-      manifestKey,
-      JSON.stringify({ files: [] }),
-      "application/json",
-    );
+    await Promise.all([
+      putS3Object(
+        bucketName,
+        manifestKey,
+        JSON.stringify({ files: [] }),
+        "application/json",
+      ),
+      putS3Object(
+        bucketName,
+        archiveKey,
+        createEmptyTarGz(),
+        "application/gzip",
+      ),
+    ]);
 
     await globalThis.services.db.transaction(async (tx) => {
       await tx
@@ -115,7 +133,7 @@ export async function ensureArtifactExists(
           s3Key,
           size: 0,
           fileCount: 0,
-          message: "Initial empty artifact (auto-created)",
+          message: `Initial empty ${storageType} (auto-created)`,
           createdBy: "user",
         })
         .onConflictDoNothing();
@@ -131,12 +149,17 @@ export async function ensureArtifactExists(
         .where(eq(storages.id, storageId));
     });
 
-    log.info("Auto-created initial artifact version", {
-      artifactName,
+    log.info("Auto-created initial storage version", {
+      storageName,
+      storageType,
       versionId,
     });
   } catch (err) {
-    log.error("Failed to create initial artifact version", { err });
+    log.error("Failed to create initial storage version", {
+      storageName,
+      storageType,
+      err,
+    });
     // Clean up the headless storage so the next call can retry
     await globalThis.services.db
       .delete(storages)
@@ -383,37 +406,29 @@ export async function prepareStorageManifest(
       })()
     : Promise.resolve(null);
 
-  // Resolve memory artifact (uses runner's scope, same as artifact)
+  // Resolve memory (uses runner's scope, same as artifact)
+  // Memory storage is guaranteed to exist after ensureStorageExists() in prepareForExecution()
   const memoryPromise = memoryName
     ? (async (): Promise<ManifestArtifact | null> => {
-        try {
-          const { versionId, s3Key } = await resolveVersion(
-            artifactScopeId,
-            memoryName,
-            "memory",
-            "latest",
-          );
+        const { versionId, s3Key } = await resolveVersion(
+          artifactScopeId,
+          memoryName,
+          "memory",
+          "latest",
+        );
 
-          const archiveKey = `${s3Key}/archive.tar.gz`;
-          const archiveUrl = await generatePresignedUrl(bucketName, archiveKey);
+        const archiveKey = `${s3Key}/archive.tar.gz`;
+        const archiveUrl = await generatePresignedUrl(bucketName, archiveKey);
 
-          const memoryArtifact: ManifestArtifact = {
-            mountPath: DEFAULT_MEMORY_MOUNT_PATH,
-            vasStorageName: memoryName,
-            vasVersionId: versionId,
-            archiveUrl,
-          };
+        const memoryArtifact: ManifestArtifact = {
+          mountPath: DEFAULT_MEMORY_MOUNT_PATH,
+          vasStorageName: memoryName,
+          vasVersionId: versionId,
+          archiveUrl,
+        };
 
-          log.debug(`Generated archive URL for memory "${memoryName}"`);
-          return memoryArtifact;
-        } catch (error) {
-          // First run: memory storage doesn't exist yet, gracefully return null
-          if (error instanceof Error && error.message.includes("not found")) {
-            log.debug(`Memory "${memoryName}" not found (first run), skipping`);
-            return null;
-          }
-          throw error;
-        }
+        log.debug(`Generated archive URL for memory "${memoryName}"`);
+        return memoryArtifact;
       })()
     : Promise.resolve(null);
 

--- a/turbo/apps/web/src/lib/telegram/handlers/shared.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/shared.ts
@@ -10,7 +10,7 @@ import {
   generateDefaultScopeSlug,
 } from "../../scope/scope-service";
 import { validateAgentSession } from "../../run";
-import { ensureArtifactExists } from "../../storage/storage-service";
+import { ensureStorageExists } from "../../storage/storage-service";
 import {
   sendMessage,
   type TelegramClient,
@@ -226,7 +226,13 @@ export async function ensureScopeAndArtifact(vm0UserId: string): Promise<void> {
     log.info("Auto-created scope for Telegram user", { userId: vm0UserId });
   }
 
-  await ensureArtifactExists(scope.id, vm0UserId, "artifact", scope.slug);
+  await ensureStorageExists(
+    scope.id,
+    vm0UserId,
+    "artifact",
+    scope.slug,
+    "artifact",
+  );
 }
 
 /**


### PR DESCRIPTION
## Summary

- Generalize `ensureArtifactExists()` into `ensureStorageExists()` that works for both artifact and memory types
- Memory storage is now auto-created before run starts (same as artifact), ensuring the mount path exists on first run so Claude Code auto-memory symlink works correctly
- Create empty `archive.tar.gz` alongside `manifest.json` in initial storage version so the download chain works consistently

## Changes

**Core: `storage-service.ts`**
- Rename `ensureArtifactExists` → `ensureStorageExists` with `storageType` parameter (`"artifact" | "memory"`)
- Add `createEmptyTarGz()` helper to create valid empty tar.gz (two 512-byte null end-of-archive blocks, gzipped)
- Upload both `manifest.json` and `archive.tar.gz` in initial version creation
- Simplify memory resolution in `prepareStorageManifest` (remove try/catch fallback — storage is guaranteed to exist)

**Callers updated:**
- `execution-preparer.ts` — parallel `ensureStorageExists` for both artifact and memory
- `slack/handlers/shared.ts` — updated import and call signature
- `telegram/handlers/shared.ts` — updated import and call signature

**Executor fallback removal:**
- `e2b-executor.ts` — remove first-run memory fallback branch
- `docker-executor.ts` — remove first-run memory fallback branch
- `runner/executor.rs` — remove first-run memory fallback branch
- `runner/types.rs` — remove unused `memory_name` field from `ExecutionContext`

## Test plan

- [x] New test: "should auto-create memory storage on first run" — verifies memory env vars are set
- [x] New test: "should succeed when memory already exists (idempotent)" — verifies second run works
- [x] All 32 existing tests pass (1 pre-existing failure on main unrelated to this PR)
- [ ] Manual: verify first-run memory storage creates mount path and symlink works

Closes #3942

🤖 Generated with [Claude Code](https://claude.com/claude-code)