### PR TITLE
fix: use upsert for storage prepare to prevent race condition

### DIFF
--- a/turbo/apps/web/app/api/storages/prepare/route.ts
+++ b/turbo/apps/web/app/api/storages/prepare/route.ts
@@ -133,36 +133,23 @@ const router = tsr.router(storagesPrepareContract, {
       }
     }
 
-    // Find or create storage
-    let [storage] = await globalThis.services.db
-      .select()
-      .from(storages)
-      .where(
-        and(
-          eq(storages.scopeId, userScope.id),
-          eq(storages.name, storageName),
-          eq(storages.type, storageType),
-        ),
-      )
-      .limit(1);
-
-    if (!storage) {
-      // Create new storage if it doesn't exist
-      const [newStorage] = await globalThis.services.db
-        .insert(storages)
-        .values({
-          userId,
-          scopeId: userScope.id,
-          name: storageName,
-          type: storageType,
-          s3Prefix: `${userScope.slug}/${storageType}/${storageName}`,
-          size: 0,
-          fileCount: 0,
-        })
-        .returning();
-      storage = newStorage;
-      log.debug(`Created new storage: ${storage?.id}`);
-    }
+    // Find or create storage (upsert to handle concurrent requests)
+    const [storage] = await globalThis.services.db
+      .insert(storages)
+      .values({
+        userId,
+        scopeId: userScope.id,
+        name: storageName,
+        type: storageType,
+        s3Prefix: `${userScope.slug}/${storageType}/${storageName}`,
+        size: 0,
+        fileCount: 0,
+      })
+      .onConflictDoUpdate({
+        target: [storages.scopeId, storages.name, storages.type],
+        set: { updatedAt: new Date() },
+      })
+      .returning();
 
     if (!storage) {
       return {
@@ -175,6 +162,8 @@ const router = tsr.router(storagesPrepareContract, {
         },
       };
     }
+
+    log.debug(`Storage ready: ${storage.id}`);
 
     // Handle incremental upload - merge files with base version
     let mergedFiles = files;

--- a/turbo/apps/web/app/api/storages/prepare/route.ts
+++ b/turbo/apps/web/app/api/storages/prepare/route.ts
@@ -7,7 +7,7 @@ import { storagesPrepareContract } from "@vm0/core";
 import { initServices } from "../../../../src/lib/init-services";
 import { agentRuns } from "../../../../src/db/schema/agent-run";
 import { storages, storageVersions } from "../../../../src/db/schema/storage";
-import { eq, and, sql } from "drizzle-orm";
+import { eq, and } from "drizzle-orm";
 import { getUserId } from "../../../../src/lib/auth/get-user-id";
 import { resolveScope } from "../../../../src/lib/scope/resolve-scope";
 import {
@@ -147,7 +147,7 @@ const router = tsr.router(storagesPrepareContract, {
       })
       .onConflictDoUpdate({
         target: [storages.scopeId, storages.name, storages.type],
-        set: { updatedAt: sql`now()` },
+        set: { updatedAt: new Date() },
       })
       .returning();
 

--- a/turbo/apps/web/app/api/storages/prepare/route.ts
+++ b/turbo/apps/web/app/api/storages/prepare/route.ts
@@ -7,7 +7,7 @@ import { storagesPrepareContract } from "@vm0/core";
 import { initServices } from "../../../../src/lib/init-services";
 import { agentRuns } from "../../../../src/db/schema/agent-run";
 import { storages, storageVersions } from "../../../../src/db/schema/storage";
-import { eq, and } from "drizzle-orm";
+import { eq, and, sql } from "drizzle-orm";
 import { getUserId } from "../../../../src/lib/auth/get-user-id";
 import { resolveScope } from "../../../../src/lib/scope/resolve-scope";
 import {
@@ -147,7 +147,7 @@ const router = tsr.router(storagesPrepareContract, {
       })
       .onConflictDoUpdate({
         target: [storages.scopeId, storages.name, storages.type],
-        set: { updatedAt: new Date() },
+        set: { updatedAt: sql`now()` },
       })
       .returning();
 

--- a/turbo/apps/web/app/api/webhooks/agent/storages/prepare/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/storages/prepare/route.ts
@@ -88,36 +88,23 @@ const router = tsr.router(webhookStoragesPrepareContract, {
       };
     }
 
-    // Find or create storage
-    let [storage] = await globalThis.services.db
-      .select()
-      .from(storages)
-      .where(
-        and(
-          eq(storages.scopeId, userScope.id),
-          eq(storages.name, storageName),
-          eq(storages.type, storageType),
-        ),
-      )
-      .limit(1);
-
-    if (!storage) {
-      // Create new storage if it doesn't exist
-      const [newStorage] = await globalThis.services.db
-        .insert(storages)
-        .values({
-          userId,
-          scopeId: userScope.id,
-          name: storageName,
-          type: storageType,
-          s3Prefix: `${userScope.slug}/${storageType}/${storageName}`,
-          size: 0,
-          fileCount: 0,
-        })
-        .returning();
-      storage = newStorage;
-      log.debug(`Created new storage: ${storage?.id}`);
-    }
+    // Find or create storage (upsert to handle concurrent requests)
+    const [storage] = await globalThis.services.db
+      .insert(storages)
+      .values({
+        userId,
+        scopeId: userScope.id,
+        name: storageName,
+        type: storageType,
+        s3Prefix: `${userScope.slug}/${storageType}/${storageName}`,
+        size: 0,
+        fileCount: 0,
+      })
+      .onConflictDoUpdate({
+        target: [storages.scopeId, storages.name, storages.type],
+        set: { updatedAt: new Date() },
+      })
+      .returning();
 
     if (!storage) {
       return {
@@ -130,6 +117,8 @@ const router = tsr.router(webhookStoragesPrepareContract, {
         },
       };
     }
+
+    log.debug(`Storage ready: ${storage.id}`);
 
     // Handle incremental upload - merge files with base version
     let mergedFiles = files;

--- a/turbo/apps/web/app/api/webhooks/agent/storages/prepare/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/storages/prepare/route.ts
@@ -10,7 +10,7 @@ import {
   storages,
   storageVersions,
 } from "../../../../../../src/db/schema/storage";
-import { eq, and, sql } from "drizzle-orm";
+import { eq, and } from "drizzle-orm";
 import { getSandboxAuthForRun } from "../../../../../../src/lib/auth/get-sandbox-auth";
 import { getUserScopeByClerkId } from "../../../../../../src/lib/scope/scope-service";
 import {
@@ -102,7 +102,7 @@ const router = tsr.router(webhookStoragesPrepareContract, {
       })
       .onConflictDoUpdate({
         target: [storages.scopeId, storages.name, storages.type],
-        set: { updatedAt: sql`now()` },
+        set: { updatedAt: new Date() },
       })
       .returning();
 

--- a/turbo/apps/web/app/api/webhooks/agent/storages/prepare/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/storages/prepare/route.ts
@@ -10,7 +10,7 @@ import {
   storages,
   storageVersions,
 } from "../../../../../../src/db/schema/storage";
-import { eq, and } from "drizzle-orm";
+import { eq, and, sql } from "drizzle-orm";
 import { getSandboxAuthForRun } from "../../../../../../src/lib/auth/get-sandbox-auth";
 import { getUserScopeByClerkId } from "../../../../../../src/lib/scope/scope-service";
 import {
@@ -102,7 +102,7 @@ const router = tsr.router(webhookStoragesPrepareContract, {
       })
       .onConflictDoUpdate({
         target: [storages.scopeId, storages.name, storages.type],
-        set: { updatedAt: new Date() },
+        set: { updatedAt: sql`now()` },
       })
       .returning();
 


### PR DESCRIPTION
## Summary

- Replace find-then-create pattern with `INSERT ... ON CONFLICT DO UPDATE` (upsert) in both `/api/storages/prepare` and `/api/webhooks/agent/storages/prepare`
- Fixes race condition where concurrent requests with the same `(scope_id, name, type)` both pass the SELECT check, then the second INSERT fails with `duplicate key value violates unique constraint "idx_storages_scope_name_type"`

Closes #3945

## Test plan

- [x] Existing storage prepare tests pass (10 tests)
- [x] Existing webhook storage prepare tests pass (4 tests)
- [ ] CI E2E parallel tests no longer flake on storage duplicate key

🤖 Generated with [Claude Code](https://claude.com/claude-code)