### PR TITLE
feat(slack): support file attachments and inject user info into prompts

### DIFF
--- a/turbo/apps/web/app/api/slack/events/route.ts
+++ b/turbo/apps/web/app/api/slack/events/route.ts
@@ -11,6 +11,7 @@ import {
   handleAppHomeOpened,
   handleMessagesTabOpened,
 } from "../../../../src/lib/slack/handlers/app-home-opened";
+import type { SlackFile } from "../../../../src/lib/slack/context";
 import { logger } from "../../../../src/lib/logger";
 
 const log = logger("slack:events");
@@ -36,23 +37,6 @@ interface SlackUrlVerificationEvent {
   token: string;
 }
 
-interface SlackEventFile {
-  id?: string;
-  name?: string;
-  title?: string;
-  mimetype?: string;
-  filetype?: string;
-  pretty_type?: string;
-  size?: number;
-  original_w?: string;
-  original_h?: string;
-  thumb_360?: string;
-  thumb_480?: string;
-  permalink?: string;
-  permalink_public?: string;
-  url_private_download?: string;
-}
-
 interface SlackAppMentionEvent {
   type: "app_mention";
   user: string;
@@ -61,7 +45,7 @@ interface SlackAppMentionEvent {
   channel: string;
   event_ts: string;
   thread_ts?: string;
-  files?: SlackEventFile[];
+  files?: SlackFile[];
 }
 
 interface SlackDirectMessageEvent {
@@ -75,7 +59,7 @@ interface SlackDirectMessageEvent {
   thread_ts?: string;
   subtype?: string;
   bot_id?: string;
-  files?: SlackEventFile[];
+  files?: SlackFile[];
 }
 
 interface SlackAppHomeOpenedEvent {

--- a/turbo/apps/web/app/api/slack/events/route.ts
+++ b/turbo/apps/web/app/api/slack/events/route.ts
@@ -36,6 +36,23 @@ interface SlackUrlVerificationEvent {
   token: string;
 }
 
+interface SlackEventFile {
+  id?: string;
+  name?: string;
+  title?: string;
+  mimetype?: string;
+  filetype?: string;
+  pretty_type?: string;
+  size?: number;
+  original_w?: string;
+  original_h?: string;
+  thumb_360?: string;
+  thumb_480?: string;
+  permalink?: string;
+  permalink_public?: string;
+  url_private_download?: string;
+}
+
 interface SlackAppMentionEvent {
   type: "app_mention";
   user: string;
@@ -44,6 +61,7 @@ interface SlackAppMentionEvent {
   channel: string;
   event_ts: string;
   thread_ts?: string;
+  files?: SlackEventFile[];
 }
 
 interface SlackDirectMessageEvent {
@@ -57,6 +75,7 @@ interface SlackDirectMessageEvent {
   thread_ts?: string;
   subtype?: string;
   bot_id?: string;
+  files?: SlackEventFile[];
 }
 
 interface SlackAppHomeOpenedEvent {
@@ -155,6 +174,7 @@ export async function POST(request: Request) {
           messageText: event.text,
           messageTs: event.ts,
           threadTs: event.thread_ts,
+          files: event.files,
         }).catch((error) => {
           log.error("Error handling app_mention", { error });
         }),
@@ -176,6 +196,7 @@ export async function POST(request: Request) {
           channelId: event.channel,
           userId: event.user,
           messageText: event.text,
+          files: event.files,
           messageTs: event.ts,
           threadTs: event.thread_ts,
         }).catch((error) => {

--- a/turbo/apps/web/src/lib/slack/__tests__/client.test.ts
+++ b/turbo/apps/web/src/lib/slack/__tests__/client.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi } from "vitest";
+import type { WebClient } from "@slack/web-api";
+import { fetchSlackUserInfo } from "../client";
+
+function createMockClient(
+  usersInfoResponse: Record<string, unknown>,
+): WebClient {
+  return {
+    users: {
+      info: vi.fn().mockResolvedValue(usersInfoResponse),
+    },
+  } as unknown as WebClient;
+}
+
+describe("Feature: Fetch Slack User Info", () => {
+  it("should return formatted user info with display name and timezone", async () => {
+    const client = createMockClient({
+      ok: true,
+      user: {
+        id: "U123",
+        name: "jdoe",
+        real_name: "Jane Doe",
+        profile: {
+          display_name: "Jane",
+          real_name: "Jane Doe",
+        },
+        tz: "America/Los_Angeles",
+        tz_label: "Pacific Standard Time",
+      },
+    });
+
+    const result = await fetchSlackUserInfo(client, "U123");
+
+    expect(result).toContain("Slack User ID: U123");
+    expect(result).toContain("Name: Jane");
+    expect(result).toContain("Timezone: Pacific Standard Time");
+  });
+
+  it("should fall back to real_name when display_name is empty", async () => {
+    const client = createMockClient({
+      ok: true,
+      user: {
+        id: "U456",
+        real_name: "Bob Smith",
+        profile: {
+          display_name: "",
+          real_name: "Bob Smith",
+        },
+        tz: "UTC",
+      },
+    });
+
+    const result = await fetchSlackUserInfo(client, "U456");
+
+    expect(result).toContain("Name: Bob Smith");
+    expect(result).toContain("Timezone: UTC");
+  });
+
+  it("should return undefined when API returns ok: false", async () => {
+    const client = createMockClient({
+      ok: false,
+      error: "user_not_found",
+    });
+
+    const result = await fetchSlackUserInfo(client, "U999");
+
+    expect(result).toBeUndefined();
+  });
+
+  it("should return undefined when user is missing", async () => {
+    const client = createMockClient({
+      ok: true,
+      user: undefined,
+    });
+
+    const result = await fetchSlackUserInfo(client, "U999");
+
+    expect(result).toBeUndefined();
+  });
+
+  it("should omit name when no name fields are available", async () => {
+    const client = createMockClient({
+      ok: true,
+      user: {
+        id: "U789",
+        profile: {},
+      },
+    });
+
+    const result = await fetchSlackUserInfo(client, "U789");
+
+    expect(result).toBe("Slack User ID: U789");
+    expect(result).not.toContain("Name:");
+  });
+});

--- a/turbo/apps/web/src/lib/slack/__tests__/context.test.ts
+++ b/turbo/apps/web/src/lib/slack/__tests__/context.test.ts
@@ -3,6 +3,7 @@ import { HttpResponse } from "msw";
 import {
   formatContextForAgent,
   formatContextForAgentWithImages,
+  formatCurrentMessageFiles,
   extractMessageContent,
   extractTextFromBlocks,
 } from "../context";
@@ -1435,5 +1436,64 @@ describe("Feature: Extract Text From Rich Text Blocks", () => {
 
       expect(result).toContain("Plain text message");
     });
+  });
+});
+
+describe("Feature: Format Current Message Files", () => {
+  beforeEach(() => {
+    context.setupMocks();
+  });
+
+  it("should format multiple files with image upload", async () => {
+    const pngMagic = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
+    const imageBuffer = Buffer.concat([pngMagic, Buffer.from("fake-content")]);
+
+    const downloadHandler = http.get(
+      "https://files.slack.com/files-pri/T123-F001/download/photo.png",
+      () => {
+        return new HttpResponse(imageBuffer, {
+          headers: { "content-type": "image/png" },
+        });
+      },
+    );
+    server.use(downloadHandler.handler);
+
+    const files = [
+      {
+        id: "F001",
+        name: "photo.png",
+        mimetype: "image/png",
+        url_private_download:
+          "https://files.slack.com/files-pri/T123-F001/download/photo.png",
+      },
+      {
+        id: "F002",
+        name: "readme.txt",
+        mimetype: "text/plain",
+        permalink: "https://slack.com/files/readme.txt",
+      },
+    ];
+
+    const result = await formatCurrentMessageFiles(
+      files,
+      "xoxb-test-token",
+      "test-session-456",
+    );
+
+    expect(result).toContain("[file]: photo.png (image/png)");
+    expect(result).toContain("[file]: readme.txt (text/plain)");
+    expect(result).toContain("View: curl");
+    expect(result).toContain("URL: https://slack.com/files/readme.txt");
+    expect(context.mocks.s3.uploadS3Buffer).toHaveBeenCalledTimes(1);
+  });
+
+  it("should return empty string for empty files array", async () => {
+    const result = await formatCurrentMessageFiles(
+      [],
+      "xoxb-test-token",
+      "test-session-456",
+    );
+
+    expect(result).toBe("");
   });
 });

--- a/turbo/apps/web/src/lib/slack/__tests__/context.test.ts
+++ b/turbo/apps/web/src/lib/slack/__tests__/context.test.ts
@@ -243,7 +243,9 @@ describe("Feature: Format Context For Agent", () => {
       expect(result).toContain("Check this article");
       expect(result).toContain("[image]: Article Preview");
       expect(result).toContain("Dimensions: 800x600");
-      expect(result).toContain("URL: https://example.com/preview.jpg");
+      expect(result).toContain(
+        'View: curl -sS -o /tmp/attachment_image.jpg "https://example.com/preview.jpg"',
+      );
     });
 
     it("should use fallback for attachment title", () => {
@@ -264,7 +266,9 @@ describe("Feature: Format Context For Agent", () => {
       const result = formatContextForAgent(messages);
 
       expect(result).toContain("[image]: Preview image");
-      expect(result).toContain("URL: https://example.com/thumb.jpg");
+      expect(result).toContain(
+        'View: curl -sS -o /tmp/attachment_image.jpg "https://example.com/thumb.jpg"',
+      );
     });
 
     it("should skip attachments without images", () => {
@@ -487,7 +491,9 @@ describe("Feature: Format Context With Image Upload", () => {
       expect(context.mocks.s3.generatePresignedUrl).toHaveBeenCalled();
       expect(result).toContain("[file]: screenshot.png (image/png)");
       expect(result).toContain("Dimensions: 1920x1080");
-      expect(result).toContain("Image URL: https://mock-presigned-url");
+      expect(result).toContain(
+        'View: curl -sS -o /tmp/F123.png "https://mock-presigned-url"',
+      );
       expect(result).toContain("- SENDER_ID: U123");
       expect(result).toContain("- MSG_ID: 1234567890.001");
     });
@@ -533,7 +539,9 @@ describe("Feature: Format Context With Image Upload", () => {
         "test-session-123",
       );
 
-      expect(result).toContain("Image URL: https://mock-presigned-url");
+      expect(result).toContain(
+        'View: curl -sS -o /tmp/F456.png "https://mock-presigned-url"',
+      );
       expect(context.mocks.s3.uploadS3Buffer).toHaveBeenCalledWith(
         "test-bucket",
         expect.stringContaining("slack-images/test-session-123/"),
@@ -850,7 +858,7 @@ describe("Feature: Format Context With Image Upload", () => {
       expect(result).toContain("[file]: img1.png");
       expect(result).toContain("[file]: img2.png");
       // Both should have presigned URLs
-      expect((result.match(/Image URL:/g) || []).length).toBe(2);
+      expect((result.match(/View: curl/g) || []).length).toBe(2);
     });
   });
 

--- a/turbo/apps/web/src/lib/slack/blocks.ts
+++ b/turbo/apps/web/src/lib/slack/blocks.ts
@@ -494,13 +494,14 @@ export function buildAgentResponseMessage(
   }
 
   // Add logs link at the end if provided
+  // Emoji must be outside the link — Slack mobile doesn't render emoji inside <url|text>
   if (logsUrl) {
     blocks.push({
       type: "context",
       elements: [
         {
           type: "mrkdwn",
-          text: `<${logsUrl}|:clipboard: View logs>`,
+          text: `:clipboard: <${logsUrl}|View logs>`,
         },
       ],
     });

--- a/turbo/apps/web/src/lib/slack/client.ts
+++ b/turbo/apps/web/src/lib/slack/client.ts
@@ -113,6 +113,33 @@ export async function updateModal(
 }
 
 /**
+ * Fetch basic Slack user info (display name, real name, timezone)
+ *
+ * @param client - Slack WebClient
+ * @param userId - Slack user ID
+ * @returns User info string for prompt context, or undefined if lookup fails
+ */
+export async function fetchSlackUserInfo(
+  client: WebClient,
+  userId: string,
+): Promise<string | undefined> {
+  const result = await client.users.info({ user: userId });
+  if (!result.ok || !result.user) return undefined;
+
+  const u = result.user;
+  const displayName =
+    u.profile?.display_name || u.profile?.real_name || u.real_name || u.name;
+  const tz = u.tz_label || u.tz;
+
+  const parts: string[] = [];
+  parts.push(`Slack User ID: ${userId}`);
+  if (displayName) parts.push(`Name: ${displayName}`);
+  if (tz) parts.push(`Timezone: ${tz}`);
+
+  return parts.join("\n");
+}
+
+/**
  * Exchange OAuth code for access token
  *
  * @param clientId - Slack app client ID

--- a/turbo/apps/web/src/lib/slack/context.ts
+++ b/turbo/apps/web/src/lib/slack/context.ts
@@ -623,14 +623,6 @@ export async function formatContextForAgentWithImages(
 }
 
 /**
- * Extract the actual message content from a Slack @mention
- * Removes the bot mention from the beginning of the message
- *
- * @param text - Raw message text
- * @param botUserId - Bot user ID
- * @returns Message without the mention
- */
-/**
  * Format files attached to the current message for inclusion in the prompt.
  * Uploads supported images to R2 and returns formatted file descriptions.
  */
@@ -647,6 +639,14 @@ export async function formatCurrentMessageFiles(
   return parts.join("\n");
 }
 
+/**
+ * Extract the actual message content from a Slack @mention
+ * Removes the bot mention from the beginning of the message
+ *
+ * @param text - Raw message text
+ * @param botUserId - Bot user ID
+ * @returns Message without the mention
+ */
 export function extractMessageContent(text: string, botUserId: string): string {
   // Slack mentions look like: <@U12345678> message
   const mentionPattern = new RegExp(`^<@${botUserId}>\\s*`, "i");

--- a/turbo/apps/web/src/lib/slack/context.ts
+++ b/turbo/apps/web/src/lib/slack/context.ts
@@ -17,7 +17,7 @@ const SUPPORTED_IMAGE_TYPES = [
   "image/webp",
 ];
 
-interface SlackFile {
+export interface SlackFile {
   id?: string;
   name?: string;
   title?: string;
@@ -410,9 +410,9 @@ async function formatFileInfoWithImage(
       sessionId,
     );
     if (presignedUrl) {
-      parts.push(`   Image URL: ${presignedUrl}`);
+      const filename = `${file.id || "image"}.${file.filetype || "png"}`;
       parts.push(
-        `   To view this image, download it with: curl -sS -o /tmp/${file.id || "image"}.${file.filetype || "png"} "${presignedUrl}" && read the downloaded file`,
+        `   View: curl -sS -o /tmp/${filename} "${presignedUrl}" && read /tmp/${filename}`,
       );
       return parts.join("\n");
     }
@@ -448,9 +448,8 @@ function formatAttachmentImage(attachment: SlackAttachment): string | null {
 
   const url = attachment.image_url || attachment.thumb_url;
   if (url) {
-    parts.push(`   URL: ${url}`);
     parts.push(
-      `   To view this image, download it with: curl -sS -o /tmp/attachment_image.jpg "${url}" && read the downloaded file`,
+      `   View: curl -sS -o /tmp/attachment_image.jpg "${url}" && read /tmp/attachment_image.jpg`,
     );
   }
 
@@ -631,6 +630,23 @@ export async function formatContextForAgentWithImages(
  * @param botUserId - Bot user ID
  * @returns Message without the mention
  */
+/**
+ * Format files attached to the current message for inclusion in the prompt.
+ * Uploads supported images to R2 and returns formatted file descriptions.
+ */
+export async function formatCurrentMessageFiles(
+  files: SlackFile[],
+  botToken: string,
+  sessionId: string,
+): Promise<string> {
+  const parts: string[] = [];
+  for (const file of files) {
+    const fileInfo = await formatFileInfoWithImage(file, botToken, sessionId);
+    parts.push(fileInfo);
+  }
+  return parts.join("\n");
+}
+
 export function extractMessageContent(text: string, botUserId: string): string {
   // Slack mentions look like: <@U12345678> message
   const mentionPattern = new RegExp(`^<@${botUserId}>\\s*`, "i");

--- a/turbo/apps/web/src/lib/slack/handlers/direct-message.ts
+++ b/turbo/apps/web/src/lib/slack/handlers/direct-message.ts
@@ -133,7 +133,13 @@ export async function handleDirectMessage(
 
   // Prepend Slack user info to the prompt
   const userInfo = await fetchSlackUserInfo(client, context.userId).catch(
-    () => undefined,
+    (err) => {
+      log.warn("Failed to fetch Slack user info", {
+        userId: context.userId,
+        error: err,
+      });
+      return undefined;
+    },
   );
   if (userInfo) {
     messageContent = `[Slack User]\n${userInfo}\n\n${messageContent}`;

--- a/turbo/apps/web/src/lib/slack/handlers/direct-message.ts
+++ b/turbo/apps/web/src/lib/slack/handlers/direct-message.ts
@@ -3,8 +3,14 @@ import { slackInstallations } from "../../../db/schema/slack-installation";
 import { slackUserLinks } from "../../../db/schema/slack-user-link";
 import { decryptCredentialValue } from "../../crypto/secrets-encryption";
 import { env } from "../../../env";
-import { createSlackClient, postMessage, setThreadStatus } from "../client";
+import {
+  createSlackClient,
+  fetchSlackUserInfo,
+  postMessage,
+  setThreadStatus,
+} from "../client";
 import { buildLoginPromptMessage } from "../blocks";
+import { formatCurrentMessageFiles, type SlackFile } from "../context";
 import { runAgentForSlack } from "./run-agent";
 import {
   fetchConversationContexts,
@@ -24,6 +30,7 @@ interface DirectMessageContext {
   messageText: string;
   messageTs: string;
   threadTs?: string;
+  files?: SlackFile[];
 }
 
 /**
@@ -111,7 +118,26 @@ export async function handleDirectMessage(
   await setThreadStatus(client, context.channelId, threadTs, "is thinking...");
 
   // Use message text directly (no mention prefix to strip in DMs)
-  const messageContent = context.messageText;
+  let messageContent = context.messageText;
+
+  // Include files attached to the current message in the prompt
+  if (context.files && context.files.length > 0) {
+    const imageSessionId = `${context.channelId}-${threadTs}`;
+    const filesText = await formatCurrentMessageFiles(
+      context.files,
+      botToken,
+      imageSessionId,
+    );
+    messageContent = `${messageContent}\n\n${filesText}`;
+  }
+
+  // Prepend Slack user info to the prompt
+  const userInfo = await fetchSlackUserInfo(client, context.userId).catch(
+    () => undefined,
+  );
+  if (userInfo) {
+    messageContent = `[Slack User]\n${userInfo}\n\n${messageContent}`;
+  }
 
   // 6. Look up existing thread session for deduplication
   let existingSessionId: string | undefined;

--- a/turbo/apps/web/src/lib/slack/handlers/direct-message.ts
+++ b/turbo/apps/web/src/lib/slack/handlers/direct-message.ts
@@ -3,16 +3,12 @@ import { slackInstallations } from "../../../db/schema/slack-installation";
 import { slackUserLinks } from "../../../db/schema/slack-user-link";
 import { decryptCredentialValue } from "../../crypto/secrets-encryption";
 import { env } from "../../../env";
-import {
-  createSlackClient,
-  fetchSlackUserInfo,
-  postMessage,
-  setThreadStatus,
-} from "../client";
+import { createSlackClient, postMessage, setThreadStatus } from "../client";
 import { buildLoginPromptMessage } from "../blocks";
-import { formatCurrentMessageFiles, type SlackFile } from "../context";
+import type { SlackFile } from "../context";
 import { runAgentForSlack } from "./run-agent";
 import {
+  enrichMessageContent,
   fetchConversationContexts,
   lookupThreadSession,
   buildLoginUrl,
@@ -118,32 +114,15 @@ export async function handleDirectMessage(
   await setThreadStatus(client, context.channelId, threadTs, "is thinking...");
 
   // Use message text directly (no mention prefix to strip in DMs)
-  let messageContent = context.messageText;
-
-  // Include files attached to the current message in the prompt
-  if (context.files && context.files.length > 0) {
-    const imageSessionId = `${context.channelId}-${threadTs}`;
-    const filesText = await formatCurrentMessageFiles(
-      context.files,
-      botToken,
-      imageSessionId,
-    );
-    messageContent = `${messageContent}\n\n${filesText}`;
-  }
-
-  // Prepend Slack user info to the prompt
-  const userInfo = await fetchSlackUserInfo(client, context.userId).catch(
-    (err) => {
-      log.warn("Failed to fetch Slack user info", {
-        userId: context.userId,
-        error: err,
-      });
-      return undefined;
-    },
-  );
-  if (userInfo) {
-    messageContent = `[Slack User]\n${userInfo}\n\n${messageContent}`;
-  }
+  const messageContent = await enrichMessageContent({
+    messageContent: context.messageText,
+    files: context.files,
+    botToken,
+    channelId: context.channelId,
+    threadTs,
+    client,
+    userId: context.userId,
+  });
 
   // 6. Look up existing thread session for deduplication
   let existingSessionId: string | undefined;

--- a/turbo/apps/web/src/lib/slack/handlers/mention.ts
+++ b/turbo/apps/web/src/lib/slack/handlers/mention.ts
@@ -142,7 +142,13 @@ export async function handleAppMention(context: MentionContext): Promise<void> {
 
   // Prepend Slack user info to the prompt
   const userInfo = await fetchSlackUserInfo(client, context.userId).catch(
-    () => undefined,
+    (err) => {
+      log.warn("Failed to fetch Slack user info", {
+        userId: context.userId,
+        error: err,
+      });
+      return undefined;
+    },
   );
   if (userInfo) {
     messageContent = `[Slack User]\n${userInfo}\n\n${messageContent}`;

--- a/turbo/apps/web/src/lib/slack/handlers/mention.ts
+++ b/turbo/apps/web/src/lib/slack/handlers/mention.ts
@@ -3,9 +3,18 @@ import { slackInstallations } from "../../../db/schema/slack-installation";
 import { slackUserLinks } from "../../../db/schema/slack-user-link";
 import { decryptCredentialValue } from "../../crypto/secrets-encryption";
 import { env } from "../../../env";
-import { createSlackClient, postMessage, setThreadStatus } from "../client";
+import {
+  createSlackClient,
+  fetchSlackUserInfo,
+  postMessage,
+  setThreadStatus,
+} from "../client";
 import { buildLoginPromptMessage } from "../blocks";
-import { extractMessageContent } from "../context";
+import {
+  extractMessageContent,
+  formatCurrentMessageFiles,
+  type SlackFile,
+} from "../context";
 import { runAgentForSlack } from "./run-agent";
 import {
   fetchConversationContexts,
@@ -25,6 +34,7 @@ interface MentionContext {
   messageText: string;
   messageTs: string;
   threadTs?: string;
+  files?: SlackFile[];
 }
 
 /**
@@ -117,7 +127,26 @@ export async function handleAppMention(context: MentionContext): Promise<void> {
   await setThreadStatus(client, context.channelId, threadTs, "is thinking...");
 
   // Extract message content (remove bot mention)
-  const messageContent = extractMessageContent(context.messageText, botUserId);
+  let messageContent = extractMessageContent(context.messageText, botUserId);
+
+  // Include files attached to the current message in the prompt
+  if (context.files && context.files.length > 0) {
+    const imageSessionId = `${context.channelId}-${threadTs}`;
+    const filesText = await formatCurrentMessageFiles(
+      context.files,
+      botToken,
+      imageSessionId,
+    );
+    messageContent = `${messageContent}\n\n${filesText}`;
+  }
+
+  // Prepend Slack user info to the prompt
+  const userInfo = await fetchSlackUserInfo(client, context.userId).catch(
+    () => undefined,
+  );
+  if (userInfo) {
+    messageContent = `[Slack User]\n${userInfo}\n\n${messageContent}`;
+  }
 
   // 6. Look up existing thread session for deduplication
   let existingSessionId: string | undefined;

--- a/turbo/apps/web/src/lib/slack/handlers/mention.ts
+++ b/turbo/apps/web/src/lib/slack/handlers/mention.ts
@@ -3,20 +3,12 @@ import { slackInstallations } from "../../../db/schema/slack-installation";
 import { slackUserLinks } from "../../../db/schema/slack-user-link";
 import { decryptCredentialValue } from "../../crypto/secrets-encryption";
 import { env } from "../../../env";
-import {
-  createSlackClient,
-  fetchSlackUserInfo,
-  postMessage,
-  setThreadStatus,
-} from "../client";
+import { createSlackClient, postMessage, setThreadStatus } from "../client";
 import { buildLoginPromptMessage } from "../blocks";
-import {
-  extractMessageContent,
-  formatCurrentMessageFiles,
-  type SlackFile,
-} from "../context";
+import { extractMessageContent, type SlackFile } from "../context";
 import { runAgentForSlack } from "./run-agent";
 import {
+  enrichMessageContent,
   fetchConversationContexts,
   lookupThreadSession,
   buildLoginUrl,
@@ -126,33 +118,16 @@ export async function handleAppMention(context: MentionContext): Promise<void> {
   // 5. Show assistant thinking status
   await setThreadStatus(client, context.channelId, threadTs, "is thinking...");
 
-  // Extract message content (remove bot mention)
-  let messageContent = extractMessageContent(context.messageText, botUserId);
-
-  // Include files attached to the current message in the prompt
-  if (context.files && context.files.length > 0) {
-    const imageSessionId = `${context.channelId}-${threadTs}`;
-    const filesText = await formatCurrentMessageFiles(
-      context.files,
-      botToken,
-      imageSessionId,
-    );
-    messageContent = `${messageContent}\n\n${filesText}`;
-  }
-
-  // Prepend Slack user info to the prompt
-  const userInfo = await fetchSlackUserInfo(client, context.userId).catch(
-    (err) => {
-      log.warn("Failed to fetch Slack user info", {
-        userId: context.userId,
-        error: err,
-      });
-      return undefined;
-    },
-  );
-  if (userInfo) {
-    messageContent = `[Slack User]\n${userInfo}\n\n${messageContent}`;
-  }
+  // Extract message content (remove bot mention) and enrich with files/user info
+  const messageContent = await enrichMessageContent({
+    messageContent: extractMessageContent(context.messageText, botUserId),
+    files: context.files,
+    botToken,
+    channelId: context.channelId,
+    threadTs,
+    client,
+    userId: context.userId,
+  });
 
   // 6. Look up existing thread session for deduplication
   let existingSessionId: string | undefined;

--- a/turbo/apps/web/src/lib/slack/handlers/shared.ts
+++ b/turbo/apps/web/src/lib/slack/handlers/shared.ts
@@ -1,10 +1,12 @@
 import { eq, and } from "drizzle-orm";
-import { createSlackClient } from "../client";
+import { createSlackClient, fetchSlackUserInfo } from "../client";
 import {
   fetchThreadContext,
   fetchChannelContext,
   formatContextForAgent,
   formatContextForAgentWithImages,
+  formatCurrentMessageFiles,
+  type SlackFile,
 } from "../context";
 import { slackThreadSessions } from "../../../db/schema/slack-thread-session";
 import { agentComposes } from "../../../db/schema/agent-compose";
@@ -277,4 +279,47 @@ export async function resolveSessionCompose(
     });
   }
   return undefined;
+}
+
+/**
+ * Enrich message content with file attachments and Slack user info.
+ * Shared between direct-message and mention handlers.
+ */
+export async function enrichMessageContent(opts: {
+  messageContent: string;
+  files: SlackFile[] | undefined;
+  botToken: string;
+  channelId: string;
+  threadTs: string;
+  client: SlackClient;
+  userId: string;
+}): Promise<string> {
+  let content = opts.messageContent;
+
+  // Include files attached to the current message in the prompt
+  if (opts.files && opts.files.length > 0) {
+    const imageSessionId = `${opts.channelId}-${opts.threadTs}`;
+    const filesText = await formatCurrentMessageFiles(
+      opts.files,
+      opts.botToken,
+      imageSessionId,
+    );
+    content = `${content}\n\n${filesText}`;
+  }
+
+  // Prepend Slack user info to the prompt
+  const userInfo = await fetchSlackUserInfo(opts.client, opts.userId).catch(
+    (err) => {
+      log.warn("Failed to fetch Slack user info", {
+        userId: opts.userId,
+        error: err,
+      });
+      return undefined;
+    },
+  );
+  if (userInfo) {
+    content = `[Slack User]\n${userInfo}\n\n${content}`;
+  }
+
+  return content;
 }


### PR DESCRIPTION
## Summary
- **File attachment support**: Forward images attached to Slack messages (both @mentions and DMs) to the agent by uploading to R2 and embedding curl download instructions in the prompt
- **User info injection**: Fetch Slack user info (display name, timezone) and prepend it to the prompt so the agent has better context about who it's talking to
- **UX fixes**: Move emoji outside `<url|text>` in the logs link so it renders correctly on Slack mobile; simplify image URL formatting to a single `View: curl ...` line

## Test plan
- [ ] Verify existing context formatting tests pass (`context.test.ts` updated)
- [ ] Send a DM with an image attachment and confirm the agent receives the image context
- [ ] @mention the bot with an image attachment and confirm the agent receives the image context
- [ ] Verify Slack user name and timezone appear in agent prompt
- [ ] Check logs link renders correctly on Slack mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)