### PR TITLE
fix(telegram): improve reliability, security, and add image support

### DIFF
--- a/turbo/apps/web/app/api/telegram/webhook/[installationId]/route.ts
+++ b/turbo/apps/web/app/api/telegram/webhook/[installationId]/route.ts
@@ -88,38 +88,34 @@ export async function POST(
   // Route to appropriate handler
   after(
     (async () => {
-      // /start command
-      if (message.text?.startsWith("/start")) {
+      const command = parseBotCommand(message.text, installation.botUsername);
+
+      if (command === "start") {
         await handleStartCommand({ message }, installationId);
         return;
       }
 
-      // /new_session command
-      if (message.text?.startsWith("/new_session")) {
+      if (command === "new_session") {
         await handleNewSessionCommand({ message }, installationId);
         return;
       }
 
-      // /connect command
-      if (message.text?.startsWith("/connect")) {
+      if (command === "connect") {
         await handleConnectCommand({ message }, installationId);
         return;
       }
 
-      // /disconnect command
-      if (message.text?.startsWith("/disconnect")) {
+      if (command === "disconnect") {
         await handleDisconnectCommand({ message }, installationId);
         return;
       }
 
-      // /settings command
-      if (message.text?.startsWith("/settings")) {
+      if (command === "settings") {
         await handleSettingsCommand({ message }, installationId);
         return;
       }
 
-      // /help command
-      if (message.text?.startsWith("/help")) {
+      if (command === "help") {
         await handleHelpCommand({ message }, installationId);
         return;
       }
@@ -157,4 +153,46 @@ export async function POST(
 
   // Return 200 immediately
   return new Response("OK", { status: 200 });
+}
+
+/**
+ * Parse a bot command from message text, respecting @username targeting.
+ *
+ * In groups, Telegram commands can be targeted: `/connect@BotA`.
+ * If the command targets a different bot, returns undefined so this
+ * bot ignores it. In private chats, the @suffix is optional.
+ *
+ * Returns the command name (without slash or @suffix), or undefined.
+ */
+function parseBotCommand(
+  text: string | undefined,
+  botUsername: string | null,
+): string | undefined {
+  if (!text || !text.startsWith("/")) {
+    return undefined;
+  }
+
+  // Extract command part (first word, e.g. "/connect@BotA")
+  const firstWord = text.split(/\s/)[0];
+  if (!firstWord) {
+    return undefined;
+  }
+
+  const atIndex = firstWord.indexOf("@");
+  if (atIndex === -1) {
+    // No @suffix — command applies to all bots (or is in DM)
+    return firstWord.slice(1).toLowerCase();
+  }
+
+  // Has @suffix — only respond if it matches this bot
+  const targetUsername = firstWord.slice(atIndex + 1);
+  if (
+    botUsername &&
+    targetUsername.toLowerCase() === botUsername.toLowerCase()
+  ) {
+    return firstWord.slice(1, atIndex).toLowerCase();
+  }
+
+  // Targeted at a different bot
+  return undefined;
 }

--- a/turbo/apps/web/app/api/telegram/webhook/[installationId]/route.ts
+++ b/turbo/apps/web/app/api/telegram/webhook/[installationId]/route.ts
@@ -78,8 +78,8 @@ export async function POST(
   }
 
   const message = update.message;
-  if (!message || !message.text) {
-    // No text message — nothing to process
+  if (!message || (!message.text && !message.photo)) {
+    // No text or photo — nothing to process
     return new Response("OK", { status: 200 });
   }
 
@@ -88,7 +88,8 @@ export async function POST(
   // Route to appropriate handler
   after(
     (async () => {
-      const command = parseBotCommand(message.text, installation.botUsername);
+      const messageText = message.text ?? message.caption;
+      const command = parseBotCommand(messageText, installation.botUsername);
 
       if (command === "start") {
         await handleStartCommand({ message }, installationId);
@@ -126,13 +127,18 @@ export async function POST(
         return;
       }
 
-      // Check for bot @mention in entities
+      // Check for bot @mention in entities or caption_entities
+      const mentionSource = message.text ?? message.caption ?? "";
+      const allEntities = [
+        ...(message.entities ?? []),
+        ...(message.caption_entities ?? []),
+      ];
       const hasBotMention =
         installation.botUsername &&
-        message.entities?.some(
+        allEntities.some(
           (e) =>
             e.type === "mention" &&
-            message.text?.slice(e.offset, e.offset + e.length).toLowerCase() ===
+            mentionSource.slice(e.offset, e.offset + e.length).toLowerCase() ===
               `@${installation.botUsername?.toLowerCase()}`,
         );
 

--- a/turbo/apps/web/app/api/telegram/webhook/__tests__/commands.test.ts
+++ b/turbo/apps/web/app/api/telegram/webhook/__tests__/commands.test.ts
@@ -98,6 +98,136 @@ describe("Telegram bot commands", () => {
     mockClerk({ userId: user.userId });
   });
 
+  describe("command routing with @username targeting", () => {
+    it("should route command with matching @botUsername", async () => {
+      const sendMsg = telegramSendMessage();
+      server.use(sendMsg.handler);
+
+      const request = createWebhookRequest({
+        update_id: 1,
+        message: {
+          message_id: 1,
+          chat: { id: TELEGRAM_USER_ID, type: "private" },
+          from: { id: TELEGRAM_USER_ID, username: "testuser" },
+          text: "/help@test_bot",
+        },
+      });
+
+      const response = await POST(request, {
+        params: Promise.resolve({ installationId }),
+      });
+      expect(response.status).toBe(200);
+      await flushAfterCallbacks();
+
+      expect(sendMsg.mocked).toHaveBeenCalled();
+      expect(sendMsg.calls[0]?.text).toContain("/help");
+    });
+
+    it("should ignore command targeted at a different bot", async () => {
+      const sendMsg = telegramSendMessage();
+      server.use(sendMsg.handler);
+
+      const request = createWebhookRequest({
+        update_id: 1,
+        message: {
+          message_id: 1,
+          chat: { id: TELEGRAM_USER_ID, type: "group" },
+          from: { id: TELEGRAM_USER_ID, username: "testuser" },
+          text: "/help@other_bot",
+        },
+      });
+
+      const response = await POST(request, {
+        params: Promise.resolve({ installationId }),
+      });
+      expect(response.status).toBe(200);
+      await flushAfterCallbacks();
+
+      // No message sent — command was for a different bot
+      expect(sendMsg.mocked).not.toHaveBeenCalled();
+    });
+
+    it("should route command without @suffix in group chat", async () => {
+      const sendMsg = telegramSendMessage();
+      server.use(sendMsg.handler);
+
+      const request = createWebhookRequest({
+        update_id: 1,
+        message: {
+          message_id: 1,
+          chat: { id: TELEGRAM_USER_ID, type: "group" },
+          from: { id: TELEGRAM_USER_ID, username: "testuser" },
+          text: "/help",
+        },
+      });
+
+      const response = await POST(request, {
+        params: Promise.resolve({ installationId }),
+      });
+      expect(response.status).toBe(200);
+      await flushAfterCallbacks();
+
+      expect(sendMsg.mocked).toHaveBeenCalled();
+      expect(sendMsg.calls[0]?.text).toContain("/help");
+    });
+
+    it("should handle case-insensitive @botUsername matching", async () => {
+      const sendMsg = telegramSendMessage();
+      server.use(sendMsg.handler);
+
+      const request = createWebhookRequest({
+        update_id: 1,
+        message: {
+          message_id: 1,
+          chat: { id: TELEGRAM_USER_ID, type: "private" },
+          from: { id: TELEGRAM_USER_ID, username: "testuser" },
+          text: "/help@TEST_BOT",
+        },
+      });
+
+      const response = await POST(request, {
+        params: Promise.resolve({ installationId }),
+      });
+      expect(response.status).toBe(200);
+      await flushAfterCallbacks();
+
+      expect(sendMsg.mocked).toHaveBeenCalled();
+      expect(sendMsg.calls[0]?.text).toContain("/help");
+    });
+  });
+
+  describe("/connect command - group chat security", () => {
+    it("should not expose connect URL in group chats", async () => {
+      const sendMsg = telegramSendMessage();
+      server.use(sendMsg.handler);
+
+      // Unconnected user sends /connect in a group
+      const request = createWebhookRequest({
+        update_id: 1,
+        message: {
+          message_id: 1,
+          chat: { id: -100123456, type: "group" },
+          from: { id: 99999, username: "unknown_user" },
+          text: "/connect",
+        },
+      });
+
+      const response = await POST(request, {
+        params: Promise.resolve({ installationId }),
+      });
+      expect(response.status).toBe(200);
+      await flushAfterCallbacks();
+
+      expect(sendMsg.mocked).toHaveBeenCalled();
+      const text = sendMsg.calls[0]?.text ?? "";
+      // Should redirect to DM instead of exposing the connect URL
+      expect(text).toContain("private message");
+      expect(text).toContain("?start=connect");
+      // Should NOT contain the actual connect URL with telegramUserId
+      expect(text).not.toContain("/telegram/connect?bot=");
+    });
+  });
+
   describe("/connect command", () => {
     it("should confirm when user is already connected", async () => {
       const sendMsg = telegramSendMessage();

--- a/turbo/apps/web/app/api/webhooks/agent/complete/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/complete/route.ts
@@ -8,7 +8,7 @@ import { initServices } from "../../../../../src/lib/init-services";
 import { agentRuns } from "../../../../../src/db/schema/agent-run";
 import { checkpoints } from "../../../../../src/db/schema/checkpoint";
 import { agentSessions } from "../../../../../src/db/schema/agent-session";
-import { eq, and } from "drizzle-orm";
+import { eq, and, inArray } from "drizzle-orm";
 import { getSandboxAuthForRun } from "../../../../../src/lib/auth/get-sandbox-auth";
 import { killSandbox } from "../../../../../src/lib/sandbox/sandbox-service";
 import type {
@@ -23,6 +23,90 @@ import { executeQueuedRun } from "../../../../../src/lib/run/run-service";
 import { after } from "next/server";
 
 const log = logger("webhook:complete");
+
+/**
+ * Atomically transition a run to a terminal status.
+ * Uses WHERE status IN ('pending', 'running') to prevent double transitions.
+ * Returns true if the transition was applied (this caller "won" the race).
+ */
+async function atomicTransition(
+  runId: string,
+  update: {
+    status: "completed" | "failed";
+    completedAt: Date;
+    result?: RunResult;
+    error?: string;
+  },
+): Promise<boolean> {
+  const [updated] = await globalThis.services.db
+    .update(agentRuns)
+    .set(update)
+    .where(
+      and(
+        eq(agentRuns.id, runId),
+        inArray(agentRuns.status, ["pending", "running"]),
+      ),
+    )
+    .returning({ id: agentRuns.id });
+  return !!updated;
+}
+
+/**
+ * Schedule callback dispatch and queue drain in a non-blocking after() block.
+ */
+function scheduleCallbackDispatch(
+  runId: string,
+  status: "completed" | "failed",
+  userId: string,
+  errorMsg?: string,
+): void {
+  after(async () => {
+    await Promise.all([
+      dispatchCallbacks(runId, status, undefined, errorMsg).catch((err) =>
+        log.error("Failed to dispatch callbacks", { err }),
+      ),
+      drainUserQueue(userId, executeQueuedRun).catch((err) =>
+        log.error("Failed to drain user queue", { err }),
+      ),
+    ]);
+  });
+}
+
+/**
+ * Build a RunResult from a checkpoint record.
+ */
+function buildRunResult(
+  checkpoint: typeof checkpoints.$inferSelect,
+  sessionId: string | undefined,
+): RunResult {
+  const artifactSnapshot =
+    checkpoint.artifactSnapshot as ArtifactSnapshot | null;
+  const memorySnapshot = checkpoint.memorySnapshot as MemorySnapshot | null;
+  const volumeVersions = checkpoint.volumeVersionsSnapshot as
+    | { versions: Record<string, string> }
+    | undefined;
+
+  const result: RunResult = {
+    checkpointId: checkpoint.id,
+    agentSessionId: sessionId ?? checkpoint.conversationId,
+    conversationId: checkpoint.conversationId,
+    volumes: volumeVersions?.versions,
+  };
+
+  if (artifactSnapshot) {
+    result.artifact = {
+      [artifactSnapshot.artifactName]: artifactSnapshot.artifactVersion,
+    };
+  }
+
+  if (memorySnapshot) {
+    result.memory = {
+      [memorySnapshot.memoryName]: memorySnapshot.memoryVersion,
+    };
+  }
+
+  return result;
+}
 
 const router = tsr.router(webhookCompleteContract, {
   complete: async ({ body, headers }) => {
@@ -91,18 +175,25 @@ const router = tsr.router(webhookCompleteContract, {
         .limit(1);
 
       if (!checkpoint) {
-        // Update run status to failed
-        await globalThis.services.db
-          .update(agentRuns)
-          .set({
-            status: "failed",
-            completedAt: new Date(),
-            error: "Checkpoint for run not found",
-          })
-          .where(eq(agentRuns.id, body.runId));
+        const transitioned = await atomicTransition(body.runId, {
+          status: "failed",
+          completedAt: new Date(),
+          error: "Checkpoint for run not found",
+        });
 
         if (sandboxId) {
           await killSandbox(sandboxId);
+        }
+
+        // Dispatch callbacks so the user gets notified about the failure
+        // (previously this path returned without dispatching)
+        if (transitioned) {
+          scheduleCallbackDispatch(
+            body.runId,
+            "failed",
+            userId,
+            "Checkpoint for run not found",
+          );
         }
 
         return {
@@ -123,45 +214,27 @@ const router = tsr.router(webhookCompleteContract, {
         .where(eq(agentSessions.conversationId, checkpoint.conversationId))
         .limit(1);
 
-      // Extract artifact and memory info from checkpoint (may be null for runs without them)
-      const artifactSnapshot =
-        checkpoint.artifactSnapshot as ArtifactSnapshot | null;
-      const memorySnapshot = checkpoint.memorySnapshot as MemorySnapshot | null;
-      const volumeVersions = checkpoint.volumeVersionsSnapshot as
-        | { versions: Record<string, string> }
-        | undefined;
+      const result = buildRunResult(checkpoint, session?.id);
 
-      // Build result object to store in run table
-      const result: RunResult = {
-        checkpointId: checkpoint.id,
-        agentSessionId: session?.id ?? checkpoint.conversationId,
-        conversationId: checkpoint.conversationId,
-        volumes: volumeVersions?.versions,
-      };
+      // Atomically transition to "completed" only if still pending/running
+      const transitioned = await atomicTransition(body.runId, {
+        status: "completed",
+        completedAt: new Date(),
+        result,
+      });
 
-      // Only add artifact if present in checkpoint
-      if (artifactSnapshot) {
-        result.artifact = {
-          [artifactSnapshot.artifactName]: artifactSnapshot.artifactVersion,
+      if (!transitioned) {
+        log.debug(
+          `Run ${body.runId} already transitioned, skipping duplicate completion`,
+        );
+        if (sandboxId) {
+          await killSandbox(sandboxId);
+        }
+        return {
+          status: 200 as const,
+          body: { success: true, status: "completed" as const },
         };
       }
-
-      // Only add memory if present in checkpoint
-      if (memorySnapshot) {
-        result.memory = {
-          [memorySnapshot.memoryName]: memorySnapshot.memoryVersion,
-        };
-      }
-
-      // Update run status and result
-      await globalThis.services.db
-        .update(agentRuns)
-        .set({
-          status: "completed",
-          completedAt: new Date(),
-          result,
-        })
-        .where(eq(agentRuns.id, body.runId));
 
       finalStatus = "completed";
       log.debug(`Run ${body.runId} completed successfully`);
@@ -170,37 +243,35 @@ const router = tsr.router(webhookCompleteContract, {
       const errorMessage =
         body.error || `Agent exited with code ${body.exitCode}`;
 
-      // Update run status and error
-      await globalThis.services.db
-        .update(agentRuns)
-        .set({
-          status: "failed",
-          completedAt: new Date(),
-          error: errorMessage,
-        })
-        .where(eq(agentRuns.id, body.runId));
+      const transitioned = await atomicTransition(body.runId, {
+        status: "failed",
+        completedAt: new Date(),
+        error: errorMessage,
+      });
+
+      if (!transitioned) {
+        log.debug(
+          `Run ${body.runId} already transitioned, skipping duplicate failure`,
+        );
+        if (sandboxId) {
+          await killSandbox(sandboxId);
+        }
+        return {
+          status: 200 as const,
+          body: { success: true, status: "failed" as const },
+        };
+      }
 
       finalStatus = "failed";
       log.warn(`Run ${body.runId} failed: ${errorMessage}`);
     }
 
     // Dispatch all registered callbacks and drain run queue (non-blocking)
-    // This handles Slack mentions, schedule notifications, email replies, etc.
-    after(async () => {
-      const errorMsg =
-        finalStatus === "failed"
-          ? (body.error ?? `Agent exited with code ${body.exitCode}`)
-          : undefined;
-
-      await Promise.all([
-        dispatchCallbacks(body.runId, finalStatus, undefined, errorMsg).catch(
-          (err) => log.error("Failed to dispatch callbacks", { err }),
-        ),
-        drainUserQueue(userId, executeQueuedRun).catch((err) =>
-          log.error("Failed to drain user queue", { err }),
-        ),
-      ]);
-    });
+    const errorMsg =
+      finalStatus === "failed"
+        ? (body.error ?? `Agent exited with code ${body.exitCode}`)
+        : undefined;
+    scheduleCallbackDispatch(body.runId, finalStatus, userId, errorMsg);
 
     // Kill sandbox (wait for completion to ensure cleanup before response)
     if (sandboxId) {

--- a/turbo/apps/web/src/db/migrations/0111_wooden_gambit.sql
+++ b/turbo/apps/web/src/db/migrations/0111_wooden_gambit.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "telegram_messages" ADD COLUMN "file_id" varchar(255);

--- a/turbo/apps/web/src/db/migrations/meta/0111_snapshot.json
+++ b/turbo/apps/web/src/db/migrations/meta/0111_snapshot.json
@@ -1,0 +1,4587 @@
+{
+  "id": "ce46d77c-5fea-4be0-9e75-d386306d80b8",
+  "prevId": "55e1aa0c-ada2-486a-9001-0657c3220ec0",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.agent_compose_versions": {
+      "name": "agent_compose_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "compose_id": {
+          "name": "compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_compose_versions_compose_id": {
+          "name": "idx_agent_compose_versions_compose_id",
+          "columns": [
+            {
+              "expression": "compose_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_compose_versions_compose_id_agent_composes_id_fk": {
+          "name": "agent_compose_versions_compose_id_agent_composes_id_fk",
+          "tableFrom": "agent_compose_versions",
+          "tableTo": "agent_composes",
+          "columnsFrom": ["compose_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_composes": {
+      "name": "agent_composes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "head_version_id": {
+          "name": "head_version_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_composes_scope_name": {
+          "name": "idx_agent_composes_scope_name",
+          "columns": [
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_composes_scope": {
+          "name": "idx_agent_composes_scope",
+          "columns": [
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_composes_scope_id_scopes_id_fk": {
+          "name": "agent_composes_scope_id_scopes_id_fk",
+          "tableFrom": "agent_composes",
+          "tableTo": "scopes",
+          "columnsFrom": ["scope_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_permissions": {
+      "name": "agent_permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "agent_compose_id": {
+          "name": "agent_compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grantee_type": {
+          "name": "grantee_type",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grantee_email": {
+          "name": "grantee_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "permission": {
+          "name": "permission",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'run_view'"
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_permissions_compose": {
+          "name": "idx_agent_permissions_compose",
+          "columns": [
+            {
+              "expression": "agent_compose_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_permissions_email": {
+          "name": "idx_agent_permissions_email",
+          "columns": [
+            {
+              "expression": "grantee_email",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "grantee_email IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_permissions_agent_compose_id_agent_composes_id_fk": {
+          "name": "agent_permissions_agent_compose_id_agent_composes_id_fk",
+          "tableFrom": "agent_permissions",
+          "tableTo": "agent_composes",
+          "columnsFrom": ["agent_compose_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "agent_permissions_compose_type_email_unique": {
+          "name": "agent_permissions_compose_type_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["agent_compose_id", "grantee_type", "grantee_email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_run_callbacks": {
+      "name": "agent_run_callbacks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_secret": {
+          "name": "encrypted_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_attempt_at": {
+          "name": "last_attempt_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_run_callbacks_run_id": {
+          "name": "idx_agent_run_callbacks_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_run_callbacks_pending": {
+          "name": "idx_agent_run_callbacks_pending",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "status = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_run_callbacks_run_id_agent_runs_id_fk": {
+          "name": "agent_run_callbacks_run_id_agent_runs_id_fk",
+          "tableFrom": "agent_run_callbacks",
+          "tableTo": "agent_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_run_events": {
+      "name": "agent_run_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence_number": {
+          "name": "sequence_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_data": {
+          "name": "event_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_run_events_run_id_agent_runs_id_fk": {
+          "name": "agent_run_events_run_id_agent_runs_id_fk",
+          "tableFrom": "agent_run_events",
+          "tableTo": "agent_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_run_events_local": {
+      "name": "agent_run_events_local",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence_number": {
+          "name": "sequence_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_data": {
+          "name": "event_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_run_events_local_run_id": {
+          "name": "idx_agent_run_events_local_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_run_events_local_run_seq": {
+          "name": "idx_agent_run_events_local_run_seq",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sequence_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_run_events_local_run_id_agent_runs_id_fk": {
+          "name": "agent_run_events_local_run_id_agent_runs_id_fk",
+          "tableFrom": "agent_run_events_local",
+          "tableTo": "agent_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_run_queue": {
+      "name": "agent_run_queue",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_params": {
+          "name": "encrypted_params",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "agent_run_queue_user_created_idx": {
+          "name": "agent_run_queue_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_run_queue_expires_at_idx": {
+          "name": "agent_run_queue_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_run_queue_run_id_agent_runs_id_fk": {
+          "name": "agent_run_queue_run_id_agent_runs_id_fk",
+          "tableFrom": "agent_run_queue",
+          "tableTo": "agent_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_runs": {
+      "name": "agent_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_compose_version_id": {
+          "name": "agent_compose_version_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resumed_from_checkpoint_id": {
+          "name": "resumed_from_checkpoint_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "continued_from_session_id": {
+          "name": "continued_from_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vars": {
+          "name": "vars",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "secret_names": {
+          "name": "secret_names",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_heartbeat_at": {
+          "name": "last_heartbeat_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_agent_runs_user_created": {
+          "name": "idx_agent_runs_user_created",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_runs_status_heartbeat": {
+          "name": "idx_agent_runs_status_heartbeat",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_heartbeat_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_runs_running_heartbeat": {
+          "name": "idx_agent_runs_running_heartbeat",
+          "columns": [
+            {
+              "expression": "last_heartbeat_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "status = 'running'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_runs_schedule_created": {
+          "name": "idx_agent_runs_schedule_created",
+          "columns": [
+            {
+              "expression": "schedule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "schedule_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_runs_scope_id_scopes_id_fk": {
+          "name": "agent_runs_scope_id_scopes_id_fk",
+          "tableFrom": "agent_runs",
+          "tableTo": "scopes",
+          "columnsFrom": ["scope_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_runs_agent_compose_version_id_agent_compose_versions_id_fk": {
+          "name": "agent_runs_agent_compose_version_id_agent_compose_versions_id_fk",
+          "tableFrom": "agent_runs",
+          "tableTo": "agent_compose_versions",
+          "columnsFrom": ["agent_compose_version_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "agent_runs_schedule_id_agent_schedules_id_fk": {
+          "name": "agent_runs_schedule_id_agent_schedules_id_fk",
+          "tableFrom": "agent_runs",
+          "tableTo": "agent_schedules",
+          "columnsFrom": ["schedule_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_schedules": {
+      "name": "agent_schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "compose_id": {
+          "name": "compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_type": {
+          "name": "trigger_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'cron'"
+        },
+        "cron_expression": {
+          "name": "cron_expression",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "at_time": {
+          "name": "at_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "interval_seconds": {
+          "name": "interval_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vars": {
+          "name": "vars",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_secrets": {
+          "name": "encrypted_secrets",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artifact_name": {
+          "name": "artifact_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artifact_version": {
+          "name": "artifact_version",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "volume_versions": {
+          "name": "volume_versions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_run_id": {
+          "name": "last_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retry_started_at": {
+          "name": "retry_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consecutive_failures": {
+          "name": "consecutive_failures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_schedules_compose_name": {
+          "name": "idx_agent_schedules_compose_name",
+          "columns": [
+            {
+              "expression": "compose_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_schedules_compose": {
+          "name": "idx_agent_schedules_compose",
+          "columns": [
+            {
+              "expression": "compose_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_schedules_next_run": {
+          "name": "idx_agent_schedules_next_run",
+          "columns": [
+            {
+              "expression": "next_run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "enabled = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_schedules_compose_id_agent_composes_id_fk": {
+          "name": "agent_schedules_compose_id_agent_composes_id_fk",
+          "tableFrom": "agent_schedules",
+          "tableTo": "agent_composes",
+          "columnsFrom": ["compose_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_schedules_last_run_id_agent_runs_id_fk": {
+          "name": "agent_schedules_last_run_id_agent_runs_id_fk",
+          "tableFrom": "agent_schedules",
+          "tableTo": "agent_runs",
+          "columnsFrom": ["last_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_sessions": {
+      "name": "agent_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_compose_id": {
+          "name": "agent_compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artifact_name": {
+          "name": "artifact_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_name": {
+          "name": "memory_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chat_messages": {
+          "name": "chat_messages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_sessions_user_compose_artifact": {
+          "name": "idx_agent_sessions_user_compose_artifact",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_compose_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "artifact_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_sessions_agent_compose_id_agent_composes_id_fk": {
+          "name": "agent_sessions_agent_compose_id_agent_composes_id_fk",
+          "tableFrom": "agent_sessions",
+          "tableTo": "agent_composes",
+          "columnsFrom": ["agent_compose_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_sessions_conversation_id_conversations_id_fk": {
+          "name": "agent_sessions_conversation_id_conversations_id_fk",
+          "tableFrom": "agent_sessions",
+          "tableTo": "conversations",
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blobs": {
+      "name": "blobs",
+      "schema": "",
+      "columns": {
+        "hash": {
+          "name": "hash",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref_count": {
+          "name": "ref_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_blobs_ref_count": {
+          "name": "idx_blobs_ref_count",
+          "columns": [
+            {
+              "expression": "ref_count",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.checkpoints": {
+      "name": "checkpoints",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_compose_snapshot": {
+          "name": "agent_compose_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_snapshot": {
+          "name": "artifact_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_snapshot": {
+          "name": "memory_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "volume_versions_snapshot": {
+          "name": "volume_versions_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "checkpoints_run_id_agent_runs_id_fk": {
+          "name": "checkpoints_run_id_agent_runs_id_fk",
+          "tableFrom": "checkpoints",
+          "tableTo": "agent_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "checkpoints_conversation_id_conversations_id_fk": {
+          "name": "checkpoints_conversation_id_conversations_id_fk",
+          "tableFrom": "checkpoints",
+          "tableTo": "conversations",
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "checkpoints_run_id_unique": {
+          "name": "checkpoints_run_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["run_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cli_tokens": {
+      "name": "cli_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cli_tokens_token_unique": {
+          "name": "cli_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.compose_jobs": {
+      "name": "compose_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_url": {
+          "name": "github_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "overwrite": {
+          "name": "overwrite",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'github'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_compose_jobs_user_status": {
+          "name": "idx_compose_jobs_user_status",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_compose_jobs_created": {
+          "name": "idx_compose_jobs_created",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_compose_jobs_user_active": {
+          "name": "idx_compose_jobs_user_active",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status IN ('pending', 'running')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.connector_sessions": {
+      "name": "connector_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(9)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "connector_session_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_connector_sessions_code": {
+          "name": "idx_connector_sessions_code",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_connector_sessions_user_status": {
+          "name": "idx_connector_sessions_user_status",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.connectors": {
+      "name": "connectors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_method": {
+          "name": "auth_method",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_username": {
+          "name": "external_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_email": {
+          "name": "external_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_scopes": {
+          "name": "oauth_scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_connectors_scope_user_type": {
+          "name": "idx_connectors_scope_user_type",
+          "columns": [
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_connectors_scope": {
+          "name": "idx_connectors_scope",
+          "columns": [
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "connectors_scope_id_scopes_id_fk": {
+          "name": "connectors_scope_id_scopes_id_fk",
+          "tableFrom": "connectors",
+          "tableTo": "scopes",
+          "columnsFrom": ["scope_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversations": {
+      "name": "conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cli_agent_type": {
+          "name": "cli_agent_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cli_agent_session_id": {
+          "name": "cli_agent_session_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cli_agent_session_history": {
+          "name": "cli_agent_session_history",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cli_agent_session_history_hash": {
+          "name": "cli_agent_session_history_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "conversations_run_id_agent_runs_id_fk": {
+          "name": "conversations_run_id_agent_runs_id_fk",
+          "tableFrom": "conversations",
+          "tableTo": "agent_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "conversations_run_id_unique": {
+          "name": "conversations_run_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["run_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.device_codes": {
+      "name": "device_codes",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "varchar(9)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "device_code_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_reply_requests": {
+      "name": "email_reply_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_thread_session_id": {
+          "name": "email_thread_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inbound_email_id": {
+          "name": "inbound_email_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inbound_message_id": {
+          "name": "inbound_message_id",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_email_reply_requests_run": {
+          "name": "idx_email_reply_requests_run",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_reply_requests_run_id_agent_runs_id_fk": {
+          "name": "email_reply_requests_run_id_agent_runs_id_fk",
+          "tableFrom": "email_reply_requests",
+          "tableTo": "agent_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "email_reply_requests_email_thread_session_id_email_thread_sessions_id_fk": {
+          "name": "email_reply_requests_email_thread_session_id_email_thread_sessions_id_fk",
+          "tableFrom": "email_reply_requests",
+          "tableTo": "email_thread_sessions",
+          "columnsFrom": ["email_thread_session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_thread_sessions": {
+      "name": "email_thread_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "compose_id": {
+          "name": "compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_session_id": {
+          "name": "agent_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_email_message_id": {
+          "name": "last_email_message_id",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_to_token": {
+          "name": "reply_to_token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_email_thread_sessions_reply_token": {
+          "name": "idx_email_thread_sessions_reply_token",
+          "columns": [
+            {
+              "expression": "reply_to_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_email_thread_sessions_user": {
+          "name": "idx_email_thread_sessions_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_thread_sessions_compose_id_agent_composes_id_fk": {
+          "name": "email_thread_sessions_compose_id_agent_composes_id_fk",
+          "tableFrom": "email_thread_sessions",
+          "tableTo": "agent_composes",
+          "columnsFrom": ["compose_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "email_thread_sessions_agent_session_id_agent_sessions_id_fk": {
+          "name": "email_thread_sessions_agent_session_id_agent_sessions_id_fk",
+          "tableFrom": "email_thread_sessions",
+          "tableTo": "agent_sessions",
+          "columnsFrom": ["agent_session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_installations": {
+      "name": "github_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_access_token": {
+          "name": "encrypted_access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_name": {
+          "name": "target_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "admin_github_user_id": {
+          "name": "admin_github_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_compose_id": {
+          "name": "default_compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_configs": {
+          "name": "repo_configs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "github_installations_installation_id_unique": {
+          "name": "github_installations_installation_id_unique",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "installation_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_installations_default_compose_id_agent_composes_id_fk": {
+          "name": "github_installations_default_compose_id_agent_composes_id_fk",
+          "tableFrom": "github_installations",
+          "tableTo": "agent_composes",
+          "columnsFrom": ["default_compose_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_issue_sessions": {
+      "name": "github_issue_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo": {
+          "name": "repo",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_number": {
+          "name": "issue_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_session_id": {
+          "name": "agent_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_comment_id": {
+          "name": "last_comment_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_github_issue_sessions_installation_repo_issue": {
+          "name": "idx_github_issue_sessions_installation_repo_issue",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "repo",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "issue_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_github_issue_sessions_installation": {
+          "name": "idx_github_issue_sessions_installation",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_issue_sessions_installation_id_github_installations_id_fk": {
+          "name": "github_issue_sessions_installation_id_github_installations_id_fk",
+          "tableFrom": "github_issue_sessions",
+          "tableTo": "github_installations",
+          "columnsFrom": ["installation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_issue_sessions_agent_session_id_agent_sessions_id_fk": {
+          "name": "github_issue_sessions_agent_session_id_agent_sessions_id_fk",
+          "tableFrom": "github_issue_sessions",
+          "tableTo": "agent_sessions",
+          "columnsFrom": ["agent_session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_user_links": {
+      "name": "github_user_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "github_user_id": {
+          "name": "github_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vm0_user_id": {
+          "name": "vm0_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_github_user_links_user_installation": {
+          "name": "idx_github_user_links_user_installation",
+          "columns": [
+            {
+              "expression": "github_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_user_links_installation_id_github_installations_id_fk": {
+          "name": "github_user_links_installation_id_github_installations_id_fk",
+          "tableFrom": "github_user_links",
+          "tableTo": "github_installations",
+          "columnsFrom": ["installation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_providers": {
+      "name": "model_providers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_id": {
+          "name": "secret_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_method": {
+          "name": "auth_method",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "selected_model": {
+          "name": "selected_model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_model_providers_scope_user_type": {
+          "name": "idx_model_providers_scope_user_type",
+          "columns": [
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_model_providers_scope": {
+          "name": "idx_model_providers_scope",
+          "columns": [
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_model_providers_secret": {
+          "name": "idx_model_providers_secret",
+          "columns": [
+            {
+              "expression": "secret_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "model_providers_scope_id_scopes_id_fk": {
+          "name": "model_providers_scope_id_scopes_id_fk",
+          "tableFrom": "model_providers",
+          "tableTo": "scopes",
+          "columnsFrom": ["scope_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "model_providers_secret_id_secrets_id_fk": {
+          "name": "model_providers_secret_id_secrets_id_fk",
+          "tableFrom": "model_providers",
+          "tableTo": "secrets",
+          "columnsFrom": ["secret_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runner_job_queue": {
+      "name": "runner_job_queue",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "runner_group": {
+          "name": "runner_group",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_context": {
+          "name": "execution_context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "runner_job_queue_group_unclaimed_idx": {
+          "name": "runner_job_queue_group_unclaimed_idx",
+          "columns": [
+            {
+              "expression": "runner_group",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "claimed_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runner_job_queue_expires_at_idx": {
+          "name": "runner_job_queue_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "runner_job_queue_run_id_agent_runs_id_fk": {
+          "name": "runner_job_queue_run_id_agent_runs_id_fk",
+          "tableFrom": "runner_job_queue",
+          "tableTo": "agent_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sandbox_telemetry": {
+      "name": "sandbox_telemetry",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_sandbox_telemetry_run_id": {
+          "name": "idx_sandbox_telemetry_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sandbox_telemetry_run_id_agent_runs_id_fk": {
+          "name": "sandbox_telemetry_run_id_agent_runs_id_fk",
+          "tableFrom": "sandbox_telemetry",
+          "tableTo": "agent_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scope_members": {
+      "name": "scope_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notify_email": {
+          "name": "notify_email",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "notify_slack": {
+          "name": "notify_slack",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_scope_members_scope_user": {
+          "name": "idx_scope_members_scope_user",
+          "columns": [
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_scope_members_scope": {
+          "name": "idx_scope_members_scope",
+          "columns": [
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_scope_members_user": {
+          "name": "idx_scope_members_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scope_members_scope_id_scopes_id_fk": {
+          "name": "scope_members_scope_id_scopes_id_fk",
+          "tableFrom": "scope_members",
+          "tableTo": "scopes",
+          "columnsFrom": ["scope_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "scope_members_role_check": {
+          "name": "scope_members_role_check",
+          "value": "\"scope_members\".\"role\" IN ('admin', 'member')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.scopes": {
+      "name": "scopes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clerk_org_id": {
+          "name": "clerk_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tier": {
+          "name": "tier",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_scopes_clerk_org": {
+          "name": "idx_scopes_clerk_org",
+          "columns": [
+            {
+              "expression": "clerk_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "scopes_slug_unique": {
+          "name": "scopes_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "scopes_tier_check": {
+          "name": "scopes_tier_check",
+          "value": "\"scopes\".\"tier\" IN ('free', 'pro')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.secrets": {
+      "name": "secrets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_value": {
+          "name": "encrypted_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_secrets_scope_user_name_type": {
+          "name": "idx_secrets_scope_user_name_type",
+          "columns": [
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_secrets_scope": {
+          "name": "idx_secrets_scope",
+          "columns": [
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_secrets_type": {
+          "name": "idx_secrets_type",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "secrets_scope_id_scopes_id_fk": {
+          "name": "secrets_scope_id_scopes_id_fk",
+          "tableFrom": "secrets",
+          "tableTo": "scopes",
+          "columnsFrom": ["scope_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_compose_requests": {
+      "name": "slack_compose_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "compose_job_id": {
+          "name": "compose_job_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_workspace_id": {
+          "name": "slack_workspace_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_user_id": {
+          "name": "slack_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_channel_id": {
+          "name": "slack_channel_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_slack_compose_requests_job": {
+          "name": "idx_slack_compose_requests_job",
+          "columns": [
+            {
+              "expression": "compose_job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "slack_compose_requests_compose_job_id_compose_jobs_id_fk": {
+          "name": "slack_compose_requests_compose_job_id_compose_jobs_id_fk",
+          "tableFrom": "slack_compose_requests",
+          "tableTo": "compose_jobs",
+          "columnsFrom": ["compose_job_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_installations": {
+      "name": "slack_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slack_workspace_id": {
+          "name": "slack_workspace_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_workspace_name": {
+          "name": "slack_workspace_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_bot_token": {
+          "name": "encrypted_bot_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bot_user_id": {
+          "name": "bot_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_compose_id": {
+          "name": "default_compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "admin_slack_user_id": {
+          "name": "admin_slack_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "slack_installations_default_compose_id_agent_composes_id_fk": {
+          "name": "slack_installations_default_compose_id_agent_composes_id_fk",
+          "tableFrom": "slack_installations",
+          "tableTo": "agent_composes",
+          "columnsFrom": ["default_compose_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "slack_installations_slack_workspace_id_unique": {
+          "name": "slack_installations_slack_workspace_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slack_workspace_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_pending_questions": {
+      "name": "slack_pending_questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_workspace_id": {
+          "name": "slack_workspace_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_channel_id": {
+          "name": "slack_channel_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_thread_ts": {
+          "name": "slack_thread_ts",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_message_ts": {
+          "name": "slack_message_ts",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_link_id": {
+          "name": "user_link_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "compose_id": {
+          "name": "compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "questions": {
+          "name": "questions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "answered_at": {
+          "name": "answered_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_slack_pending_questions_run_id": {
+          "name": "idx_slack_pending_questions_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_thread_sessions": {
+      "name": "slack_thread_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slack_user_link_id": {
+          "name": "slack_user_link_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_channel_id": {
+          "name": "slack_channel_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_thread_ts": {
+          "name": "slack_thread_ts",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_session_id": {
+          "name": "agent_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_processed_message_ts": {
+          "name": "last_processed_message_ts",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_slack_thread_sessions_thread_user_link": {
+          "name": "idx_slack_thread_sessions_thread_user_link",
+          "columns": [
+            {
+              "expression": "slack_user_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slack_channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slack_thread_ts",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_slack_thread_sessions_user_link": {
+          "name": "idx_slack_thread_sessions_user_link",
+          "columns": [
+            {
+              "expression": "slack_user_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "slack_thread_sessions_slack_user_link_id_slack_user_links_id_fk": {
+          "name": "slack_thread_sessions_slack_user_link_id_slack_user_links_id_fk",
+          "tableFrom": "slack_thread_sessions",
+          "tableTo": "slack_user_links",
+          "columnsFrom": ["slack_user_link_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "slack_thread_sessions_agent_session_id_agent_sessions_id_fk": {
+          "name": "slack_thread_sessions_agent_session_id_agent_sessions_id_fk",
+          "tableFrom": "slack_thread_sessions",
+          "tableTo": "agent_sessions",
+          "columnsFrom": ["agent_session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_user_links": {
+      "name": "slack_user_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slack_user_id": {
+          "name": "slack_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_workspace_id": {
+          "name": "slack_workspace_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vm0_user_id": {
+          "name": "vm0_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dm_welcome_sent": {
+          "name": "dm_welcome_sent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_slack_user_links_user_workspace": {
+          "name": "idx_slack_user_links_user_workspace",
+          "columns": [
+            {
+              "expression": "slack_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slack_workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.storage_versions": {
+      "name": "storage_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "storage_id": {
+          "name": "storage_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "file_count": {
+          "name": "file_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "storage_versions_storage_id_storages_id_fk": {
+          "name": "storage_versions_storage_id_storages_id_fk",
+          "tableFrom": "storage_versions",
+          "tableTo": "storages",
+          "columnsFrom": ["storage_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.storages": {
+      "name": "storages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'volume'"
+        },
+        "s3_prefix": {
+          "name": "s3_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "file_count": {
+          "name": "file_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "head_version_id": {
+          "name": "head_version_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_storages_scope_name_type": {
+          "name": "idx_storages_scope_name_type",
+          "columns": [
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_storages_scope": {
+          "name": "idx_storages_scope",
+          "columns": [
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "storages_scope_id_scopes_id_fk": {
+          "name": "storages_scope_id_scopes_id_fk",
+          "tableFrom": "storages",
+          "tableTo": "scopes",
+          "columnsFrom": ["scope_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "storages_head_version_id_storage_versions_id_fk": {
+          "name": "storages_head_version_id_storage_versions_id_fk",
+          "tableFrom": "storages",
+          "tableTo": "storage_versions",
+          "columnsFrom": ["head_version_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_installations": {
+      "name": "telegram_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "telegram_bot_id": {
+          "name": "telegram_bot_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bot_username": {
+          "name": "bot_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_bot_token": {
+          "name": "encrypted_bot_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhook_secret": {
+          "name": "webhook_secret",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_compose_id": {
+          "name": "default_compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "admin_user_id": {
+          "name": "admin_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "telegram_installations_default_compose_id_agent_composes_id_fk": {
+          "name": "telegram_installations_default_compose_id_agent_composes_id_fk",
+          "tableFrom": "telegram_installations",
+          "tableTo": "agent_composes",
+          "columnsFrom": ["default_compose_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "telegram_installations_telegram_bot_id_unique": {
+          "name": "telegram_installations_telegram_bot_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["telegram_bot_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_messages": {
+      "name": "telegram_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_user_id": {
+          "name": "from_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_username": {
+          "name": "from_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_bot": {
+          "name": "is_bot",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_telegram_messages_unique": {
+          "name": "idx_telegram_messages_unique",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_telegram_messages_chat": {
+          "name": "idx_telegram_messages_chat",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_telegram_messages_created_at": {
+          "name": "idx_telegram_messages_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "telegram_messages_installation_id_telegram_installations_id_fk": {
+          "name": "telegram_messages_installation_id_telegram_installations_id_fk",
+          "tableFrom": "telegram_messages",
+          "tableTo": "telegram_installations",
+          "columnsFrom": ["installation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_thread_sessions": {
+      "name": "telegram_thread_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "telegram_user_link_id": {
+          "name": "telegram_user_link_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "root_message_id": {
+          "name": "root_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_session_id": {
+          "name": "agent_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_processed_message_id": {
+          "name": "last_processed_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_telegram_thread_sessions_chat_user_link": {
+          "name": "idx_telegram_thread_sessions_chat_user_link",
+          "columns": [
+            {
+              "expression": "telegram_user_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "root_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_telegram_thread_sessions_user_link": {
+          "name": "idx_telegram_thread_sessions_user_link",
+          "columns": [
+            {
+              "expression": "telegram_user_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "telegram_thread_sessions_telegram_user_link_id_telegram_user_links_id_fk": {
+          "name": "telegram_thread_sessions_telegram_user_link_id_telegram_user_links_id_fk",
+          "tableFrom": "telegram_thread_sessions",
+          "tableTo": "telegram_user_links",
+          "columnsFrom": ["telegram_user_link_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "telegram_thread_sessions_agent_session_id_agent_sessions_id_fk": {
+          "name": "telegram_thread_sessions_agent_session_id_agent_sessions_id_fk",
+          "tableFrom": "telegram_thread_sessions",
+          "tableTo": "agent_sessions",
+          "columnsFrom": ["agent_session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_user_links": {
+      "name": "telegram_user_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "telegram_user_id": {
+          "name": "telegram_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vm0_user_id": {
+          "name": "vm0_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dm_welcome_sent": {
+          "name": "dm_welcome_sent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_telegram_user_links_user_installation": {
+          "name": "idx_telegram_user_links_user_installation",
+          "columns": [
+            {
+              "expression": "telegram_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "telegram_user_links_installation_id_telegram_installations_id_fk": {
+          "name": "telegram_user_links_installation_id_telegram_installations_id_fk",
+          "tableFrom": "telegram_user_links",
+          "tableTo": "telegram_installations",
+          "columnsFrom": ["installation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.usage_daily": {
+      "name": "usage_daily",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_count": {
+          "name": "run_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "run_time_ms": {
+          "name": "run_time_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_usage_daily_user_date": {
+          "name": "uq_usage_daily_user_date",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.variables": {
+      "name": "variables",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_variables_scope_user_name": {
+          "name": "idx_variables_scope_user_name",
+          "columns": [
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_variables_scope": {
+          "name": "idx_variables_scope",
+          "columns": [
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "variables_scope_id_scopes_id_fk": {
+          "name": "variables_scope_id_scopes_id_fk",
+          "tableFrom": "variables",
+          "tableTo": "scopes",
+          "columnsFrom": ["scope_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.connector_session_status": {
+      "name": "connector_session_status",
+      "schema": "public",
+      "values": ["pending", "complete", "expired", "error"]
+    },
+    "public.device_code_status": {
+      "name": "device_code_status",
+      "schema": "public",
+      "values": ["pending", "authenticated", "expired", "denied"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/turbo/apps/web/src/db/migrations/meta/_journal.json
+++ b/turbo/apps/web/src/db/migrations/meta/_journal.json
@@ -778,6 +778,13 @@
       "when": 1772877185741,
       "tag": "0110_woozy_hemingway",
       "breakpoints": true
+    },
+    {
+      "idx": 111,
+      "version": "7",
+      "when": 1773033686755,
+      "tag": "0111_wooden_gambit",
+      "breakpoints": true
     }
   ]
 }

--- a/turbo/apps/web/src/db/schema/telegram-message.ts
+++ b/turbo/apps/web/src/db/schema/telegram-message.ts
@@ -28,6 +28,8 @@ export const telegramMessages = pgTable(
     fromUserId: varchar("from_user_id", { length: 255 }).notNull(),
     fromUsername: varchar("from_username", { length: 255 }),
     text: text("text"),
+    /** Telegram file_id for photos — used to download images for context */
+    fileId: varchar("file_id", { length: 255 }),
     isBot: boolean("is_bot").default(false).notNull(),
     createdAt: timestamp("created_at").defaultNow().notNull(),
   },

--- a/turbo/apps/web/src/lib/callback/dispatcher.ts
+++ b/turbo/apps/web/src/lib/callback/dispatcher.ts
@@ -1,4 +1,4 @@
-import { eq, and } from "drizzle-orm";
+import { eq, and, or } from "drizzle-orm";
 import { agentRunCallbacks } from "../../db/schema/agent-run-callback";
 import { agentRuns } from "../../db/schema/agent-run";
 import { decryptCredentialValue } from "../crypto/secrets-encryption";
@@ -54,7 +54,7 @@ export async function dispatchCallbacks(
 ): Promise<DispatchResult[]> {
   const { SECRETS_ENCRYPTION_KEY } = env();
 
-  // Fetch all pending callbacks for this run
+  // Fetch only pending callbacks for this run (prevents double dispatch on retries)
   const callbacks = await globalThis.services.db
     .select({
       id: agentRunCallbacks.id,
@@ -63,7 +63,15 @@ export async function dispatchCallbacks(
       payload: agentRunCallbacks.payload,
     })
     .from(agentRunCallbacks)
-    .where(eq(agentRunCallbacks.runId, runId));
+    .where(
+      and(
+        eq(agentRunCallbacks.runId, runId),
+        or(
+          eq(agentRunCallbacks.status, "pending"),
+          eq(agentRunCallbacks.status, "failed"),
+        ),
+      ),
+    );
 
   if (callbacks.length === 0) {
     return [];

--- a/turbo/apps/web/src/lib/telegram/__tests__/context.test.ts
+++ b/turbo/apps/web/src/lib/telegram/__tests__/context.test.ts
@@ -16,13 +16,15 @@ describe("formatContextForAgent", () => {
         text: "Hello",
         isBot: false,
         messageId: "1",
+        fileId: null,
       },
     ];
 
     const result = formatContextForAgent(messages);
 
     expect(result).toContain("# Telegram Chat Context");
-    expect(result).toContain("[alice]: Hello");
+    expect(result).toContain("SENDER_ID: alice");
+    expect(result).toContain("Hello");
   });
 
   it("should fall back to user ID when username is null", () => {
@@ -33,12 +35,14 @@ describe("formatContextForAgent", () => {
         text: "Hi there",
         isBot: false,
         messageId: "2",
+        fileId: null,
       },
     ];
 
     const result = formatContextForAgent(messages);
 
-    expect(result).toContain("[user:222]: Hi there");
+    expect(result).toContain("SENDER_ID: user:222");
+    expect(result).toContain("Hi there");
   });
 
   it("should label bot messages as BOT", () => {
@@ -49,15 +53,17 @@ describe("formatContextForAgent", () => {
         text: "I am a bot",
         isBot: true,
         messageId: "3",
+        fileId: null,
       },
     ];
 
     const result = formatContextForAgent(messages);
 
-    expect(result).toContain("[BOT]: I am a bot");
+    expect(result).toContain("SENDER_ID: BOT");
+    expect(result).toContain("I am a bot");
   });
 
-  it("should filter out messages with null text", () => {
+  it("should filter out messages with null text and no file", () => {
     const messages = [
       {
         fromUsername: "alice",
@@ -65,6 +71,7 @@ describe("formatContextForAgent", () => {
         text: null,
         isBot: false,
         messageId: "1",
+        fileId: null,
       },
       {
         fromUsername: "bob",
@@ -72,13 +79,14 @@ describe("formatContextForAgent", () => {
         text: "Visible",
         isBot: false,
         messageId: "2",
+        fileId: null,
       },
     ];
 
     const result = formatContextForAgent(messages);
 
-    expect(result).not.toContain("[alice]");
-    expect(result).toContain("[bob]: Visible");
+    expect(result).not.toContain("alice");
+    expect(result).toContain("Visible");
   });
 
   it("should include context preamble", () => {
@@ -89,6 +97,7 @@ describe("formatContextForAgent", () => {
         text: "Hello",
         isBot: false,
         messageId: "1",
+        fileId: null,
       },
     ];
 
@@ -111,6 +120,7 @@ describe("formatContextForAgent", () => {
         text: "First",
         isBot: false,
         messageId: "1",
+        fileId: null,
       },
       {
         fromUsername: null,
@@ -118,6 +128,7 @@ describe("formatContextForAgent", () => {
         text: "Second",
         isBot: false,
         messageId: "2",
+        fileId: null,
       },
       {
         fromUsername: "bot",
@@ -125,18 +136,18 @@ describe("formatContextForAgent", () => {
         text: "Third",
         isBot: true,
         messageId: "3",
+        fileId: null,
       },
     ];
 
     const result = formatContextForAgent(messages);
 
-    const lines = result.split("\n");
-    const aliceLine = lines.findIndex((l) => l.includes("[alice]: First"));
-    const userLine = lines.findIndex((l) => l.includes("[user:222]: Second"));
-    const botLine = lines.findIndex((l) => l.includes("[BOT]: Third"));
+    const aliceIdx = result.indexOf("First");
+    const userIdx = result.indexOf("Second");
+    const botIdx = result.indexOf("Third");
 
-    expect(aliceLine).toBeLessThan(userLine);
-    expect(userLine).toBeLessThan(botLine);
+    expect(aliceIdx).toBeLessThan(userIdx);
+    expect(userIdx).toBeLessThan(botIdx);
   });
 });
 
@@ -178,11 +189,13 @@ describe("fetchTelegramContext", () => {
 
     const result = await fetchTelegramContext(installationId, chatId);
 
-    expect(result.routingContext).toContain("[alice]: First message");
-    expect(result.routingContext).toContain("[bob]: Second message");
+    expect(result.routingContext).toContain("First message");
+    expect(result.routingContext).toContain("SENDER_ID: alice");
+    expect(result.routingContext).toContain("Second message");
+    expect(result.routingContext).toContain("SENDER_ID: bob");
 
-    const firstIdx = result.routingContext.indexOf("[alice]: First message");
-    const secondIdx = result.routingContext.indexOf("[bob]: Second message");
+    const firstIdx = result.routingContext.indexOf("First message");
+    const secondIdx = result.routingContext.indexOf("Second message");
     expect(firstIdx).toBeLessThan(secondIdx);
   });
 
@@ -211,12 +224,12 @@ describe("fetchTelegramContext", () => {
     const result = await fetchTelegramContext(installationId, chatId, "10");
 
     // Routing context includes all messages
-    expect(result.routingContext).toContain("[alice]: Old message");
-    expect(result.routingContext).toContain("[bob]: New message");
+    expect(result.routingContext).toContain("Old message");
+    expect(result.routingContext).toContain("New message");
 
     // Execution context only includes messages after ID 10
-    expect(result.executionContext).not.toContain("[alice]: Old message");
-    expect(result.executionContext).toContain("[bob]: New message");
+    expect(result.executionContext).not.toContain("Old message");
+    expect(result.executionContext).toContain("New message");
   });
 
   it("should return empty execution context when no new messages after lastProcessedMessageId", async () => {
@@ -234,7 +247,7 @@ describe("fetchTelegramContext", () => {
 
     const result = await fetchTelegramContext(installationId, chatId, "5");
 
-    expect(result.routingContext).toContain("[alice]: Only message");
+    expect(result.routingContext).toContain("Only message");
     expect(result.executionContext).toBe("");
   });
 
@@ -261,8 +274,8 @@ describe("fetchTelegramContext", () => {
 
     const result = await fetchTelegramContext(installationId, chatA);
 
-    expect(result.routingContext).toContain("[alice]: Chat A message");
-    expect(result.routingContext).not.toContain("[bob]: Chat B message");
+    expect(result.routingContext).toContain("Chat A message");
+    expect(result.routingContext).not.toContain("Chat B message");
   });
 
   it("should include bot messages in context", async () => {
@@ -290,7 +303,8 @@ describe("fetchTelegramContext", () => {
 
     const result = await fetchTelegramContext(installationId, chatId);
 
-    expect(result.routingContext).toContain("[alice]: User message");
-    expect(result.routingContext).toContain("[BOT]: Bot reply");
+    expect(result.routingContext).toContain("User message");
+    expect(result.routingContext).toContain("SENDER_ID: BOT");
+    expect(result.routingContext).toContain("Bot reply");
   });
 });

--- a/turbo/apps/web/src/lib/telegram/__tests__/format.test.ts
+++ b/turbo/apps/web/src/lib/telegram/__tests__/format.test.ts
@@ -41,6 +41,18 @@ describe("markdownToTelegramHtml", () => {
     );
   });
 
+  it("should convert images to clickable links", () => {
+    expect(
+      markdownToTelegramHtml("![screenshot](https://example.com/img.png)"),
+    ).toBe('<a href="https://example.com/img.png">🖼 screenshot</a>');
+  });
+
+  it("should use default alt text for images without alt", () => {
+    expect(markdownToTelegramHtml("![](https://example.com/img.png)")).toBe(
+      '<a href="https://example.com/img.png">🖼 image</a>',
+    );
+  });
+
   it("should handle mixed formatting", () => {
     const input = "Hello **bold** and *italic* with `code`";
     const expected =

--- a/turbo/apps/web/src/lib/telegram/__tests__/images.test.ts
+++ b/turbo/apps/web/src/lib/telegram/__tests__/images.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from "vitest";
+import { pickBestPhoto, formatPhotoForContext } from "../images";
+
+describe("pickBestPhoto", () => {
+  it("should return undefined for empty array", () => {
+    expect(pickBestPhoto([])).toBeUndefined();
+  });
+
+  it("should return the single photo when only one is provided", () => {
+    const photos = [{ file_id: "a", width: 100, height: 100 }];
+    expect(pickBestPhoto(photos)).toBe(photos[0]);
+  });
+
+  it("should pick the largest photo by area", () => {
+    const photos = [
+      { file_id: "small", width: 100, height: 100, file_size: 1000 },
+      { file_id: "large", width: 800, height: 600, file_size: 50000 },
+      { file_id: "medium", width: 320, height: 240, file_size: 10000 },
+    ];
+    const result = pickBestPhoto(photos);
+    expect(result?.file_id).toBe("large");
+  });
+
+  it("should skip photos exceeding 10MB size limit", () => {
+    const photos = [
+      {
+        file_id: "huge",
+        width: 4000,
+        height: 3000,
+        file_size: 15 * 1024 * 1024,
+      },
+      { file_id: "ok", width: 800, height: 600, file_size: 500000 },
+    ];
+    const result = pickBestPhoto(photos);
+    expect(result?.file_id).toBe("ok");
+  });
+
+  it("should accept photos without file_size (treats as within limit)", () => {
+    const photos = [
+      { file_id: "no-size", width: 1920, height: 1080 },
+      { file_id: "with-size", width: 800, height: 600, file_size: 50000 },
+    ];
+    const result = pickBestPhoto(photos);
+    expect(result?.file_id).toBe("no-size");
+  });
+
+  it("should fall back to smallest when all exceed size limit", () => {
+    const photos = [
+      {
+        file_id: "huge1",
+        width: 4000,
+        height: 3000,
+        file_size: 15 * 1024 * 1024,
+      },
+      {
+        file_id: "huge2",
+        width: 2000,
+        height: 1500,
+        file_size: 12 * 1024 * 1024,
+      },
+    ];
+    // Falls back to the smallest by area (last in sorted order)
+    const result = pickBestPhoto(photos);
+    expect(result?.file_id).toBe("huge2");
+  });
+
+  it("should pick photo exactly at size limit", () => {
+    const limit = 10 * 1024 * 1024;
+    const photos = [
+      { file_id: "exact", width: 1920, height: 1080, file_size: limit },
+      { file_id: "small", width: 320, height: 240, file_size: 1000 },
+    ];
+    const result = pickBestPhoto(photos);
+    expect(result?.file_id).toBe("exact");
+  });
+});
+
+describe("formatPhotoForContext", () => {
+  it("should include image type and dimensions", () => {
+    const result = formatPhotoForContext("https://example.com/photo.jpg", {
+      file_id: "abc123",
+      width: 800,
+      height: 600,
+    });
+
+    expect(result).toContain("[image]: photo (image/jpeg)");
+    expect(result).toContain("Dimensions: 800x600");
+  });
+
+  it("should include presigned URL in curl command", () => {
+    const url = "https://r2.example.com/photo.jpg?token=abc";
+    const result = formatPhotoForContext(url, {
+      file_id: "file_1",
+      width: 400,
+      height: 300,
+    });
+
+    expect(result).toContain(`"${url}"`);
+    expect(result).toContain("curl -sS -o");
+  });
+
+  it("should use file_id in output filename", () => {
+    const result = formatPhotoForContext("https://example.com/photo.jpg", {
+      file_id: "my_file_id",
+      width: 100,
+      height: 100,
+    });
+
+    expect(result).toContain("my_file_id.jpg");
+  });
+
+  it("should skip dimensions when width or height is 0", () => {
+    const result = formatPhotoForContext("https://example.com/photo.jpg", {
+      file_id: "abc",
+      width: 0,
+      height: 0,
+    });
+
+    expect(result).not.toContain("Dimensions");
+  });
+});

--- a/turbo/apps/web/src/lib/telegram/client.ts
+++ b/turbo/apps/web/src/lib/telegram/client.ts
@@ -162,6 +162,34 @@ export async function deleteMessage(
   });
 }
 
+interface TelegramFile {
+  file_id: string;
+  file_unique_id: string;
+  file_size?: number;
+  file_path?: string;
+}
+
+/**
+ * Get file info and download path from Telegram.
+ * The returned file_path can be used to download via:
+ * https://api.telegram.org/file/bot<token>/<file_path>
+ */
+export async function getFile(
+  client: TelegramClient,
+  fileId: string,
+): Promise<TelegramFile> {
+  return callTelegramApi<TelegramFile>(client.token, "getFile", {
+    file_id: fileId,
+  });
+}
+
+/**
+ * Build a download URL for a Telegram file.
+ */
+export function buildFileDownloadUrl(token: string, filePath: string): string {
+  return `https://api.telegram.org/file/bot${token}/${filePath}`;
+}
+
 /**
  * Register bot commands
  */

--- a/turbo/apps/web/src/lib/telegram/context.ts
+++ b/turbo/apps/web/src/lib/telegram/context.ts
@@ -1,5 +1,10 @@
 import { eq, and, desc } from "drizzle-orm";
 import { telegramMessages } from "../../db/schema/telegram-message";
+import {
+  downloadAndUploadTelegramPhoto,
+  formatPhotoForContext,
+} from "./images";
+import type { TelegramClient } from "./client";
 import { logger } from "../logger";
 
 const log = logger("telegram:context");
@@ -18,6 +23,7 @@ interface TelegramContextMessage {
   fromUsername: string | null;
   fromUserId: string;
   text: string | null;
+  fileId: string | null;
   isBot: boolean;
   messageId: string;
 }
@@ -28,18 +34,23 @@ interface TelegramContextMessage {
  * @param installationId - Telegram installation ID
  * @param chatId - Telegram chat ID
  * @param lastProcessedMessageId - Only include messages after this ID for execution context
- * @returns routingContext (all recent text) and executionContext (only new messages)
+ * @param client - Telegram client (needed to download images for execution context)
+ * @param currentMessageId - The message being processed; excluded from context to avoid duplication with prompt
+ * @returns routingContext (all recent text) and executionContext (only new messages, with images)
  */
 export async function fetchTelegramContext(
   installationId: string,
   chatId: string,
   lastProcessedMessageId?: string,
+  client?: TelegramClient,
+  currentMessageId?: string,
 ): Promise<{ routingContext: string; executionContext: string }> {
   const messages = await globalThis.services.db
     .select({
       fromUsername: telegramMessages.fromUsername,
       fromUserId: telegramMessages.fromUserId,
       text: telegramMessages.text,
+      fileId: telegramMessages.fileId,
       isBot: telegramMessages.isBot,
       messageId: telegramMessages.messageId,
     })
@@ -54,13 +65,17 @@ export async function fetchTelegramContext(
     .limit(MAX_CONTEXT_MESSAGES);
 
   // Reverse to chronological order (oldest first)
-  const chronological = messages.reverse();
+  // Exclude the current message to avoid duplication with the user prompt
+  const chronological = messages
+    .reverse()
+    .filter((m) => !currentMessageId || m.messageId !== currentMessageId);
 
   log.debug("Fetched telegram context messages", {
     chatId,
     count: chronological.length,
   });
 
+  // Routing context: text only, no image downloads
   const routingContext = formatContextForAgent(chronological);
 
   // For execution context, only include messages after lastProcessedMessageId
@@ -70,16 +85,61 @@ export async function fetchTelegramContext(
       )
     : chronological;
 
+  // Execution context: include images (download + upload to R2)
   const executionContext =
     executionMessages.length > 0
-      ? formatContextForAgent(executionMessages)
+      ? await formatContextForAgentWithImages(
+          executionMessages,
+          client,
+          `${installationId}-${chatId}`,
+        )
       : "";
 
   return { routingContext, executionContext };
 }
 
 /**
- * Format message array into agent-readable text
+ * Format a single message with structured metadata.
+ *
+ * Mirrors the Slack context format so the agent sees a consistent
+ * structure across integrations:
+ *
+ * ---
+ *
+ * - RELATIVE_INDEX: -n
+ * - MSG_ID: 12345
+ * - SENDER_ID: username | user:id | BOT
+ *
+ * message text
+ */
+function formatMessageWithMetadata(
+  msg: TelegramContextMessage,
+  relativeIndex: number,
+  imageParts?: string[],
+): string {
+  const senderId = msg.isBot
+    ? "BOT"
+    : (msg.fromUsername ?? `user:${msg.fromUserId}`);
+
+  const parts: string[] = [
+    "---",
+    "",
+    `- RELATIVE_INDEX: ${relativeIndex}`,
+    `- MSG_ID: ${msg.messageId}`,
+    `- SENDER_ID: ${senderId}`,
+    "",
+    msg.text ?? "",
+  ];
+
+  if (imageParts && imageParts.length > 0) {
+    parts.push(...imageParts);
+  }
+
+  return parts.join("\n");
+}
+
+/**
+ * Format message array into agent-readable text (text only, no image downloads)
  */
 export function formatContextForAgent(
   messages: TelegramContextMessage[],
@@ -88,15 +148,78 @@ export function formatContextForAgent(
     return "";
   }
 
-  const formatted = messages
-    .filter((m) => m.text)
-    .map((m) => {
-      const sender = m.isBot
-        ? "BOT"
-        : (m.fromUsername ?? `user:${m.fromUserId}`);
-      return `[${sender}]: ${m.text}`;
-    })
-    .join("\n");
+  const totalMessages = messages.length;
 
-  return `# Telegram Chat Context\n\n${CONTEXT_PREAMBLE}\n\n${formatted}`;
+  const formattedMessages = messages
+    .filter((m) => m.text || m.fileId)
+    .map((msg, index) => {
+      const relativeIndex = index - totalMessages;
+      const imageParts: string[] = [];
+      if (msg.fileId) {
+        imageParts.push("[image]: photo (not downloaded for routing context)");
+      }
+      return formatMessageWithMetadata(msg, relativeIndex, imageParts);
+    });
+
+  const result = `# Telegram Chat Context\n\n${CONTEXT_PREAMBLE}\n\n${formattedMessages.join("\n\n")}\n\n---`;
+  log.debug("Formatted messages for context", {
+    messageCount: formattedMessages.length,
+    resultLength: result.length,
+  });
+  return result;
+}
+
+/**
+ * Format message array with image downloads (for execution context).
+ * Downloads photos via Telegram API and uploads to R2 for agent access.
+ */
+async function formatContextForAgentWithImages(
+  messages: TelegramContextMessage[],
+  client: TelegramClient | undefined,
+  sessionId: string,
+): Promise<string> {
+  if (messages.length === 0) {
+    return "";
+  }
+
+  const totalMessages = messages.length;
+
+  const formattedMessages = await Promise.all(
+    messages
+      .filter((m) => m.text || m.fileId)
+      .map(async (msg, index) => {
+        const relativeIndex = index - totalMessages;
+        const imageParts: string[] = [];
+
+        if (msg.fileId && client) {
+          const presignedUrl = await downloadAndUploadTelegramPhoto(
+            client,
+            msg.fileId,
+            sessionId,
+          );
+          if (presignedUrl) {
+            imageParts.push(
+              formatPhotoForContext(presignedUrl, {
+                file_id: msg.fileId,
+                width: 0,
+                height: 0,
+              }),
+            );
+          } else {
+            imageParts.push("[image]: photo (failed to download)");
+          }
+        } else if (msg.fileId) {
+          imageParts.push("[image]: photo (no client available)");
+        }
+
+        return formatMessageWithMetadata(msg, relativeIndex, imageParts);
+      }),
+  );
+
+  const result = `# Telegram Chat Context\n\n${CONTEXT_PREAMBLE}\n\n${formattedMessages.join("\n\n")}\n\n---`;
+  log.debug("Formatted messages for context with images", {
+    messageCount: formattedMessages.length,
+    resultLength: result.length,
+  });
+  return result;
 }

--- a/turbo/apps/web/src/lib/telegram/format.ts
+++ b/turbo/apps/web/src/lib/telegram/format.ts
@@ -46,6 +46,16 @@ export function markdownToTelegramHtml(markdown: string): string {
       continue;
     }
 
+    // Images: ![alt](url) → clickable link (Telegram doesn't support inline images)
+    const imageMatch = remaining.match(/^!\[([^\]]*)\]\(([^)]+)\)/);
+    if (imageMatch) {
+      const altText = (imageMatch[1] as string) || "image";
+      const imageUrl = imageMatch[2] as string;
+      result += `<a href="${escapeHtml(imageUrl)}">🖼 ${escapeHtml(altText)}</a>`;
+      remaining = remaining.slice(imageMatch[0].length);
+      continue;
+    }
+
     // Links: [text](url)
     const linkMatch = remaining.match(/^\[([^\]]+)\]\(([^)]+)\)/);
     if (linkMatch) {

--- a/turbo/apps/web/src/lib/telegram/handlers/commands.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/commands.ts
@@ -64,6 +64,18 @@ export async function handleConnectCommand(
     return;
   }
 
+  // In group chats, don't expose the connect URL publicly to prevent
+  // other users from hijacking the link. Direct users to DM instead.
+  if (message.chat.type !== "private") {
+    await sendMessage(
+      client,
+      chatId,
+      `🔗 Please <a href="https://t.me/${escapeHtml(installation.botUsername ?? "")}?start=connect">send me /connect</a> in a private message to connect your account.`,
+      replyOptions,
+    );
+    return;
+  }
+
   const connectUrl = buildConnectUrl(
     installationId,
     installation.telegramBotId,
@@ -74,7 +86,6 @@ export async function handleConnectCommand(
     client,
     chatId,
     `🔗 Connect your account to get started:\n\n<a href="${escapeHtml(connectUrl)}">Open Platform</a>`,
-    replyOptions,
   );
 }
 
@@ -183,18 +194,26 @@ export async function handleSettingsCommand(
       : undefined;
 
   if (!userLink) {
-    const connectUrl = buildConnectUrl(
-      installationId,
-      installation.telegramBotId,
-      fromUserId,
-      botToken,
-    );
-    await sendMessage(
-      client,
-      chatId,
-      `🔗 Connect your account to get started:\n\n<a href="${escapeHtml(connectUrl)}">Open Platform</a>`,
-      replyOptions,
-    );
+    if (message.chat.type !== "private") {
+      await sendMessage(
+        client,
+        chatId,
+        `🔗 Please <a href="https://t.me/${escapeHtml(installation.botUsername ?? "")}?start=connect">send me /connect</a> in a private message to connect your account.`,
+        replyOptions,
+      );
+    } else {
+      const connectUrl = buildConnectUrl(
+        installationId,
+        installation.telegramBotId,
+        fromUserId,
+        botToken,
+      );
+      await sendMessage(
+        client,
+        chatId,
+        `🔗 Connect your account to get started:\n\n<a href="${escapeHtml(connectUrl)}">Open Platform</a>`,
+      );
+    }
     return;
   }
 

--- a/turbo/apps/web/src/lib/telegram/handlers/direct-message.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/direct-message.ts
@@ -3,8 +3,13 @@ import { telegramInstallations } from "../../../db/schema/telegram-installation"
 import { decryptCredentialValue } from "../../crypto/secrets-encryption";
 import { env } from "../../../env";
 import { createTelegramClient, sendMessage, deleteMessage } from "../client";
-import { sendThinkingMessage } from "./shared";
+import { sendThinkingMessage, enrichTelegramPrompt } from "./shared";
 import { fetchTelegramContext } from "../context";
+import {
+  pickBestPhoto,
+  downloadAndUploadTelegramPhoto,
+  formatPhotoForContext,
+} from "../images";
 import { runAgentForTelegram } from "./run-agent";
 import {
   lookupTelegramThreadSession,
@@ -125,16 +130,35 @@ export async function handleTelegramDirectMessage(
       installationId,
       chatId,
       lastProcessedMessageId,
+      client,
+      String(message.message_id),
     );
     executionContext = ctx.executionContext;
   }
 
-  // 9. Dispatch agent run
+  // 9. Enrich prompt with user info and current message's photo
+  let enrichedPrompt = enrichTelegramPrompt(
+    message.text ?? message.caption ?? "",
+    message.from,
+  );
+  if (message.photo) {
+    const bestPhoto = pickBestPhoto(message.photo);
+    if (bestPhoto) {
+      const presignedUrl = await downloadAndUploadTelegramPhoto(
+        client,
+        bestPhoto.file_id,
+        `${installationId}-${chatId}`,
+      );
+      if (presignedUrl) {
+        enrichedPrompt += `\n\n${formatPhotoForContext(presignedUrl, bestPhoto)}`;
+      }
+    }
+  }
   const { status, response } = await runAgentForTelegram({
     composeId,
     agentName,
     sessionId: existingSessionId,
-    prompt: message.text ?? "",
+    prompt: enrichedPrompt,
     threadContext: executionContext,
     userId: userLink.vm0UserId,
     callbackContext: {

--- a/turbo/apps/web/src/lib/telegram/handlers/mention.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/mention.ts
@@ -3,8 +3,13 @@ import { telegramInstallations } from "../../../db/schema/telegram-installation"
 import { decryptCredentialValue } from "../../crypto/secrets-encryption";
 import { env } from "../../../env";
 import { createTelegramClient, sendMessage, deleteMessage } from "../client";
-import { sendThinkingMessage } from "./shared";
+import { sendThinkingMessage, enrichTelegramPrompt } from "./shared";
 import { fetchTelegramContext } from "../context";
+import {
+  pickBestPhoto,
+  downloadAndUploadTelegramPhoto,
+  formatPhotoForContext,
+} from "../images";
 import { runAgentForTelegram } from "./run-agent";
 import {
   lookupTelegramThreadSession,
@@ -96,12 +101,28 @@ export async function handleTelegramMention(
   // 5. Store incoming message
   await storeTelegramMessage(installationId, chatId, message);
 
-  // 6. Strip @botusername from message text
+  // 6. Strip @botusername from message text (entities for text, caption_entities for photos)
   const messageText = stripBotMention(
-    message.text ?? "",
+    message.text ?? message.caption ?? "",
     installation.botUsername,
-    message.entities,
+    message.entities ?? message.caption_entities,
   );
+
+  // 6b. Enrich prompt with user info and current message's photo
+  let enrichedPrompt = enrichTelegramPrompt(messageText, message.from);
+  if (message.photo) {
+    const bestPhoto = pickBestPhoto(message.photo);
+    if (bestPhoto) {
+      const presignedUrl = await downloadAndUploadTelegramPhoto(
+        client,
+        bestPhoto.file_id,
+        `${installationId}-${chatId}`,
+      );
+      if (presignedUrl) {
+        enrichedPrompt += `\n\n${formatPhotoForContext(presignedUrl, bestPhoto)}`;
+      }
+    }
+  }
 
   // 7. Determine thread anchor and resolve session
   const { rootMessageId, existingSessionId, lastProcessedMessageId } =
@@ -113,19 +134,19 @@ export async function handleTelegramMention(
       composeId,
     );
 
-  // 9. Fetch context
+  // 9. Fetch context (exclude current message to avoid duplication with prompt)
   const { executionContext } = await fetchTelegramContext(
     installationId,
     chatId,
     lastProcessedMessageId,
+    client,
+    String(message.message_id),
   );
-
-  // 10. Dispatch agent run
   const { status, response } = await runAgentForTelegram({
     composeId,
     agentName,
     sessionId: existingSessionId,
-    prompt: messageText,
+    prompt: enrichedPrompt,
     threadContext: executionContext,
     userId: userLink.vm0UserId,
     callbackContext: {

--- a/turbo/apps/web/src/lib/telegram/handlers/mention.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/mention.ts
@@ -12,7 +12,6 @@ import {
   getWorkspaceAgent,
   resolveSessionCompose,
   resolveUserLink,
-  buildConnectUrl,
 } from "./shared";
 import { escapeHtml } from "../format";
 import { logger } from "../../logger";
@@ -66,16 +65,10 @@ export async function handleTelegramMention(
   const userLink = await resolveUserLink(installationId, fromUserId);
 
   if (!userLink) {
-    const connectUrl = buildConnectUrl(
-      installationId,
-      installation.telegramBotId,
-      fromUserId,
-      botToken,
-    );
     await sendMessage(
       client,
       chatId,
-      `🔗 Connect your account to get started:\n\n<a href="${escapeHtml(connectUrl)}">Open Platform</a>`,
+      `🔗 Please <a href="https://t.me/${escapeHtml(installation.botUsername ?? "")}?start=connect">send me /connect</a> in a private message to connect your account.`,
       { replyToMessageId: message.message_id },
     );
     return;

--- a/turbo/apps/web/src/lib/telegram/handlers/run-agent.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/run-agent.ts
@@ -127,6 +127,7 @@ export async function runAgentForTelegram(
       runId: result.runId,
     };
   } catch (error) {
+    log.error("Error running agent for Telegram:", error);
     if (isConcurrentRunLimit(error)) {
       return {
         status: "failed",
@@ -135,6 +136,11 @@ export async function runAgentForTelegram(
         runId: undefined,
       };
     }
-    throw error;
+    const message = error instanceof Error ? error.message : "Unknown error";
+    return {
+      status: "failed",
+      response: `Error executing agent: ${message}`,
+      runId: undefined,
+    };
   }
 }

--- a/turbo/apps/web/src/lib/telegram/handlers/shared.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/shared.ts
@@ -18,7 +18,9 @@ import {
 } from "../client";
 import { escapeHtml } from "../format";
 import { signConnectParams } from "../connect-token";
+import { pickBestPhoto } from "../images";
 import { logger } from "../../logger";
+import type { TelegramHandlerUpdate } from "./types";
 
 const log = logger("telegram:shared");
 
@@ -126,6 +128,7 @@ export async function saveTelegramThreadSession(opts: {
 
 /**
  * Store an incoming Telegram message for context retrieval.
+ * For photo messages, stores the caption as text and the best photo's file_id.
  */
 export async function storeTelegramMessage(
   installationId: string,
@@ -134,8 +137,17 @@ export async function storeTelegramMessage(
     message_id: number;
     from?: { id: number; username?: string; is_bot?: boolean };
     text?: string;
+    caption?: string;
+    photo?: Array<{
+      file_id: string;
+      width: number;
+      height: number;
+      file_size?: number;
+    }>;
   },
 ): Promise<void> {
+  const bestPhoto = message.photo ? pickBestPhoto(message.photo) : undefined;
+
   await globalThis.services.db
     .insert(telegramMessages)
     .values({
@@ -144,7 +156,8 @@ export async function storeTelegramMessage(
       messageId: String(message.message_id),
       fromUserId: String(message.from?.id ?? 0),
       fromUsername: message.from?.username ?? null,
-      text: message.text ?? null,
+      text: message.text ?? message.caption ?? null,
+      fileId: bestPhoto?.file_id ?? null,
       isBot: message.from?.is_bot ?? false,
     })
     .onConflictDoNothing();
@@ -302,4 +315,37 @@ export async function sendThinkingMessage(
     log.warn("Failed to send thinking message", { chatId, error: err });
     return undefined;
   }
+}
+
+/**
+ * Enrich a Telegram message prompt with user info, matching Slack's
+ * `enrichMessageContent` pattern that prepends `[Slack User]\n...`.
+ *
+ * Telegram provides user info directly in the webhook payload (no API call needed).
+ */
+export function enrichTelegramPrompt(
+  prompt: string,
+  from: TelegramHandlerUpdate["message"]["from"],
+): string {
+  if (!from) {
+    return prompt;
+  }
+
+  const parts: string[] = [];
+  parts.push(`Telegram User ID: ${from.id}`);
+
+  const displayName = [from.first_name, from.last_name]
+    .filter(Boolean)
+    .join(" ");
+  if (displayName) {
+    parts.push(`Name: ${displayName}`);
+  }
+  if (from.username) {
+    parts.push(`Username: @${from.username}`);
+  }
+  if (from.language_code) {
+    parts.push(`Language: ${from.language_code}`);
+  }
+
+  return `[Telegram User]\n${parts.join("\n")}\n\n${prompt}`;
 }

--- a/turbo/apps/web/src/lib/telegram/handlers/start.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/start.ts
@@ -4,7 +4,12 @@ import { telegramUserLinks } from "../../../db/schema/telegram-user-link";
 import { decryptCredentialValue } from "../../crypto/secrets-encryption";
 import { env } from "../../../env";
 import { createTelegramClient, sendMessage } from "../client";
-import { ensureScopeAndArtifact } from "./shared";
+import {
+  ensureScopeAndArtifact,
+  resolveUserLink,
+  buildConnectUrl,
+} from "./shared";
+import { escapeHtml } from "../format";
 import { logger } from "../../logger";
 import type { TelegramHandlerUpdate } from "./types";
 import crypto from "crypto";
@@ -66,6 +71,31 @@ export async function handleStartCommand(
       client,
       chatId,
       "Welcome! Visit the platform to connect your account and start chatting with the agent.",
+    );
+    return;
+  }
+
+  // Deep link from group chat: /start connect → treat as /connect in DM
+  if (token === "connect") {
+    const userLink = await resolveUserLink(installationId, fromUserId);
+    if (userLink) {
+      await sendMessage(
+        client,
+        chatId,
+        "You are already connected! Send me a message to get started.",
+      );
+      return;
+    }
+    const connectUrl = buildConnectUrl(
+      installationId,
+      installation.telegramBotId,
+      fromUserId,
+      botToken,
+    );
+    await sendMessage(
+      client,
+      chatId,
+      `🔗 Connect your account to get started:\n\n<a href="${escapeHtml(connectUrl)}">Open Platform</a>`,
     );
     return;
   }

--- a/turbo/apps/web/src/lib/telegram/handlers/types.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/types.ts
@@ -5,14 +5,35 @@
  * individual command/message handlers (i.e. the `{ message }` wrapper).
  * The webhook route parses the raw update and passes this shape down.
  */
+export interface TelegramPhotoSize {
+  file_id: string;
+  file_unique_id: string;
+  width: number;
+  height: number;
+  file_size?: number;
+}
+
 export interface TelegramHandlerUpdate {
   message: {
     message_id: number;
     chat: { id: number; type: string };
-    from?: { id: number; username?: string; is_bot?: boolean };
+    from?: {
+      id: number;
+      username?: string;
+      first_name?: string;
+      last_name?: string;
+      language_code?: string;
+      is_bot?: boolean;
+    };
     text?: string;
-    /** Present on group messages with @mentions or bot commands */
+    /** Caption for photo/document messages */
+    caption?: string;
+    /** Photo sizes array — present when user sends a photo */
+    photo?: TelegramPhotoSize[];
+    /** Present on text messages with @mentions or bot commands */
     entities?: Array<{ type: string; offset: number; length: number }>;
+    /** Present on photo/document captions with @mentions or bot commands */
+    caption_entities?: Array<{ type: string; offset: number; length: number }>;
     /** Present when the user replies to another message */
     reply_to_message?: {
       message_id: number;

--- a/turbo/apps/web/src/lib/telegram/images.ts
+++ b/turbo/apps/web/src/lib/telegram/images.ts
@@ -2,8 +2,6 @@ import { getFile, buildFileDownloadUrl, type TelegramClient } from "./client";
 import { uploadS3Buffer, generatePresignedUrl } from "../s3/s3-client";
 import { env } from "../../env";
 import { logger } from "../logger";
-import type { TelegramPhotoSize } from "./handlers/types";
-
 const log = logger("telegram:images");
 
 /** Maximum file size to download (10MB) */

--- a/turbo/apps/web/src/lib/telegram/images.ts
+++ b/turbo/apps/web/src/lib/telegram/images.ts
@@ -1,0 +1,143 @@
+import { getFile, buildFileDownloadUrl, type TelegramClient } from "./client";
+import { uploadS3Buffer, generatePresignedUrl } from "../s3/s3-client";
+import { env } from "../../env";
+import { logger } from "../logger";
+import type { TelegramPhotoSize } from "./handlers/types";
+
+const log = logger("telegram:images");
+
+/** Maximum file size to download (10MB) */
+const MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024;
+
+/** Minimal photo fields needed for picking the best size */
+interface PhotoSizeLike {
+  file_id: string;
+  width: number;
+  height: number;
+  file_size?: number;
+}
+
+/**
+ * Pick the best photo size from Telegram's array.
+ * Telegram provides multiple sizes; pick the largest that's within our size limit.
+ */
+export function pickBestPhoto<T extends PhotoSizeLike>(
+  photos: T[],
+): T | undefined {
+  if (photos.length === 0) {
+    return undefined;
+  }
+
+  // Sort by area descending, pick first that fits size limit
+  const sorted = [...photos].sort(
+    (a, b) => b.width * b.height - a.width * a.height,
+  );
+
+  for (const photo of sorted) {
+    if (!photo.file_size || photo.file_size <= MAX_FILE_SIZE_BYTES) {
+      return photo;
+    }
+  }
+
+  // All too large — pick the smallest
+  return sorted[sorted.length - 1];
+}
+
+/**
+ * Download a Telegram photo and upload it to R2.
+ * Returns a presigned URL that the agent can access.
+ */
+export async function downloadAndUploadTelegramPhoto(
+  client: TelegramClient,
+  fileId: string,
+  sessionId: string,
+): Promise<string | null> {
+  try {
+    const file = await getFile(client, fileId);
+    if (!file.file_path) {
+      log.debug("No file_path returned from getFile", { fileId });
+      return null;
+    }
+
+    if (file.file_size && file.file_size > MAX_FILE_SIZE_BYTES) {
+      log.debug("File too large", { fileId, size: file.file_size });
+      return null;
+    }
+
+    const downloadUrl = buildFileDownloadUrl(client.token, file.file_path);
+    const response = await fetch(downloadUrl);
+
+    if (!response.ok) {
+      log.debug("Failed to download file", {
+        fileId,
+        status: response.status,
+      });
+      return null;
+    }
+
+    const arrayBuffer = await response.arrayBuffer();
+    const buffer = Buffer.from(arrayBuffer);
+
+    // Verify image magic bytes
+    const isPng = buffer[0] === 0x89 && buffer[1] === 0x50;
+    const isJpeg = buffer[0] === 0xff && buffer[1] === 0xd8;
+    const isGif = buffer[0] === 0x47 && buffer[1] === 0x49;
+    const isWebp = buffer[0] === 0x52 && buffer[1] === 0x49;
+
+    if (!isPng && !isJpeg && !isGif && !isWebp) {
+      log.debug("Downloaded content is not a valid image", {
+        fileId,
+        firstBytes: buffer.slice(0, 10).toString("hex"),
+      });
+      return null;
+    }
+
+    const contentType = isPng
+      ? "image/png"
+      : isJpeg
+        ? "image/jpeg"
+        : isGif
+          ? "image/gif"
+          : "image/webp";
+    const ext = isPng ? "png" : isJpeg ? "jpg" : isGif ? "gif" : "webp";
+
+    const bucketName = env().R2_USER_STORAGES_BUCKET_NAME;
+    const s3Key = `telegram-images/${sessionId}/${fileId}.${ext}`;
+
+    await uploadS3Buffer(bucketName, s3Key, buffer, contentType);
+
+    const presignedUrl = await generatePresignedUrl(bucketName, s3Key, 3600);
+
+    log.debug("Uploaded Telegram image to R2", {
+      fileId,
+      size: buffer.length,
+      s3Key,
+    });
+
+    return presignedUrl;
+  } catch (error) {
+    log.debug("Error downloading/uploading Telegram photo", {
+      fileId,
+      error,
+    });
+    return null;
+  }
+}
+
+/**
+ * Format a photo as a context entry with a presigned download URL.
+ */
+export function formatPhotoForContext(
+  presignedUrl: string,
+  photo: PhotoSizeLike,
+): string {
+  const parts: string[] = [];
+  parts.push(`[image]: photo (image/jpeg)`);
+  if (photo.width > 0 && photo.height > 0) {
+    parts.push(`   Dimensions: ${photo.width}x${photo.height}`);
+  }
+  parts.push(
+    `   View: curl -sS -o /tmp/${photo.file_id}.jpg "${presignedUrl}" && read /tmp/${photo.file_id}.jpg`,
+  );
+  return parts.join("\n");
+}


### PR DESCRIPTION
## Summary

Fixes #3848 and improves Telegram integration across reliability, security, and feature parity with Slack.

### 1. Fix duplicate callback dispatch (#3848)
Telegram bot was sending "Error: Agent execution failed." before the actual successful response.

- **Atomic status transitions** — `UPDATE ... WHERE status IN ('pending', 'running') RETURNING` prevents race conditions from concurrent retries
- **Callback status filter** — only dispatch callbacks in `pending` or `failed` status (skip `delivered`)
- **Checkpoint-not-found dispatches callbacks** — users now get notified instead of stuck thinking message
- **Error handling aligned with Slack** — catches all errors and returns friendly failure messages

### 2. Security: group chat connect link exposure
Connect URLs in group chats contained `telegramUserId`, allowing other users to hijack the link.

- Group chats now prompt users to DM the bot via `?start=connect` deep link
- Connect URLs only sent in private chats
- Added `/start connect` deep link handler
- Bot commands respect `@username` targeting (`/connect@BotA` only handled by BotA)

### 3. Image support
Photos were silently dropped — no image pipeline existed for Telegram.

- Accept photo messages in webhook (previously filtered by `!message.text`)
- Download photos via Telegram `getFile` API → upload to R2 → presigned URL
- Include images in both current prompt and conversation context
- Handle `caption_entities` for @mentions on photo messages
- Convert `![alt](url)` in agent responses to clickable `<a>` links
- Exclude current message from context to avoid duplication with prompt

### 4. Context and prompt improvements
- Structured context format with `RELATIVE_INDEX`, `MSG_ID`, `SENDER_ID` (matches Slack)
- User info enrichment: prepend `[Telegram User]` with ID, name, username, language (matches Slack's `enrichMessageContent`)

## Test plan

- [x] All Telegram tests pass (67 tests across 6 files)
- [x] Type check clean
- [x] Lint + Knip clean
- [ ] Manual: send message → verify single response without error
- [ ] Manual: send photo with @bot in group → verify bot processes image
- [ ] Manual: `/connect` in group → verify DM prompt instead of URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)