### PR TITLE
perf(run): parallelize user preferences fetch with credential resolution

### DIFF
--- a/turbo/apps/web/src/lib/run/build-context.ts
+++ b/turbo/apps/web/src/lib/run/build-context.ts
@@ -971,25 +971,35 @@ export async function buildExecutionContext(
     ? Object.values(compose.agents)[0]
     : undefined;
 
-  // Step 4: Resolve all credentials and secrets, then expand environment
+  // Step 4: Resolve credentials and user preferences in parallel
+  // getUserPreferences only needs userId (no scopeId dependency),
+  // so it can run concurrently with credential resolution.
   const resolveCredentialsStart = Date.now();
+  const userPreferencesStart = resolveCredentialsStart;
+  const [credentialsResult, userPrefs] = await Promise.all([
+    resolveCredentialsAndEnvironment(
+      scopeId,
+      agentCompose,
+      firstAgent,
+      vars,
+      params.secrets,
+      params.modelProvider,
+      params.runId,
+      params.checkEnv,
+      params.userId,
+    ),
+    params.userId ? getUserPreferences(params.userId) : Promise.resolve(null),
+  ]);
+  const resolveCredentialsEnd = Date.now();
+  const userPreferencesEnd = resolveCredentialsEnd;
+
   const {
     secrets: resolvedSecrets,
     credentials: resolvedCredentials,
     environment,
-  } = await resolveCredentialsAndEnvironment(
-    scopeId,
-    agentCompose,
-    firstAgent,
-    vars,
-    params.secrets,
-    params.modelProvider,
-    params.runId,
-    params.checkEnv,
-    params.userId,
-  );
-  const resolveCredentialsEnd = Date.now();
+  } = credentialsResult;
   secrets = resolvedSecrets;
+  const userTimezone = userPrefs?.timezone ?? undefined;
 
   // Step 5: Merge credentials into secrets for client-side log masking
   // Credentials are server-stored user-level secrets and must be masked like CLI secrets
@@ -997,15 +1007,6 @@ export async function buildExecutionContext(
   const mergedSecrets = resolvedCredentials
     ? { ...resolvedCredentials, ...secrets }
     : secrets;
-
-  // Fetch user timezone preference
-  const userPreferencesStart = Date.now();
-  let userTimezone: string | undefined;
-  if (params.userId) {
-    const userPrefs = await getUserPreferences(params.userId);
-    userTimezone = userPrefs.timezone ?? undefined;
-  }
-  const userPreferencesEnd = Date.now();
 
   // Build final execution context
   return {

--- a/turbo/apps/web/src/lib/run/build-context.ts
+++ b/turbo/apps/web/src/lib/run/build-context.ts
@@ -958,7 +958,6 @@ export async function buildExecutionContext(
   const scopeId = await resolveScopeId(params);
   const resolveScopeEnd = Date.now();
 
-  // Step 4: Fetch secrets/credentials from user's scope and merge with CLI secrets
   // Extract compose structure
   const compose = agentCompose as {
     agents?: Record<

--- a/turbo/apps/web/src/lib/run/build-context.ts
+++ b/turbo/apps/web/src/lib/run/build-context.ts
@@ -879,7 +879,6 @@ interface BuildContextTimings {
   resolveSource: number;
   resolveScope: number;
   resolveCredentials: number;
-  userPreferences: number;
 }
 
 interface BuildContextResult {
@@ -975,7 +974,6 @@ export async function buildExecutionContext(
   // getUserPreferences only needs userId (no scopeId dependency),
   // so it can run concurrently with credential resolution.
   const resolveCredentialsStart = Date.now();
-  const userPreferencesStart = resolveCredentialsStart;
   const [credentialsResult, userPrefs] = await Promise.all([
     resolveCredentialsAndEnvironment(
       scopeId,
@@ -991,7 +989,6 @@ export async function buildExecutionContext(
     params.userId ? getUserPreferences(params.userId) : Promise.resolve(null),
   ]);
   const resolveCredentialsEnd = Date.now();
-  const userPreferencesEnd = resolveCredentialsEnd;
 
   const {
     secrets: resolvedSecrets,
@@ -1041,7 +1038,6 @@ export async function buildExecutionContext(
       resolveSource: resolveSourceEnd - resolveSourceStart,
       resolveScope: resolveScopeEnd - resolveScopeStart,
       resolveCredentials: resolveCredentialsEnd - resolveCredentialsStart,
-      userPreferences: userPreferencesEnd - userPreferencesStart,
     },
   };
 }

--- a/turbo/apps/web/src/lib/run/run-service.ts
+++ b/turbo/apps/web/src/lib/run/run-service.ts
@@ -583,10 +583,6 @@ async function buildAndDispatchRun(opts: {
         op: "api_build_resolve_credentials",
         ms: buildContextTimings.resolveCredentials,
       },
-      {
-        op: "api_build_user_preferences",
-        ms: buildContextTimings.userPreferences,
-      },
       // Sub-step timings within prepareForExecution
       {
         op: "api_prepare_resolve_scopes",


### PR DESCRIPTION
## Summary

- Move `getUserPreferences` into a `Promise.all` alongside `resolveCredentialsAndEnvironment` so they run concurrently
- `getUserPreferences` only needs `userId` — no dependency on credential resolution results

Closes #3952

## Test plan

- [x] 55 run-related tests pass
- [x] Type check passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)