### PR TITLE
refactor(telegram): deduplicate connect url construction into shared helper

### DIFF
--- a/turbo/apps/web/src/lib/telegram/handlers/commands.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/commands.ts
@@ -4,12 +4,11 @@ import { telegramUserLinks } from "../../../db/schema/telegram-user-link";
 import { decryptCredentialValue } from "../../crypto/secrets-encryption";
 import { env } from "../../../env";
 import { createTelegramClient, sendMessage } from "../client";
-import { resolveUserLink, getWorkspaceAgent } from "./shared";
+import { resolveUserLink, getWorkspaceAgent, buildConnectUrl } from "./shared";
 import { escapeHtml } from "../format";
 import { getPlatformUrl } from "../../url";
 import { getUserEmail } from "../../auth/get-user-email";
 import { removePermission } from "../../agent/permission-service";
-import { signConnectParams } from "../connect-token";
 import { logger } from "../../logger";
 import type { TelegramHandlerUpdate } from "./types";
 
@@ -65,10 +64,12 @@ export async function handleConnectCommand(
     return;
   }
 
-  const platformUrl = getPlatformUrl();
-  const ts = Math.floor(Date.now() / 1000);
-  const sig = signConnectParams(installationId, fromUserId, ts, botToken);
-  const connectUrl = `${platformUrl}/telegram/connect?bot=${installation.telegramBotId}&tgUser=${fromUserId}&ts=${ts}&sig=${sig}`;
+  const connectUrl = buildConnectUrl(
+    installationId,
+    installation.telegramBotId,
+    fromUserId,
+    botToken,
+  );
   await sendMessage(
     client,
     chatId,
@@ -182,10 +183,12 @@ export async function handleSettingsCommand(
       : undefined;
 
   if (!userLink) {
-    const platformUrl = getPlatformUrl();
-    const ts = Math.floor(Date.now() / 1000);
-    const sig = signConnectParams(installationId, fromUserId, ts, botToken);
-    const connectUrl = `${platformUrl}/telegram/connect?bot=${installation.telegramBotId}&tgUser=${fromUserId}&ts=${ts}&sig=${sig}`;
+    const connectUrl = buildConnectUrl(
+      installationId,
+      installation.telegramBotId,
+      fromUserId,
+      botToken,
+    );
     await sendMessage(
       client,
       chatId,

--- a/turbo/apps/web/src/lib/telegram/handlers/direct-message.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/direct-message.ts
@@ -12,9 +12,9 @@ import {
   getWorkspaceAgent,
   resolveSessionCompose,
   resolveUserLink,
+  buildConnectUrl,
 } from "./shared";
 import { escapeHtml } from "../format";
-import { getPlatformUrl } from "../../url";
 import { logger } from "../../logger";
 import type { TelegramHandlerUpdate } from "./types";
 
@@ -58,8 +58,12 @@ export async function handleTelegramDirectMessage(
   const userLink = await resolveUserLink(installationId, fromUserId);
 
   if (!userLink) {
-    const platformUrl = getPlatformUrl();
-    const connectUrl = `${platformUrl}/telegram/connect?bot=${installation.telegramBotId}`;
+    const connectUrl = buildConnectUrl(
+      installationId,
+      installation.telegramBotId,
+      fromUserId,
+      botToken,
+    );
     await sendMessage(
       client,
       chatId,

--- a/turbo/apps/web/src/lib/telegram/handlers/mention.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/mention.ts
@@ -12,9 +12,9 @@ import {
   getWorkspaceAgent,
   resolveSessionCompose,
   resolveUserLink,
+  buildConnectUrl,
 } from "./shared";
 import { escapeHtml } from "../format";
-import { getPlatformUrl } from "../../url";
 import { logger } from "../../logger";
 import type { TelegramHandlerUpdate } from "./types";
 
@@ -66,8 +66,12 @@ export async function handleTelegramMention(
   const userLink = await resolveUserLink(installationId, fromUserId);
 
   if (!userLink) {
-    const platformUrl = getPlatformUrl();
-    const connectUrl = `${platformUrl}/telegram/connect?bot=${installation.telegramBotId}`;
+    const connectUrl = buildConnectUrl(
+      installationId,
+      installation.telegramBotId,
+      fromUserId,
+      botToken,
+    );
     await sendMessage(
       client,
       chatId,

--- a/turbo/apps/web/src/lib/telegram/handlers/new-session.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/new-session.ts
@@ -4,9 +4,8 @@ import { telegramThreadSessions } from "../../../db/schema/telegram-thread-sessi
 import { decryptCredentialValue } from "../../crypto/secrets-encryption";
 import { env } from "../../../env";
 import { createTelegramClient, sendMessage } from "../client";
-import { resolveUserLink, getWorkspaceAgent } from "./shared";
+import { resolveUserLink, getWorkspaceAgent, buildConnectUrl } from "./shared";
 import { escapeHtml } from "../format";
-import { getPlatformUrl } from "../../url";
 import { logger } from "../../logger";
 import type { TelegramHandlerUpdate } from "./types";
 
@@ -50,8 +49,12 @@ export async function handleNewSessionCommand(
 
   const userLink = await resolveUserLink(installationId, fromUserId);
   if (!userLink) {
-    const platformUrl = getPlatformUrl();
-    const connectUrl = `${platformUrl}/telegram/connect?bot=${installation.telegramBotId}`;
+    const connectUrl = buildConnectUrl(
+      installationId,
+      installation.telegramBotId,
+      fromUserId,
+      botToken,
+    );
     await sendMessage(
       client,
       chatId,

--- a/turbo/apps/web/src/lib/telegram/handlers/shared.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/shared.ts
@@ -17,6 +17,7 @@ import {
   type TelegramSentMessage,
 } from "../client";
 import { escapeHtml } from "../format";
+import { signConnectParams } from "../connect-token";
 import { logger } from "../../logger";
 
 const log = logger("telegram:shared");
@@ -265,6 +266,23 @@ export async function resolveSessionCompose(
     };
   }
   return undefined;
+}
+
+/**
+ * Build a signed connect URL for unlinked Telegram users.
+ * Includes HMAC signature so the platform can verify the link and
+ * create the user link with the correct Telegram user ID.
+ */
+export function buildConnectUrl(
+  installationId: string,
+  telegramBotId: string,
+  telegramUserId: string,
+  botToken: string,
+): string {
+  const platformUrl = getPlatformUrl();
+  const ts = Math.floor(Date.now() / 1000);
+  const sig = signConnectParams(installationId, telegramUserId, ts, botToken);
+  return `${platformUrl}/telegram/connect?bot=${telegramBotId}&tgUser=${telegramUserId}&ts=${ts}&sig=${sig}`;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Extract duplicated connect URL building logic into a shared `buildConnectUrl` helper in `shared.ts`
- Fix `direct-message`, `mention`, and `new-session` handlers that were generating incomplete connect URLs (missing `tgUser`, `ts`, and `sig` parameters)
- Remove now-unused direct imports of `signConnectParams` and `getPlatformUrl` from individual handler files

## Test plan
- [ ] Verify `/connect` command still generates valid signed connect URLs
- [ ] Verify `/settings` command shows correct connect URL for unlinked users
- [ ] Verify direct messages from unlinked users receive a properly signed connect URL
- [ ] Verify group mentions from unlinked users receive a properly signed connect URL
- [ ] Verify new session creation for unlinked users shows correct connect URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)