### PR TITLE
fix(cli): remove noisy sentry environment warning from user output

### DIFF
--- a/turbo/apps/cli/src/instrument.ts
+++ b/turbo/apps/cli/src/instrument.ts
@@ -60,14 +60,9 @@ function isOperationalError(error: unknown): boolean {
 }
 
 if (DSN) {
-  const sentryEnvironment = process.env.SENTRY_ENVIRONMENT;
-  if (!sentryEnvironment) {
-    console.warn("SENTRY_ENVIRONMENT not set, defaulting to 'production'");
-  }
-
   Sentry.init({
     dsn: DSN,
-    environment: sentryEnvironment ?? "production",
+    environment: process.env.SENTRY_ENVIRONMENT ?? "production",
     release: __CLI_VERSION__,
     sendDefaultPii: false,
     tracesSampleRate: 0,


### PR DESCRIPTION
## Summary
- Remove `console.warn` about `SENTRY_ENVIRONMENT` not being set from CLI output
- The warning is an internal Sentry configuration detail irrelevant to end users
- Silently defaults to `'production'` instead

## Test plan
- [ ] Run any CLI command (e.g. `vm0 cook`) and verify no Sentry warning appears
- [ ] Verify Sentry still initializes correctly with default `'production'` environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)