### PR TITLE
test(sandbox-scripts): replace relative vi.mock with fetch spy in heartbeat tests

### DIFF
--- a/turbo/packages/sandbox-scripts/src/__tests__/heartbeat.test.ts
+++ b/turbo/packages/sandbox-scripts/src/__tests__/heartbeat.test.ts
@@ -10,11 +10,14 @@ function failResponse(): Response {
 }
 
 describe("heartbeat", () => {
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
   beforeEach(() => {
     vi.useFakeTimers();
     resetShutdown();
-    // Suppress log output (log module uses console.error for all levels)
-    vi.spyOn(console, "error").mockImplementation(() => {});
+    // Spy on console.error (log module uses it for all levels) to suppress
+    // noise and allow assertions on log output in failure tests
+    consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
   });
 
   afterEach(() => {
@@ -44,6 +47,9 @@ describe("heartbeat", () => {
         "Network connectivity check failed",
       );
       expect(scheduleNext).not.toHaveBeenCalled();
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Network connectivity check failed"),
+      );
     });
 
     it("should reject when first heartbeat throws error", async () => {
@@ -61,6 +67,9 @@ describe("heartbeat", () => {
         "Network connectivity check failed",
       );
       expect(scheduleNext).not.toHaveBeenCalled();
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Network connectivity check failed"),
+      );
     });
 
     it("should schedule next heartbeat when first succeeds", async () => {
@@ -79,6 +88,9 @@ describe("heartbeat", () => {
       expect(scheduleNext).toHaveBeenCalledWith(
         expect.any(Function),
         baseConfig.intervalSeconds * 1000,
+      );
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Heartbeat sent (initial)"),
       );
     });
 

--- a/turbo/packages/sandbox-scripts/src/__tests__/heartbeat.test.ts
+++ b/turbo/packages/sandbox-scripts/src/__tests__/heartbeat.test.ts
@@ -1,26 +1,25 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-
-// Mock http-client before importing heartbeat
-vi.mock("../scripts/lib/http-client.js", () => ({
-  httpPostJson: vi.fn(),
-}));
-
-// Mock log to suppress output during tests
-vi.mock("../scripts/lib/log.js", () => ({
-  logInfo: vi.fn(),
-  logWarn: vi.fn(),
-  logError: vi.fn(),
-}));
-
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { startHeartbeat, resetShutdown } from "../scripts/lib/heartbeat.js";
-import { httpPostJson } from "../scripts/lib/http-client.js";
 
-const mockHttpPostJson = vi.mocked(httpPostJson);
+function okResponse(): Response {
+  return new Response("{}", { status: 200 });
+}
+
+function failResponse(): Response {
+  return new Response(null, { status: 500 });
+}
 
 describe("heartbeat", () => {
   beforeEach(() => {
+    vi.useFakeTimers();
     resetShutdown();
-    mockHttpPostJson.mockReset();
+    // Suppress log output (log module uses console.error for all levels)
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
   });
 
   describe("startHeartbeat", () => {
@@ -31,45 +30,51 @@ describe("heartbeat", () => {
     };
 
     it("should reject when first heartbeat returns null", async () => {
-      mockHttpPostJson.mockResolvedValue(null);
+      vi.spyOn(globalThis, "fetch").mockImplementation(() =>
+        Promise.resolve(failResponse()),
+      );
 
-      // Use scheduler that never fires (we only care about first heartbeat)
       const scheduleNext = vi.fn();
       const heartbeatPromise = startHeartbeat({ ...baseConfig, scheduleNext });
+      heartbeatPromise.catch(() => {}); // Prevent unhandled rejection warning
+
+      await vi.runAllTimersAsync();
 
       await expect(heartbeatPromise).rejects.toThrow(
         "Network connectivity check failed",
       );
-      expect(scheduleNext).not.toHaveBeenCalled(); // Loop should stop
+      expect(scheduleNext).not.toHaveBeenCalled();
     });
 
     it("should reject when first heartbeat throws error", async () => {
-      mockHttpPostJson.mockRejectedValue(new Error("Network error"));
+      vi.spyOn(globalThis, "fetch").mockImplementation(() =>
+        Promise.reject(new Error("Network error")),
+      );
 
       const scheduleNext = vi.fn();
       const heartbeatPromise = startHeartbeat({ ...baseConfig, scheduleNext });
+      heartbeatPromise.catch(() => {}); // Prevent unhandled rejection warning
+
+      await vi.runAllTimersAsync();
 
       await expect(heartbeatPromise).rejects.toThrow(
         "Network connectivity check failed",
       );
-      expect(scheduleNext).not.toHaveBeenCalled(); // Loop should stop
+      expect(scheduleNext).not.toHaveBeenCalled();
     });
 
     it("should schedule next heartbeat when first succeeds", async () => {
-      mockHttpPostJson.mockResolvedValue({});
+      vi.spyOn(globalThis, "fetch").mockImplementation(() =>
+        Promise.resolve(okResponse()),
+      );
 
       const scheduleNext = vi.fn();
       const heartbeatPromise = startHeartbeat({ ...baseConfig, scheduleNext });
-
-      // Prevent unhandled rejection
       heartbeatPromise.catch(() => {});
 
-      // Wait for first heartbeat to complete
-      await vi.waitFor(() => {
-        expect(mockHttpPostJson).toHaveBeenCalledTimes(1);
-      });
+      await vi.runAllTimersAsync();
 
-      // Verify next heartbeat was scheduled
+      expect(globalThis.fetch).toHaveBeenCalledTimes(1);
       expect(scheduleNext).toHaveBeenCalledTimes(1);
       expect(scheduleNext).toHaveBeenCalledWith(
         expect.any(Function),
@@ -78,9 +83,10 @@ describe("heartbeat", () => {
     });
 
     it("should continue sending heartbeats after first success", async () => {
-      mockHttpPostJson.mockResolvedValue({});
+      vi.spyOn(globalThis, "fetch").mockImplementation(() =>
+        Promise.resolve(okResponse()),
+      );
 
-      // Capture scheduled callbacks
       const scheduledCallbacks: Array<() => void> = [];
       const scheduleNext = vi.fn((callback: () => void) => {
         scheduledCallbacks.push(callback);
@@ -89,30 +95,33 @@ describe("heartbeat", () => {
       const heartbeatPromise = startHeartbeat({ ...baseConfig, scheduleNext });
       heartbeatPromise.catch(() => {});
 
-      // Wait for first heartbeat
-      await vi.waitFor(() => {
-        expect(mockHttpPostJson).toHaveBeenCalledTimes(1);
-      });
+      // First heartbeat
+      await vi.runAllTimersAsync();
+      expect(globalThis.fetch).toHaveBeenCalledTimes(1);
 
       // Trigger second heartbeat
       scheduledCallbacks[0]?.();
-      await vi.waitFor(() => {
-        expect(mockHttpPostJson).toHaveBeenCalledTimes(2);
-      });
+      await vi.runAllTimersAsync();
+      expect(globalThis.fetch).toHaveBeenCalledTimes(2);
 
       // Trigger third heartbeat
       scheduledCallbacks[1]?.();
-      await vi.waitFor(() => {
-        expect(mockHttpPostJson).toHaveBeenCalledTimes(3);
-      });
+      await vi.runAllTimersAsync();
+      expect(globalThis.fetch).toHaveBeenCalledTimes(3);
     });
 
     it("should not reject when subsequent heartbeat fails", async () => {
-      // First heartbeat succeeds, subsequent ones fail
-      mockHttpPostJson
-        .mockResolvedValueOnce({})
-        .mockResolvedValueOnce(null)
-        .mockResolvedValue({});
+      const fetchSpy = vi.spyOn(globalThis, "fetch");
+      let callCount = 0;
+      // First heartbeat: success (1 fetch call)
+      // Second heartbeat: all 3 retries fail (3 fetch calls returning 500)
+      // Third heartbeat: success (1 fetch call)
+      fetchSpy.mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) return Promise.resolve(okResponse());
+        if (callCount <= 4) return Promise.resolve(failResponse());
+        return Promise.resolve(okResponse());
+      });
 
       const scheduledCallbacks: Array<() => void> = [];
       const scheduleNext = vi.fn((callback: () => void) => {
@@ -121,45 +130,43 @@ describe("heartbeat", () => {
 
       const heartbeatPromise = startHeartbeat({ ...baseConfig, scheduleNext });
 
-      // Track if promise rejects
       let rejected = false;
       heartbeatPromise.catch(() => {
         rejected = true;
       });
 
       // Wait for first heartbeat (success)
-      await vi.waitFor(() => {
-        expect(mockHttpPostJson).toHaveBeenCalledTimes(1);
-      });
+      await vi.runAllTimersAsync();
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
 
-      // Trigger second heartbeat (fails - should just warn)
+      // Trigger second heartbeat (fails after 3 retries)
       scheduledCallbacks[0]?.();
-      await vi.waitFor(() => {
-        expect(mockHttpPostJson).toHaveBeenCalledTimes(2);
-      });
+      await vi.runAllTimersAsync();
+      expect(fetchSpy).toHaveBeenCalledTimes(4); // 1 initial + 3 retry attempts
 
       // Trigger third heartbeat (succeeds)
       scheduledCallbacks[1]?.();
-      await vi.waitFor(() => {
-        expect(mockHttpPostJson).toHaveBeenCalledTimes(3);
-      });
+      await vi.runAllTimersAsync();
+      expect(fetchSpy).toHaveBeenCalledTimes(5);
 
-      // Promise should not reject
       expect(rejected).toBe(false);
     });
 
     it("should stop heartbeat loop when first heartbeat fails", async () => {
-      mockHttpPostJson.mockResolvedValue(null);
+      vi.spyOn(globalThis, "fetch").mockImplementation(() =>
+        Promise.resolve(failResponse()),
+      );
 
       const scheduleNext = vi.fn();
       const heartbeatPromise = startHeartbeat({ ...baseConfig, scheduleNext });
+      heartbeatPromise.catch(() => {}); // Prevent unhandled rejection warning
+
+      await vi.runAllTimersAsync();
 
       await expect(heartbeatPromise).rejects.toThrow();
 
-      // Verify only one call was made (loop stopped)
-      expect(mockHttpPostJson).toHaveBeenCalledTimes(1);
-
-      // Verify no next heartbeat was scheduled
+      // httpPostJson retried 3 times internally, but only 1 heartbeat was attempted
+      expect(globalThis.fetch).toHaveBeenCalledTimes(3);
       expect(scheduleNext).not.toHaveBeenCalled();
     });
   });


### PR DESCRIPTION
## Summary
- Replace `vi.mock("../scripts/lib/http-client.js")` with `vi.spyOn(globalThis, "fetch")` to mock at the network boundary (external dep) instead of internal module
- Replace `vi.mock("../scripts/lib/log.js")` with `vi.spyOn(console, "error")` to suppress log output
- Use fake timers with `vi.runAllTimersAsync()` to handle httpPostJson retry delays efficiently
- All 6 test cases preserved with same semantics — only the mock layer changes

Closes #3930 (part 1 of 3)

## Test plan
- [x] All 6 heartbeat tests pass with `pnpm test`
- [x] Lint passes with `pnpm turbo run lint --filter=@vm0/sandbox-scripts`
- [x] Type check passes with `pnpm check-types`

🤖 Generated with [Claude Code](https://claude.com/claude-code)