### PR TITLE
test(sandbox-scripts): use real infrastructure in metrics tests

### DIFF
--- a/turbo/packages/sandbox-scripts/package.json
+++ b/turbo/packages/sandbox-scripts/package.json
@@ -22,7 +22,6 @@
     "@vm0/typescript-config": "workspace:*",
     "esbuild": "^0.27.3",
     "eslint": "^9.34.0",
-    "memfs": "^4.56.10",
     "oxlint": "^1.14.0",
     "tsx": "^4.20.6",
     "typescript": "5.9.3",

--- a/turbo/packages/sandbox-scripts/src/__tests__/metrics.test.ts
+++ b/turbo/packages/sandbox-scripts/src/__tests__/metrics.test.ts
@@ -1,6 +1,4 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { vol } from "memfs";
-import { execSync } from "child_process";
 import {
   getCpuPercent,
   getMemoryInfo,
@@ -8,230 +6,59 @@ import {
   collectMetrics,
 } from "../scripts/lib/metrics";
 
-// Use memfs for /proc/stat simulation
-vi.mock("fs", async () => {
-  const memfs = await import("memfs");
-  return memfs.fs;
-});
-
-// Keep execSync mock - shell commands cannot be simulated with memfs
-vi.mock("child_process");
-
 describe("metrics", () => {
   beforeEach(() => {
-    vi.clearAllMocks();
-    vol.reset();
+    // Suppress log output (log module uses console.error for all levels)
+    vi.spyOn(console, "error").mockImplementation(() => {});
   });
 
   afterEach(() => {
-    vi.resetAllMocks();
+    vi.restoreAllMocks();
   });
 
   describe("getCpuPercent", () => {
-    it("should parse /proc/stat and calculate CPU percentage", () => {
-      // cpu  user nice system idle iowait irq softirq steal guest guest_nice
-      // cpu  1000 100  500    2000  100    50  50      0     0     0
-      // Total = 3800, Idle = 2000 + 100 = 2100
-      // CPU% = 100 * (1 - 2100/3800) = 44.74%
-      const procStat = `cpu  1000 100 500 2000 100 50 50 0 0 0
-cpu0  500 50 250 1000 50 25 25 0 0 0
-cpu1  500 50 250 1000 50 25 25 0 0 0`;
-
-      vol.fromJSON({ "/proc/stat": procStat });
-
+    it("should return CPU percentage between 0 and 100", () => {
       const result = getCpuPercent();
 
-      expect(result).toBeCloseTo(44.74, 1);
-    });
-
-    it("should return 0 for empty /proc/stat", () => {
-      vol.fromJSON({ "/proc/stat": "" });
-
-      const result = getCpuPercent();
-
-      expect(result).toBe(0);
-    });
-
-    it("should return 0 when first line doesn't start with 'cpu'", () => {
-      vol.fromJSON({ "/proc/stat": "invalid line\ncpu 1 2 3 4" });
-
-      const result = getCpuPercent();
-
-      expect(result).toBe(0);
-    });
-
-    it("should return 0 when total is 0", () => {
-      vol.fromJSON({ "/proc/stat": "cpu  0 0 0 0 0 0 0 0 0 0" });
-
-      const result = getCpuPercent();
-
-      expect(result).toBe(0);
-    });
-
-    it("should return 0 on read error", () => {
-      // Don't create /proc/stat file
-      vol.fromJSON({});
-
-      const result = getCpuPercent();
-
-      expect(result).toBe(0);
-    });
-
-    it("should handle high CPU usage", () => {
-      // idle=100, iowait=100, total=10000
-      // CPU% = 100 * (1 - 200/10000) = 98%
-      vol.fromJSON({
-        "/proc/stat": "cpu  5000 500 4000 100 100 100 100 50 25 25",
-      });
-
-      const result = getCpuPercent();
-
-      expect(result).toBeCloseTo(98, 0);
-    });
-
-    it("should handle 0% CPU usage (all idle)", () => {
-      vol.fromJSON({ "/proc/stat": "cpu  0 0 0 10000 0 0 0 0 0 0" });
-
-      const result = getCpuPercent();
-
-      expect(result).toBe(0);
+      expect(result).toBeGreaterThanOrEqual(0);
+      expect(result).toBeLessThanOrEqual(100);
     });
   });
 
   describe("getMemoryInfo", () => {
-    it("should parse free -b output and return [used, total]", () => {
-      const freeOutput = `              total        used        free      shared  buff/cache   available
-Mem:    16777216000  8388608000  4194304000       65536  4194304000  8192000000
-Swap:    4294967296           0  4294967296`;
-
-      vi.mocked(execSync).mockReturnValue(freeOutput);
-
+    it("should return [used, total] with positive values where used <= total", () => {
       const [used, total] = getMemoryInfo();
 
-      expect(execSync).toHaveBeenCalledWith("free -b", expect.any(Object));
-      expect(total).toBe(16777216000);
-      expect(used).toBe(8388608000);
-    });
-
-    it("should return [0, 0] when no Mem line found", () => {
-      vi.mocked(execSync).mockReturnValue("some invalid output\n");
-
-      const [used, total] = getMemoryInfo();
-
-      expect(used).toBe(0);
-      expect(total).toBe(0);
-    });
-
-    it("should return [0, 0] on exec error", () => {
-      vi.mocked(execSync).mockImplementation(() => {
-        throw new Error("Command failed");
-      });
-
-      const [used, total] = getMemoryInfo();
-
-      expect(used).toBe(0);
-      expect(total).toBe(0);
-    });
-
-    it("should handle Mem line with missing values", () => {
-      vi.mocked(execSync).mockReturnValue("Mem:");
-
-      const [used, total] = getMemoryInfo();
-
-      expect(used).toBe(0);
-      expect(total).toBe(0);
+      expect(total).toBeGreaterThan(0);
+      expect(used).toBeGreaterThan(0);
+      expect(used).toBeLessThanOrEqual(total);
     });
   });
 
   describe("getDiskInfo", () => {
-    it("should parse df -B1 / output and return [used, total]", () => {
-      const dfOutput = `Filesystem           1B-blocks          Used     Available Use% Mounted on
-/dev/sda1        107374182400   53687091200   53687091200  50% /`;
-
-      vi.mocked(execSync).mockReturnValue(dfOutput);
-
+    it("should return [used, total] with positive values where used <= total", () => {
       const [used, total] = getDiskInfo();
 
-      expect(execSync).toHaveBeenCalledWith("df -B1 /", expect.any(Object));
-      expect(total).toBe(107374182400);
-      expect(used).toBe(53687091200);
-    });
-
-    it("should return [0, 0] when output has only header", () => {
-      vi.mocked(execSync).mockReturnValue(
-        "Filesystem  1B-blocks  Used  Available  Use%  Mounted on",
-      );
-
-      const [used, total] = getDiskInfo();
-
-      expect(used).toBe(0);
-      expect(total).toBe(0);
-    });
-
-    it("should return [0, 0] on exec error", () => {
-      vi.mocked(execSync).mockImplementation(() => {
-        throw new Error("Command failed");
-      });
-
-      const [used, total] = getDiskInfo();
-
-      expect(used).toBe(0);
-      expect(total).toBe(0);
-    });
-
-    it("should handle data line with missing values", () => {
-      vi.mocked(execSync).mockReturnValue("Header\n/dev/sda1");
-
-      const [used, total] = getDiskInfo();
-
-      expect(used).toBe(0);
-      expect(total).toBe(0);
+      expect(total).toBeGreaterThan(0);
+      expect(used).toBeGreaterThan(0);
+      expect(used).toBeLessThanOrEqual(total);
     });
   });
 
   describe("collectMetrics", () => {
-    it("should combine all metrics into single object", () => {
-      vol.fromJSON({ "/proc/stat": "cpu  1000 100 500 2000 100 50 50 0 0 0" });
-
-      vi.mocked(execSync).mockImplementation((cmd: string) => {
-        if (cmd === "free -b") {
-          return `              total        used        free      shared  buff/cache   available
-Mem:    16000000000  8000000000  4000000000       0  4000000000  8000000000
-Swap:             0           0           0`;
-        }
-        if (cmd === "df -B1 /") {
-          return `Filesystem           1B-blocks          Used     Available Use% Mounted on
-/dev/sda1        100000000000   50000000000   50000000000  50% /`;
-        }
-        return "";
-      });
-
+    it("should combine all metrics into single object with valid ranges", () => {
       const metrics = collectMetrics();
 
-      expect(metrics).toMatchObject({
-        cpu: expect.any(Number),
-        mem_used: 8000000000,
-        mem_total: 16000000000,
-        disk_used: 50000000000,
-        disk_total: 100000000000,
-      });
+      expect(metrics.cpu).toBeGreaterThanOrEqual(0);
+      expect(metrics.cpu).toBeLessThanOrEqual(100);
+      expect(metrics.mem_total).toBeGreaterThan(0);
+      expect(metrics.mem_used).toBeGreaterThan(0);
+      expect(metrics.mem_used).toBeLessThanOrEqual(metrics.mem_total);
+      expect(metrics.disk_total).toBeGreaterThan(0);
+      expect(metrics.disk_used).toBeGreaterThan(0);
+      expect(metrics.disk_used).toBeLessThanOrEqual(metrics.disk_total);
       expect(metrics.ts).toBeDefined();
       expect(new Date(metrics.ts).toISOString()).toBe(metrics.ts);
-    });
-
-    it("should return zeros when all sources fail", () => {
-      vol.fromJSON({});
-      vi.mocked(execSync).mockImplementation(() => {
-        throw new Error("Command failed");
-      });
-
-      const metrics = collectMetrics();
-
-      expect(metrics.cpu).toBe(0);
-      expect(metrics.mem_used).toBe(0);
-      expect(metrics.mem_total).toBe(0);
-      expect(metrics.disk_used).toBe(0);
-      expect(metrics.disk_total).toBe(0);
     });
   });
 });

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -576,9 +576,6 @@ importers:
       eslint:
         specifier: ^9.34.0
         version: 9.34.0(jiti@2.6.1)
-      memfs:
-        specifier: ^4.56.10
-        version: 4.56.10
       oxlint:
         specifier: ^1.14.0
         version: 1.38.0
@@ -2163,126 +2160,6 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
-
-  '@jsonjoy.com/base64@1.1.2':
-    resolution: {integrity: sha512-q6XAnWQDIMA3+FTiOYajoYqySkO+JSat0ytXGSuRdq9uXE7o92gzuQwQM14xaCRlBLGq3v5miDGC4vkVTn54xA==}
-    engines: {node: '>=10.0'}
-    peerDependencies:
-      tslib: '2'
-
-  '@jsonjoy.com/base64@17.65.0':
-    resolution: {integrity: sha512-Xrh7Fm/M0QAYpekSgmskdZYnFdSGnsxJ/tHaolA4bNwWdG9i65S8m83Meh7FOxyJyQAdo4d4J97NOomBLEfkDQ==}
-    engines: {node: '>=10.0'}
-    peerDependencies:
-      tslib: '2'
-
-  '@jsonjoy.com/buffers@1.2.1':
-    resolution: {integrity: sha512-12cdlDwX4RUM3QxmUbVJWqZ/mrK6dFQH4Zxq6+r1YXKXYBNgZXndx2qbCJwh3+WWkCSn67IjnlG3XYTvmvYtgA==}
-    engines: {node: '>=10.0'}
-    peerDependencies:
-      tslib: '2'
-
-  '@jsonjoy.com/buffers@17.65.0':
-    resolution: {integrity: sha512-eBrIXd0/Ld3p9lpDDlMaMn6IEfWqtHMD+z61u0JrIiPzsV1r7m6xDZFRxJyvIFTEO+SWdYF9EiQbXZGd8BzPfA==}
-    engines: {node: '>=10.0'}
-    peerDependencies:
-      tslib: '2'
-
-  '@jsonjoy.com/codegen@1.0.0':
-    resolution: {integrity: sha512-E8Oy+08cmCf0EK/NMxpaJZmOxPqM+6iSe2S4nlSBrPZOORoDJILxtbSUEDKQyTamm/BVAhIGllOBNU79/dwf0g==}
-    engines: {node: '>=10.0'}
-    peerDependencies:
-      tslib: '2'
-
-  '@jsonjoy.com/codegen@17.65.0':
-    resolution: {integrity: sha512-7MXcRYe7n3BG+fo3jicvjB0+6ypl2Y/bQp79Sp7KeSiiCgLqw4Oled6chVv07/xLVTdo3qa1CD0VCCnPaw+RGA==}
-    engines: {node: '>=10.0'}
-    peerDependencies:
-      tslib: '2'
-
-  '@jsonjoy.com/fs-core@4.56.10':
-    resolution: {integrity: sha512-PyAEA/3cnHhsGcdY+AmIU+ZPqTuZkDhCXQ2wkXypdLitSpd6d5Ivxhnq4wa2ETRWFVJGabYynBWxIijOswSmOw==}
-    engines: {node: '>=10.0'}
-    peerDependencies:
-      tslib: '2'
-
-  '@jsonjoy.com/fs-fsa@4.56.10':
-    resolution: {integrity: sha512-/FVK63ysNzTPOnCCcPoPHt77TOmachdMS422txM4KhxddLdbW1fIbFMYH0AM0ow/YchCyS5gqEjKLNyv71j/5Q==}
-    engines: {node: '>=10.0'}
-    peerDependencies:
-      tslib: '2'
-
-  '@jsonjoy.com/fs-node-builtins@4.56.10':
-    resolution: {integrity: sha512-uUnKz8R0YJyKq5jXpZtkGV9U0pJDt8hmYcLRrPjROheIfjMXsz82kXMgAA/qNg0wrZ1Kv+hrg7azqEZx6XZCVw==}
-    engines: {node: '>=10.0'}
-    peerDependencies:
-      tslib: '2'
-
-  '@jsonjoy.com/fs-node-to-fsa@4.56.10':
-    resolution: {integrity: sha512-oH+O6Y4lhn9NyG6aEoFwIBNKZeYy66toP5LJcDOMBgL99BKQMUf/zWJspdRhMdn/3hbzQsZ8EHHsuekbFLGUWw==}
-    engines: {node: '>=10.0'}
-    peerDependencies:
-      tslib: '2'
-
-  '@jsonjoy.com/fs-node-utils@4.56.10':
-    resolution: {integrity: sha512-8EuPBgVI2aDPwFdaNQeNpHsyqPi3rr+85tMNG/lHvQLiVjzoZsvxA//Xd8aB567LUhy4QS03ptT+unkD/DIsNg==}
-    engines: {node: '>=10.0'}
-    peerDependencies:
-      tslib: '2'
-
-  '@jsonjoy.com/fs-node@4.56.10':
-    resolution: {integrity: sha512-7R4Gv3tkUdW3dXfXiOkqxkElxKNVdd8BDOWC0/dbERd0pXpPY+s2s1Mino+aTvkGrFPiY+mmVxA7zhskm4Ue4Q==}
-    engines: {node: '>=10.0'}
-    peerDependencies:
-      tslib: '2'
-
-  '@jsonjoy.com/fs-print@4.56.10':
-    resolution: {integrity: sha512-JW4fp5mAYepzFsSGrQ48ep8FXxpg4niFWHdF78wDrFGof7F3tKDJln72QFDEn/27M1yHd4v7sKHHVPh78aWcEw==}
-    engines: {node: '>=10.0'}
-    peerDependencies:
-      tslib: '2'
-
-  '@jsonjoy.com/fs-snapshot@4.56.10':
-    resolution: {integrity: sha512-DkR6l5fj7+qj0+fVKm/OOXMGfDFCGXLfyHkORH3DF8hxkpDgIHbhf/DwncBMs2igu/ST7OEkexn1gIqoU6Y+9g==}
-    engines: {node: '>=10.0'}
-    peerDependencies:
-      tslib: '2'
-
-  '@jsonjoy.com/json-pack@1.21.0':
-    resolution: {integrity: sha512-+AKG+R2cfZMShzrF2uQw34v3zbeDYUqnQ+jg7ORic3BGtfw9p/+N6RJbq/kkV8JmYZaINknaEQ2m0/f693ZPpg==}
-    engines: {node: '>=10.0'}
-    peerDependencies:
-      tslib: '2'
-
-  '@jsonjoy.com/json-pack@17.65.0':
-    resolution: {integrity: sha512-e0SG/6qUCnVhHa0rjDJHgnXnbsacooHVqQHxspjvlYQSkHm+66wkHw6Gql+3u/WxI/b1VsOdUi0M+fOtkgKGdQ==}
-    engines: {node: '>=10.0'}
-    peerDependencies:
-      tslib: '2'
-
-  '@jsonjoy.com/json-pointer@1.0.2':
-    resolution: {integrity: sha512-Fsn6wM2zlDzY1U+v4Nc8bo3bVqgfNTGcn6dMgs6FjrEnt4ZCe60o6ByKRjOGlI2gow0aE/Q41QOigdTqkyK5fg==}
-    engines: {node: '>=10.0'}
-    peerDependencies:
-      tslib: '2'
-
-  '@jsonjoy.com/json-pointer@17.65.0':
-    resolution: {integrity: sha512-uhTe+XhlIZpWOxgPcnO+iSCDgKKBpwkDVTyYiXX9VayGV8HSFVJM67M6pUE71zdnXF1W0Da21AvnhlmdwYPpow==}
-    engines: {node: '>=10.0'}
-    peerDependencies:
-      tslib: '2'
-
-  '@jsonjoy.com/util@1.9.0':
-    resolution: {integrity: sha512-pLuQo+VPRnN8hfPqUTLTHk126wuYdXVxE6aDmjSeV4NCAgyxWbiOIeNJVtID3h1Vzpoi9m4jXezf73I6LgabgQ==}
-    engines: {node: '>=10.0'}
-    peerDependencies:
-      tslib: '2'
-
-  '@jsonjoy.com/util@17.65.0':
-    resolution: {integrity: sha512-cWiEHZccQORf96q2y6zU3wDeIVPeidmGqd9cNKJRYoVHTV0S1eHPy5JTbHpMnGfDvtvujQwQozOqgO9ABu6h0w==}
-    engines: {node: '>=10.0'}
-    peerDependencies:
-      tslib: '2'
 
   '@mdx-js/mdx@3.1.1':
     resolution: {integrity: sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ==}
@@ -6244,12 +6121,6 @@ packages:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
 
-  glob-to-regex.js@1.2.0:
-    resolution: {integrity: sha512-QMwlOQKU/IzqMUOAZWubUOT8Qft+Y0KQWnX9nK3ch0CJg0tTp4TvGZsTfudYKv2NzoQSyPcnA6TYeIQ3jGichQ==}
-    engines: {node: '>=10.0'}
-    peerDependencies:
-      tslib: '2'
-
   glob-to-regexp@0.4.1:
     resolution: {integrity: sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==}
 
@@ -6424,10 +6295,6 @@ packages:
   https-proxy-agent@5.0.1:
     resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
     engines: {node: '>= 6'}
-
-  hyperdyperid@1.2.0:
-    resolution: {integrity: sha512-Y93lCzHYgGWdrJ66yIktxiaGULYc6oGiABxhcO5AufBeOyoIdZF7bIfLaOrbM0iGIOXQQgxxRrFEnb+Y6w1n4A==}
-    engines: {node: '>=10.18'}
 
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
@@ -7045,9 +6912,6 @@ packages:
 
   mdast-util-to-string@4.0.0:
     resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
-
-  memfs@4.56.10:
-    resolution: {integrity: sha512-eLvzyrwqLHnLYalJP7YZ3wBe79MXktMdfQbvMrVD80K+NhrIukCVBvgP30zTJYEEDh9hZ/ep9z0KOdD7FSHo7w==}
 
   meow@12.1.1:
     resolution: {integrity: sha512-BhXM0Au22RwUneMPwSCnyhTOizdWoIEPU9sp0Aqa1PnDMR5Wv2FGXYDjuzJEIX+Eo2Rb8xuYe5jrnm5QowQFkw==}
@@ -8311,12 +8175,6 @@ packages:
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
 
-  thingies@2.5.0:
-    resolution: {integrity: sha512-s+2Bwztg6PhWUD7XMfeYm5qliDdSiZm7M7n8KjTkIsm3l/2lgVRc2/Gx/v+ZX8lT4FMA+i8aQvhcWylldc+ZNw==}
-    engines: {node: '>=10.18'}
-    peerDependencies:
-      tslib: ^2
-
   through@2.3.8:
     resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
 
@@ -8375,12 +8233,6 @@ packages:
 
   tr46@1.0.1:
     resolution: {integrity: sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==}
-
-  tree-dump@1.1.0:
-    resolution: {integrity: sha512-rMuvhU4MCDbcbnleZTFezWsaZXRFemSqAM+7jPnzUl1fo9w3YEKOxAeui0fz3OI4EU4hf23iyA7uQRVko+UaBA==}
-    engines: {node: '>=10.0'}
-    peerDependencies:
-      tslib: '2'
 
   tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
@@ -10525,133 +10377,6 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
-
-  '@jsonjoy.com/base64@1.1.2(tslib@2.8.1)':
-    dependencies:
-      tslib: 2.8.1
-
-  '@jsonjoy.com/base64@17.65.0(tslib@2.8.1)':
-    dependencies:
-      tslib: 2.8.1
-
-  '@jsonjoy.com/buffers@1.2.1(tslib@2.8.1)':
-    dependencies:
-      tslib: 2.8.1
-
-  '@jsonjoy.com/buffers@17.65.0(tslib@2.8.1)':
-    dependencies:
-      tslib: 2.8.1
-
-  '@jsonjoy.com/codegen@1.0.0(tslib@2.8.1)':
-    dependencies:
-      tslib: 2.8.1
-
-  '@jsonjoy.com/codegen@17.65.0(tslib@2.8.1)':
-    dependencies:
-      tslib: 2.8.1
-
-  '@jsonjoy.com/fs-core@4.56.10(tslib@2.8.1)':
-    dependencies:
-      '@jsonjoy.com/fs-node-builtins': 4.56.10(tslib@2.8.1)
-      '@jsonjoy.com/fs-node-utils': 4.56.10(tslib@2.8.1)
-      thingies: 2.5.0(tslib@2.8.1)
-      tslib: 2.8.1
-
-  '@jsonjoy.com/fs-fsa@4.56.10(tslib@2.8.1)':
-    dependencies:
-      '@jsonjoy.com/fs-core': 4.56.10(tslib@2.8.1)
-      '@jsonjoy.com/fs-node-builtins': 4.56.10(tslib@2.8.1)
-      '@jsonjoy.com/fs-node-utils': 4.56.10(tslib@2.8.1)
-      thingies: 2.5.0(tslib@2.8.1)
-      tslib: 2.8.1
-
-  '@jsonjoy.com/fs-node-builtins@4.56.10(tslib@2.8.1)':
-    dependencies:
-      tslib: 2.8.1
-
-  '@jsonjoy.com/fs-node-to-fsa@4.56.10(tslib@2.8.1)':
-    dependencies:
-      '@jsonjoy.com/fs-fsa': 4.56.10(tslib@2.8.1)
-      '@jsonjoy.com/fs-node-builtins': 4.56.10(tslib@2.8.1)
-      '@jsonjoy.com/fs-node-utils': 4.56.10(tslib@2.8.1)
-      tslib: 2.8.1
-
-  '@jsonjoy.com/fs-node-utils@4.56.10(tslib@2.8.1)':
-    dependencies:
-      '@jsonjoy.com/fs-node-builtins': 4.56.10(tslib@2.8.1)
-      tslib: 2.8.1
-
-  '@jsonjoy.com/fs-node@4.56.10(tslib@2.8.1)':
-    dependencies:
-      '@jsonjoy.com/fs-core': 4.56.10(tslib@2.8.1)
-      '@jsonjoy.com/fs-node-builtins': 4.56.10(tslib@2.8.1)
-      '@jsonjoy.com/fs-node-utils': 4.56.10(tslib@2.8.1)
-      '@jsonjoy.com/fs-print': 4.56.10(tslib@2.8.1)
-      '@jsonjoy.com/fs-snapshot': 4.56.10(tslib@2.8.1)
-      glob-to-regex.js: 1.2.0(tslib@2.8.1)
-      thingies: 2.5.0(tslib@2.8.1)
-      tslib: 2.8.1
-
-  '@jsonjoy.com/fs-print@4.56.10(tslib@2.8.1)':
-    dependencies:
-      '@jsonjoy.com/fs-node-utils': 4.56.10(tslib@2.8.1)
-      tree-dump: 1.1.0(tslib@2.8.1)
-      tslib: 2.8.1
-
-  '@jsonjoy.com/fs-snapshot@4.56.10(tslib@2.8.1)':
-    dependencies:
-      '@jsonjoy.com/buffers': 17.65.0(tslib@2.8.1)
-      '@jsonjoy.com/fs-node-utils': 4.56.10(tslib@2.8.1)
-      '@jsonjoy.com/json-pack': 17.65.0(tslib@2.8.1)
-      '@jsonjoy.com/util': 17.65.0(tslib@2.8.1)
-      tslib: 2.8.1
-
-  '@jsonjoy.com/json-pack@1.21.0(tslib@2.8.1)':
-    dependencies:
-      '@jsonjoy.com/base64': 1.1.2(tslib@2.8.1)
-      '@jsonjoy.com/buffers': 1.2.1(tslib@2.8.1)
-      '@jsonjoy.com/codegen': 1.0.0(tslib@2.8.1)
-      '@jsonjoy.com/json-pointer': 1.0.2(tslib@2.8.1)
-      '@jsonjoy.com/util': 1.9.0(tslib@2.8.1)
-      hyperdyperid: 1.2.0
-      thingies: 2.5.0(tslib@2.8.1)
-      tree-dump: 1.1.0(tslib@2.8.1)
-      tslib: 2.8.1
-
-  '@jsonjoy.com/json-pack@17.65.0(tslib@2.8.1)':
-    dependencies:
-      '@jsonjoy.com/base64': 17.65.0(tslib@2.8.1)
-      '@jsonjoy.com/buffers': 17.65.0(tslib@2.8.1)
-      '@jsonjoy.com/codegen': 17.65.0(tslib@2.8.1)
-      '@jsonjoy.com/json-pointer': 17.65.0(tslib@2.8.1)
-      '@jsonjoy.com/util': 17.65.0(tslib@2.8.1)
-      hyperdyperid: 1.2.0
-      thingies: 2.5.0(tslib@2.8.1)
-      tree-dump: 1.1.0(tslib@2.8.1)
-      tslib: 2.8.1
-
-  '@jsonjoy.com/json-pointer@1.0.2(tslib@2.8.1)':
-    dependencies:
-      '@jsonjoy.com/codegen': 1.0.0(tslib@2.8.1)
-      '@jsonjoy.com/util': 1.9.0(tslib@2.8.1)
-      tslib: 2.8.1
-
-  '@jsonjoy.com/json-pointer@17.65.0(tslib@2.8.1)':
-    dependencies:
-      '@jsonjoy.com/util': 17.65.0(tslib@2.8.1)
-      tslib: 2.8.1
-
-  '@jsonjoy.com/util@1.9.0(tslib@2.8.1)':
-    dependencies:
-      '@jsonjoy.com/buffers': 1.2.1(tslib@2.8.1)
-      '@jsonjoy.com/codegen': 1.0.0(tslib@2.8.1)
-      tslib: 2.8.1
-
-  '@jsonjoy.com/util@17.65.0(tslib@2.8.1)':
-    dependencies:
-      '@jsonjoy.com/buffers': 17.65.0(tslib@2.8.1)
-      '@jsonjoy.com/codegen': 17.65.0(tslib@2.8.1)
-      tslib: 2.8.1
 
   '@mdx-js/mdx@3.1.1':
     dependencies:
@@ -15068,10 +14793,6 @@ snapshots:
     dependencies:
       is-glob: 4.0.3
 
-  glob-to-regex.js@1.2.0(tslib@2.8.1):
-    dependencies:
-      tslib: 2.8.1
-
   glob-to-regexp@0.4.1: {}
 
   glob@10.4.5:
@@ -15381,8 +15102,6 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
-
-  hyperdyperid@1.2.0: {}
 
   iconv-lite@0.6.3:
     dependencies:
@@ -16057,23 +15776,6 @@ snapshots:
   mdast-util-to-string@4.0.0:
     dependencies:
       '@types/mdast': 4.0.4
-
-  memfs@4.56.10:
-    dependencies:
-      '@jsonjoy.com/fs-core': 4.56.10(tslib@2.8.1)
-      '@jsonjoy.com/fs-fsa': 4.56.10(tslib@2.8.1)
-      '@jsonjoy.com/fs-node': 4.56.10(tslib@2.8.1)
-      '@jsonjoy.com/fs-node-builtins': 4.56.10(tslib@2.8.1)
-      '@jsonjoy.com/fs-node-to-fsa': 4.56.10(tslib@2.8.1)
-      '@jsonjoy.com/fs-node-utils': 4.56.10(tslib@2.8.1)
-      '@jsonjoy.com/fs-print': 4.56.10(tslib@2.8.1)
-      '@jsonjoy.com/fs-snapshot': 4.56.10(tslib@2.8.1)
-      '@jsonjoy.com/json-pack': 1.21.0(tslib@2.8.1)
-      '@jsonjoy.com/util': 1.9.0(tslib@2.8.1)
-      glob-to-regex.js: 1.2.0(tslib@2.8.1)
-      thingies: 2.5.0(tslib@2.8.1)
-      tree-dump: 1.1.0(tslib@2.8.1)
-      tslib: 2.8.1
 
   meow@12.1.1: {}
 
@@ -17695,10 +17397,6 @@ snapshots:
     dependencies:
       any-promise: 1.3.0
 
-  thingies@2.5.0(tslib@2.8.1):
-    dependencies:
-      tslib: 2.8.1
-
   through@2.3.8: {}
 
   tinybench@2.9.0: {}
@@ -17746,10 +17444,6 @@ snapshots:
   tr46@1.0.1:
     dependencies:
       punycode: 2.3.1
-
-  tree-dump@1.1.0(tslib@2.8.1):
-    dependencies:
-      tslib: 2.8.1
 
   tree-kill@1.2.2: {}
 


### PR DESCRIPTION
## Summary
- Remove `vi.mock("fs")` (memfs) and `vi.mock("child_process")` from metrics tests
- Use real `/proc/stat`, real `free -b`, real `df -B1 /` available in the Linux Docker test environment
- Assertions use range-based checks (CPU 0-100, memory/disk positive integers, used <= total)
- Remove `memfs` from devDependencies

Closes #3930 (part 2 of 3)

## Test plan
- [x] All 4 metrics tests pass with `pnpm test`
- [x] Lint passes with `pnpm turbo run lint --filter=@vm0/sandbox-scripts`
- [x] Type check passes with `pnpm check-types`
- [x] `memfs` removed from package.json and lockfile

🤖 Generated with [Claude Code](https://claude.com/claude-code)