### PR TITLE
chore(eslint): add no-relative-vi-mock rule to sandbox-scripts

### DIFF
--- a/turbo/packages/eslint-config/base.js
+++ b/turbo/packages/eslint-config/base.js
@@ -33,6 +33,40 @@ const vm0Plugin = {
         };
       },
     },
+    "no-relative-vi-mock": {
+      meta: {
+        type: "problem",
+        docs: {
+          description:
+            "Disallow vi.mock() with relative paths — mock at external boundaries instead",
+        },
+        messages: {
+          noRelativeMock:
+            "Do not use vi.mock() with relative paths. Mock at external boundaries (globalThis.fetch, console, etc.) instead of internal modules.",
+        },
+        schema: [],
+      },
+      create(context) {
+        return {
+          CallExpression(node) {
+            if (
+              node.callee.type === "MemberExpression" &&
+              node.callee.object.type === "Identifier" &&
+              node.callee.object.name === "vi" &&
+              node.callee.property.type === "Identifier" &&
+              node.callee.property.name === "mock" &&
+              node.arguments.length > 0 &&
+              node.arguments[0].type === "Literal" &&
+              typeof node.arguments[0].value === "string" &&
+              (node.arguments[0].value.startsWith("./") ||
+                node.arguments[0].value.startsWith("../"))
+            ) {
+              context.report({ node, messageId: "noRelativeMock" });
+            }
+          },
+        };
+      },
+    },
   },
 };
 

--- a/turbo/packages/sandbox-scripts/eslint.config.mjs
+++ b/turbo/packages/sandbox-scripts/eslint.config.mjs
@@ -13,4 +13,10 @@ export default [
       "turbo/no-undeclared-env-vars": "off",
     },
   },
+  {
+    files: ["src/**/*.test.ts"],
+    rules: {
+      "vm0/no-relative-vi-mock": "error",
+    },
+  },
 ];

--- a/turbo/packages/sandbox-scripts/src/__tests__/heartbeat.test.ts
+++ b/turbo/packages/sandbox-scripts/src/__tests__/heartbeat.test.ts
@@ -1,26 +1,22 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-// Mock http-client before importing heartbeat
-vi.mock("../scripts/lib/http-client.js", () => ({
-  httpPostJson: vi.fn(),
-}));
-
-// Mock log to suppress output during tests
-vi.mock("../scripts/lib/log.js", () => ({
-  logInfo: vi.fn(),
-  logWarn: vi.fn(),
-  logError: vi.fn(),
-}));
-
 import { startHeartbeat, resetShutdown } from "../scripts/lib/heartbeat.js";
-import { httpPostJson } from "../scripts/lib/http-client.js";
 
-const mockHttpPostJson = vi.mocked(httpPostJson);
+// Suppress log output by mocking console.error (used by log.ts)
+vi.spyOn(console, "error").mockImplementation(() => {});
 
 describe("heartbeat", () => {
+  const mockPostJson =
+    vi.fn<
+      (
+        url: string,
+        data: Record<string, unknown>,
+      ) => Promise<Record<string, unknown> | null>
+    >();
+
   beforeEach(() => {
     resetShutdown();
-    mockHttpPostJson.mockReset();
+    mockPostJson.mockReset();
   });
 
   describe("startHeartbeat", () => {
@@ -30,12 +26,18 @@ describe("heartbeat", () => {
       intervalSeconds: 60,
     };
 
+    function configWith(
+      overrides: Partial<Parameters<typeof startHeartbeat>[0]> = {},
+    ) {
+      return { ...baseConfig, postJson: mockPostJson, ...overrides };
+    }
+
     it("should reject when first heartbeat returns null", async () => {
-      mockHttpPostJson.mockResolvedValue(null);
+      mockPostJson.mockResolvedValue(null);
 
       // Use scheduler that never fires (we only care about first heartbeat)
       const scheduleNext = vi.fn();
-      const heartbeatPromise = startHeartbeat({ ...baseConfig, scheduleNext });
+      const heartbeatPromise = startHeartbeat(configWith({ scheduleNext }));
 
       await expect(heartbeatPromise).rejects.toThrow(
         "Network connectivity check failed",
@@ -44,10 +46,10 @@ describe("heartbeat", () => {
     });
 
     it("should reject when first heartbeat throws error", async () => {
-      mockHttpPostJson.mockRejectedValue(new Error("Network error"));
+      mockPostJson.mockRejectedValue(new Error("Network error"));
 
       const scheduleNext = vi.fn();
-      const heartbeatPromise = startHeartbeat({ ...baseConfig, scheduleNext });
+      const heartbeatPromise = startHeartbeat(configWith({ scheduleNext }));
 
       await expect(heartbeatPromise).rejects.toThrow(
         "Network connectivity check failed",
@@ -56,17 +58,17 @@ describe("heartbeat", () => {
     });
 
     it("should schedule next heartbeat when first succeeds", async () => {
-      mockHttpPostJson.mockResolvedValue({});
+      mockPostJson.mockResolvedValue({});
 
       const scheduleNext = vi.fn();
-      const heartbeatPromise = startHeartbeat({ ...baseConfig, scheduleNext });
+      const heartbeatPromise = startHeartbeat(configWith({ scheduleNext }));
 
       // Prevent unhandled rejection
       heartbeatPromise.catch(() => {});
 
       // Wait for first heartbeat to complete
       await vi.waitFor(() => {
-        expect(mockHttpPostJson).toHaveBeenCalledTimes(1);
+        expect(mockPostJson).toHaveBeenCalledTimes(1);
       });
 
       // Verify next heartbeat was scheduled
@@ -78,7 +80,7 @@ describe("heartbeat", () => {
     });
 
     it("should continue sending heartbeats after first success", async () => {
-      mockHttpPostJson.mockResolvedValue({});
+      mockPostJson.mockResolvedValue({});
 
       // Capture scheduled callbacks
       const scheduledCallbacks: Array<() => void> = [];
@@ -86,30 +88,30 @@ describe("heartbeat", () => {
         scheduledCallbacks.push(callback);
       });
 
-      const heartbeatPromise = startHeartbeat({ ...baseConfig, scheduleNext });
+      const heartbeatPromise = startHeartbeat(configWith({ scheduleNext }));
       heartbeatPromise.catch(() => {});
 
       // Wait for first heartbeat
       await vi.waitFor(() => {
-        expect(mockHttpPostJson).toHaveBeenCalledTimes(1);
+        expect(mockPostJson).toHaveBeenCalledTimes(1);
       });
 
       // Trigger second heartbeat
       scheduledCallbacks[0]?.();
       await vi.waitFor(() => {
-        expect(mockHttpPostJson).toHaveBeenCalledTimes(2);
+        expect(mockPostJson).toHaveBeenCalledTimes(2);
       });
 
       // Trigger third heartbeat
       scheduledCallbacks[1]?.();
       await vi.waitFor(() => {
-        expect(mockHttpPostJson).toHaveBeenCalledTimes(3);
+        expect(mockPostJson).toHaveBeenCalledTimes(3);
       });
     });
 
     it("should not reject when subsequent heartbeat fails", async () => {
       // First heartbeat succeeds, subsequent ones fail
-      mockHttpPostJson
+      mockPostJson
         .mockResolvedValueOnce({})
         .mockResolvedValueOnce(null)
         .mockResolvedValue({});
@@ -119,7 +121,7 @@ describe("heartbeat", () => {
         scheduledCallbacks.push(callback);
       });
 
-      const heartbeatPromise = startHeartbeat({ ...baseConfig, scheduleNext });
+      const heartbeatPromise = startHeartbeat(configWith({ scheduleNext }));
 
       // Track if promise rejects
       let rejected = false;
@@ -129,19 +131,19 @@ describe("heartbeat", () => {
 
       // Wait for first heartbeat (success)
       await vi.waitFor(() => {
-        expect(mockHttpPostJson).toHaveBeenCalledTimes(1);
+        expect(mockPostJson).toHaveBeenCalledTimes(1);
       });
 
       // Trigger second heartbeat (fails - should just warn)
       scheduledCallbacks[0]?.();
       await vi.waitFor(() => {
-        expect(mockHttpPostJson).toHaveBeenCalledTimes(2);
+        expect(mockPostJson).toHaveBeenCalledTimes(2);
       });
 
       // Trigger third heartbeat (succeeds)
       scheduledCallbacks[1]?.();
       await vi.waitFor(() => {
-        expect(mockHttpPostJson).toHaveBeenCalledTimes(3);
+        expect(mockPostJson).toHaveBeenCalledTimes(3);
       });
 
       // Promise should not reject
@@ -149,15 +151,15 @@ describe("heartbeat", () => {
     });
 
     it("should stop heartbeat loop when first heartbeat fails", async () => {
-      mockHttpPostJson.mockResolvedValue(null);
+      mockPostJson.mockResolvedValue(null);
 
       const scheduleNext = vi.fn();
-      const heartbeatPromise = startHeartbeat({ ...baseConfig, scheduleNext });
+      const heartbeatPromise = startHeartbeat(configWith({ scheduleNext }));
 
       await expect(heartbeatPromise).rejects.toThrow();
 
       // Verify only one call was made (loop stopped)
-      expect(mockHttpPostJson).toHaveBeenCalledTimes(1);
+      expect(mockPostJson).toHaveBeenCalledTimes(1);
 
       // Verify no next heartbeat was scheduled
       expect(scheduleNext).not.toHaveBeenCalled();

--- a/turbo/packages/sandbox-scripts/src/scripts/lib/heartbeat.ts
+++ b/turbo/packages/sandbox-scripts/src/scripts/lib/heartbeat.ts
@@ -37,6 +37,14 @@ export interface HeartbeatConfig {
    * Injected for testing to avoid fake timers.
    */
   scheduleNext?: (callback: () => void, delayMs: number) => void;
+  /**
+   * Optional HTTP POST function. Defaults to httpPostJson.
+   * Injected for testing to avoid mocking internal modules.
+   */
+  postJson?: (
+    url: string,
+    data: Record<string, unknown>,
+  ) => Promise<Record<string, unknown> | null>;
 }
 
 /**
@@ -50,8 +58,10 @@ export interface HeartbeatConfig {
  * @returns Promise that rejects if first heartbeat fails (never resolves otherwise)
  */
 export function startHeartbeat(config: HeartbeatConfig): Promise<never> {
-  const { heartbeatUrl, runId, intervalSeconds, scheduleNext } = config;
+  const { heartbeatUrl, runId, intervalSeconds, scheduleNext, postJson } =
+    config;
   const scheduler = scheduleNext ?? setTimeout;
+  const post = postJson ?? httpPostJson;
 
   let isFirstHeartbeat = true;
   let rejectFirstHeartbeat: ((error: Error) => void) | null = null;
@@ -67,7 +77,7 @@ export function startHeartbeat(config: HeartbeatConfig): Promise<never> {
     }
 
     try {
-      const result = await httpPostJson(heartbeatUrl, { runId });
+      const result = await post(heartbeatUrl, { runId });
 
       if (result !== null) {
         logInfo(


### PR DESCRIPTION
## Summary
- Add `no-relative-vi-mock` rule to the shared `vm0Plugin` in `base.js` (next to existing `no-msw-bypass` rule)
- Enable it for `**/*.test.ts` files in sandbox-scripts ESLint config
- Prevents future violations of mocking internal modules with relative paths

**Merge order:** Must merge after #WU1 and #WU2 PRs (otherwise lint will fail on existing violations)

Closes #3930 (part 3 of 3)

## Test plan
- [x] Lint passes with `pnpm turbo run lint --filter=@vm0/sandbox-scripts`
- [x] Type check passes
- [x] Rule correctly flags `vi.mock("../foo")` and `vi.mock("./bar")` patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)