### PR TITLE
fix(web): filter browser extension errors in sentry config

### DIFF
--- a/turbo/apps/web/instrumentation-client.ts
+++ b/turbo/apps/web/instrumentation-client.ts
@@ -43,5 +43,10 @@ Sentry.init({
     "AbortError",
     // Browser extensions
     "ResizeObserver loop",
+    "func sseError not found",
+    "Failed to connect to MetaMask",
   ],
+
+  // Filter out errors from browser extension scripts
+  denyUrls: [/inpage\.js/, /chrome-extension:\/\//, /moz-extension:\/\//],
 });


### PR DESCRIPTION
## Summary
- Add MetaMask-related errors (`func sseError not found`, `Failed to connect to MetaMask`) to Sentry `ignoreErrors`
- Add `denyUrls` config to filter errors from browser extension scripts (`inpage.js`, `chrome-extension://`, `moz-extension://`)
- Eliminates 1467+ noise events from [WEB-D](https://vm0.sentry.io/issues/WEB-D) and [WEB-E](https://vm0.sentry.io/issues/WEB-E)

## Context
WEB-D is the highest volume error in the web project's production Sentry. The stacktrace is entirely from `inpage.js` (MetaMask's injected script), with 0 real users impacted. This is standard browser extension noise that should be filtered.

## Test plan
- [ ] Verify lint and type checks pass
- [ ] Confirm existing Sentry error reporting is unaffected (no over-filtering)
- [ ] Monitor Sentry after deploy to confirm extension errors are no longer reported

🤖 Generated with [Claude Code](https://claude.com/claude-code)