### PR TITLE
fix(e2e): sync missing tests to 03-experimental-runner

### DIFF
--- a/e2e/tests/03-experimental-runner/t34-vm0-logs-search.bats
+++ b/e2e/tests/03-experimental-runner/t34-vm0-logs-search.bats
@@ -1,0 +1,110 @@
+#!/usr/bin/env bats
+
+# Test VM0 logs search functionality
+# This test verifies that:
+# 1. vm0 logs search --help shows command options
+# 2. vm0 logs search finds events by keyword in a completed run
+# 3. vm0 logs search shows empty results guidance for non-matching keywords
+#
+# Test count: 3 tests with 1 vm0 run call
+
+load '../../helpers/setup'
+
+setup_file() {
+    export AGENT_NAME="e2e-t34-$(date +%s%3N)-$RANDOM"
+}
+
+setup() {
+    create_test_volume "e2e-vol-t34"
+
+    export TEST_ARTIFACT_DIR="$(mktemp -d)"
+    export ARTIFACT_NAME="e2e-search-test-$(date +%s%3N)-$RANDOM"
+    export TEST_CONFIG="$(mktemp --suffix=.yaml)"
+    cat > "$TEST_CONFIG" <<EOF
+version: "1.0"
+agents:
+  ${AGENT_NAME}:
+    description: "E2E test agent for logs search testing"
+    framework: claude-code
+    experimental_runner:
+      group: ${RUNNER_GROUP}
+    volumes:
+      - claude-files:/home/user/.claude
+    working_dir: /home/user/workspace
+volumes:
+  claude-files:
+    name: $VOLUME_NAME
+    version: latest
+EOF
+}
+
+teardown() {
+    if [ -n "$TEST_ARTIFACT_DIR" ] && [ -d "$TEST_ARTIFACT_DIR" ]; then
+        rm -rf "$TEST_ARTIFACT_DIR"
+    fi
+    if [ -n "$TEST_CONFIG" ] && [ -f "$TEST_CONFIG" ]; then
+        rm -f "$TEST_CONFIG"
+    fi
+    cleanup_test_volume
+}
+
+@test "logs search --help shows command options" {
+    run $CLI_COMMAND logs search --help
+    assert_success
+    assert_output --partial "Search agent events across runs"
+    assert_output --partial "--after-context"
+    assert_output --partial "--before-context"
+    assert_output --partial "--context"
+    assert_output --partial "--agent"
+    assert_output --partial "--run"
+    assert_output --partial "--since"
+    assert_output --partial "--limit"
+}
+
+@test "Build logs search test agent configuration" {
+    run $CLI_COMMAND compose "$TEST_CONFIG"
+    assert_success
+    assert_output --partial "$AGENT_NAME"
+}
+
+@test "logs search: run agent and search for keyword in events" {
+    # Step 1: Create artifact
+    echo "# Step 1: Creating artifact..."
+    mkdir -p "$TEST_ARTIFACT_DIR/$ARTIFACT_NAME"
+    cd "$TEST_ARTIFACT_DIR/$ARTIFACT_NAME"
+    $CLI_COMMAND artifact init --name "$ARTIFACT_NAME" >/dev/null
+    echo "search test content" > test.txt
+    run $CLI_COMMAND artifact push
+    assert_success
+
+    # Step 2: Run agent
+    echo "# Step 2: Running agent..."
+    run $CLI_COMMAND run "$AGENT_NAME" \
+        --artifact-name "$ARTIFACT_NAME" \
+        "echo 'hello from agent'"
+    assert_success
+    assert_output --partial "Run ID:"
+    assert_output --partial "◆ Claude Code Completed"
+
+    # Step 3: Extract Run ID
+    RUN_ID=$(echo "$output" | grep -oP 'Run ID:\s+\K[a-f0-9-]{36}' | head -1)
+    echo "# Run ID: $RUN_ID"
+    [ -n "$RUN_ID" ] || {
+        echo "# Failed to extract Run ID"
+        echo "$output"
+        return 1
+    }
+
+    # Step 4: Search for keyword scoped to this run
+    echo "# Step 4: Searching for 'hello from agent' in run events..."
+    SHORT_ID="${RUN_ID:0:8}"
+    run $CLI_COMMAND logs search "hello from agent" --run "$RUN_ID" --since 1h
+    assert_success
+    assert_output --partial "$SHORT_ID"
+
+    # Step 5: Search for non-matching keyword shows empty guidance
+    echo "# Step 5: Testing empty results guidance..."
+    run $CLI_COMMAND logs search "xyznonexistent99999" --run "$RUN_ID" --since 1h
+    assert_success
+    assert_output --partial "No matches found"
+}

--- a/e2e/tests/03-experimental-runner/t34-vm0-memory.bats
+++ b/e2e/tests/03-experimental-runner/t34-vm0-memory.bats
@@ -39,7 +39,8 @@ agents:
   ${AGENT_NAME}:
     description: "E2E test agent for memory flag testing"
     framework: claude-code
-    image: "vm0/claude-code:dev"
+    experimental_runner:
+      group: ${RUNNER_GROUP}
     volumes:
       - claude-files:/home/user/.claude
     working_dir: /home/user/workspace


### PR DESCRIPTION
## Summary

- Add `t34-vm0-logs-search.bats` to `03-experimental-runner` (was only in `02-parallel`)
- Fix `t34-vm0-memory.bats` in `03-experimental-runner` to use `experimental_runner` instead of `image: "vm0/claude-code:dev"`

## Test plan

- [x] Verified all 02 tests exist in 03
- [x] Verified all 03 agent definitions use `experimental_runner`
- [x] Verified test case names and counts match between 02 and 03
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)