### PR TITLE
fix(email): add missing progress status guard to trigger and schedule callbacks

### DIFF
--- a/turbo/apps/web/app/api/internal/callbacks/email/schedule/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/email/schedule/__tests__/route.test.ts
@@ -31,7 +31,7 @@ interface ScheduleCallbackPayload {
 function createCallbackRequest(
   body: {
     runId: string;
-    status: "completed" | "failed";
+    status: "completed" | "failed" | "progress";
     error?: string;
     payload: ScheduleCallbackPayload;
   },
@@ -128,6 +128,43 @@ describe("POST /api/internal/callbacks/email/schedule", () => {
       const response = await POST(request);
 
       expect(response.status).toBe(401);
+    });
+  });
+
+  describe("Progress Callback", () => {
+    it("should no-op on progress and not send any email", async () => {
+      const user = await context.setupUser({ prefix: "email-sched-prog" });
+      mockClerk({ userId: user.userId });
+      const { composeId } = await createTestCompose(uniqueId("sched-agent"));
+      const schedule = await createTestSchedule(composeId, uniqueId("sched"));
+      const { runId } = await createTestRun(composeId, "Test prompt");
+      await linkRunToSchedule(runId, schedule.id);
+
+      const payload: ScheduleCallbackPayload = {
+        scheduleId: schedule.id,
+        composeId,
+        composeName: "test-agent",
+        userId: user.userId,
+      };
+
+      const { secret } = await createTestCallback({
+        runId,
+        url: "http://localhost/api/internal/callbacks/email/schedule",
+        payload: { ...payload },
+      });
+
+      const request = createCallbackRequest(
+        { runId, status: "progress", payload },
+        secret,
+      );
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.success).toBe(true);
+
+      // No email should be sent for progress notifications
+      expect(mockResend.emails.send).not.toHaveBeenCalled();
     });
   });
 

--- a/turbo/apps/web/app/api/internal/callbacks/email/schedule/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/email/schedule/route.ts
@@ -67,6 +67,11 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 
   log.debug("Processing email schedule callback", { runId, status });
 
+  // Progress notifications are not applicable for email — no-op.
+  if (status === "progress") {
+    return NextResponse.json({ success: true });
+  }
+
   // Get user email
   const userEmail = await getUserEmail(userId);
   if (!userEmail) {

--- a/turbo/apps/web/app/api/internal/callbacks/email/trigger/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/email/trigger/__tests__/route.test.ts
@@ -39,7 +39,7 @@ interface TriggerCallbackPayload {
 function createCallbackRequest(
   body: {
     runId: string;
-    status: "completed" | "failed";
+    status: "completed" | "failed" | "progress";
     error?: string;
     payload: TriggerCallbackPayload;
   },
@@ -360,6 +360,44 @@ describe("POST /api/internal/callbacks/email/trigger", () => {
         to: string;
       };
       expect(sendArgs.to).toBe(senderEmail);
+    });
+  });
+
+  describe("Progress Callback", () => {
+    it("should no-op on progress and not send any email", async () => {
+      const user = await context.setupUser({ prefix: "trigger-progress" });
+      mockClerk({ userId: user.userId });
+      const agentName = uniqueId("progress-agent");
+      const { composeId } = await createTestCompose(agentName);
+      const { runId } = await createTestRun(composeId, "Test prompt");
+
+      const replyToken = generateReplyToken(crypto.randomUUID());
+      const payload: TriggerCallbackPayload = {
+        senderEmail: "sender@example.com",
+        composeId,
+        userId: user.userId,
+        inboundEmailId: "email-progress",
+        replyToken,
+      };
+
+      const { secret } = await createTestCallback({
+        runId,
+        url: "http://localhost/api/internal/callbacks/email/trigger",
+        payload: { ...payload },
+      });
+
+      const request = createCallbackRequest(
+        { runId, status: "progress", payload },
+        secret,
+      );
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.success).toBe(true);
+
+      // No email should be sent for progress notifications
+      expect(mockResend.emails.send).not.toHaveBeenCalled();
     });
   });
 

--- a/turbo/apps/web/app/api/internal/callbacks/email/trigger/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/email/trigger/route.ts
@@ -133,6 +133,11 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 
   log.debug("Processing email trigger callback", { runId, status });
 
+  // Progress notifications are not applicable for email — no-op.
+  if (status === "progress") {
+    return NextResponse.json({ success: true });
+  }
+
   // Get compose name
   const [compose] = await globalThis.services.db
     .select({ name: agentComposes.name })


### PR DESCRIPTION
## Summary

- Add `progress` status early-return guard to email trigger and schedule callback handlers, matching the existing pattern in the email reply callback
- Both handlers were misinterpreting heartbeat progress notifications as failures, sending spurious error emails ("The agent run failed." / "Unknown error") to users while runs were still in progress

## Test plan

- [x] New test: trigger callback returns 200 with no email sent on `progress` status
- [x] New test: schedule callback returns 200 with no email sent on `progress` status
- [x] Existing tests pass (pre-existing checkpoint failures unrelated)
- [x] Lint, type check, knip all pass

Closes #3970

🤖 Generated with [Claude Code](https://claude.com/claude-code)