### PR TITLE
fix(web): disable sentry error reporting in preview deployments

### DIFF
--- a/turbo/apps/web/instrumentation-client.ts
+++ b/turbo/apps/web/instrumentation-client.ts
@@ -3,8 +3,8 @@ import * as Sentry from "@sentry/nextjs";
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
 
-  // Only enable in production
-  enabled: process.env.NODE_ENV === "production",
+  // Only enable in production (VERCEL_ENV distinguishes preview from production)
+  enabled: process.env.NEXT_PUBLIC_VERCEL_ENV === "production",
 
   // Set environment (Vercel provides NEXT_PUBLIC_VERCEL_ENV)
   environment: process.env.NEXT_PUBLIC_VERCEL_ENV || process.env.NODE_ENV,

--- a/turbo/apps/web/sentry.edge.config.ts
+++ b/turbo/apps/web/sentry.edge.config.ts
@@ -3,8 +3,8 @@ import * as Sentry from "@sentry/nextjs";
 Sentry.init({
   dsn: process.env.SENTRY_DSN_WEB,
 
-  // Only enable in production
-  enabled: process.env.NODE_ENV === "production",
+  // Only enable in production (exclude Vercel preview deployments)
+  enabled: process.env.VERCEL_ENV === "production",
 
   // Set environment (Vercel provides VERCEL_ENV)
   environment: process.env.VERCEL_ENV || process.env.NODE_ENV,

--- a/turbo/apps/web/sentry.server.config.ts
+++ b/turbo/apps/web/sentry.server.config.ts
@@ -3,8 +3,8 @@ import * as Sentry from "@sentry/nextjs";
 Sentry.init({
   dsn: process.env.SENTRY_DSN_WEB,
 
-  // Only enable in production
-  enabled: process.env.NODE_ENV === "production",
+  // Only enable in production (exclude Vercel preview deployments)
+  enabled: process.env.VERCEL_ENV === "production",
 
   // Set environment (Vercel provides VERCEL_ENV)
   environment: process.env.VERCEL_ENV || process.env.NODE_ENV,


### PR DESCRIPTION
## Summary
- Use `VERCEL_ENV` instead of `NODE_ENV` to control whether Sentry is enabled in `sentry.server.config.ts` and `sentry.edge.config.ts`
- Vercel preview deployments set `NODE_ENV=production`, causing preview errors (e.g. [WEB-1G](https://vm0.sentry.io/issues/WEB-1G)) to pollute Sentry
- `VERCEL_ENV` correctly distinguishes `"preview"` from `"production"`

## Test plan
- [ ] Verify Sentry still reports errors in production deployment
- [ ] Verify preview deployments no longer send errors to Sentry

🤖 Generated with [Claude Code](https://claude.com/claude-code)