### PR TITLE
fix(slack): allow file_share subtype in dm event filter

### DIFF
--- a/turbo/apps/web/app/api/slack/events/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/slack/events/__tests__/route.test.ts
@@ -585,6 +585,33 @@ describe("POST /api/slack/events", () => {
     });
   });
 
+  describe("Scenario: DM with file_share subtype", () => {
+    it("should dispatch agent run for file_share messages", async () => {
+      // Given I am a linked Slack user with one agent
+      const { userLink, installation } = await givenLinkedSlackUser();
+      await givenUserHasAgent(userLink, {
+        agentName: "my-helper",
+      });
+
+      // When I send a DM with an image (subtype: file_share)
+      const request = createSlackDmEventRequest({
+        teamId: installation.slackWorkspaceId,
+        channelId: "D123",
+        userId: userLink.slackUserId,
+        text: "check this image",
+        ts: "1234567890.123456",
+        subtype: "file_share",
+      });
+      const response = await POST(request);
+      expect(response.status).toBe(200);
+      await flushAfterCallbacks();
+
+      // Then the agent should be dispatched (file_share is allowed through)
+      expect(mockClient.assistant.threads.setStatus).toHaveBeenCalledTimes(1);
+      expect(mockClient.chat.postMessage).not.toHaveBeenCalled();
+    });
+  });
+
   describe("Scenario: DM with subtype (e.g. message_changed)", () => {
     it("should silently ignore messages with subtype", async () => {
       const { installation } = await givenSlackWorkspaceInstalled();

--- a/turbo/apps/web/app/api/slack/events/route.ts
+++ b/turbo/apps/web/app/api/slack/events/route.ts
@@ -165,7 +165,7 @@ export async function POST(request: Request) {
     if (
       event.type === "message" &&
       event.channel_type === "im" &&
-      !event.subtype &&
+      (!event.subtype || event.subtype === "file_share") &&
       !event.bot_id
     ) {
       initServices();


### PR DESCRIPTION
## Summary
- DM messages with image attachments have `subtype: "file_share"`, which was filtered out by the `!event.subtype` check, preventing agent execution entirely
- Allow `file_share` subtype to pass through the DM event filter

Closes #3976

## Test plan
- [ ] Send a DM with an image attachment to the Slack bot — agent should be triggered
- [ ] Send a plain text DM — agent should still work as before
- [ ] Send a DM with `subtype` other than `file_share` (e.g. bot messages) — should still be filtered

🤖 Generated with [Claude Code](https://claude.com/claude-code)