### PR TITLE
perf(run): batch callback registration into single insert

### DIFF
--- a/turbo/apps/web/src/lib/run/run-service.ts
+++ b/turbo/apps/web/src/lib/run/run-service.ts
@@ -460,18 +460,17 @@ async function registerCallbacks(
   callbacks: Array<{ url: string; secret: string; payload: unknown }>,
 ): Promise<void> {
   const { SECRETS_ENCRYPTION_KEY } = env();
-  for (const callback of callbacks) {
-    const encryptedSecret = encryptCredentialValue(
-      callback.secret,
-      SECRETS_ENCRYPTION_KEY,
-    );
-    await globalThis.services.db.insert(agentRunCallbacks).values({
+  await globalThis.services.db.insert(agentRunCallbacks).values(
+    callbacks.map((callback) => ({
       runId,
       url: callback.url,
-      encryptedSecret,
+      encryptedSecret: encryptCredentialValue(
+        callback.secret,
+        SECRETS_ENCRYPTION_KEY,
+      ),
       payload: callback.payload,
-    });
-  }
+    })),
+  );
   log.debug(`Registered ${callbacks.length} callback(s) for run ${runId}`);
 }
 


### PR DESCRIPTION
## Summary

- Replace serial `for` loop inserting callbacks one at a time with a single batch `insert().values([...])` call
- Eliminates N-1 DB round-trips for N callbacks

Closes #3956

## Test plan

- [x] 52 run-related tests pass
- [x] Type check passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)