### PR TITLE
revert: remove e2b executor from dispatch logic (#3951)

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -694,7 +694,6 @@ jobs:
             CRON_SECRET=${{ secrets.CRON_SECRET }}
             ABLY_API_KEY=${{ secrets.ABLY_API_KEY }}
             CONCURRENT_RUN_LIMIT=0
-            RUNNER_DEFAULT_GROUP=vm0/development-${{ needs.prepare.outputs.job-ref }}
             VM0_DEBUG=*
             CLAUDE_CODE_VERSION_URL=${{ vars.CLAUDE_CODE_VERSION_URL }}
             SLACK_CLIENT_ID=${{ vars.SLACK_CLIENT_ID }}

--- a/turbo/apps/web/app/api/agent/runs/[id]/cancel/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/cancel/__tests__/route.test.ts
@@ -48,8 +48,10 @@ describe("POST /api/agent/runs/:id/cancel - Cancel Run", () => {
       expect(data.message).toBe("Run cancelled successfully");
     });
 
-    it("should cancel a running run", async () => {
-      const run = await createTestRun(testComposeId, "Run to cancel");
+    it("should kill E2B sandbox when cancelling", async () => {
+      const run = await createTestRun(testComposeId, "Run with sandbox");
+
+      context.mocks.e2b.sandbox.kill.mockClear();
 
       const request = createTestRequest(
         `http://localhost:3000/api/agent/runs/${run.runId}/cancel`,
@@ -61,6 +63,7 @@ describe("POST /api/agent/runs/:id/cancel - Cancel Run", () => {
 
       expect(response.status).toBe(200);
       expect(data.status).toBe("cancelled");
+      expect(context.mocks.e2b.sandbox.kill).toHaveBeenCalled();
     });
   });
 

--- a/turbo/apps/web/app/api/agent/runs/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/__tests__/route.test.ts
@@ -4,6 +4,7 @@ import { POST as createComposeRoute } from "../../composes/route";
 import { PUT as putSecret } from "../../../secrets/route";
 import { PUT as setVariableRoute } from "../../../variables/route";
 import { randomUUID } from "crypto";
+import { Sandbox } from "@e2b/code-interpreter";
 import {
   createTestRequest,
   createTestCompose,
@@ -64,12 +65,9 @@ describe("POST /api/agent/runs - Internal Runs API", () => {
       expect(run.completedAt).toBeNull();
     });
 
-    it("should return failed status if dispatch fails", async () => {
-      const { executeRunnerJob } = await import(
-        "../../../../../src/lib/run/executors/runner-executor"
-      );
-      vi.mocked(executeRunnerJob).mockRejectedValueOnce(
-        new Error("Runner dispatch failed"),
+    it("should return failed status if sandbox preparation fails", async () => {
+      vi.mocked(Sandbox.create).mockRejectedValueOnce(
+        new Error("Sandbox creation failed"),
       );
 
       const data = await createTestRun(testComposeId, "Test failure");
@@ -80,7 +78,7 @@ describe("POST /api/agent/runs - Internal Runs API", () => {
       const run = await getTestRun(data.runId);
 
       expect(run.status).toBe("failed");
-      expect(run.error).toContain("Runner dispatch failed");
+      expect(run.error).toContain("Sandbox creation failed");
       expect(run.completedAt).toBeDefined();
     });
 
@@ -836,10 +834,7 @@ describe("POST /api/agent/runs - Internal Runs API", () => {
 
   describe("Connector Injection", () => {
     it("should satisfy ${{ secrets.GH_TOKEN }} from connector when user has no GH_TOKEN secret", async () => {
-      const { executeRunnerJob } = await import(
-        "../../../../../src/lib/run/executors/runner-executor"
-      );
-      vi.mocked(executeRunnerJob).mockClear();
+      vi.mocked(Sandbox.create).mockClear();
 
       // Create a GitHub connector for the test user
       await createTestConnector(user.scopeId, {
@@ -859,19 +854,16 @@ describe("POST /api/agent/runs - Internal Runs API", () => {
       const data = await createTestRun(composeId, "Test with GitHub connector");
       expect(data.status).toBe("running");
 
-      // Verify executor was called with the connector's token as GH_TOKEN
-      expect(executeRunnerJob).toHaveBeenCalled();
-      const runnerContext = vi.mocked(executeRunnerJob).mock.calls[0]![0];
-      const envs = { ...runnerContext.environment, ...runnerContext.secrets };
+      // Verify Sandbox.create was called with the connector's token as GH_TOKEN
+      expect(Sandbox.create).toHaveBeenCalled();
+      const createCall = vi.mocked(Sandbox.create).mock.calls[0];
+      const envs = createCall?.[1]?.envs as Record<string, string> | undefined;
 
       expect(envs?.GH_TOKEN).toBe("ghp-test-connector-token");
     });
 
     it("should not override user-provided GH_TOKEN secret with connector token", async () => {
-      const { executeRunnerJob } = await import(
-        "../../../../../src/lib/run/executors/runner-executor"
-      );
-      vi.mocked(executeRunnerJob).mockClear();
+      vi.mocked(Sandbox.create).mockClear();
 
       // Create a GitHub connector
       await createTestConnector(user.scopeId, {
@@ -895,18 +887,15 @@ describe("POST /api/agent/runs - Internal Runs API", () => {
       expect(data.status).toBe("running");
 
       // Verify user-provided secret takes precedence
-      expect(executeRunnerJob).toHaveBeenCalled();
-      const runnerContext = vi.mocked(executeRunnerJob).mock.calls[0]![0];
-      const envs = { ...runnerContext.environment, ...runnerContext.secrets };
+      expect(Sandbox.create).toHaveBeenCalled();
+      const createCall = vi.mocked(Sandbox.create).mock.calls[0];
+      const envs = createCall?.[1]?.envs as Record<string, string> | undefined;
 
       expect(envs?.GH_TOKEN).toBe("user-provided-token");
     });
 
     it("should not inject connector secrets when compose does not reference them", async () => {
-      const { executeRunnerJob } = await import(
-        "../../../../../src/lib/run/executors/runner-executor"
-      );
-      vi.mocked(executeRunnerJob).mockClear();
+      vi.mocked(Sandbox.create).mockClear();
 
       // Create a GitHub connector
       await createTestConnector(user.scopeId, {
@@ -919,10 +908,10 @@ describe("POST /api/agent/runs - Internal Runs API", () => {
       const data = await createTestRun(composeId, "Test no GH_TOKEN ref");
       expect(data.status).toBe("running");
 
-      // Verify GH_TOKEN is NOT in executor context
-      expect(executeRunnerJob).toHaveBeenCalled();
-      const runnerContext = vi.mocked(executeRunnerJob).mock.calls[0]![0];
-      const envs = { ...runnerContext.environment, ...runnerContext.secrets };
+      // Verify GH_TOKEN is NOT in sandbox envs
+      expect(Sandbox.create).toHaveBeenCalled();
+      const createCall = vi.mocked(Sandbox.create).mock.calls[0];
+      const envs = createCall?.[1]?.envs as Record<string, string> | undefined;
 
       expect(envs?.GH_TOKEN).toBeUndefined();
       expect(envs?.GITHUB_TOKEN).toBeUndefined();
@@ -938,10 +927,7 @@ describe("POST /api/agent/runs - Internal Runs API", () => {
     });
 
     it("should satisfy ${{ secrets.SLACK_TOKEN }} from Slack connector when user has no SLACK_TOKEN secret", async () => {
-      const { executeRunnerJob } = await import(
-        "../../../../../src/lib/run/executors/runner-executor"
-      );
-      vi.mocked(executeRunnerJob).mockClear();
+      vi.mocked(Sandbox.create).mockClear();
 
       // Create a Slack connector for the test user
       await createTestConnector(user.scopeId, {
@@ -965,19 +951,16 @@ describe("POST /api/agent/runs - Internal Runs API", () => {
       const data = await createTestRun(composeId, "Test with Slack connector");
       expect(data.status).toBe("running");
 
-      // Verify executor was called with the connector's token as SLACK_TOKEN
-      expect(executeRunnerJob).toHaveBeenCalled();
-      const runnerContext = vi.mocked(executeRunnerJob).mock.calls[0]![0];
-      const envs = { ...runnerContext.environment, ...runnerContext.secrets };
+      // Verify Sandbox.create was called with the connector's token as SLACK_TOKEN
+      expect(Sandbox.create).toHaveBeenCalled();
+      const createCall = vi.mocked(Sandbox.create).mock.calls[0];
+      const envs = createCall?.[1]?.envs as Record<string, string> | undefined;
 
       expect(envs?.SLACK_TOKEN).toBe("xoxp-test-slack-connector-token");
     });
 
     it("should not override user-provided SLACK_TOKEN secret with Slack connector token", async () => {
-      const { executeRunnerJob } = await import(
-        "../../../../../src/lib/run/executors/runner-executor"
-      );
-      vi.mocked(executeRunnerJob).mockClear();
+      vi.mocked(Sandbox.create).mockClear();
 
       // Create a Slack connector
       await createTestConnector(user.scopeId, {
@@ -1009,9 +992,9 @@ describe("POST /api/agent/runs - Internal Runs API", () => {
       expect(data.status).toBe("running");
 
       // Verify user-provided secret takes precedence
-      expect(executeRunnerJob).toHaveBeenCalled();
-      const runnerContext = vi.mocked(executeRunnerJob).mock.calls[0]![0];
-      const envs = { ...runnerContext.environment, ...runnerContext.secrets };
+      expect(Sandbox.create).toHaveBeenCalled();
+      const createCall = vi.mocked(Sandbox.create).mock.calls[0];
+      const envs = createCall?.[1]?.envs as Record<string, string> | undefined;
 
       expect(envs?.SLACK_TOKEN).toBe("user-provided-slack-token");
     });
@@ -1139,7 +1122,7 @@ describe("POST /api/agent/runs - Internal Runs API", () => {
       expect(data.error.message).toMatch(/checkpoint/i);
     });
 
-    it("should pass resume session to executor for claude-code framework", async () => {
+    it("should write session history to claude-code path format for claude-code framework", async () => {
       // Create and complete a run to get a checkpoint
       const { composeId } = await createTestCompose(
         `claude-code-resume-path-${Date.now()}`,
@@ -1152,20 +1135,25 @@ describe("POST /api/agent/runs - Internal Runs API", () => {
       );
       const { checkpointId } = await completeTestRun(user.userId, initialRunId);
 
-      const { executeRunnerJob } = await import(
-        "../../../../../src/lib/run/executors/runner-executor"
-      );
-      vi.mocked(executeRunnerJob).mockClear();
+      // Clear mocks before resume run
+      context.mocks.e2b.sandbox.files.write.mockClear();
 
       // Create a resume run using checkpointId
       await createTestRun(composeId, "Resume run", { checkpointId });
 
-      // Verify executor received resume session context
-      expect(executeRunnerJob).toHaveBeenCalled();
-      const runnerContext = vi.mocked(executeRunnerJob).mock.calls[0]![0];
-      expect(runnerContext.resumeSession).toBeDefined();
-      expect(runnerContext.resumeSession?.sessionId).toBeDefined();
-      expect(runnerContext.resumeSession?.sessionHistory).toBeDefined();
+      // Find the session history write call (ends with .jsonl)
+      const writeCalls = context.mocks.e2b.sandbox.files.write.mock.calls;
+      const sessionHistoryCall = writeCalls.find((call) => {
+        const path = call?.[0] as string;
+        return path?.endsWith(".jsonl");
+      });
+
+      expect(sessionHistoryCall).toBeDefined();
+      const writePath = sessionHistoryCall?.[0] as string;
+
+      // Claude-code path format: /home/user/.claude/projects/-{workingDir}/session-id.jsonl
+      expect(writePath).toMatch(/^\/home\/user\/\.claude\/projects\/-/);
+      expect(writePath).toMatch(/\.jsonl$/);
     });
 
     // Note: "Missing required secrets" validation is tested in the Validation
@@ -1357,10 +1345,7 @@ describe("POST /api/agent/runs - Internal Runs API", () => {
     });
 
     it("should use CLI vars over server-stored vars when both exist", async () => {
-      const { executeRunnerJob } = await import(
-        "../../../../../src/lib/run/executors/runner-executor"
-      );
-      vi.mocked(executeRunnerJob).mockClear();
+      vi.mocked(Sandbox.create).mockClear();
 
       // Create compose that requires a template variable
       const { composeId } = await createTestCompose(uniqueId("cli-override"), {
@@ -1382,10 +1367,10 @@ describe("POST /api/agent/runs - Internal Runs API", () => {
 
       expect(data.status).toBe("running");
 
-      // Verify executor was called with CLI value (not server value)
-      expect(executeRunnerJob).toHaveBeenCalled();
-      const runnerContext = vi.mocked(executeRunnerJob).mock.calls[0]![0];
-      const envs = { ...runnerContext.environment, ...runnerContext.secrets };
+      // Verify Sandbox.create was called with CLI value (not server value)
+      expect(Sandbox.create).toHaveBeenCalled();
+      const createCall = vi.mocked(Sandbox.create).mock.calls[0];
+      const envs = createCall?.[1]?.envs as Record<string, string> | undefined;
 
       expect(envs?.MY_VAR).toBe("cli-value");
     });

--- a/turbo/apps/web/app/api/cron/cleanup-sandboxes/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/cron/cleanup-sandboxes/__tests__/route.test.ts
@@ -270,11 +270,11 @@ describe("GET /api/cron/cleanup-sandboxes", () => {
       expect(cleanedResult.reason).toBe("Run timed out (no heartbeat)");
     });
 
-    it("should skip sandbox.kill for runner-dispatched runs (no sandboxId)", async () => {
+    it("should call sandbox.kill for expired runs with sandboxId", async () => {
       // Record the time when run is created
       const runCreationTime = Date.now();
 
-      // Create a run (runner mock does not set sandboxId)
+      // Create a run (will have sandboxId from the mock)
       await createTestRun(testComposeId, "Test prompt");
 
       // Mock Date.now to return time 3 minutes in the future
@@ -291,8 +291,8 @@ describe("GET /api/cron/cleanup-sandboxes", () => {
 
       await GET(request);
 
-      // Runner runs have no sandboxId, so sandbox.kill should NOT be called
-      expect(context.mocks.e2b.sandbox.kill).not.toHaveBeenCalled();
+      // Verify sandbox.kill was called (via the mock from setupMocks)
+      expect(context.mocks.e2b.sandbox.kill).toHaveBeenCalled();
     });
   });
 });

--- a/turbo/apps/web/app/api/platform/logs/[id]/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/platform/logs/[id]/__tests__/route.test.ts
@@ -139,13 +139,10 @@ describe("GET /api/platform/logs/[id]", () => {
   });
 
   it("should handle failed run with error message", async () => {
-    // Make runner dispatch fail to create a failed run
-    const { executeRunnerJob } = await import(
-      "../../../../../../src/lib/run/executors/runner-executor"
-    );
-    vi.mocked(executeRunnerJob).mockRejectedValueOnce(
-      new Error("Runner dispatch failed"),
-    );
+    // Make sandbox creation fail to create a failed run
+    vi.mocked(
+      (await import("@e2b/code-interpreter")).Sandbox.create,
+    ).mockRejectedValueOnce(new Error("Sandbox creation failed"));
 
     const { runId, status } = await createTestRun(testComposeId, "Test prompt");
 

--- a/turbo/apps/web/app/api/webhooks/agent/telemetry/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/telemetry/__tests__/route.test.ts
@@ -427,11 +427,11 @@ describe("POST /api/webhooks/agent/telemetry", () => {
   });
 
   describe("Sandbox type detection", () => {
-    it("should detect runner sandbox type when run has no sandboxId", async () => {
-      // Runner runs have no sandboxId (runner mock does not set it)
+    it("should detect E2B sandbox type when run has sandboxId", async () => {
+      // E2B runs have sandboxId set by E2B executor (mock returns unique sandboxId per test)
       const { runId } = await createRunForWebhook(
         testComposeId,
-        "Test runner run",
+        "Test E2B run",
       );
       const testToken = await createTestSandboxToken(user.userId, runId);
 
@@ -462,7 +462,7 @@ describe("POST /api/webhooks/agent/telemetry", () => {
 
       expect(recordSandboxInternalOperationSpy).toHaveBeenCalledWith({
         actionType: "api_to_agent_start",
-        sandboxType: "runner",
+        sandboxType: "e2b",
         durationMs: 1500,
         success: true,
       });

--- a/turbo/apps/web/src/__tests__/setup.ts
+++ b/turbo/apps/web/src/__tests__/setup.ts
@@ -25,8 +25,6 @@ const resetEnv = vi.hoisted(() => {
     vi.stubEnv("R2_ACCESS_KEY_ID", "test-access-key");
     vi.stubEnv("R2_SECRET_ACCESS_KEY", "test-secret-key");
     vi.stubEnv("R2_USER_STORAGES_BUCKET_NAME", "test-bucket");
-    // Default runner group for tests (all runs dispatch to runner by default)
-    vi.stubEnv("RUNNER_DEFAULT_GROUP", "vm0/test");
     // Optional env vars
     vi.stubEnv("AXIOM_DATASET_SUFFIX", "dev");
     // Slack integration test vars
@@ -109,32 +107,6 @@ vi.mock("@e2b/code-interpreter", () => ({
     create: vi.fn(),
     connect: vi.fn(),
   },
-}));
-
-// Mock runner executor — simulates runner picking up job immediately
-// Updates DB to "running" with startedAt (like real runner does after claiming),
-// so that completion flows and usage calculations work correctly in tests.
-vi.mock("../lib/run/executors/runner-executor", () => ({
-  executeRunnerJob: vi
-    .fn()
-    .mockImplementation(async (context: { runId: string }) => {
-      const { agentRuns } = await import("../db/schema/agent-run");
-      const { eq } = await import("drizzle-orm");
-      await globalThis.services.db
-        .update(agentRuns)
-        .set({
-          status: "running",
-          startedAt: new Date(),
-          lastHeartbeatAt: new Date(),
-        })
-        .where(eq(agentRuns.id, context.runId));
-      return {
-        runId: context.runId,
-        status: "running",
-        createdAt: new Date().toISOString(),
-        sandboxType: "runner",
-      };
-    }),
 }));
 
 // Mock AWS S3

--- a/turbo/apps/web/src/lib/run/__tests__/create-run.test.ts
+++ b/turbo/apps/web/src/lib/run/__tests__/create-run.test.ts
@@ -26,7 +26,9 @@ import {
   type CreateRunResult,
 } from "../run-service";
 import { isForbidden, isBadRequest } from "../../errors";
+import { Sandbox } from "@e2b/code-interpreter";
 import { POST as createComposeRoute } from "../../../../app/api/agent/composes/route";
+import { mockClerk } from "../../../__tests__/clerk-mock";
 
 const context = testContext();
 
@@ -58,6 +60,7 @@ describe("createRun()", () => {
 
       expect(result.runId).toBeDefined();
       expect(result.status).toBe("running");
+      expect(result.sandboxId).toBeDefined();
       expect(result.createdAt).toBeInstanceOf(Date);
 
       // Verify run record in DB
@@ -263,15 +266,12 @@ describe("createRun()", () => {
 
   describe("Dispatch Failure", () => {
     it("should mark run as failed when dispatch throws", async () => {
-      const { executeRunnerJob } = await import(
-        "../../run/executors/runner-executor"
-      );
-      vi.mocked(executeRunnerJob).mockRejectedValueOnce(
-        new Error("Runner dispatch failed"),
+      vi.mocked(Sandbox.create).mockRejectedValueOnce(
+        new Error("Sandbox creation failed"),
       );
 
       await expect(createRun(baseParams())).rejects.toThrow(
-        "Runner dispatch failed",
+        "Sandbox creation failed",
       );
 
       // Verify run is marked as failed in DB
@@ -282,7 +282,7 @@ describe("createRun()", () => {
       const run = runs.find((r) => r.status === "failed");
 
       expect(run).toBeDefined();
-      expect(run!.error).toContain("Runner dispatch failed");
+      expect(run!.error).toContain("Sandbox creation failed");
       expect(run!.completedAt).toBeDefined();
     });
   });
@@ -319,6 +319,16 @@ describe("createRun()", () => {
 
       expect(result.runId).toBeDefined();
       expect(result.status).toBe("running");
+
+      // Verify sandbox was called with full memory env vars including VERSION_ID
+      const createCall = vi.mocked(Sandbox.create).mock.calls[0];
+      expect(createCall).toBeDefined();
+      const sandboxOptions = createCall![1] as {
+        envs?: Record<string, string>;
+      };
+      expect(sandboxOptions.envs?.VM0_MEMORY_NAME).toBe(memoryName);
+      expect(sandboxOptions.envs?.VM0_MEMORY_VERSION_ID).toBeDefined();
+      expect(sandboxOptions.envs?.VM0_MEMORY_DRIVER).toBe("vas");
     });
 
     it("should succeed when memory already exists (idempotent)", async () => {
@@ -382,10 +392,7 @@ describe("createRun()", () => {
       };
 
       // Step 2: Continue from session WITHOUT specifying memoryName
-      const { executeRunnerJob } = await import(
-        "../../run/executors/runner-executor"
-      );
-      vi.mocked(executeRunnerJob).mockClear();
+      vi.mocked(Sandbox.create).mockClear();
       const continueResult = await createRun(
         baseParams({
           sessionId: agentSessionId,
@@ -396,10 +403,13 @@ describe("createRun()", () => {
       expect(continueResult.runId).toBeDefined();
       expect(continueResult.status).toBe("running");
 
-      // Step 3: Verify runner was called with memory name in context
-      const runnerCall = vi.mocked(executeRunnerJob).mock.calls[0];
-      expect(runnerCall).toBeDefined();
-      expect(runnerCall![0].memoryName).toBe("restored-memory");
+      // Step 3: Verify Sandbox.create was called with VM0_MEMORY_NAME
+      const createCall = vi.mocked(Sandbox.create).mock.calls[0];
+      expect(createCall).toBeDefined();
+      const sandboxOptions = createCall![1] as {
+        envs?: Record<string, string>;
+      };
+      expect(sandboxOptions.envs?.VM0_MEMORY_NAME).toBe("restored-memory");
     });
   });
 
@@ -623,6 +633,39 @@ describe("createRun()", () => {
       const result = await createRun(
         baseParams({ agentComposeVersionId: compose.versionId }),
       );
+
+      expect(result.status).toBe("running");
+    });
+  });
+
+  describe("Domain-based Runner Rollout", () => {
+    it("should route @vm0.ai users to runner when RUNNER_DEFAULT_GROUP is set", async () => {
+      vi.stubEnv("RUNNER_DEFAULT_GROUP", "vm0/production");
+      reloadEnv();
+
+      mockClerk({ userId: user.userId, email: "team@vm0.ai" });
+
+      const result = await createRun(baseParams());
+
+      expect(result.status).toBe("pending");
+    });
+
+    it("should route non-vm0.ai users to E2B when RUNNER_DEFAULT_GROUP is set", async () => {
+      vi.stubEnv("RUNNER_DEFAULT_GROUP", "vm0/production");
+      reloadEnv();
+
+      mockClerk({ userId: user.userId, email: "user@example.com" });
+
+      const result = await createRun(baseParams());
+
+      expect(result.status).toBe("running");
+    });
+
+    it("should skip domain check when RUNNER_DEFAULT_GROUP is not set", async () => {
+      // RUNNER_DEFAULT_GROUP is not set by default in test env
+      mockClerk({ userId: user.userId, email: "team@vm0.ai" });
+
+      const result = await createRun(baseParams());
 
       expect(result.status).toBe("running");
     });

--- a/turbo/apps/web/src/lib/run/run-service.ts
+++ b/turbo/apps/web/src/lib/run/run-service.ts
@@ -22,6 +22,7 @@ import type { AgentComposeSnapshot } from "../checkpoint/types";
 import type { AgentComposeYaml } from "../../types/agent-compose";
 import { getAgentSessionWithConversation } from "../agent-session";
 import { prepareForExecution } from "./context/execution-preparer";
+import { executeE2bRun } from "./executors/e2b-executor";
 import { executeRunnerJob } from "./executors/runner-executor";
 import { executeDockerRun } from "./executors/docker-executor";
 import type { ExecutorResult, PreparedContext } from "./executors/types";
@@ -234,11 +235,15 @@ export async function validateAgentSession(
  * Dispatch prepared context to appropriate executor.
  *
  * Routing:
- * - Runner Group: explicit runner config in compose, or default group
- * - Docker: local dev mode, requires DOCKER_SANDBOX_IMAGE
+ * - Runner Group: explicit runner config in compose
+ * - E2B: cloud mode, requires E2B_API_KEY
+ * - Docker: local mode, requires DOCKER_SANDBOX_IMAGE
  *
  */
-async function dispatchRun(context: PreparedContext): Promise<ExecutorResult> {
+async function dispatchRun(
+  context: PreparedContext,
+  userEmail: string,
+): Promise<ExecutorResult> {
   if (context.runnerGroup) {
     log.debug(
       `Dispatching run ${context.runId} to runner group: ${context.runnerGroup}`,
@@ -246,19 +251,29 @@ async function dispatchRun(context: PreparedContext): Promise<ExecutorResult> {
     return await executeRunnerJob(context);
   }
 
-  if (env().DOCKER_SANDBOX_IMAGE) {
+  // Domain-based rollout: route @vm0.ai users to runner.
+  // Note: CI test accounts (e2e+clerk_test@vm0.ai) also match, but preview
+  // deploys don't set RUNNER_DEFAULT_GROUP so they still use E2B.
+  const defaultGroup = env().RUNNER_DEFAULT_GROUP;
+  if (defaultGroup) {
+    if (userEmail.endsWith("@vm0.ai")) {
+      log.debug(
+        `Dispatching run ${context.runId} to runner (domain rollout: ${userEmail})`,
+      );
+      return await executeRunnerJob({ ...context, runnerGroup: defaultGroup });
+    }
+  }
+
+  if (env().E2B_API_KEY) {
+    log.debug(`Dispatching run ${context.runId} to E2B executor`);
+    return await executeE2bRun(context);
+  } else if (env().DOCKER_SANDBOX_IMAGE) {
     log.debug(`Dispatching run ${context.runId} to Docker executor`);
     return await executeDockerRun(context);
   }
 
-  const defaultGroup = env().RUNNER_DEFAULT_GROUP;
-  if (defaultGroup) {
-    log.debug(`Dispatching run ${context.runId} to runner (default group)`);
-    return await executeRunnerJob({ ...context, runnerGroup: defaultGroup });
-  }
-
   throw new Error(
-    "No executor configured: set RUNNER_DEFAULT_GROUP or DOCKER_SANDBOX_IMAGE",
+    "No executor configured: set E2B_API_KEY for cloud mode or DOCKER_SANDBOX_IMAGE for Docker mode",
   );
 }
 
@@ -515,6 +530,7 @@ async function buildAndDispatchRun(opts: {
   scopeId: string | undefined;
   authorizeTime: number;
   transactionTime: number;
+  userEmail: string;
 }): Promise<{ status: string; sandboxId?: string }> {
   const {
     runId,
@@ -525,6 +541,7 @@ async function buildAndDispatchRun(opts: {
     scopeId,
     authorizeTime,
     transactionTime,
+    userEmail,
   } = opts;
   const { userId, agentComposeVersionId, prompt } = params;
 
@@ -571,7 +588,7 @@ async function buildAndDispatchRun(opts: {
     const prepareTime = Date.now();
 
     // Dispatch to executor
-    const result = await dispatchRun(prepareResult.context);
+    const result = await dispatchRun(prepareResult.context, userEmail);
     const dispatchTime = Date.now();
 
     // Record per-step timing metrics for latency diagnosis
@@ -742,6 +759,7 @@ export async function createRun(
     scopeId,
     authorizeTime,
     transactionTime,
+    userEmail,
   });
 
   return {
@@ -825,5 +843,6 @@ export async function executeQueuedRun(
     scopeId: params.scopeId,
     authorizeTime,
     transactionTime,
+    userEmail,
   });
 }

--- a/turbo/knip.json
+++ b/turbo/knip.json
@@ -116,8 +116,7 @@
     "apps/web/src/lib/telegram/**",
     "apps/web/src/lib/auth/sandbox-token.ts",
     "scripts/rebuild-snapshots.ts",
-    "scripts/rebuild-snapshots-from-db.ts",
-    "apps/web/src/lib/run/executors/e2b-executor.ts"
+    "scripts/rebuild-snapshots-from-db.ts"
   ],
   "ignoreDependencies": ["@commitlint/cli"],
   "ignoreWorkspaces": [],


### PR DESCRIPTION
## Summary

- Reverts #3951 to restore E2B executor in run dispatch logic
- Reason: local development environments don't have runner infrastructure, removing E2B executor breaks local dev workflow

## Test plan

- [ ] CI passes (build, lint, tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)