### PR TITLE
perf(run): parallelize callback registration with sandbox token generation

### DIFF
--- a/turbo/apps/web/src/lib/run/run-service.ts
+++ b/turbo/apps/web/src/lib/run/run-service.ts
@@ -528,13 +528,13 @@ async function buildAndDispatchRun(opts: {
   const { userId, agentComposeVersionId, prompt } = params;
 
   try {
-    // Register callbacks (if any)
-    if (params.callbacks && params.callbacks.length > 0) {
-      await registerCallbacks(runId, params.callbacks);
-    }
-
-    // Generate sandbox token
-    const sandboxToken = await generateSandboxToken(userId, runId);
+    // Register callbacks and generate sandbox token in parallel (independent operations)
+    const [, sandboxToken] = await Promise.all([
+      params.callbacks && params.callbacks.length > 0
+        ? registerCallbacks(runId, params.callbacks)
+        : null,
+      generateSandboxToken(userId, runId),
+    ]);
     const tokenTime = Date.now();
 
     // Build execution context


### PR DESCRIPTION
## Summary
- Run `registerCallbacks` and `generateSandboxToken` concurrently in `buildAndDispatchRun` using `Promise.all`, since they have no data dependency on each other
- Saves one DB round-trip of latency when callbacks are present

## Test plan
- [ ] Existing `create-run.test.ts` tests pass (callback registration + token generation)
- [ ] CI passes (lint, types, tests)

Closes #3994

🤖 Generated with [Claude Code](https://claude.com/claude-code)