### PR TITLE
fix: auto-create scope for new web users and consolidate scope init logic

### DIFF
--- a/turbo/apps/platform/src/signals/onboarding.ts
+++ b/turbo/apps/platform/src/signals/onboarding.ts
@@ -106,8 +106,11 @@ export const canSaveOnboarding$ = computed((get) => {
  */
 export const needsOnboarding$ = computed(async (get) => {
   const scopeExists = await get(hasScope$);
+  if (!scopeExists) {
+    return true;
+  }
   const hasProvider = await get(hasAnyModelProvider$);
-  return !scopeExists || !hasProvider;
+  return !hasProvider;
 });
 
 // ---------------------------------------------------------------------------

--- a/turbo/apps/web/app/api/cli/auth/token/route.ts
+++ b/turbo/apps/web/app/api/cli/auth/token/route.ts
@@ -9,15 +9,7 @@ import { eq } from "drizzle-orm";
 import { initServices } from "../../../../../src/lib/init-services";
 import { deviceCodes } from "../../../../../src/db/schema/device-codes";
 import { cliTokens } from "../../../../../src/db/schema/cli-tokens";
-import {
-  getUserScopeByClerkId,
-  createScope,
-  generateDefaultScopeSlug,
-} from "../../../../../src/lib/scope/scope-service";
-import { isBadRequest } from "../../../../../src/lib/errors";
-import { logger } from "../../../../../src/lib/logger";
-
-const log = logger("api:cli:auth:token");
+import { ensureDefaultScope } from "../../../../../src/lib/scope/scope-service";
 
 const router = tsr.router(cliAuthTokenContract, {
   exchange: async ({ body }) => {
@@ -82,33 +74,8 @@ const router = tsr.router(cliAuthTokenContract, {
       case "authenticated": {
         const userId = session.userId as string;
 
-        // Auto-create scope if user doesn't have one
-        const existingScope = await getUserScopeByClerkId(userId);
-        if (!existingScope) {
-          const defaultSlug = generateDefaultScopeSlug(userId);
-          try {
-            await createScope(userId, defaultSlug);
-            log.debug("auto-created default scope for user", {
-              userId,
-              slug: defaultSlug,
-            });
-          } catch (error) {
-            // Handle rare slug collision - retry with random suffix
-            if (
-              isBadRequest(error) &&
-              error.message.includes("already exists")
-            ) {
-              const fallbackSlug = `user-${crypto.randomBytes(4).toString("hex")}`;
-              await createScope(userId, fallbackSlug);
-              log.debug("auto-created fallback scope for user", {
-                userId,
-                slug: fallbackSlug,
-              });
-            } else {
-              throw error;
-            }
-          }
-        }
+        // Ensure user has a default scope
+        await ensureDefaultScope(userId);
 
         // Generate CLI token
         const randomBytes = crypto.randomBytes(32);

--- a/turbo/apps/web/app/api/scope/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/scope/__tests__/route.test.ts
@@ -24,16 +24,35 @@ describe("/api/scope", () => {
       expect(data.error.message).toContain("Not authenticated");
     });
 
-    it("should return 404 if user has no scope", async () => {
-      // Create a unique user ID that has no scope
-      mockClerk({ userId: `user-with-no-scope-${Date.now()}` });
+    it("should auto-create scope for user with no scope", async () => {
+      const userId = `user-with-no-scope-${Date.now()}`;
+      mockClerk({ userId });
 
       const request = createTestRequest("http://localhost:3000/api/scope");
       const response = await GET(request);
       const data = await response.json();
 
-      expect(response.status).toBe(404);
-      expect(data.error.message).toContain("No scope configured");
+      expect(response.status).toBe(200);
+      expect(data.id).toBeDefined();
+      expect(data.slug).toMatch(/^user-[a-f0-9]{8}$/);
+    });
+
+    it("should return same scope on repeated GET (idempotent auto-creation)", async () => {
+      const userId = `idempotent-scope-${Date.now()}`;
+      mockClerk({ userId });
+
+      const request1 = createTestRequest("http://localhost:3000/api/scope");
+      const response1 = await GET(request1);
+      const data1 = await response1.json();
+
+      const request2 = createTestRequest("http://localhost:3000/api/scope");
+      const response2 = await GET(request2);
+      const data2 = await response2.json();
+
+      expect(response1.status).toBe(200);
+      expect(response2.status).toBe(200);
+      expect(data1.id).toBe(data2.id);
+      expect(data1.slug).toBe(data2.slug);
     });
   });
 

--- a/turbo/apps/web/app/api/scope/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/scope/__tests__/route.test.ts
@@ -37,6 +37,44 @@ describe("/api/scope", () => {
       expect(data.slug).toMatch(/^user-[a-f0-9]{8}$/);
     });
 
+    it("should auto-create scope with fallback slug on collision", async () => {
+      // First, create a scope that will collide with the deterministic slug
+      // by pre-occupying the slug that ensureDefaultScope would generate
+      const collidingUserId = `collision-test-${Date.now()}`;
+
+      // Import to compute the expected slug
+      const { generateDefaultScopeSlug } = await import(
+        "../../../../src/lib/scope/scope-service"
+      );
+      const expectedSlug = generateDefaultScopeSlug(collidingUserId);
+
+      // Pre-occupy the deterministic slug with a different user
+      const occupierUserId = `occupier-${Date.now()}`;
+      mockClerk({ userId: occupierUserId });
+      const occupyRequest = createTestRequest(
+        "http://localhost:3000/api/scope",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ slug: expectedSlug }),
+        },
+      );
+      const occupyResponse = await POST(occupyRequest);
+      expect(occupyResponse.status).toBe(201);
+
+      // Now the colliding user triggers auto-creation via GET
+      mockClerk({ userId: collidingUserId });
+      const request = createTestRequest("http://localhost:3000/api/scope");
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.id).toBeDefined();
+      // Should have fallen back to a random slug, not the colliding one
+      expect(data.slug).not.toBe(expectedSlug);
+      expect(data.slug).toMatch(/^user-[a-f0-9]{8}$/);
+    });
+
     it("should return same scope on repeated GET (idempotent auto-creation)", async () => {
       const userId = `idempotent-scope-${Date.now()}`;
       mockClerk({ userId });

--- a/turbo/apps/web/app/api/scope/route.ts
+++ b/turbo/apps/web/app/api/scope/route.ts
@@ -10,6 +10,7 @@ import {
   createScope,
   updateScopeSlug,
   isVm0Admin,
+  ensureDefaultScope,
 } from "../../../src/lib/scope/scope-service";
 import { getUserEmail } from "../../../src/lib/auth/get-user-email";
 import { resolveScope } from "../../../src/lib/scope/resolve-scope";
@@ -48,10 +49,18 @@ const router = tsr.router(scopeContract, {
       };
     } catch (error) {
       if (isNotFound(error)) {
-        return createErrorResponse(
-          "NOT_FOUND",
-          "No scope configured. Set your scope with: vm0 scope set <slug>",
-        );
+        // Auto-create default scope for new users
+        const scope = await ensureDefaultScope(userId);
+        return {
+          status: 200 as const,
+          body: {
+            id: scope.id,
+            slug: scope.slug,
+            tier: scope.tier,
+            createdAt: scope.createdAt.toISOString(),
+            updatedAt: scope.updatedAt.toISOString(),
+          },
+        };
       }
       throw error;
     }

--- a/turbo/apps/web/app/api/scope/route.ts
+++ b/turbo/apps/web/app/api/scope/route.ts
@@ -19,6 +19,22 @@ import { isBadRequest, isForbidden, isNotFound } from "../../../src/lib/errors";
 
 const log = logger("api:scope");
 
+function scopeToResponseBody(scope: {
+  id: string;
+  slug: string;
+  tier: string;
+  createdAt: Date;
+  updatedAt: Date;
+}) {
+  return {
+    id: scope.id,
+    slug: scope.slug,
+    tier: scope.tier,
+    createdAt: scope.createdAt.toISOString(),
+    updatedAt: scope.updatedAt.toISOString(),
+  };
+}
+
 const router = tsr.router(scopeContract, {
   /**
    * GET /api/scope - Get current user's scope
@@ -37,30 +53,12 @@ const router = tsr.router(scopeContract, {
     try {
       const { scope } = await resolveScope(userId);
 
-      return {
-        status: 200 as const,
-        body: {
-          id: scope.id,
-          slug: scope.slug,
-          tier: scope.tier,
-          createdAt: scope.createdAt.toISOString(),
-          updatedAt: scope.updatedAt.toISOString(),
-        },
-      };
+      return { status: 200 as const, body: scopeToResponseBody(scope) };
     } catch (error) {
       if (isNotFound(error)) {
         // Auto-create default scope for new users
         const scope = await ensureDefaultScope(userId);
-        return {
-          status: 200 as const,
-          body: {
-            id: scope.id,
-            slug: scope.slug,
-            tier: scope.tier,
-            createdAt: scope.createdAt.toISOString(),
-            updatedAt: scope.updatedAt.toISOString(),
-          },
-        };
+        return { status: 200 as const, body: scopeToResponseBody(scope) };
       }
       throw error;
     }
@@ -97,16 +95,7 @@ const router = tsr.router(scopeContract, {
 
       const scope = await createScope(userId, slug, { skipSlugValidation });
 
-      return {
-        status: 201 as const,
-        body: {
-          id: scope.id,
-          slug: scope.slug,
-          tier: scope.tier,
-          createdAt: scope.createdAt.toISOString(),
-          updatedAt: scope.updatedAt.toISOString(),
-        },
-      };
+      return { status: 201 as const, body: scopeToResponseBody(scope) };
     } catch (error) {
       if (isBadRequest(error)) {
         // Check if it's a conflict error (user already has scope)
@@ -163,16 +152,7 @@ const router = tsr.router(scopeContract, {
         force,
       );
 
-      return {
-        status: 200 as const,
-        body: {
-          id: scope.id,
-          slug: scope.slug,
-          tier: scope.tier,
-          createdAt: scope.createdAt.toISOString(),
-          updatedAt: scope.updatedAt.toISOString(),
-        },
-      };
+      return { status: 200 as const, body: scopeToResponseBody(scope) };
     } catch (error) {
       if (isBadRequest(error)) {
         // Check if it's a conflict error (slug already exists)

--- a/turbo/apps/web/src/lib/scope/scope-service.ts
+++ b/turbo/apps/web/src/lib/scope/scope-service.ts
@@ -1,4 +1,4 @@
-import { createHash } from "crypto";
+import { createHash, randomBytes } from "crypto";
 import { eq } from "drizzle-orm";
 import { clerkClient } from "@clerk/nextjs/server";
 import { scopes } from "../../db/schema/scope";
@@ -8,7 +8,13 @@ import {
   getPrimaryAdminMembership,
   getDefaultScope,
 } from "./scope-member-service";
-import { badRequest, notFound, forbidden, isNotFound } from "../errors";
+import {
+  badRequest,
+  notFound,
+  forbidden,
+  isNotFound,
+  isBadRequest,
+} from "../errors";
 import { logger } from "../logger";
 import { env, hasClerkAuth } from "../../env";
 import { SELF_HOSTED_CLERK_ORG_ID } from "../auth/constants";
@@ -197,6 +203,30 @@ export async function getUserScopeByClerkId(clerkUserId: string) {
     return scope;
   } catch (error) {
     if (isNotFound(error)) return null;
+    throw error;
+  }
+}
+
+/**
+ * Ensure a user has a default scope, creating one if it doesn't exist.
+ * Consolidates the auto-creation pattern used by CLI token exchange,
+ * Slack OAuth, and the scope API.
+ *
+ * @returns The existing or newly created scope
+ */
+export async function ensureDefaultScope(clerkUserId: string) {
+  const existing = await getUserScopeByClerkId(clerkUserId);
+  if (existing) return existing;
+
+  const defaultSlug = generateDefaultScopeSlug(clerkUserId);
+  try {
+    return await createScope(clerkUserId, defaultSlug);
+  } catch (error) {
+    // Handle rare slug collision — retry with random suffix
+    if (isBadRequest(error) && error.message.includes("already exists")) {
+      const fallbackSlug = `user-${randomBytes(4).toString("hex")}`;
+      return await createScope(clerkUserId, fallbackSlug);
+    }
     throw error;
   }
 }

--- a/turbo/apps/web/src/lib/slack/handlers/shared.ts
+++ b/turbo/apps/web/src/lib/slack/handlers/shared.ts
@@ -11,11 +11,7 @@ import {
 import { slackThreadSessions } from "../../../db/schema/slack-thread-session";
 import { agentComposes } from "../../../db/schema/agent-compose";
 import { getPlatformUrl } from "../../url";
-import {
-  getUserScopeByClerkId,
-  createScope,
-  generateDefaultScopeSlug,
-} from "../../scope/scope-service";
+import { ensureDefaultScope } from "../../scope/scope-service";
 import { validateAgentSession } from "../../run";
 import { ensureStorageExists } from "../../storage/storage-service";
 import { logger } from "../../logger";
@@ -222,11 +218,7 @@ export function buildLogsUrl(runId: string, agentName: string): string {
  * 2. If no HEAD version, create an empty initial version (upload manifest to S3 + commit)
  */
 export async function ensureScopeAndArtifact(vm0UserId: string): Promise<void> {
-  let scope = await getUserScopeByClerkId(vm0UserId);
-  if (!scope) {
-    scope = await createScope(vm0UserId, generateDefaultScopeSlug(vm0UserId));
-    log.info("Auto-created scope for Slack user", { userId: vm0UserId });
-  }
+  const scope = await ensureDefaultScope(vm0UserId);
 
   // Preserve original Slack behavior: log but don't throw on artifact creation failure.
   // Slack callers (server actions, OAuth callback) don't have error handling for this.


### PR DESCRIPTION
## Summary

- Extract `ensureDefaultScope()` into `scope-service.ts` — unified scope auto-creation with slug collision handling
- Update `GET /api/scope` to auto-create default scope instead of returning 404 for new users
- Replace inline scope creation logic in CLI token exchange and Slack handler with shared function
- Short-circuit `needsOnboarding$` when scope is missing to prevent model-providers API crash

Closes #4001
Related to #3865

## Test plan

- [x] Scope API tests updated: "auto-create scope for user with no scope" + idempotent creation test
- [x] CLI token exchange tests pass (6/6)
- [x] Scope API tests pass (21/21)
- [x] Lint, type-check, knip all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)