### PR TITLE
feat: inject integration context into agent run prompts

### DIFF
--- a/turbo/apps/web/app/api/webhooks/github/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/github/__tests__/route.test.ts
@@ -267,6 +267,9 @@ describe("POST /api/webhooks/github", () => {
         callbacks: Array<{ payload: { issueNumber: number } }>;
       };
       expect(callArgs.prompt).toContain("This is a test issue body");
+      expect(callArgs.prompt).toContain(
+        "You are currently running inside: GitHub",
+      );
       expect(callArgs.callbacks[0]!.payload.issueNumber).toBe(42);
     });
 
@@ -386,6 +389,9 @@ describe("POST /api/webhooks/github", () => {
       const callArgs = createRunSpy.mock.calls[0]![0] as { prompt: string };
       // When body is null, falls back to issue title
       expect(callArgs.prompt).toContain("Test Issue");
+      expect(callArgs.prompt).toContain(
+        "You are currently running inside: GitHub",
+      );
     });
   });
 

--- a/turbo/apps/web/src/lib/email/handlers/inbound-reply.ts
+++ b/turbo/apps/web/src/lib/email/handlers/inbound-reply.ts
@@ -12,6 +12,7 @@ import {
   type HandlerResult,
 } from "./shared";
 import { createRun } from "../../run";
+import { buildIntegrationContext } from "../../integration-context";
 import { generateCallbackSecret, getApiUrl } from "../../callback";
 import { getUserIdByEmail } from "../../auth/get-user-id-by-email";
 import { logger } from "../../logger";
@@ -197,9 +198,7 @@ export async function handleInboundEmailReply(
   ];
 
   // 12. Inject integration context and create run
-  const integrationContext =
-    "# Current Integration\nYou are currently running inside: Email";
-  const fullPrompt = `${integrationContext}\n\n# User Prompt\n\n${replyContent}`;
+  const fullPrompt = `${buildIntegrationContext("Email")}\n\n# User Prompt\n\n${replyContent}`;
   const result = await createRun({
     userId: session.userId,
     agentComposeVersionId: compose.headVersionId ?? "",

--- a/turbo/apps/web/src/lib/email/handlers/inbound-trigger.ts
+++ b/turbo/apps/web/src/lib/email/handlers/inbound-trigger.ts
@@ -12,6 +12,7 @@ import {
   type HandlerResult,
 } from "./shared";
 import { createRun } from "../../run";
+import { buildIntegrationContext } from "../../integration-context";
 import { generateCallbackSecret, getApiUrl } from "../../callback";
 import { getUserIdByEmail } from "../../auth/get-user-id-by-email";
 import { getUserScopeByClerkId } from "../../scope/scope-service";
@@ -266,9 +267,7 @@ export async function handleInboundEmailTrigger(
   ];
 
   // 12. Inject integration context and create run
-  const integrationContext =
-    "# Current Integration\nYou are currently running inside: Email";
-  const fullPrompt = `${integrationContext}\n\n# User Prompt\n\n${prompt}`;
+  const fullPrompt = `${buildIntegrationContext("Email")}\n\n# User Prompt\n\n${prompt}`;
   const result = await createRun({
     userId,
     agentComposeVersionId: compose.headVersionId,

--- a/turbo/apps/web/src/lib/github/handlers/issue-event.ts
+++ b/turbo/apps/web/src/lib/github/handlers/issue-event.ts
@@ -8,6 +8,7 @@ import {
   agentComposeVersions,
 } from "../../../db/schema/agent-compose";
 import { createRun, validateAgentSession } from "../../run";
+import { buildIntegrationContext } from "../../integration-context";
 import { generateCallbackSecret, getApiUrl } from "../../callback";
 import { getInstallationAccessToken } from "../github-app";
 import {
@@ -341,8 +342,7 @@ function buildFullPrompt(
   issueContext: string,
   isCommentTrigger: boolean,
 ): string {
-  const integrationContext =
-    "# Current Integration\nYou are currently running inside: GitHub";
+  const integrationContext = buildIntegrationContext("GitHub");
 
   if (!issueContext) {
     return `${integrationContext}\n\n# User Prompt\n\n${prompt}`;

--- a/turbo/apps/web/src/lib/integration-context.ts
+++ b/turbo/apps/web/src/lib/integration-context.ts
@@ -1,0 +1,12 @@
+/**
+ * The platform (integration) an agent run originates from.
+ * Used to inject context so the agent knows which channel it is operating in.
+ */
+type IntegrationPlatform = "Email" | "GitHub" | "Slack" | "Telegram";
+
+/**
+ * Build the integration context header prepended to agent run prompts.
+ */
+export function buildIntegrationContext(platform: IntegrationPlatform): string {
+  return `# Current Integration\nYou are currently running inside: ${platform}`;
+}

--- a/turbo/apps/web/src/lib/slack/handlers/__tests__/run-agent.test.ts
+++ b/turbo/apps/web/src/lib/slack/handlers/__tests__/run-agent.test.ts
@@ -56,9 +56,20 @@ describe("runAgentForSlack", () => {
 
     // And createRun should receive artifactName: "artifact"
     expect(createRunSpy).toHaveBeenCalledTimes(1);
-    expect(createRunSpy.mock.calls[0]![0]).toMatchObject({
+    const callArgs = createRunSpy.mock.calls[0]![0] as {
+      prompt: string;
+      artifactName: string;
+      memoryName: string;
+    };
+    expect(callArgs).toMatchObject({
       artifactName: "artifact",
       memoryName: "memory",
     });
+
+    // And the prompt should contain integration context
+    expect(callArgs.prompt).toContain(
+      "You are currently running inside: Slack",
+    );
+    expect(callArgs.prompt).toContain("help me");
   });
 });

--- a/turbo/apps/web/src/lib/slack/handlers/run-agent.ts
+++ b/turbo/apps/web/src/lib/slack/handlers/run-agent.ts
@@ -4,6 +4,7 @@ import {
   agentComposeVersions,
 } from "../../../db/schema/agent-compose";
 import { createRun } from "../../run";
+import { buildIntegrationContext } from "../../integration-context";
 import { queryAxiom, getDatasetName, DATASETS } from "../../axiom";
 import { logger } from "../../logger";
 import { generateCallbackSecret, getApiUrl } from "../../callback";
@@ -96,8 +97,7 @@ export async function runAgentForSlack(
     }
 
     // Build the full prompt with integration context and thread context
-    const integrationContext =
-      "# Current Integration\nYou are currently running inside: Slack";
+    const integrationContext = buildIntegrationContext("Slack");
     const fullPrompt = threadContext
       ? `${integrationContext}\n\n${threadContext}\n\n# User Prompt\n\n${prompt}`
       : `${integrationContext}\n\n# User Prompt\n\n${prompt}`;

--- a/turbo/apps/web/src/lib/telegram/handlers/__tests__/run-agent.test.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/__tests__/run-agent.test.ts
@@ -59,9 +59,20 @@ describe("runAgentForTelegram", () => {
 
     // And createRun should receive artifactName and memoryName
     expect(createRunSpy).toHaveBeenCalledTimes(1);
-    expect(createRunSpy.mock.calls[0]![0]).toMatchObject({
+    const callArgs = createRunSpy.mock.calls[0]![0] as {
+      prompt: string;
+      artifactName: string;
+      memoryName: string;
+    };
+    expect(callArgs).toMatchObject({
       artifactName: "artifact",
       memoryName: "memory",
     });
+
+    // And the prompt should contain integration context
+    expect(callArgs.prompt).toContain(
+      "You are currently running inside: Telegram",
+    );
+    expect(callArgs.prompt).toContain("help me");
   });
 });

--- a/turbo/apps/web/src/lib/telegram/handlers/run-agent.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/run-agent.ts
@@ -4,6 +4,7 @@ import {
   agentComposeVersions,
 } from "../../../db/schema/agent-compose";
 import { createRun } from "../../run";
+import { buildIntegrationContext } from "../../integration-context";
 import { isConcurrentRunLimit } from "../../errors";
 import { logger } from "../../logger";
 import { generateCallbackSecret, getApiUrl } from "../../callback";
@@ -94,8 +95,7 @@ export async function runAgentForTelegram(
     versionId = latestVersion.id;
   }
 
-  const integrationContext =
-    "# Current Integration\nYou are currently running inside: Telegram";
+  const integrationContext = buildIntegrationContext("Telegram");
   const fullPrompt = threadContext
     ? `${integrationContext}\n\n${threadContext}\n\n# User Prompt\n\n${prompt}`
     : `${integrationContext}\n\n# User Prompt\n\n${prompt}`;


### PR DESCRIPTION
## Summary

- Prepend `# Current Integration\nYou are currently running inside: <Platform>` to all agent run prompts across integrations
- Covers Telegram, Slack, GitHub, Email (both trigger and reply handlers)
- Enables agents to know which platform they're running on and tailor responses accordingly

Closes #4004

## Test plan

- [x] All existing integration handler tests pass
- [x] Updated email inbound tests to match new prompt format
- [x] Verified all 5 `createRun` call sites in integration handlers include context

🤖 Generated with [Claude Code](https://claude.com/claude-code)