### PR TITLE
fix(web): reject invalid locale segments in middleware

### DIFF
--- a/turbo/apps/web/__tests__/middleware.locale-guard.test.ts
+++ b/turbo/apps/web/__tests__/middleware.locale-guard.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+
+// Mock next-intl/middleware to avoid ESM resolution issues in test environment.
+// This is an external dependency mock (not internal code), which is acceptable.
+vi.mock("next-intl/middleware", () => ({
+  default: () => () => NextResponse.next(),
+}));
+
+import { localeGuardLayer, runLayers } from "../middleware.layers";
+
+/**
+ * Helper to run the localeGuardLayer through the real runLayers pipeline.
+ * This exercises the full middleware context creation including route classification.
+ */
+function runGuard(url: string) {
+  const request = new NextRequest(url);
+  return runLayers(request, [localeGuardLayer]);
+}
+
+describe("localeGuardLayer", () => {
+  describe("rejects invalid locale segments containing a dot", () => {
+    it("should return 404 for /favicon.ico/blog", async () => {
+      const response = await runGuard("https://www.vm0.ai/favicon.ico/blog");
+      expect(response.status).toBe(404);
+    });
+
+    it("should return 404 for /robots.txt/page", async () => {
+      const response = await runGuard("https://www.vm0.ai/robots.txt/page");
+      expect(response.status).toBe(404);
+    });
+
+    it("should return 404 for /sitemap.xml/something", async () => {
+      const response = await runGuard(
+        "https://www.vm0.ai/sitemap.xml/something",
+      );
+      expect(response.status).toBe(404);
+    });
+  });
+
+  describe("allows valid locale segments", () => {
+    it("should pass through for /en/blog", async () => {
+      const response = await runGuard("https://www.vm0.ai/en/blog");
+      expect(response.status).toBe(200);
+    });
+
+    it("should pass through for /de/blog", async () => {
+      const response = await runGuard("https://www.vm0.ai/de/blog");
+      expect(response.status).toBe(200);
+    });
+
+    it("should pass through for /ja/pricing", async () => {
+      const response = await runGuard("https://www.vm0.ai/ja/pricing");
+      expect(response.status).toBe(200);
+    });
+
+    it("should pass through for /es/about", async () => {
+      const response = await runGuard("https://www.vm0.ai/es/about");
+      expect(response.status).toBe(200);
+    });
+  });
+
+  describe("does not affect non-page routes", () => {
+    it("should pass through for API routes", async () => {
+      const response = await runGuard(
+        "https://www.vm0.ai/api/something.ext/path",
+      );
+      expect(response.status).toBe(200);
+    });
+
+    it("should pass through for static file routes", async () => {
+      const response = await runGuard("https://www.vm0.ai/_next/static/chunk");
+      expect(response.status).toBe(200);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("should pass through for root path", async () => {
+      const response = await runGuard("https://www.vm0.ai/");
+      expect(response.status).toBe(200);
+    });
+
+    it("should pass through for segments without dots", async () => {
+      const response = await runGuard("https://www.vm0.ai/unknown/page");
+      expect(response.status).toBe(200);
+    });
+
+    it("should not return JSON content-type for 404", async () => {
+      const response = await runGuard("https://www.vm0.ai/favicon.ico/blog");
+      const contentType = response.headers.get("Content-Type");
+      expect(
+        contentType === null || !contentType.includes("application/json"),
+      ).toBe(true);
+    });
+  });
+});

--- a/turbo/apps/web/middleware.clerk.ts
+++ b/turbo/apps/web/middleware.clerk.ts
@@ -8,6 +8,7 @@ import {
   runLayers,
   corsLayer,
   authRedirectLayer,
+  localeGuardLayer,
   i18nLayer,
   MiddlewareLayer,
   isProtectedSkipRoute,
@@ -80,6 +81,7 @@ export default clerkMiddleware(async (auth, request: NextRequest) => {
   return runLayers(request, [
     corsLayer,
     authRedirectLayer,
+    localeGuardLayer,
     clerkAuthLayer,
     i18nLayer,
   ]);

--- a/turbo/apps/web/middleware.layers.ts
+++ b/turbo/apps/web/middleware.layers.ts
@@ -136,6 +136,25 @@ export const corsLayer: MiddlewareLayer = (ctx) => {
   return null;
 };
 
+/**
+ * Reject requests where the first path segment looks like a locale slot
+ * but is not a supported locale (e.g. `/favicon.ico/blog`).
+ * Returns 404 so crawlers and bots don't trigger i18n errors.
+ */
+export const localeGuardLayer: MiddlewareLayer = (ctx) => {
+  if (ctx.routeKind !== "page") return null;
+
+  const firstSegment = ctx.request.nextUrl.pathname.split("/")[1];
+  if (
+    firstSegment &&
+    !locales.includes(firstSegment as (typeof locales)[number]) &&
+    firstSegment.includes(".")
+  ) {
+    return NextResponse.json(null, { status: 404 });
+  }
+  return null;
+};
+
 /** Apply i18n for page routes. */
 export const i18nLayer: MiddlewareLayer = (ctx) => {
   if (ctx.routeKind === "page") {

--- a/turbo/apps/web/middleware.layers.ts
+++ b/turbo/apps/web/middleware.layers.ts
@@ -150,7 +150,7 @@ export const localeGuardLayer: MiddlewareLayer = (ctx) => {
     !locales.includes(firstSegment as (typeof locales)[number]) &&
     firstSegment.includes(".")
   ) {
-    return NextResponse.json(null, { status: 404 });
+    return new NextResponse(null, { status: 404 });
   }
   return null;
 };

--- a/turbo/apps/web/middleware.local.ts
+++ b/turbo/apps/web/middleware.local.ts
@@ -3,6 +3,7 @@ import {
   runLayers,
   corsLayer,
   authRedirectLayer,
+  localeGuardLayer,
   i18nLayer,
   MiddlewareLayer,
 } from "./middleware.layers";
@@ -28,6 +29,7 @@ export default async function localMiddleware(request: NextRequest) {
     authRedirectLayer,
     localAuthRedirectLayer,
     corsLayer,
+    localeGuardLayer,
     i18nLayer,
   ]);
 }


### PR DESCRIPTION
## Summary

- Add `localeGuardLayer` middleware that returns 404 for requests where the first path segment contains a dot but is not a valid locale (e.g. `/favicon.ico/blog`)
- Prevents crawlers (ChatGPT Atlas) from triggering `Cannot find module './favicon.ico.json'` errors in next-intl
- Applied to both Clerk and local middleware layer chains

Fixes WEB-4 (61 events), WEB-1 (16 events) — the highest-volume Sentry issues in the web project.

## Root Cause

Bots request URLs like `https://www.vm0.ai/favicon.ico/blog`. Next.js route `/[locale]/blog` matches `favicon.ico` as the locale parameter, causing `next-intl` to attempt loading `./messages/favicon.ico.json` which doesn't exist.

## Test plan

- [ ] Verify `GET /favicon.ico/blog` returns 404
- [ ] Verify `GET /en/blog` still works normally
- [ ] Verify `GET /de/blog` still works normally
- [ ] Verify API routes are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)