### PR TITLE
perf(run): eliminate redundant scope lookup in execution preparer

### DIFF
--- a/turbo/apps/web/src/lib/run/build-context.ts
+++ b/turbo/apps/web/src/lib/run/build-context.ts
@@ -17,7 +17,7 @@ import {
 import { agentComposeVersions } from "../../db/schema/agent-compose";
 import { badRequest, notFound } from "../errors";
 import { logger } from "../logger";
-import type { ExecutionContext, ResumeSession } from "./types";
+import type { ExecutionContext, ResumeSession, UserScope } from "./types";
 import type { ArtifactSnapshot } from "../checkpoint/types";
 import {
   resolveCheckpoint,
@@ -859,20 +859,38 @@ function applyResolutionDefaults(
 }
 
 /**
- * Build unified execution context from various parameter sources
- * Supports: new run, checkpoint resume, session continue
+ * Resolve credential scope ID and user's default scope.
  *
- * Parameter expansion:
- * - checkpointId: Expands to checkpoint snapshot (config, conversation, artifact, volumes)
- * - sessionId: Expands to session data (config, conversation, artifact=latest)
- * - Explicit parameters override expanded values
+ * The credential scope is used for secrets/variables/connectors.
+ * The user scope is used for storage (artifacts, memory) in prepareForExecution.
+ * They may differ when an org scope is explicitly selected via ?scope= param.
  *
- * @param params Unified run parameters
- * @returns Execution context for executors
+ * When params.scopeId is not provided, getDefaultScope serves both purposes.
+ * When provided, the user scope is resolved in parallel with credential resolution.
  */
-async function resolveScopeId(params: BuildContextParams): Promise<string> {
-  if (params.scopeId) return params.scopeId;
-  return (await getDefaultScope(params.userId)).scope.id;
+async function resolveScopes(params: BuildContextParams): Promise<{
+  credentialScopeId: string;
+  pendingUserScope:
+    | Promise<{ id: string; slug: string }>
+    | { id: string; slug: string };
+}> {
+  if (params.scopeId) {
+    // Credential scope is explicit (may be org scope).
+    // User's default scope (for storage) resolved later in parallel.
+    return {
+      credentialScopeId: params.scopeId,
+      pendingUserScope: getDefaultScope(params.userId).then((r) => ({
+        id: r.scope.id,
+        slug: r.scope.slug,
+      })),
+    };
+  }
+  // No explicit scope — default scope serves both purposes
+  const { scope } = await getDefaultScope(params.userId);
+  return {
+    credentialScopeId: scope.id,
+    pendingUserScope: { id: scope.id, slug: scope.slug },
+  };
 }
 
 interface BuildContextTimings {
@@ -883,9 +901,19 @@ interface BuildContextTimings {
 
 interface BuildContextResult {
   context: ExecutionContext;
+  userScope: UserScope;
   timings: BuildContextTimings;
 }
 
+/**
+ * Build unified execution context from various parameter sources.
+ * Supports: new run, checkpoint resume, session continue.
+ *
+ * Parameter expansion:
+ * - checkpointId: Expands to checkpoint snapshot (config, conversation, artifact, volumes)
+ * - sessionId: Expands to session data (config, conversation, artifact=latest)
+ * - Explicit parameters override expanded values
+ */
 export async function buildExecutionContext(
   params: BuildContextParams,
 ): Promise<BuildContextResult> {
@@ -953,9 +981,10 @@ export async function buildExecutionContext(
     throw notFound("Agent compose could not be loaded");
   }
 
-  // Resolve scope ID once for all credential/variable resolution
+  // Resolve credential scope and user's default scope (for storage).
+  // When params.scopeId is explicit, pendingUserScope is a promise resolved in parallel below.
   const resolveScopeStart = Date.now();
-  const scopeId = await resolveScopeId(params);
+  const { credentialScopeId, pendingUserScope } = await resolveScopes(params);
   const resolveScopeEnd = Date.now();
 
   // Extract compose structure
@@ -969,13 +998,12 @@ export async function buildExecutionContext(
     ? Object.values(compose.agents)[0]
     : undefined;
 
-  // Step 4: Resolve credentials and user preferences in parallel
-  // getUserPreferences only needs userId (no scopeId dependency),
-  // so it can run concurrently with credential resolution.
+  // Step 4: Resolve credentials, user preferences, and user scope in parallel.
+  // pendingUserScope may already be resolved (when scopeId was not explicit).
   const resolveCredentialsStart = Date.now();
-  const [credentialsResult, userPrefs] = await Promise.all([
+  const [credentialsResult, userPrefs, userScope] = await Promise.all([
     resolveCredentialsAndEnvironment(
-      scopeId,
+      credentialScopeId,
       agentCompose,
       firstAgent,
       vars,
@@ -986,6 +1014,7 @@ export async function buildExecutionContext(
       params.userId,
     ),
     params.userId ? getUserPreferences(params.userId) : Promise.resolve(null),
+    Promise.resolve(pendingUserScope),
   ]);
   const resolveCredentialsEnd = Date.now();
 
@@ -1006,6 +1035,7 @@ export async function buildExecutionContext(
 
   // Build final execution context
   return {
+    userScope,
     context: {
       runId: params.runId,
       userId: params.userId,

--- a/turbo/apps/web/src/lib/run/context/execution-preparer.ts
+++ b/turbo/apps/web/src/lib/run/context/execution-preparer.ts
@@ -4,7 +4,7 @@ import type {
   ExperimentalFirewall,
   FirewallRule,
 } from "../../../types/agent-compose";
-import type { ExecutionContext } from "../types";
+import type { ExecutionContext, UserScope } from "../types";
 import type { PreparedContext } from "../executors/types";
 import {
   prepareStorageManifest,
@@ -13,7 +13,6 @@ import {
 import type { StorageManifest } from "../../storage/types";
 import { badRequest } from "../../errors";
 import { logger } from "../../logger";
-import { getUserScopeByClerkId } from "../../scope/scope-service";
 import {
   agentComposes,
   agentComposeVersions,
@@ -184,6 +183,7 @@ interface PrepareResult {
 
 export async function prepareForExecution(
   context: ExecutionContext,
+  userScope: UserScope,
 ): Promise<PrepareResult> {
   log.debug(`Preparing execution context for run ${context.runId}...`);
 
@@ -199,30 +199,25 @@ export async function prepareForExecution(
     `Extracted config: workingDir=${workingDir}, cliAgentType=${cliAgentType}, runnerGroup=${runnerGroup}, firewall=${experimentalFirewall ? "enabled" : "disabled"}`,
   );
 
-  // Resolve runner's scope and owner's scope in parallel (independent DB queries)
+  // Resolve agent owner's scope for volume resolution.
+  // User scope (for storage) is pre-resolved by buildExecutionContext.
   const userId = context.userId || "";
   const scopeStart = Date.now();
-  const [runnerScope, [composeInfo]] = await Promise.all([
-    getUserScopeByClerkId(userId),
-    globalThis.services.db
-      .select({
-        scopeId: agentComposes.scopeId,
-        scopeSlug: scopes.slug,
-      })
-      .from(agentComposeVersions)
-      .innerJoin(
-        agentComposes,
-        eq(agentComposeVersions.composeId, agentComposes.id),
-      )
-      .innerJoin(scopes, eq(agentComposes.scopeId, scopes.id))
-      .where(eq(agentComposeVersions.id, context.agentComposeVersionId))
-      .limit(1),
-  ]);
+  const [composeInfo] = await globalThis.services.db
+    .select({
+      scopeId: agentComposes.scopeId,
+      scopeSlug: scopes.slug,
+    })
+    .from(agentComposeVersions)
+    .innerJoin(
+      agentComposes,
+      eq(agentComposeVersions.composeId, agentComposes.id),
+    )
+    .innerJoin(scopes, eq(agentComposes.scopeId, scopes.id))
+    .where(eq(agentComposeVersions.id, context.agentComposeVersionId))
+    .limit(1);
   const scopeEnd = Date.now();
 
-  if (!runnerScope) {
-    throw badRequest("Runner scope not found");
-  }
   if (!composeInfo) {
     throw badRequest("Agent compose not found");
   }
@@ -232,19 +227,19 @@ export async function prepareForExecution(
   await Promise.all([
     context.artifactName
       ? ensureStorageExists(
-          runnerScope.id,
+          userScope.id,
           userId,
           context.artifactName,
-          runnerScope.slug,
+          userScope.slug,
           "artifact",
         )
       : null,
     context.memoryName
       ? ensureStorageExists(
-          runnerScope.id,
+          userScope.id,
           userId,
           context.memoryName,
-          runnerScope.slug,
+          userScope.slug,
           "memory",
         )
       : null,
@@ -259,7 +254,7 @@ export async function prepareForExecution(
     context.agentCompose as AgentComposeYaml,
     context.vars || {},
     composeInfo.scopeId,
-    runnerScope.id,
+    userScope.id,
     context.artifactName,
     context.artifactVersion,
     context.volumeVersions,
@@ -270,7 +265,7 @@ export async function prepareForExecution(
   const storageEnd = Date.now();
 
   log.debug(
-    `Storage manifest prepared with dual scopes: owner=${composeInfo.scopeId}, runner=${runnerScope.id}, ${storageManifest.storages.length} storages, ${storageManifest.artifact ? "1 artifact" : "no artifact"}`,
+    `Storage manifest prepared with dual scopes: owner=${composeInfo.scopeId}, runner=${userScope.id}, ${storageManifest.storages.length} storages, ${storageManifest.artifact ? "1 artifact" : "no artifact"}`,
   );
 
   // Build PreparedContext

--- a/turbo/apps/web/src/lib/run/run-service.ts
+++ b/turbo/apps/web/src/lib/run/run-service.ts
@@ -556,7 +556,11 @@ async function buildAndDispatchRun(opts: {
     const tokenTime = Date.now();
 
     // Build execution context
-    const { context, timings: buildContextTimings } = await buildContext({
+    const {
+      context,
+      userScope,
+      timings: buildContextTimings,
+    } = await buildContext({
       checkpointId: params.checkpointId,
       sessionId: params.sessionId,
       conversationId: params.conversationId,
@@ -584,7 +588,7 @@ async function buildAndDispatchRun(opts: {
     const buildContextTime = Date.now();
 
     // Prepare execution context (storage manifest, working dir, etc.)
-    const prepareResult = await prepareForExecution(context);
+    const prepareResult = await prepareForExecution(context, userScope);
     const prepareTime = Date.now();
 
     // Dispatch to executor

--- a/turbo/apps/web/src/lib/run/types.ts
+++ b/turbo/apps/web/src/lib/run/types.ts
@@ -95,3 +95,13 @@ export interface ExecutionContext {
   // API start time for E2E timing metrics
   apiStartTime?: number;
 }
+
+/**
+ * User's default scope for storage resolution in prepareForExecution.
+ * Resolved once in buildExecutionContext to avoid redundant DB lookups.
+ * May differ from the credential scope when an org scope is explicitly selected.
+ */
+export interface UserScope {
+  id: string;
+  slug: string;
+}


### PR DESCRIPTION
## Summary
- Resolve user's default scope once in `buildExecutionContext` and pass it as a separate `UserScope` parameter to `prepareForExecution`
- Removes the redundant `getUserScopeByClerkId` DB query that was duplicating work already done earlier in the pipeline
- When `params.scopeId` is explicit (e.g., org scope), the user scope is resolved in parallel with credential resolution

## Changes
- **types.ts**: Add `UserScope` interface
- **build-context.ts**: Replace `resolveScopeId` with `resolveScopes` that returns both credential scope ID and user scope (with slug); user scope is returned alongside `ExecutionContext` in `BuildContextResult`
- **execution-preparer.ts**: Accept `UserScope` parameter, remove `getUserScopeByClerkId` import and call
- **run-service.ts**: Thread `userScope` from `buildContext` result to `prepareForExecution`

## Test plan
- [ ] Existing `create-run.test.ts` tests pass (35 tests)
- [ ] CI passes (lint, types, knip, tests)

Closes #3995

🤖 Generated with [Claude Code](https://claude.com/claude-code)