### PR TITLE
fix(platform): strip heading anchor links with escaped svg text in markdown

### DIFF
--- a/turbo/apps/platform/src/views/components/markdown.tsx
+++ b/turbo/apps/platform/src/views/components/markdown.tsx
@@ -126,21 +126,19 @@ function rehypeRewriteHandler(...args: RewriteArgs) {
     return;
   }
 
-  // Strip heading anchor links (`.anchor` class) that contain escaped `<svg>` text
-  if ("children" in node) {
-    const children = node.children;
-    for (let i = children.length - 1; i >= 0; i--) {
-      const child = children[i];
-      if (
-        child &&
-        child.type === "element" &&
-        child.tagName === "a" &&
-        Array.isArray(child.properties?.className) &&
-        (child.properties.className as string[]).includes("anchor")
-      ) {
-        children.splice(i, 1);
-      }
-    }
+  // Strip heading anchor links (`.anchor` class) that contain escaped `<svg>` text.
+  if (
+    node.type === "element" &&
+    node.tagName === "a" &&
+    node.properties?.class === "anchor"
+  ) {
+    Object.assign(node, {
+      type: "text",
+      value: "",
+      tagName: undefined,
+      properties: undefined,
+      children: undefined,
+    });
   }
 }
 

--- a/turbo/apps/platform/src/views/components/markdown.tsx
+++ b/turbo/apps/platform/src/views/components/markdown.tsx
@@ -2,109 +2,114 @@ import MarkdownPreview, {
   type MarkdownPreviewProps,
 } from "@uiw/react-markdown-preview";
 
-/**
- * Rewrite callback that converts unknown HTML tags to plain text.
- * Agent responses may contain component-like tags (e.g. <OrganizationSwitcher>)
- * that the HTML parser renders as DOM elements, causing React warnings.
- */
-function rewriteUnknownTags(
-  ...args: Parameters<NonNullable<MarkdownPreviewProps["rehypeRewrite"]>>
-) {
-  const VALID_HTML_TAGS: ReadonlySet<string> = new Set([
-    "a",
-    "abbr",
-    "address",
-    "area",
-    "article",
-    "aside",
-    "audio",
-    "b",
-    "bdi",
-    "bdo",
-    "blockquote",
-    "br",
-    "caption",
-    "cite",
-    "code",
-    "col",
-    "colgroup",
-    "data",
-    "dd",
-    "del",
-    "details",
-    "dfn",
-    "dialog",
-    "div",
-    "dl",
-    "dt",
-    "em",
-    "embed",
-    "fieldset",
-    "figcaption",
-    "figure",
-    "footer",
-    "h1",
-    "h2",
-    "h3",
-    "h4",
-    "h5",
-    "h6",
-    "header",
-    "hr",
-    "i",
-    "iframe",
-    "img",
-    "input",
-    "ins",
-    "kbd",
-    "label",
-    "legend",
-    "li",
-    "main",
-    "mark",
-    "menu",
-    "meter",
-    "nav",
-    "ol",
-    "optgroup",
-    "option",
-    "output",
-    "p",
-    "picture",
-    "pre",
-    "progress",
-    "q",
-    "rp",
-    "rt",
-    "ruby",
-    "s",
-    "samp",
-    "section",
-    "small",
-    "source",
-    "span",
-    "strong",
-    "sub",
-    "summary",
-    "sup",
-    "table",
-    "tbody",
-    "td",
-    "template",
-    "textarea",
-    "tfoot",
-    "th",
-    "thead",
-    "time",
-    "tr",
-    "u",
-    "ul",
-    "var",
-    "video",
-    "wbr",
-  ]);
+type RewriteArgs = Parameters<
+  NonNullable<MarkdownPreviewProps["rehypeRewrite"]>
+>;
 
+const VALID_HTML_TAGS: ReadonlySet<string> = new Set([
+  "a",
+  "abbr",
+  "address",
+  "area",
+  "article",
+  "aside",
+  "audio",
+  "b",
+  "bdi",
+  "bdo",
+  "blockquote",
+  "br",
+  "caption",
+  "cite",
+  "code",
+  "col",
+  "colgroup",
+  "data",
+  "dd",
+  "del",
+  "details",
+  "dfn",
+  "dialog",
+  "div",
+  "dl",
+  "dt",
+  "em",
+  "embed",
+  "fieldset",
+  "figcaption",
+  "figure",
+  "footer",
+  "h1",
+  "h2",
+  "h3",
+  "h4",
+  "h5",
+  "h6",
+  "header",
+  "hr",
+  "i",
+  "iframe",
+  "img",
+  "input",
+  "ins",
+  "kbd",
+  "label",
+  "legend",
+  "li",
+  "main",
+  "mark",
+  "menu",
+  "meter",
+  "nav",
+  "ol",
+  "optgroup",
+  "option",
+  "output",
+  "p",
+  "picture",
+  "pre",
+  "progress",
+  "q",
+  "rp",
+  "rt",
+  "ruby",
+  "s",
+  "samp",
+  "section",
+  "small",
+  "source",
+  "span",
+  "strong",
+  "sub",
+  "summary",
+  "sup",
+  "table",
+  "tbody",
+  "td",
+  "template",
+  "textarea",
+  "tfoot",
+  "th",
+  "thead",
+  "time",
+  "tr",
+  "u",
+  "ul",
+  "var",
+  "video",
+  "wbr",
+]);
+
+/**
+ * Rewrite callback that:
+ * 1. Converts unknown HTML tags to plain text (e.g. <OrganizationSwitcher>)
+ * 2. Strips auto-generated heading anchor links whose SVG icons get sanitized
+ *    into visible `<svg>` text by rehype-sanitize.
+ */
+function rehypeRewriteHandler(...args: RewriteArgs) {
   const [node, , parent] = args;
+
+  // Convert unknown HTML tags to plain text
   if (
     node.type === "element" &&
     !VALID_HTML_TAGS.has(node.tagName) &&
@@ -118,6 +123,24 @@ function rewriteUnknownTags(
       properties: undefined,
       children: undefined,
     });
+    return;
+  }
+
+  // Strip heading anchor links (`.anchor` class) that contain escaped `<svg>` text
+  if ("children" in node) {
+    const children = node.children;
+    for (let i = children.length - 1; i >= 0; i--) {
+      const child = children[i];
+      if (
+        child &&
+        child.type === "element" &&
+        child.tagName === "a" &&
+        Array.isArray(child.properties?.className) &&
+        (child.properties.className as string[]).includes("anchor")
+      ) {
+        children.splice(i, 1);
+      }
+    }
   }
 }
 
@@ -132,7 +155,7 @@ export function Markdown({ className, style, ...rest }: MarkdownPreviewProps) {
         fontFamily: "var(--font-family-sans)",
         ...style,
       }}
-      rehypeRewrite={rewriteUnknownTags}
+      rehypeRewrite={rehypeRewriteHandler}
       {...rest}
     />
   );

--- a/turbo/apps/platform/src/views/components/markdown.tsx
+++ b/turbo/apps/platform/src/views/components/markdown.tsx
@@ -6,141 +6,143 @@ type RewriteArgs = Parameters<
   NonNullable<MarkdownPreviewProps["rehypeRewrite"]>
 >;
 
-const VALID_HTML_TAGS: ReadonlySet<string> = new Set([
-  "a",
-  "abbr",
-  "address",
-  "area",
-  "article",
-  "aside",
-  "audio",
-  "b",
-  "bdi",
-  "bdo",
-  "blockquote",
-  "br",
-  "caption",
-  "cite",
-  "code",
-  "col",
-  "colgroup",
-  "data",
-  "dd",
-  "del",
-  "details",
-  "dfn",
-  "dialog",
-  "div",
-  "dl",
-  "dt",
-  "em",
-  "embed",
-  "fieldset",
-  "figcaption",
-  "figure",
-  "footer",
-  "h1",
-  "h2",
-  "h3",
-  "h4",
-  "h5",
-  "h6",
-  "header",
-  "hr",
-  "i",
-  "iframe",
-  "img",
-  "input",
-  "ins",
-  "kbd",
-  "label",
-  "legend",
-  "li",
-  "main",
-  "mark",
-  "menu",
-  "meter",
-  "nav",
-  "ol",
-  "optgroup",
-  "option",
-  "output",
-  "p",
-  "picture",
-  "pre",
-  "progress",
-  "q",
-  "rp",
-  "rt",
-  "ruby",
-  "s",
-  "samp",
-  "section",
-  "small",
-  "source",
-  "span",
-  "strong",
-  "sub",
-  "summary",
-  "sup",
-  "table",
-  "tbody",
-  "td",
-  "template",
-  "textarea",
-  "tfoot",
-  "th",
-  "thead",
-  "time",
-  "tr",
-  "u",
-  "ul",
-  "var",
-  "video",
-  "wbr",
-]);
-
 /**
  * Rewrite callback that:
  * 1. Converts unknown HTML tags to plain text (e.g. <OrganizationSwitcher>)
  * 2. Strips auto-generated heading anchor links whose SVG icons get sanitized
  *    into visible `<svg>` text by rehype-sanitize.
  */
-function rehypeRewriteHandler(...args: RewriteArgs) {
-  const [node, , parent] = args;
+const rehypeRewriteHandler = (() => {
+  const validHtmlTags: ReadonlySet<string> = new Set([
+    "a",
+    "abbr",
+    "address",
+    "area",
+    "article",
+    "aside",
+    "audio",
+    "b",
+    "bdi",
+    "bdo",
+    "blockquote",
+    "br",
+    "caption",
+    "cite",
+    "code",
+    "col",
+    "colgroup",
+    "data",
+    "dd",
+    "del",
+    "details",
+    "dfn",
+    "dialog",
+    "div",
+    "dl",
+    "dt",
+    "em",
+    "embed",
+    "fieldset",
+    "figcaption",
+    "figure",
+    "footer",
+    "h1",
+    "h2",
+    "h3",
+    "h4",
+    "h5",
+    "h6",
+    "header",
+    "hr",
+    "i",
+    "iframe",
+    "img",
+    "input",
+    "ins",
+    "kbd",
+    "label",
+    "legend",
+    "li",
+    "main",
+    "mark",
+    "menu",
+    "meter",
+    "nav",
+    "ol",
+    "optgroup",
+    "option",
+    "output",
+    "p",
+    "picture",
+    "pre",
+    "progress",
+    "q",
+    "rp",
+    "rt",
+    "ruby",
+    "s",
+    "samp",
+    "section",
+    "small",
+    "source",
+    "span",
+    "strong",
+    "sub",
+    "summary",
+    "sup",
+    "table",
+    "tbody",
+    "td",
+    "template",
+    "textarea",
+    "tfoot",
+    "th",
+    "thead",
+    "time",
+    "tr",
+    "u",
+    "ul",
+    "var",
+    "video",
+    "wbr",
+  ]);
 
-  // Convert unknown HTML tags to plain text
-  if (
-    node.type === "element" &&
-    !VALID_HTML_TAGS.has(node.tagName) &&
-    parent?.type === "element"
-  ) {
-    const text = `<${node.tagName}>`;
-    Object.assign(node, {
-      type: "text",
-      value: text,
-      tagName: undefined,
-      properties: undefined,
-      children: undefined,
-    });
-    return;
-  }
+  return (...args: RewriteArgs) => {
+    const [node, , parent] = args;
 
-  // Strip heading anchor links (`.anchor` class) that contain escaped `<svg>` text.
-  if (
-    node.type === "element" &&
-    node.tagName === "a" &&
-    node.properties?.class === "anchor"
-  ) {
-    Object.assign(node, {
-      type: "text",
-      value: "",
-      tagName: undefined,
-      properties: undefined,
-      children: undefined,
-    });
-  }
-}
+    // Convert unknown HTML tags to plain text
+    if (
+      node.type === "element" &&
+      !validHtmlTags.has(node.tagName) &&
+      parent?.type === "element"
+    ) {
+      const text = `<${node.tagName}>`;
+      Object.assign(node, {
+        type: "text",
+        value: text,
+        tagName: undefined,
+        properties: undefined,
+        children: undefined,
+      });
+      return;
+    }
+
+    // Strip heading anchor links (`.anchor` class) that contain escaped `<svg>` text.
+    if (
+      node.type === "element" &&
+      node.tagName === "a" &&
+      node.properties?.class === "anchor"
+    ) {
+      Object.assign(node, {
+        type: "text",
+        value: "",
+        tagName: undefined,
+        properties: undefined,
+        children: undefined,
+      });
+    }
+  };
+})();
 
 export function Markdown({ className, style, ...rest }: MarkdownPreviewProps) {
   return (


### PR DESCRIPTION
## Summary
- `@uiw/react-markdown-preview` adds anchor links with SVG icons to markdown headings via `rehype-autolink-headings`
- `rehype-sanitize` strips the `<svg>` tag (not in whitelist for security) but leaves the text content, causing `<svg>` to appear as visible text next to headings like "Current Integration"
- Added a `rehypeRewrite` rule to remove `.anchor` elements from the AST before rendering, merged with the existing `rewriteUnknownTags` handler

## Test plan
- [ ] Open logs detail page with a run that has markdown headings in the prompt (e.g. Telegram agent runs with `# Current Integration` context)
- [ ] Verify no `<svg>` text appears next to heading elements
- [ ] Verify existing unknown-tag rewriting still works (e.g. `<OrganizationSwitcher>` renders as text)

🤖 Generated with [Claude Code](https://claude.com/claude-code)