### PR TITLE
feat: rename "view logs" to "audit" across platforms

### DIFF
--- a/turbo/apps/web/app/api/internal/callbacks/github/issues/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/github/issues/__tests__/route.test.ts
@@ -295,7 +295,7 @@ describe("POST /api/internal/callbacks/github/issues", () => {
       expect(capturedComments[0]!.repo).toBe("test-repo");
       expect(capturedComments[0]!.issueNumber).toBe("42");
       // Verify the comment body includes the logs footer
-      expect(capturedComments[0]!.body).toContain("View logs");
+      expect(capturedComments[0]!.body).toContain("Audit");
     });
 
     it("should post error comment on failed run", async () => {

--- a/turbo/apps/web/app/api/internal/callbacks/github/issues/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/github/issues/route.ts
@@ -112,7 +112,7 @@ function formatGitHubComment(opts: {
     parts.push(`<sub>${linkText}</sub>`, "");
   }
 
-  parts.push(`<sub>📋 [View logs](${logsUrl})</sub>`);
+  parts.push(`<sub>📋 [Audit](${logsUrl})</sub>`);
 
   return parts.join("\n");
 }

--- a/turbo/apps/web/app/api/internal/callbacks/slack/schedule/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/slack/schedule/route.ts
@@ -148,7 +148,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
             elements: [
               {
                 type: "mrkdwn",
-                text: `<${logsUrl}|View logs> · Reply in this thread to continue the conversation`,
+                text: `<${logsUrl}|Audit> · Reply in this thread to continue the conversation`,
               },
             ],
           },
@@ -197,7 +197,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
             elements: [
               {
                 type: "mrkdwn",
-                text: `<${logsUrl}|View logs>`,
+                text: `<${logsUrl}|Audit>`,
               },
             ],
           },

--- a/turbo/apps/web/src/lib/email/templates/agent-reply.tsx
+++ b/turbo/apps/web/src/lib/email/templates/agent-reply.tsx
@@ -29,7 +29,7 @@ export function AgentReplyEmail({
           <Text style={signatureStyle}>{agentName} from VM0</Text>
           <Text style={footerStyle}>
             <Link href={logsUrl} style={linkStyle}>
-              View logs
+              Audit
             </Link>{" "}
             · Reply to continue
           </Text>

--- a/turbo/apps/web/src/lib/email/templates/schedule-completed.tsx
+++ b/turbo/apps/web/src/lib/email/templates/schedule-completed.tsx
@@ -29,7 +29,7 @@ export function ScheduleCompletedEmail({
           <Text style={signatureStyle}>{agentName} from VM0</Text>
           <Text style={footerStyle}>
             <Link href={logsUrl} style={linkStyle}>
-              View logs
+              Audit
             </Link>{" "}
             · Reply to continue
           </Text>

--- a/turbo/apps/web/src/lib/email/templates/schedule-failed.tsx
+++ b/turbo/apps/web/src/lib/email/templates/schedule-failed.tsx
@@ -29,7 +29,7 @@ export function ScheduleFailedEmail({
           <Text style={signatureStyle}>{agentName} from VM0</Text>
           <Text style={footerStyle}>
             <Link href={logsUrl} style={linkStyle}>
-              View logs
+              Audit
             </Link>
           </Text>
         </Container>

--- a/turbo/apps/web/src/lib/slack/blocks.ts
+++ b/turbo/apps/web/src/lib/slack/blocks.ts
@@ -501,7 +501,7 @@ export function buildAgentResponseMessage(
       elements: [
         {
           type: "mrkdwn",
-          text: `:clipboard: <${logsUrl}|View logs>`,
+          text: `:clipboard: <${logsUrl}|Audit>`,
         },
       ],
     });

--- a/turbo/apps/web/src/lib/telegram/__tests__/format.test.ts
+++ b/turbo/apps/web/src/lib/telegram/__tests__/format.test.ts
@@ -82,7 +82,7 @@ describe("buildTelegramResponse", () => {
     expect(result).toContain("🤖 <b>TestBot</b>");
     expect(result).toContain("Hello world");
     expect(result).toContain(
-      '<a href="https://example.com/logs/123">📋 View logs</a>',
+      '<a href="https://example.com/logs/123">📋 Audit</a>',
     );
   });
 
@@ -134,7 +134,7 @@ describe("buildTelegramResponse", () => {
     expect(result).toContain(
       '🔑 <a href="https://example.com/settings">Configure model providers</a>',
     );
-    expect(result).toContain("📋 View logs</a>");
+    expect(result).toContain("📋 Audit</a>");
   });
 
   it("should not include deep links section when empty", () => {
@@ -146,7 +146,7 @@ describe("buildTelegramResponse", () => {
     );
 
     expect(result).not.toContain("🔑");
-    expect(result).toContain("📋 View logs</a>");
+    expect(result).toContain("📋 Audit</a>");
   });
 });
 

--- a/turbo/apps/web/src/lib/telegram/format.ts
+++ b/turbo/apps/web/src/lib/telegram/format.ts
@@ -121,7 +121,7 @@ export function buildTelegramResponse(
       .join("  ·  ");
     footerParts.push(linkText);
   }
-  footerParts.push(`<a href="${escapeHtml(logsUrl)}">📋 View logs</a>`);
+  footerParts.push(`<a href="${escapeHtml(logsUrl)}">📋 Audit</a>`);
 
   return `${header}\n\n${content}\n\n${footerParts.join("\n")}`;
 }


### PR DESCRIPTION
## Summary

- Rename all "View logs" UI text to "Audit" across all notification platforms
- Covers Telegram, Slack, GitHub, and Email templates
- Updated corresponding tests

## Files changed

- `telegram/format.ts` — `📋 View logs` → `📋 Audit`
- `slack/blocks.ts` — `View logs` → `Audit`
- `callbacks/github/issues/route.ts` — `View logs` → `Audit`
- `callbacks/slack/schedule/route.ts` — `View logs` → `Audit` (2 occurrences)
- `email/templates/agent-reply.tsx` — `View logs` → `Audit`
- `email/templates/schedule-completed.tsx` — `View logs` → `Audit`
- `email/templates/schedule-failed.tsx` — `View logs` → `Audit`
- Updated test assertions in format.test.ts and route.test.ts

Closes #4007

## Test plan

- [x] All Telegram format tests pass
- [x] All GitHub callback tests pass
- [x] Verified zero remaining "View logs" references in codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)