### PR TITLE
perf(guest-agent): parallelize artifact and memory snapshot creation in checkpoint

### DIFF
--- a/crates/guest-agent/src/checkpoint.rs
+++ b/crates/guest-agent/src/checkpoint.rs
@@ -137,26 +137,41 @@ async fn create_checkpoint_impl(start: std::time::Instant) -> Result<(), AgentEr
     log_info!(LOG_TAG, "Session history loaded ({line_count} lines)");
     record_sandbox_op("session_history_read", start.elapsed(), true, None);
 
-    // Artifact snapshot (VAS only, optional)
-    let artifact_snapshot =
-        if !env::artifact_driver().is_empty() && !env::artifact_volume_name().is_empty() {
-            let driver = env::artifact_driver();
-            log_info!(LOG_TAG, "Processing artifact with driver: {driver}");
+    // Validate drivers before starting parallel snapshot creation.
+    // Driver validation uses early return, which cannot be done inside async blocks.
+    let has_artifact =
+        !env::artifact_driver().is_empty() && !env::artifact_volume_name().is_empty();
+    let has_memory = !env::memory_driver().is_empty() && !env::memory_name().is_empty();
 
-            if driver != "vas" {
-                return Err(AgentError::Checkpoint(format!(
-                    "Unknown artifact driver: {driver} (only 'vas' is supported)"
-                )));
+    if has_artifact && env::artifact_driver() != "vas" {
+        return Err(AgentError::Checkpoint(format!(
+            "Unknown artifact driver: {} (only 'vas' is supported)",
+            env::artifact_driver()
+        )));
+    }
+    if has_memory && env::memory_driver() != "vas" {
+        return Err(AgentError::Checkpoint(format!(
+            "Unknown memory driver: {} (only 'vas' is supported)",
+            env::memory_driver()
+        )));
+    }
+
+    // Create artifact and memory snapshots in parallel (independent directories + APIs).
+    let (artifact_snapshot, memory_snapshot) = tokio::join!(
+        async {
+            if !has_artifact {
+                log_info!(
+                    LOG_TAG,
+                    "No artifact configured, creating checkpoint without artifact snapshot"
+                );
+                return Ok::<_, AgentError>(None);
             }
-
             log_info!(
                 LOG_TAG,
                 "Creating VAS snapshot for artifact '{}' at {}",
                 env::artifact_volume_name(),
                 env::artifact_mount_path()
             );
-            log_info!(LOG_TAG, "Using direct S3 upload...");
-
             let snapshot = artifact::create_snapshot(
                 env::artifact_mount_path(),
                 env::artifact_volume_name(),
@@ -165,46 +180,34 @@ async fn create_checkpoint_impl(start: std::time::Instant) -> Result<(), AgentEr
                 &format!("Checkpoint from run {}", env::run_id()),
             )
             .await?;
-
             log_info!(
                 LOG_TAG,
                 "VAS artifact snapshot created: {}@{}",
                 env::artifact_volume_name(),
                 snapshot.version_id
             );
-
-            Some(json!({
+            Ok(Some(json!({
                 "artifactName": env::artifact_volume_name(),
                 "artifactVersion": snapshot.version_id,
-            }))
-        } else {
-            log_info!(
-                LOG_TAG,
-                "No artifact configured, creating checkpoint without artifact snapshot"
-            );
-            None
-        };
-
-    // Memory snapshot (VAS only, optional — same pattern as artifact)
-    let memory_snapshot = if !env::memory_driver().is_empty() && !env::memory_name().is_empty() {
-        let driver = env::memory_driver();
-        log_info!(LOG_TAG, "Processing memory with driver: {driver}");
-
-        if driver != "vas" {
-            return Err(AgentError::Checkpoint(format!(
-                "Unknown memory driver: {driver} (only 'vas' is supported)"
-            )));
-        }
-
-        // Only create snapshot if memory directory exists
-        if Path::new(env::memory_mount_path()).exists() {
+            })))
+        },
+        async {
+            if !has_memory {
+                return Ok::<_, AgentError>(None);
+            }
+            if !Path::new(env::memory_mount_path()).exists() {
+                log_info!(
+                    LOG_TAG,
+                    "Memory directory does not exist, skipping memory snapshot"
+                );
+                return Ok(None);
+            }
             log_info!(
                 LOG_TAG,
                 "Creating VAS snapshot for memory '{}' at {}",
                 env::memory_name(),
                 env::memory_mount_path()
             );
-
             let snapshot = artifact::create_snapshot(
                 env::memory_mount_path(),
                 env::memory_name(),
@@ -213,28 +216,20 @@ async fn create_checkpoint_impl(start: std::time::Instant) -> Result<(), AgentEr
                 &format!("Memory checkpoint from run {}", env::run_id()),
             )
             .await?;
-
             log_info!(
                 LOG_TAG,
                 "VAS memory snapshot created: {}@{}",
                 env::memory_name(),
                 snapshot.version_id
             );
-
-            Some(json!({
+            Ok(Some(json!({
                 "memoryName": env::memory_name(),
                 "memoryVersion": snapshot.version_id,
-            }))
-        } else {
-            log_info!(
-                LOG_TAG,
-                "Memory directory does not exist, skipping memory snapshot"
-            );
-            None
-        }
-    } else {
-        None
-    };
+            })))
+        },
+    );
+    let artifact_snapshot = artifact_snapshot?;
+    let memory_snapshot = memory_snapshot?;
 
     // Build and send checkpoint payload
     let mut payload = json!({


### PR DESCRIPTION
## Summary

- Use `tokio::join!` to create artifact and memory VAS snapshots concurrently during checkpoint
- Hoist driver validation before the join to preserve early-return error semantics
- Reduces checkpoint time from `artifact + memory` to `max(artifact, memory)`

Closes #4019

## Test plan

- [x] All 38 existing guest-agent tests pass (21 unit + 17 integration)
- [x] `cargo clippy` clean
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)