### PR TITLE
fix(guest-download): record 404 with allow_404 as telemetry success

### DIFF
--- a/crates/guest-download/src/lib.rs
+++ b/crates/guest-download/src/lib.rs
@@ -190,12 +190,7 @@ fn download_all_parallel(tasks: Vec<DownloadTask>) -> bool {
                             true
                         }
                         Err(e) if e.status_code == Some(404) && task.allow_404 => {
-                            record_sandbox_op(
-                                task.op_name,
-                                start.elapsed(),
-                                false,
-                                Some(&e.message),
-                            );
+                            record_sandbox_op(task.op_name, start.elapsed(), true, None);
                             log_info!(LOG_TAG, "{} not found, skipping (first run)", task.label);
                             true
                         }


### PR DESCRIPTION
## Summary
- Fix `record_sandbox_op` recording `success: false` when artifact/memory download returns 404 on first run
- 404 with `allow_404` is an expected condition, not a failure — now records `success: true`

Closes #3986

## Test plan
- [ ] CI passes (no behavioral change, only telemetry accuracy)
- [ ] First-run artifact/memory downloads no longer show as failures in metrics

🤖 Generated with [Claude Code](https://claude.com/claude-code)