### PR TITLE
perf(run): eliminate redundant compose scope query in execution preparer

### DIFF
--- a/turbo/apps/web/src/lib/run/context/execution-preparer.ts
+++ b/turbo/apps/web/src/lib/run/context/execution-preparer.ts
@@ -1,4 +1,3 @@
-import { eq } from "drizzle-orm";
 import type {
   AgentComposeYaml,
   ExperimentalFirewall,
@@ -13,11 +12,6 @@ import {
 import type { StorageManifest } from "../../storage/types";
 import { badRequest } from "../../errors";
 import { logger } from "../../logger";
-import {
-  agentComposes,
-  agentComposeVersions,
-} from "../../../db/schema/agent-compose";
-import { scopes } from "../../../db/schema/scope";
 import type { ExperimentalFirewall as CoreExperimentalFirewall } from "@vm0/core";
 import { extractCliAgentType } from "../utils";
 
@@ -171,7 +165,6 @@ function resolveRunnerGroup(agentCompose: unknown): string | null {
  * @returns PreparedContext ready for executor dispatch
  */
 interface PrepareTimings {
-  resolveScopes: number;
   ensureStorage: number;
   storageManifest: number;
 }
@@ -184,6 +177,7 @@ interface PrepareResult {
 export async function prepareForExecution(
   context: ExecutionContext,
   userScope: UserScope,
+  composeScope: { id: string; slug: string },
 ): Promise<PrepareResult> {
   log.debug(`Preparing execution context for run ${context.runId}...`);
 
@@ -199,28 +193,7 @@ export async function prepareForExecution(
     `Extracted config: workingDir=${workingDir}, cliAgentType=${cliAgentType}, runnerGroup=${runnerGroup}, firewall=${experimentalFirewall ? "enabled" : "disabled"}`,
   );
 
-  // Resolve agent owner's scope for volume resolution.
-  // User scope (for storage) is pre-resolved by buildExecutionContext.
   const userId = context.userId || "";
-  const scopeStart = Date.now();
-  const [composeInfo] = await globalThis.services.db
-    .select({
-      scopeId: agentComposes.scopeId,
-      scopeSlug: scopes.slug,
-    })
-    .from(agentComposeVersions)
-    .innerJoin(
-      agentComposes,
-      eq(agentComposeVersions.composeId, agentComposes.id),
-    )
-    .innerJoin(scopes, eq(agentComposes.scopeId, scopes.id))
-    .where(eq(agentComposeVersions.id, context.agentComposeVersionId))
-    .limit(1);
-  const scopeEnd = Date.now();
-
-  if (!composeInfo) {
-    throw badRequest("Agent compose not found");
-  }
 
   // Auto-create artifact and memory storages if they don't exist yet
   const ensureStart = Date.now();
@@ -247,13 +220,13 @@ export async function prepareForExecution(
   const ensureEnd = Date.now();
 
   // Prepare storage manifest with dual scopes
-  // - Volumes: resolved from agent owner's scope
-  // - Artifacts: resolved from runner's scope
+  // - Volumes: resolved from agent owner's scope (composeScope)
+  // - Artifacts: resolved from runner's scope (userScope)
   const storageStart = Date.now();
   const storageManifest = await prepareStorageManifest(
     context.agentCompose as AgentComposeYaml,
     context.vars || {},
-    composeInfo.scopeId,
+    composeScope.id,
     userScope.id,
     userId,
     context.artifactName,
@@ -266,7 +239,7 @@ export async function prepareForExecution(
   const storageEnd = Date.now();
 
   log.debug(
-    `Storage manifest prepared with dual scopes: owner=${composeInfo.scopeId}, runner=${userScope.id}, ${storageManifest.storages.length} storages, ${storageManifest.artifact ? "1 artifact" : "no artifact"}`,
+    `Storage manifest prepared with dual scopes: owner=${composeScope.id}, runner=${userScope.id}, ${storageManifest.storages.length} storages, ${storageManifest.artifact ? "1 artifact" : "no artifact"}`,
   );
 
   // Build PreparedContext
@@ -277,17 +250,16 @@ export async function prepareForExecution(
     runnerGroup,
     storageManifest,
     experimentalFirewall,
-    composeInfo.scopeSlug,
+    composeScope.slug,
   );
 
   const timings: PrepareTimings = {
-    resolveScopes: scopeEnd - scopeStart,
     ensureStorage: ensureEnd - ensureStart,
     storageManifest: storageEnd - storageStart,
   };
 
   log.debug(
-    `PreparedContext built for run ${context.runId} (scopes=${timings.resolveScopes}ms, ensure=${timings.ensureStorage}ms, storage=${timings.storageManifest}ms)`,
+    `PreparedContext built for run ${context.runId} (ensure=${timings.ensureStorage}ms, storage=${timings.storageManifest}ms)`,
   );
 
   return { context: preparedContext, timings };

--- a/turbo/apps/web/src/lib/run/run-service.ts
+++ b/turbo/apps/web/src/lib/run/run-service.ts
@@ -423,7 +423,7 @@ async function loadCompose(
 async function authorizeCompose(
   userId: string,
   userEmail: string,
-  compose: { id: string; userId: string; scopeId: string; scopeSlug: string },
+  compose: { id: string; userId: string; scopeId: string },
 ): Promise<void> {
   const hasAccess = await canAccessCompose(userId, userEmail, compose);
   if (!hasAccess) {

--- a/turbo/apps/web/src/lib/run/run-service.ts
+++ b/turbo/apps/web/src/lib/run/run-service.ts
@@ -6,6 +6,7 @@ import {
   agentComposeVersions,
   agentComposes,
 } from "../../db/schema/agent-compose";
+import { scopes } from "../../db/schema/scope";
 import { agentRunCallbacks } from "../../db/schema/agent-run-callback";
 import {
   notFound,
@@ -340,7 +341,7 @@ async function loadCompose(
   callerComposeId?: string,
 ): Promise<{
   composeContent: AgentComposeYaml;
-  compose: { id: string; userId: string; scopeId: string };
+  compose: { id: string; userId: string; scopeId: string; scopeSlug: string };
 }> {
   if (callerComposeId) {
     // When caller provides composeId, both queries are independent — run in parallel
@@ -355,8 +356,10 @@ async function loadCompose(
           id: agentComposes.id,
           userId: agentComposes.userId,
           scopeId: agentComposes.scopeId,
+          scopeSlug: scopes.slug,
         })
         .from(agentComposes)
+        .innerJoin(scopes, eq(agentComposes.scopeId, scopes.id))
         .where(eq(agentComposes.id, callerComposeId))
         .limit(1),
     ]);
@@ -374,7 +377,7 @@ async function loadCompose(
     };
   }
 
-  // No caller composeId — fetch version with compose via LEFT JOIN
+  // No caller composeId — fetch version with compose and scope via JOINs
   // Use LEFT JOIN so we can distinguish "version missing" from "compose missing"
   const [result] = await globalThis.services.db
     .select({
@@ -382,12 +385,14 @@ async function loadCompose(
       composeId: agentComposes.id,
       composeUserId: agentComposes.userId,
       composeScopeId: agentComposes.scopeId,
+      composeScopeSlug: scopes.slug,
     })
     .from(agentComposeVersions)
     .leftJoin(
       agentComposes,
       eq(agentComposeVersions.composeId, agentComposes.id),
     )
+    .leftJoin(scopes, eq(agentComposes.scopeId, scopes.id))
     .where(eq(agentComposeVersions.id, agentComposeVersionId))
     .limit(1);
 
@@ -395,7 +400,12 @@ async function loadCompose(
     throw notFound("Agent compose version not found");
   }
 
-  if (!result.composeId || !result.composeUserId || !result.composeScopeId) {
+  if (
+    !result.composeId ||
+    !result.composeUserId ||
+    !result.composeScopeId ||
+    !result.composeScopeSlug
+  ) {
     throw notFound("Agent compose not found");
   }
 
@@ -405,6 +415,7 @@ async function loadCompose(
       id: result.composeId,
       userId: result.composeUserId,
       scopeId: result.composeScopeId,
+      scopeSlug: result.composeScopeSlug,
     },
   };
 }
@@ -412,7 +423,7 @@ async function loadCompose(
 async function authorizeCompose(
   userId: string,
   userEmail: string,
-  compose: { id: string; userId: string; scopeId: string },
+  compose: { id: string; userId: string; scopeId: string; scopeSlug: string },
 ): Promise<void> {
   const hasAccess = await canAccessCompose(userId, userEmail, compose);
   if (!hasAccess) {
@@ -521,6 +532,7 @@ async function buildAndDispatchRun(opts: {
   composeContent: AgentComposeYaml;
   apiStartTime: number;
   scopeId: string | undefined;
+  composeScope: { id: string; slug: string };
   authorizeTime: number;
   transactionTime: number;
 }): Promise<{ status: string; sandboxId?: string }> {
@@ -531,6 +543,7 @@ async function buildAndDispatchRun(opts: {
     composeContent,
     apiStartTime,
     scopeId,
+    composeScope,
     authorizeTime,
     transactionTime,
   } = opts;
@@ -579,7 +592,11 @@ async function buildAndDispatchRun(opts: {
     const buildContextTime = Date.now();
 
     // Prepare execution context (storage manifest, working dir, etc.)
-    const prepareResult = await prepareForExecution(context, userScope);
+    const prepareResult = await prepareForExecution(
+      context,
+      userScope,
+      composeScope,
+    );
     const prepareTime = Date.now();
 
     // Dispatch to executor
@@ -607,10 +624,6 @@ async function buildAndDispatchRun(opts: {
         ms: buildContextTimings.resolveCredentials,
       },
       // Sub-step timings within prepareForExecution
-      {
-        op: "api_prepare_resolve_scopes",
-        ms: prepareResult.timings.resolveScopes,
-      },
       {
         op: "api_prepare_ensure_storage",
         ms: prepareResult.timings.ensureStorage,
@@ -748,6 +761,7 @@ export async function createRun(
     composeContent,
     apiStartTime,
     scopeId,
+    composeScope: { id: compose.scopeId, slug: compose.scopeSlug },
     authorizeTime,
     transactionTime,
   });
@@ -831,6 +845,10 @@ export async function executeQueuedRun(
     composeContent,
     apiStartTime,
     scopeId: params.scopeId,
+    composeScope: {
+      id: queuedCompose.scopeId,
+      slug: queuedCompose.scopeSlug,
+    },
     authorizeTime,
     transactionTime,
   });


### PR DESCRIPTION
## Summary
- Extend `loadCompose` to also fetch `scopes.slug` via an extra JOIN on the already-executed query
- Thread compose scope (`id` + `slug`) through `buildAndDispatchRun` → `prepareForExecution`
- Remove the entire 3-table JOIN query (`agentComposeVersions` → `agentComposes` → `scopes`) from `prepareForExecution`, eliminating one DB round-trip per run execution

Closes #4027

## Test plan
- [ ] Existing integration tests pass (no behavioral change — same data, different source)
- [ ] Verify `loadCompose` returns correct `scopeSlug` in both paths (with/without `callerComposeId`)
- [ ] Confirm `prepareForExecution` uses `composeScope.id` for volume resolution and `composeScope.slug` for `agentScopeSlug`

🤖 Generated with [Claude Code](https://claude.com/claude-code)