### PR TITLE
feat(telegram): manage queued message lifecycle via thinking message

### DIFF
--- a/turbo/apps/web/app/api/internal/callbacks/telegram/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/telegram/__tests__/route.test.ts
@@ -53,6 +53,17 @@ function telegramSendChatAction() {
   );
 }
 
+function telegramEditMessageText() {
+  return http.post(
+    `https://api.telegram.org/bot${TEST_BOT_TOKEN}/editMessageText`,
+    () =>
+      HttpResponse.json({
+        ok: true,
+        result: { message_id: 100, chat: { id: 123 }, text: "edited" },
+      }),
+  );
+}
+
 function telegramDeleteMessage() {
   return http.post(
     `https://api.telegram.org/bot${TEST_BOT_TOKEN}/deleteMessage`,
@@ -279,8 +290,13 @@ describe("POST /api/internal/callbacks/telegram", () => {
       const { runId, payload, secret } = await setupTelegramCallback();
 
       const chatActionHandler = telegramSendChatAction();
+      const editHandler = telegramEditMessageText();
       const sendMessageHandler = telegramSendMessage();
-      server.use(chatActionHandler.handler, sendMessageHandler.handler);
+      server.use(
+        chatActionHandler.handler,
+        editHandler.handler,
+        sendMessageHandler.handler,
+      );
 
       const request = createCallbackRequest(
         { runId, status: "progress", payload },
@@ -294,8 +310,32 @@ describe("POST /api/internal/callbacks/telegram", () => {
 
       // Should refresh typing indicator
       expect(chatActionHandler.mocked).toHaveBeenCalledTimes(1);
-      // Should NOT send a message (no error, no completion text)
+      // Should edit thinking message back to thinking state
+      expect(editHandler.mocked).toHaveBeenCalledTimes(1);
+      // Should NOT send a new message
       expect(sendMessageHandler.mocked).not.toHaveBeenCalled();
+    });
+
+    it("should skip editing when no thinkingMessageId is set", async () => {
+      const { runId, payload, secret } = await setupTelegramCallback();
+
+      const chatActionHandler = telegramSendChatAction();
+      const editHandler = telegramEditMessageText();
+      server.use(chatActionHandler.handler, editHandler.handler);
+
+      const request = createCallbackRequest(
+        {
+          runId,
+          status: "progress",
+          payload: { ...payload, thinkingMessageId: null },
+        },
+        secret,
+      );
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+      expect(chatActionHandler.mocked).toHaveBeenCalledTimes(1);
+      expect(editHandler.mocked).not.toHaveBeenCalled();
     });
   });
 

--- a/turbo/apps/web/app/api/internal/callbacks/telegram/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/telegram/route.ts
@@ -10,9 +10,11 @@ import {
   createTelegramClient,
   sendMessage,
   sendChatAction,
+  editMessageText,
   deleteMessage,
 } from "../../../../../src/lib/telegram/client";
 import {
+  escapeHtml,
   splitMessage,
   buildTelegramResponse,
   buildTelegramErrorResponse,
@@ -268,6 +270,15 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   if (status === "progress") {
     try {
       await sendChatAction(client, payload.chatId, "typing");
+      if (payload.thinkingMessageId) {
+        const thinkingText = `<i>🤖 ${escapeHtml(payload.agentName)} is thinking...</i>`;
+        await editMessageText(
+          client,
+          payload.chatId,
+          Number(payload.thinkingMessageId),
+          thinkingText,
+        );
+      }
     } catch (err) {
       log.debug("Failed to refresh typing indicator", { runId, error: err });
     }

--- a/turbo/apps/web/app/api/telegram/webhook/__tests__/commands.test.ts
+++ b/turbo/apps/web/app/api/telegram/webhook/__tests__/commands.test.ts
@@ -73,6 +73,33 @@ function telegramSendMessage() {
   return { ...handler, calls };
 }
 
+function telegramEditMessageText() {
+  const calls: Array<{
+    chat_id: string;
+    message_id: number;
+    text: string;
+  }> = [];
+  const handler = http.post(
+    `https://api.telegram.org/bot${TEST_BOT_TOKEN}/editMessageText`,
+    async ({ request }) => {
+      const body = (await request.json()) as {
+        chat_id: string;
+        message_id: number;
+        text: string;
+      };
+      calls.push(body);
+      return HttpResponse.json({
+        ok: true,
+        result: {
+          message_id: body.message_id,
+          chat: { id: TELEGRAM_USER_ID },
+        },
+      });
+    },
+  );
+  return { ...handler, calls };
+}
+
 describe("Telegram bot commands", () => {
   let installationId: string;
   let composeId: string;
@@ -514,7 +541,8 @@ describe("Telegram bot commands", () => {
   describe("queued run notification", () => {
     it("should send queued message for DM when run is queued", async () => {
       const sendMsg = telegramSendMessage();
-      server.use(sendMsg.handler);
+      const editMsg = telegramEditMessageText();
+      server.use(sendMsg.handler, editMsg.handler);
 
       vi.spyOn(runModule, "createRun").mockResolvedValue({
         runId: "mock-run-id",
@@ -538,8 +566,8 @@ describe("Telegram bot commands", () => {
       expect(response.status).toBe(200);
       await flushAfterCallbacks();
 
-      // Should have sent the thinking message + queued notification
-      const queuedMsg = sendMsg.calls.find((c) =>
+      // Queued notification edits the thinking message (not a new sendMessage)
+      const queuedMsg = editMsg.calls.find((c) =>
         c.text.includes("Run queued"),
       );
       expect(queuedMsg).toBeDefined();
@@ -548,7 +576,8 @@ describe("Telegram bot commands", () => {
 
     it("should send queued message for group mention when run is queued", async () => {
       const sendMsg = telegramSendMessage();
-      server.use(sendMsg.handler);
+      const editMsg = telegramEditMessageText();
+      server.use(sendMsg.handler, editMsg.handler);
 
       vi.spyOn(runModule, "createRun").mockResolvedValue({
         runId: "mock-run-id",
@@ -573,7 +602,8 @@ describe("Telegram bot commands", () => {
       expect(response.status).toBe(200);
       await flushAfterCallbacks();
 
-      const queuedMsg = sendMsg.calls.find((c) =>
+      // Queued notification edits the thinking message (not a new sendMessage)
+      const queuedMsg = editMsg.calls.find((c) =>
         c.text.includes("Run queued"),
       );
       expect(queuedMsg).toBeDefined();

--- a/turbo/apps/web/src/lib/telegram/__tests__/client.test.ts
+++ b/turbo/apps/web/src/lib/telegram/__tests__/client.test.ts
@@ -5,6 +5,7 @@ import {
   createTelegramClient,
   sendMessage,
   sendChatAction,
+  editMessageText,
   deleteMessage,
   getMe,
   setWebhook,
@@ -239,6 +240,38 @@ describe("sendChatAction", () => {
     expect(capturedBody).toEqual({
       chat_id: 42,
       action: "typing",
+    });
+  });
+});
+
+describe("editMessageText", () => {
+  it("should edit a message with HTML parse mode", async () => {
+    let capturedBody: unknown;
+    const handler = http.post(
+      `https://api.telegram.org/bot${TEST_TOKEN}/editMessageText`,
+      async ({ request }) => {
+        capturedBody = await request.json();
+        return HttpResponse.json({
+          ok: true,
+          result: { message_id: 99, chat: { id: 42 }, text: "edited" },
+        });
+      },
+    );
+    server.use(handler.handler);
+
+    const client = createTelegramClient(TEST_TOKEN);
+    const result = await editMessageText(client, 42, 99, "edited");
+
+    expect(result).toEqual({
+      message_id: 99,
+      chat: { id: 42 },
+      text: "edited",
+    });
+    expect(capturedBody).toEqual({
+      chat_id: 42,
+      message_id: 99,
+      text: "edited",
+      parse_mode: "HTML",
     });
   });
 });

--- a/turbo/apps/web/src/lib/telegram/client.ts
+++ b/turbo/apps/web/src/lib/telegram/client.ts
@@ -149,6 +149,23 @@ export async function deleteWebhook(token: string): Promise<void> {
 }
 
 /**
+ * Edit a text message
+ */
+export async function editMessageText(
+  client: TelegramClient,
+  chatId: string | number,
+  messageId: number,
+  text: string,
+): Promise<TelegramSentMessage> {
+  return callTelegramApi<TelegramSentMessage>(client.token, "editMessageText", {
+    chat_id: chatId,
+    message_id: messageId,
+    text,
+    parse_mode: "HTML",
+  });
+}
+
+/**
  * Delete a message
  */
 export async function deleteMessage(

--- a/turbo/apps/web/src/lib/telegram/handlers/direct-message.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/direct-message.ts
@@ -2,14 +2,10 @@ import { eq } from "drizzle-orm";
 import { telegramInstallations } from "../../../db/schema/telegram-installation";
 import { decryptCredentialValue } from "../../crypto/secrets-encryption";
 import { env } from "../../../env";
-import {
-  createTelegramClient,
-  sendMessage,
-  editMessageText,
-  deleteMessage,
-} from "../client";
+import { createTelegramClient, sendMessage, deleteMessage } from "../client";
 import {
   sendThinkingMessage,
+  sendQueuedNotification,
   enrichTelegramPrompt,
   formatReplyQuote,
   appendPhotoContext,
@@ -186,20 +182,7 @@ export async function handleTelegramDirectMessage(
   });
 
   if (status === "queued") {
-    if (thinkingMessage) {
-      await editMessageText(
-        client,
-        chatId,
-        thinkingMessage.message_id,
-        "⏳ Run queued — concurrency limit reached. Will start automatically when a slot is available.",
-      );
-    } else {
-      await sendMessage(
-        client,
-        chatId,
-        "⏳ Run queued — concurrency limit reached. Will start automatically when a slot is available.",
-      );
-    }
+    await sendQueuedNotification(client, chatId, thinkingMessage);
   } else if (status === "failed") {
     log.error("Failed to dispatch agent run (DM)", {
       chatId,

--- a/turbo/apps/web/src/lib/telegram/handlers/direct-message.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/direct-message.ts
@@ -2,7 +2,12 @@ import { eq } from "drizzle-orm";
 import { telegramInstallations } from "../../../db/schema/telegram-installation";
 import { decryptCredentialValue } from "../../crypto/secrets-encryption";
 import { env } from "../../../env";
-import { createTelegramClient, sendMessage, deleteMessage } from "../client";
+import {
+  createTelegramClient,
+  sendMessage,
+  editMessageText,
+  deleteMessage,
+} from "../client";
 import {
   sendThinkingMessage,
   enrichTelegramPrompt,
@@ -181,11 +186,20 @@ export async function handleTelegramDirectMessage(
   });
 
   if (status === "queued") {
-    await sendMessage(
-      client,
-      chatId,
-      "⏳ Run queued — concurrency limit reached. Will start automatically when a slot is available.",
-    );
+    if (thinkingMessage) {
+      await editMessageText(
+        client,
+        chatId,
+        thinkingMessage.message_id,
+        "⏳ Run queued — concurrency limit reached. Will start automatically when a slot is available.",
+      );
+    } else {
+      await sendMessage(
+        client,
+        chatId,
+        "⏳ Run queued — concurrency limit reached. Will start automatically when a slot is available.",
+      );
+    }
   } else if (status === "failed") {
     log.error("Failed to dispatch agent run (DM)", {
       chatId,

--- a/turbo/apps/web/src/lib/telegram/handlers/mention.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/mention.ts
@@ -2,14 +2,10 @@ import { eq } from "drizzle-orm";
 import { telegramInstallations } from "../../../db/schema/telegram-installation";
 import { decryptCredentialValue } from "../../crypto/secrets-encryption";
 import { env } from "../../../env";
-import {
-  createTelegramClient,
-  sendMessage,
-  editMessageText,
-  deleteMessage,
-} from "../client";
+import { createTelegramClient, sendMessage, deleteMessage } from "../client";
 import {
   sendThinkingMessage,
+  sendQueuedNotification,
   enrichTelegramPrompt,
   formatReplyQuote,
   appendPhotoContext,
@@ -173,21 +169,9 @@ export async function handleTelegramMention(
   });
 
   if (status === "queued") {
-    if (thinkingMessage) {
-      await editMessageText(
-        client,
-        chatId,
-        thinkingMessage.message_id,
-        "⏳ Run queued — concurrency limit reached. Will start automatically when a slot is available.",
-      );
-    } else {
-      await sendMessage(
-        client,
-        chatId,
-        "⏳ Run queued — concurrency limit reached. Will start automatically when a slot is available.",
-        { replyToMessageId: message.message_id },
-      );
-    }
+    await sendQueuedNotification(client, chatId, thinkingMessage, {
+      replyToMessageId: message.message_id,
+    });
   } else if (status === "failed") {
     log.error("Failed to dispatch agent run (mention)", {
       chatId,

--- a/turbo/apps/web/src/lib/telegram/handlers/mention.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/mention.ts
@@ -2,7 +2,12 @@ import { eq } from "drizzle-orm";
 import { telegramInstallations } from "../../../db/schema/telegram-installation";
 import { decryptCredentialValue } from "../../crypto/secrets-encryption";
 import { env } from "../../../env";
-import { createTelegramClient, sendMessage, deleteMessage } from "../client";
+import {
+  createTelegramClient,
+  sendMessage,
+  editMessageText,
+  deleteMessage,
+} from "../client";
 import {
   sendThinkingMessage,
   enrichTelegramPrompt,
@@ -168,12 +173,21 @@ export async function handleTelegramMention(
   });
 
   if (status === "queued") {
-    await sendMessage(
-      client,
-      chatId,
-      "⏳ Run queued — concurrency limit reached. Will start automatically when a slot is available.",
-      { replyToMessageId: message.message_id },
-    );
+    if (thinkingMessage) {
+      await editMessageText(
+        client,
+        chatId,
+        thinkingMessage.message_id,
+        "⏳ Run queued — concurrency limit reached. Will start automatically when a slot is available.",
+      );
+    } else {
+      await sendMessage(
+        client,
+        chatId,
+        "⏳ Run queued — concurrency limit reached. Will start automatically when a slot is available.",
+        { replyToMessageId: message.message_id },
+      );
+    }
   } else if (status === "failed") {
     log.error("Failed to dispatch agent run (mention)", {
       chatId,

--- a/turbo/apps/web/src/lib/telegram/handlers/shared.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/shared.ts
@@ -13,6 +13,7 @@ import { validateAgentSession } from "../../run";
 import { ensureStorageExists } from "../../storage/storage-service";
 import {
   sendMessage,
+  editMessageText,
   type TelegramClient,
   type TelegramSentMessage,
 } from "../client";
@@ -325,6 +326,31 @@ export async function sendThinkingMessage(
   } catch (err) {
     log.warn("Failed to send thinking message", { chatId, error: err });
     return undefined;
+  }
+}
+
+const QUEUED_MESSAGE =
+  "⏳ Run queued — concurrency limit reached. Will start automatically when a slot is available.";
+
+/**
+ * Update the thinking message to show queued status, or send a new message if
+ * no thinking message exists.
+ */
+export async function sendQueuedNotification(
+  client: TelegramClient,
+  chatId: string | number,
+  thinkingMessage: TelegramSentMessage | undefined,
+  options?: { replyToMessageId?: number },
+): Promise<void> {
+  if (thinkingMessage) {
+    await editMessageText(
+      client,
+      chatId,
+      thinkingMessage.message_id,
+      QUEUED_MESSAGE,
+    );
+  } else {
+    await sendMessage(client, chatId, QUEUED_MESSAGE, options);
   }
 }
 


### PR DESCRIPTION
## Summary
- When a Telegram run is queued, **edit** the thinking message in-place to show the queued status instead of sending a separate message
- On `progress` callback (run starts executing), edit the message back to "thinking..." state
- On completion/failure callback, the existing `thinkingMessageId` cleanup deletes the message automatically

No new DB columns or migrations needed — reuses the existing `thinkingMessageId` in `TelegramCallbackContext`.

## Test plan
- [ ] Trigger a queued run (concurrent limit) in Telegram group and DM
- [ ] Verify thinking message updates to queued text
- [ ] Verify queued message reverts to thinking when run starts
- [ ] Verify message is deleted when run completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)