### PR TITLE
fix(run): use runtime scope for artifact/memory storage

### DIFF
--- a/turbo/apps/web/app/api/agent/runs/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/route.ts
@@ -476,6 +476,7 @@ const router = tsr.router(runsMainContract, {
         modelProvider: body.modelProvider,
         checkEnv: body.checkEnv,
         scopeId: scope.id,
+        scopeSlug: scope.slug,
         scopeTier: scopeTierSchema.parse(scope.tier),
       });
 

--- a/turbo/apps/web/src/lib/email/handlers/inbound-reply.ts
+++ b/turbo/apps/web/src/lib/email/handlers/inbound-reply.ts
@@ -1,5 +1,6 @@
 import { eq } from "drizzle-orm";
 import { agentComposes } from "../../../db/schema/agent-compose";
+import { scopes } from "../../../db/schema/scope";
 import { getReceivedEmail } from "../client";
 import { processEmailAttachments } from "../attachment";
 import { extractEmailBody } from "../content-extract";
@@ -161,13 +162,16 @@ export async function handleInboundEmailReply(
     replyContent = `${replyContent}\n\n${attachmentText}`;
   }
 
-  // 10. Get compose to find agent name and version
+  // 10. Get compose to find agent name, version, and scope
   const [compose] = await globalThis.services.db
     .select({
       name: agentComposes.name,
       headVersionId: agentComposes.headVersionId,
+      scopeId: agentComposes.scopeId,
+      scopeSlug: scopes.slug,
     })
     .from(agentComposes)
+    .innerJoin(scopes, eq(agentComposes.scopeId, scopes.id))
     .where(eq(agentComposes.id, session.composeId))
     .limit(1);
 
@@ -207,6 +211,8 @@ export async function handleInboundEmailReply(
     sessionId: session.agentSessionId,
     agentName: compose.name,
     callbacks,
+    scopeId: compose.scopeId,
+    scopeSlug: compose.scopeSlug,
   });
 
   log.info("Dispatched agent run from email reply", {

--- a/turbo/apps/web/src/lib/email/handlers/inbound-trigger.ts
+++ b/turbo/apps/web/src/lib/email/handlers/inbound-trigger.ts
@@ -277,6 +277,8 @@ export async function handleInboundEmailTrigger(
     artifactName: "artifact",
     memoryName: "memory",
     callbacks,
+    scopeId: compose.scopeId,
+    scopeSlug: compose.scopeSlug,
   });
 
   log.info("Dispatched agent run from email trigger", {

--- a/turbo/apps/web/src/lib/email/handlers/shared.ts
+++ b/turbo/apps/web/src/lib/email/handlers/shared.ts
@@ -172,6 +172,7 @@ interface ResolvedAgent {
   composeId: string;
   userId: string;
   scopeId: string;
+  scopeSlug: string;
   headVersionId: string;
 }
 
@@ -218,6 +219,7 @@ export async function resolveAgentByAddress(
     composeId: compose.id,
     userId: compose.userId,
     scopeId: compose.scopeId,
+    scopeSlug,
     headVersionId: compose.headVersionId,
   };
 }

--- a/turbo/apps/web/src/lib/github/handlers/issue-event.ts
+++ b/turbo/apps/web/src/lib/github/handlers/issue-event.ts
@@ -7,6 +7,7 @@ import {
   agentComposes,
   agentComposeVersions,
 } from "../../../db/schema/agent-compose";
+import { scopes } from "../../../db/schema/scope";
 import { createRun, validateAgentSession } from "../../run";
 import { buildIntegrationContext } from "../../integration-context";
 import { generateCallbackSecret, getApiUrl } from "../../callback";
@@ -455,10 +456,17 @@ async function dispatchAgentRun(params: DispatchParams): Promise<void> {
 
   const vm0UserId = userLink.vm0UserId;
 
-  // 3. Resolve agent compose and version
+  // 3. Resolve agent compose and version (with scope slug for storage resolution)
   const [compose] = await globalThis.services.db
-    .select()
+    .select({
+      id: agentComposes.id,
+      name: agentComposes.name,
+      scopeId: agentComposes.scopeId,
+      scopeSlug: scopes.slug,
+      headVersionId: agentComposes.headVersionId,
+    })
     .from(agentComposes)
+    .innerJoin(scopes, eq(agentComposes.scopeId, scopes.id))
     .where(eq(agentComposes.id, installation.defaultComposeId))
     .limit(1);
 
@@ -533,6 +541,8 @@ async function dispatchAgentRun(params: DispatchParams): Promise<void> {
           payload: callbackContext,
         },
       ],
+      scopeId: compose.scopeId,
+      scopeSlug: compose.scopeSlug,
     });
 
     log.info("Agent run dispatched for GitHub issue", {

--- a/turbo/apps/web/src/lib/run/__tests__/create-run.test.ts
+++ b/turbo/apps/web/src/lib/run/__tests__/create-run.test.ts
@@ -15,6 +15,7 @@ import {
   findTestRunRecord,
   findTestRunCallbacks,
   findTestRunsByUserAndPrompt,
+  findTestStorage,
 } from "../../../__tests__/api-test-helpers";
 import { POST as checkpointWebhook } from "../../../../app/api/webhooks/agent/checkpoints/route";
 import type { AgentComposeYaml } from "../../../types/agent-compose";
@@ -683,6 +684,74 @@ describe("createRun()", () => {
       const result = await createRun(baseParams());
 
       expect(result.status).toBe("running");
+    });
+  });
+
+  describe("Scope Resolution for Storage", () => {
+    it("should use runtime scopeId for artifact/memory storage when scopeId is provided", async () => {
+      // Create a second scope (org scope) and make the user a member
+      const orgCompose = await context.createAgentCompose(user.userId, {
+        name: uniqueId("org-agent"),
+      });
+      const orgScopeId = orgCompose.scopeId;
+
+      // Use the default compose but pass org scope for storage resolution
+      const result = await createRun(
+        baseParams({
+          artifactName: "artifact",
+          memoryName: "memory",
+          scopeId: orgScopeId,
+          scopeSlug: uniqueId("org"), // slug used for S3 prefix (mocked in tests)
+        }),
+      );
+
+      expect(result.status).toBe("running");
+
+      // Verify the run record uses the org scope
+      const run = await findTestRunRecord(result.runId);
+      expect(run!.scopeId).toBe(orgScopeId);
+
+      // Verify artifact storage was created in the org scope (not user's default scope)
+      const artifact = await findTestStorage(
+        orgScopeId,
+        "artifact",
+        "artifact",
+      );
+      expect(artifact).toBeDefined();
+      expect(artifact!.userId).toBe(user.userId);
+
+      // Verify memory storage was created in the org scope
+      const memory = await findTestStorage(orgScopeId, "memory", "memory");
+      expect(memory).toBeDefined();
+      expect(memory!.userId).toBe(user.userId);
+    });
+
+    it("should use default scope for storage when scopeId is not provided", async () => {
+      const compose = await createTestCompose(uniqueId("agent"));
+
+      const result = await createRun(
+        baseParams({
+          agentComposeVersionId: compose.versionId,
+          artifactName: "artifact",
+          memoryName: "memory",
+        }),
+      );
+
+      expect(result.status).toBe("running");
+
+      // Verify artifact storage was created in user's default scope
+      const artifact = await findTestStorage(
+        user.scopeId,
+        "artifact",
+        "artifact",
+      );
+      expect(artifact).toBeDefined();
+      expect(artifact!.userId).toBe(user.userId);
+
+      // Verify memory storage was created in user's default scope
+      const memory = await findTestStorage(user.scopeId, "memory", "memory");
+      expect(memory).toBeDefined();
+      expect(memory!.userId).toBe(user.userId);
     });
   });
 });

--- a/turbo/apps/web/src/lib/run/build-context.ts
+++ b/turbo/apps/web/src/lib/run/build-context.ts
@@ -15,6 +15,7 @@ import {
   type ModelProviderFramework,
 } from "@vm0/core";
 import { agentComposeVersions } from "../../db/schema/agent-compose";
+import { scopes } from "../../db/schema/scope";
 import { badRequest, notFound } from "../errors";
 import { logger } from "../logger";
 import type { ExecutionContext, ResumeSession, UserScope } from "./types";
@@ -665,9 +666,11 @@ interface BuildContextParams {
   checkEnv?: boolean;
   // API start time for E2E timing metrics
   apiStartTime?: number;
-  // Caller-resolved scope ID for credential/variable resolution.
+  // Caller-resolved scope ID and slug for credential/variable/storage resolution.
+  // When provided, used for both credentials and storage (artifacts/memory).
   // When not provided, resolved via getDefaultScope fallback.
   scopeId?: string;
+  scopeSlug?: string;
 }
 
 /**
@@ -859,14 +862,13 @@ function applyResolutionDefaults(
 }
 
 /**
- * Resolve credential scope ID and user's default scope.
+ * Resolve credential scope ID and user scope for storage.
  *
  * The credential scope is used for secrets/variables/connectors.
  * The user scope is used for storage (artifacts, memory) in prepareForExecution.
- * They may differ when an org scope is explicitly selected via ?scope= param.
+ * Both use the same runtime scope when params.scopeId is provided.
  *
  * When params.scopeId is not provided, getDefaultScope serves both purposes.
- * When provided, the user scope is resolved in parallel with credential resolution.
  */
 async function resolveScopes(params: BuildContextParams): Promise<{
   credentialScopeId: string;
@@ -875,14 +877,26 @@ async function resolveScopes(params: BuildContextParams): Promise<{
     | { id: string; slug: string };
 }> {
   if (params.scopeId) {
-    // Credential scope is explicit (may be org scope).
-    // User's default scope (for storage) resolved later in parallel.
+    // Both credential scope and user scope use the explicit runtime scope.
+    // This ensures artifacts/memory are created in the same scope as credentials.
+    if (params.scopeSlug) {
+      return {
+        credentialScopeId: params.scopeId,
+        pendingUserScope: { id: params.scopeId, slug: params.scopeSlug },
+      };
+    }
+    // Fallback: query slug from DB when caller didn't provide it
     return {
       credentialScopeId: params.scopeId,
-      pendingUserScope: getDefaultScope(params.userId).then((r) => ({
-        id: r.scope.id,
-        slug: r.scope.slug,
-      })),
+      pendingUserScope: globalThis.services.db
+        .select({ slug: scopes.slug })
+        .from(scopes)
+        .where(eq(scopes.id, params.scopeId))
+        .limit(1)
+        .then(([result]) => ({
+          id: params.scopeId as string,
+          slug: result?.slug ?? "",
+        })),
     };
   }
   // No explicit scope — default scope serves both purposes

--- a/turbo/apps/web/src/lib/run/run-service.ts
+++ b/turbo/apps/web/src/lib/run/run-service.ts
@@ -319,9 +319,10 @@ export interface CreateRunParams {
   modelProvider?: string;
   debugNoMockClaude?: boolean;
   checkEnv?: boolean;
-  // Caller-resolved scope ID for variable resolution (org-aware).
-  // When provided, used instead of getUserScopeByClerkId fallback.
+  // Caller-resolved scope ID and slug for variable/storage resolution (org-aware).
+  // When provided, used instead of getDefaultScope fallback.
   scopeId?: string;
+  scopeSlug?: string;
   // Caller-resolved scope tier for concurrency limit derivation.
   scopeTier?: ScopeTier;
 }
@@ -525,6 +526,7 @@ async function buildAndDispatchRun(opts: {
   composeContent: AgentComposeYaml;
   apiStartTime: number;
   scopeId: string | undefined;
+  scopeSlug: string | undefined;
   authorizeTime: number;
   transactionTime: number;
 }): Promise<{ status: string; sandboxId?: string }> {
@@ -535,6 +537,7 @@ async function buildAndDispatchRun(opts: {
     composeContent,
     apiStartTime,
     scopeId,
+    scopeSlug,
     authorizeTime,
     transactionTime,
   } = opts;
@@ -579,6 +582,7 @@ async function buildAndDispatchRun(opts: {
       checkEnv: params.checkEnv,
       apiStartTime,
       scopeId,
+      scopeSlug,
     });
     const buildContextTime = Date.now();
 
@@ -695,8 +699,17 @@ export async function createRun(
     );
   }
 
-  // Resolve scope ID for the run record
-  const scopeId = params.scopeId ?? (await getDefaultScope(userId)).scope.id;
+  // Resolve scope ID and slug for the run record and storage
+  let scopeId: string;
+  let scopeSlug: string | undefined;
+  if (params.scopeId) {
+    scopeId = params.scopeId;
+    scopeSlug = params.scopeSlug;
+  } else {
+    const { scope } = await getDefaultScope(userId);
+    scopeId = scope.id;
+    scopeSlug = scope.slug;
+  }
 
   // Step 5: Concurrency check + INSERT in a transaction with advisory lock
   // to prevent TOCTOU race where two concurrent requests both pass the
@@ -737,7 +750,7 @@ export async function createRun(
     });
   } catch (error) {
     if (isConcurrentRunLimit(error)) {
-      return enqueueRun({ ...params, scopeId });
+      return enqueueRun({ ...params, scopeId, scopeSlug });
     }
     throw error;
   }
@@ -752,6 +765,7 @@ export async function createRun(
     composeContent,
     apiStartTime,
     scopeId,
+    scopeSlug,
     authorizeTime,
     transactionTime,
   });
@@ -835,6 +849,7 @@ export async function executeQueuedRun(
     composeContent,
     apiStartTime,
     scopeId: params.scopeId,
+    scopeSlug: params.scopeSlug,
     authorizeTime,
     transactionTime,
   });

--- a/turbo/apps/web/src/lib/schedule/schedule-service.ts
+++ b/turbo/apps/web/src/lib/schedule/schedule-service.ts
@@ -856,9 +856,9 @@ async function executeSchedule(
     return;
   }
 
-  // Load scope tier for concurrency limit
+  // Load scope tier and slug for concurrency limit and storage resolution
   const [scopeRecord] = await globalThis.services.db
-    .select({ tier: scopes.tier })
+    .select({ tier: scopes.tier, slug: scopes.slug })
     .from(scopes)
     .where(eq(scopes.id, compose.scopeId))
     .limit(1);
@@ -920,6 +920,7 @@ async function executeSchedule(
       agentName: compose.name,
       callbacks,
       scopeId: compose.scopeId,
+      scopeSlug: scopeRecord?.slug,
       scopeTier: scopeRecord
         ? scopeTierSchema.parse(scopeRecord.tier)
         : undefined,

--- a/turbo/apps/web/src/lib/slack/handlers/run-agent.ts
+++ b/turbo/apps/web/src/lib/slack/handlers/run-agent.ts
@@ -3,6 +3,7 @@ import {
   agentComposes,
   agentComposeVersions,
 } from "../../../db/schema/agent-compose";
+import { scopes } from "../../../db/schema/scope";
 import { createRun, isRunDispatchError } from "../../run";
 import { buildIntegrationContext } from "../../integration-context";
 import { queryAxiom, getDatasetName, DATASETS } from "../../axiom";
@@ -61,10 +62,16 @@ export async function runAgentForSlack(
   } = params;
 
   try {
-    // Get compose and latest version
+    // Get compose and latest version (with scope slug for storage resolution)
     const [compose] = await globalThis.services.db
-      .select()
+      .select({
+        id: agentComposes.id,
+        scopeId: agentComposes.scopeId,
+        scopeSlug: scopes.slug,
+        headVersionId: agentComposes.headVersionId,
+      })
       .from(agentComposes)
+      .innerJoin(scopes, eq(agentComposes.scopeId, scopes.id))
       .where(eq(agentComposes.id, composeId))
       .limit(1);
 
@@ -123,6 +130,8 @@ export async function runAgentForSlack(
           payload: callbackContext,
         },
       ],
+      scopeId: compose.scopeId,
+      scopeSlug: compose.scopeSlug,
     });
 
     const status = result.status === "queued" ? "queued" : "dispatched";

--- a/turbo/apps/web/src/lib/telegram/handlers/run-agent.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/run-agent.ts
@@ -3,6 +3,7 @@ import {
   agentComposes,
   agentComposeVersions,
 } from "../../../db/schema/agent-compose";
+import { scopes } from "../../../db/schema/scope";
 import { createRun, isRunDispatchError } from "../../run";
 import { buildIntegrationContext } from "../../integration-context";
 import { isConcurrentRunLimit } from "../../errors";
@@ -63,8 +64,14 @@ export async function runAgentForTelegram(
   } = params;
 
   const [compose] = await globalThis.services.db
-    .select()
+    .select({
+      id: agentComposes.id,
+      scopeId: agentComposes.scopeId,
+      scopeSlug: scopes.slug,
+      headVersionId: agentComposes.headVersionId,
+    })
     .from(agentComposes)
+    .innerJoin(scopes, eq(agentComposes.scopeId, scopes.id))
     .where(eq(agentComposes.id, composeId))
     .limit(1);
 
@@ -124,6 +131,8 @@ export async function runAgentForTelegram(
           payload: callbackContext,
         },
       ],
+      scopeId: compose.scopeId,
+      scopeSlug: compose.scopeSlug,
     });
 
     const status = result.status === "queued" ? "queued" : "dispatched";


### PR DESCRIPTION
## Summary

- Fix `resolveScopes()` in `build-context.ts` to use the explicit runtime `scopeId` for artifact/memory storage instead of `getDefaultScope(userId)` which always returns the user's personal workspace
- Plumb `scopeSlug` through all `createRun()` callers (API route, Slack, Telegram, GitHub, email, schedule handlers) so the correct scope slug is available for S3 storage paths
- Add integration tests verifying storage is created in the correct scope

## Problem

When a user runs an agent from an org scope (`?scope=acme`), artifacts and memory were incorrectly created in the user's personal scope. This happened because `resolveScopes()` used `getDefaultScope(userId)` for the storage scope, ignoring the runtime `scopeId` parameter.

## Changes

| File | Change |
|------|--------|
| `build-context.ts` | Fix `resolveScopes()` to use runtime `scopeId`/`scopeSlug` when provided |
| `run-service.ts` | Add `scopeSlug` to `CreateRunParams` and plumb through `buildAndDispatchRun` |
| `route.ts` (API) | Pass `scopeSlug` from authenticated scope |
| `slack/run-agent.ts` | Join scopes table, pass `scopeId`/`scopeSlug` |
| `telegram/run-agent.ts` | Join scopes table, pass `scopeId`/`scopeSlug` |
| `github/issue-event.ts` | Join scopes table, pass `scopeId`/`scopeSlug` |
| `email/inbound-*.ts` | Pass `scopeId`/`scopeSlug` from compose |
| `schedule-service.ts` | Include slug in scope query, pass to `createRun` |
| `create-run.test.ts` | Add scope resolution integration tests |

## Test plan

- [x] New integration tests verify storage uses runtime scope when `scopeId` provided
- [x] New integration tests verify storage uses default scope when `scopeId` omitted
- [x] Type check passes (`pnpm check-types --filter=web`)
- [x] Lint passes (`pnpm turbo run lint --filter=web`)
- [x] Format passes (`pnpm format`)
- [ ] CI pipeline checks

Closes #4026

🤖 Generated with [Claude Code](https://claude.com/claude-code)