### PR TITLE
refactor: remove one-admin-per-user constraint from scope creation

### DIFF
--- a/turbo/apps/web/app/api/scope/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/scope/__tests__/route.test.ts
@@ -158,12 +158,38 @@ describe("/api/scope", () => {
       expect(data.error.message).toContain("already exists");
     });
 
-    it("should reject duplicate scope creation for same user", async () => {
-      // Create a user and their first scope
-      const userId = `dup-test-user-${Date.now()}`;
+    it("should allow creating multiple scopes for same user", async () => {
+      const userId = `multi-scope-user-${Date.now()}`;
       mockClerk({ userId });
 
-      const slug1 = `dup-test-${Date.now()}`;
+      const slug1 = `scope-one-${Date.now()}`;
+      const request1 = createTestRequest("http://localhost:3000/api/scope", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ slug: slug1 }),
+      });
+      const response1 = await POST(request1);
+      expect(response1.status).toBe(201);
+
+      const slug2 = `scope-two-${Date.now()}`;
+      const request2 = createTestRequest("http://localhost:3000/api/scope", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ slug: slug2 }),
+      });
+      const response2 = await POST(request2);
+      const data2 = await response2.json();
+
+      expect(response2.status).toBe(201);
+      expect(data2.slug).toBe(slug2);
+    });
+
+    it("should return first scope as default after creating multiple", async () => {
+      const userId = `default-scope-user-${Date.now()}`;
+      mockClerk({ userId });
+
+      // Create first scope
+      const slug1 = `first-${Date.now()}`;
       const request1 = createTestRequest("http://localhost:3000/api/scope", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -171,17 +197,22 @@ describe("/api/scope", () => {
       });
       await POST(request1);
 
-      // Try to create another scope for same user
+      // Create second scope
+      const slug2 = `second-${Date.now()}`;
       const request2 = createTestRequest("http://localhost:3000/api/scope", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ slug: `${slug1}-2` }),
+        body: JSON.stringify({ slug: slug2 }),
       });
-      const response = await POST(request2);
+      await POST(request2);
+
+      // GET /api/scope should return the first (default) scope
+      const getRequest = createTestRequest("http://localhost:3000/api/scope");
+      const response = await GET(getRequest);
       const data = await response.json();
 
-      expect(response.status).toBe(409);
-      expect(data.error.message).toContain("already have a scope");
+      expect(response.status).toBe(200);
+      expect(data.slug).toBe(slug1);
     });
 
     describe("slug validation", () => {

--- a/turbo/apps/web/app/api/scope/route.ts
+++ b/turbo/apps/web/app/api/scope/route.ts
@@ -98,15 +98,6 @@ const router = tsr.router(scopeContract, {
       return { status: 201 as const, body: scopeToResponseBody(scope) };
     } catch (error) {
       if (isBadRequest(error)) {
-        // Check if it's a conflict error (user already has scope)
-        if (error.message.includes("already have a scope")) {
-          return {
-            status: 409 as const,
-            body: {
-              error: { message: error.message, code: "CONFLICT" },
-            },
-          };
-        }
         return createErrorResponse("BAD_REQUEST", error.message);
       }
       throw error;

--- a/turbo/apps/web/src/lib/scope/scope-service.ts
+++ b/turbo/apps/web/src/lib/scope/scope-service.ts
@@ -3,11 +3,7 @@ import { eq } from "drizzle-orm";
 import { clerkClient } from "@clerk/nextjs/server";
 import { scopes } from "../../db/schema/scope";
 import { scopeMembers } from "../../db/schema/scope-member";
-import {
-  requireScopeMember,
-  getPrimaryAdminMembership,
-  getDefaultScope,
-} from "./scope-member-service";
+import { requireScopeMember, getDefaultScope } from "./scope-member-service";
 import {
   badRequest,
   notFound,
@@ -110,7 +106,7 @@ export async function getScopeBySlug(slug: string) {
  *
  * Merges the former createUserScope() and createOrganization() functions.
  * Handles Clerk org creation (or self-hosted fallback), slug validation,
- * one-admin-per-user constraint, and atomic scope + membership creation.
+ * and atomic scope + membership creation.
  *
  * @param options.skipSlugValidation - Skip reserved-slug checks (for vm0-admin bypass)
  */
@@ -119,19 +115,6 @@ export async function createScope(
   slug: string,
   options?: { skipSlugValidation?: boolean },
 ) {
-  // Check one-admin-per-user constraint
-  const existingAdmin = await getPrimaryAdminMembership(clerkUserId);
-  if (existingAdmin) {
-    const [existingScope] = await globalThis.services.db
-      .select({ slug: scopes.slug })
-      .from(scopes)
-      .where(eq(scopes.id, existingAdmin.scopeId))
-      .limit(1);
-    throw badRequest(
-      `You already have a scope: ${existingScope?.slug ?? existingAdmin.scopeId}. Use --force to change it.`,
-    );
-  }
-
   // Validate slug (unless explicitly skipped for vm0-admin)
   if (!options?.skipSlugValidation) {
     validateScopeSlug(slug);


### PR DESCRIPTION
## Summary
- Remove the `getPrimaryAdminMembership()` check from `createScope()` that enforced one-admin-per-user constraint
- Remove the 409 CONFLICT response handling in `POST /api/scope` for "already have a scope"
- Replace constraint test with multi-scope creation test and `getDefaultScope()` regression test

Closes #4032

## Test plan
- [x] Verify creating a second scope for the same user succeeds (previously returned 409)
- [x] Verify `getDefaultScope()` still returns the first admin scope correctly
- [x] Verify all existing tests pass (23/23)
- [x] Type check, lint, format, knip all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)