### PR TITLE
feat(auth): extract org id and org slug from clerk auth session

### DIFF
--- a/turbo/apps/web/src/__tests__/clerk-mock.ts
+++ b/turbo/apps/web/src/__tests__/clerk-mock.ts
@@ -34,12 +34,21 @@ const mockClerkClient = vi.mocked(clerkClient);
  * @param options - Auth configuration
  * @param options.userId - User ID to return, or null for unauthenticated
  * @param options.email - Email address for the user (default: "test@example.com")
+ * @param options.orgId - Organization ID from active org session (optional)
+ * @param options.orgSlug - Organization slug from active org session (optional)
  */
-export function mockClerk(options: { userId: string | null; email?: string }) {
+export function mockClerk(options: {
+  userId: string | null;
+  email?: string;
+  orgId?: string | null;
+  orgSlug?: string | null;
+}) {
   const email = options.email ?? "test@example.com";
 
   mockAuth.mockResolvedValue({
     userId: options.userId,
+    orgId: options.orgId,
+    orgSlug: options.orgSlug,
   } as Awaited<ReturnType<typeof auth>>);
 
   // Also set up clerkClient mock to return user data with email

--- a/turbo/apps/web/src/lib/auth/__tests__/auth-provider.spec.ts
+++ b/turbo/apps/web/src/lib/auth/__tests__/auth-provider.spec.ts
@@ -65,6 +65,54 @@ describe("AuthProvider", () => {
       expect(email).toBe("primary@example.com");
     });
 
+    it("should return orgId from Clerk session", async () => {
+      mockAuth.mockResolvedValue({
+        userId: "clerk_user_123",
+        orgId: "org_abc",
+      } as Awaited<ReturnType<typeof auth>>);
+
+      const provider = getAuthProvider();
+      const orgId = await provider.getOrgId();
+
+      expect(orgId).toBe("org_abc");
+    });
+
+    it("should return null when no active org", async () => {
+      mockAuth.mockResolvedValue({
+        userId: "clerk_user_123",
+        orgId: undefined,
+      } as Awaited<ReturnType<typeof auth>>);
+
+      const provider = getAuthProvider();
+      const orgId = await provider.getOrgId();
+
+      expect(orgId).toBeNull();
+    });
+
+    it("should return orgSlug from Clerk session", async () => {
+      mockAuth.mockResolvedValue({
+        userId: "clerk_user_123",
+        orgSlug: "my-org",
+      } as Awaited<ReturnType<typeof auth>>);
+
+      const provider = getAuthProvider();
+      const orgSlug = await provider.getOrgSlug();
+
+      expect(orgSlug).toBe("my-org");
+    });
+
+    it("should return null orgSlug when no active org", async () => {
+      mockAuth.mockResolvedValue({
+        userId: "clerk_user_123",
+        orgSlug: undefined,
+      } as Awaited<ReturnType<typeof auth>>);
+
+      const provider = getAuthProvider();
+      const orgSlug = await provider.getOrgSlug();
+
+      expect(orgSlug).toBeNull();
+    });
+
     it("should return empty string when no email found", async () => {
       mockClerkClient.mockResolvedValue({
         users: {
@@ -115,6 +163,20 @@ describe("AuthProvider", () => {
       await provider.getUserId();
 
       expect(mockAuth).not.toHaveBeenCalled();
+    });
+
+    it("should return null for orgId", async () => {
+      const provider = getAuthProvider();
+      const orgId = await provider.getOrgId();
+
+      expect(orgId).toBeNull();
+    });
+
+    it("should return null for orgSlug", async () => {
+      const provider = getAuthProvider();
+      const orgSlug = await provider.getOrgSlug();
+
+      expect(orgSlug).toBeNull();
     });
 
     it("should return consistent values on repeated calls", async () => {

--- a/turbo/apps/web/src/lib/auth/auth-provider.ts
+++ b/turbo/apps/web/src/lib/auth/auth-provider.ts
@@ -12,6 +12,8 @@ export { SELF_HOSTED_USER_ID } from "./constants";
  */
 interface AuthProvider {
   getUserId(): Promise<string | null>;
+  getOrgId(): Promise<string | null>;
+  getOrgSlug(): Promise<string | null>;
   getUserEmail(userId: string): Promise<string>;
   getUserIdByEmail(email: string): Promise<string | null>;
 }
@@ -24,6 +26,16 @@ function createClerkAuthProvider(): AuthProvider {
     async getUserId() {
       const { userId } = await auth();
       return userId;
+    },
+
+    async getOrgId() {
+      const { orgId } = await auth();
+      return orgId ?? null;
+    },
+
+    async getOrgSlug() {
+      const { orgSlug } = await auth();
+      return orgSlug ?? null;
     },
 
     async getUserEmail(userId: string) {
@@ -51,6 +63,14 @@ function createLocalAuthProvider(): AuthProvider {
   return {
     async getUserId() {
       return SELF_HOSTED_USER_ID;
+    },
+
+    async getOrgId() {
+      return null;
+    },
+
+    async getOrgSlug() {
+      return null;
     },
 
     async getUserEmail() {


### PR DESCRIPTION
## Summary

- Add `getOrgId()` and `getOrgSlug()` methods to the `AuthProvider` interface
- Implement in `ClerkAuthProvider` (reads from Clerk session token) and `LocalAuthProvider` (returns null)
- Extend `mockClerk()` test helper to support optional `orgId`/`orgSlug` fields

Purely additive — no existing code paths are modified. These methods will be consumed by subsequent PRs for clerkOrgId-based scope resolution (#4023).

Closes #4034

## Test plan

- [x] ClerkAuthProvider returns orgId/orgSlug from Clerk session
- [x] ClerkAuthProvider returns null when no active org (undefined → null normalization)
- [x] LocalAuthProvider returns null for both methods
- [x] All 15 tests passing (6 new + 9 existing)
- [x] Lint, format, knip all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)