### PR TITLE
feat: add scope lookup by clerk organization id

### DIFF
--- a/turbo/apps/web/src/lib/scope/__tests__/scope-service.test.ts
+++ b/turbo/apps/web/src/lib/scope/__tests__/scope-service.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { testContext, uniqueId } from "../../../__tests__/test-helpers";
+import { createTestScope } from "../../../__tests__/api-test-helpers";
+import { mockClerk } from "../../../__tests__/clerk-mock";
+import { reloadEnv } from "../../../env";
+import { getScopeByClerkOrgId } from "../scope-service";
+import { SELF_HOSTED_CLERK_ORG_ID } from "../../auth/constants";
+
+const context = testContext();
+
+describe("getScopeByClerkOrgId", () => {
+  beforeEach(() => {
+    context.setupMocks();
+  });
+
+  it("should return scope for valid clerkOrgId", async () => {
+    const userId = uniqueId("test-user");
+    const slug = uniqueId("scope");
+    mockClerk({ userId });
+
+    const created = await createTestScope(slug);
+
+    // Clerk mock generates clerkOrgId as "org_mock_{slug}"
+    const result = await getScopeByClerkOrgId(`org_mock_${slug}`);
+
+    expect(result).not.toBeNull();
+    expect(result!.id).toBe(created.id);
+    expect(result!.slug).toBe(slug);
+  });
+
+  it("should return null for non-existent clerkOrgId", async () => {
+    const result = await getScopeByClerkOrgId("org_nonexistent_xyz");
+
+    expect(result).toBeNull();
+  });
+
+  it("should handle self-hosted sentinel org_self_hosted", async () => {
+    // Simulate self-hosted mode by removing Clerk keys
+    vi.stubEnv("NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY", "");
+    vi.stubEnv("CLERK_SECRET_KEY", "");
+    reloadEnv();
+
+    const userId = uniqueId("test-user");
+    const slug = uniqueId("scope");
+    mockClerk({ userId });
+
+    await createTestScope(slug);
+
+    const result = await getScopeByClerkOrgId(SELF_HOSTED_CLERK_ORG_ID);
+
+    expect(result).not.toBeNull();
+    expect(result!.clerkOrgId).toBe(SELF_HOSTED_CLERK_ORG_ID);
+  });
+});

--- a/turbo/apps/web/src/lib/scope/scope-service.ts
+++ b/turbo/apps/web/src/lib/scope/scope-service.ts
@@ -106,6 +106,19 @@ export async function getScopeBySlug(slug: string) {
 }
 
 /**
+ * Get a scope by its Clerk organization ID
+ */
+export async function getScopeByClerkOrgId(clerkOrgId: string) {
+  const result = await globalThis.services.db
+    .select()
+    .from(scopes)
+    .where(eq(scopes.clerkOrgId, clerkOrgId))
+    .limit(1);
+
+  return result[0] ?? null;
+}
+
+/**
  * Create a scope for a user with an admin membership.
  *
  * Merges the former createUserScope() and createOrganization() functions.


### PR DESCRIPTION
## Summary

- Add `getScopeByClerkOrgId(clerkOrgId: string)` function to `scope-service.ts`, mirroring the existing `getScopeBySlug()` pattern
- Add integration tests covering valid lookup, non-existent ID, and self-hosted sentinel value
- Part of Clerk-as-source-of-truth incremental migration (#4023)

Closes #4033

## Test plan

- [x] Lookup by valid clerkOrgId returns the correct scope
- [x] Lookup by non-existent clerkOrgId returns null
- [x] Self-hosted sentinel `org_self_hosted` works correctly
- [x] All pre-commit checks pass (lint, format, knip, commitlint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)