### PR TITLE
feat(env): auto-configure runner group in sync-env.sh

### DIFF
--- a/scripts/sync-env.sh
+++ b/scripts/sync-env.sh
@@ -25,14 +25,16 @@ sync_with_1password() {
 
   echo "Syncing all environment templates..."
 
-  find "$PROJECT_ROOT" -name ".env.local.tpl" -type f | while IFS= read -r tpl_file; do
+  while IFS= read -r tpl_file; do
     output_file="${tpl_file%.tpl}"
     echo ""
     echo "Syncing: $tpl_file"
     echo "Output:  $output_file"
+    save_runner_group "$output_file"
     op inject --force -i "$tpl_file" -o "$output_file"
+    restore_runner_group "$output_file"
     echo "✓ Synced successfully"
-  done
+  done < <(find "$PROJECT_ROOT" -name ".env.local.tpl" -type f)
 
   echo ""
   echo "✓ All environment variables synced successfully"
@@ -135,12 +137,78 @@ sync_with_manual_input() {
   echo "Press Enter to skip optional variables or use auto-generated defaults."
   echo ""
 
-  find "$PROJECT_ROOT" -name ".env.local.tpl" -type f | while IFS= read -r tpl_file; do
+  while IFS= read -r tpl_file; do
+    save_runner_group "${tpl_file%.tpl}"
     process_tpl_manually "$tpl_file"
-  done
+    restore_runner_group "${tpl_file%.tpl}"
+  done < <(find "$PROJECT_ROOT" -name ".env.local.tpl" -type f)
 
   echo ""
   echo "✓ All environment variables synced successfully"
+}
+
+# --- Computed variables ---
+# RUNNER_DEFAULT_GROUP is derived from user input rather than stored in 1Password.
+# It must survive template overwrites (both op inject and manual flow).
+_SAVED_RUNNER_GROUP=""
+
+# Save RUNNER_DEFAULT_GROUP from an env file before it gets overwritten.
+save_runner_group() {
+  local env_file="$1"
+  [[ -f "$env_file" ]] || return 0
+  _SAVED_RUNNER_GROUP=$(grep "^RUNNER_DEFAULT_GROUP=" "$env_file" 2>/dev/null | head -1 | cut -d= -f2-) || true
+}
+
+# Restore saved RUNNER_DEFAULT_GROUP back into the env file.
+restore_runner_group() {
+  local env_file="$1"
+  [[ -f "$env_file" ]] || return 0
+  [[ -z "$_SAVED_RUNNER_GROUP" ]] && return 0
+  if ! grep -q "^RUNNER_DEFAULT_GROUP=" "$env_file" 2>/dev/null; then
+    echo "" >> "$env_file"
+    echo "# Self-hosted Runner" >> "$env_file"
+    echo "RUNNER_DEFAULT_GROUP=${_SAVED_RUNNER_GROUP}" >> "$env_file"
+  fi
+}
+
+configure_runner_group() {
+  local web_env="$PROJECT_ROOT/turbo/apps/web/.env.local"
+  [[ -f "$web_env" ]] || return 0
+
+  local existing
+  existing=$(grep "^RUNNER_DEFAULT_GROUP=" "$web_env" 2>/dev/null | head -1 | cut -d= -f2-) || true
+
+  if [[ -n "$existing" ]]; then
+    echo "  ✓ RUNNER_DEFAULT_GROUP=$existing (already set)"
+    return 0
+  fi
+
+  echo ""
+  echo "Enter your name for the runner group (e.g. alice)."
+  echo "This sets RUNNER_DEFAULT_GROUP=vm0/local-<name> to route sandbox runs to your runner."
+
+  while true; do
+    printf "  Your name: "
+    read -r dev_name </dev/tty
+
+    if [[ -z "$dev_name" ]]; then
+      echo "  ✗ Name is required"
+      continue
+    fi
+
+    # Validate: only lowercase letters, digits, and hyphens, must start/end with alphanumeric
+    if [[ ! "$dev_name" =~ ^[a-z0-9][a-z0-9-]*[a-z0-9]$|^[a-z0-9]{1,2}$ ]]; then
+      echo "  ✗ Only lowercase letters, digits, and hyphens allowed, must start/end with alphanumeric"
+      continue
+    fi
+
+    break
+  done
+
+  echo "" >> "$web_env"
+  echo "# Self-hosted Runner" >> "$web_env"
+  echo "RUNNER_DEFAULT_GROUP=vm0/local-${dev_name}" >> "$web_env"
+  echo "  ✓ RUNNER_DEFAULT_GROUP=vm0/local-${dev_name}"
 }
 
 # --- Main ---
@@ -152,3 +220,5 @@ if [[ "$use_1password" =~ ^[Yy] ]]; then
 else
   sync_with_manual_input
 fi
+
+configure_runner_group

--- a/scripts/sync-env.sh
+++ b/scripts/sync-env.sh
@@ -151,10 +151,12 @@ sync_with_manual_input() {
 # RUNNER_DEFAULT_GROUP is derived from user input rather than stored in 1Password.
 # It must survive template overwrites (both op inject and manual flow).
 _SAVED_RUNNER_GROUP=""
+WEB_ENV_LOCAL="$PROJECT_ROOT/turbo/apps/web/.env.local"
 
 # Save RUNNER_DEFAULT_GROUP from an env file before it gets overwritten.
 save_runner_group() {
   local env_file="$1"
+  _SAVED_RUNNER_GROUP=""
   [[ -f "$env_file" ]] || return 0
   _SAVED_RUNNER_GROUP=$(grep "^RUNNER_DEFAULT_GROUP=" "$env_file" 2>/dev/null | head -1 | cut -d= -f2-) || true
 }
@@ -172,11 +174,10 @@ restore_runner_group() {
 }
 
 configure_runner_group() {
-  local web_env="$PROJECT_ROOT/turbo/apps/web/.env.local"
-  [[ -f "$web_env" ]] || return 0
+  [[ -f "$WEB_ENV_LOCAL" ]] || return 0
 
   local existing
-  existing=$(grep "^RUNNER_DEFAULT_GROUP=" "$web_env" 2>/dev/null | head -1 | cut -d= -f2-) || true
+  existing=$(grep "^RUNNER_DEFAULT_GROUP=" "$WEB_ENV_LOCAL" 2>/dev/null | head -1 | cut -d= -f2-) || true
 
   if [[ -n "$existing" ]]; then
     echo "  ✓ RUNNER_DEFAULT_GROUP=$existing (already set)"
@@ -205,9 +206,9 @@ configure_runner_group() {
     break
   done
 
-  echo "" >> "$web_env"
-  echo "# Self-hosted Runner" >> "$web_env"
-  echo "RUNNER_DEFAULT_GROUP=vm0/local-${dev_name}" >> "$web_env"
+  echo "" >> "$WEB_ENV_LOCAL"
+  echo "# Self-hosted Runner" >> "$WEB_ENV_LOCAL"
+  echo "RUNNER_DEFAULT_GROUP=vm0/local-${dev_name}" >> "$WEB_ENV_LOCAL"
   echo "  ✓ RUNNER_DEFAULT_GROUP=vm0/local-${dev_name}"
 }
 

--- a/turbo/apps/web/.env.local.tpl
+++ b/turbo/apps/web/.env.local.tpl
@@ -170,3 +170,7 @@ GITHUB_APP_ID=op://Development/github/GITHUB_APP_ID
 GITHUB_APP_PRIVATE_KEY=op://Development/github/GITHUB_APP_PRIVATE_KEY
 GITHUB_APP_SLUG=op://Development/github/GITHUB_APP_SLUG
 GITHUB_APP_WEBHOOK_SECRET=op://Development/github/GITHUB_APP_WEBHOOK_SECRET
+
+# Optional: Self-hosted Runner (for local development with runner on dev-1)
+# RUNNER_DEFAULT_GROUP is auto-configured by sync-env.sh — do not add here
+OFFICIAL_RUNNER_SECRET=op://Development/vm0/OFFICIAL_RUNNER_SECRET


### PR DESCRIPTION
## Summary
- Add `RUNNER_DEFAULT_GROUP` interactive configuration to `sync-env.sh` — prompts for developer name and generates `vm0/local-<name>`
- Save/restore computed variables across `op inject --force` and manual template overwrites so the value persists on re-runs
- Add `OFFICIAL_RUNNER_SECRET` to `.env.local.tpl` for 1Password injection

## Test plan
- [ ] Run `scripts/sync-env.sh` (1Password flow) — verify runner group prompt appears and value is written to `.env.local`
- [ ] Run `scripts/sync-env.sh` again — verify existing value is preserved ("already set")
- [ ] Run `scripts/sync-env.sh` (manual flow) — verify same behavior
- [ ] Test input validation: empty input loops, invalid chars rejected, valid name accepted

🤖 Generated with [Claude Code](https://claude.com/claude-code)