### PR TITLE
feat(scope): extend resolve-scope to support clerk org id resolution

### DIFF
--- a/turbo/apps/web/app/api/scope/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/scope/__tests__/route.test.ts
@@ -429,4 +429,75 @@ describe("/api/scope", () => {
       expect(data.slug).toBeDefined();
     });
   });
+
+  describe("GET /api/scope (clerkOrgId resolution)", () => {
+    it("should resolve scope by clerkOrgId from session", async () => {
+      const userId = `clerk-org-test-${Date.now()}`;
+      mockClerk({ userId });
+
+      // Create first scope (becomes default)
+      const slug1 = `first-org-${Date.now()}`;
+      const req1 = createTestRequest("http://localhost:3000/api/scope", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ slug: slug1 }),
+      });
+      await POST(req1);
+
+      // Create second scope
+      const slug2 = `second-org-${Date.now()}`;
+      const req2 = createTestRequest("http://localhost:3000/api/scope", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ slug: slug2 }),
+      });
+      await POST(req2);
+
+      // Set active org to second scope's clerkOrgId
+      mockClerk({ userId, orgId: `org_mock_${slug2}` });
+
+      const request = createTestRequest("http://localhost:3000/api/scope");
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.slug).toBe(slug2);
+    });
+
+    it("should fall through to default when clerkOrgId has no matching scope", async () => {
+      const userId = `no-match-org-${Date.now()}`;
+      mockClerk({ userId });
+
+      // Create a default scope
+      const slug = `default-org-${Date.now()}`;
+      const reqCreate = createTestRequest("http://localhost:3000/api/scope", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ slug }),
+      });
+      await POST(reqCreate);
+
+      // Set an orgId that doesn't match any scope
+      mockClerk({ userId, orgId: "org_nonexistent_xyz" });
+
+      const request = createTestRequest("http://localhost:3000/api/scope");
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.slug).toBe(slug);
+    });
+
+    it("should work without orgId (CLI / self-hosted compatibility)", async () => {
+      const userId = `no-org-${Date.now()}`;
+      mockClerk({ userId });
+
+      const request = createTestRequest("http://localhost:3000/api/scope");
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.slug).toMatch(/^user-[a-f0-9]{8}$/);
+    });
+  });
 });

--- a/turbo/apps/web/app/api/scope/route.ts
+++ b/turbo/apps/web/app/api/scope/route.ts
@@ -13,6 +13,7 @@ import {
   ensureDefaultScope,
 } from "../../../src/lib/scope/scope-service";
 import { getUserEmail } from "../../../src/lib/auth/get-user-email";
+import { getAuthProvider } from "../../../src/lib/auth/auth-provider";
 import { resolveScope } from "../../../src/lib/scope/resolve-scope";
 import { logger } from "../../../src/lib/logger";
 import { isBadRequest, isForbidden, isNotFound } from "../../../src/lib/errors";
@@ -39,7 +40,7 @@ const router = tsr.router(scopeContract, {
   /**
    * GET /api/scope - Get current user's scope
    *
-   * Resolves the active scope via ?scope=<slug> query param,
+   * Resolves the active scope via clerkOrgId from Clerk session,
    * or falls back to the user's default scope (first admin membership).
    */
   get: async ({ headers }) => {
@@ -50,8 +51,10 @@ const router = tsr.router(scopeContract, {
       return createErrorResponse("UNAUTHORIZED", "Not authenticated");
     }
 
+    const orgId = await getAuthProvider().getOrgId();
+
     try {
-      const { scope } = await resolveScope(userId);
+      const { scope } = await resolveScope(userId, undefined, orgId);
 
       return { status: 200 as const, body: scopeToResponseBody(scope) };
     } catch (error) {

--- a/turbo/apps/web/app/api/scope/route.ts
+++ b/turbo/apps/web/app/api/scope/route.ts
@@ -110,7 +110,7 @@ const router = tsr.router(scopeContract, {
   /**
    * PUT /api/scope - Update active scope slug
    *
-   * Resolves the active scope via ?scope=<slug> query param,
+   * Resolves the active scope via clerkOrgId from Clerk session,
    * or falls back to the user's default scope (first admin membership).
    */
   update: async ({ body, headers }) => {
@@ -122,12 +122,13 @@ const router = tsr.router(scopeContract, {
     }
 
     const { slug, force } = body;
+    const orgId = await getAuthProvider().getOrgId();
 
     log.debug("updating scope", { userId, slug, force });
 
     let existingScope;
     try {
-      ({ scope: existingScope } = await resolveScope(userId));
+      ({ scope: existingScope } = await resolveScope(userId, undefined, orgId));
     } catch (error) {
       if (isNotFound(error)) {
         return createErrorResponse(

--- a/turbo/apps/web/src/lib/scope/resolve-scope.ts
+++ b/turbo/apps/web/src/lib/scope/resolve-scope.ts
@@ -4,7 +4,7 @@ import { hasClerkAuth } from "../../env";
 import { isForbidden, badRequest, notFound } from "../errors";
 import { logger } from "../logger";
 import { scopeRoleSchema } from "@vm0/core";
-import { getScopeBySlug } from "./scope-service";
+import { getScopeBySlug, getScopeByClerkOrgId } from "./scope-service";
 import {
   requireScopeMember,
   getDefaultScope,
@@ -98,14 +98,20 @@ async function requireMemberWithClerkSync(scope: Scope, userId: string) {
  * Resolve scope from request context using scope_members.
  *
  * Resolution order:
- * 1. ?scope=<slug> query param -> look up scope, verify membership
+ * 1. scopeSlug (?scope=<slug> query param) -> look up scope, verify membership
  *    - If not in scope_members, try to sync from Clerk org membership
- * 2. Fallback -> user's default scope (first owned scope from scope_members)
+ * 2. clerkOrgId (from Clerk session token) -> look up scope by org ID
+ *    - Falls through to default if no matching scope exists yet
+ * 3. Fallback -> user's default scope (first owned scope from scope_members)
  *
  * Returns { scope, member } for the resolved scope.
  */
-export async function resolveScope(userId: string, scopeSlug?: string | null) {
-  // 1. Explicit scope selection via ?scope= query param
+export async function resolveScope(
+  userId: string,
+  scopeSlug?: string | null,
+  clerkOrgId?: string | null,
+) {
+  // 1. Explicit scope selection via ?scope= query param (highest priority)
   if (scopeSlug) {
     const scope = await getScopeBySlug(scopeSlug);
     if (!scope) throw notFound("Scope not found");
@@ -114,7 +120,18 @@ export async function resolveScope(userId: string, scopeSlug?: string | null) {
     return { scope, member };
   }
 
-  // 2. Default scope fallback
+  // 2. Clerk org ID from session token
+  if (clerkOrgId) {
+    const scope = await getScopeByClerkOrgId(clerkOrgId);
+    if (scope) {
+      const member = await requireMemberWithClerkSync(scope, userId);
+      return { scope, member };
+    }
+    // Scope not found for this clerkOrgId — fall through to default
+    // (scope may not be created yet in the migration period)
+  }
+
+  // 3. Default scope fallback
   return getDefaultScope(userId);
 }
 


### PR DESCRIPTION
## Summary

- Add `clerkOrgId` as third optional parameter to `resolveScope()` with resolution priority: `scopeSlug` > `clerkOrgId` > default
- Wire up `GET /api/scope` to pass `orgId` from Clerk session as proof of concept
- Add integration tests for clerkOrgId resolution, fallback, and CLI compatibility

Closes #4040

## Test plan

- [x] Scope resolves correctly when clerkOrgId matches a scope (selects non-default scope)
- [x] Falls through to default scope when clerkOrgId has no matching scope
- [x] CLI/self-hosted requests (no orgId) continue working via default scope
- [x] All 26 existing scope route tests pass (no regression)
- [x] Lint, type-check, format, and knip all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)