### PR TITLE
feat(connectors): add experimental connectors data pipeline

### DIFF
--- a/crates/runner/src/cmd/benchmark.rs
+++ b/crates/runner/src/cmd/benchmark.rs
@@ -178,6 +178,7 @@ async fn run_sandbox(
         mitm_enabled: false,
         seal_secrets_enabled: false,
         network_log_path: &network_log_path,
+        connectors: None,
     };
     if let Err(e) = mitm.register_vm(&source_ip, &registration).await {
         warn!(error = %e, "failed to register VM in proxy");

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -107,25 +107,34 @@ async fn execute_inner(
     }
     telemetry.record("vm_create", t.elapsed(), true, None);
 
-    // Register VM in proxy registry (only when firewall is enabled)
+    // Register VM in proxy registry when firewall is enabled or connectors are present
     let source_ip = sandbox.source_ip().to_string();
     let firewall_enabled = context
         .experimental_firewall
         .as_ref()
         .is_some_and(|fw| fw.enabled);
+    let has_connectors = context
+        .experimental_connectors
+        .as_ref()
+        .is_some_and(|c| !c.connectors.is_empty());
+    let proxy_registered = firewall_enabled || has_connectors;
     let network_log_path = config.log_paths.network_log(context.run_id);
 
-    if let Some(fw) = &context.experimental_firewall
-        && fw.enabled
-    {
+    if proxy_registered {
+        let fw = context.experimental_firewall.as_ref();
+        let fw_mitm = fw.is_some_and(|f| f.experimental_mitm.unwrap_or(false));
+        // Connectors require MITM for header injection
+        let mitm_enabled = fw_mitm || has_connectors;
+
         let run_id_str = context.run_id.to_string();
         let registration = proxy::VmRegistration {
             run_id: &run_id_str,
             sandbox_token: &context.sandbox_token,
-            firewall_rules: fw.rules.as_deref().unwrap_or(&[]),
-            mitm_enabled: fw.experimental_mitm.unwrap_or(false),
-            seal_secrets_enabled: fw.experimental_seal_secrets.unwrap_or(false),
+            firewall_rules: fw.and_then(|f| f.rules.as_deref()).unwrap_or(&[]),
+            mitm_enabled,
+            seal_secrets_enabled: fw.is_some_and(|f| f.experimental_seal_secrets.unwrap_or(false)),
             network_log_path: &network_log_path,
+            connectors: context.experimental_connectors.as_ref(),
         };
         if let Err(e) = config.registry.register_vm(&source_ip, &registration).await {
             warn!(run_id = %context.run_id, error = %e, "failed to register VM in proxy");
@@ -140,7 +149,7 @@ async fn execute_inner(
 
     // Unregister VM from proxy + upload network logs before cleanup timer.
     // Unregister first ensures the addon writes no more log entries.
-    if firewall_enabled {
+    if proxy_registered {
         if let Err(e) = config.registry.unregister_vm(&source_ip).await {
             warn!(run_id = %context.run_id, error = %e, "failed to unregister VM from proxy");
         }
@@ -575,9 +584,16 @@ fn build_env_json(context: &ExecutionContext, api_url: &str) -> HashMap<String, 
 
     // Tell Node.js to trust the proxy CA when MITM mode is enabled.
     // The certificate is pre-baked into the rootfs at build time.
-    if let Some(fw) = &context.experimental_firewall
-        && fw.experimental_mitm.unwrap_or(false)
-    {
+    // Connectors also require MITM for header injection.
+    let mitm_needed = context
+        .experimental_firewall
+        .as_ref()
+        .is_some_and(|fw| fw.experimental_mitm.unwrap_or(false))
+        || context
+            .experimental_connectors
+            .as_ref()
+            .is_some_and(|c| !c.connectors.is_empty());
+    if mitm_needed {
         env.insert("NODE_EXTRA_CA_CERTS".into(), VM_PROXY_CA_PATH.into());
     }
 
@@ -655,6 +671,7 @@ mod tests {
             secret_values: None,
             cli_agent_type: String::new(),
             experimental_firewall: None,
+            experimental_connectors: None,
             debug_no_mock_claude: None,
             api_start_time: None,
             user_timezone: None,

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -987,6 +987,71 @@ mod tests {
     }
 
     #[test]
+    fn build_env_json_connectors_enable_ca_certs() {
+        let mut ctx = minimal_context();
+        ctx.experimental_connectors = Some(crate::types::ExperimentalConnectors {
+            connectors: vec![crate::types::ConnectorEntry {
+                name: "gmail".into(),
+                targets: vec!["https://gmail.googleapis.com/gmail/v1/users/me".into()],
+                placeholder: "vm0_conn_gmail".into(),
+                auth: crate::types::ConnectorAuth {
+                    headers: [("Authorization".into(), "Bearer ${token}".into())]
+                        .into_iter()
+                        .collect(),
+                },
+            }],
+        });
+        let env = build_env_json(&ctx, "http://localhost");
+        assert_eq!(env.get("NODE_EXTRA_CA_CERTS").unwrap(), VM_PROXY_CA_PATH);
+    }
+
+    #[test]
+    fn build_env_json_empty_connectors_no_ca_certs() {
+        let mut ctx = minimal_context();
+        ctx.experimental_connectors =
+            Some(crate::types::ExperimentalConnectors { connectors: vec![] });
+        let env = build_env_json(&ctx, "http://localhost");
+        assert!(!env.contains_key("NODE_EXTRA_CA_CERTS"));
+    }
+
+    #[test]
+    fn execution_context_deserializes_with_connectors() {
+        let json = serde_json::json!({
+            "runId": "00000000-0000-0000-0000-000000000001",
+            "prompt": "test",
+            "sandboxToken": "tok",
+            "workingDir": "/workspace",
+            "cliAgentType": "claude-code",
+            "experimentalConnectors": {
+                "connectors": [{
+                    "name": "github",
+                    "targets": ["https://api.github.com"],
+                    "placeholder": "vm0_conn_github",
+                    "auth": { "headers": { "Authorization": "Bearer ${token}" } }
+                }]
+            }
+        });
+        let ctx: ExecutionContext = serde_json::from_value(json).unwrap();
+        let conns = ctx.experimental_connectors.unwrap();
+        assert_eq!(conns.connectors.len(), 1);
+        assert_eq!(conns.connectors[0].name, "github");
+        assert_eq!(conns.connectors[0].placeholder, "vm0_conn_github");
+    }
+
+    #[test]
+    fn execution_context_deserializes_without_connectors() {
+        let json = serde_json::json!({
+            "runId": "00000000-0000-0000-0000-000000000001",
+            "prompt": "test",
+            "sandboxToken": "tok",
+            "workingDir": "/workspace",
+            "cliAgentType": "claude-code"
+        });
+        let ctx: ExecutionContext = serde_json::from_value(json).unwrap();
+        assert!(ctx.experimental_connectors.is_none());
+    }
+
+    #[test]
     fn dmesg_oom_positive() {
         assert!(dmesg_indicates_oom(
             "[  12.345] Out of memory: Killed process 1234 (claude)"

--- a/crates/runner/src/provider/local.rs
+++ b/crates/runner/src/provider/local.rs
@@ -152,6 +152,7 @@ impl JobProvider for LocalProvider {
             secret_values: None,
             cli_agent_type: req.cli_agent_type,
             experimental_firewall: None,
+            experimental_connectors: None,
             debug_no_mock_claude: None,
             api_start_time: None,
             user_timezone: req.user_timezone,

--- a/crates/runner/src/proxy.rs
+++ b/crates/runner/src/proxy.rs
@@ -756,4 +756,65 @@ mod tests {
         assert_eq!(vm_json["sealSecretsEnabled"], true);
         assert_eq!(vm_json["mitmEnabled"], true);
     }
+
+    #[tokio::test]
+    async fn registry_with_connectors() {
+        let dir = tempfile::tempdir().unwrap();
+        let registry_path = dir.path().join("proxy-registry.json");
+        let lock_path = dir.path().join("proxy-registry.json.lock");
+        let empty = ProxyRegistry {
+            vms: HashMap::new(),
+            updated_at: 0,
+        };
+        write_registry(&registry_path, &empty).await.unwrap();
+
+        let handle = ProxyRegistryHandle {
+            registry_path: registry_path.clone(),
+            lock_path,
+        };
+
+        let connectors = crate::types::ExperimentalConnectors {
+            connectors: vec![crate::types::ConnectorEntry {
+                name: "gmail".to_string(),
+                targets: vec!["https://gmail.googleapis.com/gmail/v1/users/me".to_string()],
+                placeholder: "vm0_conn_gmail".to_string(),
+                auth: crate::types::ConnectorAuth {
+                    headers: [("Authorization".to_string(), "Bearer ${token}".to_string())]
+                        .into_iter()
+                        .collect(),
+                },
+            }],
+        };
+
+        let registration = VmRegistration {
+            run_id: "run-conn",
+            sandbox_token: "tok",
+            firewall_rules: &[],
+            mitm_enabled: true,
+            seal_secrets_enabled: false,
+            network_log_path: std::path::Path::new("/tmp/network-run-conn.jsonl"),
+            connectors: Some(&connectors),
+        };
+        handle
+            .register_vm("10.200.0.5", &registration)
+            .await
+            .unwrap();
+
+        // Verify connectors are stored in registry.
+        let loaded = read_registry(&registry_path).await.unwrap();
+        let vm = loaded.vms.get("10.200.0.5").unwrap();
+        let stored = vm.connectors.as_ref().unwrap();
+        assert_eq!(stored.connectors.len(), 1);
+        assert_eq!(stored.connectors[0].name, "gmail");
+        assert_eq!(stored.connectors[0].placeholder, "vm0_conn_gmail");
+
+        // Verify JSON shape matches what the Python addon expects.
+        let raw = tokio::fs::read_to_string(&registry_path).await.unwrap();
+        let value: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        let vm_json = &value["vms"]["10.200.0.5"];
+        let conn = &vm_json["connectors"]["connectors"][0];
+        assert_eq!(conn["name"], "gmail");
+        assert_eq!(conn["placeholder"], "vm0_conn_gmail");
+        assert_eq!(conn["auth"]["headers"]["Authorization"], "Bearer ${token}");
+    }
 }

--- a/crates/runner/src/proxy.rs
+++ b/crates/runner/src/proxy.rs
@@ -28,6 +28,7 @@ struct VmEntry {
     mitm_enabled: bool,
     seal_secrets_enabled: bool,
     network_log_path: String,
+    connectors: Option<crate::types::ExperimentalConnectors>,
 }
 
 /// Firewall rule for network filtering (first-match-wins).
@@ -65,6 +66,7 @@ pub struct VmRegistration<'a> {
     pub mitm_enabled: bool,
     pub seal_secrets_enabled: bool,
     pub network_log_path: &'a std::path::Path,
+    pub connectors: Option<&'a crate::types::ExperimentalConnectors>,
 }
 
 /// Embedded mitmproxy addon script (compiled into the binary).
@@ -435,6 +437,7 @@ impl ProxyRegistryHandle {
                 mitm_enabled: registration.mitm_enabled,
                 seal_secrets_enabled: registration.seal_secrets_enabled,
                 network_log_path: registration.network_log_path.to_string_lossy().into_owned(),
+                connectors: registration.connectors.cloned(),
             },
         );
         registry.updated_at = now;
@@ -510,6 +513,7 @@ mod tests {
                 mitm_enabled: true,
                 seal_secrets_enabled: false,
                 network_log_path: "/tmp/network-test-run.jsonl".to_string(),
+                connectors: None,
             },
         );
         write_registry(&registry_path, &registry).await.unwrap();
@@ -614,6 +618,7 @@ mod tests {
             mitm_enabled: true,
             seal_secrets_enabled: false,
             network_log_path: std::path::Path::new("/tmp/network-run-1.jsonl"),
+            connectors: None,
         };
         handle
             .register_vm("10.200.0.2", &registration)
@@ -633,6 +638,7 @@ mod tests {
             mitm_enabled: false,
             seal_secrets_enabled: true,
             network_log_path: std::path::Path::new("/tmp/network-run-2.jsonl"),
+            connectors: None,
         };
         handle
             .register_vm("10.200.0.2", &registration2)
@@ -686,6 +692,7 @@ mod tests {
                     mitm_enabled: false,
                     seal_secrets_enabled: false,
                     network_log_path: &log_path,
+                    connectors: None,
                 };
                 h.register_vm(&ip, &registration).await.unwrap();
             });
@@ -731,6 +738,7 @@ mod tests {
                 mitm_enabled: true,
                 seal_secrets_enabled: true,
                 network_log_path: "/tmp/network-run-1.jsonl".to_string(),
+                connectors: None,
             },
         );
         write_registry(&registry_path, &registry).await.unwrap();

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -56,6 +56,8 @@ pub struct ExecutionContext {
     #[serde(default)]
     pub experimental_firewall: Option<ExperimentalFirewall>,
     #[serde(default)]
+    pub experimental_connectors: Option<ExperimentalConnectors>,
+    #[serde(default)]
     pub debug_no_mock_claude: Option<bool>,
     #[serde(default)]
     pub api_start_time: Option<f64>,
@@ -75,6 +77,28 @@ pub struct ExperimentalFirewall {
     pub experimental_mitm: Option<bool>,
     #[serde(default)]
     pub experimental_seal_secrets: Option<bool>,
+}
+
+/// Connector manifest for proxy-side token replacement.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct ExperimentalConnectors {
+    pub connectors: Vec<ConnectorEntry>,
+}
+
+/// A single connector entry with target URLs and auth header templates.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct ConnectorEntry {
+    pub name: String,
+    pub targets: Vec<String>,
+    pub placeholder: String,
+    pub auth: ConnectorAuth,
+}
+
+/// Auth header templates for a connector.
+/// The `${token}` placeholder in header values is replaced by the proxy.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct ConnectorAuth {
+    pub headers: HashMap<String, String>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/turbo/apps/web/src/lib/run/build-context.ts
+++ b/turbo/apps/web/src/lib/run/build-context.ts
@@ -9,8 +9,11 @@ import {
   hasAuthMethods,
   getSecretNamesForAuthMethod,
   getConnectorEnvironmentMapping,
+  getConnectorProxyConfig,
   connectorTypeSchema,
   MODEL_PROVIDER_TYPES,
+  type ConnectorType,
+  type ExperimentalConnectors,
   type ModelProviderType,
   type ModelProviderFramework,
 } from "@vm0/core";
@@ -919,6 +922,54 @@ interface BuildContextResult {
 }
 
 /**
+ * Build ExperimentalConnectors from agent compose's experimental_connectors array.
+ * Returns null if no connectors are declared.
+ *
+ * For each declared connector name:
+ * 1. Validates it's a known connector type with proxy config
+ * 2. Looks up targets and auth from CONNECTOR_PROXY_CONFIGS
+ * 3. Generates a placeholder token (vm0_conn_{name})
+ */
+function buildExperimentalConnectors(
+  agentCompose: unknown,
+): ExperimentalConnectors | null {
+  const compose = agentCompose as
+    | { agents?: Record<string, { experimental_connectors?: string[] }> }
+    | undefined;
+  if (!compose?.agents) return null;
+
+  const firstAgent = Object.values(compose.agents)[0];
+  const connectorNames = firstAgent?.experimental_connectors;
+  if (!connectorNames || connectorNames.length === 0) return null;
+
+  const connectors = connectorNames.map((name) => {
+    // Validate connector type exists
+    const parsed = connectorTypeSchema.safeParse(name);
+    if (!parsed.success) {
+      throw badRequest(`Unknown connector type: "${name}"`);
+    }
+    const connectorType = parsed.data as ConnectorType;
+
+    // Look up proxy config (targets + auth)
+    const proxyConfig = getConnectorProxyConfig(connectorType);
+    if (!proxyConfig) {
+      throw badRequest(
+        `Connector "${name}" does not support proxy-side token replacement`,
+      );
+    }
+
+    return {
+      name,
+      targets: proxyConfig.targets,
+      placeholder: `vm0_conn_${name}`,
+      auth: proxyConfig.auth,
+    };
+  });
+
+  return { connectors };
+}
+
+/**
  * Build unified execution context from various parameter sources.
  * Supports: new run, checkpoint resume, session continue.
  *
@@ -1043,6 +1094,9 @@ export async function buildExecutionContext(
     ? { ...resolvedCredentials, ...secrets }
     : secrets;
 
+  // Build experimental connectors manifest from agent compose
+  const experimentalConnectors = buildExperimentalConnectors(agentCompose);
+
   // Build final execution context
   return {
     userScope,
@@ -1062,6 +1116,7 @@ export async function buildExecutionContext(
       volumeVersions,
       environment,
       userTimezone,
+      experimentalConnectors: experimentalConnectors ?? undefined,
       resumeSession,
       resumeArtifact,
       // Metadata for vm0_start event

--- a/turbo/apps/web/src/lib/run/context/execution-preparer.ts
+++ b/turbo/apps/web/src/lib/run/context/execution-preparer.ts
@@ -340,6 +340,9 @@ function buildPreparedContext(
     // Experimental firewall configuration (processed with auto-injected rules)
     experimentalFirewall,
 
+    // Experimental connectors for proxy-side token replacement
+    experimentalConnectors: context.experimentalConnectors ?? null,
+
     // Routing
     runnerGroup,
 

--- a/turbo/apps/web/src/lib/run/executors/runner-executor.ts
+++ b/turbo/apps/web/src/lib/run/executors/runner-executor.ts
@@ -59,6 +59,7 @@ export async function executeRunnerJob(
     encryptedSecrets,
     cliAgentType: context.cliAgentType,
     experimentalFirewall: context.experimentalFirewall ?? undefined,
+    experimentalConnectors: context.experimentalConnectors ?? undefined,
     debugNoMockClaude: context.debugNoMockClaude || undefined,
     apiStartTime: context.apiStartTime ?? undefined,
     userTimezone: context.userTimezone ?? undefined,

--- a/turbo/apps/web/src/lib/run/executors/types.ts
+++ b/turbo/apps/web/src/lib/run/executors/types.ts
@@ -1,7 +1,7 @@
 import type { StorageManifest } from "../../storage/types";
 import type { ResumeSession } from "../types";
 import type { ArtifactSnapshot } from "../../checkpoint/types";
-import type { ExperimentalFirewall } from "@vm0/core";
+import type { ExperimentalFirewall, ExperimentalConnectors } from "@vm0/core";
 
 /**
  * Prepared execution context for executors
@@ -44,6 +44,9 @@ export interface PreparedContext {
 
   // Experimental firewall configuration
   experimentalFirewall: ExperimentalFirewall | null;
+
+  // Experimental connectors for proxy-side token replacement
+  experimentalConnectors: ExperimentalConnectors | null;
 
   // Routing hint (null = E2B, string = runner group)
   runnerGroup: string | null;

--- a/turbo/apps/web/src/lib/run/types.ts
+++ b/turbo/apps/web/src/lib/run/types.ts
@@ -1,5 +1,5 @@
 import type { ArtifactSnapshot } from "../checkpoint/types";
-import type { ExperimentalFirewall } from "@vm0/core";
+import type { ExperimentalFirewall, ExperimentalConnectors } from "@vm0/core";
 
 /**
  * Run status values
@@ -79,6 +79,9 @@ export interface ExecutionContext {
 
   // Experimental firewall configuration for network egress control
   experimentalFirewall?: ExperimentalFirewall;
+
+  // Experimental connectors for proxy-side token replacement
+  experimentalConnectors?: ExperimentalConnectors;
 
   // Resume-specific (optional)
   resumeSession?: ResumeSession;

--- a/turbo/apps/web/src/types/agent-compose.ts
+++ b/turbo/apps/web/src/types/agent-compose.ts
@@ -81,6 +81,12 @@ interface AgentDefinition {
    * When enabled, filters outbound traffic by domain/IP rules.
    */
   experimental_firewall?: ExperimentalFirewall;
+  /**
+   * Experimental connectors for proxy-side token replacement.
+   * Array of connector type names (e.g., ["gmail", "github"]).
+   * Requires experimental_runner to be configured.
+   */
+  experimental_connectors?: string[];
 }
 
 export interface AgentComposeYaml {

--- a/turbo/packages/core/src/contracts/__tests__/connectors.test.ts
+++ b/turbo/packages/core/src/contracts/__tests__/connectors.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { hasRequiredScopes } from "../connectors";
+import {
+  hasRequiredScopes,
+  getConnectorProxyConfig,
+  CONNECTOR_TYPES,
+} from "../connectors";
+import type { ConnectorType } from "../connectors";
 
 describe("hasRequiredScopes", () => {
   it("returns true for non-OAuth connector type", () => {
@@ -33,5 +38,57 @@ describe("hasRequiredScopes", () => {
     expect(
       hasRequiredScopes("github", ["repo", "project", "read:org", "user"]),
     ).toBe(true);
+  });
+});
+
+describe("getConnectorProxyConfig", () => {
+  it("returns proxy config for known connector types", () => {
+    const config = getConnectorProxyConfig("github");
+    expect(config).toBeDefined();
+    expect(config!.targets).toEqual(["https://api.github.com"]);
+    expect(config!.auth.headers.Authorization).toBe("Bearer ${token}");
+  });
+
+  it("returns config with multiple targets for slack", () => {
+    const config = getConnectorProxyConfig("slack");
+    expect(config).toBeDefined();
+    expect(config!.targets).toEqual([
+      "https://slack.com/api",
+      "https://files.slack.com",
+    ]);
+  });
+
+  it("returns config with custom headers for notion", () => {
+    const config = getConnectorProxyConfig("notion");
+    expect(config).toBeDefined();
+    expect(config!.auth.headers["Notion-Version"]).toBe("2022-06-28");
+  });
+
+  it("returns undefined for computer connector (no proxy support)", () => {
+    const config = getConnectorProxyConfig("computer");
+    expect(config).toBeUndefined();
+  });
+
+  it("all proxy configs have valid targets and auth headers", () => {
+    const allTypes = Object.keys(CONNECTOR_TYPES) as ConnectorType[];
+
+    for (const type of allTypes) {
+      const config = getConnectorProxyConfig(type);
+      if (!config) continue;
+
+      expect(
+        config.targets.length,
+        `${type} should have at least one target`,
+      ).toBeGreaterThan(0);
+      for (const target of config.targets) {
+        expect(target, `${type} targets should be https URLs`).toMatch(
+          /^https:\/\//,
+        );
+      }
+      expect(
+        Object.keys(config.auth.headers).length,
+        `${type} should have at least one auth header`,
+      ).toBeGreaterThan(0);
+    }
   });
 });

--- a/turbo/packages/core/src/contracts/connectors.ts
+++ b/turbo/packages/core/src/contracts/connectors.ts
@@ -1106,6 +1106,155 @@ export const CONNECTOR_TYPES = {
 
 export type ConnectorType = keyof typeof CONNECTOR_TYPES;
 
+/**
+ * Proxy-side connector configuration for token replacement.
+ *
+ * Defines which URL targets each connector covers and how auth headers
+ * are constructed. Used by the proxy to intercept requests matching a
+ * connector's targets and replace placeholder tokens with real credentials.
+ *
+ * `${token}` in header values is replaced with the real OAuth access token.
+ *
+ * NOTE: Currently hardcoded in CONNECTOR_PROXY_CONFIGS below.
+ * Will be migrated to GitHub-hosted connector.yaml definitions in Phase 2.
+ */
+export interface ConnectorProxyConfig {
+  targets: string[];
+  auth: {
+    headers: Record<string, string>;
+  };
+}
+
+const BEARER_AUTH = { headers: { Authorization: "Bearer ${token}" } };
+
+const CONNECTOR_PROXY_CONFIGS: Partial<
+  Record<ConnectorType, ConnectorProxyConfig>
+> = {
+  airtable: {
+    targets: ["https://api.airtable.com"],
+    auth: BEARER_AUTH,
+  },
+  github: {
+    targets: ["https://api.github.com"],
+    auth: BEARER_AUTH,
+  },
+  notion: {
+    targets: ["https://api.notion.com/v1"],
+    auth: {
+      headers: {
+        Authorization: "Bearer ${token}",
+        "Notion-Version": "2022-06-28",
+      },
+    },
+  },
+  gmail: {
+    targets: ["https://gmail.googleapis.com/gmail/v1/users/me"],
+    auth: BEARER_AUTH,
+  },
+  "google-sheets": {
+    targets: ["https://sheets.googleapis.com/v4/spreadsheets"],
+    auth: BEARER_AUTH,
+  },
+  "google-docs": {
+    targets: ["https://docs.googleapis.com/v1/documents"],
+    auth: BEARER_AUTH,
+  },
+  "google-drive": {
+    targets: ["https://www.googleapis.com/drive/v3"],
+    auth: BEARER_AUTH,
+  },
+  "google-calendar": {
+    targets: ["https://www.googleapis.com/calendar/v3"],
+    auth: BEARER_AUTH,
+  },
+  hubspot: {
+    targets: ["https://api.hubapi.com"],
+    auth: BEARER_AUTH,
+  },
+  slack: {
+    targets: ["https://slack.com/api", "https://files.slack.com"],
+    auth: BEARER_AUTH,
+  },
+  docusign: {
+    targets: [
+      "https://demo.docusign.net/restapi",
+      "https://na1.docusign.net/restapi",
+    ],
+    auth: BEARER_AUTH,
+  },
+  dropbox: {
+    targets: [
+      "https://api.dropboxapi.com/2",
+      "https://content.dropboxapi.com/2",
+    ],
+    auth: BEARER_AUTH,
+  },
+  linear: {
+    targets: ["https://api.linear.app"],
+    auth: BEARER_AUTH,
+  },
+  deel: {
+    targets: ["https://api.deel.com"],
+    auth: BEARER_AUTH,
+  },
+  figma: {
+    targets: ["https://api.figma.com"],
+    auth: BEARER_AUTH,
+  },
+  mercury: {
+    targets: ["https://api.mercury.com"],
+    auth: BEARER_AUTH,
+  },
+  reddit: {
+    targets: ["https://oauth.reddit.com"],
+    auth: BEARER_AUTH,
+  },
+  strava: {
+    targets: ["https://www.strava.com/api/v3"],
+    auth: BEARER_AUTH,
+  },
+  x: {
+    targets: ["https://api.x.com/2"],
+    auth: BEARER_AUTH,
+  },
+  neon: {
+    targets: ["https://console.neon.tech/api/v2"],
+    auth: BEARER_AUTH,
+  },
+  vercel: {
+    targets: ["https://api.vercel.com"],
+    auth: BEARER_AUTH,
+  },
+  sentry: {
+    targets: ["https://sentry.io/api"],
+    auth: BEARER_AUTH,
+  },
+  monday: {
+    targets: ["https://api.monday.com/v2"],
+    auth: BEARER_AUTH,
+  },
+  canva: {
+    targets: ["https://api.canva.com/rest/v1"],
+    auth: BEARER_AUTH,
+  },
+  xero: {
+    targets: ["https://api.xero.com"],
+    auth: BEARER_AUTH,
+  },
+  supabase: {
+    targets: ["https://api.supabase.com/v1"],
+    auth: BEARER_AUTH,
+  },
+  todoist: {
+    targets: ["https://api.todoist.com/rest/v2"],
+    auth: BEARER_AUTH,
+  },
+  webflow: {
+    targets: ["https://api.webflow.com/v2"],
+    auth: BEARER_AUTH,
+  },
+};
+
 export const connectorTypeSchema = z.enum([
   "airtable",
   "canva",
@@ -1185,6 +1334,16 @@ export function getConnectorEnvironmentMapping(
   type: ConnectorType,
 ): Record<string, string> {
   return CONNECTOR_TYPES[type].environmentMapping;
+}
+
+/**
+ * Get proxy config for a connector type (targets + auth headers).
+ * Returns undefined if the connector has no proxy config (e.g., computer connector).
+ */
+export function getConnectorProxyConfig(
+  type: ConnectorType,
+): ConnectorProxyConfig | undefined {
+  return CONNECTOR_PROXY_CONFIGS[type];
 }
 
 /**

--- a/turbo/packages/core/src/contracts/index.ts
+++ b/turbo/packages/core/src/contracts/index.ts
@@ -312,6 +312,10 @@ export {
   type ResumeSession,
   type FirewallRule,
   type ExperimentalFirewall,
+  connectorEntrySchema,
+  experimentalConnectorsSchema,
+  type ConnectorEntry,
+  type ExperimentalConnectors,
 } from "./runners";
 
 export {
@@ -413,6 +417,7 @@ export {
   getConnectorDerivedNames,
   getConnectorProvidedSecretNames,
   getConnectorOAuthConfig,
+  getConnectorProxyConfig,
   hasRequiredScopes,
   type ConnectorsMainContract,
   type ConnectorsByTypeContract,
@@ -427,6 +432,7 @@ export {
   type ConnectorSecretConfig,
   type ConnectorAuthMethodConfig,
   type ConnectorOAuthConfig,
+  type ConnectorProxyConfig,
   // Computer connector
   computerConnectorContract,
   computerConnectorCreateResponseSchema,

--- a/turbo/packages/core/src/contracts/runners.ts
+++ b/turbo/packages/core/src/contracts/runners.ts
@@ -80,6 +80,25 @@ export const runnersPollContract = c.router({
 });
 
 /**
+ * Connector entry in experimental connectors manifest
+ */
+export const connectorEntrySchema = z.object({
+  name: z.string(),
+  targets: z.array(z.string()),
+  placeholder: z.string(),
+  auth: z.object({
+    headers: z.record(z.string(), z.string()),
+  }),
+});
+
+/**
+ * Experimental connectors configuration for proxy-side token replacement
+ */
+export const experimentalConnectorsSchema = z.object({
+  connectors: z.array(connectorEntrySchema),
+});
+
+/**
  * Storage entry in manifest
  */
 export const storageEntrySchema = z.object({
@@ -138,6 +157,8 @@ export const storedExecutionContextSchema = z.object({
   agentScopeSlug: z.string().optional(),
   // Memory storage name (for first-run when manifest.memory is null)
   memoryName: z.string().optional(),
+  // Experimental connectors for proxy-side token replacement
+  experimentalConnectors: experimentalConnectorsSchema.optional(),
 });
 
 /**
@@ -171,6 +192,8 @@ export const executionContextSchema = z.object({
   agentScopeSlug: z.string().optional(),
   // Memory storage name (for first-run when manifest.memory is null)
   memoryName: z.string().optional(),
+  // Experimental connectors for proxy-side token replacement
+  experimentalConnectors: experimentalConnectorsSchema.optional(),
 });
 
 /**
@@ -213,3 +236,7 @@ export type StorageManifest = z.infer<typeof storageManifestSchema>;
 export type ResumeSession = z.infer<typeof resumeSessionSchema>;
 export type FirewallRule = z.infer<typeof firewallRuleSchema>;
 export type ExperimentalFirewall = z.infer<typeof experimentalFirewallSchema>;
+export type ConnectorEntry = z.infer<typeof connectorEntrySchema>;
+export type ExperimentalConnectors = z.infer<
+  typeof experimentalConnectorsSchema
+>;


### PR DESCRIPTION
## Summary

- Add `CONNECTOR_PROXY_CONFIGS` (25+ connectors) with path-level URL targets and auth header templates to `@vm0/core`
- Add `ExperimentalConnectors` / `ConnectorEntry` Zod schemas to runners contract
- Wire `experimental_connectors: string[]` through the full data pipeline: agent-compose → `buildExecutionContext` → `PreparedContext` → `StoredExecutionContext` → runner job queue
- Add Rust `ExperimentalConnectors` types, proxy registry `connectors` field, auto-enable MITM when connectors are present
- Placeholder format: `vm0_conn_{name}` (never leaves sandbox, replaced by proxy)

Phase 1 scope: data pipeline only. Proxy-side token replacement and token endpoint API are separate issues.

Closes #4035

## Test plan

- [x] `cargo clippy -p runner` passes
- [x] `cargo test -p runner` — 185 tests pass
- [x] `pnpm check-types` — no new errors (only pre-existing org route errors)
- [x] `pnpm knip` — no unused exports
- [x] Pre-commit hooks pass (prettier, cargo-fmt, cargo-clippy, knip, commitlint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)