### PR TITLE
refactor(scope): discover existing clerk orgs via jit api instead of creating new ones

### DIFF
--- a/turbo/apps/web/app/api/scope/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/scope/__tests__/route.test.ts
@@ -34,21 +34,15 @@ describe("/api/scope", () => {
 
       expect(response.status).toBe(200);
       expect(data.id).toBeDefined();
-      expect(data.slug).toMatch(/^user-[a-f0-9]{8}$/);
+      // JIT discovery uses Clerk org slug, which starts with "org-"
+      expect(data.slug).toBeDefined();
     });
 
     it("should auto-create scope with fallback slug on collision", async () => {
-      // First, create a scope that will collide with the deterministic slug
-      // by pre-occupying the slug that ensureDefaultScope would generate
-      const collidingUserId = `collision-test-${Date.now()}`;
+      // JIT discovery uses Clerk org slug. Pre-occupy it to trigger fallback.
+      const clerkOrgSlug = `collision-slug-${Date.now()}`;
 
-      // Import to compute the expected slug
-      const { generateDefaultScopeSlug } = await import(
-        "../../../../src/lib/scope/scope-service"
-      );
-      const expectedSlug = generateDefaultScopeSlug(collidingUserId);
-
-      // Pre-occupy the deterministic slug with a different user
+      // Pre-occupy the Clerk org slug with a different user
       const occupierUserId = `occupier-${Date.now()}`;
       mockClerk({ userId: occupierUserId });
       const occupyRequest = createTestRequest(
@@ -56,22 +50,32 @@ describe("/api/scope", () => {
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ slug: expectedSlug }),
+          body: JSON.stringify({ slug: clerkOrgSlug }),
         },
       );
       const occupyResponse = await POST(occupyRequest);
       expect(occupyResponse.status).toBe(201);
 
-      // Now the colliding user triggers auto-creation via GET
-      mockClerk({ userId: collidingUserId });
+      // Now a user whose Clerk org has the colliding slug triggers auto-creation
+      const collidingUserId = `collision-test-${Date.now()}`;
+      mockClerk({
+        userId: collidingUserId,
+        clerkOrgs: [
+          {
+            id: `org_collision_${Date.now()}`,
+            slug: clerkOrgSlug,
+            name: "Collision Org",
+          },
+        ],
+      });
       const request = createTestRequest("http://localhost:3000/api/scope");
       const response = await GET(request);
       const data = await response.json();
 
       expect(response.status).toBe(200);
       expect(data.id).toBeDefined();
-      // Should have fallen back to a random slug, not the colliding one
-      expect(data.slug).not.toBe(expectedSlug);
+      // Should have fallen back to user-{hash}, not the colliding slug
+      expect(data.slug).not.toBe(clerkOrgSlug);
       expect(data.slug).toMatch(/^user-[a-f0-9]{8}$/);
     });
 
@@ -91,6 +95,93 @@ describe("/api/scope", () => {
       expect(response2.status).toBe(200);
       expect(data1.id).toBe(data2.id);
       expect(data1.slug).toBe(data2.slug);
+    });
+  });
+
+  describe("JIT Clerk org discovery", () => {
+    it("should create scope from discovered Clerk org with its slug", async () => {
+      const ts = Date.now();
+      const userId = `jit-discovery-${ts}`;
+      const clerkOrgId = `org_jit_${ts}`;
+      const orgSlug = `team-${ts}`;
+      mockClerk({
+        userId,
+        clerkOrgs: [{ id: clerkOrgId, slug: orgSlug, name: "My Team" }],
+      });
+
+      const request = createTestRequest("http://localhost:3000/api/scope");
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.slug).toBe(orgSlug);
+    });
+
+    it("should skip Clerk org that already has a local scope", async () => {
+      const ts = Date.now();
+      // Create a scope bound to the first org
+      const setupUserId = `jit-skip-setup-${ts}`;
+      const existingOrgId = `org_existing_${ts}`;
+      const newOrgId = `org_new_${ts}`;
+      const existingSlug = `existing-${ts}`;
+      const newSlug = `new-team-${ts}`;
+      mockClerk({
+        userId: setupUserId,
+        clerkOrgs: [
+          { id: existingOrgId, slug: existingSlug, name: "Existing" },
+        ],
+      });
+      const setupRequest = createTestRequest("http://localhost:3000/api/scope");
+      const setupResponse = await GET(setupRequest);
+      expect(setupResponse.status).toBe(200);
+
+      // Now a different user has both orgs — should skip existing, use new
+      const userId = `jit-skip-${ts}`;
+      mockClerk({
+        userId,
+        clerkOrgs: [
+          { id: existingOrgId, slug: existingSlug, name: "Existing" },
+          { id: newOrgId, slug: newSlug, name: "New Team" },
+        ],
+      });
+      const request = createTestRequest("http://localhost:3000/api/scope");
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.slug).toBe(newSlug);
+    });
+
+    it("should fall back to user-hash when Clerk slug is invalid", async () => {
+      const userId = `jit-invalid-slug-${Date.now()}`;
+      mockClerk({
+        userId,
+        clerkOrgs: [
+          { id: `org_bad_${Date.now()}`, slug: "My-Team!", name: "Bad Slug" },
+        ],
+      });
+
+      const request = createTestRequest("http://localhost:3000/api/scope");
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.slug).toMatch(/^user-[a-f0-9]{8}$/);
+    });
+
+    it("should return error when user has no Clerk orgs", async () => {
+      const userId = `jit-no-orgs-${Date.now()}`;
+      mockClerk({
+        userId,
+        clerkOrgs: [],
+      });
+
+      const request = createTestRequest("http://localhost:3000/api/scope");
+      const response = await GET(request);
+
+      // ensureDefaultScope throws NotFound, which propagates as 500
+      // because the route handler's catch already consumed its NotFound
+      expect(response.status).toBe(500);
     });
   });
 

--- a/turbo/apps/web/app/api/scope/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/scope/__tests__/route.test.ts
@@ -178,10 +178,10 @@ describe("/api/scope", () => {
 
       const request = createTestRequest("http://localhost:3000/api/scope");
       const response = await GET(request);
+      const data = await response.json();
 
-      // ensureDefaultScope throws NotFound, which propagates as 500
-      // because the route handler's catch already consumed its NotFound
-      expect(response.status).toBe(500);
+      expect(response.status).toBe(404);
+      expect(data.error.message).toContain("No organization found");
     });
   });
 

--- a/turbo/apps/web/app/api/scope/route.ts
+++ b/turbo/apps/web/app/api/scope/route.ts
@@ -56,9 +56,16 @@ const router = tsr.router(scopeContract, {
       return { status: 200 as const, body: scopeToResponseBody(scope) };
     } catch (error) {
       if (isNotFound(error)) {
-        // Auto-create default scope for new users
-        const scope = await ensureDefaultScope(userId);
-        return { status: 200 as const, body: scopeToResponseBody(scope) };
+        // Auto-create default scope for new users via JIT Clerk org discovery
+        try {
+          const scope = await ensureDefaultScope(userId);
+          return { status: 200 as const, body: scopeToResponseBody(scope) };
+        } catch (ensureError) {
+          if (isNotFound(ensureError)) {
+            return createErrorResponse("NOT_FOUND", ensureError.message);
+          }
+          throw ensureError;
+        }
       }
       throw error;
     }

--- a/turbo/apps/web/src/__tests__/clerk-mock.ts
+++ b/turbo/apps/web/src/__tests__/clerk-mock.ts
@@ -36,14 +36,36 @@ const mockClerkClient = vi.mocked(clerkClient);
  * @param options.email - Email address for the user (default: "test@example.com")
  * @param options.orgId - Organization ID from active org session (optional)
  * @param options.orgSlug - Organization slug from active org session (optional)
+ * @param options.clerkOrgs - Clerk orgs the user belongs to (for JIT discovery)
  */
 export function mockClerk(options: {
   userId: string | null;
   email?: string;
   orgId?: string | null;
   orgSlug?: string | null;
+  clerkOrgs?: Array<{ id: string; slug: string; name: string }>;
 }) {
   const email = options.email ?? "test@example.com";
+
+  // Default: one org per user (simulates signup-created org).
+  // The org ID is derived from userId to ensure uniqueness across tests.
+  const safeSlug = options.userId
+    ? `org-${options.userId}`
+        .toLowerCase()
+        .replace(/[^a-z0-9-]/g, "-")
+        .slice(0, 64)
+    : "";
+  const clerkOrgs =
+    options.clerkOrgs ??
+    (options.userId
+      ? [
+          {
+            id: `org_mock_${options.userId}`,
+            slug: safeSlug,
+            name: `org-${options.userId}`,
+          },
+        ]
+      : []);
 
   mockAuth.mockResolvedValue({
     userId: options.userId,
@@ -67,6 +89,13 @@ export function mockClerk(options: {
           });
         }
         return Promise.resolve({ data: [] });
+      }),
+      getOrganizationMembershipList: vi.fn().mockResolvedValue({
+        data: clerkOrgs.map((org) => ({
+          organization: { id: org.id, slug: org.slug, name: org.name },
+          role: "org:admin",
+          publicUserData: { userId: options.userId },
+        })),
       }),
     },
     organizations: {

--- a/turbo/apps/web/src/lib/scope/scope-service.ts
+++ b/turbo/apps/web/src/lib/scope/scope-service.ts
@@ -122,11 +122,12 @@ export async function getScopeByClerkOrgId(clerkOrgId: string) {
  * and atomic scope + membership creation.
  *
  * @param options.skipSlugValidation - Skip reserved-slug checks (for vm0-admin bypass)
+ * @param options.clerkOrgId - Use existing Clerk org instead of creating one (JIT discovery path)
  */
 export async function createScope(
   clerkUserId: string,
   slug: string,
-  options?: { skipSlugValidation?: boolean },
+  options?: { skipSlugValidation?: boolean; clerkOrgId?: string },
 ) {
   // Validate slug (unless explicitly skipped for vm0-admin)
   if (!options?.skipSlugValidation) {
@@ -139,11 +140,14 @@ export async function createScope(
     throw badRequest(`Scope "${slug}" already exists`);
   }
 
-  // Create Clerk Organization so every scope is backed by one.
-  // If Clerk auth is configured, org creation is required (fail-fast).
-  // If self-hosted (no Clerk), use the well-known sentinel ID.
+  // Determine Clerk Organization ID:
+  // 1. Use provided clerkOrgId (JIT discovery — Clerk org already exists)
+  // 2. Create new Clerk org (explicit scope creation via POST /api/scope)
+  // 3. Use sentinel ID (self-hosted mode, no Clerk)
   let clerkOrgId: string;
-  if (hasClerkAuth()) {
+  if (options?.clerkOrgId) {
+    clerkOrgId = options.clerkOrgId;
+  } else if (hasClerkAuth()) {
     const client = await clerkClient();
     const clerkOrg = await client.organizations.createOrganization({
       name: slug,
@@ -208,23 +212,85 @@ export async function getUserScopeByClerkId(clerkUserId: string) {
  * Consolidates the auto-creation pattern used by CLI token exchange,
  * Slack OAuth, and the scope API.
  *
+ * In SaaS mode (Clerk auth configured), discovers existing Clerk orgs via
+ * JIT API call and creates a local scope bound to the first unmatched org.
+ * In self-hosted mode, falls back to creating a scope with a generated slug.
+ *
  * @returns The existing or newly created scope
  */
 export async function ensureDefaultScope(clerkUserId: string) {
   const existing = await getUserScopeByClerkId(clerkUserId);
   if (existing) return existing;
 
-  const defaultSlug = generateDefaultScopeSlug(clerkUserId);
-  try {
-    return await createScope(clerkUserId, defaultSlug);
-  } catch (error) {
-    // Handle rare slug collision — retry with random suffix
-    if (isBadRequest(error) && error.message.includes("already exists")) {
-      const fallbackSlug = `user-${randomBytes(4).toString("hex")}`;
-      return await createScope(clerkUserId, fallbackSlug);
-    }
-    throw error;
+  // JIT Clerk org discovery (SaaS mode)
+  if (hasClerkAuth()) {
+    return await discoverAndCreateScope(clerkUserId);
   }
+
+  // Self-hosted fallback
+  const defaultSlug = generateDefaultScopeSlug(clerkUserId);
+  return await createScope(clerkUserId, defaultSlug);
+}
+
+/**
+ * Check if a slug is valid without throwing.
+ * Reuses the same rules as validateScopeSlug() but returns a boolean.
+ */
+function isValidSlug(slug: string): boolean {
+  return (
+    slug.length >= 3 &&
+    slug.length <= 64 &&
+    SLUG_REGEX.test(slug) &&
+    !RESERVED_SLUGS.includes(slug) &&
+    !slug.startsWith("vm0")
+  );
+}
+
+/**
+ * Discover an existing Clerk org for a user and create a local scope bound to it.
+ * Queries the Clerk API for the user's org memberships, finds the first org
+ * without a matching local scope, and creates a scope record.
+ */
+async function discoverAndCreateScope(clerkUserId: string) {
+  const client = await clerkClient();
+  const memberships = await client.users.getOrganizationMembershipList({
+    userId: clerkUserId,
+  });
+
+  for (const membership of memberships.data) {
+    const clerkOrgId = membership.organization.id;
+    const existingScope = await getScopeByClerkOrgId(clerkOrgId);
+    if (existingScope) continue;
+
+    // Prefer Clerk org slug, fall back to deterministic user-{hash}
+    const clerkSlug = membership.organization.slug;
+    let slug: string;
+    if (clerkSlug && isValidSlug(clerkSlug)) {
+      const taken = await getScopeBySlug(clerkSlug);
+      slug = taken ? generateDefaultScopeSlug(clerkUserId) : clerkSlug;
+    } else {
+      slug = generateDefaultScopeSlug(clerkUserId);
+    }
+
+    try {
+      return await createScope(clerkUserId, slug, { clerkOrgId });
+    } catch (error) {
+      if (isBadRequest(error) && error.message.includes("already exists")) {
+        // Re-check: another concurrent request may have created this scope
+        const raceScope = await getScopeByClerkOrgId(clerkOrgId);
+        if (raceScope) return raceScope;
+
+        // Slug collision with unrelated scope — retry with random slug
+        const fallbackSlug = `user-${randomBytes(4).toString("hex")}`;
+        return await createScope(clerkUserId, fallbackSlug, { clerkOrgId });
+      }
+      throw error;
+    }
+  }
+
+  throw notFound(
+    "No organization found. Please sign up again to create an organization.",
+  );
 }
 
 /**

--- a/turbo/apps/web/src/lib/telegram/handlers/shared.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/shared.ts
@@ -4,11 +4,7 @@ import { telegramMessages } from "../../../db/schema/telegram-message";
 import { telegramUserLinks } from "../../../db/schema/telegram-user-link";
 import { agentComposes } from "../../../db/schema/agent-compose";
 import { getPlatformUrl } from "../../url";
-import {
-  getUserScopeByClerkId,
-  createScope,
-  generateDefaultScopeSlug,
-} from "../../scope/scope-service";
+import { ensureDefaultScope } from "../../scope/scope-service";
 import { validateAgentSession } from "../../run";
 import { ensureStorageExists } from "../../storage/storage-service";
 import {
@@ -245,11 +241,7 @@ async function completePendingLink(
  * Ensure scope and artifact storage exist for a user.
  */
 export async function ensureScopeAndArtifact(vm0UserId: string): Promise<void> {
-  let scope = await getUserScopeByClerkId(vm0UserId);
-  if (!scope) {
-    scope = await createScope(vm0UserId, generateDefaultScopeSlug(vm0UserId));
-    log.info("Auto-created scope for Telegram user", { userId: vm0UserId });
-  }
+  const scope = await ensureDefaultScope(vm0UserId);
 
   await ensureStorageExists(
     scope.id,


### PR DESCRIPTION
## Summary

- Modify `ensureDefaultScope()` to discover existing Clerk organizations via `users.getOrganizationMembershipList` API and create local scope records bound to them, instead of creating new Clerk orgs
- Add `clerkOrgId` option to `createScope()` to skip Clerk org creation when binding to an existing org (JIT discovery path)
- Update Telegram handler to use `ensureDefaultScope()` instead of directly calling `createScope()` for consistency

## Changes

### `scope-service.ts`
- `createScope()`: New `clerkOrgId` option — when provided, skips `createOrganization()` and uses the provided ID directly
- `ensureDefaultScope()`: In SaaS mode (Clerk configured), calls new `discoverAndCreateScope()` instead of directly creating a scope
- `discoverAndCreateScope()`: Queries Clerk for user's org memberships, finds first org without a matching local scope, resolves slug (prefer Clerk org slug, fallback to `user-{hash}`), creates scope with concurrency-safe retry
- `isValidSlug()`: New helper that returns boolean instead of throwing (used for Clerk slug validation)

### `clerk-mock.ts`
- Added `clerkOrgs` option and `users.getOrganizationMembershipList` mock
- Default org ID is now per-user (`org_mock_{userId}`) to prevent cross-test DB collisions

### `route.test.ts`
- Updated existing auto-creation tests for new JIT behavior
- Added 4 new JIT discovery tests: org slug usage, skip existing org, invalid slug fallback, no orgs error

### `telegram/handlers/shared.ts`
- Replaced manual `getUserScopeByClerkId + createScope` pattern with single `ensureDefaultScope()` call

## Test plan

- [x] JIT discovery: user has Clerk org but no local scope → scope auto-created with Clerk org slug
- [x] JIT binding: skip Clerk org that already has a local scope, use next available
- [x] Invalid Clerk slug → fallback to `user-{hash}` pattern
- [x] Clerk slug conflict (pre-occupied) → fallback to `user-{hash}` pattern
- [x] No Clerk orgs → error response
- [x] Idempotency: repeated GET returns same scope
- [x] POST /api/scope still creates Clerk org (unchanged path)
- [x] All existing tests pass (27 scope tests, 6 members tests)

Closes #4041

🤖 Generated with [Claude Code](https://claude.com/claude-code)