### PR TITLE
fix(slack): add logs link to dispatch failure error messages

### DIFF
--- a/turbo/apps/web/src/lib/slack/handlers/direct-message.ts
+++ b/turbo/apps/web/src/lib/slack/handlers/direct-message.ts
@@ -4,7 +4,11 @@ import { slackUserLinks } from "../../../db/schema/slack-user-link";
 import { decryptCredentialValue } from "../../crypto/secrets-encryption";
 import { env } from "../../../env";
 import { createSlackClient, postMessage, setThreadStatus } from "../client";
-import { buildLoginPromptMessage } from "../blocks";
+import {
+  buildAgentResponseMessage,
+  buildLoginPromptMessage,
+  detectDeepLinks,
+} from "../blocks";
 import type { SlackFile } from "../context";
 import { runAgentForSlack } from "./run-agent";
 import {
@@ -12,9 +16,12 @@ import {
   fetchConversationContexts,
   lookupThreadSession,
   buildLoginUrl,
+  buildLogsUrl,
+  buildAgentLogsUrl,
   getWorkspaceAgent,
   resolveSessionCompose,
 } from "./shared";
+import { getPlatformUrl } from "../../url";
 import { logger } from "../../logger";
 
 const log = logger("slack:dm");
@@ -170,7 +177,7 @@ export async function handleDirectMessage(
 
   // 8. Dispatch agent run with callback (returns immediately)
   log.debug("Dispatching agent run", { existingSessionId });
-  const { status, response } = await runAgentForSlack({
+  const { status, response, runId } = await runAgentForSlack({
     composeId,
     agentName,
     sessionId: existingSessionId,
@@ -198,12 +205,20 @@ export async function handleDirectMessage(
     });
   } else if (status === "failed") {
     log.error("Failed to dispatch agent run", { response });
-    await postMessage(
-      client,
-      context.channelId,
-      response ?? "Sorry, an error occurred. Please try again.",
-      { threadTs },
-    );
+    const errorText = response ?? "Sorry, an error occurred. Please try again.";
+    const logsUrl = runId
+      ? buildLogsUrl(runId, agentName)
+      : buildAgentLogsUrl(agentName);
+    const deepLinks = detectDeepLinks(errorText, getPlatformUrl(), agentName);
+    await postMessage(client, context.channelId, errorText, {
+      threadTs,
+      blocks: buildAgentResponseMessage(
+        errorText,
+        agentName,
+        logsUrl,
+        deepLinks,
+      ),
+    });
     // Clear thinking status on failure since callback won't be invoked
     await setThreadStatus(client, context.channelId, threadTs, "").catch(
       (err) => log.warn("Failed to clear thread status", { error: err }),

--- a/turbo/apps/web/src/lib/slack/handlers/mention.ts
+++ b/turbo/apps/web/src/lib/slack/handlers/mention.ts
@@ -4,7 +4,11 @@ import { slackUserLinks } from "../../../db/schema/slack-user-link";
 import { decryptCredentialValue } from "../../crypto/secrets-encryption";
 import { env } from "../../../env";
 import { createSlackClient, postMessage, setThreadStatus } from "../client";
-import { buildLoginPromptMessage } from "../blocks";
+import {
+  buildAgentResponseMessage,
+  buildLoginPromptMessage,
+  detectDeepLinks,
+} from "../blocks";
 import { extractMessageContent, type SlackFile } from "../context";
 import { runAgentForSlack } from "./run-agent";
 import {
@@ -12,9 +16,12 @@ import {
   fetchConversationContexts,
   lookupThreadSession,
   buildLoginUrl,
+  buildLogsUrl,
+  buildAgentLogsUrl,
   getWorkspaceAgent,
   resolveSessionCompose,
 } from "./shared";
+import { getPlatformUrl } from "../../url";
 import { logger } from "../../logger";
 
 const log = logger("slack:mention");
@@ -175,7 +182,7 @@ export async function handleAppMention(context: MentionContext): Promise<void> {
 
   // 8. Dispatch agent run with callback (returns immediately)
   log.debug("Dispatching agent run", { existingSessionId });
-  const { status, response } = await runAgentForSlack({
+  const { status, response, runId } = await runAgentForSlack({
     composeId,
     agentName,
     sessionId: existingSessionId,
@@ -203,12 +210,20 @@ export async function handleAppMention(context: MentionContext): Promise<void> {
     });
   } else if (status === "failed") {
     log.error("Failed to dispatch agent run", { response });
-    await postMessage(
-      client,
-      context.channelId,
-      response ?? "Sorry, an error occurred. Please try again.",
-      { threadTs },
-    );
+    const errorText = response ?? "Sorry, an error occurred. Please try again.";
+    const logsUrl = runId
+      ? buildLogsUrl(runId, agentName)
+      : buildAgentLogsUrl(agentName);
+    const deepLinks = detectDeepLinks(errorText, getPlatformUrl(), agentName);
+    await postMessage(client, context.channelId, errorText, {
+      threadTs,
+      blocks: buildAgentResponseMessage(
+        errorText,
+        agentName,
+        logsUrl,
+        deepLinks,
+      ),
+    });
     // Clear thinking status on failure since callback won't be invoked
     await setThreadStatus(client, context.channelId, threadTs, "").catch(
       (err) => log.warn("Failed to clear thread status", { error: err }),

--- a/turbo/apps/web/src/lib/slack/handlers/shared.ts
+++ b/turbo/apps/web/src/lib/slack/handlers/shared.ts
@@ -210,6 +210,14 @@ export function buildLogsUrl(runId: string, agentName: string): string {
 }
 
 /**
+ * Build the agent-level logs URL (no specific run).
+ * Used as fallback when runId is unavailable (e.g. dispatch failure).
+ */
+export function buildAgentLogsUrl(agentName: string): string {
+  return `${getPlatformUrl()}/agents/${encodeURIComponent(agentName)}/logs`;
+}
+
+/**
  * Ensure scope and artifact storage exist for a user.
  * Safety net for all agent link paths (App Home button, slash command, submission).
  *


### PR DESCRIPTION
## Summary
- Slack dispatch failure errors were sent as plain text without logs links, unlike the callback path and Telegram
- Now uses `buildAgentResponseMessage()` for consistent Block Kit formatting with agent name header, logs link, and deep links
- Adds `buildAgentLogsUrl()` fallback for when `runId` is unavailable (matching Telegram's pattern)

## Test plan
- [ ] Trigger a dispatch failure in Slack DM (e.g. agent config not found) → error message should show agent name, logs link, and deep links
- [ ] Trigger a dispatch failure via @mention → same formatted error
- [ ] Callback failure path unchanged — still shows logs link as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)