### PR TITLE
fix: allow shared agent detail access without scope membership

### DIFF
--- a/turbo/apps/web/app/api/agent/composes/__tests__/get-by-name.test.ts
+++ b/turbo/apps/web/app/api/agent/composes/__tests__/get-by-name.test.ts
@@ -3,6 +3,8 @@ import { GET } from "../route";
 import {
   createTestRequest,
   createTestCompose,
+  getTestScope,
+  insertTestAgentPermission,
 } from "../../../../../src/__tests__/api-test-helpers";
 import {
   testContext,
@@ -138,5 +140,94 @@ describe("GET /api/agent/composes?name=<name>", () => {
 
     expect(getResponse.status).toBe(401);
     expect(getData.error.message).toContain("Not authenticated");
+  });
+
+  it("should return shared agent via cross-scope lookup with ?scope=", async () => {
+    const agentName = `test-shared-agent-${Date.now()}`;
+
+    // Create compose as owner
+    const { composeId } = await createTestCompose(agentName);
+
+    // Get the owner's scope slug
+    const ownerScope = await getTestScope(user.scopeId);
+
+    // Grant email permission to the recipient
+    const recipientEmail = "recipient@example.com";
+    await insertTestAgentPermission(composeId, recipientEmail, user.userId);
+
+    // Switch to recipient user
+    const recipient = await context.setupUser({ prefix: "recipient" });
+    mockClerk({ userId: recipient.userId, email: recipientEmail });
+
+    // Access the agent via cross-scope lookup
+    const getRequest = createTestRequest(
+      `http://localhost:3000/api/agent/composes?name=${agentName}&scope=${ownerScope.slug}`,
+      { method: "GET" },
+    );
+
+    const getResponse = await GET(getRequest);
+    const getData = await getResponse.json();
+
+    expect(getResponse.status).toBe(200);
+    expect(getData.id).toBe(composeId);
+    expect(getData.name).toBe(agentName);
+  });
+
+  it("should return 404 for non-shared agent via cross-scope lookup", async () => {
+    const agentName = `test-not-shared-${Date.now()}`;
+
+    // Create compose as owner (no permission granted)
+    await createTestCompose(agentName);
+
+    // Get the owner's scope slug
+    const ownerScope = await getTestScope(user.scopeId);
+
+    // Switch to another user with no permission
+    await context.setupUser({ prefix: "unauthorized" });
+
+    // Try to access via cross-scope lookup
+    const getRequest = createTestRequest(
+      `http://localhost:3000/api/agent/composes?name=${agentName}&scope=${ownerScope.slug}`,
+      { method: "GET" },
+    );
+
+    const getResponse = await GET(getRequest);
+    const getData = await getResponse.json();
+
+    expect(getResponse.status).toBe(404);
+    expect(getData.error.message).toContain("Agent compose not found");
+  });
+
+  it("should return own agent without ?scope= parameter", async () => {
+    const agentName = `test-own-agent-${Date.now()}`;
+
+    // Create compose as current user
+    const { composeId } = await createTestCompose(agentName);
+
+    // Access without scope param (uses resolveScope for own scope)
+    const getRequest = createTestRequest(
+      `http://localhost:3000/api/agent/composes?name=${agentName}`,
+      { method: "GET" },
+    );
+
+    const getResponse = await GET(getRequest);
+    const getData = await getResponse.json();
+
+    expect(getResponse.status).toBe(200);
+    expect(getData.id).toBe(composeId);
+    expect(getData.name).toBe(agentName);
+  });
+
+  it("should return 404 for invalid scope slug in cross-scope lookup", async () => {
+    const getRequest = createTestRequest(
+      "http://localhost:3000/api/agent/composes?name=any-agent&scope=nonexistent-scope",
+      { method: "GET" },
+    );
+
+    const getResponse = await GET(getRequest);
+    const getData = await getResponse.json();
+
+    expect(getResponse.status).toBe(404);
+    expect(getData.error.message).toContain("Agent compose not found");
   });
 });

--- a/turbo/apps/web/app/api/agent/composes/route.ts
+++ b/turbo/apps/web/app/api/agent/composes/route.ts
@@ -22,6 +22,7 @@ import { getUserId } from "../../../../src/lib/auth/get-user-id";
 import { eq, and } from "drizzle-orm";
 import { computeComposeVersionId } from "../../../../src/lib/agent-compose/content-hash";
 import { resolveScope } from "../../../../src/lib/scope/resolve-scope";
+import { getScopeBySlug } from "../../../../src/lib/scope/scope-service";
 import { getUserEmail } from "../../../../src/lib/auth/get-user-email";
 import { canAccessCompose } from "../../../../src/lib/agent/permission-service";
 import type { AgentComposeYaml } from "../../../../src/types/agent-compose";
@@ -40,9 +41,27 @@ const router = tsr.router(composesMainContract, {
       };
     }
 
-    // Resolve scope: use ?scope= query param or default scope
-    const { scope: resolvedScope } = await resolveScope(userId, query.scope);
-    const scopeId = resolvedScope.id;
+    // Resolve scope: for cross-scope lookups (shared agents), skip membership
+    // check and rely on canAccessCompose for authorization instead.
+    let scopeId: string;
+    if (query.scope) {
+      const scope = await getScopeBySlug(query.scope);
+      if (!scope) {
+        return {
+          status: 404 as const,
+          body: {
+            error: {
+              message: `Agent compose not found: ${query.name}`,
+              code: "NOT_FOUND",
+            },
+          },
+        };
+      }
+      scopeId = scope.id;
+    } else {
+      const { scope: resolvedScope } = await resolveScope(userId);
+      scopeId = resolvedScope.id;
+    }
 
     // JOIN compose + version in a single query
     const [result] = await globalThis.services.db


### PR DESCRIPTION
## Summary
- Email-shared agents were inaccessible from the detail page because `getByName` called `resolveScope(userId, query.scope)` which enforces scope membership
- For shared agents, the user has an `agent_permissions` entry but is NOT a member of the owner's scope, so `resolveScope` threw 403 before `canAccessCompose` could run
- Fix: when `?scope=` is provided (cross-scope lookup), use `getScopeBySlug` directly without membership check, then rely on `canAccessCompose` for authorization
- Without `?scope=` (own agents), continues to use `resolveScope` as before

**Regression introduced in** #3592 (scope unification phase 1+2), which replaced the original `getScopeBySlug` + `canAccessCompose` two-step pattern with a single `resolveScope` call.

## Test plan
- [ ] Share an agent via email with another user
- [ ] As the recipient, verify the agent appears in the agent list
- [ ] Click the shared agent → detail page should load (was 404 before)
- [ ] Verify non-shared agents still return 404 for unauthorized users

🤖 Generated with [Claude Code](https://claude.com/claude-code)