### PR TITLE
chore(e2e): remove unused skip network security test guards

### DIFF
--- a/e2e/tests/03-experimental-runner/t40-firewall-sni.bats
+++ b/e2e/tests/03-experimental-runner/t40-firewall-sni.bats
@@ -68,10 +68,6 @@ EOF
 }
 
 @test "sni-firewall: allowed domain passes through and logs captured" {
-    if [[ -n "$SKIP_NETWORK_SECURITY_TEST" ]]; then
-        skip "Network security test skipped"
-    fi
-
     cat > "$TEST_DIR/vm0.yaml" <<EOF
 version: "1.0"
 
@@ -127,10 +123,6 @@ EOF
 }
 
 @test "sni-firewall: blocked domain is denied" {
-    if [[ -n "$SKIP_NETWORK_SECURITY_TEST" ]]; then
-        skip "Network security test skipped"
-    fi
-
     cat > "$TEST_DIR/vm0.yaml" <<EOF
 version: "1.0"
 

--- a/e2e/tests/03-experimental-runner/t41-firewall-mitm.bats
+++ b/e2e/tests/03-experimental-runner/t41-firewall-mitm.bats
@@ -68,10 +68,6 @@ EOF
 }
 
 @test "mitm-firewall: allowed domain passes through and logs captured" {
-    if [[ -n "$SKIP_NETWORK_SECURITY_TEST" ]]; then
-        skip "Network security test skipped"
-    fi
-
     cat > "$TEST_DIR/vm0.yaml" <<EOF
 version: "1.0"
 
@@ -127,10 +123,6 @@ EOF
 }
 
 @test "mitm-firewall: blocked domain returns 403" {
-    if [[ -n "$SKIP_NETWORK_SECURITY_TEST" ]]; then
-        skip "Network security test skipped"
-    fi
-
     cat > "$TEST_DIR/vm0.yaml" <<EOF
 version: "1.0"
 
@@ -168,10 +160,6 @@ EOF
 }
 
 @test "mitm-firewall: seal_secrets encrypts environment secrets" {
-    if [[ -n "$SKIP_NETWORK_SECURITY_TEST" ]]; then
-        skip "Network security test skipped"
-    fi
-
     export TEST_SECRET="secret-$(date +%s%3N)-$RANDOM"
 
     cat > "$TEST_DIR/vm0.yaml" <<EOF
@@ -221,10 +209,6 @@ EOF
 }
 
 @test "mitm-firewall: secrets not encrypted without seal_secrets" {
-    if [[ -n "$SKIP_NETWORK_SECURITY_TEST" ]]; then
-        skip "Network security test skipped"
-    fi
-
     export TEST_SECRET="plain-$(date +%s%3N)-$RANDOM"
 
     cat > "$TEST_DIR/vm0.yaml" <<EOF


### PR DESCRIPTION
## Summary
- Remove `SKIP_NETWORK_SECURITY_TEST` skip guards from 6 firewall tests (2 in `t40-firewall-sni.bats`, 4 in `t41-firewall-mitm.bats`)
- The variable was never set anywhere — dead code

## Test plan
- [ ] Firewall E2E tests still run and pass without the skip guards

🤖 Generated with [Claude Code](https://claude.com/claude-code)