### PR TITLE
fix: add args parsing instructions to PR-related skills

### DIFF
--- a/.claude/skills/pr-check/SKILL.md
+++ b/.claude/skills/pr-check/SKILL.md
@@ -33,6 +33,13 @@ You are a CI pipeline specialist for the vm0 project. Your role is to monitor PR
 
 ## Step 1: Identify Target PR
 
+Parse the `args` parameter to extract a PR number. The args can be:
+- A PR number: `4062`
+- A GitHub URL: `https://github.com/owner/repo/pull/4062` or `https://github.com/owner/repo/issues/4062`
+- Empty: detect from current branch
+
+**Important:** `$PR_ID` is a placeholder — you (the LLM) must extract the PR number from the skill's `args` string yourself before running any bash commands. If args contains a URL, extract the number from the path. If args is a plain number, use it directly. If args is empty, fall back to detecting from the current branch.
+
 ```bash
 if [ -n "$PR_ID" ]; then
     pr_id="$PR_ID"

--- a/.claude/skills/pr-review-loop/SKILL.md
+++ b/.claude/skills/pr-review-loop/SKILL.md
@@ -32,7 +32,16 @@ Loop control is handled by a **bash driver script**, not by your memory. You MUS
 
 ### 1a: Identify PR
 
+Parse the `args` parameter to extract a PR number. The args can be:
+- A PR number: `4062`
+- A GitHub PR URL: `https://github.com/owner/repo/pull/4062`
+- A GitHub issue URL: `https://github.com/owner/repo/issues/4062` (treat as PR number)
+- Empty: detect from current branch
+
 ```bash
+# Parse PR_ID from args — extract number from URL if needed
+PR_ID=$(echo "$ARGS" | grep -oP '(?:pull|issues)/\K[0-9]+' || echo "$ARGS" | grep -oP '^[0-9]+$' || echo "")
+
 if [ -n "$PR_ID" ]; then
     PR_NUMBER="$PR_ID"
 else
@@ -40,6 +49,8 @@ else
     PR_NUMBER=$(gh pr list --head "$CURRENT_BRANCH" --json number --jq '.[0].number')
 fi
 ```
+
+**Important:** `$ARGS` is a placeholder — you (the LLM) must extract the PR number from the skill's `args` string yourself before running any bash commands. If args contains a URL, extract the number from the path. If args is a plain number, use it directly. If args is empty, fall back to detecting from the current branch.
 
 ### 1b: Create Driver Script
 

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -10,6 +10,13 @@ You are a PR review specialist for the vm0 project. Your role is to review pull 
 
 ### Step 1: Determine PR Number
 
+Parse the `args` parameter to extract a PR number. The args can be:
+- A PR number: `4062`
+- A GitHub URL: `https://github.com/owner/repo/pull/4062` or `https://github.com/owner/repo/issues/4062`
+- Empty: detect from current branch
+
+**Important:** `$PR_ID` is a placeholder — you (the LLM) must extract the PR number from the skill's `args` string yourself before running any bash commands. If args contains a URL, extract the number from the path. If args is a plain number, use it directly. If args is empty, fall back to detecting from the current branch.
+
 ```bash
 if [ -n "$PR_ID" ]; then
     PR_NUMBER="$PR_ID"


### PR DESCRIPTION
## Summary
- Add explicit args parsing instructions to `pr-review-loop`, `pr-review`, and `pr-check` skills
- These skills used `$PR_ID` as a placeholder but never told the LLM how to extract a PR number from the `args` parameter
- Now supports: plain PR number (`4062`), GitHub PR URL, GitHub issue URL, or empty (fallback to current branch)

## Test plan
- [ ] `/pr-review-loop 4062` — parses number correctly
- [ ] `/pr-review-loop https://github.com/vm0-ai/vm0/pull/4062` — extracts number from URL
- [ ] `/pr-review-loop https://github.com/vm0-ai/vm0/issues/4062` — extracts number from issue URL
- [ ] `/pr-review-loop` (no args) — falls back to current branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)