### PR TITLE
fix(ci): clear stale apt lists before update

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -208,7 +208,7 @@ jobs:
 
           # Provision system dependencies (idempotent)
           echo "=== Provisioning system dependencies ==="
-          apt-get update && apt-get install -y python3 python3-pip
+          rm -rf /var/lib/apt/lists/* && apt-get update && apt-get install -y python3 python3-pip
           pip3 install ansible
           cd ansible
           ansible-playbook \

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -624,7 +624,7 @@ jobs:
 
       - name: Install Python3 and Ansible
         run: |
-          apt-get update && apt-get install -y python3 python3-pip
+          rm -rf /var/lib/apt/lists/* && apt-get update && apt-get install -y python3 python3-pip
           pip3 install ansible
 
       - name: Notify Slack - Starting

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1194,7 +1194,7 @@ jobs:
 
           # Provision system dependencies on all hosts (idempotent)
           echo "=== Provisioning system dependencies ==="
-          apt-get update && apt-get install -y python3 python3-pip
+          rm -rf /var/lib/apt/lists/* && apt-get update && apt-get install -y python3 python3-pip
           pip3 install ansible
           cd ansible
           ansible-playbook \
@@ -1448,7 +1448,7 @@ jobs:
         run: cd turbo/apps/cli && pnpm link --global
 
       - name: Install GNU parallel for bats
-        run: apt-get update && apt-get install -y parallel
+        run: rm -rf /var/lib/apt/lists/* && apt-get update && apt-get install -y parallel
 
       - name: Restore test token from cache
         uses: actions/cache/restore@v5


### PR DESCRIPTION
## Summary
- Add `rm -rf /var/lib/apt/lists/*` before every `apt-get update` in CI workflows
- Applies to `turbo.yml` (2 places), `release-please.yml`, and `crates.yml`
- Prevents failures from stale package lists in cached runner images

## Test plan
- [ ] CI workflows pass with the updated apt commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)