### PR TITLE
fix: enforce strictly increasing timestamps in migration journal

### DIFF
--- a/turbo/apps/web/scripts/test-migration-consistency-schema.ts
+++ b/turbo/apps/web/scripts/test-migration-consistency-schema.ts
@@ -423,6 +423,70 @@ function compareSchemas(
   };
 }
 
+async function validateTimestampOrdering(): Promise<void> {
+  console.log("=== Phase 0.5: Validate Journal Timestamp Ordering ===\n");
+
+  const journalPath = path.join(MIGRATIONS_DIR, "meta/_journal.json");
+  const journal = JSON.parse(await fs.readFile(journalPath, "utf-8"));
+  const entries = journal.entries as Array<{
+    idx: number;
+    tag: string;
+    when: number;
+  }>;
+
+  if (entries.length < 2) {
+    console.log("   Skipping (fewer than 2 migrations)\n");
+    return;
+  }
+
+  const violations: string[] = [];
+  for (let i = 1; i < entries.length; i++) {
+    const prev = entries[i - 1]!;
+    const curr = entries[i]!;
+    if (curr.when <= prev.when) {
+      const diffMs = prev.when - curr.when;
+      const diffDays = (diffMs / (1000 * 60 * 60 * 24)).toFixed(1);
+      violations.push(
+        `   ${String(prev.idx).padStart(4, "0")} ${prev.tag} (when=${prev.when}) → ` +
+          `${String(curr.idx).padStart(4, "0")} ${curr.tag} (when=${curr.when}) — ` +
+          `timestamp goes BACKWARDS by ${diffDays} days`,
+      );
+    }
+  }
+
+  if (violations.length > 0) {
+    console.error(
+      `   ❌ Found ${violations.length} timestamp ordering violation(s):\n`,
+    );
+    for (const v of violations) {
+      console.error(v);
+    }
+    console.error(
+      `\n   Drizzle's migrator only applies migrations whose timestamp`,
+    );
+    console.error(`   is greater than the last applied migration's timestamp.`);
+    console.error(
+      `   Out-of-order timestamps cause migrations to be SKIPPED in production.`,
+    );
+    console.error(`\n   🔧 How to fix:`);
+    console.error(
+      `      Update the "when" values in meta/_journal.json so that`,
+    );
+    console.error(
+      `      each entry's timestamp is strictly greater than the previous one.`,
+    );
+    console.error(
+      `      For example, set the violating entry's "when" to prev.when + 1.\n`,
+    );
+    throw new Error("Journal timestamp ordering violation");
+  }
+
+  console.log(
+    `   ✅ All ${entries.length} migrations have strictly increasing timestamps`,
+  );
+  console.log();
+}
+
 async function validateLatestSnapshotAccuracy(): Promise<void> {
   console.log("=== Phase 1.5: Validate Latest Snapshot Accuracy ===\n");
 
@@ -524,6 +588,9 @@ async function main(): Promise<void> {
     // Step 0: Validate snapshot files
     await validateSnapshotFiles();
 
+    // Step 0.5: Validate timestamp ordering
+    await validateTimestampOrdering();
+
     // Step 1.5: Validate latest snapshot accuracy (NEW)
     await validateLatestSnapshotAccuracy();
 
@@ -554,10 +621,9 @@ async function main(): Promise<void> {
 
     if (comparisonPassed) {
       console.log("\n✅ SUCCESS: All validations passed!");
-      console.log(
-        "   ✅ Snapshot count matches migration count (89 migrations)",
-      );
+      console.log("   ✅ Snapshot count matches migration count");
       console.log("   ✅ Snapshot chain is intact (id/prevId references)");
+      console.log("   ✅ Journal timestamps are strictly increasing");
       console.log("   ✅ Latest snapshot accurately reflects final DB state");
       console.log("   ✅ Schemas are functionally equivalent");
       console.log("   ✅ All migrations match the schema definitions");

--- a/turbo/apps/web/src/db/migrations/meta/_journal.json
+++ b/turbo/apps/web/src/db/migrations/meta/_journal.json
@@ -628,7 +628,7 @@
     {
       "idx": 89,
       "version": "7",
-      "when": 1771203020572,
+      "when": 1771300000001,
       "tag": "0089_naive_darkstar",
       "breakpoints": true
     },
@@ -733,7 +733,7 @@
     {
       "idx": 104,
       "version": "7",
-      "when": 1772616051401,
+      "when": 1772698746422,
       "tag": "0104_steep_devos",
       "breakpoints": true
     },
@@ -796,7 +796,7 @@
     {
       "idx": 113,
       "version": "7",
-      "when": 1773050584231,
+      "when": 1773244800001,
       "tag": "0113_handy_galactus",
       "breakpoints": true
     }


### PR DESCRIPTION
## Summary

- Fix three timestamp ordering violations in `_journal.json` that caused Drizzle ORM to permanently skip migrations 0089 and 0113 in production, resulting in missing `email_outbox` table (Sentry WEB-1H, WEB-1J) and missing `connectors.platform`/`nango_connection_id` columns
- Add CI validation (`validateTimestampOrdering`) in `test-migration-consistency-schema.ts` to prevent future timestamp ordering violations

## Context

Drizzle's migrator uses `lastDbMigration.created_at < migration.folderMillis` to decide whether to apply a migration. If a migration's `when` timestamp in `_journal.json` is **less** than the previous migration's timestamp, it will be permanently skipped.

Three violations were found and fixed:
| Migration | Old timestamp | New timestamp | Gap |
|-----------|--------------|---------------|-----|
| 0089 | 1771203020572 | 1771300000001 | was ~1.1 days before 0088 |
| 0104 | 1772616051401 | 1772698746422 | was ~1.0 days before 0103 |
| 0113 | 1773050584231 | 1773244800001 | was ~2.2 days before 0112 |

> **Note:** A separate remediation migration with `CREATE IF NOT EXISTS` / `ADD COLUMN IF NOT EXISTS` is needed to apply the missing schema changes from 0089 and 0113 to production. See #4078.

## Test plan

- [ ] CI `test-migration-consistency-schema` passes with the new timestamp ordering validation
- [ ] Verify no regression in existing migration tests
- [ ] After merge, confirm new migrations with out-of-order timestamps are rejected by CI

Refs: #4078

🤖 Generated with [Claude Code](https://claude.com/claude-code)