### PR TITLE
refactor: align scope naming with resource model terminology

### DIFF
--- a/turbo/apps/web/app/api/agent/composes/route.ts
+++ b/turbo/apps/web/app/api/agent/composes/route.ts
@@ -234,7 +234,7 @@ const router = tsr.router(composesMainContract, {
     const versionId = computeComposeVersionId(resolvedContent);
 
     // Get user's scope (required for compose creation)
-    const { scope: runtimeScope } = await resolveScope(userId);
+    const { scope } = await resolveScope(userId);
 
     // Check compose and version existence in parallel
     const [existingComposes, existingVersions] = await Promise.all([
@@ -243,7 +243,7 @@ const router = tsr.router(composesMainContract, {
         .from(agentComposes)
         .where(
           and(
-            eq(agentComposes.scopeId, runtimeScope.id),
+            eq(agentComposes.scopeId, scope.id),
             eq(agentComposes.name, normalizedAgentName),
           ),
         )
@@ -269,7 +269,7 @@ const router = tsr.router(composesMainContract, {
         .insert(agentComposes)
         .values({
           userId,
-          scopeId: runtimeScope.id,
+          scopeId: scope.id,
           name: normalizedAgentName,
         })
         .returning({ id: agentComposes.id });

--- a/turbo/apps/web/app/api/agent/composes/route.ts
+++ b/turbo/apps/web/app/api/agent/composes/route.ts
@@ -234,7 +234,7 @@ const router = tsr.router(composesMainContract, {
     const versionId = computeComposeVersionId(resolvedContent);
 
     // Get user's scope (required for compose creation)
-    const { scope: userScope } = await resolveScope(userId);
+    const { scope: runtimeScope } = await resolveScope(userId);
 
     // Check compose and version existence in parallel
     const [existingComposes, existingVersions] = await Promise.all([
@@ -243,7 +243,7 @@ const router = tsr.router(composesMainContract, {
         .from(agentComposes)
         .where(
           and(
-            eq(agentComposes.scopeId, userScope.id),
+            eq(agentComposes.scopeId, runtimeScope.id),
             eq(agentComposes.name, normalizedAgentName),
           ),
         )
@@ -269,7 +269,7 @@ const router = tsr.router(composesMainContract, {
         .insert(agentComposes)
         .values({
           userId,
-          scopeId: userScope.id,
+          scopeId: runtimeScope.id,
           name: normalizedAgentName,
         })
         .returning({ id: agentComposes.id });

--- a/turbo/apps/web/app/api/agent/schedules/missing-secrets/route.ts
+++ b/turbo/apps/web/app/api/agent/schedules/missing-secrets/route.ts
@@ -9,7 +9,7 @@ import {
   getUserAgents,
   batchFetchVersionContents,
 } from "../../../../../src/lib/agent/get-user-agents";
-import { getUserScopeByClerkId } from "../../../../../src/lib/scope/scope-service";
+import { getDefaultScopeByClerkUserId } from "../../../../../src/lib/scope/scope-service";
 
 const log = logger("api:agents:missing-secrets");
 
@@ -51,8 +51,8 @@ export async function GET(request: Request) {
   }
 
   // Get user's scope to query configured secrets
-  const userScope = await getUserScopeByClerkId(userId);
-  if (!userScope) {
+  const runtimeScope = await getDefaultScopeByClerkUserId(userId);
+  if (!runtimeScope) {
     return NextResponse.json({ agents: [] });
   }
 
@@ -61,7 +61,7 @@ export async function GET(request: Request) {
   const userSecrets = await db
     .select({ name: secrets.name })
     .from(secrets)
-    .where(eq(secrets.scopeId, userScope.id));
+    .where(eq(secrets.scopeId, runtimeScope.id));
 
   const configuredSecretNames = new Set(userSecrets.map((s) => s.name));
 

--- a/turbo/apps/web/app/api/cli/auth/test-token/route.ts
+++ b/turbo/apps/web/app/api/cli/auth/test-token/route.ts
@@ -45,7 +45,7 @@ function isTestTokenAllowed(request: Request): boolean {
 
 /**
  * Ensure the test user has a scope, creating one directly in the database
- * if necessary. Unlike the normal createUserScope flow, this bypasses
+ * if necessary. Unlike the normal createScope flow, this bypasses
  * Clerk Organization creation entirely — test scopes don't need a real
  * Clerk org, and the Clerk Backend API rejects org creation for
  * e2e test users (403 Forbidden).

--- a/turbo/apps/web/app/api/cli/auth/test-token/route.ts
+++ b/turbo/apps/web/app/api/cli/auth/test-token/route.ts
@@ -5,7 +5,7 @@ import { cliTokens } from "../../../../../src/db/schema/cli-tokens";
 import { scopes } from "../../../../../src/db/schema/scope";
 import { scopeMembers } from "../../../../../src/db/schema/scope-member";
 import {
-  getUserScopeByClerkId,
+  getDefaultScopeByClerkUserId,
   generateDefaultScopeSlug,
 } from "../../../../../src/lib/scope/scope-service";
 import {
@@ -51,7 +51,7 @@ function isTestTokenAllowed(request: Request): boolean {
  * e2e test users (403 Forbidden).
  */
 async function ensureTestScope(userId: string): Promise<void> {
-  const existing = await getUserScopeByClerkId(userId);
+  const existing = await getDefaultScopeByClerkUserId(userId);
   if (existing) return;
 
   const slug = generateDefaultScopeSlug(userId);

--- a/turbo/apps/web/app/api/integrations/github/route.ts
+++ b/turbo/apps/web/app/api/integrations/github/route.ts
@@ -121,13 +121,13 @@ export async function GET(request: Request) {
   }
 
   // Resolve user's scope for resource queries
-  const { scope: runtimeScope } = await resolveScope(userId);
+  const { scope } = await resolveScope(userId);
 
   // Get user's existing secrets, vars, connectors
   const [userSecrets, userVars, userConnectors] = await Promise.all([
-    listSecrets(runtimeScope.id, userId),
-    listVariables(runtimeScope.id, userId),
-    listConnectors(runtimeScope.id, userId),
+    listSecrets(scope.id, userId),
+    listVariables(scope.id, userId),
+    listConnectors(scope.id, userId),
   ]);
 
   const connectorProvided = getConnectorProvidedSecretNames(

--- a/turbo/apps/web/app/api/integrations/github/route.ts
+++ b/turbo/apps/web/app/api/integrations/github/route.ts
@@ -121,13 +121,13 @@ export async function GET(request: Request) {
   }
 
   // Resolve user's scope for resource queries
-  const { scope: userScope } = await resolveScope(userId);
+  const { scope: runtimeScope } = await resolveScope(userId);
 
   // Get user's existing secrets, vars, connectors
   const [userSecrets, userVars, userConnectors] = await Promise.all([
-    listSecrets(userScope.id, userId),
-    listVariables(userScope.id, userId),
-    listConnectors(userScope.id, userId),
+    listSecrets(runtimeScope.id, userId),
+    listVariables(runtimeScope.id, userId),
+    listConnectors(runtimeScope.id, userId),
   ]);
 
   const connectorProvided = getConnectorProvidedSecretNames(

--- a/turbo/apps/web/app/api/integrations/slack/link/route.ts
+++ b/turbo/apps/web/app/api/integrations/slack/link/route.ts
@@ -115,12 +115,12 @@ async function buildAgentFields(
 
   let agents: Array<{ id: string; name: string }> = [];
   if (isAdmin) {
-    const runtimeScope = await getDefaultScopeByClerkUserId(userId);
-    if (runtimeScope) {
+    const defaultScope = await getDefaultScopeByClerkUserId(userId);
+    if (defaultScope) {
       const userAgents = await globalThis.services.db
         .select({ id: agentComposes.id, name: agentComposes.name })
         .from(agentComposes)
-        .where(eq(agentComposes.scopeId, runtimeScope.id));
+        .where(eq(agentComposes.scopeId, defaultScope.id));
 
       // Prepend default agent, deduplicate by id
       const seen = new Set<string>();

--- a/turbo/apps/web/app/api/integrations/slack/link/route.ts
+++ b/turbo/apps/web/app/api/integrations/slack/link/route.ts
@@ -16,7 +16,7 @@ import {
 } from "../../../../../src/lib/slack/handlers/shared";
 import { getUserEmail } from "../../../../../src/lib/auth/get-user-email";
 import { addPermission } from "../../../../../src/lib/agent/permission-service";
-import { getUserScopeByClerkId } from "../../../../../src/lib/scope/scope-service";
+import { getDefaultScopeByClerkUserId } from "../../../../../src/lib/scope/scope-service";
 import { agentComposes } from "../../../../../src/db/schema/agent-compose";
 import { logger } from "../../../../../src/lib/logger";
 import { syncWorkspaceAgentPermissions } from "../../../../../src/lib/slack/permission-sync";
@@ -115,12 +115,12 @@ async function buildAgentFields(
 
   let agents: Array<{ id: string; name: string }> = [];
   if (isAdmin) {
-    const userScope = await getUserScopeByClerkId(userId);
-    if (userScope) {
+    const runtimeScope = await getDefaultScopeByClerkUserId(userId);
+    if (runtimeScope) {
       const userAgents = await globalThis.services.db
         .select({ id: agentComposes.id, name: agentComposes.name })
         .from(agentComposes)
-        .where(eq(agentComposes.scopeId, userScope.id));
+        .where(eq(agentComposes.scopeId, runtimeScope.id));
 
       // Prepend default agent, deduplicate by id
       const seen = new Set<string>();

--- a/turbo/apps/web/app/api/integrations/slack/route.ts
+++ b/turbo/apps/web/app/api/integrations/slack/route.ts
@@ -124,11 +124,11 @@ export async function GET(request: Request) {
   }
 
   // Get user's existing secrets, vars, connectors
-  const { scope: userScope } = await resolveScope(userId);
+  const { scope: runtimeScope } = await resolveScope(userId);
   const [userSecrets, userVars, userConnectors] = await Promise.all([
-    listSecrets(userScope.id, userId),
-    listVariables(userScope.id, userId),
-    listConnectors(userScope.id, userId),
+    listSecrets(runtimeScope.id, userId),
+    listVariables(runtimeScope.id, userId),
+    listConnectors(runtimeScope.id, userId),
   ]);
 
   const connectorProvided = getConnectorProvidedSecretNames(

--- a/turbo/apps/web/app/api/integrations/slack/route.ts
+++ b/turbo/apps/web/app/api/integrations/slack/route.ts
@@ -124,11 +124,11 @@ export async function GET(request: Request) {
   }
 
   // Get user's existing secrets, vars, connectors
-  const { scope: runtimeScope } = await resolveScope(userId);
+  const { scope } = await resolveScope(userId);
   const [userSecrets, userVars, userConnectors] = await Promise.all([
-    listSecrets(runtimeScope.id, userId),
-    listVariables(runtimeScope.id, userId),
-    listConnectors(runtimeScope.id, userId),
+    listSecrets(scope.id, userId),
+    listVariables(scope.id, userId),
+    listConnectors(scope.id, userId),
   ]);
 
   const connectorProvided = getConnectorProvidedSecretNames(

--- a/turbo/apps/web/app/api/storages/commit/route.ts
+++ b/turbo/apps/web/app/api/storages/commit/route.ts
@@ -37,7 +37,7 @@ const router = tsr.router(storagesCommitContract, {
 
     // Resolve user's scope
     const scopeSlug = new URL(request.url).searchParams.get("scope");
-    const { scope: userScope } = await resolveScope(userId, scopeSlug);
+    const { scope: runtimeScope } = await resolveScope(userId, scopeSlug);
 
     const { storageName, storageType, versionId, files, runId, message } = body;
 
@@ -73,7 +73,7 @@ const router = tsr.router(storagesCommitContract, {
       .from(storages)
       .where(
         and(
-          eq(storages.scopeId, userScope.id),
+          eq(storages.scopeId, runtimeScope.id),
           eq(storages.userId, storageUserId),
           eq(storages.name, storageName),
           eq(storages.type, storageType),
@@ -200,7 +200,7 @@ const router = tsr.router(storagesCommitContract, {
     // Verify required S3 objects exist
     // For empty artifacts (fileCount === 0), only manifest is required
     // since there's no archive to extract
-    const s3Key = `${userScope.slug}/${storageType}/${storageName}/${versionId}`;
+    const s3Key = `${runtimeScope.slug}/${storageType}/${storageName}/${versionId}`;
     const manifestKey = `${s3Key}/manifest.json`;
     const archiveKey = `${s3Key}/archive.tar.gz`;
     const fileCount = files.length;

--- a/turbo/apps/web/app/api/storages/download/route.ts
+++ b/turbo/apps/web/app/api/storages/download/route.ts
@@ -33,12 +33,12 @@ const router = tsr.router(storagesDownloadContract, {
 
     // Resolve user's scope
     const scopeSlug = new URL(request.url).searchParams.get("scope");
-    const { scope: userScope } = await resolveScope(userId, scopeSlug);
+    const { scope: runtimeScope } = await resolveScope(userId, scopeSlug);
 
     const { name: storageName, type: storageType, version: versionId } = query;
 
     log.debug(
-      `Getting download URL for "${storageName}" (type: ${storageType})${versionId ? ` version ${versionId}` : ""} for scope ${userScope.slug}`,
+      `Getting download URL for "${storageName}" (type: ${storageType})${versionId ? ` version ${versionId}` : ""} for scope ${runtimeScope.slug}`,
     );
 
     // Volumes use sentinel userId (scope-shared); artifacts/memory use real userId
@@ -51,7 +51,7 @@ const router = tsr.router(storagesDownloadContract, {
       .from(storages)
       .where(
         and(
-          eq(storages.scopeId, userScope.id),
+          eq(storages.scopeId, runtimeScope.id),
           eq(storages.userId, storageUserId),
           eq(storages.name, storageName),
           eq(storages.type, storageType),

--- a/turbo/apps/web/app/api/storages/list/route.ts
+++ b/turbo/apps/web/app/api/storages/list/route.ts
@@ -32,13 +32,13 @@ const router = tsr.router(storagesListContract, {
 
     // Resolve user's scope
     const scopeSlug = new URL(request.url).searchParams.get("scope");
-    const { scope: userScope } = await resolveScope(userId, scopeSlug);
+    const { scope: runtimeScope } = await resolveScope(userId, scopeSlug);
 
     // Volumes use sentinel userId (scope-shared); artifacts/memory use real userId
     const storageUserId =
       storageType === "volume" ? VOLUME_SCOPE_USER_ID : userId;
 
-    log.debug(`Listing ${storageType}s for scope ${userScope.slug}`);
+    log.debug(`Listing ${storageType}s for scope ${runtimeScope.slug}`);
 
     // Query storages filtered by scope, userId, and type
     const results = await globalThis.services.db
@@ -51,7 +51,7 @@ const router = tsr.router(storagesListContract, {
       .from(storages)
       .where(
         and(
-          eq(storages.scopeId, userScope.id),
+          eq(storages.scopeId, runtimeScope.id),
           eq(storages.userId, storageUserId),
           eq(storages.type, storageType),
         ),

--- a/turbo/apps/web/app/api/storages/prepare/route.ts
+++ b/turbo/apps/web/app/api/storages/prepare/route.ts
@@ -99,7 +99,7 @@ const router = tsr.router(storagesPrepareContract, {
 
     // Resolve user's scope
     const scopeSlug = new URL(request.url).searchParams.get("scope");
-    const { scope: userScope } = await resolveScope(userId, scopeSlug);
+    const { scope: runtimeScope } = await resolveScope(userId, scopeSlug);
 
     const {
       storageName,
@@ -142,10 +142,10 @@ const router = tsr.router(storagesPrepareContract, {
       .insert(storages)
       .values({
         userId: storageUserId,
-        scopeId: userScope.id,
+        scopeId: runtimeScope.id,
         name: storageName,
         type: storageType,
-        s3Prefix: `${userScope.slug}/${storageType}/${storageName}`,
+        s3Prefix: `${runtimeScope.slug}/${storageType}/${storageName}`,
         size: 0,
         fileCount: 0,
       })
@@ -257,7 +257,7 @@ const router = tsr.router(storagesPrepareContract, {
     }
 
     // Generate presigned URLs for archive and manifest
-    const s3Key = `${userScope.slug}/${storageType}/${storageName}/${versionId}`;
+    const s3Key = `${runtimeScope.slug}/${storageType}/${storageName}/${versionId}`;
     const archiveKey = `${s3Key}/archive.tar.gz`;
     const manifestKey = `${s3Key}/manifest.json`;
 

--- a/turbo/apps/web/app/api/webhooks/agent/storages/commit/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/storages/commit/route.ts
@@ -12,7 +12,7 @@ import {
 } from "../../../../../../src/db/schema/storage";
 import { eq, and } from "drizzle-orm";
 import { getSandboxAuthForRun } from "../../../../../../src/lib/auth/get-sandbox-auth";
-import { getUserScopeByClerkId } from "../../../../../../src/lib/scope/scope-service";
+import { getDefaultScopeByClerkUserId } from "../../../../../../src/lib/scope/scope-service";
 import {
   s3ObjectExists,
   verifyS3FilesExist,
@@ -66,8 +66,8 @@ const router = tsr.router(webhookStoragesCommitContract, {
     }
 
     // Resolve user's scope
-    const userScope = await getUserScopeByClerkId(userId);
-    if (!userScope) {
+    const runtimeScope = await getDefaultScopeByClerkUserId(userId);
+    if (!runtimeScope) {
       return {
         status: 400 as const,
         body: {
@@ -89,7 +89,7 @@ const router = tsr.router(webhookStoragesCommitContract, {
       .from(storages)
       .where(
         and(
-          eq(storages.scopeId, userScope.id),
+          eq(storages.scopeId, runtimeScope.id),
           eq(storages.userId, storageUserId),
           eq(storages.name, storageName),
           eq(storages.type, storageType),
@@ -214,7 +214,7 @@ const router = tsr.router(webhookStoragesCommitContract, {
     }
 
     // Verify required S3 objects exist (manifest and archive)
-    const s3Key = `${userScope.slug}/${storageType}/${storageName}/${versionId}`;
+    const s3Key = `${runtimeScope.slug}/${storageType}/${storageName}/${versionId}`;
     const manifestKey = `${s3Key}/manifest.json`;
     const archiveKey = `${s3Key}/archive.tar.gz`;
     const fileCount = files.length;

--- a/turbo/apps/web/app/api/webhooks/agent/storages/prepare/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/storages/prepare/route.ts
@@ -15,7 +15,7 @@ import {
 } from "../../../../../../src/db/schema/storage";
 import { eq, and } from "drizzle-orm";
 import { getSandboxAuthForRun } from "../../../../../../src/lib/auth/get-sandbox-auth";
-import { getUserScopeByClerkId } from "../../../../../../src/lib/scope/scope-service";
+import { getDefaultScopeByClerkUserId } from "../../../../../../src/lib/scope/scope-service";
 import {
   generatePresignedPutUrl,
   downloadManifest,
@@ -78,8 +78,8 @@ const router = tsr.router(webhookStoragesPrepareContract, {
     }
 
     // Resolve user's scope
-    const userScope = await getUserScopeByClerkId(userId);
-    if (!userScope) {
+    const runtimeScope = await getDefaultScopeByClerkUserId(userId);
+    if (!runtimeScope) {
       return {
         status: 400 as const,
         body: {
@@ -100,10 +100,10 @@ const router = tsr.router(webhookStoragesPrepareContract, {
       .insert(storages)
       .values({
         userId: storageUserId,
-        scopeId: userScope.id,
+        scopeId: runtimeScope.id,
         name: storageName,
         type: storageType,
-        s3Prefix: `${userScope.slug}/${storageType}/${storageName}`,
+        s3Prefix: `${runtimeScope.slug}/${storageType}/${storageName}`,
         size: 0,
         fileCount: 0,
       })
@@ -260,7 +260,7 @@ const router = tsr.router(webhookStoragesPrepareContract, {
     }
 
     // Generate presigned URLs for archive and manifest
-    const s3Key = `${userScope.slug}/${storageType}/${storageName}/${versionId}`;
+    const s3Key = `${runtimeScope.slug}/${storageType}/${storageName}/${versionId}`;
     const archiveKey = `${s3Key}/archive.tar.gz`;
     const manifestKey = `${s3Key}/manifest.json`;
 

--- a/turbo/apps/web/src/lib/email/handlers/inbound-trigger.ts
+++ b/turbo/apps/web/src/lib/email/handlers/inbound-trigger.ts
@@ -15,7 +15,7 @@ import { createRun } from "../../run";
 import { buildIntegrationContext } from "../../integration-context";
 import { generateCallbackSecret, getApiUrl } from "../../callback";
 import { getUserIdByEmail } from "../../auth/get-user-id-by-email";
-import { getUserScopeByClerkId } from "../../scope/scope-service";
+import { getDefaultScopeByClerkUserId } from "../../scope/scope-service";
 import { canAccessCompose } from "../../agent/permission-service";
 import { getUserEmail } from "../../auth/get-user-email";
 import { logger } from "../../logger";
@@ -100,8 +100,8 @@ async function resolveTrigger(
     };
   }
 
-  const userScope = await getUserScopeByClerkId(userId);
-  if (!userScope) {
+  const runtimeScope = await getDefaultScopeByClerkUserId(userId);
+  if (!runtimeScope) {
     log.debug("Sender has no scope", { from: senderEmail, userId });
     return {
       ok: false,
@@ -110,7 +110,7 @@ async function resolveTrigger(
   }
 
   return {
-    triggerAddress: { scope: userScope.slug, agent: agentName },
+    triggerAddress: { scope: runtimeScope.slug, agent: agentName },
     triggerLocalPart: agentName,
     userId,
   };

--- a/turbo/apps/web/src/lib/run/build-context.ts
+++ b/turbo/apps/web/src/lib/run/build-context.ts
@@ -21,7 +21,7 @@ import { agentComposeVersions } from "../../db/schema/agent-compose";
 import { scopes } from "../../db/schema/scope";
 import { badRequest, notFound } from "../errors";
 import { logger } from "../logger";
-import type { ExecutionContext, ResumeSession, UserScope } from "./types";
+import type { ExecutionContext, ResumeSession, RuntimeScope } from "./types";
 import type { ArtifactSnapshot } from "../checkpoint/types";
 import {
   resolveCheckpoint,
@@ -865,33 +865,31 @@ function applyResolutionDefaults(
 }
 
 /**
- * Resolve credential scope ID and user scope for storage.
+ * Resolve the Runtime Scope for this execution.
  *
- * The credential scope is used for secrets/variables/connectors.
- * The user scope is used for storage (artifacts, memory) in prepareForExecution.
- * Both use the same runtime scope when params.scopeId is provided.
+ * The Runtime Scope (scopeId + userId) determines secrets, variables,
+ * connectors, model providers, artifacts, and memories.
+ * See docs/resource-model.md for the full resource model.
  *
- * When params.scopeId is not provided, getDefaultScope serves both purposes.
+ * When params.scopeId is not provided, the user's default scope is used.
  */
 async function resolveScopes(params: BuildContextParams): Promise<{
-  credentialScopeId: string;
-  pendingUserScope:
+  runtimeScopeId: string;
+  pendingRuntimeScope:
     | Promise<{ id: string; slug: string }>
     | { id: string; slug: string };
 }> {
   if (params.scopeId) {
-    // Both credential scope and user scope use the explicit runtime scope.
-    // This ensures artifacts/memory are created in the same scope as credentials.
     if (params.scopeSlug) {
       return {
-        credentialScopeId: params.scopeId,
-        pendingUserScope: { id: params.scopeId, slug: params.scopeSlug },
+        runtimeScopeId: params.scopeId,
+        pendingRuntimeScope: { id: params.scopeId, slug: params.scopeSlug },
       };
     }
     // Fallback: query slug from DB when caller didn't provide it
     return {
-      credentialScopeId: params.scopeId,
-      pendingUserScope: globalThis.services.db
+      runtimeScopeId: params.scopeId,
+      pendingRuntimeScope: globalThis.services.db
         .select({ slug: scopes.slug })
         .from(scopes)
         .where(eq(scopes.id, params.scopeId))
@@ -902,11 +900,11 @@ async function resolveScopes(params: BuildContextParams): Promise<{
         })),
     };
   }
-  // No explicit scope — default scope serves both purposes
+  // No explicit scope — default scope is used
   const { scope } = await getDefaultScope(params.userId);
   return {
-    credentialScopeId: scope.id,
-    pendingUserScope: { id: scope.id, slug: scope.slug },
+    runtimeScopeId: scope.id,
+    pendingRuntimeScope: { id: scope.id, slug: scope.slug },
   };
 }
 
@@ -917,7 +915,7 @@ interface BuildContextTimings {
 
 interface BuildContextResult {
   context: ExecutionContext;
-  userScope: UserScope;
+  runtimeScope: RuntimeScope;
   timings: BuildContextTimings;
 }
 
@@ -1000,9 +998,9 @@ export async function buildExecutionContext(
 
   // Step 1: Resolve source and scopes in parallel (independent operations).
   // resolveSource loads checkpoint/session/conversation data.
-  // resolveScopes resolves credential scope and user's default scope (for storage).
+  // resolveScopes resolves the runtime scope for credentials and storage.
   const resolveStart = Date.now();
-  const [resolution, { credentialScopeId, pendingUserScope }] =
+  const [resolution, { runtimeScopeId, pendingRuntimeScope }] =
     await Promise.all([resolveSource(params), resolveScopes(params)]);
   const resolveEnd = Date.now();
 
@@ -1059,12 +1057,12 @@ export async function buildExecutionContext(
     ? Object.values(compose.agents)[0]
     : undefined;
 
-  // Step 4: Resolve credentials, user preferences, and user scope in parallel.
-  // pendingUserScope may already be resolved (when scopeId was not explicit).
+  // Step 4: Resolve credentials, user preferences, and runtime scope in parallel.
+  // pendingRuntimeScope may already be resolved (when scopeId was not explicit).
   const resolveCredentialsStart = Date.now();
-  const [credentialsResult, userPrefs, userScope] = await Promise.all([
+  const [credentialsResult, userPrefs, runtimeScope] = await Promise.all([
     resolveCredentialsAndEnvironment(
-      credentialScopeId,
+      runtimeScopeId,
       agentCompose,
       firstAgent,
       vars,
@@ -1075,7 +1073,7 @@ export async function buildExecutionContext(
       params.userId,
     ),
     params.userId ? getUserPreferences(params.userId) : Promise.resolve(null),
-    Promise.resolve(pendingUserScope),
+    Promise.resolve(pendingRuntimeScope),
   ]);
   const resolveCredentialsEnd = Date.now();
 
@@ -1099,7 +1097,7 @@ export async function buildExecutionContext(
 
   // Build final execution context
   return {
-    userScope,
+    runtimeScope,
     context: {
       runId: params.runId,
       userId: params.userId,

--- a/turbo/apps/web/src/lib/run/context/execution-preparer.ts
+++ b/turbo/apps/web/src/lib/run/context/execution-preparer.ts
@@ -4,7 +4,7 @@ import type {
   ExperimentalFirewall,
   FirewallRule,
 } from "../../../types/agent-compose";
-import type { ExecutionContext, UserScope } from "../types";
+import type { ExecutionContext, RuntimeScope } from "../types";
 import type { PreparedContext } from "../executors/types";
 import {
   prepareStorageManifest,
@@ -183,7 +183,7 @@ interface PrepareResult {
 
 export async function prepareForExecution(
   context: ExecutionContext,
-  userScope: UserScope,
+  runtimeScope: RuntimeScope,
 ): Promise<PrepareResult> {
   log.debug(`Preparing execution context for run ${context.runId}...`);
 
@@ -199,11 +199,11 @@ export async function prepareForExecution(
     `Extracted config: workingDir=${workingDir}, cliAgentType=${cliAgentType}, runnerGroup=${runnerGroup}, firewall=${experimentalFirewall ? "enabled" : "disabled"}`,
   );
 
-  // Resolve agent owner's scope for volume resolution.
-  // User scope (for storage) is pre-resolved by buildExecutionContext.
+  // Resolve the Agent Scope for volume resolution.
+  // Runtime Scope (for artifacts/memory) is pre-resolved by buildExecutionContext.
   const userId = context.userId || "";
   const scopeStart = Date.now();
-  const [composeInfo] = await globalThis.services.db
+  const [agentScopeInfo] = await globalThis.services.db
     .select({
       scopeId: agentComposes.scopeId,
       scopeSlug: scopes.slug,
@@ -218,7 +218,7 @@ export async function prepareForExecution(
     .limit(1);
   const scopeEnd = Date.now();
 
-  if (!composeInfo) {
+  if (!agentScopeInfo) {
     throw badRequest("Agent compose not found");
   }
 
@@ -227,34 +227,34 @@ export async function prepareForExecution(
   await Promise.all([
     context.artifactName
       ? ensureStorageExists(
-          userScope.id,
+          runtimeScope.id,
           userId,
           context.artifactName,
-          userScope.slug,
+          runtimeScope.slug,
           "artifact",
         )
       : null,
     context.memoryName
       ? ensureStorageExists(
-          userScope.id,
+          runtimeScope.id,
           userId,
           context.memoryName,
-          userScope.slug,
+          runtimeScope.slug,
           "memory",
         )
       : null,
   ]);
   const ensureEnd = Date.now();
 
-  // Prepare storage manifest with dual scopes
-  // - Volumes: resolved from agent owner's scope
-  // - Artifacts: resolved from runner's scope
+  // Prepare storage manifest with dual scopes (see docs/resource-model.md)
+  // - Volumes: resolved from Agent Scope
+  // - Artifacts/Memory: resolved from Runtime Scope
   const storageStart = Date.now();
   const storageManifest = await prepareStorageManifest(
     context.agentCompose as AgentComposeYaml,
     context.vars || {},
-    composeInfo.scopeId,
-    userScope.id,
+    agentScopeInfo.scopeId,
+    runtimeScope.id,
     userId,
     context.artifactName,
     context.artifactVersion,
@@ -266,7 +266,7 @@ export async function prepareForExecution(
   const storageEnd = Date.now();
 
   log.debug(
-    `Storage manifest prepared with dual scopes: owner=${composeInfo.scopeId}, runner=${userScope.id}, ${storageManifest.storages.length} storages, ${storageManifest.artifact ? "1 artifact" : "no artifact"}`,
+    `Storage manifest prepared with dual scopes: agentScope=${agentScopeInfo.scopeId}, runtimeScope=${runtimeScope.id}, ${storageManifest.storages.length} storages, ${storageManifest.artifact ? "1 artifact" : "no artifact"}`,
   );
 
   // Build PreparedContext
@@ -277,7 +277,7 @@ export async function prepareForExecution(
     runnerGroup,
     storageManifest,
     experimentalFirewall,
-    composeInfo.scopeSlug,
+    agentScopeInfo.scopeSlug,
   );
 
   const timings: PrepareTimings = {

--- a/turbo/apps/web/src/lib/run/run-service.ts
+++ b/turbo/apps/web/src/lib/run/run-service.ts
@@ -32,7 +32,7 @@ import { canAccessCompose } from "../agent/permission-service";
 import { getUserEmail } from "../auth/get-user-email";
 import { extractTemplateVars } from "../config-validator";
 
-import { getUserScopeByClerkId } from "../scope/scope-service";
+import { getDefaultScopeByClerkUserId } from "../scope/scope-service";
 import { getDefaultScope } from "../scope/scope-member-service";
 import { getVariableValues } from "../variable/variable-service";
 import { encryptCredentialValue } from "../crypto/secrets-encryption";
@@ -382,7 +382,7 @@ async function loadCompose(
       content: agentComposeVersions.content,
       composeId: agentComposes.id,
       composeUserId: agentComposes.userId,
-      composeScopeId: agentComposes.scopeId,
+      agentScopeId: agentComposes.scopeId,
     })
     .from(agentComposeVersions)
     .leftJoin(
@@ -396,7 +396,7 @@ async function loadCompose(
     throw notFound("Agent compose version not found");
   }
 
-  if (!result.composeId || !result.composeUserId || !result.composeScopeId) {
+  if (!result.composeId || !result.composeUserId || !result.agentScopeId) {
     throw notFound("Agent compose not found");
   }
 
@@ -405,7 +405,7 @@ async function loadCompose(
     compose: {
       id: result.composeId,
       userId: result.composeUserId,
-      scopeId: result.composeScopeId,
+      scopeId: result.agentScopeId,
     },
   };
 }
@@ -445,7 +445,7 @@ async function validateComposeRequirements(
     const requiredVars = extractTemplateVars(composeContent);
     if (requiredVars.length > 0) {
       const resolvedScopeId =
-        scopeId ?? (await getUserScopeByClerkId(userId))?.id;
+        scopeId ?? (await getDefaultScopeByClerkUserId(userId))?.id;
       const storedVars = resolvedScopeId
         ? await getVariableValues(resolvedScopeId, userId)
         : {};
@@ -552,7 +552,7 @@ async function buildAndDispatchRun(opts: {
     // Build execution context
     const {
       context,
-      userScope,
+      runtimeScope,
       timings: buildContextTimings,
     } = await buildContext({
       checkpointId: params.checkpointId,
@@ -583,7 +583,7 @@ async function buildAndDispatchRun(opts: {
     const buildContextTime = Date.now();
 
     // Prepare execution context (storage manifest, working dir, etc.)
-    const prepareResult = await prepareForExecution(context, userScope);
+    const prepareResult = await prepareForExecution(context, runtimeScope);
     const prepareTime = Date.now();
 
     // Dispatch to executor

--- a/turbo/apps/web/src/lib/run/types.ts
+++ b/turbo/apps/web/src/lib/run/types.ts
@@ -100,11 +100,13 @@ export interface ExecutionContext {
 }
 
 /**
- * User's default scope for storage resolution in prepareForExecution.
+ * Runtime Scope — the scope of the user who triggers an agent run.
+ * Combined with userId, determines artifacts, memories, secrets, variables,
+ * connectors, and model providers. See docs/resource-model.md.
+ *
  * Resolved once in buildExecutionContext to avoid redundant DB lookups.
- * May differ from the credential scope when an org scope is explicitly selected.
  */
-export interface UserScope {
+export interface RuntimeScope {
   id: string;
   slug: string;
 }

--- a/turbo/apps/web/src/lib/scope/scope-member-service.ts
+++ b/turbo/apps/web/src/lib/scope/scope-member-service.ts
@@ -52,7 +52,7 @@ export async function getPrimaryAdminMembership(userId: string) {
 
 /**
  * Get user's default scope (first owned scope from scope_members)
- * Falls back to legacy getUserScopeByClerkId behavior for backward compat
+ * Falls back to legacy getDefaultScopeByClerkUserId behavior for backward compat
  */
 export async function getDefaultScope(userId: string) {
   // Find first scope where user is admin (scope creator)

--- a/turbo/apps/web/src/lib/scope/scope-service.ts
+++ b/turbo/apps/web/src/lib/scope/scope-service.ts
@@ -116,7 +116,7 @@ export async function getScopeByClerkOrgId(clerkOrgId: string) {
 /**
  * Create a scope for a user with an admin membership.
  *
- * Merges the former createUserScope() and createOrganization() functions.
+ * Merges the former scope creation and organization setup functions.
  * Handles Clerk org creation, slug validation,
  * one-admin-per-user constraint, and atomic scope + membership creation.
  *

--- a/turbo/apps/web/src/lib/scope/scope-service.ts
+++ b/turbo/apps/web/src/lib/scope/scope-service.ts
@@ -182,11 +182,11 @@ export async function createScope(
 }
 
 /**
- * Get a user's scope by their Clerk ID.
+ * Get a user's default scope by their Clerk ID.
  * Finds the first scope where the user is an admin member.
  * Returns the scope record or null if none found.
  */
-export async function getUserScopeByClerkId(clerkUserId: string) {
+export async function getDefaultScopeByClerkUserId(clerkUserId: string) {
   try {
     const { scope } = await getDefaultScope(clerkUserId);
     return scope;
@@ -208,7 +208,7 @@ export async function getUserScopeByClerkId(clerkUserId: string) {
  * @returns The existing or newly created scope
  */
 export async function ensureDefaultScope(clerkUserId: string) {
-  const existing = await getUserScopeByClerkId(clerkUserId);
+  const existing = await getDefaultScopeByClerkUserId(clerkUserId);
   if (existing) return existing;
 
   return await discoverAndCreateScope(clerkUserId);
@@ -365,17 +365,19 @@ export async function validateRunnerGroupScope(
     return;
   }
 
-  // For user runner groups, validate scope ownership
-  const userScope = await getUserScopeByClerkId(clerkUserId);
-  if (!userScope) {
+  // TODO: This checks against the user's default scope, but should check scope
+  // membership instead. A user who belongs to multiple scopes can only use runner
+  // groups from their default scope, which is incorrect.
+  const defaultScope = await getDefaultScopeByClerkUserId(clerkUserId);
+  if (!defaultScope) {
     throw forbidden(
       `Runner group scope "${scopeSlug}" requires you to have a scope configured`,
     );
   }
 
-  if (userScope.slug !== scopeSlug) {
+  if (defaultScope.slug !== scopeSlug) {
     throw forbidden(
-      `Runner group scope "${scopeSlug}" does not match your scope "${userScope.slug}"`,
+      `Runner group scope "${scopeSlug}" does not match your scope "${defaultScope.slug}"`,
     );
   }
 }

--- a/turbo/apps/web/src/lib/storage/storage-service.ts
+++ b/turbo/apps/web/src/lib/storage/storage-service.ts
@@ -270,9 +270,9 @@ async function resolveVersion(
  *
  * @param agentConfig - Agent configuration containing volume definitions
  * @param vars - Template variables for placeholder replacement
- * @param volumeScopeId - Scope ID for volume resolution (agent owner's scope)
- * @param artifactScopeId - Scope ID for artifact resolution (runner's scope)
- * @param userId - Runner's user ID (for artifact/memory ownership)
+ * @param agentScopeId - Agent Scope ID for volume resolution (where the agent is defined)
+ * @param runtimeScopeId - Runtime Scope ID for artifact/memory resolution (where the agent is executed)
+ * @param userId - User ID within the Runtime Scope (for artifact/memory ownership)
  * @param artifactName - Artifact storage name
  * @param artifactVersion - Artifact version (defaults to "latest")
  * @param volumeVersionOverrides - Optional volume version overrides
@@ -284,8 +284,8 @@ async function resolveVersion(
 export async function prepareStorageManifest(
   agentConfig: AgentVolumeConfig | undefined,
   vars: Record<string, string>,
-  volumeScopeId: string,
-  artifactScopeId: string,
+  agentScopeId: string,
+  runtimeScopeId: string,
   userId: string,
   artifactName?: string,
   artifactVersion?: string,
@@ -343,7 +343,7 @@ export async function prepareStorageManifest(
 
       try {
         const { versionId, s3Key } = await resolveVersion(
-          volumeScopeId,
+          agentScopeId,
           volume.vasStorageName,
           "volume",
           volume.vasVersion,
@@ -400,7 +400,7 @@ export async function prepareStorageManifest(
   const artifactPromise = artifactSource
     ? (async () => {
         const { versionId, s3Key } = await resolveVersion(
-          artifactScopeId,
+          runtimeScopeId,
           artifactSource.vasStorageName,
           "artifact",
           artifactSource.vasVersion,
@@ -431,12 +431,12 @@ export async function prepareStorageManifest(
       })()
     : Promise.resolve(null);
 
-  // Resolve memory (uses runner's scope, same as artifact)
+  // Resolve memory (uses Runtime Scope, same as artifact)
   // Memory storage is guaranteed to exist after ensureStorageExists() in prepareForExecution()
   const memoryPromise = memoryName
     ? (async (): Promise<ManifestArtifact | null> => {
         const { versionId, s3Key } = await resolveVersion(
-          artifactScopeId,
+          runtimeScopeId,
           memoryName,
           "memory",
           "latest",


### PR DESCRIPTION
## Summary

- Rename types, variables, and comments to use **Agent Scope** and **Runtime Scope** terminology from `docs/resource-model.md`
- Rename `getUserScopeByClerkId` → `getDefaultScopeByClerkUserId` for clarity
- Add TODO for `validateRunnerGroupScope` which checks default scope instead of scope membership

### Key renames

| Before | After | Rationale |
|--------|-------|-----------|
| `UserScope` interface | `RuntimeScope` | Aligns with resource model doc |
| `credentialScopeId` | `runtimeScopeId` | Same concept as runtime scope |
| `pendingUserScope` | `pendingRuntimeScope` | Same concept |
| `userScope` (execution path) | `runtimeScope` | Consistent terminology |
| `volumeScopeId` | `agentScopeId` | Where the agent is defined |
| `artifactScopeId` | `runtimeScopeId` | Where the agent is executed |
| `composeScopeId` | `agentScopeId` | Where the agent is defined |
| `getUserScopeByClerkId` | `getDefaultScopeByClerkUserId` | Clarifies it returns the default scope |

### Not changed (intentionally)

- `agentScopeSlug` / `VM0_AGENT_SCOPE` — already aligned
- Database schema `scope_id` columns — generic FK references
- Slack OAuth `user_scope=` — third-party API terminology

## Test plan

- [x] Type check passes
- [x] Lint passes
- [x] All 3586 tests pass
- [x] Knip finds no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)