### PR TITLE
refactor: align remaining scope terminology with resource model

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -134,7 +134,7 @@ The orchestration layer coordinates job execution between web API and runners.
 
 **Format**: `{scope}/{name}`
 - Official: `vm0/*` (e.g., `vm0/production`) - VM0-managed runners
-- User: `{userid}/*` (e.g., `user123/private`) - Self-hosted runners
+- User: `{scope-slug}/*` (e.g., `my-team/private`) - Self-hosted runners
 
 **Authentication**:
 - Official runners: HMAC signature using `OFFICIAL_RUNNER_SECRET`

--- a/turbo/apps/cli/src/commands/run/run.ts
+++ b/turbo/apps/cli/src/commands/run/run.ts
@@ -112,8 +112,8 @@ export const mainRunCommand = new Command()
         // 1.5. Validate: running another user's agent requires explicit opt-in
         if (scope && !options.experimentalSharedAgent) {
           // Check if it's the user's own scope
-          const userScope = await getScope();
-          const isOwnScope = userScope.slug === scope;
+          const defaultScope = await getScope();
+          const isOwnScope = defaultScope.slug === scope;
 
           if (!isOwnScope) {
             console.error(

--- a/turbo/apps/cli/src/lib/api/api-client.ts
+++ b/turbo/apps/cli/src/lib/api/api-client.ts
@@ -482,7 +482,7 @@ class ApiClient {
   }
 
   /**
-   * Get current user's scope
+   * Get current user's default scope
    */
   async getScope(): Promise<ScopeResponse> {
     const baseUrl = await this.getBaseUrl();
@@ -509,7 +509,7 @@ class ApiClient {
   }
 
   /**
-   * Create user's scope
+   * Create user's default scope
    */
   async createScope(body: {
     slug: string;
@@ -539,7 +539,7 @@ class ApiClient {
   }
 
   /**
-   * Update user's scope slug
+   * Update user's default scope slug
    */
   async updateScope(body: {
     slug: string;

--- a/turbo/apps/cli/src/lib/api/domains/scopes.ts
+++ b/turbo/apps/cli/src/lib/api/domains/scopes.ts
@@ -39,7 +39,7 @@ async function getUserTokenClientConfig(): Promise<{
 }
 
 /**
- * Get current user's scope
+ * Get current user's default scope
  */
 export async function getScope(): Promise<ScopeResponse> {
   const config = await getClientConfig();
@@ -55,7 +55,7 @@ export async function getScope(): Promise<ScopeResponse> {
 }
 
 /**
- * Create user's scope
+ * Create user's default scope
  */
 export async function createScope(body: {
   slug: string;
@@ -73,7 +73,7 @@ export async function createScope(body: {
 }
 
 /**
- * Update user's scope slug
+ * Update user's default scope slug
  */
 export async function updateScope(body: {
   slug: string;

--- a/turbo/apps/platform/src/mocks/handlers/api-scope.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-scope.ts
@@ -17,12 +17,12 @@ const mockScope: Scope = {
 };
 
 export const apiScopeHandlers = [
-  // GET /api/scope - Get current user's scope
+  // GET /api/scope - Get current user's default scope
   http.get("/api/scope", () => {
     return HttpResponse.json(mockScope);
   }),
 
-  // POST /api/scope - Create user's scope
+  // POST /api/scope - Create a scope
   // Always returns 409 since mock user always has scope
   http.post("/api/scope", () => {
     return HttpResponse.json(

--- a/turbo/apps/platform/src/signals/scope.ts
+++ b/turbo/apps/platform/src/signals/scope.ts
@@ -22,7 +22,7 @@ export interface Scope {
 }
 
 /**
- * Current user's scope.
+ * Current user's default scope.
  * Returns undefined if user has no scope or is not authenticated.
  */
 export const scope$ = computed(async (get) => {

--- a/turbo/apps/web/app/api/agent/composes/list/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/composes/list/__tests__/route.test.ts
@@ -55,7 +55,7 @@ describe("GET /api/agent/composes/list", () => {
     expect(data.composes).toEqual([]);
   });
 
-  it("should return all composes for the user scope", async () => {
+  it("should return all composes for the user's default scope", async () => {
     // Create two test composes via API
     const agentName1 = `test-list-agent-1-${Date.now()}`;
     const agentName2 = `test-list-agent-2-${Date.now()}`;
@@ -197,9 +197,9 @@ describe("GET /api/agent/composes/list", () => {
       const { composeId } = await createTestCompose(agentName);
       await createTestPermission(composeId, "email", MOCK_USER_EMAIL);
 
-      // Derive owner's scope slug
+      // Derive the Agent Scope slug
       const ownerSuffix = owner.userId.replace("owner-", "");
-      const ownerScopeSlug = `scope-${ownerSuffix}`;
+      const agentScopeSlug = `scope-${ownerSuffix}`;
 
       // Switch to recipient (original user) and list
       mockClerk({ userId: user.userId });
@@ -211,7 +211,7 @@ describe("GET /api/agent/composes/list", () => {
 
       expect(response.status).toBe(200);
       const names = data.composes.map((c: { name: string }) => c.name);
-      expect(names).toContain(`${ownerScopeSlug}/${agentName}`);
+      expect(names).toContain(`${agentScopeSlug}/${agentName}`);
     });
 
     it("should not show unshared agents from other users", async () => {
@@ -246,7 +246,7 @@ describe("GET /api/agent/composes/list", () => {
       await createTestPermission(composeId, "email", MOCK_USER_EMAIL);
 
       const ownerSuffix = owner.userId.replace("combo-owner-", "");
-      const ownerScopeSlug = `scope-${ownerSuffix}`;
+      const agentScopeSlug = `scope-${ownerSuffix}`;
 
       // Switch back to original user
       mockClerk({ userId: user.userId });
@@ -261,7 +261,7 @@ describe("GET /api/agent/composes/list", () => {
       // Own agent has plain name
       expect(names).toContain(ownAgentName);
       // Shared agent has scope/name format
-      expect(names).toContain(`${ownerScopeSlug}/${sharedAgentName}`);
+      expect(names).toContain(`${agentScopeSlug}/${sharedAgentName}`);
     });
 
     it("should not include shared agents when scope param is provided", async () => {

--- a/turbo/apps/web/app/api/agent/required-env/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/required-env/__tests__/route.test.ts
@@ -78,7 +78,7 @@ describe("GET /api/agent/required-env", () => {
     await createTestPermission(composeId, "email", MOCK_USER_EMAIL);
 
     const ownerSuffix = owner.userId.replace("env-owner-", "");
-    const ownerScopeSlug = `scope-${ownerSuffix}`;
+    const agentScopeSlug = `scope-${ownerSuffix}`;
 
     // Switch to recipient and fetch required env
     mockClerk({ userId: user.userId });
@@ -91,7 +91,7 @@ describe("GET /api/agent/required-env", () => {
     expect(response.status).toBe(200);
     const agent = data.agents.find(
       (a: { agentName: string }) =>
-        a.agentName === `${ownerScopeSlug}/${agentName}`,
+        a.agentName === `${agentScopeSlug}/${agentName}`,
     );
     expect(agent).toBeDefined();
     expect(agent.requiredSecrets).toContain("SHARED_SECRET");

--- a/turbo/apps/web/app/api/agent/runs/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/__tests__/route.test.ts
@@ -414,7 +414,7 @@ describe("POST /api/agent/runs - Internal Runs API", () => {
       mockClerk({ userId: ownerUser.userId });
     });
 
-    it("should resolve model provider from runner's scope for shared agent", async () => {
+    it("should resolve model provider from Runtime Scope for shared agent", async () => {
       // User A (owner) creates an agent without explicit API key
       const ownerUser = user;
       const { composeId: sharedComposeId } = await createTestCompose(

--- a/turbo/apps/web/app/api/agent/schedules/missing-secrets/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/schedules/missing-secrets/__tests__/route.test.ts
@@ -105,7 +105,7 @@ describe("GET /api/agent/schedules/missing-secrets", () => {
     await createTestPermission(composeId, "email", MOCK_USER_EMAIL);
 
     const ownerSuffix = owner.userId.replace("ms-owner-", "");
-    const ownerScopeSlug = `scope-${ownerSuffix}`;
+    const agentScopeSlug = `scope-${ownerSuffix}`;
 
     // Switch to recipient — they don't have SHARED_KEY configured
     mockClerk({ userId: user.userId });
@@ -118,7 +118,7 @@ describe("GET /api/agent/schedules/missing-secrets", () => {
     expect(response.status).toBe(200);
     const agent = data.agents.find(
       (a: { agentName: string }) =>
-        a.agentName === `${ownerScopeSlug}/${agentName}`,
+        a.agentName === `${agentScopeSlug}/${agentName}`,
     );
     expect(agent).toBeDefined();
     expect(agent.missingSecrets).toContain("SHARED_KEY");

--- a/turbo/apps/web/app/api/integrations/telegram/route.ts
+++ b/turbo/apps/web/app/api/integrations/telegram/route.ts
@@ -122,7 +122,7 @@ export async function GET(request: Request) {
     }
   }
 
-  // Resolve user scope and get existing secrets, vars, connectors
+  // Resolve user's default scope and get existing secrets, vars, connectors
   const { scope } = await resolveScope(userId);
   const [userSecrets, userVars, userConnectors] = await Promise.all([
     listSecrets(scope.id, userId),

--- a/turbo/apps/web/app/api/scope/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/scope/__tests__/route.test.ts
@@ -366,7 +366,7 @@ describe("/api/scope", () => {
       await context.setupUser();
     });
 
-    it("should return user's scope", async () => {
+    it("should return user's default scope", async () => {
       const request = createTestRequest("http://localhost:3000/api/scope");
       const response = await GET(request);
       const data = await response.json();

--- a/turbo/apps/web/app/api/scope/route.ts
+++ b/turbo/apps/web/app/api/scope/route.ts
@@ -37,7 +37,7 @@ function scopeToResponseBody(scope: {
 
 const router = tsr.router(scopeContract, {
   /**
-   * GET /api/scope - Get current user's scope
+   * GET /api/scope - Get current user's default scope
    *
    * Resolves the active scope via clerkOrgId from Clerk session,
    * or falls back to the user's default scope (first admin membership).
@@ -72,7 +72,7 @@ const router = tsr.router(scopeContract, {
   },
 
   /**
-   * POST /api/scope - Create user's scope
+   * POST /api/scope - Create a scope
    */
   create: async ({ body, headers }) => {
     initServices();
@@ -84,7 +84,7 @@ const router = tsr.router(scopeContract, {
 
     const { slug } = body;
 
-    log.debug("creating user scope", { userId, slug });
+    log.debug("creating scope", { userId, slug });
 
     try {
       // vm0-admin slug policy: allow vm0-prefixed slugs for admin users only

--- a/turbo/apps/web/app/api/storages/__tests__/per-user-isolation.test.ts
+++ b/turbo/apps/web/app/api/storages/__tests__/per-user-isolation.test.ts
@@ -19,7 +19,7 @@ function listStorages(type: string) {
   );
 }
 
-describe("Storage user-scope isolation", () => {
+describe("Storage per-user isolation", () => {
   beforeEach(async () => {
     context.setupMocks();
     await context.setupUser();

--- a/turbo/apps/web/app/api/storages/commit/route.ts
+++ b/turbo/apps/web/app/api/storages/commit/route.ts
@@ -35,7 +35,7 @@ const router = tsr.router(storagesCommitContract, {
       };
     }
 
-    // Resolve user's scope
+    // Resolve user's default scope
     const scopeSlug = new URL(request.url).searchParams.get("scope");
     const { scope: runtimeScope } = await resolveScope(userId, scopeSlug);
 

--- a/turbo/apps/web/app/api/storages/download/route.ts
+++ b/turbo/apps/web/app/api/storages/download/route.ts
@@ -31,7 +31,7 @@ const router = tsr.router(storagesDownloadContract, {
       };
     }
 
-    // Resolve user's scope
+    // Resolve user's default scope
     const scopeSlug = new URL(request.url).searchParams.get("scope");
     const { scope: runtimeScope } = await resolveScope(userId, scopeSlug);
 
@@ -45,7 +45,7 @@ const router = tsr.router(storagesDownloadContract, {
     const storageUserId =
       storageType === "volume" ? VOLUME_SCOPE_USER_ID : userId;
 
-    // Check if storage exists and belongs to user's scope
+    // Check if storage exists and belongs to user's default scope
     const [storage] = await globalThis.services.db
       .select()
       .from(storages)

--- a/turbo/apps/web/app/api/storages/list/route.ts
+++ b/turbo/apps/web/app/api/storages/list/route.ts
@@ -30,7 +30,7 @@ const router = tsr.router(storagesListContract, {
 
     const { type: storageType } = query;
 
-    // Resolve user's scope
+    // Resolve user's default scope
     const scopeSlug = new URL(request.url).searchParams.get("scope");
     const { scope: runtimeScope } = await resolveScope(userId, scopeSlug);
 

--- a/turbo/apps/web/app/api/storages/prepare/route.ts
+++ b/turbo/apps/web/app/api/storages/prepare/route.ts
@@ -97,7 +97,7 @@ const router = tsr.router(storagesPrepareContract, {
       };
     }
 
-    // Resolve user's scope
+    // Resolve user's default scope
     const scopeSlug = new URL(request.url).searchParams.get("scope");
     const { scope: runtimeScope } = await resolveScope(userId, scopeSlug);
 

--- a/turbo/apps/web/app/api/webhooks/agent/storages/commit/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/storages/commit/route.ts
@@ -65,14 +65,14 @@ const router = tsr.router(webhookStoragesCommitContract, {
       };
     }
 
-    // Resolve user's scope
+    // Resolve Runtime Scope (user's default scope)
     const runtimeScope = await getDefaultScopeByClerkUserId(userId);
     if (!runtimeScope) {
       return {
         status: 400 as const,
         body: {
           error: {
-            message: "User scope not found",
+            message: "User's default scope not found",
             code: "BAD_REQUEST",
           },
         },

--- a/turbo/apps/web/app/api/webhooks/agent/storages/prepare/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/storages/prepare/route.ts
@@ -77,14 +77,14 @@ const router = tsr.router(webhookStoragesPrepareContract, {
       };
     }
 
-    // Resolve user's scope
+    // Resolve Runtime Scope (user's default scope)
     const runtimeScope = await getDefaultScopeByClerkUserId(userId);
     if (!runtimeScope) {
       return {
         status: 400 as const,
         body: {
           error: {
-            message: "User scope not found",
+            message: "User's default scope not found",
             code: "BAD_REQUEST",
           },
         },

--- a/turbo/apps/web/src/__tests__/slack/api-helpers.ts
+++ b/turbo/apps/web/src/__tests__/slack/api-helpers.ts
@@ -106,7 +106,7 @@ export async function givenSlackWorkspaceInstalled(
   const accessToken = `xoxb-test-${uniqueId("token")}`;
   const adminSlackUserId = uniqueId("admin-slack");
 
-  // Create admin user scope + compose for the workspace agent
+  // Create admin scope + compose for the workspace agent
   const adminUserId = options.adminUserId ?? uniqueId("admin");
   mockClerk({ userId: adminUserId });
   await createTestScope(uniqueId("admin-scope"));

--- a/turbo/apps/web/src/lib/secret/secret-service.ts
+++ b/turbo/apps/web/src/lib/secret/secret-service.ts
@@ -67,7 +67,7 @@ export async function listSecrets(
 }
 
 /**
- * Get a secret by name for a user's scope (metadata only)
+ * Get a secret by name for a user's default scope (metadata only)
  * Only returns user-type secrets; model-provider secrets are managed via model-provider commands
  */
 export async function getSecret(

--- a/turbo/packages/core/src/contracts/scopes.ts
+++ b/turbo/packages/core/src/contracts/scopes.ts
@@ -58,7 +58,7 @@ export type UpdateScopeRequest = z.infer<typeof updateScopeRequestSchema>;
 export const scopeContract = c.router({
   /**
    * GET /api/scope
-   * Get current user's scope
+   * Get current user's default scope
    */
   get: {
     method: "GET",
@@ -70,12 +70,12 @@ export const scopeContract = c.router({
       404: apiErrorSchema,
       500: apiErrorSchema,
     },
-    summary: "Get current user's scope",
+    summary: "Get current user's default scope",
   },
 
   /**
    * POST /api/scope
-   * Create user's scope
+   * Create a scope
    */
   create: {
     method: "POST",
@@ -89,12 +89,12 @@ export const scopeContract = c.router({
       409: apiErrorSchema,
       500: apiErrorSchema,
     },
-    summary: "Create user's scope",
+    summary: "Create a scope",
   },
 
   /**
    * PUT /api/scope
-   * Update user's scope slug
+   * Update scope slug
    */
   update: {
     method: "PUT",
@@ -110,7 +110,7 @@ export const scopeContract = c.router({
       409: apiErrorSchema,
       500: apiErrorSchema,
     },
-    summary: "Update user's scope slug",
+    summary: "Update scope slug",
   },
 });
 


### PR DESCRIPTION
## Summary

- Audit and fix ~30 remaining terminology inconsistencies across 23 files, following `docs/resource-model.md` and the initial scope naming refactor (#4088)
- All changes are purely string/comment/variable renames with **no behavioral impact**
- Key renames: "user scope" → "user's default scope", `userScope` → `defaultScope`, `ownerScopeSlug` → `agentScopeSlug`, "runner's scope" → "Runtime Scope", "user-scope isolation" → "per-user isolation"

## Test plan

- [x] `pnpm check-types` — all packages pass
- [x] `pnpm turbo run lint` — no violations
- [x] `pnpm format` — all files unchanged
- [x] `pnpm knip` — no issues found
- [x] `pnpm vitest run` on all 6 affected test files — 111 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)