### PR TITLE
refactor: dual-write scope metadata to clerk org and membership metadata

### DIFF
--- a/turbo/apps/web/app/api/admin/scope/tier/__tests__/set-tier.test.ts
+++ b/turbo/apps/web/app/api/admin/scope/tier/__tests__/set-tier.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
+import { clerkClient } from "@clerk/nextjs/server";
 import {
   testContext,
   uniqueId,
@@ -52,6 +53,14 @@ describe("PUT /api/admin/scope/tier", () => {
     expect(body.slug).toBe(scope.slug);
     expect(body.tier).toBe("pro");
     expect(body.updatedAt).toBeDefined();
+
+    // Verify dual-write to Clerk org metadata
+    const client = await vi.mocked(clerkClient)();
+    expect(
+      client.organizations.updateOrganizationMetadata,
+    ).toHaveBeenCalledWith(expect.any(String), {
+      publicMetadata: { tier: "pro" },
+    });
   });
 
   it("should set scope tier to max when called by admin", async () => {

--- a/turbo/apps/web/app/api/admin/scope/tier/route.ts
+++ b/turbo/apps/web/app/api/admin/scope/tier/route.ts
@@ -11,6 +11,7 @@ import {
   getScopeBySlug,
   isVm0Admin,
 } from "../../../../../src/lib/scope/scope-service";
+import { clerkClient } from "@clerk/nextjs/server";
 import { scopes } from "../../../../../src/db/schema/scope";
 import { eq } from "drizzle-orm";
 import { logger } from "../../../../../src/lib/logger";
@@ -64,6 +65,19 @@ const router = tsr.router(adminScopeTierContract, {
       .set({ tier: body.tier, updatedAt: new Date() })
       .where(eq(scopes.id, scope.id))
       .returning();
+
+    // Dual-write tier to Clerk org publicMetadata (fire-and-forget)
+    try {
+      const client = await clerkClient();
+      await client.organizations.updateOrganizationMetadata(scope.clerkOrgId, {
+        publicMetadata: { tier: body.tier },
+      });
+    } catch (err) {
+      log.error("Failed to write tier to Clerk metadata", {
+        error: err,
+        clerkOrgId: scope.clerkOrgId,
+      });
+    }
 
     return {
       status: 200 as const,

--- a/turbo/apps/web/app/api/user/preferences/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/user/preferences/__tests__/route.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
+import { clerkClient } from "@clerk/nextjs/server";
 import { GET, PUT } from "../route";
 import { createTestRequest } from "../../../../../src/__tests__/api-test-helpers";
 import { testContext } from "../../../../../src/__tests__/test-helpers";
@@ -292,6 +293,56 @@ describe("PUT /api/user/preferences", () => {
     expect(data.timezone).toBe("Europe/Berlin");
     expect(data.notifyEmail).toBe(true);
     expect(data.notifySlack).toBe(false);
+  });
+
+  it("should dual-write timezone to Clerk membership metadata", async () => {
+    const user = await context.setupUser();
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/user/preferences",
+      {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ timezone: "Asia/Tokyo" }),
+      },
+    );
+    const response = await PUT(request);
+    expect(response.status).toBe(200);
+
+    const client = await vi.mocked(clerkClient)();
+    expect(
+      client.organizations.updateOrganizationMembershipMetadata,
+    ).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: user.userId,
+        publicMetadata: { timezone: "Asia/Tokyo" },
+      }),
+    );
+  });
+
+  it("should dual-write notifyEmail and notifySlack to Clerk membership metadata", async () => {
+    const user = await context.setupUser();
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/user/preferences",
+      {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ notifyEmail: true, notifySlack: false }),
+      },
+    );
+    const response = await PUT(request);
+    expect(response.status).toBe(200);
+
+    const client = await vi.mocked(clerkClient)();
+    expect(
+      client.organizations.updateOrganizationMembershipMetadata,
+    ).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: user.userId,
+        publicMetadata: { notify_email: true, notify_slack: false },
+      }),
+    );
   });
 
   it("should reject request with no preferences", async () => {

--- a/turbo/apps/web/scripts/migrations/002-backfill-clerk-metadata/backfill.ts
+++ b/turbo/apps/web/scripts/migrations/002-backfill-clerk-metadata/backfill.ts
@@ -1,0 +1,311 @@
+#!/usr/bin/env tsx
+
+/**
+ * Backfill Clerk metadata for existing scopes and members.
+ *
+ * Phase 1 of the Scope → Clerk migration: writes scope `tier` to Clerk org
+ * publicMetadata, and member preferences (timezone, notifyEmail, notifySlack)
+ * to Clerk membership publicMetadata.
+ *
+ * Usage:
+ *   tsx scripts/migrations/002-backfill-clerk-metadata/backfill.ts [--migrate]
+ *
+ * Environment:
+ *   DATABASE_URL        — Required
+ *   CLERK_SECRET_KEY    — Required (for --migrate)
+ */
+
+import { parseArgs } from "node:util";
+import { drizzle } from "drizzle-orm/postgres-js";
+import { eq, asc } from "drizzle-orm";
+import postgres from "postgres";
+
+import { scopes } from "../../../src/db/schema/scope";
+import { scopeMembers } from "../../../src/db/schema/scope-member";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface Stats {
+  total: number;
+  success: number;
+  failed: number;
+  skipped: number;
+}
+
+interface ClerkOrganizationsApi {
+  updateOrganizationMetadata: (
+    orgId: string,
+    params: { publicMetadata: Record<string, unknown> },
+  ) => Promise<unknown>;
+  updateOrganizationMembershipMetadata: (params: {
+    organizationId: string;
+    userId: string;
+    publicMetadata: Record<string, unknown>;
+  }) => Promise<unknown>;
+}
+
+interface ClerkClient {
+  organizations: ClerkOrganizationsApi;
+}
+
+// ---------------------------------------------------------------------------
+// CLI argument parsing
+// ---------------------------------------------------------------------------
+
+const { values: args } = parseArgs({
+  options: {
+    migrate: { type: "boolean", default: false },
+  },
+  strict: true,
+});
+
+const DRY_RUN = !args.migrate;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const THROTTLE_MS = 100;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function getStatus(err: unknown): number | undefined {
+  if (
+    typeof err === "object" &&
+    err !== null &&
+    "status" in err &&
+    typeof (err as Record<string, unknown>).status === "number"
+  ) {
+    return (err as Record<string, unknown>).status as number;
+  }
+  return undefined;
+}
+
+function isTransientError(err: unknown): boolean {
+  const status = getStatus(err);
+  return status === 429 || (status !== undefined && status >= 500);
+}
+
+async function withRetry<T>(fn: () => Promise<T>): Promise<T> {
+  const MAX_ATTEMPTS = 3;
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      if (isTransientError(err) && attempt < MAX_ATTEMPTS) {
+        const backoff = Math.pow(2, attempt) * 1000;
+        console.warn(
+          `  Transient error (status ${getStatus(err)}), retrying in ${backoff}ms (attempt ${attempt + 1}/${MAX_ATTEMPTS})`,
+        );
+        await sleep(backoff);
+        continue;
+      }
+      throw err;
+    }
+  }
+  throw new Error(`Failed after ${MAX_ATTEMPTS} attempts`);
+}
+
+// ---------------------------------------------------------------------------
+// Backfill: Scope tiers
+// ---------------------------------------------------------------------------
+
+async function backfillScopeTiers(
+  db: ReturnType<typeof drizzle>,
+  client: ClerkClient | null,
+): Promise<Stats> {
+  console.log("\n--- Backfilling scope tiers ---\n");
+
+  const allScopes = await db
+    .select({
+      id: scopes.id,
+      slug: scopes.slug,
+      tier: scopes.tier,
+      clerkOrgId: scopes.clerkOrgId,
+    })
+    .from(scopes)
+    .orderBy(asc(scopes.createdAt));
+
+  const total = allScopes.length;
+  console.log(`Found ${total} scope(s)\n`);
+
+  const stats: Stats = { total, success: 0, failed: 0, skipped: 0 };
+
+  for (let i = 0; i < allScopes.length; i++) {
+    const scope = allScopes[i]!;
+    const idx = `[${i + 1}/${total}]`;
+
+    if (DRY_RUN) {
+      console.log(
+        `${idx} (dry-run) scope "${scope.slug}" — would write tier="${scope.tier}" to Clerk org ${scope.clerkOrgId}`,
+      );
+      stats.success++;
+      continue;
+    }
+
+    try {
+      await withRetry(() =>
+        client!.organizations.updateOrganizationMetadata(scope.clerkOrgId, {
+          publicMetadata: { tier: scope.tier },
+        }),
+      );
+      await sleep(THROTTLE_MS);
+      console.log(`${idx} ✓ scope "${scope.slug}" → tier="${scope.tier}"`);
+      stats.success++;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error(`${idx} ✗ scope "${scope.slug}" — ${message}`);
+      stats.failed++;
+    }
+  }
+
+  return stats;
+}
+
+// ---------------------------------------------------------------------------
+// Backfill: Member preferences
+// ---------------------------------------------------------------------------
+
+async function backfillMemberPreferences(
+  db: ReturnType<typeof drizzle>,
+  client: ClerkClient | null,
+): Promise<Stats> {
+  console.log("\n--- Backfilling member preferences ---\n");
+
+  const members = await db
+    .select({
+      memberId: scopeMembers.id,
+      userId: scopeMembers.userId,
+      timezone: scopeMembers.timezone,
+      notifyEmail: scopeMembers.notifyEmail,
+      notifySlack: scopeMembers.notifySlack,
+      clerkOrgId: scopes.clerkOrgId,
+      scopeSlug: scopes.slug,
+    })
+    .from(scopeMembers)
+    .innerJoin(scopes, eq(scopeMembers.scopeId, scopes.id))
+    .orderBy(asc(scopeMembers.createdAt));
+
+  // Filter to members with non-default preferences
+  const membersWithPrefs = members.filter(
+    (m) =>
+      m.timezone !== null || m.notifyEmail !== false || m.notifySlack !== true,
+  );
+
+  const total = membersWithPrefs.length;
+  console.log(
+    `Found ${members.length} member(s), ${total} with non-default preferences\n`,
+  );
+
+  const stats: Stats = { total, success: 0, failed: 0, skipped: 0 };
+
+  for (let i = 0; i < membersWithPrefs.length; i++) {
+    const member = membersWithPrefs[i]!;
+    const idx = `[${i + 1}/${total}]`;
+    const metadata: Record<string, unknown> = {};
+
+    if (member.timezone !== null) {
+      metadata.timezone = member.timezone;
+    }
+    if (member.notifyEmail !== false) {
+      metadata.notify_email = member.notifyEmail;
+    }
+    if (member.notifySlack !== true) {
+      metadata.notify_slack = member.notifySlack;
+    }
+
+    if (DRY_RUN) {
+      console.log(
+        `${idx} (dry-run) user "${member.userId}" in scope "${member.scopeSlug}" — would write ${JSON.stringify(metadata)}`,
+      );
+      stats.success++;
+      continue;
+    }
+
+    try {
+      await withRetry(() =>
+        client!.organizations.updateOrganizationMembershipMetadata({
+          organizationId: member.clerkOrgId,
+          userId: member.userId,
+          publicMetadata: metadata,
+        }),
+      );
+      await sleep(THROTTLE_MS);
+      console.log(
+        `${idx} ✓ user "${member.userId}" in "${member.scopeSlug}" → ${JSON.stringify(metadata)}`,
+      );
+      stats.success++;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error(
+        `${idx} ✗ user "${member.userId}" in "${member.scopeSlug}" — ${message}`,
+      );
+      stats.failed++;
+    }
+  }
+
+  return stats;
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  const databaseUrl = process.env.DATABASE_URL;
+  if (!databaseUrl) {
+    throw new Error("DATABASE_URL is required");
+  }
+
+  console.log("=== Backfill Clerk Metadata ===");
+  console.log(
+    `Mode: ${DRY_RUN ? "dry-run (pass --migrate to execute)" : "MIGRATE"}`,
+  );
+  console.log();
+
+  let client: ClerkClient | null = null;
+
+  if (!DRY_RUN) {
+    const clerkSecretKey = process.env.CLERK_SECRET_KEY;
+    if (!clerkSecretKey) {
+      throw new Error("CLERK_SECRET_KEY is required for --migrate");
+    }
+    const { createClerkClient } = await import("@clerk/backend");
+    client = createClerkClient({ secretKey: clerkSecretKey });
+  }
+
+  const pg = postgres(databaseUrl, { max: 1 });
+  const db = drizzle(pg);
+
+  try {
+    const tierStats = await backfillScopeTiers(db, client);
+    const prefStats = await backfillMemberPreferences(db, client);
+
+    console.log("\n=== Summary ===");
+    console.log(
+      `Scope tiers:      ${tierStats.success} ok, ${tierStats.failed} failed (${tierStats.total} total)`,
+    );
+    console.log(
+      `Member prefs:     ${prefStats.success} ok, ${prefStats.failed} failed (${prefStats.total} total)`,
+    );
+
+    if (DRY_RUN) {
+      console.log("\n⚠ Dry run — no changes were made.");
+    }
+
+    if (tierStats.failed > 0 || prefStats.failed > 0) {
+      process.exitCode = 1;
+    }
+  } finally {
+    await pg.end();
+  }
+}
+
+main().catch((err) => {
+  console.error("Backfill failed:", err);
+  process.exit(1);
+});

--- a/turbo/apps/web/src/__tests__/clerk-mock.ts
+++ b/turbo/apps/web/src/__tests__/clerk-mock.ts
@@ -104,6 +104,8 @@ export function mockClerk(options: {
         .mockImplementation(({ name }: { name: string }) =>
           Promise.resolve({ id: `org_mock_${name}` }),
         ),
+      updateOrganizationMetadata: vi.fn().mockResolvedValue({}),
+      updateOrganizationMembershipMetadata: vi.fn().mockResolvedValue({}),
     },
   } as unknown as Awaited<ReturnType<typeof clerkClient>>);
 }

--- a/turbo/apps/web/src/__tests__/clerk-org-mock.ts
+++ b/turbo/apps/web/src/__tests__/clerk-org-mock.ts
@@ -45,6 +45,8 @@ export function setupClerkOrgMock(options: {
       id: "inv_test",
     }),
     deleteOrganizationMembership: vi.fn().mockResolvedValue({}),
+    updateOrganizationMetadata: vi.fn().mockResolvedValue({}),
+    updateOrganizationMembershipMetadata: vi.fn().mockResolvedValue({}),
   };
 
   const mockUsers = {

--- a/turbo/apps/web/src/lib/user/user-preferences-service.ts
+++ b/turbo/apps/web/src/lib/user/user-preferences-service.ts
@@ -1,7 +1,12 @@
 import { eq } from "drizzle-orm";
+import { clerkClient } from "@clerk/nextjs/server";
 import { scopeMembers } from "../../db/schema/scope-member";
+import { scopes } from "../../db/schema/scope";
 import { badRequest } from "../errors";
 import { getPrimaryAdminMembership } from "../scope/scope-member-service";
+import { logger } from "../logger";
+
+const log = logger("service:user-preferences");
 
 interface UserPreferences {
   timezone: string | null;
@@ -76,6 +81,37 @@ export async function updateUserPreferences(
       notifySlack: scopeMembers.notifySlack,
     });
 
+  // Dual-write preferences to Clerk membership publicMetadata (fire-and-forget)
+  try {
+    const [scope] = await globalThis.services.db
+      .select({ clerkOrgId: scopes.clerkOrgId })
+      .from(scopes)
+      .where(eq(scopes.id, memberRecord.scopeId))
+      .limit(1);
+
+    if (scope) {
+      const client = await clerkClient();
+      await client.organizations.updateOrganizationMembershipMetadata({
+        organizationId: scope.clerkOrgId,
+        userId,
+        publicMetadata: {
+          ...(prefs.timezone !== undefined && { timezone: prefs.timezone }),
+          ...(prefs.notifyEmail !== undefined && {
+            notify_email: prefs.notifyEmail,
+          }),
+          ...(prefs.notifySlack !== undefined && {
+            notify_slack: prefs.notifySlack,
+          }),
+        },
+      });
+    }
+  } catch (err) {
+    log.error("Failed to write preferences to Clerk metadata", {
+      error: err,
+      userId,
+    });
+  }
+
   return {
     timezone: updated?.timezone ?? null,
     notifyEmail: updated?.notifyEmail ?? false,
@@ -107,6 +143,29 @@ export async function setTimezoneIfNotSet(
           updatedAt: new Date(),
         })
         .where(eq(scopeMembers.id, memberRecord.id));
+
+      // Dual-write timezone to Clerk membership publicMetadata (fire-and-forget)
+      try {
+        const [scope] = await globalThis.services.db
+          .select({ clerkOrgId: scopes.clerkOrgId })
+          .from(scopes)
+          .where(eq(scopes.id, memberRecord.scopeId))
+          .limit(1);
+
+        if (scope) {
+          const client = await clerkClient();
+          await client.organizations.updateOrganizationMembershipMetadata({
+            organizationId: scope.clerkOrgId,
+            userId,
+            publicMetadata: { timezone },
+          });
+        }
+      } catch (err) {
+        log.error("Failed to write timezone to Clerk metadata", {
+          error: err,
+          userId,
+        });
+      }
     }
   }
 }

--- a/turbo/apps/web/src/types/global.d.ts
+++ b/turbo/apps/web/src/types/global.d.ts
@@ -21,4 +21,12 @@ declare global {
   var services: Services;
   // Captured Next.js after() callbacks for test assertions (see setup.ts)
   var nextAfterCallbacks: Array<() => Promise<unknown>>;
+
+  // Clerk custom JWT session claims (configured in Clerk Dashboard)
+  interface CustomJwtSessionClaims {
+    org_tier?: string;
+    membership_timezone?: string;
+    membership_notify_email?: boolean;
+    membership_notify_slack?: boolean;
+  }
 }


### PR DESCRIPTION
## Summary

- Add dual-write logic so scope `tier` and member preferences (`timezone`, `notifyEmail`, `notifySlack`) are written to both the local database and Clerk metadata simultaneously
- All Clerk writes are fire-and-forget: failures are logged but don't block the API response
- Add `CustomJwtSessionClaims` global type declaration for the JWT session token custom claims configured in Clerk Dashboard
- Add backfill migration script (`002-backfill-clerk-metadata`) for populating Clerk metadata from existing DB data
- Extend Clerk test mocks with `updateOrganizationMetadata` and `updateOrganizationMembershipMetadata` methods

Phase 1 (preparation) of the Scope → Clerk migration.

Closes #4100

## Test plan

- [x] Existing tier and preferences tests pass (22 tests)
- [x] New test: `setTier` calls `updateOrganizationMetadata` with correct tier
- [x] New test: `updateUserPreferences` calls `updateOrganizationMembershipMetadata` with timezone
- [x] New test: `updateUserPreferences` calls `updateOrganizationMembershipMetadata` with notifyEmail/notifySlack
- [x] Type check, lint, knip all pass
- [ ] Run backfill script in dry-run mode: `tsx scripts/migrations/002-backfill-clerk-metadata/backfill.ts`
- [ ] Run backfill script with `--migrate` against staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)