### PR TITLE
refactor: add clerk_org_id column to all scope-dependent tables

### DIFF
--- a/turbo/apps/web/app/api/agent/composes/route.ts
+++ b/turbo/apps/web/app/api/agent/composes/route.ts
@@ -294,6 +294,7 @@ const router = tsr.router(composesMainContract, {
           userId,
           scopeId: scope.id,
           name: normalizedAgentName,
+          clerkOrgId: scope.clerkOrgId,
         })
         .returning({ id: agentComposes.id });
 

--- a/turbo/apps/web/app/api/agent/runs/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/route.ts
@@ -477,6 +477,7 @@ const router = tsr.router(runsMainContract, {
         checkEnv: body.checkEnv,
         scopeId: scope.id,
         scopeSlug: scope.slug,
+        clerkOrgId: scope.clerkOrgId,
         scopeTier: scopeTierSchema.parse(scope.tier),
       });
 

--- a/turbo/apps/web/app/api/agent/schedules/route.ts
+++ b/turbo/apps/web/app/api/agent/schedules/route.ts
@@ -10,6 +10,7 @@ import { deploySchedule, listSchedules } from "../../../../src/lib/schedule";
 import { logger } from "../../../../src/lib/logger";
 import { isNotFound, isBadRequest } from "../../../../src/lib/errors";
 import { resolveScopeId } from "../../../../src/lib/scope/scope-member-service";
+import { getScopeById } from "../../../../src/lib/scope/scope-service";
 
 const log = logger("api:schedules");
 
@@ -33,8 +34,17 @@ const router = tsr.router(schedulesMainContract, {
       // Note: vars and secrets are no longer accepted via API
       // They must be managed via platform tables (vm0 secret set, vm0 var set)
       const scopeId = await resolveScopeId(userId, body.scopeId);
+      const scope = await getScopeById(scopeId);
+      if (!scope) {
+        return {
+          status: 404 as const,
+          body: {
+            error: { message: "Scope not found", code: "NOT_FOUND" },
+          },
+        };
+      }
 
-      const result = await deploySchedule(userId, scopeId, {
+      const result = await deploySchedule(userId, scopeId, scope.clerkOrgId, {
         name: body.name,
         composeId: body.composeId,
         cronExpression: body.cronExpression,

--- a/turbo/apps/web/app/api/connectors/[type]/callback/route.ts
+++ b/turbo/apps/web/app/api/connectors/[type]/callback/route.ts
@@ -209,6 +209,7 @@ export async function GET(
         email: userInfo.email,
       },
       getRequestedScopes(connectorType),
+      scope.clerkOrgId,
       { refreshToken, refreshSecretName, expiresIn },
     );
 

--- a/turbo/apps/web/app/api/connectors/[type]/token/route.ts
+++ b/turbo/apps/web/app/api/connectors/[type]/token/route.ts
@@ -26,6 +26,7 @@ const router = tsr.router(connectorTokenContract, {
         userId,
         params.type,
         body.secrets,
+        scope.clerkOrgId,
       );
 
       return {

--- a/turbo/apps/web/app/api/connectors/computer/route.ts
+++ b/turbo/apps/web/app/api/connectors/computer/route.ts
@@ -29,7 +29,11 @@ const router = tsr.router(computerConnectorContract, {
     try {
       const scopeSlug = new URL(request.url).searchParams.get("scope");
       const { scope } = await resolveScope(userId, scopeSlug);
-      const result = await createComputerConnector(scope.id, userId);
+      const result = await createComputerConnector(
+        scope.id,
+        userId,
+        scope.clerkOrgId,
+      );
       return { status: 200 as const, body: result };
     } catch (error) {
       if (isBadRequest(error)) {

--- a/turbo/apps/web/app/api/model-providers/route.ts
+++ b/turbo/apps/web/app/api/model-providers/route.ts
@@ -91,6 +91,7 @@ const router = tsr.router(modelProvidersMainContract, {
           type,
           authMethod,
           secrets,
+          scope.clerkOrgId,
           selectedModel,
         );
         provider = result.provider;
@@ -108,6 +109,7 @@ const router = tsr.router(modelProvidersMainContract, {
           userId,
           type,
           secret,
+          scope.clerkOrgId,
           selectedModel,
         );
         provider = result.provider;

--- a/turbo/apps/web/app/api/secrets/route.ts
+++ b/turbo/apps/web/app/api/secrets/route.ts
@@ -67,6 +67,7 @@ const router = tsr.router(secretsMainContract, {
         userId,
         name,
         value,
+        scope.clerkOrgId,
         description,
       );
 

--- a/turbo/apps/web/app/api/storages/prepare/route.ts
+++ b/turbo/apps/web/app/api/storages/prepare/route.ts
@@ -143,6 +143,7 @@ const router = tsr.router(storagesPrepareContract, {
       .values({
         userId: storageUserId,
         scopeId: runtimeScope.id,
+        clerkOrgId: runtimeScope.clerkOrgId,
         name: storageName,
         type: storageType,
         s3Prefix: `${runtimeScope.slug}/${storageType}/${storageName}`,

--- a/turbo/apps/web/app/api/variables/route.ts
+++ b/turbo/apps/web/app/api/variables/route.ts
@@ -74,6 +74,7 @@ const router = tsr.router(variablesMainContract, {
         userId,
         name,
         value,
+        scope.clerkOrgId,
         description,
       );
 

--- a/turbo/apps/web/app/api/webhooks/agent/storages/prepare/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/storages/prepare/route.ts
@@ -101,6 +101,7 @@ const router = tsr.router(webhookStoragesPrepareContract, {
       .values({
         userId: storageUserId,
         scopeId: runtimeScope.id,
+        clerkOrgId: runtimeScope.clerkOrgId,
         name: storageName,
         type: storageType,
         s3Prefix: `${runtimeScope.slug}/${storageType}/${storageName}`,

--- a/turbo/apps/web/src/__tests__/api-test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers.ts
@@ -527,11 +527,13 @@ async function createTestRunDirect(
     continuedFromSessionId?: string;
   },
 ): Promise<{ id: string }> {
+  const clerkOrgId = await getClerkOrgIdFromScope(scopeId);
   const [run] = await globalThis.services.db
     .insert(agentRuns)
     .values({
       userId,
       scopeId,
+      clerkOrgId,
       agentComposeVersionId: versionId,
       status: options?.status ?? "running",
       prompt: options?.prompt ?? "test prompt",
@@ -1410,6 +1412,22 @@ async function getScopeIdFromVersion(versionId: string): Promise<string> {
 }
 
 /**
+ * Resolve clerkOrgId from a scopeId.
+ * Shared by test helpers that insert records into scope-dependent tables.
+ */
+async function getClerkOrgIdFromScope(scopeId: string): Promise<string> {
+  const [scope] = await globalThis.services.db
+    .select({ clerkOrgId: scopes.clerkOrgId })
+    .from(scopes)
+    .where(eq(scopes.id, scopeId))
+    .limit(1);
+  if (!scope) {
+    throw new Error(`Scope ${scopeId} not found`);
+  }
+  return scope.clerkOrgId;
+}
+
+/**
  * Insert a stale pending run directly into the database.
  * This simulates a run stuck in "pending" state past the cleanup TTL,
  * which cannot be reproduced through normal API flows since the route
@@ -1426,6 +1444,7 @@ export async function insertStalePendingRun(
   ageMs: number = 20 * 60 * 1000,
 ): Promise<string> {
   const scopeId = await getScopeIdFromVersion(agentComposeVersionId);
+  const clerkOrgId = await getClerkOrgIdFromScope(scopeId);
 
   const staleCreatedAt = new Date(Date.now() - ageMs);
   const [run] = await globalThis.services.db
@@ -1433,6 +1452,7 @@ export async function insertStalePendingRun(
     .values({
       userId,
       scopeId,
+      clerkOrgId,
       agentComposeVersionId,
       status: "pending",
       prompt: "Stale pending run",
@@ -1520,11 +1540,14 @@ export async function createTestConnector(
     userId = member.userId;
   }
 
+  const clerkOrgId = await getClerkOrgIdFromScope(scopeId);
+
   const [connector] = await globalThis.services.db
     .insert(connectors)
     .values({
       scopeId,
       userId,
+      clerkOrgId,
       type,
       authMethod: options?.authMethod ?? "oauth",
       externalId: options?.externalId ?? "12345",
@@ -1543,6 +1566,7 @@ export async function createTestConnector(
   await globalThis.services.db.insert(secrets).values({
     scopeId,
     userId,
+    clerkOrgId,
     name: secretName,
     type: "connector",
     encryptedValue,
@@ -1724,12 +1748,14 @@ export async function createCompletedTestRun(options: {
   completedAt: Date;
 }): Promise<string> {
   const scopeId = await getScopeIdFromVersion(options.composeVersionId);
+  const clerkOrgId = await getClerkOrgIdFromScope(scopeId);
 
   const [row] = await globalThis.services.db
     .insert(agentRuns)
     .values({
       userId: options.userId,
       scopeId,
+      clerkOrgId,
       agentComposeVersionId: options.composeVersionId,
       status: "completed",
       prompt: "test",
@@ -2171,12 +2197,14 @@ export async function createTestRunnerJob(
   contextOverrides?: Partial<StoredExecutionContext>,
 ): Promise<{ runId: string }> {
   const scopeId = await getScopeIdFromVersion(versionId);
+  const clerkOrgId = await getClerkOrgIdFromScope(scopeId);
 
   const [run] = await globalThis.services.db
     .insert(agentRuns)
     .values({
       userId,
       scopeId,
+      clerkOrgId,
       agentComposeVersionId: versionId,
       status: "pending",
       prompt: "test prompt",
@@ -2476,6 +2504,7 @@ export async function createTestTelegramInstallation(options?: {
     .values({
       userId: adminUserId,
       scopeId: scope!.id,
+      clerkOrgId: scope!.clerkOrgId,
       name: uniqueId("compose"),
     })
     .returning();
@@ -2575,9 +2604,10 @@ export async function insertTestAgentCompose(
   scopeId: string,
   name: string,
 ) {
+  const clerkOrgId = await getClerkOrgIdFromScope(scopeId);
   const [row] = await globalThis.services.db
     .insert(agentComposes)
-    .values({ userId, scopeId, name })
+    .values({ userId, scopeId, clerkOrgId, name })
     .returning();
   return row!;
 }
@@ -2593,11 +2623,13 @@ export async function insertTestAgentRun(
   scopeId: string,
   options?: { status?: string; prompt?: string },
 ) {
+  const clerkOrgId = await getClerkOrgIdFromScope(scopeId);
   const [row] = await globalThis.services.db
     .insert(agentRuns)
     .values({
       userId,
       scopeId,
+      clerkOrgId,
       status: options?.status ?? "completed",
       prompt: options?.prompt ?? "test prompt",
     })
@@ -2616,9 +2648,10 @@ export async function insertTestStorageRecord(
   scopeId: string,
   name: string,
 ) {
+  const clerkOrgId = await getClerkOrgIdFromScope(scopeId);
   const [row] = await globalThis.services.db
     .insert(storages)
-    .values({ userId, scopeId, name, s3Prefix: "test/prefix" })
+    .values({ userId, scopeId, clerkOrgId, name, s3Prefix: "test/prefix" })
     .returning();
   return row!;
 }

--- a/turbo/apps/web/src/__tests__/github/api-helpers.ts
+++ b/turbo/apps/web/src/__tests__/github/api-helpers.ts
@@ -70,6 +70,7 @@ export async function givenGitHubInstallation(
     .values({
       userId,
       scopeId: scope!.id,
+      clerkOrgId: scope!.clerkOrgId,
       name: uniqueId("gh-agent"),
     })
     .returning();

--- a/turbo/apps/web/src/__tests__/test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/test-helpers.ts
@@ -537,6 +537,7 @@ export function testContext(): TestContext {
         .values({
           userId: adminUserId,
           scopeId: scopeData.id,
+          clerkOrgId: scopeData.clerkOrgId,
           name: uniqueId("default-agent"),
         })
         .returning();
@@ -642,6 +643,7 @@ export function testContext(): TestContext {
       .values({
         userId: vm0UserId,
         scopeId: scopeData.id,
+        clerkOrgId: scopeData.clerkOrgId,
         name,
       })
       .returning();
@@ -669,7 +671,7 @@ export function testContext(): TestContext {
 
     initServices();
 
-    // Look up userId from scope_members
+    // Look up userId and clerkOrgId from scope_members + scopes
     const [member] = await globalThis.services.db
       .select({ userId: scopeMembers.userId })
       .from(scopeMembers)
@@ -678,12 +680,18 @@ export function testContext(): TestContext {
     if (!member) {
       throw new Error(`No scope member found for scope ${scopeId}`);
     }
+    const [scope] = await globalThis.services.db
+      .select({ clerkOrgId: scopes.clerkOrgId })
+      .from(scopes)
+      .where(eq(scopes.id, scopeId))
+      .limit(1);
 
     const [connector] = await globalThis.services.db
       .insert(connectors)
       .values({
         scopeId,
         userId: member.userId,
+        clerkOrgId: scope!.clerkOrgId,
         type,
         authMethod,
       })

--- a/turbo/apps/web/src/db/migrations/0117_typical_starjammers.sql
+++ b/turbo/apps/web/src/db/migrations/0117_typical_starjammers.sql
@@ -1,0 +1,46 @@
+-- Step 1: Add clerk_org_id as nullable to all 8 tables
+ALTER TABLE "agent_composes" ADD COLUMN "clerk_org_id" text;--> statement-breakpoint
+ALTER TABLE "agent_runs" ADD COLUMN "clerk_org_id" text;--> statement-breakpoint
+ALTER TABLE "agent_schedules" ADD COLUMN "clerk_org_id" text;--> statement-breakpoint
+ALTER TABLE "connectors" ADD COLUMN "clerk_org_id" text;--> statement-breakpoint
+ALTER TABLE "model_providers" ADD COLUMN "clerk_org_id" text;--> statement-breakpoint
+ALTER TABLE "secrets" ADD COLUMN "clerk_org_id" text;--> statement-breakpoint
+ALTER TABLE "storages" ADD COLUMN "clerk_org_id" text;--> statement-breakpoint
+ALTER TABLE "variables" ADD COLUMN "clerk_org_id" text;--> statement-breakpoint
+
+-- Step 2: Backfill from scopes table
+UPDATE "agent_composes" t SET "clerk_org_id" = s."clerk_org_id" FROM "scopes" s WHERE t."scope_id" = s."id";--> statement-breakpoint
+UPDATE "agent_runs" t SET "clerk_org_id" = s."clerk_org_id" FROM "scopes" s WHERE t."scope_id" = s."id";--> statement-breakpoint
+UPDATE "agent_schedules" t SET "clerk_org_id" = s."clerk_org_id" FROM "scopes" s WHERE t."scope_id" = s."id";--> statement-breakpoint
+UPDATE "connectors" t SET "clerk_org_id" = s."clerk_org_id" FROM "scopes" s WHERE t."scope_id" = s."id";--> statement-breakpoint
+UPDATE "model_providers" t SET "clerk_org_id" = s."clerk_org_id" FROM "scopes" s WHERE t."scope_id" = s."id";--> statement-breakpoint
+UPDATE "secrets" t SET "clerk_org_id" = s."clerk_org_id" FROM "scopes" s WHERE t."scope_id" = s."id";--> statement-breakpoint
+UPDATE "storages" t SET "clerk_org_id" = s."clerk_org_id" FROM "scopes" s WHERE t."scope_id" = s."id";--> statement-breakpoint
+UPDATE "variables" t SET "clerk_org_id" = s."clerk_org_id" FROM "scopes" s WHERE t."scope_id" = s."id";--> statement-breakpoint
+
+-- Step 3: Set NOT NULL after backfill
+ALTER TABLE "agent_composes" ALTER COLUMN "clerk_org_id" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "agent_runs" ALTER COLUMN "clerk_org_id" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "agent_schedules" ALTER COLUMN "clerk_org_id" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "connectors" ALTER COLUMN "clerk_org_id" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "model_providers" ALTER COLUMN "clerk_org_id" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "secrets" ALTER COLUMN "clerk_org_id" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "storages" ALTER COLUMN "clerk_org_id" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "variables" ALTER COLUMN "clerk_org_id" SET NOT NULL;--> statement-breakpoint
+
+-- Step 4: Create indexes
+CREATE INDEX "idx_agent_composes_clerk_org" ON "agent_composes" USING btree ("clerk_org_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "idx_agent_composes_clerk_org_name" ON "agent_composes" USING btree ("clerk_org_id","name");--> statement-breakpoint
+CREATE INDEX "idx_agent_runs_clerk_org" ON "agent_runs" USING btree ("clerk_org_id");--> statement-breakpoint
+CREATE INDEX "idx_agent_schedules_clerk_org" ON "agent_schedules" USING btree ("clerk_org_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "idx_agent_schedules_compose_name_clerk_org_user" ON "agent_schedules" USING btree ("compose_id","name","clerk_org_id","user_id");--> statement-breakpoint
+CREATE INDEX "idx_connectors_clerk_org" ON "connectors" USING btree ("clerk_org_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "idx_connectors_clerk_org_user_type" ON "connectors" USING btree ("clerk_org_id","user_id","type");--> statement-breakpoint
+CREATE INDEX "idx_model_providers_clerk_org" ON "model_providers" USING btree ("clerk_org_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "idx_model_providers_clerk_org_user_type" ON "model_providers" USING btree ("clerk_org_id","user_id","type");--> statement-breakpoint
+CREATE INDEX "idx_secrets_clerk_org" ON "secrets" USING btree ("clerk_org_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "idx_secrets_clerk_org_user_name_type" ON "secrets" USING btree ("clerk_org_id","user_id","name","type");--> statement-breakpoint
+CREATE INDEX "idx_storages_clerk_org" ON "storages" USING btree ("clerk_org_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "idx_storages_clerk_org_user_name_type" ON "storages" USING btree ("clerk_org_id","user_id","name","type");--> statement-breakpoint
+CREATE INDEX "idx_variables_clerk_org" ON "variables" USING btree ("clerk_org_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "idx_variables_clerk_org_user_name" ON "variables" USING btree ("clerk_org_id","user_id","name");

--- a/turbo/apps/web/src/db/migrations/meta/0117_snapshot.json
+++ b/turbo/apps/web/src/db/migrations/meta/0117_snapshot.json
@@ -1,0 +1,5084 @@
+{
+  "id": "872ef7cd-7b8c-429c-92e9-3877cebd8f8c",
+  "prevId": "eafc7a96-9f90-46bb-8ae9-31a203b962a7",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.agent_compose_versions": {
+      "name": "agent_compose_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "compose_id": {
+          "name": "compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_compose_versions_compose_id": {
+          "name": "idx_agent_compose_versions_compose_id",
+          "columns": [
+            {
+              "expression": "compose_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_compose_versions_compose_id_agent_composes_id_fk": {
+          "name": "agent_compose_versions_compose_id_agent_composes_id_fk",
+          "tableFrom": "agent_compose_versions",
+          "tableTo": "agent_composes",
+          "columnsFrom": ["compose_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_composes": {
+      "name": "agent_composes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "head_version_id": {
+          "name": "head_version_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clerk_org_id": {
+          "name": "clerk_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_composes_scope_name": {
+          "name": "idx_agent_composes_scope_name",
+          "columns": [
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_composes_scope": {
+          "name": "idx_agent_composes_scope",
+          "columns": [
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_composes_clerk_org": {
+          "name": "idx_agent_composes_clerk_org",
+          "columns": [
+            {
+              "expression": "clerk_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_composes_clerk_org_name": {
+          "name": "idx_agent_composes_clerk_org_name",
+          "columns": [
+            {
+              "expression": "clerk_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_composes_scope_id_scopes_id_fk": {
+          "name": "agent_composes_scope_id_scopes_id_fk",
+          "tableFrom": "agent_composes",
+          "tableTo": "scopes",
+          "columnsFrom": ["scope_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_permissions": {
+      "name": "agent_permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "agent_compose_id": {
+          "name": "agent_compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grantee_type": {
+          "name": "grantee_type",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grantee_email": {
+          "name": "grantee_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "permission": {
+          "name": "permission",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'run_view'"
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_permissions_compose": {
+          "name": "idx_agent_permissions_compose",
+          "columns": [
+            {
+              "expression": "agent_compose_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_permissions_email": {
+          "name": "idx_agent_permissions_email",
+          "columns": [
+            {
+              "expression": "grantee_email",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "grantee_email IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_permissions_agent_compose_id_agent_composes_id_fk": {
+          "name": "agent_permissions_agent_compose_id_agent_composes_id_fk",
+          "tableFrom": "agent_permissions",
+          "tableTo": "agent_composes",
+          "columnsFrom": ["agent_compose_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "agent_permissions_compose_type_email_unique": {
+          "name": "agent_permissions_compose_type_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["agent_compose_id", "grantee_type", "grantee_email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_run_callbacks": {
+      "name": "agent_run_callbacks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_secret": {
+          "name": "encrypted_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_attempt_at": {
+          "name": "last_attempt_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_run_callbacks_run_id": {
+          "name": "idx_agent_run_callbacks_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_run_callbacks_pending": {
+          "name": "idx_agent_run_callbacks_pending",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "status = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_run_callbacks_run_id_agent_runs_id_fk": {
+          "name": "agent_run_callbacks_run_id_agent_runs_id_fk",
+          "tableFrom": "agent_run_callbacks",
+          "tableTo": "agent_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_run_events": {
+      "name": "agent_run_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence_number": {
+          "name": "sequence_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_data": {
+          "name": "event_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_run_events_run_id_agent_runs_id_fk": {
+          "name": "agent_run_events_run_id_agent_runs_id_fk",
+          "tableFrom": "agent_run_events",
+          "tableTo": "agent_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_run_queue": {
+      "name": "agent_run_queue",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_params": {
+          "name": "encrypted_params",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "agent_run_queue_user_created_idx": {
+          "name": "agent_run_queue_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_run_queue_expires_at_idx": {
+          "name": "agent_run_queue_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_run_queue_run_id_agent_runs_id_fk": {
+          "name": "agent_run_queue_run_id_agent_runs_id_fk",
+          "tableFrom": "agent_run_queue",
+          "tableTo": "agent_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_runs": {
+      "name": "agent_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_compose_version_id": {
+          "name": "agent_compose_version_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resumed_from_checkpoint_id": {
+          "name": "resumed_from_checkpoint_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "continued_from_session_id": {
+          "name": "continued_from_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vars": {
+          "name": "vars",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "secret_names": {
+          "name": "secret_names",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clerk_org_id": {
+          "name": "clerk_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_heartbeat_at": {
+          "name": "last_heartbeat_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_agent_runs_user_created": {
+          "name": "idx_agent_runs_user_created",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_runs_clerk_org": {
+          "name": "idx_agent_runs_clerk_org",
+          "columns": [
+            {
+              "expression": "clerk_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_runs_status_heartbeat": {
+          "name": "idx_agent_runs_status_heartbeat",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_heartbeat_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_runs_running_heartbeat": {
+          "name": "idx_agent_runs_running_heartbeat",
+          "columns": [
+            {
+              "expression": "last_heartbeat_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "status = 'running'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_runs_schedule_created": {
+          "name": "idx_agent_runs_schedule_created",
+          "columns": [
+            {
+              "expression": "schedule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "schedule_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_runs_scope_id_scopes_id_fk": {
+          "name": "agent_runs_scope_id_scopes_id_fk",
+          "tableFrom": "agent_runs",
+          "tableTo": "scopes",
+          "columnsFrom": ["scope_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_runs_agent_compose_version_id_agent_compose_versions_id_fk": {
+          "name": "agent_runs_agent_compose_version_id_agent_compose_versions_id_fk",
+          "tableFrom": "agent_runs",
+          "tableTo": "agent_compose_versions",
+          "columnsFrom": ["agent_compose_version_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "agent_runs_schedule_id_agent_schedules_id_fk": {
+          "name": "agent_runs_schedule_id_agent_schedules_id_fk",
+          "tableFrom": "agent_runs",
+          "tableTo": "agent_schedules",
+          "columnsFrom": ["schedule_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_schedules": {
+      "name": "agent_schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "compose_id": {
+          "name": "compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clerk_org_id": {
+          "name": "clerk_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_type": {
+          "name": "trigger_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'cron'"
+        },
+        "cron_expression": {
+          "name": "cron_expression",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "at_time": {
+          "name": "at_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "interval_seconds": {
+          "name": "interval_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vars": {
+          "name": "vars",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_secrets": {
+          "name": "encrypted_secrets",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artifact_name": {
+          "name": "artifact_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artifact_version": {
+          "name": "artifact_version",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "volume_versions": {
+          "name": "volume_versions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_run_id": {
+          "name": "last_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retry_started_at": {
+          "name": "retry_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consecutive_failures": {
+          "name": "consecutive_failures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_schedules_compose_name_scope_user": {
+          "name": "idx_agent_schedules_compose_name_scope_user",
+          "columns": [
+            {
+              "expression": "compose_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_schedules_compose": {
+          "name": "idx_agent_schedules_compose",
+          "columns": [
+            {
+              "expression": "compose_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_schedules_scope_user": {
+          "name": "idx_agent_schedules_scope_user",
+          "columns": [
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_schedules_clerk_org": {
+          "name": "idx_agent_schedules_clerk_org",
+          "columns": [
+            {
+              "expression": "clerk_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_schedules_compose_name_clerk_org_user": {
+          "name": "idx_agent_schedules_compose_name_clerk_org_user",
+          "columns": [
+            {
+              "expression": "compose_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "clerk_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_schedules_next_run": {
+          "name": "idx_agent_schedules_next_run",
+          "columns": [
+            {
+              "expression": "next_run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "enabled = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_schedules_compose_id_agent_composes_id_fk": {
+          "name": "agent_schedules_compose_id_agent_composes_id_fk",
+          "tableFrom": "agent_schedules",
+          "tableTo": "agent_composes",
+          "columnsFrom": ["compose_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_schedules_scope_id_scopes_id_fk": {
+          "name": "agent_schedules_scope_id_scopes_id_fk",
+          "tableFrom": "agent_schedules",
+          "tableTo": "scopes",
+          "columnsFrom": ["scope_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_schedules_last_run_id_agent_runs_id_fk": {
+          "name": "agent_schedules_last_run_id_agent_runs_id_fk",
+          "tableFrom": "agent_schedules",
+          "tableTo": "agent_runs",
+          "columnsFrom": ["last_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_sessions": {
+      "name": "agent_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_compose_id": {
+          "name": "agent_compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artifact_name": {
+          "name": "artifact_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_name": {
+          "name": "memory_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chat_messages": {
+          "name": "chat_messages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_sessions_user_compose_artifact": {
+          "name": "idx_agent_sessions_user_compose_artifact",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_compose_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "artifact_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_sessions_agent_compose_id_agent_composes_id_fk": {
+          "name": "agent_sessions_agent_compose_id_agent_composes_id_fk",
+          "tableFrom": "agent_sessions",
+          "tableTo": "agent_composes",
+          "columnsFrom": ["agent_compose_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_sessions_conversation_id_conversations_id_fk": {
+          "name": "agent_sessions_conversation_id_conversations_id_fk",
+          "tableFrom": "agent_sessions",
+          "tableTo": "conversations",
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blobs": {
+      "name": "blobs",
+      "schema": "",
+      "columns": {
+        "hash": {
+          "name": "hash",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref_count": {
+          "name": "ref_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_blobs_ref_count": {
+          "name": "idx_blobs_ref_count",
+          "columns": [
+            {
+              "expression": "ref_count",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.checkpoints": {
+      "name": "checkpoints",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_compose_snapshot": {
+          "name": "agent_compose_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_snapshot": {
+          "name": "artifact_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_snapshot": {
+          "name": "memory_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "volume_versions_snapshot": {
+          "name": "volume_versions_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "checkpoints_run_id_agent_runs_id_fk": {
+          "name": "checkpoints_run_id_agent_runs_id_fk",
+          "tableFrom": "checkpoints",
+          "tableTo": "agent_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "checkpoints_conversation_id_conversations_id_fk": {
+          "name": "checkpoints_conversation_id_conversations_id_fk",
+          "tableFrom": "checkpoints",
+          "tableTo": "conversations",
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "checkpoints_run_id_unique": {
+          "name": "checkpoints_run_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["run_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cli_tokens": {
+      "name": "cli_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cli_tokens_token_unique": {
+          "name": "cli_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.compose_jobs": {
+      "name": "compose_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_url": {
+          "name": "github_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "overwrite": {
+          "name": "overwrite",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'github'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_compose_jobs_user_status": {
+          "name": "idx_compose_jobs_user_status",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_compose_jobs_created": {
+          "name": "idx_compose_jobs_created",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_compose_jobs_user_active": {
+          "name": "idx_compose_jobs_user_active",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status IN ('pending', 'running')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.connector_sessions": {
+      "name": "connector_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(9)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "connector_session_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_connector_sessions_code": {
+          "name": "idx_connector_sessions_code",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_connector_sessions_user_status": {
+          "name": "idx_connector_sessions_user_status",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.connectors": {
+      "name": "connectors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_method": {
+          "name": "auth_method",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_username": {
+          "name": "external_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_email": {
+          "name": "external_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_scopes": {
+          "name": "oauth_scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clerk_org_id": {
+          "name": "clerk_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_connectors_scope_user_type": {
+          "name": "idx_connectors_scope_user_type",
+          "columns": [
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_connectors_scope": {
+          "name": "idx_connectors_scope",
+          "columns": [
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_connectors_clerk_org": {
+          "name": "idx_connectors_clerk_org",
+          "columns": [
+            {
+              "expression": "clerk_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_connectors_clerk_org_user_type": {
+          "name": "idx_connectors_clerk_org_user_type",
+          "columns": [
+            {
+              "expression": "clerk_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "connectors_scope_id_scopes_id_fk": {
+          "name": "connectors_scope_id_scopes_id_fk",
+          "tableFrom": "connectors",
+          "tableTo": "scopes",
+          "columnsFrom": ["scope_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversations": {
+      "name": "conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cli_agent_type": {
+          "name": "cli_agent_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cli_agent_session_id": {
+          "name": "cli_agent_session_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cli_agent_session_history": {
+          "name": "cli_agent_session_history",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cli_agent_session_history_hash": {
+          "name": "cli_agent_session_history_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "conversations_run_id_agent_runs_id_fk": {
+          "name": "conversations_run_id_agent_runs_id_fk",
+          "tableFrom": "conversations",
+          "tableTo": "agent_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "conversations_run_id_unique": {
+          "name": "conversations_run_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["run_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.device_codes": {
+      "name": "device_codes",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "varchar(9)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "device_code_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_outbox": {
+      "name": "email_outbox",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "from_address": {
+          "name": "from_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_addresses": {
+          "name": "to_addresses",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cc_addresses": {
+          "name": "cc_addresses",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reply_to": {
+          "name": "reply_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headers": {
+          "name": "headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "template": {
+          "name": "template",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_send_action": {
+          "name": "post_send_action",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_retry_at": {
+          "name": "next_retry_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resend_id": {
+          "name": "resend_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_outbox_drain_idx": {
+          "name": "email_outbox_drain_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_retry_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_outbox_created_at_idx": {
+          "name": "email_outbox_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_reply_requests": {
+      "name": "email_reply_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_thread_session_id": {
+          "name": "email_thread_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inbound_email_id": {
+          "name": "inbound_email_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inbound_message_id": {
+          "name": "inbound_message_id",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_email_reply_requests_run": {
+          "name": "idx_email_reply_requests_run",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_reply_requests_run_id_agent_runs_id_fk": {
+          "name": "email_reply_requests_run_id_agent_runs_id_fk",
+          "tableFrom": "email_reply_requests",
+          "tableTo": "agent_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "email_reply_requests_email_thread_session_id_email_thread_sessions_id_fk": {
+          "name": "email_reply_requests_email_thread_session_id_email_thread_sessions_id_fk",
+          "tableFrom": "email_reply_requests",
+          "tableTo": "email_thread_sessions",
+          "columnsFrom": ["email_thread_session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_thread_sessions": {
+      "name": "email_thread_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "compose_id": {
+          "name": "compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_session_id": {
+          "name": "agent_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_email_message_id": {
+          "name": "last_email_message_id",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_to_token": {
+          "name": "reply_to_token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_email_thread_sessions_reply_token": {
+          "name": "idx_email_thread_sessions_reply_token",
+          "columns": [
+            {
+              "expression": "reply_to_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_email_thread_sessions_user": {
+          "name": "idx_email_thread_sessions_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_thread_sessions_compose_id_agent_composes_id_fk": {
+          "name": "email_thread_sessions_compose_id_agent_composes_id_fk",
+          "tableFrom": "email_thread_sessions",
+          "tableTo": "agent_composes",
+          "columnsFrom": ["compose_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "email_thread_sessions_agent_session_id_agent_sessions_id_fk": {
+          "name": "email_thread_sessions_agent_session_id_agent_sessions_id_fk",
+          "tableFrom": "email_thread_sessions",
+          "tableTo": "agent_sessions",
+          "columnsFrom": ["agent_session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_installations": {
+      "name": "github_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_access_token": {
+          "name": "encrypted_access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_name": {
+          "name": "target_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "admin_github_user_id": {
+          "name": "admin_github_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_compose_id": {
+          "name": "default_compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_configs": {
+          "name": "repo_configs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "github_installations_installation_id_unique": {
+          "name": "github_installations_installation_id_unique",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "installation_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_installations_default_compose_id_agent_composes_id_fk": {
+          "name": "github_installations_default_compose_id_agent_composes_id_fk",
+          "tableFrom": "github_installations",
+          "tableTo": "agent_composes",
+          "columnsFrom": ["default_compose_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_issue_sessions": {
+      "name": "github_issue_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo": {
+          "name": "repo",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_number": {
+          "name": "issue_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_session_id": {
+          "name": "agent_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_comment_id": {
+          "name": "last_comment_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_github_issue_sessions_installation_repo_issue": {
+          "name": "idx_github_issue_sessions_installation_repo_issue",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "repo",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "issue_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_github_issue_sessions_installation": {
+          "name": "idx_github_issue_sessions_installation",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_issue_sessions_installation_id_github_installations_id_fk": {
+          "name": "github_issue_sessions_installation_id_github_installations_id_fk",
+          "tableFrom": "github_issue_sessions",
+          "tableTo": "github_installations",
+          "columnsFrom": ["installation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_issue_sessions_agent_session_id_agent_sessions_id_fk": {
+          "name": "github_issue_sessions_agent_session_id_agent_sessions_id_fk",
+          "tableFrom": "github_issue_sessions",
+          "tableTo": "agent_sessions",
+          "columnsFrom": ["agent_session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_user_links": {
+      "name": "github_user_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "github_user_id": {
+          "name": "github_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vm0_user_id": {
+          "name": "vm0_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_github_user_links_user_installation": {
+          "name": "idx_github_user_links_user_installation",
+          "columns": [
+            {
+              "expression": "github_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_user_links_installation_id_github_installations_id_fk": {
+          "name": "github_user_links_installation_id_github_installations_id_fk",
+          "tableFrom": "github_user_links",
+          "tableTo": "github_installations",
+          "columnsFrom": ["installation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_providers": {
+      "name": "model_providers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_id": {
+          "name": "secret_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_method": {
+          "name": "auth_method",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "selected_model": {
+          "name": "selected_model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clerk_org_id": {
+          "name": "clerk_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_model_providers_scope_user_type": {
+          "name": "idx_model_providers_scope_user_type",
+          "columns": [
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_model_providers_scope": {
+          "name": "idx_model_providers_scope",
+          "columns": [
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_model_providers_secret": {
+          "name": "idx_model_providers_secret",
+          "columns": [
+            {
+              "expression": "secret_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_model_providers_clerk_org": {
+          "name": "idx_model_providers_clerk_org",
+          "columns": [
+            {
+              "expression": "clerk_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_model_providers_clerk_org_user_type": {
+          "name": "idx_model_providers_clerk_org_user_type",
+          "columns": [
+            {
+              "expression": "clerk_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "model_providers_scope_id_scopes_id_fk": {
+          "name": "model_providers_scope_id_scopes_id_fk",
+          "tableFrom": "model_providers",
+          "tableTo": "scopes",
+          "columnsFrom": ["scope_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "model_providers_secret_id_secrets_id_fk": {
+          "name": "model_providers_secret_id_secrets_id_fk",
+          "tableFrom": "model_providers",
+          "tableTo": "secrets",
+          "columnsFrom": ["secret_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runner_job_queue": {
+      "name": "runner_job_queue",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "runner_group": {
+          "name": "runner_group",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_context": {
+          "name": "execution_context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "runner_job_queue_group_unclaimed_idx": {
+          "name": "runner_job_queue_group_unclaimed_idx",
+          "columns": [
+            {
+              "expression": "runner_group",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "claimed_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runner_job_queue_expires_at_idx": {
+          "name": "runner_job_queue_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "runner_job_queue_run_id_agent_runs_id_fk": {
+          "name": "runner_job_queue_run_id_agent_runs_id_fk",
+          "tableFrom": "runner_job_queue",
+          "tableTo": "agent_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sandbox_telemetry": {
+      "name": "sandbox_telemetry",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_sandbox_telemetry_run_id": {
+          "name": "idx_sandbox_telemetry_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sandbox_telemetry_run_id_agent_runs_id_fk": {
+          "name": "sandbox_telemetry_run_id_agent_runs_id_fk",
+          "tableFrom": "sandbox_telemetry",
+          "tableTo": "agent_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scope_members": {
+      "name": "scope_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notify_email": {
+          "name": "notify_email",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "notify_slack": {
+          "name": "notify_slack",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_scope_members_scope_user": {
+          "name": "idx_scope_members_scope_user",
+          "columns": [
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_scope_members_scope": {
+          "name": "idx_scope_members_scope",
+          "columns": [
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_scope_members_user": {
+          "name": "idx_scope_members_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scope_members_scope_id_scopes_id_fk": {
+          "name": "scope_members_scope_id_scopes_id_fk",
+          "tableFrom": "scope_members",
+          "tableTo": "scopes",
+          "columnsFrom": ["scope_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "scope_members_role_check": {
+          "name": "scope_members_role_check",
+          "value": "\"scope_members\".\"role\" IN ('admin', 'member')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.scopes": {
+      "name": "scopes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clerk_org_id": {
+          "name": "clerk_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tier": {
+          "name": "tier",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "default_agent_compose_id": {
+          "name": "default_agent_compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_scopes_clerk_org": {
+          "name": "idx_scopes_clerk_org",
+          "columns": [
+            {
+              "expression": "clerk_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scopes_default_agent_compose_id_agent_composes_id_fk": {
+          "name": "scopes_default_agent_compose_id_agent_composes_id_fk",
+          "tableFrom": "scopes",
+          "tableTo": "agent_composes",
+          "columnsFrom": ["default_agent_compose_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "scopes_slug_unique": {
+          "name": "scopes_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "scopes_tier_check": {
+          "name": "scopes_tier_check",
+          "value": "\"scopes\".\"tier\" IN ('free', 'pro', 'max')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.secrets": {
+      "name": "secrets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_value": {
+          "name": "encrypted_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clerk_org_id": {
+          "name": "clerk_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_secrets_scope_user_name_type": {
+          "name": "idx_secrets_scope_user_name_type",
+          "columns": [
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_secrets_scope": {
+          "name": "idx_secrets_scope",
+          "columns": [
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_secrets_type": {
+          "name": "idx_secrets_type",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_secrets_clerk_org": {
+          "name": "idx_secrets_clerk_org",
+          "columns": [
+            {
+              "expression": "clerk_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_secrets_clerk_org_user_name_type": {
+          "name": "idx_secrets_clerk_org_user_name_type",
+          "columns": [
+            {
+              "expression": "clerk_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "secrets_scope_id_scopes_id_fk": {
+          "name": "secrets_scope_id_scopes_id_fk",
+          "tableFrom": "secrets",
+          "tableTo": "scopes",
+          "columnsFrom": ["scope_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_compose_requests": {
+      "name": "slack_compose_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "compose_job_id": {
+          "name": "compose_job_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_workspace_id": {
+          "name": "slack_workspace_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_user_id": {
+          "name": "slack_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_channel_id": {
+          "name": "slack_channel_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_slack_compose_requests_job": {
+          "name": "idx_slack_compose_requests_job",
+          "columns": [
+            {
+              "expression": "compose_job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "slack_compose_requests_compose_job_id_compose_jobs_id_fk": {
+          "name": "slack_compose_requests_compose_job_id_compose_jobs_id_fk",
+          "tableFrom": "slack_compose_requests",
+          "tableTo": "compose_jobs",
+          "columnsFrom": ["compose_job_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_installations": {
+      "name": "slack_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slack_workspace_id": {
+          "name": "slack_workspace_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_workspace_name": {
+          "name": "slack_workspace_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_bot_token": {
+          "name": "encrypted_bot_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bot_user_id": {
+          "name": "bot_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_compose_id": {
+          "name": "default_compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "admin_slack_user_id": {
+          "name": "admin_slack_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "slack_installations_default_compose_id_agent_composes_id_fk": {
+          "name": "slack_installations_default_compose_id_agent_composes_id_fk",
+          "tableFrom": "slack_installations",
+          "tableTo": "agent_composes",
+          "columnsFrom": ["default_compose_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "slack_installations_slack_workspace_id_unique": {
+          "name": "slack_installations_slack_workspace_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slack_workspace_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_pending_questions": {
+      "name": "slack_pending_questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_workspace_id": {
+          "name": "slack_workspace_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_channel_id": {
+          "name": "slack_channel_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_thread_ts": {
+          "name": "slack_thread_ts",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_message_ts": {
+          "name": "slack_message_ts",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_link_id": {
+          "name": "user_link_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "compose_id": {
+          "name": "compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "questions": {
+          "name": "questions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "answered_at": {
+          "name": "answered_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_slack_pending_questions_run_id": {
+          "name": "idx_slack_pending_questions_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_thread_sessions": {
+      "name": "slack_thread_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slack_user_link_id": {
+          "name": "slack_user_link_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_channel_id": {
+          "name": "slack_channel_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_thread_ts": {
+          "name": "slack_thread_ts",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_session_id": {
+          "name": "agent_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_processed_message_ts": {
+          "name": "last_processed_message_ts",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_slack_thread_sessions_thread_user_link": {
+          "name": "idx_slack_thread_sessions_thread_user_link",
+          "columns": [
+            {
+              "expression": "slack_user_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slack_channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slack_thread_ts",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_slack_thread_sessions_user_link": {
+          "name": "idx_slack_thread_sessions_user_link",
+          "columns": [
+            {
+              "expression": "slack_user_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "slack_thread_sessions_slack_user_link_id_slack_user_links_id_fk": {
+          "name": "slack_thread_sessions_slack_user_link_id_slack_user_links_id_fk",
+          "tableFrom": "slack_thread_sessions",
+          "tableTo": "slack_user_links",
+          "columnsFrom": ["slack_user_link_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "slack_thread_sessions_agent_session_id_agent_sessions_id_fk": {
+          "name": "slack_thread_sessions_agent_session_id_agent_sessions_id_fk",
+          "tableFrom": "slack_thread_sessions",
+          "tableTo": "agent_sessions",
+          "columnsFrom": ["agent_session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_user_links": {
+      "name": "slack_user_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slack_user_id": {
+          "name": "slack_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_workspace_id": {
+          "name": "slack_workspace_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vm0_user_id": {
+          "name": "vm0_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dm_welcome_sent": {
+          "name": "dm_welcome_sent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_slack_user_links_user_workspace": {
+          "name": "idx_slack_user_links_user_workspace",
+          "columns": [
+            {
+              "expression": "slack_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slack_workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.storage_versions": {
+      "name": "storage_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "storage_id": {
+          "name": "storage_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "file_count": {
+          "name": "file_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "storage_versions_storage_id_storages_id_fk": {
+          "name": "storage_versions_storage_id_storages_id_fk",
+          "tableFrom": "storage_versions",
+          "tableTo": "storages",
+          "columnsFrom": ["storage_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.storages": {
+      "name": "storages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'volume'"
+        },
+        "clerk_org_id": {
+          "name": "clerk_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "s3_prefix": {
+          "name": "s3_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "file_count": {
+          "name": "file_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "head_version_id": {
+          "name": "head_version_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_storages_scope_user_name_type": {
+          "name": "idx_storages_scope_user_name_type",
+          "columns": [
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_storages_scope": {
+          "name": "idx_storages_scope",
+          "columns": [
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_storages_clerk_org": {
+          "name": "idx_storages_clerk_org",
+          "columns": [
+            {
+              "expression": "clerk_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_storages_clerk_org_user_name_type": {
+          "name": "idx_storages_clerk_org_user_name_type",
+          "columns": [
+            {
+              "expression": "clerk_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "storages_scope_id_scopes_id_fk": {
+          "name": "storages_scope_id_scopes_id_fk",
+          "tableFrom": "storages",
+          "tableTo": "scopes",
+          "columnsFrom": ["scope_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "storages_head_version_id_storage_versions_id_fk": {
+          "name": "storages_head_version_id_storage_versions_id_fk",
+          "tableFrom": "storages",
+          "tableTo": "storage_versions",
+          "columnsFrom": ["head_version_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_installations": {
+      "name": "telegram_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "telegram_bot_id": {
+          "name": "telegram_bot_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bot_username": {
+          "name": "bot_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_bot_token": {
+          "name": "encrypted_bot_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhook_secret": {
+          "name": "webhook_secret",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_compose_id": {
+          "name": "default_compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "admin_user_id": {
+          "name": "admin_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "telegram_installations_default_compose_id_agent_composes_id_fk": {
+          "name": "telegram_installations_default_compose_id_agent_composes_id_fk",
+          "tableFrom": "telegram_installations",
+          "tableTo": "agent_composes",
+          "columnsFrom": ["default_compose_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "telegram_installations_telegram_bot_id_unique": {
+          "name": "telegram_installations_telegram_bot_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["telegram_bot_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_messages": {
+      "name": "telegram_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_user_id": {
+          "name": "from_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_username": {
+          "name": "from_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_bot": {
+          "name": "is_bot",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_telegram_messages_unique": {
+          "name": "idx_telegram_messages_unique",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_telegram_messages_chat": {
+          "name": "idx_telegram_messages_chat",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_telegram_messages_created_at": {
+          "name": "idx_telegram_messages_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "telegram_messages_installation_id_telegram_installations_id_fk": {
+          "name": "telegram_messages_installation_id_telegram_installations_id_fk",
+          "tableFrom": "telegram_messages",
+          "tableTo": "telegram_installations",
+          "columnsFrom": ["installation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_thread_sessions": {
+      "name": "telegram_thread_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "telegram_user_link_id": {
+          "name": "telegram_user_link_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "root_message_id": {
+          "name": "root_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_session_id": {
+          "name": "agent_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_processed_message_id": {
+          "name": "last_processed_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_telegram_thread_sessions_chat_user_link": {
+          "name": "idx_telegram_thread_sessions_chat_user_link",
+          "columns": [
+            {
+              "expression": "telegram_user_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "root_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_telegram_thread_sessions_user_link": {
+          "name": "idx_telegram_thread_sessions_user_link",
+          "columns": [
+            {
+              "expression": "telegram_user_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "telegram_thread_sessions_telegram_user_link_id_telegram_user_links_id_fk": {
+          "name": "telegram_thread_sessions_telegram_user_link_id_telegram_user_links_id_fk",
+          "tableFrom": "telegram_thread_sessions",
+          "tableTo": "telegram_user_links",
+          "columnsFrom": ["telegram_user_link_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "telegram_thread_sessions_agent_session_id_agent_sessions_id_fk": {
+          "name": "telegram_thread_sessions_agent_session_id_agent_sessions_id_fk",
+          "tableFrom": "telegram_thread_sessions",
+          "tableTo": "agent_sessions",
+          "columnsFrom": ["agent_session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_user_links": {
+      "name": "telegram_user_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "telegram_user_id": {
+          "name": "telegram_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vm0_user_id": {
+          "name": "vm0_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dm_welcome_sent": {
+          "name": "dm_welcome_sent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_telegram_user_links_user_installation": {
+          "name": "idx_telegram_user_links_user_installation",
+          "columns": [
+            {
+              "expression": "telegram_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "telegram_user_links_installation_id_telegram_installations_id_fk": {
+          "name": "telegram_user_links_installation_id_telegram_installations_id_fk",
+          "tableFrom": "telegram_user_links",
+          "tableTo": "telegram_installations",
+          "columnsFrom": ["installation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.usage_daily": {
+      "name": "usage_daily",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_count": {
+          "name": "run_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "run_time_ms": {
+          "name": "run_time_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_usage_daily_user_date": {
+          "name": "uq_usage_daily_user_date",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.variables": {
+      "name": "variables",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clerk_org_id": {
+          "name": "clerk_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_variables_scope_user_name": {
+          "name": "idx_variables_scope_user_name",
+          "columns": [
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_variables_scope": {
+          "name": "idx_variables_scope",
+          "columns": [
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_variables_clerk_org": {
+          "name": "idx_variables_clerk_org",
+          "columns": [
+            {
+              "expression": "clerk_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_variables_clerk_org_user_name": {
+          "name": "idx_variables_clerk_org_user_name",
+          "columns": [
+            {
+              "expression": "clerk_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "variables_scope_id_scopes_id_fk": {
+          "name": "variables_scope_id_scopes_id_fk",
+          "tableFrom": "variables",
+          "tableTo": "scopes",
+          "columnsFrom": ["scope_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.connector_session_status": {
+      "name": "connector_session_status",
+      "schema": "public",
+      "values": ["pending", "complete", "expired", "error"]
+    },
+    "public.device_code_status": {
+      "name": "device_code_status",
+      "schema": "public",
+      "values": ["pending", "authenticated", "expired", "denied"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/turbo/apps/web/src/db/migrations/meta/_journal.json
+++ b/turbo/apps/web/src/db/migrations/meta/_journal.json
@@ -824,7 +824,7 @@
     {
       "idx": 117,
       "version": "7",
-      "when": 1773121717270,
+      "when": 1773400000003,
       "tag": "0117_typical_starjammers",
       "breakpoints": true
     }

--- a/turbo/apps/web/src/db/migrations/meta/_journal.json
+++ b/turbo/apps/web/src/db/migrations/meta/_journal.json
@@ -820,6 +820,13 @@
       "when": 1773400000002,
       "tag": "0116_gifted_meggan",
       "breakpoints": true
+    },
+    {
+      "idx": 117,
+      "version": "7",
+      "when": 1773121717270,
+      "tag": "0117_typical_starjammers",
+      "breakpoints": true
     }
   ]
 }

--- a/turbo/apps/web/src/db/schema/agent-compose.ts
+++ b/turbo/apps/web/src/db/schema/agent-compose.ts
@@ -24,6 +24,7 @@ export const agentComposes = pgTable(
       .references(() => scopes.id, { onDelete: "cascade" }), // Scope reference
     name: varchar("name", { length: 64 }).notNull().default(""), // Agent name from compose
     headVersionId: varchar("head_version_id", { length: 64 }), // Points to latest version hash
+    clerkOrgId: text("clerk_org_id").notNull(),
     createdAt: timestamp("created_at").defaultNow().notNull(),
     updatedAt: timestamp("updated_at").defaultNow().notNull(),
   },
@@ -33,6 +34,11 @@ export const agentComposes = pgTable(
       table.name,
     ),
     scopeIdx: index("idx_agent_composes_scope").on(table.scopeId),
+    clerkOrgIdx: index("idx_agent_composes_clerk_org").on(table.clerkOrgId),
+    clerkOrgNameIdx: uniqueIndex("idx_agent_composes_clerk_org_name").on(
+      table.clerkOrgId,
+      table.name,
+    ),
   }),
 );
 

--- a/turbo/apps/web/src/db/schema/agent-run.ts
+++ b/turbo/apps/web/src/db/schema/agent-run.ts
@@ -44,6 +44,7 @@ export const agentRuns = pgTable(
     sandboxId: varchar("sandbox_id", { length: 255 }),
     result: jsonb("result"),
     error: text("error"),
+    clerkOrgId: text("clerk_org_id").notNull(),
     createdAt: timestamp("created_at").defaultNow().notNull(),
     startedAt: timestamp("started_at"),
     completedAt: timestamp("completed_at"),
@@ -55,6 +56,7 @@ export const agentRuns = pgTable(
       table.userId,
       table.createdAt.desc(),
     ),
+    index("idx_agent_runs_clerk_org").on(table.clerkOrgId),
     // Composite index for status-based heartbeat queries
     index("idx_agent_runs_status_heartbeat").on(
       table.status,

--- a/turbo/apps/web/src/db/schema/agent-schedule.ts
+++ b/turbo/apps/web/src/db/schema/agent-schedule.ts
@@ -41,6 +41,7 @@ export const agentSchedules = pgTable(
       .notNull()
       .references(() => scopes.id, { onDelete: "cascade" }),
     userId: text("user_id").notNull(),
+    clerkOrgId: text("clerk_org_id").notNull(),
     name: varchar("name", { length: 64 }).notNull(),
 
     // Trigger type discriminator: 'cron' | 'once' | 'loop'
@@ -91,6 +92,13 @@ export const agentSchedules = pgTable(
     index("idx_agent_schedules_compose").on(table.composeId),
     // Index for listing user's schedules within a scope
     index("idx_agent_schedules_scope_user").on(table.scopeId, table.userId),
+    index("idx_agent_schedules_clerk_org").on(table.clerkOrgId),
+    uniqueIndex("idx_agent_schedules_compose_name_clerk_org_user").on(
+      table.composeId,
+      table.name,
+      table.clerkOrgId,
+      table.userId,
+    ),
     // Partial index for efficient cron polling: enabled schedules with due next_run_at
     index("idx_agent_schedules_next_run")
       .on(table.nextRunAt)

--- a/turbo/apps/web/src/db/schema/connector.ts
+++ b/turbo/apps/web/src/db/schema/connector.ts
@@ -32,6 +32,7 @@ export const connectors = pgTable(
     oauthScopes: text("oauth_scopes"), // JSON array of scopes
     tokenExpiresAt: timestamp("token_expires_at"), // null = non-expiring token
     userId: text("user_id").notNull(),
+    clerkOrgId: text("clerk_org_id").notNull(),
 
     createdAt: timestamp("created_at").defaultNow().notNull(),
     updatedAt: timestamp("updated_at").defaultNow().notNull(),
@@ -44,5 +45,11 @@ export const connectors = pgTable(
       table.type,
     ),
     index("idx_connectors_scope").on(table.scopeId),
+    index("idx_connectors_clerk_org").on(table.clerkOrgId),
+    uniqueIndex("idx_connectors_clerk_org_user_type").on(
+      table.clerkOrgId,
+      table.userId,
+      table.type,
+    ),
   ],
 );

--- a/turbo/apps/web/src/db/schema/model-provider.ts
+++ b/turbo/apps/web/src/db/schema/model-provider.ts
@@ -36,6 +36,7 @@ export const modelProviders = pgTable(
     isDefault: boolean("is_default").notNull().default(false),
     selectedModel: varchar("selected_model", { length: 255 }),
     userId: text("user_id").notNull(),
+    clerkOrgId: text("clerk_org_id").notNull(),
     createdAt: timestamp("created_at").defaultNow().notNull(),
     updatedAt: timestamp("updated_at").defaultNow().notNull(),
   },
@@ -48,5 +49,11 @@ export const modelProviders = pgTable(
     ),
     index("idx_model_providers_scope").on(table.scopeId),
     index("idx_model_providers_secret").on(table.secretId),
+    index("idx_model_providers_clerk_org").on(table.clerkOrgId),
+    uniqueIndex("idx_model_providers_clerk_org_user_type").on(
+      table.clerkOrgId,
+      table.userId,
+      table.type,
+    ),
   ],
 );

--- a/turbo/apps/web/src/db/schema/secret.ts
+++ b/turbo/apps/web/src/db/schema/secret.ts
@@ -26,6 +26,7 @@ export const secrets = pgTable(
     description: text("description"),
     type: varchar("type", { length: 50 }).notNull().default("user"),
     userId: text("user_id").notNull(),
+    clerkOrgId: text("clerk_org_id").notNull(),
     createdAt: timestamp("created_at").defaultNow().notNull(),
     updatedAt: timestamp("updated_at").defaultNow().notNull(),
   },
@@ -39,5 +40,12 @@ export const secrets = pgTable(
     ),
     index("idx_secrets_scope").on(table.scopeId),
     index("idx_secrets_type").on(table.type),
+    index("idx_secrets_clerk_org").on(table.clerkOrgId),
+    uniqueIndex("idx_secrets_clerk_org_user_name_type").on(
+      table.clerkOrgId,
+      table.userId,
+      table.name,
+      table.type,
+    ),
   ],
 );

--- a/turbo/apps/web/src/db/schema/storage.ts
+++ b/turbo/apps/web/src/db/schema/storage.ts
@@ -29,6 +29,7 @@ export const storages = pgTable(
       .references(() => scopes.id, { onDelete: "cascade" }), // Namespace (who owns)
     name: varchar("name", { length: 256 }).notNull(),
     type: varchar("type", { length: 16 }).notNull().default("volume"),
+    clerkOrgId: text("clerk_org_id").notNull(),
     s3Prefix: text("s3_prefix").notNull(),
     size: bigint("size", { mode: "number" }).notNull().default(0),
     fileCount: integer("file_count").notNull().default(0),
@@ -46,6 +47,10 @@ export const storages = pgTable(
       table.type,
     ),
     scopeIdx: index("idx_storages_scope").on(table.scopeId),
+    clerkOrgIdx: index("idx_storages_clerk_org").on(table.clerkOrgId),
+    clerkOrgUserNameTypeIdx: uniqueIndex(
+      "idx_storages_clerk_org_user_name_type",
+    ).on(table.clerkOrgId, table.userId, table.name, table.type),
   }),
 );
 

--- a/turbo/apps/web/src/db/schema/variable.ts
+++ b/turbo/apps/web/src/db/schema/variable.ts
@@ -25,6 +25,7 @@ export const variables = pgTable(
     value: text("value").notNull(),
     description: text("description"),
     userId: text("user_id").notNull(),
+    clerkOrgId: text("clerk_org_id").notNull(),
     createdAt: timestamp("created_at").defaultNow().notNull(),
     updatedAt: timestamp("updated_at").defaultNow().notNull(),
   },
@@ -35,5 +36,11 @@ export const variables = pgTable(
       table.name,
     ),
     index("idx_variables_scope").on(table.scopeId),
+    index("idx_variables_clerk_org").on(table.clerkOrgId),
+    uniqueIndex("idx_variables_clerk_org_user_name").on(
+      table.clerkOrgId,
+      table.userId,
+      table.name,
+    ),
   ],
 );

--- a/turbo/apps/web/src/lib/computer-connector/computer-connector-service.ts
+++ b/turbo/apps/web/src/lib/computer-connector/computer-connector-service.ts
@@ -40,6 +40,7 @@ const COMPUTER_SECRETS = [
 export async function createComputerConnector(
   scopeId: string,
   userId: string,
+  clerkOrgId: string,
 ): Promise<ComputerConnectorCreateResponse> {
   // Check for existing connector
   const [existing] = await globalThis.services.db
@@ -139,6 +140,7 @@ export async function createComputerConnector(
     .values({
       scopeId,
       userId,
+      clerkOrgId,
       type: "computer",
       authMethod: "api",
       externalId: botUser.id,
@@ -161,6 +163,7 @@ export async function createComputerConnector(
       bridgeToken,
       "connector",
       "Computer connector: COMPUTER_CONNECTOR_BRIDGE_TOKEN",
+      clerkOrgId,
     ),
     upsertSecretByScope(
       scopeId,
@@ -169,6 +172,7 @@ export async function createComputerConnector(
       reservedDomain.id,
       "connector",
       "Computer connector: COMPUTER_CONNECTOR_DOMAIN_ID",
+      clerkOrgId,
     ),
     upsertSecretByScope(
       scopeId,
@@ -177,6 +181,7 @@ export async function createComputerConnector(
       domain,
       "connector",
       "Computer connector: COMPUTER_CONNECTOR_DOMAIN",
+      clerkOrgId,
     ),
   ]);
 

--- a/turbo/apps/web/src/lib/connector/connector-service.ts
+++ b/turbo/apps/web/src/lib/connector/connector-service.ts
@@ -134,6 +134,7 @@ export async function upsertOAuthConnector(
   accessToken: string,
   userInfo: ExternalUserInfo,
   oauthScopes: string[],
+  clerkOrgId: string,
   options?: {
     refreshToken?: string | null;
     refreshSecretName?: string;
@@ -170,6 +171,7 @@ export async function upsertOAuthConnector(
     accessToken,
     "connector",
     `OAuth token for ${type} connector`,
+    clerkOrgId,
   );
 
   // Upsert refresh token secret if provided
@@ -181,6 +183,7 @@ export async function upsertOAuthConnector(
       options.refreshToken,
       "connector",
       `OAuth refresh token for ${type} connector`,
+      clerkOrgId,
     );
   }
 
@@ -234,6 +237,7 @@ export async function upsertOAuthConnector(
         externalEmail: userInfo.email,
         oauthScopes: JSON.stringify(oauthScopes),
         tokenExpiresAt,
+        clerkOrgId,
       })
       .returning();
     if (!created) {
@@ -270,6 +274,7 @@ export async function upsertApiTokenConnector(
   userId: string,
   type: ConnectorType,
   inputSecrets: Record<string, string>,
+  clerkOrgId: string,
 ): Promise<{ connector: ConnectorResponse; created: boolean }> {
   const config = CONNECTOR_TYPES[type];
   const apiTokenConfig = config.authMethods["api-token"];
@@ -298,6 +303,7 @@ export async function upsertApiTokenConnector(
         value,
         "connector",
         `API token for ${type} connector`,
+        clerkOrgId,
       );
     }
   }
@@ -369,6 +375,7 @@ export async function upsertApiTokenConnector(
         externalEmail: null,
         oauthScopes: null,
         tokenExpiresAt: null,
+        clerkOrgId,
       })
       .returning();
     if (!created) {
@@ -472,6 +479,7 @@ export async function upsertConnectorSecret(
   userId: string,
   secretName: string,
   secretValue: string,
+  clerkOrgId: string,
 ): Promise<void> {
   await upsertSecretByScope(
     scopeId,
@@ -480,5 +488,6 @@ export async function upsertConnectorSecret(
     secretValue,
     "connector",
     `Connector secret: ${secretName}`,
+    clerkOrgId,
   );
 }

--- a/turbo/apps/web/src/lib/model-provider/model-provider-service.ts
+++ b/turbo/apps/web/src/lib/model-provider/model-provider-service.ts
@@ -211,6 +211,7 @@ export async function upsertModelProvider(
   userId: string,
   type: ModelProviderType,
   secret: string,
+  clerkOrgId: string,
   selectedModel?: string,
 ): Promise<{ provider: ModelProviderInfo; created: boolean }> {
   // Multi-auth providers need different handling
@@ -258,6 +259,7 @@ export async function upsertModelProvider(
       encryptedValue,
       type: "model-provider",
       description: `Model provider secret for ${MODEL_PROVIDER_TYPES[type].label}`,
+      clerkOrgId,
     })
     .onConflictDoUpdate({
       target: [secrets.scopeId, secrets.userId, secrets.name, secrets.type],
@@ -275,6 +277,7 @@ export async function upsertModelProvider(
       secretId: upsertedSecret!.id,
       isDefault: false,
       selectedModel: selectedModel ?? null,
+      clerkOrgId,
     })
     .onConflictDoUpdate({
       target: [
@@ -337,6 +340,7 @@ async function upsertMultiAuthSecret(
   value: string,
   description: string,
   encryptionKey: string,
+  clerkOrgId: string,
 ): Promise<void> {
   const encryptedValue = encryptCredentialValue(value, encryptionKey);
 
@@ -349,6 +353,7 @@ async function upsertMultiAuthSecret(
       encryptedValue,
       type: "model-provider",
       description,
+      clerkOrgId,
     })
     .onConflictDoUpdate({
       target: [secrets.scopeId, secrets.userId, secrets.name, secrets.type],
@@ -404,6 +409,7 @@ export async function upsertMultiAuthModelProvider(
   type: ModelProviderType,
   authMethod: string,
   secretValues: Record<string, string>,
+  clerkOrgId: string,
   selectedModel?: string,
 ): Promise<{ provider: ModelProviderInfo; created: boolean }> {
   // Verify this is a multi-auth provider
@@ -487,6 +493,7 @@ export async function upsertMultiAuthModelProvider(
       value,
       secretDescription,
       encryptionKey,
+      clerkOrgId,
     );
   }
 
@@ -500,6 +507,7 @@ export async function upsertMultiAuthModelProvider(
       authMethod,
       isDefault: false,
       selectedModel: selectedModel ?? null,
+      clerkOrgId,
     })
     .onConflictDoUpdate({
       target: [

--- a/turbo/apps/web/src/lib/run/build-context.ts
+++ b/turbo/apps/web/src/lib/run/build-context.ts
@@ -324,6 +324,7 @@ async function refreshConnectorAccessToken(
   scopeId: string,
   userId: string,
   connectorSecrets: Record<string, string>,
+  clerkOrgId: string,
 ): Promise<string | null> {
   const handler =
     PROVIDER_HANDLERS[connectorType as keyof typeof PROVIDER_HANDLERS];
@@ -364,6 +365,7 @@ async function refreshConnectorAccessToken(
       userId,
       accessTokenSecret,
       result.accessToken,
+      clerkOrgId,
     );
     if (result.refreshToken) {
       await upsertConnectorSecret(
@@ -371,6 +373,7 @@ async function refreshConnectorAccessToken(
         userId,
         refreshTokenSecret,
         result.refreshToken,
+        clerkOrgId,
       );
     }
 
@@ -406,6 +409,7 @@ interface ConnectorCredentialResult {
 async function resolveConnectorCredentials(
   scopeId: string,
   userId: string,
+  clerkOrgId: string,
 ): Promise<ConnectorCredentialResult> {
   let credentials: Record<string, string> | undefined;
 
@@ -443,7 +447,13 @@ async function resolveConnectorCredentials(
         return handler?.refreshToken;
       })
       .map((type) =>
-        refreshConnectorAccessToken(type, scopeId, userId, connectorSecrets),
+        refreshConnectorAccessToken(
+          type,
+          scopeId,
+          userId,
+          connectorSecrets,
+          clerkOrgId,
+        ),
       ),
   );
 
@@ -674,6 +684,7 @@ interface BuildContextParams {
   // When not provided, resolved via getDefaultScope fallback.
   scopeId?: string;
   scopeSlug?: string;
+  clerkOrgId?: string;
 }
 
 /**
@@ -740,6 +751,7 @@ async function resolveCredentialsAndEnvironment(
   runId: string,
   checkEnv: boolean | undefined,
   userId: string,
+  clerkOrgId: string,
 ): Promise<{
   secrets: Record<string, string> | undefined;
   credentials: Record<string, string> | undefined;
@@ -764,7 +776,7 @@ async function resolveCredentialsAndEnvironment(
         hasExplicitModelProviderConfig,
         modelProvider,
       ),
-      resolveConnectorCredentials(scopeId, userId),
+      resolveConnectorCredentials(scopeId, userId, clerkOrgId),
       fetchAndMergeVariables(scopeId, userId, vars),
     ]);
 
@@ -875,36 +887,50 @@ function applyResolutionDefaults(
  */
 async function resolveScopes(params: BuildContextParams): Promise<{
   runtimeScopeId: string;
+  runtimeClerkOrgId: string;
   pendingRuntimeScope:
-    | Promise<{ id: string; slug: string }>
-    | { id: string; slug: string };
+    | Promise<{ id: string; slug: string; clerkOrgId: string }>
+    | { id: string; slug: string; clerkOrgId: string };
 }> {
   if (params.scopeId) {
-    if (params.scopeSlug) {
+    if (params.scopeSlug && params.clerkOrgId) {
       return {
         runtimeScopeId: params.scopeId,
-        pendingRuntimeScope: { id: params.scopeId, slug: params.scopeSlug },
+        runtimeClerkOrgId: params.clerkOrgId,
+        pendingRuntimeScope: {
+          id: params.scopeId,
+          slug: params.scopeSlug,
+          clerkOrgId: params.clerkOrgId,
+        },
       };
     }
-    // Fallback: query slug from DB when caller didn't provide it
+    // Fallback: query slug and clerkOrgId from DB when caller didn't provide them
+    const [result] = await globalThis.services.db
+      .select({ slug: scopes.slug, clerkOrgId: scopes.clerkOrgId })
+      .from(scopes)
+      .where(eq(scopes.id, params.scopeId))
+      .limit(1);
+    const resolved = {
+      id: params.scopeId,
+      slug: result?.slug ?? "",
+      clerkOrgId: result?.clerkOrgId ?? "",
+    };
     return {
       runtimeScopeId: params.scopeId,
-      pendingRuntimeScope: globalThis.services.db
-        .select({ slug: scopes.slug })
-        .from(scopes)
-        .where(eq(scopes.id, params.scopeId))
-        .limit(1)
-        .then(([result]) => ({
-          id: params.scopeId as string,
-          slug: result?.slug ?? "",
-        })),
+      runtimeClerkOrgId: resolved.clerkOrgId,
+      pendingRuntimeScope: resolved,
     };
   }
   // No explicit scope — default scope is used
   const { scope } = await getDefaultScope(params.userId);
   return {
     runtimeScopeId: scope.id,
-    pendingRuntimeScope: { id: scope.id, slug: scope.slug },
+    runtimeClerkOrgId: scope.clerkOrgId,
+    pendingRuntimeScope: {
+      id: scope.id,
+      slug: scope.slug,
+      clerkOrgId: scope.clerkOrgId,
+    },
   };
 }
 
@@ -1000,8 +1026,10 @@ export async function buildExecutionContext(
   // resolveSource loads checkpoint/session/conversation data.
   // resolveScopes resolves the runtime scope for credentials and storage.
   const resolveStart = Date.now();
-  const [resolution, { runtimeScopeId, pendingRuntimeScope }] =
-    await Promise.all([resolveSource(params), resolveScopes(params)]);
+  const [
+    resolution,
+    { runtimeScopeId, runtimeClerkOrgId, pendingRuntimeScope },
+  ] = await Promise.all([resolveSource(params), resolveScopes(params)]);
   const resolveEnd = Date.now();
 
   // Step 2: Apply resolution defaults and build resumeSession (unified path)
@@ -1071,6 +1099,7 @@ export async function buildExecutionContext(
       params.runId,
       params.checkEnv,
       params.userId,
+      runtimeClerkOrgId,
     ),
     params.userId ? getUserPreferences(params.userId) : Promise.resolve(null),
     Promise.resolve(pendingRuntimeScope),

--- a/turbo/apps/web/src/lib/run/context/execution-preparer.ts
+++ b/turbo/apps/web/src/lib/run/context/execution-preparer.ts
@@ -232,6 +232,7 @@ export async function prepareForExecution(
           context.artifactName,
           runtimeScope.slug,
           "artifact",
+          runtimeScope.clerkOrgId,
         )
       : null,
     context.memoryName
@@ -241,6 +242,7 @@ export async function prepareForExecution(
           context.memoryName,
           runtimeScope.slug,
           "memory",
+          runtimeScope.clerkOrgId,
         )
       : null,
   ]);

--- a/turbo/apps/web/src/lib/run/run-queue-service.ts
+++ b/turbo/apps/web/src/lib/run/run-queue-service.ts
@@ -38,8 +38,17 @@ export async function enqueueRun(
 ): Promise<CreateRunResult> {
   const { userId, agentComposeVersionId, prompt } = params;
 
-  // Resolve scope ID (caller should have already resolved it, but fall back)
-  const scopeId = params.scopeId ?? (await getDefaultScope(userId)).scope.id;
+  // Resolve scope ID and clerkOrgId (caller should have already resolved it, but fall back)
+  let scopeId: string;
+  let clerkOrgId: string;
+  if (params.scopeId && params.clerkOrgId) {
+    scopeId = params.scopeId;
+    clerkOrgId = params.clerkOrgId;
+  } else {
+    const { scope } = await getDefaultScope(userId);
+    scopeId = scope.id;
+    clerkOrgId = scope.clerkOrgId;
+  }
 
   // Encrypt the full CreateRunParams for later replay
   const paramsJson = JSON.stringify(params);
@@ -57,6 +66,7 @@ export async function enqueueRun(
       .values({
         userId,
         scopeId,
+        clerkOrgId,
         agentComposeVersionId,
         status: "queued",
         prompt,

--- a/turbo/apps/web/src/lib/run/run-service.ts
+++ b/turbo/apps/web/src/lib/run/run-service.ts
@@ -32,7 +32,10 @@ import { canAccessCompose } from "../agent/permission-service";
 import { getUserEmail } from "../auth/get-user-email";
 import { extractTemplateVars } from "../config-validator";
 
-import { getDefaultScopeByClerkUserId } from "../scope/scope-service";
+import {
+  getDefaultScopeByClerkUserId,
+  getScopeById,
+} from "../scope/scope-service";
 import { getDefaultScope } from "../scope/scope-member-service";
 import { getVariableValues } from "../variable/variable-service";
 import { encryptCredentialValue } from "../crypto/secrets-encryption";
@@ -319,6 +322,7 @@ export interface CreateRunParams {
   // When provided, used instead of getDefaultScope fallback.
   scopeId?: string;
   scopeSlug?: string;
+  clerkOrgId?: string;
   // Caller-resolved scope tier for concurrency limit derivation.
   scopeTier?: ScopeTier;
 }
@@ -523,6 +527,7 @@ async function buildAndDispatchRun(opts: {
   apiStartTime: number;
   scopeId: string | undefined;
   scopeSlug: string | undefined;
+  clerkOrgId: string | undefined;
   authorizeTime: number;
   transactionTime: number;
 }): Promise<{ status: string; sandboxId?: string }> {
@@ -534,6 +539,7 @@ async function buildAndDispatchRun(opts: {
     apiStartTime,
     scopeId,
     scopeSlug,
+    clerkOrgId,
     authorizeTime,
     transactionTime,
   } = opts;
@@ -579,6 +585,7 @@ async function buildAndDispatchRun(opts: {
       apiStartTime,
       scopeId,
       scopeSlug,
+      clerkOrgId,
     });
     const buildContextTime = Date.now();
 
@@ -698,13 +705,22 @@ export async function createRun(
   // Resolve scope ID and slug for the run record and storage
   let scopeId: string;
   let scopeSlug: string | undefined;
+  let clerkOrgId: string;
   if (params.scopeId) {
     scopeId = params.scopeId;
     scopeSlug = params.scopeSlug;
+    if (params.clerkOrgId) {
+      clerkOrgId = params.clerkOrgId;
+    } else {
+      const scope = await getScopeById(params.scopeId);
+      if (!scope) throw badRequest("Scope not found");
+      clerkOrgId = scope.clerkOrgId;
+    }
   } else {
     const { scope } = await getDefaultScope(userId);
     scopeId = scope.id;
     scopeSlug = scope.slug;
+    clerkOrgId = scope.clerkOrgId;
   }
 
   // Step 5: Concurrency check + INSERT in a transaction with advisory lock
@@ -726,6 +742,7 @@ export async function createRun(
         .values({
           userId,
           scopeId,
+          clerkOrgId,
           agentComposeVersionId,
           status: "pending",
           prompt,
@@ -746,7 +763,7 @@ export async function createRun(
     });
   } catch (error) {
     if (isConcurrentRunLimit(error)) {
-      return enqueueRun({ ...params, scopeId, scopeSlug });
+      return enqueueRun({ ...params, scopeId, scopeSlug, clerkOrgId });
     }
     throw error;
   }
@@ -762,6 +779,7 @@ export async function createRun(
     apiStartTime,
     scopeId,
     scopeSlug,
+    clerkOrgId,
     authorizeTime,
     transactionTime,
   });
@@ -846,6 +864,7 @@ export async function executeQueuedRun(
     apiStartTime,
     scopeId: params.scopeId,
     scopeSlug: params.scopeSlug,
+    clerkOrgId: params.clerkOrgId,
     authorizeTime,
     transactionTime,
   });

--- a/turbo/apps/web/src/lib/run/types.ts
+++ b/turbo/apps/web/src/lib/run/types.ts
@@ -109,4 +109,5 @@ export interface ExecutionContext {
 export interface RuntimeScope {
   id: string;
   slug: string;
+  clerkOrgId: string;
 }

--- a/turbo/apps/web/src/lib/schedule/schedule-service.ts
+++ b/turbo/apps/web/src/lib/schedule/schedule-service.ts
@@ -363,6 +363,7 @@ function resolveTrigger(request: DeployScheduleRequest): {
 export async function deploySchedule(
   userId: string,
   scopeId: string,
+  clerkOrgId: string,
   request: DeployScheduleRequest,
 ): Promise<{ schedule: ScheduleResponse; created: boolean }> {
   log.debug(
@@ -440,6 +441,7 @@ export async function deploySchedule(
         composeId: request.composeId,
         scopeId,
         userId,
+        clerkOrgId,
         name: request.name,
         triggerType,
         cronExpression: request.cronExpression ?? null,
@@ -850,7 +852,11 @@ async function executeSchedule(
 
   // Load scope tier and slug from schedule's scope (not compose's scope)
   const [scopeRecord] = await globalThis.services.db
-    .select({ tier: scopes.tier, slug: scopes.slug })
+    .select({
+      tier: scopes.tier,
+      slug: scopes.slug,
+      clerkOrgId: scopes.clerkOrgId,
+    })
     .from(scopes)
     .where(eq(scopes.id, schedule.scopeId))
     .limit(1);
@@ -913,6 +919,7 @@ async function executeSchedule(
       callbacks,
       scopeId: schedule.scopeId,
       scopeSlug: scopeRecord?.slug,
+      clerkOrgId: scopeRecord?.clerkOrgId,
       scopeTier: scopeRecord
         ? scopeTierSchema.parse(scopeRecord.tier)
         : undefined,

--- a/turbo/apps/web/src/lib/scope/scope-service.ts
+++ b/turbo/apps/web/src/lib/scope/scope-service.ts
@@ -77,11 +77,11 @@ function validateScopeSlug(slug: string): void {
 /**
  * Get a scope by its ID
  */
-async function getScopeById(scopeId: string) {
+export async function getScopeById(id: string) {
   const result = await globalThis.services.db
     .select()
     .from(scopes)
-    .where(eq(scopes.id, scopeId))
+    .where(eq(scopes.id, id))
     .limit(1);
 
   return result[0] ?? null;

--- a/turbo/apps/web/src/lib/secret/secret-service.ts
+++ b/turbo/apps/web/src/lib/secret/secret-service.ts
@@ -188,6 +188,7 @@ export async function upsertSecretByScope(
   value: string,
   type: SecretType,
   description: string,
+  clerkOrgId: string,
 ): Promise<void> {
   const encryptionKey = globalThis.services.env.SECRETS_ENCRYPTION_KEY;
   const encryptedValue = encryptCredentialValue(value, encryptionKey);
@@ -218,6 +219,7 @@ export async function upsertSecretByScope(
       encryptedValue,
       type,
       description,
+      clerkOrgId,
     });
   }
 }
@@ -230,6 +232,7 @@ export async function setSecret(
   userId: string,
   name: string,
   value: string,
+  clerkOrgId: string,
   description?: string,
 ): Promise<SecretInfo> {
   validateSecretName(name);
@@ -289,6 +292,7 @@ export async function setSecret(
       encryptedValue,
       description: description ?? null,
       userId,
+      clerkOrgId,
     })
     .returning({
       id: secrets.id,

--- a/turbo/apps/web/src/lib/slack/handlers/shared.ts
+++ b/turbo/apps/web/src/lib/slack/handlers/shared.ts
@@ -237,6 +237,7 @@ export async function ensureScopeAndArtifact(vm0UserId: string): Promise<void> {
       "artifact",
       scope.slug,
       "artifact",
+      scope.clerkOrgId,
     );
   } catch (err) {
     log.error("Failed to ensure artifact exists for Slack user", {

--- a/turbo/apps/web/src/lib/storage/storage-service.ts
+++ b/turbo/apps/web/src/lib/storage/storage-service.ts
@@ -43,6 +43,7 @@ export async function ensureStorageExists(
   storageName: string,
   scopeSlug: string,
   storageType: "artifact" | "memory",
+  clerkOrgId: string,
 ): Promise<void> {
   // Find or create storage record (artifact/memory use real userId)
   let [storage] = await globalThis.services.db
@@ -69,6 +70,7 @@ export async function ensureStorageExists(
         s3Prefix: `${scopeSlug}/${storageType}/${storageName}`,
         size: 0,
         fileCount: 0,
+        clerkOrgId,
       })
       .onConflictDoNothing()
       .returning();

--- a/turbo/apps/web/src/lib/telegram/__tests__/helpers.ts
+++ b/turbo/apps/web/src/lib/telegram/__tests__/helpers.ts
@@ -40,6 +40,7 @@ export async function createTelegramInstallation(): Promise<string> {
     .values({
       userId: uniqueId("test-user"),
       scopeId: scope!.id,
+      clerkOrgId: scope!.clerkOrgId,
       name: uniqueId("test-compose"),
     })
     .returning();

--- a/turbo/apps/web/src/lib/telegram/handlers/shared.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/shared.ts
@@ -250,6 +250,7 @@ export async function ensureScopeAndArtifact(vm0UserId: string): Promise<void> {
     "artifact",
     scope.slug,
     "artifact",
+    scope.clerkOrgId,
   );
 }
 

--- a/turbo/apps/web/src/lib/variable/variable-service.ts
+++ b/turbo/apps/web/src/lib/variable/variable-service.ts
@@ -127,6 +127,7 @@ export async function setVariable(
   userId: string,
   name: string,
   value: string,
+  clerkOrgId: string,
   description?: string,
 ): Promise<VariableInfo> {
   validateVariableName(name);
@@ -178,6 +179,7 @@ export async function setVariable(
       value,
       description: description ?? null,
       userId,
+      clerkOrgId,
     })
     .returning({
       id: variables.id,


### PR DESCRIPTION
## Summary

- Add `clerk_org_id TEXT NOT NULL` column to 8 scope-dependent tables: `secrets`, `variables`, `agent_composes`, `agent_runs`, `agent_schedules`, `storages`, `connectors`, `model_providers`
- Backfill from `scopes` table via migration SQL (nullable → UPDATE JOIN → SET NOT NULL → indexes)
- Dual-write `clerkOrgId` on all INSERT paths through service layer and API routes
- Thread `clerkOrgId` parameter through all callers (API routes, handlers, schedule executor, test helpers)

Phase 1 Task B of Scope → Clerk migration (#4097, #4099). Does NOT remove `scope_id` or change read queries (deferred to Phase 3).

Closes #4102

## Changes

### Schema (8 tables)
Each table gets: `clerk_org_id TEXT NOT NULL` column, `idx_{table}_clerk_org` index, and parallel unique constraints

### Migration
4-step safe migration: add nullable → backfill via `UPDATE t SET clerk_org_id = s.clerk_org_id FROM scopes s WHERE t.scope_id = s.id` → SET NOT NULL → create indexes

### Service layer
- `secret-service`, `variable-service`, `connector-service`, `model-provider-service`, `storage-service`, `schedule-service`, `run-service`, `run-queue-service`, `computer-connector-service` — all INSERT paths include `clerkOrgId`
- `build-context.ts` threads `clerkOrgId` through credential resolution
- `execution-preparer.ts` passes `clerkOrgId` to `ensureStorageExists`
- Added `getScopeById` helper in `scope-service.ts`

### API routes (11 files)
All routes that insert into affected tables now pass `scope.clerkOrgId`

### Test helpers (4 files)
Added `getClerkOrgIdFromScope` helper and updated all test INSERT statements

## Test plan

- [x] `pnpm check-types` passes
- [x] `pnpm turbo run lint` passes (0 errors)
- [x] `pnpm knip` passes (no unused exports)
- [x] `pnpm vitest run --project web` passes (162 files, 1806 tests)
- [x] Migration tested locally (backfill + NOT NULL constraint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)