### PR TITLE
fix(web): use clerk v6 redirect props for cross-domain sign-in

### DIFF
--- a/turbo/apps/web/app/layout.tsx
+++ b/turbo/apps/web/app/layout.tsx
@@ -136,8 +136,9 @@ export default function RootLayout({
       publishableKey={getClerkPublishableKey()}
       signInUrl="/sign-in"
       signUpUrl="/sign-up"
-      afterSignInUrl={getPlatformUrl()}
-      afterSignUpUrl={getPlatformUrl()}
+      signInFallbackRedirectUrl={getPlatformUrl()}
+      signUpFallbackRedirectUrl={getPlatformUrl()}
+      allowedRedirectOrigins={[getPlatformUrl()]}
     >
       <html lang="en" data-theme="dark" suppressHydrationWarning>
         <head>


### PR DESCRIPTION
## Summary
- Replace deprecated `afterSignInUrl`/`afterSignUpUrl` with Clerk v6 equivalents `signInFallbackRedirectUrl`/`signUpFallbackRedirectUrl`
- Add `allowedRedirectOrigins` to whitelist the platform domain for cross-domain redirects
- Fixes sign-in redirecting back to www instead of platform after session expiry

## Test plan
- [ ] Sign out from platform, verify redirect to www sign-in page
- [ ] Sign in on www, verify redirect back to platform (not staying on www)
- [ ] Sign up flow also redirects to platform after completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)