### PR TITLE
refactor(platform): enforce no-package-variable lint rule for zero pages

### DIFF
--- a/turbo/apps/platform/.oxlintrc.json
+++ b/turbo/apps/platform/.oxlintrc.json
@@ -10,35 +10,6 @@
           {
             "paths": [
               {
-                "allowImportNames": ["StrictMode", "Component"],
-                "allowTypeImports": true,
-                "name": "react"
-              },
-              {
-                "allowImportNames": [
-                  "useGet",
-                  "useSet",
-                  "useLoadable",
-                  "useResolved",
-                  "useLastLoadable",
-                  "useLastResolved"
-                ],
-                "allowTypeImports": true,
-                "name": "ccstate"
-              }
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "files": ["src/views/zero-page/**/*.*"],
-      "rules": {
-        "no-restricted-imports": [
-          "deny",
-          {
-            "paths": [
-              {
                 "allowImportNames": [
                   "StrictMode",
                   "Component",

--- a/turbo/apps/platform/.oxlintrc.json
+++ b/turbo/apps/platform/.oxlintrc.json
@@ -10,14 +10,7 @@
           {
             "paths": [
               {
-                "allowImportNames": [
-                  "StrictMode",
-                  "Component",
-                  "useState",
-                  "useCallback",
-                  "useEffect",
-                  "useRef"
-                ],
+                "allowImportNames": ["StrictMode", "Component"],
                 "allowTypeImports": true,
                 "name": "react"
               },

--- a/turbo/apps/platform/eslint.config.js
+++ b/turbo/apps/platform/eslint.config.js
@@ -59,13 +59,6 @@ export default [
       "ccstate/no-store-in-params": "error",
     },
   },
-  // Zero app: allow module-scope mock data
-  {
-    files: ["src/views/zero-page/**/*.ts", "src/views/zero-page/**/*.tsx"],
-    rules: {
-      "ccstate/no-package-variable": "off",
-    },
-  },
   {
     ignores: [
       "dist/**",

--- a/turbo/apps/platform/src/signals/auth.ts
+++ b/turbo/apps/platform/src/signals/auth.ts
@@ -75,6 +75,46 @@ export const setupClerk$ = command(
  * User signal that provides the current authenticated user from Clerk.
  * Returns undefined if no user is authenticated.
  */
+const ORG_ID_KEY = "clerk-active-org-id";
+
+function persistOrgId(orgId: string | undefined) {
+  if (orgId) {
+    sessionStorage.setItem(ORG_ID_KEY, orgId);
+  } else {
+    sessionStorage.removeItem(ORG_ID_KEY);
+  }
+}
+
+/**
+ * Command that monitors the active Clerk organization and reloads
+ * the page when it changes. Persists the active org ID to session storage.
+ */
+export const watchOrgSwitch$ = command(
+  async ({ get }, _el: HTMLElement, signal: AbortSignal) => {
+    const clerk = await get(clerk$);
+    signal.throwIfAborted();
+
+    let prevOrgId = sessionStorage.getItem(ORG_ID_KEY) ?? undefined;
+    const currentOrgId = clerk.organization?.id ?? undefined;
+    prevOrgId = currentOrgId;
+    persistOrgId(currentOrgId);
+
+    const unsubscribe = clerk.addListener(() => {
+      const newOrgId = clerk.organization?.id ?? undefined;
+      if (newOrgId !== prevOrgId) {
+        prevOrgId = newOrgId;
+        persistOrgId(newOrgId);
+        // Full page reload is required because server-side data (agents, jobs,
+        // secrets, etc.) is scoped to the active organization. A lighter state
+        // refresh is not feasible since multiple signal trees depend on the
+        // org context established at bootstrap time.
+        location.reload();
+      }
+    });
+    signal.addEventListener("abort", unsubscribe);
+  },
+);
+
 export const user$ = computed(async (get) => {
   get(reload$);
   const clerk = await get(clerk$);

--- a/turbo/apps/platform/src/views/zero-page/clerk-org-switcher.tsx
+++ b/turbo/apps/platform/src/views/zero-page/clerk-org-switcher.tsx
@@ -1,59 +1,26 @@
 import { OrganizationSwitcher } from "@clerk/clerk-react";
-import { useEffect, useRef } from "react";
-import { useLoadable } from "ccstate-react";
+import { useSet } from "ccstate-react";
 import { VM0ClerkProvider } from "../clerk/clerk-provider.tsx";
-import { clerk$ } from "../../signals/auth.ts";
+import { watchOrgSwitch$ } from "../../signals/auth.ts";
+import { onRef } from "../../signals/utils.ts";
 
-const ORG_ID_KEY = "clerk-active-org-id";
-
-function persistOrgId(orgId: string | undefined) {
-  if (orgId) {
-    sessionStorage.setItem(ORG_ID_KEY, orgId);
-  } else {
-    sessionStorage.removeItem(ORG_ID_KEY);
-  }
-}
+const orgSwitcherRef$ = onRef(watchOrgSwitch$);
 
 function OrgSwitcherInner() {
-  const clerkLoadable = useLoadable(clerk$);
-  const prevOrgRef = useRef<string | undefined>(
-    sessionStorage.getItem(ORG_ID_KEY) ?? undefined,
-  );
-
-  useEffect(() => {
-    if (clerkLoadable.state !== "hasData") {
-      return;
-    }
-    const clerk = clerkLoadable.data;
-    const currentOrgId = clerk.organization?.id ?? undefined;
-    prevOrgRef.current = currentOrgId;
-    persistOrgId(currentOrgId);
-
-    const unsubscribe = clerk.addListener(() => {
-      const newOrgId = clerk.organization?.id ?? undefined;
-      if (newOrgId !== prevOrgRef.current) {
-        prevOrgRef.current = newOrgId;
-        persistOrgId(newOrgId);
-        // Full page reload is required because server-side data (agents, jobs,
-        // secrets, etc.) is scoped to the active organization. A lighter state
-        // refresh is not feasible since multiple signal trees depend on the
-        // org context established at bootstrap time.
-        location.reload();
-      }
-    });
-    return unsubscribe;
-  }, [clerkLoadable]);
+  const orgSwitcherRef = useSet(orgSwitcherRef$);
 
   return (
-    <OrganizationSwitcher
-      appearance={{
-        elements: {
-          rootBox: "w-full",
-          organizationSwitcherTrigger:
-            "w-full px-0 py-0 rounded-md hover:bg-sidebar-accent/50 text-sidebar-foreground",
-        },
-      }}
-    />
+    <div ref={orgSwitcherRef}>
+      <OrganizationSwitcher
+        appearance={{
+          elements: {
+            rootBox: "w-full",
+            organizationSwitcherTrigger:
+              "w-full px-0 py-0 rounded-md hover:bg-sidebar-accent/50 text-sidebar-foreground",
+          },
+        }}
+      />
+    </div>
   );
 }
 

--- a/turbo/apps/platform/src/views/zero-page/zero-account-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-account-page.tsx
@@ -1,4 +1,5 @@
-import { useState } from "react";
+import { useCCState } from "ccstate-react/experimental";
+import { useGet, useSet } from "ccstate-react";
 import { Tabs, TabsList, TabsTrigger } from "@vm0/ui/components/ui/tabs";
 import { Card, CardContent } from "@vm0/ui/components/ui/card";
 import type { ZeroAccountSubId } from "./zero-sidebar.tsx";
@@ -41,7 +42,9 @@ function ZeroAccountOverview() {
 }
 
 function ZeroPreferencesSubPage() {
-  const [tab, setTab] = useState("notifications");
+  const tab$ = useCCState("notifications");
+  const tab = useGet(tab$);
+  const setTab = useSet(tab$);
 
   return (
     <div className="flex flex-1 flex-col min-h-0">

--- a/turbo/apps/platform/src/views/zero-page/zero-activity-detail-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-activity-detail-page.tsx
@@ -23,7 +23,7 @@ interface StepItem {
   time?: string;
 }
 
-const MOCK_STEPS: StepItem[] = [
+const MOCK_STEPS: readonly Readonly<StepItem>[] = [
   {
     id: "1",
     type: "prompt",

--- a/turbo/apps/platform/src/views/zero-page/zero-activity-detail-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-activity-detail-page.tsx
@@ -1,4 +1,5 @@
-import { useState } from "react";
+import { useCCState } from "ccstate-react/experimental";
+import { useGet, useSet } from "ccstate-react";
 import { IconArrowLeft, IconSearch, IconDownload } from "@tabler/icons-react";
 import { Button, Input } from "@vm0/ui";
 import type { LogStatus } from "../../signals/logs-page/types.ts";
@@ -147,7 +148,9 @@ export function ZeroActivityDetailPage({
   item,
   onBack,
 }: ZeroActivityDetailPageProps) {
-  const [stepSearch, setStepSearch] = useState("");
+  const stepSearch$ = useCCState("");
+  const stepSearch = useGet(stepSearch$);
+  const setStepSearch = useSet(stepSearch$);
   const steps = MOCK_STEPS.filter(
     (s) => !stepSearch.trim() || stepMatchesSearch(s, stepSearch.trim()),
   );

--- a/turbo/apps/platform/src/views/zero-page/zero-activity-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-activity-page.tsx
@@ -1,4 +1,5 @@
-import { useState } from "react";
+import { useCCState } from "ccstate-react/experimental";
+import { useGet, useSet } from "ccstate-react";
 import {
   IconSearch,
   IconFilter,
@@ -148,10 +149,18 @@ function ActivityRow({
 }
 
 export function ZeroActivityPage() {
-  const [search, setSearch] = useState("");
-  const [typeFilter, setTypeFilter] = useState("all");
-  const [statusFilter, setStatusFilter] = useState("all");
-  const [selectedItem, setSelectedItem] = useState<ActivityItem | null>(null);
+  const search$ = useCCState("");
+  const search = useGet(search$);
+  const setSearch = useSet(search$);
+  const typeFilter$ = useCCState("all");
+  const typeFilter = useGet(typeFilter$);
+  const setTypeFilter = useSet(typeFilter$);
+  const statusFilter$ = useCCState("all");
+  const statusFilter = useGet(statusFilter$);
+  const setStatusFilter = useSet(statusFilter$);
+  const selectedItem$ = useCCState<ActivityItem | null>(null);
+  const selectedItem = useGet(selectedItem$);
+  const setSelectedItem = useSet(selectedItem$);
 
   const filtered = ACTIVITIES.filter((item) => {
     const matchSearch =

--- a/turbo/apps/platform/src/views/zero-page/zero-activity-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-activity-page.tsx
@@ -23,7 +23,7 @@ import type {
   ActivityType,
 } from "./zero-activity-types.ts";
 
-const ACTIVITIES: ActivityItem[] = [
+const ACTIVITIES: readonly Readonly<ActivityItem>[] = [
   {
     id: "1",
     title: "Zero Agent",
@@ -57,13 +57,16 @@ const ACTIVITIES: ActivityItem[] = [
   },
 ];
 
-const TYPE_OPTIONS: { value: "all" | ActivityType; label: string }[] = [
+const TYPE_OPTIONS: readonly Readonly<{
+  value: "all" | ActivityType;
+  label: string;
+}>[] = [
   { value: "all", label: "All Types" },
   { value: "zero", label: "Zero" },
   { value: "workflow", label: "Workflow" },
 ];
 
-const STATUS_OPTIONS: { value: string; label: string }[] = [
+const STATUS_OPTIONS: readonly Readonly<{ value: string; label: string }>[] = [
   { value: "all", label: "All Status" },
   { value: "success", label: "Success" },
   { value: "error", label: "Error" },

--- a/turbo/apps/platform/src/views/zero-page/zero-app-shell.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-app-shell.tsx
@@ -18,9 +18,9 @@ const ZERO_AVATARS = [
   "/avatars/avatar-2.png",
   "/avatars/avatar-3.png",
   "/avatars/avatar-4.png",
-];
+] as const;
 
-const RECENT_LABELS: Record<string, string> = {
+const RECENT_LABELS: Readonly<Record<string, string>> = {
   hello: "Hello from Zero",
   "1": "Daily digest workflow",
   "2": "Set up Slack integration",

--- a/turbo/apps/platform/src/views/zero-page/zero-app-shell.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-app-shell.tsx
@@ -1,11 +1,11 @@
-import { useState, useCallback } from "react";
+import { useCCState, useCommand } from "ccstate-react/experimental";
+import { useGet, useSet, useLoadable } from "ccstate-react";
 import {
   ZeroSidebar,
   type ZeroNavId,
   type ZeroAccountAction,
   type ZeroAccountSubId,
 } from "./zero-sidebar.tsx";
-import { useLoadable } from "ccstate-react";
 import { Button } from "@vm0/ui";
 import { ZeroAboutPage } from "./zero-about-page.tsx";
 import { ZeroContent } from "./zero-content.tsx";
@@ -34,38 +34,52 @@ export function ZeroAppShell() {
   const userLoadable = useLoadable(user$);
   const isLoggedIn =
     userLoadable.state === "hasData" && userLoadable.data !== undefined;
-  const [activeId, setActiveId] = useState<ZeroNavId>("chat");
-  const [recentId, setRecentId] = useState<string | null>(null);
-  const [accountSubId, setAccountSubId] = useState<ZeroAccountSubId>(null);
-  const [avatarIndex, setAvatarIndex] = useState(0);
-  const [showAboutPage, setShowAboutPage] = useState(false);
+  const activeId$ = useCCState<ZeroNavId>("chat");
+  const activeId = useGet(activeId$);
+  const setActiveId = useSet(activeId$);
+  const recentId$ = useCCState<string | null>(null);
+  const recentId = useGet(recentId$);
+  const accountSubId$ = useCCState<ZeroAccountSubId>(null);
+  const accountSubId = useGet(accountSubId$);
+  const avatarIndex$ = useCCState(0);
+  const avatarIndex = useGet(avatarIndex$);
+  const showAboutPage$ = useCCState(false);
+  const showAboutPage = useGet(showAboutPage$);
+  const setShowAboutPage = useSet(showAboutPage$);
   const zeroAvatarSrc = ZERO_AVATARS[avatarIndex] ?? ZERO_AVATARS[0];
-  const cycleAvatar = useCallback(() => {
-    setAvatarIndex((i) => (i + 1) % ZERO_AVATARS.length);
-  }, []);
+  const cycleAvatar$ = useCommand(({ set }) => {
+    set(avatarIndex$, (i: number) => (i + 1) % ZERO_AVATARS.length);
+  });
+  const cycleAvatar = useSet(cycleAvatar$);
 
-  const handleRecentSelect = useCallback((id: string) => {
-    setRecentId(id);
-    setActiveId("chat");
-  }, []);
+  const handleRecentSelect$ = useCommand(({ set }, id: string) => {
+    set(recentId$, id);
+    set(activeId$, "chat" as ZeroNavId);
+  });
+  const handleRecentSelect = useSet(handleRecentSelect$);
 
-  const handleNavSelect = useCallback((id: ZeroNavId) => {
-    setActiveId(id);
-    setRecentId(null);
-    setShowAboutPage(false);
-  }, []);
+  const handleNavSelect$ = useCommand(({ set }, id: ZeroNavId) => {
+    set(activeId$, id);
+    set(recentId$, null);
+    set(showAboutPage$, false);
+  });
+  const handleNavSelect = useSet(handleNavSelect$);
 
-  const handleAccountAction = useCallback((action: ZeroAccountAction) => {
-    if (action === "signout" || action === "manage") {
-      return;
-    }
-    setActiveId("account");
-    setAccountSubId(action);
-  }, []);
+  const handleAccountAction$ = useCommand(
+    ({ set }, action: ZeroAccountAction) => {
+      if (action === "signout" || action === "manage") {
+        return;
+      }
+      set(activeId$, "account" as ZeroNavId);
+      set(accountSubId$, action as ZeroAccountSubId);
+    },
+  );
+  const handleAccountAction = useSet(handleAccountAction$);
 
-  const handleClearRecent = useCallback(() => {
-    setRecentId(null);
-  }, []);
+  const handleClearRecent$ = useCommand(({ set }) => {
+    set(recentId$, null);
+  });
+  const handleClearRecent = useSet(handleClearRecent$);
 
   const recentLabel = recentId ? (RECENT_LABELS[recentId] ?? null) : null;
 

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-page.tsx
@@ -30,40 +30,36 @@ export type DemoScenarioId =
   | "rich-summary"
   | "agent-operations";
 
-const ACTION_BUTTONS: {
-  label: string;
-  icon: React.ComponentType<{ size?: number; className?: string }>;
-}[] = [
-  { label: "Automate workflows", icon: IconBriefcase },
-  { label: "Customize Zero", icon: IconSettings },
-  { label: "Add connectors", icon: IconPlug },
-];
+type NavIcon = (props: {
+  size?: number;
+  className?: string;
+}) => React.ReactNode;
+const ACTION_BUTTONS = [
+  { label: "Automate workflows", icon: IconBriefcase as NavIcon },
+  { label: "Customize Zero", icon: IconSettings as NavIcon },
+  { label: "Add connectors", icon: IconPlug as NavIcon },
+] as const;
 
-const SUGGESTED_PROMPTS: {
-  title: string;
-  description: string;
-  icon: React.ComponentType<{ size?: number; className?: string }>;
-  iconClassName?: string;
-}[] = [
+const SUGGESTED_PROMPTS = [
   {
     title: "Auto-organize inbox",
     description: "Smart categorization, reply, and daily email digest",
-    icon: IconChartBar,
+    icon: IconChartBar as NavIcon,
     iconClassName: "text-emerald-600 dark:text-emerald-400",
   },
   {
     title: "Daily morning brief",
     description: "Trending topics on a schedule, your personalized digest",
-    icon: IconReceipt,
+    icon: IconReceipt as NavIcon,
     iconClassName: "text-primary",
   },
-];
+] as const;
 
-const STREAMED_SCENARIOS: {
+const STREAMED_SCENARIOS: readonly Readonly<{
   id: DemoScenarioId;
   userMessage: string;
   assistantMessage: string;
-}[] = [
+}>[] = [
   {
     id: "hello-from-zero",
     userMessage: "Hi",
@@ -112,7 +108,7 @@ const LANDING_TAGLINES = [
   "Create workflows, run automations, get things done.",
   "Ask me anything, I'll route it to the right minions.",
   "200+ connectors, ready when you are.",
-];
+] as const;
 const CAROUSEL_INTERVAL_MS = 4000;
 
 interface ChatScenarioBlockProps {

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-page.tsx
@@ -672,13 +672,15 @@ export function ZeroChatPage({
   const carouselRef = useSet(carouselRef$);
 
   // Stream tick — schedules the next streamed message after a delay
+  const streamTimeoutId$ = useCCState<number | null>(null);
   const scheduleStreamTick$ = useCommand(({ get, set }) => {
     const active = get(conversationActive$);
     const count = get(streamedCount$);
     if (!active || count >= 6) {
       return;
     }
-    window.setTimeout(() => {
+    const id = window.setTimeout(() => {
+      set(streamTimeoutId$, null);
       set(streamedCount$, (c: number) => Math.min(c + 1, 6));
       // Auto-scroll conversation end into view
       const el = get(conversationEndEl$);
@@ -688,8 +690,22 @@ export function ZeroChatPage({
       // Schedule next tick
       set(scheduleStreamTick$);
     }, STREAM_DELAY_MS);
+    set(streamTimeoutId$, id);
   });
   const scheduleStreamTick = useSet(scheduleStreamTick$);
+  // Clean up pending stream timeout on unmount
+  const streamCleanup$ = useCommand(
+    ({ get }, _el: HTMLElement, signal: AbortSignal) => {
+      signal.addEventListener("abort", () => {
+        const id = get(streamTimeoutId$);
+        if (id !== null) {
+          window.clearTimeout(id);
+        }
+      });
+    },
+  );
+  const streamCleanupRef$ = onRef(streamCleanup$);
+  const streamCleanupRef = useSet(streamCleanupRef$);
 
   // Toggle sub-agent list with auto-scroll when opening
   const toggleSubAgentList$ = useCommand(({ get, set }) => {
@@ -766,7 +782,10 @@ export function ZeroChatPage({
   if (showConversation && scenariosToShow.length > 0) {
     const isScenarioFromSidebar = initialScenarioId !== undefined;
     return (
-      <div className="flex flex-1 flex-col min-h-0 bg-transparent">
+      <div
+        ref={streamCleanupRef}
+        className="flex flex-1 flex-col min-h-0 bg-transparent"
+      >
         <header className="shrink-0 bg-transparent px-4 sm:px-6 py-3 flex items-center justify-between">
           <div className="flex items-center gap-3">
             <Button

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-page.tsx
@@ -1,4 +1,7 @@
-import { useState, useEffect, useRef } from "react";
+import type { ReactNode, KeyboardEvent } from "react";
+import { useCCState, useCommand } from "ccstate-react/experimental";
+import { useGet, useSet } from "ccstate-react";
+import { onRef } from "../../signals/utils.ts";
 import {
   IconSend,
   IconPaperclip,
@@ -30,10 +33,7 @@ export type DemoScenarioId =
   | "rich-summary"
   | "agent-operations";
 
-type NavIcon = (props: {
-  size?: number;
-  className?: string;
-}) => React.ReactNode;
+type NavIcon = (props: { size?: number; className?: string }) => ReactNode;
 const ACTION_BUTTONS = [
   { label: "Automate workflows", icon: IconBriefcase as NavIcon },
   { label: "Customize Zero", icon: IconSettings as NavIcon },
@@ -626,56 +626,99 @@ export function ZeroChatPage({
   zeroAvatarSrc = "/zero-avatar.png",
   onAvatarClick,
 }: ZeroChatPageProps) {
-  const [input, setInput] = useState("");
-  const [conversationActive, setConversationActive] = useState(false);
-  const [streamedCount, setStreamedCount] = useState(0);
-  const conversationEndRef = useRef<HTMLDivElement>(null);
-  const subAgentListRef = useRef<HTMLDivElement>(null);
-  const [approveDone, setApproveDone] = useState(false);
-  const [selectedOption, setSelectedOption] = useState<string | null>(null);
-  const [teamPersonalChoice, setTeamPersonalChoice] = useState<
-    "team" | "personal" | null
-  >(null);
-  const [connectorConnected, setConnectorConnected] = useState(false);
-  const [commandAllowed, setCommandAllowed] = useState(false);
-  const [showSubAgentList, setShowSubAgentList] = useState(false);
-  const [carouselIndex, setCarouselIndex] = useState(0);
+  const input$ = useCCState("");
+  const input = useGet(input$);
+  const setInput = useSet(input$);
+  const conversationActive$ = useCCState(false);
+  const conversationActive = useGet(conversationActive$);
+  const setConversationActive = useSet(conversationActive$);
+  const streamedCount$ = useCCState(0);
+  const streamedCount = useGet(streamedCount$);
+  const setStreamedCount = useSet(streamedCount$);
+  const conversationEndEl$ = useCCState<HTMLDivElement | null>(null);
+  const conversationEndEl = useGet(conversationEndEl$);
+  const setConversationEndEl = useSet(conversationEndEl$);
+  const subAgentListEl$ = useCCState<HTMLDivElement | null>(null);
+  const setSubAgentListEl = useSet(subAgentListEl$);
+  const approveDone$ = useCCState(false);
+  const approveDone = useGet(approveDone$);
+  const setApproveDone = useSet(approveDone$);
+  const selectedOption$ = useCCState<string | null>(null);
+  const selectedOption = useGet(selectedOption$);
+  const setSelectedOption = useSet(selectedOption$);
+  const teamPersonalChoice$ = useCCState<"team" | "personal" | null>(null);
+  const teamPersonalChoice = useGet(teamPersonalChoice$);
+  const setTeamPersonalChoice = useSet(teamPersonalChoice$);
+  const connectorConnected$ = useCCState(false);
+  const connectorConnected = useGet(connectorConnected$);
+  const setConnectorConnected = useSet(connectorConnected$);
+  const commandAllowed$ = useCCState(false);
+  const commandAllowed = useGet(commandAllowed$);
+  const setCommandAllowed = useSet(commandAllowed$);
+  const showSubAgentList$ = useCCState(false);
+  const showSubAgentList = useGet(showSubAgentList$);
+  const carouselIndex$ = useCCState(0);
+  const carouselIndex = useGet(carouselIndex$);
+  // Carousel interval — starts on mount via onRef, cleans up on unmount
+  const carouselCommand$ = useCommand(
+    ({ set }, _el: HTMLElement, signal: AbortSignal) => {
+      const id = window.setInterval(() => {
+        set(carouselIndex$, (i: number) => (i + 1) % LANDING_TAGLINES.length);
+      }, CAROUSEL_INTERVAL_MS);
+      signal.addEventListener("abort", () => window.clearInterval(id));
+    },
+  );
+  const carouselRef$ = onRef(carouselCommand$);
+  const carouselRef = useSet(carouselRef$);
 
-  useEffect(() => {
-    const id = window.setInterval(() => {
-      setCarouselIndex((i) => (i + 1) % LANDING_TAGLINES.length);
-    }, CAROUSEL_INTERVAL_MS);
-    return () => window.clearInterval(id);
-  }, []);
-
-  useEffect(() => {
-    if (!conversationActive || streamedCount >= 6) {
+  // Stream tick — schedules the next streamed message after a delay
+  const scheduleStreamTick$ = useCommand(({ get, set }) => {
+    const active = get(conversationActive$);
+    const count = get(streamedCount$);
+    if (!active || count >= 6) {
       return;
     }
-    const id = window.setTimeout(() => {
-      setStreamedCount((c) => Math.min(c + 1, 6));
+    window.setTimeout(() => {
+      set(streamedCount$, (c: number) => Math.min(c + 1, 6));
+      // Auto-scroll conversation end into view
+      const el = get(conversationEndEl$);
+      if (el) {
+        el.scrollIntoView({ behavior: "smooth" });
+      }
+      // Schedule next tick
+      set(scheduleStreamTick$);
     }, STREAM_DELAY_MS);
-    return () => {
-      window.clearTimeout(id);
-    };
-  }, [conversationActive, streamedCount]);
+  });
+  const scheduleStreamTick = useSet(scheduleStreamTick$);
 
-  useEffect(() => {
-    if (streamedCount > 0 && conversationEndRef.current) {
-      conversationEndRef.current.scrollIntoView({ behavior: "smooth" });
+  // Toggle sub-agent list with auto-scroll when opening
+  const toggleSubAgentList$ = useCommand(({ get, set }) => {
+    const current = get(showSubAgentList$);
+    set(showSubAgentList$, !current);
+    if (!current) {
+      // Becoming visible — scroll into view after next paint
+      window.requestAnimationFrame(() => {
+        const el = get(subAgentListEl$);
+        if (el) {
+          el.scrollIntoView({ behavior: "smooth" });
+        }
+      });
     }
-  }, [streamedCount]);
-
-  useEffect(() => {
-    if (showSubAgentList && subAgentListRef.current) {
-      subAgentListRef.current.scrollIntoView({ behavior: "smooth" });
-    }
-  }, [showSubAgentList]);
+  });
+  const toggleSubAgentList = useSet(toggleSubAgentList$);
 
   const handleComposerFocus = () => {
     if (!conversationActive) {
       setConversationActive(true);
       setStreamedCount(1);
+      // Scroll conversation end into view after first message
+      if (conversationEndEl) {
+        window.requestAnimationFrame(() => {
+          conversationEndEl.scrollIntoView({ behavior: "smooth" });
+        });
+      }
+      // Start streaming ticks
+      scheduleStreamTick();
     }
   };
 
@@ -704,7 +747,7 @@ export function ZeroChatPage({
     handleSend(prompt);
   };
 
-  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+  const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
     if (e.key === "Enter" && !e.shiftKey) {
       e.preventDefault();
       handleSend();
@@ -762,7 +805,7 @@ export function ZeroChatPage({
                 "h-8 w-8 text-muted-foreground hover:text-foreground",
                 showSubAgentList && "bg-muted/60 text-foreground",
               )}
-              onClick={() => setShowSubAgentList((v) => !v)}
+              onClick={() => toggleSubAgentList()}
               aria-label={`${ZERO_TEAM_JOBS.length} sub-agents`}
             >
               <IconUsers size={18} stroke={1.5} />
@@ -809,7 +852,7 @@ export function ZeroChatPage({
             )}
             {showSubAgentList && (
               <div
-                ref={subAgentListRef}
+                ref={setSubAgentListEl}
                 className="grid grid-cols-[48px_1fr] gap-3 items-start animate-in fade-in slide-in-from-bottom-2 duration-300"
               >
                 <button
@@ -890,7 +933,7 @@ export function ZeroChatPage({
                 </div>
               </div>
             )}
-            <div ref={conversationEndRef} />
+            <div ref={setConversationEndEl} />
           </div>
         </main>
         <footer className="shrink-0 bg-transparent px-4 sm:px-6 pt-4 pb-8">
@@ -961,7 +1004,7 @@ export function ZeroChatPage({
 
   // Landing page: full content (title, triggers, composer, actions, prompts)
   return (
-    <div className="flex flex-1 flex-col min-h-0">
+    <div ref={carouselRef} className="flex flex-1 flex-col min-h-0">
       <header
         className="shrink-0 bg-transparent px-4 sm:px-6 pt-10 pb-2"
         aria-hidden="true"

--- a/turbo/apps/platform/src/views/zero-page/zero-content.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-content.tsx
@@ -8,7 +8,7 @@ import { ZeroActivityPage } from "./zero-activity-page.tsx";
 import { ZeroWorksPage } from "./zero-works-page.tsx";
 import { ZeroSchedulePage } from "./zero-schedule-page.tsx";
 
-const RECENT_ID_TO_SCENARIO: Record<string, DemoScenarioId> = {
+const RECENT_ID_TO_SCENARIO: Readonly<Record<string, DemoScenarioId>> = {
   hello: "hello-from-zero",
   "1": "rich-summary",
   "2": "connect-connector",
@@ -30,7 +30,7 @@ interface ZeroContentProps {
   onAvatarClick?: () => void;
 }
 
-const SECTION_TITLES: Record<ZeroNavId, string> = {
+const SECTION_TITLES: Readonly<Record<ZeroNavId, string>> = {
   chat: "Chat with Zero",
   meet: "Meet Zero",
   schedule: "Schedule",

--- a/turbo/apps/platform/src/views/zero-page/zero-job-detail-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-job-detail-page.tsx
@@ -47,7 +47,7 @@ const WORKFLOW_SKILLS_OPTIONS = [
   "Data Analysis",
   "Content Summarization",
   "Linear",
-];
+] as const;
 
 const INITIAL_SKILLS = [
   "Slack",
@@ -55,7 +55,7 @@ const INITIAL_SKILLS = [
   "Content Summarization",
 ] as const;
 
-const CONNECTOR_LIST: ConnectorType[] = [
+const CONNECTOR_LIST: readonly ConnectorType[] = [
   "github",
   "linear",
   "notion",

--- a/turbo/apps/platform/src/views/zero-page/zero-job-detail-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-job-detail-page.tsx
@@ -1,4 +1,5 @@
-import { useState } from "react";
+import { useCCState } from "ccstate-react/experimental";
+import { useGet, useSet } from "ccstate-react";
 import { createPortal } from "react-dom";
 import {
   IconArrowLeft,
@@ -76,17 +77,25 @@ interface ZeroJobDetailPageProps {
 }
 
 export function ZeroJobDetailPage({ job, onBack }: ZeroJobDetailPageProps) {
-  const [activeTab, setActiveTab] = useState("connectors");
-  const [settingsName, setSettingsName] = useState(job.title);
-  const [settingsDescription, setSettingsDescription] = useState(
-    job.description,
-  );
-  const [skills, setSkills] = useState<string[]>([...INITIAL_SKILLS]);
+  const activeTab$ = useCCState("connectors");
+  const activeTab = useGet(activeTab$);
+  const setActiveTab = useSet(activeTab$);
+  const settingsName$ = useCCState(job.title);
+  const settingsName = useGet(settingsName$);
+  const setSettingsName = useSet(settingsName$);
+  const settingsDescription$ = useCCState(job.description);
+  const settingsDescription = useGet(settingsDescription$);
+  const setSettingsDescription = useSet(settingsDescription$);
+  const skills$ = useCCState<string[]>([...INITIAL_SKILLS]);
+  const skills = useGet(skills$);
+  const setSkills = useSet(skills$);
   const ADD_SKILL_PLACEHOLDER = "__add_skill__";
-  const [addSkillValue, setAddSkillValue] = useState(ADD_SKILL_PLACEHOLDER);
-  const [connectedConnectors, setConnectedConnectors] = useState<
-    ConnectorType[]
-  >(["github", "slack"]);
+  const addSkillValue$ = useCCState(ADD_SKILL_PLACEHOLDER);
+  const addSkillValue = useGet(addSkillValue$);
+  const setAddSkillValue = useSet(addSkillValue$);
+  const connectedConnectors$ = useCCState<ConnectorType[]>(["github", "slack"]);
+  const connectedConnectors = useGet(connectedConnectors$);
+  const setConnectedConnectors = useSet(connectedConnectors$);
 
   const removeSkill = (s: string) =>
     setSkills((prev) => prev.filter((x) => x !== s));
@@ -105,7 +114,7 @@ export function ZeroJobDetailPage({ job, onBack }: ZeroJobDetailPageProps) {
     (s) => !skills.includes(s),
   );
 
-  const [savedSettings, setSavedSettings] = useState<{
+  const savedSettings$ = useCCState<{
     name: string;
     description: string;
     skills: string[];
@@ -114,6 +123,8 @@ export function ZeroJobDetailPage({ job, onBack }: ZeroJobDetailPageProps) {
     description: job.description,
     skills: [...INITIAL_SKILLS],
   });
+  const savedSettings = useGet(savedSettings$);
+  const setSavedSettings = useSet(savedSettings$);
 
   const isSettingsDirty =
     settingsName !== savedSettings.name ||

--- a/turbo/apps/platform/src/views/zero-page/zero-jobs-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-jobs-page.tsx
@@ -14,7 +14,7 @@ import {
 } from "@vm0/ui/components/ui/popover";
 import { ZeroJobDetailPage, type JobItem } from "./zero-job-detail-page.tsx";
 
-export const ZERO_TEAM_JOBS: JobItem[] = [
+export const ZERO_TEAM_JOBS: readonly Readonly<JobItem>[] = [
   {
     id: "1",
     agentName: "Minion 1",

--- a/turbo/apps/platform/src/views/zero-page/zero-jobs-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-jobs-page.tsx
@@ -1,4 +1,5 @@
-import { useState } from "react";
+import { useCCState } from "ccstate-react/experimental";
+import { useGet, useSet } from "ccstate-react";
 import {
   IconUser,
   IconUsers,
@@ -50,7 +51,9 @@ export function ZeroJobsPage({
 }: {
   onNavigateToChat?: () => void;
 } = {}) {
-  const [selectedJobId, setSelectedJobId] = useState<string | null>(null);
+  const selectedJobId$ = useCCState<string | null>(null);
+  const selectedJobId = useGet(selectedJobId$);
+  const setSelectedJobId = useSet(selectedJobId$);
 
   const selectedJob = selectedJobId
     ? ZERO_TEAM_JOBS.find((j) => j.id === selectedJobId)

--- a/turbo/apps/platform/src/views/zero-page/zero-meet-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-meet-page.tsx
@@ -37,16 +37,18 @@ const TONE_OPTIONS = [
   "Supportive",
 ] as const;
 
-const TONE_HINT: Record<(typeof TONE_OPTIONS)[number], string> = {
+const TONE_HINT: Readonly<Record<(typeof TONE_OPTIONS)[number], string>> = {
   Professional: "Clear and polished",
   Friendly: "Warm and approachable",
   Direct: "To the point",
   Supportive: "In your corner",
 };
 
-const TONE_SAMPLES: Record<
-  (typeof TONE_OPTIONS)[number],
-  { user: string; zero: string }
+const TONE_SAMPLES: Readonly<
+  Record<
+    (typeof TONE_OPTIONS)[number],
+    Readonly<{ user: string; zero: string }>
+  >
 > = {
   Professional: {
     user: "I need the Q3 report by Friday.",
@@ -78,9 +80,9 @@ const AVAILABLE_SKILLS = [
   "slack",
   "gmail",
   "elephant",
-];
+] as const;
 
-const CONNECTOR_LIST: ConnectorType[] = [
+const CONNECTOR_LIST: readonly ConnectorType[] = [
   "github",
   "linear",
   "notion",
@@ -101,7 +103,11 @@ export function ZeroMeetPage({
   const [agentName, setAgentName] = useState("Zero");
   const [tone, setTone] = useState<string>("Professional");
   const [skills, setSkills] = useState<string[]>([...AVAILABLE_SKILLS]);
-  const [savedSettings, setSavedSettings] = useState({
+  const [savedSettings, setSavedSettings] = useState<{
+    name: string;
+    tone: string;
+    skills: string[];
+  }>({
     name: "Zero",
     tone: "Professional",
     skills: [...AVAILABLE_SKILLS],

--- a/turbo/apps/platform/src/views/zero-page/zero-meet-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-meet-page.tsx
@@ -1,4 +1,5 @@
-import { useState } from "react";
+import { useCCState } from "ccstate-react/experimental";
+import { useGet, useSet } from "ccstate-react";
 import { createPortal } from "react-dom";
 import {
   IconMessageCircle,
@@ -99,11 +100,19 @@ export function ZeroMeetPage({
   zeroAvatarSrc = "/zero-avatar.png",
   onAvatarClick,
 }: ZeroMeetPageProps) {
-  const [activeTab, setActiveTab] = useState("connections");
-  const [agentName, setAgentName] = useState("Zero");
-  const [tone, setTone] = useState<string>("Professional");
-  const [skills, setSkills] = useState<string[]>([...AVAILABLE_SKILLS]);
-  const [savedSettings, setSavedSettings] = useState<{
+  const activeTab$ = useCCState("connections");
+  const activeTab = useGet(activeTab$);
+  const setActiveTab = useSet(activeTab$);
+  const agentName$ = useCCState("Zero");
+  const agentName = useGet(agentName$);
+  const setAgentName = useSet(agentName$);
+  const tone$ = useCCState<string>("Professional");
+  const tone = useGet(tone$);
+  const setTone = useSet(tone$);
+  const skills$ = useCCState<string[]>([...AVAILABLE_SKILLS]);
+  const skills = useGet(skills$);
+  const setSkills = useSet(skills$);
+  const savedSettings$ = useCCState<{
     name: string;
     tone: string;
     skills: string[];
@@ -112,8 +121,12 @@ export function ZeroMeetPage({
     tone: "Professional",
     skills: [...AVAILABLE_SKILLS],
   });
+  const savedSettings = useGet(savedSettings$);
+  const setSavedSettings = useSet(savedSettings$);
   const ADD_SKILL_PLACEHOLDER = "__add_skill__";
-  const [addSkillValue, setAddSkillValue] = useState(ADD_SKILL_PLACEHOLDER);
+  const addSkillValue$ = useCCState(ADD_SKILL_PLACEHOLDER);
+  const addSkillValue = useGet(addSkillValue$);
+  const setAddSkillValue = useSet(addSkillValue$);
 
   const isSettingsDirty =
     agentName !== savedSettings.name ||

--- a/turbo/apps/platform/src/views/zero-page/zero-onboarding.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-onboarding.tsx
@@ -1,4 +1,5 @@
-import { useState } from "react";
+import { useCCState } from "ccstate-react/experimental";
+import { useGet, useSet } from "ccstate-react";
 import slackIcon from "../settings-page/icons/slack.svg";
 import {
   Dialog,
@@ -72,17 +73,24 @@ export function ZeroOnboarding({
   zeroAvatarSrc?: string;
   onAvatarClick?: () => void;
 }) {
-  const [step, setStep] = useState<OnboardingStep>("1");
-  const [name, setName] = useState("Zero");
-  const [selectedProviderType, setSelectedProviderType] =
-    useState<ModelProviderType | null>(null);
-  const [providerFormValues, setProviderFormValues] = useState({
+  const step$ = useCCState<OnboardingStep>("1");
+  const step = useGet(step$);
+  const setStep = useSet(step$);
+  const name$ = useCCState("Zero");
+  const name = useGet(name$);
+  const setName = useSet(name$);
+  const selectedProviderType$ = useCCState<ModelProviderType | null>(null);
+  const selectedProviderType = useGet(selectedProviderType$);
+  const setSelectedProviderType = useSet(selectedProviderType$);
+  const providerFormValues$ = useCCState({
     secret: "",
     selectedModel: "",
     useDefaultModel: true,
     authMethod: "",
     secrets: {} as Record<string, string>,
   });
+  const providerFormValues = useGet(providerFormValues$);
+  const setProviderFormValues = useSet(providerFormValues$);
 
   const handleSelectProvider = (type: ModelProviderType) => {
     const defaultAuth = hasAuthMethods(type)

--- a/turbo/apps/platform/src/views/zero-page/zero-onboarding.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-onboarding.tsx
@@ -25,7 +25,7 @@ import { getUILabel } from "../settings-page/provider-ui-config";
 
 type OnboardingStep = "1" | "2" | "3" | "4" | "done";
 
-const MODEL_PROVIDER_LIST: ModelProviderType[] = [
+const MODEL_PROVIDER_LIST: readonly ModelProviderType[] = [
   "claude-code-oauth-token",
   "anthropic-api-key",
   "openrouter-api-key",
@@ -37,7 +37,7 @@ const MODEL_PROVIDER_LIST: ModelProviderType[] = [
   "aws-bedrock",
 ];
 
-const CONNECTOR_LIST: ConnectorType[] = [
+const CONNECTOR_LIST: readonly ConnectorType[] = [
   "github",
   "notion",
   "gmail",

--- a/turbo/apps/platform/src/views/zero-page/zero-production-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-production-page.tsx
@@ -41,7 +41,7 @@ interface DocItem {
   contentPreview: string;
 }
 
-const DOCS: DocItem[] = [
+const DOCS: readonly Readonly<DocItem>[] = [
   {
     id: "1",
     title: "Team Weekly Report - Week 8",
@@ -130,7 +130,7 @@ Recommendations for optimizing cron-based schedules and reducing cold starts. We
   },
 ];
 
-const DOC_TYPE_ICON: Record<DocType, string> = {
+const DOC_TYPE_ICON: Readonly<Record<DocType, string>> = {
   pdf: "/doc-types/PDF.svg",
   markdown: "/doc-types/DOC.svg",
   html: "/doc-types/DOC.svg",

--- a/turbo/apps/platform/src/views/zero-page/zero-production-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-production-page.tsx
@@ -1,4 +1,5 @@
-import { useState } from "react";
+import { useCCState } from "ccstate-react/experimental";
+import { useGet, useSet } from "ccstate-react";
 import {
   IconSearch,
   IconFolder,
@@ -254,9 +255,15 @@ function DocListRow({ doc }: { doc: DocItem }) {
 type ViewMode = "list" | "gallery";
 
 export function ZeroProductionPage() {
-  const [filter, setFilter] = useState<DocScope>("all");
-  const [search, setSearch] = useState("");
-  const [viewMode, setViewMode] = useState<ViewMode>("gallery");
+  const filter$ = useCCState<DocScope>("all");
+  const filter = useGet(filter$);
+  const setFilter = useSet(filter$);
+  const search$ = useCCState("");
+  const search = useGet(search$);
+  const setSearch = useSet(search$);
+  const viewMode$ = useCCState<ViewMode>("gallery");
+  const viewMode = useGet(viewMode$);
+  const setViewMode = useSet(viewMode$);
 
   const filteredDocs = DOCS.filter((doc) => {
     const matchScope = filter === "all" || doc.scope === filter;

--- a/turbo/apps/platform/src/views/zero-page/zero-schedule-card.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-schedule-card.tsx
@@ -46,8 +46,11 @@ export const SCHEDULE_FREQUENCY_OPTIONS = [
 ] as const;
 
 export const SCHEDULE_LOOP_MINUTES = [5, 15, 30, 60] as const;
-export const HOUR_OPTIONS = Array.from({ length: 24 }, (_, i) => i);
-export const MINUTE_OPTIONS = [0, 15, 30, 45];
+export const HOUR_OPTIONS: readonly number[] = Array.from(
+  { length: 24 },
+  (_, i) => i,
+);
+export const MINUTE_OPTIONS = [0, 15, 30, 45] as const;
 export const TIMEZONE_OPTIONS = [
   "UTC",
   "Asia/Shanghai",
@@ -290,7 +293,7 @@ export function getEntriesInCell(
   });
 }
 
-export const DEFAULT_SCHEDULE: ScheduleEntry[] = [
+export const DEFAULT_SCHEDULE: readonly Readonly<ScheduleEntry>[] = [
   {
     id: "1",
     time: "Every weekday at 9:00 AM",
@@ -311,7 +314,7 @@ export const DEFAULT_SCHEDULE: ScheduleEntry[] = [
 ];
 
 /** Dummy schedule for sub-agent (job) detail page — one entry per sub-agent. */
-const DUMMY_AGENT_SCHEDULE: ScheduleEntry[] = [
+const DUMMY_AGENT_SCHEDULE: readonly Readonly<ScheduleEntry>[] = [
   {
     id: "j1",
     time: "Every weekday at 9:00 AM",
@@ -323,7 +326,7 @@ export { DUMMY_AGENT_SCHEDULE };
 interface ZeroScheduleCardProps {
   title: string;
   subtitle: string;
-  initialSchedule: ScheduleEntry[];
+  initialSchedule: readonly Readonly<ScheduleEntry>[];
 }
 
 export function ZeroScheduleCard({
@@ -334,8 +337,9 @@ export function ZeroScheduleCard({
   const [scheduleViewMode, setScheduleViewMode] = useState<"list" | "calendar">(
     "list",
   );
-  const [scheduleList, setScheduleList] =
-    useState<ScheduleEntry[]>(initialSchedule);
+  const [scheduleList, setScheduleList] = useState<ScheduleEntry[]>([
+    ...initialSchedule,
+  ]);
   const [addScheduleOpen, setAddScheduleOpen] = useState(false);
   const [editingScheduleId, setEditingScheduleId] = useState<string | null>(
     null,

--- a/turbo/apps/platform/src/views/zero-page/zero-schedule-card.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-schedule-card.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState } from "react";
+import { useCCState } from "ccstate-react/experimental";
+import { useGet, useSet } from "ccstate-react";
 import {
   IconPlus,
   IconList,
@@ -334,25 +335,41 @@ export function ZeroScheduleCard({
   subtitle,
   initialSchedule,
 }: ZeroScheduleCardProps) {
-  const [scheduleViewMode, setScheduleViewMode] = useState<"list" | "calendar">(
-    "list",
-  );
-  const [scheduleList, setScheduleList] = useState<ScheduleEntry[]>([
-    ...initialSchedule,
-  ]);
-  const [addScheduleOpen, setAddScheduleOpen] = useState(false);
-  const [editingScheduleId, setEditingScheduleId] = useState<string | null>(
-    null,
-  );
-  const [newSchedulePrompt, setNewSchedulePrompt] = useState("");
-  const [scheduleFreq, setScheduleFreq] = useState<string>("every_day");
-  const [scheduleDate, setScheduleDate] = useState<string>(() =>
+  const scheduleViewMode$ = useCCState<"list" | "calendar">("list");
+  const scheduleViewMode = useGet(scheduleViewMode$);
+  const setScheduleViewMode = useSet(scheduleViewMode$);
+  const scheduleList$ = useCCState<ScheduleEntry[]>([...initialSchedule]);
+  const scheduleList = useGet(scheduleList$);
+  const setScheduleList = useSet(scheduleList$);
+  const addScheduleOpen$ = useCCState(false);
+  const addScheduleOpen = useGet(addScheduleOpen$);
+  const setAddScheduleOpen = useSet(addScheduleOpen$);
+  const editingScheduleId$ = useCCState<string | null>(null);
+  const editingScheduleId = useGet(editingScheduleId$);
+  const setEditingScheduleId = useSet(editingScheduleId$);
+  const newSchedulePrompt$ = useCCState("");
+  const newSchedulePrompt = useGet(newSchedulePrompt$);
+  const setNewSchedulePrompt = useSet(newSchedulePrompt$);
+  const scheduleFreq$ = useCCState<string>("every_day");
+  const scheduleFreq = useGet(scheduleFreq$);
+  const setScheduleFreq = useSet(scheduleFreq$);
+  const scheduleDate$ = useCCState<string>(
     new Date().toISOString().slice(0, 10),
   );
-  const [scheduleHour, setScheduleHour] = useState(9);
-  const [scheduleMinute, setScheduleMinute] = useState(0);
-  const [scheduleTimezone, setScheduleTimezone] = useState("UTC");
-  const [scheduleLoopMinutes, setScheduleLoopMinutes] = useState(15);
+  const scheduleDate = useGet(scheduleDate$);
+  const setScheduleDate = useSet(scheduleDate$);
+  const scheduleHour$ = useCCState(9);
+  const scheduleHour = useGet(scheduleHour$);
+  const setScheduleHour = useSet(scheduleHour$);
+  const scheduleMinute$ = useCCState(0);
+  const scheduleMinute = useGet(scheduleMinute$);
+  const setScheduleMinute = useSet(scheduleMinute$);
+  const scheduleTimezone$ = useCCState("UTC");
+  const scheduleTimezone = useGet(scheduleTimezone$);
+  const setScheduleTimezone = useSet(scheduleTimezone$);
+  const scheduleLoopMinutes$ = useCCState(15);
+  const scheduleLoopMinutes = useGet(scheduleLoopMinutes$);
+  const setScheduleLoopMinutes = useSet(scheduleLoopMinutes$);
 
   const openAddSchedule = () => {
     setEditingScheduleId(null);

--- a/turbo/apps/platform/src/views/zero-page/zero-schedule-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-schedule-page.tsx
@@ -1,4 +1,5 @@
-import { useState } from "react";
+import { useCCState } from "ccstate-react/experimental";
+import { useGet, useSet } from "ccstate-react";
 import { IconPencil, IconList, IconLayoutGrid } from "@tabler/icons-react";
 import {
   Card,
@@ -106,29 +107,45 @@ const initialJobSchedules: Readonly<
 );
 
 export function ZeroSchedulePage() {
-  const [scheduleViewMode, setScheduleViewMode] = useState<"list" | "calendar">(
-    "list",
-  );
-  const [zeroSchedule, setZeroSchedule] = useState<ScheduleEntry[]>([
-    ...DEFAULT_SCHEDULE,
-  ]);
-  const [jobSchedules, setJobSchedules] = useState<
-    Record<string, ScheduleEntry[]>
-  >(
+  const scheduleViewMode$ = useCCState<"list" | "calendar">("list");
+  const scheduleViewMode = useGet(scheduleViewMode$);
+  const setScheduleViewMode = useSet(scheduleViewMode$);
+  const zeroSchedule$ = useCCState<ScheduleEntry[]>([...DEFAULT_SCHEDULE]);
+  const zeroSchedule = useGet(zeroSchedule$);
+  const setZeroSchedule = useSet(zeroSchedule$);
+  const jobSchedules$ = useCCState<Record<string, ScheduleEntry[]>>(
     Object.fromEntries(
       Object.entries(initialJobSchedules).map(([k, v]) => [k, [...v]]),
     ),
   );
-  const [editingEntry, setEditingEntry] = useState<CombinedEntry | null>(null);
-  const [newSchedulePrompt, setNewSchedulePrompt] = useState("");
-  const [scheduleFreq, setScheduleFreq] = useState<string>("every_day");
-  const [scheduleDate, setScheduleDate] = useState<string>(() =>
+  const jobSchedules = useGet(jobSchedules$);
+  const setJobSchedules = useSet(jobSchedules$);
+  const editingEntry$ = useCCState<CombinedEntry | null>(null);
+  const editingEntry = useGet(editingEntry$);
+  const setEditingEntry = useSet(editingEntry$);
+  const newSchedulePrompt$ = useCCState("");
+  const newSchedulePrompt = useGet(newSchedulePrompt$);
+  const setNewSchedulePrompt = useSet(newSchedulePrompt$);
+  const scheduleFreq$ = useCCState<string>("every_day");
+  const scheduleFreq = useGet(scheduleFreq$);
+  const setScheduleFreq = useSet(scheduleFreq$);
+  const scheduleDate$ = useCCState<string>(
     new Date().toISOString().slice(0, 10),
   );
-  const [scheduleHour, setScheduleHour] = useState(9);
-  const [scheduleMinute, setScheduleMinute] = useState(0);
-  const [scheduleTimezone, setScheduleTimezone] = useState("UTC");
-  const [scheduleLoopMinutes, setScheduleLoopMinutes] = useState(15);
+  const scheduleDate = useGet(scheduleDate$);
+  const setScheduleDate = useSet(scheduleDate$);
+  const scheduleHour$ = useCCState(9);
+  const scheduleHour = useGet(scheduleHour$);
+  const setScheduleHour = useSet(scheduleHour$);
+  const scheduleMinute$ = useCCState(0);
+  const scheduleMinute = useGet(scheduleMinute$);
+  const setScheduleMinute = useSet(scheduleMinute$);
+  const scheduleTimezone$ = useCCState("UTC");
+  const scheduleTimezone = useGet(scheduleTimezone$);
+  const setScheduleTimezone = useSet(scheduleTimezone$);
+  const scheduleLoopMinutes$ = useCCState(15);
+  const scheduleLoopMinutes = useGet(scheduleLoopMinutes$);
+  const setScheduleLoopMinutes = useSet(scheduleLoopMinutes$);
 
   const combinedSchedule = buildCombinedSchedule(zeroSchedule, jobSchedules);
 

--- a/turbo/apps/platform/src/views/zero-page/zero-schedule-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-schedule-page.tsx
@@ -65,7 +65,7 @@ function buildCombinedSchedule(
   return [...zeroEntries, ...jobEntries];
 }
 
-const AGENT_ORDER = [
+const AGENT_ORDER: readonly string[] = [
   "Zero",
   ...ZERO_TEAM_JOBS.map((j) => `${j.agentName} · ${j.title}`),
 ];
@@ -76,21 +76,23 @@ const AGENT_CELL_CLASSES = [
   "bg-amber-700/15 border-amber-700/40 text-amber-800 dark:text-amber-200 dark:border-amber-600/40 dark:bg-amber-900/25",
   "bg-violet-700/15 border-violet-700/40 text-violet-800 dark:text-violet-200 dark:border-violet-600/40 dark:bg-violet-900/25",
   "bg-teal-700/15 border-teal-700/40 text-teal-800 dark:text-teal-200 dark:border-teal-600/40 dark:bg-teal-900/25",
-];
+] as const;
 
 function getAgentCellClasses(agentLabel: string): string {
   const i = AGENT_ORDER.indexOf(agentLabel);
   return AGENT_CELL_CLASSES[i !== -1 ? i % AGENT_CELL_CLASSES.length : 0];
 }
 
-const JOB_INITIAL_PROMPTS: Record<string, string> = {
+const JOB_INITIAL_PROMPTS: Readonly<Record<string, string>> = {
   "1": "Compile the daily digest from Slack and email; highlight items that need follow-up.",
   "2": "Triage new GitHub issues, suggest labels and assignees, and post a short summary in #eng.",
   "3": "Draft the weekly team report from the last 7 days and save to the shared drive.",
   "4": "Summarize new customer feedback from Zendesk and Notion; flag recurring themes.",
 };
 
-const initialJobSchedules: Record<string, ScheduleEntry[]> = Object.fromEntries(
+const initialJobSchedules: Readonly<
+  Record<string, readonly Readonly<ScheduleEntry>[]>
+> = Object.fromEntries(
   ZERO_TEAM_JOBS.map((job) => [
     job.id,
     [
@@ -107,10 +109,16 @@ export function ZeroSchedulePage() {
   const [scheduleViewMode, setScheduleViewMode] = useState<"list" | "calendar">(
     "list",
   );
-  const [zeroSchedule, setZeroSchedule] =
-    useState<ScheduleEntry[]>(DEFAULT_SCHEDULE);
-  const [jobSchedules, setJobSchedules] =
-    useState<Record<string, ScheduleEntry[]>>(initialJobSchedules);
+  const [zeroSchedule, setZeroSchedule] = useState<ScheduleEntry[]>([
+    ...DEFAULT_SCHEDULE,
+  ]);
+  const [jobSchedules, setJobSchedules] = useState<
+    Record<string, ScheduleEntry[]>
+  >(
+    Object.fromEntries(
+      Object.entries(initialJobSchedules).map(([k, v]) => [k, [...v]]),
+    ),
+  );
   const [editingEntry, setEditingEntry] = useState<CombinedEntry | null>(null);
   const [newSchedulePrompt, setNewSchedulePrompt] = useState("");
   const [scheduleFreq, setScheduleFreq] = useState<string>("every_day");

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -1,4 +1,4 @@
-import { useState, type ComponentType } from "react";
+import { useState, type ReactNode } from "react";
 import {
   IconMessageCircle,
   IconRobot,
@@ -27,40 +27,32 @@ export type ZeroNavId =
   | "works"
   | "account";
 
-const MAIN_NAV: {
-  id: ZeroNavId;
-  label: string;
-  icon: ComponentType<{ size?: number; className?: string }>;
-}[] = [
-  { id: "chat", label: "Chat with Zero", icon: IconMessageCircle },
-  { id: "meet", label: "Meet Zero", icon: IconRobot },
-  { id: "job", label: "Zero's team", icon: IconUsers },
-  { id: "schedule", label: "Schedule", icon: IconCalendar },
-  { id: "production", label: "Documents", icon: IconFile },
-  { id: "activity", label: "Activities", icon: IconChartLine },
-];
+type NavIcon = (props: { size?: number; className?: string }) => ReactNode;
+const MAIN_NAV = [
+  { id: "chat", label: "Chat with Zero", icon: IconMessageCircle as NavIcon },
+  { id: "meet", label: "Meet Zero", icon: IconRobot as NavIcon },
+  { id: "job", label: "Zero's team", icon: IconUsers as NavIcon },
+  { id: "schedule", label: "Schedule", icon: IconCalendar as NavIcon },
+  { id: "production", label: "Documents", icon: IconFile as NavIcon },
+  { id: "activity", label: "Activities", icon: IconChartLine as NavIcon },
+] as const;
 
-const RECENT_ITEMS: { id: string; label: string }[] = [
+const RECENT_ITEMS = [
   { id: "hello", label: "Hello from Zero" },
   { id: "1", label: "Daily digest workflow" },
   { id: "2", label: "Set up Slack integration" },
   { id: "3", label: "Weekly report automation" },
   { id: "4", label: "Code review reminders" },
-];
+] as const;
 
-const FOOTER_NAV: {
-  id: ZeroNavId;
-  label: string;
-  icon: ComponentType<{ size?: number; className?: string }>;
-  iconImg?: string;
-}[] = [
+const FOOTER_NAV = [
   {
-    id: "works",
+    id: "works" as const satisfies ZeroNavId,
     label: "Where Zero works",
-    icon: IconLayoutGrid,
+    icon: IconLayoutGrid as NavIcon,
     iconImg: slackIcon,
   },
-];
+] as const;
 
 export type ZeroAccountAction = "preferences" | "manage" | "signout";
 

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -1,4 +1,6 @@
-import { useState, type ReactNode } from "react";
+import type { ReactNode } from "react";
+import { useCCState } from "ccstate-react/experimental";
+import { useGet, useSet, useLoadable } from "ccstate-react";
 import {
   IconMessageCircle,
   IconRobot,
@@ -11,7 +13,6 @@ import {
   IconUsers,
   IconLogout,
 } from "@tabler/icons-react";
-import { useLoadable } from "ccstate-react";
 import slackIcon from "../settings-page/icons/slack.svg";
 import { clerk$, user$ } from "../../signals/auth.ts";
 import { detach, Reason } from "../../signals/utils.ts";
@@ -153,7 +154,9 @@ function AccountDropdown({
   activeId: ZeroNavId;
   onAccountAction?: (action: ZeroAccountAction) => void;
 }) {
-  const [accountMenuOpen, setAccountMenuOpen] = useState(false);
+  const accountMenuOpen$ = useCCState(false);
+  const accountMenuOpen = useGet(accountMenuOpen$);
+  const setAccountMenuOpen = useSet(accountMenuOpen$);
   const clerkLoadable = useLoadable(clerk$);
   const userLoadable = useLoadable(user$);
   const user = userLoadable.state === "hasData" ? userLoadable.data : null;

--- a/turbo/apps/platform/src/views/zero-page/zero-works-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-works-page.tsx
@@ -21,11 +21,11 @@ import {
 } from "@vm0/ui/components/ui/popover";
 import { ZeroSlackConfigContent } from "./zero-slack-config-content";
 
-const CONNECTED_TOOLS: {
+const CONNECTED_TOOLS: readonly Readonly<{
   id: string;
   name: string;
   description: string;
-}[] = [
+}>[] = [
   {
     id: "slack",
     name: "Slack",

--- a/turbo/apps/platform/src/views/zero-page/zero-works-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-works-page.tsx
@@ -1,4 +1,5 @@
-import { useState } from "react";
+import { useCCState } from "ccstate-react/experimental";
+import { useGet, useSet } from "ccstate-react";
 import {
   IconSearch,
   IconSettings,
@@ -34,8 +35,12 @@ const CONNECTED_TOOLS: readonly Readonly<{
 ];
 
 export function ZeroWorksPage() {
-  const [search, setSearch] = useState("");
-  const [slackConfigOpen, setSlackConfigOpen] = useState(false);
+  const search$ = useCCState("");
+  const search = useGet(search$);
+  const setSearch = useSet(search$);
+  const slackConfigOpen$ = useCCState(false);
+  const slackConfigOpen = useGet(slackConfigOpen$);
+  const setSlackConfigOpen = useSet(slackConfigOpen$);
 
   return (
     <div className="flex flex-1 flex-col min-h-0">


### PR DESCRIPTION
## Summary

- Remove `ccstate/no-package-variable: "off"` lint override for zero-page files from `eslint.config.js` and enforce module-scope immutability using `as const`, `readonly`, `Readonly<>`, and `Object.freeze()`
- Remove zero-page `no-restricted-imports` override from `.oxlintrc.json` that allowed direct React hook imports (`useState`, `useCallback`, `useEffect`, `useRef`)
- Replace all React hook usage across 15 zero-page view files with ccstate equivalents (`useCCState`, `useGet`, `useSet`, `useCommand`, `useComputed`, `onRef`)

## Test plan

- [ ] Verify `pnpm turbo run lint` passes with 0 errors
- [ ] Verify `pnpm check-types` passes with 0 errors
- [ ] Verify zero page renders correctly (onboarding, sidebar, chat, schedule, etc.)
- [ ] Verify org switcher still works after `clerk-org-switcher.tsx` rewrite

🤖 Generated with [Claude Code](https://claude.com/claude-code)