### PR TITLE
fix: skip retry on non-retriable 4xx errors in guest-agent

### DIFF
--- a/crates/guest-agent/src/http.rs
+++ b/crates/guest-agent/src/http.rs
@@ -12,6 +12,7 @@ use std::sync::LazyLock;
 use std::time::Duration;
 
 const LOG_TAG: &str = "sandbox:guest-agent";
+const HTTP_TOO_MANY_REQUESTS: u16 = 429;
 
 static HTTP_CLIENT: LazyLock<Client> = LazyLock::new(|| {
     reqeast::builder()
@@ -24,7 +25,8 @@ static HTTP_CLIENT: LazyLock<Client> = LazyLock::new(|| {
 /// POST JSON to a webhook endpoint with Bearer auth, Vercel bypass, and retry.
 ///
 /// Returns the parsed JSON response on success, or `None` if the response body
-/// is empty. Returns `Err` only after all retries are exhausted.
+/// is empty. Returns `Err` immediately on non-retriable 4xx errors (except 429),
+/// or after all retries are exhausted for 5xx / 429 / network errors.
 pub async fn post_json(
     url: &str,
     body: &impl Serialize,
@@ -61,7 +63,7 @@ pub async fn post_json(
                     "HTTP POST failed (attempt {attempt}/{max_retries}): HTTP {status}",
                 );
                 // 4xx errors (except 429) are deterministic — retrying won't help
-                if status.is_client_error() && status.as_u16() != 429 {
+                if status.is_client_error() && status.as_u16() != HTTP_TOO_MANY_REQUESTS {
                     return Err(AgentError::Http(format!("POST {url}: HTTP {status}")));
                 }
             }
@@ -108,7 +110,7 @@ pub async fn put_presigned(url: &str, data: Bytes, content_type: &str) -> Result
                     "HTTP PUT presigned failed (attempt {attempt}/{max_retries}): HTTP {status}",
                 );
                 // 4xx errors (except 429) are deterministic — retrying won't help
-                if status.is_client_error() && status.as_u16() != 429 {
+                if status.is_client_error() && status.as_u16() != HTTP_TOO_MANY_REQUESTS {
                     return Err(AgentError::Http(format!("PUT presigned: HTTP {status}")));
                 }
             }

--- a/crates/guest-agent/src/http.rs
+++ b/crates/guest-agent/src/http.rs
@@ -55,11 +55,15 @@ pub async fn post_json(
                 return Ok(Some(val));
             }
             Ok(resp) => {
+                let status = resp.status();
                 log_warn!(
                     LOG_TAG,
-                    "HTTP POST failed (attempt {attempt}/{max_retries}): HTTP {}",
-                    resp.status()
+                    "HTTP POST failed (attempt {attempt}/{max_retries}): HTTP {status}",
                 );
+                // 4xx errors (except 429) are deterministic — retrying won't help
+                if status.is_client_error() && status.as_u16() != 429 {
+                    return Err(AgentError::Http(format!("POST {url}: HTTP {status}")));
+                }
             }
             Err(e) => {
                 log_warn!(
@@ -98,11 +102,15 @@ pub async fn put_presigned(url: &str, data: Bytes, content_type: &str) -> Result
         {
             Ok(resp) if resp.status().is_success() => return Ok(()),
             Ok(resp) => {
+                let status = resp.status();
                 log_warn!(
                     LOG_TAG,
-                    "HTTP PUT presigned failed (attempt {attempt}/{max_retries}): HTTP {}",
-                    resp.status()
+                    "HTTP PUT presigned failed (attempt {attempt}/{max_retries}): HTTP {status}",
                 );
+                // 4xx errors (except 429) are deterministic — retrying won't help
+                if status.is_client_error() && status.as_u16() != 429 {
+                    return Err(AgentError::Http(format!("PUT presigned: HTTP {status}")));
+                }
             }
             Err(e) => {
                 log_warn!(

--- a/crates/guest-agent/tests/integration.rs
+++ b/crates/guest-agent/tests/integration.rs
@@ -132,6 +132,48 @@ async fn post_json_retry_exhausted() {
 }
 
 // =========================================================================
+// Group 1b: post_json 4xx handling
+// =========================================================================
+
+#[tokio::test]
+async fn post_json_4xx_returns_immediately_no_retry() {
+    let _guard = TEST_MUTEX.lock().unwrap();
+    let server = &*MOCK_SERVER;
+
+    let mock = server.mock(|when, then| {
+        when.method(POST).path("/test/post-400");
+        then.status(400);
+    });
+
+    let url = format!("{}/test/post-400", server.base_url());
+    let result = guest_agent::http::post_json(&url, &json!({}), 3).await;
+
+    // Should fail immediately — only 1 call, no retries.
+    mock.assert_calls_async(1).await;
+    assert!(result.is_err());
+    mock.delete_async().await;
+}
+
+#[tokio::test]
+async fn post_json_429_retries() {
+    let _guard = TEST_MUTEX.lock().unwrap();
+    let server = &*MOCK_SERVER;
+
+    let mock = server.mock(|when, then| {
+        when.method(POST).path("/test/post-429");
+        then.status(429);
+    });
+
+    let url = format!("{}/test/post-429", server.base_url());
+    let result = guest_agent::http::post_json(&url, &json!({}), 3).await;
+
+    // 429 is retriable — should exhaust all retries.
+    mock.assert_calls_async(3).await;
+    assert!(result.is_err());
+    mock.delete_async().await;
+}
+
+// =========================================================================
 // Group 2: Auth headers
 // =========================================================================
 
@@ -233,6 +275,50 @@ async fn put_presigned_retry_then_succeed() {
     assert!(result.is_ok());
     success_mock.assert_calls_async(1).await;
     success_mock.delete_async().await;
+}
+
+// =========================================================================
+// Group 3b: put_presigned 4xx handling
+// =========================================================================
+
+#[tokio::test]
+async fn put_presigned_4xx_returns_immediately_no_retry() {
+    let _guard = TEST_MUTEX.lock().unwrap();
+    let server = &*MOCK_SERVER;
+
+    let mock = server.mock(|when, then| {
+        when.method(PUT).path("/test/put-403");
+        then.status(403);
+    });
+
+    let url = format!("{}/test/put-403", server.base_url());
+    let data = Bytes::from_static(b"forbidden data");
+    let result = guest_agent::http::put_presigned(&url, data, "application/octet-stream").await;
+
+    // Should fail immediately — only 1 call, no retries.
+    mock.assert_calls_async(1).await;
+    assert!(result.is_err());
+    mock.delete_async().await;
+}
+
+#[tokio::test]
+async fn put_presigned_429_retries() {
+    let _guard = TEST_MUTEX.lock().unwrap();
+    let server = &*MOCK_SERVER;
+
+    let mock = server.mock(|when, then| {
+        when.method(PUT).path("/test/put-429");
+        then.status(429);
+    });
+
+    let url = format!("{}/test/put-429", server.base_url());
+    let data = Bytes::from_static(b"rate limited data");
+    let result = guest_agent::http::put_presigned(&url, data, "application/octet-stream").await;
+
+    // 429 is retriable — should exhaust all retries.
+    mock.assert_calls_async(3).await;
+    assert!(result.is_err());
+    mock.delete_async().await;
 }
 
 // =========================================================================


### PR DESCRIPTION
## Summary

- `post_json` and `put_presigned` in `crates/guest-agent/src/http.rs` now return immediately on 4xx errors (except 429) instead of retrying
- 4xx client errors are deterministic — retrying wastes time on requests guaranteed to fail
- 429 (rate limit) is excluded since it's retriable after backoff

Closes #4120

## Test plan

- [ ] `cargo check -p guest-agent` passes
- [ ] `cargo clippy` clean
- [ ] Review: `guest-download/src/lib.rs` already uses this pattern as reference

🤖 Generated with [Claude Code](https://claude.com/claude-code)