### PR TITLE
fix(ci): add missing strapi url to release-please web deploy

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -197,6 +197,7 @@ jobs:
           environment-variables: |
             DATABASE_URL=${{ steps.get-db-url.outputs.database-url }}
             BLOG_BASE_URL=https://www.vm0.ai
+            STRAPI_URL=${{ vars.STRAPI_URL }}
             CLERK_PUBLISHABLE_KEY=${{ vars.CLERK_PUBLISHABLE_KEY }}
             CLERK_SECRET_KEY=${{ secrets.CLERK_SECRET_KEY }}
             E2B_API_KEY=${{ secrets.E2B_API_KEY }}


### PR DESCRIPTION
## Summary
- Add missing `STRAPI_URL` environment variable to `deploy-web-production` job in `release-please.yml`
- This variable was present in `turbo.yml` (preview deploys) but missing in the production release workflow
- Without it, `isBlogEnabled()` returns false and the blog page returns 404

## Test plan
- [ ] Verify `STRAPI_URL` is set as a GitHub repository variable
- [ ] Next production release via release-please should include the blog routes

🤖 Generated with [Claude Code](https://claude.com/claude-code)