### PR TITLE
refactor: resolve scope from Clerk API instead of scope_members table

### DIFF
--- a/turbo/apps/web/app/api/agent/composes/list/route.ts
+++ b/turbo/apps/web/app/api/agent/composes/list/route.ts
@@ -2,7 +2,7 @@ import { createHandler, tsr } from "../../../../../src/lib/ts-rest-handler";
 import { composesListContract } from "@vm0/core";
 import { initServices } from "../../../../../src/lib/init-services";
 import { agentComposes } from "../../../../../src/db/schema/agent-compose";
-import { getUserId } from "../../../../../src/lib/auth/get-user-id";
+import { getAuthContext } from "../../../../../src/lib/auth/get-user-id";
 import { getUserEmail } from "../../../../../src/lib/auth/get-user-email";
 import { eq, desc } from "drizzle-orm";
 import { resolveScope } from "../../../../../src/lib/scope/resolve-scope";
@@ -13,8 +13,8 @@ const router = tsr.router(composesListContract, {
   list: async ({ query, headers }) => {
     initServices();
 
-    const userId = await getUserId(headers.authorization);
-    if (!userId) {
+    const authCtx = await getAuthContext(headers.authorization);
+    if (!authCtx) {
       return {
         status: 401 as const,
         body: {
@@ -22,12 +22,18 @@ const router = tsr.router(composesListContract, {
         },
       };
     }
+    const { userId, scopeId: tokenScopeId } = authCtx;
 
     // Resolve scope: use ?scope= query param or default scope
     let clerkOrgId: string;
     let defaultAgentComposeId: string | null = null;
     try {
-      const { scope: resolvedScope } = await resolveScope(userId, query.scope);
+      const { scope: resolvedScope } = await resolveScope(
+        userId,
+        query.scope,
+        null,
+        tokenScopeId,
+      );
       clerkOrgId = resolvedScope.clerkOrgId;
       defaultAgentComposeId = resolvedScope.defaultAgentComposeId;
     } catch (error) {

--- a/turbo/apps/web/app/api/agent/composes/route.ts
+++ b/turbo/apps/web/app/api/agent/composes/route.ts
@@ -18,7 +18,7 @@ import {
   agentComposes,
   agentComposeVersions,
 } from "../../../../src/db/schema/agent-compose";
-import { getUserId } from "../../../../src/lib/auth/get-user-id";
+import { getAuthContext } from "../../../../src/lib/auth/get-user-id";
 import { eq, and } from "drizzle-orm";
 import { computeComposeVersionId } from "../../../../src/lib/agent-compose/content-hash";
 import { resolveScope } from "../../../../src/lib/scope/resolve-scope";
@@ -31,8 +31,8 @@ const router = tsr.router(composesMainContract, {
   getByName: async ({ query, headers }) => {
     initServices();
 
-    const userId = await getUserId(headers.authorization);
-    if (!userId) {
+    const authCtx = await getAuthContext(headers.authorization);
+    if (!authCtx) {
       return {
         status: 401 as const,
         body: {
@@ -40,6 +40,7 @@ const router = tsr.router(composesMainContract, {
         },
       };
     }
+    const { userId, scopeId: tokenScopeId } = authCtx;
 
     // Resolve scope: for cross-scope lookups (shared agents), skip membership
     // check and rely on canAccessCompose for authorization instead.
@@ -61,7 +62,12 @@ const router = tsr.router(composesMainContract, {
       clerkOrgId = scope.clerkOrgId;
       defaultAgentComposeId = scope.defaultAgentComposeId;
     } else {
-      const { scope: resolvedScope } = await resolveScope(userId);
+      const { scope: resolvedScope } = await resolveScope(
+        userId,
+        null,
+        null,
+        tokenScopeId,
+      );
       clerkOrgId = resolvedScope.clerkOrgId;
       defaultAgentComposeId = resolvedScope.defaultAgentComposeId;
     }
@@ -137,8 +143,8 @@ const router = tsr.router(composesMainContract, {
   create: async ({ body, headers }) => {
     initServices();
 
-    const userId = await getUserId(headers.authorization);
-    if (!userId) {
+    const authCtx = await getAuthContext(headers.authorization);
+    if (!authCtx) {
       return {
         status: 401 as const,
         body: {
@@ -146,6 +152,7 @@ const router = tsr.router(composesMainContract, {
         },
       };
     }
+    const { userId, scopeId: tokenScopeId } = authCtx;
 
     const { content } = body;
 
@@ -257,7 +264,7 @@ const router = tsr.router(composesMainContract, {
     const versionId = computeComposeVersionId(resolvedContent);
 
     // Get user's scope (required for compose creation)
-    const { scope } = await resolveScope(userId);
+    const { scope } = await resolveScope(userId, null, null, tokenScopeId);
 
     // Check compose and version existence in parallel
     const [existingComposes, existingVersions] = await Promise.all([

--- a/turbo/apps/web/app/api/agent/runs/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/route.ts
@@ -22,7 +22,7 @@ import {
   createRun,
   type RunDispatchError,
 } from "../../../../src/lib/run";
-import { getUserId } from "../../../../src/lib/auth/get-user-id";
+import { getAuthContext } from "../../../../src/lib/auth/get-user-id";
 import { logger } from "../../../../src/lib/logger";
 import {
   isForbidden,
@@ -281,8 +281,8 @@ const router = tsr.router(runsMainContract, {
   list: async ({ query, headers }) => {
     initServices();
 
-    const userId = await getUserId(headers.authorization);
-    if (!userId) {
+    const authCtx = await getAuthContext(headers.authorization);
+    if (!authCtx) {
       return {
         status: 401 as const,
         body: {
@@ -290,6 +290,7 @@ const router = tsr.router(runsMainContract, {
         },
       };
     }
+    const { userId } = authCtx;
 
     // Parse and validate status values
     const statusValues: string[] = query.status
@@ -395,8 +396,8 @@ const router = tsr.router(runsMainContract, {
   create: async ({ body, headers }, { request }) => {
     initServices();
 
-    const userId = await getUserId(headers.authorization);
-    if (!userId) {
+    const authCtx = await getAuthContext(headers.authorization);
+    if (!authCtx) {
       return {
         status: 401 as const,
         body: {
@@ -404,6 +405,7 @@ const router = tsr.router(runsMainContract, {
         },
       };
     }
+    const { userId, scopeId: tokenScopeId } = authCtx;
 
     // Validate mutually exclusive shortcuts
     if (body.checkpointId && body.sessionId) {
@@ -452,7 +454,7 @@ const router = tsr.router(runsMainContract, {
     // Resolve scope for variable/secret resolution.
     // The actual variable fetching happens in build-context.ts.
     const scopeSlug = new URL(request.url).searchParams.get("scope");
-    const { scope } = await resolveScope(userId, scopeSlug);
+    const { scope } = await resolveScope(userId, scopeSlug, null, tokenScopeId);
 
     // Delegate run creation, validation, and dispatch to createRun()
     try {

--- a/turbo/apps/web/app/api/agent/schedules/[name]/disable/route.ts
+++ b/turbo/apps/web/app/api/agent/schedules/[name]/disable/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { initServices } from "../../../../../../src/lib/init-services";
-import { getUserId } from "../../../../../../src/lib/auth/get-user-id";
+import { getAuthContext } from "../../../../../../src/lib/auth/get-user-id";
 import { disableSchedule } from "../../../../../../src/lib/schedule";
 import { logger } from "../../../../../../src/lib/logger";
 import { isNotFound } from "../../../../../../src/lib/errors";
@@ -14,15 +14,16 @@ export async function POST(
 ) {
   initServices();
 
-  const userId = await getUserId(
+  const authCtx = await getAuthContext(
     request.headers.get("Authorization") ?? undefined,
   );
-  if (!userId) {
+  if (!authCtx) {
     return NextResponse.json(
       { error: { message: "Not authenticated", code: "UNAUTHORIZED" } },
       { status: 401 },
     );
   }
+  const { userId, scopeId: tokenScopeId } = authCtx;
 
   const { name } = await params;
 
@@ -43,7 +44,7 @@ export async function POST(
     );
   }
 
-  const scopeId = await resolveScopeId(userId, body.scopeId);
+  const scopeId = await resolveScopeId(userId, body.scopeId, tokenScopeId);
 
   log.debug(`Disabling schedule ${name} for compose ${body.composeId}`);
 

--- a/turbo/apps/web/app/api/agent/schedules/[name]/enable/route.ts
+++ b/turbo/apps/web/app/api/agent/schedules/[name]/enable/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { initServices } from "../../../../../../src/lib/init-services";
-import { getUserId } from "../../../../../../src/lib/auth/get-user-id";
+import { getAuthContext } from "../../../../../../src/lib/auth/get-user-id";
 import { enableSchedule } from "../../../../../../src/lib/schedule";
 import { logger } from "../../../../../../src/lib/logger";
 import { isNotFound, isSchedulePast } from "../../../../../../src/lib/errors";
@@ -14,15 +14,16 @@ export async function POST(
 ) {
   initServices();
 
-  const userId = await getUserId(
+  const authCtx = await getAuthContext(
     request.headers.get("Authorization") ?? undefined,
   );
-  if (!userId) {
+  if (!authCtx) {
     return NextResponse.json(
       { error: { message: "Not authenticated", code: "UNAUTHORIZED" } },
       { status: 401 },
     );
   }
+  const { userId, scopeId: tokenScopeId } = authCtx;
 
   const { name } = await params;
 
@@ -43,7 +44,7 @@ export async function POST(
     );
   }
 
-  const scopeId = await resolveScopeId(userId, body.scopeId);
+  const scopeId = await resolveScopeId(userId, body.scopeId, tokenScopeId);
 
   log.debug(`Enabling schedule ${name} for compose ${body.composeId}`);
 

--- a/turbo/apps/web/app/api/agent/schedules/[name]/route.ts
+++ b/turbo/apps/web/app/api/agent/schedules/[name]/route.ts
@@ -5,7 +5,7 @@ import {
 } from "../../../../../src/lib/ts-rest-handler";
 import { schedulesByNameContract } from "@vm0/core";
 import { initServices } from "../../../../../src/lib/init-services";
-import { getUserId } from "../../../../../src/lib/auth/get-user-id";
+import { getAuthContext } from "../../../../../src/lib/auth/get-user-id";
 import {
   getScheduleByName,
   deleteSchedule,
@@ -20,8 +20,8 @@ const router = tsr.router(schedulesByNameContract, {
   getByName: async ({ params, query, headers }) => {
     initServices();
 
-    const userId = await getUserId(headers.authorization);
-    if (!userId) {
+    const authCtx = await getAuthContext(headers.authorization);
+    if (!authCtx) {
       return {
         status: 401 as const,
         body: {
@@ -29,11 +29,12 @@ const router = tsr.router(schedulesByNameContract, {
         },
       };
     }
+    const { userId, scopeId: tokenScopeId } = authCtx;
 
     log.debug(`Getting schedule ${params.name} for compose ${query.composeId}`);
 
     try {
-      const scopeId = await resolveScopeId(userId, query.scopeId);
+      const scopeId = await resolveScopeId(userId, query.scopeId, tokenScopeId);
 
       const schedule = await getScheduleByName(
         userId,
@@ -62,8 +63,8 @@ const router = tsr.router(schedulesByNameContract, {
   delete: async ({ params, query, headers }) => {
     initServices();
 
-    const userId = await getUserId(headers.authorization);
-    if (!userId) {
+    const authCtx = await getAuthContext(headers.authorization);
+    if (!authCtx) {
       return {
         status: 401 as const,
         body: {
@@ -71,13 +72,14 @@ const router = tsr.router(schedulesByNameContract, {
         },
       };
     }
+    const { userId, scopeId: tokenScopeId } = authCtx;
 
     log.debug(
       `Deleting schedule ${params.name} for compose ${query.composeId}`,
     );
 
     try {
-      const scopeId = await resolveScopeId(userId, query.scopeId);
+      const scopeId = await resolveScopeId(userId, query.scopeId, tokenScopeId);
 
       await deleteSchedule(userId, scopeId, query.composeId, params.name);
 

--- a/turbo/apps/web/app/api/agent/schedules/[name]/runs/route.ts
+++ b/turbo/apps/web/app/api/agent/schedules/[name]/runs/route.ts
@@ -5,7 +5,7 @@ import {
 } from "../../../../../../src/lib/ts-rest-handler";
 import { scheduleRunsContract } from "@vm0/core";
 import { initServices } from "../../../../../../src/lib/init-services";
-import { getUserId } from "../../../../../../src/lib/auth/get-user-id";
+import { getAuthContext } from "../../../../../../src/lib/auth/get-user-id";
 import { getScheduleRecentRuns } from "../../../../../../src/lib/schedule";
 import { logger } from "../../../../../../src/lib/logger";
 import { isNotFound } from "../../../../../../src/lib/errors";
@@ -17,8 +17,8 @@ const router = tsr.router(scheduleRunsContract, {
   listRuns: async ({ params, query, headers }) => {
     initServices();
 
-    const userId = await getUserId(headers.authorization);
-    if (!userId) {
+    const authCtx = await getAuthContext(headers.authorization);
+    if (!authCtx) {
       return {
         status: 401 as const,
         body: {
@@ -26,13 +26,14 @@ const router = tsr.router(scheduleRunsContract, {
         },
       };
     }
+    const { userId, scopeId: tokenScopeId } = authCtx;
 
     log.debug(
       `Listing runs for schedule ${params.name} (limit: ${query.limit})`,
     );
 
     try {
-      const scopeId = await resolveScopeId(userId, query.scopeId);
+      const scopeId = await resolveScopeId(userId, query.scopeId, tokenScopeId);
 
       const runs = await getScheduleRecentRuns(
         userId,

--- a/turbo/apps/web/app/api/agent/schedules/route.ts
+++ b/turbo/apps/web/app/api/agent/schedules/route.ts
@@ -5,7 +5,7 @@ import {
 } from "../../../../src/lib/ts-rest-handler";
 import { schedulesMainContract } from "@vm0/core";
 import { initServices } from "../../../../src/lib/init-services";
-import { getUserId } from "../../../../src/lib/auth/get-user-id";
+import { getAuthContext } from "../../../../src/lib/auth/get-user-id";
 import { deploySchedule, listSchedules } from "../../../../src/lib/schedule";
 import { logger } from "../../../../src/lib/logger";
 import { isNotFound, isBadRequest } from "../../../../src/lib/errors";
@@ -18,8 +18,8 @@ const router = tsr.router(schedulesMainContract, {
   deploy: async ({ body, headers }) => {
     initServices();
 
-    const userId = await getUserId(headers.authorization);
-    if (!userId) {
+    const authCtx = await getAuthContext(headers.authorization);
+    if (!authCtx) {
       return {
         status: 401 as const,
         body: {
@@ -27,13 +27,14 @@ const router = tsr.router(schedulesMainContract, {
         },
       };
     }
+    const { userId, scopeId: tokenScopeId } = authCtx;
 
     log.debug(`Deploying schedule ${body.name} for compose ${body.composeId}`);
 
     try {
       // Note: vars and secrets are no longer accepted via API
       // They must be managed via platform tables (vm0 secret set, vm0 var set)
-      const scopeId = await resolveScopeId(userId, body.scopeId);
+      const scopeId = await resolveScopeId(userId, body.scopeId, tokenScopeId);
       const scope = await getScopeById(scopeId);
       if (!scope) {
         return {
@@ -86,8 +87,8 @@ const router = tsr.router(schedulesMainContract, {
   list: async ({ headers }) => {
     initServices();
 
-    const userId = await getUserId(headers.authorization);
-    if (!userId) {
+    const authCtx = await getAuthContext(headers.authorization);
+    if (!authCtx) {
       return {
         status: 401 as const,
         body: {
@@ -95,6 +96,7 @@ const router = tsr.router(schedulesMainContract, {
         },
       };
     }
+    const { userId } = authCtx;
 
     log.debug(`Listing schedules for user ${userId}`);
 

--- a/turbo/apps/web/app/api/cli/auth/test-token/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/cli/auth/test-token/__tests__/route.test.ts
@@ -6,10 +6,16 @@ import { reloadEnv } from "../../../../../../src/env";
 
 // Mock Clerk Server API
 const mockGetUserList = vi.fn();
+const mockGetOrganizationMembershipList = vi.fn();
+const mockCreateOrganization = vi.fn();
 vi.mock("@clerk/nextjs/server", () => ({
   clerkClient: vi.fn(async () => ({
     users: {
       getUserList: mockGetUserList,
+      getOrganizationMembershipList: mockGetOrganizationMembershipList,
+    },
+    organizations: {
+      createOrganization: mockCreateOrganization,
     },
   })),
   auth: vi.fn(),
@@ -23,9 +29,26 @@ describe("/api/cli/auth/test-token", () => {
     vi.stubEnv("CLERK_SECRET_KEY", "test-secret-key");
     reloadEnv();
     mockGetUserList.mockReset();
+    mockGetOrganizationMembershipList.mockReset();
+    mockCreateOrganization.mockReset();
     mockGetUserList.mockResolvedValue({
       data: [{ id: "user_test123" }],
     });
+    // Return a Clerk org membership so ensureDefaultScope can discover/create a local scope
+    mockGetOrganizationMembershipList.mockResolvedValue({
+      data: [
+        {
+          organization: {
+            id: "org_test_token",
+            slug: "test-token-org",
+            name: "test-token-org",
+          },
+          role: "org:admin",
+          publicUserData: { userId: "user_test123" },
+        },
+      ],
+    });
+    mockCreateOrganization.mockResolvedValue({ id: "org_mock_test" });
   });
 
   describe("environment-based access control", () => {

--- a/turbo/apps/web/app/api/cli/auth/test-token/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/cli/auth/test-token/__tests__/route.test.ts
@@ -18,7 +18,7 @@ vi.mock("@clerk/nextjs/server", () => ({
       createOrganization: mockCreateOrganization,
     },
   })),
-  auth: vi.fn(),
+  auth: vi.fn(async () => ({ userId: null, orgId: null, orgRole: null })),
 }));
 
 const context = testContext();

--- a/turbo/apps/web/app/api/cli/auth/test-token/route.ts
+++ b/turbo/apps/web/app/api/cli/auth/test-token/route.ts
@@ -2,18 +2,17 @@ import { NextResponse } from "next/server";
 import crypto from "crypto";
 import { initServices } from "../../../../../src/lib/init-services";
 import { cliTokens } from "../../../../../src/db/schema/cli-tokens";
-import { scopes } from "../../../../../src/db/schema/scope";
-import { scopeMembers } from "../../../../../src/db/schema/scope-member";
-import { generateDefaultScopeSlug } from "../../../../../src/lib/scope/scope-service";
-import { getPrimaryAdminMembership } from "../../../../../src/lib/scope/scope-member-service";
+import {
+  ensureDefaultScope,
+  createScope,
+  generateDefaultScopeSlug,
+} from "../../../../../src/lib/scope/scope-service";
+import { isNotFound } from "../../../../../src/lib/errors";
 import {
   resolveTestUserId,
   isTestVariant,
 } from "../../../../../src/lib/auth/test-user";
 import { env } from "../../../../../src/env";
-
-/** Sentinel Clerk org ID for test-created scopes (never hits Clerk API) */
-const TEST_CLERK_ORG_ID = "org_test_e2e";
 
 /**
  * Check if test-token endpoint is allowed based on environment.
@@ -42,51 +41,21 @@ function isTestTokenAllowed(request: Request): boolean {
 }
 
 /**
- * Ensure the test user has a scope, creating one directly in the database
- * if necessary. Unlike the normal createScope flow, this bypasses
- * Clerk Organization creation entirely — test scopes don't need a real
- * Clerk org, and the Clerk Backend API rejects org creation for
- * e2e test users (403 Forbidden).
+ * Ensure the test user has a scope with a real Clerk organization.
+ * Uses the same flow as production (ensureDefaultScope) so that
+ * Clerk API membership verification works during E2E tests.
+ *
+ * If the user has no Clerk org yet, creates one via createScope.
  */
 async function ensureTestScope(userId: string): Promise<void> {
-  // Use direct DB lookup instead of Clerk-based getDefaultScope because
-  // test scopes use a sentinel clerkOrgId that doesn't exist in Clerk.
-  const existing = await getPrimaryAdminMembership(userId);
-  if (existing) return;
-
-  const slug = generateDefaultScopeSlug(userId);
-
-  await globalThis.services.db.transaction(async (tx) => {
-    const [newScope] = await tx
-      .insert(scopes)
-      .values({ slug, clerkOrgId: TEST_CLERK_ORG_ID })
-      .onConflictDoNothing({ target: scopes.slug })
-      .returning();
-
-    if (!newScope) {
-      // Slug conflict — use a random fallback
-      const fallbackSlug = `user-${crypto.randomBytes(4).toString("hex")}`;
-      const [fallback] = await tx
-        .insert(scopes)
-        .values({ slug: fallbackSlug, clerkOrgId: TEST_CLERK_ORG_ID })
-        .returning();
-      if (!fallback) {
-        throw new Error("Failed to create test scope with fallback slug");
-      }
-      await tx.insert(scopeMembers).values({
-        scopeId: fallback.id,
-        userId,
-        role: "admin",
-      });
-      return;
-    }
-
-    await tx.insert(scopeMembers).values({
-      scopeId: newScope.id,
-      userId,
-      role: "admin",
-    });
-  });
+  try {
+    await ensureDefaultScope(userId);
+  } catch (error) {
+    if (!isNotFound(error)) throw error;
+    // User has no Clerk org — create one via the normal scope creation flow
+    const slug = generateDefaultScopeSlug(userId);
+    await createScope(userId, slug);
+  }
 }
 
 /**
@@ -116,7 +85,7 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "Test user not found" }, { status: 500 });
   }
 
-  // Auto-create scope if user doesn't have one (bypasses Clerk org creation)
+  // Auto-create scope if user doesn't have one (creates real Clerk org)
   await ensureTestScope(userId);
 
   // Generate CLI token

--- a/turbo/apps/web/app/api/cli/auth/test-token/route.ts
+++ b/turbo/apps/web/app/api/cli/auth/test-token/route.ts
@@ -47,15 +47,19 @@ function isTestTokenAllowed(request: Request): boolean {
  *
  * If the user has no Clerk org yet, creates one via createScope.
  */
-async function ensureTestScope(userId: string): Promise<void> {
+async function ensureTestScope(
+  userId: string,
+): Promise<{ scopeId: string; clerkOrgId: string }> {
+  let scope;
   try {
-    await ensureDefaultScope(userId);
+    scope = await ensureDefaultScope(userId);
   } catch (error) {
     if (!isNotFound(error)) throw error;
     // User has no Clerk org — create one via the normal scope creation flow
     const slug = generateDefaultScopeSlug(userId);
-    await createScope(userId, slug);
+    scope = await createScope(userId, slug);
   }
+  return { scopeId: scope.id, clerkOrgId: scope.clerkOrgId };
 }
 
 /**
@@ -86,9 +90,9 @@ export async function POST(request: Request) {
   }
 
   // Auto-create scope if user doesn't have one (creates real Clerk org)
-  await ensureTestScope(userId);
+  const { scopeId, clerkOrgId } = await ensureTestScope(userId);
 
-  // Generate CLI token
+  // Generate CLI token with scope binding
   const randomBytes = crypto.randomBytes(32);
   const token = `vm0_live_${randomBytes.toString("base64url")}`;
   const now = new Date();
@@ -98,6 +102,8 @@ export async function POST(request: Request) {
     token,
     userId,
     name: "CI Test Token",
+    scopeId,
+    clerkOrgId,
     expiresAt,
     createdAt: now,
   });

--- a/turbo/apps/web/app/api/cli/auth/test-token/route.ts
+++ b/turbo/apps/web/app/api/cli/auth/test-token/route.ts
@@ -4,10 +4,8 @@ import { initServices } from "../../../../../src/lib/init-services";
 import { cliTokens } from "../../../../../src/db/schema/cli-tokens";
 import { scopes } from "../../../../../src/db/schema/scope";
 import { scopeMembers } from "../../../../../src/db/schema/scope-member";
-import {
-  getDefaultScopeByClerkUserId,
-  generateDefaultScopeSlug,
-} from "../../../../../src/lib/scope/scope-service";
+import { generateDefaultScopeSlug } from "../../../../../src/lib/scope/scope-service";
+import { getPrimaryAdminMembership } from "../../../../../src/lib/scope/scope-member-service";
 import {
   resolveTestUserId,
   isTestVariant,
@@ -51,7 +49,9 @@ function isTestTokenAllowed(request: Request): boolean {
  * e2e test users (403 Forbidden).
  */
 async function ensureTestScope(userId: string): Promise<void> {
-  const existing = await getDefaultScopeByClerkUserId(userId);
+  // Use direct DB lookup instead of Clerk-based getDefaultScope because
+  // test scopes use a sentinel clerkOrgId that doesn't exist in Clerk.
+  const existing = await getPrimaryAdminMembership(userId);
   if (existing) return;
 
   const slug = generateDefaultScopeSlug(userId);

--- a/turbo/apps/web/app/api/cli/auth/token/route.ts
+++ b/turbo/apps/web/app/api/cli/auth/token/route.ts
@@ -75,9 +75,9 @@ const router = tsr.router(cliAuthTokenContract, {
         const userId = session.userId as string;
 
         // Ensure user has a default scope
-        await ensureDefaultScope(userId);
+        const scope = await ensureDefaultScope(userId);
 
-        // Generate CLI token
+        // Generate CLI token with scope binding
         const randomBytes = crypto.randomBytes(32);
         const cliToken = `vm0_live_${randomBytes.toString("base64url")}`;
         const now = new Date();
@@ -87,6 +87,8 @@ const router = tsr.router(cliAuthTokenContract, {
           token: cliToken,
           userId,
           name: "CLI Device Flow Authentication",
+          scopeId: scope.id,
+          clerkOrgId: scope.clerkOrgId,
           expiresAt,
           createdAt: now,
         });

--- a/turbo/apps/web/app/api/connectors/[type]/callback/route.ts
+++ b/turbo/apps/web/app/api/connectors/[type]/callback/route.ts
@@ -7,7 +7,7 @@ import {
 } from "@vm0/core";
 import { env } from "../../../../../src/env";
 import { initServices } from "../../../../../src/lib/init-services";
-import { getUserIdFromRequest } from "../../../../../src/lib/auth/get-user-id";
+import { getAuthContext } from "../../../../../src/lib/auth/get-user-id";
 import { resolveScope } from "../../../../../src/lib/scope/resolve-scope";
 import { upsertOAuthConnector } from "../../../../../src/lib/connector/connector-service";
 import { connectorSessions } from "../../../../../src/db/schema/connector-session";
@@ -109,9 +109,10 @@ export async function GET(
   const connectorType = typeResult.data;
 
   // Verify user is authenticated
-  const userId = await getUserIdFromRequest(request);
-  log.debug("OAuth callback auth check", { userId, hasUserId: !!userId });
-  if (!userId) {
+  const authHeader = request.headers.get("authorization") ?? undefined;
+  const authCtx = await getAuthContext(authHeader);
+  log.debug("OAuth callback auth check", { hasAuth: !!authCtx });
+  if (!authCtx) {
     return redirectWithError(origin, type, "Not authenticated");
   }
 
@@ -180,6 +181,8 @@ export async function GET(
         codeVerifier,
       );
 
+    const { userId, scopeId: tokenScopeId } = authCtx;
+
     log.debug("Storing connector", {
       userId,
       type,
@@ -197,7 +200,7 @@ export async function GET(
     // when the code adds new scopes and prompt users to re-authorize.
     // Note: do not read "scope" from the callback URL — OAuth providers (e.g., Monday.com)
     // may append OAuth scopes as ?scope=... which would be mistaken for an app scope slug.
-    const { scope } = await resolveScope(userId);
+    const { scope } = await resolveScope(userId, null, null, tokenScopeId);
     const { created } = await upsertOAuthConnector(
       scope.id,
       userId,

--- a/turbo/apps/web/app/api/connectors/[type]/route.ts
+++ b/turbo/apps/web/app/api/connectors/[type]/route.ts
@@ -1,7 +1,7 @@
 import { createHandler, tsr } from "../../../../src/lib/ts-rest-handler";
 import { connectorsByTypeContract, createErrorResponse } from "@vm0/core";
 import { initServices } from "../../../../src/lib/init-services";
-import { getUserId } from "../../../../src/lib/auth/get-user-id";
+import { getAuthContext } from "../../../../src/lib/auth/get-user-id";
 import { resolveScope } from "../../../../src/lib/scope/resolve-scope";
 import {
   getConnector,
@@ -16,13 +16,14 @@ const router = tsr.router(connectorsByTypeContract, {
   get: async ({ params, headers }, { request }) => {
     initServices();
 
-    const userId = await getUserId(headers.authorization);
-    if (!userId) {
+    const authCtx = await getAuthContext(headers.authorization);
+    if (!authCtx) {
       return createErrorResponse("UNAUTHORIZED", "Not authenticated");
     }
+    const { userId, scopeId: tokenScopeId } = authCtx;
 
     const scopeSlug = new URL(request.url).searchParams.get("scope");
-    const { scope } = await resolveScope(userId, scopeSlug);
+    const { scope } = await resolveScope(userId, scopeSlug, null, tokenScopeId);
     const connector = await getConnector(scope.id, userId, params.type);
 
     if (!connector) {
@@ -41,14 +42,20 @@ const router = tsr.router(connectorsByTypeContract, {
   delete: async ({ params, headers }, { request }) => {
     initServices();
 
-    const userId = await getUserId(headers.authorization);
-    if (!userId) {
+    const authCtx = await getAuthContext(headers.authorization);
+    if (!authCtx) {
       return createErrorResponse("UNAUTHORIZED", "Not authenticated");
     }
+    const { userId, scopeId: tokenScopeId } = authCtx;
 
     try {
       const scopeSlug = new URL(request.url).searchParams.get("scope");
-      const { scope } = await resolveScope(userId, scopeSlug);
+      const { scope } = await resolveScope(
+        userId,
+        scopeSlug,
+        null,
+        tokenScopeId,
+      );
       await deleteConnector(scope.id, userId, params.type);
 
       return {

--- a/turbo/apps/web/app/api/connectors/computer/route.ts
+++ b/turbo/apps/web/app/api/connectors/computer/route.ts
@@ -1,7 +1,7 @@
 import { createHandler, tsr } from "../../../../src/lib/ts-rest-handler";
 import { computerConnectorContract, createErrorResponse } from "@vm0/core";
 import { initServices } from "../../../../src/lib/init-services";
-import { getUserId } from "../../../../src/lib/auth/get-user-id";
+import { getAuthContext } from "../../../../src/lib/auth/get-user-id";
 import { resolveScope } from "../../../../src/lib/scope/resolve-scope";
 import { getConnector } from "../../../../src/lib/connector/connector-service";
 import {
@@ -21,14 +21,20 @@ const router = tsr.router(computerConnectorContract, {
   create: async ({ headers }, { request }) => {
     initServices();
 
-    const userId = await getUserId(headers.authorization);
-    if (!userId) {
+    const authCtx = await getAuthContext(headers.authorization);
+    if (!authCtx) {
       return createErrorResponse("UNAUTHORIZED", "Not authenticated");
     }
+    const { userId, scopeId: tokenScopeId } = authCtx;
 
     try {
       const scopeSlug = new URL(request.url).searchParams.get("scope");
-      const { scope } = await resolveScope(userId, scopeSlug);
+      const { scope } = await resolveScope(
+        userId,
+        scopeSlug,
+        null,
+        tokenScopeId,
+      );
       const result = await createComputerConnector(
         scope.id,
         userId,
@@ -52,13 +58,14 @@ const router = tsr.router(computerConnectorContract, {
   get: async ({ headers }, { request }) => {
     initServices();
 
-    const userId = await getUserId(headers.authorization);
-    if (!userId) {
+    const authCtx = await getAuthContext(headers.authorization);
+    if (!authCtx) {
       return createErrorResponse("UNAUTHORIZED", "Not authenticated");
     }
+    const { userId, scopeId: tokenScopeId } = authCtx;
 
     const scopeSlug = new URL(request.url).searchParams.get("scope");
-    const { scope } = await resolveScope(userId, scopeSlug);
+    const { scope } = await resolveScope(userId, scopeSlug, null, tokenScopeId);
     const connector = await getConnector(scope.id, userId, "computer");
     if (!connector) {
       return createErrorResponse("NOT_FOUND", "Computer connector not found");
@@ -73,14 +80,20 @@ const router = tsr.router(computerConnectorContract, {
   delete: async ({ headers }, { request }) => {
     initServices();
 
-    const userId = await getUserId(headers.authorization);
-    if (!userId) {
+    const authCtx = await getAuthContext(headers.authorization);
+    if (!authCtx) {
       return createErrorResponse("UNAUTHORIZED", "Not authenticated");
     }
+    const { userId, scopeId: tokenScopeId } = authCtx;
 
     try {
       const scopeSlug = new URL(request.url).searchParams.get("scope");
-      const { scope } = await resolveScope(userId, scopeSlug);
+      const { scope } = await resolveScope(
+        userId,
+        scopeSlug,
+        null,
+        tokenScopeId,
+      );
       await deleteComputerConnector(scope.id, userId);
       return { status: 204 as const, body: undefined };
     } catch (error) {

--- a/turbo/apps/web/app/api/connectors/route.ts
+++ b/turbo/apps/web/app/api/connectors/route.ts
@@ -5,7 +5,7 @@ import {
   getConnectorProvidedSecretNames,
 } from "@vm0/core";
 import { initServices } from "../../../src/lib/init-services";
-import { getUserId } from "../../../src/lib/auth/get-user-id";
+import { getAuthContext } from "../../../src/lib/auth/get-user-id";
 import { resolveScope } from "../../../src/lib/scope/resolve-scope";
 import { listConnectors } from "../../../src/lib/connector/connector-service";
 import { getConfiguredConnectorTypes } from "../../../src/lib/connector/provider-registry";
@@ -17,13 +17,14 @@ const router = tsr.router(connectorsMainContract, {
   list: async ({ headers }, { request }) => {
     initServices();
 
-    const userId = await getUserId(headers.authorization);
-    if (!userId) {
+    const authCtx = await getAuthContext(headers.authorization);
+    if (!authCtx) {
       return createErrorResponse("UNAUTHORIZED", "Not authenticated");
     }
+    const { userId, scopeId: tokenScopeId } = authCtx;
 
     const scopeSlug = new URL(request.url).searchParams.get("scope");
-    const { scope } = await resolveScope(userId, scopeSlug);
+    const { scope } = await resolveScope(userId, scopeSlug, null, tokenScopeId);
     const connectorList = await listConnectors(scope.id, userId);
     const configuredTypes = getConfiguredConnectorTypes(
       globalThis.services.env,

--- a/turbo/apps/web/app/api/integrations/github/route.ts
+++ b/turbo/apps/web/app/api/integrations/github/route.ts
@@ -7,7 +7,7 @@ import {
 } from "@vm0/core";
 import { initServices } from "../../../../src/lib/init-services";
 import { env } from "../../../../src/env";
-import { getUserId } from "../../../../src/lib/auth/get-user-id";
+import { getAuthContext } from "../../../../src/lib/auth/get-user-id";
 import { getApiUrl } from "../../../../src/lib/callback";
 import { githubInstallations } from "../../../../src/db/schema/github-installation";
 import { githubUserLinks } from "../../../../src/db/schema/github-user-link";
@@ -36,14 +36,15 @@ export async function GET(request: Request) {
   initServices();
 
   const authHeader = request.headers.get("authorization");
-  const userId = await getUserId(authHeader ?? undefined);
+  const authCtx = await getAuthContext(authHeader ?? undefined);
 
-  if (!userId) {
+  if (!authCtx) {
     return NextResponse.json(
       { error: { message: "Not authenticated", code: "UNAUTHORIZED" } },
       { status: 401 },
     );
   }
+  const { userId, scopeId: tokenScopeId } = authCtx;
 
   const db = globalThis.services.db;
 
@@ -121,7 +122,7 @@ export async function GET(request: Request) {
   }
 
   // Resolve user's scope for resource queries
-  const { scope } = await resolveScope(userId);
+  const { scope } = await resolveScope(userId, null, null, tokenScopeId);
 
   // Get user's existing secrets, vars, connectors
   const [userSecrets, userVars, userConnectors] = await Promise.all([
@@ -177,14 +178,15 @@ export async function DELETE(request: Request) {
   initServices();
 
   const authHeader = request.headers.get("authorization");
-  const userId = await getUserId(authHeader ?? undefined);
+  const authCtx = await getAuthContext(authHeader ?? undefined);
 
-  if (!userId) {
+  if (!authCtx) {
     return NextResponse.json(
       { error: { message: "Not authenticated", code: "UNAUTHORIZED" } },
       { status: 401 },
     );
   }
+  const { userId } = authCtx;
 
   const db = globalThis.services.db;
 
@@ -263,14 +265,15 @@ export async function PATCH(request: Request) {
   initServices();
 
   const authHeader = request.headers.get("authorization");
-  const userId = await getUserId(authHeader ?? undefined);
+  const authCtx = await getAuthContext(authHeader ?? undefined);
 
-  if (!userId) {
+  if (!authCtx) {
     return NextResponse.json(
       { error: { message: "Not authenticated", code: "UNAUTHORIZED" } },
       { status: 401 },
     );
   }
+  const { userId } = authCtx;
 
   const body = (await request.json()) as { agentName?: string };
   if (!body.agentName) {

--- a/turbo/apps/web/app/api/integrations/slack/route.ts
+++ b/turbo/apps/web/app/api/integrations/slack/route.ts
@@ -7,7 +7,7 @@ import {
 } from "@vm0/core";
 import { initServices } from "../../../../src/lib/init-services";
 import { env } from "../../../../src/env";
-import { getUserId } from "../../../../src/lib/auth/get-user-id";
+import { getAuthContext } from "../../../../src/lib/auth/get-user-id";
 import { slackUserLinks } from "../../../../src/db/schema/slack-user-link";
 import { slackInstallations } from "../../../../src/db/schema/slack-installation";
 import {
@@ -41,14 +41,15 @@ export async function GET(request: Request) {
   initServices();
 
   const authHeader = request.headers.get("authorization");
-  const userId = await getUserId(authHeader ?? undefined);
+  const authCtx = await getAuthContext(authHeader ?? undefined);
 
-  if (!userId) {
+  if (!authCtx) {
     return NextResponse.json(
       { error: { message: "Not authenticated", code: "UNAUTHORIZED" } },
       { status: 401 },
     );
   }
+  const { userId, scopeId: tokenScopeId } = authCtx;
 
   const db = globalThis.services.db;
 
@@ -124,7 +125,7 @@ export async function GET(request: Request) {
   }
 
   // Get user's existing secrets, vars, connectors
-  const { scope } = await resolveScope(userId);
+  const { scope } = await resolveScope(userId, null, null, tokenScopeId);
   const [userSecrets, userVars, userConnectors] = await Promise.all([
     listSecrets(scope.id, userId),
     listVariables(scope.clerkOrgId, userId),
@@ -176,14 +177,15 @@ export async function DELETE(request: Request) {
   initServices();
 
   const authHeader = request.headers.get("authorization");
-  const userId = await getUserId(authHeader ?? undefined);
+  const authCtx = await getAuthContext(authHeader ?? undefined);
 
-  if (!userId) {
+  if (!authCtx) {
     return NextResponse.json(
       { error: { message: "Not authenticated", code: "UNAUTHORIZED" } },
       { status: 401 },
     );
   }
+  const { userId } = authCtx;
 
   const { SECRETS_ENCRYPTION_KEY } = env();
   const db = globalThis.services.db;
@@ -246,14 +248,15 @@ export async function PATCH(request: Request) {
   initServices();
 
   const authHeader = request.headers.get("authorization");
-  const userId = await getUserId(authHeader ?? undefined);
+  const authCtx = await getAuthContext(authHeader ?? undefined);
 
-  if (!userId) {
+  if (!authCtx) {
     return NextResponse.json(
       { error: { message: "Not authenticated", code: "UNAUTHORIZED" } },
       { status: 401 },
     );
   }
+  const { userId, scopeId: tokenScopeId } = authCtx;
 
   const body = (await request.json()) as { agentName?: string };
   if (!body.agentName) {
@@ -326,7 +329,7 @@ export async function PATCH(request: Request) {
     }
     targetClerkOrgId = targetScope.clerkOrgId;
   } else {
-    const { scope } = await resolveScope(userId);
+    const { scope } = await resolveScope(userId, null, null, tokenScopeId);
     targetClerkOrgId = scope.clerkOrgId;
   }
 

--- a/turbo/apps/web/app/api/integrations/telegram/route.ts
+++ b/turbo/apps/web/app/api/integrations/telegram/route.ts
@@ -8,7 +8,7 @@ import {
 } from "@vm0/core";
 import { initServices } from "../../../../src/lib/init-services";
 import { env } from "../../../../src/env";
-import { getUserId } from "../../../../src/lib/auth/get-user-id";
+import { getAuthContext } from "../../../../src/lib/auth/get-user-id";
 import { telegramUserLinks } from "../../../../src/db/schema/telegram-user-link";
 import { telegramInstallations } from "../../../../src/db/schema/telegram-installation";
 import {
@@ -44,14 +44,15 @@ export async function GET(request: Request) {
   initServices();
 
   const authHeader = request.headers.get("authorization");
-  const userId = await getUserId(authHeader ?? undefined);
+  const authCtx = await getAuthContext(authHeader ?? undefined);
 
-  if (!userId) {
+  if (!authCtx) {
     return NextResponse.json(
       { error: { message: "Not authenticated", code: "UNAUTHORIZED" } },
       { status: 401 },
     );
   }
+  const { userId, scopeId: tokenScopeId } = authCtx;
 
   const db = globalThis.services.db;
 
@@ -123,7 +124,7 @@ export async function GET(request: Request) {
   }
 
   // Resolve user's default scope and get existing secrets, vars, connectors
-  const { scope } = await resolveScope(userId);
+  const { scope } = await resolveScope(userId, null, null, tokenScopeId);
   const [userSecrets, userVars, userConnectors] = await Promise.all([
     listSecrets(scope.id, userId),
     listVariables(scope.clerkOrgId, userId),
@@ -187,14 +188,15 @@ export async function PATCH(request: Request) {
   initServices();
 
   const authHeader = request.headers.get("authorization");
-  const userId = await getUserId(authHeader ?? undefined);
+  const authCtx = await getAuthContext(authHeader ?? undefined);
 
-  if (!userId) {
+  if (!authCtx) {
     return NextResponse.json(
       { error: { message: "Not authenticated", code: "UNAUTHORIZED" } },
       { status: 401 },
     );
   }
+  const { userId, scopeId: tokenScopeId } = authCtx;
 
   const parseResult = patchBodySchema.safeParse(await request.json());
   if (!parseResult.success) {
@@ -268,7 +270,12 @@ export async function PATCH(request: Request) {
     }
   } else {
     try {
-      ({ scope: targetScope } = await resolveScope(userId));
+      ({ scope: targetScope } = await resolveScope(
+        userId,
+        null,
+        null,
+        tokenScopeId,
+      ));
     } catch (error) {
       if (isNotFound(error)) {
         return NextResponse.json(
@@ -318,14 +325,15 @@ export async function DELETE(request: Request) {
   initServices();
 
   const authHeader = request.headers.get("authorization");
-  const userId = await getUserId(authHeader ?? undefined);
+  const authCtx = await getAuthContext(authHeader ?? undefined);
 
-  if (!userId) {
+  if (!authCtx) {
     return NextResponse.json(
       { error: { message: "Not authenticated", code: "UNAUTHORIZED" } },
       { status: 401 },
     );
   }
+  const { userId } = authCtx;
 
   const { SECRETS_ENCRYPTION_KEY } = env();
   const db = globalThis.services.db;

--- a/turbo/apps/web/app/api/model-providers/[type]/model/route.ts
+++ b/turbo/apps/web/app/api/model-providers/[type]/model/route.ts
@@ -4,7 +4,7 @@ import {
   createErrorResponse,
 } from "@vm0/core";
 import { initServices } from "../../../../../src/lib/init-services";
-import { getUserId } from "../../../../../src/lib/auth/get-user-id";
+import { getAuthContext } from "../../../../../src/lib/auth/get-user-id";
 import { resolveScope } from "../../../../../src/lib/scope/resolve-scope";
 import { updateModelProviderModel } from "../../../../../src/lib/model-provider/model-provider-service";
 import { logger } from "../../../../../src/lib/logger";
@@ -19,10 +19,11 @@ const router = tsr.router(modelProvidersUpdateModelContract, {
   updateModel: async ({ params, body, headers }, { request }) => {
     initServices();
 
-    const userId = await getUserId(headers.authorization);
-    if (!userId) {
+    const authCtx = await getAuthContext(headers.authorization);
+    if (!authCtx) {
       return createErrorResponse("UNAUTHORIZED", "Not authenticated");
     }
+    const { userId, scopeId: tokenScopeId } = authCtx;
 
     log.debug("updating model provider model", {
       userId,
@@ -32,7 +33,12 @@ const router = tsr.router(modelProvidersUpdateModelContract, {
 
     try {
       const scopeSlug = new URL(request.url).searchParams.get("scope");
-      const { scope } = await resolveScope(userId, scopeSlug);
+      const { scope } = await resolveScope(
+        userId,
+        scopeSlug,
+        null,
+        tokenScopeId,
+      );
       const provider = await updateModelProviderModel(
         scope.id,
         userId,

--- a/turbo/apps/web/app/api/model-providers/[type]/route.ts
+++ b/turbo/apps/web/app/api/model-providers/[type]/route.ts
@@ -1,7 +1,7 @@
 import { createHandler, tsr } from "../../../../src/lib/ts-rest-handler";
 import { modelProvidersByTypeContract, createErrorResponse } from "@vm0/core";
 import { initServices } from "../../../../src/lib/init-services";
-import { getUserId } from "../../../../src/lib/auth/get-user-id";
+import { getAuthContext } from "../../../../src/lib/auth/get-user-id";
 import { resolveScope } from "../../../../src/lib/scope/resolve-scope";
 import { deleteModelProvider } from "../../../../src/lib/model-provider/model-provider-service";
 import { logger } from "../../../../src/lib/logger";
@@ -16,16 +16,22 @@ const router = tsr.router(modelProvidersByTypeContract, {
   delete: async ({ params, headers }, { request }) => {
     initServices();
 
-    const userId = await getUserId(headers.authorization);
-    if (!userId) {
+    const authCtx = await getAuthContext(headers.authorization);
+    if (!authCtx) {
       return createErrorResponse("UNAUTHORIZED", "Not authenticated");
     }
+    const { userId, scopeId: tokenScopeId } = authCtx;
 
     log.debug("deleting model provider", { userId, type: params.type });
 
     try {
       const scopeSlug = new URL(request.url).searchParams.get("scope");
-      const { scope } = await resolveScope(userId, scopeSlug);
+      const { scope } = await resolveScope(
+        userId,
+        scopeSlug,
+        null,
+        tokenScopeId,
+      );
       await deleteModelProvider(scope.id, userId, params.type);
 
       return {

--- a/turbo/apps/web/app/api/model-providers/[type]/set-default/route.ts
+++ b/turbo/apps/web/app/api/model-providers/[type]/set-default/route.ts
@@ -4,7 +4,7 @@ import {
   createErrorResponse,
 } from "@vm0/core";
 import { initServices } from "../../../../../src/lib/init-services";
-import { getUserId } from "../../../../../src/lib/auth/get-user-id";
+import { getAuthContext } from "../../../../../src/lib/auth/get-user-id";
 import { resolveScope } from "../../../../../src/lib/scope/resolve-scope";
 import { setModelProviderDefault } from "../../../../../src/lib/model-provider/model-provider-service";
 import { logger } from "../../../../../src/lib/logger";
@@ -19,10 +19,11 @@ const router = tsr.router(modelProvidersSetDefaultContract, {
   setDefault: async ({ params, headers }, { request }) => {
     initServices();
 
-    const userId = await getUserId(headers.authorization);
-    if (!userId) {
+    const authCtx = await getAuthContext(headers.authorization);
+    if (!authCtx) {
       return createErrorResponse("UNAUTHORIZED", "Not authenticated");
     }
+    const { userId, scopeId: tokenScopeId } = authCtx;
 
     log.debug("setting model provider as default", {
       userId,
@@ -31,7 +32,12 @@ const router = tsr.router(modelProvidersSetDefaultContract, {
 
     try {
       const scopeSlug = new URL(request.url).searchParams.get("scope");
-      const { scope } = await resolveScope(userId, scopeSlug);
+      const { scope } = await resolveScope(
+        userId,
+        scopeSlug,
+        null,
+        tokenScopeId,
+      );
       const provider = await setModelProviderDefault(
         scope.id,
         userId,

--- a/turbo/apps/web/app/api/model-providers/check/[type]/route.ts
+++ b/turbo/apps/web/app/api/model-providers/check/[type]/route.ts
@@ -5,7 +5,7 @@ import {
   getSecretNameForType,
 } from "@vm0/core";
 import { initServices } from "../../../../../src/lib/init-services";
-import { getUserId } from "../../../../../src/lib/auth/get-user-id";
+import { getAuthContext } from "../../../../../src/lib/auth/get-user-id";
 import { resolveScope } from "../../../../../src/lib/scope/resolve-scope";
 import { checkSecretExists } from "../../../../../src/lib/model-provider/model-provider-service";
 
@@ -16,13 +16,14 @@ const router = tsr.router(modelProvidersCheckContract, {
   check: async ({ params, headers }, { request }) => {
     initServices();
 
-    const userId = await getUserId(headers.authorization);
-    if (!userId) {
+    const authCtx = await getAuthContext(headers.authorization);
+    if (!authCtx) {
       return createErrorResponse("UNAUTHORIZED", "Not authenticated");
     }
+    const { userId, scopeId: tokenScopeId } = authCtx;
 
     const scopeSlug = new URL(request.url).searchParams.get("scope");
-    const { scope } = await resolveScope(userId, scopeSlug);
+    const { scope } = await resolveScope(userId, scopeSlug, null, tokenScopeId);
     const result = await checkSecretExists(scope.id, userId, params.type);
 
     return {

--- a/turbo/apps/web/app/api/model-providers/route.ts
+++ b/turbo/apps/web/app/api/model-providers/route.ts
@@ -5,7 +5,7 @@ import {
   hasAuthMethods,
 } from "@vm0/core";
 import { initServices } from "../../../src/lib/init-services";
-import { getUserId } from "../../../src/lib/auth/get-user-id";
+import { getAuthContext } from "../../../src/lib/auth/get-user-id";
 import { resolveScope } from "../../../src/lib/scope/resolve-scope";
 import {
   listModelProviders,
@@ -24,13 +24,14 @@ const router = tsr.router(modelProvidersMainContract, {
   list: async ({ headers }, { request }) => {
     initServices();
 
-    const userId = await getUserId(headers.authorization);
-    if (!userId) {
+    const authCtx = await getAuthContext(headers.authorization);
+    if (!authCtx) {
       return createErrorResponse("UNAUTHORIZED", "Not authenticated");
     }
+    const { userId, scopeId: tokenScopeId } = authCtx;
 
     const scopeSlug = new URL(request.url).searchParams.get("scope");
-    const { scope } = await resolveScope(userId, scopeSlug);
+    const { scope } = await resolveScope(userId, scopeSlug, null, tokenScopeId);
     const providers = await listModelProviders(scope.id, userId);
 
     return {
@@ -58,10 +59,11 @@ const router = tsr.router(modelProvidersMainContract, {
   upsert: async ({ body, headers }, { request }) => {
     initServices();
 
-    const userId = await getUserId(headers.authorization);
-    if (!userId) {
+    const authCtx = await getAuthContext(headers.authorization);
+    if (!authCtx) {
       return createErrorResponse("UNAUTHORIZED", "Not authenticated");
     }
+    const { userId, scopeId: tokenScopeId } = authCtx;
 
     const { type, secret, authMethod, secrets, selectedModel } = body;
 
@@ -69,7 +71,12 @@ const router = tsr.router(modelProvidersMainContract, {
 
     try {
       const scopeSlug = new URL(request.url).searchParams.get("scope");
-      const { scope } = await resolveScope(userId, scopeSlug);
+      const { scope } = await resolveScope(
+        userId,
+        scopeSlug,
+        null,
+        tokenScopeId,
+      );
 
       // Determine if this is a multi-auth provider or legacy provider
       const isMultiAuth = hasAuthMethods(type);

--- a/turbo/apps/web/app/api/runners/jobs/[id]/claim/route.ts
+++ b/turbo/apps/web/app/api/runners/jobs/[id]/claim/route.ts
@@ -84,7 +84,11 @@ const router = tsr.router(runnersJobClaimContract, {
       }
 
       try {
-        await validateRunnerGroupScope(auth.userId, jobWithRun.job.runnerGroup);
+        await validateRunnerGroupScope(
+          auth.userId,
+          jobWithRun.job.runnerGroup,
+          auth.scopeId,
+        );
       } catch (error) {
         return createErrorResponse(
           "FORBIDDEN",

--- a/turbo/apps/web/app/api/runners/poll/route.ts
+++ b/turbo/apps/web/app/api/runners/poll/route.ts
@@ -48,7 +48,7 @@ const router = tsr.router(runnersPollContract, {
     } else {
       // User runners: validate scope and filter by userId
       try {
-        await validateRunnerGroupScope(auth.userId, group);
+        await validateRunnerGroupScope(auth.userId, group, auth.scopeId);
       } catch (error) {
         return createErrorResponse(
           "FORBIDDEN",

--- a/turbo/apps/web/app/api/runners/realtime/token/route.ts
+++ b/turbo/apps/web/app/api/runners/realtime/token/route.ts
@@ -35,7 +35,7 @@ const router = tsr.router(runnerRealtimeTokenContract, {
     } else {
       // User runners: validate scope
       try {
-        await validateRunnerGroupScope(auth.userId, group);
+        await validateRunnerGroupScope(auth.userId, group, auth.scopeId);
       } catch (error) {
         return createErrorResponse(
           "FORBIDDEN",

--- a/turbo/apps/web/app/api/scope/__tests__/remove-member.test.ts
+++ b/turbo/apps/web/app/api/scope/__tests__/remove-member.test.ts
@@ -209,10 +209,9 @@ describe("DELETE /api/scope/members - Remove Member", () => {
     expect(removeRes.status).toBe(200);
 
     // Verify member is no longer in the Clerk org membership list.
-    // Note: the stale scope_members record still grants route access during
-    // the migration period, but the Clerk-based members list won't include them.
+    // Use admin user to check — the removed member can no longer access the scope.
     setupClerkOrgMock({
-      userId: memberUserId,
+      userId: adminUserId,
       orgId,
       memberships: [{ userId: adminUserId, role: "org:admin" }],
     });

--- a/turbo/apps/web/app/api/scope/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/scope/__tests__/route.test.ts
@@ -440,8 +440,15 @@ describe("/api/scope", () => {
       });
       await POST(req2);
 
-      // Set active org to second scope's clerkOrgId
-      mockClerk({ userId, orgId: `org_mock_${slug2}` });
+      // Set active org to second scope's clerkOrgId, include both scope orgs
+      mockClerk({
+        userId,
+        orgId: `org_mock_${slug2}`,
+        clerkOrgs: [
+          { id: `org_mock_${slug1}`, slug: slug1, name: slug1 },
+          { id: `org_mock_${slug2}`, slug: slug2, name: slug2 },
+        ],
+      });
 
       const request = createTestRequest("http://localhost:3000/api/scope");
       const response = await GET(request);
@@ -464,8 +471,12 @@ describe("/api/scope", () => {
       });
       await POST(reqCreate);
 
-      // Set an orgId that doesn't match any scope
-      mockClerk({ userId, orgId: "org_nonexistent_xyz" });
+      // Set an orgId that doesn't match any scope, but include the created scope org
+      mockClerk({
+        userId,
+        orgId: "org_nonexistent_xyz",
+        clerkOrgs: [{ id: `org_mock_${slug}`, slug, name: slug }],
+      });
 
       const request = createTestRequest("http://localhost:3000/api/scope");
       const response = await GET(request);

--- a/turbo/apps/web/app/api/scope/invite/route.ts
+++ b/turbo/apps/web/app/api/scope/invite/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { initServices } from "../../../../src/lib/init-services";
-import { getUserId } from "../../../../src/lib/auth/get-user-id";
+import { getAuthContext } from "../../../../src/lib/auth/get-user-id";
 import { requireScopeFromRequest } from "../../../../src/lib/scope/resolve-scope";
 import { inviteMember } from "../../../../src/lib/scope/scope-member-service";
 import {
@@ -16,13 +16,14 @@ export async function POST(request: Request) {
   initServices();
 
   const authHeader = request.headers.get("authorization") ?? undefined;
-  const userId = await getUserId(authHeader);
-  if (!userId) {
+  const authCtx = await getAuthContext(authHeader);
+  if (!authCtx) {
     return NextResponse.json(
       { error: { message: "Not authenticated", code: "UNAUTHORIZED" } },
       { status: 401 },
     );
   }
+  const { userId, scopeId: tokenScopeId } = authCtx;
 
   const body = (await request.json()) as { email: string };
   if (!body.email) {
@@ -33,7 +34,11 @@ export async function POST(request: Request) {
   }
 
   try {
-    const { scope, member } = await requireScopeFromRequest(request, userId);
+    const { scope, member } = await requireScopeFromRequest(
+      request,
+      userId,
+      tokenScopeId,
+    );
     await inviteMember(userId, scope.id, member.role, body.email);
     return NextResponse.json({ message: `Invitation sent to ${body.email}` });
   } catch (error) {

--- a/turbo/apps/web/app/api/scope/leave/route.ts
+++ b/turbo/apps/web/app/api/scope/leave/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { initServices } from "../../../../src/lib/init-services";
-import { getUserId } from "../../../../src/lib/auth/get-user-id";
+import { getAuthContext } from "../../../../src/lib/auth/get-user-id";
 import { requireScopeFromRequest } from "../../../../src/lib/scope/resolve-scope";
 import { leaveScope } from "../../../../src/lib/scope/scope-member-service";
 import {
@@ -16,16 +16,21 @@ export async function POST(request: Request) {
   initServices();
 
   const authHeader = request.headers.get("authorization") ?? undefined;
-  const userId = await getUserId(authHeader);
-  if (!userId) {
+  const authCtx = await getAuthContext(authHeader);
+  if (!authCtx) {
     return NextResponse.json(
       { error: { message: "Not authenticated", code: "UNAUTHORIZED" } },
       { status: 401 },
     );
   }
+  const { userId, scopeId: tokenScopeId } = authCtx;
 
   try {
-    const { scope, member } = await requireScopeFromRequest(request, userId);
+    const { scope, member } = await requireScopeFromRequest(
+      request,
+      userId,
+      tokenScopeId,
+    );
     await leaveScope(userId, scope.id, member.role);
     return NextResponse.json({ message: "Left scope" });
   } catch (error) {

--- a/turbo/apps/web/app/api/scope/members/route.ts
+++ b/turbo/apps/web/app/api/scope/members/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { initServices } from "../../../../src/lib/init-services";
-import { getUserId } from "../../../../src/lib/auth/get-user-id";
+import { getAuthContext } from "../../../../src/lib/auth/get-user-id";
 import { requireScopeFromRequest } from "../../../../src/lib/scope/resolve-scope";
 import {
   getScopeMembers,
@@ -19,16 +19,21 @@ export async function GET(request: Request) {
   initServices();
 
   const authHeader = request.headers.get("authorization") ?? undefined;
-  const userId = await getUserId(authHeader);
-  if (!userId) {
+  const authCtx = await getAuthContext(authHeader);
+  if (!authCtx) {
     return NextResponse.json(
       { error: { message: "Not authenticated", code: "UNAUTHORIZED" } },
       { status: 401 },
     );
   }
+  const { userId, scopeId: tokenScopeId } = authCtx;
 
   try {
-    const { scope } = await requireScopeFromRequest(request, userId);
+    const { scope } = await requireScopeFromRequest(
+      request,
+      userId,
+      tokenScopeId,
+    );
     const status = await getScopeMembers(
       userId,
       scope.clerkOrgId,
@@ -66,13 +71,14 @@ export async function DELETE(request: Request) {
   initServices();
 
   const authHeader = request.headers.get("authorization") ?? undefined;
-  const userId = await getUserId(authHeader);
-  if (!userId) {
+  const authCtx = await getAuthContext(authHeader);
+  if (!authCtx) {
     return NextResponse.json(
       { error: { message: "Not authenticated", code: "UNAUTHORIZED" } },
       { status: 401 },
     );
   }
+  const { userId, scopeId: tokenScopeId } = authCtx;
 
   const body = (await request.json()) as { email: string };
   if (!body.email) {
@@ -83,7 +89,11 @@ export async function DELETE(request: Request) {
   }
 
   try {
-    const { scope, member } = await requireScopeFromRequest(request, userId);
+    const { scope, member } = await requireScopeFromRequest(
+      request,
+      userId,
+      tokenScopeId,
+    );
     await removeMember(userId, scope.id, member.role, body.email);
     return NextResponse.json({
       message: `Removed ${body.email} from scope`,

--- a/turbo/apps/web/app/api/scope/route.ts
+++ b/turbo/apps/web/app/api/scope/route.ts
@@ -5,7 +5,7 @@ import {
 } from "../../../src/lib/ts-rest-handler";
 import { scopeContract, createErrorResponse, ApiError } from "@vm0/core";
 import { initServices } from "../../../src/lib/init-services";
-import { getUserId } from "../../../src/lib/auth/get-user-id";
+import { getAuthContext } from "../../../src/lib/auth/get-user-id";
 import {
   createScope,
   updateScopeSlug,
@@ -45,13 +45,14 @@ const router = tsr.router(scopeContract, {
   get: async ({ headers }) => {
     initServices();
 
-    const userId = await getUserId(headers.authorization);
-    if (!userId) {
+    const authCtx = await getAuthContext(headers.authorization);
+    if (!authCtx) {
       return createErrorResponse("UNAUTHORIZED", "Not authenticated");
     }
+    const { userId, scopeId: tokenScopeId } = authCtx;
 
     try {
-      const { scope } = await resolveScope(userId);
+      const { scope } = await resolveScope(userId, null, null, tokenScopeId);
 
       return { status: 200 as const, body: scopeToResponseBody(scope) };
     } catch (error) {
@@ -77,10 +78,11 @@ const router = tsr.router(scopeContract, {
   create: async ({ body, headers }) => {
     initServices();
 
-    const userId = await getUserId(headers.authorization);
-    if (!userId) {
+    const authCtx = await getAuthContext(headers.authorization);
+    if (!authCtx) {
       return createErrorResponse("UNAUTHORIZED", "Not authenticated");
     }
+    const { userId } = authCtx;
 
     const { slug } = body;
 
@@ -120,10 +122,11 @@ const router = tsr.router(scopeContract, {
   update: async ({ body, headers }) => {
     initServices();
 
-    const userId = await getUserId(headers.authorization);
-    if (!userId) {
+    const authCtx = await getAuthContext(headers.authorization);
+    if (!authCtx) {
       return createErrorResponse("UNAUTHORIZED", "Not authenticated");
     }
+    const { userId, scopeId: tokenScopeId } = authCtx;
 
     const { slug, force } = body;
 
@@ -131,7 +134,12 @@ const router = tsr.router(scopeContract, {
 
     let existingScope;
     try {
-      ({ scope: existingScope } = await resolveScope(userId));
+      ({ scope: existingScope } = await resolveScope(
+        userId,
+        null,
+        null,
+        tokenScopeId,
+      ));
     } catch (error) {
       if (isNotFound(error)) {
         return createErrorResponse(

--- a/turbo/apps/web/app/api/scopes/default-agent/route.ts
+++ b/turbo/apps/web/app/api/scopes/default-agent/route.ts
@@ -1,7 +1,7 @@
 import { createHandler, tsr } from "../../../../src/lib/ts-rest-handler";
 import { scopeDefaultAgentContract } from "@vm0/core";
 import { initServices } from "../../../../src/lib/init-services";
-import { getUserId } from "../../../../src/lib/auth/get-user-id";
+import { getAuthContext } from "../../../../src/lib/auth/get-user-id";
 import { resolveScope } from "../../../../src/lib/scope/resolve-scope";
 import { agentComposes } from "../../../../src/db/schema/agent-compose";
 import { scopes } from "../../../../src/db/schema/scope";
@@ -11,8 +11,8 @@ const router = tsr.router(scopeDefaultAgentContract, {
   setDefaultAgent: async ({ query, body, headers }) => {
     initServices();
 
-    const userId = await getUserId(headers.authorization);
-    if (!userId) {
+    const authCtx = await getAuthContext(headers.authorization);
+    if (!authCtx) {
       return {
         status: 401 as const,
         body: {
@@ -20,8 +20,14 @@ const router = tsr.router(scopeDefaultAgentContract, {
         },
       };
     }
+    const { userId, scopeId: tokenScopeId } = authCtx;
 
-    const { scope, member } = await resolveScope(userId, query.scope);
+    const { scope, member } = await resolveScope(
+      userId,
+      query.scope,
+      null,
+      tokenScopeId,
+    );
 
     if (member.role !== "admin") {
       return {

--- a/turbo/apps/web/app/api/secrets/[name]/route.ts
+++ b/turbo/apps/web/app/api/secrets/[name]/route.ts
@@ -9,7 +9,7 @@ import {
   ApiError,
 } from "@vm0/core";
 import { initServices } from "../../../../src/lib/init-services";
-import { getUserId } from "../../../../src/lib/auth/get-user-id";
+import { getAuthContext } from "../../../../src/lib/auth/get-user-id";
 import { resolveScope } from "../../../../src/lib/scope/resolve-scope";
 import {
   getSecret,
@@ -27,13 +27,14 @@ const router = tsr.router(secretsByNameContract, {
   get: async ({ params, headers }, { request }) => {
     initServices();
 
-    const userId = await getUserId(headers.authorization);
-    if (!userId) {
+    const authCtx = await getAuthContext(headers.authorization);
+    if (!authCtx) {
       return createErrorResponse("UNAUTHORIZED", "Not authenticated");
     }
+    const { userId, scopeId: tokenScopeId } = authCtx;
 
     const scopeSlug = new URL(request.url).searchParams.get("scope");
-    const { scope } = await resolveScope(userId, scopeSlug);
+    const { scope } = await resolveScope(userId, scopeSlug, null, tokenScopeId);
     const secret = await getSecret(scope.id, userId, params.name);
     if (!secret) {
       return createErrorResponse(
@@ -61,16 +62,22 @@ const router = tsr.router(secretsByNameContract, {
   delete: async ({ params, headers }, { request }) => {
     initServices();
 
-    const userId = await getUserId(headers.authorization);
-    if (!userId) {
+    const authCtx = await getAuthContext(headers.authorization);
+    if (!authCtx) {
       return createErrorResponse("UNAUTHORIZED", "Not authenticated");
     }
+    const { userId, scopeId: tokenScopeId } = authCtx;
 
     log.debug("deleting secret", { userId, name: params.name });
 
     try {
       const scopeSlug = new URL(request.url).searchParams.get("scope");
-      const { scope } = await resolveScope(userId, scopeSlug);
+      const { scope } = await resolveScope(
+        userId,
+        scopeSlug,
+        null,
+        tokenScopeId,
+      );
       await deleteSecret(scope.id, userId, params.name);
 
       return {

--- a/turbo/apps/web/app/api/secrets/route.ts
+++ b/turbo/apps/web/app/api/secrets/route.ts
@@ -5,7 +5,7 @@ import {
 } from "../../../src/lib/ts-rest-handler";
 import { secretsMainContract, createErrorResponse, ApiError } from "@vm0/core";
 import { initServices } from "../../../src/lib/init-services";
-import { getUserId } from "../../../src/lib/auth/get-user-id";
+import { getAuthContext } from "../../../src/lib/auth/get-user-id";
 import { resolveScope } from "../../../src/lib/scope/resolve-scope";
 import { listSecrets, setSecret } from "../../../src/lib/secret/secret-service";
 import { logger } from "../../../src/lib/logger";
@@ -20,13 +20,14 @@ const router = tsr.router(secretsMainContract, {
   list: async ({ headers }, { request }) => {
     initServices();
 
-    const userId = await getUserId(headers.authorization);
-    if (!userId) {
+    const authCtx = await getAuthContext(headers.authorization);
+    if (!authCtx) {
       return createErrorResponse("UNAUTHORIZED", "Not authenticated");
     }
+    const { userId, scopeId: tokenScopeId } = authCtx;
 
     const scopeSlug = new URL(request.url).searchParams.get("scope");
-    const { scope } = await resolveScope(userId, scopeSlug);
+    const { scope } = await resolveScope(userId, scopeSlug, null, tokenScopeId);
     const secrets = await listSecrets(scope.id, userId);
 
     return {
@@ -50,10 +51,11 @@ const router = tsr.router(secretsMainContract, {
   set: async ({ body, headers }, { request }) => {
     initServices();
 
-    const userId = await getUserId(headers.authorization);
-    if (!userId) {
+    const authCtx = await getAuthContext(headers.authorization);
+    if (!authCtx) {
       return createErrorResponse("UNAUTHORIZED", "Not authenticated");
     }
+    const { userId, scopeId: tokenScopeId } = authCtx;
 
     const { name, value, description } = body;
 
@@ -61,7 +63,12 @@ const router = tsr.router(secretsMainContract, {
 
     try {
       const scopeSlug = new URL(request.url).searchParams.get("scope");
-      const { scope } = await resolveScope(userId, scopeSlug);
+      const { scope } = await resolveScope(
+        userId,
+        scopeSlug,
+        null,
+        tokenScopeId,
+      );
       const secret = await setSecret(
         scope.id,
         userId,

--- a/turbo/apps/web/app/api/storages/commit/route.ts
+++ b/turbo/apps/web/app/api/storages/commit/route.ts
@@ -8,7 +8,7 @@ import { initServices } from "../../../../src/lib/init-services";
 import { agentRuns } from "../../../../src/db/schema/agent-run";
 import { storages, storageVersions } from "../../../../src/db/schema/storage";
 import { eq, and } from "drizzle-orm";
-import { getUserId } from "../../../../src/lib/auth/get-user-id";
+import { getAuthContext } from "../../../../src/lib/auth/get-user-id";
 import { resolveScope } from "../../../../src/lib/scope/resolve-scope";
 import {
   s3ObjectExists,
@@ -25,8 +25,8 @@ const router = tsr.router(storagesCommitContract, {
     initServices();
 
     // Authenticate user
-    const userId = await getUserId(headers.authorization);
-    if (!userId) {
+    const authCtx = await getAuthContext(headers.authorization);
+    if (!authCtx) {
       return {
         status: 401 as const,
         body: {
@@ -34,10 +34,16 @@ const router = tsr.router(storagesCommitContract, {
         },
       };
     }
+    const { userId, scopeId: tokenScopeId } = authCtx;
 
     // Resolve user's default scope
     const scopeSlug = new URL(request.url).searchParams.get("scope");
-    const { scope: runtimeScope } = await resolveScope(userId, scopeSlug);
+    const { scope: runtimeScope } = await resolveScope(
+      userId,
+      scopeSlug,
+      null,
+      tokenScopeId,
+    );
 
     const { storageName, storageType, versionId, files, runId, message } = body;
 

--- a/turbo/apps/web/app/api/storages/download/route.ts
+++ b/turbo/apps/web/app/api/storages/download/route.ts
@@ -7,7 +7,7 @@ import { storagesDownloadContract, VOLUME_SCOPE_USER_ID } from "@vm0/core";
 import { initServices } from "../../../../src/lib/init-services";
 import { storages, storageVersions } from "../../../../src/db/schema/storage";
 import { eq, and } from "drizzle-orm";
-import { getUserId } from "../../../../src/lib/auth/get-user-id";
+import { getAuthContext } from "../../../../src/lib/auth/get-user-id";
 import { resolveScope } from "../../../../src/lib/scope/resolve-scope";
 import { generatePresignedUrl } from "../../../../src/lib/s3/s3-client";
 import { env } from "../../../../src/env";
@@ -21,8 +21,8 @@ const router = tsr.router(storagesDownloadContract, {
     initServices();
 
     // Authenticate user
-    const userId = await getUserId(headers.authorization);
-    if (!userId) {
+    const authCtx = await getAuthContext(headers.authorization);
+    if (!authCtx) {
       return {
         status: 401 as const,
         body: {
@@ -30,10 +30,16 @@ const router = tsr.router(storagesDownloadContract, {
         },
       };
     }
+    const { userId, scopeId: tokenScopeId } = authCtx;
 
     // Resolve user's default scope
     const scopeSlug = new URL(request.url).searchParams.get("scope");
-    const { scope: runtimeScope } = await resolveScope(userId, scopeSlug);
+    const { scope: runtimeScope } = await resolveScope(
+      userId,
+      scopeSlug,
+      null,
+      tokenScopeId,
+    );
 
     const { name: storageName, type: storageType, version: versionId } = query;
 

--- a/turbo/apps/web/app/api/storages/list/route.ts
+++ b/turbo/apps/web/app/api/storages/list/route.ts
@@ -7,7 +7,7 @@ import { storagesListContract, VOLUME_SCOPE_USER_ID } from "@vm0/core";
 import { initServices } from "../../../../src/lib/init-services";
 import { storages } from "../../../../src/db/schema/storage";
 import { eq, and, desc } from "drizzle-orm";
-import { getUserId } from "../../../../src/lib/auth/get-user-id";
+import { getAuthContext } from "../../../../src/lib/auth/get-user-id";
 import { resolveScope } from "../../../../src/lib/scope/resolve-scope";
 import { logger } from "../../../../src/lib/logger";
 
@@ -18,8 +18,8 @@ const router = tsr.router(storagesListContract, {
     initServices();
 
     // Authenticate user
-    const userId = await getUserId(headers.authorization);
-    if (!userId) {
+    const authCtx = await getAuthContext(headers.authorization);
+    if (!authCtx) {
       return {
         status: 401 as const,
         body: {
@@ -27,12 +27,18 @@ const router = tsr.router(storagesListContract, {
         },
       };
     }
+    const { userId, scopeId: tokenScopeId } = authCtx;
 
     const { type: storageType } = query;
 
     // Resolve user's default scope
     const scopeSlug = new URL(request.url).searchParams.get("scope");
-    const { scope: runtimeScope } = await resolveScope(userId, scopeSlug);
+    const { scope: runtimeScope } = await resolveScope(
+      userId,
+      scopeSlug,
+      null,
+      tokenScopeId,
+    );
 
     // Volumes use sentinel userId (scope-shared); artifacts/memory use real userId
     const storageUserId =

--- a/turbo/apps/web/app/api/storages/prepare/route.ts
+++ b/turbo/apps/web/app/api/storages/prepare/route.ts
@@ -8,7 +8,7 @@ import { initServices } from "../../../../src/lib/init-services";
 import { agentRuns } from "../../../../src/db/schema/agent-run";
 import { storages, storageVersions } from "../../../../src/db/schema/storage";
 import { eq, and } from "drizzle-orm";
-import { getUserId } from "../../../../src/lib/auth/get-user-id";
+import { getAuthContext } from "../../../../src/lib/auth/get-user-id";
 import { resolveScope } from "../../../../src/lib/scope/resolve-scope";
 import {
   generatePresignedPutUrl,
@@ -87,8 +87,8 @@ const router = tsr.router(storagesPrepareContract, {
     initServices();
 
     // Authenticate user
-    const userId = await getUserId(headers.authorization);
-    if (!userId) {
+    const authCtx = await getAuthContext(headers.authorization);
+    if (!authCtx) {
       return {
         status: 401 as const,
         body: {
@@ -96,10 +96,16 @@ const router = tsr.router(storagesPrepareContract, {
         },
       };
     }
+    const { userId, scopeId: tokenScopeId } = authCtx;
 
     // Resolve user's default scope
     const scopeSlug = new URL(request.url).searchParams.get("scope");
-    const { scope: runtimeScope } = await resolveScope(userId, scopeSlug);
+    const { scope: runtimeScope } = await resolveScope(
+      userId,
+      scopeSlug,
+      null,
+      tokenScopeId,
+    );
 
     const {
       storageName,

--- a/turbo/apps/web/app/api/variables/[name]/route.ts
+++ b/turbo/apps/web/app/api/variables/[name]/route.ts
@@ -9,7 +9,7 @@ import {
   ApiError,
 } from "@vm0/core";
 import { initServices } from "../../../../src/lib/init-services";
-import { getUserId } from "../../../../src/lib/auth/get-user-id";
+import { getAuthContext } from "../../../../src/lib/auth/get-user-id";
 import { resolveScope } from "../../../../src/lib/scope/resolve-scope";
 import {
   getVariable,
@@ -27,13 +27,14 @@ const router = tsr.router(variablesByNameContract, {
   get: async ({ params, headers }, { request }) => {
     initServices();
 
-    const userId = await getUserId(headers.authorization);
-    if (!userId) {
+    const authCtx = await getAuthContext(headers.authorization);
+    if (!authCtx) {
       return createErrorResponse("UNAUTHORIZED", "Not authenticated");
     }
+    const { userId, scopeId: tokenScopeId } = authCtx;
 
     const scopeSlug = new URL(request.url).searchParams.get("scope");
-    const { scope } = await resolveScope(userId, scopeSlug);
+    const { scope } = await resolveScope(userId, scopeSlug, null, tokenScopeId);
     const variable = await getVariable(scope.clerkOrgId, userId, params.name);
     if (!variable) {
       return createErrorResponse(
@@ -61,16 +62,22 @@ const router = tsr.router(variablesByNameContract, {
   delete: async ({ params, headers }, { request }) => {
     initServices();
 
-    const userId = await getUserId(headers.authorization);
-    if (!userId) {
+    const authCtx = await getAuthContext(headers.authorization);
+    if (!authCtx) {
       return createErrorResponse("UNAUTHORIZED", "Not authenticated");
     }
+    const { userId, scopeId: tokenScopeId } = authCtx;
 
     log.debug("deleting variable", { userId, name: params.name });
 
     try {
       const scopeSlug = new URL(request.url).searchParams.get("scope");
-      const { scope } = await resolveScope(userId, scopeSlug);
+      const { scope } = await resolveScope(
+        userId,
+        scopeSlug,
+        null,
+        tokenScopeId,
+      );
       await deleteVariable(scope.clerkOrgId, userId, params.name);
 
       return {

--- a/turbo/apps/web/app/api/variables/route.ts
+++ b/turbo/apps/web/app/api/variables/route.ts
@@ -9,7 +9,7 @@ import {
   ApiError,
 } from "@vm0/core";
 import { initServices } from "../../../src/lib/init-services";
-import { getUserId } from "../../../src/lib/auth/get-user-id";
+import { getAuthContext } from "../../../src/lib/auth/get-user-id";
 import { resolveScope } from "../../../src/lib/scope/resolve-scope";
 import {
   listVariables,
@@ -27,13 +27,14 @@ const router = tsr.router(variablesMainContract, {
   list: async ({ headers }, { request }) => {
     initServices();
 
-    const userId = await getUserId(headers.authorization);
-    if (!userId) {
+    const authCtx = await getAuthContext(headers.authorization);
+    if (!authCtx) {
       return createErrorResponse("UNAUTHORIZED", "Not authenticated");
     }
+    const { userId, scopeId: tokenScopeId } = authCtx;
 
     const scopeSlug = new URL(request.url).searchParams.get("scope");
-    const { scope } = await resolveScope(userId, scopeSlug);
+    const { scope } = await resolveScope(userId, scopeSlug, null, tokenScopeId);
     const vars = await listVariables(scope.clerkOrgId, userId);
 
     return {
@@ -57,10 +58,11 @@ const router = tsr.router(variablesMainContract, {
   set: async ({ body, headers }, { request }) => {
     initServices();
 
-    const userId = await getUserId(headers.authorization);
-    if (!userId) {
+    const authCtx = await getAuthContext(headers.authorization);
+    if (!authCtx) {
       return createErrorResponse("UNAUTHORIZED", "Not authenticated");
     }
+    const { userId, scopeId: tokenScopeId } = authCtx;
 
     const { name, value, description } = body;
 
@@ -68,7 +70,12 @@ const router = tsr.router(variablesMainContract, {
 
     try {
       const scopeSlug = new URL(request.url).searchParams.get("scope");
-      const { scope } = await resolveScope(userId, scopeSlug);
+      const { scope } = await resolveScope(
+        userId,
+        scopeSlug,
+        null,
+        tokenScopeId,
+      );
       const variable = await setVariable(
         scope.clerkOrgId,
         scope.id,

--- a/turbo/apps/web/src/__tests__/clerk-mock.ts
+++ b/turbo/apps/web/src/__tests__/clerk-mock.ts
@@ -29,6 +29,16 @@ export const MOCK_USER_EMAIL = "test@example.com";
 const mockAuth = vi.mocked(auth);
 const mockClerkClient = vi.mocked(clerkClient);
 
+// Module-level tracking of orgs created via createOrganization.
+// Persists across mockClerk() calls so that re-mocking (e.g. to set orgId)
+// doesn't lose orgs created by earlier API calls (like createTestScope).
+let createdOrgs: Array<{
+  id: string;
+  slug: string;
+  name: string;
+  creatorUserId: string;
+}> = [];
+
 /**
  * Configure Clerk auth mock
  * @param options - Auth configuration
@@ -37,12 +47,15 @@ const mockClerkClient = vi.mocked(clerkClient);
  * @param options.orgId - Organization ID from active org session (optional)
  * @param options.orgSlug - Organization slug from active org session (optional)
  * @param options.clerkOrgs - Clerk orgs the user belongs to (for JIT discovery)
+ * @param options.orgTier - Tier to include in JWT sessionClaims.org_tier (optional)
  */
 export function mockClerk(options: {
   userId: string | null;
   email?: string;
   orgId?: string | null;
   orgSlug?: string | null;
+  orgRole?: string | null;
+  orgTier?: string;
   clerkOrgs?: Array<{ id: string; slug: string; name: string; role?: string }>;
 }) {
   const email = options.email ?? "test@example.com";
@@ -67,10 +80,20 @@ export function mockClerk(options: {
         ]
       : []);
 
+  // Note: createdOrgs is module-level (declared above) so it persists across
+  // mockClerk() calls. This is critical: setupUser() calls mockClerk() then
+  // createTestScope() (which calls createOrganization), and tests often call
+  // mockClerk() again to configure orgId — without module-level tracking,
+  // the org from createTestScope would be lost.
+
   mockAuth.mockResolvedValue({
     userId: options.userId,
     orgId: options.orgId,
     orgSlug: options.orgSlug,
+    orgRole: options.orgRole ?? (options.orgId ? "org:admin" : undefined),
+    sessionClaims: {
+      ...(options.orgTier !== undefined && { org_tier: options.orgTier }),
+    },
   } as Awaited<ReturnType<typeof auth>>);
 
   // Also set up clerkClient mock to return user data with email
@@ -90,24 +113,84 @@ export function mockClerk(options: {
         }
         return Promise.resolve({ data: [] });
       }),
-      getOrganizationMembershipList: vi.fn().mockResolvedValue({
-        data: clerkOrgs.map((org) => ({
-          organization: { id: org.id, slug: org.slug, name: org.name },
-          role: org.role ?? "org:admin",
-          publicUserData: { userId: options.userId },
-        })),
-      }),
+      getOrganizationMembershipList: vi
+        .fn()
+        .mockImplementation(({ userId: queryUserId }: { userId: string }) => {
+          // Return orgs for the queried user, not just the session user.
+          // This supports webhook routes where sandbox tokens pass a userId
+          // different from the Clerk session.
+          const queryCreated = createdOrgs.filter(
+            (o) => o.creatorUserId === queryUserId,
+          );
+          const orgs =
+            queryUserId === options.userId
+              ? [...clerkOrgs, ...queryCreated]
+              : queryCreated;
+          return Promise.resolve({
+            data: orgs.map((org) => ({
+              organization: {
+                id: org.id,
+                slug: org.slug,
+                name: org.name,
+              },
+              role: ("role" in org ? org.role : null) ?? "org:admin",
+              publicUserData: { userId: queryUserId },
+            })),
+          });
+        }),
     },
     organizations: {
       createOrganization: vi
         .fn()
-        .mockImplementation(({ name }: { name: string }) =>
-          Promise.resolve({ id: `org_mock_${name}` }),
+        .mockImplementation(({ name }: { name: string }) => {
+          const id = `org_mock_${name}`;
+          createdOrgs.push({
+            id,
+            slug: name,
+            name,
+            creatorUserId: options.userId!,
+          });
+          return Promise.resolve({ id });
+        }),
+      getOrganizationMembershipList: vi
+        .fn()
+        .mockImplementation(
+          ({ organizationId }: { organizationId: string }) => {
+            // Return members of this org.
+            // For clerkOrgs: session user is a member.
+            // For createdOrgs: the creator is a member (regardless of session).
+            const inClerkOrgs = clerkOrgs.some((o) => o.id === organizationId);
+            if (inClerkOrgs && options.userId) {
+              return Promise.resolve({
+                data: [
+                  {
+                    role: "org:admin",
+                    publicUserData: { userId: options.userId },
+                    createdAt: Date.now(),
+                  },
+                ],
+              });
+            }
+            const created = createdOrgs.find((o) => o.id === organizationId);
+            if (created) {
+              return Promise.resolve({
+                data: [
+                  {
+                    role: "org:admin",
+                    publicUserData: {
+                      userId: created.creatorUserId,
+                    },
+                    createdAt: Date.now(),
+                  },
+                ],
+              });
+            }
+            return Promise.resolve({ data: [] });
+          },
         ),
       updateOrganization: vi.fn().mockResolvedValue({}),
       updateOrganizationMetadata: vi.fn().mockResolvedValue({}),
       updateOrganizationMembershipMetadata: vi.fn().mockResolvedValue({}),
-      getOrganizationMembershipList: vi.fn().mockResolvedValue({ data: [] }),
     },
   } as unknown as Awaited<ReturnType<typeof clerkClient>>);
 }
@@ -118,4 +201,5 @@ export function mockClerk(options: {
 export function clearClerkMock() {
   mockAuth.mockClear();
   mockClerkClient.mockClear();
+  createdOrgs = [];
 }

--- a/turbo/apps/web/src/db/migrations/0121_sturdy_magdalene.sql
+++ b/turbo/apps/web/src/db/migrations/0121_sturdy_magdalene.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "cli_tokens" ADD COLUMN "scope_id" uuid;--> statement-breakpoint
+ALTER TABLE "cli_tokens" ADD COLUMN "clerk_org_id" text;

--- a/turbo/apps/web/src/db/migrations/meta/0121_snapshot.json
+++ b/turbo/apps/web/src/db/migrations/meta/0121_snapshot.json
@@ -1,0 +1,4999 @@
+{
+  "id": "d0020858-05bd-46be-8d20-243a2a7085f8",
+  "prevId": "438c893c-dc00-4640-bf9c-efe923f2228c",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.agent_compose_versions": {
+      "name": "agent_compose_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "compose_id": {
+          "name": "compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_compose_versions_compose_id": {
+          "name": "idx_agent_compose_versions_compose_id",
+          "columns": [
+            {
+              "expression": "compose_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_compose_versions_compose_id_agent_composes_id_fk": {
+          "name": "agent_compose_versions_compose_id_agent_composes_id_fk",
+          "tableFrom": "agent_compose_versions",
+          "tableTo": "agent_composes",
+          "columnsFrom": ["compose_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_composes": {
+      "name": "agent_composes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "head_version_id": {
+          "name": "head_version_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clerk_org_id": {
+          "name": "clerk_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_composes_clerk_org": {
+          "name": "idx_agent_composes_clerk_org",
+          "columns": [
+            {
+              "expression": "clerk_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_composes_clerk_org_name": {
+          "name": "idx_agent_composes_clerk_org_name",
+          "columns": [
+            {
+              "expression": "clerk_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_composes_scope_id_scopes_id_fk": {
+          "name": "agent_composes_scope_id_scopes_id_fk",
+          "tableFrom": "agent_composes",
+          "tableTo": "scopes",
+          "columnsFrom": ["scope_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_permissions": {
+      "name": "agent_permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "agent_compose_id": {
+          "name": "agent_compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grantee_type": {
+          "name": "grantee_type",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grantee_email": {
+          "name": "grantee_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "permission": {
+          "name": "permission",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'run_view'"
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_permissions_compose": {
+          "name": "idx_agent_permissions_compose",
+          "columns": [
+            {
+              "expression": "agent_compose_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_permissions_email": {
+          "name": "idx_agent_permissions_email",
+          "columns": [
+            {
+              "expression": "grantee_email",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "grantee_email IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_permissions_agent_compose_id_agent_composes_id_fk": {
+          "name": "agent_permissions_agent_compose_id_agent_composes_id_fk",
+          "tableFrom": "agent_permissions",
+          "tableTo": "agent_composes",
+          "columnsFrom": ["agent_compose_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "agent_permissions_compose_type_email_unique": {
+          "name": "agent_permissions_compose_type_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["agent_compose_id", "grantee_type", "grantee_email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_run_callbacks": {
+      "name": "agent_run_callbacks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_secret": {
+          "name": "encrypted_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_attempt_at": {
+          "name": "last_attempt_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_run_callbacks_run_id": {
+          "name": "idx_agent_run_callbacks_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_run_callbacks_pending": {
+          "name": "idx_agent_run_callbacks_pending",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "status = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_run_callbacks_run_id_agent_runs_id_fk": {
+          "name": "agent_run_callbacks_run_id_agent_runs_id_fk",
+          "tableFrom": "agent_run_callbacks",
+          "tableTo": "agent_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_run_events": {
+      "name": "agent_run_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence_number": {
+          "name": "sequence_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_data": {
+          "name": "event_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_run_events_run_id_agent_runs_id_fk": {
+          "name": "agent_run_events_run_id_agent_runs_id_fk",
+          "tableFrom": "agent_run_events",
+          "tableTo": "agent_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_run_queue": {
+      "name": "agent_run_queue",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_params": {
+          "name": "encrypted_params",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "agent_run_queue_user_created_idx": {
+          "name": "agent_run_queue_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_run_queue_expires_at_idx": {
+          "name": "agent_run_queue_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_run_queue_run_id_agent_runs_id_fk": {
+          "name": "agent_run_queue_run_id_agent_runs_id_fk",
+          "tableFrom": "agent_run_queue",
+          "tableTo": "agent_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_runs": {
+      "name": "agent_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_compose_version_id": {
+          "name": "agent_compose_version_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resumed_from_checkpoint_id": {
+          "name": "resumed_from_checkpoint_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "continued_from_session_id": {
+          "name": "continued_from_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vars": {
+          "name": "vars",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "secret_names": {
+          "name": "secret_names",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clerk_org_id": {
+          "name": "clerk_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_heartbeat_at": {
+          "name": "last_heartbeat_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_agent_runs_user_created": {
+          "name": "idx_agent_runs_user_created",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_runs_clerk_org": {
+          "name": "idx_agent_runs_clerk_org",
+          "columns": [
+            {
+              "expression": "clerk_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_runs_status_heartbeat": {
+          "name": "idx_agent_runs_status_heartbeat",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_heartbeat_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_runs_running_heartbeat": {
+          "name": "idx_agent_runs_running_heartbeat",
+          "columns": [
+            {
+              "expression": "last_heartbeat_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "status = 'running'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_runs_schedule_created": {
+          "name": "idx_agent_runs_schedule_created",
+          "columns": [
+            {
+              "expression": "schedule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "schedule_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_runs_agent_compose_version_id_agent_compose_versions_id_fk": {
+          "name": "agent_runs_agent_compose_version_id_agent_compose_versions_id_fk",
+          "tableFrom": "agent_runs",
+          "tableTo": "agent_compose_versions",
+          "columnsFrom": ["agent_compose_version_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "agent_runs_schedule_id_agent_schedules_id_fk": {
+          "name": "agent_runs_schedule_id_agent_schedules_id_fk",
+          "tableFrom": "agent_runs",
+          "tableTo": "agent_schedules",
+          "columnsFrom": ["schedule_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_schedules": {
+      "name": "agent_schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "compose_id": {
+          "name": "compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clerk_org_id": {
+          "name": "clerk_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_type": {
+          "name": "trigger_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'cron'"
+        },
+        "cron_expression": {
+          "name": "cron_expression",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "at_time": {
+          "name": "at_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "interval_seconds": {
+          "name": "interval_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vars": {
+          "name": "vars",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_secrets": {
+          "name": "encrypted_secrets",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artifact_name": {
+          "name": "artifact_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artifact_version": {
+          "name": "artifact_version",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "volume_versions": {
+          "name": "volume_versions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_run_id": {
+          "name": "last_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retry_started_at": {
+          "name": "retry_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consecutive_failures": {
+          "name": "consecutive_failures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_schedules_compose_name_scope_user": {
+          "name": "idx_agent_schedules_compose_name_scope_user",
+          "columns": [
+            {
+              "expression": "compose_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_schedules_compose": {
+          "name": "idx_agent_schedules_compose",
+          "columns": [
+            {
+              "expression": "compose_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_schedules_scope_user": {
+          "name": "idx_agent_schedules_scope_user",
+          "columns": [
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_schedules_clerk_org": {
+          "name": "idx_agent_schedules_clerk_org",
+          "columns": [
+            {
+              "expression": "clerk_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_schedules_compose_name_clerk_org_user": {
+          "name": "idx_agent_schedules_compose_name_clerk_org_user",
+          "columns": [
+            {
+              "expression": "compose_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "clerk_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_schedules_next_run": {
+          "name": "idx_agent_schedules_next_run",
+          "columns": [
+            {
+              "expression": "next_run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "enabled = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_schedules_compose_id_agent_composes_id_fk": {
+          "name": "agent_schedules_compose_id_agent_composes_id_fk",
+          "tableFrom": "agent_schedules",
+          "tableTo": "agent_composes",
+          "columnsFrom": ["compose_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_schedules_scope_id_scopes_id_fk": {
+          "name": "agent_schedules_scope_id_scopes_id_fk",
+          "tableFrom": "agent_schedules",
+          "tableTo": "scopes",
+          "columnsFrom": ["scope_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_schedules_last_run_id_agent_runs_id_fk": {
+          "name": "agent_schedules_last_run_id_agent_runs_id_fk",
+          "tableFrom": "agent_schedules",
+          "tableTo": "agent_runs",
+          "columnsFrom": ["last_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_sessions": {
+      "name": "agent_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_compose_id": {
+          "name": "agent_compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artifact_name": {
+          "name": "artifact_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_name": {
+          "name": "memory_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chat_messages": {
+          "name": "chat_messages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_sessions_user_compose_artifact": {
+          "name": "idx_agent_sessions_user_compose_artifact",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_compose_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "artifact_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_sessions_agent_compose_id_agent_composes_id_fk": {
+          "name": "agent_sessions_agent_compose_id_agent_composes_id_fk",
+          "tableFrom": "agent_sessions",
+          "tableTo": "agent_composes",
+          "columnsFrom": ["agent_compose_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_sessions_conversation_id_conversations_id_fk": {
+          "name": "agent_sessions_conversation_id_conversations_id_fk",
+          "tableFrom": "agent_sessions",
+          "tableTo": "conversations",
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blobs": {
+      "name": "blobs",
+      "schema": "",
+      "columns": {
+        "hash": {
+          "name": "hash",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref_count": {
+          "name": "ref_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_blobs_ref_count": {
+          "name": "idx_blobs_ref_count",
+          "columns": [
+            {
+              "expression": "ref_count",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.checkpoints": {
+      "name": "checkpoints",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_compose_snapshot": {
+          "name": "agent_compose_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_snapshot": {
+          "name": "artifact_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_snapshot": {
+          "name": "memory_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "volume_versions_snapshot": {
+          "name": "volume_versions_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "checkpoints_run_id_agent_runs_id_fk": {
+          "name": "checkpoints_run_id_agent_runs_id_fk",
+          "tableFrom": "checkpoints",
+          "tableTo": "agent_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "checkpoints_conversation_id_conversations_id_fk": {
+          "name": "checkpoints_conversation_id_conversations_id_fk",
+          "tableFrom": "checkpoints",
+          "tableTo": "conversations",
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "checkpoints_run_id_unique": {
+          "name": "checkpoints_run_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["run_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cli_tokens": {
+      "name": "cli_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clerk_org_id": {
+          "name": "clerk_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cli_tokens_token_unique": {
+          "name": "cli_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.compose_jobs": {
+      "name": "compose_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_url": {
+          "name": "github_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "overwrite": {
+          "name": "overwrite",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'github'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_compose_jobs_user_status": {
+          "name": "idx_compose_jobs_user_status",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_compose_jobs_created": {
+          "name": "idx_compose_jobs_created",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_compose_jobs_user_active": {
+          "name": "idx_compose_jobs_user_active",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status IN ('pending', 'running')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.connector_sessions": {
+      "name": "connector_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(9)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "connector_session_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_connector_sessions_code": {
+          "name": "idx_connector_sessions_code",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_connector_sessions_user_status": {
+          "name": "idx_connector_sessions_user_status",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.connectors": {
+      "name": "connectors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_method": {
+          "name": "auth_method",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_username": {
+          "name": "external_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_email": {
+          "name": "external_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_scopes": {
+          "name": "oauth_scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clerk_org_id": {
+          "name": "clerk_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_connectors_scope_user_type": {
+          "name": "idx_connectors_scope_user_type",
+          "columns": [
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_connectors_scope": {
+          "name": "idx_connectors_scope",
+          "columns": [
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_connectors_clerk_org": {
+          "name": "idx_connectors_clerk_org",
+          "columns": [
+            {
+              "expression": "clerk_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_connectors_clerk_org_user_type": {
+          "name": "idx_connectors_clerk_org_user_type",
+          "columns": [
+            {
+              "expression": "clerk_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "connectors_scope_id_scopes_id_fk": {
+          "name": "connectors_scope_id_scopes_id_fk",
+          "tableFrom": "connectors",
+          "tableTo": "scopes",
+          "columnsFrom": ["scope_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversations": {
+      "name": "conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cli_agent_type": {
+          "name": "cli_agent_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cli_agent_session_id": {
+          "name": "cli_agent_session_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cli_agent_session_history": {
+          "name": "cli_agent_session_history",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cli_agent_session_history_hash": {
+          "name": "cli_agent_session_history_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "conversations_run_id_agent_runs_id_fk": {
+          "name": "conversations_run_id_agent_runs_id_fk",
+          "tableFrom": "conversations",
+          "tableTo": "agent_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "conversations_run_id_unique": {
+          "name": "conversations_run_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["run_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.device_codes": {
+      "name": "device_codes",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "varchar(9)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "device_code_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_outbox": {
+      "name": "email_outbox",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "from_address": {
+          "name": "from_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_addresses": {
+          "name": "to_addresses",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cc_addresses": {
+          "name": "cc_addresses",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reply_to": {
+          "name": "reply_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headers": {
+          "name": "headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "template": {
+          "name": "template",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_send_action": {
+          "name": "post_send_action",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_retry_at": {
+          "name": "next_retry_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resend_id": {
+          "name": "resend_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_outbox_drain_idx": {
+          "name": "email_outbox_drain_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_retry_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_outbox_created_at_idx": {
+          "name": "email_outbox_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_reply_requests": {
+      "name": "email_reply_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_thread_session_id": {
+          "name": "email_thread_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inbound_email_id": {
+          "name": "inbound_email_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inbound_message_id": {
+          "name": "inbound_message_id",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_email_reply_requests_run": {
+          "name": "idx_email_reply_requests_run",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_reply_requests_run_id_agent_runs_id_fk": {
+          "name": "email_reply_requests_run_id_agent_runs_id_fk",
+          "tableFrom": "email_reply_requests",
+          "tableTo": "agent_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "email_reply_requests_email_thread_session_id_email_thread_sessions_id_fk": {
+          "name": "email_reply_requests_email_thread_session_id_email_thread_sessions_id_fk",
+          "tableFrom": "email_reply_requests",
+          "tableTo": "email_thread_sessions",
+          "columnsFrom": ["email_thread_session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_thread_sessions": {
+      "name": "email_thread_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "compose_id": {
+          "name": "compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_session_id": {
+          "name": "agent_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_email_message_id": {
+          "name": "last_email_message_id",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_to_token": {
+          "name": "reply_to_token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_email_thread_sessions_reply_token": {
+          "name": "idx_email_thread_sessions_reply_token",
+          "columns": [
+            {
+              "expression": "reply_to_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_email_thread_sessions_user": {
+          "name": "idx_email_thread_sessions_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_thread_sessions_compose_id_agent_composes_id_fk": {
+          "name": "email_thread_sessions_compose_id_agent_composes_id_fk",
+          "tableFrom": "email_thread_sessions",
+          "tableTo": "agent_composes",
+          "columnsFrom": ["compose_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "email_thread_sessions_agent_session_id_agent_sessions_id_fk": {
+          "name": "email_thread_sessions_agent_session_id_agent_sessions_id_fk",
+          "tableFrom": "email_thread_sessions",
+          "tableTo": "agent_sessions",
+          "columnsFrom": ["agent_session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_installations": {
+      "name": "github_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_access_token": {
+          "name": "encrypted_access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_name": {
+          "name": "target_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "admin_github_user_id": {
+          "name": "admin_github_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_compose_id": {
+          "name": "default_compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_configs": {
+          "name": "repo_configs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "github_installations_installation_id_unique": {
+          "name": "github_installations_installation_id_unique",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "installation_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_installations_default_compose_id_agent_composes_id_fk": {
+          "name": "github_installations_default_compose_id_agent_composes_id_fk",
+          "tableFrom": "github_installations",
+          "tableTo": "agent_composes",
+          "columnsFrom": ["default_compose_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_issue_sessions": {
+      "name": "github_issue_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo": {
+          "name": "repo",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_number": {
+          "name": "issue_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_session_id": {
+          "name": "agent_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_comment_id": {
+          "name": "last_comment_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_github_issue_sessions_installation_repo_issue": {
+          "name": "idx_github_issue_sessions_installation_repo_issue",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "repo",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "issue_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_github_issue_sessions_installation": {
+          "name": "idx_github_issue_sessions_installation",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_issue_sessions_installation_id_github_installations_id_fk": {
+          "name": "github_issue_sessions_installation_id_github_installations_id_fk",
+          "tableFrom": "github_issue_sessions",
+          "tableTo": "github_installations",
+          "columnsFrom": ["installation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_issue_sessions_agent_session_id_agent_sessions_id_fk": {
+          "name": "github_issue_sessions_agent_session_id_agent_sessions_id_fk",
+          "tableFrom": "github_issue_sessions",
+          "tableTo": "agent_sessions",
+          "columnsFrom": ["agent_session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_user_links": {
+      "name": "github_user_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "github_user_id": {
+          "name": "github_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vm0_user_id": {
+          "name": "vm0_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_github_user_links_user_installation": {
+          "name": "idx_github_user_links_user_installation",
+          "columns": [
+            {
+              "expression": "github_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_user_links_installation_id_github_installations_id_fk": {
+          "name": "github_user_links_installation_id_github_installations_id_fk",
+          "tableFrom": "github_user_links",
+          "tableTo": "github_installations",
+          "columnsFrom": ["installation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_providers": {
+      "name": "model_providers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_id": {
+          "name": "secret_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_method": {
+          "name": "auth_method",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "selected_model": {
+          "name": "selected_model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clerk_org_id": {
+          "name": "clerk_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_model_providers_scope_user_type": {
+          "name": "idx_model_providers_scope_user_type",
+          "columns": [
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_model_providers_scope": {
+          "name": "idx_model_providers_scope",
+          "columns": [
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_model_providers_secret": {
+          "name": "idx_model_providers_secret",
+          "columns": [
+            {
+              "expression": "secret_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_model_providers_clerk_org": {
+          "name": "idx_model_providers_clerk_org",
+          "columns": [
+            {
+              "expression": "clerk_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_model_providers_clerk_org_user_type": {
+          "name": "idx_model_providers_clerk_org_user_type",
+          "columns": [
+            {
+              "expression": "clerk_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "model_providers_scope_id_scopes_id_fk": {
+          "name": "model_providers_scope_id_scopes_id_fk",
+          "tableFrom": "model_providers",
+          "tableTo": "scopes",
+          "columnsFrom": ["scope_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "model_providers_secret_id_secrets_id_fk": {
+          "name": "model_providers_secret_id_secrets_id_fk",
+          "tableFrom": "model_providers",
+          "tableTo": "secrets",
+          "columnsFrom": ["secret_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runner_job_queue": {
+      "name": "runner_job_queue",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "runner_group": {
+          "name": "runner_group",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_context": {
+          "name": "execution_context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "runner_job_queue_group_unclaimed_idx": {
+          "name": "runner_job_queue_group_unclaimed_idx",
+          "columns": [
+            {
+              "expression": "runner_group",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "claimed_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runner_job_queue_expires_at_idx": {
+          "name": "runner_job_queue_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "runner_job_queue_run_id_agent_runs_id_fk": {
+          "name": "runner_job_queue_run_id_agent_runs_id_fk",
+          "tableFrom": "runner_job_queue",
+          "tableTo": "agent_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sandbox_telemetry": {
+      "name": "sandbox_telemetry",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_sandbox_telemetry_run_id": {
+          "name": "idx_sandbox_telemetry_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sandbox_telemetry_run_id_agent_runs_id_fk": {
+          "name": "sandbox_telemetry_run_id_agent_runs_id_fk",
+          "tableFrom": "sandbox_telemetry",
+          "tableTo": "agent_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scope_members": {
+      "name": "scope_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notify_email": {
+          "name": "notify_email",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "notify_slack": {
+          "name": "notify_slack",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_scope_members_scope_user": {
+          "name": "idx_scope_members_scope_user",
+          "columns": [
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_scope_members_scope": {
+          "name": "idx_scope_members_scope",
+          "columns": [
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_scope_members_user": {
+          "name": "idx_scope_members_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scope_members_scope_id_scopes_id_fk": {
+          "name": "scope_members_scope_id_scopes_id_fk",
+          "tableFrom": "scope_members",
+          "tableTo": "scopes",
+          "columnsFrom": ["scope_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "scope_members_role_check": {
+          "name": "scope_members_role_check",
+          "value": "\"scope_members\".\"role\" IN ('admin', 'member')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.scopes": {
+      "name": "scopes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clerk_org_id": {
+          "name": "clerk_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tier": {
+          "name": "tier",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "default_agent_compose_id": {
+          "name": "default_agent_compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_scopes_clerk_org": {
+          "name": "idx_scopes_clerk_org",
+          "columns": [
+            {
+              "expression": "clerk_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scopes_default_agent_compose_id_agent_composes_id_fk": {
+          "name": "scopes_default_agent_compose_id_agent_composes_id_fk",
+          "tableFrom": "scopes",
+          "tableTo": "agent_composes",
+          "columnsFrom": ["default_agent_compose_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "scopes_slug_unique": {
+          "name": "scopes_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "scopes_tier_check": {
+          "name": "scopes_tier_check",
+          "value": "\"scopes\".\"tier\" IN ('free', 'pro', 'max')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.secrets": {
+      "name": "secrets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_value": {
+          "name": "encrypted_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clerk_org_id": {
+          "name": "clerk_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_secrets_scope_user_name_type": {
+          "name": "idx_secrets_scope_user_name_type",
+          "columns": [
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_secrets_scope": {
+          "name": "idx_secrets_scope",
+          "columns": [
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_secrets_type": {
+          "name": "idx_secrets_type",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_secrets_clerk_org": {
+          "name": "idx_secrets_clerk_org",
+          "columns": [
+            {
+              "expression": "clerk_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_secrets_clerk_org_user_name_type": {
+          "name": "idx_secrets_clerk_org_user_name_type",
+          "columns": [
+            {
+              "expression": "clerk_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "secrets_scope_id_scopes_id_fk": {
+          "name": "secrets_scope_id_scopes_id_fk",
+          "tableFrom": "secrets",
+          "tableTo": "scopes",
+          "columnsFrom": ["scope_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_compose_requests": {
+      "name": "slack_compose_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "compose_job_id": {
+          "name": "compose_job_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_workspace_id": {
+          "name": "slack_workspace_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_user_id": {
+          "name": "slack_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_channel_id": {
+          "name": "slack_channel_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_slack_compose_requests_job": {
+          "name": "idx_slack_compose_requests_job",
+          "columns": [
+            {
+              "expression": "compose_job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "slack_compose_requests_compose_job_id_compose_jobs_id_fk": {
+          "name": "slack_compose_requests_compose_job_id_compose_jobs_id_fk",
+          "tableFrom": "slack_compose_requests",
+          "tableTo": "compose_jobs",
+          "columnsFrom": ["compose_job_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_installations": {
+      "name": "slack_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slack_workspace_id": {
+          "name": "slack_workspace_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_workspace_name": {
+          "name": "slack_workspace_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_bot_token": {
+          "name": "encrypted_bot_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bot_user_id": {
+          "name": "bot_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_compose_id": {
+          "name": "default_compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "admin_slack_user_id": {
+          "name": "admin_slack_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "slack_installations_default_compose_id_agent_composes_id_fk": {
+          "name": "slack_installations_default_compose_id_agent_composes_id_fk",
+          "tableFrom": "slack_installations",
+          "tableTo": "agent_composes",
+          "columnsFrom": ["default_compose_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "slack_installations_slack_workspace_id_unique": {
+          "name": "slack_installations_slack_workspace_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slack_workspace_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_pending_questions": {
+      "name": "slack_pending_questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_workspace_id": {
+          "name": "slack_workspace_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_channel_id": {
+          "name": "slack_channel_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_thread_ts": {
+          "name": "slack_thread_ts",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_message_ts": {
+          "name": "slack_message_ts",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_link_id": {
+          "name": "user_link_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "compose_id": {
+          "name": "compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "questions": {
+          "name": "questions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "answered_at": {
+          "name": "answered_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_slack_pending_questions_run_id": {
+          "name": "idx_slack_pending_questions_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_thread_sessions": {
+      "name": "slack_thread_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slack_user_link_id": {
+          "name": "slack_user_link_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_channel_id": {
+          "name": "slack_channel_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_thread_ts": {
+          "name": "slack_thread_ts",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_session_id": {
+          "name": "agent_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_processed_message_ts": {
+          "name": "last_processed_message_ts",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_slack_thread_sessions_thread_user_link": {
+          "name": "idx_slack_thread_sessions_thread_user_link",
+          "columns": [
+            {
+              "expression": "slack_user_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slack_channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slack_thread_ts",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_slack_thread_sessions_user_link": {
+          "name": "idx_slack_thread_sessions_user_link",
+          "columns": [
+            {
+              "expression": "slack_user_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "slack_thread_sessions_slack_user_link_id_slack_user_links_id_fk": {
+          "name": "slack_thread_sessions_slack_user_link_id_slack_user_links_id_fk",
+          "tableFrom": "slack_thread_sessions",
+          "tableTo": "slack_user_links",
+          "columnsFrom": ["slack_user_link_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "slack_thread_sessions_agent_session_id_agent_sessions_id_fk": {
+          "name": "slack_thread_sessions_agent_session_id_agent_sessions_id_fk",
+          "tableFrom": "slack_thread_sessions",
+          "tableTo": "agent_sessions",
+          "columnsFrom": ["agent_session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_user_links": {
+      "name": "slack_user_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slack_user_id": {
+          "name": "slack_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_workspace_id": {
+          "name": "slack_workspace_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vm0_user_id": {
+          "name": "vm0_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dm_welcome_sent": {
+          "name": "dm_welcome_sent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_slack_user_links_user_workspace": {
+          "name": "idx_slack_user_links_user_workspace",
+          "columns": [
+            {
+              "expression": "slack_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slack_workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.storage_versions": {
+      "name": "storage_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "storage_id": {
+          "name": "storage_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "file_count": {
+          "name": "file_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "storage_versions_storage_id_storages_id_fk": {
+          "name": "storage_versions_storage_id_storages_id_fk",
+          "tableFrom": "storage_versions",
+          "tableTo": "storages",
+          "columnsFrom": ["storage_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.storages": {
+      "name": "storages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'volume'"
+        },
+        "clerk_org_id": {
+          "name": "clerk_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "s3_prefix": {
+          "name": "s3_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "file_count": {
+          "name": "file_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "head_version_id": {
+          "name": "head_version_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_storages_scope_user_name_type": {
+          "name": "idx_storages_scope_user_name_type",
+          "columns": [
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_storages_scope": {
+          "name": "idx_storages_scope",
+          "columns": [
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_storages_clerk_org": {
+          "name": "idx_storages_clerk_org",
+          "columns": [
+            {
+              "expression": "clerk_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_storages_clerk_org_user_name_type": {
+          "name": "idx_storages_clerk_org_user_name_type",
+          "columns": [
+            {
+              "expression": "clerk_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "storages_scope_id_scopes_id_fk": {
+          "name": "storages_scope_id_scopes_id_fk",
+          "tableFrom": "storages",
+          "tableTo": "scopes",
+          "columnsFrom": ["scope_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "storages_head_version_id_storage_versions_id_fk": {
+          "name": "storages_head_version_id_storage_versions_id_fk",
+          "tableFrom": "storages",
+          "tableTo": "storage_versions",
+          "columnsFrom": ["head_version_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_installations": {
+      "name": "telegram_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "telegram_bot_id": {
+          "name": "telegram_bot_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bot_username": {
+          "name": "bot_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_bot_token": {
+          "name": "encrypted_bot_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhook_secret": {
+          "name": "webhook_secret",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_compose_id": {
+          "name": "default_compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "admin_user_id": {
+          "name": "admin_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "telegram_installations_default_compose_id_agent_composes_id_fk": {
+          "name": "telegram_installations_default_compose_id_agent_composes_id_fk",
+          "tableFrom": "telegram_installations",
+          "tableTo": "agent_composes",
+          "columnsFrom": ["default_compose_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "telegram_installations_telegram_bot_id_unique": {
+          "name": "telegram_installations_telegram_bot_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["telegram_bot_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_messages": {
+      "name": "telegram_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_user_id": {
+          "name": "from_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_username": {
+          "name": "from_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_bot": {
+          "name": "is_bot",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_telegram_messages_unique": {
+          "name": "idx_telegram_messages_unique",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_telegram_messages_chat": {
+          "name": "idx_telegram_messages_chat",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_telegram_messages_created_at": {
+          "name": "idx_telegram_messages_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "telegram_messages_installation_id_telegram_installations_id_fk": {
+          "name": "telegram_messages_installation_id_telegram_installations_id_fk",
+          "tableFrom": "telegram_messages",
+          "tableTo": "telegram_installations",
+          "columnsFrom": ["installation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_thread_sessions": {
+      "name": "telegram_thread_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "telegram_user_link_id": {
+          "name": "telegram_user_link_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "root_message_id": {
+          "name": "root_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_session_id": {
+          "name": "agent_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_processed_message_id": {
+          "name": "last_processed_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_telegram_thread_sessions_chat_user_link": {
+          "name": "idx_telegram_thread_sessions_chat_user_link",
+          "columns": [
+            {
+              "expression": "telegram_user_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "root_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_telegram_thread_sessions_user_link": {
+          "name": "idx_telegram_thread_sessions_user_link",
+          "columns": [
+            {
+              "expression": "telegram_user_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "telegram_thread_sessions_telegram_user_link_id_telegram_user_links_id_fk": {
+          "name": "telegram_thread_sessions_telegram_user_link_id_telegram_user_links_id_fk",
+          "tableFrom": "telegram_thread_sessions",
+          "tableTo": "telegram_user_links",
+          "columnsFrom": ["telegram_user_link_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "telegram_thread_sessions_agent_session_id_agent_sessions_id_fk": {
+          "name": "telegram_thread_sessions_agent_session_id_agent_sessions_id_fk",
+          "tableFrom": "telegram_thread_sessions",
+          "tableTo": "agent_sessions",
+          "columnsFrom": ["agent_session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_user_links": {
+      "name": "telegram_user_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "telegram_user_id": {
+          "name": "telegram_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vm0_user_id": {
+          "name": "vm0_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dm_welcome_sent": {
+          "name": "dm_welcome_sent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_telegram_user_links_user_installation": {
+          "name": "idx_telegram_user_links_user_installation",
+          "columns": [
+            {
+              "expression": "telegram_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "telegram_user_links_installation_id_telegram_installations_id_fk": {
+          "name": "telegram_user_links_installation_id_telegram_installations_id_fk",
+          "tableFrom": "telegram_user_links",
+          "tableTo": "telegram_installations",
+          "columnsFrom": ["installation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.usage_daily": {
+      "name": "usage_daily",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_count": {
+          "name": "run_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "run_time_ms": {
+          "name": "run_time_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_usage_daily_user_date": {
+          "name": "uq_usage_daily_user_date",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.variables": {
+      "name": "variables",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clerk_org_id": {
+          "name": "clerk_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_variables_clerk_org": {
+          "name": "idx_variables_clerk_org",
+          "columns": [
+            {
+              "expression": "clerk_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_variables_clerk_org_user_name": {
+          "name": "idx_variables_clerk_org_user_name",
+          "columns": [
+            {
+              "expression": "clerk_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.connector_session_status": {
+      "name": "connector_session_status",
+      "schema": "public",
+      "values": ["pending", "complete", "expired", "error"]
+    },
+    "public.device_code_status": {
+      "name": "device_code_status",
+      "schema": "public",
+      "values": ["pending", "authenticated", "expired", "denied"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/turbo/apps/web/src/db/migrations/meta/_journal.json
+++ b/turbo/apps/web/src/db/migrations/meta/_journal.json
@@ -848,6 +848,13 @@
       "when": 1773400000006,
       "tag": "0120_talented_elektra",
       "breakpoints": true
+    },
+    {
+      "idx": 121,
+      "version": "7",
+      "when": 1773400000007,
+      "tag": "0121_sturdy_magdalene",
+      "breakpoints": true
     }
   ]
 }

--- a/turbo/apps/web/src/db/schema/cli-tokens.ts
+++ b/turbo/apps/web/src/db/schema/cli-tokens.ts
@@ -5,6 +5,8 @@ export const cliTokens = pgTable("cli_tokens", {
   token: text("token").unique().notNull(), // vm0_live_xxxxx...
   userId: text("user_id").notNull(), // Clerk user ID
   name: text("name").notNull(), // User-friendly name
+  scopeId: uuid("scope_id"), // Scope bound at token creation (nullable for old tokens)
+  clerkOrgId: text("clerk_org_id"), // Clerk org ID dual-write (nullable for old tokens)
   expiresAt: timestamp("expires_at").notNull(),
   lastUsedAt: timestamp("last_used_at"),
   createdAt: timestamp("created_at").defaultNow().notNull(),

--- a/turbo/apps/web/src/lib/auth/get-user-id.ts
+++ b/turbo/apps/web/src/lib/auth/get-user-id.ts
@@ -25,7 +25,7 @@ type AuthContext = {
  * IMPORTANT: This function rejects sandbox JWT tokens.
  * Sandbox tokens can only be used on webhook endpoints via getSandboxAuth().
  */
-async function getAuthContext(
+export async function getAuthContext(
   authHeader?: string,
 ): Promise<AuthContext | null> {
   // Session auth via Clerk

--- a/turbo/apps/web/src/lib/auth/get-user-id.ts
+++ b/turbo/apps/web/src/lib/auth/get-user-id.ts
@@ -7,20 +7,31 @@ import { logger } from "../logger";
 const log = logger("auth:user");
 
 /**
- * Get the current user ID from CLI token or Clerk session.
+ * Authentication context returned by getAuthContext.
+ * - scopeId: present when auth is via a CLI token that has a stored scope
+ */
+type AuthContext = {
+  userId: string;
+  scopeId: string | null;
+};
+
+/**
+ * Get the full authentication context from CLI token or Clerk session.
  * Returns null if not authenticated.
  *
- * @param authHeader - The Authorization header value (optional)
+ * For Clerk sessions, scopeId is null (scope is resolved from JWT orgId).
+ * For CLI tokens with scope_id, returns the stored scopeId.
  *
  * IMPORTANT: This function rejects sandbox JWT tokens.
  * Sandbox tokens can only be used on webhook endpoints via getSandboxAuth().
- * This ensures sandbox tokens cannot access normal user APIs.
  */
-export async function getUserId(authHeader?: string): Promise<string | null> {
+async function getAuthContext(
+  authHeader?: string,
+): Promise<AuthContext | null> {
   // Session auth via Clerk
   const { userId } = await auth();
   if (userId) {
-    return userId;
+    return { userId, scopeId: null };
   }
 
   if (!authHeader?.startsWith("Bearer ")) {
@@ -30,7 +41,6 @@ export async function getUserId(authHeader?: string): Promise<string | null> {
   const token = authHeader.substring(7); // Remove "Bearer "
 
   // Reject sandbox JWT tokens on normal APIs
-  // They must use webhook endpoints with getSandboxAuth()
   if (isSandboxToken(token)) {
     log.debug("Rejected sandbox JWT token on normal API endpoint");
     return null;
@@ -58,7 +68,18 @@ export async function getUserId(authHeader?: string): Promise<string | null> {
     .where(eq(cliTokens.token, token))
     .catch((err) => log.error("Failed to update token lastUsedAt:", err));
 
-  return tokenRecord.userId;
+  return { userId: tokenRecord.userId, scopeId: tokenRecord.scopeId };
+}
+
+/**
+ * Get the current user ID from CLI token or Clerk session.
+ * Returns null if not authenticated.
+ *
+ * Use getAuthContext() when you also need the CLI token's scopeId.
+ */
+export async function getUserId(authHeader?: string): Promise<string | null> {
+  const ctx = await getAuthContext(authHeader);
+  return ctx?.userId ?? null;
 }
 
 /**

--- a/turbo/apps/web/src/lib/auth/runner-auth.ts
+++ b/turbo/apps/web/src/lib/auth/runner-auth.ts
@@ -25,7 +25,7 @@ const OFFICIAL_RUNNER_TOKEN_PREFIX = "vm0_official_";
  * - 'official-runner': Authenticated via official runner secret
  */
 type RunnerAuthContext =
-  | { type: "user"; userId: string }
+  | { type: "user"; userId: string; scopeId: string | null }
   | { type: "official-runner" };
 
 /**
@@ -120,7 +120,11 @@ export async function getRunnerAuth(
         .where(eq(cliTokens.token, token))
         .catch((err) => log.error("Failed to update token lastUsedAt:", err));
 
-      return { type: "user", userId: tokenRecord.userId };
+      return {
+        type: "user",
+        userId: tokenRecord.userId,
+        scopeId: tokenRecord.scopeId,
+      };
     }
 
     return null;

--- a/turbo/apps/web/src/lib/scope/__tests__/resolve-scope.test.ts
+++ b/turbo/apps/web/src/lib/scope/__tests__/resolve-scope.test.ts
@@ -6,6 +6,18 @@ import { resolveScope } from "../resolve-scope";
 
 const context = testContext();
 
+/**
+ * Build clerkOrgs array for scopes created in a test.
+ * Each scope created via createTestScope has clerkOrgId = "org_mock_{slug}".
+ */
+function scopeOrgs(...slugs: string[]) {
+  return slugs.map((slug) => ({
+    id: `org_mock_${slug}`,
+    slug,
+    name: slug,
+  }));
+}
+
 describe("resolveScope", () => {
   beforeEach(() => {
     context.setupMocks();
@@ -21,8 +33,12 @@ describe("resolveScope", () => {
     const scope1 = await createTestScope(slug1);
     const scope2 = await createTestScope(slug2);
 
-    // Mock session with orgId pointing to scope2
-    mockClerk({ userId, orgId: `org_mock_${slug2}` });
+    // Mock session with orgId pointing to scope2, include both scope orgs
+    mockClerk({
+      userId,
+      orgId: `org_mock_${slug2}`,
+      clerkOrgs: scopeOrgs(slug1, slug2),
+    });
 
     // Resolve with explicit slug for scope1 — should return scope1, not scope2
     const result = await resolveScope(userId, slug1);
@@ -40,7 +56,11 @@ describe("resolveScope", () => {
     const created = await createTestScope(slug);
 
     // Mock session with orgId matching the scope's clerkOrgId
-    mockClerk({ userId, orgId: `org_mock_${slug}` });
+    mockClerk({
+      userId,
+      orgId: `org_mock_${slug}`,
+      clerkOrgs: scopeOrgs(slug),
+    });
 
     // Resolve without slug or explicit orgId — should auto-detect from session
     const result = await resolveScope(userId);
@@ -58,7 +78,11 @@ describe("resolveScope", () => {
     const created = await createTestScope(slug);
 
     // Mock session with a different orgId (should NOT be used)
-    mockClerk({ userId, orgId: "org_session_different" });
+    mockClerk({
+      userId,
+      orgId: "org_session_different",
+      clerkOrgs: scopeOrgs(slug),
+    });
 
     // Pass explicit clerkOrgId matching the scope
     const result = await resolveScope(userId, null, `org_mock_${slug}`);
@@ -75,10 +99,14 @@ describe("resolveScope", () => {
     mockClerk({ userId });
     const created = await createTestScope(slug);
 
-    // Mock as CLI token — no orgId in session
-    mockClerk({ userId, orgId: null });
+    // Mock as CLI token — no orgId in session, but Clerk API returns user's orgs
+    mockClerk({
+      userId,
+      orgId: null,
+      clerkOrgs: scopeOrgs(slug),
+    });
 
-    // Resolve without slug — should fall through to getDefaultScope
+    // Resolve without slug — should fall through to getDefaultScope (Clerk API)
     const result = await resolveScope(userId);
 
     expect(result.scope.id).toBe(created.id);
@@ -93,7 +121,11 @@ describe("resolveScope", () => {
     const created = await createTestScope(slug);
 
     // Mock session with an orgId that doesn't match any scope
-    mockClerk({ userId, orgId: "org_nonexistent_xyz" });
+    mockClerk({
+      userId,
+      orgId: "org_nonexistent_xyz",
+      clerkOrgs: scopeOrgs(slug),
+    });
 
     // Resolve without slug — orgId lookup returns null, falls to default
     const result = await resolveScope(userId);
@@ -114,7 +146,11 @@ describe("resolveScope", () => {
     const scope2 = await createTestScope(slug2);
 
     // Mock session with orgId matching the SECOND scope
-    mockClerk({ userId, orgId: `org_mock_${slug2}` });
+    mockClerk({
+      userId,
+      orgId: `org_mock_${slug2}`,
+      clerkOrgs: scopeOrgs(slug1, slug2),
+    });
 
     // Resolve without slug — should return scope2 (from orgId), not scope1 (default)
     const result = await resolveScope(userId);
@@ -122,5 +158,110 @@ describe("resolveScope", () => {
     expect(result.scope.id).toBe(scope2.id);
     expect(result.scope.slug).toBe(slug2);
     expect(result.scope.id).not.toBe(scope1.id);
+  });
+
+  it("reads tier from JWT sessionClaims when org matches", async () => {
+    const userId = uniqueId("test-user");
+    const slug = uniqueId("scope");
+
+    mockClerk({ userId });
+    const created = await createTestScope(slug);
+
+    // Mock session with orgTier in JWT claims
+    mockClerk({
+      userId,
+      orgId: `org_mock_${slug}`,
+      orgTier: "pro",
+      clerkOrgs: scopeOrgs(slug),
+    });
+
+    const result = await resolveScope(userId);
+
+    expect(result.scope.id).toBe(created.id);
+    // tier should be overridden from JWT
+    expect(result.scope.tier).toBe("pro");
+  });
+
+  it("falls back to DB tier when JWT org_tier claim is missing", async () => {
+    const userId = uniqueId("test-user");
+    const slug = uniqueId("scope");
+
+    mockClerk({ userId });
+    await createTestScope(slug);
+
+    // Mock session WITHOUT orgTier
+    mockClerk({
+      userId,
+      orgId: `org_mock_${slug}`,
+      clerkOrgs: scopeOrgs(slug),
+    });
+
+    const result = await resolveScope(userId);
+
+    // tier should be DB default ("free")
+    expect(result.scope.tier).toBe("free");
+  });
+
+  it("does not override tier when resolving non-active org via explicit slug", async () => {
+    const userId = uniqueId("test-user");
+    const slug1 = uniqueId("scope");
+    const slug2 = uniqueId("scope");
+
+    mockClerk({ userId });
+    await createTestScope(slug1);
+    await createTestScope(slug2);
+
+    // JWT active org is scope2, but resolving scope1 via explicit slug
+    mockClerk({
+      userId,
+      orgId: `org_mock_${slug2}`,
+      orgTier: "max",
+      clerkOrgs: scopeOrgs(slug1, slug2),
+    });
+
+    const result = await resolveScope(userId, slug1);
+
+    // tier should NOT be overridden (slug1 != active org)
+    expect(result.scope.tier).toBe("free");
+  });
+
+  it("returns member with correct role", async () => {
+    const userId = uniqueId("test-user");
+    const slug = uniqueId("scope");
+
+    mockClerk({ userId });
+    await createTestScope(slug);
+
+    mockClerk({
+      userId,
+      orgId: `org_mock_${slug}`,
+      clerkOrgs: scopeOrgs(slug),
+    });
+
+    const result = await resolveScope(userId);
+
+    expect(result.member.role).toBe("admin");
+    expect(result.member.userId).toBe(userId);
+    expect(result.member.scopeId).toBe(result.scope.id);
+  });
+
+  it("throws 403 when user is not a Clerk org member", async () => {
+    const userId = uniqueId("test-user");
+    const otherUserId = uniqueId("other-user");
+    const slug = uniqueId("scope");
+
+    mockClerk({ userId });
+    await createTestScope(slug);
+
+    // Mock as different user who is NOT in the org
+    mockClerk({
+      userId: otherUserId,
+      orgId: null,
+      clerkOrgs: [], // No orgs
+    });
+
+    await expect(resolveScope(otherUserId, slug)).rejects.toThrow(
+      "You are not a member of this scope",
+    );
   });
 });

--- a/turbo/apps/web/src/lib/scope/resolve-scope.ts
+++ b/turbo/apps/web/src/lib/scope/resolve-scope.ts
@@ -1,15 +1,10 @@
 import { auth, clerkClient } from "@clerk/nextjs/server";
-import { scopeMembers } from "../../db/schema/scope-member";
-import { isForbidden, badRequest, notFound } from "../errors";
+import { forbidden, badRequest, notFound } from "../errors";
 import { logger } from "../logger";
-import { scopeRoleSchema } from "@vm0/core";
 import { getScopeBySlug, getScopeByClerkOrgId } from "./scope-service";
-import {
-  requireScopeMember,
-  getDefaultScope,
-  getScopeMember,
-} from "./scope-member-service";
+import { getDefaultScope } from "./scope-member-service";
 
+import type { ScopeRole } from "@vm0/core";
 import type { scopes } from "../../db/schema/scope";
 
 const log = logger("scope:resolve");
@@ -17,15 +12,27 @@ const log = logger("scope:resolve");
 type Scope = typeof scopes.$inferSelect;
 
 /**
- * Verify a user's Clerk org membership and lazily create a scope_members record.
- *
- * Only attempts sync when the scope has a real Clerk org ID (not a sentinel like "pending_*").
- *
- * Returns the new scope member record, or null if the user is not a Clerk member.
+ * Minimal member object returned by scope resolution.
+ * Contains only the fields used downstream (primarily `role` for permission checks).
  */
-async function syncClerkMembership(scope: Scope, userId: string) {
+type ResolvedMember = {
+  role: ScopeRole;
+  userId: string;
+  scopeId: string;
+};
+
+/**
+ * Verify a user's membership in a Clerk organization.
+ * Returns the user's role, or throws 403 if not a member.
+ *
+ * Scopes with sentinel "pending_*" clerkOrgId cannot be verified — throws 403.
+ */
+async function verifyClerkMembership(
+  scope: Scope,
+  userId: string,
+): Promise<ResolvedMember> {
   if (scope.clerkOrgId.startsWith("pending_")) {
-    return null;
+    throw forbidden("You are not a member of this scope");
   }
 
   try {
@@ -38,64 +45,57 @@ async function syncClerkMembership(scope: Scope, userId: string) {
     const membership = memberships.data.find(
       (m) => m.publicUserData?.userId === userId,
     );
-    if (!membership) return null;
+    if (!membership) {
+      throw forbidden("You are not a member of this scope");
+    }
 
-    const role = membership.role === "org:admin" ? "admin" : "member";
-
-    // Create scope_members record
-    const [member] = await globalThis.services.db
-      .insert(scopeMembers)
-      .values({ scopeId: scope.id, userId, role })
-      .onConflictDoNothing()
-      .returning();
-
-    // If onConflictDoNothing returned nothing, the record was created by another concurrent request
-    const record = member ?? (await getScopeMember(scope.id, userId));
-    if (!record) return null;
-    return { ...record, role: scopeRoleSchema.parse(record.role) };
+    const role: ScopeRole =
+      membership.role === "org:admin" ? "admin" : "member";
+    return { role, userId, scopeId: scope.id };
   } catch (error) {
-    // Intentional exception to fail-fast principle: when Clerk is unavailable,
-    // deny access (return null -> 403) rather than crashing the request.
-    // This is a security-first choice — external service failure should not
-    // grant access. The error is logged for observability.
-    log.error("syncClerkMembership failed", {
+    // Re-throw our own forbidden errors
+    if (error instanceof Error && error.message.includes("not a member")) {
+      throw error;
+    }
+    // Clerk API failure — deny access (security-first)
+    log.error("verifyClerkMembership failed", {
       scopeId: scope.id,
       userId,
       clerkOrgId: scope.clerkOrgId,
       error,
     });
-    return null;
+    throw forbidden("You are not a member of this scope");
   }
 }
 
 /**
- * Verify scope membership with Clerk org sync fallback.
- *
- * Checks scope_members first. If the user is not found and the scope has a
- * Clerk org, attempts to lazily sync membership from Clerk.
+ * Override scope.tier with JWT session claim when the resolved org matches
+ * the JWT's active org. Falls back to DB tier if claim is missing.
  */
-async function requireMemberWithClerkSync(scope: Scope, userId: string) {
-  try {
-    return await requireScopeMember(scope.id, userId);
-  } catch (error) {
-    if (!isForbidden(error) || !scope.clerkOrgId) throw error;
-
-    // User not in scope_members — check Clerk org membership
-    const member = await syncClerkMembership(scope, userId);
-    if (!member) throw error; // Not a Clerk member either
-    return member;
+function applyJwtTier(
+  scope: Scope,
+  authResult: Awaited<ReturnType<typeof auth>>,
+): Scope {
+  if (
+    scope.clerkOrgId === authResult.orgId &&
+    authResult.sessionClaims?.org_tier
+  ) {
+    return { ...scope, tier: authResult.sessionClaims.org_tier };
   }
+  return scope;
 }
 
 /**
- * Resolve scope from request context using scope_members.
+ * Resolve scope from request context using Clerk API for membership verification.
  *
  * Resolution order:
- * 1. scopeSlug (?scope=<slug> query param) -> look up scope, verify membership
- *    - If not in scope_members, try to sync from Clerk org membership
- * 2. clerkOrgId (from Clerk session token) -> look up scope by org ID
+ * 1. scopeSlug (?scope=<slug> query param) -> look up scope, verify Clerk membership
+ * 2. clerkOrgId (from Clerk session token) -> look up scope by org ID, verify membership
  *    - Falls through to default if no matching scope exists yet
- * 3. Fallback -> user's default scope (first owned scope from scope_members)
+ * 3. Fallback -> user's default scope via Clerk API getOrganizationMembershipList
+ *
+ * When the resolved org matches the JWT's active org, `tier` is read from
+ * sessionClaims.org_tier (falling back to DB value if missing).
  *
  * Returns { scope, member } for the resolved scope.
  */
@@ -104,30 +104,32 @@ export async function resolveScope(
   scopeSlug?: string | null,
   clerkOrgId?: string | null,
 ) {
+  const authResult = await auth();
+
   // 1. Explicit scope selection via ?scope= query param (highest priority)
   if (scopeSlug) {
     const scope = await getScopeBySlug(scopeSlug);
     if (!scope) throw notFound("Scope not found");
 
-    const member = await requireMemberWithClerkSync(scope, userId);
-    return { scope, member };
+    const member = await verifyClerkMembership(scope, userId);
+    return { scope: applyJwtTier(scope, authResult), member };
   }
 
   // 2. Clerk org ID — use provided value or auto-detect from session token.
   // For CLI tokens, auth().orgId returns null (no Clerk session),
   // so this tier is skipped and we fall through to the default scope.
-  const effectiveOrgId = clerkOrgId ?? (await auth()).orgId ?? null;
+  const effectiveOrgId = clerkOrgId ?? authResult.orgId ?? null;
   if (effectiveOrgId) {
     const scope = await getScopeByClerkOrgId(effectiveOrgId);
     if (scope) {
-      const member = await requireMemberWithClerkSync(scope, userId);
-      return { scope, member };
+      const member = await verifyClerkMembership(scope, userId);
+      return { scope: applyJwtTier(scope, authResult), member };
     }
     // Scope not found for this clerkOrgId — fall through to default
     // (scope may not be created yet in the migration period)
   }
 
-  // 3. Default scope fallback
+  // 3. Default scope fallback (uses Clerk API to find user's orgs)
   return getDefaultScope(userId);
 }
 
@@ -152,6 +154,6 @@ export async function requireScopeFromRequest(
     throw notFound("Scope not found");
   }
 
-  const member = await requireMemberWithClerkSync(scope, userId);
+  const member = await verifyClerkMembership(scope, userId);
   return { scope, member };
 }

--- a/turbo/apps/web/src/lib/scope/resolve-scope.ts
+++ b/turbo/apps/web/src/lib/scope/resolve-scope.ts
@@ -154,6 +154,7 @@ export async function requireScopeFromRequest(
     throw notFound("Scope not found");
   }
 
+  const authResult = await auth();
   const member = await verifyClerkMembership(scope, userId);
-  return { scope, member };
+  return { scope: applyJwtTier(scope, authResult), member };
 }

--- a/turbo/apps/web/src/lib/scope/resolve-scope.ts
+++ b/turbo/apps/web/src/lib/scope/resolve-scope.ts
@@ -1,7 +1,11 @@
 import { auth, clerkClient } from "@clerk/nextjs/server";
 import { forbidden, badRequest, notFound } from "../errors";
 import { logger } from "../logger";
-import { getScopeBySlug, getScopeByClerkOrgId } from "./scope-service";
+import {
+  getScopeBySlug,
+  getScopeByClerkOrgId,
+  getScopeById,
+} from "./scope-service";
 import { getDefaultScope } from "./scope-member-service";
 
 import type { ScopeRole } from "@vm0/core";
@@ -21,20 +25,48 @@ type ResolvedMember = {
   scopeId: string;
 };
 
+/** Map Clerk org role string to our ScopeRole type. */
+function mapOrgRole(clerkRole: string | undefined | null): ScopeRole {
+  return clerkRole === "org:admin" ? "admin" : "member";
+}
+
 /**
  * Verify a user's membership in a Clerk organization.
- * Returns the user's role, or throws 403 if not a member.
  *
- * Scopes with sentinel "pending_*" clerkOrgId cannot be verified — throws 403.
+ * Fast path: if the scope's clerkOrgId matches the JWT's active org,
+ * trust the JWT claims and skip the Clerk API call entirely.
+ *
+ * Slow path: for cross-org access (e.g. ?scope= pointing to a non-active org),
+ * fall back to Clerk Backend API.
+ *
+ * CLI token path: if tokenScopeId is provided and matches the scope,
+ * trust the token (membership was verified at token creation time).
  */
-async function verifyClerkMembership(
+async function verifyMembership(
   scope: Scope,
   userId: string,
+  authResult: Awaited<ReturnType<typeof auth>>,
+  tokenScopeId?: string | null,
 ): Promise<ResolvedMember> {
+  // CLI token with stored scope_id — trust if it matches
+  if (tokenScopeId && scope.id === tokenScopeId) {
+    return { role: "admin", userId, scopeId: scope.id };
+  }
+
+  // JWT fast path: active org matches → trust JWT, no API call
+  if (scope.clerkOrgId === authResult.orgId) {
+    return {
+      role: mapOrgRole(authResult.orgRole),
+      userId,
+      scopeId: scope.id,
+    };
+  }
+
   if (scope.clerkOrgId.startsWith("pending_")) {
     throw forbidden("You are not a member of this scope");
   }
 
+  // Slow path: cross-org access → Clerk Backend API
   try {
     const client = await clerkClient();
     const memberships =
@@ -49,16 +81,18 @@ async function verifyClerkMembership(
       throw forbidden("You are not a member of this scope");
     }
 
-    const role: ScopeRole =
-      membership.role === "org:admin" ? "admin" : "member";
-    return { role, userId, scopeId: scope.id };
+    return {
+      role: mapOrgRole(membership.role),
+      userId,
+      scopeId: scope.id,
+    };
   } catch (error) {
     // Re-throw our own forbidden errors
     if (error instanceof Error && error.message.includes("not a member")) {
       throw error;
     }
     // Clerk API failure — deny access (security-first)
-    log.error("verifyClerkMembership failed", {
+    log.error("verifyMembership failed", {
       scopeId: scope.id,
       userId,
       clerkOrgId: scope.clerkOrgId,
@@ -86,23 +120,25 @@ function applyJwtTier(
 }
 
 /**
- * Resolve scope from request context using Clerk API for membership verification.
+ * Resolve scope from request context.
+ *
+ * Uses JWT claims for membership verification when possible (zero Clerk API calls).
+ * Falls back to Clerk Backend API for cross-org access or CLI tokens without scope_id.
  *
  * Resolution order:
- * 1. scopeSlug (?scope=<slug> query param) -> look up scope, verify Clerk membership
- * 2. clerkOrgId (from Clerk session token) -> look up scope by org ID, verify membership
- *    - Falls through to default if no matching scope exists yet
- * 3. Fallback -> user's default scope via Clerk API getOrganizationMembershipList
+ * 1. tokenScopeId (from CLI token) -> direct scope lookup, trusted
+ * 2. scopeSlug (?scope=<slug> query param) -> look up scope, verify membership
+ * 3. clerkOrgId (from JWT session token) -> look up scope by org ID
+ * 4. Fallback -> user's default scope
  *
  * When the resolved org matches the JWT's active org, `tier` is read from
  * sessionClaims.org_tier (falling back to DB value if missing).
- *
- * Returns { scope, member } for the resolved scope.
  */
 export async function resolveScope(
   userId: string,
   scopeSlug?: string | null,
   clerkOrgId?: string | null,
+  tokenScopeId?: string | null,
 ) {
   const authResult = await auth();
 
@@ -111,25 +147,46 @@ export async function resolveScope(
     const scope = await getScopeBySlug(scopeSlug);
     if (!scope) throw notFound("Scope not found");
 
-    const member = await verifyClerkMembership(scope, userId);
+    const member = await verifyMembership(
+      scope,
+      userId,
+      authResult,
+      tokenScopeId,
+    );
     return { scope: applyJwtTier(scope, authResult), member };
   }
 
-  // 2. Clerk org ID — use provided value or auto-detect from session token.
+  // 2. CLI token with scope_id — direct lookup, no Clerk API needed
+  if (tokenScopeId) {
+    const scope = await getScopeById(tokenScopeId);
+    if (scope) {
+      return {
+        scope: applyJwtTier(scope, authResult),
+        member: { role: "admin" as ScopeRole, userId, scopeId: scope.id },
+      };
+    }
+  }
+
+  // 3. Clerk org ID — use provided value or auto-detect from JWT session token.
   // For CLI tokens, auth().orgId returns null (no Clerk session),
   // so this tier is skipped and we fall through to the default scope.
   const effectiveOrgId = clerkOrgId ?? authResult.orgId ?? null;
   if (effectiveOrgId) {
     const scope = await getScopeByClerkOrgId(effectiveOrgId);
     if (scope) {
-      const member = await verifyClerkMembership(scope, userId);
+      const member = await verifyMembership(
+        scope,
+        userId,
+        authResult,
+        tokenScopeId,
+      );
       return { scope: applyJwtTier(scope, authResult), member };
     }
     // Scope not found for this clerkOrgId — fall through to default
     // (scope may not be created yet in the migration period)
   }
 
-  // 3. Default scope fallback (uses Clerk API to find user's orgs)
+  // 4. Default scope fallback
   return getDefaultScope(userId);
 }
 
@@ -143,6 +200,7 @@ export async function resolveScope(
 export async function requireScopeFromRequest(
   request: Request,
   userId: string,
+  tokenScopeId?: string | null,
 ) {
   const url = new URL(request.url);
   const scopeSlug = url.searchParams.get("scope");
@@ -155,6 +213,11 @@ export async function requireScopeFromRequest(
   }
 
   const authResult = await auth();
-  const member = await verifyClerkMembership(scope, userId);
+  const member = await verifyMembership(
+    scope,
+    userId,
+    authResult,
+    tokenScopeId,
+  );
   return { scope: applyJwtTier(scope, authResult), member };
 }

--- a/turbo/apps/web/src/lib/scope/scope-member-service.ts
+++ b/turbo/apps/web/src/lib/scope/scope-member-service.ts
@@ -1,10 +1,10 @@
-import { clerkClient } from "@clerk/nextjs/server";
+import { auth, clerkClient } from "@clerk/nextjs/server";
 import { eq, and, asc } from "drizzle-orm";
 import { scopeMembers } from "../../db/schema/scope-member";
 import { scopes } from "../../db/schema/scope";
 import { badRequest, forbidden, notFound } from "../errors";
 import { logger } from "../logger";
-import { getScopesByClerkOrgIds } from "./scope-service";
+import { getScopeByClerkOrgId, getScopesByClerkOrgIds } from "./scope-service";
 import type { ScopeRole } from "@vm0/core";
 
 const log = logger("service:scope-member");
@@ -58,11 +58,32 @@ export async function getPrimaryAdminMembership(userId: string) {
 }
 
 /**
- * Get user's default scope via Clerk API.
- * Finds the user's org memberships and returns the first one with a matching local scope.
- * Prioritizes admin memberships over member memberships.
+ * Get user's default scope.
+ *
+ * Fast path: if the JWT session contains an orgId, look up the scope directly
+ * from the database — no Clerk API call needed.
+ *
+ * Slow path: for CLI tokens (no JWT) or when the JWT org has no local scope,
+ * fall back to Clerk Backend API to discover the user's org memberships.
  */
 export async function getDefaultScope(userId: string) {
+  // JWT fast path: use active org from session token
+  const authResult = await auth();
+  if (authResult.orgId) {
+    const scope = await getScopeByClerkOrgId(authResult.orgId);
+    if (scope) {
+      return {
+        scope,
+        member: {
+          role: mapClerkRole(authResult.orgRole ?? "org:member"),
+          userId,
+          scopeId: scope.id,
+        },
+      };
+    }
+  }
+
+  // Slow path: Clerk API (CLI tokens, or JWT org has no local scope yet)
   const client = await clerkClient();
   const memberships = await client.users.getOrganizationMembershipList({
     userId,

--- a/turbo/apps/web/src/lib/scope/scope-member-service.ts
+++ b/turbo/apps/web/src/lib/scope/scope-member-service.ts
@@ -4,36 +4,43 @@ import { scopeMembers } from "../../db/schema/scope-member";
 import { scopes } from "../../db/schema/scope";
 import { badRequest, forbidden, notFound } from "../errors";
 import { logger } from "../logger";
+import { getScopeByClerkOrgId } from "./scope-service";
 import type { ScopeRole } from "@vm0/core";
-import { scopeRoleSchema } from "@vm0/core";
 
 const log = logger("service:scope-member");
 
 /**
- * Get a scope member record for a specific user in a scope
- */
-export async function getScopeMember(scopeId: string, userId: string) {
-  const result = await globalThis.services.db
-    .select()
-    .from(scopeMembers)
-    .where(
-      and(eq(scopeMembers.scopeId, scopeId), eq(scopeMembers.userId, userId)),
-    )
-    .limit(1);
-
-  return result[0] ?? null;
-}
-
-/**
  * Require a user to be a member of a scope, or throw 403.
- * Returns the member record with role typed as ScopeRole.
+ * Verifies membership via Clerk API.
  */
 export async function requireScopeMember(scopeId: string, userId: string) {
-  const member = await getScopeMember(scopeId, userId);
-  if (!member) {
+  const [scope] = await globalThis.services.db
+    .select()
+    .from(scopes)
+    .where(eq(scopes.id, scopeId))
+    .limit(1);
+
+  if (!scope?.clerkOrgId || scope.clerkOrgId.startsWith("pending_")) {
     throw forbidden("You are not a member of this scope");
   }
-  return { ...member, role: scopeRoleSchema.parse(member.role) };
+
+  const client = await clerkClient();
+  const memberships = await client.organizations.getOrganizationMembershipList({
+    organizationId: scope.clerkOrgId,
+  });
+
+  const membership = memberships.data.find(
+    (m) => m.publicUserData?.userId === userId,
+  );
+  if (!membership) {
+    throw forbidden("You are not a member of this scope");
+  }
+
+  return {
+    role: mapClerkRole(membership.role),
+    userId,
+    scopeId,
+  };
 }
 
 /**
@@ -51,40 +58,37 @@ export async function getPrimaryAdminMembership(userId: string) {
 }
 
 /**
- * Get user's default scope (first owned scope from scope_members)
- * Falls back to legacy getDefaultScopeByClerkUserId behavior for backward compat
+ * Get user's default scope via Clerk API.
+ * Finds the user's org memberships and returns the first one with a matching local scope.
+ * Prioritizes admin memberships over member memberships.
  */
 export async function getDefaultScope(userId: string) {
-  // Find first scope where user is admin (scope creator)
-  const result = await globalThis.services.db
-    .select({
-      scope: scopes,
-      member: scopeMembers,
-    })
-    .from(scopeMembers)
-    .innerJoin(scopes, eq(scopeMembers.scopeId, scopes.id))
-    .where(and(eq(scopeMembers.userId, userId), eq(scopeMembers.role, "admin")))
-    .orderBy(asc(scopeMembers.createdAt))
-    .limit(1);
+  const client = await clerkClient();
+  const memberships = await client.users.getOrganizationMembershipList({
+    userId,
+  });
 
-  if (result[0]) {
-    return result[0];
-  }
+  // Priority: admin orgs first, then any org
+  const adminMembership = memberships.data.find((m) => m.role === "org:admin");
+  const candidates = adminMembership
+    ? [
+        adminMembership,
+        ...memberships.data.filter((m) => m !== adminMembership),
+      ]
+    : memberships.data;
 
-  // Fallback: find any scope the user is a member of
-  const anyMembership = await globalThis.services.db
-    .select({
-      scope: scopes,
-      member: scopeMembers,
-    })
-    .from(scopeMembers)
-    .innerJoin(scopes, eq(scopeMembers.scopeId, scopes.id))
-    .where(eq(scopeMembers.userId, userId))
-    .orderBy(asc(scopeMembers.createdAt))
-    .limit(1);
-
-  if (anyMembership[0]) {
-    return anyMembership[0];
+  for (const membership of candidates) {
+    const scope = await getScopeByClerkOrgId(membership.organization.id);
+    if (scope) {
+      return {
+        scope,
+        member: {
+          role: mapClerkRole(membership.role),
+          userId,
+          scopeId: scope.id,
+        },
+      };
+    }
   }
 
   throw notFound("No scope found for user");

--- a/turbo/apps/web/src/lib/scope/scope-member-service.ts
+++ b/turbo/apps/web/src/lib/scope/scope-member-service.ts
@@ -4,7 +4,7 @@ import { scopeMembers } from "../../db/schema/scope-member";
 import { scopes } from "../../db/schema/scope";
 import { badRequest, forbidden, notFound } from "../errors";
 import { logger } from "../logger";
-import { getScopeByClerkOrgId } from "./scope-service";
+import { getScopesByClerkOrgIds } from "./scope-service";
 import type { ScopeRole } from "@vm0/core";
 
 const log = logger("service:scope-member");
@@ -77,8 +77,12 @@ export async function getDefaultScope(userId: string) {
       ]
     : memberships.data;
 
+  // Batch-fetch all scopes by Clerk org IDs in a single query
+  const clerkOrgIds = candidates.map((m) => m.organization.id);
+  const scopeMap = await getScopesByClerkOrgIds(clerkOrgIds);
+
   for (const membership of candidates) {
-    const scope = await getScopeByClerkOrgId(membership.organization.id);
+    const scope = scopeMap.get(membership.organization.id);
     if (scope) {
       return {
         scope,

--- a/turbo/apps/web/src/lib/scope/scope-member-service.ts
+++ b/turbo/apps/web/src/lib/scope/scope-member-service.ts
@@ -125,9 +125,13 @@ export async function getDefaultScope(userId: string) {
 export async function resolveScopeId(
   userId: string,
   scopeId: string | undefined,
+  tokenScopeId?: string | null,
 ): Promise<string> {
   if (scopeId) {
     return scopeId;
+  }
+  if (tokenScopeId) {
+    return tokenScopeId;
   }
   const { scope } = await getDefaultScope(userId);
   return scope.id;

--- a/turbo/apps/web/src/lib/scope/scope-service.ts
+++ b/turbo/apps/web/src/lib/scope/scope-service.ts
@@ -372,6 +372,7 @@ export function isOfficialRunnerGroup(group: string): boolean {
 export async function validateRunnerGroupScope(
   clerkUserId: string,
   group: string,
+  tokenScopeId?: string | null,
 ): Promise<void> {
   const scopeSlug = group.split("/")[0];
   if (!scopeSlug) {
@@ -383,9 +384,17 @@ export async function validateRunnerGroupScope(
     return;
   }
 
-  // TODO: This checks against the user's default scope, but should check scope
-  // membership instead. A user who belongs to multiple scopes can only use runner
-  // groups from their default scope, which is incorrect.
+  // CLI token with stored scope_id — verify slug matches directly
+  if (tokenScopeId) {
+    const scope = await getScopeById(tokenScopeId);
+    if (scope && scope.slug === scopeSlug) {
+      return;
+    }
+    throw forbidden(
+      `Runner group scope "${scopeSlug}" does not match your scope`,
+    );
+  }
+
   const defaultScope = await getDefaultScopeByClerkUserId(clerkUserId);
   if (!defaultScope) {
     throw forbidden(

--- a/turbo/apps/web/src/lib/scope/scope-service.ts
+++ b/turbo/apps/web/src/lib/scope/scope-service.ts
@@ -1,5 +1,5 @@
 import { createHash, randomBytes } from "crypto";
-import { eq } from "drizzle-orm";
+import { eq, inArray } from "drizzle-orm";
 import { clerkClient } from "@clerk/nextjs/server";
 import { scopes } from "../../db/schema/scope";
 import { scopeMembers } from "../../db/schema/scope-member";
@@ -111,6 +111,21 @@ export async function getScopeByClerkOrgId(clerkOrgId: string) {
     .limit(1);
 
   return result[0] ?? null;
+}
+
+/**
+ * Get scopes by multiple Clerk organization IDs in a single query.
+ * Returns a Map from clerkOrgId to scope record.
+ */
+export async function getScopesByClerkOrgIds(
+  clerkOrgIds: string[],
+): Promise<Map<string, typeof scopes.$inferSelect>> {
+  if (clerkOrgIds.length === 0) return new Map();
+  const results = await globalThis.services.db
+    .select()
+    .from(scopes)
+    .where(inArray(scopes.clerkOrgId, clerkOrgIds));
+  return new Map(results.map((s) => [s.clerkOrgId, s]));
 }
 
 /**


### PR DESCRIPTION
## Summary

- Replace `scope_members` DB queries with Clerk API calls for membership verification in `resolveScope()` and `requireScopeMember()`
- Read scope `tier` from JWT `sessionClaims.org_tier` instead of relying solely on DB value
- Fix `createScope()` to use existing `clerkOrgId` for JIT discovery path instead of always creating a new Clerk org
- Upgrade Clerk mock to track org creation at module level with creator userId for proper cross-session membership verification

Closes #4114

## Test plan

- [x] All 11 resolve-scope tests pass (6 updated + 5 new for JWT tier, member role, non-member 403)
- [x] All 24 scope route tests pass
- [x] Full test suite: 3603/3604 pass (1 flaky CLI timeout test pre-existing on main)
- [x] Lint, type check, format, knip all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)