### PR TITLE
fix: remove overly broad "killed process" pattern from oom detection

### DIFF
--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -345,10 +345,7 @@ async fn read_guest_error_file(sandbox: &dyn Sandbox, run_id: Uuid) -> Option<St
 /// Returns true if dmesg output indicates an OOM kill.
 fn dmesg_indicates_oom(stdout: &str) -> bool {
     let lower = stdout.to_lowercase();
-    lower.contains("out of memory")
-        || lower.contains("oom-kill")
-        || lower.contains("oom_reaper")
-        || lower.contains("killed process")
+    lower.contains("out of memory") || lower.contains("oom-kill") || lower.contains("oom_reaper")
 }
 
 /// Copy guest log files to the host log directory.

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -1055,7 +1055,8 @@ mod tests {
         ));
         assert!(dmesg_indicates_oom("oom-kill:constraint=CONSTRAINT_MEMCG"));
         assert!(dmesg_indicates_oom("oom_reaper: reaped process 42"));
-        assert!(dmesg_indicates_oom("Killed process 42 (node)"));
+        // "Killed process" alone (without OOM context) should NOT match
+        assert!(!dmesg_indicates_oom("Killed process 42 (node)"));
     }
 
     #[test]
@@ -1063,7 +1064,6 @@ mod tests {
         assert!(!dmesg_indicates_oom(""));
         assert!(!dmesg_indicates_oom("normal kernel log output"));
         assert!(!dmesg_indicates_oom("[  1.000] eth0: link up"));
-        // "killed" alone should not match — requires "killed process"
         assert!(!dmesg_indicates_oom("task killed by signal 15"));
         // substring "oom" in unrelated words should not match
         assert!(!dmesg_indicates_oom("the room is full"));
@@ -1072,7 +1072,7 @@ mod tests {
     #[test]
     fn dmesg_oom_case_insensitive() {
         assert!(dmesg_indicates_oom("Out Of Memory: killed process 99"));
-        assert!(dmesg_indicates_oom("Killed process 99 (agent)"));
+        assert!(!dmesg_indicates_oom("Killed process 99 (agent)"));
         assert!(dmesg_indicates_oom("OOM-kill: constraint=MEMCG"));
     }
 

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -1055,13 +1055,13 @@ mod tests {
         ));
         assert!(dmesg_indicates_oom("oom-kill:constraint=CONSTRAINT_MEMCG"));
         assert!(dmesg_indicates_oom("oom_reaper: reaped process 42"));
-        // "Killed process" alone (without OOM context) should NOT match
-        assert!(!dmesg_indicates_oom("Killed process 42 (node)"));
     }
 
     #[test]
     fn dmesg_oom_negative() {
         assert!(!dmesg_indicates_oom(""));
+        // "Killed process" alone (without OOM context) should NOT match
+        assert!(!dmesg_indicates_oom("Killed process 42 (node)"));
         assert!(!dmesg_indicates_oom("normal kernel log output"));
         assert!(!dmesg_indicates_oom("[  1.000] eth0: link up"));
         assert!(!dmesg_indicates_oom("task killed by signal 15"));


### PR DESCRIPTION
## Summary

- Remove `"killed process"` from `dmesg_indicates_oom` in `crates/runner/src/executor.rs`
- This pattern matches any kernel process kill (cgroup limits, seccomp, etc.), not just OOM kills
- The remaining patterns (`out of memory`, `oom-kill`, `oom_reaper`) already cover all OOM scenarios

Closes #4126

## Test plan

- [ ] `cargo check -p runner` passes
- [ ] `cargo clippy` clean
- [ ] Review: the three remaining patterns map directly to Linux kernel OOM log messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)