### PR TITLE
refactor: fix ahrefs and mailchimp connector secret naming

### DIFF
--- a/turbo/packages/core/src/contracts/connectors.ts
+++ b/turbo/packages/core/src/contracts/connectors.ts
@@ -65,7 +65,7 @@ export const CONNECTOR_TYPES = {
         helpText:
           "1. Log in to your [Ahrefs Dashboard](https://app.ahrefs.com)\n2. Go to **API keys** under your account settings\n3. Generate a new API token\n4. Copy the token",
         secrets: {
-          AHREFS_ACCESS_TOKEN: {
+          AHREFS_TOKEN: {
             label: "API Token",
             required: true,
             placeholder: "your-ahrefs-api-token",
@@ -75,7 +75,7 @@ export const CONNECTOR_TYPES = {
     } as Record<string, ConnectorAuthMethodConfig>,
     defaultAuthMethod: "api-token",
     environmentMapping: {
-      AHREFS_API_KEY: "$secrets.AHREFS_ACCESS_TOKEN",
+      AHREFS_TOKEN: "$secrets.AHREFS_ACCESS_TOKEN",
     } as Record<string, string>,
     oauth: {
       authorizationUrl: "https://app.ahrefs.com/api/auth",
@@ -1514,7 +1514,7 @@ export const CONNECTOR_TYPES = {
         helpText:
           "1. Log in to your [Mailchimp account](https://login.mailchimp.com)\n2. Go to **Account & Billing** → **Extras** → **API keys**\n3. Click **Create A Key**\n4. Copy the API key (format: `xxxxxxxx-us00`)",
         secrets: {
-          MAILCHIMP_ACCESS_TOKEN: {
+          MAILCHIMP_TOKEN: {
             label: "API Key",
             required: true,
             placeholder: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx-us00",
@@ -1524,7 +1524,7 @@ export const CONNECTOR_TYPES = {
     } as Record<string, ConnectorAuthMethodConfig>,
     defaultAuthMethod: "api-token",
     environmentMapping: {
-      MAILCHIMP_API_KEY: "$secrets.MAILCHIMP_ACCESS_TOKEN",
+      MAILCHIMP_TOKEN: "$secrets.MAILCHIMP_ACCESS_TOKEN",
     } as Record<string, string>,
     oauth: {
       authorizationUrl: "https://login.mailchimp.com/oauth2/authorize",


### PR DESCRIPTION
## Summary
- Apply `XXX_TOKEN` naming convention to ahrefs and mailchimp connectors (added in #4113 and #4116)
- Rename api-token secrets from `_ACCESS_TOKEN` to `_TOKEN` (direct target name)
- Rename environmentMapping targets from `_API_KEY` to `_TOKEN`

Follows the convention established in #4137.

| Connector | Field | Before | After |
|-----------|-------|--------|-------|
| ahrefs | api-token secret | `AHREFS_ACCESS_TOKEN` | `AHREFS_TOKEN` |
| ahrefs | environmentMapping | `AHREFS_API_KEY` | `AHREFS_TOKEN` |
| mailchimp | api-token secret | `MAILCHIMP_ACCESS_TOKEN` | `MAILCHIMP_TOKEN` |
| mailchimp | environmentMapping | `MAILCHIMP_API_KEY` | `MAILCHIMP_TOKEN` |

## Test plan
- [ ] `pnpm turbo run lint` passes
- [ ] `pnpm knip` passes
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)