### PR TITLE
chore: update env templates vault refs and remove unused connectors

### DIFF
--- a/scripts/.env.local.tpl
+++ b/scripts/.env.local.tpl
@@ -1,5 +1,5 @@
 # Cloudflare Access service token for SSH tunnel
-CF_ACCESS_CLIENT_ID=op://Development/cloudflare/CF_ACCESS_CLIENT_ID
-CF_ACCESS_CLIENT_SECRET=op://Development/cloudflare/CF_ACCESS_CLIENT_SECRET
-CF_TUNNEL_ACCOUNT_ID=op://Development/cloudflare/CF_TUNNEL_ACCOUNT_ID
-CF_TUNNEL_API_TOKEN=op://Development/cloudflare/CF_TUNNEL_API_TOKEN
+CF_ACCESS_CLIENT_ID=op://Team/cloudflare/CF_ACCESS_CLIENT_ID
+CF_ACCESS_CLIENT_SECRET=op://Team/cloudflare/CF_ACCESS_CLIENT_SECRET
+CF_TUNNEL_ACCOUNT_ID=op://Team/cloudflare/CF_TUNNEL_ACCOUNT_ID
+CF_TUNNEL_API_TOKEN=op://Team/cloudflare/CF_TUNNEL_API_TOKEN

--- a/turbo/apps/web/.env.local.tpl
+++ b/turbo/apps/web/.env.local.tpl
@@ -34,10 +34,6 @@ CLAUDE_CODE_VERSION_URL=https://storage.googleapis.com/claude-code-dist-86c565f3
 # Optional: LLM API (OpenRouter)
 OPENROUTER_API_KEY=op://Development/openrouter/OPENROUTER_API_KEY
 
-# Optional: Ahrefs OAuth Connector
-AHREFS_OAUTH_CLIENT_ID=op://Development/ahrefs/AHREFS_OAUTH_CLIENT_ID
-AHREFS_OAUTH_CLIENT_SECRET=op://Development/ahrefs/AHREFS_OAUTH_CLIENT_SECRET
-
 # Optional: Airtable OAuth Connector
 AIRTABLE_OAUTH_CLIENT_ID=op://Development/airtable/AIRTABLE_OAUTH_CLIENT_ID
 AIRTABLE_OAUTH_CLIENT_SECRET=op://Development/airtable/AIRTABLE_OAUTH_CLIENT_SECRET
@@ -136,10 +132,6 @@ CANVA_OAUTH_CLIENT_SECRET=op://Development/canva/CANVA_OAUTH_CLIENT_SECRET
 WEBFLOW_OAUTH_CLIENT_ID=op://Development/webflow/WEBFLOW_OAUTH_CLIENT_ID
 WEBFLOW_OAUTH_CLIENT_SECRET=op://Development/webflow/WEBFLOW_OAUTH_CLIENT_SECRET
 
-# Optional: PostHog OAuth Connector
-POSTHOG_OAUTH_CLIENT_ID=op://Development/posthog/POSTHOG_OAUTH_CLIENT_ID
-POSTHOG_OAUTH_CLIENT_SECRET=op://Development/posthog/POSTHOG_OAUTH_CLIENT_SECRET
-
 # Optional: Stripe OAuth Connector
 STRIPE_OAUTH_CLIENT_ID=op://Development/stripe/STRIPE_OAUTH_CLIENT_ID
 STRIPE_OAUTH_CLIENT_SECRET=op://Development/stripe/STRIPE_OAUTH_CLIENT_SECRET
@@ -177,4 +169,4 @@ GITHUB_APP_WEBHOOK_SECRET=op://Development/github/GITHUB_APP_WEBHOOK_SECRET
 
 # Optional: Self-hosted Runner (for local development with runner on dev-1)
 # RUNNER_DEFAULT_GROUP is auto-configured by sync-env.sh — do not add here
-OFFICIAL_RUNNER_SECRET=op://Development/vm0/OFFICIAL_RUNNER_SECRET
+OFFICIAL_RUNNER_SECRET=op://Team/vm0/OFFICIAL_RUNNER_SECRET


### PR DESCRIPTION
## Summary
- Switch 1Password vault from `Development` to `Team` for Cloudflare and runner secret references
- Remove Ahrefs and PostHog OAuth connector entries (these now use API key auth, not OAuth)

## Test plan
- [ ] Verify `sync-env.sh` resolves secrets from `Team` vault correctly
- [ ] Confirm removed connectors still work via API key auth

🤖 Generated with [Claude Code](https://claude.com/claude-code)