### PR TITLE
fix(e2e): rename duplicate t34 test to t36

### DIFF
--- a/e2e/tests/03-experimental-runner/t36-vm0-logs-search.bats
+++ b/e2e/tests/03-experimental-runner/t36-vm0-logs-search.bats
@@ -11,11 +11,11 @@
 load '../../helpers/setup'
 
 setup_file() {
-    export AGENT_NAME="e2e-t34-$(date +%s%3N)-$RANDOM"
+    export AGENT_NAME="e2e-t36-$(date +%s%3N)-$RANDOM"
 }
 
 setup() {
-    create_test_volume "e2e-vol-t34"
+    create_test_volume "e2e-vol-t36"
 
     export TEST_ARTIFACT_DIR="$(mktemp -d)"
     export ARTIFACT_NAME="e2e-search-test-$(date +%s%3N)-$RANDOM"


### PR DESCRIPTION
## Summary
- `t34-vm0-logs-search.bats` and `t34-vm0-memory.bats` both used the `t34` prefix
- Renamed logs-search to `t36` and updated internal agent/volume identifiers to avoid collisions

## Test plan
- [ ] CI passes (no test logic changed, only file rename + identifier update)

🤖 Generated with [Claude Code](https://claude.com/claude-code)