### PR TITLE
refactor: simplify pr number parsing in skill files

### DIFF
--- a/.claude/skills/code-quality/SKILL.md
+++ b/.claude/skills/code-quality/SKILL.md
@@ -15,7 +15,9 @@ This skill supports two operations:
 1. **review** - Comprehensive code review with bad smell detection
 2. **cleanup** - Remove defensive try-catch blocks
 
-Parse the operation from the `args` parameter:
+Your args are: `$ARGUMENTS`
+
+Parse the operation from the args above:
 - `review <pr-id|commit-id|description>` - Review code changes
 - `cleanup` - Clean up defensive code patterns
 

--- a/.claude/skills/dev-server/SKILL.md
+++ b/.claude/skills/dev-server/SKILL.md
@@ -8,15 +8,15 @@ You are a development server specialist for the vm0 project. Your role is to man
 
 ## Operations
 
-Parse the `args` parameter to determine which operation to perform:
+Your args are: `$ARGUMENTS`
+
+Parse the args above to determine which operation to perform:
 
 - **start**: Start the development server in background mode (tunnel is automatic for web app). Supports `--tunnel-hostname=<fqdn>` to use a fixed tunnel domain instead of the auto-generated one.
 - **stop**: Stop the background development server
 - **logs [pattern]**: View development server logs with optional filtering
 - **auth**: Authenticate with local development server and get CLI token
 - **tunnel**: Full setup with tunnel and CLI authentication (for E2B testing)
-
-When invoked, check the args to determine the operation and execute accordingly.
 
 **Note**: As of issue #1726, the web app automatically starts a Cloudflare tunnel when running `pnpm dev`. The tunnel URL is displayed during startup and `VM0_API_URL` is set automatically.
 

--- a/.claude/skills/issue-create/SKILL.md
+++ b/.claude/skills/issue-create/SKILL.md
@@ -9,13 +9,13 @@ You are a GitHub issue creation specialist. Your role is to create well-structur
 
 ## Operations
 
-Parse the `args` parameter to determine which operation to perform:
+Your args are: `$ARGUMENTS`
+
+Parse the args above to determine which operation to perform:
 
 - **create** - Create issue from conversation (flexible, adapts to content)
 - **bug** - Create bug report with reproduction steps
 - **feature** - Create feature request with acceptance criteria
-
-When invoked, check the args to determine the operation and execute accordingly.
 
 ---
 

--- a/.claude/skills/issue-plan/SKILL.md
+++ b/.claude/skills/issue-plan/SKILL.md
@@ -9,7 +9,9 @@ You are a GitHub issue planning specialist. Your role is to start working on a G
 
 ## Arguments
 
-Parse the `args` parameter to get the issue ID. For example, if args is `123`, work on issue #123.
+Your args are: `$ARGUMENTS`
+
+Parse the args above to get the issue ID. For example, if args is `123`, work on issue #123.
 
 If no issue ID is provided in args, ask the user: "Which issue would you like to start working on? Please provide the issue ID."
 

--- a/.claude/skills/ops-utils/SKILL.md
+++ b/.claude/skills/ops-utils/SKILL.md
@@ -8,11 +8,11 @@ You are an operations utilities specialist for the vm0 project. Your role is to 
 
 ## Operations
 
-Parse the `args` parameter to determine which operation to perform:
+Your args are: `$ARGUMENTS`
+
+Parse the args above to determine which operation to perform:
 
 - **cleanup-previews**: Clean up old GitHub preview deployment environments
-
-When invoked, check the args to determine the operation and execute accordingly.
 
 ---
 

--- a/.claude/skills/pr-check/SKILL.md
+++ b/.claude/skills/pr-check/SKILL.md
@@ -33,25 +33,18 @@ You are a CI pipeline specialist for the vm0 project. Your role is to monitor PR
 
 ## Step 1: Identify Target PR
 
-Parse the `args` parameter to extract a PR number. The args can be:
-- A PR number: `4062`
-- A GitHub URL: `https://github.com/owner/repo/pull/4062` or `https://github.com/owner/repo/issues/4062`
-- Empty: detect from current branch
+**CRITICAL — do this FIRST before anything else.**
 
-**Important:** `$PR_ID` is a placeholder — you (the LLM) must extract the PR number from the skill's `args` string yourself before running any bash commands. If args contains a URL, extract the number from the path. If args is a plain number, use it directly. If args is empty, fall back to detecting from the current branch.
+The text that the user typed after the skill name is your `args`. Examples:
+- `/pr-check 4128` → args = `4128`
+- `/pr-check https://github.com/vm0-ai/vm0/pull/4128` → args = the URL
 
-```bash
-if [ -n "$PR_ID" ]; then
-    pr_id="$PR_ID"
-else
-    pr_id=$(gh pr list --head $(git branch --show-current) --json number --jq '.[0].number')
-fi
+Extract the PR number from args using these rules:
+1. **Args is a URL** containing `/pull/<number>` or `/issues/<number>` → extract `<number>` (e.g., `https://github.com/vm0-ai/vm0/pull/4128` → `4128`)
+2. **Args is a plain number** → use it directly (e.g., `4128`)
+3. **Args is empty** → detect from current branch using `gh pr list --head "$(git branch --show-current)" --json number --jq '.[0].number'`
 
-if [ -z "$pr_id" ]; then
-    echo "No PR found for current branch. Please specify a PR number."
-    exit 1
-fi
-```
+Once you have the PR number, **hardcode it as a literal** in all subsequent bash commands. Never use shell variables for the PR number derived from args — always substitute the actual number directly.
 
 ---
 

--- a/.claude/skills/pr-check/SKILL.md
+++ b/.claude/skills/pr-check/SKILL.md
@@ -35,11 +35,9 @@ You are a CI pipeline specialist for the vm0 project. Your role is to monitor PR
 
 **CRITICAL — do this FIRST before anything else.**
 
-The text that the user typed after the skill name is your `args`. Examples:
-- `/pr-check 4128` → args = `4128`
-- `/pr-check https://github.com/vm0-ai/vm0/pull/4128` → args = the URL
+Your args are: `$ARGUMENTS`
 
-Extract the PR number from args using these rules:
+Extract the PR number from the args above using these rules:
 1. **Args is a URL** containing `/pull/<number>` or `/issues/<number>` → extract `<number>` (e.g., `https://github.com/vm0-ai/vm0/pull/4128` → `4128`)
 2. **Args is a plain number** → use it directly (e.g., `4128`)
 3. **Args is empty** → detect from current branch using `gh pr list --head "$(git branch --show-current)" --json number --jq '.[0].number'`

--- a/.claude/skills/pr-review-loop/SKILL.md
+++ b/.claude/skills/pr-review-loop/SKILL.md
@@ -32,27 +32,28 @@ Loop control is handled by a **bash driver script**, not by your memory. You MUS
 
 ### 1a: Identify PR
 
-Parse the `args` parameter to extract a PR number. The args can be:
-- A PR number: `4062`
-- A GitHub PR URL: `https://github.com/owner/repo/pull/4062`
-- A GitHub issue URL: `https://github.com/owner/repo/issues/4062` (treat as PR number)
-- Empty: detect from current branch
+**CRITICAL — do this FIRST before anything else.**
+
+The text that the user typed after `/pr-review-loop` is your `args`. Examples:
+- `/pr-review-loop 4128` → args = `4128`
+- `/pr-review-loop https://github.com/vm0-ai/vm0/pull/4128` → args = the URL
+
+Extract the PR number from args using these rules:
+1. **Args is a URL** containing `/pull/<number>` or `/issues/<number>` → extract `<number>` (e.g., `https://github.com/vm0-ai/vm0/pull/4128` → `4128`)
+2. **Args is a plain number** → use it directly (e.g., `4128`)
+3. **Args is empty** → detect from current branch using `gh pr list --head "$(git branch --show-current)" --json number --jq '.[0].number'`
+
+Once you have the PR number, **hardcode it as a literal** in all subsequent bash commands. Never use shell variables for the PR number derived from args — always substitute the actual number directly.
+
+### 1b: Checkout PR Branch
+
+Switch to the PR branch so that fixes are applied to the correct code:
 
 ```bash
-# Parse PR_ID from args — extract number from URL if needed
-PR_ID=$(echo "$ARGS" | grep -oP '(?:pull|issues)/\K[0-9]+' || echo "$ARGS" | grep -oP '^[0-9]+$' || echo "")
-
-if [ -n "$PR_ID" ]; then
-    PR_NUMBER="$PR_ID"
-else
-    CURRENT_BRANCH=$(git branch --show-current)
-    PR_NUMBER=$(gh pr list --head "$CURRENT_BRANCH" --json number --jq '.[0].number')
-fi
+gh pr checkout <PR_NUMBER>
 ```
 
-**Important:** `$ARGS` is a placeholder — you (the LLM) must extract the PR number from the skill's `args` string yourself before running any bash commands. If args contains a URL, extract the number from the path. If args is a plain number, use it directly. If args is empty, fall back to detecting from the current branch.
-
-### 1b: Create Driver Script
+### 1c: Create Driver Script
 
 Write this script to `/tmp/pr-review-loop-driver.sh` and make it executable:
 
@@ -92,7 +93,7 @@ DRIVER
 chmod +x /tmp/pr-review-loop-driver.sh
 ```
 
-### 1c: Initialize
+### 1d: Initialize
 
 ```bash
 ACTION=$(/tmp/pr-review-loop-driver.sh "$PR_NUMBER" init)

--- a/.claude/skills/pr-review-loop/SKILL.md
+++ b/.claude/skills/pr-review-loop/SKILL.md
@@ -34,11 +34,9 @@ Loop control is handled by a **bash driver script**, not by your memory. You MUS
 
 **CRITICAL — do this FIRST before anything else.**
 
-The text that the user typed after `/pr-review-loop` is your `args`. Examples:
-- `/pr-review-loop 4128` → args = `4128`
-- `/pr-review-loop https://github.com/vm0-ai/vm0/pull/4128` → args = the URL
+Your args are: `$ARGUMENTS`
 
-Extract the PR number from args using these rules:
+Extract the PR number from the args above using these rules:
 1. **Args is a URL** containing `/pull/<number>` or `/issues/<number>` → extract `<number>` (e.g., `https://github.com/vm0-ai/vm0/pull/4128` → `4128`)
 2. **Args is a plain number** → use it directly (e.g., `4128`)
 3. **Args is empty** → detect from current branch using `gh pr list --head "$(git branch --show-current)" --json number --jq '.[0].number'`

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -10,26 +10,18 @@ You are a PR review specialist for the vm0 project. Your role is to review pull 
 
 ### Step 1: Determine PR Number
 
-Parse the `args` parameter to extract a PR number. The args can be:
-- A PR number: `4062`
-- A GitHub URL: `https://github.com/owner/repo/pull/4062` or `https://github.com/owner/repo/issues/4062`
-- Empty: detect from current branch
+**CRITICAL — do this FIRST before anything else.**
 
-**Important:** `$PR_ID` is a placeholder — you (the LLM) must extract the PR number from the skill's `args` string yourself before running any bash commands. If args contains a URL, extract the number from the path. If args is a plain number, use it directly. If args is empty, fall back to detecting from the current branch.
+The text that the user typed after the skill name is your `args`. Examples:
+- `/pr-review 4128` → args = `4128`
+- `/pr-review https://github.com/vm0-ai/vm0/pull/4128` → args = the URL
 
-```bash
-if [ -n "$PR_ID" ]; then
-    PR_NUMBER="$PR_ID"
-else
-    CURRENT_BRANCH=$(git branch --show-current)
-    PR_NUMBER=$(gh pr list --head "$CURRENT_BRANCH" --json number --jq '.[0].number')
+Extract the PR number from args using these rules:
+1. **Args is a URL** containing `/pull/<number>` or `/issues/<number>` → extract `<number>` (e.g., `https://github.com/vm0-ai/vm0/pull/4128` → `4128`)
+2. **Args is a plain number** → use it directly (e.g., `4128`)
+3. **Args is empty** → detect from current branch using `gh pr list --head "$(git branch --show-current)" --json number --jq '.[0].number'`
 
-    if [ -z "$PR_NUMBER" ]; then
-        echo "No PR found for current branch. Please specify a PR number."
-        exit 1
-    fi
-fi
-```
+Once you have the PR number, **hardcode it as a literal** in all subsequent bash commands. Never use shell variables for the PR number derived from args — always substitute the actual number directly.
 
 ### Step 2: Get PR Information
 

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -12,11 +12,9 @@ You are a PR review specialist for the vm0 project. Your role is to review pull 
 
 **CRITICAL — do this FIRST before anything else.**
 
-The text that the user typed after the skill name is your `args`. Examples:
-- `/pr-review 4128` → args = `4128`
-- `/pr-review https://github.com/vm0-ai/vm0/pull/4128` → args = the URL
+Your args are: `$ARGUMENTS`
 
-Extract the PR number from args using these rules:
+Extract the PR number from the args above using these rules:
 1. **Args is a URL** containing `/pull/<number>` or `/issues/<number>` → extract `<number>` (e.g., `https://github.com/vm0-ai/vm0/pull/4128` → `4128`)
 2. **Args is a plain number** → use it directly (e.g., `4128`)
 3. **Args is empty** → detect from current branch using `gh pr list --head "$(git branch --show-current)" --json number --jq '.[0].number'`

--- a/.claude/skills/pull-request/SKILL.md
+++ b/.claude/skills/pull-request/SKILL.md
@@ -10,14 +10,14 @@ You are a Pull Request lifecycle specialist for the vm0 project. Your role is to
 
 ## Operations
 
-This skill supports four main operations. Parse the `args` parameter to determine which operation to perform:
+Your args are: `$ARGUMENTS`
+
+This skill supports four main operations. Parse the args above to determine which operation to perform:
 
 1. **create** - Create a new PR or update existing one
 2. **merge** - Validate checks and merge PR
 3. **list** - List open pull requests for the repository
 4. **comment [pr-id]** - Summarize conversation and post as PR comment
-
-When invoked, check the args to determine the operation and execute accordingly.
 
 ---
 

--- a/.claude/skills/skill-alias/SKILL.md
+++ b/.claude/skills/skill-alias/SKILL.md
@@ -37,7 +37,9 @@ The input parameter follows this format:
 
 ### Step 1: Parse Input Parameter
 
-Parse the input from the args parameter using this format:
+Your args are: `$ARGUMENTS`
+
+Parse the input from the args above using this format:
 
 ```
 ALIAS='SKILL_NAME arguments'

--- a/.claude/skills/tech-debt/SKILL.md
+++ b/.claude/skills/tech-debt/SKILL.md
@@ -15,7 +15,9 @@ This skill supports two operations:
 1. **research** - Fast scan to locate suspicious files and detailed analysis
 2. **issue** - Create GitHub issue based on research findings
 
-Parse the operation from the `args` parameter:
+Your args are: `$ARGUMENTS`
+
+Parse the operation from the args above:
 - `research` - Scan codebase and generate detailed report
 - `issue` - Create GitHub issue from research results (auto-runs research if not done)
 


### PR DESCRIPTION
## Summary
- Replaced shell-variable-based PR number extraction with clear step-by-step rules across three skill files (pr-check, pr-review-loop, pr-review)
- Instructions now direct the LLM to hardcode the literal PR number in all subsequent bash commands, avoiding unreliable shell variable substitution
- Added explicit checkout step in pr-review-loop skill for switching to the PR branch

## Test plan
- [ ] Verify `/pr-check <number>` correctly extracts and uses the PR number
- [ ] Verify `/pr-review <url>` correctly extracts the PR number from URLs
- [ ] Verify `/pr-review-loop` with no args detects PR from current branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)