### PR TITLE
refactor(cli): use os.homedir mock for scope test config isolation

### DIFF
--- a/turbo/apps/cli/src/commands/scope/__tests__/create-scope.test.ts
+++ b/turbo/apps/cli/src/commands/scope/__tests__/create-scope.test.ts
@@ -3,7 +3,7 @@
  *
  * Tests command-level behavior via parseAsync() following CLI testing principles:
  * - Entry point: command.parseAsync()
- * - Mock (external): Web API via MSW, config file I/O
+ * - Mock (external): Web API via MSW, os.homedir for config isolation
  * - Real (internal): All CLI code, formatters, validators
  */
 
@@ -11,15 +11,16 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { http, HttpResponse } from "msw";
 import { server } from "../../../mocks/server";
 import { createCommand } from "../create-scope";
+import { mkdtempSync } from "fs";
+import * as path from "path";
+import * as os from "os";
 import chalk from "chalk";
 
-vi.mock("../../../lib/api/config", async (importOriginal) => {
-  const original =
-    await importOriginal<typeof import("../../../lib/api/config")>();
-  return {
-    ...original,
-    loadConfig: vi.fn().mockResolvedValue({ activeScope: undefined }),
-  };
+// Mock os.homedir to use temp directory
+const TEST_HOME = mkdtempSync(path.join(os.tmpdir(), "test-scope-create-"));
+vi.mock("os", async (importOriginal) => {
+  const original = await importOriginal<typeof import("os")>();
+  return { ...original, homedir: () => TEST_HOME };
 });
 
 describe("scope create command", () => {

--- a/turbo/apps/cli/src/commands/scope/__tests__/leave.test.ts
+++ b/turbo/apps/cli/src/commands/scope/__tests__/leave.test.ts
@@ -3,7 +3,7 @@
  *
  * Tests command-level behavior via parseAsync() following CLI testing principles:
  * - Entry point: command.parseAsync()
- * - Mock (external): Web API via MSW, config file I/O
+ * - Mock (external): Web API via MSW, os.homedir for config isolation
  * - Real (internal): All CLI code, formatters, validators
  */
 
@@ -11,15 +11,16 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { http, HttpResponse } from "msw";
 import { server } from "../../../mocks/server";
 import { leaveCommand } from "../leave";
+import { mkdtempSync } from "fs";
+import * as path from "path";
+import * as os from "os";
 import chalk from "chalk";
 
-vi.mock("../../../lib/api/config", async (importOriginal) => {
-  const original =
-    await importOriginal<typeof import("../../../lib/api/config")>();
-  return {
-    ...original,
-    loadConfig: vi.fn().mockResolvedValue({ activeScope: undefined }),
-  };
+// Mock os.homedir to use temp directory
+const TEST_HOME = mkdtempSync(path.join(os.tmpdir(), "test-scope-leave-"));
+vi.mock("os", async (importOriginal) => {
+  const original = await importOriginal<typeof import("os")>();
+  return { ...original, homedir: () => TEST_HOME };
 });
 
 describe("org leave command", () => {

--- a/turbo/apps/cli/src/commands/scope/__tests__/list.test.ts
+++ b/turbo/apps/cli/src/commands/scope/__tests__/list.test.ts
@@ -3,23 +3,25 @@
  *
  * Tests command-level behavior via parseAsync() following CLI testing principles:
  * - Entry point: command.parseAsync()
- * - Mock (external): Web API via MSW, config file I/O
+ * - Mock (external): Web API via MSW, os.homedir for config isolation
  * - Real (internal): All CLI code, formatters, validators
  */
 
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { http, HttpResponse } from "msw";
 import { server } from "../../../mocks/server";
 import { listCommand } from "../list";
+import { mkdtempSync } from "fs";
+import { mkdir, writeFile, rm } from "fs/promises";
+import * as path from "path";
+import * as os from "os";
 import chalk from "chalk";
 
-vi.mock("../../../lib/api/config", async (importOriginal) => {
-  const original =
-    await importOriginal<typeof import("../../../lib/api/config")>();
-  return {
-    ...original,
-    loadConfig: vi.fn().mockResolvedValue({ activeScope: "my-org" }),
-  };
+// Mock os.homedir to use temp directory
+const TEST_HOME = mkdtempSync(path.join(os.tmpdir(), "test-scope-list-"));
+vi.mock("os", async (importOriginal) => {
+  const original = await importOriginal<typeof import("os")>();
+  return { ...original, homedir: () => TEST_HOME };
 });
 
 describe("scope list command", () => {
@@ -31,10 +33,20 @@ describe("scope list command", () => {
     .spyOn(console, "error")
     .mockImplementation(() => {});
 
-  beforeEach(() => {
+  beforeEach(async () => {
     chalk.level = 0;
     vi.stubEnv("VM0_API_URL", "http://localhost:3000");
     vi.stubEnv("VM0_TOKEN", "test-token");
+    const configDir = path.join(TEST_HOME, ".vm0");
+    await mkdir(configDir, { recursive: true });
+    await writeFile(
+      path.join(configDir, "config.json"),
+      JSON.stringify({ activeScope: "my-org" }),
+    );
+  });
+
+  afterEach(async () => {
+    await rm(path.join(TEST_HOME, ".vm0"), { recursive: true, force: true });
   });
 
   it("should display scopes with roles", async () => {

--- a/turbo/apps/cli/src/commands/scope/__tests__/use.test.ts
+++ b/turbo/apps/cli/src/commands/scope/__tests__/use.test.ts
@@ -3,7 +3,7 @@
  *
  * Tests command-level behavior via parseAsync() following CLI testing principles:
  * - Entry point: command.parseAsync()
- * - Mock (external): Web API via MSW, config file I/O
+ * - Mock (external): Web API via MSW, os.homedir for config isolation
  * - Real (internal): All CLI code, formatters, validators
  */
 
@@ -11,15 +11,16 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { http, HttpResponse } from "msw";
 import { server } from "../../../mocks/server";
 import { useCommand } from "../use";
+import { mkdtempSync } from "fs";
+import * as path from "path";
+import * as os from "os";
 import chalk from "chalk";
 
-vi.mock("../../../lib/api/config", async (importOriginal) => {
-  const original =
-    await importOriginal<typeof import("../../../lib/api/config")>();
-  return {
-    ...original,
-    loadConfig: vi.fn().mockResolvedValue({ activeScope: undefined }),
-  };
+// Mock os.homedir to use temp directory
+const TEST_HOME = mkdtempSync(path.join(os.tmpdir(), "test-scope-use-"));
+vi.mock("os", async (importOriginal) => {
+  const original = await importOriginal<typeof import("os")>();
+  return { ...original, homedir: () => TEST_HOME };
 });
 
 describe("scope use command", () => {


### PR DESCRIPTION
## Summary

- Replace internal `loadConfig` module mocks with `os.homedir` temp directory isolation in scope command tests
- Tests now exercise real config file I/O paths instead of bypassing them with mocks
- Aligns with testing principle: "Only Mock External Dependencies"

## Test plan

- [ ] Verify all scope tests pass: `pnpm vitest apps/cli/src/commands/scope`
- [ ] Confirm no regressions in CLI test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)