### PR TITLE
feat: add organization selection page after sign-in/sign-up

### DIFF
--- a/turbo/apps/platform/src/__tests__/mock-auth.ts
+++ b/turbo/apps/platform/src/__tests__/mock-auth.ts
@@ -3,17 +3,17 @@ import { vi } from "vitest";
 interface MockedUser {
   id: string;
   fullName: string;
-  organizationMemberships: Array<{ id: string }>;
+  organizationMemberships: { id: string }[];
   getOrganizationInvitations: (params?: {
     status?: string;
-  }) => Promise<{ data: Array<{ id: string }>; total_count: number }>;
+  }) => Promise<{ data: { id: string }[]; total_count: number }>;
 }
 
 let internalMockedUser: MockedUser | null = null;
 let internalMockedSession: { token: string } | null = null;
 let internalMockedOrganization: { id: string; name: string } | null = null;
-let internalMockedInvitations: Array<{ id: string }> = [];
-let internalMockedMemberships: Array<{ id: string }> = [{ id: "org_default" }];
+let internalMockedInvitations: { id: string }[] = [];
+let internalMockedMemberships: { id: string }[] = [{ id: "org_default" }];
 
 export function mockUser(
   user: { id: string; fullName: string } | null,
@@ -42,8 +42,8 @@ export function mockUser(
  */
 export function mockOrganization(options: {
   activeOrg?: { id: string; name: string } | null;
-  memberships?: Array<{ id: string }>;
-  pendingInvitations?: Array<{ id: string }>;
+  memberships?: { id: string }[];
+  pendingInvitations?: { id: string }[];
 }) {
   internalMockedOrganization = options.activeOrg ?? null;
   if (options.memberships) {

--- a/turbo/apps/platform/src/__tests__/mock-auth.ts
+++ b/turbo/apps/platform/src/__tests__/mock-auth.ts
@@ -1,24 +1,71 @@
 import { vi } from "vitest";
 
-let internalMockedUser: { id: string; fullName: string } | null = null;
+interface MockedUser {
+  id: string;
+  fullName: string;
+  organizationMemberships: Array<{ id: string }>;
+  getOrganizationInvitations: (params?: {
+    status?: string;
+  }) => Promise<{ data: Array<{ id: string }>; total_count: number }>;
+}
+
+let internalMockedUser: MockedUser | null = null;
 let internalMockedSession: { token: string } | null = null;
+let internalMockedOrganization: { id: string; name: string } | null = null;
+let internalMockedInvitations: Array<{ id: string }> = [];
+let internalMockedMemberships: Array<{ id: string }> = [{ id: "org_default" }];
 
 export function mockUser(
   user: { id: string; fullName: string } | null,
   session: { token: string } | null,
 ) {
-  internalMockedUser = user;
+  if (user) {
+    internalMockedUser = {
+      ...user,
+      get organizationMemberships() {
+        return internalMockedMemberships;
+      },
+      getOrganizationInvitations: () =>
+        Promise.resolve({
+          data: internalMockedInvitations,
+          total_count: internalMockedInvitations.length,
+        }),
+    };
+  } else {
+    internalMockedUser = null;
+  }
   internalMockedSession = session;
+}
+
+/**
+ * Configure organization-related mock state for testing org selection.
+ */
+export function mockOrganization(options: {
+  activeOrg?: { id: string; name: string } | null;
+  memberships?: Array<{ id: string }>;
+  pendingInvitations?: Array<{ id: string }>;
+}) {
+  internalMockedOrganization = options.activeOrg ?? null;
+  if (options.memberships) {
+    internalMockedMemberships = options.memberships;
+  }
+  internalMockedInvitations = options.pendingInvitations ?? [];
 }
 
 export function clearMockedAuth() {
   internalMockedUser = null;
   internalMockedSession = null;
+  internalMockedOrganization = null;
+  internalMockedInvitations = [];
+  internalMockedMemberships = [{ id: "org_default" }];
 }
 
 export const mockedClerk = {
   get user() {
     return internalMockedUser;
+  },
+  get organization() {
+    return internalMockedOrganization;
   },
   get session() {
     return {

--- a/turbo/apps/platform/src/signals/__tests__/needs-org-selection.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/needs-org-selection.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect } from "vitest";
+import { FeatureSwitchKey } from "@vm0/core";
+import { testContext } from "./test-helpers.ts";
+import { setupPage } from "../../__tests__/page-helper.ts";
+import { mockOrganization } from "../../__tests__/mock-auth.ts";
+import { pathname$ } from "../route.ts";
+
+const context = testContext();
+
+describe("org selection after auth", () => {
+  describe("when Zero feature flag is disabled", () => {
+    it("does not redirect even with multiple orgs", async () => {
+      await setupPage({
+        context,
+        path: "/",
+        withoutRender: true,
+        featureSwitches: { [FeatureSwitchKey.Zero]: false },
+      });
+      mockOrganization({
+        memberships: [{ id: "org_1" }, { id: "org_2" }],
+      });
+
+      expect(context.store.get(pathname$)).not.toBe("/select-org");
+    });
+  });
+
+  describe("when Zero feature flag is enabled", () => {
+    it("redirects to /select-org when user has multiple orgs and no active org", async () => {
+      mockOrganization({
+        activeOrg: null,
+        memberships: [{ id: "org_1" }, { id: "org_2" }],
+      });
+
+      await setupPage({
+        context,
+        path: "/",
+        withoutRender: true,
+        featureSwitches: { [FeatureSwitchKey.Zero]: true },
+      });
+
+      expect(context.store.get(pathname$)).toBe("/select-org");
+    });
+
+    it("redirects to /select-org when user has pending invitations and no active org", async () => {
+      mockOrganization({
+        activeOrg: null,
+        memberships: [{ id: "org_1" }],
+        pendingInvitations: [{ id: "inv_1" }],
+      });
+
+      await setupPage({
+        context,
+        path: "/",
+        withoutRender: true,
+        featureSwitches: { [FeatureSwitchKey.Zero]: true },
+      });
+
+      expect(context.store.get(pathname$)).toBe("/select-org");
+    });
+
+    it("does not redirect when user has single org and no invitations", async () => {
+      mockOrganization({
+        activeOrg: null,
+        memberships: [{ id: "org_1" }],
+        pendingInvitations: [],
+      });
+
+      await setupPage({
+        context,
+        path: "/",
+        withoutRender: true,
+        featureSwitches: { [FeatureSwitchKey.Zero]: true },
+      });
+
+      // Zero enabled → home page redirects to /zero
+      expect(context.store.get(pathname$)).toBe("/zero");
+    });
+
+    it("does not redirect when active org is already set", async () => {
+      mockOrganization({
+        activeOrg: { id: "org_1", name: "My Org" },
+        memberships: [{ id: "org_1" }, { id: "org_2" }],
+      });
+
+      await setupPage({
+        context,
+        path: "/",
+        withoutRender: true,
+        featureSwitches: { [FeatureSwitchKey.Zero]: true },
+      });
+
+      // Should go to /zero (normal Zero flow), not /select-org
+      expect(context.store.get(pathname$)).toBe("/zero");
+    });
+
+    it("does not redirect when already on /select-org", async () => {
+      mockOrganization({
+        activeOrg: null,
+        memberships: [{ id: "org_1" }, { id: "org_2" }],
+      });
+
+      await setupPage({
+        context,
+        path: "/select-org",
+        withoutRender: true,
+        featureSwitches: { [FeatureSwitchKey.Zero]: true },
+      });
+
+      // Should stay on /select-org, not redirect in a loop
+      expect(context.store.get(pathname$)).toBe("/select-org");
+    });
+
+    it("does not redirect when user has no orgs", async () => {
+      mockOrganization({
+        activeOrg: null,
+        memberships: [],
+        pendingInvitations: [],
+      });
+
+      await setupPage({
+        context,
+        path: "/",
+        withoutRender: true,
+        featureSwitches: { [FeatureSwitchKey.Zero]: true },
+      });
+
+      // Should go to /zero (normal flow), not /select-org
+      expect(context.store.get(pathname$)).toBe("/zero");
+    });
+  });
+});

--- a/turbo/apps/platform/src/signals/auth.ts
+++ b/turbo/apps/platform/src/signals/auth.ts
@@ -141,6 +141,11 @@ export const needsOrgSelection$ = computed(async (get) => {
     return false;
   }
 
+  console.debug("[needsOrgSelection]", {
+    activeOrg: clerk.organization?.id ?? null,
+    memberships: user.organizationMemberships.length,
+  });
+
   // If an active organization is already set, no selection needed
   if (clerk.organization) {
     return false;

--- a/turbo/apps/platform/src/signals/auth.ts
+++ b/turbo/apps/platform/src/signals/auth.ts
@@ -130,6 +130,8 @@ export const user$ = computed(async (get) => {
  * - AND at least one of:
  *   - User belongs to more than 1 organization
  *   - User has pending organization invitations
+ *
+ * Note: callers should gate on the Zero feature flag before using this signal.
  */
 export const needsOrgSelection$ = computed(async (get) => {
   get(reload$);

--- a/turbo/apps/platform/src/signals/auth.ts
+++ b/turbo/apps/platform/src/signals/auth.ts
@@ -120,3 +120,42 @@ export const user$ = computed(async (get) => {
   const clerk = await get(clerk$);
   return clerk.user ?? undefined;
 });
+
+/**
+ * Determines whether the current user needs to select an organization
+ * before entering the platform.
+ *
+ * Returns true when ALL of:
+ * - No active organization is set in the Clerk session
+ * - AND at least one of:
+ *   - User belongs to more than 1 organization
+ *   - User has pending organization invitations
+ */
+export const needsOrgSelection$ = computed(async (get) => {
+  get(reload$);
+  const clerk = await get(clerk$);
+  const user = clerk.user;
+  if (!user) {
+    return false;
+  }
+
+  // If an active organization is already set, no selection needed
+  if (clerk.organization) {
+    return false;
+  }
+
+  // Check membership count (synchronous property on User)
+  if (user.organizationMemberships.length > 1) {
+    return true;
+  }
+
+  // Check pending invitations (async API call)
+  const invitations = await user.getOrganizationInvitations({
+    status: "pending",
+  });
+  if (invitations.total_count > 0) {
+    return true;
+  }
+
+  return false;
+});

--- a/turbo/apps/platform/src/signals/auth.ts
+++ b/turbo/apps/platform/src/signals/auth.ts
@@ -141,11 +141,6 @@ export const needsOrgSelection$ = computed(async (get) => {
     return false;
   }
 
-  console.debug("[needsOrgSelection]", {
-    activeOrg: clerk.organization?.id ?? null,
-    memberships: user.organizationMemberships.length,
-  });
-
   // If an active organization is already set, no selection needed
   if (clerk.organization) {
     return false;

--- a/turbo/apps/platform/src/signals/bootstrap.ts
+++ b/turbo/apps/platform/src/signals/bootstrap.ts
@@ -47,7 +47,7 @@ const ROUTE_CONFIG = [
   },
   {
     path: "/zero/:tab",
-    setup: setupAuthPageWrapper(setupZeroPage$)
+    setup: setupAuthPageWrapper(setupZeroPage$),
   },
   {
     path: "/zero",

--- a/turbo/apps/platform/src/signals/bootstrap.ts
+++ b/turbo/apps/platform/src/signals/bootstrap.ts
@@ -29,6 +29,7 @@ import { setupProviderSetupPage$ } from "./provider-setup/provider-setup-page.ts
 import { setupSlackConnectPage$ } from "./slack-connect/slack-connect-page.ts";
 import { setupSlackConnectSuccessPage$ } from "./slack-connect/slack-connect-success-page.ts";
 import { setupZeroPage$ } from "./zero-page/zero-page.ts";
+import { setupSelectOrgPage$ } from "./select-org/select-org-page.ts";
 import { setupTelegramSettingsPage$ } from "./integrations-page/telegram-settings-page.ts";
 import { setupTelegramConnectPage$ } from "./telegram-connect/telegram-connect-page.ts";
 import { setupTelegramConnectSuccessPage$ } from "./telegram-connect/telegram-connect-success-page.ts";
@@ -41,8 +42,12 @@ const ROUTE_CONFIG = [
     setup: setupAuthPageWrapper(setupHomePage$),
   },
   {
+    path: "/select-org",
+    setup: setupAuthPageWrapper(setupSelectOrgPage$),
+  },
+  {
     path: "/zero/:tab",
-    setup: setupAuthPageWrapper(setupZeroPage$),
+    setup: setupAuthPageWrapper(setupZeroPage$)
   },
   {
     path: "/zero",

--- a/turbo/apps/platform/src/signals/route.ts
+++ b/turbo/apps/platform/src/signals/route.ts
@@ -1,7 +1,9 @@
 import { command, computed, state, type Command } from "ccstate";
 import { match } from "path-to-regexp";
+import { FeatureSwitchKey } from "@vm0/core";
 import type { RoutePath } from "../types/route.ts";
 import { clerk$, needsOrgSelection$ } from "./auth.ts";
+import { featureSwitch$ } from "./external/feature-switch.ts";
 import { pathname, pushState, search } from "./location.ts";
 import { setPageSignal$ } from "./page-signal.ts";
 import { rootSignal$ } from "./root-signal.ts";
@@ -219,15 +221,20 @@ export const setupAuthPageWrapper = (
       return;
     }
 
-    // Redirect to org selection if needed (skip if already on /select-org)
+    // Redirect to org selection if needed (Zero feature flag + skip if already on /select-org)
     if (pathname() !== "/select-org") {
-      const needsSelection = await get(needsOrgSelection$);
+      const features = await get(featureSwitch$);
       signal.throwIfAborted();
 
-      if (needsSelection) {
-        L.debug("redirect to /select-org because org selection is needed");
-        set(navigateInReact$, "/select-org");
-        return;
+      if (features[FeatureSwitchKey.Zero]) {
+        const needsSelection = await get(needsOrgSelection$);
+        signal.throwIfAborted();
+
+        if (needsSelection) {
+          L.debug("redirect to /select-org because org selection is needed");
+          set(navigateInReact$, "/select-org");
+          return;
+        }
       }
     }
 

--- a/turbo/apps/platform/src/signals/route.ts
+++ b/turbo/apps/platform/src/signals/route.ts
@@ -1,7 +1,7 @@
 import { command, computed, state, type Command } from "ccstate";
 import { match } from "path-to-regexp";
 import type { RoutePath } from "../types/route.ts";
-import { clerk$ } from "./auth.ts";
+import { clerk$, needsOrgSelection$ } from "./auth.ts";
 import { pathname, pushState, search } from "./location.ts";
 import { setPageSignal$ } from "./page-signal.ts";
 import { rootSignal$ } from "./root-signal.ts";
@@ -204,6 +204,7 @@ export const setupPageWrapper = (
 /**
  * Wraps a page setup function with authentication requirement.
  * Opens sign-in dialog if user is not authenticated.
+ * Also redirects to /select-org when the user needs to choose an organization.
  */
 export const setupAuthPageWrapper = (
   fn: Command<Promise<void> | void, [AbortSignal]>,
@@ -216,6 +217,18 @@ export const setupAuthPageWrapper = (
       await clerk.redirectToSignIn();
       signal.throwIfAborted();
       return;
+    }
+
+    // Redirect to org selection if needed (skip if already on /select-org)
+    if (pathname() !== "/select-org") {
+      const needsSelection = await get(needsOrgSelection$);
+      signal.throwIfAborted();
+
+      if (needsSelection) {
+        L.debug("redirect to /select-org because org selection is needed");
+        set(navigateInReact$, "/select-org");
+        return;
+      }
     }
 
     await set(setupPageWrapper(fn), signal);

--- a/turbo/apps/platform/src/signals/select-org/select-org-page.ts
+++ b/turbo/apps/platform/src/signals/select-org/select-org-page.ts
@@ -1,0 +1,8 @@
+import { command } from "ccstate";
+import { createElement } from "react";
+import { SelectOrgPage } from "../../views/select-org/select-org-page.tsx";
+import { updatePage$ } from "../react-router.ts";
+
+export const setupSelectOrgPage$ = command(({ set }) => {
+  set(updatePage$, createElement(SelectOrgPage));
+});

--- a/turbo/apps/platform/src/types/route.ts
+++ b/turbo/apps/platform/src/types/route.ts
@@ -1,5 +1,6 @@
 export type RoutePath =
   | "/"
+  | "/select-org"
   | "/zero"
   | "/zero/:tab"
   | "/logs"

--- a/turbo/apps/platform/src/views/select-org/select-org-page.tsx
+++ b/turbo/apps/platform/src/views/select-org/select-org-page.tsx
@@ -1,0 +1,29 @@
+import { OrganizationList } from "@clerk/clerk-react";
+import { useSet } from "ccstate-react";
+import { watchOrgSwitch$ } from "../../signals/auth.ts";
+import { onRef } from "../../signals/utils.ts";
+import { VM0ClerkProvider } from "../clerk/clerk-provider.tsx";
+
+const orgListRef$ = onRef(watchOrgSwitch$);
+
+export function SelectOrgPage() {
+  const orgListRef = useSet(orgListRef$);
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-sidebar">
+      <div ref={orgListRef} className="flex flex-col items-center gap-6">
+        <div className="text-center">
+          <h1 className="text-2xl font-semibold text-sidebar-foreground">
+            Select an Organization
+          </h1>
+          <p className="mt-2 text-sm text-sidebar-foreground/60">
+            Choose an organization to continue, or accept a pending invitation.
+          </p>
+        </div>
+        <VM0ClerkProvider>
+          <OrganizationList hidePersonal skipInvitationScreen />
+        </VM0ClerkProvider>
+      </div>
+    </div>
+  );
+}

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -158,7 +158,8 @@ function AccountDropdown({
 
   const handleAccountAction = (action: ZeroAccountAction) => {
     if (action === "signout") {
-      detach(clerk?.signOut(), Reason.DomCallback);
+      const sessionId = clerk?.session?.id;
+      detach(clerk?.signOut({ sessionId }), Reason.DomCallback);
       return;
     }
     if (action === "manage") {

--- a/turbo/packages/ui/package.json
+++ b/turbo/packages/ui/package.json
@@ -17,6 +17,7 @@
     "test:watch": "vitest"
   },
   "devDependencies": {
+    "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@tailwindcss/postcss": "^4.1.18",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.7.0",
@@ -39,7 +40,6 @@
   "dependencies": {
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-dialog": "^1.1.6",
-    "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-popover": "^1.1.15",
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-slot": "^1.1.2",

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -602,9 +602,6 @@ importers:
       '@radix-ui/react-dialog':
         specifier: ^1.1.6
         version: 1.1.15(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
-      '@radix-ui/react-dropdown-menu':
-        specifier: ^2.1.16
-        version: 2.1.16(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@radix-ui/react-popover':
         specifier: ^1.1.15
         version: 1.1.15(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
@@ -639,6 +636,9 @@ importers:
         specifier: ^3.0.2
         version: 3.3.1
     devDependencies:
+      '@radix-ui/react-dropdown-menu':
+        specifier: ^2.1.16
+        version: 2.1.16(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@tailwindcss/postcss':
         specifier: ^4.1.18
         version: 4.1.18


### PR DESCRIPTION
## Summary

- Add `/select-org` route in platform app with Clerk's `<OrganizationList />` component
- Intercept auth flow in `setupAuthPageWrapper` to redirect users who need org selection
- Add `needsOrgSelection$` signal that detects: no active org AND (multiple memberships OR pending invitations)
- Single-org users with no invitations skip directly to normal flow

Closes #4158

## Changes

| File | Change |
|------|--------|
| `signals/auth.ts` | Add `needsOrgSelection$` computed signal |
| `signals/route.ts` | Add org selection check in `setupAuthPageWrapper` |
| `signals/bootstrap.ts` | Register `/select-org` route |
| `types/route.ts` | Add `/select-org` to `RoutePath` union |
| `signals/select-org/select-org-page.ts` | New page setup signal |
| `views/select-org/select-org-page.tsx` | New page component with `<OrganizationList />` |

## Test plan

- [ ] User with multiple orgs and no active org → sees org selection page
- [ ] User with pending invitations → sees org selection page
- [ ] User with single org, no invitations → goes directly to normal flow
- [ ] User with active org set → skips org selection
- [ ] After selecting org → page reloads, enters normal flow
- [ ] No infinite redirect loops on `/select-org`
- [ ] Existing org switcher in sidebar still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)