### PR TITLE
ci: increase runner e2e chunks from 4 to 8

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1134,7 +1134,7 @@ jobs:
           # Split test files into chunks via random round-robin for balanced runtime
           mapfile -t FILES < <(ls e2e/tests/03-experimental-runner/*.bats | shuf)
           NUM_FILES=${#FILES[@]}
-          NUM_CHUNKS=4
+          NUM_CHUNKS=8
           [ "$NUM_CHUNKS" -gt "$NUM_FILES" ] && NUM_CHUNKS=$NUM_FILES
           echo "Runner E2E: $NUM_FILES files, $NUM_CHUNKS chunks"
 


### PR DESCRIPTION
## Summary
- Increase runner E2E test matrix chunks from 4 to 8 for higher parallelism and faster CI

## Test plan
- [ ] Verify runner E2E tests still pass with 8 chunks
- [ ] Confirm faster overall CI time

🤖 Generated with [Claude Code](https://claude.com/claude-code)