### PR TITLE
refactor(cli): migrate agent commands to withErrorHandler

### DIFF
--- a/turbo/apps/cli/src/commands/agent/__tests__/clone.test.ts
+++ b/turbo/apps/cli/src/commands/agent/__tests__/clone.test.ts
@@ -390,7 +390,7 @@ describe("agent clone command", () => {
 
       expect(mockExit).toHaveBeenCalledWith(1);
       expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining("Clone failed"),
+        expect.stringContaining("Not authenticated"),
       );
     });
   });

--- a/turbo/apps/cli/src/commands/agent/__tests__/status.test.ts
+++ b/turbo/apps/cli/src/commands/agent/__tests__/status.test.ts
@@ -224,7 +224,7 @@ describe("agent status command", () => {
 
       expect(mockExit).toHaveBeenCalledWith(1);
       expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining("Failed to get agent compose status"),
+        expect.stringContaining("Not authenticated"),
       );
     });
   });

--- a/turbo/apps/cli/src/commands/agent/clone.ts
+++ b/turbo/apps/cli/src/commands/agent/clone.ts
@@ -10,6 +10,7 @@ import { stringify as yamlStringify } from "yaml";
 import { getComposeByName, getStorageDownload } from "../../lib/api";
 import { getInstructionsStorageName } from "@vm0/core";
 import type { AgentComposeContent } from "../../lib/domain/compose-types";
+import { withErrorHandler } from "../../lib/command";
 
 /**
  * Remove deprecated fields from compose content
@@ -103,8 +104,8 @@ export const cloneCommand = new Command()
   .description("Clone agent compose to local directory (latest version)")
   .argument("<name>", "Agent compose name to clone")
   .argument("[destination]", "Destination directory (default: agent name)")
-  .action(async (name: string, destination: string | undefined) => {
-    try {
+  .action(
+    withErrorHandler(async (name: string, destination: string | undefined) => {
       const targetDir = destination || name;
 
       // Check if destination already exists and is non-empty
@@ -174,15 +175,5 @@ export const cloneCommand = new Command()
       console.log(chalk.green(`✓ Successfully cloned agent: ${name}`));
       console.log(chalk.dim(`  Location: ${targetDir}/`));
       console.log(chalk.dim(`  Version: ${compose.headVersionId.slice(0, 8)}`));
-    } catch (error) {
-      console.error(chalk.red("✗ Clone failed"));
-      if (error instanceof Error) {
-        if (error.message.includes("Not authenticated")) {
-          console.error(chalk.dim("  Run: vm0 auth login"));
-        } else {
-          console.error(chalk.dim(`  ${error.message}`));
-        }
-      }
-      process.exit(1);
-    }
-  });
+    }),
+  );

--- a/turbo/apps/cli/src/commands/agent/delete.ts
+++ b/turbo/apps/cli/src/commands/agent/delete.ts
@@ -2,6 +2,7 @@ import { Command } from "commander";
 import chalk from "chalk";
 import { getComposeByName, deleteCompose } from "../../lib/api";
 import { isInteractive, promptConfirm } from "../../lib/utils/prompt-utils";
+import { withErrorHandler } from "../../lib/command";
 
 export const deleteCommand = new Command()
   .name("delete")
@@ -9,8 +10,8 @@ export const deleteCommand = new Command()
   .description("Delete an agent")
   .argument("<name>", "Agent name to delete")
   .option("-y, --yes", "Skip confirmation prompt")
-  .action(async (name: string, options: { yes?: boolean }) => {
-    try {
+  .action(
+    withErrorHandler(async (name: string, options: { yes?: boolean }) => {
       // 1. Resolve agent name to compose
       const compose = await getComposeByName(name);
       if (!compose) {
@@ -35,24 +36,21 @@ export const deleteCommand = new Command()
       }
 
       // 3. Call delete API
-      await deleteCompose(compose.id);
-      console.log(chalk.green(`✓ Agent '${name}' deleted`));
-    } catch (error) {
-      if (error instanceof Error) {
-        if (error.message.includes("Not authenticated")) {
-          console.error(chalk.red("✗ Not authenticated"));
-          console.error(chalk.dim("  Run: vm0 auth login"));
-        } else if (error.message.includes("currently running")) {
+      try {
+        await deleteCompose(compose.id);
+      } catch (error) {
+        if (
+          error instanceof Error &&
+          error.message.includes("currently running")
+        ) {
           console.error(
             chalk.red("✗ Cannot delete agent: agent is currently running"),
           );
           console.error(chalk.dim("  Run: vm0 run list"));
-        } else {
-          console.error(chalk.red(`✗ ${error.message}`));
+          process.exit(1);
         }
-      } else {
-        console.error(chalk.red("✗ An unexpected error occurred"));
+        throw error;
       }
-      process.exit(1);
-    }
-  });
+      console.log(chalk.green(`✓ Agent '${name}' deleted`));
+    }),
+  );

--- a/turbo/apps/cli/src/commands/agent/delete.ts
+++ b/turbo/apps/cli/src/commands/agent/delete.ts
@@ -43,11 +43,9 @@ export const deleteCommand = new Command()
           error instanceof Error &&
           error.message.includes("currently running")
         ) {
-          console.error(
-            chalk.red("✗ Cannot delete agent: agent is currently running"),
-          );
-          console.error(chalk.dim("  Run: vm0 run list"));
-          process.exit(1);
+          throw new Error("Cannot delete agent: agent is currently running", {
+            cause: new Error("Run: vm0 run list"),
+          });
         }
         throw error;
       }

--- a/turbo/apps/cli/src/commands/agent/status.ts
+++ b/turbo/apps/cli/src/commands/agent/status.ts
@@ -10,6 +10,7 @@ import type {
   AgentDefinition,
   VolumeConfig,
 } from "../../lib/domain/compose-types";
+import { withErrorHandler } from "../../lib/command";
 
 /**
  * Format a list section with label and items
@@ -128,97 +129,92 @@ export const statusCommand = new Command()
     "Agent name with optional version (e.g., my-agent:latest or my-agent:a1b2c3d4)",
   )
   .option("--no-sources", "Skip fetching skills to determine variable sources")
-  .action(async (argument: string, options: { sources?: boolean }) => {
-    try {
-      // Parse NAME:VERSION argument
-      const colonIndex = argument.lastIndexOf(":");
-      let name: string;
-      let version: string;
+  .action(
+    withErrorHandler(
+      async (argument: string, options: { sources?: boolean }) => {
+        // Parse NAME:VERSION argument
+        const colonIndex = argument.lastIndexOf(":");
+        let name: string;
+        let version: string;
 
-      if (colonIndex === -1) {
-        name = argument;
-        version = "latest";
-      } else {
-        name = argument.slice(0, colonIndex);
-        version = argument.slice(colonIndex + 1) || "latest";
-      }
+        if (colonIndex === -1) {
+          name = argument;
+          version = "latest";
+        } else {
+          name = argument.slice(0, colonIndex);
+          version = argument.slice(colonIndex + 1) || "latest";
+        }
 
-      // Get compose by name
-      const compose = await getComposeByName(name);
+        // Get compose by name
+        const compose = await getComposeByName(name);
 
-      if (!compose) {
-        console.error(chalk.red(`✗ Agent compose not found: ${name}`));
-        console.error(chalk.dim("  Run: vm0 agent list"));
-        process.exit(1);
-      }
+        if (!compose) {
+          console.error(chalk.red(`✗ Agent compose not found: ${name}`));
+          console.error(chalk.dim("  Run: vm0 agent list"));
+          process.exit(1);
+        }
 
-      // Resolve version if not "latest" or full hash
-      let resolvedVersionId = compose.headVersionId;
+        // Resolve version if not "latest" or full hash
+        let resolvedVersionId = compose.headVersionId;
 
-      if (version !== "latest" && compose.headVersionId) {
-        // Check if it's already a full hash or needs resolution
-        if (version.length < 64) {
-          // Resolve the version prefix
-          try {
-            const versionInfo = await getComposeVersion(compose.id, version);
-            resolvedVersionId = versionInfo.versionId;
-          } catch (error) {
-            if (error instanceof Error && error.message.includes("not found")) {
-              console.error(chalk.red(`✗ Version not found: ${version}`));
-              console.error(
-                chalk.dim(
-                  `  HEAD version: ${compose.headVersionId?.slice(0, 8)}`,
-                ),
-              );
-              process.exit(1);
+        if (version !== "latest" && compose.headVersionId) {
+          // Check if it's already a full hash or needs resolution
+          if (version.length < 64) {
+            // Resolve the version prefix
+            try {
+              const versionInfo = await getComposeVersion(compose.id, version);
+              resolvedVersionId = versionInfo.versionId;
+            } catch (error) {
+              if (
+                error instanceof Error &&
+                error.message.includes("not found")
+              ) {
+                console.error(chalk.red(`✗ Version not found: ${version}`));
+                console.error(
+                  chalk.dim(
+                    `  HEAD version: ${compose.headVersionId?.slice(0, 8)}`,
+                  ),
+                );
+                process.exit(1);
+              }
+              throw error;
             }
-            throw error;
+          } else {
+            resolvedVersionId = version;
           }
-        } else {
-          resolvedVersionId = version;
         }
-      }
 
-      if (!resolvedVersionId || !compose.content) {
-        console.error(chalk.red(`✗ No version found for: ${name}`));
-        process.exit(1);
-      }
+        if (!resolvedVersionId || !compose.content) {
+          console.error(chalk.red(`✗ No version found for: ${name}`));
+          process.exit(1);
+        }
 
-      const content = compose.content as AgentComposeContent;
+        const content = compose.content as AgentComposeContent;
 
-      // Derive variable sources
-      // --no-sources: skip network (skill downloads), but still extract variables
-      // Without flag: fetch skills to determine variable sources
-      let variableSources: Map<string, AgentVariableSources> | undefined;
-      try {
-        variableSources = await deriveComposeVariableSources(content, {
-          skipNetwork: options.sources === false,
-        });
-      } catch {
-        // Failed to derive sources, show warning and continue without them
-        console.error(
-          chalk.yellow(
-            "⚠ Warning: Failed to fetch skill sources, showing basic info",
-          ),
+        // Derive variable sources
+        // --no-sources: skip network (skill downloads), but still extract variables
+        // Without flag: fetch skills to determine variable sources
+        let variableSources: Map<string, AgentVariableSources> | undefined;
+        try {
+          variableSources = await deriveComposeVariableSources(content, {
+            skipNetwork: options.sources === false,
+          });
+        } catch {
+          // Failed to derive sources, show warning and continue without them
+          console.error(
+            chalk.yellow(
+              "⚠ Warning: Failed to fetch skill sources, showing basic info",
+            ),
+          );
+        }
+
+        // Format and display the compose
+        formatComposeOutput(
+          compose.name,
+          resolvedVersionId,
+          content,
+          variableSources,
         );
-      }
-
-      // Format and display the compose
-      formatComposeOutput(
-        compose.name,
-        resolvedVersionId,
-        content,
-        variableSources,
-      );
-    } catch (error) {
-      console.error(chalk.red("✗ Failed to get agent compose status"));
-      if (error instanceof Error) {
-        if (error.message.includes("Not authenticated")) {
-          console.error(chalk.dim("  Run: vm0 auth login"));
-        } else {
-          console.error(chalk.dim(`  ${error.message}`));
-        }
-      }
-      process.exit(1);
-    }
-  });
+      },
+    ),
+  );


### PR DESCRIPTION
## Summary
- Replace manual try/catch blocks with `withErrorHandler()` in agent commands (`clone`, `delete`, `status`)
- Preserves inner try/catch blocks in all three source files where specific error handling is needed
- Updates related test files (`clone.test.ts`, `status.test.ts`)
- Part of tech debt cleanup for consistent error handling across CLI commands

## Test plan
- [x] Unit tests pass (951 tests)
- [x] Lint passes (0 warnings, 0 errors)
- [x] Type check passes

Closes part of #4155

🤖 Generated with [Claude Code](https://claude.com/claude-code)