### PR TITLE
refactor(cli): migrate scope commands to withErrorHandler

### DIFF
--- a/turbo/apps/cli/src/commands/scope/__tests__/create-scope.test.ts
+++ b/turbo/apps/cli/src/commands/scope/__tests__/create-scope.test.ts
@@ -105,6 +105,11 @@ describe("scope create command", () => {
 
     await expect(async () => {
       await createCommand.parseAsync(["node", "cli", "my-team"]);
-    }).rejects.toThrow("Not authenticated");
+    }).rejects.toThrow("process.exit called");
+
+    expect(mockConsoleError).toHaveBeenCalledWith(
+      expect.stringContaining("Not authenticated"),
+    );
+    expect(mockExit).toHaveBeenCalledWith(1);
   });
 });

--- a/turbo/apps/cli/src/commands/scope/create-scope.ts
+++ b/turbo/apps/cli/src/commands/scope/create-scope.ts
@@ -2,36 +2,41 @@ import { Command } from "commander";
 import chalk from "chalk";
 import { createScope, getScope, ApiRequestError } from "../../lib/api";
 import { saveConfig } from "../../lib/api/config";
+import { withErrorHandler } from "../../lib/command";
 
 export const createCommand = new Command()
   .name("create")
   .description("Create a new scope")
   .argument("<slug>", "Scope slug (e.g., myteam)")
-  .action(async (slug: string) => {
-    // Check if user already has a scope
-    try {
-      const existingScope = await getScope();
-      console.error(
-        chalk.yellow(`✗ You already have a scope: ${existingScope.slug}`),
-      );
-      console.error();
-      console.error("To rename your scope, use:");
-      console.error(chalk.cyan(`  vm0 scope set ${slug} --force`));
-      process.exit(1);
-    } catch (error) {
-      // 404 means user has no scope — proceed with creation
-      if (!(error instanceof ApiRequestError) || error.status !== 404) {
-        throw error;
+  .action(
+    withErrorHandler(async (slug: string) => {
+      // Check if user already has a scope
+      try {
+        const existingScope = await getScope();
+        console.error(
+          chalk.yellow(`✗ You already have a scope: ${existingScope.slug}`),
+        );
+        console.error();
+        console.error("To rename your scope, use:");
+        console.error(chalk.cyan(`  vm0 scope set ${slug} --force`));
+        process.exit(1);
+      } catch (error) {
+        // 404 means user has no scope — proceed with creation
+        if (!(error instanceof ApiRequestError) || error.status !== 404) {
+          throw error;
+        }
       }
-    }
 
-    const scope = await createScope({ slug });
+      const scope = await createScope({ slug });
 
-    // Auto-switch to the new scope
-    await saveConfig({ activeScope: scope.slug });
+      // Auto-switch to the new scope
+      await saveConfig({ activeScope: scope.slug });
 
-    console.log(chalk.green(`✓ Scope '${scope.slug}' created and activated.`));
-    console.log();
-    console.log("Your agents will now be namespaced as:");
-    console.log(chalk.cyan(`  ${scope.slug}/<agent-name>`));
-  });
+      console.log(
+        chalk.green(`✓ Scope '${scope.slug}' created and activated.`),
+      );
+      console.log();
+      console.log("Your agents will now be namespaced as:");
+      console.log(chalk.cyan(`  ${scope.slug}/<agent-name>`));
+    }),
+  );

--- a/turbo/apps/cli/src/commands/scope/invite.ts
+++ b/turbo/apps/cli/src/commands/scope/invite.ts
@@ -1,21 +1,15 @@
 import { Command } from "commander";
 import chalk from "chalk";
 import { inviteScopeMember } from "../../lib/api";
+import { withErrorHandler } from "../../lib/command";
 
 export const inviteCommand = new Command()
   .name("invite")
   .description("Invite a member to the current scope")
   .requiredOption("--email <email>", "Email address of the member to invite")
-  .action(async (options: { email: string }) => {
-    try {
+  .action(
+    withErrorHandler(async (options: { email: string }) => {
       await inviteScopeMember(options.email);
       console.log(chalk.green(`✓ Invitation sent to ${options.email}`));
-    } catch (error) {
-      if (error instanceof Error) {
-        console.error(chalk.red(`✗ ${error.message}`));
-      } else {
-        console.error(chalk.red("✗ An unexpected error occurred"));
-      }
-      process.exit(1);
-    }
-  });
+    }),
+  );

--- a/turbo/apps/cli/src/commands/scope/leave.ts
+++ b/turbo/apps/cli/src/commands/scope/leave.ts
@@ -2,21 +2,15 @@ import { Command } from "commander";
 import chalk from "chalk";
 import { leaveScope } from "../../lib/api";
 import { saveConfig } from "../../lib/api/config";
+import { withErrorHandler } from "../../lib/command";
 
 export const leaveCommand = new Command()
   .name("leave")
   .description("Leave the current scope")
-  .action(async () => {
-    try {
+  .action(
+    withErrorHandler(async () => {
       await leaveScope();
       await saveConfig({ activeScope: undefined });
       console.log(chalk.green("✓ Left scope. Switched to default scope."));
-    } catch (error) {
-      if (error instanceof Error) {
-        console.error(chalk.red(`✗ ${error.message}`));
-      } else {
-        console.error(chalk.red("✗ An unexpected error occurred"));
-      }
-      process.exit(1);
-    }
-  });
+    }),
+  );

--- a/turbo/apps/cli/src/commands/scope/list.ts
+++ b/turbo/apps/cli/src/commands/scope/list.ts
@@ -2,12 +2,13 @@ import { Command } from "commander";
 import chalk from "chalk";
 import { listScopes } from "../../lib/api";
 import { loadConfig } from "../../lib/api/config";
+import { withErrorHandler } from "../../lib/command";
 
 export const listCommand = new Command()
   .name("list")
   .description("List all accessible scopes")
-  .action(async () => {
-    try {
+  .action(
+    withErrorHandler(async () => {
       const result = await listScopes();
       const config = await loadConfig();
       const activeScope = config.activeScope;
@@ -20,12 +21,5 @@ export const listCommand = new Command()
         const currentLabel = isCurrent ? chalk.dim(" ← current") : "";
         console.log(`${marker}${scope.slug}${roleLabel}${currentLabel}`);
       }
-    } catch (error) {
-      if (error instanceof Error) {
-        console.error(chalk.red(`✗ ${error.message}`));
-      } else {
-        console.error(chalk.red("✗ An unexpected error occurred"));
-      }
-      process.exit(1);
-    }
-  });
+    }),
+  );

--- a/turbo/apps/cli/src/commands/scope/members.ts
+++ b/turbo/apps/cli/src/commands/scope/members.ts
@@ -1,40 +1,41 @@
 import { Command } from "commander";
 import chalk from "chalk";
 import { getScopeMembers } from "../../lib/api";
+import { withErrorHandler } from "../../lib/command";
 
 export const membersCommand = new Command()
   .name("members")
   .description("View scope members")
-  .action(async () => {
-    try {
-      const status = await getScopeMembers();
+  .action(
+    withErrorHandler(async () => {
+      try {
+        const status = await getScopeMembers();
 
-      console.log(chalk.bold(`Scope: ${status.slug}`));
-      console.log(`  Role: ${status.role}`);
-      console.log(
-        `  Created: ${new Date(status.createdAt).toLocaleDateString()}`,
-      );
-      console.log();
-      console.log(chalk.bold("Members:"));
-      for (const member of status.members) {
-        const roleTag =
-          member.role === "admin"
-            ? chalk.yellow(` (${member.role})`)
-            : chalk.dim(` (${member.role})`);
-        console.log(`  ${member.email}${roleTag}`);
-      }
-    } catch (error) {
-      if (error instanceof Error) {
-        if (error.message.includes("Organization access token required")) {
+        console.log(chalk.bold(`Scope: ${status.slug}`));
+        console.log(`  Role: ${status.role}`);
+        console.log(
+          `  Created: ${new Date(status.createdAt).toLocaleDateString()}`,
+        );
+        console.log();
+        console.log(chalk.bold("Members:"));
+        for (const member of status.members) {
+          const roleTag =
+            member.role === "admin"
+              ? chalk.yellow(` (${member.role})`)
+              : chalk.dim(` (${member.role})`);
+          console.log(`  ${member.email}${roleTag}`);
+        }
+      } catch (error) {
+        if (
+          error instanceof Error &&
+          error.message.includes("Organization access token required")
+        ) {
           console.error(
             chalk.red("✗ No active scope selected. Run: vm0 scope use <slug>"),
           );
-        } else {
-          console.error(chalk.red(`✗ ${error.message}`));
+          process.exit(1);
         }
-      } else {
-        console.error(chalk.red("✗ An unexpected error occurred"));
+        throw error;
       }
-      process.exit(1);
-    }
-  });
+    }),
+  );

--- a/turbo/apps/cli/src/commands/scope/remove.ts
+++ b/turbo/apps/cli/src/commands/scope/remove.ts
@@ -1,21 +1,15 @@
 import { Command } from "commander";
 import chalk from "chalk";
 import { removeScopeMember } from "../../lib/api";
+import { withErrorHandler } from "../../lib/command";
 
 export const removeCommand = new Command()
   .name("remove")
   .description("Remove a member from the current scope")
   .argument("<email>", "Email address of the member to remove")
-  .action(async (email: string) => {
-    try {
+  .action(
+    withErrorHandler(async (email: string) => {
       await removeScopeMember(email);
       console.log(chalk.green(`✓ Removed ${email} from scope`));
-    } catch (error) {
-      if (error instanceof Error) {
-        console.error(chalk.red(`✗ ${error.message}`));
-      } else {
-        console.error(chalk.red("✗ An unexpected error occurred"));
-      }
-      process.exit(1);
-    }
-  });
+    }),
+  );

--- a/turbo/apps/cli/src/commands/scope/set.ts
+++ b/turbo/apps/cli/src/commands/scope/set.ts
@@ -1,53 +1,52 @@
 import { Command } from "commander";
 import chalk from "chalk";
 import { getScope, updateScope } from "../../lib/api";
+import { withErrorHandler } from "../../lib/command";
 
 export const setCommand = new Command()
   .name("set")
   .description("Rename your scope slug")
   .argument("<slug>", "The new scope slug")
   .option("--force", "Force change existing scope (may break references)")
-  .action(async (slug: string, options: { force?: boolean }) => {
-    try {
-      const existingScope = await getScope();
+  .action(
+    withErrorHandler(async (slug: string, options: { force?: boolean }) => {
+      try {
+        const existingScope = await getScope();
 
-      if (!options.force) {
-        console.error(
-          chalk.yellow(`You already have a scope: ${existingScope.slug}`),
-        );
-        console.error();
-        console.error("To change your scope, use --force:");
-        console.error(chalk.cyan(`  vm0 scope set ${slug} --force`));
-        console.error();
-        console.error(
-          chalk.yellow(
-            "Warning: Changing your scope may break existing agent references.",
-          ),
-        );
-        process.exit(1);
-      }
+        if (!options.force) {
+          console.error(
+            chalk.yellow(`You already have a scope: ${existingScope.slug}`),
+          );
+          console.error();
+          console.error("To change your scope, use --force:");
+          console.error(chalk.cyan(`  vm0 scope set ${slug} --force`));
+          console.error();
+          console.error(
+            chalk.yellow(
+              "Warning: Changing your scope may break existing agent references.",
+            ),
+          );
+          process.exit(1);
+        }
 
-      const scope = await updateScope({ slug, force: true });
-      console.log(chalk.green(`✓ Scope updated to ${scope.slug}`));
-      console.log();
-      console.log("Your agents will now be namespaced as:");
-      console.log(chalk.cyan(`  ${scope.slug}/<agent-name>`));
-    } catch (error) {
-      if (error instanceof Error) {
-        if (error.message.includes("Not authenticated")) {
-          console.error(chalk.red("✗ Not authenticated. Run: vm0 auth login"));
-        } else if (error.message.includes("already exists")) {
+        const scope = await updateScope({ slug, force: true });
+        console.log(chalk.green(`✓ Scope updated to ${scope.slug}`));
+        console.log();
+        console.log("Your agents will now be namespaced as:");
+        console.log(chalk.cyan(`  ${scope.slug}/<agent-name>`));
+      } catch (error) {
+        if (
+          error instanceof Error &&
+          error.message.includes("already exists")
+        ) {
           console.error(
             chalk.red(
               `✗ Scope "${slug}" is already taken. Please choose a different slug.`,
             ),
           );
-        } else {
-          console.error(chalk.red(`✗ ${error.message}`));
+          process.exit(1);
         }
-      } else {
-        console.error(chalk.red("✗ An unexpected error occurred"));
+        throw error;
       }
-      process.exit(1);
-    }
-  });
+    }),
+  );

--- a/turbo/apps/cli/src/commands/scope/status.ts
+++ b/turbo/apps/cli/src/commands/scope/status.ts
@@ -1,24 +1,26 @@
 import { Command } from "commander";
 import chalk from "chalk";
 import { getScope } from "../../lib/api";
+import { withErrorHandler } from "../../lib/command";
 
 export const statusCommand = new Command()
   .name("status")
   .description("View current scope status")
-  .action(async () => {
-    try {
-      const scope = await getScope();
+  .action(
+    withErrorHandler(async () => {
+      try {
+        const scope = await getScope();
 
-      console.log(chalk.bold("Scope Information:"));
-      console.log(`  Slug: ${chalk.green(scope.slug)}`);
-      console.log(
-        `  Created: ${new Date(scope.createdAt).toLocaleDateString()}`,
-      );
-    } catch (error) {
-      if (error instanceof Error) {
-        if (error.message.includes("Not authenticated")) {
-          console.error(chalk.red("✗ Not authenticated. Run: vm0 auth login"));
-        } else if (error.message.includes("No scope configured")) {
+        console.log(chalk.bold("Scope Information:"));
+        console.log(`  Slug: ${chalk.green(scope.slug)}`);
+        console.log(
+          `  Created: ${new Date(scope.createdAt).toLocaleDateString()}`,
+        );
+      } catch (error) {
+        if (
+          error instanceof Error &&
+          error.message.includes("No scope configured")
+        ) {
           console.log(chalk.yellow("No scope configured"));
           console.log();
           console.log("Set your scope with:");
@@ -26,12 +28,9 @@ export const statusCommand = new Command()
           console.log();
           console.log("Example:");
           console.log(chalk.dim("  vm0 scope set myusername"));
-        } else {
-          console.error(chalk.red(`✗ ${error.message}`));
+          process.exit(1);
         }
-      } else {
-        console.error(chalk.red("✗ An unexpected error occurred"));
+        throw error;
       }
-      process.exit(1);
-    }
-  });
+    }),
+  );

--- a/turbo/apps/cli/src/commands/scope/use.ts
+++ b/turbo/apps/cli/src/commands/scope/use.ts
@@ -2,47 +2,43 @@ import { Command } from "commander";
 import chalk from "chalk";
 import { listScopes } from "../../lib/api";
 import { saveConfig } from "../../lib/api/config";
+import { withErrorHandler } from "../../lib/command";
 
 export const useCommand = new Command()
   .name("use")
   .description("Switch to a different scope")
   .argument("[slug]", "Scope slug to switch to")
   .option("--personal", "Switch to personal scope")
-  .action(async (slug: string | undefined, options: { personal?: boolean }) => {
-    try {
-      if (options.personal) {
-        await saveConfig({ activeScope: undefined });
-        console.log(chalk.green("✓ Switched to default scope."));
-        return;
-      }
+  .action(
+    withErrorHandler(
+      async (slug: string | undefined, options: { personal?: boolean }) => {
+        if (options.personal) {
+          await saveConfig({ activeScope: undefined });
+          console.log(chalk.green("✓ Switched to default scope."));
+          return;
+        }
 
-      if (!slug) {
-        console.error(
-          chalk.red(
-            "✗ Scope slug is required. Use --personal to switch to default scope.",
-          ),
-        );
-        process.exit(1);
-      }
+        if (!slug) {
+          console.error(
+            chalk.red(
+              "✗ Scope slug is required. Use --personal to switch to default scope.",
+            ),
+          );
+          process.exit(1);
+        }
 
-      // Verify the scope exists and user has access
-      const scopeList = await listScopes();
-      const target = scopeList.scopes.find((s) => s.slug === slug);
-      if (!target) {
-        console.error(
-          chalk.red(`✗ Scope '${slug}' not found or not accessible.`),
-        );
-        process.exit(1);
-      }
+        // Verify the scope exists and user has access
+        const scopeList = await listScopes();
+        const target = scopeList.scopes.find((s) => s.slug === slug);
+        if (!target) {
+          console.error(
+            chalk.red(`✗ Scope '${slug}' not found or not accessible.`),
+          );
+          process.exit(1);
+        }
 
-      await saveConfig({ activeScope: slug });
-      console.log(chalk.green(`✓ Switched to scope: ${slug}`));
-    } catch (error) {
-      if (error instanceof Error) {
-        console.error(chalk.red(`✗ ${error.message}`));
-      } else {
-        console.error(chalk.red("✗ An unexpected error occurred"));
-      }
-      process.exit(1);
-    }
-  });
+        await saveConfig({ activeScope: slug });
+        console.log(chalk.green(`✓ Switched to scope: ${slug}`));
+      },
+    ),
+  );


### PR DESCRIPTION
## Summary
- Replace manual try/catch blocks with `withErrorHandler()` in scope commands (`leave`, `list`, `members`, `remove`, `invite`, `use`, `set`, `status`, `create-scope`)
- Preserves inner try/catch blocks in `create-scope`, `members`, `set`, `status` where specific error handling is needed
- Updates related test file

## Test plan
- [x] Unit tests pass (951 tests)
- [x] Lint passes (0 warnings, 0 errors)
- [x] Type check passes
- [x] Knip finds no issues

Closes part of #4155

🤖 Generated with [Claude Code](https://claude.com/claude-code)