### PR TITLE
refactor(cli): migrate connector commands to centralized error handler

### DIFF
--- a/turbo/apps/cli/src/commands/connector/__tests__/disconnect.test.ts
+++ b/turbo/apps/cli/src/commands/connector/__tests__/disconnect.test.ts
@@ -84,7 +84,7 @@ describe("connector disconnect command", () => {
       }).rejects.toThrow("process.exit called");
 
       expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining("is not connected"),
+        expect.stringContaining("not found"),
       );
       expect(mockExit).toHaveBeenCalledWith(1);
     });

--- a/turbo/apps/cli/src/commands/connector/connect.ts
+++ b/turbo/apps/cli/src/commands/connector/connect.ts
@@ -15,6 +15,7 @@ import {
 } from "@vm0/core";
 import { getApiUrl, getActiveToken } from "../../lib/api/config";
 import { deleteConnector, setSecret } from "../../lib/api";
+import { withErrorHandler } from "../../lib/command";
 import {
   checkComputerDependencies,
   startComputerServices,
@@ -313,8 +314,8 @@ export const connectCommand = new Command()
   .description("Connect a third-party service (e.g., GitHub)")
   .argument("<type>", "Connector type (e.g., github)")
   .option("--token <value>", "API token value (skip interactive prompt)")
-  .action(async (type: string, options: { token?: string }) => {
-    try {
+  .action(
+    withErrorHandler(async (type: string, options: { token?: string }) => {
       const parseResult = connectorTypeSchema.safeParse(type);
       if (!parseResult.success) {
         console.error(chalk.red(`✗ Unknown connector type: ${type}`));
@@ -339,15 +340,5 @@ export const connectCommand = new Command()
       }
 
       await connectViaOAuth(connectorType, apiUrl, headers);
-    } catch (error) {
-      if (error instanceof Error) {
-        console.error(chalk.red(`✗ ${error.message}`));
-        if (error.cause instanceof Error) {
-          console.error(chalk.dim(`  Cause: ${error.cause.message}`));
-        }
-      } else {
-        console.error(chalk.red("✗ An unexpected error occurred"));
-      }
-      process.exit(1);
-    }
-  });
+    }),
+  );

--- a/turbo/apps/cli/src/commands/connector/disconnect.ts
+++ b/turbo/apps/cli/src/commands/connector/disconnect.ts
@@ -2,13 +2,14 @@ import { Command } from "commander";
 import chalk from "chalk";
 import { CONNECTOR_TYPES, connectorTypeSchema } from "@vm0/core";
 import { deleteConnector } from "../../lib/api";
+import { withErrorHandler } from "../../lib/command";
 
 export const disconnectCommand = new Command()
   .name("disconnect")
   .description("Disconnect a third-party service")
   .argument("<type>", "Connector type to disconnect (e.g., github)")
-  .action(async (type: string) => {
-    try {
+  .action(
+    withErrorHandler(async (type: string) => {
       const parseResult = connectorTypeSchema.safeParse(type);
       if (!parseResult.success) {
         console.error(chalk.red(`✗ Unknown connector type: ${type}`));
@@ -23,21 +24,5 @@ export const disconnectCommand = new Command()
       const connectorType = parseResult.data;
       await deleteConnector(connectorType);
       console.log(chalk.green(`✓ Disconnected ${type}`));
-    } catch (error) {
-      if (error instanceof Error) {
-        if (error.message.includes("not found")) {
-          console.error(chalk.red(`✗ Connector "${type}" is not connected`));
-        } else if (error.message.includes("Not authenticated")) {
-          console.error(chalk.red("✗ Not authenticated. Run: vm0 auth login"));
-        } else {
-          console.error(chalk.red(`✗ ${error.message}`));
-          if (error.cause instanceof Error) {
-            console.error(chalk.dim(`  Cause: ${error.cause.message}`));
-          }
-        }
-      } else {
-        console.error(chalk.red("✗ An unexpected error occurred"));
-      }
-      process.exit(1);
-    }
-  });
+    }),
+  );


### PR DESCRIPTION
## Summary
- Replace manual try/catch blocks with `withErrorHandler()` in connector commands (`connect`, `disconnect`)
- Updates related test file (`disconnect.test.ts`)
- Part of tech debt cleanup for consistent error handling across CLI commands

## Test plan
- [x] Unit tests pass (951/951)
- [x] Lint passes (0 warnings, 0 errors)
- [x] Type check passes

Closes part of #4155

🤖 Generated with [Claude Code](https://claude.com/claude-code)