### PR TITLE
refactor(cli): migrate storage status commands to withErrorHandler

### DIFF
--- a/turbo/apps/cli/src/commands/artifact/__tests__/status.test.ts
+++ b/turbo/apps/cli/src/commands/artifact/__tests__/status.test.ts
@@ -185,10 +185,10 @@ describe("artifact status", () => {
       }).rejects.toThrow("process.exit called");
 
       expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining("Not found on remote"),
+        expect.stringContaining("404"),
       );
       expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining("vm0 artifact push"),
+        expect.stringContaining("not found"),
       );
       expect(mockExit).toHaveBeenCalledWith(1);
     });
@@ -223,7 +223,10 @@ describe("artifact status", () => {
       }).rejects.toThrow("process.exit called");
 
       expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining("Status check failed"),
+        expect.stringContaining("500"),
+      );
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Internal server error"),
       );
       expect(mockExit).toHaveBeenCalledWith(1);
     });
@@ -243,7 +246,7 @@ describe("artifact status", () => {
       }).rejects.toThrow("process.exit called");
 
       expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining("Status check failed"),
+        expect.stringContaining("500"),
       );
       expect(mockConsoleError).toHaveBeenCalledWith(
         expect.stringContaining("Network error"),

--- a/turbo/apps/cli/src/commands/artifact/__tests__/status.test.ts
+++ b/turbo/apps/cli/src/commands/artifact/__tests__/status.test.ts
@@ -185,10 +185,10 @@ describe("artifact status", () => {
       }).rejects.toThrow("process.exit called");
 
       expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining("404"),
+        expect.stringContaining("Not found on remote"),
       );
       expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining("not found"),
+        expect.stringContaining("vm0 artifact push"),
       );
       expect(mockExit).toHaveBeenCalledWith(1);
     });

--- a/turbo/apps/cli/src/commands/artifact/status.ts
+++ b/turbo/apps/cli/src/commands/artifact/status.ts
@@ -3,12 +3,13 @@ import chalk from "chalk";
 import { readStorageConfig } from "../../lib/storage/storage-utils";
 import { getStorageDownload } from "../../lib/api";
 import { formatBytes } from "../../lib/utils/file-utils";
+import { withErrorHandler } from "../../lib/command";
 
 export const statusCommand = new Command()
   .name("status")
   .description("Show status of cloud artifact")
-  .action(async () => {
-    try {
+  .action(
+    withErrorHandler(async () => {
       const cwd = process.cwd();
 
       // Read config
@@ -48,16 +49,5 @@ export const statusCommand = new Command()
         console.log(chalk.dim(`  Files: ${info.fileCount.toLocaleString()}`));
         console.log(chalk.dim(`  Size: ${formatBytes(info.size)}`));
       }
-    } catch (error) {
-      if (error instanceof Error && error.message.includes("not found")) {
-        console.error(chalk.red("✗ Not found on remote"));
-        console.error(chalk.dim("  Run: vm0 artifact push"));
-      } else {
-        console.error(chalk.red("✗ Status check failed"));
-        if (error instanceof Error) {
-          console.error(chalk.dim(`  ${error.message}`));
-        }
-      }
-      process.exit(1);
-    }
-  });
+    }),
+  );

--- a/turbo/apps/cli/src/commands/artifact/status.ts
+++ b/turbo/apps/cli/src/commands/artifact/status.ts
@@ -1,7 +1,7 @@
 import { Command } from "commander";
 import chalk from "chalk";
 import { readStorageConfig } from "../../lib/storage/storage-utils";
-import { getStorageDownload } from "../../lib/api";
+import { getStorageDownload, ApiRequestError } from "../../lib/api";
 import { formatBytes } from "../../lib/utils/file-utils";
 import { withErrorHandler } from "../../lib/command";
 
@@ -34,20 +34,29 @@ export const statusCommand = new Command()
       console.log(`Checking artifact: ${config.name}`);
 
       // Call API
-      const info = await getStorageDownload({
-        name: config.name,
-        type: "artifact",
-      });
-      const shortVersion = info.versionId.slice(0, 8);
+      try {
+        const info = await getStorageDownload({
+          name: config.name,
+          type: "artifact",
+        });
+        const shortVersion = info.versionId.slice(0, 8);
 
-      if ("empty" in info) {
-        console.log(chalk.green("✓ Found (empty)"));
-        console.log(chalk.dim(`  Version: ${shortVersion}`));
-      } else {
-        console.log(chalk.green("✓ Found"));
-        console.log(chalk.dim(`  Version: ${shortVersion}`));
-        console.log(chalk.dim(`  Files: ${info.fileCount.toLocaleString()}`));
-        console.log(chalk.dim(`  Size: ${formatBytes(info.size)}`));
+        if ("empty" in info) {
+          console.log(chalk.green("✓ Found (empty)"));
+          console.log(chalk.dim(`  Version: ${shortVersion}`));
+        } else {
+          console.log(chalk.green("✓ Found"));
+          console.log(chalk.dim(`  Version: ${shortVersion}`));
+          console.log(chalk.dim(`  Files: ${info.fileCount.toLocaleString()}`));
+          console.log(chalk.dim(`  Size: ${formatBytes(info.size)}`));
+        }
+      } catch (error) {
+        if (error instanceof ApiRequestError && error.status === 404) {
+          console.error(chalk.red("✗ Not found on remote"));
+          console.error(chalk.dim("  Run: vm0 artifact push"));
+          process.exit(1);
+        }
+        throw error;
       }
     }),
   );

--- a/turbo/apps/cli/src/commands/memory/__tests__/status.test.ts
+++ b/turbo/apps/cli/src/commands/memory/__tests__/status.test.ts
@@ -179,10 +179,10 @@ describe("memory status", () => {
       }).rejects.toThrow("process.exit called");
 
       expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining("404"),
+        expect.stringContaining("Not found on remote"),
       );
       expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining("not found"),
+        expect.stringContaining("vm0 memory push"),
       );
       expect(mockExit).toHaveBeenCalledWith(1);
     });

--- a/turbo/apps/cli/src/commands/memory/__tests__/status.test.ts
+++ b/turbo/apps/cli/src/commands/memory/__tests__/status.test.ts
@@ -179,10 +179,10 @@ describe("memory status", () => {
       }).rejects.toThrow("process.exit called");
 
       expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining("Not found on remote"),
+        expect.stringContaining("404"),
       );
       expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining("vm0 memory push"),
+        expect.stringContaining("not found"),
       );
       expect(mockExit).toHaveBeenCalledWith(1);
     });
@@ -217,7 +217,10 @@ describe("memory status", () => {
       }).rejects.toThrow("process.exit called");
 
       expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining("Status check failed"),
+        expect.stringContaining("500"),
+      );
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Internal server error"),
       );
       expect(mockExit).toHaveBeenCalledWith(1);
     });

--- a/turbo/apps/cli/src/commands/memory/status.ts
+++ b/turbo/apps/cli/src/commands/memory/status.ts
@@ -3,12 +3,13 @@ import chalk from "chalk";
 import { readStorageConfig } from "../../lib/storage/storage-utils";
 import { getStorageDownload } from "../../lib/api";
 import { formatBytes } from "../../lib/utils/file-utils";
+import { withErrorHandler } from "../../lib/command";
 
 export const statusCommand = new Command()
   .name("status")
   .description("Show status of cloud memory")
-  .action(async () => {
-    try {
+  .action(
+    withErrorHandler(async () => {
       const cwd = process.cwd();
 
       // Read config
@@ -48,16 +49,5 @@ export const statusCommand = new Command()
         console.log(chalk.dim(`  Files: ${info.fileCount.toLocaleString()}`));
         console.log(chalk.dim(`  Size: ${formatBytes(info.size)}`));
       }
-    } catch (error) {
-      if (error instanceof Error && error.message.includes("not found")) {
-        console.error(chalk.red("✗ Not found on remote"));
-        console.error(chalk.dim("  Run: vm0 memory push"));
-      } else {
-        console.error(chalk.red("✗ Status check failed"));
-        if (error instanceof Error) {
-          console.error(chalk.dim(`  ${error.message}`));
-        }
-      }
-      process.exit(1);
-    }
-  });
+    }),
+  );

--- a/turbo/apps/cli/src/commands/memory/status.ts
+++ b/turbo/apps/cli/src/commands/memory/status.ts
@@ -1,7 +1,7 @@
 import { Command } from "commander";
 import chalk from "chalk";
 import { readStorageConfig } from "../../lib/storage/storage-utils";
-import { getStorageDownload } from "../../lib/api";
+import { getStorageDownload, ApiRequestError } from "../../lib/api";
 import { formatBytes } from "../../lib/utils/file-utils";
 import { withErrorHandler } from "../../lib/command";
 
@@ -34,20 +34,29 @@ export const statusCommand = new Command()
       console.log(`Checking memory: ${config.name}`);
 
       // Call API
-      const info = await getStorageDownload({
-        name: config.name,
-        type: "memory",
-      });
-      const shortVersion = info.versionId.slice(0, 8);
+      try {
+        const info = await getStorageDownload({
+          name: config.name,
+          type: "memory",
+        });
+        const shortVersion = info.versionId.slice(0, 8);
 
-      if ("empty" in info) {
-        console.log(chalk.green("✓ Found (empty)"));
-        console.log(chalk.dim(`  Version: ${shortVersion}`));
-      } else {
-        console.log(chalk.green("✓ Found"));
-        console.log(chalk.dim(`  Version: ${shortVersion}`));
-        console.log(chalk.dim(`  Files: ${info.fileCount.toLocaleString()}`));
-        console.log(chalk.dim(`  Size: ${formatBytes(info.size)}`));
+        if ("empty" in info) {
+          console.log(chalk.green("✓ Found (empty)"));
+          console.log(chalk.dim(`  Version: ${shortVersion}`));
+        } else {
+          console.log(chalk.green("✓ Found"));
+          console.log(chalk.dim(`  Version: ${shortVersion}`));
+          console.log(chalk.dim(`  Files: ${info.fileCount.toLocaleString()}`));
+          console.log(chalk.dim(`  Size: ${formatBytes(info.size)}`));
+        }
+      } catch (error) {
+        if (error instanceof ApiRequestError && error.status === 404) {
+          console.error(chalk.red("✗ Not found on remote"));
+          console.error(chalk.dim("  Run: vm0 memory push"));
+          process.exit(1);
+        }
+        throw error;
       }
     }),
   );

--- a/turbo/apps/cli/src/commands/volume/__tests__/status.test.ts
+++ b/turbo/apps/cli/src/commands/volume/__tests__/status.test.ts
@@ -185,10 +185,10 @@ describe("volume status", () => {
       }).rejects.toThrow("process.exit called");
 
       expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining("404"),
+        expect.stringContaining("Not found on remote"),
       );
       expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining("not found"),
+        expect.stringContaining("vm0 volume push"),
       );
       expect(mockExit).toHaveBeenCalledWith(1);
     });

--- a/turbo/apps/cli/src/commands/volume/__tests__/status.test.ts
+++ b/turbo/apps/cli/src/commands/volume/__tests__/status.test.ts
@@ -185,10 +185,10 @@ describe("volume status", () => {
       }).rejects.toThrow("process.exit called");
 
       expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining("Not found on remote"),
+        expect.stringContaining("404"),
       );
       expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining("vm0 volume push"),
+        expect.stringContaining("not found"),
       );
       expect(mockExit).toHaveBeenCalledWith(1);
     });
@@ -223,7 +223,10 @@ describe("volume status", () => {
       }).rejects.toThrow("process.exit called");
 
       expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining("Status check failed"),
+        expect.stringContaining("500"),
+      );
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Internal server error"),
       );
       expect(mockExit).toHaveBeenCalledWith(1);
     });
@@ -243,7 +246,7 @@ describe("volume status", () => {
       }).rejects.toThrow("process.exit called");
 
       expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining("Status check failed"),
+        expect.stringContaining("500"),
       );
       expect(mockConsoleError).toHaveBeenCalledWith(
         expect.stringContaining("Network error"),

--- a/turbo/apps/cli/src/commands/volume/status.ts
+++ b/turbo/apps/cli/src/commands/volume/status.ts
@@ -3,12 +3,13 @@ import chalk from "chalk";
 import { readStorageConfig } from "../../lib/storage/storage-utils";
 import { getStorageDownload } from "../../lib/api";
 import { formatBytes } from "../../lib/utils/file-utils";
+import { withErrorHandler } from "../../lib/command";
 
 export const statusCommand = new Command()
   .name("status")
   .description("Show status of cloud volume")
-  .action(async () => {
-    try {
+  .action(
+    withErrorHandler(async () => {
       const cwd = process.cwd();
 
       // Read config
@@ -48,20 +49,5 @@ export const statusCommand = new Command()
         console.log(chalk.dim(`  Files: ${info.fileCount.toLocaleString()}`));
         console.log(chalk.dim(`  Size: ${formatBytes(info.size)}`));
       }
-    } catch (error) {
-      if (error instanceof Error && error.message.includes("not found")) {
-        console.error(chalk.red("✗ Not found on remote"));
-        console.error(chalk.dim("  Run: vm0 volume push"));
-      } else {
-        console.error(chalk.red("✗ Status check failed"));
-        if (error instanceof Error) {
-          if (error.message.includes("Not authenticated")) {
-            console.error(chalk.dim("  Run: vm0 auth login"));
-          } else {
-            console.error(chalk.dim(`  ${error.message}`));
-          }
-        }
-      }
-      process.exit(1);
-    }
-  });
+    }),
+  );

--- a/turbo/apps/cli/src/commands/volume/status.ts
+++ b/turbo/apps/cli/src/commands/volume/status.ts
@@ -1,7 +1,7 @@
 import { Command } from "commander";
 import chalk from "chalk";
 import { readStorageConfig } from "../../lib/storage/storage-utils";
-import { getStorageDownload } from "../../lib/api";
+import { getStorageDownload, ApiRequestError } from "../../lib/api";
 import { formatBytes } from "../../lib/utils/file-utils";
 import { withErrorHandler } from "../../lib/command";
 
@@ -34,20 +34,29 @@ export const statusCommand = new Command()
       console.log(`Checking volume: ${config.name}`);
 
       // Call API
-      const info = await getStorageDownload({
-        name: config.name,
-        type: "volume",
-      });
-      const shortVersion = info.versionId.slice(0, 8);
+      try {
+        const info = await getStorageDownload({
+          name: config.name,
+          type: "volume",
+        });
+        const shortVersion = info.versionId.slice(0, 8);
 
-      if ("empty" in info) {
-        console.log(chalk.green("✓ Found (empty)"));
-        console.log(chalk.dim(`  Version: ${shortVersion}`));
-      } else {
-        console.log(chalk.green("✓ Found"));
-        console.log(chalk.dim(`  Version: ${shortVersion}`));
-        console.log(chalk.dim(`  Files: ${info.fileCount.toLocaleString()}`));
-        console.log(chalk.dim(`  Size: ${formatBytes(info.size)}`));
+        if ("empty" in info) {
+          console.log(chalk.green("✓ Found (empty)"));
+          console.log(chalk.dim(`  Version: ${shortVersion}`));
+        } else {
+          console.log(chalk.green("✓ Found"));
+          console.log(chalk.dim(`  Version: ${shortVersion}`));
+          console.log(chalk.dim(`  Files: ${info.fileCount.toLocaleString()}`));
+          console.log(chalk.dim(`  Size: ${formatBytes(info.size)}`));
+        }
+      } catch (error) {
+        if (error instanceof ApiRequestError && error.status === 404) {
+          console.error(chalk.red("✗ Not found on remote"));
+          console.error(chalk.dim("  Run: vm0 volume push"));
+          process.exit(1);
+        }
+        throw error;
       }
     }),
   );


### PR DESCRIPTION
## Summary
- Replace manual try/catch blocks with `withErrorHandler()` in storage status commands (`artifact/status`, `memory/status`, `volume/status`)
- Updates related test files for all three status commands
- Part of tech debt cleanup for consistent error handling across CLI commands

## Test plan
- [x] Unit tests pass (82 files, 951 tests)
- [x] Lint passes (0 warnings, 0 errors)
- [x] Type check passes

Closes part of #4155

🤖 Generated with [Claude Code](https://claude.com/claude-code)