### PR TITLE
refactor(cli): migrate run kill command to withErrorHandler

### DIFF
--- a/turbo/apps/cli/src/commands/run/__tests__/kill.test.ts
+++ b/turbo/apps/cli/src/commands/run/__tests__/kill.test.ts
@@ -79,7 +79,7 @@ describe("run kill command", () => {
       }).rejects.toThrow("process.exit called");
 
       expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining("Failed to kill run"),
+        expect.stringContaining("Not authenticated"),
       );
       expect(mockConsoleError).toHaveBeenCalledWith(
         expect.stringContaining("vm0 auth login"),
@@ -107,10 +107,7 @@ describe("run kill command", () => {
       }).rejects.toThrow("process.exit called");
 
       expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining("Failed to kill run"),
-      );
-      expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining("Run not found"),
+        expect.stringContaining("No such run"),
       );
       expect(mockExit).toHaveBeenCalledWith(1);
     });
@@ -134,9 +131,6 @@ describe("run kill command", () => {
         await killCommand.parseAsync(["node", "cli", "completed-run"]);
       }).rejects.toThrow("process.exit called");
 
-      expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining("Failed to kill run"),
-      );
       expect(mockConsoleError).toHaveBeenCalledWith(
         expect.stringContaining("cannot be cancelled"),
       );
@@ -162,9 +156,6 @@ describe("run kill command", () => {
         await killCommand.parseAsync(["node", "cli", "run-123"]);
       }).rejects.toThrow("process.exit called");
 
-      expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining("Failed to kill run"),
-      );
       expect(mockConsoleError).toHaveBeenCalledWith(
         expect.stringContaining("Internal server error"),
       );

--- a/turbo/apps/cli/src/commands/run/kill.ts
+++ b/turbo/apps/cli/src/commands/run/kill.ts
@@ -1,31 +1,15 @@
 import { Command } from "commander";
 import chalk from "chalk";
 import { cancelRun } from "../../lib/api";
+import { withErrorHandler } from "../../lib/command";
 
 export const killCommand = new Command()
   .name("kill")
   .description("Kill (cancel) a pending or running run")
   .argument("<run-id>", "Run ID to kill")
-  .action(async (runId: string) => {
-    try {
+  .action(
+    withErrorHandler(async (runId: string) => {
       await cancelRun(runId);
       console.log(chalk.green(`✓ Run ${runId} cancelled`));
-    } catch (error) {
-      console.error(chalk.red("✗ Failed to kill run"));
-      if (error instanceof Error) {
-        if (error.message.includes("Not authenticated")) {
-          console.error(chalk.dim("  Run: vm0 auth login"));
-        } else if (
-          error.message.includes("not found") ||
-          error.message.includes("No such run")
-        ) {
-          console.error(chalk.dim(`  Run not found: ${runId}`));
-        } else if (error.message.includes("cannot be cancelled")) {
-          console.error(chalk.dim(`  ${error.message}`));
-        } else {
-          console.error(chalk.dim(`  ${error.message}`));
-        }
-      }
-      process.exit(1);
-    }
-  });
+    }),
+  );


### PR DESCRIPTION
## Summary
- Replace manual try/catch block with `withErrorHandler()` in run kill command
- Updates related test file (`kill.test.ts`)
- Part of tech debt cleanup for consistent error handling across CLI commands

## Test plan
- [x] Unit tests pass
- [x] Lint passes
- [x] Type check passes

Closes part of #4155

🤖 Generated with [Claude Code](https://claude.com/claude-code)