### PR TITLE
refactor(cli): migrate cook commands to use error handler

### DIFF
--- a/turbo/apps/cli/src/commands/cook/continue.ts
+++ b/turbo/apps/cli/src/commands/cook/continue.ts
@@ -2,6 +2,7 @@ import { Command, Option } from "commander";
 import chalk from "chalk";
 import path from "path";
 import { loadCookState, saveCookState } from "../../lib/domain/cook-state";
+import { withErrorHandler } from "../../lib/command";
 import {
   ARTIFACT_DIR,
   printCommand,
@@ -23,15 +24,15 @@ export const continueCommand = new Command()
   .option("-v, --verbose", "Show full tool inputs and outputs")
   .addOption(new Option("--debug-no-mock-claude").hideHelp())
   .action(
-    async (
-      prompt: string,
-      options: {
-        envFile?: string;
-        verbose?: boolean;
-        debugNoMockClaude?: boolean;
-      },
-    ) => {
-      try {
+    withErrorHandler(
+      async (
+        prompt: string,
+        options: {
+          envFile?: string;
+          verbose?: boolean;
+          debugNoMockClaude?: boolean;
+        },
+      ) => {
         const state = await loadCookState();
         if (!state.lastSessionId) {
           console.error(chalk.red("✗ No previous session found"));
@@ -81,16 +82,6 @@ export const continueCommand = new Command()
 
         // Auto-pull artifact
         await autoPullArtifact(runOutput, artifactDir);
-      } catch (error) {
-        if (error instanceof Error) {
-          console.error(chalk.red(`✗ ${error.message}`));
-          if (error.cause instanceof Error) {
-            console.error(chalk.dim(`  Cause: ${error.cause.message}`));
-          }
-        } else {
-          console.error(chalk.red("✗ An unexpected error occurred"));
-        }
-        process.exit(1);
-      }
-    },
+      },
+    ),
   );

--- a/turbo/apps/cli/src/commands/cook/logs.ts
+++ b/turbo/apps/cli/src/commands/cook/logs.ts
@@ -1,6 +1,7 @@
 import { Command } from "commander";
 import chalk from "chalk";
 import { loadCookState } from "../../lib/domain/cook-state";
+import { withErrorHandler } from "../../lib/command";
 import { printCommand, execVm0Command } from "./utils";
 
 export const logsCommand = new Command()
@@ -17,16 +18,16 @@ export const logsCommand = new Command()
   .option("--tail <n>", "Show last N entries (default: 5, max: 100)")
   .option("--head <n>", "Show first N entries (max: 100)")
   .action(
-    async (options: {
-      agent?: boolean;
-      system?: boolean;
-      metrics?: boolean;
-      network?: boolean;
-      since?: string;
-      tail?: string;
-      head?: string;
-    }) => {
-      try {
+    withErrorHandler(
+      async (options: {
+        agent?: boolean;
+        system?: boolean;
+        metrics?: boolean;
+        network?: boolean;
+        since?: string;
+        tail?: string;
+        head?: string;
+      }) => {
         const state = await loadCookState();
         if (!state.lastRunId) {
           console.error(chalk.red("✗ No previous run found"));
@@ -69,16 +70,6 @@ export const logsCommand = new Command()
 
         printCommand(displayArgs.join(" "));
         await execVm0Command(args);
-      } catch (error) {
-        if (error instanceof Error) {
-          console.error(chalk.red(`✗ ${error.message}`));
-          if (error.cause instanceof Error) {
-            console.error(chalk.dim(`  Cause: ${error.cause.message}`));
-          }
-        } else {
-          console.error(chalk.red("✗ An unexpected error occurred"));
-        }
-        process.exit(1);
-      }
-    },
+      },
+    ),
   );

--- a/turbo/apps/cli/src/commands/cook/resume.ts
+++ b/turbo/apps/cli/src/commands/cook/resume.ts
@@ -2,6 +2,7 @@ import { Command, Option } from "commander";
 import chalk from "chalk";
 import path from "path";
 import { loadCookState, saveCookState } from "../../lib/domain/cook-state";
+import { withErrorHandler } from "../../lib/command";
 import {
   ARTIFACT_DIR,
   printCommand,
@@ -23,15 +24,15 @@ export const resumeCommand = new Command()
   .option("-v, --verbose", "Show full tool inputs and outputs")
   .addOption(new Option("--debug-no-mock-claude").hideHelp())
   .action(
-    async (
-      prompt: string,
-      options: {
-        envFile?: string;
-        verbose?: boolean;
-        debugNoMockClaude?: boolean;
-      },
-    ) => {
-      try {
+    withErrorHandler(
+      async (
+        prompt: string,
+        options: {
+          envFile?: string;
+          verbose?: boolean;
+          debugNoMockClaude?: boolean;
+        },
+      ) => {
         const state = await loadCookState();
         if (!state.lastCheckpointId) {
           console.error(chalk.red("✗ No previous checkpoint found"));
@@ -81,16 +82,6 @@ export const resumeCommand = new Command()
 
         // Auto-pull artifact
         await autoPullArtifact(runOutput, artifactDir);
-      } catch (error) {
-        if (error instanceof Error) {
-          console.error(chalk.red(`✗ ${error.message}`));
-          if (error.cause instanceof Error) {
-            console.error(chalk.dim(`  Cause: ${error.cause.message}`));
-          }
-        } else {
-          console.error(chalk.red("✗ An unexpected error occurred"));
-        }
-        process.exit(1);
-      }
-    },
+      },
+    ),
   );


### PR DESCRIPTION
## Summary
- Replace manual try/catch blocks with `withErrorHandler()` in cook commands (`continue`, `resume`, `logs`)
- Part of tech debt cleanup for consistent error handling across CLI commands

## Test plan
- [x] Unit tests pass (951/951)
- [x] Lint passes (0 warnings, 0 errors)
- [x] Type check passes

Closes part of #4155

🤖 Generated with [Claude Code](https://claude.com/claude-code)