### PR TITLE
refactor(cli): migrate misc commands to withErrorHandler

### DIFF
--- a/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
@@ -427,7 +427,7 @@ describe("logs command", () => {
       expect(requestCount).toBe(2);
       expect(mockExit).toHaveBeenCalledWith(1);
       expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining("Failed to fetch logs"),
+        expect.stringContaining("Server error"),
       );
     });
 
@@ -1000,7 +1000,7 @@ describe("logs command", () => {
 
       expect(mockExit).toHaveBeenCalledWith(1);
       expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining("Failed to fetch logs"),
+        expect.stringContaining("Internal server error"),
       );
     });
   });

--- a/turbo/apps/cli/src/commands/logs/index.ts
+++ b/turbo/apps/cli/src/commands/logs/index.ts
@@ -14,6 +14,7 @@ import { EventRenderer } from "../../lib/events/event-renderer";
 import { CodexEventRenderer } from "../../lib/events/codex-event-renderer";
 import { paginate } from "../../lib/utils/paginate";
 import { searchCommand } from "./search";
+import { withErrorHandler } from "../../lib/command";
 
 /**
  * Maximum entries per API request
@@ -202,25 +203,25 @@ export const logsCommand = new Command()
   .option("--head <n>", "Show first N entries")
   .option("--all", "Fetch all log entries")
   .action(
-    async (
-      runId: string | undefined,
-      options: {
-        agent?: boolean;
-        system?: boolean;
-        metrics?: boolean;
-        network?: boolean;
-        since?: string;
-        tail?: string;
-        head?: string;
-        all?: boolean;
-      },
-    ) => {
-      if (!runId) {
-        logsCommand.help();
-        return;
-      }
+    withErrorHandler(
+      async (
+        runId: string | undefined,
+        options: {
+          agent?: boolean;
+          system?: boolean;
+          metrics?: boolean;
+          network?: boolean;
+          since?: string;
+          tail?: string;
+          head?: string;
+          all?: boolean;
+        },
+      ) => {
+        if (!runId) {
+          logsCommand.help();
+          return;
+        }
 
-      try {
         const logType = getLogType(options);
 
         // Validate --tail, --head, and --all are mutually exclusive
@@ -287,11 +288,8 @@ export const logsCommand = new Command()
             await showNetworkLogs(runId, { since, targetCount, order });
             break;
         }
-      } catch (error) {
-        handleError(error, runId);
-        process.exit(1);
-      }
-    },
+      },
+    ),
   );
 
 /**
@@ -579,26 +577,5 @@ async function showNetworkLogs(
 
   for (const entry of networkLogs) {
     console.log(formatNetworkLog(entry));
-  }
-}
-
-/**
- * Handle errors with friendly messages
- */
-function handleError(error: unknown, runId: string): void {
-  if (error instanceof Error) {
-    if (error.message.includes("Not authenticated")) {
-      console.error(chalk.red("✗ Not authenticated"));
-      console.error(chalk.dim("  Run: vm0 auth login"));
-    } else if (error.message.includes("not found")) {
-      console.error(chalk.red(`✗ Run not found: ${runId}`));
-    } else if (error.message.includes("Invalid time format")) {
-      console.error(chalk.red(`✗ ${error.message}`));
-    } else {
-      console.error(chalk.red("✗ Failed to fetch logs"));
-      console.error(chalk.dim(`  ${error.message}`));
-    }
-  } else {
-    console.error(chalk.red("✗ An unexpected error occurred"));
   }
 }

--- a/turbo/apps/cli/src/commands/logs/search.ts
+++ b/turbo/apps/cli/src/commands/logs/search.ts
@@ -8,6 +8,7 @@ import {
 import { parseTime } from "../../lib/utils/time-parser";
 import { ClaudeEventParser } from "../../lib/events/claude-event-parser";
 import { EventRenderer } from "../../lib/events/event-renderer";
+import { withErrorHandler } from "../../lib/command";
 
 const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
 
@@ -147,22 +148,6 @@ function renderResults(response: LogsSearchResponse): void {
   }
 }
 
-/**
- * Handle errors from the search API call
- */
-function handleSearchError(error: unknown): void {
-  if (error instanceof Error) {
-    if (error.message.includes("Not authenticated")) {
-      console.error(chalk.red("✗ Not authenticated"));
-      console.error(chalk.dim("  Run: vm0 auth login"));
-    } else {
-      console.error(chalk.red("✗ Failed to search logs"));
-      console.error(chalk.dim(`  ${error.message}`));
-    }
-  }
-  process.exit(1);
-}
-
 export const searchCommand = new Command()
   .name("search")
   .description("Search agent events across runs")
@@ -174,8 +159,8 @@ export const searchCommand = new Command()
   .option("--run <id>", "Filter by specific run ID")
   .option("--since <time>", "Search logs since (default: 7d)")
   .option("--limit <n>", "Maximum number of matches (default: 20)")
-  .action(async (keyword: string, options: SearchOptions) => {
-    try {
+  .action(
+    withErrorHandler(async (keyword: string, options: SearchOptions) => {
       const { before, after } = parseContextOptions(options);
       const since = options.since
         ? parseTime(options.since)
@@ -203,7 +188,5 @@ export const searchCommand = new Command()
       }
 
       renderResults(response);
-    } catch (error) {
-      handleSearchError(error);
-    }
-  });
+    }),
+  );

--- a/turbo/apps/cli/src/commands/onboard/index.ts
+++ b/turbo/apps/cli/src/commands/onboard/index.ts
@@ -28,6 +28,7 @@ import {
   type PluginScope,
 } from "../../lib/domain/onboard/index.js";
 import type { ModelProviderType } from "@vm0/core";
+import { withErrorHandler } from "../../lib/command";
 
 const DEFAULT_AGENT_NAME = "my-vm0-agent";
 
@@ -299,8 +300,8 @@ export const onboardCommand = new Command()
   .description("Guided setup for new VM0 users")
   .option("-y, --yes", "Skip confirmation prompts")
   .option("--name <name>", `Agent name (default: ${DEFAULT_AGENT_NAME})`)
-  .action(async (options: OnboardOptions) => {
-    try {
+  .action(
+    withErrorHandler(async (options: OnboardOptions) => {
       const interactive = isInteractive();
 
       // Clear screen and print welcome banner at the start
@@ -328,15 +329,5 @@ export const onboardCommand = new Command()
       });
 
       printNextSteps(agentName, pluginInstalled);
-    } catch (error) {
-      if (error instanceof Error) {
-        console.error(chalk.red(`✗ ${error.message}`));
-        if (error.cause instanceof Error) {
-          console.error(chalk.dim(`  Cause: ${error.cause.message}`));
-        }
-      } else {
-        console.error(chalk.red("✗ An unexpected error occurred"));
-      }
-      process.exit(1);
-    }
-  });
+    }),
+  );

--- a/turbo/apps/cli/src/commands/usage/index.ts
+++ b/turbo/apps/cli/src/commands/usage/index.ts
@@ -3,6 +3,7 @@ import chalk from "chalk";
 import { getUsage } from "../../lib/api";
 import { parseTime } from "../../lib/utils/time-parser";
 import { formatDuration } from "../../lib/utils/duration-formatter";
+import { withErrorHandler } from "../../lib/command";
 
 /**
  * Maximum time range allowed (30 days in milliseconds)
@@ -99,8 +100,8 @@ export const usageCommand = new Command()
     "--until <date>",
     "End date (ISO format or relative, defaults to now)",
   )
-  .action(async (options: { since?: string; until?: string }) => {
-    try {
+  .action(
+    withErrorHandler(async (options: { since?: string; until?: string }) => {
       // Calculate date range
       const now = new Date();
       let endDate: Date;
@@ -196,17 +197,5 @@ export const usageCommand = new Command()
         `${"TOTAL".padEnd(10)}${totalRunsDisplay}    ${totalTimeDisplay}`,
       );
       console.log();
-    } catch (error) {
-      if (error instanceof Error) {
-        if (error.message.includes("Not authenticated")) {
-          console.error(chalk.red("✗ Not authenticated"));
-          console.error(chalk.dim("  Run: vm0 auth login"));
-        } else {
-          console.error(chalk.red(`✗ ${error.message}`));
-        }
-      } else {
-        console.error(chalk.red("✗ An unexpected error occurred"));
-      }
-      process.exit(1);
-    }
-  });
+    }),
+  );

--- a/turbo/apps/cli/src/lib/api/api-client.ts
+++ b/turbo/apps/cli/src/lib/api/api-client.ts
@@ -34,6 +34,7 @@ import {
 } from "@vm0/core";
 import type { z } from "zod";
 import { getApiUrl, getActiveToken } from "./config";
+import { handleError } from "./core/client-factory";
 
 // Import types from @vm0/core contracts
 import type {
@@ -1259,9 +1260,7 @@ class ApiClient {
       return result.body;
     }
 
-    const errorBody = result.body as ApiErrorResponse;
-    const message = errorBody.error?.message || "Failed to search logs";
-    throw new Error(message);
+    handleError(result, "Failed to search logs");
   }
 }
 

--- a/turbo/apps/cli/src/lib/api/domains/usage.ts
+++ b/turbo/apps/cli/src/lib/api/domains/usage.ts
@@ -1,4 +1,4 @@
-import { getBaseUrl, getHeaders } from "../core/client-factory";
+import { getBaseUrl, getHeaders, handleError } from "../core/client-factory";
 import type { UsageResponse } from "../core/types";
 
 /**
@@ -22,8 +22,13 @@ export async function getUsage(options: {
   });
 
   if (!response.ok) {
-    const error = (await response.json()) as { error?: { message?: string } };
-    throw new Error(error.error?.message || "Failed to fetch usage data");
+    const body = (await response.json()) as {
+      error?: { message?: string; code?: string };
+    };
+    handleError(
+      { status: response.status, body },
+      "Failed to fetch usage data",
+    );
   }
 
   return response.json() as Promise<UsageResponse>;


### PR DESCRIPTION
## Summary
- Replace manual try/catch blocks with `withErrorHandler()` in misc commands (`usage`, `onboard`, `logs`, `logs/search`)
- Updates related test file (`logs/__tests__/index.test.ts`)
- Part of tech debt cleanup for consistent error handling across CLI commands

## Test plan
- [x] Unit tests pass (951/951)
- [x] Lint passes
- [x] Type check passes
- [x] Knip passes (no unused code)

Closes part of #4155

🤖 Generated with [Claude Code](https://claude.com/claude-code)