### PR TITLE
refactor(cli): migrate variable and secret commands to withErrorHandler

### DIFF
--- a/turbo/apps/cli/src/commands/secret/delete.ts
+++ b/turbo/apps/cli/src/commands/secret/delete.ts
@@ -2,20 +2,29 @@ import { Command } from "commander";
 import chalk from "chalk";
 import { getSecret, deleteSecret } from "../../lib/api";
 import { isInteractive, promptConfirm } from "../../lib/utils/prompt-utils";
+import { withErrorHandler } from "../../lib/command";
 
 export const deleteCommand = new Command()
   .name("delete")
   .description("Delete a secret")
   .argument("<name>", "Secret name to delete")
   .option("-y, --yes", "Skip confirmation prompt")
-  .action(async (name: string, options: { yes?: boolean }) => {
-    try {
+  .action(
+    withErrorHandler(async (name: string, options: { yes?: boolean }) => {
       // Verify secret exists first
       try {
         await getSecret(name);
-      } catch {
-        console.error(chalk.red(`✗ Secret "${name}" not found`));
-        process.exit(1);
+      } catch (error) {
+        // Only show "not found" if it's actually a not found error
+        // Otherwise, re-throw to let withErrorHandler handle it properly
+        if (
+          error instanceof Error &&
+          error.message.toLowerCase().includes("not found")
+        ) {
+          console.error(chalk.red(`✗ Secret "${name}" not found`));
+          process.exit(1);
+        }
+        throw error;
       }
 
       // Confirm deletion unless --yes is passed
@@ -40,16 +49,5 @@ export const deleteCommand = new Command()
 
       await deleteSecret(name);
       console.log(chalk.green(`✓ Secret "${name}" deleted`));
-    } catch (error) {
-      if (error instanceof Error) {
-        if (error.message.includes("Not authenticated")) {
-          console.error(chalk.red("✗ Not authenticated. Run: vm0 auth login"));
-        } else {
-          console.error(chalk.red(`✗ ${error.message}`));
-        }
-      } else {
-        console.error(chalk.red("✗ An unexpected error occurred"));
-      }
-      process.exit(1);
-    }
-  });
+    }),
+  );

--- a/turbo/apps/cli/src/commands/secret/set.ts
+++ b/turbo/apps/cli/src/commands/secret/set.ts
@@ -2,6 +2,7 @@ import { Command } from "commander";
 import chalk from "chalk";
 import { setSecret } from "../../lib/api";
 import { isInteractive, promptPassword } from "../../lib/utils/prompt-utils";
+import { withErrorHandler } from "../../lib/command";
 
 export const setCommand = new Command()
   .name("set")
@@ -13,8 +14,11 @@ export const setCommand = new Command()
   )
   .option("-d, --description <description>", "Optional description")
   .action(
-    async (name: string, options: { body?: string; description?: string }) => {
-      try {
+    withErrorHandler(
+      async (
+        name: string,
+        options: { body?: string; description?: string },
+      ) => {
         // Resolve the secret value
         let value: string;
 
@@ -50,26 +54,6 @@ export const setCommand = new Command()
         console.log("Use in vm0.yaml:");
         console.log(chalk.cyan(`  environment:`));
         console.log(chalk.cyan(`    ${name}: \${{ secrets.${name} }}`));
-      } catch (error) {
-        if (error instanceof Error) {
-          if (error.message.includes("Not authenticated")) {
-            console.error(
-              chalk.red("✗ Not authenticated. Run: vm0 auth login"),
-            );
-          } else if (error.message.includes("must contain only uppercase")) {
-            console.error(chalk.red(`✗ ${error.message}`));
-            console.error();
-            console.error("Examples of valid secret names:");
-            console.error(chalk.dim("  MY_API_KEY"));
-            console.error(chalk.dim("  GITHUB_TOKEN"));
-            console.error(chalk.dim("  AWS_ACCESS_KEY_ID"));
-          } else {
-            console.error(chalk.red(`✗ ${error.message}`));
-          }
-        } else {
-          console.error(chalk.red("✗ An unexpected error occurred"));
-        }
-        process.exit(1);
-      }
-    },
+      },
+    ),
   );

--- a/turbo/apps/cli/src/commands/secret/set.ts
+++ b/turbo/apps/cli/src/commands/secret/set.ts
@@ -43,11 +43,29 @@ export const setCommand = new Command()
           process.exit(1);
         }
 
-        const secret = await setSecret({
-          name,
-          value,
-          description: options.description,
-        });
+        let secret;
+        try {
+          secret = await setSecret({
+            name,
+            value,
+            description: options.description,
+          });
+        } catch (error) {
+          // Provide helpful examples for naming validation errors
+          if (
+            error instanceof Error &&
+            error.message.includes("must contain only uppercase")
+          ) {
+            console.error(chalk.red(`✗ ${error.message}`));
+            console.error();
+            console.error("Examples of valid secret names:");
+            console.error(chalk.dim("  MY_API_KEY"));
+            console.error(chalk.dim("  GITHUB_TOKEN"));
+            console.error(chalk.dim("  AWS_ACCESS_KEY_ID"));
+            process.exit(1);
+          }
+          throw error;
+        }
 
         console.log(chalk.green(`✓ Secret "${secret.name}" saved`));
         console.log();

--- a/turbo/apps/cli/src/commands/variable/delete.ts
+++ b/turbo/apps/cli/src/commands/variable/delete.ts
@@ -2,20 +2,21 @@ import { Command } from "commander";
 import chalk from "chalk";
 import { getVariable, deleteVariable } from "../../lib/api";
 import { isInteractive, promptConfirm } from "../../lib/utils/prompt-utils";
+import { withErrorHandler } from "../../lib/command";
 
 export const deleteCommand = new Command()
   .name("delete")
   .description("Delete a variable")
   .argument("<name>", "Variable name to delete")
   .option("-y, --yes", "Skip confirmation prompt")
-  .action(async (name: string, options: { yes?: boolean }) => {
-    try {
+  .action(
+    withErrorHandler(async (name: string, options: { yes?: boolean }) => {
       // Verify variable exists first
       try {
         await getVariable(name);
       } catch (error) {
         // Only show "not found" if it's actually a not found error
-        // Otherwise, re-throw to let the outer catch handle it properly
+        // Otherwise, re-throw to let withErrorHandler handle it properly
         if (
           error instanceof Error &&
           error.message.toLowerCase().includes("not found")
@@ -48,16 +49,5 @@ export const deleteCommand = new Command()
 
       await deleteVariable(name);
       console.log(chalk.green(`✓ Variable "${name}" deleted`));
-    } catch (error) {
-      if (error instanceof Error) {
-        if (error.message.includes("Not authenticated")) {
-          console.error(chalk.red("✗ Not authenticated. Run: vm0 auth login"));
-        } else {
-          console.error(chalk.red(`✗ ${error.message}`));
-        }
-      } else {
-        console.error(chalk.red("✗ An unexpected error occurred"));
-      }
-      process.exit(1);
-    }
-  });
+    }),
+  );

--- a/turbo/apps/cli/src/commands/variable/set.ts
+++ b/turbo/apps/cli/src/commands/variable/set.ts
@@ -1,6 +1,7 @@
 import { Command } from "commander";
 import chalk from "chalk";
 import { setVariable } from "../../lib/api";
+import { withErrorHandler } from "../../lib/command";
 
 export const setCommand = new Command()
   .name("set")
@@ -9,8 +10,12 @@ export const setCommand = new Command()
   .argument("<value>", "Variable value")
   .option("-d, --description <description>", "Optional description")
   .action(
-    async (name: string, value: string, options: { description?: string }) => {
-      try {
+    withErrorHandler(
+      async (
+        name: string,
+        value: string,
+        options: { description?: string },
+      ) => {
         const variable = await setVariable({
           name,
           value,
@@ -22,26 +27,6 @@ export const setCommand = new Command()
         console.log("Use in vm0.yaml:");
         console.log(chalk.cyan(`  environment:`));
         console.log(chalk.cyan(`    ${name}: \${{ vars.${name} }}`));
-      } catch (error) {
-        if (error instanceof Error) {
-          if (error.message.includes("Not authenticated")) {
-            console.error(
-              chalk.red("✗ Not authenticated. Run: vm0 auth login"),
-            );
-          } else if (error.message.includes("must contain only uppercase")) {
-            console.error(chalk.red(`✗ ${error.message}`));
-            console.error();
-            console.error("Examples of valid variable names:");
-            console.error(chalk.dim("  MY_VAR"));
-            console.error(chalk.dim("  API_URL"));
-            console.error(chalk.dim("  DEBUG_MODE"));
-          } else {
-            console.error(chalk.red(`✗ ${error.message}`));
-          }
-        } else {
-          console.error(chalk.red("✗ An unexpected error occurred"));
-        }
-        process.exit(1);
-      }
-    },
+      },
+    ),
   );

--- a/turbo/apps/cli/src/commands/variable/set.ts
+++ b/turbo/apps/cli/src/commands/variable/set.ts
@@ -16,11 +16,29 @@ export const setCommand = new Command()
         value: string,
         options: { description?: string },
       ) => {
-        const variable = await setVariable({
-          name,
-          value,
-          description: options.description,
-        });
+        let variable;
+        try {
+          variable = await setVariable({
+            name,
+            value,
+            description: options.description,
+          });
+        } catch (error) {
+          // Provide helpful examples for naming validation errors
+          if (
+            error instanceof Error &&
+            error.message.includes("must contain only uppercase")
+          ) {
+            console.error(chalk.red(`✗ ${error.message}`));
+            console.error();
+            console.error("Examples of valid variable names:");
+            console.error(chalk.dim("  MY_VAR"));
+            console.error(chalk.dim("  API_URL"));
+            console.error(chalk.dim("  DEBUG_MODE"));
+            process.exit(1);
+          }
+          throw error;
+        }
 
         console.log(chalk.green(`✓ Variable "${variable.name}" saved`));
         console.log();


### PR DESCRIPTION
## Summary
- Replace manual try/catch blocks with `withErrorHandler()` in variable and secret commands (`delete`, `set`)
- Preserves inner try/catch in delete commands for specific error recovery (not-found handling)
- Part of tech debt cleanup for consistent error handling across CLI commands

## Test plan
- [x] Unit tests pass (82 files, 951 tests)
- [x] Lint passes (0 warnings, 0 errors)
- [x] Type check passes

Closes part of #4155

🤖 Generated with [Claude Code](https://claude.com/claude-code)