### PR TITLE
refactor(cli): migrate model-provider commands to withErrorHandler

### DIFF
--- a/turbo/apps/cli/src/commands/model-provider/delete.ts
+++ b/turbo/apps/cli/src/commands/model-provider/delete.ts
@@ -1,14 +1,15 @@
 import { Command } from "commander";
 import chalk from "chalk";
 import { deleteModelProvider } from "../../lib/api";
+import { withErrorHandler } from "../../lib/command";
 import { MODEL_PROVIDER_TYPES, type ModelProviderType } from "@vm0/core";
 
 export const deleteCommand = new Command()
   .name("delete")
   .description("Delete a model provider")
   .argument("<type>", "Model provider type to delete")
-  .action(async (type: string) => {
-    try {
+  .action(
+    withErrorHandler(async (type: string) => {
       if (!Object.keys(MODEL_PROVIDER_TYPES).includes(type)) {
         console.error(chalk.red(`✗ Invalid type "${type}"`));
         console.log();
@@ -21,18 +22,5 @@ export const deleteCommand = new Command()
 
       await deleteModelProvider(type as ModelProviderType);
       console.log(chalk.green(`✓ Model provider "${type}" deleted`));
-    } catch (error) {
-      if (error instanceof Error) {
-        if (error.message.includes("not found")) {
-          console.error(chalk.red(`✗ Model provider "${type}" not found`));
-        } else if (error.message.includes("Not authenticated")) {
-          console.error(chalk.red("✗ Not authenticated. Run: vm0 auth login"));
-        } else {
-          console.error(chalk.red(`✗ ${error.message}`));
-        }
-      } else {
-        console.error(chalk.red("✗ An unexpected error occurred"));
-      }
-      process.exit(1);
-    }
-  });
+    }),
+  );

--- a/turbo/apps/cli/src/commands/model-provider/set-default.ts
+++ b/turbo/apps/cli/src/commands/model-provider/set-default.ts
@@ -1,14 +1,15 @@
 import { Command } from "commander";
 import chalk from "chalk";
 import { setModelProviderDefault } from "../../lib/api";
+import { withErrorHandler } from "../../lib/command";
 import { MODEL_PROVIDER_TYPES, type ModelProviderType } from "@vm0/core";
 
 export const setDefaultCommand = new Command()
   .name("set-default")
   .description("Set a model provider as default for its framework")
   .argument("<type>", "Model provider type to set as default")
-  .action(async (type: string) => {
-    try {
+  .action(
+    withErrorHandler(async (type: string) => {
       if (!Object.keys(MODEL_PROVIDER_TYPES).includes(type)) {
         console.error(chalk.red(`✗ Invalid type "${type}"`));
         console.log();
@@ -25,18 +26,5 @@ export const setDefaultCommand = new Command()
           `✓ Default for ${provider.framework} set to "${provider.type}"`,
         ),
       );
-    } catch (error) {
-      if (error instanceof Error) {
-        if (error.message.includes("not found")) {
-          console.error(chalk.red(`✗ Model provider "${type}" not found`));
-        } else if (error.message.includes("Not authenticated")) {
-          console.error(chalk.red("✗ Not authenticated. Run: vm0 auth login"));
-        } else {
-          console.error(chalk.red(`✗ ${error.message}`));
-        }
-      } else {
-        console.error(chalk.red("✗ An unexpected error occurred"));
-      }
-      process.exit(1);
-    }
-  });
+    }),
+  );


### PR DESCRIPTION
## Summary
- Replace manual try/catch blocks with `withErrorHandler()` in model-provider commands (`delete`, `set-default`)
- Part of tech debt cleanup for consistent error handling across CLI commands

## Test plan
- [x] Unit tests pass (951/951)
- [x] Lint passes (0 warnings, 0 errors)
- [x] Type check passes

Closes part of #4155

🤖 Generated with [Claude Code](https://claude.com/claude-code)