### PR TITLE
feat: add experimental label to connectors with feature flag but no api-token auth

### DIFF
--- a/turbo/apps/platform/src/signals/settings-page/connectors.ts
+++ b/turbo/apps/platform/src/signals/settings-page/connectors.ts
@@ -101,9 +101,10 @@ export const allConnectorTypes$ = computed(async (get) => {
       if (hasApiToken) {
         availableAuthMethods.push("api-token");
       }
+      const isExperimental = !!flag && !hasApiToken;
       return {
         type,
-        label: config.label,
+        label: isExperimental ? `[Experimental] ${config.label}` : config.label,
         helpText: config.helpText,
         connected: connector !== null,
         connector,


### PR DESCRIPTION
## Summary
- Adds an `[Experimental]` prefix to connector labels when the connector has a feature flag but does not support api-token authentication
- This helps users identify which connectors are still in experimental/OAuth-only stage

## Test plan
- [ ] Verify connectors with a feature flag and no api-token auth show `[Experimental]` prefix
- [ ] Verify connectors with api-token auth do not show the prefix
- [ ] Verify connectors without a feature flag do not show the prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)