### PR TITLE
feat(platform): add real connector integration to zero meet page connections tab

### DIFF
--- a/turbo/apps/platform/src/signals/__tests__/route.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/route.test.ts
@@ -7,6 +7,7 @@ import {
   pathname$,
   pathParams$,
   searchParams$,
+  updatePathname$,
   updateSearchParams$,
 } from "../route.ts";
 import { setRootSignal$ } from "../root-signal.ts";
@@ -50,6 +51,19 @@ describe("route", () => {
       store.set(updateSearchParams$, params);
 
       expect(store.get(pathname$)).toBe("/test-path");
+    });
+  });
+
+  describe("updatePathname$", () => {
+    it("should update pathname without reloading the route", () => {
+      const { store, signal } = context;
+      const pushStateMock = createPushStateMock(signal);
+      mockLocation({ pathname: "/zero", search: "" }, signal);
+
+      store.set(updatePathname$, "/zero/meet");
+
+      expect(pushStateMock).toHaveBeenCalledWith({}, "", "/zero/meet");
+      expect(store.get(pathname$)).toBe("/zero/meet");
     });
   });
 

--- a/turbo/apps/platform/src/signals/bootstrap.ts
+++ b/turbo/apps/platform/src/signals/bootstrap.ts
@@ -41,6 +41,10 @@ const ROUTE_CONFIG = [
     setup: setupAuthPageWrapper(setupHomePage$),
   },
   {
+    path: "/zero/:tab",
+    setup: setupAuthPageWrapper(setupZeroPage$),
+  },
+  {
     path: "/zero",
     setup: setupAuthPageWrapper(setupZeroPage$),
   },

--- a/turbo/apps/platform/src/signals/route.ts
+++ b/turbo/apps/platform/src/signals/route.ts
@@ -30,6 +30,15 @@ export const updateSearchParams$ = command(
   },
 );
 
+/**
+ * Lightweight pathname update — pushes a new history entry and
+ * triggers pathname$ recomputation without reloading the route.
+ */
+export const updatePathname$ = command(({ set }, newPathname: string) => {
+  pushState({}, "", newPathname);
+  set(reloadPathname$, (x) => x + 1);
+});
+
 interface Route {
   path: string;
   setup: Command<Promise<void> | void, [AbortSignal]>;

--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-nav.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-nav.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+import { mockLocation } from "../../location.ts";
+import { testContext } from "../../__tests__/test-helpers.ts";
+import { createPushStateMock } from "../../../__tests__/page-helper.ts";
+import { zeroActiveId$, setZeroActiveId$ } from "../zero-nav.ts";
+
+const context = testContext();
+
+describe("zero-nav", () => {
+  describe("zeroActiveId$", () => {
+    it("should default to 'chat' for /zero", () => {
+      mockLocation({ pathname: "/zero", search: "" }, context.signal);
+      expect(context.store.get(zeroActiveId$)).toBe("chat");
+    });
+
+    it("should default to 'chat' for /zero/", () => {
+      mockLocation({ pathname: "/zero/", search: "" }, context.signal);
+      expect(context.store.get(zeroActiveId$)).toBe("chat");
+    });
+
+    it("should resolve /zero/chat to 'chat'", () => {
+      mockLocation({ pathname: "/zero/chat", search: "" }, context.signal);
+      expect(context.store.get(zeroActiveId$)).toBe("chat");
+    });
+
+    it("should resolve /zero/meet to 'meet'", () => {
+      mockLocation({ pathname: "/zero/meet", search: "" }, context.signal);
+      expect(context.store.get(zeroActiveId$)).toBe("meet");
+    });
+
+    it("should resolve /zero/schedule to 'schedule'", () => {
+      mockLocation({ pathname: "/zero/schedule", search: "" }, context.signal);
+      expect(context.store.get(zeroActiveId$)).toBe("schedule");
+    });
+
+    it("should resolve /zero/job to 'job'", () => {
+      mockLocation({ pathname: "/zero/job", search: "" }, context.signal);
+      expect(context.store.get(zeroActiveId$)).toBe("job");
+    });
+
+    it("should resolve /zero/production to 'production'", () => {
+      mockLocation(
+        { pathname: "/zero/production", search: "" },
+        context.signal,
+      );
+      expect(context.store.get(zeroActiveId$)).toBe("production");
+    });
+
+    it("should resolve /zero/activity to 'activity'", () => {
+      mockLocation({ pathname: "/zero/activity", search: "" }, context.signal);
+      expect(context.store.get(zeroActiveId$)).toBe("activity");
+    });
+
+    it("should resolve /zero/works to 'works'", () => {
+      mockLocation({ pathname: "/zero/works", search: "" }, context.signal);
+      expect(context.store.get(zeroActiveId$)).toBe("works");
+    });
+
+    it("should resolve /zero/account to 'account'", () => {
+      mockLocation({ pathname: "/zero/account", search: "" }, context.signal);
+      expect(context.store.get(zeroActiveId$)).toBe("account");
+    });
+
+    it("should fall back to 'chat' for invalid tab", () => {
+      mockLocation({ pathname: "/zero/invalid", search: "" }, context.signal);
+      expect(context.store.get(zeroActiveId$)).toBe("chat");
+    });
+
+    it("should fall back to 'chat' for non-zero path", () => {
+      mockLocation({ pathname: "/settings", search: "" }, context.signal);
+      expect(context.store.get(zeroActiveId$)).toBe("chat");
+    });
+  });
+
+  describe("setZeroActiveId$", () => {
+    it("should navigate to /zero for 'chat'", () => {
+      const pushStateMock = createPushStateMock(context.signal);
+      mockLocation({ pathname: "/zero", search: "" }, context.signal);
+
+      context.store.set(setZeroActiveId$, "chat");
+
+      expect(pushStateMock).toHaveBeenCalledWith({}, "", "/zero");
+      expect(context.store.get(zeroActiveId$)).toBe("chat");
+    });
+
+    it("should navigate to /zero/meet for 'meet'", () => {
+      const pushStateMock = createPushStateMock(context.signal);
+      mockLocation({ pathname: "/zero", search: "" }, context.signal);
+
+      context.store.set(setZeroActiveId$, "meet");
+
+      expect(pushStateMock).toHaveBeenCalledWith({}, "", "/zero/meet");
+      expect(context.store.get(zeroActiveId$)).toBe("meet");
+    });
+
+    it("should navigate to /zero/schedule for 'schedule'", () => {
+      const pushStateMock = createPushStateMock(context.signal);
+      mockLocation({ pathname: "/zero", search: "" }, context.signal);
+
+      context.store.set(setZeroActiveId$, "schedule");
+
+      expect(pushStateMock).toHaveBeenCalledWith({}, "", "/zero/schedule");
+      expect(context.store.get(zeroActiveId$)).toBe("schedule");
+    });
+  });
+});

--- a/turbo/apps/platform/src/signals/zero-page/zero-nav.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-nav.ts
@@ -1,0 +1,38 @@
+import { command, computed } from "ccstate";
+import { pathname$, updatePathname$ } from "../route.ts";
+import type { ZeroNavId } from "../../views/zero-page/zero-sidebar.tsx";
+
+function isValidTab(tab: string): tab is ZeroNavId {
+  return (
+    tab === "chat" ||
+    tab === "meet" ||
+    tab === "schedule" ||
+    tab === "job" ||
+    tab === "production" ||
+    tab === "activity" ||
+    tab === "works" ||
+    tab === "account"
+  );
+}
+
+/**
+ * Active zero nav id, derived from the URL path `/zero/:tab`.
+ * `/zero` and `/zero/chat` both resolve to "chat".
+ */
+export const zeroActiveId$ = computed((get): ZeroNavId => {
+  const path = get(pathname$);
+  const segment = path.replace(/^\/zero\/?/, "").split("/")[0];
+  if (segment && isValidTab(segment)) {
+    return segment;
+  }
+  return "chat";
+});
+
+/**
+ * Navigate to a zero tab — updates the URL path to `/zero/:tab`.
+ * "chat" maps to `/zero` (the default, no suffix needed).
+ */
+export const setZeroActiveId$ = command(({ set }, id: ZeroNavId) => {
+  const newPath = id === "chat" ? "/zero" : `/zero/${id}`;
+  set(updatePathname$, newPath);
+});

--- a/turbo/apps/platform/src/types/route.ts
+++ b/turbo/apps/platform/src/types/route.ts
@@ -1,6 +1,7 @@
 export type RoutePath =
   | "/"
   | "/zero"
+  | "/zero/:tab"
   | "/logs"
   | "/logs/:id"
   | "/settings"

--- a/turbo/apps/platform/src/views/zero-page/zero-app-shell.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-app-shell.tsx
@@ -15,6 +15,11 @@ import { zeroNeedsOnboarding$ } from "../../signals/zero-page/zero-onboarding.ts
 import { agentDisplayName$ } from "../../signals/zero-page/zero-agent-name.ts";
 import { resetDefaultAgent$ } from "../../signals/zero-page/zero-dev-tools.ts";
 import { detach, Reason } from "../../signals/utils.ts";
+import {
+  zeroActiveId$,
+  setZeroActiveId$,
+} from "../../signals/zero-page/zero-nav.ts";
+import { updateSearchParams$ } from "../../signals/route.ts";
 
 const ZERO_AVATARS = [
   "/zero-avatar.png",
@@ -114,6 +119,16 @@ function ZeroAppSkeleton({ visible }: { visible: boolean }) {
   );
 }
 
+function useSkeletonVisibility(isLoggedIn: boolean, dataReady: boolean) {
+  const everReady$ = useCCState(false);
+  const everReady = useGet(everReady$);
+  const setEverReady = useSet(everReady$);
+  if (dataReady && !everReady) {
+    setEverReady(true);
+  }
+  return isLoggedIn && !dataReady && !everReady;
+}
+
 function getRecentLabels(agentName: string): Readonly<Record<string, string>> {
   return {
     hello: `Hello from ${agentName}`,
@@ -129,18 +144,16 @@ export function ZeroAppShell() {
   const isLoggedIn =
     userLoadable.state === "hasData" && userLoadable.data !== undefined;
   const onboardingLoadable = useLoadable(zeroNeedsOnboarding$);
+  const onboardingReady = onboardingLoadable.state === "hasData";
   const showOnboarding =
-    isLoggedIn &&
-    onboardingLoadable.state === "hasData" &&
-    onboardingLoadable.data === true;
+    isLoggedIn && onboardingReady && onboardingLoadable.data === true;
   const agentDisplayNameLoadable = useLoadable(agentDisplayName$);
-  const agentDisplayName =
-    agentDisplayNameLoadable.state === "hasData"
-      ? agentDisplayNameLoadable.data
-      : "Zero";
-  const activeId$ = useCCState<ZeroNavId>("chat");
-  const activeId = useGet(activeId$);
-  const setActiveId = useSet(activeId$);
+  const agentNameReady = agentDisplayNameLoadable.state === "hasData";
+  const agentDisplayName = agentNameReady
+    ? agentDisplayNameLoadable.data
+    : "Zero";
+  const activeId = useGet(zeroActiveId$);
+  const setActiveId = useSet(setZeroActiveId$);
   const recentId$ = useCCState<string | null>(null);
   const recentId = useGet(recentId$);
   const accountSubId$ = useCCState<ZeroAccountSubId>(null);
@@ -158,12 +171,12 @@ export function ZeroAppShell() {
 
   const handleRecentSelect$ = useCommand(({ set }, id: string) => {
     set(recentId$, id);
-    set(activeId$, "chat" as ZeroNavId);
+    set(setZeroActiveId$, "chat");
   });
   const handleRecentSelect = useSet(handleRecentSelect$);
 
   const handleNavSelect$ = useCommand(({ set }, id: ZeroNavId) => {
-    set(activeId$, id);
+    set(setZeroActiveId$, id);
     set(recentId$, null);
     set(showAboutPage$, false);
   });
@@ -174,7 +187,7 @@ export function ZeroAppShell() {
       if (action === "signout" || action === "manage") {
         return;
       }
-      set(activeId$, "account" as ZeroNavId);
+      set(setZeroActiveId$, "account");
       set(accountSubId$, action as ZeroAccountSubId);
     },
   );
@@ -185,27 +198,15 @@ export function ZeroAppShell() {
   });
   const handleClearRecent = useSet(handleClearRecent$);
 
+  const updateSearchParams = useSet(updateSearchParams$);
   const resetDefaultAgent = useSet(resetDefaultAgent$);
 
   const recentLabel = recentId
     ? (getRecentLabels(agentDisplayName)[recentId] ?? null)
     : null;
 
-  const dataReady =
-    isLoggedIn &&
-    onboardingLoadable.state === "hasData" &&
-    agentDisplayNameLoadable.state === "hasData";
-
-  // Track: once data has been ready, never show skeleton again
-  const everReady$ = useCCState(false);
-  const everReady = useGet(everReady$);
-  const setEverReady = useSet(everReady$);
-  if (dataReady && !everReady) {
-    setEverReady(true);
-  }
-
-  // Show skeleton only for logged-in users whose data hasn't arrived yet
-  const showSkeleton = isLoggedIn && !dataReady && !everReady;
+  const dataReady = isLoggedIn && onboardingReady && agentNameReady;
+  const showSkeleton = useSkeletonVisibility(isLoggedIn, dataReady);
 
   return (
     <div className="zero-app flex h-dvh w-full bg-background">
@@ -281,6 +282,14 @@ export function ZeroAppShell() {
             onNavigateToSchedule={() => setActiveId("schedule")}
             onNavigateToJob={() => setActiveId("job")}
             onNavigateToChat={() => setActiveId("chat")}
+            onNavigateToMeet={(section) => {
+              setActiveId("meet");
+              if (section) {
+                const next = new URLSearchParams();
+                next.set("section", section);
+                updateSearchParams(next);
+              }
+            }}
             zeroAvatarSrc={zeroAvatarSrc}
             onAvatarClick={cycleAvatar}
           />

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-page.tsx
@@ -35,11 +35,24 @@ export type DemoScenarioId =
   | "agent-operations";
 
 type NavIcon = (props: { size?: number; className?: string }) => ReactNode;
+type ActionId = "automate" | "customize" | "connectors";
 function getActionButtons(agentName: string) {
   return [
-    { label: "Automate workflows", icon: IconBriefcase as NavIcon },
-    { label: `Customize ${agentName}`, icon: IconSettings as NavIcon },
-    { label: "Add connectors", icon: IconPlug as NavIcon },
+    {
+      id: "automate" as ActionId,
+      label: "Automate workflows",
+      icon: IconBriefcase as NavIcon,
+    },
+    {
+      id: "customize" as ActionId,
+      label: `Customize ${agentName}`,
+      icon: IconSettings as NavIcon,
+    },
+    {
+      id: "connectors" as ActionId,
+      label: "Add connectors",
+      icon: IconPlug as NavIcon,
+    },
   ] as const;
 }
 
@@ -636,6 +649,7 @@ interface ZeroChatPageProps {
   onNavigateToActivity?: () => void;
   onNavigateToSchedule?: () => void;
   onNavigateToJob?: () => void;
+  onNavigateToMeet?: (tab?: string) => void;
   zeroAvatarSrc?: string;
   onAvatarClick?: () => void;
 }
@@ -646,6 +660,7 @@ export function ZeroChatPage({
   onNavigateToActivity,
   onNavigateToSchedule,
   onNavigateToJob,
+  onNavigateToMeet,
   zeroAvatarSrc = "/zero-avatar.png",
   onAvatarClick,
 }: ZeroChatPageProps) {
@@ -1150,12 +1165,21 @@ export function ZeroChatPage({
           {/* Action buttons */}
           <div className="flex flex-wrap justify-between items-center gap-2 w-full">
             <div className="flex flex-wrap gap-2">
-              {getActionButtons(agentName).map(({ label, icon: Icon }) => (
+              {getActionButtons(agentName).map(({ id, label, icon: Icon }) => (
                 <Button
-                  key={label}
+                  key={id}
                   variant="outline"
                   size="sm"
                   className="zero-btn-morandi rounded-lg h-8 px-3.5 text-sm font-medium gap-2 border"
+                  onClick={() => {
+                    if (id === "automate") {
+                      onNavigateToSchedule?.();
+                    } else if (id === "customize") {
+                      onNavigateToMeet?.("settings");
+                    } else if (id === "connectors") {
+                      onNavigateToMeet?.("connections");
+                    }
+                  }}
                 >
                   <Icon size={16} />
                   {label}

--- a/turbo/apps/platform/src/views/zero-page/zero-content.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-content.tsx
@@ -28,6 +28,7 @@ interface ZeroContentProps {
   onNavigateToSchedule?: () => void;
   onNavigateToJob?: () => void;
   onNavigateToChat?: () => void;
+  onNavigateToMeet?: (tab?: string) => void;
   zeroAvatarSrc?: string;
   onAvatarClick?: () => void;
 }
@@ -57,6 +58,7 @@ export function ZeroContent({
   onNavigateToSchedule,
   onNavigateToJob,
   onNavigateToChat,
+  onNavigateToMeet,
   zeroAvatarSrc = "/zero-avatar.png",
   onAvatarClick,
 }: ZeroContentProps) {
@@ -74,6 +76,7 @@ export function ZeroContent({
         onNavigateToActivity={onNavigateToActivity}
         onNavigateToSchedule={onNavigateToSchedule}
         onNavigateToJob={onNavigateToJob}
+        onNavigateToMeet={onNavigateToMeet}
         zeroAvatarSrc={zeroAvatarSrc}
         onAvatarClick={onAvatarClick}
       />

--- a/turbo/apps/platform/src/views/zero-page/zero-meet-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-meet-page.tsx
@@ -11,8 +11,9 @@ import {
   IconTool,
   IconCalendar,
   IconPencil,
+  IconLoader2,
 } from "@tabler/icons-react";
-import { CONNECTOR_TYPES, type ConnectorType } from "@vm0/core";
+import type { ConnectorType } from "@vm0/core";
 import { ConnectorIcon } from "../settings-page/connector-icons";
 import {
   Card,
@@ -29,8 +30,22 @@ import {
   SelectValue,
   cn,
 } from "@vm0/ui";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@vm0/ui/components/ui/dialog";
 import { ZeroScheduleCard, DEFAULT_SCHEDULE } from "./zero-schedule-card";
 import { agentDisplayName$ } from "../../signals/zero-page/zero-agent-name.ts";
+import {
+  allConnectorTypes$,
+  connectConnector$,
+  pollingConnectorType$,
+} from "../../signals/settings-page/connectors.ts";
+import { deleteConnector$ } from "../../signals/external/connectors.ts";
+import { pageSignal$ } from "../../signals/page-signal.ts";
+import { detach, Reason } from "../../signals/utils.ts";
 
 const TONE_OPTIONS = [
   "Professional",
@@ -54,19 +69,19 @@ const TONE_SAMPLES: Readonly<
 > = {
   Professional: {
     user: "I need the Q3 report by Friday.",
-    zero: "I’ll have the Q3 report ready by Friday. I’ll send a draft by Thursday for your review.",
+    zero: "I'll have the Q3 report ready by Friday. I'll send a draft by Thursday for your review.",
   },
   Friendly: {
     user: "I need the Q3 report by Friday.",
-    zero: "Sure thing! I’ll get that Q3 report to you by Friday—I’ll send over a draft Thursday so you can take a look.",
+    zero: "Sure thing! I'll get that Q3 report to you by Friday—I'll send over a draft Thursday so you can take a look.",
   },
   Direct: {
     user: "I need the Q3 report by Friday.",
-    zero: "Friday. I’ll send a draft Thursday.",
+    zero: "Friday. I'll send a draft Thursday.",
   },
   Supportive: {
     user: "I need the Q3 report by Friday.",
-    zero: "I’ll make sure you have the Q3 report by Friday. I’ll send a draft on Thursday so you have time to review—let me know if you’d like anything else.",
+    zero: "I'll make sure you have the Q3 report by Friday. I'll send a draft on Thursday so you have time to review—let me know if you'd like anything else.",
   },
 };
 
@@ -84,13 +99,170 @@ const AVAILABLE_SKILLS = [
   "elephant",
 ] as const;
 
-const CONNECTOR_LIST: readonly ConnectorType[] = [
-  "github",
-  "linear",
-  "notion",
-  "gmail",
-  "slack",
-];
+function isConnectorSkill(skill: string): skill is ConnectorType {
+  return (
+    skill === "github" ||
+    skill === "linear" ||
+    skill === "notion" ||
+    skill === "gmail" ||
+    skill === "slack"
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Connections tab — real connector status + OAuth connect
+// ---------------------------------------------------------------------------
+
+function ZeroConnectionsTab() {
+  const allTypesLoadable = useLoadable(allConnectorTypes$);
+  const pollingType = useGet(pollingConnectorType$);
+  const connect = useSet(connectConnector$);
+  const disconnect = useSet(deleteConnector$);
+  const signal = useGet(pageSignal$);
+  const dialogOpen$ = useCCState(false);
+  const dialogOpen = useGet(dialogOpen$);
+  const setDialogOpen = useSet(dialogOpen$);
+
+  const allTypes =
+    allTypesLoadable.state === "hasData" ? allTypesLoadable.data : [];
+  const connectedItems = allTypes.filter(
+    (item) => item.connected || pollingType === item.type,
+  );
+  const unconnectedItems = allTypes.filter(
+    (item) => !item.connected && pollingType !== item.type,
+  );
+
+  return (
+    <div className="mx-auto max-w-[900px] px-7 flex flex-col gap-6">
+      <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
+        <div>
+          <h2 className="text-base font-semibold tracking-tight text-foreground">
+            Connectors
+          </h2>
+          <p className="text-sm text-muted-foreground">
+            Connect and authorize these services so your agent can act on your
+            behalf.
+          </p>
+        </div>
+        <Button
+          size="sm"
+          className="h-9 shrink-0 gap-2 rounded-lg"
+          onClick={() => setDialogOpen(true)}
+        >
+          <IconPlus size={16} stroke={2} />
+          Add Connector
+        </Button>
+      </div>
+
+      {connectedItems.length === 0 ? (
+        <div className="flex flex-col items-center gap-3 rounded-xl border border-dashed border-border/60 py-12">
+          <IconPlug
+            size={32}
+            stroke={1.2}
+            className="text-muted-foreground/50"
+          />
+          <p className="text-sm text-muted-foreground">
+            No connectors yet. Add one to get started.
+          </p>
+        </div>
+      ) : (
+        <ul className="flex flex-col gap-3">
+          {connectedItems.map((item) => (
+            <li key={item.type}>
+              <Card className="zero-card">
+                <CardContent className="flex items-center gap-4 px-4 py-3">
+                  <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-muted overflow-hidden">
+                    <ConnectorIcon type={item.type} size={24} />
+                  </span>
+                  <div className="min-w-0 flex-1">
+                    <p className="text-sm font-medium text-foreground">
+                      {item.label}
+                    </p>
+                    <p className="text-xs text-muted-foreground">
+                      {item.connected && item.connector?.externalUsername
+                        ? `Connected as @${item.connector.externalUsername}`
+                        : item.helpText}
+                    </p>
+                  </div>
+                  {pollingType === item.type ? (
+                    <span className="flex h-8 items-center gap-1.5 rounded-lg border px-3 text-xs text-muted-foreground">
+                      <IconLoader2
+                        size={14}
+                        stroke={1.5}
+                        className="animate-spin"
+                      />
+                      Connecting…
+                    </span>
+                  ) : (
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      className="h-8 shrink-0 rounded-lg px-3 text-xs text-muted-foreground hover:text-destructive"
+                      onClick={() =>
+                        detach(disconnect(item.type), Reason.DomCallback)
+                      }
+                    >
+                      Disconnect
+                    </Button>
+                  )}
+                </CardContent>
+              </Card>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+        <DialogContent className="sm:max-w-2xl max-h-[85vh] overflow-hidden flex flex-col">
+          <DialogHeader>
+            <DialogTitle>Add Connector</DialogTitle>
+          </DialogHeader>
+          <div className="flex-1 overflow-y-auto -mx-6 px-6 pb-1">
+            {unconnectedItems.length === 0 ? (
+              <p className="py-8 text-center text-sm text-muted-foreground">
+                All available connectors are connected.
+              </p>
+            ) : (
+              <div className="grid grid-cols-2 gap-3">
+                {unconnectedItems.map((item) => {
+                  const isPolling = pollingType === item.type;
+                  return (
+                    <button
+                      key={item.type}
+                      type="button"
+                      disabled={isPolling}
+                      className="flex items-start gap-3 rounded-xl border border-border bg-card p-3 text-left transition-colors hover:bg-muted/50 disabled:opacity-60"
+                      onClick={() => {
+                        setDialogOpen(false);
+                        detach(connect(item.type, signal), Reason.DomCallback);
+                      }}
+                    >
+                      <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-muted overflow-hidden mt-0.5">
+                        <ConnectorIcon type={item.type} size={22} />
+                      </span>
+                      <div className="min-w-0 flex-1">
+                        <p className="text-sm font-medium text-foreground">
+                          {item.label}
+                        </p>
+                        <p className="text-xs text-muted-foreground line-clamp-2 mt-0.5">
+                          {item.helpText}
+                        </p>
+                      </div>
+                    </button>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main meet page
+// ---------------------------------------------------------------------------
 
 interface ZeroMeetPageProps {
   zeroAvatarSrc?: string;
@@ -356,7 +528,7 @@ export function ZeroMeetPage({
                           className="flex min-w-[120px] max-w-[220px] flex-1 basis-[120px]"
                         >
                           <span className="zero-chip flex w-full min-w-0 items-center gap-2 rounded-2xl border px-3 py-2.5 text-sm text-foreground transition-colors duration-200">
-                            {CONNECTOR_LIST.includes(skill as ConnectorType) ? (
+                            {isConnectorSkill(skill) ? (
                               <ConnectorIcon
                                 type={skill as ConnectorType}
                                 size={16}
@@ -487,56 +659,7 @@ export function ZeroMeetPage({
           </div>
         )}
 
-        {activeTab === "connections" && (
-          <div className="mx-auto max-w-[900px] px-7 flex flex-col gap-6">
-            <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
-              <div>
-                <h2 className="text-base font-semibold tracking-tight text-foreground">
-                  Connectors
-                </h2>
-                <p className="text-sm text-muted-foreground">
-                  Connect and authorize these services so your agent can act on
-                  your behalf.
-                </p>
-              </div>
-              <Button size="sm" className="h-9 shrink-0 gap-2 rounded-lg">
-                <IconPlus size={16} stroke={2} />
-                Add Connector
-              </Button>
-            </div>
-            <ul className="flex flex-col gap-3">
-              {CONNECTOR_LIST.map((type) => {
-                const config = CONNECTOR_TYPES[type];
-                return (
-                  <li key={type}>
-                    <Card className="zero-card">
-                      <CardContent className="flex items-center gap-4 px-4 py-3">
-                        <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-muted overflow-hidden">
-                          <ConnectorIcon type={type} size={24} />
-                        </span>
-                        <div className="min-w-0 flex-1">
-                          <p className="text-sm font-medium text-foreground">
-                            {config.label}
-                          </p>
-                          <p className="text-xs text-muted-foreground">
-                            {config.helpText}
-                          </p>
-                        </div>
-                        <Button
-                          size="sm"
-                          variant="outline"
-                          className="zero-btn-morandi h-8 shrink-0 rounded-lg border px-3"
-                        >
-                          Connect
-                        </Button>
-                      </CardContent>
-                    </Card>
-                  </li>
-                );
-              })}
-            </ul>
-          </div>
-        )}
+        {activeTab === "connections" && <ZeroConnectionsTab />}
       </main>
 
       {showSaveBar &&

--- a/turbo/apps/platform/src/views/zero-page/zero-onboarding.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-onboarding.tsx
@@ -387,7 +387,7 @@ export function ZeroOnboarding({
               className="rounded-lg min-w-[100px]"
               disabled={!providerPicked || !canSave || saving}
             >
-              {saving ? "Saving…" : "Next"}
+              {saving ? "Saving\u2026" : "Next"}
             </Button>
           </div>
         </DialogContent>
@@ -475,7 +475,7 @@ export function ZeroOnboarding({
                   onClick={handleAddToSlack}
                   disabled={saving}
                 >
-                  {saving ? "Saving…" : "Add to Slack"}
+                  {saving ? "Saving\u2026" : "Add to Slack"}
                 </Button>
               </div>
               <div className="zero-card flex flex-col items-center text-center rounded-xl border border-border p-5">
@@ -501,7 +501,7 @@ export function ZeroOnboarding({
                   onClick={handleContinueWithWeb}
                   disabled={saving}
                 >
-                  {saving ? "Saving…" : `Chat with ${name || "Zero"}`}
+                  {saving ? "Saving\u2026" : `Chat with ${name || "Zero"}`}
                 </Button>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- Replace hardcoded connector list in the zero meet page connections tab with real connector data from `allConnectorTypes$` signal
- Add Dialog for adding connectors, disconnect support, loading states, and empty state handling
- Wire URL-based navigation for zero tabs via `/zero/:tab` route pattern

## Test plan
- [ ] Verify the meet page connections tab displays real connector data
- [ ] Test adding a connector via the dialog
- [ ] Test disconnecting a connector
- [ ] Verify loading and empty states render correctly
- [ ] Verify URL-based tab navigation works (e.g., `/zero/meet`, `/zero/chat`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)