### PR TITLE
refactor: rename provision-metal.yml to provision-runner.yml

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -226,7 +226,7 @@ jobs:
           cd ansible
           ansible-playbook \
             -i "${HOST}," \
-            playbooks/provision-metal.yml \
+            playbooks/provision-runner.yml \
             -e "ansible_user=${METAL_USER}" \
             -v
           if [ -n "${GRAFANA_CLOUD_API_KEY}" ]; then

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -733,7 +733,7 @@ jobs:
           cd ansible
           ansible-playbook \
             -i "${AWS_METAL_RUNNER_HOSTS}," \
-            playbooks/provision-metal.yml \
+            playbooks/provision-runner.yml \
             -e "ansible_user=${AWS_METAL_RUNNER_USER}" \
             -v
           if [ -n "${GRAFANA_CLOUD_API_KEY}" ]; then

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1178,7 +1178,7 @@ jobs:
           cd ansible
           ansible-playbook \
             -i "${METAL_HOSTS}," \
-            playbooks/provision-metal.yml \
+            playbooks/provision-runner.yml \
             -e "ansible_user=${METAL_USER}" \
             -v
           if [ -n "${GRAFANA_CLOUD_API_KEY}" ]; then

--- a/ansible/playbooks/provision-runner.yml
+++ b/ansible/playbooks/provision-runner.yml
@@ -1,14 +1,14 @@
-# Provision Metal Host Dependencies
+# Provision Runner Host Dependencies
 #
 # Idempotent playbook that installs all system-level dependencies required by
-# the VM0 runner on bare-metal hosts. Safe to run repeatedly — all tasks use
+# the VM0 runner on runner hosts. Safe to run repeatedly — all tasks use
 # idempotent operations (apt state=present, group append, chmod).
 #
 # Usage:
 #   ansible-playbook -i "host1,host2," playbooks/provision-runner.yml \
 #     -e "ansible_user=ubuntu"
 
-- name: Provision metal host dependencies
+- name: Provision runner host dependencies
   hosts: all
 
   tasks:

--- a/ansible/playbooks/provision-runner.yml
+++ b/ansible/playbooks/provision-runner.yml
@@ -5,7 +5,7 @@
 # idempotent operations (apt state=present, group append, chmod).
 #
 # Usage:
-#   ansible-playbook -i "host1,host2," playbooks/provision-metal.yml \
+#   ansible-playbook -i "host1,host2," playbooks/provision-runner.yml \
 #     -e "ansible_user=ubuntu"
 
 - name: Provision metal host dependencies


### PR DESCRIPTION
## Summary
- Rename `provision-metal.yml` to `provision-runner.yml` for clearer naming
- Update all workflow references in turbo.yml, release-please.yml, and crates.yml

## Test plan
- [ ] CI workflows reference the correct playbook path

🤖 Generated with [Claude Code](https://claude.com/claude-code)