### PR TITLE
feat(zero): wire meet page schedule tab to real API

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-schedule.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-schedule.test.ts
@@ -1,0 +1,301 @@
+import { describe, expect, it } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../mocks/server.ts";
+import { testContext } from "../../__tests__/test-helpers.ts";
+import { setupPage } from "../../../__tests__/page-helper.ts";
+import {
+  fetchZeroSchedules$,
+  zeroScheduleEntries$,
+  saveZeroSchedule$,
+  deleteZeroSchedule$,
+} from "../zero-schedule.ts";
+
+const context = testContext();
+
+function createMockSchedules() {
+  return [
+    {
+      id: "sched-1",
+      composeId: "mock-compose-id",
+      composeName: "zero",
+      scopeSlug: "test",
+      name: "morning-briefing",
+      triggerType: "cron",
+      cronExpression: "0 9 * * 1-5",
+      atTime: null,
+      intervalSeconds: null,
+      timezone: "UTC",
+      prompt: "Summarize yesterday's threads",
+      enabled: true,
+      nextRunAt: null,
+      lastRunAt: null,
+      createdAt: "2026-03-01T00:00:00Z",
+      updatedAt: "2026-03-01T00:00:00Z",
+    },
+    {
+      id: "sched-2",
+      composeId: "mock-compose-id",
+      composeName: "zero",
+      scopeSlug: "test",
+      name: "check-inbox",
+      triggerType: "loop",
+      cronExpression: null,
+      atTime: null,
+      intervalSeconds: 900,
+      timezone: "UTC",
+      prompt: "Check inbox for urgent items",
+      enabled: true,
+      nextRunAt: null,
+      lastRunAt: null,
+      createdAt: "2026-03-01T00:00:00Z",
+      updatedAt: "2026-03-01T00:00:00Z",
+    },
+    {
+      id: "sched-other",
+      composeId: "other-compose-id",
+      composeName: "other-agent",
+      scopeSlug: "test",
+      name: "other-schedule",
+      triggerType: "cron",
+      cronExpression: "0 12 * * *",
+      atTime: null,
+      intervalSeconds: null,
+      timezone: "UTC",
+      prompt: "This belongs to another agent",
+      enabled: true,
+      nextRunAt: null,
+      lastRunAt: null,
+      createdAt: "2026-03-01T00:00:00Z",
+      updatedAt: "2026-03-01T00:00:00Z",
+    },
+  ];
+}
+
+async function setup() {
+  await setupPage({
+    context,
+    path: "/zero/meet",
+    withoutRender: true,
+  });
+}
+
+describe("zero-schedule signals", () => {
+  describe("fetchZeroSchedules$", () => {
+    it("should fetch and filter schedules for the default agent", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/agent/schedules", () => {
+          return HttpResponse.json({ schedules: createMockSchedules() });
+        }),
+      );
+
+      await setup();
+      await context.store.set(fetchZeroSchedules$);
+
+      const entries = context.store.get(zeroScheduleEntries$);
+      expect(entries).toHaveLength(2);
+      expect(entries[0]?.prompt).toBe("Summarize yesterday's threads");
+      expect(entries[1]?.prompt).toBe("Check inbox for urgent items");
+    });
+
+    it("should convert cron schedule to display string", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/agent/schedules", () => {
+          return HttpResponse.json({ schedules: createMockSchedules() });
+        }),
+      );
+
+      await setup();
+      await context.store.set(fetchZeroSchedules$);
+
+      const entries = context.store.get(zeroScheduleEntries$);
+      expect(entries[0]?.time).toBe("Every weekday at 9:00 AM");
+    });
+
+    it("should convert loop schedule to display string", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/agent/schedules", () => {
+          return HttpResponse.json({ schedules: createMockSchedules() });
+        }),
+      );
+
+      await setup();
+      await context.store.set(fetchZeroSchedules$);
+
+      const entries = context.store.get(zeroScheduleEntries$);
+      expect(entries[1]?.time).toBe("Every 15 minutes");
+    });
+
+    it("should handle empty response", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/agent/schedules", () => {
+          return HttpResponse.json({ schedules: [] });
+        }),
+      );
+
+      await setup();
+      await context.store.set(fetchZeroSchedules$);
+
+      const entries = context.store.get(zeroScheduleEntries$);
+      expect(entries).toHaveLength(0);
+    });
+
+    it("should handle API error gracefully", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/agent/schedules", () => {
+          return new HttpResponse(null, { status: 500 });
+        }),
+      );
+
+      await setup();
+      await context.store.set(fetchZeroSchedules$);
+
+      const entries = context.store.get(zeroScheduleEntries$);
+      expect(entries).toHaveLength(0);
+    });
+  });
+
+  describe("saveZeroSchedule$", () => {
+    it("should POST a cron schedule and refresh the list", async () => {
+      const captured: { body: Record<string, unknown> | null } = { body: null };
+
+      server.use(
+        http.post(
+          "http://localhost:3000/api/agent/schedules",
+          async ({ request }) => {
+            captured.body = (await request.json()) as Record<string, unknown>;
+            return HttpResponse.json({ success: true });
+          },
+        ),
+        http.post(
+          "http://localhost:3000/api/agent/schedules/:name/enable",
+          () => {
+            return HttpResponse.json({ success: true });
+          },
+        ),
+        http.get("http://localhost:3000/api/agent/schedules", () => {
+          return HttpResponse.json({ schedules: [] });
+        }),
+      );
+
+      await setup();
+      await context.store.set(saveZeroSchedule$, {
+        prompt: "Daily standup summary",
+        freq: "every_day",
+        date: "2026-03-15",
+        hour: 9,
+        minute: 0,
+        timezone: "UTC",
+        loopMinutes: 15,
+      });
+
+      expect(captured.body).not.toBeNull();
+      expect(captured.body?.composeId).toBe("mock-compose-id");
+      expect(captured.body?.prompt).toBe("Daily standup summary");
+      expect(captured.body?.cronExpression).toBe("0 9 * * *");
+      expect(captured.body?.timezone).toBe("UTC");
+    });
+
+    it("should POST a loop schedule", async () => {
+      const captured: { body: Record<string, unknown> | null } = { body: null };
+
+      server.use(
+        http.post(
+          "http://localhost:3000/api/agent/schedules",
+          async ({ request }) => {
+            captured.body = (await request.json()) as Record<string, unknown>;
+            return HttpResponse.json({ success: true });
+          },
+        ),
+        http.post(
+          "http://localhost:3000/api/agent/schedules/:name/enable",
+          () => {
+            return HttpResponse.json({ success: true });
+          },
+        ),
+        http.get("http://localhost:3000/api/agent/schedules", () => {
+          return HttpResponse.json({ schedules: [] });
+        }),
+      );
+
+      await setup();
+      await context.store.set(saveZeroSchedule$, {
+        prompt: "Check inbox",
+        freq: "every_n_minutes",
+        date: "2026-03-15",
+        hour: 9,
+        minute: 0,
+        timezone: "UTC",
+        loopMinutes: 15,
+      });
+
+      expect(captured.body).not.toBeNull();
+      expect(captured.body?.intervalSeconds).toBe(900);
+    });
+
+    it("should use editName when editing an existing schedule", async () => {
+      const captured: { body: Record<string, unknown> | null } = { body: null };
+
+      server.use(
+        http.post(
+          "http://localhost:3000/api/agent/schedules",
+          async ({ request }) => {
+            captured.body = (await request.json()) as Record<string, unknown>;
+            return HttpResponse.json({ success: true });
+          },
+        ),
+        http.post(
+          "http://localhost:3000/api/agent/schedules/:name/enable",
+          () => {
+            return HttpResponse.json({ success: true });
+          },
+        ),
+        http.get("http://localhost:3000/api/agent/schedules", () => {
+          return HttpResponse.json({ schedules: [] });
+        }),
+      );
+
+      await setup();
+      await context.store.set(saveZeroSchedule$, {
+        prompt: "Updated prompt",
+        freq: "every_weekday",
+        date: "2026-03-15",
+        hour: 10,
+        minute: 30,
+        timezone: "America/New_York",
+        loopMinutes: 15,
+        editName: "existing-schedule",
+      });
+
+      expect(captured.body?.name).toBe("existing-schedule");
+      expect(captured.body?.cronExpression).toBe("30 10 * * 1-5");
+    });
+  });
+
+  describe("deleteZeroSchedule$", () => {
+    it("should DELETE a schedule and refresh the list", async () => {
+      let deletedName: string | null = null;
+      let deletedComposeId: string | null = null;
+
+      server.use(
+        http.delete(
+          "http://localhost:3000/api/agent/schedules/:name",
+          ({ params, request }) => {
+            deletedName = params["name"] as string;
+            const url = new URL(request.url);
+            deletedComposeId = url.searchParams.get("composeId");
+            return new HttpResponse(null, { status: 204 });
+          },
+        ),
+        http.get("http://localhost:3000/api/agent/schedules", () => {
+          return HttpResponse.json({ schedules: [] });
+        }),
+      );
+
+      await setup();
+      await context.store.set(deleteZeroSchedule$, "morning-briefing");
+
+      expect(deletedName).toBe("morning-briefing");
+      expect(deletedComposeId).toBe("mock-compose-id");
+    });
+  });
+});

--- a/turbo/apps/platform/src/signals/zero-page/zero-schedule.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-schedule.ts
@@ -268,7 +268,7 @@ export const deleteZeroSchedule$ = command(
     const status = await get(zeroOnboardingStatus$);
     const composeId = status.defaultAgentComposeId;
     if (!composeId) {
-      return;
+      throw new Error("No default agent configured");
     }
 
     const fetchFn = get(fetch$);

--- a/turbo/apps/platform/src/signals/zero-page/zero-schedule.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-schedule.ts
@@ -8,6 +8,7 @@ import {
   buildCronExpression,
   buildAtTime,
   type ScheduleBody,
+  type CronTimeOption,
 } from "../agent-detail/cron.ts";
 
 const L = logger("ZeroSchedule");
@@ -40,7 +41,6 @@ interface ScheduleResponse {
 // ---------------------------------------------------------------------------
 
 const internalSchedules$ = state<ScheduleResponse[]>([]);
-const internalLoading$ = state(false);
 
 // ---------------------------------------------------------------------------
 // Convert ScheduleResponse to display time string
@@ -130,7 +130,6 @@ export const fetchZeroSchedules$ = command(async ({ get, set }) => {
     return;
   }
 
-  set(internalLoading$, true);
   try {
     const fetchFn = get(fetch$);
     const response = await fetchFn("/api/agent/schedules");
@@ -153,8 +152,6 @@ export const fetchZeroSchedules$ = command(async ({ get, set }) => {
     throwIfAbort(error);
     L.error("Failed to fetch zero schedules:", error);
     set(internalSchedules$, []);
-  } finally {
-    set(internalLoading$, false);
   }
 });
 
@@ -208,19 +205,18 @@ export const saveZeroSchedule$ = command(
       body = { ...base, atTime: new Date().toISOString() };
     } else {
       // Map freq to cron time option
-      const freqMap: Record<string, string> = {
+      const freqMap: Record<string, CronTimeOption> = {
         every_weekday: "every-weekday",
         every_day: "every-day",
         every_week: "every-week",
         every_month: "every-month",
       };
-      const timeOption = freqMap[params.freq] ?? "every-day";
+      const timeOption = freqMap[params.freq];
+      if (!timeOption) {
+        throw new Error(`Unknown schedule frequency: ${params.freq}`);
+      }
       const cronExpression = buildCronExpression({
-        timeOption: timeOption as
-          | "every-weekday"
-          | "every-day"
-          | "every-week"
-          | "every-month",
+        timeOption,
         hour: String(params.hour),
         minute: String(params.minute),
       });
@@ -253,7 +249,9 @@ export const saveZeroSchedule$ = command(
     );
 
     if (!enableResponse.ok) {
-      L.warn("Failed to enable schedule:", enableResponse.statusText);
+      throw new Error(
+        `Schedule saved but failed to enable: ${enableResponse.statusText}`,
+      );
     }
 
     toast.success(params.editName ? "Schedule updated" : "Schedule created");

--- a/turbo/apps/platform/src/signals/zero-page/zero-schedule.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-schedule.ts
@@ -1,0 +1,294 @@
+import { command, computed, state } from "ccstate";
+import { toast } from "@vm0/ui/components/ui/sonner";
+import { fetch$ } from "../fetch.ts";
+import { throwIfAbort } from "../utils.ts";
+import { logger } from "../log.ts";
+import { zeroOnboardingStatus$ } from "./zero-onboarding.ts";
+import {
+  buildCronExpression,
+  buildAtTime,
+  type ScheduleBody,
+} from "../agent-detail/cron.ts";
+
+const L = logger("ZeroSchedule");
+
+// ---------------------------------------------------------------------------
+// Schedule response type (matches API schema)
+// ---------------------------------------------------------------------------
+
+interface ScheduleResponse {
+  id: string;
+  composeId: string;
+  composeName: string;
+  scopeSlug: string;
+  name: string;
+  triggerType: "cron" | "once" | "loop";
+  cronExpression: string | null;
+  atTime: string | null;
+  intervalSeconds: number | null;
+  timezone: string;
+  prompt: string;
+  enabled: boolean;
+  nextRunAt: string | null;
+  lastRunAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+// ---------------------------------------------------------------------------
+// State
+// ---------------------------------------------------------------------------
+
+const internalSchedules$ = state<ScheduleResponse[]>([]);
+const internalLoading$ = state(false);
+
+// ---------------------------------------------------------------------------
+// Convert ScheduleResponse to display time string
+// ---------------------------------------------------------------------------
+
+function scheduleToTimeString(s: ScheduleResponse): string {
+  if (s.triggerType === "loop" && s.intervalSeconds !== null) {
+    const minutes = Math.round(s.intervalSeconds / 60);
+    return `Every ${minutes} minutes`;
+  }
+
+  if (s.triggerType === "once" && s.atTime) {
+    const at = new Date(s.atTime);
+    const date = `${at.getFullYear()}-${String(at.getMonth() + 1).padStart(2, "0")}-${String(at.getDate()).padStart(2, "0")}`;
+    const hour = at.getHours();
+    const minute = at.getMinutes();
+    const ampm = hour >= 12 ? "PM" : "AM";
+    const h12 = hour === 0 ? 12 : hour > 12 ? hour - 12 : hour;
+    return `Once on ${date} at ${h12}:${String(minute).padStart(2, "0")} ${ampm}`;
+  }
+
+  if (s.cronExpression) {
+    return cronToTimeString(s.cronExpression);
+  }
+
+  return "Scheduled";
+}
+
+function cronToTimeString(cron: string): string {
+  const parts = cron.split(" ");
+  const minute = Number(parts[0]);
+  const hour = Number(parts[1]);
+  const dayOfMonth = parts[2] ?? "*";
+  const dayOfWeek = parts[4] ?? "*";
+
+  const ampm = hour >= 12 ? "PM" : "AM";
+  const h12 = hour === 0 ? 12 : hour > 12 ? hour - 12 : hour;
+  const timeStr = `${h12}:${String(minute).padStart(2, "0")} ${ampm}`;
+
+  if (dayOfWeek === "1-5") {
+    return `Every weekday at ${timeStr}`;
+  }
+  if (dayOfMonth !== "*") {
+    return `Every month at ${timeStr}`;
+  }
+  if (dayOfWeek !== "*") {
+    return `Every week at ${timeStr}`;
+  }
+  return `Every day at ${timeStr}`;
+}
+
+// ---------------------------------------------------------------------------
+// Exported schedule entries (display format)
+// ---------------------------------------------------------------------------
+
+interface ZeroScheduleEntry {
+  id: string;
+  time: string;
+  prompt: string;
+  enabled: boolean;
+  /** Original schedule name for API operations */
+  name: string;
+}
+
+export const zeroScheduleEntries$ = computed((get) => {
+  const schedules = get(internalSchedules$);
+  return schedules.map(
+    (s): ZeroScheduleEntry => ({
+      id: s.id,
+      time: scheduleToTimeString(s),
+      prompt: s.prompt,
+      enabled: s.enabled,
+      name: s.name,
+    }),
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Fetch schedules for the default agent
+// ---------------------------------------------------------------------------
+
+export const fetchZeroSchedules$ = command(async ({ get, set }) => {
+  const status = await get(zeroOnboardingStatus$);
+  const composeId = status.defaultAgentComposeId;
+  if (!composeId) {
+    set(internalSchedules$, []);
+    return;
+  }
+
+  set(internalLoading$, true);
+  try {
+    const fetchFn = get(fetch$);
+    const response = await fetchFn("/api/agent/schedules");
+
+    if (!response.ok) {
+      set(internalSchedules$, []);
+      return;
+    }
+
+    const data = (await response.json()) as {
+      schedules: ScheduleResponse[];
+    };
+
+    // Filter schedules for this agent's composeId
+    const agentSchedules = data.schedules.filter(
+      (s) => s.composeId === composeId,
+    );
+    set(internalSchedules$, agentSchedules);
+  } catch (error) {
+    throwIfAbort(error);
+    L.error("Failed to fetch zero schedules:", error);
+    set(internalSchedules$, []);
+  } finally {
+    set(internalLoading$, false);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Save schedule (create or update)
+// ---------------------------------------------------------------------------
+
+export interface ZeroScheduleSaveParams {
+  prompt: string;
+  freq: string;
+  date: string;
+  hour: number;
+  minute: number;
+  timezone: string;
+  loopMinutes: number;
+  /** Schedule name when editing an existing schedule */
+  editName?: string;
+}
+
+export const saveZeroSchedule$ = command(
+  async ({ get, set }, params: ZeroScheduleSaveParams) => {
+    const status = await get(zeroOnboardingStatus$);
+    const composeId = status.defaultAgentComposeId;
+    if (!composeId) {
+      throw new Error("No default agent configured");
+    }
+
+    const fetchFn = get(fetch$);
+    const scheduleName = params.editName ?? `zero-${Date.now().toString(36)}`;
+
+    const base = {
+      composeId,
+      name: scheduleName,
+      timezone: params.timezone,
+      prompt: params.prompt.trim(),
+    };
+
+    let body: ScheduleBody;
+
+    if (params.freq === "every_n_minutes") {
+      body = { ...base, intervalSeconds: params.loopMinutes * 60 };
+    } else if (params.freq === "once") {
+      const atTime = buildAtTime(
+        params.date,
+        String(params.hour),
+        String(params.minute),
+      );
+      body = { ...base, atTime };
+    } else if (params.freq === "now") {
+      // "Now" → run once immediately (atTime = now)
+      body = { ...base, atTime: new Date().toISOString() };
+    } else {
+      // Map freq to cron time option
+      const freqMap: Record<string, string> = {
+        every_weekday: "every-weekday",
+        every_day: "every-day",
+        every_week: "every-week",
+        every_month: "every-month",
+      };
+      const timeOption = freqMap[params.freq] ?? "every-day";
+      const cronExpression = buildCronExpression({
+        timeOption: timeOption as
+          | "every-weekday"
+          | "every-day"
+          | "every-week"
+          | "every-month",
+        hour: String(params.hour),
+        minute: String(params.minute),
+      });
+      body = { ...base, cronExpression };
+    }
+
+    const response = await fetchFn("/api/agent/schedules", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+
+    if (!response.ok) {
+      const errorData = (await response.json().catch(() => null)) as {
+        error?: { message?: string };
+      } | null;
+      throw new Error(
+        errorData?.error?.message ?? `Save failed: ${response.statusText}`,
+      );
+    }
+
+    // Enable the schedule
+    const enableResponse = await fetchFn(
+      `/api/agent/schedules/${encodeURIComponent(scheduleName)}/enable`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ composeId }),
+      },
+    );
+
+    if (!enableResponse.ok) {
+      L.warn("Failed to enable schedule:", enableResponse.statusText);
+    }
+
+    toast.success(params.editName ? "Schedule updated" : "Schedule created");
+    await set(fetchZeroSchedules$);
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Delete schedule
+// ---------------------------------------------------------------------------
+
+export const deleteZeroSchedule$ = command(
+  async ({ get, set }, scheduleName: string) => {
+    const status = await get(zeroOnboardingStatus$);
+    const composeId = status.defaultAgentComposeId;
+    if (!composeId) {
+      return;
+    }
+
+    const fetchFn = get(fetch$);
+    const response = await fetchFn(
+      `/api/agent/schedules/${encodeURIComponent(scheduleName)}?composeId=${encodeURIComponent(composeId)}`,
+      { method: "DELETE" },
+    );
+
+    if (!response.ok && response.status !== 204) {
+      const errorData = (await response.json().catch(() => null)) as {
+        error?: { message?: string };
+      } | null;
+      throw new Error(
+        errorData?.error?.message ?? `Delete failed: ${response.statusText}`,
+      );
+    }
+
+    toast.success("Schedule deleted");
+    await set(fetchZeroSchedules$);
+  },
+);

--- a/turbo/apps/platform/src/views/zero-page/zero-meet-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-meet-page.tsx
@@ -30,8 +30,15 @@ import {
   DropdownMenuItem,
   cn,
 } from "@vm0/ui";
-import { ZeroScheduleCard, DEFAULT_SCHEDULE } from "./zero-schedule-card";
+import { ZeroScheduleCard, type ScheduleEntry } from "./zero-schedule-card";
 import { agentDisplayName$ } from "../../signals/zero-page/zero-agent-name.ts";
+import {
+  fetchZeroSchedules$,
+  zeroScheduleEntries$,
+  saveZeroSchedule$,
+  deleteZeroSchedule$,
+  type ZeroScheduleSaveParams,
+} from "../../signals/zero-page/zero-schedule.ts";
 import {
   type ConnectorTypeWithStatus,
   allConnectorTypes$,
@@ -222,6 +229,54 @@ function ZeroSkillItem({
           </DropdownMenuContent>
         </DropdownMenu>
       )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Schedule tab — real schedule CRUD
+// ---------------------------------------------------------------------------
+
+function ZeroScheduleTab({ resolvedAgentName }: { resolvedAgentName: string }) {
+  const entriesLoadable = useLoadable(zeroScheduleEntries$);
+  const fetchSchedules = useSet(fetchZeroSchedules$);
+  const saveSchedule = useSet(saveZeroSchedule$);
+  const deleteSchedule = useSet(deleteZeroSchedule$);
+  const saving$ = useCCState(false);
+  const saving = useGet(saving$);
+  const setSaving = useSet(saving$);
+
+  // Fetch schedules on mount
+  const initialized$ = useCCState(false);
+  const initialized = useGet(initialized$);
+  const setInitialized = useSet(initialized$);
+  if (!initialized) {
+    setInitialized(true);
+    detach(fetchSchedules(), Reason.DomCallback);
+  }
+
+  const entries: ScheduleEntry[] =
+    entriesLoadable.state === "hasData" ? entriesLoadable.data : [];
+
+  const handleSave = async (params: ZeroScheduleSaveParams) => {
+    setSaving(true);
+    try {
+      await saveSchedule(params);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="mx-auto max-w-[900px] px-7">
+      <ZeroScheduleCard
+        title={`${resolvedAgentName}'s schedule`}
+        subtitle={`Set a time and prompt for ${resolvedAgentName} to run automatically.`}
+        initialSchedule={entries}
+        onSave={handleSave}
+        onDelete={deleteSchedule}
+        saving={saving}
+      />
     </div>
   );
 }
@@ -666,13 +721,7 @@ export function ZeroMeetPage({
         {activeTab === "skills" && <ZeroSkillsTab />}
 
         {activeTab === "schedule" && (
-          <div className="mx-auto max-w-[900px] px-7">
-            <ZeroScheduleCard
-              title={`${resolvedAgentName}'s schedule`}
-              subtitle={`Set a time and prompt for ${resolvedAgentName} to run automatically.`}
-              initialSchedule={DEFAULT_SCHEDULE}
-            />
-          </div>
+          <ZeroScheduleTab resolvedAgentName={resolvedAgentName} />
         )}
 
         {activeTab === "settings" && (

--- a/turbo/apps/platform/src/views/zero-page/zero-schedule-card.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-schedule-card.tsx
@@ -85,6 +85,27 @@ export interface ScheduleEntry {
   enabled?: boolean;
 }
 
+function DeleteButton({
+  name,
+  label,
+  onDelete,
+}: {
+  name: string;
+  label: string;
+  onDelete: (name: string) => Promise<void>;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={() => void onDelete(name)}
+      className="rounded p-1.5 text-muted-foreground hover:bg-muted hover:text-destructive focus:outline-none focus-visible:ring-2 focus-visible:ring-ring shrink-0"
+      aria-label={`Delete ${label}`}
+    >
+      <IconTrash size={14} stroke={1.5} />
+    </button>
+  );
+}
+
 function formatTimeOfDay(hour: number, minute: number): string {
   if (hour === 0 && minute === 0) {
     return "12:00 AM";
@@ -549,15 +570,12 @@ export function ZeroScheduleCard({
                     >
                       <IconPencil size={14} stroke={1.5} />
                     </button>
-                    {onDelete && entry.name && (
-                      <button
-                        type="button"
-                        onClick={() => void onDelete(entry.name!)}
-                        className="rounded p-1.5 text-muted-foreground hover:bg-muted hover:text-destructive focus:outline-none focus-visible:ring-2 focus-visible:ring-ring shrink-0"
-                        aria-label={`Delete ${entry.time}`}
-                      >
-                        <IconTrash size={14} stroke={1.5} />
-                      </button>
+                    {onDelete && entry.name !== undefined && (
+                      <DeleteButton
+                        name={entry.name}
+                        label={entry.time}
+                        onDelete={onDelete}
+                      />
                     )}
                   </li>
                 ))}

--- a/turbo/apps/platform/src/views/zero-page/zero-schedule-card.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-schedule-card.tsx
@@ -7,6 +7,7 @@ import {
   IconList,
   IconLayoutGrid,
   IconPencil,
+  IconTrash,
 } from "@tabler/icons-react";
 import {
   Card,
@@ -79,6 +80,9 @@ export interface ScheduleEntry {
   id: string;
   time: string;
   prompt: string;
+  /** Schedule name used for API operations (edit/delete). */
+  name?: string;
+  enabled?: boolean;
 }
 
 function formatTimeOfDay(hour: number, minute: number): string {
@@ -328,19 +332,41 @@ interface ZeroScheduleCardProps {
   title: string;
   subtitle: string;
   initialSchedule: readonly Readonly<ScheduleEntry>[];
+  /** When provided, called on save instead of local state mutation. */
+  onSave?: (params: {
+    prompt: string;
+    freq: string;
+    date: string;
+    hour: number;
+    minute: number;
+    timezone: string;
+    loopMinutes: number;
+    editName?: string;
+  }) => Promise<void>;
+  /** When provided, called to delete a schedule by name. */
+  onDelete?: (name: string) => Promise<void>;
+  /** When true, the save button shows a loading state. */
+  saving?: boolean;
 }
 
 export function ZeroScheduleCard({
   title,
   subtitle,
   initialSchedule,
+  onSave,
+  onDelete,
+  saving,
 }: ZeroScheduleCardProps) {
   const scheduleViewMode$ = useCCState<"list" | "calendar">("list");
   const scheduleViewMode = useGet(scheduleViewMode$);
   const setScheduleViewMode = useSet(scheduleViewMode$);
-  const scheduleList$ = useCCState<ScheduleEntry[]>([...initialSchedule]);
-  const scheduleList = useGet(scheduleList$);
-  const setScheduleList = useSet(scheduleList$);
+  const internalScheduleList$ = useCCState<ScheduleEntry[]>([
+    ...initialSchedule,
+  ]);
+  const internalScheduleList = useGet(internalScheduleList$);
+  const setScheduleList = useSet(internalScheduleList$);
+  // In API mode (onSave provided), use prop directly; otherwise use internal state
+  const scheduleList = onSave ? [...initialSchedule] : internalScheduleList;
   const addScheduleOpen$ = useCCState(false);
   const addScheduleOpen = useGet(addScheduleOpen$);
   const setAddScheduleOpen = useSet(addScheduleOpen$);
@@ -396,10 +422,32 @@ export function ZeroScheduleCard({
     setAddScheduleOpen(true);
   };
 
-  const addScheduleEntry = () => {
+  const addScheduleEntry = async () => {
     if (!newSchedulePrompt.trim()) {
       return;
     }
+
+    if (onSave) {
+      // Find the editing entry's name for API update
+      const editingEntry = editingScheduleId
+        ? scheduleList.find((e) => e.id === editingScheduleId)
+        : null;
+      await onSave({
+        prompt: newSchedulePrompt.trim(),
+        freq: scheduleFreq,
+        date: scheduleDate,
+        hour: scheduleHour,
+        minute: scheduleMinute,
+        timezone: scheduleTimezone,
+        loopMinutes: scheduleLoopMinutes,
+        editName: editingEntry?.name,
+      });
+      setNewSchedulePrompt("");
+      setEditingScheduleId(null);
+      setAddScheduleOpen(false);
+      return;
+    }
+
     const timeStr = buildScheduleTimeString({
       freq: scheduleFreq,
       date: scheduleFreq === "once" ? scheduleDate : undefined,
@@ -501,6 +549,16 @@ export function ZeroScheduleCard({
                     >
                       <IconPencil size={14} stroke={1.5} />
                     </button>
+                    {onDelete && entry.name && (
+                      <button
+                        type="button"
+                        onClick={() => void onDelete(entry.name!)}
+                        className="rounded p-1.5 text-muted-foreground hover:bg-muted hover:text-destructive focus:outline-none focus-visible:ring-2 focus-visible:ring-ring shrink-0"
+                        aria-label={`Delete ${entry.time}`}
+                      >
+                        <IconTrash size={14} stroke={1.5} />
+                      </button>
+                    )}
                   </li>
                 ))}
               </ul>
@@ -865,10 +923,10 @@ export function ZeroScheduleCard({
             </Button>
             <Button
               type="button"
-              onClick={addScheduleEntry}
-              disabled={!newSchedulePrompt.trim()}
+              onClick={() => void addScheduleEntry()}
+              disabled={!newSchedulePrompt.trim() || saving}
             >
-              {editingScheduleId ? "Save" : "Add"}
+              {saving ? "Saving…" : editingScheduleId ? "Save" : "Add"}
             </Button>
           </DialogFooter>
         </DialogContent>


### PR DESCRIPTION
## Summary
- Created `signals/zero-page/zero-schedule.ts` to manage schedule state for the default agent, with signals for fetch, create/update, and delete operations
- Updated `ZeroScheduleCard` to accept optional `onSave`, `onDelete`, and `saving` props for API-connected mode (backwards compatible — local-only mode still works for sub-agent pages)
- Replaced hardcoded `DEFAULT_SCHEDULE` in the meet page with a new `ZeroScheduleTab` component that fetches real schedules from `/api/agent/schedules` and wires up full CRUD

Closes #4184

## Test plan
- [ ] Navigate to Zero meet page → Schedule tab → verify empty state loads (no mock data)
- [ ] Add a schedule (prompt + frequency) → verify it persists via API and appears in the list
- [ ] Edit an existing schedule → verify changes are saved
- [ ] Delete a schedule → verify it's removed
- [ ] Verify sub-agent schedule pages still work with local-only mode (no `onSave`/`onDelete` props)

🤖 Generated with [Claude Code](https://claude.com/claude-code)