### PR TITLE
refactor: switch secrets, connectors, model_providers, agent_schedules from scope_id to clerk_org_id

### DIFF
--- a/turbo/apps/web/app/api/agent/schedules/[name]/disable/route.ts
+++ b/turbo/apps/web/app/api/agent/schedules/[name]/disable/route.ts
@@ -5,6 +5,7 @@ import { disableSchedule } from "../../../../../../src/lib/schedule";
 import { logger } from "../../../../../../src/lib/logger";
 import { isNotFound } from "../../../../../../src/lib/errors";
 import { resolveScopeId } from "../../../../../../src/lib/scope/scope-member-service";
+import { getScopeById } from "../../../../../../src/lib/scope/scope-service";
 
 const log = logger("api:schedules:disable");
 
@@ -45,13 +46,20 @@ export async function POST(
   }
 
   const scopeId = await resolveScopeId(userId, body.scopeId, tokenScopeId);
+  const scope = await getScopeById(scopeId);
+  if (!scope) {
+    return NextResponse.json(
+      { error: { message: "Scope not found", code: "NOT_FOUND" } },
+      { status: 404 },
+    );
+  }
 
   log.debug(`Disabling schedule ${name} for compose ${body.composeId}`);
 
   try {
     const schedule = await disableSchedule(
       userId,
-      scopeId,
+      scope.clerkOrgId,
       body.composeId,
       name,
     );

--- a/turbo/apps/web/app/api/agent/schedules/[name]/enable/route.ts
+++ b/turbo/apps/web/app/api/agent/schedules/[name]/enable/route.ts
@@ -5,6 +5,7 @@ import { enableSchedule } from "../../../../../../src/lib/schedule";
 import { logger } from "../../../../../../src/lib/logger";
 import { isNotFound, isSchedulePast } from "../../../../../../src/lib/errors";
 import { resolveScopeId } from "../../../../../../src/lib/scope/scope-member-service";
+import { getScopeById } from "../../../../../../src/lib/scope/scope-service";
 
 const log = logger("api:schedules:enable");
 
@@ -45,13 +46,20 @@ export async function POST(
   }
 
   const scopeId = await resolveScopeId(userId, body.scopeId, tokenScopeId);
+  const scope = await getScopeById(scopeId);
+  if (!scope) {
+    return NextResponse.json(
+      { error: { message: "Scope not found", code: "NOT_FOUND" } },
+      { status: 404 },
+    );
+  }
 
   log.debug(`Enabling schedule ${name} for compose ${body.composeId}`);
 
   try {
     const schedule = await enableSchedule(
       userId,
-      scopeId,
+      scope.clerkOrgId,
       body.composeId,
       name,
     );

--- a/turbo/apps/web/app/api/agent/schedules/[name]/route.ts
+++ b/turbo/apps/web/app/api/agent/schedules/[name]/route.ts
@@ -13,6 +13,7 @@ import {
 import { logger } from "../../../../../src/lib/logger";
 import { isNotFound } from "../../../../../src/lib/errors";
 import { resolveScopeId } from "../../../../../src/lib/scope/scope-member-service";
+import { getScopeById } from "../../../../../src/lib/scope/scope-service";
 
 const log = logger("api:schedules:name");
 
@@ -35,10 +36,19 @@ const router = tsr.router(schedulesByNameContract, {
 
     try {
       const scopeId = await resolveScopeId(userId, query.scopeId, tokenScopeId);
+      const scope = await getScopeById(scopeId);
+      if (!scope) {
+        return {
+          status: 404 as const,
+          body: {
+            error: { message: "Scope not found", code: "NOT_FOUND" },
+          },
+        };
+      }
 
       const schedule = await getScheduleByName(
         userId,
-        scopeId,
+        scope.clerkOrgId,
         query.composeId,
         params.name,
       );
@@ -80,8 +90,22 @@ const router = tsr.router(schedulesByNameContract, {
 
     try {
       const scopeId = await resolveScopeId(userId, query.scopeId, tokenScopeId);
+      const scope = await getScopeById(scopeId);
+      if (!scope) {
+        return {
+          status: 404 as const,
+          body: {
+            error: { message: "Scope not found", code: "NOT_FOUND" },
+          },
+        };
+      }
 
-      await deleteSchedule(userId, scopeId, query.composeId, params.name);
+      await deleteSchedule(
+        userId,
+        scope.clerkOrgId,
+        query.composeId,
+        params.name,
+      );
 
       return {
         status: 204 as const,

--- a/turbo/apps/web/app/api/agent/schedules/[name]/runs/route.ts
+++ b/turbo/apps/web/app/api/agent/schedules/[name]/runs/route.ts
@@ -10,6 +10,7 @@ import { getScheduleRecentRuns } from "../../../../../../src/lib/schedule";
 import { logger } from "../../../../../../src/lib/logger";
 import { isNotFound } from "../../../../../../src/lib/errors";
 import { resolveScopeId } from "../../../../../../src/lib/scope/scope-member-service";
+import { getScopeById } from "../../../../../../src/lib/scope/scope-service";
 
 const log = logger("api:schedules:runs");
 
@@ -34,10 +35,19 @@ const router = tsr.router(scheduleRunsContract, {
 
     try {
       const scopeId = await resolveScopeId(userId, query.scopeId, tokenScopeId);
+      const scope = await getScopeById(scopeId);
+      if (!scope) {
+        return {
+          status: 404 as const,
+          body: {
+            error: { message: "Scope not found", code: "NOT_FOUND" },
+          },
+        };
+      }
 
       const runs = await getScheduleRecentRuns(
         userId,
-        scopeId,
+        scope.clerkOrgId,
         query.composeId,
         params.name,
         query.limit,

--- a/turbo/apps/web/app/api/agent/schedules/missing-secrets/route.ts
+++ b/turbo/apps/web/app/api/agent/schedules/missing-secrets/route.ts
@@ -61,7 +61,7 @@ export async function GET(request: Request) {
   const userSecrets = await db
     .select({ name: secrets.name })
     .from(secrets)
-    .where(eq(secrets.scopeId, runtimeScope.id));
+    .where(eq(secrets.clerkOrgId, runtimeScope.clerkOrgId));
 
   const configuredSecretNames = new Set(userSecrets.map((s) => s.name));
 

--- a/turbo/apps/web/app/api/agent/schedules/route.ts
+++ b/turbo/apps/web/app/api/agent/schedules/route.ts
@@ -45,7 +45,7 @@ const router = tsr.router(schedulesMainContract, {
         };
       }
 
-      const result = await deploySchedule(userId, scopeId, scope.clerkOrgId, {
+      const result = await deploySchedule(userId, scope.clerkOrgId, scopeId, {
         name: body.name,
         composeId: body.composeId,
         cronExpression: body.cronExpression,

--- a/turbo/apps/web/app/api/cli/auth/test-connector/route.ts
+++ b/turbo/apps/web/app/api/cli/auth/test-connector/route.ts
@@ -100,6 +100,7 @@ export async function POST(request: Request) {
   }
 
   await upsertOAuthConnector(
+    scope.clerkOrgId,
     scope.id,
     userId,
     connectorType,
@@ -110,7 +111,6 @@ export async function POST(request: Request) {
       email: `e2e-${connectorType}@test.vm0.ai`,
     },
     [],
-    scope.clerkOrgId,
   );
 
   return NextResponse.json({

--- a/turbo/apps/web/app/api/connectors/[type]/callback/route.ts
+++ b/turbo/apps/web/app/api/connectors/[type]/callback/route.ts
@@ -202,6 +202,7 @@ export async function GET(
     // may append OAuth scopes as ?scope=... which would be mistaken for an app scope slug.
     const { scope } = await resolveScope(userId, null, null, tokenScopeId);
     const { created } = await upsertOAuthConnector(
+      scope.clerkOrgId,
       scope.id,
       userId,
       connectorType,
@@ -212,7 +213,6 @@ export async function GET(
         email: userInfo.email,
       },
       getRequestedScopes(connectorType),
-      scope.clerkOrgId,
       { refreshToken, refreshSecretName, expiresIn },
     );
 

--- a/turbo/apps/web/app/api/connectors/[type]/route.ts
+++ b/turbo/apps/web/app/api/connectors/[type]/route.ts
@@ -24,7 +24,7 @@ const router = tsr.router(connectorsByTypeContract, {
 
     const scopeSlug = new URL(request.url).searchParams.get("scope");
     const { scope } = await resolveScope(userId, scopeSlug, null, tokenScopeId);
-    const connector = await getConnector(scope.id, userId, params.type);
+    const connector = await getConnector(scope.clerkOrgId, userId, params.type);
 
     if (!connector) {
       return createErrorResponse("NOT_FOUND", "Connector not found");
@@ -56,7 +56,7 @@ const router = tsr.router(connectorsByTypeContract, {
         null,
         tokenScopeId,
       );
-      await deleteConnector(scope.id, userId, params.type);
+      await deleteConnector(scope.clerkOrgId, userId, params.type);
 
       return {
         status: 204 as const,

--- a/turbo/apps/web/app/api/connectors/computer/route.ts
+++ b/turbo/apps/web/app/api/connectors/computer/route.ts
@@ -36,9 +36,9 @@ const router = tsr.router(computerConnectorContract, {
         tokenScopeId,
       );
       const result = await createComputerConnector(
+        scope.clerkOrgId,
         scope.id,
         userId,
-        scope.clerkOrgId,
       );
       return { status: 200 as const, body: result };
     } catch (error) {
@@ -66,7 +66,7 @@ const router = tsr.router(computerConnectorContract, {
 
     const scopeSlug = new URL(request.url).searchParams.get("scope");
     const { scope } = await resolveScope(userId, scopeSlug, null, tokenScopeId);
-    const connector = await getConnector(scope.id, userId, "computer");
+    const connector = await getConnector(scope.clerkOrgId, userId, "computer");
     if (!connector) {
       return createErrorResponse("NOT_FOUND", "Computer connector not found");
     }
@@ -94,7 +94,7 @@ const router = tsr.router(computerConnectorContract, {
         null,
         tokenScopeId,
       );
-      await deleteComputerConnector(scope.id, userId);
+      await deleteComputerConnector(scope.clerkOrgId, userId);
       return { status: 204 as const, body: undefined };
     } catch (error) {
       if (isNotFound(error)) {

--- a/turbo/apps/web/app/api/connectors/route.ts
+++ b/turbo/apps/web/app/api/connectors/route.ts
@@ -25,7 +25,7 @@ const router = tsr.router(connectorsMainContract, {
 
     const scopeSlug = new URL(request.url).searchParams.get("scope");
     const { scope } = await resolveScope(userId, scopeSlug, null, tokenScopeId);
-    const connectorList = await listConnectors(scope.id, userId);
+    const connectorList = await listConnectors(scope.clerkOrgId, userId);
     const configuredTypes = getConfiguredConnectorTypes(
       globalThis.services.env,
     );

--- a/turbo/apps/web/app/api/integrations/github/route.ts
+++ b/turbo/apps/web/app/api/integrations/github/route.ts
@@ -126,9 +126,9 @@ export async function GET(request: Request) {
 
   // Get user's existing secrets, vars, connectors
   const [userSecrets, userVars, userConnectors] = await Promise.all([
-    listSecrets(scope.id, userId),
+    listSecrets(scope.clerkOrgId, userId),
     listVariables(scope.clerkOrgId, userId),
-    listConnectors(scope.id, userId),
+    listConnectors(scope.clerkOrgId, userId),
   ]);
 
   const connectorProvided = getConnectorProvidedSecretNames(

--- a/turbo/apps/web/app/api/integrations/slack/route.ts
+++ b/turbo/apps/web/app/api/integrations/slack/route.ts
@@ -127,9 +127,9 @@ export async function GET(request: Request) {
   // Get user's existing secrets, vars, connectors
   const { scope } = await resolveScope(userId, null, null, tokenScopeId);
   const [userSecrets, userVars, userConnectors] = await Promise.all([
-    listSecrets(scope.id, userId),
+    listSecrets(scope.clerkOrgId, userId),
     listVariables(scope.clerkOrgId, userId),
-    listConnectors(scope.id, userId),
+    listConnectors(scope.clerkOrgId, userId),
   ]);
 
   const connectorProvided = getConnectorProvidedSecretNames(

--- a/turbo/apps/web/app/api/integrations/telegram/route.ts
+++ b/turbo/apps/web/app/api/integrations/telegram/route.ts
@@ -126,9 +126,9 @@ export async function GET(request: Request) {
   // Resolve user's default scope and get existing secrets, vars, connectors
   const { scope } = await resolveScope(userId, null, null, tokenScopeId);
   const [userSecrets, userVars, userConnectors] = await Promise.all([
-    listSecrets(scope.id, userId),
+    listSecrets(scope.clerkOrgId, userId),
     listVariables(scope.clerkOrgId, userId),
-    listConnectors(scope.id, userId),
+    listConnectors(scope.clerkOrgId, userId),
   ]);
 
   const connectorProvided = getConnectorProvidedSecretNames(

--- a/turbo/apps/web/app/api/model-providers/[type]/model/route.ts
+++ b/turbo/apps/web/app/api/model-providers/[type]/model/route.ts
@@ -40,7 +40,7 @@ const router = tsr.router(modelProvidersUpdateModelContract, {
         tokenScopeId,
       );
       const provider = await updateModelProviderModel(
-        scope.id,
+        scope.clerkOrgId,
         userId,
         params.type,
         body.selectedModel,

--- a/turbo/apps/web/app/api/model-providers/[type]/route.ts
+++ b/turbo/apps/web/app/api/model-providers/[type]/route.ts
@@ -32,7 +32,7 @@ const router = tsr.router(modelProvidersByTypeContract, {
         null,
         tokenScopeId,
       );
-      await deleteModelProvider(scope.id, userId, params.type);
+      await deleteModelProvider(scope.clerkOrgId, userId, params.type);
 
       return {
         status: 204 as const,

--- a/turbo/apps/web/app/api/model-providers/[type]/set-default/route.ts
+++ b/turbo/apps/web/app/api/model-providers/[type]/set-default/route.ts
@@ -39,7 +39,7 @@ const router = tsr.router(modelProvidersSetDefaultContract, {
         tokenScopeId,
       );
       const provider = await setModelProviderDefault(
-        scope.id,
+        scope.clerkOrgId,
         userId,
         params.type,
       );

--- a/turbo/apps/web/app/api/model-providers/check/[type]/route.ts
+++ b/turbo/apps/web/app/api/model-providers/check/[type]/route.ts
@@ -24,7 +24,11 @@ const router = tsr.router(modelProvidersCheckContract, {
 
     const scopeSlug = new URL(request.url).searchParams.get("scope");
     const { scope } = await resolveScope(userId, scopeSlug, null, tokenScopeId);
-    const result = await checkSecretExists(scope.id, userId, params.type);
+    const result = await checkSecretExists(
+      scope.clerkOrgId,
+      userId,
+      params.type,
+    );
 
     return {
       status: 200 as const,

--- a/turbo/apps/web/app/api/model-providers/route.ts
+++ b/turbo/apps/web/app/api/model-providers/route.ts
@@ -32,7 +32,7 @@ const router = tsr.router(modelProvidersMainContract, {
 
     const scopeSlug = new URL(request.url).searchParams.get("scope");
     const { scope } = await resolveScope(userId, scopeSlug, null, tokenScopeId);
-    const providers = await listModelProviders(scope.id, userId);
+    const providers = await listModelProviders(scope.clerkOrgId, userId);
 
     return {
       status: 200 as const,
@@ -93,12 +93,12 @@ const router = tsr.router(modelProvidersMainContract, {
           );
         }
         const result = await upsertMultiAuthModelProvider(
+          scope.clerkOrgId,
           scope.id,
           userId,
           type,
           authMethod,
           secrets,
-          scope.clerkOrgId,
           selectedModel,
         );
         provider = result.provider;
@@ -112,11 +112,11 @@ const router = tsr.router(modelProvidersMainContract, {
           );
         }
         const result = await upsertModelProvider(
+          scope.clerkOrgId,
           scope.id,
           userId,
           type,
           secret,
-          scope.clerkOrgId,
           selectedModel,
         );
         provider = result.provider;

--- a/turbo/apps/web/app/api/onboarding/status/route.ts
+++ b/turbo/apps/web/app/api/onboarding/status/route.ts
@@ -37,7 +37,7 @@ const router = tsr.router(onboardingStatusContract, {
       const [provider] = await globalThis.services.db
         .select({ id: modelProviders.id })
         .from(modelProviders)
-        .where(eq(modelProviders.scopeId, scope.id))
+        .where(eq(modelProviders.clerkOrgId, scope.clerkOrgId))
         .limit(1);
 
       hasModelProvider = provider !== undefined;

--- a/turbo/apps/web/app/api/secrets/[name]/route.ts
+++ b/turbo/apps/web/app/api/secrets/[name]/route.ts
@@ -35,7 +35,7 @@ const router = tsr.router(secretsByNameContract, {
 
     const scopeSlug = new URL(request.url).searchParams.get("scope");
     const { scope } = await resolveScope(userId, scopeSlug, null, tokenScopeId);
-    const secret = await getSecret(scope.id, userId, params.name);
+    const secret = await getSecret(scope.clerkOrgId, userId, params.name);
     if (!secret) {
       return createErrorResponse(
         "NOT_FOUND",
@@ -78,7 +78,7 @@ const router = tsr.router(secretsByNameContract, {
         null,
         tokenScopeId,
       );
-      await deleteSecret(scope.id, userId, params.name);
+      await deleteSecret(scope.clerkOrgId, userId, params.name);
 
       return {
         status: 204 as const,

--- a/turbo/apps/web/app/api/secrets/route.ts
+++ b/turbo/apps/web/app/api/secrets/route.ts
@@ -28,7 +28,7 @@ const router = tsr.router(secretsMainContract, {
 
     const scopeSlug = new URL(request.url).searchParams.get("scope");
     const { scope } = await resolveScope(userId, scopeSlug, null, tokenScopeId);
-    const secrets = await listSecrets(scope.id, userId);
+    const secrets = await listSecrets(scope.clerkOrgId, userId);
 
     return {
       status: 200 as const,
@@ -70,11 +70,11 @@ const router = tsr.router(secretsMainContract, {
         tokenScopeId,
       );
       const secret = await setSecret(
+        scope.clerkOrgId,
         scope.id,
         userId,
         name,
         value,
-        scope.clerkOrgId,
         description,
       );
 

--- a/turbo/apps/web/app/api/webhooks/agent/connectors/auth/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/connectors/auth/route.ts
@@ -35,9 +35,9 @@ async function refreshConnectorToken(
   connectorType: string,
   connectorSecrets: Record<string, string>,
   accessTokenName: string,
+  clerkOrgId: string,
   scopeId: string,
   userId: string,
-  clerkOrgId: string,
   runId: string,
 ): Promise<Response | null> {
   if (!handler.refreshToken || !handler.getRefreshSecretName) return null;
@@ -72,19 +72,19 @@ async function refreshConnectorToken(
       currentRefreshToken,
     );
     await upsertConnectorSecret(
+      clerkOrgId,
       scopeId,
       userId,
       accessTokenName,
       result.accessToken,
-      clerkOrgId,
     );
     if (result.refreshToken) {
       await upsertConnectorSecret(
+        clerkOrgId,
         scopeId,
         userId,
         refreshTokenName,
         result.refreshToken,
-        clerkOrgId,
       );
     }
     connectorSecrets[accessTokenName] = result.accessToken;
@@ -248,7 +248,7 @@ export async function POST(request: Request) {
     .from(connectors)
     .where(
       and(
-        eq(connectors.scopeId, run.scopeId),
+        eq(connectors.clerkOrgId, run.clerkOrgId),
         eq(connectors.userId, auth.userId),
         eq(connectors.type, connectorType),
       ),
@@ -269,7 +269,7 @@ export async function POST(request: Request) {
 
   // Get connector secrets and refresh if needed
   const connectorSecrets = await getSecretValues(
-    run.scopeId,
+    run.clerkOrgId,
     auth.userId,
     "connector",
   );
@@ -285,9 +285,9 @@ export async function POST(request: Request) {
       connectorType,
       connectorSecrets,
       accessTokenName,
+      run.clerkOrgId,
       run.scopeId,
       auth.userId,
-      run.clerkOrgId,
       body.runId,
     );
     if (refreshError) return refreshError;

--- a/turbo/apps/web/src/__tests__/api-test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers.ts
@@ -1724,12 +1724,13 @@ export async function findTestConnectorSecret(
   secretName: string,
   type: "connector" | "user" = "connector",
 ): Promise<string | undefined> {
+  const clerkOrgId = await getClerkOrgIdFromScope(scopeId);
   const [storedSecret] = await globalThis.services.db
     .select()
     .from(secrets)
     .where(
       and(
-        eq(secrets.scopeId, scopeId),
+        eq(secrets.clerkOrgId, clerkOrgId),
         eq(secrets.name, secretName),
         eq(secrets.type, type),
       ),
@@ -1756,10 +1757,13 @@ export async function findTestConnectorTokenExpiresAt(
   scopeId: string,
   type: string,
 ): Promise<Date | null | undefined> {
+  const clerkOrgId = await getClerkOrgIdFromScope(scopeId);
   const [row] = await globalThis.services.db
     .select({ tokenExpiresAt: connectors.tokenExpiresAt })
     .from(connectors)
-    .where(and(eq(connectors.scopeId, scopeId), eq(connectors.type, type)))
+    .where(
+      and(eq(connectors.clerkOrgId, clerkOrgId), eq(connectors.type, type)),
+    )
     .limit(1);
 
   if (!row) return undefined;

--- a/turbo/apps/web/src/db/migrations/0123_rare_longshot.sql
+++ b/turbo/apps/web/src/db/migrations/0123_rare_longshot.sql
@@ -1,0 +1,16 @@
+ALTER TABLE "agent_schedules" DROP CONSTRAINT "agent_schedules_scope_id_scopes_id_fk";
+--> statement-breakpoint
+ALTER TABLE "connectors" DROP CONSTRAINT "connectors_scope_id_scopes_id_fk";
+--> statement-breakpoint
+ALTER TABLE "model_providers" DROP CONSTRAINT "model_providers_scope_id_scopes_id_fk";
+--> statement-breakpoint
+ALTER TABLE "secrets" DROP CONSTRAINT "secrets_scope_id_scopes_id_fk";
+--> statement-breakpoint
+DROP INDEX "idx_agent_schedules_compose_name_scope_user";--> statement-breakpoint
+DROP INDEX "idx_agent_schedules_scope_user";--> statement-breakpoint
+DROP INDEX "idx_connectors_scope_user_type";--> statement-breakpoint
+DROP INDEX "idx_connectors_scope";--> statement-breakpoint
+DROP INDEX "idx_model_providers_scope_user_type";--> statement-breakpoint
+DROP INDEX "idx_model_providers_scope";--> statement-breakpoint
+DROP INDEX "idx_secrets_scope_user_name_type";--> statement-breakpoint
+DROP INDEX "idx_secrets_scope";

--- a/turbo/apps/web/src/db/migrations/meta/0123_snapshot.json
+++ b/turbo/apps/web/src/db/migrations/meta/0123_snapshot.json
@@ -1,0 +1,4718 @@
+{
+  "id": "76d27381-f6e5-48db-91cb-717d217c3557",
+  "prevId": "b5529ea1-91de-47d2-8e7b-4a2cdb670fa0",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.agent_compose_versions": {
+      "name": "agent_compose_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "compose_id": {
+          "name": "compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_compose_versions_compose_id": {
+          "name": "idx_agent_compose_versions_compose_id",
+          "columns": [
+            {
+              "expression": "compose_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_compose_versions_compose_id_agent_composes_id_fk": {
+          "name": "agent_compose_versions_compose_id_agent_composes_id_fk",
+          "tableFrom": "agent_compose_versions",
+          "tableTo": "agent_composes",
+          "columnsFrom": ["compose_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_composes": {
+      "name": "agent_composes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "head_version_id": {
+          "name": "head_version_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clerk_org_id": {
+          "name": "clerk_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_composes_clerk_org": {
+          "name": "idx_agent_composes_clerk_org",
+          "columns": [
+            {
+              "expression": "clerk_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_composes_clerk_org_name": {
+          "name": "idx_agent_composes_clerk_org_name",
+          "columns": [
+            {
+              "expression": "clerk_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_composes_scope_id_scopes_id_fk": {
+          "name": "agent_composes_scope_id_scopes_id_fk",
+          "tableFrom": "agent_composes",
+          "tableTo": "scopes",
+          "columnsFrom": ["scope_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_permissions": {
+      "name": "agent_permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "agent_compose_id": {
+          "name": "agent_compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grantee_type": {
+          "name": "grantee_type",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grantee_email": {
+          "name": "grantee_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "permission": {
+          "name": "permission",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'run_view'"
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_permissions_compose": {
+          "name": "idx_agent_permissions_compose",
+          "columns": [
+            {
+              "expression": "agent_compose_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_permissions_email": {
+          "name": "idx_agent_permissions_email",
+          "columns": [
+            {
+              "expression": "grantee_email",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "grantee_email IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_permissions_agent_compose_id_agent_composes_id_fk": {
+          "name": "agent_permissions_agent_compose_id_agent_composes_id_fk",
+          "tableFrom": "agent_permissions",
+          "tableTo": "agent_composes",
+          "columnsFrom": ["agent_compose_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "agent_permissions_compose_type_email_unique": {
+          "name": "agent_permissions_compose_type_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["agent_compose_id", "grantee_type", "grantee_email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_run_callbacks": {
+      "name": "agent_run_callbacks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_secret": {
+          "name": "encrypted_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_attempt_at": {
+          "name": "last_attempt_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_run_callbacks_run_id": {
+          "name": "idx_agent_run_callbacks_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_run_callbacks_pending": {
+          "name": "idx_agent_run_callbacks_pending",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "status = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_run_callbacks_run_id_agent_runs_id_fk": {
+          "name": "agent_run_callbacks_run_id_agent_runs_id_fk",
+          "tableFrom": "agent_run_callbacks",
+          "tableTo": "agent_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_run_events": {
+      "name": "agent_run_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence_number": {
+          "name": "sequence_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_data": {
+          "name": "event_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_run_events_run_id_agent_runs_id_fk": {
+          "name": "agent_run_events_run_id_agent_runs_id_fk",
+          "tableFrom": "agent_run_events",
+          "tableTo": "agent_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_run_queue": {
+      "name": "agent_run_queue",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_params": {
+          "name": "encrypted_params",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "agent_run_queue_user_created_idx": {
+          "name": "agent_run_queue_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_run_queue_expires_at_idx": {
+          "name": "agent_run_queue_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_run_queue_run_id_agent_runs_id_fk": {
+          "name": "agent_run_queue_run_id_agent_runs_id_fk",
+          "tableFrom": "agent_run_queue",
+          "tableTo": "agent_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_runs": {
+      "name": "agent_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_compose_version_id": {
+          "name": "agent_compose_version_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resumed_from_checkpoint_id": {
+          "name": "resumed_from_checkpoint_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "continued_from_session_id": {
+          "name": "continued_from_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vars": {
+          "name": "vars",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "secret_names": {
+          "name": "secret_names",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clerk_org_id": {
+          "name": "clerk_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_heartbeat_at": {
+          "name": "last_heartbeat_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_agent_runs_user_created": {
+          "name": "idx_agent_runs_user_created",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_runs_clerk_org": {
+          "name": "idx_agent_runs_clerk_org",
+          "columns": [
+            {
+              "expression": "clerk_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_runs_status_heartbeat": {
+          "name": "idx_agent_runs_status_heartbeat",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_heartbeat_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_runs_running_heartbeat": {
+          "name": "idx_agent_runs_running_heartbeat",
+          "columns": [
+            {
+              "expression": "last_heartbeat_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "status = 'running'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_runs_schedule_created": {
+          "name": "idx_agent_runs_schedule_created",
+          "columns": [
+            {
+              "expression": "schedule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "schedule_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_runs_agent_compose_version_id_agent_compose_versions_id_fk": {
+          "name": "agent_runs_agent_compose_version_id_agent_compose_versions_id_fk",
+          "tableFrom": "agent_runs",
+          "tableTo": "agent_compose_versions",
+          "columnsFrom": ["agent_compose_version_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "agent_runs_schedule_id_agent_schedules_id_fk": {
+          "name": "agent_runs_schedule_id_agent_schedules_id_fk",
+          "tableFrom": "agent_runs",
+          "tableTo": "agent_schedules",
+          "columnsFrom": ["schedule_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_schedules": {
+      "name": "agent_schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "compose_id": {
+          "name": "compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clerk_org_id": {
+          "name": "clerk_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_type": {
+          "name": "trigger_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'cron'"
+        },
+        "cron_expression": {
+          "name": "cron_expression",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "at_time": {
+          "name": "at_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "interval_seconds": {
+          "name": "interval_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vars": {
+          "name": "vars",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_secrets": {
+          "name": "encrypted_secrets",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artifact_name": {
+          "name": "artifact_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artifact_version": {
+          "name": "artifact_version",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "volume_versions": {
+          "name": "volume_versions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_run_id": {
+          "name": "last_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retry_started_at": {
+          "name": "retry_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consecutive_failures": {
+          "name": "consecutive_failures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_schedules_compose": {
+          "name": "idx_agent_schedules_compose",
+          "columns": [
+            {
+              "expression": "compose_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_schedules_clerk_org": {
+          "name": "idx_agent_schedules_clerk_org",
+          "columns": [
+            {
+              "expression": "clerk_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_schedules_compose_name_clerk_org_user": {
+          "name": "idx_agent_schedules_compose_name_clerk_org_user",
+          "columns": [
+            {
+              "expression": "compose_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "clerk_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_schedules_next_run": {
+          "name": "idx_agent_schedules_next_run",
+          "columns": [
+            {
+              "expression": "next_run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "enabled = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_schedules_compose_id_agent_composes_id_fk": {
+          "name": "agent_schedules_compose_id_agent_composes_id_fk",
+          "tableFrom": "agent_schedules",
+          "tableTo": "agent_composes",
+          "columnsFrom": ["compose_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_schedules_last_run_id_agent_runs_id_fk": {
+          "name": "agent_schedules_last_run_id_agent_runs_id_fk",
+          "tableFrom": "agent_schedules",
+          "tableTo": "agent_runs",
+          "columnsFrom": ["last_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_sessions": {
+      "name": "agent_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_compose_id": {
+          "name": "agent_compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artifact_name": {
+          "name": "artifact_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_name": {
+          "name": "memory_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chat_messages": {
+          "name": "chat_messages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_sessions_user_compose_artifact": {
+          "name": "idx_agent_sessions_user_compose_artifact",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_compose_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "artifact_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_sessions_agent_compose_id_agent_composes_id_fk": {
+          "name": "agent_sessions_agent_compose_id_agent_composes_id_fk",
+          "tableFrom": "agent_sessions",
+          "tableTo": "agent_composes",
+          "columnsFrom": ["agent_compose_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_sessions_conversation_id_conversations_id_fk": {
+          "name": "agent_sessions_conversation_id_conversations_id_fk",
+          "tableFrom": "agent_sessions",
+          "tableTo": "conversations",
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blobs": {
+      "name": "blobs",
+      "schema": "",
+      "columns": {
+        "hash": {
+          "name": "hash",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref_count": {
+          "name": "ref_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_blobs_ref_count": {
+          "name": "idx_blobs_ref_count",
+          "columns": [
+            {
+              "expression": "ref_count",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.checkpoints": {
+      "name": "checkpoints",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_compose_snapshot": {
+          "name": "agent_compose_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_snapshot": {
+          "name": "artifact_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_snapshot": {
+          "name": "memory_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "volume_versions_snapshot": {
+          "name": "volume_versions_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "checkpoints_run_id_agent_runs_id_fk": {
+          "name": "checkpoints_run_id_agent_runs_id_fk",
+          "tableFrom": "checkpoints",
+          "tableTo": "agent_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "checkpoints_conversation_id_conversations_id_fk": {
+          "name": "checkpoints_conversation_id_conversations_id_fk",
+          "tableFrom": "checkpoints",
+          "tableTo": "conversations",
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "checkpoints_run_id_unique": {
+          "name": "checkpoints_run_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["run_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cli_tokens": {
+      "name": "cli_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clerk_org_id": {
+          "name": "clerk_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cli_tokens_token_unique": {
+          "name": "cli_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.compose_jobs": {
+      "name": "compose_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_url": {
+          "name": "github_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "overwrite": {
+          "name": "overwrite",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'github'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_compose_jobs_user_status": {
+          "name": "idx_compose_jobs_user_status",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_compose_jobs_created": {
+          "name": "idx_compose_jobs_created",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_compose_jobs_user_active": {
+          "name": "idx_compose_jobs_user_active",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status IN ('pending', 'running')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.connector_sessions": {
+      "name": "connector_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(9)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "connector_session_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_connector_sessions_code": {
+          "name": "idx_connector_sessions_code",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_connector_sessions_user_status": {
+          "name": "idx_connector_sessions_user_status",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.connectors": {
+      "name": "connectors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_method": {
+          "name": "auth_method",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_username": {
+          "name": "external_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_email": {
+          "name": "external_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_scopes": {
+          "name": "oauth_scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clerk_org_id": {
+          "name": "clerk_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_connectors_clerk_org": {
+          "name": "idx_connectors_clerk_org",
+          "columns": [
+            {
+              "expression": "clerk_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_connectors_clerk_org_user_type": {
+          "name": "idx_connectors_clerk_org_user_type",
+          "columns": [
+            {
+              "expression": "clerk_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversations": {
+      "name": "conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cli_agent_type": {
+          "name": "cli_agent_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cli_agent_session_id": {
+          "name": "cli_agent_session_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cli_agent_session_history": {
+          "name": "cli_agent_session_history",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cli_agent_session_history_hash": {
+          "name": "cli_agent_session_history_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "conversations_run_id_agent_runs_id_fk": {
+          "name": "conversations_run_id_agent_runs_id_fk",
+          "tableFrom": "conversations",
+          "tableTo": "agent_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "conversations_run_id_unique": {
+          "name": "conversations_run_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["run_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.device_codes": {
+      "name": "device_codes",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "varchar(9)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "device_code_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_outbox": {
+      "name": "email_outbox",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "from_address": {
+          "name": "from_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_addresses": {
+          "name": "to_addresses",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cc_addresses": {
+          "name": "cc_addresses",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reply_to": {
+          "name": "reply_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headers": {
+          "name": "headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "template": {
+          "name": "template",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_send_action": {
+          "name": "post_send_action",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_retry_at": {
+          "name": "next_retry_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resend_id": {
+          "name": "resend_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_outbox_drain_idx": {
+          "name": "email_outbox_drain_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_retry_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_outbox_created_at_idx": {
+          "name": "email_outbox_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_reply_requests": {
+      "name": "email_reply_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_thread_session_id": {
+          "name": "email_thread_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inbound_email_id": {
+          "name": "inbound_email_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inbound_message_id": {
+          "name": "inbound_message_id",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_email_reply_requests_run": {
+          "name": "idx_email_reply_requests_run",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_reply_requests_run_id_agent_runs_id_fk": {
+          "name": "email_reply_requests_run_id_agent_runs_id_fk",
+          "tableFrom": "email_reply_requests",
+          "tableTo": "agent_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "email_reply_requests_email_thread_session_id_email_thread_sessions_id_fk": {
+          "name": "email_reply_requests_email_thread_session_id_email_thread_sessions_id_fk",
+          "tableFrom": "email_reply_requests",
+          "tableTo": "email_thread_sessions",
+          "columnsFrom": ["email_thread_session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_thread_sessions": {
+      "name": "email_thread_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "compose_id": {
+          "name": "compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_session_id": {
+          "name": "agent_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_email_message_id": {
+          "name": "last_email_message_id",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_to_token": {
+          "name": "reply_to_token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_email_thread_sessions_reply_token": {
+          "name": "idx_email_thread_sessions_reply_token",
+          "columns": [
+            {
+              "expression": "reply_to_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_email_thread_sessions_user": {
+          "name": "idx_email_thread_sessions_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_thread_sessions_compose_id_agent_composes_id_fk": {
+          "name": "email_thread_sessions_compose_id_agent_composes_id_fk",
+          "tableFrom": "email_thread_sessions",
+          "tableTo": "agent_composes",
+          "columnsFrom": ["compose_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "email_thread_sessions_agent_session_id_agent_sessions_id_fk": {
+          "name": "email_thread_sessions_agent_session_id_agent_sessions_id_fk",
+          "tableFrom": "email_thread_sessions",
+          "tableTo": "agent_sessions",
+          "columnsFrom": ["agent_session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_installations": {
+      "name": "github_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_access_token": {
+          "name": "encrypted_access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_name": {
+          "name": "target_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "admin_github_user_id": {
+          "name": "admin_github_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_compose_id": {
+          "name": "default_compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_configs": {
+          "name": "repo_configs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "github_installations_installation_id_unique": {
+          "name": "github_installations_installation_id_unique",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "installation_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_installations_default_compose_id_agent_composes_id_fk": {
+          "name": "github_installations_default_compose_id_agent_composes_id_fk",
+          "tableFrom": "github_installations",
+          "tableTo": "agent_composes",
+          "columnsFrom": ["default_compose_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_issue_sessions": {
+      "name": "github_issue_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo": {
+          "name": "repo",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_number": {
+          "name": "issue_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_session_id": {
+          "name": "agent_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_comment_id": {
+          "name": "last_comment_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_github_issue_sessions_installation_repo_issue": {
+          "name": "idx_github_issue_sessions_installation_repo_issue",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "repo",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "issue_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_github_issue_sessions_installation": {
+          "name": "idx_github_issue_sessions_installation",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_issue_sessions_installation_id_github_installations_id_fk": {
+          "name": "github_issue_sessions_installation_id_github_installations_id_fk",
+          "tableFrom": "github_issue_sessions",
+          "tableTo": "github_installations",
+          "columnsFrom": ["installation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_issue_sessions_agent_session_id_agent_sessions_id_fk": {
+          "name": "github_issue_sessions_agent_session_id_agent_sessions_id_fk",
+          "tableFrom": "github_issue_sessions",
+          "tableTo": "agent_sessions",
+          "columnsFrom": ["agent_session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_user_links": {
+      "name": "github_user_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "github_user_id": {
+          "name": "github_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vm0_user_id": {
+          "name": "vm0_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_github_user_links_user_installation": {
+          "name": "idx_github_user_links_user_installation",
+          "columns": [
+            {
+              "expression": "github_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_user_links_installation_id_github_installations_id_fk": {
+          "name": "github_user_links_installation_id_github_installations_id_fk",
+          "tableFrom": "github_user_links",
+          "tableTo": "github_installations",
+          "columnsFrom": ["installation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_providers": {
+      "name": "model_providers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_id": {
+          "name": "secret_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_method": {
+          "name": "auth_method",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "selected_model": {
+          "name": "selected_model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clerk_org_id": {
+          "name": "clerk_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_model_providers_secret": {
+          "name": "idx_model_providers_secret",
+          "columns": [
+            {
+              "expression": "secret_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_model_providers_clerk_org": {
+          "name": "idx_model_providers_clerk_org",
+          "columns": [
+            {
+              "expression": "clerk_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_model_providers_clerk_org_user_type": {
+          "name": "idx_model_providers_clerk_org_user_type",
+          "columns": [
+            {
+              "expression": "clerk_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "model_providers_secret_id_secrets_id_fk": {
+          "name": "model_providers_secret_id_secrets_id_fk",
+          "tableFrom": "model_providers",
+          "tableTo": "secrets",
+          "columnsFrom": ["secret_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runner_job_queue": {
+      "name": "runner_job_queue",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "runner_group": {
+          "name": "runner_group",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_context": {
+          "name": "execution_context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "runner_job_queue_group_unclaimed_idx": {
+          "name": "runner_job_queue_group_unclaimed_idx",
+          "columns": [
+            {
+              "expression": "runner_group",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "claimed_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runner_job_queue_expires_at_idx": {
+          "name": "runner_job_queue_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "runner_job_queue_run_id_agent_runs_id_fk": {
+          "name": "runner_job_queue_run_id_agent_runs_id_fk",
+          "tableFrom": "runner_job_queue",
+          "tableTo": "agent_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sandbox_telemetry": {
+      "name": "sandbox_telemetry",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_sandbox_telemetry_run_id": {
+          "name": "idx_sandbox_telemetry_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sandbox_telemetry_run_id_agent_runs_id_fk": {
+          "name": "sandbox_telemetry_run_id_agent_runs_id_fk",
+          "tableFrom": "sandbox_telemetry",
+          "tableTo": "agent_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scope_members": {
+      "name": "scope_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notify_email": {
+          "name": "notify_email",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "notify_slack": {
+          "name": "notify_slack",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_scope_members_scope_user": {
+          "name": "idx_scope_members_scope_user",
+          "columns": [
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_scope_members_scope": {
+          "name": "idx_scope_members_scope",
+          "columns": [
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_scope_members_user": {
+          "name": "idx_scope_members_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scope_members_scope_id_scopes_id_fk": {
+          "name": "scope_members_scope_id_scopes_id_fk",
+          "tableFrom": "scope_members",
+          "tableTo": "scopes",
+          "columnsFrom": ["scope_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "scope_members_role_check": {
+          "name": "scope_members_role_check",
+          "value": "\"scope_members\".\"role\" IN ('admin', 'member')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.scopes": {
+      "name": "scopes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clerk_org_id": {
+          "name": "clerk_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tier": {
+          "name": "tier",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "default_agent_compose_id": {
+          "name": "default_agent_compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_scopes_clerk_org": {
+          "name": "idx_scopes_clerk_org",
+          "columns": [
+            {
+              "expression": "clerk_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scopes_default_agent_compose_id_agent_composes_id_fk": {
+          "name": "scopes_default_agent_compose_id_agent_composes_id_fk",
+          "tableFrom": "scopes",
+          "tableTo": "agent_composes",
+          "columnsFrom": ["default_agent_compose_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "scopes_slug_unique": {
+          "name": "scopes_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "scopes_tier_check": {
+          "name": "scopes_tier_check",
+          "value": "\"scopes\".\"tier\" IN ('free', 'pro', 'max')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.secrets": {
+      "name": "secrets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_value": {
+          "name": "encrypted_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clerk_org_id": {
+          "name": "clerk_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_secrets_type": {
+          "name": "idx_secrets_type",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_secrets_clerk_org": {
+          "name": "idx_secrets_clerk_org",
+          "columns": [
+            {
+              "expression": "clerk_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_secrets_clerk_org_user_name_type": {
+          "name": "idx_secrets_clerk_org_user_name_type",
+          "columns": [
+            {
+              "expression": "clerk_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_compose_requests": {
+      "name": "slack_compose_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "compose_job_id": {
+          "name": "compose_job_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_workspace_id": {
+          "name": "slack_workspace_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_user_id": {
+          "name": "slack_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_channel_id": {
+          "name": "slack_channel_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_slack_compose_requests_job": {
+          "name": "idx_slack_compose_requests_job",
+          "columns": [
+            {
+              "expression": "compose_job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "slack_compose_requests_compose_job_id_compose_jobs_id_fk": {
+          "name": "slack_compose_requests_compose_job_id_compose_jobs_id_fk",
+          "tableFrom": "slack_compose_requests",
+          "tableTo": "compose_jobs",
+          "columnsFrom": ["compose_job_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_installations": {
+      "name": "slack_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slack_workspace_id": {
+          "name": "slack_workspace_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_workspace_name": {
+          "name": "slack_workspace_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_bot_token": {
+          "name": "encrypted_bot_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bot_user_id": {
+          "name": "bot_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_compose_id": {
+          "name": "default_compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "admin_slack_user_id": {
+          "name": "admin_slack_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "slack_installations_default_compose_id_agent_composes_id_fk": {
+          "name": "slack_installations_default_compose_id_agent_composes_id_fk",
+          "tableFrom": "slack_installations",
+          "tableTo": "agent_composes",
+          "columnsFrom": ["default_compose_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "slack_installations_slack_workspace_id_unique": {
+          "name": "slack_installations_slack_workspace_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slack_workspace_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_pending_questions": {
+      "name": "slack_pending_questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_workspace_id": {
+          "name": "slack_workspace_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_channel_id": {
+          "name": "slack_channel_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_thread_ts": {
+          "name": "slack_thread_ts",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_message_ts": {
+          "name": "slack_message_ts",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_link_id": {
+          "name": "user_link_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "compose_id": {
+          "name": "compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "questions": {
+          "name": "questions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "answered_at": {
+          "name": "answered_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_slack_pending_questions_run_id": {
+          "name": "idx_slack_pending_questions_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_thread_sessions": {
+      "name": "slack_thread_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slack_user_link_id": {
+          "name": "slack_user_link_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_channel_id": {
+          "name": "slack_channel_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_thread_ts": {
+          "name": "slack_thread_ts",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_session_id": {
+          "name": "agent_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_processed_message_ts": {
+          "name": "last_processed_message_ts",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_slack_thread_sessions_thread_user_link": {
+          "name": "idx_slack_thread_sessions_thread_user_link",
+          "columns": [
+            {
+              "expression": "slack_user_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slack_channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slack_thread_ts",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_slack_thread_sessions_user_link": {
+          "name": "idx_slack_thread_sessions_user_link",
+          "columns": [
+            {
+              "expression": "slack_user_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "slack_thread_sessions_slack_user_link_id_slack_user_links_id_fk": {
+          "name": "slack_thread_sessions_slack_user_link_id_slack_user_links_id_fk",
+          "tableFrom": "slack_thread_sessions",
+          "tableTo": "slack_user_links",
+          "columnsFrom": ["slack_user_link_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "slack_thread_sessions_agent_session_id_agent_sessions_id_fk": {
+          "name": "slack_thread_sessions_agent_session_id_agent_sessions_id_fk",
+          "tableFrom": "slack_thread_sessions",
+          "tableTo": "agent_sessions",
+          "columnsFrom": ["agent_session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_user_links": {
+      "name": "slack_user_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slack_user_id": {
+          "name": "slack_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_workspace_id": {
+          "name": "slack_workspace_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vm0_user_id": {
+          "name": "vm0_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dm_welcome_sent": {
+          "name": "dm_welcome_sent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_slack_user_links_user_workspace": {
+          "name": "idx_slack_user_links_user_workspace",
+          "columns": [
+            {
+              "expression": "slack_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slack_workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.storage_versions": {
+      "name": "storage_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "storage_id": {
+          "name": "storage_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "file_count": {
+          "name": "file_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "storage_versions_storage_id_storages_id_fk": {
+          "name": "storage_versions_storage_id_storages_id_fk",
+          "tableFrom": "storage_versions",
+          "tableTo": "storages",
+          "columnsFrom": ["storage_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.storages": {
+      "name": "storages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'volume'"
+        },
+        "clerk_org_id": {
+          "name": "clerk_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "s3_prefix": {
+          "name": "s3_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "file_count": {
+          "name": "file_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "head_version_id": {
+          "name": "head_version_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_storages_clerk_org": {
+          "name": "idx_storages_clerk_org",
+          "columns": [
+            {
+              "expression": "clerk_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_storages_clerk_org_user_name_type": {
+          "name": "idx_storages_clerk_org_user_name_type",
+          "columns": [
+            {
+              "expression": "clerk_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "storages_head_version_id_storage_versions_id_fk": {
+          "name": "storages_head_version_id_storage_versions_id_fk",
+          "tableFrom": "storages",
+          "tableTo": "storage_versions",
+          "columnsFrom": ["head_version_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_installations": {
+      "name": "telegram_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "telegram_bot_id": {
+          "name": "telegram_bot_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bot_username": {
+          "name": "bot_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_bot_token": {
+          "name": "encrypted_bot_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhook_secret": {
+          "name": "webhook_secret",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_compose_id": {
+          "name": "default_compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "admin_user_id": {
+          "name": "admin_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "telegram_installations_default_compose_id_agent_composes_id_fk": {
+          "name": "telegram_installations_default_compose_id_agent_composes_id_fk",
+          "tableFrom": "telegram_installations",
+          "tableTo": "agent_composes",
+          "columnsFrom": ["default_compose_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "telegram_installations_telegram_bot_id_unique": {
+          "name": "telegram_installations_telegram_bot_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["telegram_bot_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_messages": {
+      "name": "telegram_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_user_id": {
+          "name": "from_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_username": {
+          "name": "from_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_bot": {
+          "name": "is_bot",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_telegram_messages_unique": {
+          "name": "idx_telegram_messages_unique",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_telegram_messages_chat": {
+          "name": "idx_telegram_messages_chat",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_telegram_messages_created_at": {
+          "name": "idx_telegram_messages_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "telegram_messages_installation_id_telegram_installations_id_fk": {
+          "name": "telegram_messages_installation_id_telegram_installations_id_fk",
+          "tableFrom": "telegram_messages",
+          "tableTo": "telegram_installations",
+          "columnsFrom": ["installation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_thread_sessions": {
+      "name": "telegram_thread_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "telegram_user_link_id": {
+          "name": "telegram_user_link_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "root_message_id": {
+          "name": "root_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_session_id": {
+          "name": "agent_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_processed_message_id": {
+          "name": "last_processed_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_telegram_thread_sessions_chat_user_link": {
+          "name": "idx_telegram_thread_sessions_chat_user_link",
+          "columns": [
+            {
+              "expression": "telegram_user_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "root_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_telegram_thread_sessions_user_link": {
+          "name": "idx_telegram_thread_sessions_user_link",
+          "columns": [
+            {
+              "expression": "telegram_user_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "telegram_thread_sessions_telegram_user_link_id_telegram_user_links_id_fk": {
+          "name": "telegram_thread_sessions_telegram_user_link_id_telegram_user_links_id_fk",
+          "tableFrom": "telegram_thread_sessions",
+          "tableTo": "telegram_user_links",
+          "columnsFrom": ["telegram_user_link_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "telegram_thread_sessions_agent_session_id_agent_sessions_id_fk": {
+          "name": "telegram_thread_sessions_agent_session_id_agent_sessions_id_fk",
+          "tableFrom": "telegram_thread_sessions",
+          "tableTo": "agent_sessions",
+          "columnsFrom": ["agent_session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_user_links": {
+      "name": "telegram_user_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "telegram_user_id": {
+          "name": "telegram_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vm0_user_id": {
+          "name": "vm0_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dm_welcome_sent": {
+          "name": "dm_welcome_sent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_telegram_user_links_user_installation": {
+          "name": "idx_telegram_user_links_user_installation",
+          "columns": [
+            {
+              "expression": "telegram_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "telegram_user_links_installation_id_telegram_installations_id_fk": {
+          "name": "telegram_user_links_installation_id_telegram_installations_id_fk",
+          "tableFrom": "telegram_user_links",
+          "tableTo": "telegram_installations",
+          "columnsFrom": ["installation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.usage_daily": {
+      "name": "usage_daily",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_count": {
+          "name": "run_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "run_time_ms": {
+          "name": "run_time_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_usage_daily_user_date": {
+          "name": "uq_usage_daily_user_date",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.variables": {
+      "name": "variables",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clerk_org_id": {
+          "name": "clerk_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_variables_clerk_org": {
+          "name": "idx_variables_clerk_org",
+          "columns": [
+            {
+              "expression": "clerk_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_variables_clerk_org_user_name": {
+          "name": "idx_variables_clerk_org_user_name",
+          "columns": [
+            {
+              "expression": "clerk_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.connector_session_status": {
+      "name": "connector_session_status",
+      "schema": "public",
+      "values": ["pending", "complete", "expired", "error"]
+    },
+    "public.device_code_status": {
+      "name": "device_code_status",
+      "schema": "public",
+      "values": ["pending", "authenticated", "expired", "denied"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/turbo/apps/web/src/db/migrations/meta/_journal.json
+++ b/turbo/apps/web/src/db/migrations/meta/_journal.json
@@ -866,7 +866,7 @@
     {
       "idx": 123,
       "version": "7",
-      "when": 1773143266761,
+      "when": 1773400000009,
       "tag": "0123_rare_longshot",
       "breakpoints": true
     }

--- a/turbo/apps/web/src/db/migrations/meta/_journal.json
+++ b/turbo/apps/web/src/db/migrations/meta/_journal.json
@@ -862,6 +862,13 @@
       "when": 1773400000008,
       "tag": "0122_big_black_cat",
       "breakpoints": true
+    },
+    {
+      "idx": 123,
+      "version": "7",
+      "when": 1773143266761,
+      "tag": "0123_rare_longshot",
+      "breakpoints": true
     }
   ]
 }

--- a/turbo/apps/web/src/db/schema/agent-schedule.ts
+++ b/turbo/apps/web/src/db/schema/agent-schedule.ts
@@ -13,7 +13,6 @@ import {
 import { sql } from "drizzle-orm";
 import { agentComposes } from "./agent-compose";
 import { agentRuns } from "./agent-run";
-import { scopes } from "./scope";
 
 /**
  * Agent Schedules table
@@ -37,9 +36,7 @@ export const agentSchedules = pgTable(
     composeId: uuid("compose_id")
       .notNull()
       .references(() => agentComposes.id, { onDelete: "cascade" }),
-    scopeId: uuid("scope_id")
-      .notNull()
-      .references(() => scopes.id, { onDelete: "cascade" }),
+    scopeId: uuid("scope_id").notNull(),
     userId: text("user_id").notNull(),
     clerkOrgId: text("clerk_org_id").notNull(),
     name: varchar("name", { length: 64 }).notNull(),
@@ -81,17 +78,8 @@ export const agentSchedules = pgTable(
     updatedAt: timestamp("updated_at").defaultNow().notNull(),
   },
   (table) => [
-    // Schedule name unique within agent per scope+user
-    uniqueIndex("idx_agent_schedules_compose_name_scope_user").on(
-      table.composeId,
-      table.name,
-      table.scopeId,
-      table.userId,
-    ),
     // Index for finding schedules by compose
     index("idx_agent_schedules_compose").on(table.composeId),
-    // Index for listing user's schedules within a scope
-    index("idx_agent_schedules_scope_user").on(table.scopeId, table.userId),
     index("idx_agent_schedules_clerk_org").on(table.clerkOrgId),
     uniqueIndex("idx_agent_schedules_compose_name_clerk_org_user").on(
       table.composeId,

--- a/turbo/apps/web/src/db/schema/connector.ts
+++ b/turbo/apps/web/src/db/schema/connector.ts
@@ -7,7 +7,6 @@ import {
   uniqueIndex,
   index,
 } from "drizzle-orm/pg-core";
-import { scopes } from "./scope";
 
 /**
  * Connectors table
@@ -19,9 +18,7 @@ export const connectors = pgTable(
   "connectors",
   {
     id: uuid("id").defaultRandom().primaryKey(),
-    scopeId: uuid("scope_id")
-      .references(() => scopes.id, { onDelete: "cascade" })
-      .notNull(),
+    scopeId: uuid("scope_id").notNull(),
     type: varchar("type", { length: 50 }).notNull(), // "github"
     authMethod: varchar("auth_method", { length: 50 }).notNull(), // "oauth"
 
@@ -38,13 +35,6 @@ export const connectors = pgTable(
     updatedAt: timestamp("updated_at").defaultNow().notNull(),
   },
   (table) => [
-    // One connector per type per user within a scope
-    uniqueIndex("idx_connectors_scope_user_type").on(
-      table.scopeId,
-      table.userId,
-      table.type,
-    ),
-    index("idx_connectors_scope").on(table.scopeId),
     index("idx_connectors_clerk_org").on(table.clerkOrgId),
     uniqueIndex("idx_connectors_clerk_org_user_type").on(
       table.clerkOrgId,

--- a/turbo/apps/web/src/db/schema/model-provider.ts
+++ b/turbo/apps/web/src/db/schema/model-provider.ts
@@ -8,7 +8,6 @@ import {
   uniqueIndex,
   index,
 } from "drizzle-orm/pg-core";
-import { scopes } from "./scope";
 import { secrets } from "./secret";
 
 /**
@@ -23,9 +22,7 @@ export const modelProviders = pgTable(
   "model_providers",
   {
     id: uuid("id").defaultRandom().primaryKey(),
-    scopeId: uuid("scope_id")
-      .references(() => scopes.id, { onDelete: "cascade" })
-      .notNull(),
+    scopeId: uuid("scope_id").notNull(),
     type: varchar("type", { length: 50 }).notNull(),
     // Legacy single secret FK - null for multi-auth providers
     secretId: uuid("secret_id").references(() => secrets.id, {
@@ -41,13 +38,6 @@ export const modelProviders = pgTable(
     updatedAt: timestamp("updated_at").defaultNow().notNull(),
   },
   (table) => [
-    // One provider per type per user within a scope
-    uniqueIndex("idx_model_providers_scope_user_type").on(
-      table.scopeId,
-      table.userId,
-      table.type,
-    ),
-    index("idx_model_providers_scope").on(table.scopeId),
     index("idx_model_providers_secret").on(table.secretId),
     index("idx_model_providers_clerk_org").on(table.clerkOrgId),
     uniqueIndex("idx_model_providers_clerk_org_user_type").on(

--- a/turbo/apps/web/src/db/schema/secret.ts
+++ b/turbo/apps/web/src/db/schema/secret.ts
@@ -7,7 +7,6 @@ import {
   uniqueIndex,
   index,
 } from "drizzle-orm/pg-core";
-import { scopes } from "./scope";
 
 /**
  * Secrets table (formerly "credentials")
@@ -18,9 +17,7 @@ export const secrets = pgTable(
   "secrets",
   {
     id: uuid("id").defaultRandom().primaryKey(),
-    scopeId: uuid("scope_id")
-      .references(() => scopes.id, { onDelete: "cascade" })
-      .notNull(),
+    scopeId: uuid("scope_id").notNull(),
     name: varchar("name", { length: 255 }).notNull(),
     encryptedValue: text("encrypted_value").notNull(),
     description: text("description"),
@@ -31,14 +28,6 @@ export const secrets = pgTable(
     updatedAt: timestamp("updated_at").defaultNow().notNull(),
   },
   (table) => [
-    // Unique per user within scope — different users can have the same secret name
-    uniqueIndex("idx_secrets_scope_user_name_type").on(
-      table.scopeId,
-      table.userId,
-      table.name,
-      table.type,
-    ),
-    index("idx_secrets_scope").on(table.scopeId),
     index("idx_secrets_type").on(table.type),
     index("idx_secrets_clerk_org").on(table.clerkOrgId),
     uniqueIndex("idx_secrets_clerk_org_user_name_type").on(

--- a/turbo/apps/web/src/lib/computer-connector/computer-connector-service.ts
+++ b/turbo/apps/web/src/lib/computer-connector/computer-connector-service.ts
@@ -38,16 +38,19 @@ const COMPUTER_SECRETS = [
  * and its 4 secrets (AUTHTOKEN, TOKEN, ENDPOINT, DOMAIN).
  */
 export async function createComputerConnector(
+  clerkOrgId: string,
   scopeId: string,
   userId: string,
-  clerkOrgId: string,
 ): Promise<ComputerConnectorCreateResponse> {
   // Check for existing connector
   const [existing] = await globalThis.services.db
     .select({ id: connectors.id })
     .from(connectors)
     .where(
-      and(eq(connectors.scopeId, scopeId), eq(connectors.type, "computer")),
+      and(
+        eq(connectors.clerkOrgId, clerkOrgId),
+        eq(connectors.type, "computer"),
+      ),
     )
     .limit(1);
 
@@ -157,31 +160,31 @@ export async function createComputerConnector(
   // Store secrets (ngrok token is one-time use, returned to client only)
   await Promise.all([
     upsertSecretByScope(
+      clerkOrgId,
       scopeId,
       userId,
       "COMPUTER_CONNECTOR_BRIDGE_TOKEN",
       bridgeToken,
       "connector",
       "Computer connector: COMPUTER_CONNECTOR_BRIDGE_TOKEN",
-      clerkOrgId,
     ),
     upsertSecretByScope(
+      clerkOrgId,
       scopeId,
       userId,
       "COMPUTER_CONNECTOR_DOMAIN_ID",
       reservedDomain.id,
       "connector",
       "Computer connector: COMPUTER_CONNECTOR_DOMAIN_ID",
-      clerkOrgId,
     ),
     upsertSecretByScope(
+      clerkOrgId,
       scopeId,
       userId,
       "COMPUTER_CONNECTOR_DOMAIN",
       domain,
       "connector",
       "Computer connector: COMPUTER_CONNECTOR_DOMAIN",
-      clerkOrgId,
     ),
   ]);
 
@@ -223,7 +226,7 @@ async function safeDeleteNgrokResource(
  * Delete the computer connector and revoke ngrok credentials.
  */
 export async function deleteComputerConnector(
-  scopeId: string,
+  clerkOrgId: string,
   userId: string,
 ): Promise<void> {
   const db = globalThis.services.db;
@@ -238,7 +241,7 @@ export async function deleteComputerConnector(
     .from(connectors)
     .where(
       and(
-        eq(connectors.scopeId, scopeId),
+        eq(connectors.clerkOrgId, clerkOrgId),
         eq(connectors.userId, userId),
         eq(connectors.type, "computer"),
       ),
@@ -275,7 +278,7 @@ export async function deleteComputerConnector(
       .from(secrets)
       .where(
         and(
-          eq(secrets.scopeId, scopeId),
+          eq(secrets.clerkOrgId, clerkOrgId),
           eq(secrets.userId, userId),
           eq(secrets.name, "COMPUTER_CONNECTOR_DOMAIN_ID"),
           eq(secrets.type, "connector"),
@@ -307,7 +310,7 @@ export async function deleteComputerConnector(
       .delete(secrets)
       .where(
         and(
-          eq(secrets.scopeId, scopeId),
+          eq(secrets.clerkOrgId, clerkOrgId),
           eq(secrets.userId, userId),
           eq(secrets.name, secretName),
           eq(secrets.type, "connector"),
@@ -315,5 +318,5 @@ export async function deleteComputerConnector(
       );
   }
 
-  log.debug("Computer connector deleted", { scopeId });
+  log.debug("Computer connector deleted", { clerkOrgId });
 }

--- a/turbo/apps/web/src/lib/connector/connector-service.ts
+++ b/turbo/apps/web/src/lib/connector/connector-service.ts
@@ -41,7 +41,7 @@ function getSecretNameForConnector(type: ConnectorType): string {
  * based on user secrets that match api-token required secret names.
  */
 export async function listConnectors(
-  scopeId: string,
+  clerkOrgId: string,
   userId: string,
 ): Promise<ConnectorResponse[]> {
   const db = globalThis.services.db;
@@ -62,7 +62,10 @@ export async function listConnectors(
       })
       .from(connectors)
       .where(
-        and(eq(connectors.scopeId, scopeId), eq(connectors.userId, userId)),
+        and(
+          eq(connectors.clerkOrgId, clerkOrgId),
+          eq(connectors.userId, userId),
+        ),
       )
       .orderBy(connectors.type),
     db
@@ -70,7 +73,7 @@ export async function listConnectors(
       .from(secrets)
       .where(
         and(
-          eq(secrets.scopeId, scopeId),
+          eq(secrets.clerkOrgId, clerkOrgId),
           eq(secrets.userId, userId),
           eq(secrets.type, "user"),
         ),
@@ -119,7 +122,7 @@ export async function listConnectors(
  * connectors whose required user secrets are all present.
  */
 export async function getConnector(
-  scopeId: string,
+  clerkOrgId: string,
   userId: string,
   type: ConnectorType,
 ): Promise<ConnectorResponse | null> {
@@ -138,7 +141,7 @@ export async function getConnector(
     .from(connectors)
     .where(
       and(
-        eq(connectors.scopeId, scopeId),
+        eq(connectors.clerkOrgId, clerkOrgId),
         eq(connectors.userId, userId),
         eq(connectors.type, type),
       ),
@@ -169,7 +172,7 @@ export async function getConnector(
     .from(secrets)
     .where(
       and(
-        eq(secrets.scopeId, scopeId),
+        eq(secrets.clerkOrgId, clerkOrgId),
         eq(secrets.userId, userId),
         eq(secrets.type, "user"),
       ),
@@ -203,13 +206,13 @@ interface ExternalUserInfo {
  * Also stores the associated secret with type="connector"
  */
 export async function upsertOAuthConnector(
+  clerkOrgId: string,
   scopeId: string,
   userId: string,
   type: ConnectorType,
   accessToken: string,
   userInfo: ExternalUserInfo,
   oauthScopes: string[],
-  clerkOrgId: string,
   options?: {
     refreshToken?: string | null;
     refreshSecretName?: string;
@@ -229,7 +232,7 @@ export async function upsertOAuthConnector(
     .from(connectors)
     .where(
       and(
-        eq(connectors.scopeId, scopeId),
+        eq(connectors.clerkOrgId, clerkOrgId),
         eq(connectors.userId, userId),
         eq(connectors.type, type),
       ),
@@ -240,25 +243,25 @@ export async function upsertOAuthConnector(
 
   // Upsert access token secret
   await upsertSecretByScope(
+    clerkOrgId,
     scopeId,
     userId,
     secretName,
     accessToken,
     "connector",
     `OAuth token for ${type} connector`,
-    clerkOrgId,
   );
 
   // Upsert refresh token secret if provided
   if (options?.refreshToken && options.refreshSecretName) {
     await upsertSecretByScope(
+      clerkOrgId,
       scopeId,
       userId,
       options.refreshSecretName,
       options.refreshToken,
       "connector",
       `OAuth refresh token for ${type} connector`,
-      clerkOrgId,
     );
   }
 
@@ -346,7 +349,7 @@ export async function upsertOAuthConnector(
  * For api-token connectors (no DB record): deletes user secrets matching required api-token secret names.
  */
 export async function deleteConnector(
-  scopeId: string,
+  clerkOrgId: string,
   userId: string,
   type: ConnectorType,
 ): Promise<void> {
@@ -358,7 +361,7 @@ export async function deleteConnector(
     .from(connectors)
     .where(
       and(
-        eq(connectors.scopeId, scopeId),
+        eq(connectors.clerkOrgId, clerkOrgId),
         eq(connectors.userId, userId),
         eq(connectors.type, type),
       ),
@@ -390,7 +393,7 @@ export async function deleteConnector(
         .delete(secrets)
         .where(
           and(
-            eq(secrets.scopeId, scopeId),
+            eq(secrets.clerkOrgId, clerkOrgId),
             eq(secrets.userId, userId),
             eq(secrets.name, name),
             eq(secrets.type, "connector"),
@@ -398,7 +401,7 @@ export async function deleteConnector(
         );
     }
 
-    log.debug("connector deleted", { scopeId, type });
+    log.debug("connector deleted", { clerkOrgId, type });
     return;
   }
 
@@ -411,7 +414,7 @@ export async function deleteConnector(
         .delete(secrets)
         .where(
           and(
-            eq(secrets.scopeId, scopeId),
+            eq(secrets.clerkOrgId, clerkOrgId),
             eq(secrets.userId, userId),
             eq(secrets.name, name),
             eq(secrets.type, "user"),
@@ -422,7 +425,7 @@ export async function deleteConnector(
     }
     if (deletedAny) {
       log.debug("api-token connector deleted via user secrets", {
-        scopeId,
+        clerkOrgId,
         type,
       });
       return;
@@ -436,19 +439,19 @@ export async function deleteConnector(
  * Create or update a connector secret (e.g., refresh token)
  */
 export async function upsertConnectorSecret(
+  clerkOrgId: string,
   scopeId: string,
   userId: string,
   secretName: string,
   secretValue: string,
-  clerkOrgId: string,
 ): Promise<void> {
   await upsertSecretByScope(
+    clerkOrgId,
     scopeId,
     userId,
     secretName,
     secretValue,
     "connector",
     `Connector secret: ${secretName}`,
-    clerkOrgId,
   );
 }

--- a/turbo/apps/web/src/lib/model-provider/model-provider-service.ts
+++ b/turbo/apps/web/src/lib/model-provider/model-provider-service.ts
@@ -87,7 +87,7 @@ function getTypesForFramework(framework: ModelProviderFramework): string[] {
  * @returns true if isDefault was set, false if another default already exists
  */
 async function assignDefaultIfFirst(
-  scopeId: string,
+  clerkOrgId: string,
   providerId: string,
   framework: ModelProviderFramework,
 ): Promise<boolean> {
@@ -105,7 +105,7 @@ async function assignDefaultIfFirst(
             .from(modelProviders)
             .where(
               and(
-                eq(modelProviders.scopeId, scopeId),
+                eq(modelProviders.clerkOrgId, clerkOrgId),
                 eq(modelProviders.isDefault, true),
                 ne(modelProviders.id, providerId),
                 inArray(modelProviders.type, frameworkTypes),
@@ -122,7 +122,7 @@ async function assignDefaultIfFirst(
  * List all model providers for a scope
  */
 export async function listModelProviders(
-  scopeId: string,
+  clerkOrgId: string,
   userId: string,
 ): Promise<ModelProviderInfo[]> {
   // Use leftJoin to include multi-auth providers that don't have secretId
@@ -141,7 +141,7 @@ export async function listModelProviders(
     .leftJoin(secrets, eq(modelProviders.secretId, secrets.id))
     .where(
       and(
-        eq(modelProviders.scopeId, scopeId),
+        eq(modelProviders.clerkOrgId, clerkOrgId),
         eq(modelProviders.userId, userId),
       ),
     )
@@ -166,7 +166,7 @@ export async function listModelProviders(
  * Note: Multi-auth providers (like aws-bedrock) are not supported by this function
  */
 export async function checkSecretExists(
-  scopeId: string,
+  clerkOrgId: string,
   userId: string,
   type: ModelProviderType,
 ): Promise<{ exists: boolean }> {
@@ -186,7 +186,7 @@ export async function checkSecretExists(
     .from(secrets)
     .where(
       and(
-        eq(secrets.scopeId, scopeId),
+        eq(secrets.clerkOrgId, clerkOrgId),
         eq(secrets.userId, userId),
         eq(secrets.name, secretName),
         eq(secrets.type, "model-provider"),
@@ -207,11 +207,11 @@ export async function checkSecretExists(
  * Note: User secrets and model-provider secrets are isolated by type, so no conflict detection needed
  */
 export async function upsertModelProvider(
+  clerkOrgId: string,
   scopeId: string,
   userId: string,
   type: ModelProviderType,
   secret: string,
-  clerkOrgId: string,
   selectedModel?: string,
 ): Promise<{ provider: ModelProviderInfo; created: boolean }> {
   // Multi-auth providers need different handling
@@ -230,7 +230,7 @@ export async function upsertModelProvider(
   const encryptedValue = encryptCredentialValue(secret, encryptionKey);
 
   log.debug("upserting model provider", {
-    scopeId,
+    clerkOrgId,
     type,
     secretName,
   });
@@ -242,7 +242,7 @@ export async function upsertModelProvider(
     .from(modelProviders)
     .where(
       and(
-        eq(modelProviders.scopeId, scopeId),
+        eq(modelProviders.clerkOrgId, clerkOrgId),
         eq(modelProviders.userId, userId),
         eq(modelProviders.type, type),
       ),
@@ -262,7 +262,7 @@ export async function upsertModelProvider(
       clerkOrgId,
     })
     .onConflictDoUpdate({
-      target: [secrets.scopeId, secrets.userId, secrets.name, secrets.type],
+      target: [secrets.clerkOrgId, secrets.userId, secrets.name, secrets.type],
       set: { encryptedValue, updatedAt: new Date() },
     })
     .returning();
@@ -281,7 +281,7 @@ export async function upsertModelProvider(
     })
     .onConflictDoUpdate({
       target: [
-        modelProviders.scopeId,
+        modelProviders.clerkOrgId,
         modelProviders.userId,
         modelProviders.type,
       ],
@@ -298,7 +298,7 @@ export async function upsertModelProvider(
   // Assign default if this is a new provider and no other default exists for the framework
   if (wasCreated) {
     const isDefault = await assignDefaultIfFirst(
-      scopeId,
+      clerkOrgId,
       provider!.id,
       framework,
     );
@@ -334,13 +334,13 @@ export async function upsertModelProvider(
  * Note: Only targets model-provider type secrets (user secrets are independent)
  */
 async function upsertMultiAuthSecret(
+  clerkOrgId: string,
   scopeId: string,
   userId: string,
   name: string,
   value: string,
   description: string,
   encryptionKey: string,
-  clerkOrgId: string,
 ): Promise<void> {
   const encryptedValue = encryptCredentialValue(value, encryptionKey);
 
@@ -356,7 +356,7 @@ async function upsertMultiAuthSecret(
       clerkOrgId,
     })
     .onConflictDoUpdate({
-      target: [secrets.scopeId, secrets.userId, secrets.name, secrets.type],
+      target: [secrets.clerkOrgId, secrets.userId, secrets.name, secrets.type],
       set: { encryptedValue, description, updatedAt: new Date() },
     });
 }
@@ -365,7 +365,7 @@ async function upsertMultiAuthSecret(
  * Clean up old secrets when switching auth methods
  */
 async function cleanupOldAuthMethodSecrets(
-  scopeId: string,
+  clerkOrgId: string,
   userId: string,
   type: ModelProviderType,
   oldAuthMethod: string,
@@ -383,13 +383,13 @@ async function cleanupOldAuthMethodSecrets(
       .delete(secrets)
       .where(
         and(
-          eq(secrets.scopeId, scopeId),
+          eq(secrets.clerkOrgId, clerkOrgId),
           eq(secrets.userId, userId),
           inArray(secrets.name, secretsToDelete),
         ),
       );
     log.debug("old auth method secrets cleaned up", {
-      scopeId,
+      clerkOrgId,
       type,
       oldAuthMethod,
       deletedSecrets: secretsToDelete,
@@ -404,12 +404,12 @@ async function cleanupOldAuthMethodSecrets(
  * @param selectedModel Optional selected model
  */
 export async function upsertMultiAuthModelProvider(
+  clerkOrgId: string,
   scopeId: string,
   userId: string,
   type: ModelProviderType,
   authMethod: string,
   secretValues: Record<string, string>,
-  clerkOrgId: string,
   selectedModel?: string,
 ): Promise<{ provider: ModelProviderInfo; created: boolean }> {
   // Verify this is a multi-auth provider
@@ -451,7 +451,7 @@ export async function upsertMultiAuthModelProvider(
   const encryptionKey = globalThis.services.env.SECRETS_ENCRYPTION_KEY;
 
   log.debug("upserting multi-auth model provider", {
-    scopeId,
+    clerkOrgId,
     type,
     authMethod,
     secretNames: Object.keys(secretValues),
@@ -463,7 +463,7 @@ export async function upsertMultiAuthModelProvider(
     .from(modelProviders)
     .where(
       and(
-        eq(modelProviders.scopeId, scopeId),
+        eq(modelProviders.clerkOrgId, clerkOrgId),
         eq(modelProviders.userId, userId),
         eq(modelProviders.type, type),
       ),
@@ -473,7 +473,7 @@ export async function upsertMultiAuthModelProvider(
   // If switching auth methods, clean up old secrets that are no longer used
   if (existingProvider && existingProvider.authMethod !== authMethod) {
     await cleanupOldAuthMethodSecrets(
-      scopeId,
+      clerkOrgId,
       userId,
       type,
       existingProvider.authMethod ?? "",
@@ -487,13 +487,13 @@ export async function upsertMultiAuthModelProvider(
 
   for (const [name, value] of Object.entries(secretValues)) {
     await upsertMultiAuthSecret(
+      clerkOrgId,
       scopeId,
       userId,
       name,
       value,
       secretDescription,
       encryptionKey,
-      clerkOrgId,
     );
   }
 
@@ -511,7 +511,7 @@ export async function upsertMultiAuthModelProvider(
     })
     .onConflictDoUpdate({
       target: [
-        modelProviders.scopeId,
+        modelProviders.clerkOrgId,
         modelProviders.userId,
         modelProviders.type,
       ],
@@ -528,7 +528,7 @@ export async function upsertMultiAuthModelProvider(
   // Assign default if this is a new provider and no other default exists for the framework
   if (wasCreated) {
     const isDefault = await assignDefaultIfFirst(
-      scopeId,
+      clerkOrgId,
       provider!.id,
       framework,
     );
@@ -580,7 +580,7 @@ export async function convertSecretToModelProvider(): Promise<never> {
  * Delete a model provider and its secret
  */
 export async function deleteModelProvider(
-  scopeId: string,
+  clerkOrgId: string,
   userId: string,
   type: ModelProviderType,
 ): Promise<void> {
@@ -592,7 +592,7 @@ export async function deleteModelProvider(
     .from(modelProviders)
     .where(
       and(
-        eq(modelProviders.scopeId, scopeId),
+        eq(modelProviders.clerkOrgId, clerkOrgId),
         eq(modelProviders.userId, userId),
         eq(modelProviders.type, type),
       ),
@@ -623,13 +623,13 @@ export async function deleteModelProvider(
           .delete(secrets)
           .where(
             and(
-              eq(secrets.scopeId, scopeId),
+              eq(secrets.clerkOrgId, clerkOrgId),
               eq(secrets.userId, userId),
               inArray(secrets.name, secretNames),
             ),
           );
         log.debug("multi-auth secrets deleted", {
-          scopeId,
+          clerkOrgId,
           type,
           secretNames,
         });
@@ -641,14 +641,19 @@ export async function deleteModelProvider(
       .where(eq(modelProviders.id, provider.id));
   }
 
-  log.debug("model provider deleted", { scopeId, type });
+  log.debug("model provider deleted", { clerkOrgId, type });
 
   // If it was default, assign new default for framework
   if (wasDefault) {
     const remaining = await globalThis.services.db
       .select({ id: modelProviders.id, type: modelProviders.type })
       .from(modelProviders)
-      .where(eq(modelProviders.scopeId, scopeId))
+      .where(
+        and(
+          eq(modelProviders.clerkOrgId, clerkOrgId),
+          eq(modelProviders.userId, userId),
+        ),
+      )
       .orderBy(modelProviders.createdAt);
 
     const nextDefault = remaining.find(
@@ -673,7 +678,7 @@ export async function deleteModelProvider(
  * Set a model provider as default for its framework
  */
 export async function setModelProviderDefault(
-  scopeId: string,
+  clerkOrgId: string,
   userId: string,
   type: ModelProviderType,
 ): Promise<ModelProviderInfo> {
@@ -687,7 +692,7 @@ export async function setModelProviderDefault(
     .from(modelProviders)
     .where(
       and(
-        eq(modelProviders.scopeId, scopeId),
+        eq(modelProviders.clerkOrgId, clerkOrgId),
         eq(modelProviders.userId, userId),
         eq(modelProviders.type, type),
       ),
@@ -715,7 +720,12 @@ export async function setModelProviderDefault(
   const allProviders = await globalThis.services.db
     .select({ id: modelProviders.id, type: modelProviders.type })
     .from(modelProviders)
-    .where(eq(modelProviders.scopeId, scopeId));
+    .where(
+      and(
+        eq(modelProviders.clerkOrgId, clerkOrgId),
+        eq(modelProviders.userId, userId),
+      ),
+    );
 
   const sameFrameworkIds = allProviders
     .filter(
@@ -758,7 +768,7 @@ export async function setModelProviderDefault(
  * Update model selection for an existing provider (keeps secret unchanged)
  */
 export async function updateModelProviderModel(
-  scopeId: string,
+  clerkOrgId: string,
   userId: string,
   type: ModelProviderType,
   selectedModel?: string,
@@ -772,7 +782,7 @@ export async function updateModelProviderModel(
     .from(modelProviders)
     .where(
       and(
-        eq(modelProviders.scopeId, scopeId),
+        eq(modelProviders.clerkOrgId, clerkOrgId),
         eq(modelProviders.userId, userId),
         eq(modelProviders.type, type),
       ),
@@ -815,7 +825,7 @@ export async function updateModelProviderModel(
  * Supports both legacy single-secret and multi-auth providers
  */
 export async function getDefaultModelProvider(
-  scopeId: string,
+  clerkOrgId: string,
   userId: string,
   framework: ModelProviderFramework,
 ): Promise<ModelProviderInfo | null> {
@@ -835,7 +845,7 @@ export async function getDefaultModelProvider(
     .leftJoin(secrets, eq(modelProviders.secretId, secrets.id))
     .where(
       and(
-        eq(modelProviders.scopeId, scopeId),
+        eq(modelProviders.clerkOrgId, clerkOrgId),
         eq(modelProviders.userId, userId),
       ),
     );

--- a/turbo/apps/web/src/lib/run/build-context.ts
+++ b/turbo/apps/web/src/lib/run/build-context.ts
@@ -182,7 +182,7 @@ interface ModelProviderCredentialResult {
  * For providers with environment mapping (e.g., moonshot), resolves all env vars
  */
 async function resolveModelProviderCredential(
-  scopeId: string,
+  clerkOrgId: string,
   userId: string,
   framework: string,
   hasExplicitModelProviderConfig: boolean,
@@ -200,7 +200,7 @@ async function resolveModelProviderCredential(
 
   // Fetch default provider once (used for type resolution, model selection, and auth method)
   const defaultProvider = await getDefaultModelProvider(
-    scopeId,
+    clerkOrgId,
     userId,
     framework as ModelProviderFramework,
   );
@@ -234,7 +234,7 @@ async function resolveModelProviderCredential(
 
     // Fetch all model-provider credentials by name
     const allCredentialValues = await getSecretValues(
-      scopeId,
+      clerkOrgId,
       userId,
       "model-provider",
     );
@@ -283,7 +283,7 @@ async function resolveModelProviderCredential(
   }
 
   const credentialValue = await getSecretValue(
-    scopeId,
+    clerkOrgId,
     userId,
     credentialName,
     "model-provider",
@@ -321,10 +321,10 @@ async function resolveModelProviderCredential(
  */
 async function refreshConnectorAccessToken(
   connectorType: string,
+  clerkOrgId: string,
   scopeId: string,
   userId: string,
   connectorSecrets: Record<string, string>,
-  clerkOrgId: string,
 ): Promise<string | null> {
   const handler =
     PROVIDER_HANDLERS[connectorType as keyof typeof PROVIDER_HANDLERS];
@@ -361,19 +361,19 @@ async function refreshConnectorAccessToken(
 
     // Persist new tokens to database
     await upsertConnectorSecret(
+      clerkOrgId,
       scopeId,
       userId,
       accessTokenSecret,
       result.accessToken,
-      clerkOrgId,
     );
     if (result.refreshToken) {
       await upsertConnectorSecret(
+        clerkOrgId,
         scopeId,
         userId,
         refreshTokenSecret,
         result.refreshToken,
-        clerkOrgId,
       );
     }
 
@@ -410,15 +410,17 @@ interface ConnectorCredentialResult {
  * environment variables (e.g., GH_TOKEN, GITHUB_TOKEN for GitHub connector).
  */
 async function resolveConnectorCredentials(
+  clerkOrgId: string,
   scopeId: string,
   userId: string,
-  clerkOrgId: string,
 ): Promise<ConnectorCredentialResult> {
   // Query connected connectors (need type for environmentMapping, authMethod for refresh filter)
   const userConnectors = await globalThis.services.db
     .select({ type: connectors.type, authMethod: connectors.authMethod })
     .from(connectors)
-    .where(and(eq(connectors.scopeId, scopeId), eq(connectors.userId, userId)));
+    .where(
+      and(eq(connectors.clerkOrgId, clerkOrgId), eq(connectors.userId, userId)),
+    );
 
   if (userConnectors.length === 0) {
     return {
@@ -428,7 +430,11 @@ async function resolveConnectorCredentials(
     };
   }
 
-  const connectorSecrets = await getSecretValues(scopeId, userId, "connector");
+  const connectorSecrets = await getSecretValues(
+    clerkOrgId,
+    userId,
+    "connector",
+  );
   if (Object.keys(connectorSecrets).length === 0) {
     return {
       connectorSecrets: undefined,
@@ -462,10 +468,10 @@ async function resolveConnectorCredentials(
       .map(({ type }) =>
         refreshConnectorAccessToken(
           type,
+          clerkOrgId,
           scopeId,
           userId,
           connectorSecrets,
-          clerkOrgId,
         ),
       ),
   );
@@ -505,7 +511,7 @@ async function resolveConnectorCredentials(
  * Fetch credentials referenced in compose environment
  */
 async function fetchReferencedCredentials(
-  scopeId: string,
+  clerkOrgId: string,
   userId: string,
   environment: Record<string, string> | undefined,
 ): Promise<Record<string, string> | undefined> {
@@ -527,9 +533,9 @@ async function fetchReferencedCredentials(
   log.debug(`Secrets referenced in environment: ${referencedNames.join(", ")}`);
 
   // Only fetch user secrets for variable expansion (model-provider secrets are isolated)
-  const userSecrets = await getSecretValues(scopeId, userId, "user");
+  const userSecrets = await getSecretValues(clerkOrgId, userId, "user");
   log.debug(
-    `Fetched ${Object.keys(userSecrets).length} user secret(s) from scope ${scopeId}`,
+    `Fetched ${Object.keys(userSecrets).length} user secret(s) for org ${clerkOrgId}`,
   );
   return userSecrets;
 }
@@ -756,6 +762,7 @@ async function loadAgentComposeForNewRun(
  * Extracted from buildExecutionContext to reduce complexity.
  */
 async function resolveCredentialsAndEnvironment(
+  clerkOrgId: string,
   scopeId: string,
   agentCompose: unknown,
   firstAgent:
@@ -767,7 +774,6 @@ async function resolveCredentialsAndEnvironment(
   runId: string,
   checkEnv: boolean | undefined,
   userId: string,
-  clerkOrgId: string,
 ): Promise<{
   secrets: Record<string, string> | undefined;
   credentials: Record<string, string> | undefined;
@@ -784,15 +790,15 @@ async function resolveCredentialsAndEnvironment(
   // so there is no data dependency between them.
   const [dbSecrets, modelProviderResult, connectorResult, mergedVars] =
     await Promise.all([
-      fetchReferencedCredentials(scopeId, userId, firstAgent?.environment),
+      fetchReferencedCredentials(clerkOrgId, userId, firstAgent?.environment),
       resolveModelProviderCredential(
-        scopeId,
+        clerkOrgId,
         userId,
         framework,
         hasExplicitModelProviderConfig,
         modelProvider,
       ),
-      resolveConnectorCredentials(scopeId, userId, clerkOrgId),
+      resolveConnectorCredentials(clerkOrgId, scopeId, userId),
       fetchAndMergeVariables(clerkOrgId, userId, vars),
     ]);
 
@@ -1117,6 +1123,7 @@ export async function buildExecutionContext(
   const resolveCredentialsStart = Date.now();
   const [credentialsResult, userPrefs, runtimeScope] = await Promise.all([
     resolveCredentialsAndEnvironment(
+      runtimeClerkOrgId,
       runtimeScopeId,
       agentCompose,
       firstAgent,
@@ -1126,7 +1133,6 @@ export async function buildExecutionContext(
       params.runId,
       params.checkEnv,
       params.userId,
-      runtimeClerkOrgId,
     ),
     params.userId ? getUserPreferences(params.userId) : Promise.resolve(null),
     Promise.resolve(pendingRuntimeScope),

--- a/turbo/apps/web/src/lib/schedule/schedule-service.ts
+++ b/turbo/apps/web/src/lib/schedule/schedule-service.ts
@@ -243,7 +243,7 @@ async function getScopeSlug(scopeId: string): Promise<string> {
  */
 async function verifyScheduleOwnership(
   userId: string,
-  scopeId: string,
+  clerkOrgId: string,
   composeId: string,
   name: string,
 ): Promise<{
@@ -258,7 +258,7 @@ async function verifyScheduleOwnership(
       and(
         eq(agentSchedules.composeId, composeId),
         eq(agentSchedules.name, name),
-        eq(agentSchedules.scopeId, scopeId),
+        eq(agentSchedules.clerkOrgId, clerkOrgId),
         eq(agentSchedules.userId, userId),
       ),
     )
@@ -269,7 +269,7 @@ async function verifyScheduleOwnership(
   }
 
   const compose = await loadCompose(composeId);
-  const scopeSlug = await getScopeSlug(scopeId);
+  const scopeSlug = await getScopeSlug(schedule.scopeId);
 
   return { schedule, compose, scopeSlug };
 }
@@ -280,9 +280,8 @@ async function verifyScheduleOwnership(
  */
 async function validateRequiredConfig(
   compose: typeof agentComposes.$inferSelect,
-  scopeId: string,
-  userId: string,
   clerkOrgId: string,
+  userId: string,
 ): Promise<void> {
   if (!compose.headVersionId) return;
 
@@ -297,7 +296,7 @@ async function validateRequiredConfig(
   const required = extractRequiredConfiguration(version.content);
 
   // Fetch platform-managed secrets and vars from schedule's scope + user
-  const platformSecrets = await getSecretValues(scopeId, userId, "user");
+  const platformSecrets = await getSecretValues(clerkOrgId, userId, "user");
   const platformSecretNames = Object.keys(platformSecrets);
   log.debug(
     `Fetched ${platformSecretNames.length} platform secret(s) for validation`,
@@ -313,7 +312,9 @@ async function validateRequiredConfig(
   const userConnectors = await globalThis.services.db
     .select({ type: connectors.type })
     .from(connectors)
-    .where(and(eq(connectors.scopeId, scopeId), eq(connectors.userId, userId)));
+    .where(
+      and(eq(connectors.clerkOrgId, clerkOrgId), eq(connectors.userId, userId)),
+    );
   const connectorProvidedNames = getConnectorProvidedSecretNames(
     userConnectors.map((c) => c.type),
   );
@@ -363,8 +364,8 @@ function resolveTrigger(request: DeployScheduleRequest): {
  */
 export async function deploySchedule(
   userId: string,
-  scopeId: string,
   clerkOrgId: string,
+  scopeId: string,
   request: DeployScheduleRequest,
 ): Promise<{ schedule: ScheduleResponse; created: boolean }> {
   log.debug(
@@ -388,14 +389,14 @@ export async function deploySchedule(
       and(
         eq(agentSchedules.composeId, request.composeId),
         eq(agentSchedules.name, request.name),
-        eq(agentSchedules.scopeId, scopeId),
+        eq(agentSchedules.clerkOrgId, clerkOrgId),
         eq(agentSchedules.userId, userId),
       ),
     )
     .limit(1);
 
   // Validate required secrets/vars against schedule's scope + user
-  await validateRequiredConfig(compose, scopeId, userId, clerkOrgId);
+  await validateRequiredConfig(compose, clerkOrgId, userId);
 
   const { triggerType, nextRunAt } = resolveTrigger(request);
 
@@ -530,7 +531,7 @@ export async function listSchedules(
  */
 export async function getScheduleByName(
   userId: string,
-  scopeId: string,
+  clerkOrgId: string,
   composeId: string,
   name: string,
 ): Promise<ScheduleResponse> {
@@ -538,7 +539,7 @@ export async function getScheduleByName(
 
   const { schedule, compose, scopeSlug } = await verifyScheduleOwnership(
     userId,
-    scopeId,
+    clerkOrgId,
     composeId,
     name,
   );
@@ -551,7 +552,7 @@ export async function getScheduleByName(
  */
 export async function getScheduleRecentRuns(
   userId: string,
-  scopeId: string,
+  clerkOrgId: string,
   composeId: string,
   scheduleName: string,
   limit: number,
@@ -562,7 +563,7 @@ export async function getScheduleRecentRuns(
 
   const { schedule } = await verifyScheduleOwnership(
     userId,
-    scopeId,
+    clerkOrgId,
     composeId,
     scheduleName,
   );
@@ -595,7 +596,7 @@ export async function getScheduleRecentRuns(
  */
 export async function deleteSchedule(
   userId: string,
-  scopeId: string,
+  clerkOrgId: string,
   composeId: string,
   name: string,
 ): Promise<void> {
@@ -603,7 +604,7 @@ export async function deleteSchedule(
 
   const { schedule } = await verifyScheduleOwnership(
     userId,
-    scopeId,
+    clerkOrgId,
     composeId,
     name,
   );
@@ -620,7 +621,7 @@ export async function deleteSchedule(
  */
 export async function enableSchedule(
   userId: string,
-  scopeId: string,
+  clerkOrgId: string,
   composeId: string,
   name: string,
 ): Promise<ScheduleResponse> {
@@ -628,7 +629,7 @@ export async function enableSchedule(
 
   const { schedule, compose, scopeSlug } = await verifyScheduleOwnership(
     userId,
-    scopeId,
+    clerkOrgId,
     composeId,
     name,
   );
@@ -678,7 +679,7 @@ export async function enableSchedule(
  */
 export async function disableSchedule(
   userId: string,
-  scopeId: string,
+  clerkOrgId: string,
   composeId: string,
   name: string,
 ): Promise<ScheduleResponse> {
@@ -686,7 +687,7 @@ export async function disableSchedule(
 
   const { schedule, compose, scopeSlug } = await verifyScheduleOwnership(
     userId,
-    scopeId,
+    clerkOrgId,
     composeId,
     name,
   );

--- a/turbo/apps/web/src/lib/secret/secret-service.ts
+++ b/turbo/apps/web/src/lib/secret/secret-service.ts
@@ -44,7 +44,7 @@ interface SecretInfo {
  * List all secrets for a scope (metadata only, no values)
  */
 export async function listSecrets(
-  scopeId: string,
+  clerkOrgId: string,
   userId: string,
 ): Promise<SecretInfo[]> {
   const result = await globalThis.services.db
@@ -57,7 +57,7 @@ export async function listSecrets(
       updatedAt: secrets.updatedAt,
     })
     .from(secrets)
-    .where(and(eq(secrets.scopeId, scopeId), eq(secrets.userId, userId)))
+    .where(and(eq(secrets.clerkOrgId, clerkOrgId), eq(secrets.userId, userId)))
     .orderBy(secrets.name);
 
   return result.map((row) => ({
@@ -71,7 +71,7 @@ export async function listSecrets(
  * Only returns user-type secrets; model-provider secrets are managed via model-provider commands
  */
 export async function getSecret(
-  scopeId: string,
+  clerkOrgId: string,
   userId: string,
   name: string,
 ): Promise<SecretInfo | null> {
@@ -87,7 +87,7 @@ export async function getSecret(
     .from(secrets)
     .where(
       and(
-        eq(secrets.scopeId, scopeId),
+        eq(secrets.clerkOrgId, clerkOrgId),
         eq(secrets.userId, userId),
         eq(secrets.name, name),
         eq(secrets.type, "user"),
@@ -111,13 +111,13 @@ export async function getSecret(
  * @param type - Optional type filter to isolate user vs model-provider secrets
  */
 export async function getSecretValue(
-  scopeId: string,
+  clerkOrgId: string,
   userId: string,
   name: string,
   type?: SecretType,
 ): Promise<string | null> {
   const conditions = [
-    eq(secrets.scopeId, scopeId),
+    eq(secrets.clerkOrgId, clerkOrgId),
     eq(secrets.userId, userId),
     eq(secrets.name, name),
   ];
@@ -147,11 +147,14 @@ export async function getSecretValue(
  * @param type - Optional type filter to isolate user vs model-provider secrets
  */
 export async function getSecretValues(
-  scopeId: string,
+  clerkOrgId: string,
   userId: string,
   type?: SecretType,
 ): Promise<Record<string, string>> {
-  const conditions = [eq(secrets.scopeId, scopeId), eq(secrets.userId, userId)];
+  const conditions = [
+    eq(secrets.clerkOrgId, clerkOrgId),
+    eq(secrets.userId, userId),
+  ];
   if (type) {
     conditions.push(eq(secrets.type, type));
   }
@@ -182,13 +185,13 @@ export async function getSecretValues(
  * Used internally by connector services for managing connector/model-provider secrets.
  */
 export async function upsertSecretByScope(
+  clerkOrgId: string,
   scopeId: string,
   userId: string,
   name: string,
   value: string,
   type: SecretType,
   description: string,
-  clerkOrgId: string,
 ): Promise<void> {
   const encryptionKey = globalThis.services.env.SECRETS_ENCRYPTION_KEY;
   const encryptedValue = encryptCredentialValue(value, encryptionKey);
@@ -198,7 +201,7 @@ export async function upsertSecretByScope(
     .from(secrets)
     .where(
       and(
-        eq(secrets.scopeId, scopeId),
+        eq(secrets.clerkOrgId, clerkOrgId),
         eq(secrets.userId, userId),
         eq(secrets.name, name),
         eq(secrets.type, type),
@@ -228,11 +231,11 @@ export async function upsertSecretByScope(
  * Create or update a secret (upsert)
  */
 export async function setSecret(
+  clerkOrgId: string,
   scopeId: string,
   userId: string,
   name: string,
   value: string,
-  clerkOrgId: string,
   description?: string,
 ): Promise<SecretInfo> {
   validateSecretName(name);
@@ -240,7 +243,7 @@ export async function setSecret(
   const encryptionKey = globalThis.services.env.SECRETS_ENCRYPTION_KEY;
   const encryptedValue = encryptCredentialValue(value, encryptionKey);
 
-  log.debug("setting secret", { scopeId, name });
+  log.debug("setting secret", { clerkOrgId, name });
 
   // Check if user secret exists with same name
   // Note: We only check for user type to allow coexistence with model-provider secrets
@@ -249,7 +252,7 @@ export async function setSecret(
     .from(secrets)
     .where(
       and(
-        eq(secrets.scopeId, scopeId),
+        eq(secrets.clerkOrgId, clerkOrgId),
         eq(secrets.userId, userId),
         eq(secrets.name, name),
         eq(secrets.type, "user"),
@@ -315,7 +318,7 @@ export async function setSecret(
  * Note: Model-provider secrets are managed via model-provider commands
  */
 export async function deleteSecret(
-  scopeId: string,
+  clerkOrgId: string,
   userId: string,
   name: string,
 ): Promise<void> {
@@ -325,7 +328,7 @@ export async function deleteSecret(
     .from(secrets)
     .where(
       and(
-        eq(secrets.scopeId, scopeId),
+        eq(secrets.clerkOrgId, clerkOrgId),
         eq(secrets.userId, userId),
         eq(secrets.name, name),
         eq(secrets.type, "user"),
@@ -339,5 +342,5 @@ export async function deleteSecret(
 
   await globalThis.services.db.delete(secrets).where(eq(secrets.id, secret.id));
 
-  log.debug("secret deleted", { scopeId, name });
+  log.debug("secret deleted", { clerkOrgId, name });
 }


### PR DESCRIPTION
## Summary

Phase 3 of the Scope → Clerk migration. Switches all queries for 4 tables from `scope_id` to `clerk_org_id`:

- **secrets** — closes #4134
- **connectors** — closes #4135
- **model_providers** — closes #4136
- **agent_schedules** — closes #4133

### Changes

- **Schema files (4):** Remove scope FK references and scope-based unique indexes; keep `scopeId` column as simple `notNull()`
- **Migration (0122):** Drop 4 FK constraints + 8 scope-based indexes
- **Service files (6):** Switch all READ queries to `clerkOrgId`; WRITE functions dual-write both `clerkOrgId` and `scopeId` on INSERT
- **Critical:** `onConflictDoUpdate` targets in model-provider-service updated to match new clerkOrgId-based unique indexes
- **API routes (~20):** Pass `scope.clerkOrgId` for reads, both `scope.clerkOrgId` + `scope.id` for writes
- **Test helpers:** Updated direct DB queries to use `clerkOrgId`
- **Schedule service:** Retains `schedule.scopeId` for scope metadata lookups (`getScopeSlug`, `executeSchedule`)

Follows the same pattern as the `variables` table reference implementation (PR #4138, Migration 0120).

## Test plan

- [x] `pnpm check-types` — passes
- [x] `pnpm turbo run lint` — passes
- [x] `pnpm format` — passes
- [x] `pnpm knip` — passes
- [x] `pnpm vitest` — 3625 tests passed
- [ ] Verify migration applies cleanly on staging DB
- [ ] Verify connector CRUD operations work end-to-end
- [ ] Verify model provider upsert with onConflictDoUpdate targets

🤖 Generated with [Claude Code](https://claude.com/claude-code)