### PR TITLE
refactor(cli): migrate auth commands to withErrorHandler

### DIFF
--- a/turbo/apps/cli/src/commands/auth/logout.ts
+++ b/turbo/apps/cli/src/commands/auth/logout.ts
@@ -1,22 +1,12 @@
 import { Command } from "commander";
-import chalk from "chalk";
 import { logout } from "../../lib/api/auth";
+import { withErrorHandler } from "../../lib/command";
 
 export const logoutCommand = new Command()
   .name("logout")
   .description("Log out of VM0")
-  .action(async () => {
-    try {
+  .action(
+    withErrorHandler(async () => {
       await logout();
-    } catch (error) {
-      if (error instanceof Error) {
-        console.error(chalk.red(`✗ ${error.message}`));
-        if (error.cause instanceof Error) {
-          console.error(chalk.dim(`  Cause: ${error.cause.message}`));
-        }
-      } else {
-        console.error(chalk.red("✗ An unexpected error occurred"));
-      }
-      process.exit(1);
-    }
-  });
+    }),
+  );

--- a/turbo/apps/cli/src/commands/auth/setup-token.ts
+++ b/turbo/apps/cli/src/commands/auth/setup-token.ts
@@ -1,22 +1,12 @@
 import { Command } from "commander";
-import chalk from "chalk";
 import { setupToken } from "../../lib/api/auth";
+import { withErrorHandler } from "../../lib/command";
 
 export const setupTokenCommand = new Command()
   .name("setup-token")
   .description("Output auth token for CI/CD environments")
-  .action(async () => {
-    try {
+  .action(
+    withErrorHandler(async () => {
       await setupToken();
-    } catch (error) {
-      if (error instanceof Error) {
-        console.error(chalk.red(`✗ ${error.message}`));
-        if (error.cause instanceof Error) {
-          console.error(chalk.dim(`  Cause: ${error.cause.message}`));
-        }
-      } else {
-        console.error(chalk.red("✗ An unexpected error occurred"));
-      }
-      process.exit(1);
-    }
-  });
+    }),
+  );

--- a/turbo/apps/cli/src/commands/auth/status.ts
+++ b/turbo/apps/cli/src/commands/auth/status.ts
@@ -1,22 +1,12 @@
 import { Command } from "commander";
-import chalk from "chalk";
 import { checkAuthStatus } from "../../lib/api/auth";
+import { withErrorHandler } from "../../lib/command";
 
 export const statusCommand = new Command()
   .name("status")
   .description("Show current authentication status")
-  .action(async () => {
-    try {
+  .action(
+    withErrorHandler(async () => {
       await checkAuthStatus();
-    } catch (error) {
-      if (error instanceof Error) {
-        console.error(chalk.red(`✗ ${error.message}`));
-        if (error.cause instanceof Error) {
-          console.error(chalk.dim(`  Cause: ${error.cause.message}`));
-        }
-      } else {
-        console.error(chalk.red("✗ An unexpected error occurred"));
-      }
-      process.exit(1);
-    }
-  });
+    }),
+  );


### PR DESCRIPTION
## Summary
- Migrate `logout.ts`, `setup-token.ts`, and `status.ts` auth commands from manual try/catch error handling to centralized `withErrorHandler()` wrapper
- Part of tech debt cleanup tracked in #4155

## Test plan
- [x] All existing tests pass
- [x] lint, type-check, knip pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)