### PR TITLE
refactor: update connector token submission to use secrets api

### DIFF
--- a/turbo/apps/platform/src/signals/settings-page/connectors.ts
+++ b/turbo/apps/platform/src/signals/settings-page/connectors.ts
@@ -303,7 +303,9 @@ export const submitApiToken$ = command(
   ) => {
     const fetchFn = get(fetch$);
     for (const [name, value] of Object.entries(inputSecrets)) {
-      if (!value) continue;
+      if (!value) {
+        continue;
+      }
       const resp = await fetchFn("/api/secrets", {
         method: "PUT",
         headers: { "Content-Type": "application/json" },

--- a/turbo/apps/platform/src/signals/settings-page/connectors.ts
+++ b/turbo/apps/platform/src/signals/settings-page/connectors.ts
@@ -302,17 +302,21 @@ export const submitApiToken$ = command(
     signal: AbortSignal,
   ) => {
     const fetchFn = get(fetch$);
-    const resp = await fetchFn(`/api/connectors/${type}/token`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ secrets: inputSecrets }),
-    });
-    signal.throwIfAborted();
-    if (!resp.ok) {
-      const data = (await resp.json()) as { error?: { message?: string } };
-      throw new Error(
-        data?.error?.message ?? `Failed to submit token (${resp.status})`,
-      );
+    for (const [name, value] of Object.entries(inputSecrets)) {
+      if (!value) continue;
+      const resp = await fetchFn("/api/secrets", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name, value }),
+      });
+      signal.throwIfAborted();
+      if (!resp.ok) {
+        const data = (await resp.json()) as { error?: { message?: string } };
+        throw new Error(
+          data?.error?.message ??
+            `Failed to save secret ${name} (${resp.status})`,
+        );
+      }
     }
     signal.throwIfAborted();
     set(reloadConnectors$);

--- a/turbo/apps/platform/src/views/settings-page/__tests__/connectors.test.tsx
+++ b/turbo/apps/platform/src/views/settings-page/__tests__/connectors.test.tsx
@@ -6,7 +6,11 @@ import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { screen, within } from "@testing-library/react";
 import { userEvent } from "@testing-library/user-event";
 import { setMockConnectors } from "../../../mocks/handlers/api-connectors.ts";
-import type { ConnectorResponse } from "@vm0/core";
+import {
+  CONNECTOR_TYPES,
+  type ConnectorResponse,
+  type ConnectorType,
+} from "@vm0/core";
 
 const context = testContext();
 const user = userEvent.setup();
@@ -105,5 +109,99 @@ describe("connections tab", () => {
       expect(screen.getByText("GitHub")).toBeInTheDocument();
     });
     expect(screen.getByText("Notion")).toBeInTheDocument();
+  });
+});
+
+describe("add connection via api token", () => {
+  it("connects mercury via api token and shows connected status", async () => {
+    let capturedSecretBody: { name: string; value: string } | null = null;
+    let mercuryConnected = false;
+
+    server.use(
+      http.get("/api/connectors", () => {
+        return HttpResponse.json({
+          connectors: mercuryConnected
+            ? [
+                {
+                  id: null,
+                  type: "mercury",
+                  authMethod: "api-token",
+                  externalId: null,
+                  externalUsername: null,
+                  externalEmail: null,
+                  oauthScopes: null,
+                  createdAt: new Date().toISOString(),
+                  updatedAt: new Date().toISOString(),
+                },
+              ]
+            : [],
+          configuredTypes: Object.keys(CONNECTOR_TYPES) as ConnectorType[],
+          connectorProvidedSecretNames: [],
+        });
+      }),
+      http.put("/api/secrets", async ({ request }) => {
+        capturedSecretBody = (await request.json()) as {
+          name: string;
+          value: string;
+        };
+        mercuryConnected = true;
+        return HttpResponse.json({
+          id: crypto.randomUUID(),
+          name: capturedSecretBody.name,
+          description: null,
+          type: "user",
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        });
+      }),
+    );
+
+    await setupPage({
+      context,
+      path: "/settings?tab=connections",
+      featureSwitches: { mercuryConnector: false },
+    });
+
+    // Click "Add connection" to open the dialog
+    await user.click(screen.getByRole("button", { name: /add connection/i }));
+
+    // In the Add Connection dialog, find the Mercury card and click Connect
+    const addDialog = await screen.findByRole("dialog", {
+      name: /add connection/i,
+    });
+    const mercuryCard = within(addDialog)
+      .getByText("Mercury")
+      .closest('[class*="rounded-xl"]')!;
+    await user.click(
+      within(mercuryCard).getByRole("button", { name: /connect/i }),
+    );
+
+    // The Connect modal for Mercury should open
+    const connectModal = await screen.findByRole("dialog", {
+      name: /^mercury$/i,
+    });
+
+    // Fill in the API Token field
+    const tokenInput = within(connectModal).getByPlaceholderText(
+      /secret-token:mercury_production_/i,
+    );
+    await user.click(tokenInput);
+    await user.paste("secret-token:mercury_production_test123");
+
+    // Submit
+    await user.click(
+      within(connectModal).getByRole("button", { name: /^save$/i }),
+    );
+
+    // Verify the correct secret was sent and Mercury is now shown as connected
+    await vi.waitFor(() => {
+      expect(capturedSecretBody).toStrictEqual({
+        name: "MERCURY_TOKEN",
+        value: "secret-token:mercury_production_test123",
+      });
+      expect(
+        screen.getAllByText("Connected via API Token").length,
+      ).toBeGreaterThan(0);
+    });
   });
 });

--- a/turbo/apps/platform/src/views/settings-page/__tests__/connectors.test.tsx
+++ b/turbo/apps/platform/src/views/settings-page/__tests__/connectors.test.tsx
@@ -171,7 +171,7 @@ describe("add connection via api token", () => {
     });
     const mercuryCard = within(addDialog)
       .getByText("Mercury")
-      .closest('[class*="rounded-xl"]')!;
+      .closest('[class*="rounded-xl"]') as HTMLElement;
     await user.click(
       within(mercuryCard).getByRole("button", { name: /connect/i }),
     );


### PR DESCRIPTION
## Summary

- Replaces the single batch POST to `/api/connectors/{type}/token` with individual PUT requests to `/api/secrets` for each secret
- Skips secrets with empty/falsy values to avoid storing blank entries
- Error messages now include the specific secret name for easier debugging

## Test plan

- [ ] Verify connector token submission works end-to-end in the settings page
- [ ] Verify that empty secret values are skipped and not persisted
- [ ] Verify error messages correctly identify which secret failed to save

🤖 Generated with [Claude Code](https://claude.com/claude-code)