### PR TITLE
refactor: inline connector feature flags into connector types config

### DIFF
--- a/docs/add-oauth-connector.md
+++ b/docs/add-oauth-connector.md
@@ -11,7 +11,7 @@ Run all checks for a given `<PROVIDER>` (e.g., `hubspot`, `todoist`, `gmail`). U
 | 1 | **Connector code exists** | `ls turbo/apps/web/src/lib/connector/providers/<provider>*.ts` | Whether implementation has started |
 | 2 | **CONNECTOR_TYPES entry** | `grep '<provider>' turbo/packages/core/src/contracts/connectors.ts` | Whether the connector is registered |
 | 3 | **Feature switch exists** | `grep '<provider>' turbo/packages/core/src/feature-switch.ts` | Whether the connector is behind a feature flag |
-| 4 | **Feature switch enabled** | Check `enabled: true/false` in `FEATURE_SWITCHES[FeatureSwitchKey.<Provider>Connector]` in `turbo/packages/core/src/feature-switch.ts` | `false` = still gated (dev/testing); removed from `CONNECTOR_FEATURE_FLAGS` or `true` = public |
+| 4 | **Feature switch enabled** | Check `enabled: true/false` in `FEATURE_SWITCHES[FeatureSwitchKey.<Provider>Connector]` in `turbo/packages/core/src/feature-switch.ts` | `false` = still gated (dev/testing); `true` = public |
 | 5 | **`.env.tpl` entry** | `grep '<PREFIX>_OAUTH' turbo/apps/web/.env.local.tpl` | Whether 1Password references are set up |
 | 6 | **GitHub vars/secrets** | `gh variable list \| grep <PREFIX>_OAUTH` and `gh secret list \| grep <PREFIX>_OAUTH` | Whether CI/CD credentials are synced |
 | 7 | **Workflow env vars** | `grep '<PREFIX>_OAUTH' .github/workflows/turbo.yml .github/workflows/release-please.yml` | Whether deploy pipelines pass the credentials |

--- a/turbo/apps/cli/src/commands/connector/connect.ts
+++ b/turbo/apps/cli/src/commands/connector/connect.ts
@@ -3,7 +3,6 @@ import chalk from "chalk";
 import { initClient } from "@ts-rest/core";
 import {
   CONNECTOR_TYPES,
-  CONNECTOR_FEATURE_FLAGS,
   connectorSessionsContract,
   connectorSessionByIdContract,
   connectorTypeSchema,
@@ -164,7 +163,7 @@ async function resolveAuthMethod(
   tokenFlag?: string,
 ): Promise<"oauth" | "api-token"> {
   const config = CONNECTOR_TYPES[connectorType];
-  const oauthFlag = CONNECTOR_FEATURE_FLAGS[connectorType];
+  const oauthFlag = CONNECTOR_TYPES[connectorType].featureFlag;
   const oauthAvailable =
     "oauth" in config.authMethods &&
     (!oauthFlag || (await isFeatureEnabled(oauthFlag)));

--- a/turbo/apps/cli/src/commands/connector/list.ts
+++ b/turbo/apps/cli/src/commands/connector/list.ts
@@ -2,7 +2,6 @@ import { Command } from "commander";
 import chalk from "chalk";
 import {
   CONNECTOR_TYPES,
-  CONNECTOR_FEATURE_FLAGS,
   isFeatureEnabled,
   type ConnectorType,
 } from "@vm0/core";
@@ -21,7 +20,7 @@ export const listCommand = new Command()
       const allTypesRaw = Object.keys(CONNECTOR_TYPES) as ConnectorType[];
       const allTypes: ConnectorType[] = [];
       for (const type of allTypesRaw) {
-        const flag = CONNECTOR_FEATURE_FLAGS[type];
+        const flag = CONNECTOR_TYPES[type].featureFlag;
         const hasApiToken = "api-token" in CONNECTOR_TYPES[type].authMethods;
         if (flag && !(await isFeatureEnabled(flag)) && !hasApiToken) {
           continue;

--- a/turbo/apps/platform/src/signals/settings-page/connectors.ts
+++ b/turbo/apps/platform/src/signals/settings-page/connectors.ts
@@ -2,7 +2,6 @@ import { command, computed, state } from "ccstate";
 import { toast } from "@vm0/ui/components/ui/sonner";
 import {
   CONNECTOR_TYPES,
-  FeatureSwitchKey,
   hasRequiredScopes,
   type ConnectorType,
   type ConnectorResponse,
@@ -44,37 +43,6 @@ export interface ConnectorTypeWithStatus {
   scopeMismatch: boolean;
 }
 
-/**
- * Maps connector types to their OAuth feature switch keys.
- * Controls whether the OAuth auth method is available for each connector.
- * Connectors not listed here have OAuth always available.
- */
-const CONNECTOR_FEATURE_FLAGS = Object.freeze<
-  Partial<Record<ConnectorType, FeatureSwitchKey>>
->({
-  canva: FeatureSwitchKey.CanvaConnector,
-  computer: FeatureSwitchKey.ComputerConnector,
-  deel: FeatureSwitchKey.DeelConnector,
-  docusign: FeatureSwitchKey.DocuSignConnector,
-  dropbox: FeatureSwitchKey.DropboxConnector,
-  figma: FeatureSwitchKey.FigmaConnector,
-  gmail: FeatureSwitchKey.GmailConnector,
-  "google-sheets": FeatureSwitchKey.GoogleSheetsConnector,
-  "google-docs": FeatureSwitchKey.GoogleDocsConnector,
-  "google-drive": FeatureSwitchKey.GoogleDriveConnector,
-  "google-calendar": FeatureSwitchKey.GoogleCalendarConnector,
-  mercury: FeatureSwitchKey.MercuryConnector,
-  neon: FeatureSwitchKey.NeonConnector,
-  strava: FeatureSwitchKey.StravaConnector,
-  "garmin-connect": FeatureSwitchKey.GarminConnectConnector,
-  reddit: FeatureSwitchKey.RedditConnector,
-  "intervals-icu": FeatureSwitchKey.IntervalsIcuConnector,
-  supabase: FeatureSwitchKey.SupabaseConnector,
-  webflow: FeatureSwitchKey.WebflowConnector,
-  "meta-ads": FeatureSwitchKey.MetaAdsConnector,
-  stripe: FeatureSwitchKey.StripeConnector,
-});
-
 export const allConnectorTypes$ = computed(async (get) => {
   const { connectors } = await get(connectors$);
   const connectorMap = new Map(connectors.map((c) => [c.type, c]));
@@ -82,7 +50,7 @@ export const allConnectorTypes$ = computed(async (get) => {
 
   return (Object.keys(CONNECTOR_TYPES) as ConnectorType[])
     .filter((type) => {
-      const flag = CONNECTOR_FEATURE_FLAGS[type];
+      const flag = CONNECTOR_TYPES[type].featureFlag;
       const oauthEnabled = !flag || !!features?.[flag];
       const hasApiToken = "api-token" in CONNECTOR_TYPES[type].authMethods;
       // Connector visible if OAuth is enabled OR it has an api-token method
@@ -91,7 +59,7 @@ export const allConnectorTypes$ = computed(async (get) => {
     .map((type) => {
       const config = CONNECTOR_TYPES[type];
       const connector = connectorMap.get(type) ?? null;
-      const flag = CONNECTOR_FEATURE_FLAGS[type];
+      const flag = CONNECTOR_TYPES[type].featureFlag;
       const oauthEnabled = !flag || !!features?.[flag];
       const hasApiToken = "api-token" in config.authMethods;
       const availableAuthMethods: string[] = [];

--- a/turbo/packages/core/src/contracts/connectors.ts
+++ b/turbo/packages/core/src/contracts/connectors.ts
@@ -34,6 +34,19 @@ export interface ConnectorOAuthConfig {
 }
 
 /**
+ * Base configuration shape for all connector types.
+ */
+interface ConnectorConfig {
+  readonly label: string;
+  readonly helpText: string;
+  readonly featureFlag?: FeatureSwitchKey;
+  readonly authMethods: Record<string, ConnectorAuthMethodConfig>;
+  readonly defaultAuthMethod?: string;
+  readonly environmentMapping?: Record<string, string>;
+  readonly oauth?: ConnectorOAuthConfig;
+}
+
+/**
  * Connector type configuration
  * Maps type to display info, auth methods, and environment mapping
  *
@@ -41,7 +54,7 @@ export interface ConnectorOAuthConfig {
  * - `$secrets.X` - lookup secret X from the connector's secrets
  * - Other values are passed through as literals
  */
-export const CONNECTOR_TYPES = {
+export const CONNECTOR_TYPES: Record<ConnectorType, ConnectorConfig> = {
   axiom: {
     label: "Axiom",
     helpText:

--- a/turbo/packages/core/src/contracts/connectors.ts
+++ b/turbo/packages/core/src/contracts/connectors.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { authHeadersSchema, initContract } from "./base";
 import { apiErrorSchema } from "./errors";
+import { FeatureSwitchKey } from "../feature-switch-key";
 
 const c = initContract();
 
@@ -66,6 +67,7 @@ export const CONNECTOR_TYPES = {
   },
   ahrefs: {
     label: "Ahrefs",
+    featureFlag: FeatureSwitchKey.AhrefsConnector,
     helpText:
       "Connect your Ahrefs account to access SEO data, backlink analysis, and keyword research",
     authMethods: {
@@ -225,6 +227,7 @@ export const CONNECTOR_TYPES = {
   },
   gmail: {
     label: "Gmail",
+    featureFlag: FeatureSwitchKey.GmailConnector,
     helpText: "Connect your Gmail account to send and read emails",
     authMethods: {
       oauth: {
@@ -254,6 +257,7 @@ export const CONNECTOR_TYPES = {
   },
   "google-sheets": {
     label: "Google Sheets",
+    featureFlag: FeatureSwitchKey.GoogleSheetsConnector,
     helpText: "Connect your Google account to access and manage spreadsheets",
     authMethods: {
       oauth: {
@@ -286,6 +290,7 @@ export const CONNECTOR_TYPES = {
   },
   "google-docs": {
     label: "Google Docs",
+    featureFlag: FeatureSwitchKey.GoogleDocsConnector,
     helpText: "Connect your Google account to access and manage documents",
     authMethods: {
       oauth: {
@@ -318,6 +323,7 @@ export const CONNECTOR_TYPES = {
   },
   "google-drive": {
     label: "Google Drive",
+    featureFlag: FeatureSwitchKey.GoogleDriveConnector,
     helpText: "Connect your Google account to access and manage files in Drive",
     authMethods: {
       oauth: {
@@ -350,6 +356,7 @@ export const CONNECTOR_TYPES = {
   },
   "google-calendar": {
     label: "Google Calendar",
+    featureFlag: FeatureSwitchKey.GoogleCalendarConnector,
     helpText:
       "Connect your Google account to access and manage calendar events",
     authMethods: {
@@ -383,6 +390,7 @@ export const CONNECTOR_TYPES = {
   },
   close: {
     label: "Close",
+    featureFlag: FeatureSwitchKey.CloseConnector,
     helpText:
       "Connect your Close account to manage leads, contacts, and opportunities",
     authMethods: {
@@ -456,6 +464,7 @@ export const CONNECTOR_TYPES = {
   },
   computer: {
     label: "Computer",
+    featureFlag: FeatureSwitchKey.ComputerConnector,
     helpText:
       "Expose local services to remote sandboxes via authenticated ngrok tunnels",
     authMethods: {
@@ -519,6 +528,7 @@ export const CONNECTOR_TYPES = {
   },
   docusign: {
     label: "DocuSign",
+    featureFlag: FeatureSwitchKey.DocuSignConnector,
     helpText:
       "Connect your DocuSign account to send and manage electronic signatures",
     authMethods: {
@@ -549,6 +559,7 @@ export const CONNECTOR_TYPES = {
   },
   dropbox: {
     label: "Dropbox",
+    featureFlag: FeatureSwitchKey.DropboxConnector,
     helpText: "Connect your Dropbox account to access and manage files",
     authMethods: {
       oauth: {
@@ -623,6 +634,7 @@ export const CONNECTOR_TYPES = {
   },
   deel: {
     label: "Deel",
+    featureFlag: FeatureSwitchKey.DeelConnector,
     helpText:
       "Connect your Deel account to access HR, payroll, and contractor data",
     authMethods: {
@@ -673,6 +685,7 @@ export const CONNECTOR_TYPES = {
   },
   figma: {
     label: "Figma",
+    featureFlag: FeatureSwitchKey.FigmaConnector,
     helpText: "Connect your Figma account to access design files and projects",
     authMethods: {
       oauth: {
@@ -724,6 +737,7 @@ export const CONNECTOR_TYPES = {
   },
   mercury: {
     label: "Mercury",
+    featureFlag: FeatureSwitchKey.MercuryConnector,
     helpText:
       "Connect your Mercury account to access banking and financial data",
     authMethods: {
@@ -766,6 +780,7 @@ export const CONNECTOR_TYPES = {
   },
   reddit: {
     label: "Reddit",
+    featureFlag: FeatureSwitchKey.RedditConnector,
     helpText:
       "Connect your Reddit account to access Reddit discussions and content",
     authMethods: {
@@ -796,6 +811,7 @@ export const CONNECTOR_TYPES = {
   },
   strava: {
     label: "Strava",
+    featureFlag: FeatureSwitchKey.StravaConnector,
     helpText:
       "Connect your Strava account to access activities and athlete data",
     authMethods: {
@@ -861,6 +877,7 @@ export const CONNECTOR_TYPES = {
   },
   neon: {
     label: "Neon",
+    featureFlag: FeatureSwitchKey.NeonConnector,
     helpText:
       "Connect your Neon account to manage serverless Postgres databases and projects",
     authMethods: {
@@ -910,6 +927,7 @@ export const CONNECTOR_TYPES = {
   },
   "garmin-connect": {
     label: "Garmin Connect",
+    featureFlag: FeatureSwitchKey.GarminConnectConnector,
     helpText:
       "Connect your Garmin Connect account to access wellness and activity data",
     authMethods: {
@@ -1002,6 +1020,7 @@ export const CONNECTOR_TYPES = {
   },
   posthog: {
     label: "PostHog",
+    featureFlag: FeatureSwitchKey.PosthogConnector,
     helpText:
       "Connect your PostHog account to access product analytics, feature flags, and experiments",
     authMethods: {
@@ -1090,6 +1109,7 @@ export const CONNECTOR_TYPES = {
   },
   "intervals-icu": {
     label: "Intervals.icu",
+    featureFlag: FeatureSwitchKey.IntervalsIcuConnector,
     helpText:
       "Connect your Intervals.icu account to access training, activity, wellness, and calendar data",
     authMethods: {
@@ -1172,6 +1192,7 @@ export const CONNECTOR_TYPES = {
   },
   canva: {
     label: "Canva",
+    featureFlag: FeatureSwitchKey.CanvaConnector,
     helpText:
       "Connect your Canva account to access designs, assets, and projects",
     authMethods: {
@@ -1268,6 +1289,7 @@ export const CONNECTOR_TYPES = {
   },
   supabase: {
     label: "Supabase",
+    featureFlag: FeatureSwitchKey.SupabaseConnector,
     helpText:
       "Connect your Supabase account to manage projects, databases, and APIs",
     authMethods: {
@@ -1349,6 +1371,7 @@ export const CONNECTOR_TYPES = {
   },
   webflow: {
     label: "Webflow",
+    featureFlag: FeatureSwitchKey.WebflowConnector,
     helpText:
       "Connect your Webflow account to manage sites, pages, CMS collections, and ecommerce",
     authMethods: {
@@ -1403,6 +1426,7 @@ export const CONNECTOR_TYPES = {
   },
   "outlook-mail": {
     label: "Outlook Mail",
+    featureFlag: FeatureSwitchKey.OutlookMailConnector,
     helpText: "Connect your Microsoft Outlook account to send and read emails",
     authMethods: {
       oauth: {
@@ -1433,6 +1457,7 @@ export const CONNECTOR_TYPES = {
   },
   "outlook-calendar": {
     label: "Outlook Calendar",
+    featureFlag: FeatureSwitchKey.OutlookCalendarConnector,
     helpText:
       "Connect your Microsoft account to access and manage Outlook calendar events",
     authMethods: {
@@ -1494,6 +1519,7 @@ export const CONNECTOR_TYPES = {
   },
   "meta-ads": {
     label: "Meta Ads",
+    featureFlag: FeatureSwitchKey.MetaAdsConnector,
     helpText:
       "Connect your Meta Ads Manager account to manage ad campaigns, audiences, and insights",
     authMethods: {
@@ -1520,6 +1546,7 @@ export const CONNECTOR_TYPES = {
   },
   stripe: {
     label: "Stripe",
+    featureFlag: FeatureSwitchKey.StripeConnector,
     helpText:
       "Connect your Stripe account to manage payments, customers, and subscriptions",
     authMethods: {
@@ -1596,6 +1623,7 @@ export const CONNECTOR_TYPES = {
   },
   mailchimp: {
     label: "Mailchimp",
+    featureFlag: FeatureSwitchKey.MailchimpConnector,
     helpText:
       "Connect your Mailchimp account to manage audiences, campaigns, templates, and automations",
     authMethods: {
@@ -1624,6 +1652,7 @@ export const CONNECTOR_TYPES = {
   },
   resend: {
     label: "Resend",
+    featureFlag: FeatureSwitchKey.ResendConnector,
     helpText:
       "Connect your Resend account to send transactional emails, manage domains, audiences, and contacts",
     authMethods: {

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -6,7 +6,6 @@
  */
 
 import { FeatureSwitchKey } from "./feature-switch-key";
-import type { ConnectorType } from "./contracts/connectors";
 
 export interface FeatureSwitch {
   readonly maintainer: string;
@@ -220,44 +219,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     maintainer: "ethan@vm0.ai",
     enabled: false,
   },
-};
-
-/**
- * Maps connector types to their feature switch keys.
- * Connectors not listed here are always visible.
- */
-export const CONNECTOR_FEATURE_FLAGS: Partial<
-  Record<ConnectorType, FeatureSwitchKey>
-> = {
-  ahrefs: FeatureSwitchKey.AhrefsConnector,
-  canva: FeatureSwitchKey.CanvaConnector,
-  close: FeatureSwitchKey.CloseConnector,
-  computer: FeatureSwitchKey.ComputerConnector,
-  deel: FeatureSwitchKey.DeelConnector,
-  docusign: FeatureSwitchKey.DocuSignConnector,
-  dropbox: FeatureSwitchKey.DropboxConnector,
-  figma: FeatureSwitchKey.FigmaConnector,
-  gmail: FeatureSwitchKey.GmailConnector,
-  "google-sheets": FeatureSwitchKey.GoogleSheetsConnector,
-  "google-docs": FeatureSwitchKey.GoogleDocsConnector,
-  "google-drive": FeatureSwitchKey.GoogleDriveConnector,
-  "google-calendar": FeatureSwitchKey.GoogleCalendarConnector,
-  mercury: FeatureSwitchKey.MercuryConnector,
-  neon: FeatureSwitchKey.NeonConnector,
-  strava: FeatureSwitchKey.StravaConnector,
-  "garmin-connect": FeatureSwitchKey.GarminConnectConnector,
-
-  reddit: FeatureSwitchKey.RedditConnector,
-  "intervals-icu": FeatureSwitchKey.IntervalsIcuConnector,
-  supabase: FeatureSwitchKey.SupabaseConnector,
-  webflow: FeatureSwitchKey.WebflowConnector,
-  "outlook-mail": FeatureSwitchKey.OutlookMailConnector,
-  "outlook-calendar": FeatureSwitchKey.OutlookCalendarConnector,
-  "meta-ads": FeatureSwitchKey.MetaAdsConnector,
-  stripe: FeatureSwitchKey.StripeConnector,
-  posthog: FeatureSwitchKey.PosthogConnector,
-  mailchimp: FeatureSwitchKey.MailchimpConnector,
-  resend: FeatureSwitchKey.ResendConnector,
 };
 
 /**


### PR DESCRIPTION
## Summary

- Moves `featureFlag` property directly into each connector's definition in `CONNECTOR_TYPES` instead of maintaining a separate `CONNECTOR_FEATURE_FLAGS` map
- Removes the standalone `CONNECTOR_FEATURE_FLAGS` export from `feature-switch.ts` and the local copy in `connectors.ts` (platform signals)
- Consumers now read `CONNECTOR_TYPES[type].featureFlag` directly, eliminating the need to cross-reference a separate lookup table

## Test plan

- [ ] Verify `connector list` CLI command still filters connectors by feature flag correctly
- [ ] Verify `connector connect` CLI command still resolves auth method (oauth vs api-token) correctly
- [ ] Verify the platform settings page still shows/hides connectors based on feature flags

🤖 Generated with [Claude Code](https://claude.com/claude-code)