### PR TITLE
refactor(cli): replace process.exit with throw in scope members command

### DIFF
--- a/turbo/apps/cli/src/commands/scope/members.ts
+++ b/turbo/apps/cli/src/commands/scope/members.ts
@@ -8,7 +8,24 @@ export const membersCommand = new Command()
   .description("View scope members")
   .action(
     withErrorHandler(async () => {
-      const status = await getScopeMembers().catch((error: unknown) => {
+      try {
+        const status = await getScopeMembers();
+
+        console.log(chalk.bold(`Scope: ${status.slug}`));
+        console.log(`  Role: ${status.role}`);
+        console.log(
+          `  Created: ${new Date(status.createdAt).toLocaleDateString()}`,
+        );
+        console.log();
+        console.log(chalk.bold("Members:"));
+        for (const member of status.members) {
+          const roleTag =
+            member.role === "admin"
+              ? chalk.yellow(` (${member.role})`)
+              : chalk.dim(` (${member.role})`);
+          console.log(`  ${member.email}${roleTag}`);
+        }
+      } catch (error) {
         if (
           error instanceof Error &&
           error.message.includes("Organization access token required")
@@ -18,21 +35,6 @@ export const membersCommand = new Command()
           });
         }
         throw error;
-      });
-
-      console.log(chalk.bold(`Scope: ${status.slug}`));
-      console.log(`  Role: ${status.role}`);
-      console.log(
-        `  Created: ${new Date(status.createdAt).toLocaleDateString()}`,
-      );
-      console.log();
-      console.log(chalk.bold("Members:"));
-      for (const member of status.members) {
-        const roleTag =
-          member.role === "admin"
-            ? chalk.yellow(` (${member.role})`)
-            : chalk.dim(` (${member.role})`);
-        console.log(`  ${member.email}${roleTag}`);
       }
     }),
   );

--- a/turbo/apps/cli/src/commands/scope/members.ts
+++ b/turbo/apps/cli/src/commands/scope/members.ts
@@ -8,34 +8,31 @@ export const membersCommand = new Command()
   .description("View scope members")
   .action(
     withErrorHandler(async () => {
-      try {
-        const status = await getScopeMembers();
-
-        console.log(chalk.bold(`Scope: ${status.slug}`));
-        console.log(`  Role: ${status.role}`);
-        console.log(
-          `  Created: ${new Date(status.createdAt).toLocaleDateString()}`,
-        );
-        console.log();
-        console.log(chalk.bold("Members:"));
-        for (const member of status.members) {
-          const roleTag =
-            member.role === "admin"
-              ? chalk.yellow(` (${member.role})`)
-              : chalk.dim(` (${member.role})`);
-          console.log(`  ${member.email}${roleTag}`);
-        }
-      } catch (error) {
+      const status = await getScopeMembers().catch((error: unknown) => {
         if (
           error instanceof Error &&
           error.message.includes("Organization access token required")
         ) {
-          console.error(
-            chalk.red("✗ No active scope selected. Run: vm0 scope use <slug>"),
-          );
-          process.exit(1);
+          throw new Error("No active scope selected", {
+            cause: new Error("Run: vm0 scope use <slug>"),
+          });
         }
         throw error;
+      });
+
+      console.log(chalk.bold(`Scope: ${status.slug}`));
+      console.log(`  Role: ${status.role}`);
+      console.log(
+        `  Created: ${new Date(status.createdAt).toLocaleDateString()}`,
+      );
+      console.log();
+      console.log(chalk.bold("Members:"));
+      for (const member of status.members) {
+        const roleTag =
+          member.role === "admin"
+            ? chalk.yellow(` (${member.role})`)
+            : chalk.dim(` (${member.role})`);
+        console.log(`  ${member.email}${roleTag}`);
       }
     }),
   );


### PR DESCRIPTION
## Summary
- Replace inner `process.exit(1)` with `throw new Error()` + `cause` pattern inside `withErrorHandler` in `scope/members.ts`
- Eliminates the dual exit path anti-pattern (same fix as #4165 for `agent/delete.ts`)
- Error "Organization access token required" is now mapped to a user-friendly message via throw + cause, letting `withErrorHandler` handle formatting and exit

## Test plan
- [x] Type check passes
- [x] `members.test.ts` — 2 tests pass
- [x] Knip clean

Part of #4155

🤖 Generated with [Claude Code](https://claude.com/claude-code)