### PR TITLE
fix: preserve line breaks in connection dialog help text

### DIFF
--- a/turbo/apps/platform/src/views/settings-page/add-connection-dialog.tsx
+++ b/turbo/apps/platform/src/views/settings-page/add-connection-dialog.tsx
@@ -121,7 +121,7 @@ function ApiTokenForm({
       )}
       {apiTokenConfig.helpText && (
         <div
-          className="text-sm text-muted-foreground leading-relaxed [&_a]:text-primary [&_a]:underline"
+          className="text-sm text-muted-foreground leading-relaxed whitespace-pre-line [&_a]:text-primary [&_a]:underline"
           dangerouslySetInnerHTML={{
             __html: renderMarkdown(apiTokenConfig.helpText),
           }}


### PR DESCRIPTION
## Summary

- Adds `whitespace-pre-line` Tailwind class to the help text container in the API token form within the add connection dialog
- This ensures that newline characters in `helpText` content are rendered as visible line breaks in the UI

## Test plan

- [ ] Open the add connection dialog for a connector that has multi-line `helpText`
- [ ] Verify that line breaks in the help text are displayed correctly in the rendered output

🤖 Generated with [Claude Code](https://claude.com/claude-code)