### PR TITLE
fix: resolve circular type reference in connector types

### DIFF
--- a/turbo/apps/platform/src/signals/agent-detail/connections.ts
+++ b/turbo/apps/platform/src/signals/agent-detail/connections.ts
@@ -98,7 +98,7 @@ export const agentRequiredConnectorTypes$ = computed(
         if (type === "computer") {
           continue;
         }
-        const mapping = CONNECTOR_TYPES[type].environmentMapping;
+        const mapping = CONNECTOR_TYPES[type].environmentMapping ?? {};
         for (const envKey of Object.keys(mapping)) {
           if (envVarNames.has(envKey)) {
             required.add(type);

--- a/turbo/apps/platform/src/signals/environment-variables-setup/environment-variables-setup.ts
+++ b/turbo/apps/platform/src/signals/environment-variables-setup/environment-variables-setup.ts
@@ -60,7 +60,7 @@ interface MissingItem {
 function buildEnvVarToConnectorMap(): Readonly<Record<string, ConnectorType>> {
   const map: Record<string, ConnectorType> = {};
   for (const [type, config] of Object.entries(CONNECTOR_TYPES)) {
-    for (const envVar of Object.keys(config.environmentMapping)) {
+    for (const envVar of Object.keys(config.environmentMapping ?? {})) {
       map[envVar] = type as ConnectorType;
     }
   }

--- a/turbo/packages/core/src/contracts/connectors.ts
+++ b/turbo/packages/core/src/contracts/connectors.ts
@@ -36,7 +36,7 @@ export interface ConnectorOAuthConfig {
 /**
  * Base configuration shape for all connector types.
  */
-interface ConnectorConfig {
+export interface ConnectorConfig {
   readonly label: string;
   readonly helpText: string;
   readonly featureFlag?: FeatureSwitchKey;
@@ -54,7 +54,7 @@ interface ConnectorConfig {
  * - `$secrets.X` - lookup secret X from the connector's secrets
  * - Other values are passed through as literals
  */
-export const CONNECTOR_TYPES: Record<ConnectorType, ConnectorConfig> = {
+const CONNECTOR_TYPES_DEF = {
   axiom: {
     label: "Axiom",
     helpText:
@@ -1687,9 +1687,12 @@ export const CONNECTOR_TYPES: Record<ConnectorType, ConnectorConfig> = {
       RESEND_API_KEY: "$secrets.RESEND_API_KEY",
     } as Record<string, string>,
   },
-} as const;
+} satisfies Record<string, ConnectorConfig>;
 
-export type ConnectorType = keyof typeof CONNECTOR_TYPES;
+export type ConnectorType = keyof typeof CONNECTOR_TYPES_DEF;
+
+export const CONNECTOR_TYPES: Record<ConnectorType, ConnectorConfig> =
+  CONNECTOR_TYPES_DEF;
 
 /**
  * Proxy-side connector configuration for token replacement.

--- a/turbo/packages/core/src/contracts/connectors.ts
+++ b/turbo/packages/core/src/contracts/connectors.ts
@@ -2088,7 +2088,9 @@ export function getConnectorAuthMethods(
 /**
  * Get default auth method for a connector type
  */
-export function getConnectorDefaultAuthMethod(type: ConnectorType): string {
+export function getConnectorDefaultAuthMethod(
+  type: ConnectorType,
+): string | undefined {
   return CONNECTOR_TYPES[type].defaultAuthMethod;
 }
 
@@ -2120,7 +2122,7 @@ export function getConnectorSecretNames(
 export function getConnectorEnvironmentMapping(
   type: ConnectorType,
 ): Record<string, string> {
-  return CONNECTOR_TYPES[type].environmentMapping;
+  return CONNECTOR_TYPES[type].environmentMapping ?? {};
 }
 
 /**

--- a/turbo/packages/core/src/contracts/index.ts
+++ b/turbo/packages/core/src/contracts/index.ts
@@ -433,6 +433,7 @@ export {
   type ConnectorListResponse,
   type ConnectorSessionResponse,
   type ConnectorSessionStatusResponse,
+  type ConnectorConfig,
   type ConnectorSecretConfig,
   type ConnectorAuthMethodConfig,
   type ConnectorOAuthConfig,


### PR DESCRIPTION
## Summary

- `CONNECTOR_TYPES: Record<ConnectorType, ConnectorConfig>` and `ConnectorType = keyof typeof CONNECTOR_TYPES` formed a circular type reference introduced in #4203
- Split into `CONNECTOR_TYPES_DEF` (unannotated internal object for key inference) and `CONNECTOR_TYPES` (exported, typed as `Record<ConnectorType, ConnectorConfig>`)
- `ConnectorType` is now derived from `CONNECTOR_TYPES_DEF` before `CONNECTOR_TYPES` is declared — no circularity
- Also exports `ConnectorConfig` interface via `contracts/index.ts`

## Test plan

- [ ] `pnpm build` passes with no type errors
- [ ] `pnpm lint` passes for core, cli, platform
- [ ] CI `lint-types` passes on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)