### PR TITLE
refactor(cli): replace process.exit with throw in scope set command

### DIFF
--- a/turbo/apps/cli/src/commands/scope/set.ts
+++ b/turbo/apps/cli/src/commands/scope/set.ts
@@ -14,19 +14,9 @@ export const setCommand = new Command()
         const existingScope = await getScope();
 
         if (!options.force) {
-          console.error(
-            chalk.yellow(`You already have a scope: ${existingScope.slug}`),
-          );
-          console.error();
-          console.error("To change your scope, use --force:");
-          console.error(chalk.cyan(`  vm0 scope set ${slug} --force`));
-          console.error();
-          console.error(
-            chalk.yellow(
-              "Warning: Changing your scope may break existing agent references.",
-            ),
-          );
-          process.exit(1);
+          throw new Error(`You already have a scope: ${existingScope.slug}`, {
+            cause: new Error(`To change, use: vm0 scope set ${slug} --force`),
+          });
         }
 
         const scope = await updateScope({ slug, force: true });
@@ -39,12 +29,9 @@ export const setCommand = new Command()
           error instanceof Error &&
           error.message.includes("already exists")
         ) {
-          console.error(
-            chalk.red(
-              `✗ Scope "${slug}" is already taken. Please choose a different slug.`,
-            ),
+          throw new Error(
+            `Scope "${slug}" is already taken. Please choose a different slug.`,
           );
-          process.exit(1);
         }
         throw error;
       }


### PR DESCRIPTION
## Summary
- Replace 2x `process.exit(1)` with `throw new Error()` + cause inside `withErrorHandler` in scope set command
- Existing scope without `--force`: throws with cause hint
- Slug already taken: throws with descriptive message

Part of #4155

## Test plan
- [x] Type check passes
- [x] Lint passes
- [x] Knip clean
- [x] Existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)