### PR TITLE
refactor(cli): replace process.exit with throw in scope status command

### DIFF
--- a/turbo/apps/cli/src/commands/scope/__tests__/status.test.ts
+++ b/turbo/apps/cli/src/commands/scope/__tests__/status.test.ts
@@ -54,10 +54,10 @@ describe("scope status command", () => {
         await statusCommand.parseAsync(["node", "cli"]);
       }).rejects.toThrow("process.exit called");
 
-      expect(mockConsoleLog).toHaveBeenCalledWith(
+      expect(mockConsoleError).toHaveBeenCalledWith(
         expect.stringContaining("No scope configured"),
       );
-      expect(mockConsoleLog).toHaveBeenCalledWith(
+      expect(mockConsoleError).toHaveBeenCalledWith(
         expect.stringContaining("vm0 scope set"),
       );
       expect(mockExit).toHaveBeenCalledWith(1);

--- a/turbo/apps/cli/src/commands/scope/status.ts
+++ b/turbo/apps/cli/src/commands/scope/status.ts
@@ -21,14 +21,9 @@ export const statusCommand = new Command()
           error instanceof Error &&
           error.message.includes("No scope configured")
         ) {
-          console.log(chalk.yellow("No scope configured"));
-          console.log();
-          console.log("Set your scope with:");
-          console.log(chalk.cyan("  vm0 scope set <slug>"));
-          console.log();
-          console.log("Example:");
-          console.log(chalk.dim("  vm0 scope set myusername"));
-          process.exit(1);
+          throw new Error("No scope configured", {
+            cause: new Error("Set your scope with: vm0 scope set <slug>"),
+          });
         }
         throw error;
       }


### PR DESCRIPTION
## Summary
- Replace `process.exit(1)` with `throw new Error()` + cause inside `withErrorHandler` in scope status command
- No scope configured: throws with cause hint to use `vm0 scope set`
- Update test assertions to match new error output format

Part of #4155

## Test plan
- [x] Type check passes
- [x] Lint passes
- [x] Knip clean
- [x] Tests updated and passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)