### PR TITLE
refactor(cli): replace process.exit with throw in storage status commands

### DIFF
--- a/turbo/apps/cli/src/commands/artifact/status.ts
+++ b/turbo/apps/cli/src/commands/artifact/status.ts
@@ -15,19 +15,16 @@ export const statusCommand = new Command()
       // Read config
       const config = await readStorageConfig(cwd);
       if (!config) {
-        console.error(chalk.red("✗ No artifact initialized in this directory"));
-        console.error(chalk.dim("  Run: vm0 artifact init"));
-        process.exit(1);
+        throw new Error("No artifact initialized in this directory", {
+          cause: new Error("Run: vm0 artifact init"),
+        });
       }
 
       if (config.type !== "artifact") {
-        console.error(
-          chalk.red(
-            "✗ This directory is initialized as a volume, not an artifact",
-          ),
+        throw new Error(
+          "This directory is initialized as a volume, not an artifact",
+          { cause: new Error("Use: vm0 volume status") },
         );
-        console.error(chalk.dim("  Use: vm0 volume status"));
-        process.exit(1);
       }
 
       // Start message
@@ -52,9 +49,9 @@ export const statusCommand = new Command()
         }
       } catch (error) {
         if (error instanceof ApiRequestError && error.status === 404) {
-          console.error(chalk.red("✗ Not found on remote"));
-          console.error(chalk.dim("  Run: vm0 artifact push"));
-          process.exit(1);
+          throw new Error("Not found on remote", {
+            cause: new Error("Run: vm0 artifact push"),
+          });
         }
         throw error;
       }

--- a/turbo/apps/cli/src/commands/memory/status.ts
+++ b/turbo/apps/cli/src/commands/memory/status.ts
@@ -15,19 +15,16 @@ export const statusCommand = new Command()
       // Read config
       const config = await readStorageConfig(cwd);
       if (!config) {
-        console.error(chalk.red("✗ No memory initialized in this directory"));
-        console.error(chalk.dim("  Run: vm0 memory init"));
-        process.exit(1);
+        throw new Error("No memory initialized in this directory", {
+          cause: new Error("Run: vm0 memory init"),
+        });
       }
 
       if (config.type !== "memory") {
-        console.error(
-          chalk.red(
-            `✗ This directory is initialized as ${config.type === "artifact" ? "an artifact" : "a volume"}, not a memory`,
-          ),
+        throw new Error(
+          `This directory is initialized as ${config.type === "artifact" ? "an artifact" : "a volume"}, not a memory`,
+          { cause: new Error(`Use: vm0 ${config.type} status`) },
         );
-        console.error(chalk.dim(`  Use: vm0 ${config.type} status`));
-        process.exit(1);
       }
 
       // Start message
@@ -52,9 +49,9 @@ export const statusCommand = new Command()
         }
       } catch (error) {
         if (error instanceof ApiRequestError && error.status === 404) {
-          console.error(chalk.red("✗ Not found on remote"));
-          console.error(chalk.dim("  Run: vm0 memory push"));
-          process.exit(1);
+          throw new Error("Not found on remote", {
+            cause: new Error("Run: vm0 memory push"),
+          });
         }
         throw error;
       }

--- a/turbo/apps/cli/src/commands/volume/status.ts
+++ b/turbo/apps/cli/src/commands/volume/status.ts
@@ -15,19 +15,16 @@ export const statusCommand = new Command()
       // Read config
       const config = await readStorageConfig(cwd);
       if (!config) {
-        console.error(chalk.red("✗ No volume initialized in this directory"));
-        console.error(chalk.dim("  Run: vm0 volume init"));
-        process.exit(1);
+        throw new Error("No volume initialized in this directory", {
+          cause: new Error("Run: vm0 volume init"),
+        });
       }
 
       if (config.type !== "volume") {
-        console.error(
-          chalk.red(
-            "✗ This directory is initialized as an artifact, not a volume",
-          ),
+        throw new Error(
+          "This directory is initialized as an artifact, not a volume",
+          { cause: new Error("Use: vm0 artifact status") },
         );
-        console.error(chalk.dim("  Use: vm0 artifact status"));
-        process.exit(1);
       }
 
       // Start message
@@ -52,9 +49,9 @@ export const statusCommand = new Command()
         }
       } catch (error) {
         if (error instanceof ApiRequestError && error.status === 404) {
-          console.error(chalk.red("✗ Not found on remote"));
-          console.error(chalk.dim("  Run: vm0 volume push"));
-          process.exit(1);
+          throw new Error("Not found on remote", {
+            cause: new Error("Run: vm0 volume push"),
+          });
         }
         throw error;
       }


### PR DESCRIPTION
## Summary
- Replace `process.exit(1)` with `throw new Error()` + cause in volume/status, memory/status, artifact/status commands
- No config, wrong type, 404 not found: all converted to throw with cause hints

Part of #4155

## Test plan
- [x] Type check passes
- [x] Lint passes
- [x] Knip clean
- [x] Existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)