### PR TITLE
refactor(cli): migrate init command to centralized error handler

### DIFF
--- a/turbo/apps/cli/src/commands/init/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/init/__tests__/index.test.ts
@@ -86,10 +86,10 @@ describe("init command", () => {
       }).rejects.toThrow("process.exit called");
 
       expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining("vm0.yaml already exists"),
+        expect.stringContaining("vm0.yaml, AGENTS.md already exists"),
       );
       expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining("AGENTS.md already exists"),
+        expect.stringContaining("vm0 init --force"),
       );
       expect(mockExit).toHaveBeenCalledWith(1);
     });

--- a/turbo/apps/cli/src/commands/init/index.ts
+++ b/turbo/apps/cli/src/commands/init/index.ts
@@ -5,6 +5,7 @@ import { existsSync } from "fs";
 import { writeFile } from "fs/promises";
 import { validateAgentName } from "../../lib/domain/yaml-validator";
 import { promptText, isInteractive } from "../../lib/utils/prompt-utils";
+import { withErrorHandler } from "../../lib/command";
 
 const VM0_YAML_FILE = "vm0.yaml";
 const AGENTS_MD_FILE = "AGENTS.md";
@@ -49,91 +50,86 @@ export const initCommand = new Command()
   .description("Initialize a new VM0 project in the current directory")
   .option("-f, --force", "Overwrite existing files")
   .option("-n, --name <name>", "Agent name (required in non-interactive mode)")
-  .action(async (options: { force?: boolean; name?: string }) => {
-    // Check existing files
-    const existingFiles = checkExistingFiles();
-    if (existingFiles.length > 0 && !options.force) {
-      for (const file of existingFiles) {
-        console.error(chalk.red(`✗ ${file} already exists`));
-      }
-      console.error();
-      console.error(`To overwrite: ${chalk.cyan("vm0 init --force")}`);
-      process.exit(1);
-    }
-
-    // Get agent name from option or prompt
-    let agentName: string;
-    if (options.name) {
-      agentName = options.name.trim();
-    } else if (!isInteractive()) {
-      // Non-interactive mode without --name flag
-      console.error(
-        chalk.red("✗ --name flag is required in non-interactive mode"),
-      );
-      console.error(chalk.dim("  Usage: vm0 init --name <agent-name>"));
-      process.exit(1);
-    } else {
-      // Use directory name as default suggestion
-      const dirName = path.basename(process.cwd());
-      const defaultName = validateAgentName(dirName) ? dirName : undefined;
-
-      const name = await promptText(
-        "Enter agent name",
-        defaultName,
-        (value: string) => {
-          if (!validateAgentName(value)) {
-            return "Must be 3-64 characters, alphanumeric and hyphens, start/end with letter or number";
-          }
-          return true;
-        },
-      );
-
-      if (name === undefined) {
-        // User cancelled
-        console.log(chalk.dim("Cancelled"));
-        return;
+  .action(
+    withErrorHandler(async (options: { force?: boolean; name?: string }) => {
+      // Check existing files
+      const existingFiles = checkExistingFiles();
+      if (existingFiles.length > 0 && !options.force) {
+        throw new Error(`${existingFiles.join(", ")} already exists`, {
+          cause: new Error("To overwrite: vm0 init --force"),
+        });
       }
 
-      agentName = name;
-    }
+      // Get agent name from option or prompt
+      let agentName: string;
+      if (options.name) {
+        agentName = options.name.trim();
+      } else if (!isInteractive()) {
+        throw new Error("--name flag is required in non-interactive mode", {
+          cause: new Error("Usage: vm0 init --name <agent-name>"),
+        });
+      } else {
+        // Use directory name as default suggestion
+        const dirName = path.basename(process.cwd());
+        const defaultName = validateAgentName(dirName) ? dirName : undefined;
 
-    // Validate agent name
-    if (!agentName || !validateAgentName(agentName)) {
-      console.error(chalk.red("✗ Invalid agent name"));
-      console.error(
-        chalk.dim("  Must be 3-64 characters, alphanumeric and hyphens only"),
+        const name = await promptText(
+          "Enter agent name",
+          defaultName,
+          (value: string) => {
+            if (!validateAgentName(value)) {
+              return "Must be 3-64 characters, alphanumeric and hyphens, start/end with letter or number";
+            }
+            return true;
+          },
+        );
+
+        if (name === undefined) {
+          // User cancelled
+          console.log(chalk.dim("Cancelled"));
+          return;
+        }
+
+        agentName = name;
+      }
+
+      // Validate agent name
+      if (!agentName || !validateAgentName(agentName)) {
+        throw new Error("Invalid agent name", {
+          cause: new Error(
+            "Must be 3-64 characters, alphanumeric and hyphens only, start and end with letter or number",
+          ),
+        });
+      }
+
+      // Write vm0.yaml
+      await writeFile(VM0_YAML_FILE, generateVm0Yaml(agentName));
+      const vm0Status = existingFiles.includes(VM0_YAML_FILE)
+        ? " (overwritten)"
+        : "";
+      console.log(chalk.green(`✓ Created ${VM0_YAML_FILE}${vm0Status}`));
+
+      // Write AGENTS.md
+      await writeFile(AGENTS_MD_FILE, generateAgentsMd());
+      const agentsStatus = existingFiles.includes(AGENTS_MD_FILE)
+        ? " (overwritten)"
+        : "";
+      console.log(chalk.green(`✓ Created ${AGENTS_MD_FILE}${agentsStatus}`));
+
+      // Print next steps
+      console.log();
+      console.log("Next steps:");
+      console.log(
+        `  1. Set up model provider (one-time): ${chalk.cyan("vm0 model-provider setup")}`,
       );
-      console.error(chalk.dim("  Must start and end with letter or number"));
-      process.exit(1);
-    }
-
-    // Write vm0.yaml
-    await writeFile(VM0_YAML_FILE, generateVm0Yaml(agentName));
-    const vm0Status = existingFiles.includes(VM0_YAML_FILE)
-      ? " (overwritten)"
-      : "";
-    console.log(chalk.green(`✓ Created ${VM0_YAML_FILE}${vm0Status}`));
-
-    // Write AGENTS.md
-    await writeFile(AGENTS_MD_FILE, generateAgentsMd());
-    const agentsStatus = existingFiles.includes(AGENTS_MD_FILE)
-      ? " (overwritten)"
-      : "";
-    console.log(chalk.green(`✓ Created ${AGENTS_MD_FILE}${agentsStatus}`));
-
-    // Print next steps
-    console.log();
-    console.log("Next steps:");
-    console.log(
-      `  1. Set up model provider (one-time): ${chalk.cyan("vm0 model-provider setup")}`,
-    );
-    console.log(
-      `  2. Edit ${chalk.cyan("AGENTS.md")} to customize your agent's workflow`,
-    );
-    console.log(
-      `     Or install Claude plugin: ${chalk.cyan('vm0 setup-claude && claude "/vm0-agent let\'s build an agent"')}`,
-    );
-    console.log(
-      `  3. Run your agent: ${chalk.cyan('vm0 cook "let\'s start working"')}`,
-    );
-  });
+      console.log(
+        `  2. Edit ${chalk.cyan("AGENTS.md")} to customize your agent's workflow`,
+      );
+      console.log(
+        `     Or install Claude plugin: ${chalk.cyan('vm0 setup-claude && claude "/vm0-agent let\'s build an agent"')}`,
+      );
+      console.log(
+        `  3. Run your agent: ${chalk.cyan('vm0 cook "let\'s start working"')}`,
+      );
+    }),
+  );


### PR DESCRIPTION
## Summary
- Wrap init command action with `withErrorHandler`
- Replace 3x `process.exit(1)` with `throw new Error()` + cause: existing files, non-interactive without name, invalid agent name
- Update test assertions to match new error output format

Part of #4155

## Test plan
- [x] Type check passes
- [x] Lint passes
- [x] Knip clean
- [x] Tests updated and passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)