### PR TITLE
refactor(cli): migrate upgrade command to centralized error handler

### DIFF
--- a/turbo/apps/cli/src/commands/upgrade/index.ts
+++ b/turbo/apps/cli/src/commands/upgrade/index.ts
@@ -7,66 +7,70 @@ import {
   isAutoUpgradeSupported,
   performUpgrade,
 } from "../../lib/utils/update-checker";
+import { withErrorHandler } from "../../lib/command";
 
 declare const __CLI_VERSION__: string;
 
 export const upgradeCommand = new Command()
   .name("upgrade")
   .description("Upgrade vm0 CLI to the latest version")
-  .action(async () => {
-    console.log("Checking for updates...");
+  .action(
+    withErrorHandler(async () => {
+      console.log("Checking for updates...");
 
-    const latestVersion = await getLatestVersion();
+      const latestVersion = await getLatestVersion();
 
-    if (latestVersion === null) {
-      console.error(
-        chalk.yellow("⚠ Could not check for updates. Please try again later."),
-      );
-      process.exit(1);
-    }
-
-    if (latestVersion === __CLI_VERSION__) {
-      console.log(chalk.green(`✓ Already up to date (${__CLI_VERSION__})`));
-      return;
-    }
-
-    console.log(
-      chalk.yellow(
-        `Current version: ${__CLI_VERSION__} -> Latest version: ${latestVersion}`,
-      ),
-    );
-    console.log();
-
-    const packageManager = detectPackageManager();
-
-    if (!isAutoUpgradeSupported(packageManager)) {
-      if (packageManager === "unknown") {
-        console.log(
-          chalk.yellow(
-            "Could not detect your package manager for auto-upgrade.",
-          ),
-        );
-      } else {
-        console.log(
-          chalk.yellow(`Auto-upgrade is not supported for ${packageManager}.`),
-        );
+      if (latestVersion === null) {
+        throw new Error("Could not check for updates. Please try again later.");
       }
-      console.log(chalk.yellow("Please upgrade manually:"));
-      console.log(chalk.cyan(`  ${getManualUpgradeCommand(packageManager)}`));
-      return;
-    }
 
-    console.log(`Upgrading via ${packageManager}...`);
-    const success = await performUpgrade(packageManager);
+      if (latestVersion === __CLI_VERSION__) {
+        console.log(chalk.green(`✓ Already up to date (${__CLI_VERSION__})`));
+        return;
+      }
 
-    if (success) {
       console.log(
-        chalk.green(`✓ Upgraded from ${__CLI_VERSION__} to ${latestVersion}`),
+        chalk.yellow(
+          `Current version: ${__CLI_VERSION__} -> Latest version: ${latestVersion}`,
+        ),
       );
-      return;
-    }
+      console.log();
 
-    console.error(chalk.red("✗ Upgrade failed. Please run manually:"));
-    console.error(chalk.cyan(`  ${getManualUpgradeCommand(packageManager)}`));
-    process.exit(1);
-  });
+      const packageManager = detectPackageManager();
+
+      if (!isAutoUpgradeSupported(packageManager)) {
+        if (packageManager === "unknown") {
+          console.log(
+            chalk.yellow(
+              "Could not detect your package manager for auto-upgrade.",
+            ),
+          );
+        } else {
+          console.log(
+            chalk.yellow(
+              `Auto-upgrade is not supported for ${packageManager}.`,
+            ),
+          );
+        }
+        console.log(chalk.yellow("Please upgrade manually:"));
+        console.log(chalk.cyan(`  ${getManualUpgradeCommand(packageManager)}`));
+        return;
+      }
+
+      console.log(`Upgrading via ${packageManager}...`);
+      const success = await performUpgrade(packageManager);
+
+      if (success) {
+        console.log(
+          chalk.green(`✓ Upgraded from ${__CLI_VERSION__} to ${latestVersion}`),
+        );
+        return;
+      }
+
+      throw new Error("Upgrade failed", {
+        cause: new Error(
+          `Please run manually: ${getManualUpgradeCommand(packageManager)}`,
+        ),
+      });
+    }),
+  );


### PR DESCRIPTION
## Summary
- Wrap upgrade command action with `withErrorHandler`
- Replace 2x `process.exit(1)` with `throw new Error()`: update check failed, upgrade failed

Part of #4155

## Test plan
- [x] Type check passes
- [x] Lint passes
- [x] Knip clean
- [x] Existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)