### PR TITLE
chore: update toolchain images to 20260310

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "VM0 Development",
-  "image": "ghcr.io/vm0-ai/vm0-dev:20260306",
+  "image": "ghcr.io/vm0-ai/vm0-dev:20260310",
   "features": {
     "ghcr.io/itsmechlark/features/postgresql:1": {
       "version": "17"

--- a/.github/workflows/cleanup-stale.yml
+++ b/.github/workflows/cleanup-stale.yml
@@ -17,7 +17,7 @@ jobs:
   cleanup-neon-branches:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260306
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260310
     steps:
       - name: Install neonctl
         run: npm install -g neonctl@2.15.0

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -72,7 +72,7 @@ jobs:
   cleanup-database:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260306
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260310
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -23,7 +23,7 @@ jobs:
   detect:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260306
+      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260310
     outputs:
       ci-changed: ${{ steps.detect.outputs.ci-changed }}
       ably-subscriber-changed: ${{ steps.detect.outputs.ably-subscriber-changed }}
@@ -72,7 +72,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260306
+      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260310
     needs: [detect]
     steps:
       - uses: actions/checkout@v6
@@ -126,7 +126,7 @@ jobs:
   runner-build:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260306
+      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260310
     needs: [detect]
     if: |
       needs.detect.outputs.ci-changed == 'true' ||

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -47,7 +47,7 @@ jobs:
     if: ${{ needs.release-please.outputs.web_release_created == 'true' }}
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260306
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260310
     permissions:
       contents: read
     environment: production
@@ -144,7 +144,7 @@ jobs:
     if: ${{ needs.release-please.outputs.web_release_created == 'true' }}
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260306
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260310
     permissions:
       contents: read
       deployments: write
@@ -350,7 +350,7 @@ jobs:
     if: ${{ needs.release-please.outputs.docs_release_created == 'true' }}
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260306
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260310
     permissions:
       contents: read
       deployments: write
@@ -438,7 +438,7 @@ jobs:
     if: ${{ needs.release-please.outputs.platform_release_created == 'true' }}
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260306
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260310
     permissions:
       contents: read
       deployments: write
@@ -629,7 +629,7 @@ jobs:
     if: ${{ needs.release-please.outputs.runner_rs_release_created == 'true' }}
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260306
+      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260310
     permissions:
       contents: write
     environment: production
@@ -807,7 +807,7 @@ jobs:
     if: ${{ needs.release-please.outputs.releases_created == 'true' }}
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260306
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260310
     permissions:
       contents: read
     environment: production

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -21,7 +21,7 @@ jobs:
   prepare:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260306
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260310
     outputs:
       job-ref: ${{ steps.set-job-ref.outputs.job-ref }}
       web-preview-url: ${{ steps.preview-urls.outputs.web-url }}
@@ -257,7 +257,7 @@ jobs:
     # Skip for release-please commits (only version bumps and changelogs)
     if: "${{ github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore: release') }}"
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260306
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260310
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/toolchain-init
@@ -271,7 +271,7 @@ jobs:
   lint-types:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260306
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260310
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/toolchain-init
@@ -285,7 +285,7 @@ jobs:
   lint-format:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260306
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260310
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/toolchain-init
@@ -296,7 +296,7 @@ jobs:
   lint-knip:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260306
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260310
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/toolchain-init
@@ -314,7 +314,7 @@ jobs:
     # Skip for release-please commits (only version bumps and changelogs)
     if: "${{ github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore: release') }}"
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260306
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260310
     services:
       postgres:
         image: postgres:17-alpine
@@ -348,7 +348,7 @@ jobs:
     # Only run when migration or schema files changed
     if: needs.prepare.outputs.migration-changed == 'true'
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260306
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260310
     services:
       postgres:
         image: postgres:17-alpine
@@ -371,7 +371,7 @@ jobs:
   test-cli:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260306
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260310
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/toolchain-init
@@ -385,7 +385,7 @@ jobs:
   test-platform:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260306
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260310
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/toolchain-init
@@ -399,7 +399,7 @@ jobs:
   test-other:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260306
+      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260310
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/toolchain-init
@@ -414,7 +414,7 @@ jobs:
   deploy-web:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260306
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260310
     needs: [prepare]
     # Deploy if job-ref is set (PR or main), not a release-please commit, and web, CLI, runner, or platform changed
     if: |
@@ -804,7 +804,7 @@ jobs:
   deploy-docs:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260306
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260310
     needs: [prepare]
     # Deploy if job-ref is set (PR or main), not a release-please commit, and docs changed
     if: "${{ (github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore: release')) && needs.prepare.outputs.job-ref != '' && needs.prepare.outputs.docs-changed == 'true' }}"
@@ -846,7 +846,7 @@ jobs:
   deploy-platform:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260306
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260310
     needs: [prepare]
     # Deploy if job-ref is set (PR or main), not a release-please commit, and platform changed
     if: "${{ (github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore: release')) && needs.prepare.outputs.job-ref != '' && needs.prepare.outputs.platform-changed == 'true' }}"
@@ -897,7 +897,7 @@ jobs:
   e2e-auth:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260306
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260310
     needs: [prepare, deploy-web]
     if: |
       (github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore: release')) &&
@@ -957,7 +957,7 @@ jobs:
   cli-e2e-01-serial:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260306
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260310
     needs:
       [
         prepare,
@@ -1048,7 +1048,7 @@ jobs:
   deploy-runner-prepare:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260306
+      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260310
     needs: [prepare]
     timeout-minutes: 10
     env:
@@ -1380,7 +1380,7 @@ jobs:
   cli-e2e-03-runner:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260306
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260310
     needs:
       [
         prepare,
@@ -1520,7 +1520,7 @@ jobs:
   runner-stress-test:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260306
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260310
     needs:
       [
         prepare,
@@ -1668,7 +1668,7 @@ jobs:
   build-e2b-template:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260306
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260310
     needs: [prepare]
     # Build on PR or main push when E2B templates changed, skip release-please commits
     if: |


### PR DESCRIPTION
## Summary
- Update `vm0-toolchain`, `vm0-toolchain-rust`, and `vm0-dev` image tags from `20260306` to `20260310`
- 6 files, 31 references updated

## Test plan
- [ ] CI passes with new image tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)