### PR TITLE
refactor(cli): replace process.exit with throw in agent commands

### DIFF
--- a/turbo/apps/cli/src/commands/agent/clone.ts
+++ b/turbo/apps/cli/src/commands/agent/clone.ts
@@ -111,8 +111,7 @@ export const cloneCommand = new Command()
       // Check if destination already exists and is non-empty
       const dirStatus = checkDirectoryStatus(targetDir);
       if (dirStatus.exists && !dirStatus.empty) {
-        console.error(chalk.red(`✗ Directory "${targetDir}" is not empty`));
-        process.exit(1);
+        throw new Error(`Directory "${targetDir}" is not empty`);
       }
 
       console.log(`Cloning agent compose: ${name}`);
@@ -121,13 +120,11 @@ export const cloneCommand = new Command()
       const compose = await getComposeByName(name);
 
       if (!compose) {
-        console.error(chalk.red(`✗ Agent compose not found: ${name}`));
-        process.exit(1);
+        throw new Error(`Agent compose not found: ${name}`);
       }
 
       if (!compose.content || !compose.headVersionId) {
-        console.error(chalk.red(`✗ Agent compose has no content: ${name}`));
-        process.exit(1);
+        throw new Error(`Agent compose has no content: ${name}`);
       }
 
       const content = compose.content as AgentComposeContent;

--- a/turbo/apps/cli/src/commands/agent/delete.ts
+++ b/turbo/apps/cli/src/commands/agent/delete.ts
@@ -15,18 +15,15 @@ export const deleteCommand = new Command()
       // 1. Resolve agent name to compose
       const compose = await getComposeByName(name);
       if (!compose) {
-        console.error(chalk.red(`✗ Agent '${name}' not found`));
-        console.error(chalk.dim("  Run: vm0 agent list"));
-        process.exit(1);
+        throw new Error(`Agent '${name}' not found`, {
+          cause: new Error("Run: vm0 agent list"),
+        });
       }
 
       // 2. Confirm deletion
       if (!options.yes) {
         if (!isInteractive()) {
-          console.error(
-            chalk.red("✗ --yes flag is required in non-interactive mode"),
-          );
-          process.exit(1);
+          throw new Error("--yes flag is required in non-interactive mode");
         }
         const confirmed = await promptConfirm(`Delete agent '${name}'?`, false);
         if (!confirmed) {

--- a/turbo/apps/cli/src/commands/agent/permission.ts
+++ b/turbo/apps/cli/src/commands/agent/permission.ts
@@ -30,30 +30,20 @@ export const permissionCommand = new Command()
       async (name: string, options: { experimentalSharedAgent?: boolean }) => {
         // Validate experimental flag
         if (!options.experimentalSharedAgent) {
-          console.error(
-            chalk.red(
-              "✗ This command requires --experimental-shared-agent flag",
-            ),
+          throw new Error(
+            "This command requires --experimental-shared-agent flag",
+            {
+              cause: new Error(
+                `Use: vm0 agent permission ${name} --experimental-shared-agent`,
+              ),
+            },
           );
-          console.error();
-          console.error(
-            chalk.dim("  Agent sharing is an experimental feature."),
-          );
-          console.error();
-          console.error("Example:");
-          console.error(
-            chalk.cyan(
-              `  vm0 agent permission ${name} --experimental-shared-agent`,
-            ),
-          );
-          process.exit(1);
         }
 
         // Resolve compose by name
         const compose = await getComposeByName(name);
         if (!compose) {
-          console.error(chalk.red(`✗ Agent not found: ${name}`));
-          process.exit(1);
+          throw new Error(`Agent not found: ${name}`);
         }
 
         // Get permissions

--- a/turbo/apps/cli/src/commands/agent/private.ts
+++ b/turbo/apps/cli/src/commands/agent/private.ts
@@ -16,30 +16,20 @@ export const privateCommand = new Command()
       async (name: string, options: { experimentalSharedAgent?: boolean }) => {
         // Validate experimental flag
         if (!options.experimentalSharedAgent) {
-          console.error(
-            chalk.red(
-              "✗ This command requires --experimental-shared-agent flag",
-            ),
+          throw new Error(
+            "This command requires --experimental-shared-agent flag",
+            {
+              cause: new Error(
+                `Use: vm0 agent private ${name} --experimental-shared-agent`,
+              ),
+            },
           );
-          console.error();
-          console.error(
-            chalk.dim("  Agent sharing is an experimental feature."),
-          );
-          console.error();
-          console.error("Example:");
-          console.error(
-            chalk.cyan(
-              `  vm0 agent private ${name} --experimental-shared-agent`,
-            ),
-          );
-          process.exit(1);
         }
 
         // Resolve compose by name
         const compose = await getComposeByName(name);
         if (!compose) {
-          console.error(chalk.red(`✗ Agent not found: ${name}`));
-          process.exit(1);
+          throw new Error(`Agent not found: ${name}`);
         }
 
         // Remove public permission

--- a/turbo/apps/cli/src/commands/agent/public.ts
+++ b/turbo/apps/cli/src/commands/agent/public.ts
@@ -21,30 +21,20 @@ export const publicCommand = new Command()
       async (name: string, options: { experimentalSharedAgent?: boolean }) => {
         // Validate experimental flag
         if (!options.experimentalSharedAgent) {
-          console.error(
-            chalk.red(
-              "✗ This command requires --experimental-shared-agent flag",
-            ),
+          throw new Error(
+            "This command requires --experimental-shared-agent flag",
+            {
+              cause: new Error(
+                `Use: vm0 agent public ${name} --experimental-shared-agent`,
+              ),
+            },
           );
-          console.error();
-          console.error(
-            chalk.dim("  Agent sharing is an experimental feature."),
-          );
-          console.error();
-          console.error("Example:");
-          console.error(
-            chalk.cyan(
-              `  vm0 agent public ${name} --experimental-shared-agent`,
-            ),
-          );
-          process.exit(1);
         }
 
         // Resolve compose by name
         const compose = await getComposeByName(name);
         if (!compose) {
-          console.error(chalk.red(`✗ Agent not found: ${name}`));
-          process.exit(1);
+          throw new Error(`Agent not found: ${name}`);
         }
 
         // Get scope for display

--- a/turbo/apps/cli/src/commands/agent/share.ts
+++ b/turbo/apps/cli/src/commands/agent/share.ts
@@ -25,30 +25,20 @@ export const shareCommand = new Command()
       ) => {
         // Validate experimental flag
         if (!options.experimentalSharedAgent) {
-          console.error(
-            chalk.red(
-              "✗ This command requires --experimental-shared-agent flag",
-            ),
+          throw new Error(
+            "This command requires --experimental-shared-agent flag",
+            {
+              cause: new Error(
+                `Use: vm0 agent share ${name} --email ${options.email} --experimental-shared-agent`,
+              ),
+            },
           );
-          console.error();
-          console.error(
-            chalk.dim("  Agent sharing is an experimental feature."),
-          );
-          console.error();
-          console.error("Example:");
-          console.error(
-            chalk.cyan(
-              `  vm0 agent share ${name} --email ${options.email} --experimental-shared-agent`,
-            ),
-          );
-          process.exit(1);
         }
 
         // Resolve compose by name
         const compose = await getComposeByName(name);
         if (!compose) {
-          console.error(chalk.red(`✗ Agent not found: ${name}`));
-          process.exit(1);
+          throw new Error(`Agent not found: ${name}`);
         }
 
         // Get scope for display

--- a/turbo/apps/cli/src/commands/agent/status.ts
+++ b/turbo/apps/cli/src/commands/agent/status.ts
@@ -149,9 +149,9 @@ export const statusCommand = new Command()
         const compose = await getComposeByName(name);
 
         if (!compose) {
-          console.error(chalk.red(`✗ Agent compose not found: ${name}`));
-          console.error(chalk.dim("  Run: vm0 agent list"));
-          process.exit(1);
+          throw new Error(`Agent compose not found: ${name}`, {
+            cause: new Error("Run: vm0 agent list"),
+          });
         }
 
         // Resolve version if not "latest" or full hash
@@ -169,13 +169,11 @@ export const statusCommand = new Command()
                 error instanceof Error &&
                 error.message.includes("not found")
               ) {
-                console.error(chalk.red(`✗ Version not found: ${version}`));
-                console.error(
-                  chalk.dim(
-                    `  HEAD version: ${compose.headVersionId?.slice(0, 8)}`,
+                throw new Error(`Version not found: ${version}`, {
+                  cause: new Error(
+                    `HEAD version: ${compose.headVersionId?.slice(0, 8)}`,
                   ),
-                );
-                process.exit(1);
+                });
               }
               throw error;
             }
@@ -185,8 +183,7 @@ export const statusCommand = new Command()
         }
 
         if (!resolvedVersionId || !compose.content) {
-          console.error(chalk.red(`✗ No version found for: ${name}`));
-          process.exit(1);
+          throw new Error(`No version found for: ${name}`);
         }
 
         const content = compose.content as AgentComposeContent;

--- a/turbo/apps/cli/src/commands/agent/unshare.ts
+++ b/turbo/apps/cli/src/commands/agent/unshare.ts
@@ -20,30 +20,20 @@ export const unshareCommand = new Command()
       ) => {
         // Validate experimental flag
         if (!options.experimentalSharedAgent) {
-          console.error(
-            chalk.red(
-              "✗ This command requires --experimental-shared-agent flag",
-            ),
+          throw new Error(
+            "This command requires --experimental-shared-agent flag",
+            {
+              cause: new Error(
+                `Use: vm0 agent unshare ${name} --email ${options.email} --experimental-shared-agent`,
+              ),
+            },
           );
-          console.error();
-          console.error(
-            chalk.dim("  Agent sharing is an experimental feature."),
-          );
-          console.error();
-          console.error("Example:");
-          console.error(
-            chalk.cyan(
-              `  vm0 agent unshare ${name} --email ${options.email} --experimental-shared-agent`,
-            ),
-          );
-          process.exit(1);
         }
 
         // Resolve compose by name
         const compose = await getComposeByName(name);
         if (!compose) {
-          console.error(chalk.red(`✗ Agent not found: ${name}`));
-          process.exit(1);
+          throw new Error(`Agent not found: ${name}`);
         }
 
         // Remove email permission


### PR DESCRIPTION
## Summary

- Replace `console.error` + `process.exit(1)` dual exit paths with `throw new Error` (with optional `cause`) in 8 agent command files
- Ensures all error handling flows through the centralized `withErrorHandler` pattern
- Files modified: clone, delete, permission, private, public, share, unshare, status (17 fixes total)

Closes #4155 (partial)

## Test plan

- [x] All 48 agent command tests pass
- [x] Type check passes
- [x] Lint passes (0 warnings, 0 errors)
- [x] Knip passes (no unused exports)
- [x] Format check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)