### PR TITLE
feat: dual-write default agent compose id to clerk org metadata

### DIFF
--- a/turbo/apps/web/app/api/scopes/default-agent/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/scopes/default-agent/__tests__/route.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { clerkClient } from "@clerk/nextjs/server";
 import { PUT } from "../route";
 import {
   createTestRequest,
@@ -84,6 +85,35 @@ describe("PUT /api/scopes/default-agent", () => {
       "00000000-0000-0000-0000-000000000000",
     );
     expect(response.status).toBe(404);
+  });
+
+  it("should dual-write default agent to Clerk org metadata", async () => {
+    await context.setupUser();
+    const compose = await createTestCompose("test-agent");
+
+    await putDefaultAgent(undefined, compose.composeId);
+
+    const client = await vi.mocked(clerkClient)();
+    expect(
+      client.organizations.updateOrganizationMetadata,
+    ).toHaveBeenCalledWith(expect.any(String), {
+      publicMetadata: { default_agent_compose_id: compose.composeId },
+    });
+  });
+
+  it("should dual-write null to Clerk org metadata when unsetting", async () => {
+    await context.setupUser();
+    const compose = await createTestCompose("test-agent");
+
+    await putDefaultAgent(undefined, compose.composeId);
+    await putDefaultAgent(undefined, null);
+
+    const client = await vi.mocked(clerkClient)();
+    expect(
+      client.organizations.updateOrganizationMetadata,
+    ).toHaveBeenLastCalledWith(expect.any(String), {
+      publicMetadata: { default_agent_compose_id: null },
+    });
   });
 
   it("should return 200 when setting same agent twice", async () => {

--- a/turbo/apps/web/app/api/scopes/default-agent/route.ts
+++ b/turbo/apps/web/app/api/scopes/default-agent/route.ts
@@ -6,6 +6,10 @@ import { resolveScope } from "../../../../src/lib/scope/resolve-scope";
 import { agentComposes } from "../../../../src/db/schema/agent-compose";
 import { scopes } from "../../../../src/db/schema/scope";
 import { eq, and } from "drizzle-orm";
+import { clerkClient } from "@clerk/nextjs/server";
+import { logger } from "../../../../src/lib/logger";
+
+const log = logger("api:scopes:default-agent");
 
 const router = tsr.router(scopeDefaultAgentContract, {
   setDefaultAgent: async ({ query, body, headers }) => {
@@ -73,6 +77,19 @@ const router = tsr.router(scopeDefaultAgentContract, {
       .update(scopes)
       .set({ defaultAgentComposeId: agentComposeId })
       .where(eq(scopes.id, scope.id));
+
+    // Dual-write to Clerk org publicMetadata (fire-and-forget)
+    try {
+      const client = await clerkClient();
+      await client.organizations.updateOrganizationMetadata(scope.clerkOrgId, {
+        publicMetadata: { default_agent_compose_id: agentComposeId },
+      });
+    } catch (err) {
+      log.error("Failed to write default agent to Clerk metadata", {
+        error: err,
+        clerkOrgId: scope.clerkOrgId,
+      });
+    }
 
     return {
       status: 200 as const,

--- a/turbo/apps/web/scripts/migrations/004-backfill-default-agent/backfill.ts
+++ b/turbo/apps/web/scripts/migrations/004-backfill-default-agent/backfill.ts
@@ -1,0 +1,219 @@
+#!/usr/bin/env tsx
+
+/**
+ * Backfill Clerk org publicMetadata with default agent compose IDs.
+ *
+ * Part of the Scope → Clerk migration: writes scopes.defaultAgentComposeId
+ * to the corresponding Clerk org's publicMetadata.default_agent_compose_id.
+ *
+ * Usage:
+ *   tsx scripts/migrations/004-backfill-default-agent/backfill.ts [--migrate]
+ *
+ * Environment:
+ *   DATABASE_URL        — Required
+ *   CLERK_SECRET_KEY    — Required (for --migrate)
+ */
+
+import { parseArgs } from "node:util";
+import { drizzle } from "drizzle-orm/postgres-js";
+import { isNotNull, asc } from "drizzle-orm";
+import postgres from "postgres";
+
+import { scopes } from "../../../src/db/schema/scope";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface ClerkOrganizationsApi {
+  updateOrganizationMetadata: (
+    orgId: string,
+    params: { publicMetadata: Record<string, unknown> },
+  ) => Promise<unknown>;
+}
+
+interface ClerkClient {
+  organizations: ClerkOrganizationsApi;
+}
+
+interface Stats {
+  total: number;
+  success: number;
+  failed: number;
+}
+
+// ---------------------------------------------------------------------------
+// CLI argument parsing
+// ---------------------------------------------------------------------------
+
+const { values: args } = parseArgs({
+  options: {
+    migrate: { type: "boolean", default: false },
+  },
+  strict: true,
+});
+
+const DRY_RUN = !args.migrate;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const THROTTLE_MS = 100;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function getStatus(err: unknown): number | undefined {
+  if (
+    typeof err === "object" &&
+    err !== null &&
+    "status" in err &&
+    typeof (err as Record<string, unknown>).status === "number"
+  ) {
+    return (err as Record<string, unknown>).status as number;
+  }
+  return undefined;
+}
+
+function isTransientError(err: unknown): boolean {
+  const status = getStatus(err);
+  return status === 429 || (status !== undefined && status >= 500);
+}
+
+async function withRetry<T>(fn: () => Promise<T>): Promise<T> {
+  const MAX_ATTEMPTS = 3;
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      if (isTransientError(err) && attempt < MAX_ATTEMPTS) {
+        const backoff = Math.pow(2, attempt) * 1000;
+        console.warn(
+          `  Transient error (status ${getStatus(err)}), retrying in ${backoff}ms (attempt ${attempt + 1}/${MAX_ATTEMPTS})`,
+        );
+        await sleep(backoff);
+        continue;
+      }
+      throw err;
+    }
+  }
+  throw new Error(`Failed after ${MAX_ATTEMPTS} attempts`);
+}
+
+// ---------------------------------------------------------------------------
+// Backfill: Default agent compose IDs
+// ---------------------------------------------------------------------------
+
+async function backfillDefaultAgents(
+  db: ReturnType<typeof drizzle>,
+  client: ClerkClient | null,
+): Promise<Stats> {
+  console.log("\n--- Backfilling default agent compose IDs ---\n");
+
+  const scopesWithDefault = await db
+    .select({
+      id: scopes.id,
+      slug: scopes.slug,
+      clerkOrgId: scopes.clerkOrgId,
+      defaultAgentComposeId: scopes.defaultAgentComposeId,
+    })
+    .from(scopes)
+    .where(isNotNull(scopes.defaultAgentComposeId))
+    .orderBy(asc(scopes.createdAt));
+
+  const total = scopesWithDefault.length;
+  console.log(`Found ${total} scope(s) with a default agent\n`);
+
+  const stats: Stats = { total, success: 0, failed: 0 };
+
+  for (let i = 0; i < scopesWithDefault.length; i++) {
+    const scope = scopesWithDefault[i]!;
+    const idx = `[${i + 1}/${total}]`;
+
+    if (DRY_RUN) {
+      console.log(
+        `${idx} (dry-run) scope "${scope.slug}" — would write default_agent_compose_id="${scope.defaultAgentComposeId}" to Clerk org ${scope.clerkOrgId}`,
+      );
+      stats.success++;
+      continue;
+    }
+
+    try {
+      await withRetry(() =>
+        client!.organizations.updateOrganizationMetadata(scope.clerkOrgId, {
+          publicMetadata: {
+            default_agent_compose_id: scope.defaultAgentComposeId,
+          },
+        }),
+      );
+      await sleep(THROTTLE_MS);
+      console.log(
+        `${idx} ✓ scope "${scope.slug}" → default_agent_compose_id="${scope.defaultAgentComposeId}"`,
+      );
+      stats.success++;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error(`${idx} ✗ scope "${scope.slug}" — ${message}`);
+      stats.failed++;
+    }
+  }
+
+  return stats;
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  const databaseUrl = process.env.DATABASE_URL;
+  if (!databaseUrl) {
+    throw new Error("DATABASE_URL is required");
+  }
+
+  console.log("=== Backfill Default Agent to Clerk Metadata ===");
+  console.log(
+    `Mode: ${DRY_RUN ? "dry-run (pass --migrate to execute)" : "MIGRATE"}`,
+  );
+  console.log();
+
+  let client: ClerkClient | null = null;
+
+  if (!DRY_RUN) {
+    const clerkSecretKey = process.env.CLERK_SECRET_KEY;
+    if (!clerkSecretKey) {
+      throw new Error("CLERK_SECRET_KEY is required for --migrate");
+    }
+    const { createClerkClient } = await import("@clerk/backend");
+    client = createClerkClient({ secretKey: clerkSecretKey });
+  }
+
+  const pg = postgres(databaseUrl, { max: 1 });
+  const db = drizzle(pg);
+
+  try {
+    const stats = await backfillDefaultAgents(db, client);
+
+    console.log("\n=== Summary ===");
+    console.log(
+      `Default agents:   ${stats.success} ok, ${stats.failed} failed (${stats.total} total)`,
+    );
+
+    if (DRY_RUN) {
+      console.log("\n⚠ Dry run — no changes were made.");
+    }
+
+    if (stats.failed > 0) {
+      process.exitCode = 1;
+    }
+  } finally {
+    await pg.end();
+  }
+}
+
+main().catch((err) => {
+  console.error("Backfill failed:", err);
+  process.exit(1);
+});

--- a/turbo/apps/web/scripts/migrations/004-backfill-default-agent/backfill.ts
+++ b/turbo/apps/web/scripts/migrations/004-backfill-default-agent/backfill.ts
@@ -19,6 +19,7 @@ import { drizzle } from "drizzle-orm/postgres-js";
 import { isNotNull, asc } from "drizzle-orm";
 import postgres from "postgres";
 
+import { createClerkClient } from "@clerk/backend";
 import { scopes } from "../../../src/db/schema/scope";
 
 // ---------------------------------------------------------------------------
@@ -186,7 +187,6 @@ async function main() {
     if (!clerkSecretKey) {
       throw new Error("CLERK_SECRET_KEY is required for --migrate");
     }
-    const { createClerkClient } = await import("@clerk/backend");
     client = createClerkClient({ secretKey: clerkSecretKey });
   }
 

--- a/turbo/apps/web/src/types/global.d.ts
+++ b/turbo/apps/web/src/types/global.d.ts
@@ -25,6 +25,7 @@ declare global {
   // Clerk custom JWT session claims (configured in Clerk Dashboard)
   interface CustomJwtSessionClaims {
     org_tier?: string;
+    org_default_agent?: string | null;
     membership_timezone?: string;
     membership_notify_email?: boolean;
     membership_notify_slack?: boolean;

--- a/turbo/apps/web/src/types/global.d.ts
+++ b/turbo/apps/web/src/types/global.d.ts
@@ -25,7 +25,7 @@ declare global {
   // Clerk custom JWT session claims (configured in Clerk Dashboard)
   interface CustomJwtSessionClaims {
     org_tier?: string;
-    org_default_agent?: string | null;
+    org_default_agent_compose_id?: string | null;
     membership_timezone?: string;
     membership_notify_email?: boolean;
     membership_notify_slack?: boolean;


### PR DESCRIPTION
## Summary

- Add Clerk `publicMetadata.default_agent_compose_id` dual-write to the `PUT /api/scopes/default-agent` endpoint (fire-and-forget, matching the `tier` pattern)
- Add `org_default_agent` to `CustomJwtSessionClaims` type definition
- Add backfill script at `scripts/migrations/004-backfill-default-agent/backfill.ts` for existing scopes with a default agent

## Context

Phase 4 (Additive Preparation) of the Scope → Clerk migration (#4146). This replaces the previous `isDefault` column approach (#4220) with the correct org-level Clerk metadata pattern, consistent with how `tier` is already handled.

## Test plan

- [x] Integration tests verify Clerk `updateOrganizationMetadata` is called with correct compose ID when setting
- [x] Integration tests verify Clerk metadata is set to `null` when unsetting
- [x] All 8 existing default-agent tests pass
- [x] Lint, type-check, format, knip all pass

Closes #4219

🤖 Generated with [Claude Code](https://claude.com/claude-code)