### PR TITLE
refactor(cli): replace process.exit with throw in storage commands

### DIFF
--- a/turbo/apps/cli/src/commands/artifact/__tests__/init.test.ts
+++ b/turbo/apps/cli/src/commands/artifact/__tests__/init.test.ts
@@ -150,13 +150,13 @@ describe("artifact init", () => {
       );
     });
 
-    it("should show example valid names on error", async () => {
+    it("should show naming rules in error cause", async () => {
       await expect(async () => {
         await initCommand.parseAsync(["node", "cli", "--name", "X"]);
       }).rejects.toThrow("process.exit called");
 
       expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining("my-project"),
+        expect.stringContaining("3-64 characters"),
       );
     });
   });

--- a/turbo/apps/cli/src/commands/artifact/init.ts
+++ b/turbo/apps/cli/src/commands/artifact/init.ts
@@ -55,14 +55,9 @@ export const initCommand = new Command()
         // Use provided name (non-interactive mode)
         artifactName = options.name;
       } else if (!isInteractive()) {
-        // Non-interactive mode without --name flag
-        console.error(
-          chalk.red("✗ --name flag is required in non-interactive mode"),
-        );
-        console.error(
-          chalk.dim("  Usage: vm0 artifact init --name <artifact-name>"),
-        );
-        process.exit(1);
+        throw new Error("--name flag is required in non-interactive mode", {
+          cause: new Error("Usage: vm0 artifact init --name <artifact-name>"),
+        });
       } else {
         // Interactive prompt with directory name as default
         const defaultName = isValidStorageName(dirName) ? dirName : undefined;
@@ -88,16 +83,11 @@ export const initCommand = new Command()
 
       // Validate name
       if (!isValidStorageName(artifactName)) {
-        console.error(chalk.red(`✗ Invalid artifact name: "${artifactName}"`));
-        console.error(
-          chalk.dim(
-            "  Artifact names must be 3-64 characters, lowercase alphanumeric with hyphens",
+        throw new Error(`Invalid artifact name: "${artifactName}"`, {
+          cause: new Error(
+            "Artifact names must be 3-64 characters, lowercase alphanumeric with hyphens",
           ),
-        );
-        console.error(
-          chalk.dim("  Example: my-project, user-workspace, code-artifact"),
-        );
-        process.exit(1);
+        });
       }
 
       // Write config file with type: artifact

--- a/turbo/apps/cli/src/commands/artifact/pull.ts
+++ b/turbo/apps/cli/src/commands/artifact/pull.ts
@@ -25,19 +25,16 @@ export const pullCommand = new Command()
       // Read config
       const config = await readStorageConfig(cwd);
       if (!config) {
-        console.error(chalk.red("✗ No artifact initialized in this directory"));
-        console.error(chalk.dim("  Run: vm0 artifact init"));
-        process.exit(1);
+        throw new Error("No artifact initialized in this directory", {
+          cause: new Error("Run: vm0 artifact init"),
+        });
       }
 
       if (config.type !== "artifact") {
-        console.error(
-          chalk.red(
-            `✗ This directory is initialized as a volume, not an artifact`,
-          ),
+        throw new Error(
+          "This directory is initialized as a volume, not an artifact",
+          { cause: new Error("Use: vm0 volume pull") },
         );
-        console.error(chalk.dim("  Use: vm0 volume pull"));
-        process.exit(1);
       }
 
       if (versionId) {

--- a/turbo/apps/cli/src/commands/artifact/push.ts
+++ b/turbo/apps/cli/src/commands/artifact/push.ts
@@ -19,19 +19,16 @@ export const pushCommand = new Command()
       // Read config
       const config = await readStorageConfig(cwd);
       if (!config) {
-        console.error(chalk.red("✗ No artifact initialized in this directory"));
-        console.error(chalk.dim("  Run: vm0 artifact init"));
-        process.exit(1);
+        throw new Error("No artifact initialized in this directory", {
+          cause: new Error("Run: vm0 artifact init"),
+        });
       }
 
       if (config.type !== "artifact") {
-        console.error(
-          chalk.red(
-            `✗ This directory is initialized as a volume, not an artifact`,
-          ),
+        throw new Error(
+          "This directory is initialized as a volume, not an artifact",
+          { cause: new Error("Use: vm0 volume push") },
         );
-        console.error(chalk.dim("  Use: vm0 volume push"));
-        process.exit(1);
       }
 
       console.log(`Pushing artifact: ${config.name}`);

--- a/turbo/apps/cli/src/commands/memory/init.ts
+++ b/turbo/apps/cli/src/commands/memory/init.ts
@@ -49,13 +49,9 @@ export const initCommand = new Command()
       if (options.name) {
         memoryName = options.name;
       } else if (!isInteractive()) {
-        console.error(
-          chalk.red("✗ --name flag is required in non-interactive mode"),
-        );
-        console.error(
-          chalk.dim("  Usage: vm0 memory init --name <memory-name>"),
-        );
-        process.exit(1);
+        throw new Error("--name flag is required in non-interactive mode", {
+          cause: new Error("Usage: vm0 memory init --name <memory-name>"),
+        });
       } else {
         // Interactive prompt with directory name as default
         const defaultName = isValidStorageName(dirName) ? dirName : undefined;
@@ -80,16 +76,11 @@ export const initCommand = new Command()
 
       // Validate name
       if (!isValidStorageName(memoryName)) {
-        console.error(chalk.red(`✗ Invalid memory name: "${memoryName}"`));
-        console.error(
-          chalk.dim(
-            "  Memory names must be 3-64 characters, lowercase alphanumeric with hyphens",
+        throw new Error(`Invalid memory name: "${memoryName}"`, {
+          cause: new Error(
+            "Memory names must be 3-64 characters, lowercase alphanumeric with hyphens",
           ),
-        );
-        console.error(
-          chalk.dim("  Example: my-memory, agent-context, project-memory"),
-        );
-        process.exit(1);
+        });
       }
 
       // Write config file with type: memory

--- a/turbo/apps/cli/src/commands/memory/push.ts
+++ b/turbo/apps/cli/src/commands/memory/push.ts
@@ -19,19 +19,16 @@ export const pushCommand = new Command()
       // Read config
       const config = await readStorageConfig(cwd);
       if (!config) {
-        console.error(chalk.red("✗ No memory initialized in this directory"));
-        console.error(chalk.dim("  Run: vm0 memory init"));
-        process.exit(1);
+        throw new Error("No memory initialized in this directory", {
+          cause: new Error("Run: vm0 memory init"),
+        });
       }
 
       if (config.type !== "memory") {
-        console.error(
-          chalk.red(
-            `✗ This directory is initialized as ${config.type === "artifact" ? "an artifact" : "a volume"}, not a memory`,
-          ),
+        throw new Error(
+          `This directory is initialized as ${config.type === "artifact" ? "an artifact" : "a volume"}, not a memory`,
+          { cause: new Error(`Use: vm0 ${config.type} push`) },
         );
-        console.error(chalk.dim(`  Use: vm0 ${config.type} push`));
-        process.exit(1);
       }
 
       console.log(`Pushing memory: ${config.name}`);

--- a/turbo/apps/cli/src/commands/volume/__tests__/init.test.ts
+++ b/turbo/apps/cli/src/commands/volume/__tests__/init.test.ts
@@ -104,13 +104,13 @@ describe("volume init", () => {
       );
     });
 
-    it("should show example valid names on error", async () => {
+    it("should show naming rules in error cause", async () => {
       await expect(async () => {
         await initCommand.parseAsync(["node", "cli", "--name", "X"]);
       }).rejects.toThrow("process.exit called");
 
       expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining("my-dataset"),
+        expect.stringContaining("3-64 characters"),
       );
     });
   });

--- a/turbo/apps/cli/src/commands/volume/init.ts
+++ b/turbo/apps/cli/src/commands/volume/init.ts
@@ -37,14 +37,9 @@ export const initCommand = new Command()
         // Use provided name (non-interactive mode)
         volumeName = options.name;
       } else if (!isInteractive()) {
-        // Non-interactive mode without --name flag
-        console.error(
-          chalk.red("✗ --name flag is required in non-interactive mode"),
-        );
-        console.error(
-          chalk.dim("  Usage: vm0 volume init --name <volume-name>"),
-        );
-        process.exit(1);
+        throw new Error("--name flag is required in non-interactive mode", {
+          cause: new Error("Usage: vm0 volume init --name <volume-name>"),
+        });
       } else {
         // Interactive prompt with directory name as default
         const defaultName = isValidStorageName(dirName) ? dirName : undefined;
@@ -70,16 +65,11 @@ export const initCommand = new Command()
 
       // Validate volume name
       if (!isValidStorageName(volumeName)) {
-        console.error(chalk.red(`✗ Invalid volume name: "${volumeName}"`));
-        console.error(
-          chalk.dim(
-            "  Volume names must be 3-64 characters, lowercase alphanumeric with hyphens",
+        throw new Error(`Invalid volume name: "${volumeName}"`, {
+          cause: new Error(
+            "Volume names must be 3-64 characters, lowercase alphanumeric with hyphens",
           ),
-        );
-        console.error(
-          chalk.dim("  Example: my-dataset, user-data-v2, training-set-2024"),
-        );
-        process.exit(1);
+        });
       }
 
       // Write config file

--- a/turbo/apps/cli/src/commands/volume/pull.ts
+++ b/turbo/apps/cli/src/commands/volume/pull.ts
@@ -25,9 +25,9 @@ export const pullCommand = new Command()
       // Read storage config
       const config = await readStorageConfig(cwd);
       if (!config) {
-        console.error(chalk.red("✗ No volume initialized in this directory"));
-        console.error(chalk.dim("  Run: vm0 volume init"));
-        process.exit(1);
+        throw new Error("No volume initialized in this directory", {
+          cause: new Error("Run: vm0 volume init"),
+        });
       }
 
       if (versionId) {

--- a/turbo/apps/cli/src/commands/volume/push.ts
+++ b/turbo/apps/cli/src/commands/volume/push.ts
@@ -19,9 +19,9 @@ export const pushCommand = new Command()
       // Read storage config
       const config = await readStorageConfig(cwd);
       if (!config) {
-        console.error(chalk.red("✗ No volume initialized in this directory"));
-        console.error(chalk.dim("  Run: vm0 volume init"));
-        process.exit(1);
+        throw new Error("No volume initialized in this directory", {
+          cause: new Error("Run: vm0 volume init"),
+        });
       }
 
       console.log(`Pushing volume: ${config.name}`);


### PR DESCRIPTION
## Summary

- Replace 14 `console.error` + `process.exit(1)` dual exit paths with `throw new Error` (with optional `cause`) in 8 storage command files
- **volume**: init (2 fixes), push (1 fix), pull (1 fix)
- **memory**: init (2 fixes), push (2 fixes)
- **artifact**: init (2 fixes), push (2 fixes), pull (2 fixes)
- Updated 2 test files (volume/init, artifact/init) to match new error output format

Closes #4155 (partial)

## Test plan

- [x] All 193 storage command tests pass (volume + memory + artifact)
- [x] Type check passes
- [x] Lint passes
- [x] Knip passes
- [x] Format check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)