### PR TITLE
feat: remove Clerk org creation from scope service

### DIFF
--- a/turbo/apps/web/app/api/agent/composes/__tests__/get-by-name.test.ts
+++ b/turbo/apps/web/app/api/agent/composes/__tests__/get-by-name.test.ts
@@ -226,7 +226,7 @@ describe("GET /api/agent/composes?name=<name>", () => {
 
     // Get the owner's scope slug to derive clerkOrgId
     const ownerScope = await getTestScope(user.scopeId);
-    const ownerClerkOrgId = `org_mock_${ownerScope.slug}`;
+    const ownerClerkOrgId = ownerScope.clerkOrgId;
 
     // Grant email permission to the recipient
     const recipientEmail = "recipient-org@example.com";
@@ -258,7 +258,7 @@ describe("GET /api/agent/composes?name=<name>", () => {
 
     // Get the owner's scope slug to derive clerkOrgId
     const ownerScope = await getTestScope(user.scopeId);
-    const ownerClerkOrgId = `org_mock_${ownerScope.slug}`;
+    const ownerClerkOrgId = ownerScope.clerkOrgId;
 
     // Switch to another user with no permission
     await context.setupUser({ prefix: "unauthorized-org" });

--- a/turbo/apps/web/app/api/cli/auth/test-token/route.ts
+++ b/turbo/apps/web/app/api/cli/auth/test-token/route.ts
@@ -55,9 +55,11 @@ async function ensureTestScope(
     scope = await ensureDefaultScope(userId);
   } catch (error) {
     if (!isNotFound(error)) throw error;
-    // User has no Clerk org — create one via the normal scope creation flow
+    // User has no Clerk org — create a test scope with a sentinel clerkOrgId
     const slug = generateDefaultScopeSlug(userId);
-    scope = await createScope(userId, slug);
+    scope = await createScope(userId, slug, {
+      clerkOrgId: `org_test_${userId}`,
+    });
   }
   return { scopeId: scope.id, clerkOrgId: scope.clerkOrgId };
 }

--- a/turbo/apps/web/app/api/scope/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/scope/__tests__/route.test.ts
@@ -309,6 +309,34 @@ describe("/api/scope", () => {
         expect(data.error.message).toContain("reserved");
       });
     });
+
+    it("should return 400 when user has no unmatched Clerk org", async () => {
+      const userId = `no-org-avail-${Date.now()}`;
+      mockClerk({ userId });
+
+      // First creation succeeds (matches user's default mock org)
+      const slug1 = `first-${Date.now()}`;
+      const req1 = createTestRequest("http://localhost:3000/api/scope", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ slug: slug1 }),
+      });
+      const res1 = await POST(req1);
+      expect(res1.status).toBe(201);
+
+      // Second creation fails (no more unmatched orgs)
+      const slug2 = `second-${Date.now()}`;
+      const req2 = createTestRequest("http://localhost:3000/api/scope", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ slug: slug2 }),
+      });
+      const res2 = await POST(req2);
+      const data = await res2.json();
+
+      expect(res2.status).toBe(400);
+      expect(data.error.message).toContain("No available Clerk organization");
+    });
   });
 
   describe("PUT /api/scope", () => {
@@ -420,9 +448,19 @@ describe("/api/scope", () => {
   describe("GET /api/scope (clerkOrgId resolution)", () => {
     it("should resolve scope by clerkOrgId from session", async () => {
       const userId = `clerk-org-test-${Date.now()}`;
-      mockClerk({ userId });
+      const org1Id = `org_first_${Date.now()}`;
+      const org2Id = `org_second_${Date.now()}`;
 
-      // Create first scope (becomes default)
+      // User has two Clerk orgs
+      mockClerk({
+        userId,
+        clerkOrgs: [
+          { id: org1Id, slug: `first-org`, name: "First Org" },
+          { id: org2Id, slug: `second-org`, name: "Second Org" },
+        ],
+      });
+
+      // Create first scope (matches first Clerk org)
       const slug1 = `first-org-${Date.now()}`;
       const req1 = createTestRequest("http://localhost:3000/api/scope", {
         method: "POST",
@@ -431,7 +469,7 @@ describe("/api/scope", () => {
       });
       await POST(req1);
 
-      // Create second scope
+      // Create second scope (matches second Clerk org)
       const slug2 = `second-org-${Date.now()}`;
       const req2 = createTestRequest("http://localhost:3000/api/scope", {
         method: "POST",
@@ -440,15 +478,8 @@ describe("/api/scope", () => {
       });
       await POST(req2);
 
-      // Set active org to second scope's clerkOrgId, include both scope orgs
-      mockClerk({
-        userId,
-        orgId: `org_mock_${slug2}`,
-        clerkOrgs: [
-          { id: `org_mock_${slug1}`, slug: slug1, name: slug1 },
-          { id: `org_mock_${slug2}`, slug: slug2, name: slug2 },
-        ],
-      });
+      // Set active org to second scope's clerkOrgId
+      mockClerk({ userId, orgId: org2Id });
 
       const request = createTestRequest("http://localhost:3000/api/scope");
       const response = await GET(request);

--- a/turbo/apps/web/app/api/scope/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/scope/__tests__/route.test.ts
@@ -491,7 +491,12 @@ describe("/api/scope", () => {
 
     it("should fall through to default when clerkOrgId has no matching scope", async () => {
       const userId = `no-match-org-${Date.now()}`;
-      mockClerk({ userId });
+      const clerkOrgs = [
+        { id: `org_mock_${userId}`, slug: `default-org`, name: "Default Org" },
+      ];
+
+      // Set up Clerk org BEFORE creating scope so POST resolves correct clerkOrgId
+      mockClerk({ userId, clerkOrgs });
 
       // Create a default scope
       const slug = `default-org-${Date.now()}`;
@@ -506,7 +511,7 @@ describe("/api/scope", () => {
       mockClerk({
         userId,
         orgId: "org_nonexistent_xyz",
-        clerkOrgs: [{ id: `org_mock_${slug}`, slug, name: slug }],
+        clerkOrgs,
       });
 
       const request = createTestRequest("http://localhost:3000/api/scope");

--- a/turbo/apps/web/app/api/scope/route.ts
+++ b/turbo/apps/web/app/api/scope/route.ts
@@ -111,6 +111,13 @@ const router = tsr.router(scopeContract, {
         userId,
       });
 
+      if (memberships.data.length === 0) {
+        return createErrorResponse(
+          "BAD_REQUEST",
+          "No available Clerk organization to associate with this scope",
+        );
+      }
+
       const orgIds = memberships.data.map((m) => m.organization.id);
       const matchedScopes = await globalThis.services.db
         .select({ clerkOrgId: scopes.clerkOrgId })

--- a/turbo/apps/web/app/api/scope/route.ts
+++ b/turbo/apps/web/app/api/scope/route.ts
@@ -11,14 +11,12 @@ import {
   updateScopeSlug,
   isVm0Admin,
   ensureDefaultScope,
+  resolveUnmatchedClerkOrg,
 } from "../../../src/lib/scope/scope-service";
 import { getUserEmail } from "../../../src/lib/auth/get-user-email";
 import { resolveScope } from "../../../src/lib/scope/resolve-scope";
 import { logger } from "../../../src/lib/logger";
 import { isBadRequest, isForbidden, isNotFound } from "../../../src/lib/errors";
-import { clerkClient } from "@clerk/nextjs/server";
-import { inArray } from "drizzle-orm";
-import { scopes } from "../../../src/db/schema/scope";
 
 const log = logger("api:scope");
 
@@ -106,28 +104,7 @@ const router = tsr.router(scopeContract, {
       }
 
       // Resolve clerkOrgId from user's Clerk org memberships
-      const client = await clerkClient();
-      const memberships = await client.users.getOrganizationMembershipList({
-        userId,
-      });
-
-      if (memberships.data.length === 0) {
-        return createErrorResponse(
-          "BAD_REQUEST",
-          "No available Clerk organization to associate with this scope",
-        );
-      }
-
-      const orgIds = memberships.data.map((m) => m.organization.id);
-      const matchedScopes = await globalThis.services.db
-        .select({ clerkOrgId: scopes.clerkOrgId })
-        .from(scopes)
-        .where(inArray(scopes.clerkOrgId, orgIds));
-      const existingOrgIds = new Set(matchedScopes.map((s) => s.clerkOrgId));
-
-      const unmatchedOrg = memberships.data.find(
-        (m) => !existingOrgIds.has(m.organization.id),
-      );
+      const unmatchedOrg = await resolveUnmatchedClerkOrg(userId);
 
       if (!unmatchedOrg) {
         return createErrorResponse(

--- a/turbo/apps/web/app/api/scope/route.ts
+++ b/turbo/apps/web/app/api/scope/route.ts
@@ -17,6 +17,7 @@ import { resolveScope } from "../../../src/lib/scope/resolve-scope";
 import { logger } from "../../../src/lib/logger";
 import { isBadRequest, isForbidden, isNotFound } from "../../../src/lib/errors";
 import { clerkClient } from "@clerk/nextjs/server";
+import { inArray } from "drizzle-orm";
 import { scopes } from "../../../src/db/schema/scope";
 
 const log = logger("api:scope");
@@ -110,10 +111,12 @@ const router = tsr.router(scopeContract, {
         userId,
       });
 
-      const existingScopes = await globalThis.services.db
+      const orgIds = memberships.data.map((m) => m.organization.id);
+      const matchedScopes = await globalThis.services.db
         .select({ clerkOrgId: scopes.clerkOrgId })
-        .from(scopes);
-      const existingOrgIds = new Set(existingScopes.map((s) => s.clerkOrgId));
+        .from(scopes)
+        .where(inArray(scopes.clerkOrgId, orgIds));
+      const existingOrgIds = new Set(matchedScopes.map((s) => s.clerkOrgId));
 
       const unmatchedOrg = memberships.data.find(
         (m) => !existingOrgIds.has(m.organization.id),

--- a/turbo/apps/web/app/api/scope/route.ts
+++ b/turbo/apps/web/app/api/scope/route.ts
@@ -16,6 +16,8 @@ import { getUserEmail } from "../../../src/lib/auth/get-user-email";
 import { resolveScope } from "../../../src/lib/scope/resolve-scope";
 import { logger } from "../../../src/lib/logger";
 import { isBadRequest, isForbidden, isNotFound } from "../../../src/lib/errors";
+import { clerkClient } from "@clerk/nextjs/server";
+import { scopes } from "../../../src/db/schema/scope";
 
 const log = logger("api:scope");
 
@@ -102,7 +104,32 @@ const router = tsr.router(scopeContract, {
         skipSlugValidation = true;
       }
 
-      const scope = await createScope(userId, slug, { skipSlugValidation });
+      // Resolve clerkOrgId from user's Clerk org memberships
+      const client = await clerkClient();
+      const memberships = await client.users.getOrganizationMembershipList({
+        userId,
+      });
+
+      const existingScopes = await globalThis.services.db
+        .select({ clerkOrgId: scopes.clerkOrgId })
+        .from(scopes);
+      const existingOrgIds = new Set(existingScopes.map((s) => s.clerkOrgId));
+
+      const unmatchedOrg = memberships.data.find(
+        (m) => !existingOrgIds.has(m.organization.id),
+      );
+
+      if (!unmatchedOrg) {
+        return createErrorResponse(
+          "BAD_REQUEST",
+          "No available Clerk organization to associate with this scope",
+        );
+      }
+
+      const scope = await createScope(userId, slug, {
+        skipSlugValidation,
+        clerkOrgId: unmatchedOrg.organization.id,
+      });
 
       return { status: 201 as const, body: scopeToResponseBody(scope) };
     } catch (error) {

--- a/turbo/apps/web/app/api/webhooks/agent/storages/commit/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/storages/commit/__tests__/route.test.ts
@@ -12,7 +12,6 @@ import {
   uniqueId,
   type UserContext,
 } from "../../../../../../../src/__tests__/test-helpers";
-import { mockClerk } from "../../../../../../../src/__tests__/clerk-mock";
 
 vi.hoisted(() => {
   vi.stubEnv("R2_USER_STORAGES_BUCKET_NAME", "test-storages-bucket");
@@ -78,8 +77,6 @@ describe("POST /api/webhooks/agent/storages/commit", () => {
     const { runId } = await createTestRun(composeId, "Test prompt");
     testRunId = runId;
     testToken = await createTestSandboxToken(user.userId, testRunId);
-
-    mockClerk({ userId: null });
   });
 
   it("should return 401 without authentication", async () => {

--- a/turbo/apps/web/app/api/webhooks/agent/storages/prepare/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/storages/prepare/__tests__/route.test.ts
@@ -12,7 +12,7 @@ import {
   uniqueId,
   type UserContext,
 } from "../../../../../../../src/__tests__/test-helpers";
-import { mockClerk } from "../../../../../../../src/__tests__/clerk-mock";
+
 import { randomUUID } from "crypto";
 
 vi.hoisted(() => {
@@ -55,8 +55,6 @@ describe("POST /api/webhooks/agent/storages/prepare", () => {
     const { runId } = await createTestRun(composeId, "Test prompt");
     testRunId = runId;
     testToken = await createTestSandboxToken(user.userId, testRunId);
-
-    mockClerk({ userId: null });
   });
 
   it("should return 401 without authentication", async () => {

--- a/turbo/apps/web/src/__tests__/api-test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers.ts
@@ -353,9 +353,14 @@ export async function setScopeTier(
  */
 export async function getTestScope(
   scopeId: string,
-): Promise<{ id: string; slug: string; tier: string }> {
+): Promise<{ id: string; slug: string; tier: string; clerkOrgId: string }> {
   const [scope] = await globalThis.services.db
-    .select({ id: scopes.id, slug: scopes.slug, tier: scopes.tier })
+    .select({
+      id: scopes.id,
+      slug: scopes.slug,
+      tier: scopes.tier,
+      clerkOrgId: scopes.clerkOrgId,
+    })
     .from(scopes)
     .where(eq(scopes.id, scopeId))
     .limit(1);

--- a/turbo/apps/web/src/lib/scope/__tests__/org-cache-service.test.ts
+++ b/turbo/apps/web/src/lib/scope/__tests__/org-cache-service.test.ts
@@ -19,9 +19,11 @@ describe("getOrgData", () => {
   it("fetches from Clerk and caches on miss", async () => {
     const userId = uniqueId("test-user");
     const slug = uniqueId("scope");
-    mockClerk({ userId });
-
-    // Create a scope so Clerk mock has the org registered
+    // Set up Clerk org with slug-based ID BEFORE creating scope
+    mockClerk({
+      userId,
+      clerkOrgs: [{ id: `org_mock_${slug}`, slug, name: slug }],
+    });
     await createTestScope(slug);
     const clerkOrgId = `org_mock_${slug}`;
 
@@ -75,7 +77,11 @@ describe("getOrgData", () => {
   it("refetches from Clerk when cache is stale", async () => {
     const userId = uniqueId("test-user");
     const slug = uniqueId("scope");
-    mockClerk({ userId });
+    // Set up Clerk org with slug-based ID BEFORE creating scope
+    mockClerk({
+      userId,
+      clerkOrgs: [{ id: `org_mock_${slug}`, slug, name: slug }],
+    });
     await createTestScope(slug);
     const clerkOrgId = `org_mock_${slug}`;
 

--- a/turbo/apps/web/src/lib/scope/__tests__/resolve-scope.test.ts
+++ b/turbo/apps/web/src/lib/scope/__tests__/resolve-scope.test.ts
@@ -8,7 +8,8 @@ const context = testContext();
 
 /**
  * Build clerkOrgs array for scopes created in a test.
- * Each scope created via createTestScope has clerkOrgId = "org_mock_{slug}".
+ * Must be used BEFORE calling createTestScope() so the POST route
+ * resolves the correct clerkOrgId from the user's org memberships.
  */
 function scopeOrgs(...slugs: string[]) {
   return slugs.map((slug) => ({
@@ -26,14 +27,25 @@ describe("resolveScope", () => {
   it("tier 1: scopeSlug takes priority over orgId from session", async () => {
     const { userId } = await context.setupUser();
 
-    // Create two scopes for the same user
+    // Create two additional scopes — set up Clerk orgs BEFORE creating scopes
     const slug1 = uniqueId("scope");
     const slug2 = uniqueId("scope");
-    mockClerk({ userId });
+    mockClerk({
+      userId,
+      clerkOrgs: [
+        // Include the org from setupUser so it's already matched
+        {
+          id: `org_mock_${userId}`,
+          slug: `org-${userId}`,
+          name: `org-${userId}`,
+        },
+        ...scopeOrgs(slug1, slug2),
+      ],
+    });
     const scope1 = await createTestScope(slug1);
     const scope2 = await createTestScope(slug2);
 
-    // Mock session with orgId pointing to scope2, include both scope orgs
+    // Mock session with orgId pointing to scope2
     mockClerk({
       userId,
       orgId: `org_mock_${slug2}`,
@@ -51,8 +63,8 @@ describe("resolveScope", () => {
     const userId = uniqueId("test-user");
     const slug = uniqueId("scope");
 
-    // Create scope (clerkOrgId = "org_mock_{slug}" via Clerk mock)
-    mockClerk({ userId });
+    // Set up Clerk org BEFORE creating scope so POST resolves correct clerkOrgId
+    mockClerk({ userId, clerkOrgs: scopeOrgs(slug) });
     const created = await createTestScope(slug);
 
     // Mock session with orgId matching the scope's clerkOrgId
@@ -73,8 +85,8 @@ describe("resolveScope", () => {
     const userId = uniqueId("test-user");
     const slug = uniqueId("scope");
 
-    // Create scope
-    mockClerk({ userId });
+    // Set up Clerk org BEFORE creating scope
+    mockClerk({ userId, clerkOrgs: scopeOrgs(slug) });
     const created = await createTestScope(slug);
 
     // Mock session with a different orgId (should NOT be used)
@@ -95,8 +107,8 @@ describe("resolveScope", () => {
     const userId = uniqueId("test-user");
     const slug = uniqueId("scope");
 
-    // Create scope (user's default scope)
-    mockClerk({ userId });
+    // Set up Clerk org BEFORE creating scope
+    mockClerk({ userId, clerkOrgs: scopeOrgs(slug) });
     const created = await createTestScope(slug);
 
     // Mock as CLI token — no orgId in session, but Clerk API returns user's orgs
@@ -116,8 +128,8 @@ describe("resolveScope", () => {
     const userId = uniqueId("test-user");
     const slug = uniqueId("scope");
 
-    // Create scope (user's default scope)
-    mockClerk({ userId });
+    // Set up Clerk org BEFORE creating scope
+    mockClerk({ userId, clerkOrgs: scopeOrgs(slug) });
     const created = await createTestScope(slug);
 
     // Mock session with an orgId that doesn't match any scope
@@ -138,8 +150,13 @@ describe("resolveScope", () => {
     const slug1 = uniqueId("scope");
     const slug2 = uniqueId("scope");
 
+    // Set up two Clerk orgs BEFORE creating scopes
+    mockClerk({
+      userId,
+      clerkOrgs: scopeOrgs(slug1, slug2),
+    });
+
     // Create first scope (will be the default — earliest createdAt)
-    mockClerk({ userId });
     const scope1 = await createTestScope(slug1);
 
     // Create second scope
@@ -164,7 +181,8 @@ describe("resolveScope", () => {
     const userId = uniqueId("test-user");
     const slug = uniqueId("scope");
 
-    mockClerk({ userId });
+    // Set up Clerk org BEFORE creating scope
+    mockClerk({ userId, clerkOrgs: scopeOrgs(slug) });
     const created = await createTestScope(slug);
 
     // Mock session with orgTier in JWT claims
@@ -186,7 +204,8 @@ describe("resolveScope", () => {
     const userId = uniqueId("test-user");
     const slug = uniqueId("scope");
 
-    mockClerk({ userId });
+    // Set up Clerk org BEFORE creating scope
+    mockClerk({ userId, clerkOrgs: scopeOrgs(slug) });
     await createTestScope(slug);
 
     // Mock session WITHOUT orgTier
@@ -207,7 +226,8 @@ describe("resolveScope", () => {
     const slug1 = uniqueId("scope");
     const slug2 = uniqueId("scope");
 
-    mockClerk({ userId });
+    // Set up two Clerk orgs BEFORE creating scopes
+    mockClerk({ userId, clerkOrgs: scopeOrgs(slug1, slug2) });
     await createTestScope(slug1);
     await createTestScope(slug2);
 
@@ -229,7 +249,8 @@ describe("resolveScope", () => {
     const userId = uniqueId("test-user");
     const slug = uniqueId("scope");
 
-    mockClerk({ userId });
+    // Set up Clerk org BEFORE creating scope
+    mockClerk({ userId, clerkOrgs: scopeOrgs(slug) });
     await createTestScope(slug);
 
     mockClerk({
@@ -250,7 +271,8 @@ describe("resolveScope", () => {
     const otherUserId = uniqueId("other-user");
     const slug = uniqueId("scope");
 
-    mockClerk({ userId });
+    // Set up Clerk org BEFORE creating scope
+    mockClerk({ userId, clerkOrgs: scopeOrgs(slug) });
     await createTestScope(slug);
 
     // Mock as different user who is NOT in the org
@@ -269,7 +291,8 @@ describe("resolveScope", () => {
     const userId = uniqueId("test-user");
     const slug = uniqueId("scope");
 
-    mockClerk({ userId });
+    // Set up Clerk org BEFORE creating scope
+    mockClerk({ userId, clerkOrgs: scopeOrgs(slug) });
     const created = await createTestScope(slug);
 
     // Mock session — orgId is different from the explicit clerkOrgId
@@ -291,7 +314,8 @@ describe("resolveScope", () => {
     const slug1 = uniqueId("scope");
     const slug2 = uniqueId("scope");
 
-    mockClerk({ userId });
+    // Set up two Clerk orgs BEFORE creating scopes
+    mockClerk({ userId, clerkOrgs: scopeOrgs(slug1, slug2) });
     const scope1 = await createTestScope(slug1);
     await createTestScope(slug2);
 
@@ -318,7 +342,8 @@ describe("requireScopeFromRequest", () => {
     const userId = uniqueId("test-user");
     const slug = uniqueId("scope");
 
-    mockClerk({ userId });
+    // Set up Clerk org BEFORE creating scope
+    mockClerk({ userId, clerkOrgs: scopeOrgs(slug) });
     const created = await createTestScope(slug);
 
     mockClerk({
@@ -341,7 +366,8 @@ describe("requireScopeFromRequest", () => {
     const slug1 = uniqueId("scope");
     const slug2 = uniqueId("scope");
 
-    mockClerk({ userId });
+    // Set up two Clerk orgs BEFORE creating scopes
+    mockClerk({ userId, clerkOrgs: scopeOrgs(slug1, slug2) });
     const scope1 = await createTestScope(slug1);
     await createTestScope(slug2);
 

--- a/turbo/apps/web/src/lib/scope/__tests__/scope-service.test.ts
+++ b/turbo/apps/web/src/lib/scope/__tests__/scope-service.test.ts
@@ -19,8 +19,8 @@ describe("getScopeByClerkOrgId", () => {
 
     const created = await createTestScope(slug);
 
-    // Clerk mock generates clerkOrgId as "org_mock_{slug}"
-    const result = await getScopeByClerkOrgId(`org_mock_${slug}`);
+    // POST route resolves clerkOrgId from user's Clerk org membership (org_mock_{userId})
+    const result = await getScopeByClerkOrgId(`org_mock_${userId}`);
 
     expect(result).not.toBeNull();
     expect(result!.id).toBe(created.id);
@@ -57,22 +57,15 @@ describe("createScope", () => {
     expect(client.organizations.createOrganization).not.toHaveBeenCalled();
   });
 
-  it("should create a new Clerk org when clerkOrgId is not provided", async () => {
+  it("should require clerkOrgId parameter", async () => {
     const userId = uniqueId("test-user");
     const slug = uniqueId("scope");
+    const clerkOrgId = `org_required_${slug}`;
     mockClerk({ userId });
 
-    const scope = await createScope(userId, slug);
+    const scope = await createScope(userId, slug, { clerkOrgId });
 
     expect(scope.slug).toBe(slug);
-    // Clerk mock generates org ID as "org_mock_{slug}"
-    expect(scope.clerkOrgId).toBe(`org_mock_${slug}`);
-
-    // Verify Clerk createOrganization WAS called
-    const client = await clerkClient();
-    expect(client.organizations.createOrganization).toHaveBeenCalledWith({
-      name: slug,
-      createdBy: userId,
-    });
+    expect(scope.clerkOrgId).toBe(clerkOrgId);
   });
 });

--- a/turbo/apps/web/src/lib/scope/scope-service.ts
+++ b/turbo/apps/web/src/lib/scope/scope-service.ts
@@ -238,50 +238,72 @@ function isValidSlug(slug: string): boolean {
 }
 
 /**
- * Discover an existing Clerk org for a user and create a local scope bound to it.
- * Queries the Clerk API for the user's org memberships, finds the first org
- * without a matching local scope, and creates a scope record.
+ * Resolve the first Clerk org membership for a user that has no matching local scope.
+ * Fetches the user's Clerk org memberships, batch-queries existing scopes, and
+ * returns the first unmatched membership (or null if all orgs are already bound).
  */
-async function discoverAndCreateScope(clerkUserId: string) {
+export async function resolveUnmatchedClerkOrg(clerkUserId: string) {
   const client = await clerkClient();
   const memberships = await client.users.getOrganizationMembershipList({
     userId: clerkUserId,
   });
 
-  for (const membership of memberships.data) {
-    const clerkOrgId = membership.organization.id;
-    const existingScope = await getScopeByClerkOrgId(clerkOrgId);
-    if (existingScope) continue;
-
-    // Prefer Clerk org slug, fall back to deterministic user-{hash}
-    const clerkSlug = membership.organization.slug;
-    let slug: string;
-    if (clerkSlug && isValidSlug(clerkSlug)) {
-      const taken = await getScopeBySlug(clerkSlug);
-      slug = taken ? generateDefaultScopeSlug(clerkUserId) : clerkSlug;
-    } else {
-      slug = generateDefaultScopeSlug(clerkUserId);
-    }
-
-    try {
-      return await createScope(clerkUserId, slug, { clerkOrgId });
-    } catch (error) {
-      if (isBadRequest(error) && error.message.includes("already exists")) {
-        // Re-check: another concurrent request may have created this scope
-        const raceScope = await getScopeByClerkOrgId(clerkOrgId);
-        if (raceScope) return raceScope;
-
-        // Slug collision with unrelated scope — retry with random slug
-        const fallbackSlug = `user-${randomBytes(4).toString("hex")}`;
-        return await createScope(clerkUserId, fallbackSlug, { clerkOrgId });
-      }
-      throw error;
-    }
+  if (memberships.data.length === 0) {
+    return null;
   }
 
-  throw notFound(
-    "No organization found. Please sign up again to create an organization.",
+  const orgIds = memberships.data.map((m) => m.organization.id);
+  const matchedScopes = await globalThis.services.db
+    .select({ clerkOrgId: scopes.clerkOrgId })
+    .from(scopes)
+    .where(inArray(scopes.clerkOrgId, orgIds));
+  const existingOrgIds = new Set(matchedScopes.map((s) => s.clerkOrgId));
+
+  return (
+    memberships.data.find((m) => !existingOrgIds.has(m.organization.id)) ?? null
   );
+}
+
+/**
+ * Discover an existing Clerk org for a user and create a local scope bound to it.
+ * Queries the Clerk API for the user's org memberships, finds the first org
+ * without a matching local scope, and creates a scope record.
+ */
+async function discoverAndCreateScope(clerkUserId: string) {
+  const unmatchedMembership = await resolveUnmatchedClerkOrg(clerkUserId);
+
+  if (!unmatchedMembership) {
+    throw notFound(
+      "No organization found. Please sign up again to create an organization.",
+    );
+  }
+
+  const clerkOrgId = unmatchedMembership.organization.id;
+
+  // Prefer Clerk org slug, fall back to deterministic user-{hash}
+  const clerkSlug = unmatchedMembership.organization.slug;
+  let slug: string;
+  if (clerkSlug && isValidSlug(clerkSlug)) {
+    const taken = await getScopeBySlug(clerkSlug);
+    slug = taken ? generateDefaultScopeSlug(clerkUserId) : clerkSlug;
+  } else {
+    slug = generateDefaultScopeSlug(clerkUserId);
+  }
+
+  try {
+    return await createScope(clerkUserId, slug, { clerkOrgId });
+  } catch (error) {
+    if (isBadRequest(error) && error.message.includes("already exists")) {
+      // Re-check: another concurrent request may have created this scope
+      const raceScope = await getScopeByClerkOrgId(clerkOrgId);
+      if (raceScope) return raceScope;
+
+      // Slug collision with unrelated scope — retry with random slug
+      const fallbackSlug = `user-${randomBytes(4).toString("hex")}`;
+      return await createScope(clerkUserId, fallbackSlug, { clerkOrgId });
+    }
+    throw error;
+  }
 }
 
 /**

--- a/turbo/apps/web/src/lib/scope/scope-service.ts
+++ b/turbo/apps/web/src/lib/scope/scope-service.ts
@@ -141,29 +141,20 @@ export async function getScopesByClerkOrgIds(
 export async function createScope(
   clerkUserId: string,
   slug: string,
-  options?: { skipSlugValidation?: boolean; clerkOrgId?: string },
+  options: { skipSlugValidation?: boolean; clerkOrgId: string },
 ) {
   // Validate slug (unless explicitly skipped for vm0-admin)
-  if (!options?.skipSlugValidation) {
+  if (!options.skipSlugValidation) {
     validateScopeSlug(slug);
   }
 
-  // Pre-check slug availability for clear error before Clerk API call
+  // Pre-check slug availability for clear error
   const existingScope = await getScopeBySlug(slug);
   if (existingScope) {
     throw badRequest(`Scope "${slug}" already exists`);
   }
 
-  // Use provided Clerk org ID (JIT discovery path) or create a new one.
-  let clerkOrgId = options?.clerkOrgId;
-  if (!clerkOrgId) {
-    const client = await clerkClient();
-    const clerkOrg = await client.organizations.createOrganization({
-      name: slug,
-      createdBy: clerkUserId,
-    });
-    clerkOrgId = clerkOrg.id;
-  }
+  const { clerkOrgId } = options;
 
   // Create scope + admin membership atomically
   const scope = await globalThis.services.db.transaction(async (tx) => {


### PR DESCRIPTION
## Summary

- Remove `createOrganization()` call from `createScope()` — vm0 is now a pure Clerk consumer
- Make `clerkOrgId` a required parameter in `createScope()` (aligns with DB NOT NULL constraint)
- Update `POST /api/scope` to resolve `clerkOrgId` from user's Clerk org memberships before creating scope
- Add test for "no available Clerk org" error case

Closes #4234

## Test plan

- [x] All 37 scope-related tests pass (scope-service, route, resolve-scope)
- [x] New test: returns 400 when user has no unmatched Clerk org
- [x] TypeScript type checking passes (no callers missing required `clerkOrgId`)
- [x] Lint, format, and knip checks pass
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)