### PR TITLE
refactor(cli): replace process.exit with throw in run and cook commands

### DIFF
--- a/turbo/apps/cli/src/commands/cook/continue.ts
+++ b/turbo/apps/cli/src/commands/cook/continue.ts
@@ -1,5 +1,4 @@
 import { Command, Option } from "commander";
-import chalk from "chalk";
 import path from "path";
 import { loadCookState, saveCookState } from "../../lib/domain/cook-state";
 import { withErrorHandler } from "../../lib/command";

--- a/turbo/apps/cli/src/commands/cook/continue.ts
+++ b/turbo/apps/cli/src/commands/cook/continue.ts
@@ -35,9 +35,9 @@ export const continueCommand = new Command()
       ) => {
         const state = await loadCookState();
         if (!state.lastSessionId) {
-          console.error(chalk.red("✗ No previous session found"));
-          console.error(chalk.dim("  Run 'vm0 cook <prompt>' first"));
-          process.exit(1);
+          throw new Error("No previous session found", {
+            cause: new Error("Run 'vm0 cook <prompt>' first"),
+          });
         }
 
         const cwd = process.cwd();
@@ -66,8 +66,7 @@ export const continueCommand = new Command()
             { cwd },
           );
         } catch {
-          // Error already displayed by vm0 run
-          process.exit(1);
+          throw new Error("Run command failed");
         }
 
         // Update state with new IDs

--- a/turbo/apps/cli/src/commands/cook/logs.ts
+++ b/turbo/apps/cli/src/commands/cook/logs.ts
@@ -30,9 +30,9 @@ export const logsCommand = new Command()
       }) => {
         const state = await loadCookState();
         if (!state.lastRunId) {
-          console.error(chalk.red("✗ No previous run found"));
-          console.error(chalk.dim("  Run 'vm0 cook <prompt>' first"));
-          process.exit(1);
+          throw new Error("No previous run found", {
+            cause: new Error("Run 'vm0 cook <prompt>' first"),
+          });
         }
 
         // Build command args

--- a/turbo/apps/cli/src/commands/cook/logs.ts
+++ b/turbo/apps/cli/src/commands/cook/logs.ts
@@ -1,5 +1,4 @@
 import { Command } from "commander";
-import chalk from "chalk";
 import { loadCookState } from "../../lib/domain/cook-state";
 import { withErrorHandler } from "../../lib/command";
 import { printCommand, execVm0Command } from "./utils";

--- a/turbo/apps/cli/src/commands/cook/resume.ts
+++ b/turbo/apps/cli/src/commands/cook/resume.ts
@@ -1,5 +1,4 @@
 import { Command, Option } from "commander";
-import chalk from "chalk";
 import path from "path";
 import { loadCookState, saveCookState } from "../../lib/domain/cook-state";
 import { withErrorHandler } from "../../lib/command";

--- a/turbo/apps/cli/src/commands/cook/resume.ts
+++ b/turbo/apps/cli/src/commands/cook/resume.ts
@@ -35,9 +35,9 @@ export const resumeCommand = new Command()
       ) => {
         const state = await loadCookState();
         if (!state.lastCheckpointId) {
-          console.error(chalk.red("✗ No previous checkpoint found"));
-          console.error(chalk.dim("  Run 'vm0 cook <prompt>' first"));
-          process.exit(1);
+          throw new Error("No previous checkpoint found", {
+            cause: new Error("Run 'vm0 cook <prompt>' first"),
+          });
         }
 
         const cwd = process.cwd();
@@ -66,8 +66,7 @@ export const resumeCommand = new Command()
             { cwd },
           );
         } catch {
-          // Error already displayed by vm0 run
-          process.exit(1);
+          throw new Error("Run command failed");
         }
 
         // Update state with new IDs

--- a/turbo/apps/cli/src/commands/run/continue.ts
+++ b/turbo/apps/cli/src/commands/run/continue.ts
@@ -117,7 +117,7 @@ export const continueCommand = new Command()
         const verbose = options.verbose || allOpts.verbose;
         const result = await pollEvents(response.runId, { verbose });
         if (!result.succeeded) {
-          process.exit(1);
+          throw new Error("Run failed");
         }
         showNextSteps(result);
       },

--- a/turbo/apps/cli/src/commands/run/list.ts
+++ b/turbo/apps/cli/src/commands/run/list.ts
@@ -58,12 +58,9 @@ function parseStatusFilter(options: ListOptions): string | undefined {
     const values = options.status.split(",").map((s) => s.trim());
     for (const v of values) {
       if (!ALL_RUN_STATUSES.includes(v as RunStatus)) {
-        console.error(
-          chalk.red(
-            `Error: Invalid status "${v}". Valid values: ${VALID_STATUSES}`,
-          ),
-        );
-        process.exit(1);
+        throw new Error(`Invalid status "${v}"`, {
+          cause: new Error(`Valid values: ${VALID_STATUSES}`),
+        });
       }
     }
     return values.join(",");
@@ -85,12 +82,9 @@ function parseTimeOption(value: string, optionName: string): string {
   try {
     return new Date(parseTime(value)).toISOString();
   } catch {
-    console.error(
-      chalk.red(
-        `Error: Invalid ${optionName} format. Use ISO (2026-01-01) or relative (1h, 7d, 30d)`,
-      ),
+    throw new Error(
+      `Invalid ${optionName} format. Use ISO (2026-01-01) or relative (1h, 7d, 30d)`,
     );
-    process.exit(1);
   }
 }
 
@@ -102,8 +96,7 @@ function parseLimit(value: string | undefined): number | undefined {
 
   const limit = parseInt(value, 10);
   if (isNaN(limit) || limit < 1 || limit > 100) {
-    console.error(chalk.red("Error: --limit must be between 1 and 100"));
-    process.exit(1);
+    throw new Error("--limit must be between 1 and 100");
   }
   return limit;
 }
@@ -166,10 +159,7 @@ export const listCommand = new Command()
     withErrorHandler(async (options: ListOptions) => {
       // Validate mutual exclusion
       if (options.all && options.status) {
-        console.error(
-          chalk.red("Error: --all and --status are mutually exclusive"),
-        );
-        process.exit(1);
+        throw new Error("--all and --status are mutually exclusive");
       }
 
       // Parse options
@@ -184,8 +174,7 @@ export const listCommand = new Command()
 
       // Validate since < until
       if (since && until && new Date(since) >= new Date(until)) {
-        console.error(chalk.red("Error: --since must be before --until"));
-        process.exit(1);
+        throw new Error("--since must be before --until");
       }
 
       // Fetch runs with filters

--- a/turbo/apps/cli/src/commands/run/resume.ts
+++ b/turbo/apps/cli/src/commands/run/resume.ts
@@ -127,7 +127,7 @@ export const resumeCommand = new Command()
         const verbose = options.verbose || allOpts.verbose;
         const result = await pollEvents(response.runId, { verbose });
         if (!result.succeeded) {
-          process.exit(1);
+          throw new Error("Run failed");
         }
         showNextSteps(result);
       },

--- a/turbo/apps/cli/src/commands/run/run.ts
+++ b/turbo/apps/cli/src/commands/run/run.ts
@@ -214,7 +214,7 @@ export const mainRunCommand = new Command()
           verbose: options.verbose,
         });
         if (!result.succeeded) {
-          process.exit(1);
+          throw new Error("Run failed");
         }
         showNextSteps(result);
 


### PR DESCRIPTION
## Summary

- Replace 13 `console.error` + `process.exit(1)` dual exit paths with `throw new Error` (with optional `cause`) in 7 command files
- **run/list.ts**: 5 fixes — status validation, time parsing, limit validation, mutual exclusion checks
- **run/run.ts, run/resume.ts, run/continue.ts**: 3 fixes — failed run exit codes
- **cook/resume.ts, cook/continue.ts**: 4 fixes — missing state checks and subprocess error handling
- **cook/logs.ts**: 1 fix — missing run state check

Closes #4155 (partial)

## Test plan

- [x] All 156 run + cook command tests pass
- [x] Type check passes
- [x] Lint passes
- [x] Knip passes
- [x] Format check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)