### PR TITLE
feat(monitoring): add firecracker process count metric

### DIFF
--- a/ansible/playbooks/provision-monitoring.yml
+++ b/ansible/playbooks/provision-monitoring.yml
@@ -75,9 +75,20 @@
             }
           }
 
-          // Override instance label with inventory hostname
+          // Count firecracker processes
+          prometheus.exporter.process "default" {
+            matcher {
+              name = "firecracker"
+              comm = ["firecracker"]
+            }
+          }
+
+          // Merge all exporter targets and override instance label
           discovery.relabel "default" {
-            targets = prometheus.exporter.unix.default.targets
+            targets = concat(
+              prometheus.exporter.unix.default.targets,
+              prometheus.exporter.process.default.targets,
+            )
 
             rule {
               target_label = "instance"
@@ -85,15 +96,23 @@
             }
           }
 
-          // Rewrite nodename label to inventory hostname
+          // Relabel and filter before remote write
           prometheus.relabel "default" {
             forward_to = [prometheus.remote_write.grafana_cloud.receiver]
 
+            // Rewrite nodename label to inventory hostname
             rule {
               source_labels = ["nodename"]
               regex         = ".+"
               target_label  = "nodename"
               replacement   = "{{ inventory_hostname }}"
+            }
+
+            // Drop all process exporter metrics except num_procs
+            rule {
+              source_labels = ["__name__"]
+              regex         = "namedprocess_(?!namegroup_num_procs).+"
+              action        = "drop"
             }
           }
 


### PR DESCRIPTION
## Summary
- Add `prometheus.exporter.process` to Alloy config to track firecracker process count per host
- Drop all process exporter metrics except `namedprocess_namegroup_num_procs` to minimize cardinality
- Update comments to reflect merged exporter targets and relabel/filter pipeline

## Grafana query
```promql
namedprocess_namegroup_num_procs{groupname="firecracker"}
```

## Test plan
- [ ] Deploy to dev-1 via `ansible-playbook` and verify Alloy restarts without errors
- [ ] Confirm `namedprocess_namegroup_num_procs{groupname="firecracker"}` appears in Grafana Cloud

🤖 Generated with [Claude Code](https://claude.com/claude-code)