### PR TITLE
feat: auto-provision ssh key from 1password for dev-runner

### DIFF
--- a/scripts/dev-runner.sh
+++ b/scripts/dev-runner.sh
@@ -38,7 +38,13 @@ RUNNER_BIN="~/$REMOTE_BIN_DIR/runner"
 RUNNER_DIR="~/.vm0-runner/runners/$RUNNER_NAME"
 
 CF_SSH="$SCRIPT_DIR/cf-ssh.sh"
-ssh_cmd() { "$CF_SSH" "$HOST" -l "$SSH_USER" "$@"; }
+SSH_KEY="$PROJECT_ROOT/.certs/vm0-metal-local.pem"
+if [[ ! -f "$SSH_KEY" ]]; then
+  log "Error: SSH key not found at $SSH_KEY"
+  log "Run 'scripts/sync-env.sh' to provision it from 1Password."
+  exit 1
+fi
+ssh_cmd() { "$CF_SSH" "$HOST" -l "$SSH_USER" -i "$SSH_KEY" "$@"; }
 
 # --- Commands ---
 

--- a/scripts/sync-env.sh
+++ b/scripts/sync-env.sh
@@ -78,6 +78,20 @@ configure_runner_group() {
   echo "  ✓ RUNNER_DEFAULT_GROUP=${group_name}"
 }
 
+# --- SSH key provisioning ---
+provision_ssh_key() {
+  local key_ref="op://Team/vm0-metal-local/private_key"
+  local key_path="$PROJECT_ROOT/.certs/vm0-metal-local.pem"
+
+  echo ""
+  echo "Provisioning SSH key..."
+  mkdir -p "$PROJECT_ROOT/.certs"
+  op read "${key_ref}?ssh-format=openssh" -o "$key_path" --force
+  chmod 600 "$key_path"
+  echo "  ✓ SSH key written to ${key_path}"
+}
+
 # --- Main ---
 sync_with_1password
 configure_runner_group
+provision_ssh_key


### PR DESCRIPTION
## Summary
- `sync-env.sh` now fetches the metal host SSH key from 1Password (`op://Team/vm0-metal-local/private_key`) and writes to `.certs/vm0-metal-local.pem`
- `dev-runner.sh` passes `-i .certs/vm0-metal-local.pem` to `cf-ssh.sh` when connecting
- Clear error message if the key file is missing, directing user to run `sync-env.sh`

## Test plan
- [x] `pnpm runner` picks up the key and connects successfully
- [ ] Fresh `sync-env.sh` run provisions the key from 1Password

Closes #4218

🤖 Generated with [Claude Code](https://claude.com/claude-code)