### PR TITLE
feat: add elevenlabs api-token connector

### DIFF
--- a/turbo/apps/platform/src/views/settings-page/connector-icons.tsx
+++ b/turbo/apps/platform/src/views/settings-page/connector-icons.tsx
@@ -11,6 +11,7 @@ import computerIcon from "./icons/computer.svg";
 import deelIcon from "./icons/deel.svg";
 import docusignIcon from "./icons/docusign.svg";
 import dropboxIcon from "./icons/dropbox.svg";
+import elevenlabsIcon from "./icons/elevenlabs.svg";
 import figmaIcon from "./icons/figma.svg";
 import garminConnectIcon from "./icons/garmin-connect.svg";
 import githubIcon from "./icons/github.svg";
@@ -59,6 +60,7 @@ const CONNECTOR_ICONS: Readonly<Record<ConnectorType, string>> = Object.freeze({
   deel: deelIcon,
   docusign: docusignIcon,
   dropbox: dropboxIcon,
+  elevenlabs: elevenlabsIcon,
   figma: figmaIcon,
   "garmin-connect": garminConnectIcon,
   github: githubIcon,

--- a/turbo/apps/platform/src/views/settings-page/icons/elevenlabs.svg
+++ b/turbo/apps/platform/src/views/settings-page/icons/elevenlabs.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 24 24" fill="none"><path d="M4.6035 0v24h4.9317V0zm9.8613 0v24h4.9317V0z" fill="#000000"/></svg>

--- a/turbo/apps/web/src/lib/connector/provider-registry.ts
+++ b/turbo/apps/web/src/lib/connector/provider-registry.ts
@@ -15,6 +15,7 @@ import { closeHandler } from "./providers/close-handler";
 import { deelHandler } from "./providers/deel-handler";
 import { docusignHandler } from "./providers/docusign-handler";
 import { dropboxHandler } from "./providers/dropbox-handler";
+import { elevenlabsHandler } from "./providers/elevenlabs-handler";
 import { figmaHandler } from "./providers/figma-handler";
 import { garminConnectHandler } from "./providers/garmin-connect-handler";
 import { githubHandler } from "./providers/github-handler";
@@ -67,6 +68,7 @@ export const PROVIDER_HANDLERS: Record<
   deel: deelHandler,
   docusign: docusignHandler,
   dropbox: dropboxHandler,
+  elevenlabs: elevenlabsHandler,
   figma: figmaHandler,
   "garmin-connect": garminConnectHandler,
   github: githubHandler,

--- a/turbo/apps/web/src/lib/connector/providers/elevenlabs-handler.ts
+++ b/turbo/apps/web/src/lib/connector/providers/elevenlabs-handler.ts
@@ -1,0 +1,13 @@
+import { type ProviderHandler } from "../provider-types";
+
+export const elevenlabsHandler: ProviderHandler = {
+  buildAuthUrl() {
+    throw new Error("ElevenLabs does not support OAuth — use API key auth");
+  },
+  exchangeCode() {
+    throw new Error("ElevenLabs does not support OAuth — use API key auth");
+  },
+  getClientId: () => undefined,
+  getClientSecret: () => undefined,
+  getSecretName: () => "ELEVENLABS_TOKEN",
+};

--- a/turbo/packages/core/src/contracts/connectors.ts
+++ b/turbo/packages/core/src/contracts/connectors.ts
@@ -1687,6 +1687,27 @@ const CONNECTOR_TYPES_DEF = {
       RESEND_API_KEY: "$secrets.RESEND_API_KEY",
     } as Record<string, string>,
   },
+  elevenlabs: {
+    label: "ElevenLabs",
+    helpText:
+      "Connect your ElevenLabs account to generate speech, clone voices, manage audio projects, and access sound effects",
+    authMethods: {
+      "api-token": {
+        label: "API Key",
+        helpText:
+          "1. Log in to [ElevenLabs](https://elevenlabs.io)\n2. Click your profile icon → **Profile + API key**\n3. Copy your API key",
+        secrets: {
+          ELEVENLABS_TOKEN: {
+            label: "API Key",
+            required: true,
+            placeholder: "your-elevenlabs-api-key",
+          },
+        },
+      },
+    } as Record<string, ConnectorAuthMethodConfig>,
+    defaultAuthMethod: "api-token",
+    environmentMapping: {} as Record<string, string>,
+  },
 } satisfies Record<string, ConnectorConfig>;
 
 export type ConnectorType = keyof typeof CONNECTOR_TYPES_DEF;
@@ -2025,6 +2046,13 @@ const CONNECTOR_PROXY_CONFIGS: Partial<
   resend: {
     services: [service("https://api.resend.com", bearerAuth("RESEND_API_KEY"))],
   },
+  elevenlabs: {
+    services: [
+      service("https://api.elevenlabs.io", {
+        headers: { "xi-api-key": "${secrets.ELEVENLABS_TOKEN}" },
+      }),
+    ],
+  },
 };
 
 export const connectorTypeSchema = z.enum([
@@ -2074,6 +2102,7 @@ export const connectorTypeSchema = z.enum([
   "plausible",
   "productlane",
   "resend",
+  "elevenlabs",
 ]);
 
 /**


### PR DESCRIPTION
## Summary
- Add ElevenLabs as an API-token-only connector (Decision Matrix row 4)
- Users authenticate with their ElevenLabs API key, stored as `ELEVENLABS_TOKEN`
- MITM proxy uses `xi-api-key` header for `https://api.elevenlabs.io`

## Test plan
- [ ] Verify connector appears in settings connections page
- [ ] Set API key via `vm0 secret set ELEVENLABS_TOKEN <key>` and validate with skill
- [ ] Confirm no feature switch needed — connector is immediately available

🤖 Generated with [Claude Code](https://claude.com/claude-code)