### PR TITLE
feat(zero): implement team page with real subagent list and detail navigation

### DIFF
--- a/turbo/apps/platform/src/mocks/handlers/api-agents.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-agents.ts
@@ -13,11 +13,12 @@ export const apiAgentsHandlers = [
     return HttpResponse.json({
       composes: [
         {
-          id: "compose_1",
-          name: "default-agent",
+          id: "mock-compose-id",
+          name: "zero",
+          displayName: null,
           headVersionId: "version_1",
-          createdAt: "2024-01-01T00:00:00Z",
           updatedAt: "2024-01-01T00:00:00Z",
+          isOwner: true,
         },
       ],
     });

--- a/turbo/apps/platform/src/signals/agent-detail/types.ts
+++ b/turbo/apps/platform/src/signals/agent-detail/types.ts
@@ -20,6 +20,7 @@ interface AgentDefinition {
   instructions?: string;
   skills?: string[];
   environment?: Record<string, string>;
+  metadata?: { displayName?: string; sound?: string };
   experimental_runner?: { group: string };
   experimental_firewall?: {
     default: "allow" | "deny";

--- a/turbo/apps/platform/src/signals/bootstrap.ts
+++ b/turbo/apps/platform/src/signals/bootstrap.ts
@@ -51,7 +51,7 @@ const ROUTE_CONFIG = [
     setup: setupAuthPageWrapper(setupZeroPage$),
   },
   {
-    path: "/zero/job/:name",
+    path: "/zero/team/:name",
     setup: setupAuthPageWrapper(setupZeroJobDetailRoute$),
   },
   {

--- a/turbo/apps/platform/src/signals/bootstrap.ts
+++ b/turbo/apps/platform/src/signals/bootstrap.ts
@@ -29,6 +29,7 @@ import { setupProviderSetupPage$ } from "./provider-setup/provider-setup-page.ts
 import { setupSlackConnectPage$ } from "./slack-connect/slack-connect-page.ts";
 import { setupSlackConnectSuccessPage$ } from "./slack-connect/slack-connect-success-page.ts";
 import { setupZeroPage$ } from "./zero-page/zero-page.ts";
+import { setupZeroJobDetailRoute$ } from "./zero-page/zero-job-detail-route.ts";
 import { setupSelectOrgPage$ } from "./select-org/select-org-page.ts";
 import { setupTelegramSettingsPage$ } from "./integrations-page/telegram-settings-page.ts";
 import { setupTelegramConnectPage$ } from "./telegram-connect/telegram-connect-page.ts";
@@ -48,6 +49,10 @@ const ROUTE_CONFIG = [
   {
     path: "/zero/chat/:sessionId",
     setup: setupAuthPageWrapper(setupZeroPage$),
+  },
+  {
+    path: "/zero/job/:name",
+    setup: setupAuthPageWrapper(setupZeroJobDetailRoute$),
   },
   {
     path: "/zero/:tab/:sub",

--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-job-detail.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-job-detail.test.ts
@@ -13,6 +13,10 @@ import {
   zeroJobScheduleEntries$,
   zeroJobScheduleError$,
   fetchZeroJobData$,
+  saveZeroJobSchedule$,
+  deleteZeroJobSchedule$,
+  toggleZeroJobScheduleEnabled$,
+  type ZeroJobScheduleSaveParams,
 } from "../zero-job-detail";
 
 const context = testContext();
@@ -249,6 +253,336 @@ describe("zero-job-detail signals", () => {
       const detail = context.store.get(zeroJobDetail$);
       expect(detail).not.toBeNull();
       expect(detail!.isOwner).toBeFalsy();
+    });
+  });
+
+  describe("saveZeroJobSchedule$", () => {
+    async function setupWithAgent() {
+      server.use(
+        http.get("http://localhost:3000/api/agent/composes", () => {
+          return HttpResponse.json(mockAgentResponse());
+        }),
+        http.get(
+          "http://localhost:3000/api/agent/composes/compose-1/instructions",
+          () => {
+            return HttpResponse.json(mockInstructions());
+          },
+        ),
+        http.get("http://localhost:3000/api/agent/schedules", () => {
+          return HttpResponse.json({ schedules: [] });
+        }),
+      );
+
+      await setupPage({ context, path: "/", withoutRender: true });
+      await context.store.set(fetchZeroJobData$, "my-agent");
+    }
+
+    it("should save a cron schedule with every_day frequency", async () => {
+      let capturedBody: Record<string, unknown> = {};
+
+      await setupWithAgent();
+
+      server.use(
+        http.post(
+          "http://localhost:3000/api/agent/schedules",
+          async ({ request }) => {
+            capturedBody = (await request.json()) as Record<string, unknown>;
+            return HttpResponse.json({ id: "new-sched" });
+          },
+        ),
+        http.get("http://localhost:3000/api/agent/schedules", () => {
+          return HttpResponse.json({ schedules: [] });
+        }),
+      );
+
+      const params: ZeroJobScheduleSaveParams = {
+        prompt: "Run daily task",
+        freq: "every_day",
+        date: "2030-01-01",
+        hour: 9,
+        minute: 30,
+        timezone: "UTC",
+        intervalSeconds: 0,
+      };
+
+      await context.store.set(saveZeroJobSchedule$, params);
+
+      expect(capturedBody).toMatchObject({
+        composeId: "compose-1",
+        timezone: "UTC",
+        prompt: "Run daily task",
+        enabled: true,
+        cronExpression: "30 9 * * *",
+      });
+    });
+
+    it("should save a loop schedule with intervalSeconds", async () => {
+      let capturedBody: Record<string, unknown> = {};
+
+      await setupWithAgent();
+
+      server.use(
+        http.post(
+          "http://localhost:3000/api/agent/schedules",
+          async ({ request }) => {
+            capturedBody = (await request.json()) as Record<string, unknown>;
+            return HttpResponse.json({ id: "new-sched" });
+          },
+        ),
+        http.get("http://localhost:3000/api/agent/schedules", () => {
+          return HttpResponse.json({ schedules: [] });
+        }),
+      );
+
+      const params: ZeroJobScheduleSaveParams = {
+        prompt: "Poll every 5 min",
+        freq: "every_n_minutes",
+        date: "2030-01-01",
+        hour: 0,
+        minute: 0,
+        timezone: "UTC",
+        intervalSeconds: 300,
+      };
+
+      await context.store.set(saveZeroJobSchedule$, params);
+
+      expect(capturedBody).toMatchObject({
+        composeId: "compose-1",
+        prompt: "Poll every 5 min",
+        intervalSeconds: 300,
+      });
+      expect(capturedBody).not.toHaveProperty("cronExpression");
+      expect(capturedBody).not.toHaveProperty("atTime");
+    });
+
+    it("should throw for save when API returns error", async () => {
+      await setupWithAgent();
+
+      server.use(
+        http.post("http://localhost:3000/api/agent/schedules", () => {
+          return HttpResponse.json(
+            { error: { message: "Quota exceeded" } },
+            { status: 429, statusText: "Too Many Requests" },
+          );
+        }),
+      );
+
+      const params: ZeroJobScheduleSaveParams = {
+        prompt: "Task",
+        freq: "every_day",
+        date: "2030-01-01",
+        hour: 9,
+        minute: 0,
+        timezone: "UTC",
+        intervalSeconds: 0,
+      };
+
+      await expect(
+        context.store.set(saveZeroJobSchedule$, params),
+      ).rejects.toThrow("Quota exceeded");
+    });
+  });
+
+  describe("deleteZeroJobSchedule$", () => {
+    it("should send DELETE request with correct URL", async () => {
+      let capturedUrl = "";
+
+      server.use(
+        http.get("http://localhost:3000/api/agent/composes", () => {
+          return HttpResponse.json(mockAgentResponse());
+        }),
+        http.get(
+          "http://localhost:3000/api/agent/composes/compose-1/instructions",
+          () => {
+            return HttpResponse.json(mockInstructions());
+          },
+        ),
+        http.get("http://localhost:3000/api/agent/schedules", () => {
+          return HttpResponse.json(mockSchedules());
+        }),
+      );
+
+      await setupPage({ context, path: "/", withoutRender: true });
+      await context.store.set(fetchZeroJobData$, "my-agent");
+
+      server.use(
+        http.delete(
+          "http://localhost:3000/api/agent/schedules/:name",
+          ({ request }) => {
+            capturedUrl = request.url;
+            return new HttpResponse(null, { status: 204 });
+          },
+        ),
+        http.get("http://localhost:3000/api/agent/schedules", () => {
+          return HttpResponse.json({ schedules: [] });
+        }),
+      );
+
+      await context.store.set(deleteZeroJobSchedule$, "daily-run");
+
+      expect(capturedUrl).toContain("/api/agent/schedules/daily-run");
+      expect(capturedUrl).toContain("composeId=compose-1");
+
+      const entries = await context.store.get(zeroJobScheduleEntries$);
+      expect(entries).toStrictEqual([]);
+    });
+
+    it("should throw when delete API returns error", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/agent/composes", () => {
+          return HttpResponse.json(mockAgentResponse());
+        }),
+        http.get(
+          "http://localhost:3000/api/agent/composes/compose-1/instructions",
+          () => {
+            return HttpResponse.json(mockInstructions());
+          },
+        ),
+        http.get("http://localhost:3000/api/agent/schedules", () => {
+          return HttpResponse.json(mockSchedules());
+        }),
+      );
+
+      await setupPage({ context, path: "/", withoutRender: true });
+      await context.store.set(fetchZeroJobData$, "my-agent");
+
+      server.use(
+        http.delete("http://localhost:3000/api/agent/schedules/:name", () => {
+          return HttpResponse.json(
+            { error: { message: "Not found" } },
+            { status: 404, statusText: "Not Found" },
+          );
+        }),
+      );
+
+      await expect(
+        context.store.set(deleteZeroJobSchedule$, "nonexistent"),
+      ).rejects.toThrow("Not found");
+    });
+  });
+
+  describe("toggleZeroJobScheduleEnabled$", () => {
+    it("should send enable request for a schedule", async () => {
+      let capturedUrl = "";
+
+      server.use(
+        http.get("http://localhost:3000/api/agent/composes", () => {
+          return HttpResponse.json(mockAgentResponse());
+        }),
+        http.get(
+          "http://localhost:3000/api/agent/composes/compose-1/instructions",
+          () => {
+            return HttpResponse.json(mockInstructions());
+          },
+        ),
+        http.get("http://localhost:3000/api/agent/schedules", () => {
+          return HttpResponse.json(mockSchedules());
+        }),
+      );
+
+      await setupPage({ context, path: "/", withoutRender: true });
+      await context.store.set(fetchZeroJobData$, "my-agent");
+
+      server.use(
+        http.post(
+          "http://localhost:3000/api/agent/schedules/:name/:action",
+          ({ request }) => {
+            capturedUrl = request.url;
+            return HttpResponse.json({ ok: true });
+          },
+        ),
+        http.get("http://localhost:3000/api/agent/schedules", () => {
+          return HttpResponse.json(mockSchedules());
+        }),
+      );
+
+      await context.store.set(toggleZeroJobScheduleEnabled$, {
+        name: "daily-run",
+        enabled: true,
+      });
+
+      expect(capturedUrl).toContain("/api/agent/schedules/daily-run/enable");
+    });
+
+    it("should send disable request for a schedule", async () => {
+      let capturedUrl = "";
+
+      server.use(
+        http.get("http://localhost:3000/api/agent/composes", () => {
+          return HttpResponse.json(mockAgentResponse());
+        }),
+        http.get(
+          "http://localhost:3000/api/agent/composes/compose-1/instructions",
+          () => {
+            return HttpResponse.json(mockInstructions());
+          },
+        ),
+        http.get("http://localhost:3000/api/agent/schedules", () => {
+          return HttpResponse.json(mockSchedules());
+        }),
+      );
+
+      await setupPage({ context, path: "/", withoutRender: true });
+      await context.store.set(fetchZeroJobData$, "my-agent");
+
+      server.use(
+        http.post(
+          "http://localhost:3000/api/agent/schedules/:name/:action",
+          ({ request }) => {
+            capturedUrl = request.url;
+            return HttpResponse.json({ ok: true });
+          },
+        ),
+        http.get("http://localhost:3000/api/agent/schedules", () => {
+          return HttpResponse.json(mockSchedules());
+        }),
+      );
+
+      await context.store.set(toggleZeroJobScheduleEnabled$, {
+        name: "daily-run",
+        enabled: false,
+      });
+
+      expect(capturedUrl).toContain("/api/agent/schedules/daily-run/disable");
+    });
+
+    it("should show toast error when toggle API fails", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/agent/composes", () => {
+          return HttpResponse.json(mockAgentResponse());
+        }),
+        http.get(
+          "http://localhost:3000/api/agent/composes/compose-1/instructions",
+          () => {
+            return HttpResponse.json(mockInstructions());
+          },
+        ),
+        http.get("http://localhost:3000/api/agent/schedules", () => {
+          return HttpResponse.json(mockSchedules());
+        }),
+      );
+
+      await setupPage({ context, path: "/", withoutRender: true });
+      await context.store.set(fetchZeroJobData$, "my-agent");
+
+      server.use(
+        http.post(
+          "http://localhost:3000/api/agent/schedules/:name/:action",
+          () => {
+            return HttpResponse.json(
+              { error: { message: "Server error" } },
+              { status: 500, statusText: "Internal Server Error" },
+            );
+          },
+        ),
+      );
+
+      await expect(
+        context.store.set(toggleZeroJobScheduleEnabled$, {
+          name: "daily-run",
+          enabled: true,
+        }),
+      ).rejects.toThrow("Server error");
     });
   });
 });

--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-job-detail.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-job-detail.test.ts
@@ -1,0 +1,245 @@
+import { describe, expect, it } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../mocks/server";
+import { testContext } from "../../__tests__/test-helpers";
+import { setupPage } from "../../../__tests__/page-helper";
+import {
+  zeroJobDetail$,
+  zeroJobDetailLoading$,
+  zeroJobDetailError$,
+  zeroJobInstructions$,
+  zeroJobInstructionsLoading$,
+  zeroJobInstructionsError$,
+  zeroJobSchedule$,
+  zeroJobScheduleError$,
+  fetchZeroJobData$,
+} from "../zero-job-detail";
+
+const context = testContext();
+
+function mockAgentResponse() {
+  return {
+    id: "compose-1",
+    name: "my-agent",
+    headVersionId: "v1",
+    content: {
+      version: "1",
+      agents: {
+        main: {
+          description: "A test agent",
+          framework: "claude",
+          skills: ["search"],
+        },
+      },
+    },
+    createdAt: "2024-01-01T00:00:00Z",
+    updatedAt: "2024-06-15T12:00:00Z",
+  };
+}
+
+function mockInstructions() {
+  return {
+    content: "# Instructions\nDo the thing.",
+    filename: "instructions.md",
+  };
+}
+
+function mockSchedules() {
+  return {
+    schedules: [
+      {
+        id: "sched-1",
+        composeName: "my-agent",
+        name: "daily-run",
+        enabled: true,
+        cronExpression: "0 9 * * *",
+        atTime: null,
+        timezone: "UTC",
+        prompt: "Run the daily digest",
+      },
+      {
+        id: "sched-2",
+        composeName: "other-agent",
+        name: "other-run",
+        enabled: true,
+        cronExpression: "0 12 * * *",
+        atTime: null,
+        timezone: "UTC",
+        prompt: "Something else",
+      },
+    ],
+  };
+}
+
+describe("zero-job-detail signals", () => {
+  describe("fetchZeroJobData$", () => {
+    it("should fetch detail, instructions, and schedules successfully", async () => {
+      const agentResponse = mockAgentResponse();
+      server.use(
+        http.get("http://localhost:3000/api/agent/composes", () => {
+          return HttpResponse.json(agentResponse);
+        }),
+        http.get(
+          "http://localhost:3000/api/agent/composes/compose-1/instructions",
+          () => {
+            return HttpResponse.json(mockInstructions());
+          },
+        ),
+        http.get("http://localhost:3000/api/agent/schedules", () => {
+          return HttpResponse.json(mockSchedules());
+        }),
+      );
+
+      await setupPage({ context, path: "/", withoutRender: true });
+      await context.store.set(fetchZeroJobData$, "my-agent");
+
+      const detail = context.store.get(zeroJobDetail$);
+      const loading = context.store.get(zeroJobDetailLoading$);
+      const error = context.store.get(zeroJobDetailError$);
+
+      expect(detail).toStrictEqual({ ...agentResponse, isOwner: true });
+      expect(loading).toBeFalsy();
+      expect(error).toBeNull();
+
+      const instructions = context.store.get(zeroJobInstructions$);
+      const instructionsLoading = context.store.get(
+        zeroJobInstructionsLoading$,
+      );
+      const instructionsError = context.store.get(zeroJobInstructionsError$);
+
+      expect(instructions).toStrictEqual(mockInstructions());
+      expect(instructionsLoading).toBeFalsy();
+      expect(instructionsError).toBeNull();
+
+      const schedules = context.store.get(zeroJobSchedule$);
+      const scheduleError = context.store.get(zeroJobScheduleError$);
+
+      expect(schedules).toHaveLength(1);
+      expect(schedules[0]!.composeName).toBe("my-agent");
+      expect(scheduleError).toBeNull();
+    });
+
+    it("should set error state when detail API fails", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/agent/composes", () => {
+          return HttpResponse.json(
+            { error: "Not Found" },
+            { status: 404, statusText: "Not Found" },
+          );
+        }),
+      );
+
+      await setupPage({ context, path: "/", withoutRender: true });
+      await context.store.set(fetchZeroJobData$, "missing-agent");
+
+      const detail = context.store.get(zeroJobDetail$);
+      const loading = context.store.get(zeroJobDetailLoading$);
+      const error = context.store.get(zeroJobDetailError$);
+
+      expect(detail).toBeNull();
+      expect(loading).toBeFalsy();
+      expect(error).toBe("Failed to fetch agent: Not Found");
+    });
+
+    it("should set instructions error when instructions API fails", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/agent/composes", () => {
+          return HttpResponse.json(mockAgentResponse());
+        }),
+        http.get(
+          "http://localhost:3000/api/agent/composes/compose-1/instructions",
+          () => {
+            return HttpResponse.json(
+              { error: "Internal Server Error" },
+              { status: 500, statusText: "Internal Server Error" },
+            );
+          },
+        ),
+        http.get("http://localhost:3000/api/agent/schedules", () => {
+          return HttpResponse.json(mockSchedules());
+        }),
+      );
+
+      await setupPage({ context, path: "/", withoutRender: true });
+      await context.store.set(fetchZeroJobData$, "my-agent");
+
+      const instructions = context.store.get(zeroJobInstructions$);
+      const instructionsError = context.store.get(zeroJobInstructionsError$);
+
+      expect(instructions).toBeNull();
+      expect(instructionsError).toBe(
+        "Failed to fetch instructions: Internal Server Error",
+      );
+
+      // Detail should still succeed
+      expect(context.store.get(zeroJobDetail$)).not.toBeNull();
+    });
+
+    it("should set schedule error when schedules API fails", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/agent/composes", () => {
+          return HttpResponse.json(mockAgentResponse());
+        }),
+        http.get(
+          "http://localhost:3000/api/agent/composes/compose-1/instructions",
+          () => {
+            return HttpResponse.json(mockInstructions());
+          },
+        ),
+        http.get("http://localhost:3000/api/agent/schedules", () => {
+          return HttpResponse.json(
+            { error: "Forbidden" },
+            { status: 403, statusText: "Forbidden" },
+          );
+        }),
+      );
+
+      await setupPage({ context, path: "/", withoutRender: true });
+      await context.store.set(fetchZeroJobData$, "my-agent");
+
+      const schedules = context.store.get(zeroJobSchedule$);
+      const scheduleError = context.store.get(zeroJobScheduleError$);
+
+      expect(schedules).toStrictEqual([]);
+      expect(scheduleError).toBe("Failed to fetch schedules: Forbidden");
+
+      // Detail and instructions should still succeed
+      expect(context.store.get(zeroJobDetail$)).not.toBeNull();
+      expect(context.store.get(zeroJobInstructions$)).not.toBeNull();
+    });
+
+    it("should parse scoped agent name correctly", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/agent/composes", ({ request }) => {
+          const url = new URL(request.url);
+          const name = url.searchParams.get("name");
+          const scope = url.searchParams.get("scope");
+
+          expect(name).toBe("sub-agent");
+          expect(scope).toBe("my-org");
+
+          return HttpResponse.json({
+            ...mockAgentResponse(),
+            name: "sub-agent",
+          });
+        }),
+        http.get(
+          "http://localhost:3000/api/agent/composes/compose-1/instructions",
+          () => {
+            return HttpResponse.json(mockInstructions());
+          },
+        ),
+        http.get("http://localhost:3000/api/agent/schedules", () => {
+          return HttpResponse.json({ schedules: [] });
+        }),
+      );
+
+      await setupPage({ context, path: "/", withoutRender: true });
+      await context.store.set(fetchZeroJobData$, "my-org/sub-agent");
+
+      const detail = context.store.get(zeroJobDetail$);
+      expect(detail).not.toBeNull();
+      expect(detail!.isOwner).toBeFalsy();
+    });
+  });
+});

--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-job-detail.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-job-detail.test.ts
@@ -10,7 +10,7 @@ import {
   zeroJobInstructions$,
   zeroJobInstructionsLoading$,
   zeroJobInstructionsError$,
-  zeroJobSchedule$,
+  zeroJobScheduleEntries$,
   zeroJobScheduleError$,
   fetchZeroJobData$,
 } from "../zero-job-detail";
@@ -49,23 +49,31 @@ function mockSchedules() {
     schedules: [
       {
         id: "sched-1",
+        composeId: "compose-1",
         composeName: "my-agent",
         name: "daily-run",
         enabled: true,
+        triggerType: "cron",
         cronExpression: "0 9 * * *",
         atTime: null,
+        intervalSeconds: null,
         timezone: "UTC",
         prompt: "Run the daily digest",
+        createdAt: "2024-06-01T00:00:00Z",
       },
       {
         id: "sched-2",
+        composeId: "compose-2",
         composeName: "other-agent",
         name: "other-run",
         enabled: true,
+        triggerType: "cron",
         cronExpression: "0 12 * * *",
         atTime: null,
+        intervalSeconds: null,
         timezone: "UTC",
         prompt: "Something else",
+        createdAt: "2024-06-01T00:00:00Z",
       },
     ],
   };
@@ -111,11 +119,12 @@ describe("zero-job-detail signals", () => {
       expect(instructionsLoading).toBeFalsy();
       expect(instructionsError).toBeNull();
 
-      const schedules = context.store.get(zeroJobSchedule$);
+      const entries = await context.store.get(zeroJobScheduleEntries$);
       const scheduleError = context.store.get(zeroJobScheduleError$);
 
-      expect(schedules).toHaveLength(1);
-      expect(schedules[0]!.composeName).toBe("my-agent");
+      expect(entries).toHaveLength(1);
+      expect(entries[0]!.name).toBe("daily-run");
+      expect(entries[0]!.time).toBe("Every day at 9:00 AM");
       expect(scheduleError).toBeNull();
     });
 
@@ -197,10 +206,10 @@ describe("zero-job-detail signals", () => {
       await setupPage({ context, path: "/", withoutRender: true });
       await context.store.set(fetchZeroJobData$, "my-agent");
 
-      const schedules = context.store.get(zeroJobSchedule$);
+      const entries = await context.store.get(zeroJobScheduleEntries$);
       const scheduleError = context.store.get(zeroJobScheduleError$);
 
-      expect(schedules).toStrictEqual([]);
+      expect(entries).toStrictEqual([]);
       expect(scheduleError).toBe("Failed to fetch schedules: Forbidden");
 
       // Detail and instructions should still succeed

--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-job-detail.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-job-detail.test.ts
@@ -16,6 +16,21 @@ import {
   saveZeroJobSchedule$,
   deleteZeroJobSchedule$,
   toggleZeroJobScheduleEnabled$,
+  setZeroJobEditedContent$,
+  zeroJobEditedContent$,
+  zeroJobInstructionsDirty$,
+  discardZeroJobEdit$,
+  buildZeroJobInstructions$,
+  zeroJobBuilding$,
+  zeroJobBuildError$,
+  zeroJobUpdateSettings$,
+  zeroJobSettingsSaving$,
+  zeroJobAddedSkills$,
+  zeroJobSkillsDirty$,
+  addZeroJobSkill$,
+  removeZeroJobSkill$,
+  saveZeroJobSkills$,
+  discardZeroJobSkills$,
   type ZeroJobScheduleSaveParams,
 } from "../zero-job-detail";
 
@@ -31,7 +46,7 @@ function mockAgentResponse() {
       agents: {
         main: {
           description: "A test agent",
-          framework: "claude",
+          framework: "claude-code",
           skills: ["search"],
         },
       },
@@ -583,6 +598,387 @@ describe("zero-job-detail signals", () => {
           enabled: true,
         }),
       ).rejects.toThrow("Server error");
+    });
+  });
+
+  describe("instructions editing", () => {
+    async function setupWithAgent() {
+      server.use(
+        http.get("http://localhost:3000/api/agent/composes", () => {
+          return HttpResponse.json(mockAgentResponse());
+        }),
+        http.get(
+          "http://localhost:3000/api/agent/composes/compose-1/instructions",
+          () => {
+            return HttpResponse.json(mockInstructions());
+          },
+        ),
+        http.get("http://localhost:3000/api/agent/schedules", () => {
+          return HttpResponse.json({ schedules: [] });
+        }),
+      );
+
+      await setupPage({ context, path: "/", withoutRender: true });
+      await context.store.set(fetchZeroJobData$, "my-agent");
+    }
+
+    it("should track edited content and dirty state", async () => {
+      await setupWithAgent();
+
+      expect(context.store.get(zeroJobEditedContent$)).toBeNull();
+      expect(context.store.get(zeroJobInstructionsDirty$)).toBeFalsy();
+
+      context.store.set(setZeroJobEditedContent$, "New instructions");
+
+      expect(context.store.get(zeroJobEditedContent$)).toBe("New instructions");
+      expect(context.store.get(zeroJobInstructionsDirty$)).toBeTruthy();
+    });
+
+    it("should reset edited content on discard", async () => {
+      await setupWithAgent();
+
+      context.store.set(setZeroJobEditedContent$, "New instructions");
+      expect(context.store.get(zeroJobInstructionsDirty$)).toBeTruthy();
+
+      context.store.set(discardZeroJobEdit$);
+
+      expect(context.store.get(zeroJobEditedContent$)).toBeNull();
+      expect(context.store.get(zeroJobInstructionsDirty$)).toBeFalsy();
+    });
+
+    it("should build instructions via compose job and update state", async () => {
+      let capturedJobBody: Record<string, unknown> = {};
+
+      await setupWithAgent();
+
+      server.use(
+        http.post("*/api/compose/jobs", async ({ request }) => {
+          capturedJobBody = (await request.json()) as Record<string, unknown>;
+          return HttpResponse.json({
+            jobId: "job-1",
+            status: "completed",
+            result: {
+              composeId: "compose-1",
+              composeName: "my-agent",
+              versionId: "v2",
+              warnings: [],
+            },
+          });
+        }),
+        http.get("http://localhost:3000/api/agent/composes", () => {
+          return HttpResponse.json(mockAgentResponse());
+        }),
+      );
+
+      context.store.set(setZeroJobEditedContent$, "Updated instructions");
+      await context.store.set(buildZeroJobInstructions$);
+
+      // Build should succeed without errors
+      expect(context.store.get(zeroJobBuildError$)).toBeNull();
+
+      // Should have sent the edited content in the compose job
+      expect(capturedJobBody).toHaveProperty("instructions");
+      expect(capturedJobBody["instructions"]).toBe("Updated instructions");
+
+      // After build, edited content should be cleared
+      expect(context.store.get(zeroJobEditedContent$)).toBeNull();
+      expect(context.store.get(zeroJobBuilding$)).toBeFalsy();
+      expect(context.store.get(zeroJobBuildError$)).toBeNull();
+
+      // Instructions state should be optimistically updated
+      const instructions = context.store.get(zeroJobInstructions$);
+      expect(instructions?.content).toBe("Updated instructions");
+    });
+
+    it("should set build error on compose job failure", async () => {
+      await setupWithAgent();
+
+      server.use(
+        http.post("http://localhost:3000/api/compose/jobs", () => {
+          return HttpResponse.json(
+            { error: { message: "Build quota exceeded" } },
+            { status: 429, statusText: "Too Many Requests" },
+          );
+        }),
+      );
+
+      context.store.set(setZeroJobEditedContent$, "Updated instructions");
+      await context.store.set(buildZeroJobInstructions$);
+
+      expect(context.store.get(zeroJobBuilding$)).toBeFalsy();
+      expect(context.store.get(zeroJobBuildError$)).toBe(
+        "Failed to build instructions. Please try again.",
+      );
+
+      // Edited content should NOT be cleared on failure
+      expect(context.store.get(zeroJobEditedContent$)).toBe(
+        "Updated instructions",
+      );
+    });
+
+    it("should not build when no edited content", async () => {
+      let composeJobCalled = false;
+
+      await setupWithAgent();
+
+      server.use(
+        http.post("http://localhost:3000/api/compose/jobs", () => {
+          composeJobCalled = true;
+          return HttpResponse.json({ jobId: "job-1", status: "completed" });
+        }),
+      );
+
+      await context.store.set(buildZeroJobInstructions$);
+      expect(composeJobCalled).toBeFalsy();
+    });
+  });
+
+  describe("zeroJobUpdateSettings$", () => {
+    async function setupWithAgent() {
+      server.use(
+        http.get("http://localhost:3000/api/agent/composes", () => {
+          return HttpResponse.json(mockAgentResponse());
+        }),
+        http.get(
+          "http://localhost:3000/api/agent/composes/compose-1/instructions",
+          () => {
+            return HttpResponse.json(mockInstructions());
+          },
+        ),
+        http.get("http://localhost:3000/api/agent/schedules", () => {
+          return HttpResponse.json({ schedules: [] });
+        }),
+      );
+
+      await setupPage({ context, path: "/", withoutRender: true });
+      await context.store.set(fetchZeroJobData$, "my-agent");
+    }
+
+    it("should update settings via compose job and refetch", async () => {
+      let capturedJobBody: Record<string, unknown> = {};
+
+      await setupWithAgent();
+
+      server.use(
+        http.post(
+          "http://localhost:3000/api/compose/jobs",
+          async ({ request }) => {
+            capturedJobBody = (await request.json()) as Record<string, unknown>;
+            return HttpResponse.json({
+              jobId: "job-1",
+              status: "completed",
+              result: {
+                composeId: "compose-1",
+                composeName: "my-agent",
+                versionId: "v2",
+                warnings: [],
+              },
+            });
+          },
+        ),
+        http.get("http://localhost:3000/api/agent/composes", () => {
+          return HttpResponse.json(mockAgentResponse());
+        }),
+        http.get(
+          "http://localhost:3000/api/agent/composes/compose-1/instructions",
+          () => {
+            return HttpResponse.json(mockInstructions());
+          },
+        ),
+      );
+
+      await context.store.set(zeroJobUpdateSettings$, {
+        displayName: "New Name",
+        sound: "friendly",
+      });
+
+      // Should have sent updated content with new metadata
+      const content = capturedJobBody["content"] as Record<string, unknown>;
+      const agents = content["agents"] as Record<
+        string,
+        Record<string, unknown>
+      >;
+      const mainAgent = agents["main"];
+      const metadata = mainAgent["metadata"] as Record<string, string>;
+      expect(metadata["displayName"]).toBe("New Name");
+      expect(metadata["sound"]).toBe("friendly");
+
+      // Saving state should be reset
+      expect(context.store.get(zeroJobSettingsSaving$)).toBeFalsy();
+    });
+
+    it("should skip update when metadata has not changed", async () => {
+      let composeJobCalled = false;
+
+      await setupWithAgent();
+
+      server.use(
+        http.post("http://localhost:3000/api/compose/jobs", () => {
+          composeJobCalled = true;
+          return HttpResponse.json({ jobId: "job-1", status: "completed" });
+        }),
+      );
+
+      // Default sound is "professional" (from extractAgentFields fallback)
+      // and no displayName is set — pass same values
+      await context.store.set(zeroJobUpdateSettings$, {});
+
+      expect(composeJobCalled).toBeFalsy();
+    });
+
+    it("should show error toast on compose job failure", async () => {
+      await setupWithAgent();
+
+      server.use(
+        http.post("http://localhost:3000/api/compose/jobs", () => {
+          return HttpResponse.json(
+            { error: { message: "Internal error" } },
+            { status: 500, statusText: "Internal Server Error" },
+          );
+        }),
+      );
+
+      // Should not throw — errors are caught and shown via toast
+      await context.store.set(zeroJobUpdateSettings$, {
+        displayName: "New Name",
+      });
+
+      expect(context.store.get(zeroJobSettingsSaving$)).toBeFalsy();
+    });
+  });
+
+  describe("skills management", () => {
+    async function setupWithAgent() {
+      server.use(
+        http.get("http://localhost:3000/api/agent/composes", () => {
+          return HttpResponse.json(mockAgentResponse());
+        }),
+        http.get(
+          "http://localhost:3000/api/agent/composes/compose-1/instructions",
+          () => {
+            return HttpResponse.json(mockInstructions());
+          },
+        ),
+        http.get("http://localhost:3000/api/agent/schedules", () => {
+          return HttpResponse.json({ schedules: [] });
+        }),
+      );
+
+      await setupPage({ context, path: "/", withoutRender: true });
+      await context.store.set(fetchZeroJobData$, "my-agent");
+    }
+
+    it("should seed skills from agent detail", async () => {
+      await setupWithAgent();
+
+      const skills = context.store.get(zeroJobAddedSkills$);
+      // mockAgentResponse has skills: ["search"], skillUrlToValue returns the value as-is
+      // since "search" doesn't start with the GitHub URL prefix
+      expect(skills).toStrictEqual(["search"]);
+      expect(context.store.get(zeroJobSkillsDirty$)).toBeFalsy();
+    });
+
+    it("should add and remove skills with dirty tracking", async () => {
+      await setupWithAgent();
+
+      context.store.set(addZeroJobSkill$, "gmail");
+
+      expect(context.store.get(zeroJobAddedSkills$)).toStrictEqual([
+        "search",
+        "gmail",
+      ]);
+      expect(context.store.get(zeroJobSkillsDirty$)).toBeTruthy();
+
+      context.store.set(removeZeroJobSkill$, "search");
+
+      expect(context.store.get(zeroJobAddedSkills$)).toStrictEqual(["gmail"]);
+      expect(context.store.get(zeroJobSkillsDirty$)).toBeTruthy();
+    });
+
+    it("should discard skill changes", async () => {
+      await setupWithAgent();
+
+      context.store.set(addZeroJobSkill$, "gmail");
+      expect(context.store.get(zeroJobSkillsDirty$)).toBeTruthy();
+
+      context.store.set(discardZeroJobSkills$);
+
+      expect(context.store.get(zeroJobAddedSkills$)).toStrictEqual(["search"]);
+      expect(context.store.get(zeroJobSkillsDirty$)).toBeFalsy();
+    });
+
+    it("should save skills via compose job", async () => {
+      let capturedJobBody: Record<string, unknown> = {};
+
+      await setupWithAgent();
+
+      server.use(
+        http.post(
+          "http://localhost:3000/api/compose/jobs",
+          async ({ request }) => {
+            capturedJobBody = (await request.json()) as Record<string, unknown>;
+            return HttpResponse.json({
+              jobId: "job-1",
+              status: "completed",
+              result: {
+                composeId: "compose-1",
+                composeName: "my-agent",
+                versionId: "v2",
+                warnings: [],
+              },
+            });
+          },
+        ),
+        http.get("http://localhost:3000/api/agent/composes", () => {
+          return HttpResponse.json(mockAgentResponse());
+        }),
+        http.get(
+          "http://localhost:3000/api/agent/composes/compose-1/instructions",
+          () => {
+            return HttpResponse.json(mockInstructions());
+          },
+        ),
+      );
+
+      context.store.set(addZeroJobSkill$, "gmail");
+      await context.store.set(saveZeroJobSkills$);
+
+      // Verify skills were sent in the compose content
+      const content = capturedJobBody["content"] as Record<string, unknown>;
+      const agents = content["agents"] as Record<
+        string,
+        Record<string, unknown>
+      >;
+      const mainAgent = agents["main"];
+      const skills = mainAgent["skills"] as string[];
+      expect(skills).toHaveLength(2);
+      // Skills should be converted to URLs via skillValueToUrl
+      expect(skills[0]).toContain("search");
+      expect(skills[1]).toContain("gmail");
+
+      // After save, dirty state should be reset
+      expect(context.store.get(zeroJobSkillsDirty$)).toBeFalsy();
+      expect(context.store.get(zeroJobSettingsSaving$)).toBeFalsy();
+    });
+
+    it("should show error toast on save failure", async () => {
+      await setupWithAgent();
+
+      server.use(
+        http.post("http://localhost:3000/api/compose/jobs", () => {
+          return HttpResponse.json(
+            { error: { message: "Build failed" } },
+            { status: 500, statusText: "Internal Server Error" },
+          );
+        }),
+      );
+
+      context.store.set(addZeroJobSkill$, "gmail");
+
+      // Should not throw — errors are caught and shown via toast
+      await context.store.set(saveZeroJobSkills$);
+
+      expect(context.store.get(zeroJobSettingsSaving$)).toBeFalsy();
     });
   });
 });

--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-nav.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-nav.test.ts
@@ -33,9 +33,9 @@ describe("zero-nav", () => {
       expect(context.store.get(zeroActiveId$)).toBe("schedule");
     });
 
-    it("should resolve /zero/job to 'job'", () => {
-      mockLocation({ pathname: "/zero/job", search: "" }, context.signal);
-      expect(context.store.get(zeroActiveId$)).toBe("job");
+    it("should resolve /zero/team to 'team'", () => {
+      mockLocation({ pathname: "/zero/team", search: "" }, context.signal);
+      expect(context.store.get(zeroActiveId$)).toBe("team");
     });
 
     it("should resolve /zero/activity to 'activity'", () => {

--- a/turbo/apps/platform/src/signals/zero-page/zero-agents.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-agents.ts
@@ -27,5 +27,6 @@ export const zeroSubagents$ = computed(async (get) => {
   const agents = await get(agentsList$);
   const status = await get(zeroOnboardingStatus$);
   const defaultName = status.defaultAgentName;
-  return agents.filter((a) => a.name !== defaultName);
+  const defaultId = status.defaultAgentComposeId;
+  return agents.filter((a) => a.name !== defaultName && a.id !== defaultId);
 });

--- a/turbo/apps/platform/src/signals/zero-page/zero-agents.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-agents.ts
@@ -1,0 +1,28 @@
+import { computed } from "ccstate";
+import {
+  agentsList$,
+  schedules$,
+  agentsMissingItems$,
+  agentsLoading$,
+  agentsError$,
+  fetchAgentsList$,
+  getAgentScheduleStatus,
+} from "../agents-page/agents-list.ts";
+
+export {
+  schedules$,
+  agentsMissingItems$,
+  agentsLoading$,
+  agentsError$,
+  fetchAgentsList$,
+  getAgentScheduleStatus,
+};
+
+/**
+ * Non-default agents for display in the Zero team page.
+ * Filters out the default agent from the full agents list.
+ */
+export const zeroSubagents$ = computed(async (get) => {
+  const agents = await get(agentsList$);
+  return agents.filter((a) => !a.isDefault);
+});

--- a/turbo/apps/platform/src/signals/zero-page/zero-agents.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-agents.ts
@@ -8,6 +8,7 @@ import {
   fetchAgentsList$,
   getAgentScheduleStatus,
 } from "../agents-page/agents-list.ts";
+import { zeroOnboardingStatus$ } from "./zero-onboarding.ts";
 
 export {
   schedules$,
@@ -24,5 +25,7 @@ export {
  */
 export const zeroSubagents$ = computed(async (get) => {
   const agents = await get(agentsList$);
-  return agents.filter((a) => !a.isDefault);
+  const status = await get(zeroOnboardingStatus$);
+  const defaultName = status.defaultAgentName;
+  return agents.filter((a) => a.name !== defaultName);
 });

--- a/turbo/apps/platform/src/signals/zero-page/zero-job-detail-route.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-job-detail-route.ts
@@ -1,0 +1,21 @@
+import { command } from "ccstate";
+import { createElement } from "react";
+import { updatePage$ } from "../react-router.ts";
+import { pathParams$ } from "../route.ts";
+import { ZeroPage } from "../../views/zero-page/zero-page.tsx";
+import { fetchAgentsList$ } from "./zero-agents.ts";
+import { fetchZeroJobData$ } from "./zero-job-detail.ts";
+import { initZeroOnboarding$ } from "./zero-onboarding.ts";
+
+export const setupZeroJobDetailRoute$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const params = get(pathParams$) as { name?: string } | undefined;
+    const agentName = params?.name ?? null;
+    set(updatePage$, createElement(ZeroPage, { initialJobAgent: agentName }));
+    await Promise.all([
+      set(fetchAgentsList$),
+      set(initZeroOnboarding$, signal),
+      agentName ? set(fetchZeroJobData$, agentName) : Promise.resolve(),
+    ]);
+  },
+);

--- a/turbo/apps/platform/src/signals/zero-page/zero-job-detail.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-job-detail.ts
@@ -4,6 +4,9 @@ import { fetch$ } from "../fetch.ts";
 import { throwIfAbort } from "../utils.ts";
 import { logger } from "../log.ts";
 import type { AgentDetail, AgentInstructions } from "../agent-detail/types.ts";
+import { triggerAndPollComposeJob } from "../agent-detail/compose-job.ts";
+import { getInstructionsFilename, stripMetadataFrontmatter } from "@vm0/core";
+import { skillValueToUrl, skillUrlToValue } from "../../data/skills.ts";
 import {
   buildCronExpression,
   buildAtTime,
@@ -154,6 +157,340 @@ const fetchZeroJobInstructions$ = command(async ({ get, set }) => {
       error:
         error instanceof Error ? error.message : "Failed to load instructions",
     });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Compose reload trigger
+// ---------------------------------------------------------------------------
+
+const internalComposeReload$ = state(0);
+
+function refetchDetail(
+  set: (atom: typeof fetchZeroJobDetail$) => Promise<void>,
+) {
+  return set(fetchZeroJobDetail$);
+}
+
+// ---------------------------------------------------------------------------
+// Instructions editing
+// ---------------------------------------------------------------------------
+
+const editedContent$ = state<string | null>(null);
+
+export const zeroJobEditedContent$ = computed((get) => get(editedContent$));
+
+export const zeroJobInstructionsDirty$ = computed((get) => {
+  const edited = get(editedContent$);
+  const instructions = get(instructionsState$).instructions;
+  const savedBody = stripMetadataFrontmatter(instructions?.content ?? "");
+  return edited !== null && edited !== savedBody;
+});
+
+export const setZeroJobEditedContent$ = command(({ set }, value: string) => {
+  set(editedContent$, value);
+});
+
+export const discardZeroJobEdit$ = command(({ set }) => {
+  set(editedContent$, null);
+});
+
+const jobBuilding$ = state(false);
+export const zeroJobBuilding$ = computed((get) => get(jobBuilding$));
+
+const internalBuildError$ = state<string | null>(null);
+export const zeroJobBuildError$ = computed((get) => get(internalBuildError$));
+
+export const buildZeroJobInstructions$ = command(async ({ get, set }) => {
+  const detail = get(zeroJobDetail$);
+  const edited = get(editedContent$);
+  if (!detail?.content || edited === null) {
+    return;
+  }
+
+  set(jobBuilding$, true);
+  set(internalBuildError$, null);
+
+  try {
+    const fetchFn = get(fetch$);
+    const agentKey = Object.keys(detail.content.agents)[0];
+    const agent = agentKey ? detail.content.agents[agentKey] : undefined;
+
+    const contentWithInstructions =
+      agentKey && agent
+        ? {
+            ...detail.content,
+            agents: {
+              ...detail.content.agents,
+              [agentKey]: {
+                ...agent,
+                instructions: getInstructionsFilename(agent.framework),
+              },
+            },
+          }
+        : detail.content;
+
+    const job = await triggerAndPollComposeJob(
+      fetchFn,
+      contentWithInstructions,
+      edited,
+    );
+    if (!job.result) {
+      throw new Error("Build completed without result");
+    }
+
+    // Optimistically update instructions state
+    const current = get(instructionsState$).instructions;
+    set(instructionsState$, {
+      instructions: { content: edited, filename: current?.filename ?? null },
+      loading: false,
+      error: null,
+    });
+
+    set(editedContent$, null);
+    set(internalComposeReload$, (x) => x + 1);
+    await refetchDetail(set);
+  } catch (error) {
+    throwIfAbort(error);
+    set(internalBuildError$, "Failed to build instructions. Please try again.");
+  } finally {
+    set(jobBuilding$, false);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Settings: update agent metadata (displayName, sound)
+// ---------------------------------------------------------------------------
+
+const internalSaving$ = state(false);
+export const zeroJobSettingsSaving$ = computed((get) => get(internalSaving$));
+
+interface ZeroJobSettingsUpdate {
+  displayName?: string;
+  sound?: string;
+}
+
+export const zeroJobUpdateSettings$ = command(
+  async ({ get, set }, update: ZeroJobSettingsUpdate) => {
+    const detail = get(zeroJobDetail$);
+    if (!detail?.content) {
+      throw new Error("No compose content found");
+    }
+
+    const agentKey = Object.keys(detail.content.agents)[0];
+    if (!agentKey) {
+      throw new Error("No agent found in compose");
+    }
+
+    const agentConfig = detail.content.agents[agentKey];
+    const currentMetadata = agentConfig.metadata ?? {};
+    const newMetadata = { ...currentMetadata };
+    if (update.displayName !== undefined) {
+      newMetadata.displayName = update.displayName;
+    }
+    if (update.sound !== undefined) {
+      newMetadata.sound = update.sound;
+    }
+
+    if (
+      newMetadata.displayName === currentMetadata.displayName &&
+      newMetadata.sound === currentMetadata.sound
+    ) {
+      return;
+    }
+
+    set(internalSaving$, true);
+    try {
+      const fetchFn = get(fetch$);
+      const newContent = {
+        ...detail.content,
+        agents: {
+          [agentKey]: { ...agentConfig, metadata: newMetadata },
+        },
+      };
+
+      // Resolve existing instructions so the compose job keeps them
+      let instructions: string | undefined;
+      const instrContent = get(instructionsState$).instructions?.content;
+      if (instrContent) {
+        instructions = stripMetadataFrontmatter(instrContent);
+      } else {
+        const resp = await fetchFn(
+          `/api/agent/composes/${detail.id}/instructions`,
+        );
+        if (resp.ok) {
+          const data = (await resp.json()) as AgentInstructions;
+          instructions = data.content
+            ? stripMetadataFrontmatter(data.content)
+            : undefined;
+        }
+      }
+
+      // Ensure instructions field in content
+      const agent = newContent.agents[agentKey];
+      if (agent && !("instructions" in agent)) {
+        newContent.agents[agentKey] = {
+          ...agent,
+          instructions: getInstructionsFilename(agent.framework),
+        };
+      }
+
+      const job = await triggerAndPollComposeJob(
+        fetchFn,
+        newContent,
+        instructions ?? "",
+      );
+      if (!job.result) {
+        throw new Error("Build completed without result");
+      }
+
+      set(internalComposeReload$, (x) => x + 1);
+      await refetchDetail(set);
+      await set(fetchZeroJobInstructions$);
+      toast.success("Settings saved");
+    } catch (error) {
+      throwIfAbort(error);
+      L.error("Failed to update settings:", error);
+      toast.error(error instanceof Error ? error.message : "Save failed");
+    } finally {
+      set(internalSaving$, false);
+    }
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Skills management
+// ---------------------------------------------------------------------------
+
+const internalAddedSkills$ = state<string[] | null>(null);
+
+const seededSkills$ = computed((get) => {
+  const detail = get(zeroJobDetail$);
+  if (!detail?.content) {
+    return [];
+  }
+  const agentKey = Object.keys(detail.content.agents)[0];
+  if (!agentKey) {
+    return [];
+  }
+  const agent = detail.content.agents[agentKey];
+  return (agent?.skills ?? []).map(skillUrlToValue);
+});
+
+export const zeroJobAddedSkills$ = computed((get) => {
+  const local = get(internalAddedSkills$);
+  if (local !== null) {
+    return local;
+  }
+  return get(seededSkills$);
+});
+
+export const zeroJobSkillsDirty$ = computed((get) => {
+  const local = get(internalAddedSkills$);
+  if (local === null) {
+    return false;
+  }
+  const seeded = get(seededSkills$);
+  if (local.length !== seeded.length) {
+    return true;
+  }
+  const sorted = [...local].sort();
+  const seededSorted = [...seeded].sort();
+  return sorted.some((s, i) => s !== seededSorted[i]);
+});
+
+export const addZeroJobSkill$ = command(({ get, set }, name: string) => {
+  if (get(internalAddedSkills$) === null) {
+    set(internalAddedSkills$, get(seededSkills$));
+  }
+  set(internalAddedSkills$, (prev) => [...(prev ?? []), name]);
+});
+
+export const removeZeroJobSkill$ = command(({ get, set }, name: string) => {
+  if (get(internalAddedSkills$) === null) {
+    set(internalAddedSkills$, get(seededSkills$));
+  }
+  set(internalAddedSkills$, (prev) => (prev ?? []).filter((s) => s !== name));
+});
+
+export const discardZeroJobSkills$ = command(({ set }) => {
+  set(internalAddedSkills$, null);
+});
+
+export const saveZeroJobSkills$ = command(async ({ get, set }) => {
+  const detail = get(zeroJobDetail$);
+  if (!detail?.content) {
+    throw new Error("No compose content found");
+  }
+
+  const agentKey = Object.keys(detail.content.agents)[0];
+  if (!agentKey) {
+    throw new Error("No agent found in compose");
+  }
+
+  set(internalSaving$, true);
+  try {
+    const newSkills = get(internalAddedSkills$) ?? [];
+    const agent = detail.content.agents[agentKey];
+    const newContent = {
+      ...detail.content,
+      agents: {
+        [agentKey]: {
+          ...agent,
+          skills:
+            newSkills.length > 0 ? newSkills.map(skillValueToUrl) : undefined,
+        },
+      },
+    };
+
+    const fetchFn = get(fetch$);
+    // Resolve existing instructions
+    let instructions: string | undefined;
+    const instrContent = get(instructionsState$).instructions?.content;
+    if (instrContent) {
+      instructions = stripMetadataFrontmatter(instrContent);
+    } else {
+      const resp = await fetchFn(
+        `/api/agent/composes/${detail.id}/instructions`,
+      );
+      if (resp.ok) {
+        const data = (await resp.json()) as AgentInstructions;
+        instructions = data.content
+          ? stripMetadataFrontmatter(data.content)
+          : undefined;
+      }
+    }
+
+    // Ensure instructions field
+    const updatedAgent = newContent.agents[agentKey];
+    if (updatedAgent && !("instructions" in updatedAgent)) {
+      newContent.agents[agentKey] = {
+        ...updatedAgent,
+        instructions: getInstructionsFilename(updatedAgent.framework),
+      };
+    }
+
+    const job = await triggerAndPollComposeJob(
+      fetchFn,
+      newContent,
+      instructions ?? "",
+    );
+    if (!job.result) {
+      throw new Error("Build completed without result");
+    }
+
+    set(internalAddedSkills$, null);
+    set(internalComposeReload$, (x) => x + 1);
+    await refetchDetail(set);
+    toast.success("Skills saved");
+  } catch (error) {
+    throwIfAbort(error);
+    L.error("Failed to save skills:", error);
+    toast.error(
+      error instanceof Error ? error.message : "Failed to save skills",
+    );
+  } finally {
+    set(internalSaving$, false);
   }
 });
 
@@ -463,6 +800,16 @@ export const deleteZeroJobSchedule$ = command(
 // ---------------------------------------------------------------------------
 
 export const fetchZeroJobData$ = command(async ({ set }, agentName: string) => {
+  // Reset all state so the skeleton screen shows while loading new data
+  set(detailState$, { detail: null, loading: false, error: null });
+  set(instructionsState$, { instructions: null, loading: false, error: null });
+  set(scheduleState$, { schedules: [], error: null });
+  set(editedContent$, null);
+  set(internalAddedSkills$, null);
+  set(internalBuildError$, null);
+  set(jobBuilding$, false);
+  set(internalSaving$, false);
+
   set(setZeroJobAgentName$, agentName);
   await set(fetchZeroJobDetail$);
   await Promise.all([

--- a/turbo/apps/platform/src/signals/zero-page/zero-job-detail.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-job-detail.ts
@@ -161,15 +161,24 @@ const fetchZeroJobInstructions$ = command(async ({ get, set }) => {
 });
 
 // ---------------------------------------------------------------------------
-// Compose reload trigger
+// Shared: resolve existing instructions (cache → API fallback)
 // ---------------------------------------------------------------------------
 
-const internalComposeReload$ = state(0);
-
-function refetchDetail(
-  set: (atom: typeof fetchZeroJobDetail$) => Promise<void>,
-) {
-  return set(fetchZeroJobDetail$);
+async function resolveExistingInstructions(
+  get: (atom: typeof instructionsState$) => ZeroJobInstructionsState,
+  fetchFn: typeof fetch,
+  composeId: string,
+): Promise<string | undefined> {
+  const instrContent = get(instructionsState$).instructions?.content;
+  if (instrContent) {
+    return stripMetadataFrontmatter(instrContent);
+  }
+  const resp = await fetchFn(`/api/agent/composes/${composeId}/instructions`);
+  if (resp.ok) {
+    const data = (await resp.json()) as AgentInstructions;
+    return data.content ? stripMetadataFrontmatter(data.content) : undefined;
+  }
+  return undefined;
 }
 
 // ---------------------------------------------------------------------------
@@ -248,8 +257,7 @@ export const buildZeroJobInstructions$ = command(async ({ get, set }) => {
     });
 
     set(editedContent$, null);
-    set(internalComposeReload$, (x) => x + 1);
-    await refetchDetail(set);
+    await set(fetchZeroJobDetail$);
   } catch (error) {
     throwIfAbort(error);
     set(internalBuildError$, "Failed to build instructions. Please try again.");
@@ -309,22 +317,11 @@ export const zeroJobUpdateSettings$ = command(
         },
       };
 
-      // Resolve existing instructions so the compose job keeps them
-      let instructions: string | undefined;
-      const instrContent = get(instructionsState$).instructions?.content;
-      if (instrContent) {
-        instructions = stripMetadataFrontmatter(instrContent);
-      } else {
-        const resp = await fetchFn(
-          `/api/agent/composes/${detail.id}/instructions`,
-        );
-        if (resp.ok) {
-          const data = (await resp.json()) as AgentInstructions;
-          instructions = data.content
-            ? stripMetadataFrontmatter(data.content)
-            : undefined;
-        }
-      }
+      const instructions = await resolveExistingInstructions(
+        get,
+        fetchFn,
+        detail.id,
+      );
 
       // Ensure instructions field in content
       const agent = newContent.agents[agentKey];
@@ -344,8 +341,7 @@ export const zeroJobUpdateSettings$ = command(
         throw new Error("Build completed without result");
       }
 
-      set(internalComposeReload$, (x) => x + 1);
-      await refetchDetail(set);
+      await set(fetchZeroJobDetail$);
       await set(fetchZeroJobInstructions$);
       toast.success("Settings saved");
     } catch (error) {
@@ -444,22 +440,11 @@ export const saveZeroJobSkills$ = command(async ({ get, set }) => {
     };
 
     const fetchFn = get(fetch$);
-    // Resolve existing instructions
-    let instructions: string | undefined;
-    const instrContent = get(instructionsState$).instructions?.content;
-    if (instrContent) {
-      instructions = stripMetadataFrontmatter(instrContent);
-    } else {
-      const resp = await fetchFn(
-        `/api/agent/composes/${detail.id}/instructions`,
-      );
-      if (resp.ok) {
-        const data = (await resp.json()) as AgentInstructions;
-        instructions = data.content
-          ? stripMetadataFrontmatter(data.content)
-          : undefined;
-      }
-    }
+    const instructions = await resolveExistingInstructions(
+      get,
+      fetchFn,
+      detail.id,
+    );
 
     // Ensure instructions field
     const updatedAgent = newContent.agents[agentKey];
@@ -480,8 +465,7 @@ export const saveZeroJobSkills$ = command(async ({ get, set }) => {
     }
 
     set(internalAddedSkills$, null);
-    set(internalComposeReload$, (x) => x + 1);
-    await refetchDetail(set);
+    await set(fetchZeroJobDetail$);
     toast.success("Skills saved");
   } catch (error) {
     throwIfAbort(error);

--- a/turbo/apps/platform/src/signals/zero-page/zero-job-detail.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-job-detail.ts
@@ -1,0 +1,188 @@
+import { command, computed, state } from "ccstate";
+import { fetch$ } from "../fetch.ts";
+import { throwIfAbort } from "../utils.ts";
+import { logger } from "../log.ts";
+import type { AgentDetail, AgentInstructions } from "../agent-detail/types.ts";
+
+const L = logger("ZeroJobDetail");
+
+// ---------------------------------------------------------------------------
+// Agent name — set when navigating to a subagent detail page
+// ---------------------------------------------------------------------------
+
+const internalAgentName$ = state<string | null>(null);
+const setZeroJobAgentName$ = command(({ set }, name: string | null) => {
+  set(internalAgentName$, name);
+});
+
+// ---------------------------------------------------------------------------
+// Agent detail
+// ---------------------------------------------------------------------------
+
+interface ZeroJobDetailState {
+  detail: AgentDetail | null;
+  loading: boolean;
+  error: string | null;
+}
+
+const detailState$ = state<ZeroJobDetailState>({
+  detail: null,
+  loading: false,
+  error: null,
+});
+
+export const zeroJobDetail$ = computed((get) => get(detailState$).detail);
+export const zeroJobDetailLoading$ = computed(
+  (get) => get(detailState$).loading,
+);
+export const zeroJobDetailError$ = computed((get) => get(detailState$).error);
+
+const fetchZeroJobDetail$ = command(async ({ get, set }) => {
+  const name = get(internalAgentName$);
+  if (!name) {
+    return;
+  }
+
+  set(detailState$, (prev) => ({ ...prev, loading: true, error: null }));
+
+  try {
+    const fetchFn = get(fetch$);
+    const slashIndex = name.indexOf("/");
+    const isOwner = slashIndex === -1;
+    const agentName = isOwner ? name : name.slice(slashIndex + 1);
+    const scope = isOwner ? undefined : name.slice(0, slashIndex);
+
+    const params = new URLSearchParams({ name: agentName });
+    if (scope) {
+      params.set("scope", scope);
+    }
+
+    const response = await fetchFn(`/api/agent/composes?${params.toString()}`);
+    if (!response.ok) {
+      throw new Error(`Failed to fetch agent: ${response.statusText}`);
+    }
+
+    const data = (await response.json()) as {
+      id: string;
+      name: string;
+      headVersionId: string | null;
+      content: AgentDetail["content"];
+      createdAt: string;
+      updatedAt: string;
+    };
+
+    set(detailState$, {
+      detail: { ...data, isOwner },
+      loading: false,
+      error: null,
+    });
+  } catch (error) {
+    throwIfAbort(error);
+    L.error("Failed to fetch agent detail:", error);
+    set(detailState$, (prev) => ({
+      ...prev,
+      loading: false,
+      error: error instanceof Error ? error.message : "Unknown error",
+    }));
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Agent instructions
+// ---------------------------------------------------------------------------
+
+interface ZeroJobInstructionsState {
+  instructions: AgentInstructions | null;
+  loading: boolean;
+}
+
+const instructionsState$ = state<ZeroJobInstructionsState>({
+  instructions: null,
+  loading: false,
+});
+
+export const zeroJobInstructions$ = computed(
+  (get) => get(instructionsState$).instructions,
+);
+export const zeroJobInstructionsLoading$ = computed(
+  (get) => get(instructionsState$).loading,
+);
+
+const fetchZeroJobInstructions$ = command(async ({ get, set }) => {
+  const detail = get(zeroJobDetail$);
+  if (!detail) {
+    return;
+  }
+
+  set(instructionsState$, { instructions: null, loading: true });
+
+  try {
+    const fetchFn = get(fetch$);
+    const response = await fetchFn(
+      `/api/agent/composes/${detail.id}/instructions`,
+    );
+    if (!response.ok) {
+      throw new Error(`Failed to fetch instructions: ${response.statusText}`);
+    }
+
+    const data = (await response.json()) as AgentInstructions;
+    set(instructionsState$, { instructions: data, loading: false });
+  } catch (error) {
+    throwIfAbort(error);
+    L.error("Failed to fetch instructions:", error);
+    set(instructionsState$, { instructions: null, loading: false });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Agent schedule
+// ---------------------------------------------------------------------------
+
+interface ScheduleItem {
+  id: string;
+  composeName: string;
+  name: string;
+  enabled: boolean;
+  cronExpression: string | null;
+  atTime: string | null;
+  timezone: string;
+  prompt: string;
+}
+
+const scheduleState$ = state<ScheduleItem[]>([]);
+export const zeroJobSchedule$ = computed((get) => get(scheduleState$));
+
+const fetchZeroJobSchedule$ = command(async ({ get, set }) => {
+  const name = get(internalAgentName$);
+  if (!name) {
+    return;
+  }
+
+  try {
+    const fetchFn = get(fetch$);
+    const response = await fetchFn("/api/agent/schedules");
+    if (!response.ok) {
+      return;
+    }
+
+    const data = (await response.json()) as { schedules: ScheduleItem[] };
+    const agentSchedules = data.schedules.filter((s) => s.composeName === name);
+    set(scheduleState$, agentSchedules);
+  } catch (error) {
+    throwIfAbort(error);
+    L.error("Failed to fetch schedules:", error);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Combined fetch — loads detail, then instructions + schedule in parallel
+// ---------------------------------------------------------------------------
+
+export const fetchZeroJobData$ = command(async ({ set }, agentName: string) => {
+  set(setZeroJobAgentName$, agentName);
+  await set(fetchZeroJobDetail$);
+  await Promise.all([
+    set(fetchZeroJobInstructions$),
+    set(fetchZeroJobSchedule$),
+  ]);
+});

--- a/turbo/apps/platform/src/signals/zero-page/zero-job-detail.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-job-detail.ts
@@ -1,8 +1,17 @@
 import { command, computed, state } from "ccstate";
+import { toast } from "@vm0/ui/components/ui/sonner";
 import { fetch$ } from "../fetch.ts";
 import { throwIfAbort } from "../utils.ts";
 import { logger } from "../log.ts";
 import type { AgentDetail, AgentInstructions } from "../agent-detail/types.ts";
+import {
+  buildCronExpression,
+  buildAtTime,
+  isAtTimePast,
+  type ScheduleBody,
+  type CronTimeOption,
+} from "../agent-detail/cron.ts";
+import type { ScheduleEntry } from "../../views/zero-page/zero-schedule-card.tsx";
 
 const L = logger("ZeroJobDetail");
 
@@ -154,14 +163,87 @@ const fetchZeroJobInstructions$ = command(async ({ get, set }) => {
 
 interface ScheduleItem {
   id: string;
+  composeId: string;
   composeName: string;
   name: string;
   enabled: boolean;
+  triggerType: "cron" | "once" | "loop";
   cronExpression: string | null;
   atTime: string | null;
+  intervalSeconds: number | null;
   timezone: string;
   prompt: string;
+  createdAt: string;
 }
+
+// ---------------------------------------------------------------------------
+// Schedule time string conversion
+// ---------------------------------------------------------------------------
+
+function cronToTimeString(cron: string): string {
+  const parts = cron.split(" ");
+  const minute = Number(parts[0]);
+  const hour = Number(parts[1]);
+  const dayOfMonth = parts[2] ?? "*";
+  const dayOfWeek = parts[4] ?? "*";
+
+  const ampm = hour >= 12 ? "PM" : "AM";
+  const h12 = hour === 0 ? 12 : hour > 12 ? hour - 12 : hour;
+  const timeStr = `${h12}:${String(minute).padStart(2, "0")} ${ampm}`;
+
+  if (dayOfWeek === "1-5") {
+    return `Every weekday at ${timeStr}`;
+  }
+  if (dayOfMonth !== "*") {
+    return `Every month on day ${dayOfMonth} at ${timeStr}`;
+  }
+  if (dayOfWeek !== "*") {
+    const dayNames: Record<string, string> = {
+      "0": "Sunday",
+      "1": "Monday",
+      "2": "Tuesday",
+      "3": "Wednesday",
+      "4": "Thursday",
+      "5": "Friday",
+      "6": "Saturday",
+    };
+    const days = dayOfWeek
+      .split(",")
+      .map((d) => dayNames[d])
+      .filter(Boolean);
+    if (days.length > 0) {
+      return `Every week on ${days.join(", ")} at ${timeStr}`;
+    }
+    return `Every week at ${timeStr}`;
+  }
+  return `Every day at ${timeStr}`;
+}
+
+function scheduleToTimeString(s: ScheduleItem): string {
+  if (s.triggerType === "loop" && s.intervalSeconds !== null) {
+    if (s.intervalSeconds % 60 === 0) {
+      return `Every ${s.intervalSeconds / 60} minutes`;
+    }
+    return `Every ${s.intervalSeconds} seconds`;
+  }
+  if (s.triggerType === "once" && s.atTime) {
+    const at = new Date(s.atTime);
+    const date = `${at.getFullYear()}-${String(at.getMonth() + 1).padStart(2, "0")}-${String(at.getDate()).padStart(2, "0")}`;
+    const hour = at.getHours();
+    const minute = at.getMinutes();
+    const ampm = hour >= 12 ? "PM" : "AM";
+    const h12 = hour === 0 ? 12 : hour > 12 ? hour - 12 : hour;
+    return `Once on ${date} at ${h12}:${String(minute).padStart(2, "0")} ${ampm}`;
+  }
+  if (s.cronExpression) {
+    return cronToTimeString(s.cronExpression);
+  }
+  return "Scheduled";
+}
+
+// ---------------------------------------------------------------------------
+// Schedule state
+// ---------------------------------------------------------------------------
 
 interface ZeroJobScheduleState {
   schedules: ScheduleItem[];
@@ -172,9 +254,23 @@ const scheduleState$ = state<ZeroJobScheduleState>({
   schedules: [],
   error: null,
 });
-export const zeroJobSchedule$ = computed(
-  (get) => get(scheduleState$).schedules,
-);
+
+export const zeroJobScheduleEntries$ = computed((get) => {
+  const items = get(scheduleState$).schedules;
+  return [...items]
+    .sort((a, b) => b.createdAt.localeCompare(a.createdAt))
+    .map(
+      (s): ScheduleEntry => ({
+        id: s.id,
+        time: scheduleToTimeString(s),
+        prompt: s.prompt,
+        enabled: s.enabled,
+        name: s.name,
+        intervalSeconds: s.intervalSeconds,
+      }),
+    );
+});
+
 export const zeroJobScheduleError$ = computed(
   (get) => get(scheduleState$).error,
 );
@@ -207,6 +303,160 @@ const fetchZeroJobSchedule$ = command(async ({ get, set }) => {
     });
   }
 });
+
+// ---------------------------------------------------------------------------
+// Schedule CRUD
+// ---------------------------------------------------------------------------
+
+export interface ZeroJobScheduleSaveParams {
+  prompt: string;
+  freq: string;
+  date: string;
+  hour: number;
+  minute: number;
+  timezone: string;
+  intervalSeconds: number;
+  dayOfWeek?: string;
+  dayOfMonth?: string;
+  editName?: string;
+}
+
+export const saveZeroJobSchedule$ = command(
+  async ({ get, set }, params: ZeroJobScheduleSaveParams) => {
+    const detail = get(zeroJobDetail$);
+    if (!detail) {
+      throw new Error("No agent detail loaded");
+    }
+
+    const fetchFn = get(fetch$);
+    const scheduleName = params.editName ?? `zero-${Date.now().toString(36)}`;
+
+    const base = {
+      composeId: detail.id,
+      name: scheduleName,
+      timezone: params.timezone,
+      prompt: params.prompt.trim(),
+      enabled: true,
+    };
+
+    let body: ScheduleBody;
+
+    if (params.freq === "every_n_minutes") {
+      body = { ...base, intervalSeconds: params.intervalSeconds };
+    } else if (params.freq === "once") {
+      if (
+        isAtTimePast(params.date, String(params.hour), String(params.minute))
+      ) {
+        throw new Error("Scheduled time must be in the future");
+      }
+      const atTime = buildAtTime(
+        params.date,
+        String(params.hour),
+        String(params.minute),
+      );
+      body = { ...base, atTime };
+    } else if (params.freq === "now") {
+      body = { ...base, atTime: new Date().toISOString() };
+    } else {
+      const freqMap: Record<string, CronTimeOption> = {
+        every_weekday: "every-weekday",
+        every_day: "every-day",
+        every_week: "every-week",
+        every_month: "every-month",
+      };
+      const timeOption = freqMap[params.freq];
+      if (!timeOption) {
+        throw new Error(`Unknown schedule frequency: ${params.freq}`);
+      }
+      const cronExpression = buildCronExpression({
+        timeOption,
+        hour: String(params.hour),
+        minute: String(params.minute),
+        dayOfWeek: params.dayOfWeek,
+        dayOfMonth: params.dayOfMonth,
+      });
+      body = { ...base, cronExpression };
+    }
+
+    const response = await fetchFn("/api/agent/schedules", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+
+    if (!response.ok) {
+      const errorData = (await response.json().catch(() => null)) as {
+        error?: { message?: string };
+      } | null;
+      throw new Error(
+        errorData?.error?.message ?? `Save failed: ${response.statusText}`,
+      );
+    }
+
+    toast.success(params.editName ? "Schedule updated" : "Schedule created");
+    await set(fetchZeroJobSchedule$);
+  },
+);
+
+export const toggleZeroJobScheduleEnabled$ = command(
+  async ({ get, set }, params: { name: string; enabled: boolean }) => {
+    const detail = get(zeroJobDetail$);
+    if (!detail) {
+      throw new Error("No agent detail loaded");
+    }
+
+    const fetchFn = get(fetch$);
+    const action = params.enabled ? "enable" : "disable";
+    const response = await fetchFn(
+      `/api/agent/schedules/${encodeURIComponent(params.name)}/${action}`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ composeId: detail.id }),
+      },
+    );
+
+    if (!response.ok) {
+      const errorData = (await response.json().catch(() => null)) as {
+        error?: { message?: string };
+      } | null;
+      const message =
+        errorData?.error?.message ??
+        `Failed to ${action} schedule: ${response.statusText}`;
+      toast.error(message);
+      throw new Error(message);
+    }
+
+    await set(fetchZeroJobSchedule$);
+  },
+);
+
+export const deleteZeroJobSchedule$ = command(
+  async ({ get, set }, scheduleName: string) => {
+    const detail = get(zeroJobDetail$);
+    if (!detail) {
+      throw new Error("No agent detail loaded");
+    }
+
+    const fetchFn = get(fetch$);
+    const response = await fetchFn(
+      `/api/agent/schedules/${encodeURIComponent(scheduleName)}?composeId=${encodeURIComponent(detail.id)}`,
+      { method: "DELETE" },
+    );
+
+    if (!response.ok && response.status !== 204) {
+      const errorData = (await response.json().catch(() => null)) as {
+        error?: { message?: string };
+      } | null;
+      throw new Error(
+        errorData?.error?.message ?? `Delete failed: ${response.statusText}`,
+      );
+    }
+
+    toast.success("Schedule deleted");
+    await set(fetchZeroJobSchedule$);
+  },
+);
 
 // ---------------------------------------------------------------------------
 // Combined fetch — loads detail, then instructions + schedule in parallel

--- a/turbo/apps/platform/src/signals/zero-page/zero-job-detail.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-job-detail.ts
@@ -94,11 +94,13 @@ const fetchZeroJobDetail$ = command(async ({ get, set }) => {
 interface ZeroJobInstructionsState {
   instructions: AgentInstructions | null;
   loading: boolean;
+  error: string | null;
 }
 
 const instructionsState$ = state<ZeroJobInstructionsState>({
   instructions: null,
   loading: false,
+  error: null,
 });
 
 export const zeroJobInstructions$ = computed(
@@ -107,6 +109,9 @@ export const zeroJobInstructions$ = computed(
 export const zeroJobInstructionsLoading$ = computed(
   (get) => get(instructionsState$).loading,
 );
+export const zeroJobInstructionsError$ = computed(
+  (get) => get(instructionsState$).error,
+);
 
 const fetchZeroJobInstructions$ = command(async ({ get, set }) => {
   const detail = get(zeroJobDetail$);
@@ -114,7 +119,7 @@ const fetchZeroJobInstructions$ = command(async ({ get, set }) => {
     return;
   }
 
-  set(instructionsState$, { instructions: null, loading: true });
+  set(instructionsState$, { instructions: null, loading: true, error: null });
 
   try {
     const fetchFn = get(fetch$);
@@ -126,11 +131,20 @@ const fetchZeroJobInstructions$ = command(async ({ get, set }) => {
     }
 
     const data = (await response.json()) as AgentInstructions;
-    set(instructionsState$, { instructions: data, loading: false });
+    set(instructionsState$, {
+      instructions: data,
+      loading: false,
+      error: null,
+    });
   } catch (error) {
     throwIfAbort(error);
     L.error("Failed to fetch instructions:", error);
-    set(instructionsState$, { instructions: null, loading: false });
+    set(instructionsState$, {
+      instructions: null,
+      loading: false,
+      error:
+        error instanceof Error ? error.message : "Failed to load instructions",
+    });
   }
 });
 
@@ -149,8 +163,21 @@ interface ScheduleItem {
   prompt: string;
 }
 
-const scheduleState$ = state<ScheduleItem[]>([]);
-export const zeroJobSchedule$ = computed((get) => get(scheduleState$));
+interface ZeroJobScheduleState {
+  schedules: ScheduleItem[];
+  error: string | null;
+}
+
+const scheduleState$ = state<ZeroJobScheduleState>({
+  schedules: [],
+  error: null,
+});
+export const zeroJobSchedule$ = computed(
+  (get) => get(scheduleState$).schedules,
+);
+export const zeroJobScheduleError$ = computed(
+  (get) => get(scheduleState$).error,
+);
 
 const fetchZeroJobSchedule$ = command(async ({ get, set }) => {
   const name = get(internalAgentName$);
@@ -158,19 +185,26 @@ const fetchZeroJobSchedule$ = command(async ({ get, set }) => {
     return;
   }
 
+  set(scheduleState$, { schedules: [], error: null });
+
   try {
     const fetchFn = get(fetch$);
     const response = await fetchFn("/api/agent/schedules");
     if (!response.ok) {
-      return;
+      throw new Error(`Failed to fetch schedules: ${response.statusText}`);
     }
 
     const data = (await response.json()) as { schedules: ScheduleItem[] };
     const agentSchedules = data.schedules.filter((s) => s.composeName === name);
-    set(scheduleState$, agentSchedules);
+    set(scheduleState$, { schedules: agentSchedules, error: null });
   } catch (error) {
     throwIfAbort(error);
     L.error("Failed to fetch schedules:", error);
+    set(scheduleState$, {
+      schedules: [],
+      error:
+        error instanceof Error ? error.message : "Failed to load schedules",
+    });
   }
 });
 

--- a/turbo/apps/platform/src/signals/zero-page/zero-nav.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-nav.ts
@@ -7,7 +7,7 @@ function isValidTab(tab: string): tab is ZeroNavId {
     tab === "chat" ||
     tab === "meet" ||
     tab === "schedule" ||
-    tab === "job" ||
+    tab === "team" ||
     tab === "activity" ||
     tab === "works" ||
     tab === "settings" ||

--- a/turbo/apps/platform/src/signals/zero-page/zero-page.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-page.ts
@@ -2,6 +2,7 @@ import { command } from "ccstate";
 import { createElement } from "react";
 import { ZeroPage } from "../../views/zero-page/zero-page.tsx";
 import { updatePage$ } from "../react-router.ts";
+import { fetchAgentsList$ } from "./zero-agents.ts";
 import { initZeroOnboarding$ } from "./zero-onboarding.ts";
 import { initZeroActivity$ } from "./zero-activity.ts";
 import { Reason, detach } from "../utils.ts";
@@ -9,6 +10,6 @@ import { Reason, detach } from "../utils.ts";
 export const setupZeroPage$ = command(async ({ set }, signal: AbortSignal) => {
   set(updatePage$, createElement(ZeroPage));
 
-  await set(initZeroOnboarding$, signal);
+  await Promise.all([set(fetchAgentsList$), set(initZeroOnboarding$, signal)]);
   detach(set(initZeroActivity$), Reason.Daemon);
 });

--- a/turbo/apps/platform/src/signals/zero-page/zero-page.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-page.ts
@@ -11,5 +11,6 @@ export const setupZeroPage$ = command(async ({ set }, signal: AbortSignal) => {
   set(updatePage$, createElement(ZeroPage));
 
   await Promise.all([set(fetchAgentsList$), set(initZeroOnboarding$, signal)]);
+  signal.throwIfAborted();
   detach(set(initZeroActivity$), Reason.Daemon);
 });

--- a/turbo/apps/platform/src/types/route.ts
+++ b/turbo/apps/platform/src/types/route.ts
@@ -22,5 +22,5 @@ export type RoutePath =
   | "/settings/telegram"
   | "/telegram/connect"
   | "/telegram/connect/success"
-  | "/zero/job/:name"
+  | "/zero/team/:name"
   | `/projects/${string}`;

--- a/turbo/apps/platform/src/types/route.ts
+++ b/turbo/apps/platform/src/types/route.ts
@@ -22,4 +22,5 @@ export type RoutePath =
   | "/settings/telegram"
   | "/telegram/connect"
   | "/telegram/connect/success"
+  | "/zero/job/:name"
   | `/projects/${string}`;

--- a/turbo/apps/platform/src/views/zero-page/zero-app-shell.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-app-shell.tsx
@@ -178,7 +178,11 @@ function useSessionLifecycle(
   return { recentSessions, recentSessionsLoading, recentSessionsError };
 }
 
-export function ZeroAppShell() {
+interface ZeroAppShellProps {
+  initialJobAgent?: string | null;
+}
+
+export function ZeroAppShell({ initialJobAgent }: ZeroAppShellProps) {
   const userLoadable = useLoadable(user$);
   const isLoggedIn =
     userLoadable.state === "hasData" && userLoadable.data !== undefined;
@@ -346,6 +350,10 @@ export function ZeroAppShell() {
             sectionId={activeId}
             inSession={inSession}
             onSendMessage={handleSendFromDemo}
+            recentLabel={recentLabel}
+            recentId={recentId}
+            selectedAgentName={initialJobAgent}
+            onClearRecent={handleClearRecent}
             onNavigateToActivity={() => setActiveId("activity")}
             onNavigateToSchedule={() => setActiveId("schedule")}
             onNavigateToJob={() => setActiveId("job")}

--- a/turbo/apps/platform/src/views/zero-page/zero-app-shell.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-app-shell.tsx
@@ -353,7 +353,7 @@ export function ZeroAppShell({ initialJobAgent }: ZeroAppShellProps) {
             selectedAgentName={initialJobAgent}
             onNavigateToActivity={() => setActiveId("activity")}
             onNavigateToSchedule={() => setActiveId("schedule")}
-            onNavigateToJob={() => setActiveId("job")}
+            onNavigateToTeam={() => setActiveId("team")}
             onNavigateToChat={() => setActiveId("chat")}
             onNavigateToMeet={(section) => {
               setActiveId("meet");

--- a/turbo/apps/platform/src/views/zero-page/zero-app-shell.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-app-shell.tsx
@@ -350,10 +350,7 @@ export function ZeroAppShell({ initialJobAgent }: ZeroAppShellProps) {
             sectionId={activeId}
             inSession={inSession}
             onSendMessage={handleSendFromDemo}
-            recentLabel={recentLabel}
-            recentId={recentId}
             selectedAgentName={initialJobAgent}
-            onClearRecent={handleClearRecent}
             onNavigateToActivity={() => setActiveId("activity")}
             onNavigateToSchedule={() => setActiveId("schedule")}
             onNavigateToJob={() => setActiveId("job")}

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-page.tsx
@@ -24,7 +24,7 @@ import {
   IconCalendar,
 } from "@tabler/icons-react";
 import { Button, Card, CardContent, cn } from "@vm0/ui";
-import { ZERO_TEAM_JOBS } from "./zero-jobs-page";
+import { ZERO_TEAM_JOBS } from "./zero-mock-data";
 import { agentDisplayName$ } from "../../signals/zero-page/zero-agent-name.ts";
 import { AttachmentChips } from "./zero-attachment-chips.tsx";
 

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-page.tsx
@@ -651,7 +651,7 @@ interface ZeroChatPageProps {
   onClearScenario?: () => void;
   onNavigateToActivity?: () => void;
   onNavigateToSchedule?: () => void;
-  onNavigateToJob?: () => void;
+  onNavigateToTeam?: () => void;
   onNavigateToMeet?: (tab?: string) => void;
   onSendMessage?: (message: string) => void;
   zeroAvatarSrc?: string;
@@ -663,7 +663,7 @@ export function ZeroChatPage({
   onClearScenario,
   onNavigateToActivity,
   onNavigateToSchedule,
-  onNavigateToJob,
+  onNavigateToTeam,
   onNavigateToMeet,
   onSendMessage,
   zeroAvatarSrc = "/zero-avatar.png",
@@ -1010,7 +1010,7 @@ export function ZeroChatPage({
                       variant="outline"
                       size="sm"
                       className="w-fit rounded-lg"
-                      onClick={onNavigateToJob}
+                      onClick={onNavigateToTeam}
                     >
                       Manage in {agentName}&apos;s team
                     </Button>

--- a/turbo/apps/platform/src/views/zero-page/zero-content.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-content.tsx
@@ -20,6 +20,7 @@ interface ZeroContentProps {
   onNavigateToSchedule?: () => void;
   onNavigateToJob?: () => void;
   onNavigateToChat?: () => void;
+  selectedAgentName?: string | null;
   onNavigateToMeet?: (tab?: string) => void;
   onBackFromSession?: () => void;
   zeroAvatarSrc?: string;
@@ -49,6 +50,7 @@ export function ZeroContent({
   onNavigateToSchedule,
   onNavigateToJob,
   onNavigateToChat,
+  selectedAgentName,
   onNavigateToMeet,
   onBackFromSession,
   zeroAvatarSrc = "/zero-avatar.png",
@@ -93,7 +95,12 @@ export function ZeroContent({
     return <ZeroSchedulePage />;
   }
   if (sectionId === "job") {
-    return <ZeroJobsPage onNavigateToChat={onNavigateToChat} />;
+    return (
+      <ZeroJobsPage
+        onNavigateToChat={onNavigateToChat}
+        selectedAgentName={selectedAgentName}
+      />
+    );
   }
   if (sectionId === "activity") {
     return <ZeroActivityPage />;
@@ -124,7 +131,7 @@ export function ZeroContent({
         <div className="mx-auto max-w-[900px]">
           <div className="zero-card p-6">
             <p className="text-sm text-muted-foreground">
-              Content for “{title}” will appear here.
+              Content for &quot;{title}&quot; will appear here.
             </p>
           </div>
         </div>

--- a/turbo/apps/platform/src/views/zero-page/zero-content.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-content.tsx
@@ -18,7 +18,7 @@ interface ZeroContentProps {
   onSendMessage?: (message: string) => void;
   onNavigateToActivity?: () => void;
   onNavigateToSchedule?: () => void;
-  onNavigateToJob?: () => void;
+  onNavigateToTeam?: () => void;
   onNavigateToChat?: () => void;
   selectedAgentName?: string | null;
   onNavigateToMeet?: (tab?: string) => void;
@@ -34,7 +34,7 @@ function getSectionTitles(
     chat: `Chat with ${agentName}`,
     meet: `Meet ${agentName}`,
     schedule: "Schedule",
-    job: `${agentName}'s team`,
+    team: `${agentName}'s team`,
     activity: "Activities",
     works: `Where ${agentName} works`,
     settings: "Settings",
@@ -48,7 +48,7 @@ export function ZeroContent({
   onSendMessage,
   onNavigateToActivity,
   onNavigateToSchedule,
-  onNavigateToJob,
+  onNavigateToTeam,
   onNavigateToChat,
   selectedAgentName,
   onNavigateToMeet,
@@ -66,7 +66,7 @@ export function ZeroContent({
           zeroAvatarSrc={zeroAvatarSrc}
           onAvatarClick={onAvatarClick}
           onBack={onBackFromSession}
-          onNavigateToJob={onNavigateToJob}
+          onNavigateToTeam={onNavigateToTeam}
           onNavigateToSchedule={onNavigateToSchedule}
         />
       );
@@ -76,7 +76,7 @@ export function ZeroContent({
         onSendMessage={onSendMessage}
         onNavigateToActivity={onNavigateToActivity}
         onNavigateToSchedule={onNavigateToSchedule}
-        onNavigateToJob={onNavigateToJob}
+        onNavigateToTeam={onNavigateToTeam}
         onNavigateToMeet={onNavigateToMeet}
         zeroAvatarSrc={zeroAvatarSrc}
         onAvatarClick={onAvatarClick}
@@ -94,7 +94,7 @@ export function ZeroContent({
   if (sectionId === "schedule") {
     return <ZeroSchedulePage />;
   }
-  if (sectionId === "job") {
+  if (sectionId === "team") {
     return (
       <ZeroJobsPage
         onNavigateToChat={onNavigateToChat}

--- a/turbo/apps/platform/src/views/zero-page/zero-instructions-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-instructions-tab.tsx
@@ -1,0 +1,82 @@
+import { stripMetadataFrontmatter } from "@vm0/core";
+import { Card, CardContent } from "@vm0/ui";
+import type { AgentInstructions } from "../../signals/agent-detail/types.ts";
+import { ZeroUnsavedBar } from "./zero-unsaved-bar.tsx";
+
+interface ZeroInstructionsTabProps {
+  instructions: AgentInstructions | null;
+  loading: boolean;
+  fetchError: string | null;
+  editedContent: string | null;
+  isDirty: boolean;
+  isBuilding: boolean;
+  buildError: string | null;
+  onEdit: (value: string) => void;
+  onDiscard: () => void;
+  onBuild: () => void;
+}
+
+export function ZeroInstructionsTab({
+  instructions,
+  loading,
+  fetchError,
+  editedContent,
+  isDirty,
+  isBuilding,
+  buildError,
+  onEdit,
+  onDiscard,
+  onBuild,
+}: ZeroInstructionsTabProps) {
+  const rawContent = instructions?.content ?? "";
+  const strippedContent = stripMetadataFrontmatter(rawContent);
+  const displayContent = editedContent ?? strippedContent;
+
+  return (
+    <div className="mx-auto max-w-[900px] px-7">
+      <Card className="zero-card-white">
+        <CardContent className="py-7">
+          {loading ? (
+            <div className="space-y-4 animate-pulse">
+              <div className="h-5 w-40 rounded bg-muted/50" />
+              <div className="h-64 w-full rounded bg-muted/30" />
+            </div>
+          ) : fetchError ? (
+            <p className="text-sm text-destructive">{fetchError}</p>
+          ) : (
+            <>
+              <textarea
+                aria-label="Agent instructions editor"
+                className="px-1 text-sm font-mono text-foreground w-full min-h-[200px] bg-transparent border-none outline-none resize-none whitespace-pre-wrap leading-relaxed"
+                value={displayContent}
+                onChange={(e) => onEdit(e.target.value)}
+                rows={Math.max(10, displayContent.split("\n").length + 2)}
+                disabled={isBuilding}
+                placeholder="Write instructions for your agent..."
+              />
+              <div className="flex items-center gap-2 pt-5 mt-5 border-t border-border/60">
+                <p className="text-muted-foreground text-xs">
+                  Edit the instructions directly to customize your agent&apos;s
+                  behavior.
+                </p>
+                {buildError && (
+                  <span className="text-xs font-medium text-destructive">
+                    {buildError}
+                  </span>
+                )}
+              </div>
+            </>
+          )}
+        </CardContent>
+      </Card>
+
+      {(isDirty || isBuilding) && (
+        <ZeroUnsavedBar
+          onDiscard={onDiscard}
+          onSave={onBuild}
+          saving={isBuilding}
+        />
+      )}
+    </div>
+  );
+}

--- a/turbo/apps/platform/src/views/zero-page/zero-job-detail-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-job-detail-page.tsx
@@ -31,7 +31,7 @@ import {
 } from "../../signals/zero-page/zero-job-detail.ts";
 import { navigateInReact$ } from "../../signals/route.ts";
 
-function getConnectorTypes(): ConnectorType[] {
+function getAllConnectorTypes(): readonly ConnectorType[] {
   return Object.keys(CONNECTOR_TYPES) as ConnectorType[];
 }
 
@@ -68,7 +68,7 @@ function ConnectorsTab() {
         </p>
       </div>
       <ul className="flex flex-col gap-3">
-        {getConnectorTypes().map((type) => {
+        {getAllConnectorTypes().map((type) => {
           const config = CONNECTOR_TYPES[type];
           return (
             <li key={type}>

--- a/turbo/apps/platform/src/views/zero-page/zero-job-detail-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-job-detail-page.tsx
@@ -25,17 +25,15 @@ import {
   zeroJobDetailError$,
   zeroJobInstructions$,
   zeroJobInstructionsLoading$,
+  zeroJobInstructionsError$,
   zeroJobSchedule$,
+  zeroJobScheduleError$,
 } from "../../signals/zero-page/zero-job-detail.ts";
 import { navigateInReact$ } from "../../signals/route.ts";
 
-const CONNECTOR_LIST: readonly ConnectorType[] = [
-  "github",
-  "linear",
-  "notion",
-  "gmail",
-  "slack",
-];
+function getConnectorTypes(): ConnectorType[] {
+  return Object.keys(CONNECTOR_TYPES) as ConnectorType[];
+}
 
 interface ZeroJobDetailPageProps {
   agentName: string;
@@ -70,7 +68,7 @@ function ConnectorsTab() {
         </p>
       </div>
       <ul className="flex flex-col gap-3">
-        {CONNECTOR_LIST.map((type) => {
+        {getConnectorTypes().map((type) => {
           const config = CONNECTOR_TYPES[type];
           return (
             <li key={type}>
@@ -166,6 +164,7 @@ function SettingsTab({
 function InstructionsTab() {
   const instructions = useGet(zeroJobInstructions$);
   const instructionsLoading = useGet(zeroJobInstructionsLoading$);
+  const instructionsError = useGet(zeroJobInstructionsError$);
 
   return (
     <Card className="zero-card-white">
@@ -177,14 +176,19 @@ function InstructionsTab() {
             <div className="h-4 w-5/6 rounded bg-muted" />
           </div>
         )}
-        {!instructionsLoading && instructions?.content && (
-          <Markdown source={instructions.content} />
+        {!instructionsLoading && instructionsError && (
+          <p className="text-sm text-destructive">{instructionsError}</p>
         )}
-        {!instructionsLoading && !instructions?.content && (
-          <p className="text-sm text-muted-foreground">
-            No instructions configured for this agent.
-          </p>
-        )}
+        {!instructionsLoading &&
+          !instructionsError &&
+          instructions?.content && <Markdown source={instructions.content} />}
+        {!instructionsLoading &&
+          !instructionsError &&
+          !instructions?.content && (
+            <p className="text-sm text-muted-foreground">
+              No instructions configured for this agent.
+            </p>
+          )}
       </CardContent>
     </Card>
   );
@@ -248,6 +252,17 @@ function DetailError({
 function ScheduleTab({ agentName }: { agentName: string }) {
   const detail = useGet(zeroJobDetail$);
   const schedules = useGet(zeroJobSchedule$);
+  const scheduleError = useGet(zeroJobScheduleError$);
+
+  if (scheduleError) {
+    return (
+      <Card className="zero-card">
+        <CardContent className="px-6 py-6 text-center">
+          <p className="text-sm text-destructive">{scheduleError}</p>
+        </CardContent>
+      </Card>
+    );
+  }
 
   const scheduleEntries = schedules.map((s) => ({
     id: s.id,

--- a/turbo/apps/platform/src/views/zero-page/zero-job-detail-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-job-detail-page.tsx
@@ -1,16 +1,10 @@
-import { useCCState } from "ccstate-react/experimental";
 import { useGet, useSet } from "ccstate-react";
-import { createPortal } from "react-dom";
 import {
   IconArrowLeft,
   IconFileText,
   IconSettings,
   IconPlug,
-  IconSparkles,
-  IconPlus,
   IconCalendar,
-  IconPencil,
-  IconDotsVertical,
 } from "@tabler/icons-react";
 import {
   Button,
@@ -19,437 +13,394 @@ import {
   TabsTrigger,
   Card,
   CardContent,
-  Input,
-  DropdownMenu,
-  DropdownMenuTrigger,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  cn,
 } from "@vm0/ui";
-import type { ConnectorType } from "@vm0/core";
+import { useCCState } from "ccstate-react/experimental";
+import { CONNECTOR_TYPES, type ConnectorType } from "@vm0/core";
 import { ConnectorIcon } from "../settings-page/connector-icons";
-import { ZeroScheduleCard, DUMMY_AGENT_SCHEDULE } from "./zero-schedule-card";
+import { Markdown } from "../components/markdown.tsx";
+import { ZeroScheduleCard } from "./zero-schedule-card";
+import {
+  zeroJobDetail$,
+  zeroJobDetailLoading$,
+  zeroJobDetailError$,
+  zeroJobInstructions$,
+  zeroJobInstructionsLoading$,
+  zeroJobSchedule$,
+} from "../../signals/zero-page/zero-job-detail.ts";
+import { navigateInReact$ } from "../../signals/route.ts";
 
-export interface JobItem {
-  id: string;
+const CONNECTOR_LIST: readonly ConnectorType[] = [
+  "github",
+  "linear",
+  "notion",
+  "gmail",
+  "slack",
+];
+
+interface ZeroJobDetailPageProps {
   agentName: string;
-  title: string;
-  description: string;
-  scope: "personal" | "team";
+  onBack: () => void;
 }
 
-const DUMMY_SKILLS = [
-  {
-    type: "notion" as ConnectorType,
-    label: "Notion",
-    connected: true,
-    statusText: "Connected",
-  },
-  {
-    type: "github" as ConnectorType,
-    label: "GitHub",
-    connected: false,
-    statusText: "",
-  },
-  {
-    type: "axiom" as ConnectorType,
-    label: "Axiom",
-    connected: true,
-    statusText: "Connected",
-  },
-  {
-    type: "slack" as ConnectorType,
-    label: "Slack",
-    connected: false,
-    statusText: "",
-  },
-] as const;
-
-function SubAgentSkillsTab() {
-  const removedTypes$ = useCCState<ConnectorType[]>([]);
-  const removedTypes = useGet(removedTypes$);
-  const setRemovedTypes = useSet(removedTypes$);
-  const displayItems = DUMMY_SKILLS.filter(
-    (item) => !removedTypes.includes(item.type),
-  );
-
+function BackButton({ onBack }: { onBack: () => void }) {
   return (
-    <div className="flex flex-col gap-4">
-      <p className="text-sm text-muted-foreground">
-        Skills manage your connections and help you get more out of these
-        services.
-      </p>
-
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
-        {/* Add skill */}
-        <button
-          type="button"
-          className="flex flex-col rounded-[var(--zero-card-radius)] border border-dashed border-border/80 transition-colors hover:border-border hover:bg-muted/30 group"
-        >
-          <div className="flex h-14 items-center gap-2.5 px-5">
-            <span className="flex h-7 w-7 shrink-0 items-center justify-center">
-              <IconPlus
-                size={18}
-                stroke={2}
-                className="text-muted-foreground group-hover:text-foreground"
-              />
-            </span>
-            <span className="text-sm font-medium text-muted-foreground group-hover:text-foreground">
-              Add skill
-            </span>
-          </div>
-          <div className="flex h-11 items-center border-t border-dashed border-border/80 px-5 group-hover:border-border">
-            <span className="text-xs text-muted-foreground/70">
-              Browse 100+ popular skills
-            </span>
-          </div>
-        </button>
-
-        {/* Skill cards */}
-        {displayItems.map((item) => (
-          <div
-            key={item.type}
-            className="flex flex-col rounded-[var(--zero-card-radius)] border border-[var(--zero-card-border)] bg-card shadow-[var(--zero-card-shadow)]"
-          >
-            <div className="flex h-14 items-center gap-2.5 px-5">
-              <span className="flex h-7 w-7 shrink-0 items-center justify-center">
-                <ConnectorIcon type={item.type} size={22} />
-              </span>
-              <span className="min-w-0 flex-1 text-sm font-medium text-foreground truncate">
-                {item.label}
-              </span>
-            </div>
-
-            <div className="flex h-11 items-center justify-between border-t border-border/50 pl-5 pr-2">
-              <div className="flex items-center gap-2 min-w-0">
-                {item.connected ? (
-                  <span className="flex items-center gap-2 text-xs text-muted-foreground truncate">
-                    <span className="h-1.5 w-1.5 rounded-full bg-emerald-500 shrink-0" />
-                    {item.statusText}
-                  </span>
-                ) : (
-                  <button
-                    type="button"
-                    className="text-xs font-medium text-primary hover:text-primary/80 transition-colors"
-                  >
-                    Connect
-                  </button>
-                )}
-              </div>
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    className="h-7 w-7 shrink-0 rounded-lg text-muted-foreground hover:text-foreground"
-                    aria-label="More options"
-                  >
-                    <IconDotsVertical size={14} stroke={1.5} />
-                  </Button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent align="end" className="w-40">
-                  {item.connected ? (
-                    <DropdownMenuItem>Disconnect</DropdownMenuItem>
-                  ) : (
-                    <DropdownMenuItem
-                      onClick={() =>
-                        setRemovedTypes((prev) =>
-                          prev.includes(item.type)
-                            ? prev
-                            : [...prev, item.type],
-                        )
-                      }
-                    >
-                      Remove skill
-                    </DropdownMenuItem>
-                  )}
-                </DropdownMenuContent>
-              </DropdownMenu>
-            </div>
-          </div>
-        ))}
-      </div>
+    <div className="mb-3">
+      <Button
+        variant="ghost"
+        size="icon"
+        className="h-8 w-8 shrink-0 -ml-2"
+        onClick={onBack}
+        aria-label="Back to agents"
+      >
+        <IconArrowLeft size={20} stroke={1.5} />
+      </Button>
     </div>
   );
 }
 
-interface ZeroJobDetailPageProps {
-  job: JobItem;
-  onBack: () => void;
+function ConnectorsTab() {
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex flex-col gap-1">
+        <h2 className="text-sm font-semibold tracking-tight text-foreground">
+          Connectors
+        </h2>
+        <p className="text-sm text-muted-foreground">
+          Third-party services this agent can use
+        </p>
+      </div>
+      <ul className="flex flex-col gap-3">
+        {CONNECTOR_LIST.map((type) => {
+          const config = CONNECTOR_TYPES[type];
+          return (
+            <li key={type}>
+              <Card className="zero-card">
+                <CardContent className="flex items-center gap-4 px-4 py-3">
+                  <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-muted overflow-hidden">
+                    <ConnectorIcon type={type} size={24} />
+                  </span>
+                  <div className="min-w-0 flex-1">
+                    <p className="text-sm font-medium text-foreground">
+                      {config.label}
+                    </p>
+                    <p className="text-xs text-muted-foreground">
+                      {config.helpText}
+                    </p>
+                  </div>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    className="h-8 shrink-0 rounded-lg px-3 zero-btn-morandi border"
+                  >
+                    Connect
+                  </Button>
+                </CardContent>
+              </Card>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
 }
 
-export function ZeroJobDetailPage({ job, onBack }: ZeroJobDetailPageProps) {
+function SettingsTab({
+  name,
+  description,
+  framework,
+  skills,
+}: {
+  name: string;
+  description: string | null;
+  framework: string | null;
+  skills: string[];
+}) {
+  return (
+    <Card className="zero-card">
+      <CardContent className="px-7 py-7 flex flex-col gap-6">
+        <div className="flex flex-col gap-2">
+          <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            Name
+          </span>
+          <p className="text-sm text-foreground">{name}</p>
+        </div>
+        {description && (
+          <div className="flex flex-col gap-2">
+            <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              Description
+            </span>
+            <p className="text-sm text-foreground">{description}</p>
+          </div>
+        )}
+        {framework && (
+          <div className="flex flex-col gap-2">
+            <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              Framework
+            </span>
+            <p className="text-sm text-foreground">{framework}</p>
+          </div>
+        )}
+        {skills.length > 0 && (
+          <div className="flex flex-col gap-3">
+            <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              Skills
+            </span>
+            <ul className="flex flex-wrap gap-2" role="list">
+              {skills.map((skill) => (
+                <li key={skill}>
+                  <span className="zero-chip inline-flex items-center gap-2 rounded-2xl border px-3 py-2.5 text-sm text-foreground">
+                    <span className="min-w-0 truncate font-medium">
+                      {skill}
+                    </span>
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function InstructionsTab() {
+  const instructions = useGet(zeroJobInstructions$);
+  const instructionsLoading = useGet(zeroJobInstructionsLoading$);
+
+  return (
+    <Card className="zero-card-white">
+      <CardContent className="px-7 py-7">
+        {instructionsLoading && (
+          <div className="animate-pulse space-y-3">
+            <div className="h-4 w-3/4 rounded bg-muted" />
+            <div className="h-4 w-1/2 rounded bg-muted" />
+            <div className="h-4 w-5/6 rounded bg-muted" />
+          </div>
+        )}
+        {!instructionsLoading && instructions?.content && (
+          <Markdown source={instructions.content} />
+        )}
+        {!instructionsLoading && !instructions?.content && (
+          <p className="text-sm text-muted-foreground">
+            No instructions configured for this agent.
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function DetailSkeleton({ onBack }: { onBack: () => void }) {
+  return (
+    <div className="flex flex-1 flex-col min-h-0">
+      <header className="shrink-0 bg-transparent px-4 sm:px-6 pt-4 pb-3">
+        <BackButton onBack={onBack} />
+        <div className="mx-auto max-w-[900px] animate-pulse space-y-3">
+          <div className="h-5 w-48 rounded bg-muted" />
+          <div className="h-4 w-72 rounded bg-muted" />
+          <div className="h-9 w-80 rounded bg-muted mt-4" />
+        </div>
+      </header>
+    </div>
+  );
+}
+
+function DetailError({
+  error,
+  agentName,
+  onBack,
+}: {
+  error: string;
+  agentName: string;
+  onBack: () => void;
+}) {
+  const navigate = useSet(navigateInReact$);
+  return (
+    <div className="flex flex-1 flex-col min-h-0">
+      <header className="shrink-0 bg-transparent px-4 sm:px-6 pt-4 pb-3">
+        <BackButton onBack={onBack} />
+      </header>
+      <main className="flex-1 px-4 sm:px-6 pt-4 pb-8">
+        <div className="mx-auto max-w-[900px]">
+          <Card className="zero-card">
+            <CardContent className="px-6 py-6 text-center space-y-3">
+              <p className="text-sm text-destructive">{error}</p>
+              <Button
+                variant="outline"
+                size="sm"
+                className="zero-btn-morandi"
+                onClick={() =>
+                  navigate("/zero/job/:name", {
+                    pathParams: { name: agentName },
+                  })
+                }
+              >
+                Retry
+              </Button>
+            </CardContent>
+          </Card>
+        </div>
+      </main>
+    </div>
+  );
+}
+
+function ScheduleTab({ agentName }: { agentName: string }) {
+  const detail = useGet(zeroJobDetail$);
+  const schedules = useGet(zeroJobSchedule$);
+
+  const scheduleEntries = schedules.map((s) => ({
+    id: s.id,
+    time: s.cronExpression
+      ? `Cron: ${s.cronExpression} (${s.timezone})`
+      : s.atTime
+        ? `Once at ${new Date(s.atTime).toLocaleString()}`
+        : "Unknown schedule",
+    prompt: s.prompt,
+  }));
+
+  return (
+    <ZeroScheduleCard
+      title={`${detail?.name ?? agentName} schedule`}
+      subtitle="Set a time and prompt for this agent to run automatically."
+      initialSchedule={scheduleEntries}
+    />
+  );
+}
+
+const TAB_TRIGGER_CLASS =
+  "gap-1.5 text-sm data-[state=active]:bg-background px-3";
+
+function DetailTabs({
+  activeTab,
+  onValueChange,
+}: {
+  activeTab: string;
+  onValueChange: (v: string) => void;
+}) {
+  return (
+    <Tabs
+      value={activeTab}
+      onValueChange={onValueChange}
+      className="mt-4 w-full"
+    >
+      <TabsList className="zero-tabs h-9 w-full sm:w-auto gap-1 px-1 py-1">
+        <TabsTrigger value="connectors" className={TAB_TRIGGER_CLASS}>
+          <IconPlug size={14} stroke={1.5} />
+          Connectors
+        </TabsTrigger>
+        <TabsTrigger value="schedule" className={TAB_TRIGGER_CLASS}>
+          <IconCalendar size={14} stroke={1.5} />
+          Schedule
+        </TabsTrigger>
+        <TabsTrigger value="settings" className={TAB_TRIGGER_CLASS}>
+          <IconSettings size={14} stroke={1.5} />
+          Settings
+        </TabsTrigger>
+        <TabsTrigger value="instructions" className={TAB_TRIGGER_CLASS}>
+          <IconFileText size={14} stroke={1.5} />
+          Instructions
+        </TabsTrigger>
+      </TabsList>
+    </Tabs>
+  );
+}
+
+function TabContent({
+  activeTab,
+  agentName,
+  displayName,
+  description,
+  framework,
+  skills,
+}: {
+  activeTab: string;
+  agentName: string;
+  displayName: string;
+  description: string | null;
+  framework: string | null;
+  skills: string[];
+}) {
+  if (activeTab === "connectors") {
+    return <ConnectorsTab />;
+  }
+  if (activeTab === "schedule") {
+    return <ScheduleTab agentName={agentName} />;
+  }
+  if (activeTab === "settings") {
+    return (
+      <SettingsTab
+        name={displayName}
+        description={description}
+        framework={framework}
+        skills={skills}
+      />
+    );
+  }
+  if (activeTab === "instructions") {
+    return <InstructionsTab />;
+  }
+  return null;
+}
+
+export function ZeroJobDetailPage({
+  agentName,
+  onBack,
+}: ZeroJobDetailPageProps) {
   const activeTab$ = useCCState("connectors");
   const activeTab = useGet(activeTab$);
   const setActiveTab = useSet(activeTab$);
-  const settingsName$ = useCCState(job.title);
-  const settingsName = useGet(settingsName$);
-  const setSettingsName = useSet(settingsName$);
-  const settingsDescription$ = useCCState(job.description);
-  const settingsDescription = useGet(settingsDescription$);
-  const setSettingsDescription = useSet(settingsDescription$);
 
-  const savedSettings$ = useCCState<{
-    name: string;
-    description: string;
-  }>({
-    name: job.title,
-    description: job.description,
-  });
-  const savedSettings = useGet(savedSettings$);
-  const setSavedSettings = useSet(savedSettings$);
+  const detail = useGet(zeroJobDetail$);
+  const loading = useGet(zeroJobDetailLoading$);
+  const error = useGet(zeroJobDetailError$);
 
-  const isSettingsDirty =
-    settingsName !== savedSettings.name ||
-    settingsDescription !== savedSettings.description;
-  const showSaveBar = isSettingsDirty;
+  const agentDef = detail?.content
+    ? Object.values(detail.content.agents)[0]
+    : null;
+  const description = agentDef?.description ?? null;
+  const framework = agentDef?.framework ?? null;
+  const skills = agentDef?.skills ?? [];
 
-  const handleReset = () => {
-    setSettingsName(savedSettings.name);
-    setSettingsDescription(savedSettings.description);
-  };
+  if (loading && !detail) {
+    return <DetailSkeleton onBack={onBack} />;
+  }
 
-  const handleSave = () => {
-    setSavedSettings({
-      name: settingsName,
-      description: settingsDescription,
-    });
-  };
+  if (error) {
+    return <DetailError error={error} agentName={agentName} onBack={onBack} />;
+  }
 
   return (
     <div className="flex flex-1 flex-col min-h-0">
       <header className="shrink-0 bg-transparent px-4 sm:px-6 pt-4 pb-3">
-        <div className="mb-3">
-          <Button
-            variant="ghost"
-            size="icon"
-            className="h-8 w-8 shrink-0 -ml-2"
-            onClick={onBack}
-            aria-label="Back to agents"
-          >
-            <IconArrowLeft size={20} stroke={1.5} />
-          </Button>
-        </div>
+        <BackButton onBack={onBack} />
         <div className="mx-auto max-w-[900px]">
-          <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between sm:gap-6">
-            <div className="min-w-0 flex-1 space-y-1.5">
-              <div className="flex flex-wrap items-baseline gap-2 text-base">
-                <span className="text-muted-foreground">{job.agentName}</span>
-                <span className="text-muted-foreground/50">·</span>
-                <h1 className="font-semibold tracking-tight text-foreground">
-                  {job.title}
-                </h1>
-              </div>
+          <div className="min-w-0 flex-1 space-y-1.5">
+            <h1 className="text-base font-semibold tracking-tight text-foreground">
+              {detail?.name ?? agentName}
+            </h1>
+            {description && (
               <p className="text-sm text-muted-foreground leading-relaxed max-w-[36rem]">
-                {job.description}
+                {description}
               </p>
-            </div>
-            <Button
-              variant="outline"
-              size="sm"
-              className="zero-btn-morandi h-9 shrink-0 gap-2 rounded-lg border px-4"
-            >
-              <IconSparkles size={14} stroke={1.5} />
-              Just ask
-            </Button>
+            )}
           </div>
-
-          <Tabs
-            value={activeTab}
-            onValueChange={setActiveTab}
-            className="mt-4 w-full"
-          >
-            <TabsList className="zero-tabs h-9 w-full sm:w-auto gap-1 px-1 py-1">
-              <TabsTrigger
-                value="connectors"
-                className="gap-1.5 text-sm data-[state=active]:bg-background px-3"
-              >
-                <IconPlug size={14} stroke={1.5} />
-                Skills
-              </TabsTrigger>
-              <TabsTrigger
-                value="schedule"
-                className="gap-1.5 text-sm data-[state=active]:bg-background px-3"
-              >
-                <IconCalendar size={14} stroke={1.5} />
-                Schedule
-              </TabsTrigger>
-              <TabsTrigger
-                value="settings"
-                className="gap-1.5 text-sm data-[state=active]:bg-background px-3"
-              >
-                <IconSettings size={14} stroke={1.5} />
-                Settings
-              </TabsTrigger>
-              <TabsTrigger
-                value="instructions"
-                className="gap-1.5 text-sm data-[state=active]:bg-background px-3"
-              >
-                <IconFileText size={14} stroke={1.5} />
-                Instructions
-              </TabsTrigger>
-            </TabsList>
-          </Tabs>
+          <DetailTabs activeTab={activeTab} onValueChange={setActiveTab} />
         </div>
       </header>
 
-      <main
-        className={cn(
-          "flex-1 overflow-auto px-4 sm:px-6 pt-4",
-          showSaveBar ? "pb-24" : "pb-8",
-        )}
-      >
+      <main className="flex-1 overflow-auto px-4 sm:px-6 pt-4 pb-8">
         <div className="mx-auto max-w-[900px]">
-          {activeTab === "instructions" && (
-            <Card className="zero-card-white">
-              <CardContent className="px-7 py-7">
-                <div className="flex flex-col sm:flex-row gap-6 sm:gap-8 sm:items-end">
-                  <div className="space-y-5 text-sm text-foreground leading-relaxed flex-1 min-w-0">
-                    <div>
-                      <h2 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground mb-1.5">
-                        Description
-                      </h2>
-                      <p>
-                        This agent collects and summarizes important team
-                        information every morning.
-                      </p>
-                    </div>
-                    <div>
-                      <h2 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground mb-1.5">
-                        Trigger
-                      </h2>
-                      <ul className="list-disc pl-4 space-y-0.5">
-                        <li>Schedule: Every day at 9:00 AM</li>
-                        <li>Timezone: UTC</li>
-                      </ul>
-                    </div>
-                    <div>
-                      <h2 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground mb-1.5">
-                        Steps
-                      </h2>
-                      <ol className="list-decimal pl-4 space-y-1">
-                        <li>
-                          <span className="font-medium">Fetch Messages</span>
-                          <ul className="list-disc pl-4 mt-0.5 space-y-0.5">
-                            <li>
-                              Source: Slack channels (#general, #engineering)
-                            </li>
-                            <li>Time range: Last 24 hours</li>
-                          </ul>
-                        </li>
-                        <li>
-                          <span className="font-medium">Analyze Content</span>
-                          <ul className="list-disc pl-4 mt-0.5 space-y-0.5">
-                            <li>Extract key discussions</li>
-                            <li>Identify action items</li>
-                          </ul>
-                        </li>
-                      </ol>
-                    </div>
-                  </div>
-                </div>
-                <p className="text-muted-foreground text-xs pt-5 mt-5 border-t border-border/60">
-                  Edit the instructions directly to customize your
-                  workflow&apos;s behavior.
-                </p>
-              </CardContent>
-            </Card>
-          )}
-
-          {activeTab === "schedule" && (
-            <ZeroScheduleCard
-              title={`${job.title} schedule`}
-              subtitle="Set a time and prompt for this agent to run automatically."
-              initialSchedule={DUMMY_AGENT_SCHEDULE}
-            />
-          )}
-
-          {activeTab === "settings" && (
-            <Card className="zero-card">
-              <CardContent className="px-7 py-7 flex flex-col gap-6">
-                <div className="flex flex-col gap-2">
-                  <label
-                    htmlFor="wf-name"
-                    className="text-xs font-semibold uppercase tracking-wide text-muted-foreground"
-                  >
-                    Name
-                  </label>
-                  <Input
-                    id="wf-name"
-                    value={settingsName}
-                    onChange={(e) => setSettingsName(e.target.value)}
-                    className="h-9"
-                  />
-                </div>
-                <div className="flex flex-col gap-2">
-                  <label
-                    htmlFor="wf-description"
-                    className="text-xs font-semibold uppercase tracking-wide text-muted-foreground"
-                  >
-                    Description
-                  </label>
-                  <textarea
-                    id="wf-description"
-                    value={settingsDescription}
-                    onChange={(e) => setSettingsDescription(e.target.value)}
-                    rows={3}
-                    className="w-full rounded-lg border border-border bg-input px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground outline-none transition-colors focus:border-primary focus:ring-[3px] focus:ring-primary/10 resize-y min-h-[72px]"
-                  />
-                </div>
-              </CardContent>
-            </Card>
-          )}
-
-          {activeTab === "connectors" && <SubAgentSkillsTab />}
-
-          {activeTab !== "instructions" &&
-            activeTab !== "settings" &&
-            activeTab !== "connectors" &&
-            activeTab !== "schedule" && (
-              <Card className="zero-card">
-                <CardContent className="px-7 py-7">
-                  <p className="text-sm text-muted-foreground">
-                    {activeTab} — coming soon
-                  </p>
-                </CardContent>
-              </Card>
-            )}
+          <TabContent
+            activeTab={activeTab}
+            agentName={agentName}
+            displayName={detail?.name ?? agentName}
+            description={description}
+            framework={framework}
+            skills={skills}
+          />
         </div>
       </main>
-
-      {showSaveBar &&
-        createPortal(
-          <div className="zero-app fixed bottom-6 left-0 right-0 z-50 flex justify-center px-4 sm:left-[255px]">
-            <div className="zero-card flex max-w-md items-center justify-between gap-4 rounded-xl border border-border bg-card px-5 py-4 shadow-lg">
-              <div className="flex items-center gap-2 text-sm text-foreground">
-                <IconPencil
-                  size={18}
-                  stroke={1.5}
-                  className="shrink-0 text-muted-foreground"
-                />
-                <span>You have unsaved changes</span>
-              </div>
-              <div className="flex items-center gap-2 shrink-0">
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className="text-destructive hover:bg-destructive/10 hover:text-destructive"
-                  onClick={handleReset}
-                >
-                  Discard
-                </Button>
-                <Button
-                  size="sm"
-                  className="h-9 rounded-lg px-4 bg-primary text-primary-foreground hover:bg-primary/90"
-                  onClick={handleSave}
-                >
-                  Save
-                </Button>
-              </div>
-            </div>
-          </div>,
-          document.body,
-        )}
     </div>
   );
 }

--- a/turbo/apps/platform/src/views/zero-page/zero-job-detail-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-job-detail-page.tsx
@@ -1,4 +1,5 @@
-import { useGet, useSet } from "ccstate-react";
+import { useGet, useSet, useLoadable } from "ccstate-react";
+import { useCCState } from "ccstate-react/experimental";
 import {
   IconArrowLeft,
   IconFileText,
@@ -14,11 +15,10 @@ import {
   Card,
   CardContent,
 } from "@vm0/ui";
-import { useCCState } from "ccstate-react/experimental";
 import { CONNECTOR_TYPES, type ConnectorType } from "@vm0/core";
 import { ConnectorIcon } from "../settings-page/connector-icons";
 import { Markdown } from "../components/markdown.tsx";
-import { ZeroScheduleCard } from "./zero-schedule-card";
+import { ZeroScheduleCard, type ScheduleEntry } from "./zero-schedule-card.tsx";
 import {
   zeroJobDetail$,
   zeroJobDetailLoading$,
@@ -26,9 +26,14 @@ import {
   zeroJobInstructions$,
   zeroJobInstructionsLoading$,
   zeroJobInstructionsError$,
-  zeroJobSchedule$,
+  zeroJobScheduleEntries$,
   zeroJobScheduleError$,
+  saveZeroJobSchedule$,
+  deleteZeroJobSchedule$,
+  toggleZeroJobScheduleEnabled$,
+  type ZeroJobScheduleSaveParams,
 } from "../../signals/zero-page/zero-job-detail.ts";
+import { notificationPreferences$ } from "../../signals/settings-page/notification-settings.ts";
 import { navigateInReact$ } from "../../signals/route.ts";
 
 function getAllConnectorTypes(): readonly ConnectorType[] {
@@ -58,7 +63,7 @@ function BackButton({ onBack }: { onBack: () => void }) {
 
 function ConnectorsTab() {
   return (
-    <div className="flex flex-col gap-6">
+    <div className="mx-auto max-w-[900px] px-7 flex flex-col gap-6">
       <div className="flex flex-col gap-1">
         <h2 className="text-sm font-semibold tracking-tight text-foreground">
           Connectors
@@ -102,6 +107,59 @@ function ConnectorsTab() {
   );
 }
 
+function JobScheduleTab({ agentName }: { agentName: string }) {
+  const entriesLoadable = useLoadable(zeroJobScheduleEntries$);
+  const scheduleError = useGet(zeroJobScheduleError$);
+  const prefsLoadable = useLoadable(notificationPreferences$);
+  const userTimezone =
+    prefsLoadable.state === "hasData" ? prefsLoadable.data.timezone : null;
+  const saveSchedule = useSet(saveZeroJobSchedule$);
+  const deleteSchedule = useSet(deleteZeroJobSchedule$);
+  const toggleEnabled = useSet(toggleZeroJobScheduleEnabled$);
+  const saving$ = useCCState(false);
+  const saving = useGet(saving$);
+  const setSaving = useSet(saving$);
+
+  const entries: ScheduleEntry[] =
+    entriesLoadable.state === "hasData" ? entriesLoadable.data : [];
+
+  if (scheduleError) {
+    return (
+      <div className="mx-auto max-w-[900px] px-7">
+        <Card className="zero-card">
+          <CardContent className="px-6 py-6 text-center">
+            <p className="text-sm text-destructive">{scheduleError}</p>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  const handleSave = async (params: ZeroJobScheduleSaveParams) => {
+    setSaving(true);
+    try {
+      await saveSchedule(params);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="mx-auto max-w-[900px] px-7">
+      <ZeroScheduleCard
+        title={`${agentName} schedule`}
+        subtitle={`Set a time and prompt for ${agentName} to run automatically.`}
+        initialSchedule={entries}
+        onSave={handleSave}
+        onDelete={deleteSchedule}
+        onToggleEnabled={toggleEnabled}
+        saving={saving}
+        defaultTimezone={userTimezone ?? undefined}
+      />
+    </div>
+  );
+}
+
 function SettingsTab({
   name,
   description,
@@ -114,50 +172,52 @@ function SettingsTab({
   skills: string[];
 }) {
   return (
-    <Card className="zero-card">
-      <CardContent className="px-7 py-7 flex flex-col gap-6">
-        <div className="flex flex-col gap-2">
-          <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-            Name
-          </span>
-          <p className="text-sm text-foreground">{name}</p>
-        </div>
-        {description && (
+    <div className="mx-auto max-w-[900px] px-7">
+      <Card className="zero-card">
+        <CardContent className="px-7 py-7 flex flex-col gap-6">
           <div className="flex flex-col gap-2">
             <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-              Description
+              Name
             </span>
-            <p className="text-sm text-foreground">{description}</p>
+            <p className="text-sm text-foreground">{name}</p>
           </div>
-        )}
-        {framework && (
-          <div className="flex flex-col gap-2">
-            <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-              Framework
-            </span>
-            <p className="text-sm text-foreground">{framework}</p>
-          </div>
-        )}
-        {skills.length > 0 && (
-          <div className="flex flex-col gap-3">
-            <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-              Skills
-            </span>
-            <ul className="flex flex-wrap gap-2" role="list">
-              {skills.map((skill) => (
-                <li key={skill}>
-                  <span className="zero-chip inline-flex items-center gap-2 rounded-2xl border px-3 py-2.5 text-sm text-foreground">
-                    <span className="min-w-0 truncate font-medium">
-                      {skill}
+          {description && (
+            <div className="flex flex-col gap-2">
+              <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                Description
+              </span>
+              <p className="text-sm text-foreground">{description}</p>
+            </div>
+          )}
+          {framework && (
+            <div className="flex flex-col gap-2">
+              <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                Framework
+              </span>
+              <p className="text-sm text-foreground">{framework}</p>
+            </div>
+          )}
+          {skills.length > 0 && (
+            <div className="flex flex-col gap-3">
+              <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                Skills
+              </span>
+              <ul className="flex flex-wrap gap-2" role="list">
+                {skills.map((skill) => (
+                  <li key={skill}>
+                    <span className="zero-chip inline-flex items-center gap-2 rounded-2xl border px-3 py-2.5 text-sm text-foreground">
+                      <span className="min-w-0 truncate font-medium">
+                        {skill}
+                      </span>
                     </span>
-                  </span>
-                </li>
-              ))}
-            </ul>
-          </div>
-        )}
-      </CardContent>
-    </Card>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
   );
 }
 
@@ -167,30 +227,32 @@ function InstructionsTab() {
   const instructionsError = useGet(zeroJobInstructionsError$);
 
   return (
-    <Card className="zero-card-white">
-      <CardContent className="px-7 py-7">
-        {instructionsLoading && (
-          <div className="animate-pulse space-y-3">
-            <div className="h-4 w-3/4 rounded bg-muted" />
-            <div className="h-4 w-1/2 rounded bg-muted" />
-            <div className="h-4 w-5/6 rounded bg-muted" />
-          </div>
-        )}
-        {!instructionsLoading && instructionsError && (
-          <p className="text-sm text-destructive">{instructionsError}</p>
-        )}
-        {!instructionsLoading &&
-          !instructionsError &&
-          instructions?.content && <Markdown source={instructions.content} />}
-        {!instructionsLoading &&
-          !instructionsError &&
-          !instructions?.content && (
-            <p className="text-sm text-muted-foreground">
-              No instructions configured for this agent.
-            </p>
+    <div className="mx-auto max-w-[900px] px-7">
+      <Card className="zero-card-white">
+        <CardContent className="px-7 py-7">
+          {instructionsLoading && (
+            <div className="animate-pulse space-y-3">
+              <div className="h-4 w-3/4 rounded bg-muted" />
+              <div className="h-4 w-1/2 rounded bg-muted" />
+              <div className="h-4 w-5/6 rounded bg-muted" />
+            </div>
           )}
-      </CardContent>
-    </Card>
+          {!instructionsLoading && instructionsError && (
+            <p className="text-sm text-destructive">{instructionsError}</p>
+          )}
+          {!instructionsLoading &&
+            !instructionsError &&
+            instructions?.content && <Markdown source={instructions.content} />}
+          {!instructionsLoading &&
+            !instructionsError &&
+            !instructions?.content && (
+              <p className="text-sm text-muted-foreground">
+                No instructions configured for this agent.
+              </p>
+            )}
+        </CardContent>
+      </Card>
+    </div>
   );
 }
 
@@ -198,11 +260,13 @@ function DetailSkeleton({ onBack }: { onBack: () => void }) {
   return (
     <div className="flex flex-1 flex-col min-h-0">
       <header className="shrink-0 bg-transparent px-4 sm:px-6 pt-4 pb-3">
-        <BackButton onBack={onBack} />
-        <div className="mx-auto max-w-[900px] animate-pulse space-y-3">
-          <div className="h-5 w-48 rounded bg-muted" />
-          <div className="h-4 w-72 rounded bg-muted" />
-          <div className="h-9 w-80 rounded bg-muted mt-4" />
+        <div className="mx-auto max-w-[900px] px-7">
+          <BackButton onBack={onBack} />
+          <div className="animate-pulse space-y-3">
+            <div className="h-5 w-48 rounded bg-muted" />
+            <div className="h-4 w-72 rounded bg-muted" />
+            <div className="h-9 w-80 rounded bg-muted mt-4" />
+          </div>
         </div>
       </header>
     </div>
@@ -222,10 +286,12 @@ function DetailError({
   return (
     <div className="flex flex-1 flex-col min-h-0">
       <header className="shrink-0 bg-transparent px-4 sm:px-6 pt-4 pb-3">
-        <BackButton onBack={onBack} />
+        <div className="mx-auto max-w-[900px] px-7">
+          <BackButton onBack={onBack} />
+        </div>
       </header>
       <main className="flex-1 px-4 sm:px-6 pt-4 pb-8">
-        <div className="mx-auto max-w-[900px]">
+        <div className="mx-auto max-w-[900px] px-7">
           <Card className="zero-card">
             <CardContent className="px-6 py-6 text-center space-y-3">
               <p className="text-sm text-destructive">{error}</p>
@@ -249,123 +315,103 @@ function DetailError({
   );
 }
 
-function ScheduleTab({ agentName }: { agentName: string }) {
-  const detail = useGet(zeroJobDetail$);
-  const schedules = useGet(zeroJobSchedule$);
-  const scheduleError = useGet(zeroJobScheduleError$);
-
-  if (scheduleError) {
-    return (
-      <Card className="zero-card">
-        <CardContent className="px-6 py-6 text-center">
-          <p className="text-sm text-destructive">{scheduleError}</p>
-        </CardContent>
-      </Card>
-    );
-  }
-
-  const scheduleEntries = schedules.map((s) => ({
-    id: s.id,
-    time: s.cronExpression
-      ? `Cron: ${s.cronExpression} (${s.timezone})`
-      : s.atTime
-        ? `Once at ${new Date(s.atTime).toLocaleString()}`
-        : "Unknown schedule",
-    prompt: s.prompt,
-  }));
-
-  return (
-    <ZeroScheduleCard
-      title={`${detail?.name ?? agentName} schedule`}
-      subtitle="Set a time and prompt for this agent to run automatically."
-      initialSchedule={scheduleEntries}
-    />
-  );
-}
-
 const TAB_TRIGGER_CLASS =
   "gap-1.5 text-sm data-[state=active]:bg-background px-3";
 
-function DetailTabs({
-  activeTab,
-  onValueChange,
-}: {
-  activeTab: string;
-  onValueChange: (v: string) => void;
-}) {
+function isValidTab(tab: string): boolean {
   return (
-    <Tabs
-      value={activeTab}
-      onValueChange={onValueChange}
-      className="mt-4 w-full"
-    >
-      <TabsList className="zero-tabs h-9 w-full sm:w-auto gap-1 px-1 py-1">
-        <TabsTrigger value="connectors" className={TAB_TRIGGER_CLASS}>
-          <IconPlug size={14} stroke={1.5} />
-          Connectors
-        </TabsTrigger>
-        <TabsTrigger value="schedule" className={TAB_TRIGGER_CLASS}>
-          <IconCalendar size={14} stroke={1.5} />
-          Schedule
-        </TabsTrigger>
-        <TabsTrigger value="settings" className={TAB_TRIGGER_CLASS}>
-          <IconSettings size={14} stroke={1.5} />
-          Settings
-        </TabsTrigger>
-        <TabsTrigger value="instructions" className={TAB_TRIGGER_CLASS}>
-          <IconFileText size={14} stroke={1.5} />
-          Instructions
-        </TabsTrigger>
-      </TabsList>
-    </Tabs>
+    tab === "connectors" ||
+    tab === "schedule" ||
+    tab === "settings" ||
+    tab === "instructions"
   );
 }
 
-function TabContent({
+function getInitialTab(): string {
+  if (typeof window === "undefined") {
+    return "connectors";
+  }
+  const params = new URLSearchParams(window.location.search);
+  const tab = params.get("tab") ?? "";
+  return isValidTab(tab) ? tab : "connectors";
+}
+
+function syncTabToUrl(tab: string) {
+  if (typeof window === "undefined") {
+    return;
+  }
+  const url = new URL(window.location.href);
+  if (tab === "connectors") {
+    url.searchParams.delete("tab");
+  } else {
+    url.searchParams.set("tab", tab);
+  }
+  window.history.replaceState(null, "", url.toString());
+}
+
+function DetailHeader({
   activeTab,
-  agentName,
+  onTabChange,
   displayName,
   description,
-  framework,
-  skills,
+  onBack,
 }: {
   activeTab: string;
-  agentName: string;
+  onTabChange: (tab: string) => void;
   displayName: string;
   description: string | null;
-  framework: string | null;
-  skills: string[];
+  onBack: () => void;
 }) {
-  if (activeTab === "connectors") {
-    return <ConnectorsTab />;
-  }
-  if (activeTab === "schedule") {
-    return <ScheduleTab agentName={agentName} />;
-  }
-  if (activeTab === "settings") {
-    return (
-      <SettingsTab
-        name={displayName}
-        description={description}
-        framework={framework}
-        skills={skills}
-      />
-    );
-  }
-  if (activeTab === "instructions") {
-    return <InstructionsTab />;
-  }
-  return null;
+  return (
+    <header className="shrink-0 bg-transparent px-4 pt-4 pb-4 sm:px-6">
+      <div className="mx-auto max-w-[900px] px-7">
+        <BackButton onBack={onBack} />
+        <div className="min-w-0 flex-1 space-y-1.5">
+          <h1 className="text-xl font-semibold tracking-tight text-foreground leading-tight">
+            {displayName}
+          </h1>
+          {description && (
+            <p className="text-sm text-muted-foreground leading-relaxed max-w-[36rem]">
+              {description}
+            </p>
+          )}
+        </div>
+
+        <div className="mt-6 flex h-9 items-center">
+          <Tabs
+            value={activeTab}
+            onValueChange={onTabChange}
+            className="flex-1 min-w-0"
+          >
+            <TabsList className="zero-tabs h-9 w-full sm:w-auto gap-1 px-1 py-1">
+              <TabsTrigger value="connectors" className={TAB_TRIGGER_CLASS}>
+                <IconPlug size={14} stroke={1.5} />
+                Connectors
+              </TabsTrigger>
+              <TabsTrigger value="schedule" className={TAB_TRIGGER_CLASS}>
+                <IconCalendar size={14} stroke={1.5} />
+                Schedule
+              </TabsTrigger>
+              <TabsTrigger value="settings" className={TAB_TRIGGER_CLASS}>
+                <IconSettings size={14} stroke={1.5} />
+                Settings
+              </TabsTrigger>
+              <TabsTrigger value="instructions" className={TAB_TRIGGER_CLASS}>
+                <IconFileText size={14} stroke={1.5} />
+                Instructions
+              </TabsTrigger>
+            </TabsList>
+          </Tabs>
+        </div>
+      </div>
+    </header>
+  );
 }
 
 export function ZeroJobDetailPage({
   agentName,
   onBack,
 }: ZeroJobDetailPageProps) {
-  const activeTab$ = useCCState("connectors");
-  const activeTab = useGet(activeTab$);
-  const setActiveTab = useSet(activeTab$);
-
   const detail = useGet(zeroJobDetail$);
   const loading = useGet(zeroJobDetailLoading$);
   const error = useGet(zeroJobDetailError$);
@@ -376,6 +422,15 @@ export function ZeroJobDetailPage({
   const description = agentDef?.description ?? null;
   const framework = agentDef?.framework ?? null;
   const skills = agentDef?.skills ?? [];
+  const displayName = detail?.name ?? agentName;
+
+  const activeTab$ = useCCState(getInitialTab());
+  const activeTab = useGet(activeTab$);
+  const rawSetActiveTab = useSet(activeTab$);
+  const setActiveTab = (tab: string) => {
+    rawSetActiveTab(tab);
+    syncTabToUrl(tab);
+  };
 
   if (loading && !detail) {
     return <DetailSkeleton onBack={onBack} />;
@@ -386,35 +441,30 @@ export function ZeroJobDetailPage({
   }
 
   return (
-    <div className="flex flex-1 flex-col min-h-0">
-      <header className="shrink-0 bg-transparent px-4 sm:px-6 pt-4 pb-3">
-        <BackButton onBack={onBack} />
-        <div className="mx-auto max-w-[900px]">
-          <div className="min-w-0 flex-1 space-y-1.5">
-            <h1 className="text-base font-semibold tracking-tight text-foreground">
-              {detail?.name ?? agentName}
-            </h1>
-            {description && (
-              <p className="text-sm text-muted-foreground leading-relaxed max-w-[36rem]">
-                {description}
-              </p>
-            )}
-          </div>
-          <DetailTabs activeTab={activeTab} onValueChange={setActiveTab} />
-        </div>
-      </header>
+    <div className="flex flex-1 flex-col min-h-0 overflow-auto [scrollbar-gutter:stable]">
+      <DetailHeader
+        activeTab={activeTab}
+        onTabChange={setActiveTab}
+        displayName={displayName}
+        description={description}
+        onBack={onBack}
+      />
 
-      <main className="flex-1 overflow-auto px-4 sm:px-6 pt-4 pb-8">
-        <div className="mx-auto max-w-[900px]">
-          <TabContent
-            activeTab={activeTab}
-            agentName={agentName}
-            displayName={detail?.name ?? agentName}
+      <main className="shrink-0 px-4 sm:px-6 pt-4 pb-16">
+        {activeTab === "connectors" && <ConnectorsTab />}
+
+        {activeTab === "schedule" && <JobScheduleTab agentName={displayName} />}
+
+        {activeTab === "settings" && (
+          <SettingsTab
+            name={displayName}
             description={description}
             framework={framework}
             skills={skills}
           />
-        </div>
+        )}
+
+        {activeTab === "instructions" && <InstructionsTab />}
       </main>
     </div>
   );

--- a/turbo/apps/platform/src/views/zero-page/zero-job-detail-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-job-detail-page.tsx
@@ -27,6 +27,7 @@ import {
   zeroJobDetailError$,
   zeroJobInstructions$,
   zeroJobInstructionsLoading$,
+  zeroJobInstructionsError$,
   zeroJobScheduleEntries$,
   zeroJobScheduleError$,
   saveZeroJobSchedule$,
@@ -238,6 +239,7 @@ function JobScheduleTab({ agentName }: { agentName: string }) {
 function JobInstructionsTab() {
   const instructionsLoadable = useLoadable(zeroJobInstructions$);
   const loadingLoadable = useLoadable(zeroJobInstructionsLoading$);
+  const instructionsErrorLoadable = useLoadable(zeroJobInstructionsError$);
   const editedLoadable = useLoadable(zeroJobEditedContent$);
   const dirtyLoadable = useLoadable(zeroJobInstructionsDirty$);
   const buildingLoadable = useLoadable(zeroJobBuilding$);
@@ -247,6 +249,10 @@ function JobInstructionsTab() {
     instructionsLoadable.state === "hasData" ? instructionsLoadable.data : null;
   const loading =
     loadingLoadable.state === "hasData" && loadingLoadable.data === true;
+  const fetchError =
+    instructionsErrorLoadable.state === "hasData"
+      ? instructionsErrorLoadable.data
+      : null;
   const edited =
     editedLoadable.state === "hasData" ? editedLoadable.data : null;
   const isDirty =
@@ -264,7 +270,7 @@ function JobInstructionsTab() {
     <ZeroInstructionsTab
       instructions={instructions}
       loading={loading}
-      fetchError={null}
+      fetchError={fetchError}
       editedContent={edited}
       isDirty={isDirty}
       isBuilding={isBuilding}

--- a/turbo/apps/platform/src/views/zero-page/zero-job-detail-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-job-detail-page.tsx
@@ -3,7 +3,7 @@ import { useCCState } from "ccstate-react/experimental";
 import {
   IconArrowLeft,
   IconFileText,
-  IconSettings,
+  IconUser,
   IconPlug,
   IconCalendar,
 } from "@tabler/icons-react";
@@ -15,44 +15,65 @@ import {
   Card,
   CardContent,
 } from "@vm0/ui";
-import { CONNECTOR_TYPES, type ConnectorType } from "@vm0/core";
-import { ConnectorIcon } from "../settings-page/connector-icons";
-import { Markdown } from "../components/markdown.tsx";
-import { ZeroScheduleCard, type ScheduleEntry } from "./zero-schedule-card.tsx";
+import { ZeroScheduleTab } from "./zero-schedule-tab.tsx";
+import { ZeroSkillsTab } from "./zero-skills-tab.tsx";
+import { ZeroInstructionsTab } from "./zero-instructions-tab.tsx";
+import { ZeroSettingsTab } from "./zero-settings-tab.tsx";
+import { TONE_OPTIONS, type Tone } from "./zero-tone-constants.ts";
+import type { ScheduleEntry } from "./zero-schedule-card.tsx";
 import {
   zeroJobDetail$,
   zeroJobDetailLoading$,
   zeroJobDetailError$,
   zeroJobInstructions$,
   zeroJobInstructionsLoading$,
-  zeroJobInstructionsError$,
   zeroJobScheduleEntries$,
   zeroJobScheduleError$,
   saveZeroJobSchedule$,
   deleteZeroJobSchedule$,
   toggleZeroJobScheduleEnabled$,
-  type ZeroJobScheduleSaveParams,
+  zeroJobEditedContent$,
+  zeroJobInstructionsDirty$,
+  setZeroJobEditedContent$,
+  discardZeroJobEdit$,
+  buildZeroJobInstructions$,
+  zeroJobBuilding$,
+  zeroJobBuildError$,
+  zeroJobUpdateSettings$,
+  zeroJobSettingsSaving$,
+  zeroJobAddedSkills$,
+  zeroJobSkillsDirty$,
+  addZeroJobSkill$,
+  removeZeroJobSkill$,
+  saveZeroJobSkills$,
+  discardZeroJobSkills$,
 } from "../../signals/zero-page/zero-job-detail.ts";
-import { notificationPreferences$ } from "../../signals/settings-page/notification-settings.ts";
+import type { AgentDetail } from "../../signals/agent-detail/types.ts";
 import { navigateInReact$ } from "../../signals/route.ts";
+import { detach, Reason } from "../../signals/utils.ts";
 
-function getAllConnectorTypes(): readonly ConnectorType[] {
-  return Object.keys(CONNECTOR_TYPES) as ConnectorType[];
-}
+// ---------------------------------------------------------------------------
+// Page shell: skeleton, error, header
+// ---------------------------------------------------------------------------
 
 interface ZeroJobDetailPageProps {
   agentName: string;
-  onBack: () => void;
 }
 
-function BackButton({ onBack }: { onBack: () => void }) {
+function useNavigateBack() {
+  const navigate = useSet(navigateInReact$);
+  return () => navigate("/zero/:tab", { pathParams: { tab: "team" } });
+}
+
+function BackButton() {
+  const navigateBack = useNavigateBack();
   return (
     <div className="mb-3">
       <Button
         variant="ghost"
         size="icon"
         className="h-8 w-8 shrink-0 -ml-2"
-        onClick={onBack}
+        onClick={navigateBack}
         aria-label="Back to agents"
       >
         <IconArrowLeft size={20} stroke={1.5} />
@@ -61,207 +82,12 @@ function BackButton({ onBack }: { onBack: () => void }) {
   );
 }
 
-function ConnectorsTab() {
-  return (
-    <div className="mx-auto max-w-[900px] px-7 flex flex-col gap-6">
-      <div className="flex flex-col gap-1">
-        <h2 className="text-sm font-semibold tracking-tight text-foreground">
-          Connectors
-        </h2>
-        <p className="text-sm text-muted-foreground">
-          Third-party services this agent can use
-        </p>
-      </div>
-      <ul className="flex flex-col gap-3">
-        {getAllConnectorTypes().map((type) => {
-          const config = CONNECTOR_TYPES[type];
-          return (
-            <li key={type}>
-              <Card className="zero-card">
-                <CardContent className="flex items-center gap-4 px-4 py-3">
-                  <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-muted overflow-hidden">
-                    <ConnectorIcon type={type} size={24} />
-                  </span>
-                  <div className="min-w-0 flex-1">
-                    <p className="text-sm font-medium text-foreground">
-                      {config.label}
-                    </p>
-                    <p className="text-xs text-muted-foreground">
-                      {config.helpText}
-                    </p>
-                  </div>
-                  <Button
-                    size="sm"
-                    variant="outline"
-                    className="h-8 shrink-0 rounded-lg px-3 zero-btn-morandi border"
-                  >
-                    Connect
-                  </Button>
-                </CardContent>
-              </Card>
-            </li>
-          );
-        })}
-      </ul>
-    </div>
-  );
-}
-
-function JobScheduleTab({ agentName }: { agentName: string }) {
-  const entriesLoadable = useLoadable(zeroJobScheduleEntries$);
-  const scheduleError = useGet(zeroJobScheduleError$);
-  const prefsLoadable = useLoadable(notificationPreferences$);
-  const userTimezone =
-    prefsLoadable.state === "hasData" ? prefsLoadable.data.timezone : null;
-  const saveSchedule = useSet(saveZeroJobSchedule$);
-  const deleteSchedule = useSet(deleteZeroJobSchedule$);
-  const toggleEnabled = useSet(toggleZeroJobScheduleEnabled$);
-  const saving$ = useCCState(false);
-  const saving = useGet(saving$);
-  const setSaving = useSet(saving$);
-
-  const entries: ScheduleEntry[] =
-    entriesLoadable.state === "hasData" ? entriesLoadable.data : [];
-
-  if (scheduleError) {
-    return (
-      <div className="mx-auto max-w-[900px] px-7">
-        <Card className="zero-card">
-          <CardContent className="px-6 py-6 text-center">
-            <p className="text-sm text-destructive">{scheduleError}</p>
-          </CardContent>
-        </Card>
-      </div>
-    );
-  }
-
-  const handleSave = async (params: ZeroJobScheduleSaveParams) => {
-    setSaving(true);
-    try {
-      await saveSchedule(params);
-    } finally {
-      setSaving(false);
-    }
-  };
-
-  return (
-    <div className="mx-auto max-w-[900px] px-7">
-      <ZeroScheduleCard
-        title={`${agentName} schedule`}
-        subtitle={`Set a time and prompt for ${agentName} to run automatically.`}
-        initialSchedule={entries}
-        onSave={handleSave}
-        onDelete={deleteSchedule}
-        onToggleEnabled={toggleEnabled}
-        saving={saving}
-        defaultTimezone={userTimezone ?? undefined}
-      />
-    </div>
-  );
-}
-
-function SettingsTab({
-  name,
-  description,
-  framework,
-  skills,
-}: {
-  name: string;
-  description: string | null;
-  framework: string | null;
-  skills: string[];
-}) {
-  return (
-    <div className="mx-auto max-w-[900px] px-7">
-      <Card className="zero-card">
-        <CardContent className="px-7 py-7 flex flex-col gap-6">
-          <div className="flex flex-col gap-2">
-            <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-              Name
-            </span>
-            <p className="text-sm text-foreground">{name}</p>
-          </div>
-          {description && (
-            <div className="flex flex-col gap-2">
-              <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                Description
-              </span>
-              <p className="text-sm text-foreground">{description}</p>
-            </div>
-          )}
-          {framework && (
-            <div className="flex flex-col gap-2">
-              <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                Framework
-              </span>
-              <p className="text-sm text-foreground">{framework}</p>
-            </div>
-          )}
-          {skills.length > 0 && (
-            <div className="flex flex-col gap-3">
-              <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                Skills
-              </span>
-              <ul className="flex flex-wrap gap-2" role="list">
-                {skills.map((skill) => (
-                  <li key={skill}>
-                    <span className="zero-chip inline-flex items-center gap-2 rounded-2xl border px-3 py-2.5 text-sm text-foreground">
-                      <span className="min-w-0 truncate font-medium">
-                        {skill}
-                      </span>
-                    </span>
-                  </li>
-                ))}
-              </ul>
-            </div>
-          )}
-        </CardContent>
-      </Card>
-    </div>
-  );
-}
-
-function InstructionsTab() {
-  const instructions = useGet(zeroJobInstructions$);
-  const instructionsLoading = useGet(zeroJobInstructionsLoading$);
-  const instructionsError = useGet(zeroJobInstructionsError$);
-
-  return (
-    <div className="mx-auto max-w-[900px] px-7">
-      <Card className="zero-card-white">
-        <CardContent className="px-7 py-7">
-          {instructionsLoading && (
-            <div className="animate-pulse space-y-3">
-              <div className="h-4 w-3/4 rounded bg-muted" />
-              <div className="h-4 w-1/2 rounded bg-muted" />
-              <div className="h-4 w-5/6 rounded bg-muted" />
-            </div>
-          )}
-          {!instructionsLoading && instructionsError && (
-            <p className="text-sm text-destructive">{instructionsError}</p>
-          )}
-          {!instructionsLoading &&
-            !instructionsError &&
-            instructions?.content && <Markdown source={instructions.content} />}
-          {!instructionsLoading &&
-            !instructionsError &&
-            !instructions?.content && (
-              <p className="text-sm text-muted-foreground">
-                No instructions configured for this agent.
-              </p>
-            )}
-        </CardContent>
-      </Card>
-    </div>
-  );
-}
-
-function DetailSkeleton({ onBack }: { onBack: () => void }) {
+function DetailSkeleton() {
   return (
     <div className="flex flex-1 flex-col min-h-0">
       <header className="shrink-0 bg-transparent px-4 sm:px-6 pt-4 pb-3">
         <div className="mx-auto max-w-[900px] px-7">
-          <BackButton onBack={onBack} />
+          <BackButton />
           <div className="animate-pulse space-y-3">
             <div className="h-5 w-48 rounded bg-muted" />
             <div className="h-4 w-72 rounded bg-muted" />
@@ -276,18 +102,16 @@ function DetailSkeleton({ onBack }: { onBack: () => void }) {
 function DetailError({
   error,
   agentName,
-  onBack,
 }: {
   error: string;
   agentName: string;
-  onBack: () => void;
 }) {
   const navigate = useSet(navigateInReact$);
   return (
     <div className="flex flex-1 flex-col min-h-0">
       <header className="shrink-0 bg-transparent px-4 sm:px-6 pt-4 pb-3">
         <div className="mx-auto max-w-[900px] px-7">
-          <BackButton onBack={onBack} />
+          <BackButton />
         </div>
       </header>
       <main className="flex-1 px-4 sm:px-6 pt-4 pb-8">
@@ -300,7 +124,7 @@ function DetailError({
                 size="sm"
                 className="zero-btn-morandi"
                 onClick={() =>
-                  navigate("/zero/job/:name", {
+                  navigate("/zero/team/:name", {
                     pathParams: { name: agentName },
                   })
                 }
@@ -320,7 +144,7 @@ const TAB_TRIGGER_CLASS =
 
 function isValidTab(tab: string): boolean {
   return (
-    tab === "connectors" ||
+    tab === "skills" ||
     tab === "schedule" ||
     tab === "settings" ||
     tab === "instructions"
@@ -329,11 +153,11 @@ function isValidTab(tab: string): boolean {
 
 function getInitialTab(): string {
   if (typeof window === "undefined") {
-    return "connectors";
+    return "skills";
   }
   const params = new URLSearchParams(window.location.search);
   const tab = params.get("tab") ?? "";
-  return isValidTab(tab) ? tab : "connectors";
+  return isValidTab(tab) ? tab : "skills";
 }
 
 function syncTabToUrl(tab: string) {
@@ -341,7 +165,7 @@ function syncTabToUrl(tab: string) {
     return;
   }
   const url = new URL(window.location.href);
-  if (tab === "connectors") {
+  if (tab === "skills") {
     url.searchParams.delete("tab");
   } else {
     url.searchParams.set("tab", tab);
@@ -349,80 +173,129 @@ function syncTabToUrl(tab: string) {
   window.history.replaceState(null, "", url.toString());
 }
 
-function DetailHeader({
-  activeTab,
-  onTabChange,
-  displayName,
-  description,
-  onBack,
-}: {
-  activeTab: string;
-  onTabChange: (tab: string) => void;
-  displayName: string;
-  description: string | null;
-  onBack: () => void;
-}) {
-  return (
-    <header className="shrink-0 bg-transparent px-4 pt-4 pb-4 sm:px-6">
-      <div className="mx-auto max-w-[900px] px-7">
-        <BackButton onBack={onBack} />
-        <div className="min-w-0 flex-1 space-y-1.5">
-          <h1 className="text-xl font-semibold tracking-tight text-foreground leading-tight">
-            {displayName}
-          </h1>
-          {description && (
-            <p className="text-sm text-muted-foreground leading-relaxed max-w-[36rem]">
-              {description}
-            </p>
-          )}
-        </div>
+function extractAgentFields(detail: AgentDetail | null, fallbackName: string) {
+  const agentDef = detail?.content
+    ? Object.values(detail.content.agents)[0]
+    : null;
+  return {
+    description: agentDef?.description ?? null,
+    framework: agentDef?.framework ?? null,
+    sound: agentDef?.metadata?.sound ?? "professional",
+    displayName:
+      agentDef?.metadata?.displayName ?? detail?.name ?? fallbackName,
+  };
+}
 
-        <div className="mt-6 flex h-9 items-center">
-          <Tabs
-            value={activeTab}
-            onValueChange={onTabChange}
-            className="flex-1 min-w-0"
-          >
-            <TabsList className="zero-tabs h-9 w-full sm:w-auto gap-1 px-1 py-1">
-              <TabsTrigger value="connectors" className={TAB_TRIGGER_CLASS}>
-                <IconPlug size={14} stroke={1.5} />
-                Connectors
-              </TabsTrigger>
-              <TabsTrigger value="schedule" className={TAB_TRIGGER_CLASS}>
-                <IconCalendar size={14} stroke={1.5} />
-                Schedule
-              </TabsTrigger>
-              <TabsTrigger value="settings" className={TAB_TRIGGER_CLASS}>
-                <IconSettings size={14} stroke={1.5} />
-                Settings
-              </TabsTrigger>
-              <TabsTrigger value="instructions" className={TAB_TRIGGER_CLASS}>
-                <IconFileText size={14} stroke={1.5} />
-                Instructions
-              </TabsTrigger>
-            </TabsList>
-          </Tabs>
-        </div>
-      </div>
-    </header>
+// ---------------------------------------------------------------------------
+// Tab wrappers — resolve signals into shared component props
+// ---------------------------------------------------------------------------
+
+function JobSkillsTab() {
+  const addedSkills = useGet(zeroJobAddedSkills$);
+  const skillsDirty = useGet(zeroJobSkillsDirty$);
+  const skillsSaving = useGet(zeroJobSettingsSaving$);
+  const addSkill = useSet(addZeroJobSkill$);
+  const removeSkill = useSet(removeZeroJobSkill$);
+  const saveSkills = useSet(saveZeroJobSkills$);
+  const discardSkills = useSet(discardZeroJobSkills$);
+
+  return (
+    <ZeroSkillsTab
+      addedSkills={addedSkills}
+      addedSkillsLoading={false}
+      skillsDirty={skillsDirty}
+      skillsSaving={skillsSaving}
+      onAddSkill={addSkill}
+      onRemoveSkill={removeSkill}
+      onSaveSkills={() => detach(saveSkills(), Reason.DomCallback)}
+      onDiscardSkills={() => discardSkills()}
+    />
   );
 }
 
-export function ZeroJobDetailPage({
-  agentName,
-  onBack,
-}: ZeroJobDetailPageProps) {
+function JobScheduleTab({ agentName }: { agentName: string }) {
+  const entriesLoadable = useLoadable(zeroJobScheduleEntries$);
+  const scheduleError = useGet(zeroJobScheduleError$);
+  const saveSchedule = useSet(saveZeroJobSchedule$);
+  const deleteSchedule = useSet(deleteZeroJobSchedule$);
+  const toggleEnabled = useSet(toggleZeroJobScheduleEnabled$);
+
+  const entries: ScheduleEntry[] =
+    entriesLoadable.state === "hasData" ? entriesLoadable.data : [];
+
+  return (
+    <ZeroScheduleTab
+      agentName={agentName}
+      entries={entries}
+      scheduleError={scheduleError}
+      onSave={saveSchedule}
+      onDelete={deleteSchedule}
+      onToggleEnabled={toggleEnabled}
+    />
+  );
+}
+
+function JobInstructionsTab() {
+  const instructionsLoadable = useLoadable(zeroJobInstructions$);
+  const loadingLoadable = useLoadable(zeroJobInstructionsLoading$);
+  const editedLoadable = useLoadable(zeroJobEditedContent$);
+  const dirtyLoadable = useLoadable(zeroJobInstructionsDirty$);
+  const buildingLoadable = useLoadable(zeroJobBuilding$);
+  const buildErrorLoadable = useLoadable(zeroJobBuildError$);
+
+  const instructions =
+    instructionsLoadable.state === "hasData" ? instructionsLoadable.data : null;
+  const loading =
+    loadingLoadable.state === "hasData" && loadingLoadable.data === true;
+  const edited =
+    editedLoadable.state === "hasData" ? editedLoadable.data : null;
+  const isDirty =
+    dirtyLoadable.state === "hasData" && dirtyLoadable.data === true;
+  const isBuilding =
+    buildingLoadable.state === "hasData" && buildingLoadable.data === true;
+  const buildError =
+    buildErrorLoadable.state === "hasData" ? buildErrorLoadable.data : null;
+
+  const setEdited = useSet(setZeroJobEditedContent$);
+  const discard = useSet(discardZeroJobEdit$);
+  const build = useSet(buildZeroJobInstructions$);
+
+  return (
+    <ZeroInstructionsTab
+      instructions={instructions}
+      loading={loading}
+      fetchError={null}
+      editedContent={edited}
+      isDirty={isDirty}
+      isBuilding={isBuilding}
+      buildError={buildError}
+      onEdit={setEdited}
+      onDiscard={discard}
+      onBuild={() => detach(build(), Reason.DomCallback)}
+    />
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main page
+// ---------------------------------------------------------------------------
+
+export function ZeroJobDetailPage({ agentName }: ZeroJobDetailPageProps) {
   const detail = useGet(zeroJobDetail$);
   const loading = useGet(zeroJobDetailLoading$);
   const error = useGet(zeroJobDetailError$);
 
-  const agentDef = detail?.content
-    ? Object.values(detail.content.agents)[0]
-    : null;
-  const description = agentDef?.description ?? null;
-  const framework = agentDef?.framework ?? null;
-  const skills = agentDef?.skills ?? [];
-  const displayName = detail?.name ?? agentName;
+  const { description, displayName, sound } = extractAgentFields(
+    detail,
+    agentName,
+  );
+  const resolvedSound: Tone = (TONE_OPTIONS as readonly string[]).includes(
+    sound,
+  )
+    ? (sound as Tone)
+    : "professional";
+
+  const saving = useGet(zeroJobSettingsSaving$);
 
   const activeTab$ = useCCState(getInitialTab());
   const activeTab = useGet(activeTab$);
@@ -433,38 +306,74 @@ export function ZeroJobDetailPage({
   };
 
   if (loading && !detail) {
-    return <DetailSkeleton onBack={onBack} />;
+    return <DetailSkeleton />;
   }
 
   if (error) {
-    return <DetailError error={error} agentName={agentName} onBack={onBack} />;
+    return <DetailError error={error} agentName={agentName} />;
   }
 
   return (
     <div className="flex flex-1 flex-col min-h-0 overflow-auto [scrollbar-gutter:stable]">
-      <DetailHeader
-        activeTab={activeTab}
-        onTabChange={setActiveTab}
-        displayName={displayName}
-        description={description}
-        onBack={onBack}
-      />
+      <header className="shrink-0 bg-transparent px-4 pt-4 pb-4 sm:px-6">
+        <div className="mx-auto max-w-[900px] px-7">
+          <BackButton />
+          <div className="min-w-0 flex-1 space-y-1.5">
+            <h1 className="text-xl font-semibold tracking-tight text-foreground leading-tight">
+              {displayName}
+            </h1>
+            {description && (
+              <p className="text-sm text-muted-foreground leading-relaxed max-w-[36rem]">
+                {description}
+              </p>
+            )}
+          </div>
+
+          <div className="mt-6 flex h-9 items-center">
+            <Tabs
+              value={activeTab}
+              onValueChange={setActiveTab}
+              className="flex-1 min-w-0"
+            >
+              <TabsList className="zero-tabs h-9 w-full sm:w-auto gap-1 px-1 py-1">
+                <TabsTrigger value="skills" className={TAB_TRIGGER_CLASS}>
+                  <IconPlug size={14} stroke={1.5} />
+                  Skills
+                </TabsTrigger>
+                <TabsTrigger value="schedule" className={TAB_TRIGGER_CLASS}>
+                  <IconCalendar size={14} stroke={1.5} />
+                  Schedule
+                </TabsTrigger>
+                <TabsTrigger value="settings" className={TAB_TRIGGER_CLASS}>
+                  <IconUser size={14} stroke={1.5} />
+                  Settings
+                </TabsTrigger>
+                <TabsTrigger value="instructions" className={TAB_TRIGGER_CLASS}>
+                  <IconFileText size={14} stroke={1.5} />
+                  Instructions
+                </TabsTrigger>
+              </TabsList>
+            </Tabs>
+          </div>
+        </div>
+      </header>
 
       <main className="shrink-0 px-4 sm:px-6 pt-4 pb-16">
-        {activeTab === "connectors" && <ConnectorsTab />}
+        {activeTab === "skills" && <JobSkillsTab />}
 
         {activeTab === "schedule" && <JobScheduleTab agentName={displayName} />}
 
         {activeTab === "settings" && (
-          <SettingsTab
-            name={displayName}
-            description={description}
-            framework={framework}
-            skills={skills}
+          <ZeroSettingsTab
+            agentName={displayName}
+            sound={resolvedSound}
+            saving={saving}
+            updateSettings$={zeroJobUpdateSettings$}
+            inputId="job-agent-name"
           />
         )}
 
-        {activeTab === "instructions" && <InstructionsTab />}
+        {activeTab === "instructions" && <JobInstructionsTab />}
       </main>
     </div>
   );

--- a/turbo/apps/platform/src/views/zero-page/zero-jobs-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-jobs-page.tsx
@@ -1,11 +1,11 @@
-import { useCCState } from "ccstate-react/experimental";
-import { useGet, useSet, useLoadable } from "ccstate-react";
+import { useGet, useLastResolved, useSet, useLoadable } from "ccstate-react";
 import {
-  IconUser,
-  IconUsers,
-  IconTrash,
+  IconCalendarCheck,
+  IconCalendarOff,
+  IconAlertTriangle,
   IconDotsVertical,
   IconMessageCircle,
+  IconTrash,
 } from "@tabler/icons-react";
 import { Button, Card, CardContent } from "@vm0/ui";
 import {
@@ -13,61 +13,49 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@vm0/ui/components/ui/popover";
-import { ZeroJobDetailPage, type JobItem } from "./zero-job-detail-page.tsx";
+import {
+  zeroSubagents$,
+  schedules$,
+  agentsMissingItems$,
+  agentsLoading$,
+  agentsError$,
+  getAgentScheduleStatus,
+} from "../../signals/zero-page/zero-agents.ts";
+import { navigateInReact$ } from "../../signals/route.ts";
 import { agentDisplayName$ } from "../../signals/zero-page/zero-agent-name.ts";
+import { ZeroJobDetailPage } from "./zero-job-detail-page.tsx";
 
-export const ZERO_TEAM_JOBS: readonly Readonly<JobItem>[] = [
-  {
-    id: "1",
-    agentName: "Minion 1",
-    title: "Daily Digest",
-    description: "Get a daily summary of your team's important updates.",
-    scope: "team",
-  },
-  {
-    id: "2",
-    agentName: "Minion 2",
-    title: "GitHub Issue Triage",
-    description: "Automatically categorize and prioritize new GitHub issues.",
-    scope: "personal",
-  },
-  {
-    id: "3",
-    agentName: "Minion 3",
-    title: "Weekly Report",
-    description: "Receive a weekly summary of your team's achievements.",
-    scope: "team",
-  },
-  {
-    id: "4",
-    agentName: "Minion 4",
-    title: "Customer Feedback Digest",
-    description: "Compile and analyze customer feedback from multiple sources.",
-    scope: "personal",
-  },
-];
+interface ZeroJobsPageProps {
+  onNavigateToChat?: () => void;
+  selectedAgentName?: string | null;
+  onClearSelectedAgent?: () => void;
+}
 
 export function ZeroJobsPage({
   onNavigateToChat,
-}: {
-  onNavigateToChat?: () => void;
-} = {}) {
+  selectedAgentName,
+  onClearSelectedAgent,
+}: ZeroJobsPageProps) {
   const agentNameLoadable = useLoadable(agentDisplayName$);
   const agentName =
     agentNameLoadable.state === "hasData" ? agentNameLoadable.data : "Zero";
-  const selectedJobId$ = useCCState<string | null>(null);
-  const selectedJobId = useGet(selectedJobId$);
-  const setSelectedJobId = useSet(selectedJobId$);
+  const agents = useLastResolved(zeroSubagents$);
+  const schedulesList = useGet(schedules$);
+  const missingItems = useLastResolved(agentsMissingItems$);
+  const loading = useGet(agentsLoading$);
+  const error = useGet(agentsError$);
+  const navigate = useSet(navigateInReact$);
 
-  const selectedJob = selectedJobId
-    ? ZERO_TEAM_JOBS.find((j) => j.id === selectedJobId)
-    : null;
+  const missingMap = new Map(missingItems?.map((a) => [a.agentName, a]));
 
-  if (selectedJob) {
+  if (selectedAgentName) {
     return (
       <ZeroJobDetailPage
-        job={selectedJob}
-        onBack={() => setSelectedJobId(null)}
+        agentName={selectedAgentName}
+        onBack={() => {
+          onClearSelectedAgent?.();
+          navigate("/zero");
+        }}
       />
     );
   }
@@ -99,76 +87,150 @@ export function ZeroJobsPage({
 
       <main className="flex-1 overflow-auto px-4 sm:px-6 pt-4 pb-8">
         <div className="mx-auto max-w-[900px] flex flex-col gap-4">
-          {ZERO_TEAM_JOBS.map((job) => (
-            <Card
-              key={job.id}
-              role="button"
-              tabIndex={0}
-              className="zero-card cursor-pointer hover:border-border transition-colors"
-              onClick={() => setSelectedJobId(job.id)}
-              onKeyDown={(e) => e.key === "Enter" && setSelectedJobId(job.id)}
-            >
-              <CardContent className="px-6 py-4">
-                <div className="flex items-center gap-4">
-                  <div className="min-w-0 flex-1">
-                    <div className="flex flex-wrap items-center gap-2">
-                      <span className="text-sm text-muted-foreground">
-                        {job.agentName}
-                      </span>
-                      <span className="text-muted-foreground/60">·</span>
-                      <h2 className="text-sm font-semibold tracking-tight text-foreground">
-                        {job.title}
-                      </h2>
-                      <span className="zero-pill inline-flex items-center gap-1.5 rounded-md border px-1.5 py-0.5 text-xs font-medium">
-                        {job.scope === "team" ? (
-                          <IconUsers
-                            size={12}
-                            stroke={1.5}
-                            className="h-3 w-3 shrink-0 text-sky-600 dark:text-sky-400"
-                          />
-                        ) : (
-                          <IconUser
-                            size={12}
-                            stroke={1.5}
-                            className="h-3 w-3 shrink-0 text-amber-600 dark:text-amber-400"
-                          />
-                        )}
-                        {job.scope === "team" ? "Team" : "Personal"}
-                      </span>
+          {loading && (!agents || agents.length === 0) && (
+            <>
+              {[1, 2, 3].map((i) => (
+                <Card key={i} className="zero-card">
+                  <CardContent className="px-6 py-4">
+                    <div className="flex items-center gap-4 animate-pulse">
+                      <div className="min-w-0 flex-1 space-y-2">
+                        <div className="h-4 w-40 rounded bg-muted" />
+                        <div className="h-3 w-64 rounded bg-muted" />
+                      </div>
                     </div>
-                    <p className="mt-0.5 text-sm text-muted-foreground truncate">
-                      {job.description}
-                    </p>
-                  </div>
-                  <Popover>
-                    <PopoverTrigger asChild>
-                      <button
-                        type="button"
-                        className="shrink-0 rounded p-1.5 text-muted-foreground hover:bg-muted hover:text-foreground transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-                        onClick={(e) => e.stopPropagation()}
-                        aria-label="Agent actions"
-                      >
-                        <IconDotsVertical size={16} stroke={1.5} />
-                      </button>
-                    </PopoverTrigger>
-                    <PopoverContent
-                      align="end"
-                      className="flex flex-col gap-0.5 w-40 p-2"
-                      onClick={(e) => e.stopPropagation()}
-                    >
-                      <button
-                        type="button"
-                        className="flex w-full items-center gap-2 rounded-md px-3 py-2 text-sm text-left text-destructive hover:bg-accent hover:text-accent-foreground transition-colors"
-                      >
-                        <IconTrash size={14} stroke={1.5} />
-                        Delete
-                      </button>
-                    </PopoverContent>
-                  </Popover>
-                </div>
+                  </CardContent>
+                </Card>
+              ))}
+            </>
+          )}
+
+          {error && (
+            <Card className="zero-card">
+              <CardContent className="px-6 py-6 text-center space-y-3">
+                <p className="text-sm text-destructive">{error}</p>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="zero-btn-morandi"
+                  onClick={() => navigate("/zero")}
+                >
+                  Retry
+                </Button>
               </CardContent>
             </Card>
-          ))}
+          )}
+
+          {!loading && !error && agents && agents.length === 0 && (
+            <Card className="zero-card">
+              <CardContent className="px-6 py-8 text-center">
+                <p className="text-sm text-muted-foreground">
+                  No sub-agents yet. Create one by chatting with Zero.
+                </p>
+              </CardContent>
+            </Card>
+          )}
+
+          {agents?.map((agent) => {
+            const hasSchedule = getAgentScheduleStatus(
+              agent.name,
+              schedulesList,
+            );
+            const missing = missingMap.get(agent.name);
+            const missingCount =
+              (missing?.missingSecrets.length ?? 0) +
+              (missing?.missingVariables.length ?? 0);
+
+            return (
+              <Card
+                key={agent.name}
+                role="button"
+                tabIndex={0}
+                className="zero-card cursor-pointer hover:border-border transition-colors"
+                onClick={() =>
+                  navigate("/zero/job/:name", {
+                    pathParams: { name: agent.name },
+                  })
+                }
+                onKeyDown={(e) =>
+                  e.key === "Enter" &&
+                  navigate("/zero/job/:name", {
+                    pathParams: { name: agent.name },
+                  })
+                }
+              >
+                <CardContent className="px-6 py-4">
+                  <div className="flex items-center gap-4">
+                    <div className="min-w-0 flex-1">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <h2 className="text-sm font-semibold tracking-tight text-foreground">
+                          {agent.name}
+                        </h2>
+                        <span className="zero-pill inline-flex items-center gap-1.5 rounded-md border px-1.5 py-0.5 text-xs font-medium">
+                          {hasSchedule ? (
+                            <IconCalendarCheck
+                              size={12}
+                              stroke={1.5}
+                              className="h-3 w-3 shrink-0 text-emerald-600 dark:text-emerald-400"
+                            />
+                          ) : (
+                            <IconCalendarOff
+                              size={12}
+                              stroke={1.5}
+                              className="h-3 w-3 shrink-0 text-muted-foreground"
+                            />
+                          )}
+                          {hasSchedule ? "Scheduled" : "No schedule"}
+                        </span>
+                        {missingCount > 0 && (
+                          <span className="zero-pill inline-flex items-center gap-1.5 rounded-md border border-amber-300 dark:border-amber-700 px-1.5 py-0.5 text-xs font-medium text-amber-700 dark:text-amber-400">
+                            <IconAlertTriangle
+                              size={12}
+                              stroke={1.5}
+                              className="h-3 w-3 shrink-0"
+                            />
+                            {missingCount} missing
+                          </span>
+                        )}
+                      </div>
+                      <p className="mt-0.5 text-xs text-muted-foreground">
+                        Last edited{" "}
+                        {new Date(agent.updatedAt).toLocaleDateString("en-US", {
+                          month: "short",
+                          day: "numeric",
+                          year: "numeric",
+                        })}
+                      </p>
+                    </div>
+                    <Popover>
+                      <PopoverTrigger asChild>
+                        <button
+                          type="button"
+                          className="shrink-0 rounded p-1.5 text-muted-foreground hover:bg-muted hover:text-foreground transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                          onClick={(e) => e.stopPropagation()}
+                          aria-label="Agent actions"
+                        >
+                          <IconDotsVertical size={16} stroke={1.5} />
+                        </button>
+                      </PopoverTrigger>
+                      <PopoverContent
+                        align="end"
+                        className="flex flex-col gap-0.5 w-40 p-2"
+                        onClick={(e) => e.stopPropagation()}
+                      >
+                        <button
+                          type="button"
+                          className="flex w-full items-center gap-2 rounded-md px-3 py-2 text-sm text-left text-destructive hover:bg-accent hover:text-accent-foreground transition-colors"
+                        >
+                          <IconTrash size={14} stroke={1.5} />
+                          Delete
+                        </button>
+                      </PopoverContent>
+                    </Popover>
+                  </div>
+                </CardContent>
+              </Card>
+            );
+          })}
         </div>
       </main>
     </div>

--- a/turbo/apps/platform/src/views/zero-page/zero-jobs-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-jobs-page.tsx
@@ -28,13 +28,11 @@ import { ZeroJobDetailPage } from "./zero-job-detail-page.tsx";
 interface ZeroJobsPageProps {
   onNavigateToChat?: () => void;
   selectedAgentName?: string | null;
-  onClearSelectedAgent?: () => void;
 }
 
 export function ZeroJobsPage({
   onNavigateToChat,
   selectedAgentName,
-  onClearSelectedAgent,
 }: ZeroJobsPageProps) {
   const agentNameLoadable = useLoadable(agentDisplayName$);
   const agentName =
@@ -49,15 +47,7 @@ export function ZeroJobsPage({
   const missingMap = new Map(missingItems?.map((a) => [a.agentName, a]));
 
   if (selectedAgentName) {
-    return (
-      <ZeroJobDetailPage
-        agentName={selectedAgentName}
-        onBack={() => {
-          onClearSelectedAgent?.();
-          navigate("/zero");
-        }}
-      />
-    );
+    return <ZeroJobDetailPage agentName={selectedAgentName} />;
   }
 
   return (
@@ -147,13 +137,13 @@ export function ZeroJobsPage({
                 tabIndex={0}
                 className="zero-card cursor-pointer hover:border-border transition-colors"
                 onClick={() =>
-                  navigate("/zero/job/:name", {
+                  navigate("/zero/team/:name", {
                     pathParams: { name: agent.name },
                   })
                 }
                 onKeyDown={(e) =>
                   e.key === "Enter" &&
-                  navigate("/zero/job/:name", {
+                  navigate("/zero/team/:name", {
                     pathParams: { name: agent.name },
                   })
                 }
@@ -163,7 +153,7 @@ export function ZeroJobsPage({
                     <div className="min-w-0 flex-1">
                       <div className="flex flex-wrap items-center gap-2">
                         <h2 className="text-sm font-semibold tracking-tight text-foreground">
-                          {agent.name}
+                          {agent.displayName ?? agent.name}
                         </h2>
                         <span className="zero-pill inline-flex items-center gap-1.5 rounded-md border px-1.5 py-0.5 text-xs font-medium">
                           {hasSchedule ? (

--- a/turbo/apps/platform/src/views/zero-page/zero-meet-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-meet-page.tsx
@@ -1,40 +1,20 @@
-import { useCCState, useCommand } from "ccstate-react/experimental";
+import { useCCState } from "ccstate-react/experimental";
 import { useGet, useSet, useLoadable, useLastLoadable } from "ccstate-react";
-import { createPortal } from "react-dom";
 import {
   IconMessageCircle,
   IconUser,
   IconFileText,
   IconPlug,
-  IconPlus,
   IconCalendar,
-  IconPencil,
-  IconLoader2,
   IconCrown,
-  IconDotsVertical,
 } from "@tabler/icons-react";
-import {
-  CONNECTOR_TYPES,
-  type ConnectorType,
-  stripMetadataFrontmatter,
-} from "@vm0/core";
-import { skills$ } from "../../data/skills.ts";
-import { ConnectorIcon } from "../settings-page/connector-icons.tsx";
-import {
-  Card,
-  CardContent,
-  Input,
-  Button,
-  Tabs,
-  TabsList,
-  TabsTrigger,
-  DropdownMenu,
-  DropdownMenuTrigger,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  cn,
-} from "@vm0/ui";
-import { ZeroScheduleCard, type ScheduleEntry } from "./zero-schedule-card";
+import { Button, Tabs, TabsList, TabsTrigger } from "@vm0/ui";
+import { ZeroScheduleTab } from "./zero-schedule-tab.tsx";
+import { ZeroSkillsTab } from "./zero-skills-tab.tsx";
+import { ZeroInstructionsTab } from "./zero-instructions-tab.tsx";
+import { ZeroSettingsTab } from "./zero-settings-tab.tsx";
+import { TONE_OPTIONS, type Tone } from "./zero-tone-constants.ts";
+import type { ScheduleEntry } from "./zero-schedule-card.tsx";
 import {
   agentDisplayName$,
   defaultAgentMetadata$,
@@ -45,30 +25,9 @@ import {
   saveZeroSchedule$,
   deleteZeroSchedule$,
   toggleZeroScheduleEnabled$,
-  type ZeroScheduleSaveParams,
 } from "../../signals/zero-page/zero-schedule.ts";
-import {
-  type ConnectorTypeWithStatus,
-  allConnectorTypes$,
-  connectConnector$,
-  addConnectionDialogOpen$,
-  setAddConnectionDialogOpen$,
-  selectedConnectorType$,
-  setSelectedConnectorType$,
-  pollingConnectorType$,
-  justConnectedTypes$,
-  clearJustConnectedTypes$,
-} from "../../signals/settings-page/connectors.ts";
-import { deleteConnector$ } from "../../signals/external/connectors.ts";
-import { pageSignal$ } from "../../signals/page-signal.ts";
 import { updatePathname$ } from "../../signals/route.ts";
-import {
-  AddConnectionDialog,
-  ConnectModal,
-} from "../settings-page/add-connection-dialog.tsx";
-import { toast } from "@vm0/ui/components/ui/sonner";
 import { detach, Reason } from "../../signals/utils.ts";
-import { notificationPreferences$ } from "../../signals/settings-page/notification-settings.ts";
 import {
   zeroInstructions$,
   zeroInstructionsLoading$,
@@ -91,168 +50,45 @@ import {
   discardZeroSkills$,
 } from "../../signals/zero-page/zero-meet.ts";
 
-/** Stored as lowercase in metadata.sound. */
-const TONE_OPTIONS = [
-  "professional",
-  "friendly",
-  "direct",
-  "supportive",
-] as const;
-
-type Tone = (typeof TONE_OPTIONS)[number];
-
-function toneLabel(t: Tone) {
-  return t.charAt(0).toUpperCase() + t.slice(1);
-}
-
-const TONE_HINT: Readonly<Record<Tone, string>> = {
-  professional: "Clear and polished",
-  friendly: "Warm and approachable",
-  direct: "To the point",
-  supportive: "In your corner",
-};
-
-const TONE_SAMPLES: Readonly<
-  Record<Tone, Readonly<{ user: string; zero: string }>>
-> = {
-  professional: {
-    user: "I need the Q3 report by Friday.",
-    zero: "I'll have the Q3 report ready by Friday. I'll send a draft by Thursday for your review.",
-  },
-  friendly: {
-    user: "I need the Q3 report by Friday.",
-    zero: "Sure thing! I'll get that Q3 report to you by Friday—I'll send over a draft Thursday so you can take a look.",
-  },
-  direct: {
-    user: "I need the Q3 report by Friday.",
-    zero: "Friday. I'll send a draft Thursday.",
-  },
-  supportive: {
-    user: "I need the Q3 report by Friday.",
-    zero: "I'll make sure you have the Q3 report by Friday. I'll send a draft on Thursday so you have time to review—let me know if you'd like anything else.",
-  },
-};
-
 // ---------------------------------------------------------------------------
-// Skill card — a single card in the skills grid
+// Tab wrappers — resolve signals into shared component props
 // ---------------------------------------------------------------------------
 
-function ZeroSkillCard({
-  name,
-  label,
-  iconUrl,
-  connector,
-  pollingType,
-  onConnect,
-  onDisconnect,
-  onRemove,
-}: {
-  name: string;
-  label: string;
-  iconUrl: string | undefined;
-  connector: ConnectorTypeWithStatus | null;
-  pollingType: ConnectorType | null;
-  onConnect: () => void;
-  onDisconnect: () => void;
-  onRemove: () => void;
-}) {
-  const isPolling = pollingType === name;
+function MeetSkillsTab() {
+  const addedSkillsLoadable = useLastLoadable(zeroAddedSkills$);
+  const addedSkills =
+    addedSkillsLoadable.state === "hasData" ? addedSkillsLoadable.data : [];
+  const skillsDirtyLoadable = useLastLoadable(zeroSkillsDirty$);
+  const skillsDirty =
+    skillsDirtyLoadable.state === "hasData" ? skillsDirtyLoadable.data : false;
+  const skillsSaving = useGet(zeroSettingsSaving$);
+  const addSkill = useSet(addZeroSkill$);
+  const removeSkill = useSet(removeZeroSkill$);
+  const saveSkills = useSet(saveZeroSkills$);
+  const discardSkills = useSet(discardZeroSkills$);
 
   return (
-    <div className="flex flex-col rounded-[var(--zero-card-radius)] border border-[var(--zero-card-border)] bg-card shadow-[var(--zero-card-shadow)]">
-      <div className="flex h-14 items-center gap-2.5 px-5">
-        <span className="flex h-7 w-7 shrink-0 items-center justify-center">
-          {name in CONNECTOR_TYPES ? (
-            <ConnectorIcon type={name as ConnectorType} size={22} />
-          ) : iconUrl ? (
-            <img src={iconUrl} alt="" className="h-5 w-5 object-contain" />
-          ) : (
-            <IconPlug
-              size={18}
-              stroke={1.5}
-              className="text-muted-foreground"
-            />
-          )}
-        </span>
-        <span className="min-w-0 flex-1 text-sm font-medium text-foreground truncate">
-          {label}
-        </span>
-      </div>
-
-      <div className="flex h-11 items-center justify-between border-t border-border/50 pl-5 pr-2">
-        <div className="flex items-center gap-2 min-w-0">
-          {connector &&
-            (isPolling ? (
-              <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
-                <IconLoader2 size={12} stroke={1.5} className="animate-spin" />
-                Connecting…
-              </span>
-            ) : connector.connected ? (
-              <span className="flex items-center gap-2 text-xs text-muted-foreground truncate">
-                <span className="h-1.5 w-1.5 rounded-full bg-emerald-500 shrink-0" />
-                {connector.connector?.externalUsername
-                  ? `@${connector.connector.externalUsername}`
-                  : connector.connector?.authMethod === "api-token"
-                    ? "API key"
-                    : "Connected"}
-              </span>
-            ) : (
-              <button
-                type="button"
-                onClick={onConnect}
-                className="text-xs font-medium text-primary hover:text-primary/80 transition-colors"
-              >
-                {connector.availableAuthMethods.length === 1 &&
-                connector.availableAuthMethods[0] === "api-token"
-                  ? "Add API key"
-                  : "Connect"}
-              </button>
-            ))}
-          {!connector && (
-            <span className="text-xs text-muted-foreground">Added</span>
-          )}
-        </div>
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button
-              variant="ghost"
-              size="icon"
-              className="h-7 w-7 shrink-0 rounded-lg text-muted-foreground hover:text-foreground"
-              aria-label="More options"
-            >
-              <IconDotsVertical size={14} stroke={1.5} />
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end" className="w-40">
-            {connector?.connected && (
-              <DropdownMenuItem onClick={onDisconnect}>
-                Disconnect
-              </DropdownMenuItem>
-            )}
-            <DropdownMenuItem onClick={onRemove}>Remove skill</DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
-      </div>
-    </div>
+    <ZeroSkillsTab
+      addedSkills={addedSkills}
+      addedSkillsLoading={
+        addedSkillsLoadable.state !== "hasData" && addedSkills.length === 0
+      }
+      skillsDirty={skillsDirty}
+      skillsSaving={skillsSaving}
+      onAddSkill={(name) => detach(addSkill(name), Reason.DomCallback)}
+      onRemoveSkill={(name) => detach(removeSkill(name), Reason.DomCallback)}
+      onSaveSkills={() => detach(saveSkills(), Reason.DomCallback)}
+      onDiscardSkills={() => discardSkills()}
+    />
   );
 }
 
-// ---------------------------------------------------------------------------
-// Schedule tab — real schedule CRUD
-// ---------------------------------------------------------------------------
-
-function ZeroScheduleTab({ resolvedAgentName }: { resolvedAgentName: string }) {
+function MeetScheduleTab({ agentName }: { agentName: string }) {
   const entriesLoadable = useLoadable(zeroScheduleEntries$);
-  const prefsLoadable = useLoadable(notificationPreferences$);
-  const userTimezone =
-    prefsLoadable.state === "hasData" ? prefsLoadable.data.timezone : null;
   const fetchSchedules = useSet(fetchZeroSchedules$);
   const saveSchedule = useSet(saveZeroSchedule$);
   const deleteSchedule = useSet(deleteZeroSchedule$);
   const toggleEnabled = useSet(toggleZeroScheduleEnabled$);
-  const saving$ = useCCState(false);
-  const saving = useGet(saving$);
-  const setSaving = useSet(saving$);
 
   // Fetch schedules on mount
   const initialized$ = useCCState(false);
@@ -266,266 +102,18 @@ function ZeroScheduleTab({ resolvedAgentName }: { resolvedAgentName: string }) {
   const entries: ScheduleEntry[] =
     entriesLoadable.state === "hasData" ? entriesLoadable.data : [];
 
-  const handleSave = async (params: ZeroScheduleSaveParams) => {
-    setSaving(true);
-    try {
-      await saveSchedule(params);
-    } finally {
-      setSaving(false);
-    }
-  };
-
   return (
-    <div className="mx-auto max-w-[900px] px-7">
-      <ZeroScheduleCard
-        title={`${resolvedAgentName}'s schedule`}
-        subtitle={`Set a time and prompt for ${resolvedAgentName} to run automatically.`}
-        initialSchedule={entries}
-        onSave={handleSave}
-        onDelete={deleteSchedule}
-        onToggleEnabled={toggleEnabled}
-        saving={saving}
-        defaultTimezone={userTimezone ?? undefined}
-      />
-    </div>
+    <ZeroScheduleTab
+      agentName={agentName}
+      entries={entries}
+      onSave={saveSchedule}
+      onDelete={deleteSchedule}
+      onToggleEnabled={toggleEnabled}
+    />
   );
 }
 
-// ---------------------------------------------------------------------------
-// Skills tab — merged skills + connector management
-// ---------------------------------------------------------------------------
-
-function ZeroSkillsTab() {
-  const allTypesLoadable = useLastLoadable(allConnectorTypes$);
-  const pollingType = useGet(pollingConnectorType$);
-  const connect = useSet(connectConnector$);
-  const disconnect = useSet(deleteConnector$);
-  const signal = useGet(pageSignal$);
-  const addDialogOpen = useGet(addConnectionDialogOpen$);
-  const setAddDialogOpen = useSet(setAddConnectionDialogOpen$);
-  const selectedType = useGet(selectedConnectorType$);
-  const setSelected = useSet(setSelectedConnectorType$);
-
-  // Skills list: local draft, saved via compose jobs on explicit Save
-  const addedSkillsLoadable = useLastLoadable(zeroAddedSkills$);
-  const addedSkills =
-    addedSkillsLoadable.state === "hasData" ? addedSkillsLoadable.data : [];
-  const allSkills = useGet(skills$);
-  const addSkill = useSet(addZeroSkill$);
-  const removeSkill = useSet(removeZeroSkill$);
-  const skillsDirtyLoadable = useLastLoadable(zeroSkillsDirty$);
-  const skillsDirty =
-    skillsDirtyLoadable.state === "hasData" ? skillsDirtyLoadable.data : false;
-  const saveSkills = useSet(saveZeroSkills$);
-  const discardSkills = useSet(discardZeroSkills$);
-  const skillsSaving = useGet(zeroSettingsSaving$);
-
-  // Optimistic connected state — set by connectConnector$/submitApiToken$
-  // so the skill shows "Connected" immediately without waiting for refetch.
-  const optimisticConnected = useGet(justConnectedTypes$);
-  const clearOptimistic = useSet(clearJustConnectedTypes$);
-
-  // Cache previous connector data so the list doesn't flash during refetch
-  const allConnectors =
-    allTypesLoadable.state === "hasData" ? allTypesLoadable.data : [];
-  // Clear optimistic state once real data reflects the connection.
-  // This is a safe render-body side effect: after clearing, optimisticConnected
-  // becomes empty so the condition won't fire again (self-limiting, no loop).
-  if (allTypesLoadable.state === "hasData" && optimisticConnected.size > 0) {
-    clearOptimistic();
-  }
-  const connectorMap = new Map(allConnectors.map((c) => [c.type, c]));
-  const skillMap = new Map(allSkills.map((s) => [s.value, s]));
-  const addedSet = new Set(addedSkills);
-
-  const handleConnectSuccess = (type: string) => {
-    detach(addSkill(type), Reason.DomCallback);
-    const label =
-      skillMap.get(type)?.label ??
-      connectorMap.get(type as ConnectorType)?.label ??
-      type;
-    toast.success(`${label} added to skills`);
-  };
-
-  const handleRemoveSkill = (name: string) => {
-    detach(removeSkill(name), Reason.DomCallback);
-    const label =
-      skillMap.get(name)?.label ??
-      connectorMap.get(name as ConnectorType)?.label ??
-      name;
-    toast.success(`${label} removed from skills`);
-  };
-
-  return (
-    <div className="mx-auto max-w-[900px] px-7 flex flex-col gap-4">
-      <p className="text-sm text-muted-foreground">
-        Skills manage your connections and help you get more out of these
-        services.
-      </p>
-
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
-        {/* Add skill */}
-        <button
-          type="button"
-          onClick={() => setAddDialogOpen(true)}
-          className="flex flex-col rounded-[var(--zero-card-radius)] border border-dashed border-border/80 transition-colors hover:border-border hover:bg-muted/30 group"
-        >
-          <div className="flex h-14 items-center gap-2.5 px-5">
-            <span className="flex h-7 w-7 shrink-0 items-center justify-center">
-              <IconPlus
-                size={18}
-                stroke={2}
-                className="text-muted-foreground group-hover:text-foreground"
-              />
-            </span>
-            <span className="text-sm font-medium text-muted-foreground group-hover:text-foreground">
-              Add skill
-            </span>
-          </div>
-          <div className="flex h-11 items-center border-t border-dashed border-border/80 px-5 group-hover:border-border">
-            <span className="text-xs text-muted-foreground/70">
-              Browse 100+ popular skills
-            </span>
-          </div>
-        </button>
-
-        {/* Skeleton cards while loading */}
-        {addedSkillsLoadable.state !== "hasData" &&
-          addedSkills.length === 0 && (
-            <>
-              {Array.from({ length: 3 }, (_, i) => (
-                <div
-                  key={i}
-                  className="flex flex-col rounded-[var(--zero-card-radius)] border border-border/50 bg-card animate-pulse"
-                >
-                  <div className="flex h-14 items-center gap-2.5 px-5">
-                    <span className="h-7 w-7 shrink-0 rounded-lg bg-muted/50" />
-                    <span className="h-4 w-24 rounded bg-muted/50" />
-                  </div>
-                  <div className="flex h-11 items-center border-t border-border/30 px-5">
-                    <span className="h-3 w-16 rounded bg-muted/30" />
-                  </div>
-                </div>
-              ))}
-            </>
-          )}
-
-        {/* Skill cards */}
-        {addedSkills.map((name) => {
-          const skill = skillMap.get(name);
-          const connector = connectorMap.get(name as ConnectorType) ?? null;
-          const effectiveConnector =
-            optimisticConnected.has(name) && connector && !connector.connected
-              ? { ...connector, connected: true }
-              : connector;
-          return (
-            <ZeroSkillCard
-              key={name}
-              name={name}
-              label={skill?.label ?? name}
-              iconUrl={skill?.icon}
-              connector={effectiveConnector}
-              pollingType={pollingType}
-              onConnect={() => {
-                const ct = connectorMap.get(name as ConnectorType);
-                if (
-                  ct &&
-                  ct.availableAuthMethods.length === 1 &&
-                  ct.availableAuthMethods[0] === "api-token"
-                ) {
-                  setSelected(name as ConnectorType);
-                } else {
-                  detach(
-                    connect(name as ConnectorType, signal),
-                    Reason.DomCallback,
-                  );
-                }
-              }}
-              onDisconnect={() => {
-                detach(disconnect(name as ConnectorType), Reason.DomCallback);
-                const label =
-                  skillMap.get(name)?.label ??
-                  connectorMap.get(name as ConnectorType)?.label ??
-                  name;
-                toast.success(`${label} disconnected`);
-              }}
-              onRemove={() => handleRemoveSkill(name)}
-            />
-          );
-        })}
-      </div>
-
-      <AddConnectionDialog
-        open={addDialogOpen}
-        onOpenChange={setAddDialogOpen}
-        variant="zero"
-        excludeTypes={addedSet}
-        onConnectSuccess={handleConnectSuccess}
-        onAdd={handleConnectSuccess}
-      />
-
-      {selectedType && (
-        <ConnectModal
-          onClose={() => setSelected(null)}
-          onSuccess={() => {
-            if (selectedType && !addedSet.has(selectedType)) {
-              handleConnectSuccess(selectedType);
-            }
-          }}
-        />
-      )}
-
-      {(skillsDirty || skillsSaving) &&
-        createPortal(
-          <div className="zero-app fixed bottom-6 left-0 right-0 z-40 flex justify-center px-4 sm:left-[255px]">
-            <div className="zero-card flex max-w-md items-center justify-between gap-4 rounded-xl border border-border bg-card px-5 py-4 shadow-lg">
-              <div className="flex items-center gap-2 text-sm text-foreground">
-                <IconPencil
-                  size={18}
-                  stroke={1.5}
-                  className="shrink-0 text-muted-foreground"
-                />
-                <span>You have unsaved changes</span>
-              </div>
-              <div className="flex items-center gap-2 shrink-0">
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className="text-destructive hover:bg-destructive/10 hover:text-destructive"
-                  onClick={() => discardSkills()}
-                  disabled={skillsSaving}
-                >
-                  Discard
-                </Button>
-                <Button
-                  size="sm"
-                  className="h-9 rounded-lg px-4 bg-primary text-primary-foreground hover:bg-primary/90"
-                  onClick={() => detach(saveSkills(), Reason.DomCallback)}
-                  disabled={skillsSaving}
-                >
-                  {skillsSaving ? (
-                    <IconLoader2
-                      size={14}
-                      stroke={1.5}
-                      className="animate-spin mr-1.5"
-                    />
-                  ) : null}
-                  Save
-                </Button>
-              </div>
-            </div>
-          </div>,
-          document.body,
-        )}
-    </div>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Instructions tab — editable textarea with build
-// ---------------------------------------------------------------------------
-
-function ZeroInstructionsTab() {
+function MeetInstructionsTab() {
   const instructionsLoadable = useLoadable(zeroInstructions$);
   const loadingLoadable = useLoadable(zeroInstructionsLoading$);
   const editedLoadable = useLoadable(zeroEditedContent$);
@@ -562,276 +150,19 @@ function ZeroInstructionsTab() {
     detach(fetchInstructions(), Reason.DomCallback);
   }
 
-  const rawContent = instructions?.content ?? "";
-  const strippedContent = stripMetadataFrontmatter(rawContent);
-  const displayContent = edited ?? strippedContent;
-
   return (
-    <div className="mx-auto max-w-[900px] px-7">
-      <Card className="zero-card-white">
-        <CardContent className="py-7">
-          {loading ? (
-            <div className="space-y-4 animate-pulse">
-              <div className="h-5 w-40 rounded bg-muted/50" />
-              <div className="h-64 w-full rounded bg-muted/30" />
-            </div>
-          ) : fetchError ? (
-            <p className="text-sm text-destructive">{fetchError}</p>
-          ) : (
-            <>
-              <textarea
-                aria-label="Agent instructions editor"
-                className="px-1 text-sm font-mono text-foreground w-full min-h-[200px] bg-transparent border-none outline-none resize-none whitespace-pre-wrap leading-relaxed"
-                value={displayContent}
-                onChange={(e) => setEdited(e.target.value)}
-                rows={Math.max(10, displayContent.split("\n").length + 2)}
-                disabled={isBuilding}
-                placeholder="Write instructions for your agent..."
-              />
-              <div className="flex items-center gap-2 pt-5 mt-5 border-t border-border/60">
-                <p className="text-muted-foreground text-xs">
-                  Edit the instructions directly to customize your agent&apos;s
-                  behavior.
-                </p>
-                {buildError && (
-                  <span className="text-xs font-medium text-destructive">
-                    {buildError}
-                  </span>
-                )}
-              </div>
-            </>
-          )}
-        </CardContent>
-      </Card>
-
-      {(isDirty || isBuilding) &&
-        createPortal(
-          <div className="zero-app fixed bottom-6 left-0 right-0 z-40 flex justify-center px-4 sm:left-[255px]">
-            <div className="zero-card flex max-w-md items-center justify-between gap-4 rounded-xl border border-border bg-card px-5 py-4 shadow-lg">
-              <div className="flex items-center gap-2 text-sm text-foreground">
-                <IconPencil
-                  size={18}
-                  stroke={1.5}
-                  className="shrink-0 text-muted-foreground"
-                />
-                <span>You have unsaved changes</span>
-              </div>
-              <div className="flex items-center gap-2 shrink-0">
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className="text-destructive hover:bg-destructive/10 hover:text-destructive"
-                  onClick={discard}
-                  disabled={isBuilding}
-                >
-                  Discard
-                </Button>
-                <Button
-                  size="sm"
-                  className="h-9 rounded-lg px-4 bg-primary text-primary-foreground hover:bg-primary/90"
-                  onClick={() => detach(build(), Reason.DomCallback)}
-                  disabled={isBuilding}
-                >
-                  {isBuilding ? (
-                    <IconLoader2
-                      size={14}
-                      stroke={1.5}
-                      className="animate-spin mr-1.5"
-                    />
-                  ) : null}
-                  Save
-                </Button>
-              </div>
-            </div>
-          </div>,
-          document.body,
-        )}
-    </div>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Settings tab — name + tone (wired to real API for agent name persistence)
-// ---------------------------------------------------------------------------
-
-function ZeroSettingsTab({
-  agentName: resolvedAgentName,
-  sound: initialSound,
-}: {
-  agentName: string;
-  sound: Tone;
-}) {
-  const agentName$ = useCCState(resolvedAgentName);
-  const agentName = useGet(agentName$);
-  const setAgentName = useSet(agentName$);
-  const tone$ = useCCState<Tone>(initialSound);
-  const tone = useGet(tone$);
-  const setTone = useSet(tone$);
-  const savedSettings$ = useCCState<{ name: string; tone: Tone }>({
-    name: resolvedAgentName,
-    tone: initialSound,
-  });
-  const savedSettings = useGet(savedSettings$);
-  const setSavedSettings = useSet(savedSettings$);
-  const saving = useGet(zeroSettingsSaving$);
-
-  // Sync local state when props change (e.g. metadata finishes loading)
-  const prevProps$ = useCCState({
-    name: resolvedAgentName,
-    tone: initialSound,
-  });
-  const prevProps = useGet(prevProps$);
-  const setPrevProps = useSet(prevProps$);
-  if (resolvedAgentName !== prevProps.name || initialSound !== prevProps.tone) {
-    queueMicrotask(() => {
-      setPrevProps({ name: resolvedAgentName, tone: initialSound });
-      setAgentName(resolvedAgentName);
-      setTone(initialSound);
-      setSavedSettings({ name: resolvedAgentName, tone: initialSound });
-    });
-  }
-
-  const isSettingsDirty =
-    agentName !== savedSettings.name || tone !== savedSettings.tone;
-
-  const handleResetSettings = () => {
-    setAgentName(savedSettings.name);
-    setTone(savedSettings.tone);
-  };
-
-  const handleSaveSettings$ = useCommand(async ({ get, set }) => {
-    const currentName = get(agentName$);
-    const currentTone = get(tone$);
-    await set(zeroUpdateSettings$, {
-      displayName: currentName,
-      sound: currentTone,
-    });
-    set(savedSettings$, { name: currentName, tone: currentTone });
-  });
-  const handleSaveSettings = useSet(handleSaveSettings$);
-
-  return (
-    <>
-      <div className="mx-auto max-w-[900px] px-7">
-        <Card className="zero-card">
-          <CardContent className="py-5 flex flex-col gap-4">
-            <div className="flex flex-col gap-8">
-              <div className="flex flex-col gap-2">
-                <label
-                  htmlFor="zero-agent-name"
-                  className="text-xs font-semibold uppercase tracking-wide text-muted-foreground"
-                >
-                  Name
-                </label>
-                <Input
-                  id="zero-agent-name"
-                  value={agentName}
-                  onChange={(e) => setAgentName(e.target.value)}
-                  placeholder="What should we call them?"
-                  className="h-9"
-                />
-              </div>
-              <div
-                className="flex flex-col gap-2"
-                role="group"
-                aria-label={`How ${resolvedAgentName} sounds`}
-              >
-                <span className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-                  How they sound
-                </span>
-                <div
-                  className="flex flex-wrap gap-2"
-                  role="group"
-                  aria-label="Tone"
-                >
-                  {TONE_OPTIONS.map((opt) => (
-                    <button
-                      key={opt}
-                      type="button"
-                      onClick={() => setTone(opt)}
-                      className={cn(
-                        "rounded-lg border px-4 py-2.5 text-sm font-medium transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
-                        tone === opt
-                          ? "border-primary/40 bg-primary/10 text-primary dark:border-primary/50 dark:bg-primary/15"
-                          : "zero-chip text-muted-foreground hover:text-foreground",
-                      )}
-                    >
-                      {toneLabel(opt)}
-                    </button>
-                  ))}
-                </div>
-                <div
-                  className="zero-chip rounded-lg border px-3 py-2 transition-colors duration-200"
-                  key={tone}
-                >
-                  <p className="text-xs text-muted-foreground italic min-h-[1.25rem] leading-relaxed">
-                    {TONE_HINT[tone]}
-                  </p>
-                  <div className="my-2 border-t border-border/30" />
-                  <div className="flex flex-col gap-1.5 pb-1.5">
-                    <div className="flex justify-end">
-                      <div className="zero-bubble-cool max-w-[85%] rounded-2xl px-3 py-2 text-sm leading-relaxed transition-colors duration-200">
-                        {TONE_SAMPLES[tone].user}
-                      </div>
-                    </div>
-                    <div className="flex justify-start">
-                      <div className="zero-chat-bubble-assistant max-w-[85%] rounded-2xl border px-3 py-2 text-sm text-foreground leading-relaxed transition-colors duration-200">
-                        {TONE_SAMPLES[tone].zero}
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </CardContent>
-        </Card>
-      </div>
-
-      {isSettingsDirty &&
-        createPortal(
-          <div className="zero-app fixed bottom-6 left-0 right-0 z-40 flex justify-center px-4 sm:left-[255px]">
-            <div className="zero-card flex max-w-md items-center justify-between gap-4 rounded-xl border border-border bg-card px-5 py-4 shadow-lg">
-              <div className="flex items-center gap-2 text-sm text-foreground">
-                <IconPencil
-                  size={18}
-                  stroke={1.5}
-                  className="shrink-0 text-muted-foreground"
-                />
-                <span>You have unsaved changes</span>
-              </div>
-              <div className="flex items-center gap-2 shrink-0">
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className="text-destructive hover:bg-destructive/10 hover:text-destructive"
-                  onClick={handleResetSettings}
-                  disabled={saving}
-                >
-                  Discard
-                </Button>
-                <Button
-                  size="sm"
-                  className="h-9 rounded-lg px-4 bg-primary text-primary-foreground hover:bg-primary/90"
-                  onClick={() =>
-                    detach(handleSaveSettings(), Reason.DomCallback)
-                  }
-                  disabled={saving}
-                >
-                  {saving ? (
-                    <IconLoader2
-                      size={14}
-                      stroke={1.5}
-                      className="animate-spin mr-1.5"
-                    />
-                  ) : null}
-                  Save
-                </Button>
-              </div>
-            </div>
-          </div>,
-          document.body,
-        )}
-    </>
+    <ZeroInstructionsTab
+      instructions={instructions}
+      loading={loading}
+      fetchError={fetchError}
+      editedContent={edited}
+      isDirty={isDirty}
+      isBuilding={isBuilding}
+      buildError={buildError}
+      onEdit={setEdited}
+      onDiscard={discard}
+      onBuild={() => detach(build(), Reason.DomCallback)}
+    />
   );
 }
 
@@ -862,6 +193,7 @@ export function ZeroMeetPage({
   )
     ? (rawSound as Tone)
     : "professional";
+  const saving = useGet(zeroSettingsSaving$);
   const params =
     typeof window !== "undefined"
       ? new URLSearchParams(window.location.search)
@@ -975,20 +307,22 @@ export function ZeroMeetPage({
       </header>
 
       <main className="shrink-0 px-4 sm:px-6 pt-4 pb-16">
-        {activeTab === "skills" && <ZeroSkillsTab />}
+        {activeTab === "skills" && <MeetSkillsTab />}
 
         {activeTab === "schedule" && (
-          <ZeroScheduleTab resolvedAgentName={resolvedAgentName} />
+          <MeetScheduleTab agentName={resolvedAgentName} />
         )}
 
         {activeTab === "settings" && (
           <ZeroSettingsTab
             agentName={resolvedAgentName}
             sound={resolvedSound}
+            saving={saving}
+            updateSettings$={zeroUpdateSettings$}
           />
         )}
 
-        {activeTab === "instructions" && <ZeroInstructionsTab />}
+        {activeTab === "instructions" && <MeetInstructionsTab />}
       </main>
     </div>
   );

--- a/turbo/apps/platform/src/views/zero-page/zero-mock-data.ts
+++ b/turbo/apps/platform/src/views/zero-page/zero-mock-data.ts
@@ -1,0 +1,43 @@
+/**
+ * Mock data for Zero demo pages (chat, schedule).
+ * TODO: Remove once these pages are connected to real API data.
+ */
+
+interface MockJobItem {
+  id: string;
+  agentName: string;
+  title: string;
+  description: string;
+  scope: "personal" | "team";
+}
+
+export const ZERO_TEAM_JOBS: readonly Readonly<MockJobItem>[] = [
+  {
+    id: "1",
+    agentName: "Minion 1",
+    title: "Daily Digest",
+    description: "Get a daily summary of your team's important updates.",
+    scope: "team",
+  },
+  {
+    id: "2",
+    agentName: "Minion 2",
+    title: "GitHub Issue Triage",
+    description: "Automatically categorize and prioritize new GitHub issues.",
+    scope: "personal",
+  },
+  {
+    id: "3",
+    agentName: "Minion 3",
+    title: "Weekly Report",
+    description: "Receive a weekly summary of your team's achievements.",
+    scope: "team",
+  },
+  {
+    id: "4",
+    agentName: "Minion 4",
+    title: "Customer Feedback Digest",
+    description: "Compile and analyze customer feedback from multiple sources.",
+    scope: "personal",
+  },
+];

--- a/turbo/apps/platform/src/views/zero-page/zero-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-page.tsx
@@ -1,9 +1,13 @@
 import { ZeroAppShell } from "./zero-app-shell.tsx";
 
+interface ZeroPageProps {
+  initialJobAgent?: string | null;
+}
+
 /**
  * Zero is a standalone product at /zero. It uses its own app shell and
  * sidebar; platform layout (navbar, sidebar) is not used here.
  */
-export function ZeroPage() {
-  return <ZeroAppShell />;
+export function ZeroPage({ initialJobAgent }: ZeroPageProps) {
+  return <ZeroAppShell initialJobAgent={initialJobAgent} />;
 }

--- a/turbo/apps/platform/src/views/zero-page/zero-schedule-card.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-schedule-card.tsx
@@ -371,16 +371,6 @@ export function getEntriesInCell(
   });
 }
 
-/** Dummy schedule for sub-agent (job) detail page — one entry per sub-agent. */
-const DUMMY_AGENT_SCHEDULE: readonly Readonly<ScheduleEntry>[] = [
-  {
-    id: "j1",
-    time: "Every weekday at 9:00 AM",
-    prompt: "Run the usual morning briefing and post a short summary.",
-  },
-];
-export { DUMMY_AGENT_SCHEDULE };
-
 function CalendarEntryPopover({
   entry,
   onEdit,

--- a/turbo/apps/platform/src/views/zero-page/zero-schedule-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-schedule-tab.tsx
@@ -1,0 +1,82 @@
+import { useCCState } from "ccstate-react/experimental";
+import { useGet, useSet, useLoadable } from "ccstate-react";
+import { Card, CardContent } from "@vm0/ui";
+import { ZeroScheduleCard, type ScheduleEntry } from "./zero-schedule-card.tsx";
+import { notificationPreferences$ } from "../../signals/settings-page/notification-settings.ts";
+
+interface ZeroScheduleSaveParams {
+  prompt: string;
+  freq: string;
+  date: string;
+  hour: number;
+  minute: number;
+  timezone: string;
+  intervalSeconds: number;
+  dayOfWeek?: string;
+  dayOfMonth?: string;
+  editName?: string;
+}
+
+interface ZeroScheduleTabProps {
+  agentName: string;
+  entries: ScheduleEntry[];
+  scheduleError?: string | null;
+  onSave: (params: ZeroScheduleSaveParams) => Promise<void>;
+  onDelete: (name: string) => Promise<void>;
+  onToggleEnabled: (params: {
+    name: string;
+    enabled: boolean;
+  }) => Promise<void>;
+}
+
+export function ZeroScheduleTab({
+  agentName,
+  entries,
+  scheduleError,
+  onSave,
+  onDelete,
+  onToggleEnabled,
+}: ZeroScheduleTabProps) {
+  const prefsLoadable = useLoadable(notificationPreferences$);
+  const userTimezone =
+    prefsLoadable.state === "hasData" ? prefsLoadable.data.timezone : null;
+  const saving$ = useCCState(false);
+  const saving = useGet(saving$);
+  const setSaving = useSet(saving$);
+
+  if (scheduleError) {
+    return (
+      <div className="mx-auto max-w-[900px] px-7">
+        <Card className="zero-card">
+          <CardContent className="px-6 py-6 text-center">
+            <p className="text-sm text-destructive">{scheduleError}</p>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  const handleSave = async (params: ZeroScheduleSaveParams) => {
+    setSaving(true);
+    try {
+      await onSave(params);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="mx-auto max-w-[900px] px-7">
+      <ZeroScheduleCard
+        title={`${agentName}'s schedule`}
+        subtitle={`Set a time and prompt for ${agentName} to run automatically.`}
+        initialSchedule={entries}
+        onSave={handleSave}
+        onDelete={onDelete}
+        onToggleEnabled={onToggleEnabled}
+        saving={saving}
+        defaultTimezone={userTimezone ?? undefined}
+      />
+    </div>
+  );
+}

--- a/turbo/apps/platform/src/views/zero-page/zero-session-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-session-chat-page.tsx
@@ -43,7 +43,7 @@ interface ZeroSessionChatPageProps {
   zeroAvatarSrc?: string;
   onAvatarClick?: () => void;
   onBack?: () => void;
-  onNavigateToJob?: () => void;
+  onNavigateToTeam?: () => void;
   onNavigateToSchedule?: () => void;
 }
 
@@ -51,7 +51,7 @@ export function ZeroSessionChatPage({
   zeroAvatarSrc = "/zero-avatar.png",
   onAvatarClick,
   onBack,
-  onNavigateToJob,
+  onNavigateToTeam,
   onNavigateToSchedule,
 }: ZeroSessionChatPageProps) {
   const agentNameLoadable = useLoadable(agentDisplayName$);
@@ -149,7 +149,7 @@ export function ZeroSessionChatPage({
             variant="ghost"
             size="icon"
             className="h-8 w-8 text-muted-foreground hover:text-foreground"
-            onClick={onNavigateToJob}
+            onClick={onNavigateToTeam}
             aria-label="Sub-agents"
           >
             <IconUsers size={18} stroke={1.5} />

--- a/turbo/apps/platform/src/views/zero-page/zero-settings-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-settings-tab.tsx
@@ -1,0 +1,167 @@
+import { useCCState, useCommand } from "ccstate-react/experimental";
+import { useGet, useSet } from "ccstate-react";
+import { Card, CardContent, Input, cn } from "@vm0/ui";
+import {
+  type Tone,
+  TONE_OPTIONS,
+  toneLabel,
+  TONE_HINT,
+  TONE_SAMPLES,
+} from "./zero-tone-constants.ts";
+import { detach, Reason } from "../../signals/utils.ts";
+import { ZeroUnsavedBar } from "./zero-unsaved-bar.tsx";
+import type { Command } from "ccstate";
+
+interface ZeroSettingsTabProps {
+  agentName: string;
+  sound: Tone;
+  saving: boolean;
+  updateSettings$: Command<
+    Promise<void>,
+    [{ displayName: string; sound: string }]
+  >;
+  inputId?: string;
+}
+
+export function ZeroSettingsTab({
+  agentName: resolvedAgentName,
+  sound: initialSound,
+  saving,
+  updateSettings$,
+  inputId = "zero-agent-name",
+}: ZeroSettingsTabProps) {
+  const agentName$ = useCCState(resolvedAgentName);
+  const agentName = useGet(agentName$);
+  const setAgentName = useSet(agentName$);
+  const tone$ = useCCState<Tone>(initialSound);
+  const tone = useGet(tone$);
+  const setTone = useSet(tone$);
+  const savedSettings$ = useCCState<{ name: string; tone: Tone }>({
+    name: resolvedAgentName,
+    tone: initialSound,
+  });
+  const savedSettings = useGet(savedSettings$);
+  const setSavedSettings = useSet(savedSettings$);
+
+  // Sync local state when props change (e.g. metadata finishes loading)
+  const prevProps$ = useCCState({
+    name: resolvedAgentName,
+    tone: initialSound,
+  });
+  const prevProps = useGet(prevProps$);
+  const setPrevProps = useSet(prevProps$);
+  if (resolvedAgentName !== prevProps.name || initialSound !== prevProps.tone) {
+    queueMicrotask(() => {
+      setPrevProps({ name: resolvedAgentName, tone: initialSound });
+      setAgentName(resolvedAgentName);
+      setTone(initialSound);
+      setSavedSettings({ name: resolvedAgentName, tone: initialSound });
+    });
+  }
+
+  const isSettingsDirty =
+    agentName !== savedSettings.name || tone !== savedSettings.tone;
+
+  const handleResetSettings = () => {
+    setAgentName(savedSettings.name);
+    setTone(savedSettings.tone);
+  };
+
+  const handleSaveSettings$ = useCommand(async ({ get, set }) => {
+    const currentName = get(agentName$);
+    const currentTone = get(tone$);
+    await set(updateSettings$, {
+      displayName: currentName,
+      sound: currentTone,
+    });
+    set(savedSettings$, { name: currentName, tone: currentTone });
+  });
+  const handleSaveSettings = useSet(handleSaveSettings$);
+
+  return (
+    <>
+      <div className="mx-auto max-w-[900px] px-7">
+        <Card className="zero-card">
+          <CardContent className="py-5 flex flex-col gap-4">
+            <div className="flex flex-col gap-8">
+              <div className="flex flex-col gap-2">
+                <label
+                  htmlFor={inputId}
+                  className="text-xs font-semibold uppercase tracking-wide text-muted-foreground"
+                >
+                  Name
+                </label>
+                <Input
+                  id={inputId}
+                  value={agentName}
+                  onChange={(e) => setAgentName(e.target.value)}
+                  placeholder="What should we call them?"
+                  className="h-9"
+                />
+              </div>
+              <div
+                className="flex flex-col gap-2"
+                role="group"
+                aria-label={`How ${resolvedAgentName} sounds`}
+              >
+                <span className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                  How they sound
+                </span>
+                <div
+                  className="flex flex-wrap gap-2"
+                  role="group"
+                  aria-label="Tone"
+                >
+                  {TONE_OPTIONS.map((opt) => (
+                    <button
+                      key={opt}
+                      type="button"
+                      onClick={() => setTone(opt)}
+                      className={cn(
+                        "rounded-lg border px-4 py-2.5 text-sm font-medium transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+                        tone === opt
+                          ? "border-primary/40 bg-primary/10 text-primary dark:border-primary/50 dark:bg-primary/15"
+                          : "zero-chip text-muted-foreground hover:text-foreground",
+                      )}
+                    >
+                      {toneLabel(opt)}
+                    </button>
+                  ))}
+                </div>
+                <div
+                  className="zero-chip rounded-lg border px-3 py-2 transition-colors duration-200"
+                  key={tone}
+                >
+                  <p className="text-xs text-muted-foreground italic min-h-[1.25rem] leading-relaxed">
+                    {TONE_HINT[tone]}
+                  </p>
+                  <div className="my-2 border-t border-border/30" />
+                  <div className="flex flex-col gap-1.5 pb-1.5">
+                    <div className="flex justify-end">
+                      <div className="zero-bubble-cool max-w-[85%] rounded-2xl px-3 py-2 text-sm leading-relaxed transition-colors duration-200">
+                        {TONE_SAMPLES[tone].user}
+                      </div>
+                    </div>
+                    <div className="flex justify-start">
+                      <div className="zero-chat-bubble-assistant max-w-[85%] rounded-2xl border px-3 py-2 text-sm text-foreground leading-relaxed transition-colors duration-200">
+                        {TONE_SAMPLES[tone].zero}
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      {isSettingsDirty && (
+        <ZeroUnsavedBar
+          onDiscard={handleResetSettings}
+          onSave={() => detach(handleSaveSettings(), Reason.DomCallback)}
+          saving={saving}
+        />
+      )}
+    </>
+  );
+}

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -41,7 +41,7 @@ export type ZeroNavId =
   | "chat"
   | "meet"
   | "schedule"
-  | "job"
+  | "team"
   | "activity"
   | "works"
   | "settings"
@@ -51,7 +51,7 @@ type NavIcon = (props: { size?: number; className?: string }) => ReactNode;
 const MAIN_NAV = [
   { id: "chat", label: "Chat with Zero", icon: IconMessageCircle as NavIcon },
   { id: "meet", label: "Meet Zero", icon: IconRobot as NavIcon },
-  { id: "job", label: "Zero's team", icon: IconUsers as NavIcon },
+  { id: "team", label: "Zero's team", icon: IconUsers as NavIcon },
   { id: "schedule", label: "Schedule", icon: IconCalendar as NavIcon },
   { id: "activity", label: "Activities", icon: IconChartLine as NavIcon },
 ] as const;

--- a/turbo/apps/platform/src/views/zero-page/zero-skill-card.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-skill-card.tsx
@@ -1,0 +1,113 @@
+import { IconPlug, IconLoader2, IconDotsVertical } from "@tabler/icons-react";
+import { CONNECTOR_TYPES, type ConnectorType } from "@vm0/core";
+import { ConnectorIcon } from "../settings-page/connector-icons.tsx";
+import type { ConnectorTypeWithStatus } from "../../signals/settings-page/connectors.ts";
+import {
+  Button,
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+} from "@vm0/ui";
+
+interface ZeroSkillCardProps {
+  name: string;
+  label: string;
+  iconUrl: string | undefined;
+  connector: ConnectorTypeWithStatus | null;
+  pollingType: ConnectorType | null;
+  onConnect: () => void;
+  onDisconnect: () => void;
+  onRemove: () => void;
+}
+
+export function ZeroSkillCard({
+  name,
+  label,
+  iconUrl,
+  connector,
+  pollingType,
+  onConnect,
+  onDisconnect,
+  onRemove,
+}: ZeroSkillCardProps) {
+  const isPolling = pollingType === name;
+
+  return (
+    <div className="flex flex-col rounded-[var(--zero-card-radius)] border border-[var(--zero-card-border)] bg-card shadow-[var(--zero-card-shadow)]">
+      <div className="flex h-14 items-center gap-2.5 px-5">
+        <span className="flex h-7 w-7 shrink-0 items-center justify-center">
+          {name in CONNECTOR_TYPES ? (
+            <ConnectorIcon type={name as ConnectorType} size={22} />
+          ) : iconUrl ? (
+            <img src={iconUrl} alt="" className="h-5 w-5 object-contain" />
+          ) : (
+            <IconPlug
+              size={18}
+              stroke={1.5}
+              className="text-muted-foreground"
+            />
+          )}
+        </span>
+        <span className="min-w-0 flex-1 text-sm font-medium text-foreground truncate">
+          {label}
+        </span>
+      </div>
+
+      <div className="flex h-11 items-center justify-between border-t border-border/50 pl-5 pr-2">
+        <div className="flex items-center gap-2 min-w-0">
+          {connector &&
+            (isPolling ? (
+              <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                <IconLoader2 size={12} stroke={1.5} className="animate-spin" />
+                Connecting…
+              </span>
+            ) : connector.connected ? (
+              <span className="flex items-center gap-2 text-xs text-muted-foreground truncate">
+                <span className="h-1.5 w-1.5 rounded-full bg-emerald-500 shrink-0" />
+                {connector.connector?.externalUsername
+                  ? `@${connector.connector.externalUsername}`
+                  : connector.connector?.authMethod === "api-token"
+                    ? "API key"
+                    : "Connected"}
+              </span>
+            ) : (
+              <button
+                type="button"
+                onClick={onConnect}
+                className="text-xs font-medium text-primary hover:text-primary/80 transition-colors"
+              >
+                {connector.availableAuthMethods.length === 1 &&
+                connector.availableAuthMethods[0] === "api-token"
+                  ? "Add API key"
+                  : "Connect"}
+              </button>
+            ))}
+          {!connector && (
+            <span className="text-xs text-muted-foreground">Added</span>
+          )}
+        </div>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-7 w-7 shrink-0 rounded-lg text-muted-foreground hover:text-foreground"
+              aria-label="More options"
+            >
+              <IconDotsVertical size={14} stroke={1.5} />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" className="w-40">
+            {connector?.connected && (
+              <DropdownMenuItem onClick={onDisconnect}>
+                Disconnect
+              </DropdownMenuItem>
+            )}
+            <DropdownMenuItem onClick={onRemove}>Remove skill</DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+    </div>
+  );
+}

--- a/turbo/apps/platform/src/views/zero-page/zero-skills-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-skills-tab.tsx
@@ -1,0 +1,217 @@
+import { useGet, useSet, useLastLoadable } from "ccstate-react";
+import { IconPlus } from "@tabler/icons-react";
+import type { ConnectorType } from "@vm0/core";
+import { skills$ } from "../../data/skills.ts";
+import { ZeroSkillCard } from "./zero-skill-card.tsx";
+import {
+  allConnectorTypes$,
+  connectConnector$,
+  addConnectionDialogOpen$,
+  setAddConnectionDialogOpen$,
+  selectedConnectorType$,
+  setSelectedConnectorType$,
+  pollingConnectorType$,
+  justConnectedTypes$,
+  clearJustConnectedTypes$,
+} from "../../signals/settings-page/connectors.ts";
+import { deleteConnector$ } from "../../signals/external/connectors.ts";
+import { pageSignal$ } from "../../signals/page-signal.ts";
+import {
+  AddConnectionDialog,
+  ConnectModal,
+} from "../settings-page/add-connection-dialog.tsx";
+import { toast } from "@vm0/ui/components/ui/sonner";
+import { detach, Reason } from "../../signals/utils.ts";
+import { ZeroUnsavedBar } from "./zero-unsaved-bar.tsx";
+
+interface ZeroSkillsTabProps {
+  addedSkills: string[];
+  addedSkillsLoading: boolean;
+  skillsDirty: boolean;
+  skillsSaving: boolean;
+  onAddSkill: (name: string) => void;
+  onRemoveSkill: (name: string) => void;
+  onSaveSkills: () => void;
+  onDiscardSkills: () => void;
+}
+
+export function ZeroSkillsTab({
+  addedSkills,
+  addedSkillsLoading,
+  skillsDirty,
+  skillsSaving,
+  onAddSkill,
+  onRemoveSkill,
+  onSaveSkills,
+  onDiscardSkills,
+}: ZeroSkillsTabProps) {
+  const allTypesLoadable = useLastLoadable(allConnectorTypes$);
+  const pollingType = useGet(pollingConnectorType$);
+  const connect = useSet(connectConnector$);
+  const disconnect = useSet(deleteConnector$);
+  const signal = useGet(pageSignal$);
+  const addDialogOpen = useGet(addConnectionDialogOpen$);
+  const setAddDialogOpen = useSet(setAddConnectionDialogOpen$);
+  const selectedType = useGet(selectedConnectorType$);
+  const setSelected = useSet(setSelectedConnectorType$);
+
+  const allSkills = useGet(skills$);
+
+  const optimisticConnected = useGet(justConnectedTypes$);
+  const clearOptimistic = useSet(clearJustConnectedTypes$);
+
+  const allConnectors =
+    allTypesLoadable.state === "hasData" ? allTypesLoadable.data : [];
+  if (allTypesLoadable.state === "hasData" && optimisticConnected.size > 0) {
+    clearOptimistic();
+  }
+  const connectorMap = new Map(allConnectors.map((c) => [c.type, c]));
+  const skillMap = new Map(allSkills.map((s) => [s.value, s]));
+  const addedSet = new Set(addedSkills);
+
+  const handleConnectSuccess = (type: string) => {
+    onAddSkill(type);
+    const label =
+      skillMap.get(type)?.label ??
+      connectorMap.get(type as ConnectorType)?.label ??
+      type;
+    toast.success(`${label} added to skills`);
+  };
+
+  const handleRemoveSkill = (name: string) => {
+    onRemoveSkill(name);
+    const label =
+      skillMap.get(name)?.label ??
+      connectorMap.get(name as ConnectorType)?.label ??
+      name;
+    toast.success(`${label} removed from skills`);
+  };
+
+  return (
+    <div className="mx-auto max-w-[900px] px-7 flex flex-col gap-4">
+      <p className="text-sm text-muted-foreground">
+        Skills manage your connections and help you get more out of these
+        services.
+      </p>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+        {/* Add skill */}
+        <button
+          type="button"
+          onClick={() => setAddDialogOpen(true)}
+          className="flex flex-col rounded-[var(--zero-card-radius)] border border-dashed border-border/80 transition-colors hover:border-border hover:bg-muted/30 group"
+        >
+          <div className="flex h-14 items-center gap-2.5 px-5">
+            <span className="flex h-7 w-7 shrink-0 items-center justify-center">
+              <IconPlus
+                size={18}
+                stroke={2}
+                className="text-muted-foreground group-hover:text-foreground"
+              />
+            </span>
+            <span className="text-sm font-medium text-muted-foreground group-hover:text-foreground">
+              Add skill
+            </span>
+          </div>
+          <div className="flex h-11 items-center border-t border-dashed border-border/80 px-5 group-hover:border-border">
+            <span className="text-xs text-muted-foreground/70">
+              Browse 100+ popular skills
+            </span>
+          </div>
+        </button>
+
+        {/* Skeleton cards while loading */}
+        {addedSkillsLoading && (
+          <>
+            {Array.from({ length: 3 }, (_, i) => (
+              <div
+                key={i}
+                className="flex flex-col rounded-[var(--zero-card-radius)] border border-border/50 bg-card animate-pulse"
+              >
+                <div className="flex h-14 items-center gap-2.5 px-5">
+                  <span className="h-7 w-7 shrink-0 rounded-lg bg-muted/50" />
+                  <span className="h-4 w-24 rounded bg-muted/50" />
+                </div>
+                <div className="flex h-11 items-center border-t border-border/30 px-5">
+                  <span className="h-3 w-16 rounded bg-muted/30" />
+                </div>
+              </div>
+            ))}
+          </>
+        )}
+
+        {/* Skill cards */}
+        {addedSkills.map((name) => {
+          const skill = skillMap.get(name);
+          const connector = connectorMap.get(name as ConnectorType) ?? null;
+          const effectiveConnector =
+            optimisticConnected.has(name) && connector && !connector.connected
+              ? { ...connector, connected: true }
+              : connector;
+          return (
+            <ZeroSkillCard
+              key={name}
+              name={name}
+              label={skill?.label ?? name}
+              iconUrl={skill?.icon}
+              connector={effectiveConnector}
+              pollingType={pollingType}
+              onConnect={() => {
+                const ct = connectorMap.get(name as ConnectorType);
+                if (
+                  ct &&
+                  ct.availableAuthMethods.length === 1 &&
+                  ct.availableAuthMethods[0] === "api-token"
+                ) {
+                  setSelected(name as ConnectorType);
+                } else {
+                  detach(
+                    connect(name as ConnectorType, signal),
+                    Reason.DomCallback,
+                  );
+                }
+              }}
+              onDisconnect={() => {
+                detach(disconnect(name as ConnectorType), Reason.DomCallback);
+                const label =
+                  skillMap.get(name)?.label ??
+                  connectorMap.get(name as ConnectorType)?.label ??
+                  name;
+                toast.success(`${label} disconnected`);
+              }}
+              onRemove={() => handleRemoveSkill(name)}
+            />
+          );
+        })}
+      </div>
+
+      <AddConnectionDialog
+        open={addDialogOpen}
+        onOpenChange={setAddDialogOpen}
+        variant="zero"
+        excludeTypes={addedSet}
+        onConnectSuccess={handleConnectSuccess}
+        onAdd={handleConnectSuccess}
+      />
+
+      {selectedType && (
+        <ConnectModal
+          onClose={() => setSelected(null)}
+          onSuccess={() => {
+            if (selectedType && !addedSet.has(selectedType)) {
+              handleConnectSuccess(selectedType);
+            }
+          }}
+        />
+      )}
+
+      {(skillsDirty || skillsSaving) && (
+        <ZeroUnsavedBar
+          onDiscard={onDiscardSkills}
+          onSave={onSaveSkills}
+          saving={skillsSaving}
+        />
+      )}
+    </div>
+  );
+}

--- a/turbo/apps/platform/src/views/zero-page/zero-tone-constants.ts
+++ b/turbo/apps/platform/src/views/zero-page/zero-tone-constants.ts
@@ -1,0 +1,41 @@
+/** Stored as lowercase in metadata.sound. */
+export const TONE_OPTIONS = [
+  "professional",
+  "friendly",
+  "direct",
+  "supportive",
+] as const;
+
+export type Tone = (typeof TONE_OPTIONS)[number];
+
+export function toneLabel(t: Tone) {
+  return t.charAt(0).toUpperCase() + t.slice(1);
+}
+
+export const TONE_HINT: Readonly<Record<Tone, string>> = {
+  professional: "Clear and polished",
+  friendly: "Warm and approachable",
+  direct: "To the point",
+  supportive: "In your corner",
+};
+
+export const TONE_SAMPLES: Readonly<
+  Record<Tone, Readonly<{ user: string; zero: string }>>
+> = {
+  professional: {
+    user: "I need the Q3 report by Friday.",
+    zero: "I'll have the Q3 report ready by Friday. I'll send a draft by Thursday for your review.",
+  },
+  friendly: {
+    user: "I need the Q3 report by Friday.",
+    zero: "Sure thing! I'll get that Q3 report to you by Friday—I'll send over a draft Thursday so you can take a look.",
+  },
+  direct: {
+    user: "I need the Q3 report by Friday.",
+    zero: "Friday. I'll send a draft Thursday.",
+  },
+  supportive: {
+    user: "I need the Q3 report by Friday.",
+    zero: "I'll make sure you have the Q3 report by Friday. I'll send a draft on Thursday so you have time to review—let me know if you'd like anything else.",
+  },
+};

--- a/turbo/apps/platform/src/views/zero-page/zero-unsaved-bar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-unsaved-bar.tsx
@@ -1,0 +1,57 @@
+import { createPortal } from "react-dom";
+import { IconPencil, IconLoader2 } from "@tabler/icons-react";
+import { Button } from "@vm0/ui";
+
+interface ZeroUnsavedBarProps {
+  onDiscard: () => void;
+  onSave: () => void;
+  saving: boolean;
+}
+
+export function ZeroUnsavedBar({
+  onDiscard,
+  onSave,
+  saving,
+}: ZeroUnsavedBarProps) {
+  return createPortal(
+    <div className="zero-app fixed bottom-6 left-0 right-0 z-40 flex justify-center px-4 sm:left-[255px]">
+      <div className="zero-card flex max-w-md items-center justify-between gap-4 rounded-xl border border-border bg-card px-5 py-4 shadow-lg">
+        <div className="flex items-center gap-2 text-sm text-foreground">
+          <IconPencil
+            size={18}
+            stroke={1.5}
+            className="shrink-0 text-muted-foreground"
+          />
+          <span>You have unsaved changes</span>
+        </div>
+        <div className="flex items-center gap-2 shrink-0">
+          <Button
+            variant="ghost"
+            size="sm"
+            className="text-destructive hover:bg-destructive/10 hover:text-destructive"
+            onClick={onDiscard}
+            disabled={saving}
+          >
+            Discard
+          </Button>
+          <Button
+            size="sm"
+            className="h-9 rounded-lg px-4 bg-primary text-primary-foreground hover:bg-primary/90"
+            onClick={onSave}
+            disabled={saving}
+          >
+            {saving ? (
+              <IconLoader2
+                size={14}
+                stroke={1.5}
+                className="animate-spin mr-1.5"
+              />
+            ) : null}
+            Save
+          </Button>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/turbo/apps/web/app/api/agent/composes/list/route.ts
+++ b/turbo/apps/web/app/api/agent/composes/list/route.ts
@@ -118,6 +118,7 @@ const router = tsr.router(composesListContract, {
 
     // When using default org (no ?scope= param), also include email-shared agents
     let sharedComposes: {
+      id: string;
       name: string;
       headVersionId: string | null;
       updatedAt: Date;
@@ -133,6 +134,7 @@ const router = tsr.router(composesListContract, {
     // Combine: own agents first, then shared agents with org/name format
     const allComposes = [
       ...ownComposes.map((c) => ({
+        id: c.id,
         name: c.name,
         displayName: extractDisplayName(c.headContent),
         headVersionId: c.headVersionId,
@@ -140,6 +142,7 @@ const router = tsr.router(composesListContract, {
         isOwner: true,
       })),
       ...sharedComposes.map((c) => ({
+        id: c.id,
         name: `${c.orgSlug}/${c.name}`,
         displayName: null as string | null,
         headVersionId: c.headVersionId,

--- a/turbo/packages/core/src/contracts/composes.ts
+++ b/turbo/packages/core/src/contracts/composes.ts
@@ -314,6 +314,7 @@ export const composesVersionsContract = c.router({
  * Compose list item schema (used in list response)
  */
 const composeListItemSchema = z.object({
+  id: z.string(),
   name: z.string(),
   displayName: z.string().nullable().optional(),
   headVersionId: z.string().nullable(),


### PR DESCRIPTION
## Summary

- Replace mock data in Zero Team page with real API data from `/api/agent/composes/list`
- Add URL-routed subagent detail page at `/zero/job/:name` with 4 tabs (Connections, Schedule, Settings, Instructions) backed by real API data
- Create signal layer for data fetching (reuses existing agents-list signals)
- Preserve Zero shell (sidebar stays visible) when navigating to detail page

## Changes

- **New**: `zero-agents.ts` signal - filters non-default agents from agents list
- **New**: `zero-job-detail.ts` signal - fetches agent detail, instructions, schedule
- **New**: `zero-job-detail-route.ts` - route setup for `/zero/job/:name`
- **New**: `zero-mock-data.ts` - extracted mock data for chat/schedule pages
- **Modified**: List page shows real agents with schedule badges, missing items warnings, last edit dates
- **Modified**: Detail page displays real data across all 4 tabs with loading/error states
- **Modified**: URL routing added via bootstrap.ts, props threaded through Zero shell

Closes #4187

## Test plan

- [ ] Navigate to `/zero`, click "Zero's team" in sidebar - verify real agents load
- [ ] Click an agent card - verify navigation to `/zero/job/:name` with detail page
- [ ] Verify all 4 tabs show real data (Connectors, Schedule, Settings, Instructions)
- [ ] Click back button - verify return to agent list
- [ ] Navigate directly to `/zero/job/:name` URL - verify detail page renders with Zero shell
- [ ] Verify loading skeletons appear during data fetch
- [ ] Verify error states with retry button

🤖 Generated with [Claude Code](https://claude.com/claude-code)