### PR TITLE
chore: add claude scheduled tasks lock to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -182,3 +182,5 @@ __pycache__/
 
 # Debug screenshots
 debug-*.png
+
+.claude/scheduled_tasks.lock


### PR DESCRIPTION
## Summary
- Add `.claude/scheduled_tasks.lock` to `.gitignore` to prevent committing Claude Code's internal lock file

## Test plan
- [x] Verify `.claude/scheduled_tasks.lock` is excluded from git tracking

🤖 Generated with [Claude Code](https://claude.com/claude-code)