### PR TITLE
chore: remove scheduled tasks lock file

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"7b7386f0-c46a-4a29-b26a-41541fcce8d1","pid":2440,"acquiredAt":1773202214790}


### PR DESCRIPTION
## Summary
- Remove `.claude/scheduled_tasks.lock` file that was already added to `.gitignore` in #4312

## Test plan
- [x] File is already in `.gitignore`, no functional impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)