### PR TITLE
refactor(cli): replace process.exit with throw in logs commands

### DIFF
--- a/turbo/apps/cli/src/commands/logs/index.ts
+++ b/turbo/apps/cli/src/commands/logs/index.ts
@@ -172,12 +172,9 @@ function getLogType(options: {
   ].filter(Boolean).length;
 
   if (selected > 1) {
-    console.error(
-      chalk.red(
-        "Options --agent, --system, --metrics, and --network are mutually exclusive",
-      ),
+    throw new Error(
+      "Options --agent, --system, --metrics, and --network are mutually exclusive",
     );
-    process.exit(1);
   }
 
   if (options.system) return "system";
@@ -231,12 +228,9 @@ export const logsCommand = new Command()
           options.all === true,
         ].filter(Boolean).length;
         if (countModes > 1) {
-          console.error(
-            chalk.red(
-              "Options --tail, --head, and --all are mutually exclusive",
-            ),
+          throw new Error(
+            "Options --tail, --head, and --all are mutually exclusive",
           );
-          process.exit(1);
         }
 
         // Parse since option

--- a/turbo/apps/cli/src/commands/logs/search.ts
+++ b/turbo/apps/cli/src/commands/logs/search.ts
@@ -63,12 +63,10 @@ function parseContextOptions(options: SearchOptions): {
     : contextN;
 
   if (isNaN(before) || before < 0 || before > 10) {
-    console.error(chalk.red("✗ --before-context must be between 0 and 10"));
-    process.exit(1);
+    throw new Error("--before-context must be between 0 and 10");
   }
   if (isNaN(after) || after < 0 || after > 10) {
-    console.error(chalk.red("✗ --after-context must be between 0 and 10"));
-    process.exit(1);
+    throw new Error("--after-context must be between 0 and 10");
   }
 
   return { before, after };
@@ -81,8 +79,7 @@ function parseLimit(value: string | undefined): number | undefined {
   if (!value) return undefined;
   const limit = parseInt(value, 10);
   if (isNaN(limit) || limit < 1 || limit > 50) {
-    console.error(chalk.red("✗ --limit must be between 1 and 50"));
-    process.exit(1);
+    throw new Error("--limit must be between 1 and 50");
   }
   return limit;
 }


### PR DESCRIPTION
## Summary
- Replace `console.error(chalk.red(...)) + process.exit(1)` with `throw new Error(...)` in `logs/index.ts` and `logs/search.ts`
- Both files already use `withErrorHandler`, so thrown errors are caught and formatted consistently
- 5 replacements total: 2 mutual exclusion checks in index.ts, 3 validation checks in search.ts

Closes #4155 (partial)

## Test plan
- [x] All 50 existing logs tests pass without changes
- [x] Type check passes
- [x] Lint passes
- [x] Knip passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)