### PR TITLE
docs: rename scope to org in resource model

### DIFF
--- a/docs/resource-model.md
+++ b/docs/resource-model.md
@@ -3,58 +3,58 @@
 ## Table of Contents
 
 - [Overview](#overview)
-- [Scope](#scope)
-- [Two Scopes at Runtime](#two-scopes-at-runtime)
-  - [Agent Scope](#agent-scope)
-  - [Runtime Scope](#runtime-scope)
+- [Org](#org)
+- [Two Orgs at Runtime](#two-orgs-at-runtime)
+  - [Agent Org](#agent-org)
+  - [Runtime Org](#runtime-org)
 - [Resource Classification](#resource-classification)
   - [Static Resources](#static-resources)
   - [Dynamic Resources](#dynamic-resources)
   - [User Private Resources](#user-private-resources)
 - [Resource Resolution at Runtime](#resource-resolution-at-runtime)
-- [Cross-Scope Execution](#cross-scope-execution)
+- [Cross-Org Execution](#cross-org-execution)
 
 ---
 
 ## Overview
 
-VM0 organizes all resources under **scopes**. A scope is a namespace that provides isolation — every resource belongs to exactly one scope.
+VM0 organizes all resources under **orgs** (Clerk Organizations). An org is a namespace that provides isolation — every resource belongs to exactly one org.
 
-When an agent runs, two scopes are involved:
+When an agent runs, two orgs are involved:
 
-- **Agent Scope**: Where the agent is defined. Owns the agent definition and its static dependencies.
-- **Runtime Scope**: Where the agent is executed. Determined by who triggers the run.
+- **Agent Org**: Where the agent is defined. Owns the agent definition and its static dependencies.
+- **Runtime Org**: Where the agent is executed. Determined by who triggers the run.
 
 ---
 
-## Scope
+## Org
 
-A scope is the fundamental unit of resource isolation in VM0. Each scope:
+An org is the fundamental unit of resource isolation in VM0. Each org:
 
+- Is a **Clerk Organization** — Clerk is the single source of truth for identity, membership, and metadata
 - Has a globally unique **slug** (e.g., `acme-corp`, `user-a3b4c5d6`)
-- Is backed by a Clerk Organization (for authentication and membership)
 - Has a **tier** (`free`, `pro`, `max`) that governs usage limits
 
-Users are associated with scopes through **membership**. A user can belong to multiple scopes with different roles (`admin` or `member`). Every user has a **default scope** — typically the first scope they created.
+Users are associated with orgs through **Clerk membership**. A user can belong to multiple orgs with different roles (`admin` or `member`). Every user has a **default org** — typically the first org they joined.
 
 ---
 
-## Two Scopes at Runtime
+## Two Orgs at Runtime
 
-When an agent runs, the system resolves resources from two different scopes:
+When an agent runs, the system resolves resources from two different orgs:
 
-### Agent Scope
+### Agent Org
 
-The scope where the agent compose is defined. This scope owns:
+The org where the agent compose is defined. This org owns:
 
 - **Agent Compose** — the agent definition itself
 - **Volumes** — read-only data dependencies declared by the agent
 
-These resources are **shared across all members** within the scope. Any scope member can access them regardless of who created them.
+These resources are **shared across all members** within the org. Any org member can access them regardless of who created them.
 
-### Runtime Scope
+### Runtime Org
 
-The scope of the user who triggers the run. Combined with the **user's identity**, this scope determines:
+The org of the user who triggers the run. Combined with the **user's identity**, this org determines:
 
 - **Artifacts** — read-write working directories produced by runs
 - **Memories** — persistent memory across runs
@@ -63,9 +63,9 @@ The scope of the user who triggers the run. Combined with the **user's identity*
 - **Connectors** — third-party service connections (GitHub, Slack, etc.)
 - **Model Providers** — LLM provider configurations (Anthropic, OpenAI, etc.)
 
-These resources are **isolated per user within the scope**. Two users in the same Runtime Scope each have their own independent set of secrets, artifacts, memories, and so on.
+These resources are **isolated per user within the org**. Two users in the same Runtime Org each have their own independent set of secrets, artifacts, memories, and so on.
 
-> **Key distinction**: Agent Scope resources are identified by scope alone. Runtime Scope resources are identified by **scope + userId**.
+> **Key distinction**: Agent Org resources are identified by org alone. Runtime Org resources are identified by **org + userId**.
 
 ---
 
@@ -73,36 +73,36 @@ These resources are **isolated per user within the scope**. Two users in the sam
 
 ### Static Resources
 
-Static resources belong to the Agent Scope. They are created by explicit user actions (deploy, upload) and do not change during agent execution.
+Static resources belong to the Agent Org. They are created by explicit user actions (deploy, upload) and do not change during agent execution.
 
 #### Agent Compose
 
-The agent definition, written as a `vm0.yaml` file and deployed to a scope.
+The agent definition, written as a `vm0.yaml` file and deployed to an org.
 
-- **Ownership**: Scope-level. One agent name maps to exactly one definition within a scope.
+- **Ownership**: Org-level. One agent name maps to exactly one definition within an org.
 - **Versioning**: Content-addressed (SHA-256). Each deploy creates an immutable version. A HEAD pointer tracks the current active version.
 - **Access control**: Three-tier model:
   1. **Owner** — the user who created the compose (can delete, manage permissions)
-  2. **Scope member** — any member of the same scope (can run, view)
+  2. **Org member** — any member of the same org (can run, view)
   3. **ACL grants** — explicit public or email-based access for external users
 
 #### Volume
 
 Read-only data mounted into the agent sandbox at specified paths.
 
-- **Ownership**: Scope-level. Volumes are shared by all members within the scope.
+- **Ownership**: Org-level. Volumes are shared by all members within the org.
 - **Versioning**: Content-addressed (SHA-256), same mechanism as agent compose.
 - **Typical use**: Code repositories, reference datasets, dependency bundles.
 
 ### Dynamic Resources
 
-Dynamic resources belong to the Runtime Scope + userId. They are created or updated automatically during agent execution.
+Dynamic resources belong to the Runtime Org + userId. They are created or updated automatically during agent execution.
 
 #### Artifact
 
 A read-write working directory that persists agent output across runs.
 
-- **Ownership**: Per-user within the Runtime Scope.
+- **Ownership**: Per-user within the Runtime Org.
 - **Versioning**: A new version is committed after each run completes.
 - **Typical use**: Generated code, modified files, build outputs.
 
@@ -110,19 +110,19 @@ A read-write working directory that persists agent output across runs.
 
 Persistent storage that carries context across multiple runs of the same agent.
 
-- **Ownership**: Per-user within the Runtime Scope.
+- **Ownership**: Per-user within the Runtime Org.
 - **Versioning**: A new version is committed after each run completes.
 - **Typical use**: Accumulated knowledge, learned preferences, conversation history.
 
 ### User Private Resources
 
-User private resources belong to the Runtime Scope + userId. They are configured by the user and consumed during agent execution.
+User private resources belong to the Runtime Org + userId. They are configured by the user and consumed during agent execution.
 
 #### Secret
 
 Encrypted credentials for third-party services.
 
-- **Ownership**: Per-user within the Runtime Scope.
+- **Ownership**: Per-user within the Runtime Org.
 - **Storage**: Encrypted at rest (AES-256-GCM).
 - **Sub-types**:
   - `user` — user-defined secrets (e.g., custom API keys)
@@ -134,7 +134,7 @@ Encrypted credentials for third-party services.
 
 Non-sensitive configuration values stored in plaintext.
 
-- **Ownership**: Per-user within the Runtime Scope.
+- **Ownership**: Per-user within the Runtime Org.
 - **Overridable**: CLI-provided values take priority over stored values.
 - **Referenced in compose**: `${{ vars.MY_VAR }}`
 
@@ -142,14 +142,14 @@ Non-sensitive configuration values stored in plaintext.
 
 Metadata for connected third-party services (GitHub, Slack, Linear, etc.).
 
-- **Ownership**: Per-user within the Runtime Scope. One connector per service type per user.
+- **Ownership**: Per-user within the Runtime Org. One connector per service type per user.
 - **Note**: Connectors store OAuth metadata only. The actual tokens are stored as secrets with `type=connector`.
 
 #### Model Provider
 
 LLM provider configuration (Anthropic, OpenAI, AWS Bedrock, etc.).
 
-- **Ownership**: Per-user within the Runtime Scope. One provider per type per user.
+- **Ownership**: Per-user within the Runtime Org. One provider per type per user.
 - **Features**: Default provider selection, model selection, multi-auth support.
 
 ---
@@ -159,37 +159,37 @@ LLM provider configuration (Anthropic, OpenAI, AWS Bedrock, etc.).
 When an agent run is triggered, the system resolves all required resources in two phases:
 
 ```
-Phase 1: Build Execution Context (Runtime Scope + userId)
+Phase 1: Build Execution Context (Runtime Org + userId)
   ├── Resolve secrets referenced in agent compose environment
   ├── Resolve model provider and its credentials
   ├── Resolve connector tokens (with automatic OAuth refresh)
   └── Resolve and merge variables (stored + CLI overrides)
 
-Phase 2: Prepare for Execution (Agent Scope + Runtime Scope)
-  ├── Resolve volumes from Agent Scope
-  ├── Ensure artifact storage exists in Runtime Scope
-  ├── Ensure memory storage exists in Runtime Scope
+Phase 2: Prepare for Execution (Agent Org + Runtime Org)
+  ├── Resolve volumes from Agent Org
+  ├── Ensure artifact storage exists in Runtime Org
+  ├── Ensure memory storage exists in Runtime Org
   └── Generate storage manifest with presigned URLs
 ```
 
-All Runtime Scope queries use the **(scopeId, userId)** key to locate the correct user-specific resources.
+All Runtime Org queries use the **(clerkOrgId, userId)** key to locate the correct user-specific resources.
 
 ---
 
-## Cross-Scope Execution
+## Cross-Org Execution
 
-The two-scope model enables cross-scope execution: a user in one scope can run an agent defined in another scope.
+The two-org model enables cross-org execution: a user in one org can run an agent defined in another org.
 
-**Example**: User B (member of `scope-b`) runs an agent owned by User A (defined in `scope-a`).
+**Example**: User B (member of `org-b`) runs an agent owned by User A (defined in `org-a`).
 
 ```
-Agent Scope = scope-a
+Agent Org = org-a
   → Agent compose definition
   → Volumes
 
-Runtime Scope = scope-b, userId = User B
+Runtime Org = org-b, userId = User B
   → User B's secrets, variables, connectors, model providers
   → User B's artifacts and memories
 ```
 
-This pattern is also used by **scheduled runs**. A schedule carries its own `(scopeId, userId)` pair, which becomes the Runtime Scope when the schedule fires. This allows User B to schedule User A's agent while using User B's own credentials and producing User B's own artifacts.
+This pattern is also used by **scheduled runs**. A schedule carries its own `(clerkOrgId, userId)` pair, which becomes the Runtime Org when the schedule fires. This allows User B to schedule User A's agent while using User B's own credentials and producing User B's own artifacts.


### PR DESCRIPTION
## Summary
- Rename all "Scope" terminology to "Org" in `docs/resource-model.md` to align with the Clerk Organization migration (#4146)
- Update identifiers: `scopeId` → `clerkOrgId`, `scope-a/b` → `org-a/b`
- Clarify that Clerk is the single source of truth for org identity, membership, and metadata (no longer "backed by" Clerk)

## Test plan
- [ ] Verify markdown renders correctly and all internal links work

🤖 Generated with [Claude Code](https://claude.com/claude-code)