### PR TITLE
refactor(cli): replace process.exit with throw in scope and onboard commands

### DIFF
--- a/turbo/apps/cli/src/commands/onboard/index.ts
+++ b/turbo/apps/cli/src/commands/onboard/index.ts
@@ -51,9 +51,9 @@ async function handleAuthentication(ctx: OnboardContext): Promise<void> {
     }
 
     if (!ctx.interactive) {
-      console.error(chalk.red("✗ Not authenticated"));
-      console.error("Run 'vm0 auth login' first or set VM0_TOKEN");
-      process.exit(1);
+      throw new Error("Not authenticated", {
+        cause: new Error("Run 'vm0 auth login' first or set VM0_TOKEN"),
+      });
     }
 
     await runAuthFlow({
@@ -72,11 +72,7 @@ async function handleAuthentication(ctx: OnboardContext): Promise<void> {
         // Will be shown as completed step
       },
       onError: (error) => {
-        console.error(chalk.red(`\n✗ ${error.message}`));
-        if (error.cause instanceof Error) {
-          console.error(chalk.dim(`  Cause: ${error.cause.message}`));
-        }
-        process.exit(1);
+        throw error;
       },
     });
   });
@@ -90,9 +86,9 @@ async function handleModelProvider(ctx: OnboardContext): Promise<void> {
     }
 
     if (!ctx.interactive) {
-      console.error(chalk.red("✗ No model provider configured"));
-      console.error("Run 'vm0 model-provider setup' first");
-      process.exit(1);
+      throw new Error("No model provider configured", {
+        cause: new Error("Run 'vm0 model-provider setup' first"),
+      });
     }
 
     const choices = getProviderChoices();
@@ -217,20 +213,17 @@ async function handleAgentCreation(ctx: OnboardContext): Promise<string> {
     } else {
       // Non-interactive mode: validate and fail if exists
       if (!validateAgentName(agentName)) {
-        console.error(
-          chalk.red(
-            "Invalid agent name: must be 3-64 chars, alphanumeric + hyphens",
-          ),
+        throw new Error(
+          "Invalid agent name: must be 3-64 chars, alphanumeric + hyphens",
         );
-        process.exit(1);
       }
 
       if (existsSync(agentName)) {
-        console.error(chalk.red(`✗ ${agentName}/ already exists`));
-        console.error();
-        console.error("Remove it first or choose a different name:");
-        console.error(chalk.cyan(`  rm -rf ${agentName}`));
-        process.exit(1);
+        throw new Error(`${agentName}/ already exists`, {
+          cause: new Error(
+            `Remove it first or choose a different name: rm -rf ${agentName}`,
+          ),
+        });
       }
     }
 

--- a/turbo/apps/cli/src/commands/scope/use.ts
+++ b/turbo/apps/cli/src/commands/scope/use.ts
@@ -19,22 +19,16 @@ export const useCommand = new Command()
         }
 
         if (!slug) {
-          console.error(
-            chalk.red(
-              "✗ Scope slug is required. Use --personal to switch to default scope.",
-            ),
+          throw new Error(
+            "Scope slug is required. Use --personal to switch to default scope.",
           );
-          process.exit(1);
         }
 
         // Verify the scope exists and user has access
         const scopeList = await listScopes();
         const target = scopeList.scopes.find((s) => s.slug === slug);
         if (!target) {
-          console.error(
-            chalk.red(`✗ Scope '${slug}' not found or not accessible.`),
-          );
-          process.exit(1);
+          throw new Error(`Scope '${slug}' not found or not accessible.`);
         }
 
         await saveConfig({ activeScope: slug });


### PR DESCRIPTION
## Summary
- Replace `console.error(chalk.red(...)) + process.exit(1)` with `throw new Error(...)` in `scope/use.ts` and `onboard/index.ts`
- Both files already use `withErrorHandler`, so thrown errors are caught and formatted consistently
- 7 replacements total: 2 in scope/use.ts, 5 in onboard/index.ts
- `process.exit(0)` calls (user cancellation) are left unchanged as they are not error paths

Closes #4155 (partial)

## Test plan
- [x] All 50 existing scope + onboard tests pass without changes
- [x] Type check passes
- [x] Lint passes
- [x] Knip passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)