### PR TITLE
refactor(cli): replace process.exit with throw in secret and variable commands

### DIFF
--- a/turbo/apps/cli/src/commands/secret/delete.ts
+++ b/turbo/apps/cli/src/commands/secret/delete.ts
@@ -21,8 +21,7 @@ export const deleteCommand = new Command()
           error instanceof Error &&
           error.message.toLowerCase().includes("not found")
         ) {
-          console.error(chalk.red(`✗ Secret "${name}" not found`));
-          process.exit(1);
+          throw new Error(`Secret "${name}" not found`);
         }
         throw error;
       }
@@ -30,10 +29,7 @@ export const deleteCommand = new Command()
       // Confirm deletion unless --yes is passed
       if (!options.yes) {
         if (!isInteractive()) {
-          console.error(
-            chalk.red("✗ --yes flag is required in non-interactive mode"),
-          );
-          process.exit(1);
+          throw new Error("--yes flag is required in non-interactive mode");
         }
 
         const confirmed = await promptConfirm(

--- a/turbo/apps/cli/src/commands/secret/set.ts
+++ b/turbo/apps/cli/src/commands/secret/set.ts
@@ -32,15 +32,11 @@ export const setCommand = new Command()
           }
           value = prompted;
         } else {
-          console.error(
-            chalk.red("✗ --body is required in non-interactive mode"),
-          );
-          console.error();
-          console.error("Usage:");
-          console.error(
-            chalk.cyan(`  vm0 secret set ${name} --body "your-secret-value"`),
-          );
-          process.exit(1);
+          throw new Error("--body is required in non-interactive mode", {
+            cause: new Error(
+              `Usage: vm0 secret set ${name} --body "your-secret-value"`,
+            ),
+          });
         }
 
         let secret;
@@ -56,13 +52,11 @@ export const setCommand = new Command()
             error instanceof Error &&
             error.message.includes("must contain only uppercase")
           ) {
-            console.error(chalk.red(`✗ ${error.message}`));
-            console.error();
-            console.error("Examples of valid secret names:");
-            console.error(chalk.dim("  MY_API_KEY"));
-            console.error(chalk.dim("  GITHUB_TOKEN"));
-            console.error(chalk.dim("  AWS_ACCESS_KEY_ID"));
-            process.exit(1);
+            throw new Error(error.message, {
+              cause: new Error(
+                "Examples of valid secret names: MY_API_KEY, GITHUB_TOKEN, AWS_ACCESS_KEY_ID",
+              ),
+            });
           }
           throw error;
         }

--- a/turbo/apps/cli/src/commands/variable/delete.ts
+++ b/turbo/apps/cli/src/commands/variable/delete.ts
@@ -21,8 +21,7 @@ export const deleteCommand = new Command()
           error instanceof Error &&
           error.message.toLowerCase().includes("not found")
         ) {
-          console.error(chalk.red(`✗ Variable "${name}" not found`));
-          process.exit(1);
+          throw new Error(`Variable "${name}" not found`);
         }
         throw error;
       }
@@ -30,10 +29,7 @@ export const deleteCommand = new Command()
       // Confirm deletion unless --yes is passed
       if (!options.yes) {
         if (!isInteractive()) {
-          console.error(
-            chalk.red("✗ --yes flag is required in non-interactive mode"),
-          );
-          process.exit(1);
+          throw new Error("--yes flag is required in non-interactive mode");
         }
 
         const confirmed = await promptConfirm(

--- a/turbo/apps/cli/src/commands/variable/set.ts
+++ b/turbo/apps/cli/src/commands/variable/set.ts
@@ -29,13 +29,11 @@ export const setCommand = new Command()
             error instanceof Error &&
             error.message.includes("must contain only uppercase")
           ) {
-            console.error(chalk.red(`✗ ${error.message}`));
-            console.error();
-            console.error("Examples of valid variable names:");
-            console.error(chalk.dim("  MY_VAR"));
-            console.error(chalk.dim("  API_URL"));
-            console.error(chalk.dim("  DEBUG_MODE"));
-            process.exit(1);
+            throw new Error(error.message, {
+              cause: new Error(
+                "Examples of valid variable names: MY_VAR, API_URL, DEBUG_MODE",
+              ),
+            });
           }
           throw error;
         }


### PR DESCRIPTION
## Summary
- Replace `console.error(chalk.red(...)) + process.exit(1)` with `throw new Error(...)` in secret and variable commands
- All files already use `withErrorHandler`, so thrown errors are caught and formatted consistently
- 7 replacements across 4 files: secret/delete.ts (2), secret/set.ts (2), variable/delete.ts (2), variable/set.ts (1)

Closes #4155 (partial)

## Test plan
- [x] All 34 existing secret + variable tests pass without changes
- [x] Type check passes
- [x] Lint passes
- [x] Knip passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)