### PR TITLE
fix: prevent zero meet skills list flash and spurious auth reloads

### DIFF
--- a/turbo/apps/platform/src/__tests__/mock-auth.ts
+++ b/turbo/apps/platform/src/__tests__/mock-auth.ts
@@ -58,7 +58,10 @@ export function clearMockedAuth() {
   internalMockedOrganization = null;
   internalMockedInvitations = [];
   internalMockedMemberships = [{ id: "org_default" }];
+  clerkListeners.length = 0;
 }
+
+const clerkListeners: (() => void)[] = [];
 
 export const mockedClerk = {
   get user() {
@@ -73,6 +76,21 @@ export const mockedClerk = {
     };
   },
   load: () => Promise.resolve(),
-  addListener: () => () => {},
+  addListener: (cb: () => void) => {
+    clerkListeners.push(cb);
+    return () => {
+      const idx = clerkListeners.indexOf(cb);
+      if (idx !== -1) {
+        clerkListeners.splice(idx, 1);
+      }
+    };
+  },
   redirectToSignIn: vi.fn(),
 };
+
+/** Fire all registered Clerk listeners (simulates token refresh / auth change). */
+export function fireClerkListeners() {
+  for (const cb of clerkListeners) {
+    cb();
+  }
+}

--- a/turbo/apps/platform/src/signals/__tests__/auth.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/auth.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import { testContext } from "./test-helpers";
+import { setupPage } from "../../__tests__/page-helper";
+import { fireClerkListeners, mockUser } from "../../__tests__/mock-auth";
+import { setupClerk$, user$ } from "../auth";
+
+const context = testContext();
+
+describe("setupClerk$ auth reload filtering", () => {
+  it("should not trigger user$ recomputation on token refresh (same user)", async () => {
+    const { store, signal } = context;
+
+    await setupPage({ context, path: "/", withoutRender: true });
+    await store.set(setupClerk$, signal);
+
+    const userBefore = await store.get(user$);
+    expect(userBefore?.id).toBe("test-user-123");
+
+    // Simulate a Clerk token refresh — user stays the same
+    fireClerkListeners();
+
+    const userAfter = await store.get(user$);
+    expect(userAfter?.id).toBe("test-user-123");
+  });
+
+  it("should update user$ when user signs out", async () => {
+    const { store, signal } = context;
+
+    await setupPage({ context, path: "/", withoutRender: true });
+    await store.set(setupClerk$, signal);
+
+    const userBefore = await store.get(user$);
+    expect(userBefore?.id).toBe("test-user-123");
+
+    // Simulate sign-out: clear the mocked user, then fire listeners
+    mockUser(null, null);
+    fireClerkListeners();
+
+    const userAfter = await store.get(user$);
+    expect(userAfter).toBeUndefined();
+  });
+});

--- a/turbo/apps/platform/src/signals/auth.ts
+++ b/turbo/apps/platform/src/signals/auth.ts
@@ -58,6 +58,10 @@ export const setupClerk$ = command(
       setSentryUser(clerk.user.id);
     }
 
+    // Track the user ID so we only trigger a reload on actual auth state
+    // changes (sign-in / sign-out), not on token refreshes which fire the
+    // Clerk listener but don't change the user.
+    let prevUserId = clerk.user?.id ?? null;
     const unsubscribe = clerk.addListener(() => {
       // Update Sentry user context on auth state change
       if (clerk.user) {
@@ -65,7 +69,11 @@ export const setupClerk$ = command(
       } else {
         clearSentryUser();
       }
-      set(reload$, (x) => x + 1);
+      const currentUserId = clerk.user?.id ?? null;
+      if (currentUserId !== prevUserId) {
+        prevUserId = currentUserId;
+        set(reload$, (x) => x + 1);
+      }
     });
     signal.addEventListener("abort", unsubscribe);
   },

--- a/turbo/apps/platform/src/signals/settings-page/__tests__/connectors.test.ts
+++ b/turbo/apps/platform/src/signals/settings-page/__tests__/connectors.test.ts
@@ -6,6 +6,9 @@ import {
   openDisconnectDialog$,
   confirmDisconnect$,
   disconnectDialogState$,
+  justConnectedTypes$,
+  clearJustConnectedTypes$,
+  submitApiToken$,
 } from "../connectors";
 import { server } from "../../../mocks/server";
 import { http, HttpResponse } from "msw";
@@ -334,5 +337,70 @@ describe("disconnect dialog", () => {
     await store.set(openDisconnectDialog$, "github");
 
     await expect(store.set(confirmDisconnect$, signal)).rejects.toThrow();
+  });
+});
+
+describe("optimistic connected state", () => {
+  it("should mark type as optimistically connected after api token submit", async () => {
+    const { store, signal } = context;
+
+    server.use(
+      http.put("/api/secrets", () => {
+        return HttpResponse.json({ success: true });
+      }),
+      http.get("/api/connectors", () => {
+        return HttpResponse.json({
+          connectors: [],
+          configuredTypes: Object.keys(CONNECTOR_TYPES) as ConnectorType[],
+        });
+      }),
+    );
+
+    await setupPage({ context, path: "/", withoutRender: true });
+
+    await store.set(
+      submitApiToken$,
+      "serpapi" as ConnectorType,
+      { SERPAPI_API_KEY: "test-key" },
+      signal,
+    );
+
+    const optimistic = await store.get(justConnectedTypes$);
+    expect(optimistic.has("serpapi")).toBeTruthy();
+  });
+
+  it("should clear optimistic state via clearJustConnectedTypes$", async () => {
+    const { store, signal } = context;
+
+    server.use(
+      http.put("/api/secrets", () => {
+        return HttpResponse.json({ success: true });
+      }),
+      http.get("/api/connectors", () => {
+        return HttpResponse.json({
+          connectors: [],
+          configuredTypes: Object.keys(CONNECTOR_TYPES) as ConnectorType[],
+        });
+      }),
+    );
+
+    await setupPage({ context, path: "/", withoutRender: true });
+
+    await store.set(
+      submitApiToken$,
+      "serpapi" as ConnectorType,
+      { SERPAPI_API_KEY: "test-key" },
+      signal,
+    );
+
+    // Verify it's set
+    const before = await store.get(justConnectedTypes$);
+    expect(before.has("serpapi")).toBeTruthy();
+
+    // Clear it
+    store.set(clearJustConnectedTypes$);
+
+    const after = await store.get(justConnectedTypes$);
+    expect(after.size).toBe(0);
   });
 });

--- a/turbo/apps/platform/src/signals/settings-page/connectors.ts
+++ b/turbo/apps/platform/src/signals/settings-page/connectors.ts
@@ -289,6 +289,7 @@ export const submitApiToken$ = command(
       }
     }
     signal.throwIfAborted();
+    set(internalJustConnectedTypes$, (prev) => new Set([...prev, type]));
     set(reloadConnectors$);
     // Show in connections list
     const hidden = new Set(get(hiddenConnectorTypes$));
@@ -307,6 +308,22 @@ const internalPollingType$ = state<ConnectorType | null>(null);
 export const pollingConnectorType$ = computed((get) =>
   get(internalPollingType$),
 );
+
+// ---------------------------------------------------------------------------
+// Optimistic connected state — bridges the gap between connect success and
+// allConnectorTypes$ recomputation so the UI doesn't flash.
+// ---------------------------------------------------------------------------
+
+const internalJustConnectedTypes$ = state<Set<string>>(new Set());
+
+/** Types that were just connected but may not yet be reflected in allConnectorTypes$. */
+export const justConnectedTypes$ = computed((get) =>
+  get(internalJustConnectedTypes$),
+);
+
+export const clearJustConnectedTypes$ = command(({ set }) => {
+  set(internalJustConnectedTypes$, new Set());
+});
 
 // ---------------------------------------------------------------------------
 // Connect command
@@ -339,13 +356,18 @@ export const connectConnector$ = command(
       const { connectors: freshConnectors } = await get(connectors$);
       signal.throwIfAborted();
 
+      // Mark as optimistically connected before clearing polling so the UI
+      // transitions directly from "Connecting…" to "Connected" without flash.
+      const isConnected = freshConnectors.some((c) => c.type === type);
+      if (isConnected) {
+        set(internalJustConnectedTypes$, (prev) => new Set([...prev, type]));
+      }
       set(internalPollingType$, null);
       // Show in connections list again when user connects
       const hidden = new Set(get(hiddenConnectorTypes$));
       hidden.delete(type);
       set(setHiddenConnectorTypes$, JSON.stringify([...hidden]));
       // Close connect modal on OAuth success
-      const isConnected = freshConnectors.some((c) => c.type === type);
       if (isConnected) {
         set(internalSelectedConnectorType$, null);
       }

--- a/turbo/apps/platform/src/views/zero-page/zero-meet-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-meet-page.tsx
@@ -1,6 +1,5 @@
 import { useCCState, useCommand } from "ccstate-react/experimental";
-import { useGet, useSet, useLoadable } from "ccstate-react";
-import { useRef } from "react";
+import { useGet, useSet, useLoadable, useLastLoadable } from "ccstate-react";
 import { createPortal } from "react-dom";
 import {
   IconMessageCircle,
@@ -239,7 +238,7 @@ function ZeroSkillItem({
 // ---------------------------------------------------------------------------
 
 function ZeroSkillsTab() {
-  const allTypesLoadable = useLoadable(allConnectorTypes$);
+  const allTypesLoadable = useLastLoadable(allConnectorTypes$);
   const pollingType = useGet(pollingConnectorType$);
   const connect = useSet(connectConnector$);
   const disconnect = useSet(deleteConnector$);
@@ -250,12 +249,9 @@ function ZeroSkillsTab() {
   const setSelected = useSet(setSelectedConnectorType$);
 
   // Skills list: auto-seeded from compose content, synced via compose jobs
-  const addedSkillsLoadable = useLoadable(zeroAddedSkills$);
-  const addedSkillsRef = useRef<string[]>([]);
-  if (addedSkillsLoadable.state === "hasData") {
-    addedSkillsRef.current = addedSkillsLoadable.data;
-  }
-  const addedSkills = addedSkillsRef.current;
+  const addedSkillsLoadable = useLastLoadable(zeroAddedSkills$);
+  const addedSkills =
+    addedSkillsLoadable.state === "hasData" ? addedSkillsLoadable.data : [];
   const allSkills = useGet(skills$);
   const addSkill = useSet(addZeroSkill$);
   const removeSkill = useSet(removeZeroSkill$);
@@ -266,15 +262,12 @@ function ZeroSkillsTab() {
   const clearOptimistic = useSet(clearJustConnectedTypes$);
 
   // Cache previous connector data so the list doesn't flash during refetch
-  const allConnectorsRef = useRef<ConnectorTypeWithStatus[]>([]);
-  if (allTypesLoadable.state === "hasData") {
-    allConnectorsRef.current = allTypesLoadable.data;
-    // Clear optimistic state once real data reflects the connection
-    if (optimisticConnected.size > 0) {
-      clearOptimistic();
-    }
+  const allConnectors =
+    allTypesLoadable.state === "hasData" ? allTypesLoadable.data : [];
+  // Clear optimistic state once real data reflects the connection
+  if (allTypesLoadable.state === "hasData" && optimisticConnected.size > 0) {
+    clearOptimistic();
   }
-  const allConnectors = allConnectorsRef.current;
   const connectorMap = new Map(allConnectors.map((c) => [c.type, c]));
   const skillMap = new Map(allSkills.map((s) => [s.value, s]));
   const addedSet = new Set(addedSkills);

--- a/turbo/apps/platform/src/views/zero-page/zero-meet-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-meet-page.tsx
@@ -264,7 +264,9 @@ function ZeroSkillsTab() {
   // Cache previous connector data so the list doesn't flash during refetch
   const allConnectors =
     allTypesLoadable.state === "hasData" ? allTypesLoadable.data : [];
-  // Clear optimistic state once real data reflects the connection
+  // Clear optimistic state once real data reflects the connection.
+  // This is a safe render-body side effect: after clearing, optimisticConnected
+  // becomes empty so the condition won't fire again (self-limiting, no loop).
   if (allTypesLoadable.state === "hasData" && optimisticConnected.size > 0) {
     clearOptimistic();
   }
@@ -368,7 +370,11 @@ function ZeroSkillsTab() {
                   pollingType={pollingType}
                   onConnect={() => {
                     const ct = connectorMap.get(name as ConnectorType);
-                    if (ct && ct.availableAuthMethods.includes("api-token")) {
+                    if (
+                      ct &&
+                      ct.availableAuthMethods.length === 1 &&
+                      ct.availableAuthMethods[0] === "api-token"
+                    ) {
                       setSelected(name as ConnectorType);
                     } else {
                       detach(

--- a/turbo/apps/platform/src/views/zero-page/zero-meet-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-meet-page.tsx
@@ -1,5 +1,6 @@
 import { useCCState, useCommand } from "ccstate-react/experimental";
 import { useGet, useSet, useLoadable } from "ccstate-react";
+import { useRef } from "react";
 import { createPortal } from "react-dom";
 import {
   IconMessageCircle,
@@ -41,6 +42,8 @@ import {
   selectedConnectorType$,
   setSelectedConnectorType$,
   pollingConnectorType$,
+  justConnectedTypes$,
+  clearJustConnectedTypes$,
 } from "../../signals/settings-page/connectors.ts";
 import { deleteConnector$ } from "../../signals/external/connectors.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
@@ -153,7 +156,9 @@ function ZeroSkillItem({
             <span className="text-xs text-muted-foreground shrink-0">
               {connector.connector?.externalUsername
                 ? `Connected as @${connector.connector.externalUsername}`
-                : "Connected"}
+                : connector.connector?.authMethod === "api-token"
+                  ? "Connected via API key"
+                  : "Connected"}
             </span>
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
@@ -184,7 +189,10 @@ function ZeroSkillItem({
               className="h-8 rounded-lg px-3 zero-btn-morandi border"
               onClick={onConnect}
             >
-              Connect
+              {connector.availableAuthMethods.length === 1 &&
+              connector.availableAuthMethods[0] === "api-token"
+                ? "Add API key"
+                : "Connect"}
             </Button>
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
@@ -243,14 +251,30 @@ function ZeroSkillsTab() {
 
   // Skills list: auto-seeded from compose content, synced via compose jobs
   const addedSkillsLoadable = useLoadable(zeroAddedSkills$);
-  const addedSkills =
-    addedSkillsLoadable.state === "hasData" ? addedSkillsLoadable.data : [];
+  const addedSkillsRef = useRef<string[]>([]);
+  if (addedSkillsLoadable.state === "hasData") {
+    addedSkillsRef.current = addedSkillsLoadable.data;
+  }
+  const addedSkills = addedSkillsRef.current;
   const allSkills = useGet(skills$);
   const addSkill = useSet(addZeroSkill$);
   const removeSkill = useSet(removeZeroSkill$);
 
-  const allConnectors =
-    allTypesLoadable.state === "hasData" ? allTypesLoadable.data : [];
+  // Optimistic connected state — set by connectConnector$/submitApiToken$
+  // so the skill shows "Connected" immediately without waiting for refetch.
+  const optimisticConnected = useGet(justConnectedTypes$);
+  const clearOptimistic = useSet(clearJustConnectedTypes$);
+
+  // Cache previous connector data so the list doesn't flash during refetch
+  const allConnectorsRef = useRef<ConnectorTypeWithStatus[]>([]);
+  if (allTypesLoadable.state === "hasData") {
+    allConnectorsRef.current = allTypesLoadable.data;
+    // Clear optimistic state once real data reflects the connection
+    if (optimisticConnected.size > 0) {
+      clearOptimistic();
+    }
+  }
+  const allConnectors = allConnectorsRef.current;
   const connectorMap = new Map(allConnectors.map((c) => [c.type, c]));
   const skillMap = new Map(allSkills.map((s) => [s.value, s]));
   const addedSet = new Set(addedSkills);
@@ -295,7 +319,7 @@ function ZeroSkillsTab() {
         </Button>
       </div>
 
-      {addedSkillsLoadable.state !== "hasData" ? (
+      {addedSkillsLoadable.state !== "hasData" && addedSkills.length === 0 ? (
         <Card className="zero-card">
           <CardContent className="p-0">
             {Array.from({ length: 3 }, (_, i) => (
@@ -334,20 +358,32 @@ function ZeroSkillsTab() {
           <CardContent className="p-0">
             {addedSkills.map((name, index) => {
               const skill = skillMap.get(name);
+              const connector = connectorMap.get(name as ConnectorType) ?? null;
+              const effectiveConnector =
+                optimisticConnected.has(name) &&
+                connector &&
+                !connector.connected
+                  ? { ...connector, connected: true }
+                  : connector;
               return (
                 <ZeroSkillItem
                   key={name}
                   name={name}
                   label={skill?.label ?? name}
                   iconUrl={skill?.icon}
-                  connector={connectorMap.get(name as ConnectorType) ?? null}
+                  connector={effectiveConnector}
                   pollingType={pollingType}
-                  onConnect={() =>
-                    detach(
-                      connect(name as ConnectorType, signal),
-                      Reason.DomCallback,
-                    )
-                  }
+                  onConnect={() => {
+                    const ct = connectorMap.get(name as ConnectorType);
+                    if (ct && ct.availableAuthMethods.includes("api-token")) {
+                      setSelected(name as ConnectorType);
+                    } else {
+                      detach(
+                        connect(name as ConnectorType, signal),
+                        Reason.DomCallback,
+                      );
+                    }
+                  }}
                   onDisconnect={() =>
                     detach(
                       disconnect(name as ConnectorType),


### PR DESCRIPTION
## Summary
- **Auth reload fix**: Stop Clerk listener from triggering `reload$` on token refreshes — only reload on actual sign-in/sign-out (user ID change), preventing unnecessary data refetches
- **Optimistic connected state**: Add `justConnectedTypes$` signal so the skills list transitions directly from "Connecting..." to "Connected" without flashing back to the disconnected state during refetch
- **Cached loadable data**: Use refs to cache previous `addedSkills` and `allConnectors` so the list stays visible during refetch cycles instead of showing skeleton loaders
- **API-key connector labels**: Show "Add API key" button and "Connected via API key" status for API-token-only connectors; route their connect action through the settings dialog

## Test plan
- [ ] Sign in to platform, verify page does not re-fetch data on Clerk token refresh
- [ ] Connect an OAuth skill (e.g. GitHub), verify it shows "Connected" immediately without flash
- [ ] Connect an API-key skill (e.g. Cloudflare), verify button says "Add API key" and status shows "Connected via API key"
- [ ] Navigate away and back to Meet settings, verify skills list doesn't flash skeleton loaders

🤖 Generated with [Claude Code](https://claude.com/claude-code)