### PR TITLE
refactor(cli): replace process.exit with throw in usage and dev-tool commands

### DIFF
--- a/turbo/apps/cli/src/commands/dev-tool/set-tier.ts
+++ b/turbo/apps/cli/src/commands/dev-tool/set-tier.ts
@@ -11,10 +11,9 @@ export const setTierCommand = new Command()
   .action(
     withErrorHandler(async (slug: string, tier: string) => {
       if (tier !== "free" && tier !== "pro" && tier !== "max") {
-        console.error(
-          chalk.red(`Invalid tier: ${tier}. Must be "free", "pro", or "max"`),
+        throw new Error(
+          `Invalid tier: ${tier}. Must be "free", "pro", or "max"`,
         );
-        process.exit(1);
       }
 
       const response = await httpPut("/api/admin/scope/tier", { slug, tier });

--- a/turbo/apps/cli/src/commands/usage/index.ts
+++ b/turbo/apps/cli/src/commands/usage/index.ts
@@ -112,12 +112,9 @@ export const usageCommand = new Command()
           const untilMs = parseTime(options.until);
           endDate = new Date(untilMs);
         } catch {
-          console.error(
-            chalk.red(
-              "✗ Invalid --until format. Use ISO (2026-01-01) or relative (7d, 30d)",
-            ),
+          throw new Error(
+            "Invalid --until format. Use ISO (2026-01-01) or relative (7d, 30d)",
           );
-          process.exit(1);
         }
       } else {
         endDate = now;
@@ -128,12 +125,9 @@ export const usageCommand = new Command()
           const sinceMs = parseTime(options.since);
           startDate = new Date(sinceMs);
         } catch {
-          console.error(
-            chalk.red(
-              "✗ Invalid --since format. Use ISO (2026-01-01) or relative (7d, 30d)",
-            ),
+          throw new Error(
+            "Invalid --since format. Use ISO (2026-01-01) or relative (7d, 30d)",
           );
-          process.exit(1);
         }
       } else {
         startDate = new Date(endDate.getTime() - DEFAULT_RANGE_MS);
@@ -141,18 +135,14 @@ export const usageCommand = new Command()
 
       // Validate date range
       if (startDate >= endDate) {
-        console.error(chalk.red("✗ --since must be before --until"));
-        process.exit(1);
+        throw new Error("--since must be before --until");
       }
 
       const rangeMs = endDate.getTime() - startDate.getTime();
       if (rangeMs > MAX_RANGE_MS) {
-        console.error(
-          chalk.red(
-            "✗ Time range exceeds maximum of 30 days. Use --until to specify an end date",
-          ),
+        throw new Error(
+          "Time range exceeds maximum of 30 days. Use --until to specify an end date",
         );
-        process.exit(1);
       }
 
       // Fetch usage data


### PR DESCRIPTION
## Summary
- Replace `console.error(chalk.red(...)) + process.exit(1)` with `throw new Error(...)` in `usage/index.ts` and `dev-tool/set-tier.ts`
- Both files already use `withErrorHandler`, so thrown errors are caught and formatted consistently
- 5 replacements across 2 files: usage/index.ts (4), dev-tool/set-tier.ts (1)

Closes #4155 (partial)

## Test plan
- [x] All 31 existing usage tests pass without changes
- [x] Type check passes
- [x] Lint passes
- [x] Knip passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)