### PR TITLE
refactor: rename skill references from dev.to/fal.ai to devto/fal

### DIFF
--- a/turbo/apps/docs/content/docs/agent-skills/devto.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/devto.mdx
@@ -20,7 +20,7 @@ agents:
   my-agent:
     framework: claude-code
     skills:
-      - https://github.com/vm0-ai/vm0-skills/tree/main/dev.to # [!code highlight]
+      - https://github.com/vm0-ai/vm0-skills/tree/main/devto # [!code highlight]
 ```
 
 ## Run

--- a/turbo/apps/docs/content/docs/agent-skills/fal-ai.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/fal-ai.mdx
@@ -20,7 +20,7 @@ agents:
   my-agent:
     framework: claude-code
     skills:
-      - https://github.com/vm0-ai/vm0-skills/tree/main/fal.ai # [!code highlight]
+      - https://github.com/vm0-ai/vm0-skills/tree/main/fal # [!code highlight]
 ```
 
 ## Run

--- a/turbo/apps/platform/src/data/skills.ts
+++ b/turbo/apps/platform/src/data/skills.ts
@@ -30,7 +30,7 @@ function s(value: string, label: string, icon: string): ComboboxOption {
 function aiMediaSkills(): ComboboxOption[] {
   return [
     s("elevenlabs", "elevenlabs", "https://vm0.ai/skills/elevenlabs.svg"),
-    s("fal.ai", "fal.ai", "https://vm0.ai/skills/fal-image.svg"),
+    s("fal", "fal", "https://vm0.ai/skills/fal-image.svg"),
     s(
       "htmlcsstoimage",
       "htmlcsstoimage",
@@ -114,7 +114,7 @@ function developmentSkills(): ComboboxOption[] {
       "https://cdn.simpleicons.org/anthropic",
     ),
     s("deepseek", "deepseek", "https://vm0.ai/skills/deepseek.svg"),
-    s("dev.to", "dev.to", "https://cdn.simpleicons.org/devdotto"),
+    s("devto", "devto", "https://cdn.simpleicons.org/devdotto"),
     s("github", "github", "https://vm0.ai/skills/github.svg"),
     s(
       "github-copilot",

--- a/turbo/apps/web/app/api/web/skills/route.ts
+++ b/turbo/apps/web/app/api/web/skills/route.ts
@@ -198,7 +198,7 @@ const SKILL_CATEGORIES: Record<
     description:
       "Advanced AI coding assistant with code generation and technical problem-solving",
   },
-  "dev.to": {
+  devto: {
     category: "Development",
     logo: "/skills/devdotto.svg",
     description:
@@ -238,7 +238,7 @@ const SKILL_CATEGORIES: Record<
     description:
       "Generate natural-sounding speech with advanced AI voice synthesis and cloning",
   },
-  "fal.ai": {
+  fal: {
     category: "AI & Media",
     logo: "/skills/fal-image.svg",
     description:
@@ -681,8 +681,7 @@ const SKILLS_WITH_DOCS = new Set([
 
 // Map repo directory names to doc page slugs where they differ
 const SKILL_DOC_SLUG_MAP: Record<string, string> = {
-  "dev.to": "devto",
-  "fal.ai": "fal-ai",
+  fal: "fal-ai",
 };
 
 // Get documentation URL for a skill

--- a/turbo/apps/web/app/components/LandingPage.tsx
+++ b/turbo/apps/web/app/components/LandingPage.tsx
@@ -1420,14 +1420,14 @@ function RunEditorContent({
           {"      "}
           <span className="text-[#827d77]">-</span>{" "}
           <span className="text-[#06b6d4]">
-            https://github.com/vm0-ai/vm0-skills/tree/main/fal.ai
+            https://github.com/vm0-ai/vm0-skills/tree/main/fal
           </span>
         </p>
         <p className="m-0">
           {"      "}
           <span className="text-[#827d77]">-</span>{" "}
           <span className="text-[#06b6d4]">
-            https://github.com/vm0-ai/vm0-skills/tree/main/dev.to
+            https://github.com/vm0-ai/vm0-skills/tree/main/devto
           </span>
         </p>
       </div>


### PR DESCRIPTION
## Summary
- Rename skill references to match connector type schema exactly: `dev.to` → `devto`, `fal.ai` → `fal`
- Updated skills combobox, SKILL_CATEGORIES, SKILL_DOC_SLUG_MAP, and LandingPage GitHub URLs
- Corresponding vm0-skills repo directories already renamed (vm0-ai/vm0-skills@8c0a36f)

## Test plan
- [ ] Verify skills combobox displays correctly on platform
- [ ] Verify `/api/web/skills` endpoint returns correct metadata for `devto` and `fal`
- [ ] Verify LandingPage skill URLs resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)