### PR TITLE
refactor: remove unused default flag from agent compose response

### DIFF
--- a/turbo/apps/web/app/api/agent/composes/[id]/route.ts
+++ b/turbo/apps/web/app/api/agent/composes/[id]/route.ts
@@ -10,7 +10,6 @@ import {
   agentComposes,
   agentComposeVersions,
 } from "../../../../../src/db/schema/agent-compose";
-import { scopes } from "../../../../../src/db/schema/scope";
 import { storages } from "../../../../../src/db/schema/storage";
 import { agentRuns } from "../../../../../src/db/schema/agent-run";
 import { getUserId } from "../../../../../src/lib/auth/get-user-id";
@@ -36,7 +35,7 @@ const router = tsr.router(composesByIdContract, {
       };
     }
 
-    // JOIN compose + version + scope in a single query
+    // JOIN compose + version in a single query
     const [result] = await globalThis.services.db
       .select({
         id: agentComposes.id,
@@ -47,14 +46,12 @@ const router = tsr.router(composesByIdContract, {
         createdAt: agentComposes.createdAt,
         updatedAt: agentComposes.updatedAt,
         content: agentComposeVersions.content,
-        defaultAgentComposeId: scopes.defaultAgentComposeId,
       })
       .from(agentComposes)
       .leftJoin(
         agentComposeVersions,
         eq(agentComposes.headVersionId, agentComposeVersions.id),
       )
-      .leftJoin(scopes, eq(agentComposes.clerkOrgId, scopes.clerkOrgId))
       .where(eq(agentComposes.id, params.id))
       .limit(1);
 
@@ -86,7 +83,6 @@ const router = tsr.router(composesByIdContract, {
         name: result.name,
         headVersionId: result.headVersionId,
         content: (result.content as AgentComposeYaml) ?? null,
-        isDefault: result.id === result.defaultAgentComposeId,
         createdAt: result.createdAt.toISOString(),
         updatedAt: result.updatedAt.toISOString(),
       },

--- a/turbo/apps/web/app/api/agent/composes/list/route.ts
+++ b/turbo/apps/web/app/api/agent/composes/list/route.ts
@@ -26,7 +26,6 @@ const router = tsr.router(composesListContract, {
 
     // Resolve scope: use ?scope= query param or default scope
     let clerkOrgId: string;
-    let defaultAgentComposeId: string | null = null;
     try {
       const { scope: resolvedScope } = await resolveScope(
         userId,
@@ -35,7 +34,6 @@ const router = tsr.router(composesListContract, {
         tokenScopeId,
       );
       clerkOrgId = resolvedScope.clerkOrgId;
-      defaultAgentComposeId = resolvedScope.defaultAgentComposeId;
     } catch (error) {
       if (isNotFound(error)) {
         return {
@@ -92,14 +90,12 @@ const router = tsr.router(composesListContract, {
         headVersionId: c.headVersionId,
         updatedAt: c.updatedAt.toISOString(),
         isOwner: true,
-        isDefault: c.id === defaultAgentComposeId,
       })),
       ...sharedComposes.map((c) => ({
         name: `${c.scopeSlug}/${c.name}`,
         headVersionId: c.headVersionId,
         updatedAt: c.updatedAt.toISOString(),
         isOwner: false,
-        isDefault: false,
       })),
     ];
 

--- a/turbo/apps/web/app/api/agent/composes/route.ts
+++ b/turbo/apps/web/app/api/agent/composes/route.ts
@@ -51,7 +51,6 @@ const router = tsr.router(composesMainContract, {
     // which requires canAccessCompose authorization below.
     const isCrossScopeLookup = Boolean(query.scope || query.org);
     let clerkOrgId: string;
-    let defaultAgentComposeId: string | null = null;
     if (query.scope) {
       const scope = await getScopeBySlug(query.scope);
       if (!scope) {
@@ -66,7 +65,6 @@ const router = tsr.router(composesMainContract, {
         };
       }
       clerkOrgId = scope.clerkOrgId;
-      defaultAgentComposeId = scope.defaultAgentComposeId;
     } else if (query.org) {
       const scope = await getScopeByClerkOrgId(query.org);
       if (!scope) {
@@ -81,7 +79,6 @@ const router = tsr.router(composesMainContract, {
         };
       }
       clerkOrgId = scope.clerkOrgId;
-      defaultAgentComposeId = scope.defaultAgentComposeId;
     } else {
       const { scope: resolvedScope } = await resolveScope(
         userId,
@@ -90,7 +87,6 @@ const router = tsr.router(composesMainContract, {
         tokenScopeId,
       );
       clerkOrgId = resolvedScope.clerkOrgId;
-      defaultAgentComposeId = resolvedScope.defaultAgentComposeId;
     }
 
     // JOIN compose + version in a single query
@@ -154,7 +150,6 @@ const router = tsr.router(composesMainContract, {
         name: result.name,
         headVersionId: result.headVersionId,
         content: (result.content as AgentComposeYaml) ?? null,
-        isDefault: result.id === defaultAgentComposeId,
         createdAt: result.createdAt.toISOString(),
         updatedAt: result.updatedAt.toISOString(),
       },

--- a/turbo/packages/core/src/contracts/composes.ts
+++ b/turbo/packages/core/src/contracts/composes.ts
@@ -128,7 +128,6 @@ const composeResponseSchema = z.object({
   name: z.string(),
   headVersionId: z.string().nullable(),
   content: agentComposeContentSchema.nullable(),
-  isDefault: z.boolean(),
   createdAt: z.string(),
   updatedAt: z.string(),
 });
@@ -278,7 +277,6 @@ const composeListItemSchema = z.object({
   headVersionId: z.string().nullable(),
   updatedAt: z.string(),
   isOwner: z.boolean(),
-  isDefault: z.boolean(),
 });
 
 /**


### PR DESCRIPTION
## Summary
- Remove unused `isDefault` field from compose API responses (`getById`, `getByName`, `list`)
- Eliminate the `scopes` LEFT JOIN from `composes/[id]` route (existed solely for `defaultAgentComposeId`)
- Remove `isDefault` from `composeResponseSchema` and `composeListItemSchema` contracts

Closes #4337

## Test plan
- [x] All 92 compose-related tests pass
- [x] Lint, format, and knip checks pass
- [ ] Verify no consumers depend on `isDefault` in compose responses (confirmed: CLI and platform have no references)

🤖 Generated with [Claude Code](https://claude.com/claude-code)