### PR TITLE
fix(mitm-addon): stream all responses to prevent zlib error

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -119,8 +119,8 @@ jobs:
 
       - name: Run mitm-addon tests
         run: |
-          pip install pytest mitmproxy
           cd crates/runner/mitm-addon
+          pip install ".[test]"
           python -m pytest tests/ -v
 
   runner-build:

--- a/crates/runner/mitm-addon/pyproject.toml
+++ b/crates/runner/mitm-addon/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["setuptools>=64"]
+build-backend = "setuptools.build_meta"
+
 [project]
 name = "mitm-addon"
 version = "0.1.0"

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -577,7 +577,7 @@ def response(flow: http.HTTPFlow) -> None:
 
     # Calculate sizes
     request_size = len(flow.request.content) if flow.request.content else 0
-    response_size = len(flow.response.content) if flow.response and flow.response.content else 0
+    response_size = int(flow.response.headers.get("content-length", 0)) if flow.response else 0
     status_code = flow.response.status_code if flow.response else 0
 
     # Parse URL for host

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -546,22 +546,18 @@ def request(flow: http.HTTPFlow) -> None:
 
 def responseheaders(flow: http.HTTPFlow) -> None:
     """
-    Enable streaming for SSE responses to avoid ZlibError.
+    Enable streaming for all responses to avoid ZlibError.
 
     Without streaming, mitmproxy buffers the entire response body and
-    decompresses/recompresses gzip content. For SSE streaming responses
-    (e.g., api.anthropic.com with gzip + text/event-stream), this causes
-    ZlibError because the gzip stream may be incomplete when mitmproxy
-    tries to decode it.
+    decompresses/recompresses gzip content, which causes ZlibError for
+    chunked gzip responses (e.g., api.anthropic.com).
 
-    Only SSE responses are streamed. Other responses remain buffered so
-    the response() hook can still access flow.response.content.
+    Since the response() hook does not process response bodies, it is
+    safe to stream all responses unconditionally.
     """
     if not flow.response:
         return
-    content_type = flow.response.headers.get("content-type", "").lower()
-    if "text/event-stream" in content_type:
-        flow.response.stream = True
+    flow.response.stream = True
 
 
 def response(flow: http.HTTPFlow) -> None:

--- a/crates/runner/mitm-addon/tests/test_handlers.py
+++ b/crates/runner/mitm-addon/tests/test_handlers.py
@@ -212,57 +212,18 @@ class TestRequestHandler:
 
 
 class TestResponseHeadersHandler:
-    """Tests for the responseheaders() hook that enables selective streaming."""
+    """Tests for the responseheaders() hook that enables streaming."""
 
-    def test_sse_enables_streaming(self):
-        """text/event-stream responses should be streamed."""
-        flow = _make_http_flow(host="api.anthropic.com")
+    def test_enables_streaming(self):
+        """All responses should be streamed to avoid ZlibError."""
+        flow = _make_http_flow(host="api.example.com")
         flow.response = MagicMock()
-        flow.response.headers = {"content-type": "text/event-stream"}
+        flow.response.headers = {"content-type": "application/json"}
         flow.response.stream = False
 
         mitm_addon.responseheaders(flow)
 
         assert flow.response.stream is True
-
-    def test_sse_with_charset_enables_streaming(self):
-        """text/event-stream with charset should be streamed."""
-        flow = _make_http_flow(host="api.anthropic.com")
-        flow.response = MagicMock()
-        flow.response.headers = {"content-type": "text/event-stream; charset=utf-8"}
-        flow.response.stream = False
-
-        mitm_addon.responseheaders(flow)
-
-        assert flow.response.stream is True
-
-    def test_non_sse_not_streamed(self):
-        """Non-SSE responses should not be streamed (even if chunked)."""
-        flow = _make_http_flow(host="api.example.com")
-        flow.response = MagicMock()
-        flow.response.headers = {
-            "content-type": "application/json",
-            "transfer-encoding": "chunked",
-        }
-        flow.response.stream = False
-
-        mitm_addon.responseheaders(flow)
-
-        assert flow.response.stream is False
-
-    def test_normal_response_not_streamed(self):
-        """Normal JSON response with Content-Length should not be streamed."""
-        flow = _make_http_flow(host="api.example.com")
-        flow.response = MagicMock()
-        flow.response.headers = {
-            "content-type": "application/json",
-            "content-length": "256",
-        }
-        flow.response.stream = False
-
-        mitm_addon.responseheaders(flow)
-
-        assert flow.response.stream is False
 
     def test_no_response_is_noop(self):
         """Flow without response should not raise."""

--- a/crates/runner/mitm-addon/tests/test_handlers.py
+++ b/crates/runner/mitm-addon/tests/test_handlers.py
@@ -287,7 +287,7 @@ class TestResponseHandler:
 
         flow.response = MagicMock()
         flow.response.status_code = 401
-        flow.response.content = b"Unauthorized"
+        flow.response.headers = {}
 
         # Pre-populate connector token cache
         cache_key = ("run-conn-1", "github", "https://api.github.com")
@@ -315,7 +315,7 @@ class TestResponseHandler:
 
         flow.response = MagicMock()
         flow.response.status_code = 500
-        flow.response.content = b"Internal Server Error"
+        flow.response.headers = {}
 
         mock_log = MagicMock()
         with patch.object(mitm_addon.ctx, "log", mock_log, create=True):

--- a/crates/runner/mitm-addon/tests/test_handlers.py
+++ b/crates/runner/mitm-addon/tests/test_handlers.py
@@ -253,7 +253,7 @@ class TestResponseHandler:
         # Add response
         flow.response = MagicMock()
         flow.response.status_code = 200
-        flow.response.content = b"ok"
+        flow.response.headers = {"content-length": "256"}
 
         # Simulate tracked start time
         mitm_addon._request_start_times[flow.id] = __import__("time").time() - 0.1

--- a/crates/runner/mitm-addon/tests/test_handlers.py
+++ b/crates/runner/mitm-addon/tests/test_handlers.py
@@ -271,6 +271,7 @@ class TestResponseHandler:
         assert entry["action"] == "ALLOW"
         assert entry["host"] == "api.anthropic.com"
         assert entry["latency_ms"] > 0
+        assert entry["response_size"] == 256
 
     def test_401_connector_cache_invalidation(self):
         """401 response with connector firewall_rule pops the cache entry."""


### PR DESCRIPTION
## Summary
- Stream all mitmproxy responses unconditionally to prevent ZlibError on chunked gzip responses (e.g., `api.anthropic.com/v1/messages`)
- Since the `response()` hook only reads metadata and never processes body content, buffering is unnecessary
- Add `[build-system]` to `pyproject.toml` and update CI to use `pip install ".[test]"` for centralized dependency management

## Test plan
- [x] All 82 mitm-addon tests pass locally
- [ ] CI `mitm-addon-test` job passes with new `pip install ".[test]"` install method
- [ ] Verify no more ZlibError when fetching from `api.anthropic.com` in MITM mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)