### PR TITLE
feat: add domain and email variables to atlassian connector

### DIFF
--- a/turbo/packages/core/src/contracts/connectors.ts
+++ b/turbo/packages/core/src/contracts/connectors.ts
@@ -1761,6 +1761,22 @@ const CONNECTOR_TYPES_DEF = {
             required: true,
             placeholder: "your-api-token",
           },
+          ATLASSIAN_EMAIL: {
+            label: "Email",
+            required: true,
+            placeholder: "you@example.com",
+            helpText:
+              "The email address associated with your Atlassian account",
+            type: "variable",
+          },
+          ATLASSIAN_DOMAIN: {
+            label: "Domain",
+            required: true,
+            placeholder: "mycompany",
+            helpText:
+              "Your Atlassian domain (e.g. 'mycompany' from mycompany.atlassian.net)",
+            type: "variable",
+          },
         },
       },
     } as Record<string, ConnectorAuthMethodConfig>,


### PR DESCRIPTION
## Summary
- Add `ATLASSIAN_DOMAIN` and `ATLASSIAN_EMAIL` as `variable`-type fields to the atlassian connector definition
- These are required for basic auth (email:token) when using the Atlassian REST API (Jira + Confluence)
- Follows the same pattern as the zendesk connector (which has `ZENDESK_EMAIL` and `ZENDESK_SUBDOMAIN` as variables)
- Corresponding `atlassian` skill has been pushed to [vm0-ai/vm0-skills](https://github.com/vm0-ai/vm0-skills) covering both Jira and Confluence APIs

## Test plan
- [ ] Verify the atlassian connector setup UI shows Domain and Email fields alongside the API Token field
- [ ] Verify stored variables are passed correctly to sandbox environments
- [ ] Verify the atlassian skill works end-to-end with the connector

Related to #4349

🤖 Generated with [Claude Code](https://claude.com/claude-code)