### PR TITLE
refactor(cli): clean up defensive try/catch in cook commands

### DIFF
--- a/turbo/apps/cli/src/commands/cook/continue.ts
+++ b/turbo/apps/cli/src/commands/cook/continue.ts
@@ -50,23 +50,18 @@ export const continueCommand = new Command()
         );
         console.log();
 
-        let runOutput: string;
-        try {
-          runOutput = await execVm0RunWithCapture(
-            [
-              "run",
-              "continue",
-              ...(options.envFile ? ["--env-file", options.envFile] : []),
-              ...(options.verbose ? ["--verbose"] : []),
-              state.lastSessionId,
-              ...(options.debugNoMockClaude ? ["--debug-no-mock-claude"] : []),
-              prompt,
-            ],
-            { cwd },
-          );
-        } catch {
-          throw new Error("Run command failed");
-        }
+        const runOutput = await execVm0RunWithCapture(
+          [
+            "run",
+            "continue",
+            ...(options.envFile ? ["--env-file", options.envFile] : []),
+            ...(options.verbose ? ["--verbose"] : []),
+            state.lastSessionId,
+            ...(options.debugNoMockClaude ? ["--debug-no-mock-claude"] : []),
+            prompt,
+          ],
+          { cwd },
+        );
 
         // Update state with new IDs
         const newIds = parseRunIdsFromOutput(runOutput);

--- a/turbo/apps/cli/src/commands/cook/resume.ts
+++ b/turbo/apps/cli/src/commands/cook/resume.ts
@@ -50,23 +50,18 @@ export const resumeCommand = new Command()
         );
         console.log();
 
-        let runOutput: string;
-        try {
-          runOutput = await execVm0RunWithCapture(
-            [
-              "run",
-              "resume",
-              ...(options.envFile ? ["--env-file", options.envFile] : []),
-              ...(options.verbose ? ["--verbose"] : []),
-              state.lastCheckpointId,
-              ...(options.debugNoMockClaude ? ["--debug-no-mock-claude"] : []),
-              prompt,
-            ],
-            { cwd },
-          );
-        } catch {
-          throw new Error("Run command failed");
-        }
+        const runOutput = await execVm0RunWithCapture(
+          [
+            "run",
+            "resume",
+            ...(options.envFile ? ["--env-file", options.envFile] : []),
+            ...(options.verbose ? ["--verbose"] : []),
+            state.lastCheckpointId,
+            ...(options.debugNoMockClaude ? ["--debug-no-mock-claude"] : []),
+            prompt,
+          ],
+          { cwd },
+        );
 
         // Update state with new IDs
         const newIds = parseRunIdsFromOutput(runOutput);


### PR DESCRIPTION
## Summary

- Remove defensive try/catch blocks in `resume.ts` and `continue.ts` that caught `execVm0RunWithCapture` errors and re-threw with a generic `"Run command failed"` message, discarding the original error context (stderr/exit code)
- Errors now propagate naturally to `withErrorHandler`, which displays the original error message from the subprocess

Closes #4155

## Audit Report

| File | Location | Pattern | Decision | Reasoning |
|------|----------|---------|----------|-----------|
| `resume.ts` | L54-69 | Catch `execVm0RunWithCapture`, throw `"Run command failed"` | **FIX** | Discards original error (stderr/exit code) with less informative generic message |
| `continue.ts` | L54-69 | Catch `execVm0RunWithCapture`, throw `"Run command failed"` | **FIX** | Same as above |
| `cook.ts` | L62-70 (`loadAndValidateConfig`) | Catch YAML parse error, throw `"Invalid YAML format"` with cause | **KEEP** | Transforms cryptic YAML parser error into user-friendly message while preserving original as cause |
| `cook.ts` | L111-138 (`processVolumes`) | Catch volume ops error, throw `"Volume processing failed"` with cause | **KEEP** | Adds step-level context ("which step failed") and preserves original error as cause for `withErrorHandler` to display |
| `cook.ts` | L150-183 (`processArtifact`) | Catch artifact ops error, throw `"Artifact processing failed"` with cause | **KEEP** | Same pattern — adds meaningful step context with cause chain |
| `cook.ts` | L198-205 (`composeAgent`) | Catch compose error, throw `"Compose failed"` with cause | **KEEP** | Same pattern — adds meaningful step context with cause chain |
| `utils.ts` | L200-212 (`autoPullArtifact`) | Catch artifact pull error, log and continue | **KEEP** | Best-effort pattern for non-critical optional operation — comment explicitly states "Don't exit - the run succeeded, pull is optional" |

## Test plan

- [x] `pnpm check-types` passes
- [x] `pnpm --filter @vm0/cli run lint` passes (0 warnings, 0 errors)
- [x] `pnpm vitest run apps/cli/src/commands/cook` passes (37/37 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)