### PR TITLE
refactor(cli): preserve error cause in version resolution try/catch

### DIFF
--- a/turbo/apps/cli/src/commands/run/run.ts
+++ b/turbo/apps/cli/src/commands/run/run.ts
@@ -158,9 +158,10 @@ export const mainRunCommand = new Command()
           try {
             const versionInfo = await getComposeVersion(composeId, version);
             agentComposeVersionId = versionInfo.versionId;
-          } catch {
-            // Wrap version errors with specific message for better error handling
-            throw new Error(`Version not found: ${version}`);
+          } catch (error) {
+            throw new Error(`Version not found: ${version}`, {
+              cause: error instanceof Error ? error : undefined,
+            });
           }
         }
         // Note: "latest" version uses agentComposeId which resolves to HEAD


### PR DESCRIPTION
## Summary

- Audit all try/catch blocks in CLI schedule, run, onboard, secret, variable, usage, compose, and connector commands for issue #4155
- Fix one block in `commands/run/run.ts`: the version resolution `catch` was discarding the original error. Now preserves it via `{ cause: error }` so `withErrorHandler` can display the underlying reason
- All other try/catch blocks (14 total) are justified and left as-is (see audit table below)

## Audit Report

| File | Location | Verdict | Reason |
|------|----------|---------|--------|
| `schedule/setup.ts` L361-366 | `gatherTimezone` — `getUserPreferences()` | KEEP | Best-effort: non-critical timezone pref fetch, falls back to system TZ |
| `schedule/setup.ts` L644-663 | `tryEnableSchedule` | KEEP | Handles specific `ApiRequestError` codes (e.g. `SCHEDULE_PAST`), shows recovery hint |
| `schedule/status.ts` L138-162 | `printRecentRuns` | KEEP | Best-effort: run history display should not block main status output |
| `run/list.ts` L82-89 | `parseTimeOption` | KEEP | Transforms generic parse error into user-friendly message with format hints |
| `run/run.ts` L158-164 | version resolution | **FIX** | Was discarding original error; now preserves as `cause` |
| `onboard/index.ts` L262-271 | `handlePluginInstallation` | KEEP | Delegates to dedicated `handlePluginError`; plugin install is non-critical in onboard flow |
| `secret/delete.ts` L15-27 | `getSecret` existence check | KEEP | Transforms "not found" into user-friendly message, re-throws others |
| `secret/set.ts` L43-62 | `setSecret` naming validation | KEEP | Adds helpful examples for naming errors, re-throws others |
| `variable/delete.ts` L15-27 | `getVariable` existence check | KEEP | Same pattern as secret/delete — transforms "not found", re-throws others |
| `variable/set.ts` L20-39 | `setVariable` naming validation | KEEP | Same pattern as secret/set — adds examples, re-throws others |
| `usage/index.ts` L111-118 | `parseTime(--until)` | KEEP | Transforms parse error into format hint |
| `usage/index.ts` L124-131 | `parseTime(--since)` | KEEP | Same pattern as above |
| `compose/index.ts` L96-101 | YAML parsing | KEEP | Wraps parse error with "Invalid YAML format:" prefix |
| `compose/index.ts` L553-636 | `handleGitHubCompose` | KEEP | try/finally for temp directory cleanup |
| `compose/index.ts` L691-743 | main action | KEEP | JSON error output mode — formats error as JSON before exit |
| `connector/.../start-services.ts` L44-48 | `findBinary` | KEEP | Expected control flow: file access check where "not found" is normal |
| `connector/.../start-services.ts` L126-175 | `startComputerServices` | KEEP | try/finally for service cleanup (kill processes, stop tunnels) |

## Test plan

- [x] `pnpm check-types` passes
- [x] `pnpm --filter @vm0/cli run lint` passes (0 warnings, 0 errors)
- [x] All 412 tests pass across schedule, run, onboard, secret, variable, usage, and compose commands

Refs #4155

🤖 Generated with [Claude Code](https://claude.com/claude-code)