### PR TITLE
feat: add clickup skill to platform, web, and docs

### DIFF
--- a/turbo/apps/docs/content/docs/agent-skills/clickup.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/clickup.mdx
@@ -1,0 +1,80 @@
+---
+title: ClickUp
+description: Project management and task tracking platform
+---
+
+[ClickUp](https://clickup.com/) is a project management platform for managing tasks, lists, folders, spaces, and workspaces via REST API.
+
+## Required Environment
+
+| Name            | Type   | Description                                                                             |
+| --------------- | ------ | --------------------------------------------------------------------------------------- |
+| `CLICKUP_TOKEN` | secret | API token from ClickUp (Avatar > Settings > Apps > API Token > Generate and copy token) |
+
+## Configuration
+
+```yaml title="vm0.yaml"
+version: "1.0"
+
+agents:
+  my-agent:
+    framework: claude-code
+    skills:
+      - https://github.com/vm0-ai/vm0-skills/tree/main/clickup # [!code highlight]
+```
+
+## Run
+
+Store your secret on the platform (recommended, one-time setup):
+
+```bash
+vm0 secret set CLICKUP_TOKEN your-clickup-api-token
+```
+
+Then run your agent - secret is automatically loaded:
+
+```bash
+vm0 run my-agent "list all tasks in my ClickUp workspace"
+```
+
+<Callout type="info">
+For CI/CD or temporary overrides, pass secrets at runtime: `--secrets CLICKUP_TOKEN=value`. See [Environment Variables](/docs/core-concept/environment-variable) for details.
+</Callout>
+
+## Example Instructions
+
+```markdown title="AGENTS.md"
+# Task Manager Agent
+
+You manage ClickUp tasks and projects.
+
+## Workflow
+
+1. List workspaces and spaces
+2. Create and organize tasks in lists
+3. Update task status and assignees
+4. Track time entries on tasks
+
+## Key Concepts
+
+- Hierarchy: Workspace > Space > Folder > List > Task
+- Task statuses are lowercase (to do, in progress, complete)
+- Priority: 1=urgent, 2=high, 3=normal, 4=low
+```
+
+```markdown title="AGENTS.md"
+# Project Reporter Agent
+
+You generate reports from ClickUp data.
+
+## Workflow
+
+1. Get tasks filtered by status and assignee
+2. Summarize task counts by status
+3. List overdue tasks
+4. Report time tracking data
+
+## Filters
+
+- statuses, assignees, due dates, tags
+```

--- a/turbo/apps/docs/content/docs/agent-skills/meta.json
+++ b/turbo/apps/docs/content/docs/agent-skills/meta.json
@@ -11,6 +11,7 @@
     "browserbase",
     "browserless",
     "chatwoot",
+    "clickup",
     "cloudflare-tunnel",
     "cloudinary",
     "cronlytic",

--- a/turbo/apps/platform/src/data/skills.ts
+++ b/turbo/apps/platform/src/data/skills.ts
@@ -151,6 +151,7 @@ function otherSkills(): ComboboxOption[] {
 function productivitySkills(): ComboboxOption[] {
   return [
     s("bitrix", "bitrix", "https://vm0.ai/skills/bitrix.svg"),
+    s("clickup", "clickup", "https://cdn.simpleicons.org/clickup"),
     s("figma", "figma", "https://cdn.simpleicons.org/figma"),
     s(
       "google-sheets",

--- a/turbo/apps/web/app/api/web/skills/route.ts
+++ b/turbo/apps/web/app/api/web/skills/route.ts
@@ -276,6 +276,12 @@ const SKILL_CATEGORIES: Record<
     description:
       "Access design files, comments, components, and projects in Figma workspaces via REST API",
   },
+  clickup: {
+    category: "Productivity",
+    logo: "https://cdn.simpleicons.org/clickup",
+    description:
+      "Manage tasks, lists, folders, spaces, and workspaces in ClickUp for project management",
+  },
   jira: {
     category: "Productivity",
     logo: "https://cdn.simpleicons.org/jira",
@@ -606,6 +612,7 @@ const SKILLS_WITH_DOCS = new Set([
   "browserbase",
   "browserless",
   "chatwoot",
+  "clickup",
   "cloudflare-tunnel",
   "cloudinary",
   "cronlytic",


### PR DESCRIPTION
## Summary

- Add ClickUp as a productivity skill across the vm0 platform
- Created `clickup/SKILL.md` in vm0-skills repo (already pushed to main)
- Added ClickUp to platform skills.ts, web skills route, and docs

Part of #4349 — processes the `clickup` connector (1 of 6 remaining: clickup, cloudflare, dify, line, make, wrike)

## Changes

- `turbo/apps/platform/src/data/skills.ts` — add clickup to productivitySkills
- `turbo/apps/web/app/api/web/skills/route.ts` — add clickup category entry and docs listing
- `turbo/apps/docs/content/docs/agent-skills/clickup.mdx` — new docs page
- `turbo/apps/docs/content/docs/agent-skills/meta.json` — add to navigation

## Test plan

- [ ] Verify clickup appears in the skills combobox on the platform
- [ ] Verify `/api/web/skills` returns clickup with correct category
- [ ] Verify docs page renders at `/docs/agent-skills/clickup`

🤖 Generated with [Claude Code](https://claude.com/claude-code)