### PR TITLE
fix: hide connector-managed secrets from custom api section

### DIFF
--- a/turbo/apps/platform/src/signals/settings-page/__tests__/secrets-and-variables.test.ts
+++ b/turbo/apps/platform/src/signals/settings-page/__tests__/secrets-and-variables.test.ts
@@ -4,6 +4,7 @@ import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../__tests__/test-helpers.ts";
 import { setupPage } from "../../../__tests__/page-helper.ts";
 import { mergedItems$ } from "../secrets-and-variables.ts";
+import { CONNECTOR_TYPES, type ConnectorType } from "@vm0/core";
 
 const context = testContext();
 
@@ -73,5 +74,94 @@ describe("mergedItems$", () => {
 
     const items = await context.store.get(mergedItems$);
     expect(items).toHaveLength(0);
+  });
+
+  it("should exclude secrets and variables managed by connected connectors", async () => {
+    server.use(
+      http.get("/api/connectors", () => {
+        return HttpResponse.json({
+          connectors: [
+            {
+              id: "conn-1",
+              type: "atlassian",
+              authMethod: "api-token",
+              externalId: null,
+              externalUsername: null,
+              externalEmail: null,
+              oauthScopes: null,
+              createdAt: new Date().toISOString(),
+              updatedAt: new Date().toISOString(),
+            },
+          ],
+          configuredTypes: Object.keys(CONNECTOR_TYPES) as ConnectorType[],
+          connectorProvidedSecretNames: [],
+        });
+      }),
+      http.get("http://localhost:3000/api/secrets", () => {
+        return HttpResponse.json({
+          secrets: [
+            {
+              id: "s1",
+              name: "ATLASSIAN_TOKEN",
+              description: null,
+              type: "user",
+              createdAt: "2024-01-01",
+              updatedAt: "2024-01-01",
+            },
+            {
+              id: "s2",
+              name: "MY_CUSTOM_KEY",
+              description: null,
+              type: "user",
+              createdAt: "2024-01-01",
+              updatedAt: "2024-01-01",
+            },
+          ],
+        });
+      }),
+      http.get("http://localhost:3000/api/variables", () => {
+        return HttpResponse.json({
+          variables: [
+            {
+              id: "v1",
+              name: "ATLASSIAN_EMAIL",
+              value: "test@example.com",
+              description: null,
+              createdAt: "2024-01-01",
+              updatedAt: "2024-01-01",
+            },
+            {
+              id: "v2",
+              name: "ATLASSIAN_DOMAIN",
+              value: "mycompany",
+              description: null,
+              createdAt: "2024-01-01",
+              updatedAt: "2024-01-01",
+            },
+            {
+              id: "v3",
+              name: "MY_CUSTOM_VAR",
+              value: "custom",
+              description: null,
+              createdAt: "2024-01-01",
+              updatedAt: "2024-01-01",
+            },
+          ],
+        });
+      }),
+    );
+
+    await setupPage({ context, path: "/", withoutRender: true });
+
+    const items = await context.store.get(mergedItems$);
+
+    // Only custom (non-connector) items should remain
+    const names = items.map((i) => i.name);
+    expect(names).toContain("MY_CUSTOM_KEY");
+    expect(names).toContain("MY_CUSTOM_VAR");
+    expect(names).not.toContain("ATLASSIAN_TOKEN");
+    expect(names).not.toContain("ATLASSIAN_EMAIL");
+    expect(names).not.toContain("ATLASSIAN_DOMAIN");
+    expect(items).toHaveLength(2);
   });
 });

--- a/turbo/apps/platform/src/signals/settings-page/secrets-and-variables.ts
+++ b/turbo/apps/platform/src/signals/settings-page/secrets-and-variables.ts
@@ -58,7 +58,9 @@ export const mergedItems$ = computed(async (get) => {
   const items: MergedItem[] = [];
 
   for (const secret of secretsList) {
-    if (managedNames.has(secret.name)) continue;
+    if (managedNames.has(secret.name)) {
+      continue;
+    }
     items.push({
       kind: "secret",
       name: secret.name,
@@ -67,7 +69,9 @@ export const mergedItems$ = computed(async (get) => {
   }
 
   for (const variable of variablesList) {
-    if (managedNames.has(variable.name)) continue;
+    if (managedNames.has(variable.name)) {
+      continue;
+    }
     items.push({
       kind: "variable",
       name: variable.name,

--- a/turbo/apps/platform/src/signals/settings-page/secrets-and-variables.ts
+++ b/turbo/apps/platform/src/signals/settings-page/secrets-and-variables.ts
@@ -1,7 +1,13 @@
 import { computed } from "ccstate";
-import type { SecretResponse, VariableResponse } from "@vm0/core";
+import {
+  CONNECTOR_TYPES,
+  type ConnectorType,
+  type SecretResponse,
+  type VariableResponse,
+} from "@vm0/core";
 import { secrets$ } from "./secrets.ts";
 import { variables$ } from "./variables.ts";
+import { connectors$ } from "../external/connectors.ts";
 
 // ---------------------------------------------------------------------------
 // Merged items
@@ -19,15 +25,40 @@ export type MergedItem =
       data: VariableResponse;
     };
 
+/**
+ * Collect all secret and variable names managed by connected connectors.
+ */
+function getConnectorManagedNames(
+  connectedTypes: ConnectorType[],
+): Set<string> {
+  const managed = new Set<string>();
+  for (const type of connectedTypes) {
+    const config = CONNECTOR_TYPES[type];
+    for (const method of Object.values(config.authMethods)) {
+      for (const name of Object.keys(method.secrets)) {
+        managed.add(name);
+      }
+    }
+  }
+  return managed;
+}
+
 export const mergedItems$ = computed(async (get) => {
-  const [secretsList, variablesList] = await Promise.all([
+  const [secretsList, variablesList, connectorsData] = await Promise.all([
     get(secrets$),
     get(variables$),
+    get(connectors$),
   ]);
+
+  const connectedTypes = connectorsData.connectors.map(
+    (c) => c.type as ConnectorType,
+  );
+  const managedNames = getConnectorManagedNames(connectedTypes);
 
   const items: MergedItem[] = [];
 
   for (const secret of secretsList) {
+    if (managedNames.has(secret.name)) continue;
     items.push({
       kind: "secret",
       name: secret.name,
@@ -36,6 +67,7 @@ export const mergedItems$ = computed(async (get) => {
   }
 
   for (const variable of variablesList) {
+    if (managedNames.has(variable.name)) continue;
     items.push({
       kind: "variable",
       name: variable.name,


### PR DESCRIPTION
## Summary
- When a connector (e.g. Atlassian) is connected, its managed secrets/variables (ATLASSIAN_TOKEN, ATLASSIAN_EMAIL, ATLASSIAN_DOMAIN) were duplicated in the "Custom API" section below the connector card
- Filter `mergedItems$` to exclude secrets and variables whose names match fields declared by connected connectors
- Added integration test verifying connector-managed items are excluded while custom items are preserved

## Test plan
- [x] New test: `mergedItems$` should exclude secrets and variables managed by connected connectors
- [x] All 46 settings-related tests pass
- [x] TypeScript type check passes
- [x] Browser verification: Custom API section no longer shows connector-managed items

🤖 Generated with [Claude Code](https://claude.com/claude-code)