### PR TITLE
feat: add fireflies api-token connector

### DIFF
--- a/turbo/apps/platform/src/views/settings-page/connector-icons.tsx
+++ b/turbo/apps/platform/src/views/settings-page/connector-icons.tsx
@@ -25,6 +25,7 @@ import dropboxIcon from "./icons/dropbox.svg";
 import elevenlabsIcon from "./icons/elevenlabs.svg";
 import falIcon from "./icons/fal.svg";
 import figmaIcon from "./icons/figma.svg";
+import firefliesIcon from "./icons/fireflies.svg";
 import firecrawlIcon from "./icons/firecrawl.svg";
 import garminConnectIcon from "./icons/garmin-connect.svg";
 import githubIcon from "./icons/github.svg";
@@ -118,6 +119,7 @@ const CONNECTOR_ICONS: Readonly<Record<ConnectorType, string>> = Object.freeze({
   elevenlabs: elevenlabsIcon,
   fal: falIcon,
   figma: figmaIcon,
+  fireflies: firefliesIcon,
   firecrawl: firecrawlIcon,
   "garmin-connect": garminConnectIcon,
   github: githubIcon,

--- a/turbo/apps/platform/src/views/settings-page/icons/fireflies.svg
+++ b/turbo/apps/platform/src/views/settings-page/icons/fireflies.svg
@@ -1,0 +1,76 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M10.5199 0H0V10.4427H10.5199V0Z" fill="url(#paint0_linear_449_4429)"/>
+<path d="M22.9812 12.6066H12.4613V23.0492H22.9812V12.6066Z" fill="url(#paint1_linear_449_4429)"/>
+<path d="M22.9812 0H12.4613V10.4426H31.9996V8.95045C31.9994 6.57656 31.0492 4.30001 29.3581 2.6215C27.667 0.942992 25.3735 -1.19843e-08 22.9821 0H22.9812Z" fill="url(#paint2_linear_449_4429)"/>
+<path d="M0 12.6066V23.0492C0.000240298 25.4231 0.950411 27.6997 2.64151 29.3782C4.3326 31.0567 6.62612 31.9997 9.01757 31.9997H10.5199V12.6066H0Z" fill="url(#paint3_linear_449_4429)"/>
+<path opacity="0.18" d="M0 0L10.5199 10.4426H0V0Z" fill="url(#paint4_linear_449_4429)"/>
+<path opacity="0.18" d="M12.4613 12.6066L22.9812 23.0492H12.4613V12.6066Z" fill="url(#paint5_linear_449_4429)"/>
+<path opacity="0.18" d="M0 23.0492C0.000240298 25.4231 0.950411 27.6997 2.64151 29.3782C4.3326 31.0567 6.62612 31.9997 9.01757 31.9997H10.5199V12.6066L0 23.0492Z" fill="url(#paint6_linear_449_4429)"/>
+<path opacity="0.18" d="M22.9821 0C25.3735 -1.19842e-08 27.667 0.942992 29.3581 2.6215C31.0492 4.30001 31.9994 6.57656 31.9996 8.95045V10.4426H12.4613L22.9821 0Z" fill="url(#paint7_linear_449_4429)"/>
+<defs>
+<linearGradient id="paint0_linear_449_4429" x1="25.7316" y1="26.4199" x2="-18.4886" y2="-20.0413" gradientUnits="userSpaceOnUse">
+<stop stop-color="#E82A73"/>
+<stop offset="0.113" stop-color="#DE2D7A"/>
+<stop offset="0.3" stop-color="#C5388F"/>
+<stop offset="0.54" stop-color="#9B4AB0"/>
+<stop offset="0.818" stop-color="#6262DE"/>
+<stop offset="0.994" stop-color="#3B73FF"/>
+</linearGradient>
+<linearGradient id="paint1_linear_449_4429" x1="25.8846" y1="26.276" x2="-18.3356" y2="-20.1852" gradientUnits="userSpaceOnUse">
+<stop stop-color="#FF3C82"/>
+<stop offset="0.103" stop-color="#F53E88"/>
+<stop offset="0.274" stop-color="#DC4598"/>
+<stop offset="0.492" stop-color="#B251B2"/>
+<stop offset="0.745" stop-color="#7961D7"/>
+<stop offset="0.994" stop-color="#3B73FF"/>
+</linearGradient>
+<linearGradient id="paint2_linear_449_4429" x1="33.2305" y1="19.2876" x2="18.247" y2="-35.0114" gradientUnits="userSpaceOnUse">
+<stop stop-color="#E82A73"/>
+<stop offset="0.113" stop-color="#DE2D7A"/>
+<stop offset="0.3" stop-color="#C5388F"/>
+<stop offset="0.54" stop-color="#9B4AB0"/>
+<stop offset="0.818" stop-color="#6262DE"/>
+<stop offset="0.994" stop-color="#3B73FF"/>
+</linearGradient>
+<linearGradient id="paint3_linear_449_4429" x1="18.4834" y1="33.3184" x2="-35.1559" y2="16.9772" gradientUnits="userSpaceOnUse">
+<stop stop-color="#E82A73"/>
+<stop offset="0.113" stop-color="#DE2D7A"/>
+<stop offset="0.3" stop-color="#C5388F"/>
+<stop offset="0.54" stop-color="#9B4AB0"/>
+<stop offset="0.818" stop-color="#6262DE"/>
+<stop offset="0.994" stop-color="#3B73FF"/>
+</linearGradient>
+<linearGradient id="paint4_linear_449_4429" x1="-5.14422" y1="-13.0429" x2="9.88058" y2="21.3846" gradientUnits="userSpaceOnUse">
+<stop stop-color="#E82A73"/>
+<stop offset="0.114" stop-color="#DE286E"/>
+<stop offset="0.303" stop-color="#C52361"/>
+<stop offset="0.544" stop-color="#9B1A4D"/>
+<stop offset="0.825" stop-color="#620F30"/>
+<stop offset="0.994" stop-color="#3D081E"/>
+</linearGradient>
+<linearGradient id="paint5_linear_449_4429" x1="7.31705" y1="-0.43628" x2="22.3418" y2="33.9912" gradientUnits="userSpaceOnUse">
+<stop stop-color="#E82A73"/>
+<stop offset="0.114" stop-color="#DE286E"/>
+<stop offset="0.303" stop-color="#C52361"/>
+<stop offset="0.544" stop-color="#9B1A4D"/>
+<stop offset="0.825" stop-color="#620F30"/>
+<stop offset="0.994" stop-color="#3D081E"/>
+</linearGradient>
+<linearGradient id="paint6_linear_449_4429" x1="-3.4926" y1="-0.987982" x2="30.5351" y2="21.6175" gradientUnits="userSpaceOnUse">
+<stop stop-color="#E82A73"/>
+<stop offset="0.114" stop-color="#DE286E"/>
+<stop offset="0.303" stop-color="#C52361"/>
+<stop offset="0.544" stop-color="#9B1A4D"/>
+<stop offset="0.825" stop-color="#620F30"/>
+<stop offset="0.994" stop-color="#3D081E"/>
+</linearGradient>
+<linearGradient id="paint7_linear_449_4429" x1="-744.884" y1="734.671" x2="-739.054" y2="780.707" gradientUnits="userSpaceOnUse">
+<stop stop-color="#E82A73"/>
+<stop offset="0.114" stop-color="#DE286E"/>
+<stop offset="0.303" stop-color="#C52361"/>
+<stop offset="0.544" stop-color="#9B1A4D"/>
+<stop offset="0.825" stop-color="#620F30"/>
+<stop offset="0.994" stop-color="#3D081E"/>
+</linearGradient>
+</defs>
+</svg>

--- a/turbo/apps/web/src/lib/connector/provider-registry.ts
+++ b/turbo/apps/web/src/lib/connector/provider-registry.ts
@@ -29,6 +29,7 @@ import { dropboxHandler } from "./providers/dropbox-handler";
 import { elevenlabsHandler } from "./providers/elevenlabs-handler";
 import { falHandler } from "./providers/fal-handler";
 import { figmaHandler } from "./providers/figma-handler";
+import { firefliesHandler } from "./providers/fireflies-handler";
 import { firecrawlHandler } from "./providers/firecrawl-handler";
 import { garminConnectHandler } from "./providers/garmin-connect-handler";
 import { githubHandler } from "./providers/github-handler";
@@ -126,6 +127,7 @@ export const PROVIDER_HANDLERS: Record<
   elevenlabs: elevenlabsHandler,
   fal: falHandler,
   figma: figmaHandler,
+  fireflies: firefliesHandler,
   firecrawl: firecrawlHandler,
   "garmin-connect": garminConnectHandler,
   github: githubHandler,

--- a/turbo/apps/web/src/lib/connector/providers/fireflies-handler.ts
+++ b/turbo/apps/web/src/lib/connector/providers/fireflies-handler.ts
@@ -1,0 +1,13 @@
+import { type ProviderHandler } from "../provider-types";
+
+export const firefliesHandler: ProviderHandler = {
+  buildAuthUrl() {
+    throw new Error("Fireflies does not support OAuth — use API token auth");
+  },
+  exchangeCode() {
+    throw new Error("Fireflies does not support OAuth — use API token auth");
+  },
+  getClientId: () => undefined,
+  getClientSecret: () => undefined,
+  getSecretName: () => "FIREFLIES_TOKEN",
+};

--- a/turbo/packages/core/src/contracts/connectors.ts
+++ b/turbo/packages/core/src/contracts/connectors.ts
@@ -2171,6 +2171,25 @@ const CONNECTOR_TYPES_DEF = {
     } as Record<string, ConnectorAuthMethodConfig>,
     defaultAuthMethod: "api-token",
   },
+  fireflies: {
+    label: "Fireflies",
+    helpText:
+      "Connect your Fireflies.ai account to transcribe and analyze meetings",
+    authMethods: {
+      "api-token": {
+        label: "API Token",
+        helpText:
+          "1. Log in to [Fireflies.ai](https://app.fireflies.ai)\n2. Go to **Settings > Developer Settings**\n3. Copy your **API Key**",
+        secrets: {
+          FIREFLIES_TOKEN: {
+            label: "API Token",
+            required: true,
+          },
+        },
+      },
+    } as Record<string, ConnectorAuthMethodConfig>,
+    defaultAuthMethod: "api-token",
+  },
   firecrawl: {
     label: "Firecrawl",
     helpText:
@@ -3069,6 +3088,14 @@ const CONNECTOR_PROXY_CONFIGS: Partial<
       }),
     ],
   },
+  fireflies: {
+    services: [
+      service(
+        "https://api.fireflies.ai/graphql",
+        bearerAuth("FIREFLIES_TOKEN"),
+      ),
+    ],
+  },
   firecrawl: {
     services: [
       service("https://api.firecrawl.dev/v1", bearerAuth("FIRECRAWL_TOKEN")),
@@ -3238,6 +3265,7 @@ export const connectorTypeSchema = z.enum([
   "bright-data",
   "browserbase",
   "browserless",
+  "fireflies",
   "firecrawl",
   "scrapeninja",
   "elevenlabs",


### PR DESCRIPTION
## Summary
- Add Fireflies as an api-token connector
- Proxy config with Bearer auth for `https://api.fireflies.ai/graphql`
- SVG logo sourced from fireflies.ai official website

Closes #4292

🤖 Generated with [Claude Code](https://claude.com/claude-code)