### PR TITLE
feat: inject agent metadata into instructions as frontmatter during compose

### DIFF
--- a/turbo/apps/cli/src/commands/compose/index.ts
+++ b/turbo/apps/cli/src/commands/compose/index.ts
@@ -70,6 +70,7 @@ interface AgentConfig {
   framework?: string;
   skills?: string[];
   environment?: Record<string, string>;
+  metadata?: { displayName?: string; sound?: string };
 }
 
 interface LoadedConfig {
@@ -171,6 +172,7 @@ async function uploadAssets(
       agent.instructions,
       basePath,
       agent.framework,
+      agent.metadata,
     );
     if (!jsonMode) {
       console.log(

--- a/turbo/apps/cli/src/lib/storage/system-storage.ts
+++ b/turbo/apps/cli/src/lib/storage/system-storage.ts
@@ -11,7 +11,7 @@ import {
   type SkillFrontmatter,
 } from "../domain/github-skills";
 import { directUpload } from "./direct-upload";
-import { getInstructionsFilename } from "@vm0/core";
+import { getInstructionsFilename, injectMetadataFrontmatter } from "@vm0/core";
 
 interface StorageUploadResult {
   name: string;
@@ -41,6 +41,7 @@ export async function uploadInstructions(
   instructionsFilePath: string,
   basePath: string,
   framework?: string,
+  metadata?: { displayName?: string; sound?: string },
 ): Promise<StorageUploadResult> {
   // Normalize agent name to lowercase to match server's normalization behavior
   // Server normalizes agent names to lowercase when storing compose configs
@@ -51,8 +52,9 @@ export async function uploadInstructions(
     ? instructionsFilePath
     : path.join(basePath, instructionsFilePath);
 
-  // Read the instructions file
-  const content = await fs.readFile(absolutePath, "utf8");
+  // Read the instructions file and inject metadata frontmatter
+  const rawContent = await fs.readFile(absolutePath, "utf8");
+  const content = injectMetadataFrontmatter(rawContent, metadata);
 
   // Create a temporary directory with the file
   const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "vm0-instructions-"));

--- a/turbo/apps/platform/src/signals/zero-page/zero-meet.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-meet.ts
@@ -14,6 +14,35 @@ import { skillValueToUrl, skillUrlToValue } from "../../data/skills.ts";
 
 const L = logger("ZeroMeet");
 
+const METADATA_FRONTMATTER_KEYS = new Set(["name", "tone"]);
+
+/**
+ * Strip only our metadata keys (name, tone) from frontmatter.
+ * User-defined frontmatter fields are preserved.
+ */
+function stripMetadataFrontmatter(content: string): string {
+  const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---(\r?\n|$)/);
+  if (!match) {
+    return content;
+  }
+  const rawYaml = match[1] ?? "";
+  const body = content.slice(match[0].length);
+
+  const remaining = rawYaml
+    .split("\n")
+    .filter((line) => {
+      const key = line.split(":")[0]?.trim();
+      return !key || !METADATA_FRONTMATTER_KEYS.has(key);
+    })
+    .join("\n")
+    .trim();
+
+  if (!remaining) {
+    return body.replace(/^\n/, "");
+  }
+  return `---\n${remaining}\n---${body}`;
+}
+
 // ---------------------------------------------------------------------------
 // Instructions state
 // ---------------------------------------------------------------------------
@@ -137,7 +166,8 @@ export const zeroEditedContent$ = computed((get) => get(editedContent$));
 export const zeroInstructionsDirty$ = computed((get) => {
   const edited = get(editedContent$);
   const instructions = get(instructionsState$).instructions;
-  return edited !== null && edited !== (instructions?.content ?? "");
+  const savedBody = stripMetadataFrontmatter(instructions?.content ?? "");
+  return edited !== null && edited !== savedBody;
 });
 
 export const setZeroEditedContent$ = command(({ set }, value: string) => {
@@ -333,14 +363,64 @@ export const removeZeroSkill$ = command(async ({ get, set }, name: string) => {
 });
 
 // ---------------------------------------------------------------------------
+// Shared helper: resolve current instructions content
+// ---------------------------------------------------------------------------
+
+/**
+ * Get the current instructions content, fetching from API if not already loaded.
+ * This ensures compose jobs always include the instructions file when the
+ * compose content references one (e.g., instructions: "CLAUDE.md").
+ */
+async function resolveInstructionsContent(
+  fetchFn: typeof fetch,
+  composeId: string | undefined,
+  localContent: string | null | undefined,
+): Promise<string | undefined> {
+  if (localContent) {
+    return localContent;
+  }
+  if (!composeId) {
+    return undefined;
+  }
+  const resp = await fetchFn(`/api/agent/composes/${composeId}/instructions`);
+  if (!resp.ok) {
+    return undefined;
+  }
+  const data = (await resp.json()) as AgentInstructions;
+  return data.content ?? undefined;
+}
+
+// ---------------------------------------------------------------------------
 // Shared helper: build compose and update default agent reference
 // ---------------------------------------------------------------------------
 
 async function buildAndSetDefaultAgent(
   fetchFn: typeof fetch,
   newContent: ZeroComposeContent,
+  instructions?: string,
 ): Promise<void> {
-  const job = await triggerAndPollComposeJob(fetchFn, newContent);
+  // Ensure compose content includes instructions field so the CLI uploads it
+  const agentKey = Object.keys(newContent.agents)[0];
+  const agent = agentKey ? newContent.agents[agentKey] : undefined;
+  const contentWithInstructions: ZeroComposeContent =
+    agentKey && agent && !("instructions" in agent)
+      ? {
+          ...newContent,
+          agents: {
+            ...newContent.agents,
+            [agentKey]: {
+              ...agent,
+              instructions: getInstructionsFilename(agent.framework),
+            },
+          },
+        }
+      : newContent;
+
+  const job = await triggerAndPollComposeJob(
+    fetchFn,
+    contentWithInstructions,
+    instructions,
+  );
   if (!job.result) {
     throw new Error("Build completed without result");
   }
@@ -389,7 +469,12 @@ const syncSkillsToCompose$ = command(
     };
 
     const fetchFn = get(fetch$);
-    await buildAndSetDefaultAgent(fetchFn, newContent);
+    const instructions = await resolveInstructionsContent(
+      fetchFn,
+      compose.id,
+      get(instructionsState$).instructions?.content,
+    );
+    await buildAndSetDefaultAgent(fetchFn, newContent, instructions);
     await set(reloadOnboardingStatus$);
     set(internalComposeReload$, (x) => x + 1);
   },
@@ -445,7 +530,12 @@ export const zeroUpdateSettings$ = command(
       };
 
       const fetchFn = get(fetch$);
-      await buildAndSetDefaultAgent(fetchFn, newContent);
+      const instructions = await resolveInstructionsContent(
+        fetchFn,
+        compose.id,
+        get(instructionsState$).instructions?.content,
+      );
+      await buildAndSetDefaultAgent(fetchFn, newContent, instructions);
 
       await set(reloadOnboardingStatus$);
       set(internalComposeReload$, (x) => x + 1);

--- a/turbo/apps/platform/src/signals/zero-page/zero-meet.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-meet.ts
@@ -9,39 +9,10 @@ import { triggerAndPollComposeJob } from "../agent-detail/compose-job.ts";
 import type { AgentInstructions } from "../agent-detail/types.ts";
 import { throwIfAbort } from "../utils.ts";
 import { logger } from "../log.ts";
-import { getInstructionsFilename } from "@vm0/core";
+import { getInstructionsFilename, stripMetadataFrontmatter } from "@vm0/core";
 import { skillValueToUrl, skillUrlToValue } from "../../data/skills.ts";
 
 const L = logger("ZeroMeet");
-
-const METADATA_FRONTMATTER_KEYS = new Set(["name", "tone"]);
-
-/**
- * Strip only our metadata keys (name, tone) from frontmatter.
- * User-defined frontmatter fields are preserved.
- */
-function stripMetadataFrontmatter(content: string): string {
-  const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---(\r?\n|$)/);
-  if (!match) {
-    return content;
-  }
-  const rawYaml = match[1] ?? "";
-  const body = content.slice(match[0].length);
-
-  const remaining = rawYaml
-    .split("\n")
-    .filter((line) => {
-      const key = line.split(":")[0]?.trim();
-      return !key || !METADATA_FRONTMATTER_KEYS.has(key);
-    })
-    .join("\n")
-    .trim();
-
-  if (!remaining) {
-    return body.replace(/^\n/, "");
-  }
-  return `---\n${remaining}\n---${body}`;
-}
 
 // ---------------------------------------------------------------------------
 // Instructions state
@@ -384,6 +355,9 @@ async function resolveInstructionsContent(
   }
   const resp = await fetchFn(`/api/agent/composes/${composeId}/instructions`);
   if (!resp.ok) {
+    L.warn(
+      `Failed to fetch instructions for compose ${composeId}: ${resp.status} ${resp.statusText}`,
+    );
     return undefined;
   }
   const data = (await resp.json()) as AgentInstructions;

--- a/turbo/apps/platform/src/views/zero-page/zero-meet-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-meet-page.tsx
@@ -495,6 +495,39 @@ function ZeroSkillsTab() {
 }
 
 // ---------------------------------------------------------------------------
+// Frontmatter parser — splits YAML frontmatter from body content
+// ---------------------------------------------------------------------------
+
+const METADATA_FRONTMATTER_KEYS = new Set(["name", "tone"]);
+
+/**
+ * Strip only our metadata keys (name, tone) from frontmatter.
+ * User-defined frontmatter fields are preserved.
+ */
+function stripMetadataFrontmatter(content: string): string {
+  const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---(\r?\n|$)/);
+  if (!match) {
+    return content;
+  }
+  const rawYaml = match[1] ?? "";
+  const body = content.slice(match[0].length);
+
+  const remaining = rawYaml
+    .split("\n")
+    .filter((line) => {
+      const key = line.split(":")[0]?.trim();
+      return !key || !METADATA_FRONTMATTER_KEYS.has(key);
+    })
+    .join("\n")
+    .trim();
+
+  if (!remaining) {
+    return body.replace(/^\n/, "");
+  }
+  return `---\n${remaining}\n---${body}`;
+}
+
+// ---------------------------------------------------------------------------
 // Instructions tab — editable textarea with build
 // ---------------------------------------------------------------------------
 
@@ -535,7 +568,9 @@ function ZeroInstructionsTab() {
     detach(fetchInstructions(), Reason.DomCallback);
   }
 
-  const displayContent = edited ?? instructions?.content ?? "";
+  const rawContent = instructions?.content ?? "";
+  const strippedContent = stripMetadataFrontmatter(rawContent);
+  const displayContent = edited ?? strippedContent;
 
   return (
     <div className="mx-auto max-w-[900px] px-7">

--- a/turbo/apps/platform/src/views/zero-page/zero-meet-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-meet-page.tsx
@@ -13,7 +13,11 @@ import {
   IconCrown,
   IconDotsVertical,
 } from "@tabler/icons-react";
-import { CONNECTOR_TYPES, type ConnectorType } from "@vm0/core";
+import {
+  CONNECTOR_TYPES,
+  type ConnectorType,
+  stripMetadataFrontmatter,
+} from "@vm0/core";
 import { skills$ } from "../../data/skills.ts";
 import { ConnectorIcon } from "../settings-page/connector-icons.tsx";
 import {
@@ -492,39 +496,6 @@ function ZeroSkillsTab() {
       )}
     </div>
   );
-}
-
-// ---------------------------------------------------------------------------
-// Frontmatter parser — splits YAML frontmatter from body content
-// ---------------------------------------------------------------------------
-
-const METADATA_FRONTMATTER_KEYS = new Set(["name", "tone"]);
-
-/**
- * Strip only our metadata keys (name, tone) from frontmatter.
- * User-defined frontmatter fields are preserved.
- */
-function stripMetadataFrontmatter(content: string): string {
-  const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---(\r?\n|$)/);
-  if (!match) {
-    return content;
-  }
-  const rawYaml = match[1] ?? "";
-  const body = content.slice(match[0].length);
-
-  const remaining = rawYaml
-    .split("\n")
-    .filter((line) => {
-      const key = line.split(":")[0]?.trim();
-      return !key || !METADATA_FRONTMATTER_KEYS.has(key);
-    })
-    .join("\n")
-    .trim();
-
-  if (!remaining) {
-    return body.replace(/^\n/, "");
-  }
-  return `---\n${remaining}\n---${body}`;
 }
 
 // ---------------------------------------------------------------------------

--- a/turbo/apps/web/src/lib/compose/trigger-compose-job.ts
+++ b/turbo/apps/web/src/lib/compose/trigger-compose-job.ts
@@ -9,6 +9,7 @@ import { env } from "../../env";
 import { e2bConfig } from "../e2b/config";
 import { logger } from "../logger";
 import { notifySlackComposeComplete } from "../slack/handlers/compose-notification";
+import { injectMetadataFrontmatter } from "@vm0/core";
 
 const log = logger("compose:trigger");
 
@@ -199,6 +200,25 @@ main().catch(async (error) => {
 `;
 
 /**
+ * Extract agent metadata from compose content.
+ * Looks for the `metadata` field in the first agent's config.
+ */
+function getAgentMetadata(
+  content: Record<string, unknown>,
+): { displayName?: string; sound?: string } | undefined {
+  const agents = content.agents as
+    | Record<string, Record<string, unknown>>
+    | undefined;
+  if (!agents) return undefined;
+  const agentName = Object.keys(agents)[0];
+  if (!agentName) return undefined;
+  const metadata = agents[agentName]?.metadata as
+    | { displayName?: string; sound?: string }
+    | undefined;
+  return metadata;
+}
+
+/**
  * Extract instructions filename from compose content.
  * Looks for the `instructions` field in the first agent's config.
  */
@@ -279,13 +299,18 @@ async function spawnComposeJobSandbox(
     const yamlContent = JSON.stringify(params.content, null, 2);
     await sandbox.files.write("/tmp/compose/vm0.yaml", yamlContent);
 
-    // Write instructions file if provided
+    // Write instructions file if provided, with metadata frontmatter injected
     if (params.instructions) {
       const instructionsFilename = getInstructionsFilename(params.content);
       if (instructionsFilename) {
+        const metadata = getAgentMetadata(params.content);
+        const instructionsContent = injectMetadataFrontmatter(
+          params.instructions,
+          metadata,
+        );
         await sandbox.files.write(
           `/tmp/compose/${instructionsFilename}`,
-          params.instructions,
+          instructionsContent,
         );
       }
     }

--- a/turbo/packages/core/src/__tests__/instructions-frontmatter.spec.ts
+++ b/turbo/packages/core/src/__tests__/instructions-frontmatter.spec.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from "vitest";
-import { injectMetadataFrontmatter } from "../instructions-frontmatter";
+import {
+  injectMetadataFrontmatter,
+  stripMetadataFrontmatter,
+} from "../instructions-frontmatter";
 
 describe("injectMetadataFrontmatter", () => {
   it("should return content unchanged when metadata is undefined", () => {
@@ -80,5 +83,54 @@ describe("injectMetadataFrontmatter", () => {
       displayName: "Aria",
     });
     expect(result).toBe("---\nkey: value\nname: Aria\n---\n");
+  });
+});
+
+describe("stripMetadataFrontmatter", () => {
+  it("should return content unchanged when no frontmatter", () => {
+    const content = "# Instructions\nDo stuff.";
+    expect(stripMetadataFrontmatter(content)).toBe(content);
+  });
+
+  it("should strip name and tone from frontmatter", () => {
+    const content =
+      "---\nname: Aria\ntone: professional\n---\n\n# Instructions";
+    expect(stripMetadataFrontmatter(content)).toBe("# Instructions");
+  });
+
+  it("should preserve non-metadata frontmatter fields", () => {
+    const content =
+      "---\nname: Aria\nvm0_secrets:\n  - API_KEY\ntone: friendly\n---\n\n# Instructions";
+    expect(stripMetadataFrontmatter(content)).toBe(
+      "---\nvm0_secrets:\n  - API_KEY\n---\n# Instructions",
+    );
+  });
+
+  it("should strip only metadata keys and keep the rest intact", () => {
+    const content = "---\ncustom: value\nname: Aria\n---\n\nBody text here.";
+    expect(stripMetadataFrontmatter(content)).toBe(
+      "---\ncustom: value\n---\nBody text here.",
+    );
+  });
+
+  it("should handle frontmatter with only non-metadata keys", () => {
+    const content = "---\nvm0_secrets:\n  - KEY\n---\n\n# Instructions";
+    expect(stripMetadataFrontmatter(content)).toBe(
+      "---\nvm0_secrets:\n  - KEY\n---\n# Instructions",
+    );
+  });
+
+  it("should handle CRLF line endings in frontmatter delimiter", () => {
+    const content = "---\r\nname: Aria\r\n---\r\n\n# Instructions";
+    expect(stripMetadataFrontmatter(content)).toBe("# Instructions");
+  });
+
+  it("should be the inverse of injectMetadataFrontmatter for simple cases", () => {
+    const original = "# Instructions\nDo stuff.";
+    const injected = injectMetadataFrontmatter(original, {
+      displayName: "Aria",
+      sound: "professional",
+    });
+    expect(stripMetadataFrontmatter(injected)).toBe(original);
   });
 });

--- a/turbo/packages/core/src/__tests__/instructions-frontmatter.spec.ts
+++ b/turbo/packages/core/src/__tests__/instructions-frontmatter.spec.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from "vitest";
+import { injectMetadataFrontmatter } from "../instructions-frontmatter";
+
+describe("injectMetadataFrontmatter", () => {
+  it("should return content unchanged when metadata is undefined", () => {
+    const content = "# Instructions\nDo stuff.";
+    expect(injectMetadataFrontmatter(content)).toBe(content);
+  });
+
+  it("should return content unchanged when metadata is null", () => {
+    const content = "# Instructions\nDo stuff.";
+    expect(injectMetadataFrontmatter(content, null)).toBe(content);
+  });
+
+  it("should return content unchanged when metadata is empty", () => {
+    const content = "# Instructions\nDo stuff.";
+    expect(injectMetadataFrontmatter(content, {})).toBe(content);
+  });
+
+  it("should return content unchanged when metadata has only falsy fields", () => {
+    const content = "# Instructions";
+    expect(
+      injectMetadataFrontmatter(content, { displayName: "", sound: "" }),
+    ).toBe(content);
+  });
+
+  it("should prepend frontmatter with full metadata", () => {
+    const content = "# Instructions\nDo stuff.";
+    const result = injectMetadataFrontmatter(content, {
+      displayName: "Aria",
+      sound: "professional",
+    });
+    expect(result).toBe(
+      "---\nname: Aria\ntone: professional\n---\n\n# Instructions\nDo stuff.",
+    );
+  });
+
+  it("should prepend frontmatter with only displayName", () => {
+    const content = "# Instructions";
+    const result = injectMetadataFrontmatter(content, {
+      displayName: "Aria",
+    });
+    expect(result).toBe("---\nname: Aria\n---\n\n# Instructions");
+  });
+
+  it("should prepend frontmatter with only sound", () => {
+    const content = "# Instructions";
+    const result = injectMetadataFrontmatter(content, {
+      sound: "friendly",
+    });
+    expect(result).toBe("---\ntone: friendly\n---\n\n# Instructions");
+  });
+
+  it("should merge with existing frontmatter preserving other fields", () => {
+    const content =
+      "---\nvm0_secrets:\n  - API_KEY\n---\n\n# Instructions\nDo stuff.";
+    const result = injectMetadataFrontmatter(content, {
+      displayName: "Aria",
+      sound: "professional",
+    });
+    expect(result).toBe(
+      "---\nvm0_secrets:\n  - API_KEY\nname: Aria\ntone: professional\n---\n\n# Instructions\nDo stuff.",
+    );
+  });
+
+  it("should overwrite existing name and tone in frontmatter", () => {
+    const content = "---\nname: OldName\ntone: casual\n---\n\n# Instructions";
+    const result = injectMetadataFrontmatter(content, {
+      displayName: "NewName",
+      sound: "formal",
+    });
+    expect(result).toBe(
+      "---\nname: NewName\ntone: formal\n---\n\n# Instructions",
+    );
+  });
+
+  it("should handle frontmatter with no trailing content", () => {
+    const content = "---\nkey: value\n---\n";
+    const result = injectMetadataFrontmatter(content, {
+      displayName: "Aria",
+    });
+    expect(result).toBe("---\nkey: value\nname: Aria\n---\n");
+  });
+});

--- a/turbo/packages/core/src/index.ts
+++ b/turbo/packages/core/src/index.ts
@@ -9,3 +9,4 @@ export * from "./frameworks";
 export * from "./feature-switch-key";
 export * from "./feature-switch";
 export * from "./skill-frontmatter";
+export * from "./instructions-frontmatter";

--- a/turbo/packages/core/src/instructions-frontmatter.ts
+++ b/turbo/packages/core/src/instructions-frontmatter.ts
@@ -1,0 +1,56 @@
+import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
+
+interface AgentMetadata {
+  displayName?: string;
+  sound?: string;
+}
+
+const METADATA_KEY_MAP: Record<string, string> = {
+  displayName: "name",
+  sound: "tone",
+};
+
+/**
+ * Inject agent metadata into instructions content as YAML frontmatter.
+ *
+ * - If metadata is undefined/null or has no truthy fields, returns content unchanged.
+ * - If content already has frontmatter, merges metadata fields into it.
+ * - If no existing frontmatter, prepends a new frontmatter block.
+ *
+ * Key mapping: displayName → name, sound → tone
+ */
+export function injectMetadataFrontmatter(
+  content: string,
+  metadata?: AgentMetadata | null,
+): string {
+  if (!metadata) {
+    return content;
+  }
+
+  const fields: Record<string, string> = {};
+  for (const [key, value] of Object.entries(metadata)) {
+    if (value && METADATA_KEY_MAP[key]) {
+      fields[METADATA_KEY_MAP[key]] = value;
+    }
+  }
+
+  if (Object.keys(fields).length === 0) {
+    return content;
+  }
+
+  const frontmatterMatch = content.match(
+    /^---\r?\n([\s\S]*?)\r?\n---(\r?\n|$)/,
+  );
+
+  if (frontmatterMatch) {
+    const existingYaml = frontmatterMatch[1] ?? "";
+    const parsed = (parseYaml(existingYaml) ?? {}) as Record<string, unknown>;
+    const merged = { ...parsed, ...fields };
+    const newYaml = stringifyYaml(merged).trimEnd();
+    const rest = content.slice(frontmatterMatch[0].length);
+    return `---\n${newYaml}\n---\n${rest}`;
+  }
+
+  const yaml = stringifyYaml(fields).trimEnd();
+  return `---\n${yaml}\n---\n\n${content}`;
+}

--- a/turbo/packages/core/src/instructions-frontmatter.ts
+++ b/turbo/packages/core/src/instructions-frontmatter.ts
@@ -54,3 +54,35 @@ export function injectMetadataFrontmatter(
   const yaml = stringifyYaml(fields).trimEnd();
   return `---\n${yaml}\n---\n\n${content}`;
 }
+
+/** Frontmatter keys injected by {@link injectMetadataFrontmatter}. */
+const METADATA_FRONTMATTER_KEYS: ReadonlySet<string> = Object.freeze(
+  new Set(Object.values(METADATA_KEY_MAP)),
+);
+
+/**
+ * Strip only our metadata keys (name, tone) from frontmatter.
+ * User-defined frontmatter fields are preserved.
+ */
+export function stripMetadataFrontmatter(content: string): string {
+  const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---(\r?\n|$)/);
+  if (!match) {
+    return content;
+  }
+  const rawYaml = match[1] ?? "";
+  const body = content.slice(match[0].length);
+
+  const remaining = rawYaml
+    .split("\n")
+    .filter((line) => {
+      const key = line.split(":")[0]?.trim();
+      return !key || !METADATA_FRONTMATTER_KEYS.has(key);
+    })
+    .join("\n")
+    .trim();
+
+  if (!remaining) {
+    return body.replace(/^\n/, "");
+  }
+  return `---\n${remaining}\n---${body}`;
+}


### PR DESCRIPTION
## Summary
- Add `injectMetadataFrontmatter()` utility in `@vm0/core` that maps agent metadata (`displayName` → `name`, `sound` → `tone`) into YAML frontmatter
- Wire through CLI compose flow: `AgentConfig.metadata` → `uploadInstructions()` → frontmatter injection before upload
- Handles: no metadata (no-op), empty metadata (no-op), partial metadata, merge with existing frontmatter, overwrite existing `name`/`tone`

## Test plan
- [x] 10 integration tests covering all cases: no metadata, empty, partial, full, merge, overwrite, edge cases
- [x] Lint and knip pass
- [x] Type check passes for `@vm0/core` and `@vm0/cli`

Closes #4380

🤖 Generated with [Claude Code](https://claude.com/claude-code)