### PR TITLE
feat(zero): implement chat with real agent run pipeline

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-chat.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-chat.test.ts
@@ -1,0 +1,343 @@
+import { describe, it, expect } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../mocks/server.ts";
+import { testContext } from "../../__tests__/test-helpers.ts";
+import { setupPage } from "../../../__tests__/page-helper.ts";
+import {
+  zeroChatMessages$,
+  zeroChatSending$,
+  zeroChatInput$,
+  zeroCurrentSessionId$,
+  zeroSessionList$,
+  zeroSessionListLoading$,
+  zeroSessionListError$,
+  zeroSessionError$,
+  setZeroChatInput$,
+  clearZeroChatInput$,
+  fetchZeroSessionList$,
+  switchZeroSession$,
+  startNewZeroSession$,
+  sendZeroChatMessage$,
+} from "../zero-chat.ts";
+
+const context = testContext();
+
+async function setup() {
+  await setupPage({
+    context,
+    path: "/",
+    withoutRender: true,
+  });
+}
+
+describe("zero-chat signals", () => {
+  describe("chat input", () => {
+    it("should set and clear chat input", async () => {
+      await setup();
+
+      context.store.set(setZeroChatInput$, "hello world");
+      expect(context.store.get(zeroChatInput$)).toBe("hello world");
+
+      context.store.set(clearZeroChatInput$);
+      expect(context.store.get(zeroChatInput$)).toBe("");
+    });
+  });
+
+  describe("fetchZeroSessionList$", () => {
+    it("should fetch and store session list", async () => {
+      server.use(
+        http.get("*/api/agent/sessions", () => {
+          return HttpResponse.json({
+            sessions: [
+              { id: "s1", preview: "Hello", createdAt: "2026-03-10T00:00:00Z" },
+              { id: "s2", preview: "World", createdAt: "2026-03-10T01:00:00Z" },
+            ],
+          });
+        }),
+      );
+
+      await setup();
+      await context.store.set(fetchZeroSessionList$);
+
+      const sessions = context.store.get(zeroSessionList$);
+      expect(sessions).toHaveLength(2);
+      expect(sessions[0]?.id).toBe("s1");
+      expect(sessions[1]?.preview).toBe("World");
+      expect(context.store.get(zeroSessionListLoading$)).toBeFalsy();
+      expect(context.store.get(zeroSessionListError$)).toBeNull();
+    });
+
+    it("should set error on API failure", async () => {
+      server.use(
+        http.get("*/api/agent/sessions", () => {
+          return new HttpResponse(null, {
+            status: 500,
+            statusText: "Internal Server Error",
+          });
+        }),
+      );
+
+      await setup();
+      await context.store.set(fetchZeroSessionList$);
+
+      expect(context.store.get(zeroSessionListError$)).toBe(
+        "Failed to load sessions: Internal Server Error",
+      );
+      expect(context.store.get(zeroSessionListLoading$)).toBeFalsy();
+    });
+
+    it("should pass agentComposeId as query parameter", async () => {
+      let capturedUrl = "";
+      server.use(
+        http.get("*/api/agent/sessions", ({ request }) => {
+          capturedUrl = request.url;
+          return HttpResponse.json({ sessions: [] });
+        }),
+      );
+
+      await setup();
+      await context.store.set(fetchZeroSessionList$);
+
+      const url = new URL(capturedUrl);
+      expect(url.searchParams.get("agentComposeId")).toBe("mock-compose-id");
+    });
+  });
+
+  describe("switchZeroSession$", () => {
+    it("should set session id immediately and load messages", async () => {
+      server.use(
+        http.get("*/api/agent/sessions/:id", () => {
+          return HttpResponse.json({
+            chatMessages: [
+              {
+                role: "user",
+                content: "Hi there",
+                createdAt: "2026-03-10T00:00:00Z",
+              },
+              {
+                role: "assistant",
+                content: "Hello!",
+                runId: "run-1",
+                createdAt: "2026-03-10T00:00:01Z",
+              },
+            ],
+          });
+        }),
+      );
+
+      await setup();
+      await context.store.set(switchZeroSession$, "session-abc");
+
+      expect(context.store.get(zeroCurrentSessionId$)).toBe("session-abc");
+
+      const messages = context.store.get(zeroChatMessages$);
+      expect(messages).toHaveLength(2);
+      expect(messages[0]?.role).toBe("user");
+      expect(messages[0]?.content).toBe("Hi there");
+      expect(messages[1]?.role).toBe("assistant");
+      expect(messages[1]?.content).toBe("Hello!");
+      expect(context.store.get(zeroSessionError$)).toBeNull();
+    });
+
+    it("should set error on API failure", async () => {
+      server.use(
+        http.get("*/api/agent/sessions/:id", () => {
+          return new HttpResponse(null, {
+            status: 404,
+            statusText: "Not Found",
+          });
+        }),
+      );
+
+      await setup();
+      await context.store.set(switchZeroSession$, "bad-session");
+
+      expect(context.store.get(zeroSessionError$)).toBe(
+        "Failed to load session: Not Found",
+      );
+    });
+
+    it("should clear previous messages when switching", async () => {
+      server.use(
+        http.get("*/api/agent/sessions/:id", () => {
+          return HttpResponse.json({ chatMessages: [] });
+        }),
+      );
+
+      await setup();
+
+      // Set some initial state
+      context.store.set(setZeroChatInput$, "draft");
+      await context.store.set(switchZeroSession$, "session-1");
+
+      // Messages should be empty (from the empty response)
+      expect(context.store.get(zeroChatMessages$)).toHaveLength(0);
+      expect(context.store.get(zeroChatSending$)).toBeFalsy();
+    });
+  });
+
+  describe("startNewZeroSession$", () => {
+    it("should reset all chat state", async () => {
+      await setup();
+
+      // Populate some state first
+      context.store.set(setZeroChatInput$, "some input");
+
+      context.store.set(startNewZeroSession$);
+
+      expect(context.store.get(zeroChatMessages$)).toHaveLength(0);
+      expect(context.store.get(zeroCurrentSessionId$)).toBeNull();
+      expect(context.store.get(zeroChatSending$)).toBeFalsy();
+      expect(context.store.get(zeroChatInput$)).toBe("");
+    });
+  });
+
+  describe("sendZeroChatMessage$", () => {
+    it("should add user and placeholder messages then start a run", async () => {
+      let capturedBody: Record<string, string> | null = null;
+      server.use(
+        http.post("*/api/agent/runs", async ({ request }) => {
+          capturedBody = (await request.json()) as Record<string, string>;
+          return HttpResponse.json({ runId: "run-123" });
+        }),
+        // Phase 1: telemetry events (eager load)
+        http.get("*/api/agent/runs/:runId/telemetry/agent", () => {
+          return HttpResponse.json({
+            events: [],
+            hasMore: false,
+            framework: "claude-code",
+          });
+        }),
+        // Phase 2: polling checks /api/platform/logs/:runId for terminal status
+        http.get("*/api/platform/logs/:runId", () => {
+          return HttpResponse.json({
+            id: "run-123",
+            status: "completed",
+            error: null,
+            prompt: "What can you do?",
+            createdAt: "2026-03-10T00:00:00Z",
+            startedAt: "2026-03-10T00:00:01Z",
+            completedAt: "2026-03-10T00:00:02Z",
+          });
+        }),
+        // onZeroRunComplete$ fetches /api/agent/runs/:runId for session id
+        http.get("*/api/agent/runs/:runId", () => {
+          return HttpResponse.json({
+            result: { agentSessionId: "new-session-id" },
+          });
+        }),
+        // Persist messages endpoint
+        http.post("*/api/agent/sessions/:id/messages", () => {
+          return HttpResponse.json({ ok: true });
+        }),
+        // Session list refresh
+        http.get("*/api/agent/sessions", () => {
+          return HttpResponse.json({ sessions: [] });
+        }),
+      );
+
+      await setup();
+      await context.store.set(sendZeroChatMessage$, "What can you do?");
+
+      // Verify the run was started with correct payload
+      expect(capturedBody).toBeTruthy();
+      expect(capturedBody!.agentComposeId).toBe("mock-compose-id");
+      expect(capturedBody!.prompt).toBe("What can you do?");
+
+      // After completion, sending should be false
+      expect(context.store.get(zeroChatSending$)).toBeFalsy();
+
+      // Messages should contain at least user + assistant
+      const messages = context.store.get(zeroChatMessages$);
+      expect(messages.length).toBeGreaterThanOrEqual(2);
+      expect(messages[0]?.role).toBe("user");
+      expect(messages[0]?.content).toBe("What can you do?");
+      expect(messages[1]?.role).toBe("assistant");
+    });
+
+    it("should set error on run creation failure", async () => {
+      server.use(
+        http.post("*/api/agent/runs", () => {
+          return new HttpResponse(null, { status: 500 });
+        }),
+      );
+
+      await setup();
+      await context.store.set(sendZeroChatMessage$, "Hello");
+
+      const messages = context.store.get(zeroChatMessages$);
+      const lastMsg = messages[messages.length - 1];
+      expect(lastMsg?.error).toBe("Failed to start agent run");
+      expect(context.store.get(zeroChatSending$)).toBeFalsy();
+    });
+
+    it("should not send empty messages", async () => {
+      let runCalled = false;
+      server.use(
+        http.post("*/api/agent/runs", () => {
+          runCalled = true;
+          return HttpResponse.json({ runId: "run-123" });
+        }),
+      );
+
+      await setup();
+      await context.store.set(sendZeroChatMessage$, "   ");
+
+      expect(runCalled).toBeFalsy();
+      expect(context.store.get(zeroChatMessages$)).toHaveLength(0);
+    });
+
+    it("should include sessionId when one exists", async () => {
+      let capturedBody: Record<string, string> | null = null;
+      server.use(
+        http.get("*/api/agent/sessions/:id", () => {
+          return HttpResponse.json({ chatMessages: [] });
+        }),
+        http.post("*/api/agent/runs", async ({ request }) => {
+          capturedBody = (await request.json()) as Record<string, string>;
+          return HttpResponse.json({ runId: "run-456" });
+        }),
+        http.get("*/api/agent/runs/:runId/telemetry/agent", () => {
+          return HttpResponse.json({
+            events: [],
+            hasMore: false,
+            framework: "claude-code",
+          });
+        }),
+        http.get("*/api/platform/logs/:runId", () => {
+          return HttpResponse.json({
+            id: "run-456",
+            status: "completed",
+            error: null,
+            prompt: "Follow up",
+            createdAt: "2026-03-10T00:00:00Z",
+            startedAt: "2026-03-10T00:00:01Z",
+            completedAt: "2026-03-10T00:00:02Z",
+          });
+        }),
+        http.get("*/api/agent/runs/:runId", () => {
+          return HttpResponse.json({
+            result: { agentSessionId: "existing-session" },
+          });
+        }),
+        http.post("*/api/agent/sessions/:id/messages", () => {
+          return HttpResponse.json({ ok: true });
+        }),
+        http.get("*/api/agent/sessions", () => {
+          return HttpResponse.json({ sessions: [] });
+        }),
+      );
+
+      await setup();
+
+      // First switch to a session to set the sessionId
+      await context.store.set(switchZeroSession$, "existing-session");
+
+      // Now send a message — it should include the sessionId
+      await context.store.set(sendZeroChatMessage$, "Follow up");
+
+      expect(capturedBody).toBeTruthy();
+      expect(capturedBody!.sessionId).toBe("existing-session");
+    });
+  });
+});

--- a/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
@@ -10,9 +10,62 @@ import type { SessionListItem } from "@vm0/core";
 const L = logger("ZeroChat");
 
 // ---------------------------------------------------------------------------
-// Session list state
+// Helpers
 // ---------------------------------------------------------------------------
 
+/** Scan telemetry event pages for the last "result" event content. */
+async function extractResultFromEvents(
+  pages: Computed<Promise<PageResult>>[],
+  get: (c: Computed<Promise<PageResult>>) => Promise<PageResult>,
+): Promise<string> {
+  let result = "";
+  for (const page$ of pages) {
+    const page = await get(page$);
+    for (const event of page.events) {
+      if (event.eventType === "result") {
+        const data = event.eventData as { result?: string };
+        if (data.result) {
+          result = data.result;
+        }
+      }
+    }
+  }
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Chat message types
+// ---------------------------------------------------------------------------
+
+export interface ZeroChatMessage {
+  id: string;
+  role: "user" | "assistant";
+  content: string;
+  runId?: string;
+  status?: LogStatus;
+  error?: string;
+}
+
+// ---------------------------------------------------------------------------
+// State
+// ---------------------------------------------------------------------------
+
+const internalMessages$ = state<ZeroChatMessage[]>([]);
+export const zeroChatMessages$ = computed((get) => get(internalMessages$));
+
+const internalSessionId$ = state<string | null>(null);
+export const zeroCurrentSessionId$ = computed((get) => get(internalSessionId$));
+
+const internalActiveRunId$ = state<string | null>(null);
+const internalRunStatus$ = state<LogStatus | null>(null);
+const internalRunEvents$ = state<Computed<Promise<PageResult>>[]>([]);
+
+const internalSending$ = state(false);
+export const zeroChatSending$ = computed((get) => get(internalSending$));
+
+const pollingAbortController$ = state<AbortController | null>(null);
+
+// Session list state
 const internalSessionList$ = state<SessionListItem[]>([]);
 export const zeroSessionList$ = computed((get) => get(internalSessionList$));
 
@@ -20,6 +73,18 @@ const internalSessionListLoading$ = state(false);
 export const zeroSessionListLoading$ = computed((get) =>
   get(internalSessionListLoading$),
 );
+
+// Chat input
+const internalChatInput$ = state("");
+export const zeroChatInput$ = computed((get) => get(internalChatInput$));
+
+export const setZeroChatInput$ = command(({ set }, value: string) => {
+  set(internalChatInput$, value);
+});
+
+export const clearZeroChatInput$ = command(({ set }) => {
+  set(internalChatInput$, "");
+});
 
 // ---------------------------------------------------------------------------
 // Commands: session list management
@@ -50,14 +115,291 @@ export const fetchZeroSessionList$ = command(async ({ get, set }) => {
   }
 });
 
+export const switchZeroSession$ = command(
+  async ({ get, set }, sessionId: string) => {
+    set(internalSessionListLoading$, true);
+    try {
+      const fetchFn = get(fetch$);
+      const res = await fetchFn(`/api/agent/sessions/${sessionId}`);
+      if (!res.ok) {
+        L.error("Failed to fetch session:", res.statusText);
+        return;
+      }
+
+      const data = (await res.json()) as {
+        chatMessages?: {
+          role: "user" | "assistant";
+          content: string;
+          runId?: string;
+          createdAt: string;
+        }[];
+      };
+
+      const messages: ZeroChatMessage[] = (data.chatMessages ?? []).map(
+        (m) => ({
+          id: crypto.randomUUID(),
+          role: m.role,
+          content: m.content,
+          runId: m.runId,
+        }),
+      );
+
+      set(internalMessages$, messages);
+      set(internalSessionId$, sessionId);
+      set(internalActiveRunId$, null);
+      set(internalRunEvents$, []);
+      set(internalRunStatus$, null);
+      set(internalSending$, false);
+    } catch (error) {
+      throwIfAbort(error);
+      L.error("Failed to switch session:", error);
+    } finally {
+      set(internalSessionListLoading$, false);
+    }
+  },
+);
+
+export const startNewZeroSession$ = command(({ set }) => {
+  set(internalMessages$, []);
+  set(internalSessionId$, null);
+  set(internalActiveRunId$, null);
+  set(internalRunEvents$, []);
+  set(internalRunStatus$, null);
+  set(internalSending$, false);
+  set(internalChatInput$, "");
+});
+
+// ---------------------------------------------------------------------------
+// Commands: send message
+// ---------------------------------------------------------------------------
+
+export const sendZeroChatMessage$ = command(
+  async ({ get, set }, prompt: string) => {
+    const status = await get(zeroOnboardingStatus$);
+    const composeId = status.defaultAgentComposeId;
+    if (!composeId || !prompt.trim()) {
+      return;
+    }
+
+    set(internalSending$, true);
+
+    // Add user message
+    const userMessage: ZeroChatMessage = {
+      id: crypto.randomUUID(),
+      role: "user",
+      content: prompt.trim(),
+    };
+    set(internalMessages$, (prev) => [...prev, userMessage]);
+
+    // Add placeholder assistant message
+    const assistantPlaceholder: ZeroChatMessage = {
+      id: crypto.randomUUID(),
+      role: "assistant",
+      content: "",
+    };
+    set(internalMessages$, (prev) => [...prev, assistantPlaceholder]);
+
+    try {
+      const fetchFn = get(fetch$);
+      const sessionId = get(internalSessionId$);
+
+      const body: {
+        agentComposeId: string;
+        prompt: string;
+        sessionId?: string;
+      } = {
+        agentComposeId: composeId,
+        prompt: prompt.trim(),
+      };
+      if (sessionId) {
+        body.sessionId = sessionId;
+      }
+
+      const response = await fetchFn("/api/agent/runs", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+
+      if (!response.ok) {
+        const errorData = (await response.json().catch(() => null)) as {
+          message?: string;
+        } | null;
+        const errorMsg =
+          errorData?.message ?? `Run failed: ${response.statusText}`;
+        set(internalMessages$, (prev) => {
+          const updated = [...prev];
+          updated[updated.length - 1] = {
+            ...updated[updated.length - 1],
+            error: errorMsg,
+          };
+          return updated;
+        });
+        set(internalSending$, false);
+        return;
+      }
+
+      const data = (await response.json()) as { runId: string };
+      const runId = data.runId;
+
+      set(internalMessages$, (prev) => {
+        const updated = [...prev];
+        updated[updated.length - 1] = {
+          ...updated[updated.length - 1],
+          runId,
+        };
+        return updated;
+      });
+
+      set(internalActiveRunId$, runId);
+      set(internalRunEvents$, []);
+      set(internalRunStatus$, null);
+
+      // Abort any existing polling
+      const prev = get(pollingAbortController$);
+      if (prev) {
+        prev.abort();
+      }
+      const controller = new AbortController();
+      set(pollingAbortController$, controller);
+
+      await set(setupPollingLoop$, {
+        runId,
+        signal: controller.signal,
+        state: {
+          get events$() {
+            return get(internalRunEvents$);
+          },
+          setEvents: (updater) => {
+            set(internalRunEvents$, updater);
+          },
+          setStatus: (s) => {
+            set(internalRunStatus$, s);
+          },
+        },
+        onTerminal: (completedRunId) => {
+          set(onZeroRunComplete$, completedRunId).catch((error: unknown) => {
+            throwIfAbort(error);
+            L.error("onRunComplete error:", error);
+          });
+        },
+      });
+    } catch (error) {
+      throwIfAbort(error);
+      L.error("Chat send error:", error);
+      set(internalMessages$, (prev) => {
+        const updated = [...prev];
+        updated[updated.length - 1] = {
+          ...updated[updated.length - 1],
+          error: error instanceof Error ? error.message : "Unknown error",
+        };
+        return updated;
+      });
+    } finally {
+      set(internalSending$, false);
+    }
+  },
+);
+
+// ---------------------------------------------------------------------------
+// On run complete: extract session, update message
+// ---------------------------------------------------------------------------
+
+const onZeroRunComplete$ = command(async ({ get, set }, runId: string) => {
+  const runStatus = get(internalRunStatus$);
+  const messages = get(internalMessages$);
+
+  const lastIdx = messages.length - 1;
+  if (lastIdx >= 0 && messages[lastIdx].role === "assistant") {
+    set(internalMessages$, (prev) => {
+      const updated = [...prev];
+      updated[lastIdx] = {
+        ...updated[lastIdx],
+        status: runStatus ?? undefined,
+        runId,
+      };
+      return updated;
+    });
+  }
+
+  set(internalActiveRunId$, null);
+
+  try {
+    const fetchFn = get(fetch$);
+    const res = await fetchFn(`/api/agent/runs/${runId}`);
+    if (res.ok) {
+      const data = (await res.json()) as {
+        result?: { output?: string; agentSessionId?: string };
+      };
+      if (data.result?.agentSessionId) {
+        set(internalSessionId$, data.result.agentSessionId);
+      }
+    }
+
+    // Extract result content from telemetry events
+    const pages = get(internalRunEvents$);
+    const resultContent = await extractResultFromEvents(pages, get);
+
+    if (resultContent) {
+      set(internalMessages$, (prev) => {
+        const idx = prev.findIndex(
+          (m) => m.role === "assistant" && m.runId === runId,
+        );
+        if (idx === -1) {
+          return prev;
+        }
+        const updated = [...prev];
+        updated[idx] = { ...updated[idx], content: resultContent };
+        return updated;
+      });
+    }
+
+    // Persist messages to server, then refresh session list
+    const sessionId = get(internalSessionId$);
+    const currentMessages = get(internalMessages$);
+    const assistantIdx = sessionId
+      ? currentMessages.findIndex(
+          (m) => m.role === "assistant" && m.runId === runId,
+        )
+      : -1;
+    const userMsg =
+      assistantIdx > 0 ? currentMessages[assistantIdx - 1] : undefined;
+    const assistantMsg =
+      assistantIdx > 0 ? currentMessages[assistantIdx] : undefined;
+
+    if (sessionId && userMsg?.role === "user" && assistantMsg) {
+      try {
+        await fetchFn(`/api/agent/sessions/${sessionId}/messages`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            messages: [
+              { role: "user", content: userMsg.content },
+              { role: "assistant", content: assistantMsg.content, runId },
+            ],
+          }),
+        });
+      } catch (error) {
+        throwIfAbort(error);
+        L.error("Failed to persist messages:", error);
+      }
+
+      // Refresh session list
+      set(fetchZeroSessionList$).catch((error: unknown) => {
+        throwIfAbort(error);
+        L.error("Failed to refresh session list:", error);
+      });
+    }
+  } catch (error) {
+    throwIfAbort(error);
+    L.error("Failed to extract run result:", error);
+  }
+});
+
 // ---------------------------------------------------------------------------
 // Commands: send intro message (fire-and-forget, creates a session)
 // ---------------------------------------------------------------------------
 
-/**
- * Sends a prompt to the default agent, polls until complete, then refreshes
- * the session list. Used after onboarding to auto-create the first session.
- */
 export const sendZeroIntroMessage$ = command(
   async ({ get, set }, prompt: string) => {
     const status = await get(zeroOnboardingStatus$);
@@ -86,13 +428,10 @@ export const sendZeroIntroMessage$ = command(
       const data = (await response.json()) as { runId: string };
       const runId = data.runId;
 
-      // Internal polling state
       const runEvents$ = state<Computed<Promise<PageResult>>[]>([]);
       const runStatus$ = state<LogStatus | null>(null);
-
       const controller = new AbortController();
 
-      // Poll until terminal
       await set(setupPollingLoop$, {
         runId,
         signal: controller.signal,
@@ -108,7 +447,6 @@ export const sendZeroIntroMessage$ = command(
           },
         },
         onTerminal: () => {
-          // Refresh session list so the new session appears in sidebar
           set(fetchZeroSessionList$).catch((error: unknown) => {
             throwIfAbort(error);
             L.error("Failed to refresh session list:", error);

--- a/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
@@ -1,0 +1,407 @@
+import { command, computed, state, type Computed } from "ccstate";
+import type { LogStatus } from "../logs-page/types.ts";
+import { fetch$ } from "../fetch.ts";
+import { throwIfAbort } from "../utils.ts";
+import { logger } from "../log.ts";
+import { setupPollingLoop$, type PageResult } from "../agent-detail/polling.ts";
+import { zeroOnboardingStatus$ } from "./zero-onboarding.ts";
+import type { SessionListItem } from "@vm0/core";
+
+const L = logger("ZeroChat");
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Scan telemetry event pages for the last "result" event content. */
+async function extractResultFromEvents(
+  pages: Computed<Promise<PageResult>>[],
+  get: (c: Computed<Promise<PageResult>>) => Promise<PageResult>,
+): Promise<string> {
+  let result = "";
+  for (const page$ of pages) {
+    const page = await get(page$);
+    for (const event of page.events) {
+      if (event.eventType === "result") {
+        const data = event.eventData as { result?: string };
+        if (data.result) {
+          result = data.result;
+        }
+      }
+    }
+  }
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Chat message types
+// ---------------------------------------------------------------------------
+
+export interface ZeroChatMessage {
+  id: string;
+  role: "user" | "assistant";
+  content: string;
+  runId?: string;
+  status?: LogStatus;
+  error?: string;
+}
+
+// ---------------------------------------------------------------------------
+// State
+// ---------------------------------------------------------------------------
+
+const internalMessages$ = state<ZeroChatMessage[]>([]);
+export const zeroChatMessages$ = computed((get) => get(internalMessages$));
+
+const internalSessionId$ = state<string | null>(null);
+export const zeroCurrentSessionId$ = computed((get) => get(internalSessionId$));
+
+const internalActiveRunId$ = state<string | null>(null);
+
+const internalRunStatus$ = state<LogStatus | null>(null);
+
+const internalRunEvents$ = state<Computed<Promise<PageResult>>[]>([]);
+
+const internalSending$ = state(false);
+export const zeroChatSending$ = computed((get) => get(internalSending$));
+
+const pollingAbortController$ = state<AbortController | null>(null);
+
+// Session list state
+const internalSessionList$ = state<SessionListItem[]>([]);
+export const zeroSessionList$ = computed((get) => get(internalSessionList$));
+
+const internalSessionListLoading$ = state(false);
+export const zeroSessionListLoading$ = computed((get) =>
+  get(internalSessionListLoading$),
+);
+
+// ---------------------------------------------------------------------------
+// Chat input
+// ---------------------------------------------------------------------------
+
+const internalChatInput$ = state("");
+export const zeroChatInput$ = computed((get) => get(internalChatInput$));
+
+export const setZeroChatInput$ = command(({ set }, value: string) => {
+  set(internalChatInput$, value);
+});
+
+export const clearZeroChatInput$ = command(({ set }) => {
+  set(internalChatInput$, "");
+});
+
+// ---------------------------------------------------------------------------
+// Commands: session list management
+// ---------------------------------------------------------------------------
+
+export const fetchZeroSessionList$ = command(async ({ get, set }) => {
+  const status = await get(zeroOnboardingStatus$);
+  const composeId = status.defaultAgentComposeId;
+  if (!composeId) {
+    return;
+  }
+
+  set(internalSessionListLoading$, true);
+  try {
+    const fetchFn = get(fetch$);
+    const res = await fetchFn(
+      `/api/agent/sessions?agentComposeId=${encodeURIComponent(composeId)}`,
+    );
+    if (res.ok) {
+      const data = (await res.json()) as { sessions: SessionListItem[] };
+      set(internalSessionList$, data.sessions);
+    }
+  } catch (error) {
+    throwIfAbort(error);
+    L.error("Failed to fetch session list:", error);
+  } finally {
+    set(internalSessionListLoading$, false);
+  }
+});
+
+export const switchZeroSession$ = command(
+  async ({ get, set }, sessionId: string) => {
+    set(internalSessionListLoading$, true);
+    try {
+      const fetchFn = get(fetch$);
+      const res = await fetchFn(`/api/agent/sessions/${sessionId}`);
+      if (!res.ok) {
+        L.error("Failed to fetch session:", res.statusText);
+        return;
+      }
+
+      const data = (await res.json()) as {
+        chatMessages?: {
+          role: "user" | "assistant";
+          content: string;
+          runId?: string;
+          createdAt: string;
+        }[];
+      };
+
+      const messages: ZeroChatMessage[] = (data.chatMessages ?? []).map(
+        (m) => ({
+          id: crypto.randomUUID(),
+          role: m.role,
+          content: m.content,
+          runId: m.runId,
+        }),
+      );
+
+      set(internalMessages$, messages);
+      set(internalSessionId$, sessionId);
+      // Reset transient run state
+      set(internalActiveRunId$, null);
+      set(internalRunEvents$, []);
+      set(internalRunStatus$, null);
+      set(internalSending$, false);
+    } catch (error) {
+      throwIfAbort(error);
+      L.error("Failed to switch session:", error);
+    } finally {
+      set(internalSessionListLoading$, false);
+    }
+  },
+);
+
+export const startNewZeroSession$ = command(({ set }) => {
+  set(internalMessages$, []);
+  set(internalSessionId$, null);
+  set(internalActiveRunId$, null);
+  set(internalRunEvents$, []);
+  set(internalRunStatus$, null);
+  set(internalSending$, false);
+});
+
+// ---------------------------------------------------------------------------
+// Commands: send message
+// ---------------------------------------------------------------------------
+
+export const sendZeroChatMessage$ = command(
+  async ({ get, set }, prompt: string) => {
+    const status = await get(zeroOnboardingStatus$);
+    const composeId = status.defaultAgentComposeId;
+    if (!composeId || !prompt.trim()) {
+      return;
+    }
+
+    set(internalSending$, true);
+
+    // Add user message
+    const userMessage: ZeroChatMessage = {
+      id: crypto.randomUUID(),
+      role: "user",
+      content: prompt.trim(),
+    };
+    set(internalMessages$, (prev) => [...prev, userMessage]);
+
+    // Add placeholder assistant message
+    const assistantPlaceholder: ZeroChatMessage = {
+      id: crypto.randomUUID(),
+      role: "assistant",
+      content: "",
+    };
+    set(internalMessages$, (prev) => [...prev, assistantPlaceholder]);
+
+    try {
+      const fetchFn = get(fetch$);
+      const sessionId = get(internalSessionId$);
+
+      const body: {
+        agentComposeId: string;
+        prompt: string;
+        sessionId?: string;
+      } = {
+        agentComposeId: composeId,
+        prompt: prompt.trim(),
+      };
+      if (sessionId) {
+        body.sessionId = sessionId;
+      }
+
+      const response = await fetchFn("/api/agent/runs", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+
+      if (!response.ok) {
+        const errorData = (await response.json().catch(() => null)) as {
+          message?: string;
+        } | null;
+        const errorMsg =
+          errorData?.message ?? `Run failed: ${response.statusText}`;
+        set(internalMessages$, (prev) => {
+          const updated = [...prev];
+          updated[updated.length - 1] = {
+            ...updated[updated.length - 1],
+            error: errorMsg,
+          };
+          return updated;
+        });
+        set(internalSending$, false);
+        return;
+      }
+
+      const data = (await response.json()) as { runId: string };
+      const runId = data.runId;
+
+      // Update placeholder with runId
+      set(internalMessages$, (prev) => {
+        const updated = [...prev];
+        updated[updated.length - 1] = {
+          ...updated[updated.length - 1],
+          runId,
+        };
+        return updated;
+      });
+
+      set(internalActiveRunId$, runId);
+      set(internalRunEvents$, []);
+      set(internalRunStatus$, null);
+
+      // Abort any existing polling
+      const prev = get(pollingAbortController$);
+      if (prev) {
+        prev.abort();
+      }
+      const controller = new AbortController();
+      set(pollingAbortController$, controller);
+
+      // Start polling
+      await set(setupPollingLoop$, {
+        runId,
+        signal: controller.signal,
+        state: {
+          get events$() {
+            return get(internalRunEvents$);
+          },
+          setEvents: (updater) => {
+            set(internalRunEvents$, updater);
+          },
+          setStatus: (status) => {
+            set(internalRunStatus$, status);
+          },
+        },
+        onTerminal: (completedRunId) => {
+          set(onZeroRunComplete$, completedRunId).catch((error: unknown) => {
+            throwIfAbort(error);
+            L.error("onRunComplete error:", error);
+          });
+        },
+      });
+    } catch (error) {
+      throwIfAbort(error);
+      L.error("Chat send error:", error);
+      set(internalMessages$, (prev) => {
+        const updated = [...prev];
+        updated[updated.length - 1] = {
+          ...updated[updated.length - 1],
+          error: error instanceof Error ? error.message : "Unknown error",
+        };
+        return updated;
+      });
+    } finally {
+      set(internalSending$, false);
+    }
+  },
+);
+
+// ---------------------------------------------------------------------------
+// On run complete: extract session, update message
+// ---------------------------------------------------------------------------
+
+const onZeroRunComplete$ = command(async ({ get, set }, runId: string) => {
+  const status = get(internalRunStatus$);
+  const messages = get(internalMessages$);
+
+  // Update the assistant message with final status
+  const lastIdx = messages.length - 1;
+  if (lastIdx >= 0 && messages[lastIdx].role === "assistant") {
+    set(internalMessages$, (prev) => {
+      const updated = [...prev];
+      updated[lastIdx] = {
+        ...updated[lastIdx],
+        status: status ?? undefined,
+        runId,
+      };
+      return updated;
+    });
+  }
+
+  // Clear active run
+  set(internalActiveRunId$, null);
+
+  // Fetch run details to extract sessionId and result
+  try {
+    const fetchFn = get(fetch$);
+    const res = await fetchFn(`/api/agent/runs/${runId}`);
+    if (res.ok) {
+      const data = (await res.json()) as {
+        result?: { output?: string; agentSessionId?: string };
+      };
+      if (data.result?.agentSessionId) {
+        set(internalSessionId$, data.result.agentSessionId);
+      }
+    }
+
+    // Extract result content from telemetry events
+    const pages = get(internalRunEvents$);
+    const resultContent = await extractResultFromEvents(pages, get);
+
+    if (resultContent) {
+      set(internalMessages$, (prev) => {
+        const idx = prev.findIndex(
+          (m) => m.role === "assistant" && m.runId === runId,
+        );
+        if (idx === -1) {
+          return prev;
+        }
+        const updated = [...prev];
+        updated[idx] = { ...updated[idx], content: resultContent };
+        return updated;
+      });
+    }
+
+    // Persist messages to server, then refresh session list
+    const sessionId = get(internalSessionId$);
+    const currentMessages = get(internalMessages$);
+    const assistantIdx = sessionId
+      ? currentMessages.findIndex(
+          (m) => m.role === "assistant" && m.runId === runId,
+        )
+      : -1;
+    const userMsg =
+      assistantIdx > 0 ? currentMessages[assistantIdx - 1] : undefined;
+    const assistantMsg =
+      assistantIdx > 0 ? currentMessages[assistantIdx] : undefined;
+
+    if (sessionId && userMsg?.role === "user" && assistantMsg) {
+      try {
+        await fetchFn(`/api/agent/sessions/${sessionId}/messages`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            messages: [
+              { role: "user", content: userMsg.content },
+              { role: "assistant", content: assistantMsg.content, runId },
+            ],
+          }),
+        });
+      } catch (error) {
+        throwIfAbort(error);
+        L.error("Failed to persist messages:", error);
+      }
+
+      // Refresh session list
+      set(fetchZeroSessionList$).catch((error: unknown) => {
+        throwIfAbort(error);
+        L.error("Failed to refresh session list:", error);
+      });
+    }
+  } catch (error) {
+    throwIfAbort(error);
+    L.error("Failed to extract run result:", error);
+  }
+});

--- a/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
@@ -58,6 +58,7 @@ export const zeroCurrentSessionId$ = computed((get) => get(internalSessionId$));
 
 const internalActiveRunId$ = state<string | null>(null);
 const internalRunStatus$ = state<LogStatus | null>(null);
+const internalRunError$ = state<string | null>(null);
 const internalRunEvents$ = state<Computed<Promise<PageResult>>[]>([]);
 
 const internalSending$ = state(false);
@@ -149,6 +150,7 @@ export const switchZeroSession$ = command(
       set(internalActiveRunId$, null);
       set(internalRunEvents$, []);
       set(internalRunStatus$, null);
+      set(internalRunError$, null);
       set(internalSending$, false);
     } catch (error) {
       throwIfAbort(error);
@@ -165,6 +167,7 @@ export const startNewZeroSession$ = command(({ set }) => {
   set(internalActiveRunId$, null);
   set(internalRunEvents$, []);
   set(internalRunStatus$, null);
+  set(internalRunError$, null);
   set(internalSending$, false);
   set(internalChatInput$, "");
 });
@@ -254,6 +257,7 @@ export const sendZeroChatMessage$ = command(
       set(internalActiveRunId$, runId);
       set(internalRunEvents$, []);
       set(internalRunStatus$, null);
+      set(internalRunError$, null);
 
       // Abort any existing polling
       const prev = get(pollingAbortController$);
@@ -275,6 +279,9 @@ export const sendZeroChatMessage$ = command(
           },
           setStatus: (s) => {
             set(internalRunStatus$, s);
+          },
+          setError: (e) => {
+            set(internalRunError$, e);
           },
         },
         onTerminal: (completedRunId) => {
@@ -307,7 +314,9 @@ export const sendZeroChatMessage$ = command(
 
 const onZeroRunComplete$ = command(async ({ get, set }, runId: string) => {
   const runStatus = get(internalRunStatus$);
+  const runError = get(internalRunError$);
   const messages = get(internalMessages$);
+  const isFailed = runStatus === "failed";
 
   const lastIdx = messages.length - 1;
   if (lastIdx >= 0 && messages[lastIdx].role === "assistant") {
@@ -316,10 +325,17 @@ const onZeroRunComplete$ = command(async ({ get, set }, runId: string) => {
       updated[lastIdx] = {
         ...updated[lastIdx],
         status: runStatus ?? undefined,
+        error: isFailed ? (runError ?? "Run failed") : undefined,
         runId,
       };
       return updated;
     });
+  }
+
+  // If run failed, no need to extract result or persist
+  if (isFailed) {
+    set(internalActiveRunId$, null);
+    return;
   }
 
   set(internalActiveRunId$, null);

--- a/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
@@ -118,7 +118,15 @@ export const fetchZeroSessionList$ = command(async ({ get, set }) => {
 
 export const switchZeroSession$ = command(
   async ({ get, set }, sessionId: string) => {
-    set(internalSessionListLoading$, true);
+    // Set session immediately so the UI switches without loading delay
+    set(internalSessionId$, sessionId);
+    set(internalMessages$, []);
+    set(internalActiveRunId$, null);
+    set(internalRunEvents$, []);
+    set(internalRunStatus$, null);
+    set(internalRunError$, null);
+    set(internalSending$, false);
+
     try {
       const fetchFn = get(fetch$);
       const res = await fetchFn(`/api/agent/sessions/${sessionId}`);
@@ -146,17 +154,9 @@ export const switchZeroSession$ = command(
       );
 
       set(internalMessages$, messages);
-      set(internalSessionId$, sessionId);
-      set(internalActiveRunId$, null);
-      set(internalRunEvents$, []);
-      set(internalRunStatus$, null);
-      set(internalRunError$, null);
-      set(internalSending$, false);
     } catch (error) {
       throwIfAbort(error);
       L.error("Failed to switch session:", error);
-    } finally {
-      set(internalSessionListLoading$, false);
     }
   },
 );

--- a/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
@@ -10,64 +10,9 @@ import type { SessionListItem } from "@vm0/core";
 const L = logger("ZeroChat");
 
 // ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-/** Scan telemetry event pages for the last "result" event content. */
-async function extractResultFromEvents(
-  pages: Computed<Promise<PageResult>>[],
-  get: (c: Computed<Promise<PageResult>>) => Promise<PageResult>,
-): Promise<string> {
-  let result = "";
-  for (const page$ of pages) {
-    const page = await get(page$);
-    for (const event of page.events) {
-      if (event.eventType === "result") {
-        const data = event.eventData as { result?: string };
-        if (data.result) {
-          result = data.result;
-        }
-      }
-    }
-  }
-  return result;
-}
-
-// ---------------------------------------------------------------------------
-// Chat message types
-// ---------------------------------------------------------------------------
-
-export interface ZeroChatMessage {
-  id: string;
-  role: "user" | "assistant";
-  content: string;
-  runId?: string;
-  status?: LogStatus;
-  error?: string;
-}
-
-// ---------------------------------------------------------------------------
-// State
-// ---------------------------------------------------------------------------
-
-const internalMessages$ = state<ZeroChatMessage[]>([]);
-export const zeroChatMessages$ = computed((get) => get(internalMessages$));
-
-const internalSessionId$ = state<string | null>(null);
-export const zeroCurrentSessionId$ = computed((get) => get(internalSessionId$));
-
-const internalActiveRunId$ = state<string | null>(null);
-
-const internalRunStatus$ = state<LogStatus | null>(null);
-
-const internalRunEvents$ = state<Computed<Promise<PageResult>>[]>([]);
-
-const internalSending$ = state(false);
-export const zeroChatSending$ = computed((get) => get(internalSending$));
-
-const pollingAbortController$ = state<AbortController | null>(null);
-
 // Session list state
+// ---------------------------------------------------------------------------
+
 const internalSessionList$ = state<SessionListItem[]>([]);
 export const zeroSessionList$ = computed((get) => get(internalSessionList$));
 
@@ -75,21 +20,6 @@ const internalSessionListLoading$ = state(false);
 export const zeroSessionListLoading$ = computed((get) =>
   get(internalSessionListLoading$),
 );
-
-// ---------------------------------------------------------------------------
-// Chat input
-// ---------------------------------------------------------------------------
-
-const internalChatInput$ = state("");
-export const zeroChatInput$ = computed((get) => get(internalChatInput$));
-
-export const setZeroChatInput$ = command(({ set }, value: string) => {
-  set(internalChatInput$, value);
-});
-
-export const clearZeroChatInput$ = command(({ set }) => {
-  set(internalChatInput$, "");
-});
 
 // ---------------------------------------------------------------------------
 // Commands: session list management
@@ -120,65 +50,15 @@ export const fetchZeroSessionList$ = command(async ({ get, set }) => {
   }
 });
 
-export const switchZeroSession$ = command(
-  async ({ get, set }, sessionId: string) => {
-    set(internalSessionListLoading$, true);
-    try {
-      const fetchFn = get(fetch$);
-      const res = await fetchFn(`/api/agent/sessions/${sessionId}`);
-      if (!res.ok) {
-        L.error("Failed to fetch session:", res.statusText);
-        return;
-      }
-
-      const data = (await res.json()) as {
-        chatMessages?: {
-          role: "user" | "assistant";
-          content: string;
-          runId?: string;
-          createdAt: string;
-        }[];
-      };
-
-      const messages: ZeroChatMessage[] = (data.chatMessages ?? []).map(
-        (m) => ({
-          id: crypto.randomUUID(),
-          role: m.role,
-          content: m.content,
-          runId: m.runId,
-        }),
-      );
-
-      set(internalMessages$, messages);
-      set(internalSessionId$, sessionId);
-      // Reset transient run state
-      set(internalActiveRunId$, null);
-      set(internalRunEvents$, []);
-      set(internalRunStatus$, null);
-      set(internalSending$, false);
-    } catch (error) {
-      throwIfAbort(error);
-      L.error("Failed to switch session:", error);
-    } finally {
-      set(internalSessionListLoading$, false);
-    }
-  },
-);
-
-export const startNewZeroSession$ = command(({ set }) => {
-  set(internalMessages$, []);
-  set(internalSessionId$, null);
-  set(internalActiveRunId$, null);
-  set(internalRunEvents$, []);
-  set(internalRunStatus$, null);
-  set(internalSending$, false);
-});
-
 // ---------------------------------------------------------------------------
-// Commands: send message
+// Commands: send intro message (fire-and-forget, creates a session)
 // ---------------------------------------------------------------------------
 
-export const sendZeroChatMessage$ = command(
+/**
+ * Sends a prompt to the default agent, polls until complete, then refreshes
+ * the session list. Used after onboarding to auto-create the first session.
+ */
+export const sendZeroIntroMessage$ = command(
   async ({ get, set }, prompt: string) => {
     const status = await get(zeroOnboardingStatus$);
     const composeId = status.defaultAgentComposeId;
@@ -186,222 +66,58 @@ export const sendZeroChatMessage$ = command(
       return;
     }
 
-    set(internalSending$, true);
-
-    // Add user message
-    const userMessage: ZeroChatMessage = {
-      id: crypto.randomUUID(),
-      role: "user",
-      content: prompt.trim(),
-    };
-    set(internalMessages$, (prev) => [...prev, userMessage]);
-
-    // Add placeholder assistant message
-    const assistantPlaceholder: ZeroChatMessage = {
-      id: crypto.randomUUID(),
-      role: "assistant",
-      content: "",
-    };
-    set(internalMessages$, (prev) => [...prev, assistantPlaceholder]);
-
     try {
       const fetchFn = get(fetch$);
-      const sessionId = get(internalSessionId$);
-
-      const body: {
-        agentComposeId: string;
-        prompt: string;
-        sessionId?: string;
-      } = {
-        agentComposeId: composeId,
-        prompt: prompt.trim(),
-      };
-      if (sessionId) {
-        body.sessionId = sessionId;
-      }
 
       const response = await fetchFn("/api/agent/runs", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(body),
+        body: JSON.stringify({
+          agentComposeId: composeId,
+          prompt: prompt.trim(),
+        }),
       });
 
       if (!response.ok) {
-        const errorData = (await response.json().catch(() => null)) as {
-          message?: string;
-        } | null;
-        const errorMsg =
-          errorData?.message ?? `Run failed: ${response.statusText}`;
-        set(internalMessages$, (prev) => {
-          const updated = [...prev];
-          updated[updated.length - 1] = {
-            ...updated[updated.length - 1],
-            error: errorMsg,
-          };
-          return updated;
-        });
-        set(internalSending$, false);
+        L.error("Intro message run failed:", response.statusText);
         return;
       }
 
       const data = (await response.json()) as { runId: string };
       const runId = data.runId;
 
-      // Update placeholder with runId
-      set(internalMessages$, (prev) => {
-        const updated = [...prev];
-        updated[updated.length - 1] = {
-          ...updated[updated.length - 1],
-          runId,
-        };
-        return updated;
-      });
+      // Internal polling state
+      const runEvents$ = state<Computed<Promise<PageResult>>[]>([]);
+      const runStatus$ = state<LogStatus | null>(null);
 
-      set(internalActiveRunId$, runId);
-      set(internalRunEvents$, []);
-      set(internalRunStatus$, null);
-
-      // Abort any existing polling
-      const prev = get(pollingAbortController$);
-      if (prev) {
-        prev.abort();
-      }
       const controller = new AbortController();
-      set(pollingAbortController$, controller);
 
-      // Start polling
+      // Poll until terminal
       await set(setupPollingLoop$, {
         runId,
         signal: controller.signal,
         state: {
           get events$() {
-            return get(internalRunEvents$);
+            return get(runEvents$);
           },
           setEvents: (updater) => {
-            set(internalRunEvents$, updater);
+            set(runEvents$, updater);
           },
-          setStatus: (status) => {
-            set(internalRunStatus$, status);
+          setStatus: (s) => {
+            set(runStatus$, s);
           },
         },
-        onTerminal: (completedRunId) => {
-          set(onZeroRunComplete$, completedRunId).catch((error: unknown) => {
+        onTerminal: () => {
+          // Refresh session list so the new session appears in sidebar
+          set(fetchZeroSessionList$).catch((error: unknown) => {
             throwIfAbort(error);
-            L.error("onRunComplete error:", error);
+            L.error("Failed to refresh session list:", error);
           });
         },
       });
     } catch (error) {
       throwIfAbort(error);
-      L.error("Chat send error:", error);
-      set(internalMessages$, (prev) => {
-        const updated = [...prev];
-        updated[updated.length - 1] = {
-          ...updated[updated.length - 1],
-          error: error instanceof Error ? error.message : "Unknown error",
-        };
-        return updated;
-      });
-    } finally {
-      set(internalSending$, false);
+      L.error("Intro message error:", error);
     }
   },
 );
-
-// ---------------------------------------------------------------------------
-// On run complete: extract session, update message
-// ---------------------------------------------------------------------------
-
-const onZeroRunComplete$ = command(async ({ get, set }, runId: string) => {
-  const status = get(internalRunStatus$);
-  const messages = get(internalMessages$);
-
-  // Update the assistant message with final status
-  const lastIdx = messages.length - 1;
-  if (lastIdx >= 0 && messages[lastIdx].role === "assistant") {
-    set(internalMessages$, (prev) => {
-      const updated = [...prev];
-      updated[lastIdx] = {
-        ...updated[lastIdx],
-        status: status ?? undefined,
-        runId,
-      };
-      return updated;
-    });
-  }
-
-  // Clear active run
-  set(internalActiveRunId$, null);
-
-  // Fetch run details to extract sessionId and result
-  try {
-    const fetchFn = get(fetch$);
-    const res = await fetchFn(`/api/agent/runs/${runId}`);
-    if (res.ok) {
-      const data = (await res.json()) as {
-        result?: { output?: string; agentSessionId?: string };
-      };
-      if (data.result?.agentSessionId) {
-        set(internalSessionId$, data.result.agentSessionId);
-      }
-    }
-
-    // Extract result content from telemetry events
-    const pages = get(internalRunEvents$);
-    const resultContent = await extractResultFromEvents(pages, get);
-
-    if (resultContent) {
-      set(internalMessages$, (prev) => {
-        const idx = prev.findIndex(
-          (m) => m.role === "assistant" && m.runId === runId,
-        );
-        if (idx === -1) {
-          return prev;
-        }
-        const updated = [...prev];
-        updated[idx] = { ...updated[idx], content: resultContent };
-        return updated;
-      });
-    }
-
-    // Persist messages to server, then refresh session list
-    const sessionId = get(internalSessionId$);
-    const currentMessages = get(internalMessages$);
-    const assistantIdx = sessionId
-      ? currentMessages.findIndex(
-          (m) => m.role === "assistant" && m.runId === runId,
-        )
-      : -1;
-    const userMsg =
-      assistantIdx > 0 ? currentMessages[assistantIdx - 1] : undefined;
-    const assistantMsg =
-      assistantIdx > 0 ? currentMessages[assistantIdx] : undefined;
-
-    if (sessionId && userMsg?.role === "user" && assistantMsg) {
-      try {
-        await fetchFn(`/api/agent/sessions/${sessionId}/messages`, {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            messages: [
-              { role: "user", content: userMsg.content },
-              { role: "assistant", content: assistantMsg.content, runId },
-            ],
-          }),
-        });
-      } catch (error) {
-        throwIfAbort(error);
-        L.error("Failed to persist messages:", error);
-      }
-
-      // Refresh session list
-      set(fetchZeroSessionList$).catch((error: unknown) => {
-        throwIfAbort(error);
-        L.error("Failed to refresh session list:", error);
-      });
-    }
-  } catch (error) {
-    throwIfAbort(error);
-    L.error("Failed to extract run result:", error);
-  }
-});

--- a/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
@@ -13,6 +13,16 @@ const L = logger("ZeroChat");
 // Helpers
 // ---------------------------------------------------------------------------
 
+/** Type guard for event data containing a result string. */
+function isResultEventData(data: unknown): data is { result: string } {
+  return (
+    typeof data === "object" &&
+    data !== null &&
+    "result" in data &&
+    typeof (data as { result: unknown }).result === "string"
+  );
+}
+
 /** Scan telemetry event pages for the last "result" event content. */
 async function extractResultFromEvents(
   pages: Computed<Promise<PageResult>>[],
@@ -22,11 +32,8 @@ async function extractResultFromEvents(
   for (const page$ of pages) {
     const page = await get(page$);
     for (const event of page.events) {
-      if (event.eventType === "result") {
-        const data = event.eventData as { result?: string };
-        if (data.result) {
-          result = data.result;
-        }
+      if (event.eventType === "result" && isResultEventData(event.eventData)) {
+        result = event.eventData.result;
       }
     }
   }
@@ -75,6 +82,14 @@ export const zeroSessionListLoading$ = computed((get) =>
   get(internalSessionListLoading$),
 );
 
+const internalSessionListError$ = state<string | null>(null);
+export const zeroSessionListError$ = computed((get) =>
+  get(internalSessionListError$),
+);
+
+const internalSessionError$ = state<string | null>(null);
+export const zeroSessionError$ = computed((get) => get(internalSessionError$));
+
 // Chat input
 const internalChatInput$ = state("");
 export const zeroChatInput$ = computed((get) => get(internalChatInput$));
@@ -99,17 +114,26 @@ export const fetchZeroSessionList$ = command(async ({ get, set }) => {
   }
 
   set(internalSessionListLoading$, true);
+  set(internalSessionListError$, null);
   try {
     const fetchFn = get(fetch$);
     const res = await fetchFn(
       `/api/agent/sessions?agentComposeId=${encodeURIComponent(composeId)}`,
     );
-    if (res.ok) {
-      const data = (await res.json()) as { sessions: SessionListItem[] };
-      set(internalSessionList$, data.sessions);
+    if (!res.ok) {
+      set(
+        internalSessionListError$,
+        `Failed to load sessions: ${res.statusText}`,
+      );
+      return;
     }
+    const data = (await res.json()) as { sessions: SessionListItem[] };
+    set(internalSessionList$, data.sessions);
   } catch (error) {
     throwIfAbort(error);
+    const msg =
+      error instanceof Error ? error.message : "Failed to load sessions";
+    set(internalSessionListError$, msg);
     L.error("Failed to fetch session list:", error);
   } finally {
     set(internalSessionListLoading$, false);
@@ -126,12 +150,13 @@ export const switchZeroSession$ = command(
     set(internalRunStatus$, null);
     set(internalRunError$, null);
     set(internalSending$, false);
+    set(internalSessionError$, null);
 
     try {
       const fetchFn = get(fetch$);
       const res = await fetchFn(`/api/agent/sessions/${sessionId}`);
       if (!res.ok) {
-        L.error("Failed to fetch session:", res.statusText);
+        set(internalSessionError$, `Failed to load session: ${res.statusText}`);
         return;
       }
 
@@ -156,6 +181,9 @@ export const switchZeroSession$ = command(
       set(internalMessages$, messages);
     } catch (error) {
       throwIfAbort(error);
+      const msg =
+        error instanceof Error ? error.message : "Failed to load session";
+      set(internalSessionError$, msg);
       L.error("Failed to switch session:", error);
     }
   },
@@ -384,8 +412,9 @@ const onZeroRunComplete$ = command(async ({ get, set }, runId: string) => {
       assistantIdx > 0 ? currentMessages[assistantIdx] : undefined;
 
     if (sessionId && userMsg?.role === "user" && assistantMsg) {
-      try {
-        await fetchFn(`/api/agent/sessions/${sessionId}/messages`, {
+      const persistRes = await fetchFn(
+        `/api/agent/sessions/${sessionId}/messages`,
+        {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
@@ -394,10 +423,10 @@ const onZeroRunComplete$ = command(async ({ get, set }, runId: string) => {
               { role: "assistant", content: assistantMsg.content, runId },
             ],
           }),
-        });
-      } catch (error) {
-        throwIfAbort(error);
-        L.error("Failed to persist messages:", error);
+        },
+      );
+      if (!persistRes.ok) {
+        L.error("Failed to persist messages:", persistRes.statusText);
       }
 
       // Refresh session list

--- a/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
@@ -40,6 +40,35 @@ async function extractResultFromEvents(
   return result;
 }
 
+/** Start an agent run and return the runId, or null on failure. */
+async function startAgentRun(
+  fetchFn: typeof fetch,
+  composeId: string,
+  prompt: string,
+  sessionId?: string | null,
+): Promise<string | null> {
+  const body: Record<string, string> = {
+    agentComposeId: composeId,
+    prompt: prompt.trim(),
+  };
+  if (sessionId) {
+    body.sessionId = sessionId;
+  }
+
+  const response = await fetchFn("/api/agent/runs", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    return null;
+  }
+
+  const data = (await response.json()) as { runId: string };
+  return data.runId;
+}
+
 // ---------------------------------------------------------------------------
 // Chat message types
 // ---------------------------------------------------------------------------
@@ -234,44 +263,20 @@ export const sendZeroChatMessage$ = command(
       const fetchFn = get(fetch$);
       const sessionId = get(internalSessionId$);
 
-      const body: {
-        agentComposeId: string;
-        prompt: string;
-        sessionId?: string;
-      } = {
-        agentComposeId: composeId,
-        prompt: prompt.trim(),
-      };
-      if (sessionId) {
-        body.sessionId = sessionId;
-      }
+      const runId = await startAgentRun(fetchFn, composeId, prompt, sessionId);
 
-      const response = await fetchFn("/api/agent/runs", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(body),
-      });
-
-      if (!response.ok) {
-        const errorData = (await response.json().catch(() => null)) as {
-          message?: string;
-        } | null;
-        const errorMsg =
-          errorData?.message ?? `Run failed: ${response.statusText}`;
+      if (!runId) {
         set(internalMessages$, (prev) => {
           const updated = [...prev];
           updated[updated.length - 1] = {
             ...updated[updated.length - 1],
-            error: errorMsg,
+            error: "Failed to start agent run",
           };
           return updated;
         });
         set(internalSending$, false);
         return;
       }
-
-      const data = (await response.json()) as { runId: string };
-      const runId = data.runId;
 
       set(internalMessages$, (prev) => {
         const updated = [...prev];
@@ -456,22 +461,12 @@ export const sendZeroIntroMessage$ = command(
     try {
       const fetchFn = get(fetch$);
 
-      const response = await fetchFn("/api/agent/runs", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          agentComposeId: composeId,
-          prompt: prompt.trim(),
-        }),
-      });
+      const runId = await startAgentRun(fetchFn, composeId, prompt);
 
-      if (!response.ok) {
-        L.error("Intro message run failed:", response.statusText);
+      if (!runId) {
+        L.error("Intro message run failed");
         return;
       }
-
-      const data = (await response.json()) as { runId: string };
-      const runId = data.runId;
 
       const runEvents$ = state<Computed<Promise<PageResult>>[]>([]);
       const runStatus$ = state<LogStatus | null>(null);

--- a/turbo/apps/platform/src/views/zero-page/zero-app-shell.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-app-shell.tsx
@@ -238,6 +238,11 @@ export function ZeroAppShell() {
   });
   const handleSendFromDemo = useSet(handleSendFromDemo$);
 
+  const handleBackFromSession$ = useCommand(({ set }) => {
+    set(inSession$, false);
+  });
+  const handleBackFromSession = useSet(handleBackFromSession$);
+
   const handleNavSelect$ = useCommand(({ set }, id: ZeroNavId) => {
     set(setZeroActiveId$, id);
     set(inSession$, false);
@@ -348,6 +353,7 @@ export function ZeroAppShell() {
                 updateSearchParams(next);
               }
             }}
+            onBackFromSession={handleBackFromSession}
             zeroAvatarSrc={zeroAvatarSrc}
             onAvatarClick={cycleAvatar}
           />

--- a/turbo/apps/platform/src/views/zero-page/zero-app-shell.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-app-shell.tsx
@@ -150,14 +150,15 @@ function useSessionLifecycle(
   // "init" → "onboarding" → "ready" lifecycle
   const lifecycleRef$ = useCCState<"init" | "onboarding" | "ready">("init");
   const lifecycle = useGet(lifecycleRef$);
+  const setLifecycle = useSet(lifecycleRef$);
 
-  const triggerLifecycle$ = useCommand(({ set }) => {
-    if (isLoggedIn && onboardingReady) {
-      if (needsOnboarding && lifecycle === "init") {
-        set(lifecycleRef$, "onboarding");
-      } else if (!needsOnboarding && lifecycle !== "ready") {
-        const wasOnboarding = lifecycle === "onboarding";
-        set(lifecycleRef$, "ready");
+  if (isLoggedIn && onboardingReady) {
+    if (needsOnboarding && lifecycle === "init") {
+      queueMicrotask(() => setLifecycle("onboarding"));
+    } else if (!needsOnboarding && lifecycle !== "ready") {
+      const wasOnboarding = lifecycle === "onboarding";
+      queueMicrotask(() => {
+        setLifecycle("ready");
         detach(fetchSessionList(), Reason.DomCallback);
         if (wasOnboarding) {
           detach(
@@ -165,17 +166,7 @@ function useSessionLifecycle(
             Reason.DomCallback,
           );
         }
-      }
-    }
-  });
-  const triggerLifecycle = useSet(triggerLifecycle$);
-
-  if (isLoggedIn && onboardingReady) {
-    if (
-      (needsOnboarding && lifecycle === "init") ||
-      (!needsOnboarding && lifecycle !== "ready")
-    ) {
-      queueMicrotask(triggerLifecycle);
+      });
     }
   }
 

--- a/turbo/apps/platform/src/views/zero-page/zero-app-shell.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-app-shell.tsx
@@ -23,7 +23,11 @@ import { updateSearchParams$ } from "../../signals/route.ts";
 import {
   zeroSessionList$,
   zeroSessionListLoading$,
+  zeroCurrentSessionId$,
   fetchZeroSessionList$,
+  switchZeroSession$,
+  startNewZeroSession$,
+  sendZeroChatMessage$,
   sendZeroIntroMessage$,
 } from "../../signals/zero-page/zero-chat.ts";
 
@@ -209,8 +213,12 @@ export function ZeroAppShell() {
   });
   const cycleAvatar = useSet(cycleAvatar$);
 
-  const recentId$ = useCCState<string | null>(null);
-  const recentId = useGet(recentId$);
+  const inSession$ = useCCState(false);
+  const inSession = useGet(inSession$);
+  const currentSessionId = useGet(zeroCurrentSessionId$);
+  const switchSession = useSet(switchZeroSession$);
+  const startNewSession = useSet(startNewZeroSession$);
+  const sendMessage = useSet(sendZeroChatMessage$);
 
   const { recentSessions, recentSessionsLoading } = useSessionLifecycle(
     isLoggedIn,
@@ -219,20 +227,29 @@ export function ZeroAppShell() {
   );
 
   const handleRecentSelect$ = useCommand(({ set }, sessionId: string) => {
-    set(recentId$, sessionId);
     set(setZeroActiveId$, "chat");
+    set(inSession$, true);
+    detach(switchSession(sessionId), Reason.DomCallback);
   });
   const handleRecentSelect = useSet(handleRecentSelect$);
 
   const handleNewChat$ = useCommand(({ set }) => {
-    set(recentId$, null);
     set(setZeroActiveId$, "chat");
+    set(inSession$, true);
+    startNewSession();
   });
   const handleNewChat = useSet(handleNewChat$);
 
+  const handleSendFromDemo$ = useCommand(({ set }, message: string) => {
+    set(inSession$, true);
+    startNewSession();
+    detach(sendMessage(message), Reason.DomCallback);
+  });
+  const handleSendFromDemo = useSet(handleSendFromDemo$);
+
   const handleNavSelect$ = useCommand(({ set }, id: ZeroNavId) => {
     set(setZeroActiveId$, id);
-    set(recentId$, null);
+    set(inSession$, false);
     set(showAboutPage$, false);
   });
   const handleNavSelect = useSet(handleNavSelect$);
@@ -248,17 +265,8 @@ export function ZeroAppShell() {
   );
   const handleAccountAction = useSet(handleAccountAction$);
 
-  const handleClearRecent$ = useCommand(({ set }) => {
-    set(recentId$, null);
-  });
-  const handleClearRecent = useSet(handleClearRecent$);
-
   const updateSearchParams = useSet(updateSearchParams$);
   const resetDefaultAgent = useSet(resetDefaultAgent$);
-
-  const recentLabel = recentId
-    ? (recentSessions.find((s) => s.id === recentId)?.preview ?? null)
-    : null;
 
   const dataReady = isLoggedIn && onboardingReady && agentNameReady;
   const showSkeleton = useSkeletonVisibility(isLoggedIn, dataReady);
@@ -277,7 +285,9 @@ export function ZeroAppShell() {
         agentName={agentDisplayName}
         onSelect={handleNavSelect}
         onRecentSelect={handleRecentSelect}
-        selectedRecentId={activeId === "chat" ? recentId : null}
+        selectedRecentId={
+          activeId === "chat" && inSession ? currentSessionId : null
+        }
         onAccountAction={handleAccountAction}
         recentSessions={recentSessions}
         recentSessionsLoading={recentSessionsLoading}
@@ -333,9 +343,8 @@ export function ZeroAppShell() {
           <ZeroContent
             sectionId={activeId}
             accountSubId={accountSubId}
-            recentLabel={recentLabel}
-            recentId={recentId}
-            onClearRecent={handleClearRecent}
+            inSession={inSession}
+            onSendMessage={handleSendFromDemo}
             onNavigateToActivity={() => setActiveId("activity")}
             onNavigateToSchedule={() => setActiveId("schedule")}
             onNavigateToJob={() => setActiveId("job")}

--- a/turbo/apps/platform/src/views/zero-page/zero-app-shell.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-app-shell.tsx
@@ -146,21 +146,32 @@ function useSessionLifecycle(
   // "init" → "onboarding" → "ready" lifecycle
   const lifecycleRef$ = useCCState<"init" | "onboarding" | "ready">("init");
   const lifecycle = useGet(lifecycleRef$);
-  const setLifecycle = useSet(lifecycleRef$);
+
+  const triggerLifecycle$ = useCommand(({ set }) => {
+    if (isLoggedIn && onboardingReady) {
+      if (needsOnboarding && lifecycle === "init") {
+        set(lifecycleRef$, "onboarding");
+      } else if (!needsOnboarding && lifecycle !== "ready") {
+        const wasOnboarding = lifecycle === "onboarding";
+        set(lifecycleRef$, "ready");
+        detach(fetchSessionList(), Reason.DomCallback);
+        if (wasOnboarding) {
+          detach(
+            sendIntro("Who are you and what can you do?"),
+            Reason.DomCallback,
+          );
+        }
+      }
+    }
+  });
+  const triggerLifecycle = useSet(triggerLifecycle$);
 
   if (isLoggedIn && onboardingReady) {
-    if (needsOnboarding && lifecycle === "init") {
-      setLifecycle("onboarding");
-    } else if (!needsOnboarding && lifecycle !== "ready") {
-      const wasOnboarding = lifecycle === "onboarding";
-      setLifecycle("ready");
-      detach(fetchSessionList(), Reason.DomCallback);
-      if (wasOnboarding) {
-        detach(
-          sendIntro("Who are you and what can you do?"),
-          Reason.DomCallback,
-        );
-      }
+    if (
+      (needsOnboarding && lifecycle === "init") ||
+      (!needsOnboarding && lifecycle !== "ready")
+    ) {
+      queueMicrotask(triggerLifecycle);
     }
   }
 

--- a/turbo/apps/platform/src/views/zero-page/zero-app-shell.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-app-shell.tsx
@@ -23,11 +23,8 @@ import { updateSearchParams$ } from "../../signals/route.ts";
 import {
   zeroSessionList$,
   zeroSessionListLoading$,
-  zeroCurrentSessionId$,
   fetchZeroSessionList$,
-  switchZeroSession$,
-  startNewZeroSession$,
-  sendZeroChatMessage$,
+  sendZeroIntroMessage$,
 } from "../../signals/zero-page/zero-chat.ts";
 
 const ZERO_AVATARS = [
@@ -133,21 +130,18 @@ function useSkeletonVisibility(isLoggedIn: boolean, dataReady: boolean) {
 }
 
 /**
- * Manages the chat session lifecycle: fetches session list when onboarding
- * completes, and auto-sends an introductory message for new users.
+ * Manages session lifecycle: fetches session list when onboarding completes,
+ * and auto-sends an introductory message for new users.
  */
-function useChatLifecycle(
+function useSessionLifecycle(
   isLoggedIn: boolean,
   onboardingReady: boolean,
   needsOnboarding: boolean,
 ) {
   const recentSessions = useGet(zeroSessionList$);
   const recentSessionsLoading = useGet(zeroSessionListLoading$);
-  const currentSessionId = useGet(zeroCurrentSessionId$);
   const fetchSessionList = useSet(fetchZeroSessionList$);
-  const switchSession = useSet(switchZeroSession$);
-  const startNewSession = useSet(startNewZeroSession$);
-  const sendMessage = useSet(sendZeroChatMessage$);
+  const sendIntro = useSet(sendZeroIntroMessage$);
 
   // "init" → "onboarding" → "ready" lifecycle
   const lifecycleRef$ = useCCState<"init" | "onboarding" | "ready">("init");
@@ -163,20 +157,14 @@ function useChatLifecycle(
       detach(fetchSessionList(), Reason.DomCallback);
       if (wasOnboarding) {
         detach(
-          sendMessage("Who are you and what can you do?"),
+          sendIntro("Who are you and what can you do?"),
           Reason.DomCallback,
         );
       }
     }
   }
 
-  return {
-    recentSessions,
-    recentSessionsLoading,
-    currentSessionId,
-    switchSession,
-    startNewSession,
-  };
+  return { recentSessions, recentSessionsLoading };
 }
 
 export function ZeroAppShell() {
@@ -210,28 +198,30 @@ export function ZeroAppShell() {
   });
   const cycleAvatar = useSet(cycleAvatar$);
 
-  const {
-    recentSessions,
-    recentSessionsLoading,
-    currentSessionId,
-    switchSession,
-    startNewSession,
-  } = useChatLifecycle(isLoggedIn, onboardingReady, needsOnboarding);
+  const recentId$ = useCCState<string | null>(null);
+  const recentId = useGet(recentId$);
+
+  const { recentSessions, recentSessionsLoading } = useSessionLifecycle(
+    isLoggedIn,
+    onboardingReady,
+    needsOnboarding,
+  );
 
   const handleRecentSelect$ = useCommand(({ set }, sessionId: string) => {
+    set(recentId$, sessionId);
     set(setZeroActiveId$, "chat");
-    detach(switchSession(sessionId), Reason.DomCallback);
   });
   const handleRecentSelect = useSet(handleRecentSelect$);
 
   const handleNewChat$ = useCommand(({ set }) => {
+    set(recentId$, null);
     set(setZeroActiveId$, "chat");
-    startNewSession();
   });
   const handleNewChat = useSet(handleNewChat$);
 
   const handleNavSelect$ = useCommand(({ set }, id: ZeroNavId) => {
     set(setZeroActiveId$, id);
+    set(recentId$, null);
     set(showAboutPage$, false);
   });
   const handleNavSelect = useSet(handleNavSelect$);
@@ -247,8 +237,17 @@ export function ZeroAppShell() {
   );
   const handleAccountAction = useSet(handleAccountAction$);
 
+  const handleClearRecent$ = useCommand(({ set }) => {
+    set(recentId$, null);
+  });
+  const handleClearRecent = useSet(handleClearRecent$);
+
   const updateSearchParams = useSet(updateSearchParams$);
   const resetDefaultAgent = useSet(resetDefaultAgent$);
+
+  const recentLabel = recentId
+    ? (recentSessions.find((s) => s.id === recentId)?.preview ?? null)
+    : null;
 
   const dataReady = isLoggedIn && onboardingReady && agentNameReady;
   const showSkeleton = useSkeletonVisibility(isLoggedIn, dataReady);
@@ -267,7 +266,7 @@ export function ZeroAppShell() {
         agentName={agentDisplayName}
         onSelect={handleNavSelect}
         onRecentSelect={handleRecentSelect}
-        selectedRecentId={activeId === "chat" ? currentSessionId : null}
+        selectedRecentId={activeId === "chat" ? recentId : null}
         onAccountAction={handleAccountAction}
         recentSessions={recentSessions}
         recentSessionsLoading={recentSessionsLoading}
@@ -323,6 +322,9 @@ export function ZeroAppShell() {
           <ZeroContent
             sectionId={activeId}
             accountSubId={accountSubId}
+            recentLabel={recentLabel}
+            recentId={recentId}
+            onClearRecent={handleClearRecent}
             onNavigateToActivity={() => setActiveId("activity")}
             onNavigateToSchedule={() => setActiveId("schedule")}
             onNavigateToJob={() => setActiveId("job")}

--- a/turbo/apps/platform/src/views/zero-page/zero-app-shell.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-app-shell.tsx
@@ -20,6 +20,15 @@ import {
   setZeroActiveId$,
 } from "../../signals/zero-page/zero-nav.ts";
 import { updateSearchParams$ } from "../../signals/route.ts";
+import {
+  zeroSessionList$,
+  zeroSessionListLoading$,
+  zeroCurrentSessionId$,
+  fetchZeroSessionList$,
+  switchZeroSession$,
+  startNewZeroSession$,
+  sendZeroChatMessage$,
+} from "../../signals/zero-page/zero-chat.ts";
 
 const ZERO_AVATARS = [
   "/zero-avatar.png",
@@ -123,13 +132,50 @@ function useSkeletonVisibility(isLoggedIn: boolean, dataReady: boolean) {
   return isLoggedIn && !dataReady;
 }
 
-function getRecentLabels(agentName: string): Readonly<Record<string, string>> {
+/**
+ * Manages the chat session lifecycle: fetches session list when onboarding
+ * completes, and auto-sends an introductory message for new users.
+ */
+function useChatLifecycle(
+  isLoggedIn: boolean,
+  onboardingReady: boolean,
+  needsOnboarding: boolean,
+) {
+  const recentSessions = useGet(zeroSessionList$);
+  const recentSessionsLoading = useGet(zeroSessionListLoading$);
+  const currentSessionId = useGet(zeroCurrentSessionId$);
+  const fetchSessionList = useSet(fetchZeroSessionList$);
+  const switchSession = useSet(switchZeroSession$);
+  const startNewSession = useSet(startNewZeroSession$);
+  const sendMessage = useSet(sendZeroChatMessage$);
+
+  // "init" → "onboarding" → "ready" lifecycle
+  const lifecycleRef$ = useCCState<"init" | "onboarding" | "ready">("init");
+  const lifecycle = useGet(lifecycleRef$);
+  const setLifecycle = useSet(lifecycleRef$);
+
+  if (isLoggedIn && onboardingReady) {
+    if (needsOnboarding && lifecycle === "init") {
+      setLifecycle("onboarding");
+    } else if (!needsOnboarding && lifecycle !== "ready") {
+      const wasOnboarding = lifecycle === "onboarding";
+      setLifecycle("ready");
+      detach(fetchSessionList(), Reason.DomCallback);
+      if (wasOnboarding) {
+        detach(
+          sendMessage("Who are you and what can you do?"),
+          Reason.DomCallback,
+        );
+      }
+    }
+  }
+
   return {
-    hello: `Hello from ${agentName}`,
-    "1": "Daily digest workflow",
-    "2": "Set up Slack integration",
-    "3": "Weekly report automation",
-    "4": "Code review reminders",
+    recentSessions,
+    recentSessionsLoading,
+    currentSessionId,
+    switchSession,
+    startNewSession,
   };
 }
 
@@ -141,8 +187,9 @@ export function ZeroAppShell() {
   // session touch), preventing the onboarding dialog from unmounting.
   const onboardingLoadable = useLastLoadable(zeroNeedsOnboarding$);
   const onboardingReady = onboardingLoadable.state === "hasData";
-  const showOnboarding =
-    isLoggedIn && onboardingReady && onboardingLoadable.data === true;
+  const needsOnboarding =
+    onboardingLoadable.state === "hasData" && onboardingLoadable.data === true;
+  const showOnboarding = isLoggedIn && onboardingReady && needsOnboarding;
   const agentDisplayNameLoadable = useLastLoadable(agentDisplayName$);
   const agentNameReady = agentDisplayNameLoadable.state === "hasData";
   const agentDisplayName = agentNameReady
@@ -150,8 +197,6 @@ export function ZeroAppShell() {
     : "Zero";
   const activeId = useGet(zeroActiveId$);
   const setActiveId = useSet(setZeroActiveId$);
-  const recentId$ = useCCState<string | null>(null);
-  const recentId = useGet(recentId$);
   const accountSubId$ = useCCState<ZeroAccountSubId>(null);
   const accountSubId = useGet(accountSubId$);
   const avatarIndex$ = useCCState(0);
@@ -165,15 +210,28 @@ export function ZeroAppShell() {
   });
   const cycleAvatar = useSet(cycleAvatar$);
 
-  const handleRecentSelect$ = useCommand(({ set }, id: string) => {
-    set(recentId$, id);
+  const {
+    recentSessions,
+    recentSessionsLoading,
+    currentSessionId,
+    switchSession,
+    startNewSession,
+  } = useChatLifecycle(isLoggedIn, onboardingReady, needsOnboarding);
+
+  const handleRecentSelect$ = useCommand(({ set }, sessionId: string) => {
     set(setZeroActiveId$, "chat");
+    detach(switchSession(sessionId), Reason.DomCallback);
   });
   const handleRecentSelect = useSet(handleRecentSelect$);
 
+  const handleNewChat$ = useCommand(({ set }) => {
+    set(setZeroActiveId$, "chat");
+    startNewSession();
+  });
+  const handleNewChat = useSet(handleNewChat$);
+
   const handleNavSelect$ = useCommand(({ set }, id: ZeroNavId) => {
     set(setZeroActiveId$, id);
-    set(recentId$, null);
     set(showAboutPage$, false);
   });
   const handleNavSelect = useSet(handleNavSelect$);
@@ -189,17 +247,8 @@ export function ZeroAppShell() {
   );
   const handleAccountAction = useSet(handleAccountAction$);
 
-  const handleClearRecent$ = useCommand(({ set }) => {
-    set(recentId$, null);
-  });
-  const handleClearRecent = useSet(handleClearRecent$);
-
   const updateSearchParams = useSet(updateSearchParams$);
   const resetDefaultAgent = useSet(resetDefaultAgent$);
-
-  const recentLabel = recentId
-    ? (getRecentLabels(agentDisplayName)[recentId] ?? null)
-    : null;
 
   const dataReady = isLoggedIn && onboardingReady && agentNameReady;
   const showSkeleton = useSkeletonVisibility(isLoggedIn, dataReady);
@@ -218,8 +267,11 @@ export function ZeroAppShell() {
         agentName={agentDisplayName}
         onSelect={handleNavSelect}
         onRecentSelect={handleRecentSelect}
-        selectedRecentId={activeId === "chat" ? recentId : null}
+        selectedRecentId={activeId === "chat" ? currentSessionId : null}
         onAccountAction={handleAccountAction}
+        recentSessions={recentSessions}
+        recentSessionsLoading={recentSessionsLoading}
+        onNewChat={handleNewChat}
       />
       <div className="flex flex-1 flex-col min-w-0 zero-workspace-bg">
         {import.meta.env.DEV && isLoggedIn && (
@@ -271,9 +323,6 @@ export function ZeroAppShell() {
           <ZeroContent
             sectionId={activeId}
             accountSubId={accountSubId}
-            recentLabel={recentLabel}
-            recentId={recentId}
-            onClearRecent={handleClearRecent}
             onNavigateToActivity={() => setActiveId("activity")}
             onNavigateToSchedule={() => setActiveId("schedule")}
             onNavigateToJob={() => setActiveId("job")}

--- a/turbo/apps/platform/src/views/zero-page/zero-app-shell.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-app-shell.tsx
@@ -288,19 +288,9 @@ export function ZeroAppShell() {
         recentSessions={recentSessions}
         recentSessionsLoading={recentSessionsLoading}
         onNewChat={handleNewChat}
+        onResetAgent={() => detach(resetDefaultAgent(), Reason.DomCallback)}
       />
       <div className="flex flex-1 flex-col min-w-0 zero-workspace-bg">
-        {import.meta.env.DEV && isLoggedIn && (
-          <div className="absolute right-6 top-6 z-10">
-            <button
-              type="button"
-              onClick={() => detach(resetDefaultAgent(), Reason.DomCallback)}
-              className="rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-1.5 text-xs font-medium text-amber-400 transition-colors hover:bg-amber-500/20"
-            >
-              Reset Default Agent
-            </button>
-          </div>
-        )}
         {!isLoggedIn && (
           <nav
             className="pointer-events-none absolute right-6 top-6 z-10"

--- a/turbo/apps/platform/src/views/zero-page/zero-app-shell.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-app-shell.tsx
@@ -23,6 +23,7 @@ import { updateSearchParams$ } from "../../signals/route.ts";
 import {
   zeroSessionList$,
   zeroSessionListLoading$,
+  zeroSessionListError$,
   zeroCurrentSessionId$,
   fetchZeroSessionList$,
   switchZeroSession$,
@@ -144,6 +145,7 @@ function useSessionLifecycle(
 ) {
   const recentSessions = useGet(zeroSessionList$);
   const recentSessionsLoading = useGet(zeroSessionListLoading$);
+  const recentSessionsError = useGet(zeroSessionListError$);
   const fetchSessionList = useSet(fetchZeroSessionList$);
   const sendIntro = useSet(sendZeroIntroMessage$);
 
@@ -170,7 +172,7 @@ function useSessionLifecycle(
     }
   }
 
-  return { recentSessions, recentSessionsLoading };
+  return { recentSessions, recentSessionsLoading, recentSessionsError };
 }
 
 export function ZeroAppShell() {
@@ -211,11 +213,8 @@ export function ZeroAppShell() {
   const startNewSession = useSet(startNewZeroSession$);
   const sendMessage = useSet(sendZeroChatMessage$);
 
-  const { recentSessions, recentSessionsLoading } = useSessionLifecycle(
-    isLoggedIn,
-    onboardingReady,
-    needsOnboarding,
-  );
+  const { recentSessions, recentSessionsLoading, recentSessionsError } =
+    useSessionLifecycle(isLoggedIn, onboardingReady, needsOnboarding);
 
   const handleRecentSelect$ = useCommand(({ set }, sessionId: string) => {
     set(setZeroActiveId$, "chat");
@@ -287,6 +286,7 @@ export function ZeroAppShell() {
         onAccountAction={handleAccountAction}
         recentSessions={recentSessions}
         recentSessionsLoading={recentSessionsLoading}
+        recentSessionsError={recentSessionsError}
         onNewChat={handleNewChat}
         onResetAgent={() => detach(resetDefaultAgent(), Reason.DomCallback)}
       />

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-page.tsx
@@ -1,1237 +1,279 @@
-import type { ReactNode, KeyboardEvent } from "react";
-import { useCCState, useCommand } from "ccstate-react/experimental";
+import { useCCState } from "ccstate-react/experimental";
 import { useGet, useSet, useLoadable } from "ccstate-react";
-import { onRef } from "../../signals/utils.ts";
 import {
   IconSend,
-  IconPaperclip,
-  IconMoodSmile,
-  IconMicrophone,
-  IconPlus,
-  IconBriefcase,
-  IconSettings,
-  IconPlug,
+  IconLoader2,
+  IconAlertCircle,
   IconSparkles,
-  IconChartBar,
-  IconReceipt,
-  IconUser,
-  IconUsers,
-  IconCheck,
-  IconArrowLeft,
-  IconChartLine,
-  IconCalendar,
 } from "@tabler/icons-react";
-import { Button, Card, CardContent, cn } from "@vm0/ui";
-import { ZERO_TEAM_JOBS } from "./zero-jobs-page";
+import { Button } from "@vm0/ui";
+import { Markdown } from "../components/markdown.tsx";
+import { StatusDot } from "../logs-page/components/status-dot.tsx";
+import { detach, Reason } from "../../signals/utils.ts";
 import { agentDisplayName$ } from "../../signals/zero-page/zero-agent-name.ts";
+import {
+  zeroChatMessages$,
+  zeroChatSending$,
+  zeroChatInput$,
+  setZeroChatInput$,
+  clearZeroChatInput$,
+  sendZeroChatMessage$,
+  type ZeroChatMessage,
+} from "../../signals/zero-page/zero-chat.ts";
 
-export type DemoScenarioId =
-  | "hello-from-zero"
-  | "approve"
-  | "ask-options"
-  | "team-personal"
-  | "connect-connector"
-  | "rich-summary"
-  | "agent-operations";
-
-type NavIcon = (props: { size?: number; className?: string }) => ReactNode;
-type ActionId = "automate" | "customize" | "connectors";
-function getActionButtons(agentName: string) {
-  return [
-    {
-      id: "automate" as ActionId,
-      label: "Automate workflows",
-      icon: IconBriefcase as NavIcon,
-    },
-    {
-      id: "customize" as ActionId,
-      label: `Customize ${agentName}`,
-      icon: IconSettings as NavIcon,
-    },
-    {
-      id: "connectors" as ActionId,
-      label: "Add connectors",
-      icon: IconPlug as NavIcon,
-    },
-  ] as const;
-}
+// ---------------------------------------------------------------------------
+// Suggested prompts for welcome state
+// ---------------------------------------------------------------------------
 
 const SUGGESTED_PROMPTS = [
-  {
-    title: "Auto-organize inbox",
-    description: "Smart categorization, reply, and daily email digest",
-    icon: IconChartBar as NavIcon,
-    iconClassName: "text-emerald-600 dark:text-emerald-400",
-  },
-  {
-    title: "Daily morning brief",
-    description: "Trending topics on a schedule, your personalized digest",
-    icon: IconReceipt as NavIcon,
-    iconClassName: "text-primary",
-  },
+  "What can you help me with?",
+  "Summarize my recent activity",
+  "Set up a daily digest workflow",
+  "Help me automate a task",
 ] as const;
 
-function getStreamedScenarios(agentName: string): readonly Readonly<{
-  id: DemoScenarioId;
-  userMessage: string;
-  assistantMessage: string;
-}>[] {
-  return [
-    {
-      id: "hello-from-zero",
-      userMessage: "Hi",
-      assistantMessage: "",
-    },
-    {
-      id: "approve",
-      userMessage: "Run the deployment to production",
-      assistantMessage: `This action requires approval. Allow ${agentName} to run the deployment?`,
-    },
-    {
-      id: "ask-options",
-      userMessage: "Send a summary of this week’s activity",
-      assistantMessage: "Where should I send the summary?",
-    },
-    {
-      id: "team-personal",
-      userMessage:
-        "Create a daily digest workflow that summarizes important updates",
-      assistantMessage:
-        "I can create a Daily Digest workflow. Would you like this to be a Team workflow or a Personal workflow?",
-    },
-    {
-      id: "connect-connector",
-      userMessage: "Notify #releases when a PR is merged",
-      assistantMessage: "Connect Slack to enable this workflow.",
-    },
-    {
-      id: "rich-summary",
-      userMessage: "Run the HN AI daily digest workflow",
-      assistantMessage: "",
-    },
-    {
-      id: "agent-operations",
-      userMessage: "Test the Google Calendar connector and show me the steps",
-      assistantMessage: "",
-    },
-  ];
-}
-
-const STREAM_DELAY_MS = 1400;
-
-function getLandingTaglines(agentName: string) {
-  return [
-    `I'm ${agentName}. Customize me and assign tasks anytime.`,
-    "Your intelligent teammate, tuned to you.",
-    "Create workflows, run automations, get things done.",
-    "Ask me anything, I'll route it to the right minions.",
-    "200+ connectors, ready when you are.",
-  ] as const;
-}
-const CAROUSEL_INTERVAL_MS = 4000;
-
-interface StreamedScenario {
-  id: DemoScenarioId;
-  userMessage: string;
-  assistantMessage: string;
-}
-
-interface ChatScenarioBlockProps {
-  scene: StreamedScenario;
-  onNavigateToActivity?: () => void;
-  commandAllowed: boolean;
-  setCommandAllowed: (v: boolean) => void;
-  approveDone: boolean;
-  setApproveDone: (v: boolean) => void;
-  selectedOption: string | null;
-  setSelectedOption: (v: string | null) => void;
-  teamPersonalChoice: "team" | "personal" | null;
-  setTeamPersonalChoice: (v: "team" | "personal" | null) => void;
-  connectorConnected: boolean;
-  setConnectorConnected: (v: boolean) => void;
-  zeroAvatarSrc?: string;
-  onAvatarClick?: () => void;
-  agentName?: string;
-}
-
-function HelloFromZeroBlock({
-  zeroAvatarSrc = "/zero-avatar.png",
-  onAvatarClick,
-  agentName = "Zero",
-}: {
-  zeroAvatarSrc?: string;
-  onAvatarClick?: () => void;
-  agentName?: string;
-}) {
-  const avatarButton = (
-    <button
-      type="button"
-      onClick={onAvatarClick}
-      className="h-9 w-9 shrink-0 mt-0.5 flex items-center justify-center overflow-hidden rounded-xl transition-colors duration-150 hover:bg-muted/50 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-      aria-label="Switch Zero avatar"
-    >
-      <img
-        src={zeroAvatarSrc}
-        alt=""
-        role="presentation"
-        className="h-9 w-9 rounded-full object-cover object-top"
-      />
-    </button>
-  );
-  return (
-    <div className="flex flex-col gap-4 animate-in fade-in slide-in-from-bottom-2 duration-300">
-      <div className="grid grid-cols-[48px_1fr] gap-3 items-start">
-        {avatarButton}
-        <div className="zero-chat-bubble-assistant rounded-2xl border backdrop-blur-sm px-4 py-4 text-sm leading-relaxed min-w-0">
-          <p className="text-foreground">
-            Hi! I&apos;m {agentName}, your AI teammate. I help you automate
-            tasks, run workflows, and get things done across your connected
-            tools.
-          </p>
-        </div>
-      </div>
-      <div className="grid grid-cols-[48px_1fr] gap-3 items-start">
-        {avatarButton}
-        <div className="zero-chat-bubble-assistant rounded-2xl border backdrop-blur-sm px-4 py-4 text-sm leading-relaxed min-w-0 flex flex-col gap-2">
-          <p className="font-medium text-foreground">
-            You&apos;ve connected Notion.
-          </p>
-          <p className="text-muted-foreground">
-            Here are a few ways you can use me with it:
-          </p>
-          <ul className="list-disc list-inside space-y-1 text-muted-foreground">
-            <li>Create a weekly summary page from your meeting notes</li>
-            <li>Sync action items from Slack into a Notion database</li>
-            <li>
-              Generate doc outlines from a prompt and save to a Notion page
-            </li>
-            <li>Turn emails into structured Notion tasks with due dates</li>
-          </ul>
-        </div>
-      </div>
-    </div>
-  );
-}
-
-function ChatScenarioBlock({
-  scene,
-  onNavigateToActivity,
-  commandAllowed,
-  setCommandAllowed,
-  approveDone,
-  setApproveDone,
-  selectedOption,
-  setSelectedOption,
-  teamPersonalChoice,
-  setTeamPersonalChoice,
-  connectorConnected,
-  setConnectorConnected,
-  zeroAvatarSrc = "/zero-avatar.png",
-  onAvatarClick,
-  agentName = "Zero",
-}: ChatScenarioBlockProps) {
-  return (
-    <div className="flex flex-col gap-4 animate-in fade-in slide-in-from-bottom-2 duration-300">
-      <div className="grid grid-cols-[48px_1fr] gap-3 items-start">
-        <div className="w-9 h-9 shrink-0" />
-        <div className="flex min-w-0 justify-end">
-          <div className="zero-chat-bubble-user rounded-2xl px-4 py-3 max-w-[85%] text-sm leading-relaxed">
-            {scene.userMessage}
-          </div>
-        </div>
-      </div>
-      <div className="grid grid-cols-[48px_1fr] gap-3 items-start">
-        <button
-          type="button"
-          onClick={onAvatarClick}
-          className="h-9 w-9 shrink-0 mt-0.5 flex items-center justify-center overflow-hidden rounded-xl transition-colors duration-150 hover:bg-muted/50 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-          aria-label="Switch Zero avatar"
-        >
-          <img
-            src={zeroAvatarSrc}
-            alt=""
-            role="presentation"
-            className="h-9 w-9 rounded-full object-cover object-top"
-          />
-        </button>
-        <div className="zero-chat-bubble-assistant rounded-2xl border backdrop-blur-sm px-4 py-4 text-sm leading-relaxed min-w-0 flex flex-col gap-0">
-          <ChatScenarioAssistantContent
-            scene={scene}
-            onNavigateToActivity={onNavigateToActivity}
-            commandAllowed={commandAllowed}
-            setCommandAllowed={setCommandAllowed}
-            approveDone={approveDone}
-            setApproveDone={setApproveDone}
-            selectedOption={selectedOption}
-            setSelectedOption={setSelectedOption}
-            teamPersonalChoice={teamPersonalChoice}
-            setTeamPersonalChoice={setTeamPersonalChoice}
-            connectorConnected={connectorConnected}
-            setConnectorConnected={setConnectorConnected}
-            agentName={agentName}
-          />
-        </div>
-      </div>
-    </div>
-  );
-}
-
-type ChatScenarioAssistantContentProps = ChatScenarioBlockProps;
-
-function ChatScenarioAssistantContent({
-  scene,
-  onNavigateToActivity,
-  commandAllowed,
-  setCommandAllowed,
-  approveDone,
-  setApproveDone,
-  selectedOption,
-  setSelectedOption,
-  teamPersonalChoice,
-  setTeamPersonalChoice,
-  connectorConnected,
-  setConnectorConnected,
-  agentName = "Zero",
-}: ChatScenarioAssistantContentProps) {
-  if (scene.id === "rich-summary") {
-    return (
-      <div className="text-foreground text-sm leading-relaxed space-y-3">
-        <p className="font-medium">
-          Scheduled run for hn-ai-digest completed. {"Here's"} what was
-          accomplished:
-        </p>
-        <h3 className="text-sm font-semibold text-foreground leading-6 mt-4 mb-1.5">
-          Summary
-        </h3>
-        <p className="text-muted-foreground">
-          Found 7 AI-related stories from the top 50 HN posts, selected the top
-          5 by score:
-        </p>
-        <ol className="list-decimal list-inside space-y-1 text-muted-foreground">
-          <li>
-            <strong className="text-foreground font-medium">
-              [Discussion]
-            </strong>{" "}
-            Pope tells priests to use their brains, not AI (520 pts, 411
-            comments)
-          </li>
-          <li>
-            <strong className="text-foreground font-medium">
-              [Open Source]
-            </strong>{" "}
-            FreeBSD Wi-Fi driver built with AI assistance (160 pts, 124
-            comments)
-          </li>
-          <li>
-            <strong className="text-foreground font-medium">[Product]</strong>{" "}
-            AI Timeline tracking 171 LLMs (131 pts, 48 comments)
-          </li>
-          <li>
-            <strong className="text-foreground font-medium">[Industry]</strong>{" "}
-            Goldman Sachs: AI added zero to US GDP growth (32 pts, 2 comments)
-          </li>
-          <li>
-            <strong className="text-foreground font-medium">
-              [Discussion]
-            </strong>{" "}
-            Magical Mushroom mycelium packaging (342 pts, 111 comments)
-          </li>
-        </ol>
-        <h3 className="text-sm font-semibold text-foreground leading-6 mt-4 mb-1.5">
-          Files created
-        </h3>
-        <ul className="list-disc list-inside space-y-0.5 text-muted-foreground">
-          <li>
-            <code className="text-foreground bg-muted/50 px-1 rounded text-xs font-mono">
-              ~/digest-2026-02-24.md
-            </code>{" "}
-            — Full markdown digest with summaries
-          </li>
-          <li>
-            <code className="text-foreground bg-muted/50 px-1 rounded text-xs font-mono">
-              ~/slack_digest.json
-            </code>{" "}
-            — Slack Block Kit formatted message ready to post
-          </li>
-        </ul>
-        <p className="text-muted-foreground text-xs mt-3">
-          The digest has been saved to your HOME directory. To post to Slack,
-          set up a valid Slack Bot Token and run the post command.
-        </p>
-        <pre className="mt-2 p-3 rounded-lg bg-muted/30 text-xs font-mono text-foreground overflow-x-auto border border-border/40">
-          <code>{`curl -s -X POST "https://slack.com/api/chat.postMessage" \\
-  -H "Authorization: Bearer $SLACK_BOT_TOKEN" \\
-  -H "Content-Type: application/json" \\
-  -d @~/slack_digest.json`}</code>
-        </pre>
-        <div className="mt-3.5 pt-3.5 border-t border-border/30">
-          <Button
-            size="sm"
-            variant="outline"
-            className="zero-chat-btn rounded-lg h-8 px-3.5 text-sm font-medium gap-1.5 border"
-            onClick={onNavigateToActivity}
-          >
-            <IconChartLine size={13} />
-            View activity
-          </Button>
-        </div>
-      </div>
-    );
-  }
-  if (scene.id === "agent-operations") {
-    return (
-      <ChatScenarioAgentOperations
-        commandAllowed={commandAllowed}
-        setCommandAllowed={setCommandAllowed}
-        agentName={agentName}
-      />
-    );
-  }
-  return (
-    <>
-      <p className="text-foreground text-sm leading-relaxed">
-        {scene.assistantMessage}
-      </p>
-      {scene.id === "approve" && (
-        <>
-          {!approveDone ? (
-            <div className="mt-3.5 pt-3.5 border-t border-border/30 flex flex-wrap gap-2">
-              <Button
-                size="sm"
-                variant="outline"
-                className="rounded-lg h-8 px-3.5 text-sm font-medium gap-1.5 border-primary/40 bg-primary/10 text-primary hover:bg-primary/15"
-                onClick={() => setApproveDone(true)}
-              >
-                <IconCheck size={13} />
-                Approve
-              </Button>
-              <Button
-                size="sm"
-                variant="outline"
-                className="zero-chat-btn rounded-lg h-8 px-3.5 text-sm font-medium border"
-                onClick={() => setApproveDone(false)}
-              >
-                Deny
-              </Button>
-            </div>
-          ) : (
-            <p className="mt-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-              Approved
-            </p>
-          )}
-        </>
-      )}
-      {scene.id === "ask-options" && (
-        <>
-          <div className="mt-3.5 pt-3.5 border-t border-border/30 rounded-lg bg-muted/5 py-2 flex flex-wrap gap-2">
-            {["Email", "Slack", "Both"].map((opt) => (
-              <button
-                key={opt}
-                type="button"
-                className={cn(
-                  "zero-chat-btn rounded-lg h-8 px-3.5 text-sm font-medium border transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
-                  selectedOption === opt &&
-                    "border-primary/40 bg-primary/10 text-primary ring-1 ring-primary/20 ring-inset",
-                )}
-                onClick={() =>
-                  setSelectedOption(selectedOption === opt ? null : opt)
-                }
-              >
-                {opt}
-              </button>
-            ))}
-          </div>
-          {selectedOption && (
-            <p className="mt-2.5 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-              Chose {selectedOption}
-            </p>
-          )}
-        </>
-      )}
-      {scene.id === "team-personal" && (
-        <>
-          <div className="mt-3.5 pt-3.5 border-t border-border/30 rounded-lg bg-muted/5 py-2 flex flex-wrap gap-2">
-            <button
-              type="button"
-              className={cn(
-                "zero-chat-btn rounded-lg h-8 px-3.5 text-sm font-medium border transition-all duration-200 flex items-center gap-1.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
-                teamPersonalChoice === "team" &&
-                  "border-primary/40 bg-primary/10 text-primary ring-1 ring-primary/20 ring-inset",
-              )}
-              onClick={() =>
-                setTeamPersonalChoice(
-                  teamPersonalChoice === "team" ? null : "team",
-                )
-              }
-            >
-              <IconUsers size={13} />
-              Team
-            </button>
-            <button
-              type="button"
-              className={cn(
-                "zero-chat-btn rounded-lg h-8 px-3.5 text-sm font-medium border transition-all duration-200 flex items-center gap-1.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
-                teamPersonalChoice === "personal" &&
-                  "border-primary/40 bg-primary/10 text-primary ring-1 ring-primary/20 ring-inset",
-              )}
-              onClick={() =>
-                setTeamPersonalChoice(
-                  teamPersonalChoice === "personal" ? null : "personal",
-                )
-              }
-            >
-              <IconUser size={13} />
-              Personal
-            </button>
-          </div>
-          {teamPersonalChoice && (
-            <p className="mt-2.5 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-              {teamPersonalChoice === "team"
-                ? "Team workflow"
-                : "Personal workflow"}
-            </p>
-          )}
-        </>
-      )}
-      {scene.id === "connect-connector" && (
-        <>
-          {!connectorConnected ? (
-            <div className="mt-3.5 pt-3.5 border-t border-border/30">
-              <Button
-                size="sm"
-                variant="outline"
-                className="rounded-lg h-8 px-3.5 text-sm font-medium gap-1.5 border-primary/40 bg-primary/10 text-primary hover:bg-primary/15"
-                onClick={() => setConnectorConnected(true)}
-              >
-                <IconPlug size={13} />
-                Connect Slack
-              </Button>
-            </div>
-          ) : (
-            <p className="mt-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-              Slack connected
-            </p>
-          )}
-        </>
-      )}
-    </>
-  );
-}
-
-function ChatScenarioAgentOperations({
-  commandAllowed,
-  setCommandAllowed,
-  agentName = "Zero",
-}: {
-  commandAllowed: boolean;
-  setCommandAllowed: (v: boolean) => void;
-  agentName?: string;
-}) {
-  return (
-    <div className="text-foreground text-sm leading-relaxed">
-      <p className="mb-5 leading-relaxed">
-        {"I'll"} run the Google Calendar connector demo: discover tools, fetch
-        live data, and verify the environment.
-      </p>
-      <div className="relative">
-        <div
-          className="absolute left-0 top-0 bottom-0 w-4 flex justify-center pointer-events-none"
-          aria-hidden
-        >
-          <div className="w-px h-full border-l border-dotted border-border/80" />
-        </div>
-        <div className="flex gap-3 items-start">
-          <div className="w-4 shrink-0 flex justify-center pt-1.5 relative z-[1]">
-            <span className="flex h-4 w-4 items-center justify-center rounded-full border border-border bg-muted/80 shadow-[0_1px_2px_rgba(0,0,0,0.06)] dark:shadow-[0_1px_2px_rgba(0,0,0,0.2)]">
-              <span
-                className="h-1.5 w-1.5 rounded-full bg-primary"
-                aria-hidden
-              />
-            </span>
-          </div>
-          <div className="flex-1 min-w-0 pb-6">
-            <h4 className="text-sm font-semibold text-foreground leading-6">
-              Discover available Google Calendar MCP tools
-            </h4>
-            <p className="text-muted-foreground text-sm mt-1.5 leading-relaxed">
-              Initiating discovery of MCP tools before fetching live data.
-            </p>
-          </div>
-        </div>
-        <div className="flex gap-3 items-start">
-          <div className="w-4 shrink-0 flex justify-center pt-1.5 relative z-[1]">
-            <span className="flex h-4 w-4 items-center justify-center rounded-full border border-border bg-muted/80 shadow-[0_1px_2px_rgba(0,0,0,0.06)] dark:shadow-[0_1px_2px_rgba(0,0,0,0.2)]">
-              <span
-                className="h-1.5 w-1.5 rounded-full bg-primary"
-                aria-hidden
-              />
-            </span>
-          </div>
-          <div className="flex-1 min-w-0 pb-6">
-            <h4 className="text-sm font-semibold text-foreground leading-6">
-              Fetch live data (calendars, events)
-            </h4>
-            <p className="text-muted-foreground text-sm mt-1.5 leading-relaxed">
-              Discovery done. Testing live data retrieval next.
-            </p>
-          </div>
-        </div>
-        <div className="flex gap-3 items-start">
-          <div className="w-4 shrink-0 flex justify-center pt-1.5 relative z-[1]">
-            <span
-              className={cn(
-                "flex h-4 w-4 shrink-0 items-center justify-center rounded-full border shadow-[0_1px_2px_rgba(0,0,0,0.06)] dark:shadow-[0_1px_2px_rgba(0,0,0,0.2)]",
-                commandAllowed
-                  ? "border-border bg-muted/80"
-                  : "border-border bg-muted/60 dark:bg-muted/50",
-              )}
-            >
-              {commandAllowed && (
-                <span
-                  className="h-1.5 w-1.5 rounded-full bg-primary"
-                  aria-hidden
-                />
-              )}
-            </span>
-          </div>
-          <div className="flex-1 min-w-0">
-            <h4 className="text-sm font-semibold text-foreground leading-6">
-              Verify environment and run command
-            </h4>
-            <p className="text-muted-foreground text-sm mt-1.5 leading-relaxed">
-              Allow {agentName} to run the following command to verify Node and
-              npm.
-            </p>
-            {!commandAllowed ? (
-              <div className="mt-3 rounded-lg border border-border/40 bg-muted/10 px-4 py-3">
-                <p className="text-sm text-foreground leading-relaxed">
-                  Allow {agentName} to run the following command to verify
-                  Node.js and npm:{" "}
-                  <code className="font-mono text-xs bg-muted/50 px-1.5 py-0.5 rounded">
-                    node --version && npm --version
-                  </code>
-                </p>
-                <div className="mt-3 pt-3 flex flex-wrap gap-2 border-t border-border/30">
-                  <Button
-                    size="sm"
-                    variant="outline"
-                    className="rounded-lg h-8 px-3.5 text-sm font-medium gap-1.5 border-primary/40 bg-primary/10 text-primary hover:bg-primary/15"
-                    onClick={() => setCommandAllowed(true)}
-                  >
-                    <IconCheck size={13} />
-                    Allow once
-                  </Button>
-                  <Button
-                    size="sm"
-                    variant="outline"
-                    className="zero-chat-btn rounded-lg h-8 px-3.5 text-sm font-medium border"
-                    onClick={() => setCommandAllowed(false)}
-                  >
-                    Deny
-                  </Button>
-                </div>
-              </div>
-            ) : (
-              <p className="mt-2 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                Command allowed
-              </p>
-            )}
-          </div>
-        </div>
-      </div>
-    </div>
-  );
-}
+// ---------------------------------------------------------------------------
+// ZeroChatPage
+// ---------------------------------------------------------------------------
 
 interface ZeroChatPageProps {
-  initialScenarioId?: DemoScenarioId;
-  onClearScenario?: () => void;
-  onNavigateToActivity?: () => void;
-  onNavigateToSchedule?: () => void;
-  onNavigateToJob?: () => void;
-  onNavigateToMeet?: (tab?: string) => void;
   zeroAvatarSrc?: string;
   onAvatarClick?: () => void;
 }
 
 export function ZeroChatPage({
-  initialScenarioId,
-  onClearScenario,
-  onNavigateToActivity,
-  onNavigateToSchedule,
-  onNavigateToJob,
-  onNavigateToMeet,
   zeroAvatarSrc = "/zero-avatar.png",
   onAvatarClick,
 }: ZeroChatPageProps) {
   const agentNameLoadable = useLoadable(agentDisplayName$);
   const agentName =
     agentNameLoadable.state === "hasData" ? agentNameLoadable.data : "Zero";
-  const input$ = useCCState("");
-  const input = useGet(input$);
-  const setInput = useSet(input$);
-  const conversationActive$ = useCCState(false);
-  const conversationActive = useGet(conversationActive$);
-  const setConversationActive = useSet(conversationActive$);
-  const streamedCount$ = useCCState(0);
-  const streamedCount = useGet(streamedCount$);
-  const setStreamedCount = useSet(streamedCount$);
-  const conversationEndEl$ = useCCState<HTMLDivElement | null>(null);
-  const conversationEndEl = useGet(conversationEndEl$);
-  const setConversationEndEl = useSet(conversationEndEl$);
-  const subAgentListEl$ = useCCState<HTMLDivElement | null>(null);
-  const setSubAgentListEl = useSet(subAgentListEl$);
-  const approveDone$ = useCCState(false);
-  const approveDone = useGet(approveDone$);
-  const setApproveDone = useSet(approveDone$);
-  const selectedOption$ = useCCState<string | null>(null);
-  const selectedOption = useGet(selectedOption$);
-  const setSelectedOption = useSet(selectedOption$);
-  const teamPersonalChoice$ = useCCState<"team" | "personal" | null>(null);
-  const teamPersonalChoice = useGet(teamPersonalChoice$);
-  const setTeamPersonalChoice = useSet(teamPersonalChoice$);
-  const connectorConnected$ = useCCState(false);
-  const connectorConnected = useGet(connectorConnected$);
-  const setConnectorConnected = useSet(connectorConnected$);
-  const commandAllowed$ = useCCState(false);
-  const commandAllowed = useGet(commandAllowed$);
-  const setCommandAllowed = useSet(commandAllowed$);
-  const showSubAgentList$ = useCCState(false);
-  const showSubAgentList = useGet(showSubAgentList$);
-  const carouselIndex$ = useCCState(0);
-  const carouselIndex = useGet(carouselIndex$);
-  // Carousel interval — starts on mount via onRef, cleans up on unmount
-  const carouselCommand$ = useCommand(
-    ({ set }, _el: HTMLElement, signal: AbortSignal) => {
-      const id = window.setInterval(() => {
-        set(
-          carouselIndex$,
-          (i: number) => (i + 1) % getLandingTaglines(agentName).length,
-        );
-      }, CAROUSEL_INTERVAL_MS);
-      signal.addEventListener("abort", () => window.clearInterval(id));
-    },
-  );
-  const carouselRef$ = onRef(carouselCommand$);
-  const carouselRef = useSet(carouselRef$);
+  const messages = useGet(zeroChatMessages$);
+  const sending = useGet(zeroChatSending$);
+  const input = useGet(zeroChatInput$);
+  const setInput = useSet(setZeroChatInput$);
+  const clearInput = useSet(clearZeroChatInput$);
+  const send = useSet(sendZeroChatMessage$);
 
-  // Stream tick — schedules the next streamed message after a delay
-  const streamTimeoutId$ = useCCState<number | null>(null);
-  const scheduleStreamTick$ = useCommand(({ get, set }) => {
-    const active = get(conversationActive$);
-    const count = get(streamedCount$);
-    if (!active || count >= 6) {
+  const messagesEndEl$ = useCCState<HTMLDivElement | null>(null);
+  const messagesEndEl = useGet(messagesEndEl$);
+  const setMessagesEndEl = useSet(messagesEndEl$);
+
+  // Auto-scroll when messages change
+  if (messagesEndEl && messages.length > 0) {
+    messagesEndEl.scrollIntoView({ behavior: "smooth" });
+  }
+
+  const handleSend = () => {
+    const trimmed = input.trim();
+    if (!trimmed || sending) {
       return;
     }
-    const id = window.setTimeout(() => {
-      set(streamTimeoutId$, null);
-      set(streamedCount$, (c: number) => Math.min(c + 1, 6));
-      // Auto-scroll conversation end into view
-      const el = get(conversationEndEl$);
-      if (el) {
-        el.scrollIntoView({ behavior: "smooth" });
-      }
-      // Schedule next tick
-      set(scheduleStreamTick$);
-    }, STREAM_DELAY_MS);
-    set(streamTimeoutId$, id);
-  });
-  const scheduleStreamTick = useSet(scheduleStreamTick$);
-  // Clean up pending stream timeout on unmount
-  const streamCleanup$ = useCommand(
-    ({ get }, _el: HTMLElement, signal: AbortSignal) => {
-      signal.addEventListener("abort", () => {
-        const id = get(streamTimeoutId$);
-        if (id !== null) {
-          window.clearTimeout(id);
-        }
-      });
-    },
-  );
-  const streamCleanupRef$ = onRef(streamCleanup$);
-  const streamCleanupRef = useSet(streamCleanupRef$);
-
-  // Toggle sub-agent list with auto-scroll when opening
-  const toggleSubAgentList$ = useCommand(({ get, set }) => {
-    const current = get(showSubAgentList$);
-    set(showSubAgentList$, !current);
-    if (!current) {
-      // Becoming visible — scroll into view after next paint
-      window.requestAnimationFrame(() => {
-        const el = get(subAgentListEl$);
-        if (el) {
-          el.scrollIntoView({ behavior: "smooth" });
-        }
-      });
-    }
-  });
-  const toggleSubAgentList = useSet(toggleSubAgentList$);
-
-  const handleComposerFocus = () => {
-    if (!conversationActive) {
-      setConversationActive(true);
-      setStreamedCount(1);
-      // Scroll conversation end into view after first message
-      if (conversationEndEl) {
-        window.requestAnimationFrame(() => {
-          conversationEndEl.scrollIntoView({ behavior: "smooth" });
-        });
-      }
-      // Start streaming ticks
-      scheduleStreamTick();
-    }
+    clearInput();
+    detach(send(trimmed), Reason.DomCallback);
   };
 
-  const handleSend = (messageOverride?: string) => {
-    const text = (messageOverride ?? input).trim();
-    if (!text) {
-      return;
-    }
-    if (!messageOverride) {
-      setInput("");
-    }
-    // TODO: send message
-  };
-
-  const LUCKY_PROMPTS = [
-    "What can you help me with today?",
-    "Suggest something useful I might have missed",
-    "Summarize my last few days in one sentence",
-    "What’s one quick win I could do right now?",
-  ];
-
-  const handleFeelingLucky = () => {
-    handleComposerFocus();
-    const prompt =
-      LUCKY_PROMPTS[Math.floor(Math.random() * LUCKY_PROMPTS.length)];
-    handleSend(prompt);
-  };
-
-  const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if (e.key === "Enter" && !e.shiftKey) {
       e.preventDefault();
       handleSend();
     }
   };
 
-  const streamedScenarios = getStreamedScenarios(agentName);
-  const scenariosToShow = initialScenarioId
-    ? streamedScenarios.filter((s) => s.id === initialScenarioId)
-    : conversationActive
-      ? streamedScenarios.slice(0, streamedCount)
-      : [];
-  const showConversation =
-    (initialScenarioId !== undefined && scenariosToShow.length > 0) ||
-    conversationActive;
+  const handleSuggestedPrompt = (prompt: string) => {
+    clearInput();
+    detach(send(prompt), Reason.DomCallback);
+  };
 
-  if (showConversation && scenariosToShow.length > 0) {
-    const isScenarioFromSidebar = initialScenarioId !== undefined;
-    return (
-      <div
-        ref={streamCleanupRef}
-        className="flex flex-1 flex-col min-h-0 bg-transparent"
-      >
-        <header className="shrink-0 bg-transparent px-4 sm:px-6 py-3 flex items-center justify-between">
-          <div className="flex items-center gap-3">
-            <Button
-              variant="ghost"
-              size="icon"
-              className="h-8 w-8 shrink-0 -ml-2"
-              onClick={() =>
-                isScenarioFromSidebar
-                  ? onClearScenario?.()
-                  : setConversationActive(false)
-              }
-              aria-label="Back to chat home"
-            >
-              <IconArrowLeft size={20} stroke={1.5} />
-            </Button>
+  const hasMessages = messages.length > 0;
+
+  return (
+    <div className="flex flex-1 flex-col min-h-0">
+      {hasMessages ? (
+        /* Chat view — message list + input */
+        <>
+          <div className="flex-1 overflow-y-auto px-4 sm:px-6 py-4">
+            <div className="mx-auto max-w-[720px] flex flex-col gap-1">
+              {messages.map((msg) => (
+                <ChatMessageRow key={msg.id} message={msg} />
+              ))}
+              <div ref={setMessagesEndEl} />
+            </div>
+          </div>
+          <div className="shrink-0 px-4 sm:px-6 pb-4 sm:pb-6">
+            <div className="mx-auto max-w-[720px]">
+              <ChatInput
+                input={input}
+                sending={sending}
+                onInputChange={setInput}
+                onSend={handleSend}
+                onKeyDown={handleKeyDown}
+                placeholder={`Message ${agentName}...`}
+              />
+            </div>
+          </div>
+        </>
+      ) : (
+        /* Welcome state — avatar, greeting, prompts, input */
+        <div className="flex-1 flex flex-col items-center justify-center px-4 sm:px-6 pb-4">
+          <div className="flex flex-col items-center gap-4 mb-8">
             <button
               type="button"
               onClick={onAvatarClick}
-              className="h-8 w-8 shrink-0 flex items-center justify-center overflow-hidden rounded-xl transition-colors duration-150 hover:bg-muted/50 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-              aria-label="Switch Zero avatar"
+              className="rounded-full overflow-hidden h-16 w-16 transition-transform hover:scale-105"
             >
               <img
                 src={zeroAvatarSrc}
-                alt=""
-                role="presentation"
-                className="h-8 w-8 rounded-full object-cover object-top"
+                alt={agentName}
+                className="h-full w-full object-cover"
               />
             </button>
-            <span className="font-semibold text-foreground">{agentName}</span>
+            <div className="text-center">
+              <h2 className="text-xl font-semibold text-foreground">
+                {agentName}
+              </h2>
+              <p className="text-sm text-muted-foreground mt-1">
+                Your AI assistant — ask me anything
+              </p>
+            </div>
           </div>
-          <div className="flex items-center gap-0.5">
-            <Button
-              variant="ghost"
-              size="icon"
-              className={cn(
-                "h-8 w-8 text-muted-foreground hover:text-foreground",
-                showSubAgentList && "bg-muted/60 text-foreground",
-              )}
-              onClick={() => toggleSubAgentList()}
-              aria-label={`${ZERO_TEAM_JOBS.length} sub-agents`}
-            >
-              <IconUsers size={18} stroke={1.5} />
-            </Button>
-            <Button
-              variant="ghost"
-              size="icon"
-              className="h-8 w-8 text-muted-foreground hover:text-foreground"
-              onClick={onNavigateToSchedule}
-              aria-label={`${agentName} schedule`}
-            >
-              <IconCalendar size={18} stroke={1.5} />
-            </Button>
-          </div>
-        </header>
-        <main className="flex-1 overflow-auto px-4 sm:px-6 py-4">
-          <div className="mx-auto max-w-[900px] flex flex-col gap-6 pb-4">
-            {scenariosToShow.map((scene) =>
-              scene.id === "hello-from-zero" ? (
-                <HelloFromZeroBlock
-                  key={scene.id}
-                  zeroAvatarSrc={zeroAvatarSrc}
-                  onAvatarClick={onAvatarClick}
-                  agentName={agentName}
-                />
-              ) : (
-                <ChatScenarioBlock
-                  key={scene.id}
-                  scene={scene}
-                  onNavigateToActivity={onNavigateToActivity}
-                  commandAllowed={commandAllowed}
-                  setCommandAllowed={setCommandAllowed}
-                  approveDone={approveDone}
-                  setApproveDone={setApproveDone}
-                  selectedOption={selectedOption}
-                  setSelectedOption={setSelectedOption}
-                  teamPersonalChoice={teamPersonalChoice}
-                  setTeamPersonalChoice={setTeamPersonalChoice}
-                  connectorConnected={connectorConnected}
-                  setConnectorConnected={setConnectorConnected}
-                  zeroAvatarSrc={zeroAvatarSrc}
-                  onAvatarClick={onAvatarClick}
-                  agentName={agentName}
-                />
-              ),
-            )}
-            {showSubAgentList && (
-              <div
-                ref={setSubAgentListEl}
-                className="grid grid-cols-[48px_1fr] gap-3 items-start animate-in fade-in slide-in-from-bottom-2 duration-300"
-              >
+
+          <div className="w-full max-w-[720px] space-y-4">
+            <ChatInput
+              input={input}
+              sending={sending}
+              onInputChange={setInput}
+              onSend={handleSend}
+              onKeyDown={handleKeyDown}
+              placeholder={`Message ${agentName}...`}
+            />
+
+            <div className="flex flex-wrap gap-2 justify-center">
+              {SUGGESTED_PROMPTS.map((prompt) => (
                 <button
+                  key={prompt}
                   type="button"
-                  onClick={onAvatarClick}
-                  className="h-9 w-9 shrink-0 mt-0.5 flex items-center justify-center overflow-hidden rounded-xl transition-colors duration-150 hover:bg-muted/50 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-                  aria-label="Switch Zero avatar"
+                  onClick={() => handleSuggestedPrompt(prompt)}
+                  disabled={sending}
+                  className="flex items-center gap-1.5 rounded-full border border-border bg-card px-3 py-1.5 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:opacity-50"
                 >
-                  <img
-                    src={zeroAvatarSrc}
-                    alt=""
-                    role="presentation"
-                    className="h-9 w-9 rounded-full object-cover object-top"
-                  />
+                  <IconSparkles size={12} />
+                  {prompt}
                 </button>
-                <div className="zero-chat-bubble-assistant rounded-2xl border backdrop-blur-sm overflow-hidden min-w-0 flex flex-col">
-                  <div className="px-4 pt-4 pb-2">
-                    <p className="text-sm text-foreground leading-relaxed">
-                      You have {ZERO_TEAM_JOBS.length} sub-agents with different
-                      expertise. Assign tasks as needed—I’ll route them and
-                      return the results.
-                    </p>
-                  </div>
-                  <div className="px-4 py-2.5 border-t border-border/50">
-                    <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                      Sub-agents ({ZERO_TEAM_JOBS.length})
-                    </span>
-                  </div>
-                  <ul role="list">
-                    {ZERO_TEAM_JOBS.map((job) => (
-                      <li
-                        key={job.id}
-                        className="hover:bg-muted/20 transition-colors"
-                      >
-                        <div className="min-w-0 py-3 mx-4">
-                          <div className="flex flex-wrap items-center gap-2">
-                            <span className="text-sm text-muted-foreground">
-                              {job.agentName}
-                            </span>
-                            <span className="text-muted-foreground/60">·</span>
-                            <span className="text-sm font-medium text-foreground">
-                              {job.title}
-                            </span>
-                            <span className="zero-pill inline-flex items-center gap-1.5 rounded-md border px-1.5 py-0.5 text-xs font-medium">
-                              {job.scope === "team" ? (
-                                <IconUsers
-                                  size={12}
-                                  stroke={1.5}
-                                  className="h-3 w-3 shrink-0 text-sky-600 dark:text-sky-400"
-                                />
-                              ) : (
-                                <IconUser
-                                  size={12}
-                                  stroke={1.5}
-                                  className="h-3 w-3 shrink-0 text-amber-600 dark:text-amber-400"
-                                />
-                              )}
-                              {job.scope === "team" ? "Team" : "Personal"}
-                            </span>
-                          </div>
-                          <p className="mt-0.5 text-xs text-muted-foreground truncate">
-                            {job.description}
-                          </p>
-                        </div>
-                      </li>
-                    ))}
-                  </ul>
-                  <div className="border-t border-border/50 px-4 py-3">
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      className="w-fit rounded-lg"
-                      onClick={onNavigateToJob}
-                    >
-                      Manage in {agentName}&apos;s team
-                    </Button>
-                  </div>
-                </div>
-              </div>
-            )}
-            <div ref={setConversationEndEl} />
+              ))}
+            </div>
           </div>
-        </main>
-        <footer className="shrink-0 bg-transparent px-4 sm:px-6 pt-4 pb-8">
-          <div className="mx-auto max-w-[900px] grid grid-cols-[48px_1fr] gap-3">
-            <div className="w-9 shrink-0" />
-            <Card className="zero-composer w-full min-w-0 overflow-hidden transition-colors duration-200">
-              <CardContent className="p-0">
-                <div className="flex flex-col">
-                  <textarea
-                    className="w-full resize-none bg-transparent px-5 pt-4 pb-2 text-sm text-foreground placeholder:text-muted-foreground border-0 min-h-[88px] focus:outline-none focus:ring-0"
-                    rows={3}
-                    placeholder="Ask me to automate workflows, manage tasks..."
-                    value={input}
-                    onChange={(e) => setInput(e.target.value)}
-                    onKeyDown={handleKeyDown}
-                  />
-                  <div className="flex items-center justify-between gap-2 px-4 py-3 border-t border-border/50">
-                    <div className="flex items-center gap-1 text-muted-foreground">
-                      <button
-                        type="button"
-                        className="p-2 rounded-lg hover:bg-muted/60 hover:text-foreground transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-                        aria-label="Add"
-                      >
-                        <IconPlus size={18} stroke={1.5} />
-                      </button>
-                      <button
-                        type="button"
-                        className="p-2 rounded-lg hover:bg-muted/60 hover:text-foreground transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-                        aria-label="Attach"
-                      >
-                        <IconPaperclip size={18} stroke={1.5} />
-                      </button>
-                      <button
-                        type="button"
-                        className="p-2 rounded-lg hover:bg-muted/60 hover:text-foreground transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-                        aria-label="Emoji"
-                      >
-                        <IconMoodSmile size={18} stroke={1.5} />
-                      </button>
-                    </div>
-                    <div className="flex items-center gap-1">
-                      <button
-                        type="button"
-                        className="p-2 rounded-lg text-muted-foreground hover:bg-muted/60 hover:text-foreground transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-                        aria-label="Voice input"
-                      >
-                        <IconMicrophone size={18} stroke={1.5} />
-                      </button>
-                      <Button
-                        size="sm"
-                        className="rounded-lg h-9 w-9 p-0 shrink-0"
-                        onClick={() => handleSend()}
-                        disabled={!input.trim()}
-                        aria-label="Send"
-                      >
-                        <IconSend size={16} stroke={2} />
-                      </Button>
-                    </div>
-                  </div>
-                </div>
-              </CardContent>
-            </Card>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// ChatInput
+// ---------------------------------------------------------------------------
+
+function ChatInput({
+  input,
+  sending,
+  onInputChange,
+  onSend,
+  onKeyDown,
+  placeholder,
+}: {
+  input: string;
+  sending: boolean;
+  onInputChange: (value: string) => void;
+  onSend: () => void;
+  onKeyDown: (e: React.KeyboardEvent<HTMLTextAreaElement>) => void;
+  placeholder: string;
+}) {
+  return (
+    <div className="flex items-end gap-2 md:gap-2.5 rounded-xl border border-border bg-card p-3 md:p-4 shadow-sm">
+      <textarea
+        className="flex-1 resize-none bg-transparent text-sm text-secondary-foreground placeholder:text-muted-foreground focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+        rows={2}
+        placeholder={placeholder}
+        value={input}
+        onChange={(e) => onInputChange(e.target.value)}
+        onKeyDown={onKeyDown}
+        disabled={sending}
+      />
+      <Button
+        onClick={onSend}
+        disabled={!input.trim() || sending}
+        size="icon"
+        className="shrink-0 rounded-lg h-9 w-9"
+      >
+        {sending ? (
+          <IconLoader2 size={16} className="animate-spin" />
+        ) : (
+          <IconSend size={16} />
+        )}
+      </Button>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Chat message components
+// ---------------------------------------------------------------------------
+
+function ChatMessageRow({ message }: { message: ZeroChatMessage }) {
+  if (message.role === "user") {
+    return <UserMessage content={message.content} />;
+  }
+  return <AssistantMessage message={message} />;
+}
+
+function UserMessage({ content }: { content: string }) {
+  return (
+    <div className="py-2">
+      <div className="flex justify-end">
+        <div className="max-w-[85%] rounded-lg bg-primary px-3 py-2 [&_*]:!text-primary-foreground">
+          <Markdown source={content} />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function AssistantMessage({ message }: { message: ZeroChatMessage }) {
+  if (message.error) {
+    return (
+      <div className="py-2">
+        <div className="flex gap-2 items-start">
+          <StatusDot variant="error" className="mt-1.5" />
+          <div className="flex-1 min-w-0">
+            <div className="flex items-start gap-1.5 text-sm text-destructive">
+              <IconAlertCircle size={14} className="shrink-0 mt-0.5" />
+              <span>{message.error}</span>
+            </div>
           </div>
-        </footer>
+        </div>
       </div>
     );
   }
 
-  // Landing page: full content (title, triggers, composer, actions, prompts)
-  return (
-    <div ref={carouselRef} className="flex flex-1 flex-col min-h-0">
-      <header
-        className="shrink-0 bg-transparent px-4 sm:px-6 pt-10 pb-2"
-        aria-hidden="true"
-      />
-
-      <main className="flex flex-1 flex-col justify-center overflow-auto px-4 sm:px-6 py-12">
-        <div className="mx-auto w-full max-w-[900px] flex flex-col items-stretch gap-8 -mt-24">
-          <div className="flex items-center gap-4 w-full">
-            <button
-              type="button"
-              onClick={onAvatarClick}
-              className="h-14 w-14 shrink-0 sm:h-16 sm:w-16 flex items-center justify-center overflow-hidden rounded-xl transition-colors duration-150 hover:bg-muted/50 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-              aria-label="Switch Zero avatar"
-            >
-              <img
-                src={zeroAvatarSrc}
-                alt=""
-                role="presentation"
-                className="h-14 w-14 rounded-full object-cover object-top sm:h-16 sm:w-16"
-              />
-            </button>
-            <div className="h-[4.5rem] sm:h-20 overflow-hidden flex-1 min-w-0 flex flex-col justify-center">
-              <h2
-                key={carouselIndex}
-                className="text-2xl sm:text-3xl font-semibold tracking-tight text-foreground zero-tagline-animate-in"
-              >
-                {getLandingTaglines(agentName)[carouselIndex]}
-              </h2>
-            </div>
-          </div>
-
-          {/* Composer */}
-          <Card className="zero-composer w-full overflow-hidden transition-colors duration-200">
-            <CardContent className="p-0">
-              <div className="flex flex-col">
-                <textarea
-                  className="w-full resize-none bg-transparent px-5 pt-4 pb-2 text-sm text-foreground placeholder:text-muted-foreground border-0 min-h-[88px] focus:outline-none focus:ring-0"
-                  rows={3}
-                  placeholder="Ask me to automate workflows, manage tasks..."
-                  value={input}
-                  onChange={(e) => setInput(e.target.value)}
-                  onKeyDown={handleKeyDown}
-                  onFocus={handleComposerFocus}
-                />
-                <div className="flex items-center justify-between gap-2 px-4 py-3 border-t border-border/50">
-                  <div className="flex items-center gap-1 text-muted-foreground">
-                    <button
-                      type="button"
-                      className="p-2 rounded-lg hover:bg-muted/60 hover:text-foreground transition-colors"
-                      aria-label="Add"
-                    >
-                      <IconPlus size={18} stroke={1.5} />
-                    </button>
-                    <button
-                      type="button"
-                      className="p-2 rounded-lg hover:bg-muted/60 hover:text-foreground transition-colors"
-                      aria-label="Attach"
-                    >
-                      <IconPaperclip size={18} stroke={1.5} />
-                    </button>
-                    <button
-                      type="button"
-                      className="p-2 rounded-lg hover:bg-muted/60 hover:text-foreground transition-colors"
-                      aria-label="Emoji"
-                    >
-                      <IconMoodSmile size={18} stroke={1.5} />
-                    </button>
-                  </div>
-                  <div className="flex items-center gap-1">
-                    <button
-                      type="button"
-                      className="p-2 rounded-lg text-muted-foreground hover:bg-muted/60 hover:text-foreground transition-colors"
-                      aria-label="Voice input"
-                    >
-                      <IconMicrophone size={18} stroke={1.5} />
-                    </button>
-                    <Button
-                      size="sm"
-                      className="rounded-lg h-9 w-9 p-0 shrink-0"
-                      onClick={() => handleSend()}
-                      disabled={!input.trim()}
-                      aria-label="Send"
-                    >
-                      <IconSend size={16} stroke={2} />
-                    </Button>
-                  </div>
-                </div>
-              </div>
-            </CardContent>
-          </Card>
-
-          {/* Action buttons */}
-          <div className="flex flex-wrap justify-between items-center gap-2 w-full">
-            <div className="flex flex-wrap gap-2">
-              {getActionButtons(agentName).map(({ id, label, icon: Icon }) => (
-                <Button
-                  key={id}
-                  variant="outline"
-                  size="sm"
-                  className="zero-btn-morandi rounded-lg h-8 px-3.5 text-sm font-medium gap-2 border"
-                  onClick={() => {
-                    if (id === "automate") {
-                      onNavigateToSchedule?.();
-                    } else if (id === "customize") {
-                      onNavigateToMeet?.("settings");
-                    } else if (id === "connectors") {
-                      onNavigateToMeet?.("connections");
-                    }
-                  }}
-                >
-                  <Icon size={16} />
-                  {label}
-                </Button>
-              ))}
-            </div>
-            <Button
-              variant="outline"
-              size="sm"
-              className="rounded-lg h-8 px-3.5 text-sm font-medium gap-2 border-primary/30 text-primary hover:bg-primary/5 hover:border-primary/50 shrink-0"
-              type="button"
-              onClick={handleFeelingLucky}
-            >
-              <IconSparkles size={16} />
-              Feeling great
-            </Button>
-          </div>
-
-          {/* Suggested prompts grid */}
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 w-full">
-            {SUGGESTED_PROMPTS.map(
-              ({ title, description, icon: Icon, iconClassName }) => (
-                <button
-                  key={title}
-                  type="button"
-                  className={cn(
-                    "zero-card-morandi p-4 text-left transition-colors",
-                    "flex gap-3 items-start",
-                  )}
-                >
-                  <span
-                    className={cn(
-                      "shrink-0 mt-0.5 rounded-lg p-1.5 bg-[hsl(220,6%,95%)]",
-                      iconClassName ?? "text-muted-foreground",
-                    )}
-                  >
-                    <Icon size={18} />
-                  </span>
-                  <div className="min-w-0">
-                    <p className="text-sm font-medium text-foreground">
-                      {title}
-                    </p>
-                    <p className="text-xs text-muted-foreground mt-0.5">
-                      {description}
-                    </p>
-                  </div>
-                </button>
-              ),
-            )}
+  if (message.content) {
+    return (
+      <div className="py-2">
+        <div className="flex gap-2 items-start">
+          <StatusDot variant="success" className="mt-1.5" />
+          <div className="flex-1 min-w-0">
+            <Markdown source={message.content} />
           </div>
         </div>
-      </main>
+      </div>
+    );
+  }
+
+  return (
+    <div className="py-2">
+      <div className="flex gap-2 items-center">
+        <StatusDot variant="pending" className="animate-pulse" />
+        <span className="text-sm text-muted-foreground">Thinking...</span>
+      </div>
     </div>
   );
 }

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-page.tsx
@@ -25,7 +25,7 @@ import { Button, Card, CardContent, cn } from "@vm0/ui";
 import { ZERO_TEAM_JOBS } from "./zero-jobs-page";
 import { agentDisplayName$ } from "../../signals/zero-page/zero-agent-name.ts";
 
-export type DemoScenarioId =
+type DemoScenarioId =
   | "hello-from-zero"
   | "approve"
   | "ask-options"
@@ -650,6 +650,7 @@ interface ZeroChatPageProps {
   onNavigateToSchedule?: () => void;
   onNavigateToJob?: () => void;
   onNavigateToMeet?: (tab?: string) => void;
+  onSendMessage?: (message: string) => void;
   zeroAvatarSrc?: string;
   onAvatarClick?: () => void;
 }
@@ -661,6 +662,7 @@ export function ZeroChatPage({
   onNavigateToSchedule,
   onNavigateToJob,
   onNavigateToMeet,
+  onSendMessage,
   zeroAvatarSrc = "/zero-avatar.png",
   onAvatarClick,
 }: ZeroChatPageProps) {
@@ -790,7 +792,7 @@ export function ZeroChatPage({
     if (!messageOverride) {
       setInput("");
     }
-    // TODO: send message
+    onSendMessage?.(text);
   };
 
   const LUCKY_PROMPTS = [

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-page.tsx
@@ -677,9 +677,7 @@ export function ZeroChatPage({
   const setConversationActive = useSet(conversationActive$);
   const streamedCount$ = useCCState(0);
   const streamedCount = useGet(streamedCount$);
-  const setStreamedCount = useSet(streamedCount$);
   const conversationEndEl$ = useCCState<HTMLDivElement | null>(null);
-  const conversationEndEl = useGet(conversationEndEl$);
   const setConversationEndEl = useSet(conversationEndEl$);
   const subAgentListEl$ = useCCState<HTMLDivElement | null>(null);
   const setSubAgentListEl = useSet(subAgentListEl$);
@@ -738,7 +736,6 @@ export function ZeroChatPage({
     }, STREAM_DELAY_MS);
     set(streamTimeoutId$, id);
   });
-  const scheduleStreamTick = useSet(scheduleStreamTick$);
   // Clean up pending stream timeout on unmount
   const streamCleanup$ = useCommand(
     ({ get }, _el: HTMLElement, signal: AbortSignal) => {
@@ -769,21 +766,6 @@ export function ZeroChatPage({
   });
   const toggleSubAgentList = useSet(toggleSubAgentList$);
 
-  const handleComposerFocus = () => {
-    if (!conversationActive) {
-      setConversationActive(true);
-      setStreamedCount(1);
-      // Scroll conversation end into view after first message
-      if (conversationEndEl) {
-        window.requestAnimationFrame(() => {
-          conversationEndEl.scrollIntoView({ behavior: "smooth" });
-        });
-      }
-      // Start streaming ticks
-      scheduleStreamTick();
-    }
-  };
-
   const handleSend = (messageOverride?: string) => {
     const text = (messageOverride ?? input).trim();
     if (!text) {
@@ -803,7 +785,6 @@ export function ZeroChatPage({
   ];
 
   const handleFeelingLucky = () => {
-    handleComposerFocus();
     const prompt =
       LUCKY_PROMPTS[Math.floor(Math.random() * LUCKY_PROMPTS.length)];
     handleSend(prompt);
@@ -1115,7 +1096,6 @@ export function ZeroChatPage({
                   value={input}
                   onChange={(e) => setInput(e.target.value)}
                   onKeyDown={handleKeyDown}
-                  onFocus={handleComposerFocus}
                 />
                 <div className="flex items-center justify-between gap-2 px-4 py-3 border-t border-border/50">
                   <div className="flex items-center gap-1 text-muted-foreground">

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-page.tsx
@@ -1,279 +1,1237 @@
-import { useCCState } from "ccstate-react/experimental";
+import type { ReactNode, KeyboardEvent } from "react";
+import { useCCState, useCommand } from "ccstate-react/experimental";
 import { useGet, useSet, useLoadable } from "ccstate-react";
+import { onRef } from "../../signals/utils.ts";
 import {
   IconSend,
-  IconLoader2,
-  IconAlertCircle,
+  IconPaperclip,
+  IconMoodSmile,
+  IconMicrophone,
+  IconPlus,
+  IconBriefcase,
+  IconSettings,
+  IconPlug,
   IconSparkles,
+  IconChartBar,
+  IconReceipt,
+  IconUser,
+  IconUsers,
+  IconCheck,
+  IconArrowLeft,
+  IconChartLine,
+  IconCalendar,
 } from "@tabler/icons-react";
-import { Button } from "@vm0/ui";
-import { Markdown } from "../components/markdown.tsx";
-import { StatusDot } from "../logs-page/components/status-dot.tsx";
-import { detach, Reason } from "../../signals/utils.ts";
+import { Button, Card, CardContent, cn } from "@vm0/ui";
+import { ZERO_TEAM_JOBS } from "./zero-jobs-page";
 import { agentDisplayName$ } from "../../signals/zero-page/zero-agent-name.ts";
-import {
-  zeroChatMessages$,
-  zeroChatSending$,
-  zeroChatInput$,
-  setZeroChatInput$,
-  clearZeroChatInput$,
-  sendZeroChatMessage$,
-  type ZeroChatMessage,
-} from "../../signals/zero-page/zero-chat.ts";
 
-// ---------------------------------------------------------------------------
-// Suggested prompts for welcome state
-// ---------------------------------------------------------------------------
+export type DemoScenarioId =
+  | "hello-from-zero"
+  | "approve"
+  | "ask-options"
+  | "team-personal"
+  | "connect-connector"
+  | "rich-summary"
+  | "agent-operations";
+
+type NavIcon = (props: { size?: number; className?: string }) => ReactNode;
+type ActionId = "automate" | "customize" | "connectors";
+function getActionButtons(agentName: string) {
+  return [
+    {
+      id: "automate" as ActionId,
+      label: "Automate workflows",
+      icon: IconBriefcase as NavIcon,
+    },
+    {
+      id: "customize" as ActionId,
+      label: `Customize ${agentName}`,
+      icon: IconSettings as NavIcon,
+    },
+    {
+      id: "connectors" as ActionId,
+      label: "Add connectors",
+      icon: IconPlug as NavIcon,
+    },
+  ] as const;
+}
 
 const SUGGESTED_PROMPTS = [
-  "What can you help me with?",
-  "Summarize my recent activity",
-  "Set up a daily digest workflow",
-  "Help me automate a task",
+  {
+    title: "Auto-organize inbox",
+    description: "Smart categorization, reply, and daily email digest",
+    icon: IconChartBar as NavIcon,
+    iconClassName: "text-emerald-600 dark:text-emerald-400",
+  },
+  {
+    title: "Daily morning brief",
+    description: "Trending topics on a schedule, your personalized digest",
+    icon: IconReceipt as NavIcon,
+    iconClassName: "text-primary",
+  },
 ] as const;
 
-// ---------------------------------------------------------------------------
-// ZeroChatPage
-// ---------------------------------------------------------------------------
+function getStreamedScenarios(agentName: string): readonly Readonly<{
+  id: DemoScenarioId;
+  userMessage: string;
+  assistantMessage: string;
+}>[] {
+  return [
+    {
+      id: "hello-from-zero",
+      userMessage: "Hi",
+      assistantMessage: "",
+    },
+    {
+      id: "approve",
+      userMessage: "Run the deployment to production",
+      assistantMessage: `This action requires approval. Allow ${agentName} to run the deployment?`,
+    },
+    {
+      id: "ask-options",
+      userMessage: "Send a summary of this week’s activity",
+      assistantMessage: "Where should I send the summary?",
+    },
+    {
+      id: "team-personal",
+      userMessage:
+        "Create a daily digest workflow that summarizes important updates",
+      assistantMessage:
+        "I can create a Daily Digest workflow. Would you like this to be a Team workflow or a Personal workflow?",
+    },
+    {
+      id: "connect-connector",
+      userMessage: "Notify #releases when a PR is merged",
+      assistantMessage: "Connect Slack to enable this workflow.",
+    },
+    {
+      id: "rich-summary",
+      userMessage: "Run the HN AI daily digest workflow",
+      assistantMessage: "",
+    },
+    {
+      id: "agent-operations",
+      userMessage: "Test the Google Calendar connector and show me the steps",
+      assistantMessage: "",
+    },
+  ];
+}
+
+const STREAM_DELAY_MS = 1400;
+
+function getLandingTaglines(agentName: string) {
+  return [
+    `I'm ${agentName}. Customize me and assign tasks anytime.`,
+    "Your intelligent teammate, tuned to you.",
+    "Create workflows, run automations, get things done.",
+    "Ask me anything, I'll route it to the right minions.",
+    "200+ connectors, ready when you are.",
+  ] as const;
+}
+const CAROUSEL_INTERVAL_MS = 4000;
+
+interface StreamedScenario {
+  id: DemoScenarioId;
+  userMessage: string;
+  assistantMessage: string;
+}
+
+interface ChatScenarioBlockProps {
+  scene: StreamedScenario;
+  onNavigateToActivity?: () => void;
+  commandAllowed: boolean;
+  setCommandAllowed: (v: boolean) => void;
+  approveDone: boolean;
+  setApproveDone: (v: boolean) => void;
+  selectedOption: string | null;
+  setSelectedOption: (v: string | null) => void;
+  teamPersonalChoice: "team" | "personal" | null;
+  setTeamPersonalChoice: (v: "team" | "personal" | null) => void;
+  connectorConnected: boolean;
+  setConnectorConnected: (v: boolean) => void;
+  zeroAvatarSrc?: string;
+  onAvatarClick?: () => void;
+  agentName?: string;
+}
+
+function HelloFromZeroBlock({
+  zeroAvatarSrc = "/zero-avatar.png",
+  onAvatarClick,
+  agentName = "Zero",
+}: {
+  zeroAvatarSrc?: string;
+  onAvatarClick?: () => void;
+  agentName?: string;
+}) {
+  const avatarButton = (
+    <button
+      type="button"
+      onClick={onAvatarClick}
+      className="h-9 w-9 shrink-0 mt-0.5 flex items-center justify-center overflow-hidden rounded-xl transition-colors duration-150 hover:bg-muted/50 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+      aria-label="Switch Zero avatar"
+    >
+      <img
+        src={zeroAvatarSrc}
+        alt=""
+        role="presentation"
+        className="h-9 w-9 rounded-full object-cover object-top"
+      />
+    </button>
+  );
+  return (
+    <div className="flex flex-col gap-4 animate-in fade-in slide-in-from-bottom-2 duration-300">
+      <div className="grid grid-cols-[48px_1fr] gap-3 items-start">
+        {avatarButton}
+        <div className="zero-chat-bubble-assistant rounded-2xl border backdrop-blur-sm px-4 py-4 text-sm leading-relaxed min-w-0">
+          <p className="text-foreground">
+            Hi! I&apos;m {agentName}, your AI teammate. I help you automate
+            tasks, run workflows, and get things done across your connected
+            tools.
+          </p>
+        </div>
+      </div>
+      <div className="grid grid-cols-[48px_1fr] gap-3 items-start">
+        {avatarButton}
+        <div className="zero-chat-bubble-assistant rounded-2xl border backdrop-blur-sm px-4 py-4 text-sm leading-relaxed min-w-0 flex flex-col gap-2">
+          <p className="font-medium text-foreground">
+            You&apos;ve connected Notion.
+          </p>
+          <p className="text-muted-foreground">
+            Here are a few ways you can use me with it:
+          </p>
+          <ul className="list-disc list-inside space-y-1 text-muted-foreground">
+            <li>Create a weekly summary page from your meeting notes</li>
+            <li>Sync action items from Slack into a Notion database</li>
+            <li>
+              Generate doc outlines from a prompt and save to a Notion page
+            </li>
+            <li>Turn emails into structured Notion tasks with due dates</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ChatScenarioBlock({
+  scene,
+  onNavigateToActivity,
+  commandAllowed,
+  setCommandAllowed,
+  approveDone,
+  setApproveDone,
+  selectedOption,
+  setSelectedOption,
+  teamPersonalChoice,
+  setTeamPersonalChoice,
+  connectorConnected,
+  setConnectorConnected,
+  zeroAvatarSrc = "/zero-avatar.png",
+  onAvatarClick,
+  agentName = "Zero",
+}: ChatScenarioBlockProps) {
+  return (
+    <div className="flex flex-col gap-4 animate-in fade-in slide-in-from-bottom-2 duration-300">
+      <div className="grid grid-cols-[48px_1fr] gap-3 items-start">
+        <div className="w-9 h-9 shrink-0" />
+        <div className="flex min-w-0 justify-end">
+          <div className="zero-chat-bubble-user rounded-2xl px-4 py-3 max-w-[85%] text-sm leading-relaxed">
+            {scene.userMessage}
+          </div>
+        </div>
+      </div>
+      <div className="grid grid-cols-[48px_1fr] gap-3 items-start">
+        <button
+          type="button"
+          onClick={onAvatarClick}
+          className="h-9 w-9 shrink-0 mt-0.5 flex items-center justify-center overflow-hidden rounded-xl transition-colors duration-150 hover:bg-muted/50 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+          aria-label="Switch Zero avatar"
+        >
+          <img
+            src={zeroAvatarSrc}
+            alt=""
+            role="presentation"
+            className="h-9 w-9 rounded-full object-cover object-top"
+          />
+        </button>
+        <div className="zero-chat-bubble-assistant rounded-2xl border backdrop-blur-sm px-4 py-4 text-sm leading-relaxed min-w-0 flex flex-col gap-0">
+          <ChatScenarioAssistantContent
+            scene={scene}
+            onNavigateToActivity={onNavigateToActivity}
+            commandAllowed={commandAllowed}
+            setCommandAllowed={setCommandAllowed}
+            approveDone={approveDone}
+            setApproveDone={setApproveDone}
+            selectedOption={selectedOption}
+            setSelectedOption={setSelectedOption}
+            teamPersonalChoice={teamPersonalChoice}
+            setTeamPersonalChoice={setTeamPersonalChoice}
+            connectorConnected={connectorConnected}
+            setConnectorConnected={setConnectorConnected}
+            agentName={agentName}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+type ChatScenarioAssistantContentProps = ChatScenarioBlockProps;
+
+function ChatScenarioAssistantContent({
+  scene,
+  onNavigateToActivity,
+  commandAllowed,
+  setCommandAllowed,
+  approveDone,
+  setApproveDone,
+  selectedOption,
+  setSelectedOption,
+  teamPersonalChoice,
+  setTeamPersonalChoice,
+  connectorConnected,
+  setConnectorConnected,
+  agentName = "Zero",
+}: ChatScenarioAssistantContentProps) {
+  if (scene.id === "rich-summary") {
+    return (
+      <div className="text-foreground text-sm leading-relaxed space-y-3">
+        <p className="font-medium">
+          Scheduled run for hn-ai-digest completed. {"Here's"} what was
+          accomplished:
+        </p>
+        <h3 className="text-sm font-semibold text-foreground leading-6 mt-4 mb-1.5">
+          Summary
+        </h3>
+        <p className="text-muted-foreground">
+          Found 7 AI-related stories from the top 50 HN posts, selected the top
+          5 by score:
+        </p>
+        <ol className="list-decimal list-inside space-y-1 text-muted-foreground">
+          <li>
+            <strong className="text-foreground font-medium">
+              [Discussion]
+            </strong>{" "}
+            Pope tells priests to use their brains, not AI (520 pts, 411
+            comments)
+          </li>
+          <li>
+            <strong className="text-foreground font-medium">
+              [Open Source]
+            </strong>{" "}
+            FreeBSD Wi-Fi driver built with AI assistance (160 pts, 124
+            comments)
+          </li>
+          <li>
+            <strong className="text-foreground font-medium">[Product]</strong>{" "}
+            AI Timeline tracking 171 LLMs (131 pts, 48 comments)
+          </li>
+          <li>
+            <strong className="text-foreground font-medium">[Industry]</strong>{" "}
+            Goldman Sachs: AI added zero to US GDP growth (32 pts, 2 comments)
+          </li>
+          <li>
+            <strong className="text-foreground font-medium">
+              [Discussion]
+            </strong>{" "}
+            Magical Mushroom mycelium packaging (342 pts, 111 comments)
+          </li>
+        </ol>
+        <h3 className="text-sm font-semibold text-foreground leading-6 mt-4 mb-1.5">
+          Files created
+        </h3>
+        <ul className="list-disc list-inside space-y-0.5 text-muted-foreground">
+          <li>
+            <code className="text-foreground bg-muted/50 px-1 rounded text-xs font-mono">
+              ~/digest-2026-02-24.md
+            </code>{" "}
+            — Full markdown digest with summaries
+          </li>
+          <li>
+            <code className="text-foreground bg-muted/50 px-1 rounded text-xs font-mono">
+              ~/slack_digest.json
+            </code>{" "}
+            — Slack Block Kit formatted message ready to post
+          </li>
+        </ul>
+        <p className="text-muted-foreground text-xs mt-3">
+          The digest has been saved to your HOME directory. To post to Slack,
+          set up a valid Slack Bot Token and run the post command.
+        </p>
+        <pre className="mt-2 p-3 rounded-lg bg-muted/30 text-xs font-mono text-foreground overflow-x-auto border border-border/40">
+          <code>{`curl -s -X POST "https://slack.com/api/chat.postMessage" \\
+  -H "Authorization: Bearer $SLACK_BOT_TOKEN" \\
+  -H "Content-Type: application/json" \\
+  -d @~/slack_digest.json`}</code>
+        </pre>
+        <div className="mt-3.5 pt-3.5 border-t border-border/30">
+          <Button
+            size="sm"
+            variant="outline"
+            className="zero-chat-btn rounded-lg h-8 px-3.5 text-sm font-medium gap-1.5 border"
+            onClick={onNavigateToActivity}
+          >
+            <IconChartLine size={13} />
+            View activity
+          </Button>
+        </div>
+      </div>
+    );
+  }
+  if (scene.id === "agent-operations") {
+    return (
+      <ChatScenarioAgentOperations
+        commandAllowed={commandAllowed}
+        setCommandAllowed={setCommandAllowed}
+        agentName={agentName}
+      />
+    );
+  }
+  return (
+    <>
+      <p className="text-foreground text-sm leading-relaxed">
+        {scene.assistantMessage}
+      </p>
+      {scene.id === "approve" && (
+        <>
+          {!approveDone ? (
+            <div className="mt-3.5 pt-3.5 border-t border-border/30 flex flex-wrap gap-2">
+              <Button
+                size="sm"
+                variant="outline"
+                className="rounded-lg h-8 px-3.5 text-sm font-medium gap-1.5 border-primary/40 bg-primary/10 text-primary hover:bg-primary/15"
+                onClick={() => setApproveDone(true)}
+              >
+                <IconCheck size={13} />
+                Approve
+              </Button>
+              <Button
+                size="sm"
+                variant="outline"
+                className="zero-chat-btn rounded-lg h-8 px-3.5 text-sm font-medium border"
+                onClick={() => setApproveDone(false)}
+              >
+                Deny
+              </Button>
+            </div>
+          ) : (
+            <p className="mt-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+              Approved
+            </p>
+          )}
+        </>
+      )}
+      {scene.id === "ask-options" && (
+        <>
+          <div className="mt-3.5 pt-3.5 border-t border-border/30 rounded-lg bg-muted/5 py-2 flex flex-wrap gap-2">
+            {["Email", "Slack", "Both"].map((opt) => (
+              <button
+                key={opt}
+                type="button"
+                className={cn(
+                  "zero-chat-btn rounded-lg h-8 px-3.5 text-sm font-medium border transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+                  selectedOption === opt &&
+                    "border-primary/40 bg-primary/10 text-primary ring-1 ring-primary/20 ring-inset",
+                )}
+                onClick={() =>
+                  setSelectedOption(selectedOption === opt ? null : opt)
+                }
+              >
+                {opt}
+              </button>
+            ))}
+          </div>
+          {selectedOption && (
+            <p className="mt-2.5 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+              Chose {selectedOption}
+            </p>
+          )}
+        </>
+      )}
+      {scene.id === "team-personal" && (
+        <>
+          <div className="mt-3.5 pt-3.5 border-t border-border/30 rounded-lg bg-muted/5 py-2 flex flex-wrap gap-2">
+            <button
+              type="button"
+              className={cn(
+                "zero-chat-btn rounded-lg h-8 px-3.5 text-sm font-medium border transition-all duration-200 flex items-center gap-1.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+                teamPersonalChoice === "team" &&
+                  "border-primary/40 bg-primary/10 text-primary ring-1 ring-primary/20 ring-inset",
+              )}
+              onClick={() =>
+                setTeamPersonalChoice(
+                  teamPersonalChoice === "team" ? null : "team",
+                )
+              }
+            >
+              <IconUsers size={13} />
+              Team
+            </button>
+            <button
+              type="button"
+              className={cn(
+                "zero-chat-btn rounded-lg h-8 px-3.5 text-sm font-medium border transition-all duration-200 flex items-center gap-1.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+                teamPersonalChoice === "personal" &&
+                  "border-primary/40 bg-primary/10 text-primary ring-1 ring-primary/20 ring-inset",
+              )}
+              onClick={() =>
+                setTeamPersonalChoice(
+                  teamPersonalChoice === "personal" ? null : "personal",
+                )
+              }
+            >
+              <IconUser size={13} />
+              Personal
+            </button>
+          </div>
+          {teamPersonalChoice && (
+            <p className="mt-2.5 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+              {teamPersonalChoice === "team"
+                ? "Team workflow"
+                : "Personal workflow"}
+            </p>
+          )}
+        </>
+      )}
+      {scene.id === "connect-connector" && (
+        <>
+          {!connectorConnected ? (
+            <div className="mt-3.5 pt-3.5 border-t border-border/30">
+              <Button
+                size="sm"
+                variant="outline"
+                className="rounded-lg h-8 px-3.5 text-sm font-medium gap-1.5 border-primary/40 bg-primary/10 text-primary hover:bg-primary/15"
+                onClick={() => setConnectorConnected(true)}
+              >
+                <IconPlug size={13} />
+                Connect Slack
+              </Button>
+            </div>
+          ) : (
+            <p className="mt-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+              Slack connected
+            </p>
+          )}
+        </>
+      )}
+    </>
+  );
+}
+
+function ChatScenarioAgentOperations({
+  commandAllowed,
+  setCommandAllowed,
+  agentName = "Zero",
+}: {
+  commandAllowed: boolean;
+  setCommandAllowed: (v: boolean) => void;
+  agentName?: string;
+}) {
+  return (
+    <div className="text-foreground text-sm leading-relaxed">
+      <p className="mb-5 leading-relaxed">
+        {"I'll"} run the Google Calendar connector demo: discover tools, fetch
+        live data, and verify the environment.
+      </p>
+      <div className="relative">
+        <div
+          className="absolute left-0 top-0 bottom-0 w-4 flex justify-center pointer-events-none"
+          aria-hidden
+        >
+          <div className="w-px h-full border-l border-dotted border-border/80" />
+        </div>
+        <div className="flex gap-3 items-start">
+          <div className="w-4 shrink-0 flex justify-center pt-1.5 relative z-[1]">
+            <span className="flex h-4 w-4 items-center justify-center rounded-full border border-border bg-muted/80 shadow-[0_1px_2px_rgba(0,0,0,0.06)] dark:shadow-[0_1px_2px_rgba(0,0,0,0.2)]">
+              <span
+                className="h-1.5 w-1.5 rounded-full bg-primary"
+                aria-hidden
+              />
+            </span>
+          </div>
+          <div className="flex-1 min-w-0 pb-6">
+            <h4 className="text-sm font-semibold text-foreground leading-6">
+              Discover available Google Calendar MCP tools
+            </h4>
+            <p className="text-muted-foreground text-sm mt-1.5 leading-relaxed">
+              Initiating discovery of MCP tools before fetching live data.
+            </p>
+          </div>
+        </div>
+        <div className="flex gap-3 items-start">
+          <div className="w-4 shrink-0 flex justify-center pt-1.5 relative z-[1]">
+            <span className="flex h-4 w-4 items-center justify-center rounded-full border border-border bg-muted/80 shadow-[0_1px_2px_rgba(0,0,0,0.06)] dark:shadow-[0_1px_2px_rgba(0,0,0,0.2)]">
+              <span
+                className="h-1.5 w-1.5 rounded-full bg-primary"
+                aria-hidden
+              />
+            </span>
+          </div>
+          <div className="flex-1 min-w-0 pb-6">
+            <h4 className="text-sm font-semibold text-foreground leading-6">
+              Fetch live data (calendars, events)
+            </h4>
+            <p className="text-muted-foreground text-sm mt-1.5 leading-relaxed">
+              Discovery done. Testing live data retrieval next.
+            </p>
+          </div>
+        </div>
+        <div className="flex gap-3 items-start">
+          <div className="w-4 shrink-0 flex justify-center pt-1.5 relative z-[1]">
+            <span
+              className={cn(
+                "flex h-4 w-4 shrink-0 items-center justify-center rounded-full border shadow-[0_1px_2px_rgba(0,0,0,0.06)] dark:shadow-[0_1px_2px_rgba(0,0,0,0.2)]",
+                commandAllowed
+                  ? "border-border bg-muted/80"
+                  : "border-border bg-muted/60 dark:bg-muted/50",
+              )}
+            >
+              {commandAllowed && (
+                <span
+                  className="h-1.5 w-1.5 rounded-full bg-primary"
+                  aria-hidden
+                />
+              )}
+            </span>
+          </div>
+          <div className="flex-1 min-w-0">
+            <h4 className="text-sm font-semibold text-foreground leading-6">
+              Verify environment and run command
+            </h4>
+            <p className="text-muted-foreground text-sm mt-1.5 leading-relaxed">
+              Allow {agentName} to run the following command to verify Node and
+              npm.
+            </p>
+            {!commandAllowed ? (
+              <div className="mt-3 rounded-lg border border-border/40 bg-muted/10 px-4 py-3">
+                <p className="text-sm text-foreground leading-relaxed">
+                  Allow {agentName} to run the following command to verify
+                  Node.js and npm:{" "}
+                  <code className="font-mono text-xs bg-muted/50 px-1.5 py-0.5 rounded">
+                    node --version && npm --version
+                  </code>
+                </p>
+                <div className="mt-3 pt-3 flex flex-wrap gap-2 border-t border-border/30">
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    className="rounded-lg h-8 px-3.5 text-sm font-medium gap-1.5 border-primary/40 bg-primary/10 text-primary hover:bg-primary/15"
+                    onClick={() => setCommandAllowed(true)}
+                  >
+                    <IconCheck size={13} />
+                    Allow once
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    className="zero-chat-btn rounded-lg h-8 px-3.5 text-sm font-medium border"
+                    onClick={() => setCommandAllowed(false)}
+                  >
+                    Deny
+                  </Button>
+                </div>
+              </div>
+            ) : (
+              <p className="mt-2 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                Command allowed
+              </p>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
 
 interface ZeroChatPageProps {
+  initialScenarioId?: DemoScenarioId;
+  onClearScenario?: () => void;
+  onNavigateToActivity?: () => void;
+  onNavigateToSchedule?: () => void;
+  onNavigateToJob?: () => void;
+  onNavigateToMeet?: (tab?: string) => void;
   zeroAvatarSrc?: string;
   onAvatarClick?: () => void;
 }
 
 export function ZeroChatPage({
+  initialScenarioId,
+  onClearScenario,
+  onNavigateToActivity,
+  onNavigateToSchedule,
+  onNavigateToJob,
+  onNavigateToMeet,
   zeroAvatarSrc = "/zero-avatar.png",
   onAvatarClick,
 }: ZeroChatPageProps) {
   const agentNameLoadable = useLoadable(agentDisplayName$);
   const agentName =
     agentNameLoadable.state === "hasData" ? agentNameLoadable.data : "Zero";
-  const messages = useGet(zeroChatMessages$);
-  const sending = useGet(zeroChatSending$);
-  const input = useGet(zeroChatInput$);
-  const setInput = useSet(setZeroChatInput$);
-  const clearInput = useSet(clearZeroChatInput$);
-  const send = useSet(sendZeroChatMessage$);
+  const input$ = useCCState("");
+  const input = useGet(input$);
+  const setInput = useSet(input$);
+  const conversationActive$ = useCCState(false);
+  const conversationActive = useGet(conversationActive$);
+  const setConversationActive = useSet(conversationActive$);
+  const streamedCount$ = useCCState(0);
+  const streamedCount = useGet(streamedCount$);
+  const setStreamedCount = useSet(streamedCount$);
+  const conversationEndEl$ = useCCState<HTMLDivElement | null>(null);
+  const conversationEndEl = useGet(conversationEndEl$);
+  const setConversationEndEl = useSet(conversationEndEl$);
+  const subAgentListEl$ = useCCState<HTMLDivElement | null>(null);
+  const setSubAgentListEl = useSet(subAgentListEl$);
+  const approveDone$ = useCCState(false);
+  const approveDone = useGet(approveDone$);
+  const setApproveDone = useSet(approveDone$);
+  const selectedOption$ = useCCState<string | null>(null);
+  const selectedOption = useGet(selectedOption$);
+  const setSelectedOption = useSet(selectedOption$);
+  const teamPersonalChoice$ = useCCState<"team" | "personal" | null>(null);
+  const teamPersonalChoice = useGet(teamPersonalChoice$);
+  const setTeamPersonalChoice = useSet(teamPersonalChoice$);
+  const connectorConnected$ = useCCState(false);
+  const connectorConnected = useGet(connectorConnected$);
+  const setConnectorConnected = useSet(connectorConnected$);
+  const commandAllowed$ = useCCState(false);
+  const commandAllowed = useGet(commandAllowed$);
+  const setCommandAllowed = useSet(commandAllowed$);
+  const showSubAgentList$ = useCCState(false);
+  const showSubAgentList = useGet(showSubAgentList$);
+  const carouselIndex$ = useCCState(0);
+  const carouselIndex = useGet(carouselIndex$);
+  // Carousel interval — starts on mount via onRef, cleans up on unmount
+  const carouselCommand$ = useCommand(
+    ({ set }, _el: HTMLElement, signal: AbortSignal) => {
+      const id = window.setInterval(() => {
+        set(
+          carouselIndex$,
+          (i: number) => (i + 1) % getLandingTaglines(agentName).length,
+        );
+      }, CAROUSEL_INTERVAL_MS);
+      signal.addEventListener("abort", () => window.clearInterval(id));
+    },
+  );
+  const carouselRef$ = onRef(carouselCommand$);
+  const carouselRef = useSet(carouselRef$);
 
-  const messagesEndEl$ = useCCState<HTMLDivElement | null>(null);
-  const messagesEndEl = useGet(messagesEndEl$);
-  const setMessagesEndEl = useSet(messagesEndEl$);
-
-  // Auto-scroll when messages change
-  if (messagesEndEl && messages.length > 0) {
-    messagesEndEl.scrollIntoView({ behavior: "smooth" });
-  }
-
-  const handleSend = () => {
-    const trimmed = input.trim();
-    if (!trimmed || sending) {
+  // Stream tick — schedules the next streamed message after a delay
+  const streamTimeoutId$ = useCCState<number | null>(null);
+  const scheduleStreamTick$ = useCommand(({ get, set }) => {
+    const active = get(conversationActive$);
+    const count = get(streamedCount$);
+    if (!active || count >= 6) {
       return;
     }
-    clearInput();
-    detach(send(trimmed), Reason.DomCallback);
+    const id = window.setTimeout(() => {
+      set(streamTimeoutId$, null);
+      set(streamedCount$, (c: number) => Math.min(c + 1, 6));
+      // Auto-scroll conversation end into view
+      const el = get(conversationEndEl$);
+      if (el) {
+        el.scrollIntoView({ behavior: "smooth" });
+      }
+      // Schedule next tick
+      set(scheduleStreamTick$);
+    }, STREAM_DELAY_MS);
+    set(streamTimeoutId$, id);
+  });
+  const scheduleStreamTick = useSet(scheduleStreamTick$);
+  // Clean up pending stream timeout on unmount
+  const streamCleanup$ = useCommand(
+    ({ get }, _el: HTMLElement, signal: AbortSignal) => {
+      signal.addEventListener("abort", () => {
+        const id = get(streamTimeoutId$);
+        if (id !== null) {
+          window.clearTimeout(id);
+        }
+      });
+    },
+  );
+  const streamCleanupRef$ = onRef(streamCleanup$);
+  const streamCleanupRef = useSet(streamCleanupRef$);
+
+  // Toggle sub-agent list with auto-scroll when opening
+  const toggleSubAgentList$ = useCommand(({ get, set }) => {
+    const current = get(showSubAgentList$);
+    set(showSubAgentList$, !current);
+    if (!current) {
+      // Becoming visible — scroll into view after next paint
+      window.requestAnimationFrame(() => {
+        const el = get(subAgentListEl$);
+        if (el) {
+          el.scrollIntoView({ behavior: "smooth" });
+        }
+      });
+    }
+  });
+  const toggleSubAgentList = useSet(toggleSubAgentList$);
+
+  const handleComposerFocus = () => {
+    if (!conversationActive) {
+      setConversationActive(true);
+      setStreamedCount(1);
+      // Scroll conversation end into view after first message
+      if (conversationEndEl) {
+        window.requestAnimationFrame(() => {
+          conversationEndEl.scrollIntoView({ behavior: "smooth" });
+        });
+      }
+      // Start streaming ticks
+      scheduleStreamTick();
+    }
   };
 
-  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+  const handleSend = (messageOverride?: string) => {
+    const text = (messageOverride ?? input).trim();
+    if (!text) {
+      return;
+    }
+    if (!messageOverride) {
+      setInput("");
+    }
+    // TODO: send message
+  };
+
+  const LUCKY_PROMPTS = [
+    "What can you help me with today?",
+    "Suggest something useful I might have missed",
+    "Summarize my last few days in one sentence",
+    "What’s one quick win I could do right now?",
+  ];
+
+  const handleFeelingLucky = () => {
+    handleComposerFocus();
+    const prompt =
+      LUCKY_PROMPTS[Math.floor(Math.random() * LUCKY_PROMPTS.length)];
+    handleSend(prompt);
+  };
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
     if (e.key === "Enter" && !e.shiftKey) {
       e.preventDefault();
       handleSend();
     }
   };
 
-  const handleSuggestedPrompt = (prompt: string) => {
-    clearInput();
-    detach(send(prompt), Reason.DomCallback);
-  };
+  const streamedScenarios = getStreamedScenarios(agentName);
+  const scenariosToShow = initialScenarioId
+    ? streamedScenarios.filter((s) => s.id === initialScenarioId)
+    : conversationActive
+      ? streamedScenarios.slice(0, streamedCount)
+      : [];
+  const showConversation =
+    (initialScenarioId !== undefined && scenariosToShow.length > 0) ||
+    conversationActive;
 
-  const hasMessages = messages.length > 0;
-
-  return (
-    <div className="flex flex-1 flex-col min-h-0">
-      {hasMessages ? (
-        /* Chat view — message list + input */
-        <>
-          <div className="flex-1 overflow-y-auto px-4 sm:px-6 py-4">
-            <div className="mx-auto max-w-[720px] flex flex-col gap-1">
-              {messages.map((msg) => (
-                <ChatMessageRow key={msg.id} message={msg} />
-              ))}
-              <div ref={setMessagesEndEl} />
-            </div>
-          </div>
-          <div className="shrink-0 px-4 sm:px-6 pb-4 sm:pb-6">
-            <div className="mx-auto max-w-[720px]">
-              <ChatInput
-                input={input}
-                sending={sending}
-                onInputChange={setInput}
-                onSend={handleSend}
-                onKeyDown={handleKeyDown}
-                placeholder={`Message ${agentName}...`}
-              />
-            </div>
-          </div>
-        </>
-      ) : (
-        /* Welcome state — avatar, greeting, prompts, input */
-        <div className="flex-1 flex flex-col items-center justify-center px-4 sm:px-6 pb-4">
-          <div className="flex flex-col items-center gap-4 mb-8">
+  if (showConversation && scenariosToShow.length > 0) {
+    const isScenarioFromSidebar = initialScenarioId !== undefined;
+    return (
+      <div
+        ref={streamCleanupRef}
+        className="flex flex-1 flex-col min-h-0 bg-transparent"
+      >
+        <header className="shrink-0 bg-transparent px-4 sm:px-6 py-3 flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8 shrink-0 -ml-2"
+              onClick={() =>
+                isScenarioFromSidebar
+                  ? onClearScenario?.()
+                  : setConversationActive(false)
+              }
+              aria-label="Back to chat home"
+            >
+              <IconArrowLeft size={20} stroke={1.5} />
+            </Button>
             <button
               type="button"
               onClick={onAvatarClick}
-              className="rounded-full overflow-hidden h-16 w-16 transition-transform hover:scale-105"
+              className="h-8 w-8 shrink-0 flex items-center justify-center overflow-hidden rounded-xl transition-colors duration-150 hover:bg-muted/50 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+              aria-label="Switch Zero avatar"
             >
               <img
                 src={zeroAvatarSrc}
-                alt={agentName}
-                className="h-full w-full object-cover"
+                alt=""
+                role="presentation"
+                className="h-8 w-8 rounded-full object-cover object-top"
               />
             </button>
-            <div className="text-center">
-              <h2 className="text-xl font-semibold text-foreground">
-                {agentName}
+            <span className="font-semibold text-foreground">{agentName}</span>
+          </div>
+          <div className="flex items-center gap-0.5">
+            <Button
+              variant="ghost"
+              size="icon"
+              className={cn(
+                "h-8 w-8 text-muted-foreground hover:text-foreground",
+                showSubAgentList && "bg-muted/60 text-foreground",
+              )}
+              onClick={() => toggleSubAgentList()}
+              aria-label={`${ZERO_TEAM_JOBS.length} sub-agents`}
+            >
+              <IconUsers size={18} stroke={1.5} />
+            </Button>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8 text-muted-foreground hover:text-foreground"
+              onClick={onNavigateToSchedule}
+              aria-label={`${agentName} schedule`}
+            >
+              <IconCalendar size={18} stroke={1.5} />
+            </Button>
+          </div>
+        </header>
+        <main className="flex-1 overflow-auto px-4 sm:px-6 py-4">
+          <div className="mx-auto max-w-[900px] flex flex-col gap-6 pb-4">
+            {scenariosToShow.map((scene) =>
+              scene.id === "hello-from-zero" ? (
+                <HelloFromZeroBlock
+                  key={scene.id}
+                  zeroAvatarSrc={zeroAvatarSrc}
+                  onAvatarClick={onAvatarClick}
+                  agentName={agentName}
+                />
+              ) : (
+                <ChatScenarioBlock
+                  key={scene.id}
+                  scene={scene}
+                  onNavigateToActivity={onNavigateToActivity}
+                  commandAllowed={commandAllowed}
+                  setCommandAllowed={setCommandAllowed}
+                  approveDone={approveDone}
+                  setApproveDone={setApproveDone}
+                  selectedOption={selectedOption}
+                  setSelectedOption={setSelectedOption}
+                  teamPersonalChoice={teamPersonalChoice}
+                  setTeamPersonalChoice={setTeamPersonalChoice}
+                  connectorConnected={connectorConnected}
+                  setConnectorConnected={setConnectorConnected}
+                  zeroAvatarSrc={zeroAvatarSrc}
+                  onAvatarClick={onAvatarClick}
+                  agentName={agentName}
+                />
+              ),
+            )}
+            {showSubAgentList && (
+              <div
+                ref={setSubAgentListEl}
+                className="grid grid-cols-[48px_1fr] gap-3 items-start animate-in fade-in slide-in-from-bottom-2 duration-300"
+              >
+                <button
+                  type="button"
+                  onClick={onAvatarClick}
+                  className="h-9 w-9 shrink-0 mt-0.5 flex items-center justify-center overflow-hidden rounded-xl transition-colors duration-150 hover:bg-muted/50 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                  aria-label="Switch Zero avatar"
+                >
+                  <img
+                    src={zeroAvatarSrc}
+                    alt=""
+                    role="presentation"
+                    className="h-9 w-9 rounded-full object-cover object-top"
+                  />
+                </button>
+                <div className="zero-chat-bubble-assistant rounded-2xl border backdrop-blur-sm overflow-hidden min-w-0 flex flex-col">
+                  <div className="px-4 pt-4 pb-2">
+                    <p className="text-sm text-foreground leading-relaxed">
+                      You have {ZERO_TEAM_JOBS.length} sub-agents with different
+                      expertise. Assign tasks as needed—I’ll route them and
+                      return the results.
+                    </p>
+                  </div>
+                  <div className="px-4 py-2.5 border-t border-border/50">
+                    <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                      Sub-agents ({ZERO_TEAM_JOBS.length})
+                    </span>
+                  </div>
+                  <ul role="list">
+                    {ZERO_TEAM_JOBS.map((job) => (
+                      <li
+                        key={job.id}
+                        className="hover:bg-muted/20 transition-colors"
+                      >
+                        <div className="min-w-0 py-3 mx-4">
+                          <div className="flex flex-wrap items-center gap-2">
+                            <span className="text-sm text-muted-foreground">
+                              {job.agentName}
+                            </span>
+                            <span className="text-muted-foreground/60">·</span>
+                            <span className="text-sm font-medium text-foreground">
+                              {job.title}
+                            </span>
+                            <span className="zero-pill inline-flex items-center gap-1.5 rounded-md border px-1.5 py-0.5 text-xs font-medium">
+                              {job.scope === "team" ? (
+                                <IconUsers
+                                  size={12}
+                                  stroke={1.5}
+                                  className="h-3 w-3 shrink-0 text-sky-600 dark:text-sky-400"
+                                />
+                              ) : (
+                                <IconUser
+                                  size={12}
+                                  stroke={1.5}
+                                  className="h-3 w-3 shrink-0 text-amber-600 dark:text-amber-400"
+                                />
+                              )}
+                              {job.scope === "team" ? "Team" : "Personal"}
+                            </span>
+                          </div>
+                          <p className="mt-0.5 text-xs text-muted-foreground truncate">
+                            {job.description}
+                          </p>
+                        </div>
+                      </li>
+                    ))}
+                  </ul>
+                  <div className="border-t border-border/50 px-4 py-3">
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className="w-fit rounded-lg"
+                      onClick={onNavigateToJob}
+                    >
+                      Manage in {agentName}&apos;s team
+                    </Button>
+                  </div>
+                </div>
+              </div>
+            )}
+            <div ref={setConversationEndEl} />
+          </div>
+        </main>
+        <footer className="shrink-0 bg-transparent px-4 sm:px-6 pt-4 pb-8">
+          <div className="mx-auto max-w-[900px] grid grid-cols-[48px_1fr] gap-3">
+            <div className="w-9 shrink-0" />
+            <Card className="zero-composer w-full min-w-0 overflow-hidden transition-colors duration-200">
+              <CardContent className="p-0">
+                <div className="flex flex-col">
+                  <textarea
+                    className="w-full resize-none bg-transparent px-5 pt-4 pb-2 text-sm text-foreground placeholder:text-muted-foreground border-0 min-h-[88px] focus:outline-none focus:ring-0"
+                    rows={3}
+                    placeholder="Ask me to automate workflows, manage tasks..."
+                    value={input}
+                    onChange={(e) => setInput(e.target.value)}
+                    onKeyDown={handleKeyDown}
+                  />
+                  <div className="flex items-center justify-between gap-2 px-4 py-3 border-t border-border/50">
+                    <div className="flex items-center gap-1 text-muted-foreground">
+                      <button
+                        type="button"
+                        className="p-2 rounded-lg hover:bg-muted/60 hover:text-foreground transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                        aria-label="Add"
+                      >
+                        <IconPlus size={18} stroke={1.5} />
+                      </button>
+                      <button
+                        type="button"
+                        className="p-2 rounded-lg hover:bg-muted/60 hover:text-foreground transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                        aria-label="Attach"
+                      >
+                        <IconPaperclip size={18} stroke={1.5} />
+                      </button>
+                      <button
+                        type="button"
+                        className="p-2 rounded-lg hover:bg-muted/60 hover:text-foreground transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                        aria-label="Emoji"
+                      >
+                        <IconMoodSmile size={18} stroke={1.5} />
+                      </button>
+                    </div>
+                    <div className="flex items-center gap-1">
+                      <button
+                        type="button"
+                        className="p-2 rounded-lg text-muted-foreground hover:bg-muted/60 hover:text-foreground transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                        aria-label="Voice input"
+                      >
+                        <IconMicrophone size={18} stroke={1.5} />
+                      </button>
+                      <Button
+                        size="sm"
+                        className="rounded-lg h-9 w-9 p-0 shrink-0"
+                        onClick={() => handleSend()}
+                        disabled={!input.trim()}
+                        aria-label="Send"
+                      >
+                        <IconSend size={16} stroke={2} />
+                      </Button>
+                    </div>
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+          </div>
+        </footer>
+      </div>
+    );
+  }
+
+  // Landing page: full content (title, triggers, composer, actions, prompts)
+  return (
+    <div ref={carouselRef} className="flex flex-1 flex-col min-h-0">
+      <header
+        className="shrink-0 bg-transparent px-4 sm:px-6 pt-10 pb-2"
+        aria-hidden="true"
+      />
+
+      <main className="flex flex-1 flex-col justify-center overflow-auto px-4 sm:px-6 py-12">
+        <div className="mx-auto w-full max-w-[900px] flex flex-col items-stretch gap-8 -mt-24">
+          <div className="flex items-center gap-4 w-full">
+            <button
+              type="button"
+              onClick={onAvatarClick}
+              className="h-14 w-14 shrink-0 sm:h-16 sm:w-16 flex items-center justify-center overflow-hidden rounded-xl transition-colors duration-150 hover:bg-muted/50 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+              aria-label="Switch Zero avatar"
+            >
+              <img
+                src={zeroAvatarSrc}
+                alt=""
+                role="presentation"
+                className="h-14 w-14 rounded-full object-cover object-top sm:h-16 sm:w-16"
+              />
+            </button>
+            <div className="h-[4.5rem] sm:h-20 overflow-hidden flex-1 min-w-0 flex flex-col justify-center">
+              <h2
+                key={carouselIndex}
+                className="text-2xl sm:text-3xl font-semibold tracking-tight text-foreground zero-tagline-animate-in"
+              >
+                {getLandingTaglines(agentName)[carouselIndex]}
               </h2>
-              <p className="text-sm text-muted-foreground mt-1">
-                Your AI assistant — ask me anything
-              </p>
             </div>
           </div>
 
-          <div className="w-full max-w-[720px] space-y-4">
-            <ChatInput
-              input={input}
-              sending={sending}
-              onInputChange={setInput}
-              onSend={handleSend}
-              onKeyDown={handleKeyDown}
-              placeholder={`Message ${agentName}...`}
-            />
+          {/* Composer */}
+          <Card className="zero-composer w-full overflow-hidden transition-colors duration-200">
+            <CardContent className="p-0">
+              <div className="flex flex-col">
+                <textarea
+                  className="w-full resize-none bg-transparent px-5 pt-4 pb-2 text-sm text-foreground placeholder:text-muted-foreground border-0 min-h-[88px] focus:outline-none focus:ring-0"
+                  rows={3}
+                  placeholder="Ask me to automate workflows, manage tasks..."
+                  value={input}
+                  onChange={(e) => setInput(e.target.value)}
+                  onKeyDown={handleKeyDown}
+                  onFocus={handleComposerFocus}
+                />
+                <div className="flex items-center justify-between gap-2 px-4 py-3 border-t border-border/50">
+                  <div className="flex items-center gap-1 text-muted-foreground">
+                    <button
+                      type="button"
+                      className="p-2 rounded-lg hover:bg-muted/60 hover:text-foreground transition-colors"
+                      aria-label="Add"
+                    >
+                      <IconPlus size={18} stroke={1.5} />
+                    </button>
+                    <button
+                      type="button"
+                      className="p-2 rounded-lg hover:bg-muted/60 hover:text-foreground transition-colors"
+                      aria-label="Attach"
+                    >
+                      <IconPaperclip size={18} stroke={1.5} />
+                    </button>
+                    <button
+                      type="button"
+                      className="p-2 rounded-lg hover:bg-muted/60 hover:text-foreground transition-colors"
+                      aria-label="Emoji"
+                    >
+                      <IconMoodSmile size={18} stroke={1.5} />
+                    </button>
+                  </div>
+                  <div className="flex items-center gap-1">
+                    <button
+                      type="button"
+                      className="p-2 rounded-lg text-muted-foreground hover:bg-muted/60 hover:text-foreground transition-colors"
+                      aria-label="Voice input"
+                    >
+                      <IconMicrophone size={18} stroke={1.5} />
+                    </button>
+                    <Button
+                      size="sm"
+                      className="rounded-lg h-9 w-9 p-0 shrink-0"
+                      onClick={() => handleSend()}
+                      disabled={!input.trim()}
+                      aria-label="Send"
+                    >
+                      <IconSend size={16} stroke={2} />
+                    </Button>
+                  </div>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
 
-            <div className="flex flex-wrap gap-2 justify-center">
-              {SUGGESTED_PROMPTS.map((prompt) => (
-                <button
-                  key={prompt}
-                  type="button"
-                  onClick={() => handleSuggestedPrompt(prompt)}
-                  disabled={sending}
-                  className="flex items-center gap-1.5 rounded-full border border-border bg-card px-3 py-1.5 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:opacity-50"
+          {/* Action buttons */}
+          <div className="flex flex-wrap justify-between items-center gap-2 w-full">
+            <div className="flex flex-wrap gap-2">
+              {getActionButtons(agentName).map(({ id, label, icon: Icon }) => (
+                <Button
+                  key={id}
+                  variant="outline"
+                  size="sm"
+                  className="zero-btn-morandi rounded-lg h-8 px-3.5 text-sm font-medium gap-2 border"
+                  onClick={() => {
+                    if (id === "automate") {
+                      onNavigateToSchedule?.();
+                    } else if (id === "customize") {
+                      onNavigateToMeet?.("settings");
+                    } else if (id === "connectors") {
+                      onNavigateToMeet?.("connections");
+                    }
+                  }}
                 >
-                  <IconSparkles size={12} />
-                  {prompt}
-                </button>
+                  <Icon size={16} />
+                  {label}
+                </Button>
               ))}
             </div>
+            <Button
+              variant="outline"
+              size="sm"
+              className="rounded-lg h-8 px-3.5 text-sm font-medium gap-2 border-primary/30 text-primary hover:bg-primary/5 hover:border-primary/50 shrink-0"
+              type="button"
+              onClick={handleFeelingLucky}
+            >
+              <IconSparkles size={16} />
+              Feeling great
+            </Button>
+          </div>
+
+          {/* Suggested prompts grid */}
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 w-full">
+            {SUGGESTED_PROMPTS.map(
+              ({ title, description, icon: Icon, iconClassName }) => (
+                <button
+                  key={title}
+                  type="button"
+                  className={cn(
+                    "zero-card-morandi p-4 text-left transition-colors",
+                    "flex gap-3 items-start",
+                  )}
+                >
+                  <span
+                    className={cn(
+                      "shrink-0 mt-0.5 rounded-lg p-1.5 bg-[hsl(220,6%,95%)]",
+                      iconClassName ?? "text-muted-foreground",
+                    )}
+                  >
+                    <Icon size={18} />
+                  </span>
+                  <div className="min-w-0">
+                    <p className="text-sm font-medium text-foreground">
+                      {title}
+                    </p>
+                    <p className="text-xs text-muted-foreground mt-0.5">
+                      {description}
+                    </p>
+                  </div>
+                </button>
+              ),
+            )}
           </div>
         </div>
-      )}
-    </div>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// ChatInput
-// ---------------------------------------------------------------------------
-
-function ChatInput({
-  input,
-  sending,
-  onInputChange,
-  onSend,
-  onKeyDown,
-  placeholder,
-}: {
-  input: string;
-  sending: boolean;
-  onInputChange: (value: string) => void;
-  onSend: () => void;
-  onKeyDown: (e: React.KeyboardEvent<HTMLTextAreaElement>) => void;
-  placeholder: string;
-}) {
-  return (
-    <div className="flex items-end gap-2 md:gap-2.5 rounded-xl border border-border bg-card p-3 md:p-4 shadow-sm">
-      <textarea
-        className="flex-1 resize-none bg-transparent text-sm text-secondary-foreground placeholder:text-muted-foreground focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
-        rows={2}
-        placeholder={placeholder}
-        value={input}
-        onChange={(e) => onInputChange(e.target.value)}
-        onKeyDown={onKeyDown}
-        disabled={sending}
-      />
-      <Button
-        onClick={onSend}
-        disabled={!input.trim() || sending}
-        size="icon"
-        className="shrink-0 rounded-lg h-9 w-9"
-      >
-        {sending ? (
-          <IconLoader2 size={16} className="animate-spin" />
-        ) : (
-          <IconSend size={16} />
-        )}
-      </Button>
-    </div>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Chat message components
-// ---------------------------------------------------------------------------
-
-function ChatMessageRow({ message }: { message: ZeroChatMessage }) {
-  if (message.role === "user") {
-    return <UserMessage content={message.content} />;
-  }
-  return <AssistantMessage message={message} />;
-}
-
-function UserMessage({ content }: { content: string }) {
-  return (
-    <div className="py-2">
-      <div className="flex justify-end">
-        <div className="max-w-[85%] rounded-lg bg-primary px-3 py-2 [&_*]:!text-primary-foreground">
-          <Markdown source={content} />
-        </div>
-      </div>
-    </div>
-  );
-}
-
-function AssistantMessage({ message }: { message: ZeroChatMessage }) {
-  if (message.error) {
-    return (
-      <div className="py-2">
-        <div className="flex gap-2 items-start">
-          <StatusDot variant="error" className="mt-1.5" />
-          <div className="flex-1 min-w-0">
-            <div className="flex items-start gap-1.5 text-sm text-destructive">
-              <IconAlertCircle size={14} className="shrink-0 mt-0.5" />
-              <span>{message.error}</span>
-            </div>
-          </div>
-        </div>
-      </div>
-    );
-  }
-
-  if (message.content) {
-    return (
-      <div className="py-2">
-        <div className="flex gap-2 items-start">
-          <StatusDot variant="success" className="mt-1.5" />
-          <div className="flex-1 min-w-0">
-            <Markdown source={message.content} />
-          </div>
-        </div>
-      </div>
-    );
-  }
-
-  return (
-    <div className="py-2">
-      <div className="flex gap-2 items-center">
-        <StatusDot variant="pending" className="animate-pulse" />
-        <span className="text-sm text-muted-foreground">Thinking...</span>
-      </div>
+      </main>
     </div>
   );
 }

--- a/turbo/apps/platform/src/views/zero-page/zero-content.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-content.tsx
@@ -1,6 +1,7 @@
 import { useLoadable } from "ccstate-react";
 import type { ZeroNavId, ZeroAccountSubId } from "./zero-sidebar.tsx";
-import { ZeroChatPage, type DemoScenarioId } from "./zero-chat-page.tsx";
+import { ZeroChatPage } from "./zero-chat-page.tsx";
+import { ZeroSessionChatPage } from "./zero-session-chat-page.tsx";
 import { ZeroAccountPage } from "./zero-account-page.tsx";
 import { ZeroJobsPage } from "./zero-jobs-page.tsx";
 import { ZeroMeetPage } from "./zero-meet-page.tsx";
@@ -10,20 +11,12 @@ import { ZeroWorksPage } from "./zero-works-page.tsx";
 import { ZeroSchedulePage } from "./zero-schedule-page.tsx";
 import { agentDisplayName$ } from "../../signals/zero-page/zero-agent-name.ts";
 
-const RECENT_ID_TO_SCENARIO: Readonly<Record<string, DemoScenarioId>> = {
-  hello: "hello-from-zero",
-  "1": "rich-summary",
-  "2": "connect-connector",
-  "3": "agent-operations",
-  "4": "approve",
-};
-
 interface ZeroContentProps {
   sectionId: ZeroNavId;
   accountSubId?: ZeroAccountSubId | null;
-  recentLabel?: string | null;
-  recentId?: string | null;
-  onClearRecent?: () => void;
+  /** When set, shows the real session chat page instead of the demo page. */
+  inSession?: boolean;
+  onSendMessage?: (message: string) => void;
   onNavigateToActivity?: () => void;
   onNavigateToSchedule?: () => void;
   onNavigateToJob?: () => void;
@@ -51,9 +44,8 @@ function getSectionTitles(
 export function ZeroContent({
   sectionId,
   accountSubId = null,
-  recentLabel,
-  recentId,
-  onClearRecent,
+  inSession = false,
+  onSendMessage,
   onNavigateToActivity,
   onNavigateToSchedule,
   onNavigateToJob,
@@ -66,13 +58,12 @@ export function ZeroContent({
   const agentName =
     agentNameLoadable.state === "hasData" ? agentNameLoadable.data : "Zero";
   if (sectionId === "chat") {
-    const initialScenarioId = recentId
-      ? (RECENT_ID_TO_SCENARIO[recentId] ?? undefined)
-      : undefined;
+    if (inSession) {
+      return <ZeroSessionChatPage />;
+    }
     return (
       <ZeroChatPage
-        initialScenarioId={initialScenarioId}
-        onClearScenario={onClearRecent}
+        onSendMessage={onSendMessage}
         onNavigateToActivity={onNavigateToActivity}
         onNavigateToSchedule={onNavigateToSchedule}
         onNavigateToJob={onNavigateToJob}
@@ -109,7 +100,7 @@ export function ZeroContent({
     return <ZeroAccountPage accountSubId={accountSubId ?? null} />;
   }
 
-  const title = recentLabel ?? getSectionTitles(agentName)[sectionId];
+  const title = getSectionTitles(agentName)[sectionId];
 
   return (
     <div className="flex flex-1 flex-col min-h-0">
@@ -118,9 +109,7 @@ export function ZeroContent({
           {title}
         </h1>
         <p className="mt-0.5 text-sm text-muted-foreground">
-          {recentLabel
-            ? `Continue your dialogue with ${agentName}`
-            : `${agentName} — your AI assistant`}
+          {agentName} — your AI assistant
         </p>
       </header>
       <main className="flex-1 overflow-auto px-4 sm:px-6 pb-8">

--- a/turbo/apps/platform/src/views/zero-page/zero-content.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-content.tsx
@@ -1,6 +1,6 @@
 import { useLoadable } from "ccstate-react";
 import type { ZeroNavId, ZeroAccountSubId } from "./zero-sidebar.tsx";
-import { ZeroChatPage, type DemoScenarioId } from "./zero-chat-page.tsx";
+import { ZeroChatPage } from "./zero-chat-page.tsx";
 import { ZeroAccountPage } from "./zero-account-page.tsx";
 import { ZeroJobsPage } from "./zero-jobs-page.tsx";
 import { ZeroMeetPage } from "./zero-meet-page.tsx";
@@ -10,20 +10,9 @@ import { ZeroWorksPage } from "./zero-works-page.tsx";
 import { ZeroSchedulePage } from "./zero-schedule-page.tsx";
 import { agentDisplayName$ } from "../../signals/zero-page/zero-agent-name.ts";
 
-const RECENT_ID_TO_SCENARIO: Readonly<Record<string, DemoScenarioId>> = {
-  hello: "hello-from-zero",
-  "1": "rich-summary",
-  "2": "connect-connector",
-  "3": "agent-operations",
-  "4": "approve",
-};
-
 interface ZeroContentProps {
   sectionId: ZeroNavId;
   accountSubId?: ZeroAccountSubId | null;
-  recentLabel?: string | null;
-  recentId?: string | null;
-  onClearRecent?: () => void;
   onNavigateToActivity?: () => void;
   onNavigateToSchedule?: () => void;
   onNavigateToJob?: () => void;
@@ -51,14 +40,7 @@ function getSectionTitles(
 export function ZeroContent({
   sectionId,
   accountSubId = null,
-  recentLabel,
-  recentId,
-  onClearRecent,
-  onNavigateToActivity,
-  onNavigateToSchedule,
-  onNavigateToJob,
   onNavigateToChat,
-  onNavigateToMeet,
   zeroAvatarSrc = "/zero-avatar.png",
   onAvatarClick,
 }: ZeroContentProps) {
@@ -66,17 +48,8 @@ export function ZeroContent({
   const agentName =
     agentNameLoadable.state === "hasData" ? agentNameLoadable.data : "Zero";
   if (sectionId === "chat") {
-    const initialScenarioId = recentId
-      ? (RECENT_ID_TO_SCENARIO[recentId] ?? undefined)
-      : undefined;
     return (
       <ZeroChatPage
-        initialScenarioId={initialScenarioId}
-        onClearScenario={onClearRecent}
-        onNavigateToActivity={onNavigateToActivity}
-        onNavigateToSchedule={onNavigateToSchedule}
-        onNavigateToJob={onNavigateToJob}
-        onNavigateToMeet={onNavigateToMeet}
         zeroAvatarSrc={zeroAvatarSrc}
         onAvatarClick={onAvatarClick}
       />
@@ -109,7 +82,7 @@ export function ZeroContent({
     return <ZeroAccountPage accountSubId={accountSubId ?? null} />;
   }
 
-  const title = recentLabel ?? getSectionTitles(agentName)[sectionId];
+  const title = getSectionTitles(agentName)[sectionId];
 
   return (
     <div className="flex flex-1 flex-col min-h-0">
@@ -118,16 +91,14 @@ export function ZeroContent({
           {title}
         </h1>
         <p className="mt-0.5 text-sm text-muted-foreground">
-          {recentLabel
-            ? `Continue your dialogue with ${agentName}`
-            : `${agentName} — your AI assistant`}
+          {agentName} — your AI assistant
         </p>
       </header>
       <main className="flex-1 overflow-auto px-4 sm:px-6 pb-8">
         <div className="mx-auto max-w-[900px]">
           <div className="zero-card p-6">
             <p className="text-sm text-muted-foreground">
-              Content for “{title}” will appear here.
+              Content for &quot;{title}&quot; will appear here.
             </p>
           </div>
         </div>

--- a/turbo/apps/platform/src/views/zero-page/zero-content.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-content.tsx
@@ -66,6 +66,8 @@ export function ZeroContent({
           zeroAvatarSrc={zeroAvatarSrc}
           onAvatarClick={onAvatarClick}
           onBack={onBackFromSession}
+          onNavigateToJob={onNavigateToJob}
+          onNavigateToSchedule={onNavigateToSchedule}
         />
       );
     }

--- a/turbo/apps/platform/src/views/zero-page/zero-content.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-content.tsx
@@ -59,7 +59,12 @@ export function ZeroContent({
     agentNameLoadable.state === "hasData" ? agentNameLoadable.data : "Zero";
   if (sectionId === "chat") {
     if (inSession) {
-      return <ZeroSessionChatPage />;
+      return (
+        <ZeroSessionChatPage
+          zeroAvatarSrc={zeroAvatarSrc}
+          onAvatarClick={onAvatarClick}
+        />
+      );
     }
     return (
       <ZeroChatPage

--- a/turbo/apps/platform/src/views/zero-page/zero-content.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-content.tsx
@@ -22,6 +22,7 @@ interface ZeroContentProps {
   onNavigateToJob?: () => void;
   onNavigateToChat?: () => void;
   onNavigateToMeet?: (tab?: string) => void;
+  onBackFromSession?: () => void;
   zeroAvatarSrc?: string;
   onAvatarClick?: () => void;
 }
@@ -51,6 +52,7 @@ export function ZeroContent({
   onNavigateToJob,
   onNavigateToChat,
   onNavigateToMeet,
+  onBackFromSession,
   zeroAvatarSrc = "/zero-avatar.png",
   onAvatarClick,
 }: ZeroContentProps) {
@@ -63,6 +65,7 @@ export function ZeroContent({
         <ZeroSessionChatPage
           zeroAvatarSrc={zeroAvatarSrc}
           onAvatarClick={onAvatarClick}
+          onBack={onBackFromSession}
         />
       );
     }

--- a/turbo/apps/platform/src/views/zero-page/zero-content.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-content.tsx
@@ -1,6 +1,6 @@
 import { useLoadable } from "ccstate-react";
 import type { ZeroNavId, ZeroAccountSubId } from "./zero-sidebar.tsx";
-import { ZeroChatPage } from "./zero-chat-page.tsx";
+import { ZeroChatPage, type DemoScenarioId } from "./zero-chat-page.tsx";
 import { ZeroAccountPage } from "./zero-account-page.tsx";
 import { ZeroJobsPage } from "./zero-jobs-page.tsx";
 import { ZeroMeetPage } from "./zero-meet-page.tsx";
@@ -10,9 +10,20 @@ import { ZeroWorksPage } from "./zero-works-page.tsx";
 import { ZeroSchedulePage } from "./zero-schedule-page.tsx";
 import { agentDisplayName$ } from "../../signals/zero-page/zero-agent-name.ts";
 
+const RECENT_ID_TO_SCENARIO: Readonly<Record<string, DemoScenarioId>> = {
+  hello: "hello-from-zero",
+  "1": "rich-summary",
+  "2": "connect-connector",
+  "3": "agent-operations",
+  "4": "approve",
+};
+
 interface ZeroContentProps {
   sectionId: ZeroNavId;
   accountSubId?: ZeroAccountSubId | null;
+  recentLabel?: string | null;
+  recentId?: string | null;
+  onClearRecent?: () => void;
   onNavigateToActivity?: () => void;
   onNavigateToSchedule?: () => void;
   onNavigateToJob?: () => void;
@@ -40,7 +51,14 @@ function getSectionTitles(
 export function ZeroContent({
   sectionId,
   accountSubId = null,
+  recentLabel,
+  recentId,
+  onClearRecent,
+  onNavigateToActivity,
+  onNavigateToSchedule,
+  onNavigateToJob,
   onNavigateToChat,
+  onNavigateToMeet,
   zeroAvatarSrc = "/zero-avatar.png",
   onAvatarClick,
 }: ZeroContentProps) {
@@ -48,8 +66,17 @@ export function ZeroContent({
   const agentName =
     agentNameLoadable.state === "hasData" ? agentNameLoadable.data : "Zero";
   if (sectionId === "chat") {
+    const initialScenarioId = recentId
+      ? (RECENT_ID_TO_SCENARIO[recentId] ?? undefined)
+      : undefined;
     return (
       <ZeroChatPage
+        initialScenarioId={initialScenarioId}
+        onClearScenario={onClearRecent}
+        onNavigateToActivity={onNavigateToActivity}
+        onNavigateToSchedule={onNavigateToSchedule}
+        onNavigateToJob={onNavigateToJob}
+        onNavigateToMeet={onNavigateToMeet}
         zeroAvatarSrc={zeroAvatarSrc}
         onAvatarClick={onAvatarClick}
       />
@@ -82,7 +109,7 @@ export function ZeroContent({
     return <ZeroAccountPage accountSubId={accountSubId ?? null} />;
   }
 
-  const title = getSectionTitles(agentName)[sectionId];
+  const title = recentLabel ?? getSectionTitles(agentName)[sectionId];
 
   return (
     <div className="flex flex-1 flex-col min-h-0">
@@ -91,14 +118,16 @@ export function ZeroContent({
           {title}
         </h1>
         <p className="mt-0.5 text-sm text-muted-foreground">
-          {agentName} — your AI assistant
+          {recentLabel
+            ? `Continue your dialogue with ${agentName}`
+            : `${agentName} — your AI assistant`}
         </p>
       </header>
       <main className="flex-1 overflow-auto px-4 sm:px-6 pb-8">
         <div className="mx-auto max-w-[900px]">
           <div className="zero-card p-6">
             <p className="text-sm text-muted-foreground">
-              Content for &quot;{title}&quot; will appear here.
+              Content for “{title}” will appear here.
             </p>
           </div>
         </div>

--- a/turbo/apps/platform/src/views/zero-page/zero-session-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-session-chat-page.tsx
@@ -58,9 +58,11 @@ export function ZeroSessionChatPage({
   const messagesEndEl = useGet(messagesEndEl$);
   const setMessagesEndEl = useSet(messagesEndEl$);
 
-  // Auto-scroll when messages change
+  // Auto-scroll when messages change (deferred to avoid side effect during render)
   if (messagesEndEl && messages.length > 0) {
-    messagesEndEl.scrollIntoView({ behavior: "smooth" });
+    queueMicrotask(() => {
+      messagesEndEl.scrollIntoView({ behavior: "smooth" });
+    });
   }
 
   const handleSend = () => {

--- a/turbo/apps/platform/src/views/zero-page/zero-session-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-session-chat-page.tsx
@@ -3,10 +3,6 @@ import { useCCState } from "ccstate-react/experimental";
 import { useGet, useSet, useLoadable } from "ccstate-react";
 import {
   IconSend,
-  IconPlus,
-  IconPaperclip,
-  IconMoodSmile,
-  IconMicrophone,
   IconAlertCircle,
   IconLoader2,
   IconArrowLeft,
@@ -21,6 +17,7 @@ import {
   zeroChatMessages$,
   zeroChatSending$,
   zeroChatInput$,
+  zeroSessionError$,
   setZeroChatInput$,
   clearZeroChatInput$,
   sendZeroChatMessage$,
@@ -51,6 +48,7 @@ export function ZeroSessionChatPage({
     agentNameLoadable.state === "hasData" ? agentNameLoadable.data : "Zero";
   const messages = useGet(zeroChatMessages$);
   const sending = useGet(zeroChatSending$);
+  const sessionError = useGet(zeroSessionError$);
   const input = useGet(zeroChatInput$);
   const setInput = useSet(setZeroChatInput$);
   const clearInput = useSet(clearZeroChatInput$);
@@ -135,7 +133,15 @@ export function ZeroSessionChatPage({
       {/* Message list */}
       <main className="flex-1 overflow-auto px-4 sm:px-6 py-4">
         <div className="mx-auto max-w-[900px] flex flex-col gap-6 pb-4">
-          {messages.length === 0 && (
+          {sessionError && (
+            <div className="flex-1 flex items-center justify-center py-16">
+              <div className="flex items-center gap-2 text-destructive">
+                <IconAlertCircle size={16} />
+                <p className="text-sm">{sessionError}</p>
+              </div>
+            </div>
+          )}
+          {!sessionError && messages.length === 0 && (
             <div className="flex-1 flex items-center justify-center py-16">
               <p className="text-sm text-muted-foreground">
                 Send a message to start the conversation
@@ -170,52 +176,20 @@ export function ZeroSessionChatPage({
                   onKeyDown={handleKeyDown}
                   disabled={sending}
                 />
-                <div className="flex items-center justify-between gap-2 px-4 py-3 border-t border-border/50">
-                  <div className="flex items-center gap-1 text-muted-foreground">
-                    <button
-                      type="button"
-                      className="p-2 rounded-lg hover:bg-muted/60 hover:text-foreground transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-                      aria-label="Add"
-                    >
-                      <IconPlus size={18} stroke={1.5} />
-                    </button>
-                    <button
-                      type="button"
-                      className="p-2 rounded-lg hover:bg-muted/60 hover:text-foreground transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-                      aria-label="Attach"
-                    >
-                      <IconPaperclip size={18} stroke={1.5} />
-                    </button>
-                    <button
-                      type="button"
-                      className="p-2 rounded-lg hover:bg-muted/60 hover:text-foreground transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-                      aria-label="Emoji"
-                    >
-                      <IconMoodSmile size={18} stroke={1.5} />
-                    </button>
-                  </div>
-                  <div className="flex items-center gap-1">
-                    <button
-                      type="button"
-                      className="p-2 rounded-lg text-muted-foreground hover:bg-muted/60 hover:text-foreground transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-                      aria-label="Voice input"
-                    >
-                      <IconMicrophone size={18} stroke={1.5} />
-                    </button>
-                    <Button
-                      size="sm"
-                      className="rounded-lg h-9 w-9 p-0 shrink-0"
-                      onClick={handleSend}
-                      disabled={!input.trim() || sending}
-                      aria-label="Send"
-                    >
-                      {sending ? (
-                        <IconLoader2 size={16} className="animate-spin" />
-                      ) : (
-                        <IconSend size={16} stroke={2} />
-                      )}
-                    </Button>
-                  </div>
+                <div className="flex items-center justify-end gap-2 px-4 py-3 border-t border-border/50">
+                  <Button
+                    size="sm"
+                    className="rounded-lg h-9 w-9 p-0 shrink-0"
+                    onClick={handleSend}
+                    disabled={!input.trim() || sending}
+                    aria-label="Send"
+                  >
+                    {sending ? (
+                      <IconLoader2 size={16} className="animate-spin" />
+                    ) : (
+                      <IconSend size={16} stroke={2} />
+                    )}
+                  </Button>
                 </div>
               </div>
             </CardContent>

--- a/turbo/apps/platform/src/views/zero-page/zero-session-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-session-chat-page.tsx
@@ -1,0 +1,171 @@
+import { useCCState } from "ccstate-react/experimental";
+import { useGet, useSet, useLoadable } from "ccstate-react";
+import { IconSend, IconLoader2, IconAlertCircle } from "@tabler/icons-react";
+import { Button } from "@vm0/ui";
+import { Markdown } from "../components/markdown.tsx";
+import { StatusDot } from "../logs-page/components/status-dot.tsx";
+import { detach, Reason } from "../../signals/utils.ts";
+import { agentDisplayName$ } from "../../signals/zero-page/zero-agent-name.ts";
+import {
+  zeroChatMessages$,
+  zeroChatSending$,
+  zeroChatInput$,
+  setZeroChatInput$,
+  clearZeroChatInput$,
+  sendZeroChatMessage$,
+  type ZeroChatMessage,
+} from "../../signals/zero-page/zero-chat.ts";
+
+// ---------------------------------------------------------------------------
+// ZeroSessionChatPage — real conversation backed by agent runs
+// ---------------------------------------------------------------------------
+
+export function ZeroSessionChatPage() {
+  const agentNameLoadable = useLoadable(agentDisplayName$);
+  const agentName =
+    agentNameLoadable.state === "hasData" ? agentNameLoadable.data : "Zero";
+  const messages = useGet(zeroChatMessages$);
+  const sending = useGet(zeroChatSending$);
+  const input = useGet(zeroChatInput$);
+  const setInput = useSet(setZeroChatInput$);
+  const clearInput = useSet(clearZeroChatInput$);
+  const send = useSet(sendZeroChatMessage$);
+
+  const messagesEndEl$ = useCCState<HTMLDivElement | null>(null);
+  const messagesEndEl = useGet(messagesEndEl$);
+  const setMessagesEndEl = useSet(messagesEndEl$);
+
+  // Auto-scroll when messages change
+  if (messagesEndEl && messages.length > 0) {
+    messagesEndEl.scrollIntoView({ behavior: "smooth" });
+  }
+
+  const handleSend = () => {
+    const trimmed = input.trim();
+    if (!trimmed || sending) {
+      return;
+    }
+    clearInput();
+    detach(send(trimmed), Reason.DomCallback);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      handleSend();
+    }
+  };
+
+  return (
+    <div className="flex flex-1 flex-col min-h-0">
+      {/* Message list */}
+      <div className="flex-1 overflow-y-auto px-4 sm:px-6 py-4">
+        <div className="mx-auto max-w-[720px] flex flex-col gap-1">
+          {messages.length === 0 && (
+            <div className="flex-1 flex items-center justify-center py-16">
+              <p className="text-sm text-muted-foreground">
+                Send a message to start the conversation
+              </p>
+            </div>
+          )}
+          {messages.map((msg) => (
+            <ChatMessageRow key={msg.id} message={msg} />
+          ))}
+          <div ref={setMessagesEndEl} />
+        </div>
+      </div>
+
+      {/* Input */}
+      <div className="shrink-0 px-4 sm:px-6 pb-4 sm:pb-6">
+        <div className="mx-auto max-w-[720px]">
+          <div className="flex items-end gap-2 md:gap-2.5 rounded-xl border border-border bg-card p-3 md:p-4 shadow-sm">
+            <textarea
+              className="flex-1 resize-none bg-transparent text-sm text-secondary-foreground placeholder:text-muted-foreground focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+              rows={2}
+              placeholder={`Message ${agentName}...`}
+              value={input}
+              onChange={(e) => setInput(e.target.value)}
+              onKeyDown={handleKeyDown}
+              disabled={sending}
+            />
+            <Button
+              onClick={handleSend}
+              disabled={!input.trim() || sending}
+              size="icon"
+              className="shrink-0 rounded-lg h-9 w-9"
+            >
+              {sending ? (
+                <IconLoader2 size={16} className="animate-spin" />
+              ) : (
+                <IconSend size={16} />
+              )}
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Chat message components
+// ---------------------------------------------------------------------------
+
+function ChatMessageRow({ message }: { message: ZeroChatMessage }) {
+  if (message.role === "user") {
+    return <UserMessage content={message.content} />;
+  }
+  return <AssistantMessage message={message} />;
+}
+
+function UserMessage({ content }: { content: string }) {
+  return (
+    <div className="py-2">
+      <div className="flex justify-end">
+        <div className="max-w-[85%] rounded-lg bg-primary px-3 py-2 [&_*]:!text-primary-foreground">
+          <Markdown source={content} />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function AssistantMessage({ message }: { message: ZeroChatMessage }) {
+  if (message.error) {
+    return (
+      <div className="py-2">
+        <div className="flex gap-2 items-start">
+          <StatusDot variant="error" className="mt-1.5" />
+          <div className="flex-1 min-w-0">
+            <div className="flex items-start gap-1.5 text-sm text-destructive">
+              <IconAlertCircle size={14} className="shrink-0 mt-0.5" />
+              <span>{message.error}</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (message.content) {
+    return (
+      <div className="py-2">
+        <div className="flex gap-2 items-start">
+          <StatusDot variant="success" className="mt-1.5" />
+          <div className="flex-1 min-w-0">
+            <Markdown source={message.content} />
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="py-2">
+      <div className="flex gap-2 items-center">
+        <StatusDot variant="pending" className="animate-pulse" />
+        <span className="text-sm text-muted-foreground">Thinking...</span>
+      </div>
+    </div>
+  );
+}

--- a/turbo/apps/platform/src/views/zero-page/zero-session-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-session-chat-page.tsx
@@ -1,9 +1,17 @@
+import type { KeyboardEvent } from "react";
 import { useCCState } from "ccstate-react/experimental";
 import { useGet, useSet, useLoadable } from "ccstate-react";
-import { IconSend, IconLoader2, IconAlertCircle } from "@tabler/icons-react";
-import { Button } from "@vm0/ui";
+import {
+  IconSend,
+  IconPlus,
+  IconPaperclip,
+  IconMoodSmile,
+  IconMicrophone,
+  IconAlertCircle,
+  IconLoader2,
+} from "@tabler/icons-react";
+import { Button, Card, CardContent } from "@vm0/ui";
 import { Markdown } from "../components/markdown.tsx";
-import { StatusDot } from "../logs-page/components/status-dot.tsx";
 import { detach, Reason } from "../../signals/utils.ts";
 import { agentDisplayName$ } from "../../signals/zero-page/zero-agent-name.ts";
 import {
@@ -20,7 +28,15 @@ import {
 // ZeroSessionChatPage — real conversation backed by agent runs
 // ---------------------------------------------------------------------------
 
-export function ZeroSessionChatPage() {
+interface ZeroSessionChatPageProps {
+  zeroAvatarSrc?: string;
+  onAvatarClick?: () => void;
+}
+
+export function ZeroSessionChatPage({
+  zeroAvatarSrc = "/zero-avatar.png",
+  onAvatarClick,
+}: ZeroSessionChatPageProps) {
   const agentNameLoadable = useLoadable(agentDisplayName$);
   const agentName =
     agentNameLoadable.state === "hasData" ? agentNameLoadable.data : "Zero";
@@ -49,7 +65,7 @@ export function ZeroSessionChatPage() {
     detach(send(trimmed), Reason.DomCallback);
   };
 
-  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+  const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
     if (e.key === "Enter" && !e.shiftKey) {
       e.preventDefault();
       handleSend();
@@ -57,10 +73,10 @@ export function ZeroSessionChatPage() {
   };
 
   return (
-    <div className="flex flex-1 flex-col min-h-0">
+    <div className="flex flex-1 flex-col min-h-0 bg-transparent">
       {/* Message list */}
-      <div className="flex-1 overflow-y-auto px-4 sm:px-6 py-4">
-        <div className="mx-auto max-w-[720px] flex flex-col gap-1">
+      <main className="flex-1 overflow-auto px-4 sm:px-6 py-4">
+        <div className="mx-auto max-w-[900px] flex flex-col gap-6 pb-4">
           {messages.length === 0 && (
             <div className="flex-1 flex items-center justify-center py-16">
               <p className="text-sm text-muted-foreground">
@@ -69,40 +85,85 @@ export function ZeroSessionChatPage() {
             </div>
           )}
           {messages.map((msg) => (
-            <ChatMessageRow key={msg.id} message={msg} />
+            <ChatMessageRow
+              key={msg.id}
+              message={msg}
+              zeroAvatarSrc={zeroAvatarSrc}
+              onAvatarClick={onAvatarClick}
+            />
           ))}
           <div ref={setMessagesEndEl} />
         </div>
-      </div>
+      </main>
 
-      {/* Input */}
-      <div className="shrink-0 px-4 sm:px-6 pb-4 sm:pb-6">
-        <div className="mx-auto max-w-[720px]">
-          <div className="flex items-end gap-2 md:gap-2.5 rounded-xl border border-border bg-card p-3 md:p-4 shadow-sm">
-            <textarea
-              className="flex-1 resize-none bg-transparent text-sm text-secondary-foreground placeholder:text-muted-foreground focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
-              rows={2}
-              placeholder={`Message ${agentName}...`}
-              value={input}
-              onChange={(e) => setInput(e.target.value)}
-              onKeyDown={handleKeyDown}
-              disabled={sending}
-            />
-            <Button
-              onClick={handleSend}
-              disabled={!input.trim() || sending}
-              size="icon"
-              className="shrink-0 rounded-lg h-9 w-9"
-            >
-              {sending ? (
-                <IconLoader2 size={16} className="animate-spin" />
-              ) : (
-                <IconSend size={16} />
-              )}
-            </Button>
-          </div>
+      {/* Composer */}
+      <footer className="shrink-0 bg-transparent px-4 sm:px-6 pt-4 pb-8">
+        <div className="mx-auto max-w-[900px] grid grid-cols-[48px_1fr] gap-3">
+          <div className="w-9 shrink-0" />
+          <Card className="zero-composer w-full min-w-0 overflow-hidden transition-colors duration-200">
+            <CardContent className="p-0">
+              <div className="flex flex-col">
+                <textarea
+                  className="w-full resize-none bg-transparent px-5 pt-4 pb-2 text-sm text-foreground placeholder:text-muted-foreground border-0 min-h-[88px] focus:outline-none focus:ring-0"
+                  rows={3}
+                  placeholder={`Message ${agentName}...`}
+                  value={input}
+                  onChange={(e) => setInput(e.target.value)}
+                  onKeyDown={handleKeyDown}
+                  disabled={sending}
+                />
+                <div className="flex items-center justify-between gap-2 px-4 py-3 border-t border-border/50">
+                  <div className="flex items-center gap-1 text-muted-foreground">
+                    <button
+                      type="button"
+                      className="p-2 rounded-lg hover:bg-muted/60 hover:text-foreground transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                      aria-label="Add"
+                    >
+                      <IconPlus size={18} stroke={1.5} />
+                    </button>
+                    <button
+                      type="button"
+                      className="p-2 rounded-lg hover:bg-muted/60 hover:text-foreground transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                      aria-label="Attach"
+                    >
+                      <IconPaperclip size={18} stroke={1.5} />
+                    </button>
+                    <button
+                      type="button"
+                      className="p-2 rounded-lg hover:bg-muted/60 hover:text-foreground transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                      aria-label="Emoji"
+                    >
+                      <IconMoodSmile size={18} stroke={1.5} />
+                    </button>
+                  </div>
+                  <div className="flex items-center gap-1">
+                    <button
+                      type="button"
+                      className="p-2 rounded-lg text-muted-foreground hover:bg-muted/60 hover:text-foreground transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                      aria-label="Voice input"
+                    >
+                      <IconMicrophone size={18} stroke={1.5} />
+                    </button>
+                    <Button
+                      size="sm"
+                      className="rounded-lg h-9 w-9 p-0 shrink-0"
+                      onClick={handleSend}
+                      disabled={!input.trim() || sending}
+                      aria-label="Send"
+                    >
+                      {sending ? (
+                        <IconLoader2 size={16} className="animate-spin" />
+                      ) : (
+                        <IconSend size={16} stroke={2} />
+                      )}
+                    </Button>
+                  </div>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
         </div>
-      </div>
+      </footer>
     </div>
   );
 }
@@ -111,36 +172,77 @@ export function ZeroSessionChatPage() {
 // Chat message components
 // ---------------------------------------------------------------------------
 
-function ChatMessageRow({ message }: { message: ZeroChatMessage }) {
+interface ChatMessageRowProps {
+  message: ZeroChatMessage;
+  zeroAvatarSrc: string;
+  onAvatarClick?: () => void;
+}
+
+function ChatMessageRow({
+  message,
+  zeroAvatarSrc,
+  onAvatarClick,
+}: ChatMessageRowProps) {
   if (message.role === "user") {
     return <UserMessage content={message.content} />;
   }
-  return <AssistantMessage message={message} />;
+  return (
+    <AssistantMessage
+      message={message}
+      zeroAvatarSrc={zeroAvatarSrc}
+      onAvatarClick={onAvatarClick}
+    />
+  );
 }
 
 function UserMessage({ content }: { content: string }) {
   return (
-    <div className="py-2">
-      <div className="flex justify-end">
-        <div className="max-w-[85%] rounded-lg bg-primary px-3 py-2 [&_*]:!text-primary-foreground">
-          <Markdown source={content} />
+    <div className="grid grid-cols-[48px_1fr] gap-3 items-start animate-in fade-in slide-in-from-bottom-2 duration-300">
+      <div className="w-9 h-9 shrink-0" />
+      <div className="flex min-w-0 justify-end">
+        <div className="zero-chat-bubble-user rounded-2xl px-4 py-3 max-w-[85%] text-sm leading-relaxed">
+          {content}
         </div>
       </div>
     </div>
   );
 }
 
-function AssistantMessage({ message }: { message: ZeroChatMessage }) {
+interface AssistantMessageProps {
+  message: ZeroChatMessage;
+  zeroAvatarSrc: string;
+  onAvatarClick?: () => void;
+}
+
+function AssistantMessage({
+  message,
+  zeroAvatarSrc,
+  onAvatarClick,
+}: AssistantMessageProps) {
+  const avatarButton = (
+    <button
+      type="button"
+      onClick={onAvatarClick}
+      className="h-9 w-9 shrink-0 mt-0.5 flex items-center justify-center overflow-hidden rounded-xl transition-colors duration-150 hover:bg-muted/50 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+      aria-label="Switch Zero avatar"
+    >
+      <img
+        src={zeroAvatarSrc}
+        alt=""
+        role="presentation"
+        className="h-9 w-9 rounded-full object-cover object-top"
+      />
+    </button>
+  );
+
   if (message.error) {
     return (
-      <div className="py-2">
-        <div className="flex gap-2 items-start">
-          <StatusDot variant="error" className="mt-1.5" />
-          <div className="flex-1 min-w-0">
-            <div className="flex items-start gap-1.5 text-sm text-destructive">
-              <IconAlertCircle size={14} className="shrink-0 mt-0.5" />
-              <span>{message.error}</span>
-            </div>
+      <div className="grid grid-cols-[48px_1fr] gap-3 items-start animate-in fade-in slide-in-from-bottom-2 duration-300">
+        {avatarButton}
+        <div className="zero-chat-bubble-assistant rounded-2xl border backdrop-blur-sm px-4 py-4 text-sm leading-relaxed min-w-0">
+          <div className="flex items-start gap-1.5 text-destructive">
+            <IconAlertCircle size={14} className="shrink-0 mt-0.5" />
+            <span>{message.error}</span>
           </div>
         </div>
       </div>
@@ -149,22 +251,27 @@ function AssistantMessage({ message }: { message: ZeroChatMessage }) {
 
   if (message.content) {
     return (
-      <div className="py-2">
-        <div className="flex gap-2 items-start">
-          <StatusDot variant="success" className="mt-1.5" />
-          <div className="flex-1 min-w-0">
-            <Markdown source={message.content} />
-          </div>
+      <div className="grid grid-cols-[48px_1fr] gap-3 items-start animate-in fade-in slide-in-from-bottom-2 duration-300">
+        {avatarButton}
+        <div className="zero-chat-bubble-assistant rounded-2xl border backdrop-blur-sm px-4 py-4 text-sm leading-relaxed min-w-0">
+          <Markdown source={message.content} />
         </div>
       </div>
     );
   }
 
+  // Thinking / loading state
   return (
-    <div className="py-2">
-      <div className="flex gap-2 items-center">
-        <StatusDot variant="pending" className="animate-pulse" />
-        <span className="text-sm text-muted-foreground">Thinking...</span>
+    <div className="grid grid-cols-[48px_1fr] gap-3 items-start animate-in fade-in slide-in-from-bottom-2 duration-300">
+      {avatarButton}
+      <div className="zero-chat-bubble-assistant rounded-2xl border backdrop-blur-sm px-4 py-4 text-sm leading-relaxed min-w-0">
+        <div className="flex items-center gap-2">
+          <IconLoader2
+            size={14}
+            className="animate-spin text-muted-foreground"
+          />
+          <span className="text-muted-foreground">Thinking...</span>
+        </div>
       </div>
     </div>
   );

--- a/turbo/apps/platform/src/views/zero-page/zero-session-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-session-chat-page.tsx
@@ -9,6 +9,7 @@ import {
   IconMicrophone,
   IconAlertCircle,
   IconLoader2,
+  IconArrowLeft,
 } from "@tabler/icons-react";
 import { Button, Card, CardContent } from "@vm0/ui";
 import { Markdown } from "../components/markdown.tsx";
@@ -31,11 +32,13 @@ import {
 interface ZeroSessionChatPageProps {
   zeroAvatarSrc?: string;
   onAvatarClick?: () => void;
+  onBack?: () => void;
 }
 
 export function ZeroSessionChatPage({
   zeroAvatarSrc = "/zero-avatar.png",
   onAvatarClick,
+  onBack,
 }: ZeroSessionChatPageProps) {
   const agentNameLoadable = useLoadable(agentDisplayName$);
   const agentName =
@@ -74,6 +77,35 @@ export function ZeroSessionChatPage({
 
   return (
     <div className="flex flex-1 flex-col min-h-0 bg-transparent">
+      {/* Header */}
+      <header className="shrink-0 bg-transparent px-4 sm:px-6 py-3 flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-8 w-8 shrink-0 -ml-2"
+            onClick={onBack}
+            aria-label="Back to chat home"
+          >
+            <IconArrowLeft size={20} stroke={1.5} />
+          </Button>
+          <button
+            type="button"
+            onClick={onAvatarClick}
+            className="h-8 w-8 shrink-0 flex items-center justify-center overflow-hidden rounded-xl transition-colors duration-150 hover:bg-muted/50 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+            aria-label="Switch Zero avatar"
+          >
+            <img
+              src={zeroAvatarSrc}
+              alt=""
+              role="presentation"
+              className="h-8 w-8 rounded-full object-cover object-top"
+            />
+          </button>
+          <span className="font-semibold text-foreground">{agentName}</span>
+        </div>
+      </header>
+
       {/* Message list */}
       <main className="flex-1 overflow-auto px-4 sm:px-6 py-4">
         <div className="mx-auto max-w-[900px] flex flex-col gap-6 pb-4">
@@ -106,7 +138,7 @@ export function ZeroSessionChatPage({
                 <textarea
                   className="w-full resize-none bg-transparent px-5 pt-4 pb-2 text-sm text-foreground placeholder:text-muted-foreground border-0 min-h-[88px] focus:outline-none focus:ring-0"
                   rows={3}
-                  placeholder={`Message ${agentName}...`}
+                  placeholder="Ask me to automate workflows, manage tasks..."
                   value={input}
                   onChange={(e) => setInput(e.target.value)}
                   onKeyDown={handleKeyDown}

--- a/turbo/apps/platform/src/views/zero-page/zero-session-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-session-chat-page.tsx
@@ -10,6 +10,8 @@ import {
   IconAlertCircle,
   IconLoader2,
   IconArrowLeft,
+  IconUsers,
+  IconCalendar,
 } from "@tabler/icons-react";
 import { Button, Card, CardContent } from "@vm0/ui";
 import { Markdown } from "../components/markdown.tsx";
@@ -33,12 +35,16 @@ interface ZeroSessionChatPageProps {
   zeroAvatarSrc?: string;
   onAvatarClick?: () => void;
   onBack?: () => void;
+  onNavigateToJob?: () => void;
+  onNavigateToSchedule?: () => void;
 }
 
 export function ZeroSessionChatPage({
   zeroAvatarSrc = "/zero-avatar.png",
   onAvatarClick,
   onBack,
+  onNavigateToJob,
+  onNavigateToSchedule,
 }: ZeroSessionChatPageProps) {
   const agentNameLoadable = useLoadable(agentDisplayName$);
   const agentName =
@@ -103,6 +109,26 @@ export function ZeroSessionChatPage({
             />
           </button>
           <span className="font-semibold text-foreground">{agentName}</span>
+        </div>
+        <div className="flex items-center gap-0.5">
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-8 w-8 text-muted-foreground hover:text-foreground"
+            onClick={onNavigateToJob}
+            aria-label="Sub-agents"
+          >
+            <IconUsers size={18} stroke={1.5} />
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-8 w-8 text-muted-foreground hover:text-foreground"
+            onClick={onNavigateToSchedule}
+            aria-label="Schedule"
+          >
+            <IconCalendar size={18} stroke={1.5} />
+          </Button>
         </div>
       </header>
 

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -15,6 +15,7 @@ import {
   IconChevronRight,
   IconSwitchHorizontal,
   IconLoader2,
+  IconRefresh,
 } from "@tabler/icons-react";
 import type { SessionListItem } from "@vm0/core";
 import {
@@ -85,6 +86,7 @@ interface ZeroSidebarProps {
   recentSessions?: SessionListItem[];
   recentSessionsLoading?: boolean;
   onNewChat?: () => void;
+  onResetAgent?: () => void;
 }
 
 function AccountAvatar({
@@ -140,9 +142,11 @@ function useAccountSessions() {
 function AccountDropdown({
   activeId,
   onAccountAction,
+  onResetAgent,
 }: {
   activeId: ZeroNavId;
   onAccountAction?: (action: ZeroAccountAction) => void;
+  onResetAgent?: () => void;
 }) {
   const { user, clerk, accounts } = useAccountSessions();
   const accountName = user?.fullName ?? "User";
@@ -318,6 +322,18 @@ function AccountDropdown({
           <IconUser size={18} stroke={1.5} />
           <span>Manage account</span>
         </DropdownMenuItem>
+        {import.meta.env.DEV && onResetAgent && (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem
+              onClick={onResetAgent}
+              className="gap-3 px-3 py-2.5 text-amber-500"
+            >
+              <IconRefresh size={18} stroke={1.5} />
+              <span>Reset Default Agent</span>
+            </DropdownMenuItem>
+          </>
+        )}
         <DropdownMenuSeparator />
         <DropdownMenuItem
           onClick={() => handleAccountAction("signout")}
@@ -341,6 +357,7 @@ export function ZeroSidebar({
   recentSessions = [],
   recentSessionsLoading = false,
   onNewChat,
+  onResetAgent,
 }: ZeroSidebarProps) {
   const displayName = agentName || "Zero";
   const mainNav = MAIN_NAV.map((item) => ({
@@ -465,6 +482,7 @@ export function ZeroSidebar({
             <AccountDropdown
               activeId={activeId}
               onAccountAction={onAccountAction}
+              onResetAgent={onResetAgent}
             />
           </div>
         </div>

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -85,6 +85,7 @@ interface ZeroSidebarProps {
   onAccountAction?: (action: ZeroAccountAction) => void;
   recentSessions?: SessionListItem[];
   recentSessionsLoading?: boolean;
+  recentSessionsError?: string | null;
   onNewChat?: () => void;
   onResetAgent?: () => void;
 }
@@ -356,6 +357,7 @@ export function ZeroSidebar({
   onAccountAction,
   recentSessions = [],
   recentSessionsLoading = false,
+  recentSessionsError = null,
   onNewChat,
   onResetAgent,
 }: ZeroSidebarProps) {
@@ -424,6 +426,10 @@ export function ZeroSidebar({
                     className="animate-spin text-muted-foreground"
                   />
                 </div>
+              ) : recentSessionsError ? (
+                <p className="px-2 py-2 text-xs text-destructive">
+                  {recentSessionsError}
+                </p>
               ) : recentSessions.length === 0 ? (
                 <p className="px-2 py-2 text-xs text-muted-foreground">
                   No recent chats

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -14,7 +14,9 @@ import {
   IconPlus,
   IconChevronRight,
   IconSwitchHorizontal,
+  IconLoader2,
 } from "@tabler/icons-react";
+import type { SessionListItem } from "@vm0/core";
 import {
   DropdownMenu,
   DropdownMenuTrigger,
@@ -51,14 +53,6 @@ const MAIN_NAV = [
   { id: "activity", label: "Activities", icon: IconChartLine as NavIcon },
 ] as const;
 
-const RECENT_ITEMS = [
-  { id: "hello", label: "Hello from Zero" },
-  { id: "1", label: "Daily digest workflow" },
-  { id: "2", label: "Set up Slack integration" },
-  { id: "3", label: "Weekly report automation" },
-  { id: "4", label: "Code review reminders" },
-] as const;
-
 const FOOTER_NAV = [
   {
     id: "works" as const satisfies ZeroNavId,
@@ -88,6 +82,9 @@ interface ZeroSidebarProps {
   onRecentSelect?: (id: string) => void;
   selectedRecentId?: string | null;
   onAccountAction?: (action: ZeroAccountAction) => void;
+  recentSessions?: SessionListItem[];
+  recentSessionsLoading?: boolean;
+  onNewChat?: () => void;
 }
 
 function AccountAvatar({
@@ -341,13 +338,12 @@ export function ZeroSidebar({
   onRecentSelect,
   selectedRecentId = null,
   onAccountAction,
+  recentSessions = [],
+  recentSessionsLoading = false,
+  onNewChat,
 }: ZeroSidebarProps) {
   const displayName = agentName || "Zero";
   const mainNav = MAIN_NAV.map((item) => ({
-    ...item,
-    label: item.label.replace("Zero", displayName),
-  }));
-  const recentItems = RECENT_ITEMS.map((item) => ({
     ...item,
     label: item.label.replace("Zero", displayName),
   }));
@@ -386,34 +382,53 @@ export function ZeroSidebar({
             ))}
           </div>
 
-          {/* Recent dialogue — no extra wrapper padding so label/items align with main nav (nav already has p-2) */}
+          {/* Recent chat sessions */}
           <div className="mt-4">
-            <div className="zero-nav-recent-label h-8 flex items-center px-2">
+            <div className="zero-nav-recent-label h-8 flex items-center justify-between px-2">
               <span className="text-xs leading-4 text-sidebar-foreground uppercase tracking-wider">
                 recent chat
               </span>
+              {onNewChat && (
+                <button
+                  type="button"
+                  onClick={onNewChat}
+                  className="text-sidebar-foreground/60 hover:text-sidebar-foreground transition-colors"
+                  aria-label="New chat"
+                >
+                  <IconPlus size={14} />
+                </button>
+              )}
             </div>
             <div className="flex flex-col gap-1">
-              {recentItems.map(({ id, label }) => (
-                <button
-                  key={id}
-                  type="button"
-                  onClick={() => onRecentSelect?.(id)}
-                  className={`flex h-8 items-center gap-2 rounded-lg p-2 text-left text-sm leading-5 transition-colors ${
-                    selectedRecentId === id
-                      ? "bg-sidebar-active text-sidebar-primary"
-                      : "text-sidebar-foreground hover:bg-sidebar-accent"
-                  }`}
-                >
-                  <span className="truncate min-w-0 flex-1">{label}</span>
-                  {id === "hello" && (
-                    <span
-                      className="shrink-0 w-1.5 h-1.5 rounded-full bg-red-500"
-                      aria-hidden
-                    />
-                  )}
-                </button>
-              ))}
+              {recentSessionsLoading ? (
+                <div className="flex items-center justify-center py-3">
+                  <IconLoader2
+                    size={14}
+                    className="animate-spin text-muted-foreground"
+                  />
+                </div>
+              ) : recentSessions.length === 0 ? (
+                <p className="px-2 py-2 text-xs text-muted-foreground">
+                  No recent chats
+                </p>
+              ) : (
+                recentSessions.map((session) => (
+                  <button
+                    key={session.id}
+                    type="button"
+                    onClick={() => onRecentSelect?.(session.id)}
+                    className={`flex h-8 items-center gap-2 rounded-lg p-2 text-left text-sm leading-5 transition-colors ${
+                      selectedRecentId === session.id
+                        ? "bg-sidebar-active text-sidebar-primary"
+                        : "text-sidebar-foreground hover:bg-sidebar-accent"
+                    }`}
+                  >
+                    <span className="truncate min-w-0 flex-1">
+                      {session.preview ?? "New chat"}
+                    </span>
+                  </button>
+                ))
+              )}
             </div>
           </div>
         </nav>


### PR DESCRIPTION
## Summary

- Add `zero-chat.ts` signals for chat state management, session list, and message sending via real agent run pipeline (POST `/api/agent/runs` → polling → result extraction → session persistence)
- Rewrite `zero-chat-page.tsx` replacing ~1200 lines of demo/simulation with ~230 lines of real chat UI (welcome state with suggested prompts + message list)
- Wire sidebar recent sessions with live data from session list API, with loading/empty states and new chat button
- Auto-send introductory message ("Who are you and what can you do?") after onboarding completes
- Add session switching and new chat creation functionality

Closes #4381

## Test plan

- [ ] Complete onboarding flow → verify auto-message is sent and response appears
- [ ] Send messages in chat → verify they appear with real agent responses
- [ ] Check sidebar recent sessions populate after first chat
- [ ] Click recent session → verify it loads previous messages
- [ ] Click "+" button → verify new empty chat starts
- [ ] Verify welcome state shows when no messages exist
- [ ] Test suggested prompt buttons trigger real agent runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)