### PR TITLE
refactor: standardize connector secret names to use token convention

### DIFF
--- a/turbo/apps/docs/content/docs/agent-skills/axiom.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/axiom.mdx
@@ -9,7 +9,7 @@ description: Cloud-native observability platform for logs and analytics
 
 | Name                          | Type   | Description                                                               |
 | ----------------------------- | ------ | ------------------------------------------------------------------------- |
-| `AXIOM_API_TOKEN`             | secret | API token from [Axiom Settings](https://app.axiom.co/settings/api-tokens) |
+| `AXIOM_TOKEN`             | secret | API token from [Axiom Settings](https://app.axiom.co/settings/api-tokens) |
 | `AXIOM_PERSONAL_ACCESS_TOKEN` | secret | Personal access token for full account access (optional)                  |
 | `AXIOM_ORG_ID`                | var    | Organization ID (required when using PAT)                                 |
 
@@ -30,7 +30,7 @@ agents:
 Store your secrets on the platform (recommended, one-time setup):
 
 ```bash
-vm0 secret set AXIOM_API_TOKEN your-axiom-api-token
+vm0 secret set AXIOM_TOKEN your-axiom-api-token
 vm0 secret set AXIOM_PERSONAL_ACCESS_TOKEN your-axiom-personal-access-token
 ```
 
@@ -41,7 +41,7 @@ vm0 run my-agent "query error logs from last hour"
 ```
 
 <Callout type="info">
-For CI/CD or temporary overrides, pass secrets at runtime: `--secrets AXIOM_API_TOKEN=value`. See [Environment Variables](/docs/core-concept/environment-variable) for details.
+For CI/CD or temporary overrides, pass secrets at runtime: `--secrets AXIOM_TOKEN=value`. See [Environment Variables](/docs/core-concept/environment-variable) for details.
 </Callout>
 
 ## Example Instructions

--- a/turbo/apps/docs/content/docs/agent-skills/bright-data.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/bright-data.mdx
@@ -9,7 +9,7 @@ description: Web scraping with proxies and data collection
 
 | Name                 | Type   | Description                                                                   |
 | -------------------- | ------ | ----------------------------------------------------------------------------- |
-| `BRIGHTDATA_API_KEY` | secret | API key from [Bright Data Dashboard](https://brightdata.com/cp/setting/users) |
+| `BRIGHTDATA_TOKEN` | secret | API key from [Bright Data Dashboard](https://brightdata.com/cp/setting/users) |
 
 ## Configuration
 
@@ -28,7 +28,7 @@ agents:
 Store your secret on the platform (recommended, one-time setup):
 
 ```bash
-vm0 secret set BRIGHTDATA_API_KEY your-brightdata-api-key
+vm0 secret set BRIGHTDATA_TOKEN your-brightdata-api-key
 ```
 
 Then run your agent - secret is automatically loaded:
@@ -38,7 +38,7 @@ vm0 run my-agent "scrape social media data"
 ```
 
 <Callout type="info">
-For CI/CD or temporary overrides, pass secrets at runtime: `--secrets BRIGHTDATA_API_KEY=value`. See [Environment Variables](/docs/core-concept/environment-variable) for details.
+For CI/CD or temporary overrides, pass secrets at runtime: `--secrets BRIGHTDATA_TOKEN=value`. See [Environment Variables](/docs/core-concept/environment-variable) for details.
 </Callout>
 
 ## Example Instructions

--- a/turbo/apps/docs/content/docs/agent-skills/fal-ai.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/fal-ai.mdx
@@ -9,7 +9,7 @@ description: AI image generation from text prompts
 
 | Name      | Type   | Description                                      |
 | --------- | ------ | ------------------------------------------------ |
-| `FAL_KEY` | secret | API key from [fal.ai Dashboard](https://fal.ai/) |
+| `FAL_TOKEN` | secret | API key from [fal.ai Dashboard](https://fal.ai/) |
 
 ## Configuration
 
@@ -28,7 +28,7 @@ agents:
 Store your secret on the platform (recommended, one-time setup):
 
 ```bash
-vm0 secret set FAL_KEY your-fal-key
+vm0 secret set FAL_TOKEN your-fal-key
 ```
 
 Then run your agent - secret is automatically loaded:
@@ -38,7 +38,7 @@ vm0 run my-agent "generate an image of a sunset"
 ```
 
 <Callout type="info">
-For CI/CD or temporary overrides, pass secrets at runtime: `--secrets FAL_KEY=value`. See [Environment Variables](/docs/core-concept/environment-variable) for details.
+For CI/CD or temporary overrides, pass secrets at runtime: `--secrets FAL_TOKEN=value`. See [Environment Variables](/docs/core-concept/environment-variable) for details.
 </Callout>
 
 ## Example Instructions

--- a/turbo/apps/docs/content/docs/agent-skills/linear.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/linear.mdx
@@ -9,7 +9,7 @@ description: Manage issues and projects in Linear
 
 | Name             | Type   | Description                                                     |
 | ---------------- | ------ | --------------------------------------------------------------- |
-| `LINEAR_API_KEY` | secret | API key from [Linear Settings](https://linear.app/settings/api) |
+| `LINEAR_TOKEN` | secret | API key from [Linear Settings](https://linear.app/settings/api) |
 
 ## Configuration
 
@@ -28,7 +28,7 @@ agents:
 Store your secret on the platform (recommended, one-time setup):
 
 ```bash
-vm0 secret set LINEAR_API_KEY your-linear-api-key
+vm0 secret set LINEAR_TOKEN your-linear-api-key
 ```
 
 Then run your agent - secret is automatically loaded:
@@ -38,7 +38,7 @@ vm0 run my-agent "create an issue"
 ```
 
 <Callout type="info">
-For CI/CD or temporary overrides, pass secrets at runtime: `--secrets LINEAR_API_KEY=value`. See [Environment Variables](/docs/core-concept/environment-variable) for details.
+For CI/CD or temporary overrides, pass secrets at runtime: `--secrets LINEAR_TOKEN=value`. See [Environment Variables](/docs/core-concept/environment-variable) for details.
 </Callout>
 
 ## Example Instructions

--- a/turbo/apps/docs/content/docs/agent-skills/resend.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/resend.mdx
@@ -9,7 +9,7 @@ description: Transactional email API
 
 | Name             | Type   | Description                                                  |
 | ---------------- | ------ | ------------------------------------------------------------ |
-| `RESEND_API_KEY` | secret | API key from [Resend Dashboard](https://resend.com/api-keys) |
+| `RESEND_TOKEN` | secret | API key from [Resend Dashboard](https://resend.com/api-keys) |
 
 ## Configuration
 
@@ -28,7 +28,7 @@ agents:
 Store your secret on the platform (recommended, one-time setup):
 
 ```bash
-vm0 secret set RESEND_API_KEY your-resend-api-key
+vm0 secret set RESEND_TOKEN your-resend-api-key
 ```
 
 Then run your agent - secret is automatically loaded:
@@ -38,7 +38,7 @@ vm0 run my-agent "send welcome email"
 ```
 
 <Callout type="info">
-For CI/CD or temporary overrides, pass secrets at runtime: `--secrets RESEND_API_KEY=value`. See [Environment Variables](/docs/core-concept/environment-variable) for details.
+For CI/CD or temporary overrides, pass secrets at runtime: `--secrets RESEND_TOKEN=value`. See [Environment Variables](/docs/core-concept/environment-variable) for details.
 </Callout>
 
 ## Example Instructions

--- a/turbo/apps/platform/src/views/logs-page/log-detail/components/log-detail-content.tsx
+++ b/turbo/apps/platform/src/views/logs-page/log-detail/components/log-detail-content.tsx
@@ -26,7 +26,7 @@ import { detach, Reason } from "../../../../signals/utils.ts";
 
 /**
  * Parse missing secrets from error message
- * Example: "Missing required secrets: FAL_KEY, BRIGHTDATA_API_KEY. Use '--secrets FAL_KEY=<value>' or '--env-file <path>' to provide them."
+ * Example: "Missing required secrets: FAL_TOKEN, BRIGHTDATA_TOKEN. Use '--secrets FAL_TOKEN=<value>' or '--env-file <path>' to provide them."
  */
 function parseMissingSecrets(errorMessage: string): string[] {
   const match = errorMessage.match(/Missing required secrets:\s*([^.]+)/i);

--- a/turbo/apps/web/src/lib/connector/providers/resend-handler.ts
+++ b/turbo/apps/web/src/lib/connector/providers/resend-handler.ts
@@ -9,5 +9,5 @@ export const resendHandler: ProviderHandler = {
   },
   getClientId: () => undefined,
   getClientSecret: () => undefined,
-  getSecretName: () => "RESEND_API_KEY",
+  getSecretName: () => "RESEND_TOKEN",
 };

--- a/turbo/packages/core/src/contracts/connectors.ts
+++ b/turbo/packages/core/src/contracts/connectors.ts
@@ -702,7 +702,7 @@ const CONNECTOR_TYPES_DEF = {
       tokenUrl: "https://api.linear.app/oauth/token",
       scopes: ["read", "write"],
       environmentMapping: {
-        LINEAR_API_KEY: "$secrets.LINEAR_ACCESS_TOKEN",
+        LINEAR_TOKEN: "$secrets.LINEAR_ACCESS_TOKEN",
       },
     } as ConnectorOAuthConfig,
   },
@@ -1895,7 +1895,7 @@ const CONNECTOR_TYPES_DEF = {
       tokenUrl: "https://connect.stripe.com/oauth/token",
       scopes: ["read_write"],
       environmentMapping: {
-        STRIPE_API_KEY: "$secrets.STRIPE_ACCESS_TOKEN",
+        STRIPE_TOKEN: "$secrets.STRIPE_ACCESS_TOKEN",
       },
     } as ConnectorOAuthConfig,
   },
@@ -2039,7 +2039,7 @@ const CONNECTOR_TYPES_DEF = {
         helpText:
           "1. Log in to [Resend](https://resend.com)\n2. Go to **API Keys** in the sidebar\n3. Click **Create API Key**\n4. Choose permissions (Full access recommended) and copy the key",
         secrets: {
-          RESEND_API_KEY: {
+          RESEND_TOKEN: {
             label: "API Key",
             required: true,
             placeholder: "re_xxxxxxxxxx",
@@ -2673,10 +2673,10 @@ const CONNECTOR_PROXY_CONFIGS: Partial<
   Record<ConnectorType, ConnectorProxyConfig>
 > = {
   ahrefs: {
-    services: [service("https://api.ahrefs.com", bearerAuth("AHREFS_API_KEY"))],
+    services: [service("https://api.ahrefs.com", bearerAuth("AHREFS_TOKEN"))],
   },
   axiom: {
-    services: [service("https://api.axiom.co", bearerAuth("AXIOM_API_TOKEN"))],
+    services: [service("https://api.axiom.co", bearerAuth("AXIOM_TOKEN"))],
   },
   airtable: {
     services: [
@@ -2787,7 +2787,7 @@ const CONNECTOR_PROXY_CONFIGS: Partial<
     ],
   },
   linear: {
-    services: [service("https://api.linear.app", bearerAuth("LINEAR_API_KEY"))],
+    services: [service("https://api.linear.app", bearerAuth("LINEAR_TOKEN"))],
   },
   intercom: {
     services: [
@@ -2871,7 +2871,7 @@ const CONNECTOR_PROXY_CONFIGS: Partial<
   },
   neon: {
     services: [
-      service("https://console.neon.tech/api/v2", bearerAuth("NEON_API_KEY")),
+      service("https://console.neon.tech/api/v2", bearerAuth("NEON_TOKEN")),
     ],
   },
   vercel: {
@@ -2928,7 +2928,7 @@ const CONNECTOR_PROXY_CONFIGS: Partial<
     ],
   },
   stripe: {
-    services: [service("https://api.stripe.com", bearerAuth("STRIPE_API_KEY"))],
+    services: [service("https://api.stripe.com", bearerAuth("STRIPE_TOKEN"))],
   },
   productlane: {
     services: [
@@ -2962,87 +2962,87 @@ const CONNECTOR_PROXY_CONFIGS: Partial<
     services: [
       service(
         "https://us1.api.mailchimp.com/3.0",
-        bearerAuth("MAILCHIMP_API_KEY"),
+        bearerAuth("MAILCHIMP_TOKEN"),
       ),
       service(
         "https://us2.api.mailchimp.com/3.0",
-        bearerAuth("MAILCHIMP_API_KEY"),
+        bearerAuth("MAILCHIMP_TOKEN"),
       ),
       service(
         "https://us3.api.mailchimp.com/3.0",
-        bearerAuth("MAILCHIMP_API_KEY"),
+        bearerAuth("MAILCHIMP_TOKEN"),
       ),
       service(
         "https://us4.api.mailchimp.com/3.0",
-        bearerAuth("MAILCHIMP_API_KEY"),
+        bearerAuth("MAILCHIMP_TOKEN"),
       ),
       service(
         "https://us5.api.mailchimp.com/3.0",
-        bearerAuth("MAILCHIMP_API_KEY"),
+        bearerAuth("MAILCHIMP_TOKEN"),
       ),
       service(
         "https://us6.api.mailchimp.com/3.0",
-        bearerAuth("MAILCHIMP_API_KEY"),
+        bearerAuth("MAILCHIMP_TOKEN"),
       ),
       service(
         "https://us7.api.mailchimp.com/3.0",
-        bearerAuth("MAILCHIMP_API_KEY"),
+        bearerAuth("MAILCHIMP_TOKEN"),
       ),
       service(
         "https://us8.api.mailchimp.com/3.0",
-        bearerAuth("MAILCHIMP_API_KEY"),
+        bearerAuth("MAILCHIMP_TOKEN"),
       ),
       service(
         "https://us9.api.mailchimp.com/3.0",
-        bearerAuth("MAILCHIMP_API_KEY"),
+        bearerAuth("MAILCHIMP_TOKEN"),
       ),
       service(
         "https://us10.api.mailchimp.com/3.0",
-        bearerAuth("MAILCHIMP_API_KEY"),
+        bearerAuth("MAILCHIMP_TOKEN"),
       ),
       service(
         "https://us11.api.mailchimp.com/3.0",
-        bearerAuth("MAILCHIMP_API_KEY"),
+        bearerAuth("MAILCHIMP_TOKEN"),
       ),
       service(
         "https://us12.api.mailchimp.com/3.0",
-        bearerAuth("MAILCHIMP_API_KEY"),
+        bearerAuth("MAILCHIMP_TOKEN"),
       ),
       service(
         "https://us13.api.mailchimp.com/3.0",
-        bearerAuth("MAILCHIMP_API_KEY"),
+        bearerAuth("MAILCHIMP_TOKEN"),
       ),
       service(
         "https://us14.api.mailchimp.com/3.0",
-        bearerAuth("MAILCHIMP_API_KEY"),
+        bearerAuth("MAILCHIMP_TOKEN"),
       ),
       service(
         "https://us15.api.mailchimp.com/3.0",
-        bearerAuth("MAILCHIMP_API_KEY"),
+        bearerAuth("MAILCHIMP_TOKEN"),
       ),
       service(
         "https://us16.api.mailchimp.com/3.0",
-        bearerAuth("MAILCHIMP_API_KEY"),
+        bearerAuth("MAILCHIMP_TOKEN"),
       ),
       service(
         "https://us17.api.mailchimp.com/3.0",
-        bearerAuth("MAILCHIMP_API_KEY"),
+        bearerAuth("MAILCHIMP_TOKEN"),
       ),
       service(
         "https://us18.api.mailchimp.com/3.0",
-        bearerAuth("MAILCHIMP_API_KEY"),
+        bearerAuth("MAILCHIMP_TOKEN"),
       ),
       service(
         "https://us19.api.mailchimp.com/3.0",
-        bearerAuth("MAILCHIMP_API_KEY"),
+        bearerAuth("MAILCHIMP_TOKEN"),
       ),
       service(
         "https://us20.api.mailchimp.com/3.0",
-        bearerAuth("MAILCHIMP_API_KEY"),
+        bearerAuth("MAILCHIMP_TOKEN"),
       ),
       service(
         "https://us21.api.mailchimp.com/3.0",
-        bearerAuth("MAILCHIMP_API_KEY"),
+        bearerAuth("MAILCHIMP_TOKEN"),
       ),
     ],
   },
@@ -3052,7 +3052,7 @@ const CONNECTOR_PROXY_CONFIGS: Partial<
     ],
   },
   resend: {
-    services: [service("https://api.resend.com", bearerAuth("RESEND_API_KEY"))],
+    services: [service("https://api.resend.com", bearerAuth("RESEND_TOKEN"))],
   },
   revenuecat: {
     services: [
@@ -3123,7 +3123,7 @@ const CONNECTOR_PROXY_CONFIGS: Partial<
     ],
   },
   fal: {
-    services: [service("https://fal.run", bearerAuth("FAL_KEY"))],
+    services: [service("https://fal.run", bearerAuth("FAL_TOKEN"))],
   },
   podchaser: {
     services: [


### PR DESCRIPTION
## Summary
- Rename connector secret/environment variable names from inconsistent patterns (`*_API_KEY`, `*_KEY`, `*_API_TOKEN`) to a unified `*_TOKEN` convention
- Update affected connectors: Axiom, Bright Data, fal.ai, Linear, Resend, Stripe, Neon, Mailchimp, Ahrefs
- Update corresponding docs, platform UI comment, resend handler, and core connector proxy configs

## Test plan
- [ ] Verify connector proxy configs resolve correct env var names at runtime
- [ ] Verify docs display updated secret names
- [ ] Confirm existing OAuth flows still map to correct secret names

🤖 Generated with [Claude Code](https://claude.com/claude-code)