### PR TITLE
refactor: decouple service proxy config from connector concept

### DIFF
--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -62,8 +62,8 @@ _registry_cache_key = (0, 0)
 # Track request start times for latency calculation
 _request_start_times = {}
 
-# Cache for connector auth headers: (run_id, connector_name, base) -> {"headers": dict, "expires_at": float}
-_connector_token_cache = {}
+# Cache for service auth headers: (run_id, base) -> {"headers": dict, "expires_at": float}
+_service_token_cache = {}
 
 
 def load_registry() -> dict:
@@ -122,32 +122,32 @@ def get_original_url(flow: http.HTTPFlow) -> str:
 
 
 # ============================================================================
-# Connector Token Replacement
+# Service Token Replacement
 # ============================================================================
 
-def match_connector(url: str, vm_connectors: dict | None) -> dict | None:
-    """Match URL against connector base URLs. Returns connector entry or None.
+def match_service(url: str, vm_services: dict | None) -> dict | None:
+    """Match URL against service API base URLs. Returns API entry or None.
 
     Matches if the URL starts with the base and the next character is '/', '?', or end-of-string.
     This prevents https://api.github.com matching https://api.github.com.evil.com.
     """
-    if not vm_connectors:
+    if not vm_services:
         return None
-    for connector in vm_connectors.get("connectors", []):
-        base = connector.get("base", "").rstrip("/")
+    for api_entry in vm_services.get("apis", []):
+        base = api_entry.get("base", "").rstrip("/")
         if base and url.startswith(base):
             # Ensure match is at a path boundary, not mid-hostname
             rest = url[len(base):]
             if not rest or rest[0] in ("/" , "?", "#"):
-                return connector
+                return api_entry
     return None
 
 
-def fetch_connector_headers(connector_name: str, base: str, sandbox_token: str, run_id: str) -> dict:
+def fetch_service_headers(base: str, sandbox_token: str, run_id: str) -> dict:
     """Fetch resolved auth headers from API."""
     api_url = get_api_url()
-    url = f"{api_url}/api/webhooks/agent/connectors/auth"
-    data = json.dumps({"runId": run_id, "connectorName": connector_name, "base": base}).encode()
+    url = f"{api_url}/api/webhooks/agent/services/auth"
+    data = json.dumps({"runId": run_id, "base": base}).encode()
     req = urllib.request.Request(url, data=data, headers={
         "Authorization": f"Bearer {sandbox_token}",
         "Content-Type": "application/json",
@@ -158,41 +158,40 @@ def fetch_connector_headers(connector_name: str, base: str, sandbox_token: str, 
     return json.loads(resp.read())
 
 
-def get_connector_headers(run_id: str, connector_name: str, base: str, sandbox_token: str) -> dict:
-    """Get connector auth headers with caching. Returns resolved headers dict."""
-    cache_key = (run_id, connector_name, base)
-    cached = _connector_token_cache.get(cache_key)
+def get_service_headers(run_id: str, base: str, sandbox_token: str) -> dict:
+    """Get service auth headers with caching. Returns resolved headers dict."""
+    cache_key = (run_id, base)
+    cached = _service_token_cache.get(cache_key)
     if cached and cached["expires_at"] > time.time():
         return cached["headers"]
 
-    result = fetch_connector_headers(connector_name, base, sandbox_token, run_id)
+    result = fetch_service_headers(base, sandbox_token, run_id)
     headers = result["headers"]
     expires_in = result.get("expiresIn", 1800)
-    _connector_token_cache[cache_key] = {
+    _service_token_cache[cache_key] = {
         "headers": headers,
         "expires_at": time.time() + min(expires_in, 1800),
     }
     return headers
 
 
-def handle_connector_request(flow: http.HTTPFlow, connector: dict, vm_info: dict) -> None:
-    """Handle a connector-matched request: fetch resolved headers, inject into request."""
+def handle_service_request(flow: http.HTTPFlow, api_entry: dict, vm_info: dict) -> None:
+    """Handle a service-matched request: fetch resolved headers, inject into request."""
     client_ip = flow.client_conn.peername[0]
-    connector_name = connector["name"]
-    connector_base = connector["base"]
+    service_base = api_entry["base"]
     run_id = vm_info.get("runId", "")
     sandbox_token = vm_info.get("sandboxToken", "")
 
     try:
-        headers = get_connector_headers(run_id, connector_name, connector_base, sandbox_token)
+        headers = get_service_headers(run_id, service_base, sandbox_token)
     except Exception as e:
-        ctx.log.error(f"[{run_id}] Connector {connector_name} header fetch failed: {e}")
+        ctx.log.error(f"[{run_id}] Service {service_base} header fetch failed: {e}")
         flow.metadata["firewall_action"] = "DENY"
-        flow.metadata["firewall_rule"] = f"connector:{connector_name}"
+        flow.metadata["firewall_rule"] = f"service:{service_base}"
         flow.metadata["original_url"] = get_original_url(flow)
         flow.response = http.Response.make(
             502,
-            b"Connector header fetch failed",
+            b"Service header fetch failed",
             {"Content-Type": "text/plain"},
         )
         return
@@ -203,8 +202,8 @@ def handle_connector_request(flow: http.HTTPFlow, connector: dict, vm_info: dict
 
     # Store metadata for logging
     flow.metadata["firewall_action"] = "ALLOW"
-    flow.metadata["firewall_rule"] = f"connector:{connector_name}"
-    flow.metadata["connector_base"] = connector_base
+    flow.metadata["firewall_rule"] = f"service:{service_base}"
+    flow.metadata["service_base"] = service_base
     flow.metadata["original_url"] = get_original_url(flow)
     flow.metadata["skip_rewrite"] = True
     flow.metadata["vm_run_id"] = run_id
@@ -212,7 +211,7 @@ def handle_connector_request(flow: http.HTTPFlow, connector: dict, vm_info: dict
     flow.metadata["vm_mitm_enabled"] = True
     flow.metadata["vm_network_log_path"] = vm_info.get("networkLogPath", "")
 
-    ctx.log.info(f"[{run_id}] Connector {connector_name}: {flow.request.pretty_host}")
+    ctx.log.info(f"[{run_id}] Service {service_base}: {flow.request.pretty_host}")
 
 
 # ============================================================================
@@ -432,14 +431,14 @@ def request(flow: http.HTTPFlow) -> None:
     flow.metadata["vm_mitm_enabled"] = mitm_enabled
     flow.metadata["vm_network_log_path"] = vm_info.get("networkLogPath", "")
 
-    # Check connector match BEFORE firewall rules.
-    # Connector requests go directly to the target API with real tokens injected.
-    vm_connectors = vm_info.get("connectors")
-    if vm_connectors:
+    # Check service match BEFORE firewall rules.
+    # Service requests go directly to the target API with real tokens injected.
+    vm_services = vm_info.get("services")
+    if vm_services:
         original_url = get_original_url(flow)
-        connector = match_connector(original_url, vm_connectors)
-        if connector:
-            handle_connector_request(flow, connector, vm_info)
+        api_entry = match_service(original_url, vm_services)
+        if api_entry:
+            handle_service_request(flow, api_entry, vm_info)
             return
 
     # Get target hostname
@@ -615,14 +614,13 @@ def response(flow: http.HTTPFlow) -> None:
 
         log_network_entry({"networkLogPath": network_log_path}, log_entry)
 
-    # Invalidate connector header cache on 401 so next request gets fresh headers
+    # Invalidate service header cache on 401 so next request gets fresh headers
     if flow.response and flow.response.status_code == 401 and firewall_rule:
-        if firewall_rule.startswith("connector:"):
-            connector_name = firewall_rule.split(":", 1)[1]
-            connector_base = flow.metadata.get("connector_base", "")
-            cache_key = (run_id, connector_name, connector_base)
-            if _connector_token_cache.pop(cache_key, None):
-                ctx.log.info(f"[{run_id}] Connector {connector_name}: 401 - cleared header cache")
+        if firewall_rule.startswith("service:"):
+            service_base = flow.metadata.get("service_base", "")
+            cache_key = (run_id, service_base)
+            if _service_token_cache.pop(cache_key, None):
+                ctx.log.info(f"[{run_id}] Service {service_base}: 401 - cleared header cache")
 
     # Log errors to mitmproxy console
     if flow.response and flow.response.status_code >= 400:

--- a/crates/runner/mitm-addon/tests/test_connectors.py
+++ b/crates/runner/mitm-addon/tests/test_connectors.py
@@ -1,4 +1,4 @@
-"""Tests for connector subsystem: matching, caching, header injection, and HTTP fetching."""
+"""Tests for service subsystem: matching, caching, header injection, and HTTP fetching."""
 import json
 import time
 from unittest.mock import MagicMock, patch
@@ -7,7 +7,7 @@ import mitm_addon
 
 
 def _make_http_flow(client_ip="10.200.0.1", host="api.github.com", port=443, path="/repos"):
-    """Create a mock HTTP flow for connector tests."""
+    """Create a mock HTTP flow for service tests."""
     flow = MagicMock()
     flow.id = f"flow-{id(flow)}"
     flow.client_conn.peername = (client_ip, 12345)
@@ -24,131 +24,131 @@ def _make_http_flow(client_ip="10.200.0.1", host="api.github.com", port=443, pat
 
 
 # =========================================================================
-# match_connector
+# match_service
 # =========================================================================
 
 
-class TestMatchConnector:
+class TestMatchService:
     def test_exact_base_match(self):
-        connectors = {"connectors": [{"name": "github", "base": "https://api.github.com"}]}
-        result = mitm_addon.match_connector("https://api.github.com", connectors)
+        services = {"apis": [{"base": "https://api.github.com", "auth": {"headers": {"Authorization": "Bearer tok"}}}]}
+        result = mitm_addon.match_service("https://api.github.com", services)
         assert result is not None
-        assert result["name"] == "github"
+        assert result["base"] == "https://api.github.com"
 
     def test_base_with_path(self):
-        connectors = {"connectors": [{"name": "github", "base": "https://api.github.com"}]}
-        result = mitm_addon.match_connector("https://api.github.com/repos/owner/repo", connectors)
+        services = {"apis": [{"base": "https://api.github.com", "auth": {"headers": {}}}]}
+        result = mitm_addon.match_service("https://api.github.com/repos/owner/repo", services)
         assert result is not None
-        assert result["name"] == "github"
+        assert result["base"] == "https://api.github.com"
 
     def test_base_with_query(self):
-        connectors = {"connectors": [{"name": "github", "base": "https://api.github.com"}]}
-        result = mitm_addon.match_connector("https://api.github.com?page=1", connectors)
+        services = {"apis": [{"base": "https://api.github.com", "auth": {"headers": {}}}]}
+        result = mitm_addon.match_service("https://api.github.com?page=1", services)
         assert result is not None
-        assert result["name"] == "github"
+        assert result["base"] == "https://api.github.com"
 
     def test_base_with_fragment(self):
-        connectors = {"connectors": [{"name": "github", "base": "https://api.github.com"}]}
-        result = mitm_addon.match_connector("https://api.github.com#section", connectors)
+        services = {"apis": [{"base": "https://api.github.com", "auth": {"headers": {}}}]}
+        result = mitm_addon.match_service("https://api.github.com#section", services)
         assert result is not None
-        assert result["name"] == "github"
+        assert result["base"] == "https://api.github.com"
 
     def test_path_boundary_prevents_evil_domain(self):
         """Prevents api.github.com matching api.github.com.evil.com."""
-        connectors = {"connectors": [{"name": "github", "base": "https://api.github.com"}]}
-        result = mitm_addon.match_connector("https://api.github.com.evil.com/steal", connectors)
+        services = {"apis": [{"base": "https://api.github.com", "auth": {"headers": {}}}]}
+        result = mitm_addon.match_service("https://api.github.com.evil.com/steal", services)
         assert result is None
 
     def test_path_boundary_prevents_suffix_attack(self):
-        connectors = {"connectors": [{"name": "slack", "base": "https://slack.com"}]}
-        result = mitm_addon.match_connector("https://slack.com.attacker.io/hook", connectors)
+        services = {"apis": [{"base": "https://slack.com", "auth": {"headers": {}}}]}
+        result = mitm_addon.match_service("https://slack.com.attacker.io/hook", services)
         assert result is None
 
-    def test_no_connectors_returns_none(self):
-        assert mitm_addon.match_connector("https://api.github.com/repos", None) is None
+    def test_no_services_returns_none(self):
+        assert mitm_addon.match_service("https://api.github.com/repos", None) is None
 
-    def test_empty_connectors_list(self):
-        connectors = {"connectors": []}
-        assert mitm_addon.match_connector("https://api.github.com/repos", connectors) is None
+    def test_empty_apis_list(self):
+        services = {"apis": []}
+        assert mitm_addon.match_service("https://api.github.com/repos", services) is None
 
-    def test_no_matching_connector(self):
-        connectors = {"connectors": [{"name": "github", "base": "https://api.github.com"}]}
-        result = mitm_addon.match_connector("https://api.gitlab.com/repos", connectors)
+    def test_no_matching_service(self):
+        services = {"apis": [{"base": "https://api.github.com", "auth": {"headers": {}}}]}
+        result = mitm_addon.match_service("https://api.gitlab.com/repos", services)
         assert result is None
 
     def test_trailing_slash_on_base_stripped(self):
         """Base URLs with trailing slashes should still match."""
-        connectors = {"connectors": [{"name": "github", "base": "https://api.github.com/"}]}
-        result = mitm_addon.match_connector("https://api.github.com/repos", connectors)
+        services = {"apis": [{"base": "https://api.github.com/", "auth": {"headers": {}}}]}
+        result = mitm_addon.match_service("https://api.github.com/repos", services)
         assert result is not None
-        assert result["name"] == "github"
+        assert result["base"] == "https://api.github.com/"
 
-    def test_first_matching_connector_wins(self):
-        connectors = {"connectors": [
-            {"name": "specific", "base": "https://api.github.com/v3"},
-            {"name": "broad", "base": "https://api.github.com"},
+    def test_first_matching_api_wins(self):
+        services = {"apis": [
+            {"base": "https://api.github.com/v3", "auth": {"headers": {}}},
+            {"base": "https://api.github.com", "auth": {"headers": {}}},
         ]}
-        result = mitm_addon.match_connector("https://api.github.com/v3/repos", connectors)
-        assert result["name"] == "specific"
+        result = mitm_addon.match_service("https://api.github.com/v3/repos", services)
+        assert result["base"] == "https://api.github.com/v3"
 
     def test_empty_base_skipped(self):
-        connectors = {"connectors": [
-            {"name": "empty", "base": ""},
-            {"name": "github", "base": "https://api.github.com"},
+        services = {"apis": [
+            {"base": "", "auth": {"headers": {}}},
+            {"base": "https://api.github.com", "auth": {"headers": {}}},
         ]}
-        result = mitm_addon.match_connector("https://api.github.com/repos", connectors)
-        assert result["name"] == "github"
+        result = mitm_addon.match_service("https://api.github.com/repos", services)
+        assert result["base"] == "https://api.github.com"
 
 
 # =========================================================================
-# get_connector_headers (caching)
+# get_service_headers (caching)
 # =========================================================================
 
 
-class TestGetConnectorHeaders:
+class TestGetServiceHeaders:
     def setup_method(self):
-        mitm_addon._connector_token_cache.clear()
+        mitm_addon._service_token_cache.clear()
 
     def test_cache_miss_fetches_and_caches(self):
         mock_headers = {"Authorization": "Bearer fresh-token"}
         mock_result = {"headers": mock_headers, "expiresIn": 900}
 
-        with patch.object(mitm_addon, "fetch_connector_headers", return_value=mock_result) as mock_fetch:
-            headers = mitm_addon.get_connector_headers("run-1", "github", "https://api.github.com", "tok-xyz")
+        with patch.object(mitm_addon, "fetch_service_headers", return_value=mock_result) as mock_fetch:
+            headers = mitm_addon.get_service_headers("run-1", "https://api.github.com", "tok-xyz")
 
         assert headers == mock_headers
-        mock_fetch.assert_called_once_with("github", "https://api.github.com", "tok-xyz", "run-1")
+        mock_fetch.assert_called_once_with("https://api.github.com", "tok-xyz", "run-1")
 
         # Verify the cache was populated
-        cache_key = ("run-1", "github", "https://api.github.com")
-        assert cache_key in mitm_addon._connector_token_cache
-        assert mitm_addon._connector_token_cache[cache_key]["headers"] == mock_headers
+        cache_key = ("run-1", "https://api.github.com")
+        assert cache_key in mitm_addon._service_token_cache
+        assert mitm_addon._service_token_cache[cache_key]["headers"] == mock_headers
 
     def test_cache_hit_returns_cached(self):
-        cache_key = ("run-1", "github", "https://api.github.com")
+        cache_key = ("run-1", "https://api.github.com")
         cached_headers = {"Authorization": "Bearer cached-token"}
-        mitm_addon._connector_token_cache[cache_key] = {
+        mitm_addon._service_token_cache[cache_key] = {
             "headers": cached_headers,
             "expires_at": time.time() + 600,  # 10 minutes in future
         }
 
-        with patch.object(mitm_addon, "fetch_connector_headers") as mock_fetch:
-            headers = mitm_addon.get_connector_headers("run-1", "github", "https://api.github.com", "tok-xyz")
+        with patch.object(mitm_addon, "fetch_service_headers") as mock_fetch:
+            headers = mitm_addon.get_service_headers("run-1", "https://api.github.com", "tok-xyz")
 
         assert headers == cached_headers
         mock_fetch.assert_not_called()
 
     def test_cache_expired_fetches_again(self):
-        cache_key = ("run-1", "github", "https://api.github.com")
-        mitm_addon._connector_token_cache[cache_key] = {
+        cache_key = ("run-1", "https://api.github.com")
+        mitm_addon._service_token_cache[cache_key] = {
             "headers": {"Authorization": "Bearer old-token"},
             "expires_at": time.time() - 1,  # expired 1 second ago
         }
         new_headers = {"Authorization": "Bearer new-token"}
         mock_result = {"headers": new_headers, "expiresIn": 900}
 
-        with patch.object(mitm_addon, "fetch_connector_headers", return_value=mock_result) as mock_fetch:
-            headers = mitm_addon.get_connector_headers("run-1", "github", "https://api.github.com", "tok-xyz")
+        with patch.object(mitm_addon, "fetch_service_headers", return_value=mock_result) as mock_fetch:
+            headers = mitm_addon.get_service_headers("run-1", "https://api.github.com", "tok-xyz")
 
         assert headers == new_headers
         mock_fetch.assert_called_once()
@@ -157,38 +157,38 @@ class TestGetConnectorHeaders:
         """expiresIn values above 1800 are capped to 1800 seconds."""
         mock_result = {"headers": {"Authorization": "Bearer tok"}, "expiresIn": 7200}
 
-        with patch.object(mitm_addon, "fetch_connector_headers", return_value=mock_result):
-            mitm_addon.get_connector_headers("run-1", "github", "https://api.github.com", "tok-xyz")
+        with patch.object(mitm_addon, "fetch_service_headers", return_value=mock_result):
+            mitm_addon.get_service_headers("run-1", "https://api.github.com", "tok-xyz")
 
-        cache_key = ("run-1", "github", "https://api.github.com")
-        cached = mitm_addon._connector_token_cache[cache_key]
+        cache_key = ("run-1", "https://api.github.com")
+        cached = mitm_addon._service_token_cache[cache_key]
         # The expiry should be at most ~1800 seconds from now
         assert cached["expires_at"] <= time.time() + 1801
 
     def test_default_expires_in_used_when_missing(self):
         mock_result = {"headers": {"Authorization": "Bearer tok"}}
 
-        with patch.object(mitm_addon, "fetch_connector_headers", return_value=mock_result):
-            mitm_addon.get_connector_headers("run-1", "github", "https://api.github.com", "tok-xyz")
+        with patch.object(mitm_addon, "fetch_service_headers", return_value=mock_result):
+            mitm_addon.get_service_headers("run-1", "https://api.github.com", "tok-xyz")
 
-        cache_key = ("run-1", "github", "https://api.github.com")
-        cached = mitm_addon._connector_token_cache[cache_key]
+        cache_key = ("run-1", "https://api.github.com")
+        cached = mitm_addon._service_token_cache[cache_key]
         # Default expiresIn is 1800, so expires_at should be ~1800s from now
         assert cached["expires_at"] > time.time() + 1700
 
 
 # =========================================================================
-# handle_connector_request
+# handle_service_request
 # =========================================================================
 
 
-class TestHandleConnectorRequest:
+class TestHandleServiceRequest:
     def setup_method(self):
-        mitm_addon._connector_token_cache.clear()
+        mitm_addon._service_token_cache.clear()
 
     def test_success_injects_headers(self):
         flow = _make_http_flow()
-        connector = {"name": "github", "base": "https://api.github.com"}
+        api_entry = {"base": "https://api.github.com", "auth": {"headers": {"Authorization": "Bearer ${secrets.GITHUB_TOKEN}"}}}
         vm_info = {
             "runId": "run-1",
             "sandboxToken": "tok-xyz",
@@ -197,10 +197,10 @@ class TestHandleConnectorRequest:
         resolved_headers = {"Authorization": "Bearer real-token", "X-Custom": "value"}
 
         with (
-            patch.object(mitm_addon, "get_connector_headers", return_value=resolved_headers),
+            patch.object(mitm_addon, "get_service_headers", return_value=resolved_headers),
             patch.object(mitm_addon.ctx, "log", MagicMock(), create=True),
         ):
-            mitm_addon.handle_connector_request(flow, connector, vm_info)
+            mitm_addon.handle_service_request(flow, api_entry, vm_info)
 
         # Headers injected
         assert flow.request.headers["Authorization"] == "Bearer real-token"
@@ -208,14 +208,14 @@ class TestHandleConnectorRequest:
 
         # Metadata set correctly
         assert flow.metadata["firewall_action"] == "ALLOW"
-        assert flow.metadata["firewall_rule"] == "connector:github"
-        assert flow.metadata["connector_base"] == "https://api.github.com"
+        assert flow.metadata["firewall_rule"] == "service:https://api.github.com"
+        assert flow.metadata["service_base"] == "https://api.github.com"
         assert flow.metadata["skip_rewrite"] is True
         assert flow.metadata["vm_run_id"] == "run-1"
 
     def test_failure_returns_502(self):
         flow = _make_http_flow()
-        connector = {"name": "github", "base": "https://api.github.com"}
+        api_entry = {"base": "https://api.github.com", "auth": {"headers": {}}}
         vm_info = {
             "runId": "run-1",
             "sandboxToken": "tok-xyz",
@@ -224,40 +224,40 @@ class TestHandleConnectorRequest:
 
         with (
             patch.object(
-                mitm_addon, "get_connector_headers",
+                mitm_addon, "get_service_headers",
                 side_effect=Exception("API unreachable"),
             ),
             patch.object(mitm_addon.ctx, "log", MagicMock(), create=True),
             patch.object(mitm_addon, "get_api_url", return_value="https://api.vm0.ai"),
         ):
-            mitm_addon.handle_connector_request(flow, connector, vm_info)
+            mitm_addon.handle_service_request(flow, api_entry, vm_info)
 
         assert flow.response is not None
         assert flow.response.status_code == 502
         assert flow.metadata["firewall_action"] == "DENY"
-        assert flow.metadata["firewall_rule"] == "connector:github"
+        assert flow.metadata["firewall_rule"] == "service:https://api.github.com"
 
     def test_no_response_set_on_success(self):
         """On success, flow.response should remain None (request continues to origin)."""
         flow = _make_http_flow()
-        connector = {"name": "github", "base": "https://api.github.com"}
+        api_entry = {"base": "https://api.github.com", "auth": {"headers": {}}}
         vm_info = {"runId": "run-1", "sandboxToken": "tok-xyz", "networkLogPath": ""}
 
         with (
-            patch.object(mitm_addon, "get_connector_headers", return_value={"Auth": "tok"}),
+            patch.object(mitm_addon, "get_service_headers", return_value={"Auth": "tok"}),
             patch.object(mitm_addon.ctx, "log", MagicMock(), create=True),
         ):
-            mitm_addon.handle_connector_request(flow, connector, vm_info)
+            mitm_addon.handle_service_request(flow, api_entry, vm_info)
 
         assert flow.response is None
 
 
 # =========================================================================
-# fetch_connector_headers
+# fetch_service_headers
 # =========================================================================
 
 
-class TestFetchConnectorHeaders:
+class TestFetchServiceHeaders:
     def test_builds_correct_request(self):
         mock_resp = MagicMock()
         mock_resp.read.return_value = json.dumps({"headers": {"Authorization": "Bearer tok"}}).encode()
@@ -268,18 +268,18 @@ class TestFetchConnectorHeaders:
             patch("mitm_addon.urllib.request.urlopen", return_value=mock_resp),
             patch.object(mitm_addon, "VERCEL_BYPASS", ""),
         ):
-            result = mitm_addon.fetch_connector_headers("github", "https://api.github.com", "tok-xyz", "run-1")
+            result = mitm_addon.fetch_service_headers("https://api.github.com", "tok-xyz", "run-1")
 
         assert result == {"headers": {"Authorization": "Bearer tok"}}
 
         # Verify the request was constructed correctly
         mock_req_cls.assert_called_once()
         call_args = mock_req_cls.call_args
-        assert call_args[0][0] == "https://api.vm0.ai/api/webhooks/agent/connectors/auth"
+        assert call_args[0][0] == "https://api.vm0.ai/api/webhooks/agent/services/auth"
         body = json.loads(call_args[1]["data"])
         assert body["runId"] == "run-1"
-        assert body["connectorName"] == "github"
         assert body["base"] == "https://api.github.com"
+        assert "connectorName" not in body
         assert call_args[1]["headers"]["Authorization"] == "Bearer tok-xyz"
         assert call_args[1]["headers"]["Content-Type"] == "application/json"
 
@@ -295,7 +295,7 @@ class TestFetchConnectorHeaders:
             patch("mitm_addon.urllib.request.urlopen", return_value=mock_resp),
             patch.object(mitm_addon, "VERCEL_BYPASS", "secret-bypass-value"),
         ):
-            mitm_addon.fetch_connector_headers("github", "https://api.github.com", "tok-xyz", "run-1")
+            mitm_addon.fetch_service_headers("https://api.github.com", "tok-xyz", "run-1")
 
         mock_req_instance.add_header.assert_called_once_with("x-vercel-protection-bypass", "secret-bypass-value")
 
@@ -311,6 +311,6 @@ class TestFetchConnectorHeaders:
             patch("mitm_addon.urllib.request.urlopen", return_value=mock_resp),
             patch.object(mitm_addon, "VERCEL_BYPASS", ""),
         ):
-            mitm_addon.fetch_connector_headers("github", "https://api.github.com", "tok-xyz", "run-1")
+            mitm_addon.fetch_service_headers("https://api.github.com", "tok-xyz", "run-1")
 
         mock_req_instance.add_header.assert_not_called()

--- a/crates/runner/mitm-addon/tests/test_handlers.py
+++ b/crates/runner/mitm-addon/tests/test_handlers.py
@@ -154,8 +154,8 @@ class TestRequestHandler:
         assert flow.request.pretty_host == "mybucket.s3.amazonaws.com"
         assert flow.response is None
 
-    def test_connector_match_calls_handler(self, tmp_path):
-        """When URL matches a connector, handle_connector_request is called."""
+    def test_service_match_calls_handler(self, tmp_path):
+        """When URL matches a service, handle_service_request is called."""
         registry = {
             "vms": {
                 "10.200.0.5": {
@@ -164,9 +164,9 @@ class TestRequestHandler:
                     "mitmEnabled": True,
                     "firewallRules": [{"final": "DENY"}],
                     "networkLogPath": str(tmp_path / "net.jsonl"),
-                    "connectors": {
-                        "connectors": [
-                            {"name": "github", "base": "https://api.github.com"},
+                    "services": {
+                        "apis": [
+                            {"base": "https://api.github.com", "auth": {"headers": {"Authorization": "Bearer ${secrets.GITHUB_TOKEN}"}}},
                         ]
                     },
                 }
@@ -183,14 +183,14 @@ class TestRequestHandler:
             patch.object(mitm_addon, "get_registry_path", return_value=str(reg_path)),
             patch.object(mitm_addon, "get_api_url", return_value="https://api.vm0.ai"),
             patch.object(mitm_addon.ctx, "log", MagicMock(), create=True),
-            patch.object(mitm_addon, "handle_connector_request") as mock_handler,
+            patch.object(mitm_addon, "handle_service_request") as mock_handler,
         ):
             mitm_addon.request(flow)
 
         mock_handler.assert_called_once()
         call_args = mock_handler.call_args
         assert call_args[0][0] is flow
-        assert call_args[0][1]["name"] == "github"
+        assert call_args[0][1]["base"] == "https://api.github.com"
 
     def test_no_mitm_allows_without_rewrite(self, registry_file):
         """mitmEnabled=False with allowed request passes through without rewrite."""
@@ -273,25 +273,25 @@ class TestResponseHandler:
         assert entry["latency_ms"] > 0
         assert entry["response_size"] == 256
 
-    def test_401_connector_cache_invalidation(self):
-        """401 response with connector firewall_rule pops the cache entry."""
+    def test_401_service_cache_invalidation(self):
+        """401 response with service firewall_rule pops the cache entry."""
         flow = _make_http_flow(host="api.github.com")
         flow.metadata["vm_run_id"] = "run-conn-1"
         flow.metadata["vm_client_ip"] = "10.200.0.5"
         flow.metadata["vm_mitm_enabled"] = True
         flow.metadata["vm_network_log_path"] = ""
         flow.metadata["firewall_action"] = "ALLOW"
-        flow.metadata["firewall_rule"] = "connector:github"
-        flow.metadata["connector_base"] = "https://api.github.com"
+        flow.metadata["firewall_rule"] = "service:https://api.github.com"
+        flow.metadata["service_base"] = "https://api.github.com"
         flow.metadata["original_url"] = "https://api.github.com/repos"
 
         flow.response = MagicMock()
         flow.response.status_code = 401
         flow.response.headers = {}
 
-        # Pre-populate connector token cache
-        cache_key = ("run-conn-1", "github", "https://api.github.com")
-        mitm_addon._connector_token_cache[cache_key] = {
+        # Pre-populate service token cache
+        cache_key = ("run-conn-1", "https://api.github.com")
+        mitm_addon._service_token_cache[cache_key] = {
             "headers": {"Authorization": "Bearer old-token"},
             "expires_at": time.time() + 3600,
         }
@@ -300,7 +300,7 @@ class TestResponseHandler:
             mitm_addon.response(flow)
 
         # Cache entry should have been removed
-        assert cache_key not in mitm_addon._connector_token_cache
+        assert cache_key not in mitm_addon._service_token_cache
 
     def test_error_status_logs_warning(self, tmp_path):
         """Response with status >= 400 calls ctx.log.warn."""

--- a/crates/runner/src/cmd/benchmark.rs
+++ b/crates/runner/src/cmd/benchmark.rs
@@ -178,7 +178,7 @@ async fn run_sandbox(
         mitm_enabled: false,
         seal_secrets_enabled: false,
         network_log_path: &network_log_path,
-        connectors: None,
+        services: None,
     };
     if let Err(e) = mitm.register_vm(&source_ip, &registration).await {
         warn!(error = %e, "failed to register VM in proxy");

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -107,24 +107,24 @@ async fn execute_inner(
     }
     telemetry.record("vm_create", t.elapsed(), true, None);
 
-    // Register VM in proxy registry when firewall is enabled or connectors are present
+    // Register VM in proxy registry when firewall is enabled or services are present
     let source_ip = sandbox.source_ip().to_string();
     let firewall_enabled = context
         .experimental_firewall
         .as_ref()
         .is_some_and(|fw| fw.enabled);
-    let has_connectors = context
-        .experimental_connectors
+    let has_services = context
+        .experimental_services
         .as_ref()
-        .is_some_and(|c| !c.connectors.is_empty());
-    let proxy_registered = firewall_enabled || has_connectors;
+        .is_some_and(|s| !s.apis.is_empty());
+    let proxy_registered = firewall_enabled || has_services;
     let network_log_path = config.log_paths.network_log(context.run_id);
 
     if proxy_registered {
         let fw = context.experimental_firewall.as_ref();
         let fw_mitm = fw.is_some_and(|f| f.experimental_mitm.unwrap_or(false));
-        // Connectors require MITM for header injection
-        let mitm_enabled = fw_mitm || has_connectors;
+        // Services require MITM for header injection
+        let mitm_enabled = fw_mitm || has_services;
 
         let run_id_str = context.run_id.to_string();
         let registration = proxy::VmRegistration {
@@ -134,7 +134,7 @@ async fn execute_inner(
             mitm_enabled,
             seal_secrets_enabled: fw.is_some_and(|f| f.experimental_seal_secrets.unwrap_or(false)),
             network_log_path: &network_log_path,
-            connectors: context.experimental_connectors.as_ref(),
+            services: context.experimental_services.as_ref(),
         };
         if let Err(e) = config.registry.register_vm(&source_ip, &registration).await {
             warn!(run_id = %context.run_id, error = %e, "failed to register VM in proxy");
@@ -587,9 +587,9 @@ fn build_env_json(context: &ExecutionContext, api_url: &str) -> HashMap<String, 
         .as_ref()
         .is_some_and(|fw| fw.experimental_mitm.unwrap_or(false))
         || context
-            .experimental_connectors
+            .experimental_services
             .as_ref()
-            .is_some_and(|c| !c.connectors.is_empty());
+            .is_some_and(|s| !s.apis.is_empty());
     if mitm_needed {
         env.insert("NODE_EXTRA_CA_CERTS".into(), VM_PROXY_CA_PATH.into());
     }
@@ -671,7 +671,7 @@ mod tests {
             secret_values: None,
             cli_agent_type: String::new(),
             experimental_firewall: None,
-            experimental_connectors: None,
+            experimental_services: None,
             debug_no_mock_claude: None,
             api_start_time: None,
             user_timezone: None,
@@ -987,12 +987,17 @@ mod tests {
     }
 
     #[test]
-    fn build_env_json_connectors_enable_ca_certs() {
+    fn build_env_json_services_enable_ca_certs() {
         let mut ctx = minimal_context();
-        ctx.experimental_connectors = Some(crate::types::ExperimentalConnectors {
-            connectors: vec![crate::types::ConnectorEntry {
-                name: "gmail".into(),
+        ctx.experimental_services = Some(crate::types::ExperimentalServices {
+            apis: vec![crate::types::ServiceApiEntry {
                 base: "https://gmail.googleapis.com/gmail/v1/users/me".into(),
+                auth: crate::types::ServiceApiAuth {
+                    headers: std::collections::HashMap::from([(
+                        "Authorization".into(),
+                        "Bearer ${secrets.GMAIL_TOKEN}".into(),
+                    )]),
+                },
             }],
         });
         let env = build_env_json(&ctx, "http://localhost");
@@ -1000,37 +1005,40 @@ mod tests {
     }
 
     #[test]
-    fn build_env_json_empty_connectors_no_ca_certs() {
+    fn build_env_json_empty_services_no_ca_certs() {
         let mut ctx = minimal_context();
-        ctx.experimental_connectors =
-            Some(crate::types::ExperimentalConnectors { connectors: vec![] });
+        ctx.experimental_services = Some(crate::types::ExperimentalServices { apis: vec![] });
         let env = build_env_json(&ctx, "http://localhost");
         assert!(!env.contains_key("NODE_EXTRA_CA_CERTS"));
     }
 
     #[test]
-    fn execution_context_deserializes_with_connectors() {
+    fn execution_context_deserializes_with_services() {
         let json = serde_json::json!({
             "runId": "00000000-0000-0000-0000-000000000001",
             "prompt": "test",
             "sandboxToken": "tok",
             "workingDir": "/workspace",
             "cliAgentType": "claude-code",
-            "experimentalConnectors": {
-                "connectors": [{
-                    "name": "github",
-                    "base": "https://api.github.com"
+            "experimentalServices": {
+                "apis": [{
+                    "base": "https://api.github.com",
+                    "auth": {
+                        "headers": {
+                            "Authorization": "Bearer ${secrets.GITHUB_TOKEN}"
+                        }
+                    }
                 }]
             }
         });
         let ctx: ExecutionContext = serde_json::from_value(json).unwrap();
-        let conns = ctx.experimental_connectors.unwrap();
-        assert_eq!(conns.connectors.len(), 1);
-        assert_eq!(conns.connectors[0].name, "github");
+        let svcs = ctx.experimental_services.unwrap();
+        assert_eq!(svcs.apis.len(), 1);
+        assert_eq!(svcs.apis[0].base, "https://api.github.com");
     }
 
     #[test]
-    fn execution_context_deserializes_without_connectors() {
+    fn execution_context_deserializes_without_services() {
         let json = serde_json::json!({
             "runId": "00000000-0000-0000-0000-000000000001",
             "prompt": "test",
@@ -1039,7 +1047,7 @@ mod tests {
             "cliAgentType": "claude-code"
         });
         let ctx: ExecutionContext = serde_json::from_value(json).unwrap();
-        assert!(ctx.experimental_connectors.is_none());
+        assert!(ctx.experimental_services.is_none());
     }
 
     #[test]

--- a/crates/runner/src/provider/local.rs
+++ b/crates/runner/src/provider/local.rs
@@ -152,7 +152,7 @@ impl JobProvider for LocalProvider {
             secret_values: None,
             cli_agent_type: req.cli_agent_type,
             experimental_firewall: None,
-            experimental_connectors: None,
+            experimental_services: None,
             debug_no_mock_claude: None,
             api_start_time: None,
             user_timezone: req.user_timezone,

--- a/crates/runner/src/proxy.rs
+++ b/crates/runner/src/proxy.rs
@@ -28,7 +28,7 @@ struct VmEntry {
     mitm_enabled: bool,
     seal_secrets_enabled: bool,
     network_log_path: String,
-    connectors: Option<crate::types::ExperimentalConnectors>,
+    services: Option<crate::types::ExperimentalServices>,
 }
 
 /// Firewall rule for network filtering (first-match-wins).
@@ -66,7 +66,7 @@ pub struct VmRegistration<'a> {
     pub mitm_enabled: bool,
     pub seal_secrets_enabled: bool,
     pub network_log_path: &'a std::path::Path,
-    pub connectors: Option<&'a crate::types::ExperimentalConnectors>,
+    pub services: Option<&'a crate::types::ExperimentalServices>,
 }
 
 /// Embedded mitmproxy addon script (compiled into the binary).
@@ -437,7 +437,7 @@ impl ProxyRegistryHandle {
                 mitm_enabled: registration.mitm_enabled,
                 seal_secrets_enabled: registration.seal_secrets_enabled,
                 network_log_path: registration.network_log_path.to_string_lossy().into_owned(),
-                connectors: registration.connectors.cloned(),
+                services: registration.services.cloned(),
             },
         );
         registry.updated_at = now;
@@ -513,7 +513,7 @@ mod tests {
                 mitm_enabled: true,
                 seal_secrets_enabled: false,
                 network_log_path: "/tmp/network-test-run.jsonl".to_string(),
-                connectors: None,
+                services: None,
             },
         );
         write_registry(&registry_path, &registry).await.unwrap();
@@ -618,7 +618,7 @@ mod tests {
             mitm_enabled: true,
             seal_secrets_enabled: false,
             network_log_path: std::path::Path::new("/tmp/network-run-1.jsonl"),
-            connectors: None,
+            services: None,
         };
         handle
             .register_vm("10.200.0.2", &registration)
@@ -638,7 +638,7 @@ mod tests {
             mitm_enabled: false,
             seal_secrets_enabled: true,
             network_log_path: std::path::Path::new("/tmp/network-run-2.jsonl"),
-            connectors: None,
+            services: None,
         };
         handle
             .register_vm("10.200.0.2", &registration2)
@@ -692,7 +692,7 @@ mod tests {
                     mitm_enabled: false,
                     seal_secrets_enabled: false,
                     network_log_path: &log_path,
-                    connectors: None,
+                    services: None,
                 };
                 h.register_vm(&ip, &registration).await.unwrap();
             });
@@ -738,7 +738,7 @@ mod tests {
                 mitm_enabled: true,
                 seal_secrets_enabled: true,
                 network_log_path: "/tmp/network-run-1.jsonl".to_string(),
-                connectors: None,
+                services: None,
             },
         );
         write_registry(&registry_path, &registry).await.unwrap();
@@ -758,7 +758,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn registry_with_connectors() {
+    async fn registry_with_services() {
         let dir = tempfile::tempdir().unwrap();
         let registry_path = dir.path().join("proxy-registry.json");
         let lock_path = dir.path().join("proxy-registry.json.lock");
@@ -773,39 +773,50 @@ mod tests {
             lock_path,
         };
 
-        let connectors = crate::types::ExperimentalConnectors {
-            connectors: vec![crate::types::ConnectorEntry {
-                name: "gmail".to_string(),
+        let services = crate::types::ExperimentalServices {
+            apis: vec![crate::types::ServiceApiEntry {
                 base: "https://gmail.googleapis.com/gmail/v1/users/me".to_string(),
+                auth: crate::types::ServiceApiAuth {
+                    headers: std::collections::HashMap::from([(
+                        "Authorization".to_string(),
+                        "Bearer ${secrets.GMAIL_TOKEN}".to_string(),
+                    )]),
+                },
             }],
         };
 
         let registration = VmRegistration {
-            run_id: "run-conn",
+            run_id: "run-svc",
             sandbox_token: "tok",
             firewall_rules: &[],
             mitm_enabled: true,
             seal_secrets_enabled: false,
-            network_log_path: std::path::Path::new("/tmp/network-run-conn.jsonl"),
-            connectors: Some(&connectors),
+            network_log_path: std::path::Path::new("/tmp/network-run-svc.jsonl"),
+            services: Some(&services),
         };
         handle
             .register_vm("10.200.0.5", &registration)
             .await
             .unwrap();
 
-        // Verify connectors are stored in registry.
+        // Verify services are stored in registry.
         let loaded = read_registry(&registry_path).await.unwrap();
         let vm = loaded.vms.get("10.200.0.5").unwrap();
-        let stored = vm.connectors.as_ref().unwrap();
-        assert_eq!(stored.connectors.len(), 1);
-        assert_eq!(stored.connectors[0].name, "gmail");
+        let stored = vm.services.as_ref().unwrap();
+        assert_eq!(stored.apis.len(), 1);
+        assert_eq!(
+            stored.apis[0].base,
+            "https://gmail.googleapis.com/gmail/v1/users/me"
+        );
 
         // Verify JSON shape matches what the Python addon expects.
         let raw = tokio::fs::read_to_string(&registry_path).await.unwrap();
         let value: serde_json::Value = serde_json::from_str(&raw).unwrap();
         let vm_json = &value["vms"]["10.200.0.5"];
-        let conn = &vm_json["connectors"]["connectors"][0];
-        assert_eq!(conn["name"], "gmail");
+        let svc = &vm_json["services"]["apis"][0];
+        assert_eq!(
+            svc["base"],
+            "https://gmail.googleapis.com/gmail/v1/users/me"
+        );
     }
 }

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -56,7 +56,7 @@ pub struct ExecutionContext {
     #[serde(default)]
     pub experimental_firewall: Option<ExperimentalFirewall>,
     #[serde(default)]
-    pub experimental_connectors: Option<ExperimentalConnectors>,
+    pub experimental_services: Option<ExperimentalServices>,
     #[serde(default)]
     pub debug_no_mock_claude: Option<bool>,
     #[serde(default)]
@@ -79,18 +79,23 @@ pub struct ExperimentalFirewall {
     pub experimental_seal_secrets: Option<bool>,
 }
 
-/// Connector manifest for proxy-side token replacement.
+/// Service manifest for proxy-side token replacement.
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct ExperimentalConnectors {
-    pub connectors: Vec<ConnectorEntry>,
+pub struct ExperimentalServices {
+    pub apis: Vec<ServiceApiEntry>,
 }
 
-/// A single connector service entry with a base URL for proxy-side matching.
+/// A single service API entry with base URL and auth headers for proxy-side matching.
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct ConnectorEntry {
-    pub name: String,
+pub struct ServiceApiEntry {
     pub base: String,
+    pub auth: ServiceApiAuth,
+}
+
+/// Auth configuration for a service API entry.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct ServiceApiAuth {
+    pub headers: std::collections::HashMap<String, String>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/e2e/tests/03-experimental-runner/t42-connector-placeholder.bats
+++ b/e2e/tests/03-experimental-runner/t42-connector-placeholder.bats
@@ -1,8 +1,8 @@
 #!/usr/bin/env bats
 
-# Test experimental_connectors placeholder env var injection and token replacement
+# Test experimental_services placeholder env var injection and token replacement
 #
-# Verifies that when experimental_connectors is declared:
+# Verifies that when experimental_services is declared:
 # 1. Compose accepts the configuration
 # 2. Placeholder env vars replace secret values in the sandbox (with custom formats)
 # 3. Multiple connectors work together
@@ -73,7 +73,7 @@ setup_test_connector() {
     fi
 }
 
-@test "connector: compose accepts experimental_connectors" {
+@test "connector: compose accepts experimental_services" {
     cat > "$TEST_DIR/vm0.yaml" <<EOF
 version: "1.0"
 
@@ -84,7 +84,7 @@ agents:
     working_dir: /home/user/workspace
     experimental_runner:
       group: ${RUNNER_GROUP}
-    experimental_connectors:
+    experimental_services:
       - github
 EOF
 
@@ -105,7 +105,7 @@ agents:
     working_dir: /home/user/workspace
     experimental_runner:
       group: ${RUNNER_GROUP}
-    experimental_connectors:
+    experimental_services:
       - github
     environment:
       GH_TOKEN: \${{ secrets.GH_TOKEN }}
@@ -147,7 +147,7 @@ agents:
     working_dir: /home/user/workspace
     experimental_runner:
       group: ${RUNNER_GROUP}
-    experimental_connectors:
+    experimental_services:
       - github
       - slack
     environment:
@@ -196,7 +196,7 @@ agents:
     working_dir: /home/user/workspace
     experimental_runner:
       group: ${RUNNER_GROUP}
-    experimental_connectors:
+    experimental_services:
       - github
     environment:
       GITHUB_TOKEN: \${{ secrets.GITHUB_TOKEN }}

--- a/turbo/apps/web/app/api/runners/jobs/[id]/claim/route.ts
+++ b/turbo/apps/web/app/api/runners/jobs/[id]/claim/route.ts
@@ -197,7 +197,7 @@ const router = tsr.router(runnersJobClaimContract, {
         secretValues, // Decrypted secrets
         cliAgentType: storedContext.cliAgentType,
         experimentalFirewall: storedContext.experimentalFirewall,
-        experimentalConnectors: storedContext.experimentalConnectors,
+        experimentalServices: storedContext.experimentalServices,
         debugNoMockClaude: storedContext.debugNoMockClaude,
         apiStartTime: storedContext.apiStartTime,
         userTimezone: storedContext.userTimezone,

--- a/turbo/apps/web/app/api/webhooks/agent/services/auth/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/services/auth/__tests__/route.test.ts
@@ -18,7 +18,7 @@ const context = testContext();
 
 function makeRequest(body: Record<string, unknown>, token?: string): Request {
   return createTestRequest(
-    "http://localhost:3000/api/webhooks/agent/connectors/auth",
+    "http://localhost:3000/api/webhooks/agent/services/auth",
     {
       method: "POST",
       headers: {
@@ -30,7 +30,7 @@ function makeRequest(body: Record<string, unknown>, token?: string): Request {
   );
 }
 
-describe("POST /api/webhooks/agent/connectors/auth", () => {
+describe("POST /api/webhooks/agent/services/auth", () => {
   let user: UserContext;
   let testComposeId: string;
   let testRunId: string;
@@ -42,7 +42,7 @@ describe("POST /api/webhooks/agent/connectors/auth", () => {
     user = await context.setupUser();
 
     const { composeId } = await createTestCompose(
-      `agent-connector-token-${Date.now()}`,
+      `agent-service-auth-${Date.now()}`,
     );
     testComposeId = composeId;
 
@@ -59,7 +59,6 @@ describe("POST /api/webhooks/agent/connectors/auth", () => {
       const response = await POST(
         makeRequest({
           runId: testRunId,
-          connectorName: "github",
           base: "https://api.github.com",
         }),
       );
@@ -71,7 +70,6 @@ describe("POST /api/webhooks/agent/connectors/auth", () => {
         makeRequest(
           {
             runId: testRunId,
-            connectorName: "github",
             base: "https://api.github.com",
           },
           "invalid-token",
@@ -86,7 +84,6 @@ describe("POST /api/webhooks/agent/connectors/auth", () => {
         makeRequest(
           {
             runId: otherRunId,
-            connectorName: "github",
             base: "https://api.github.com",
           },
           testToken,
@@ -99,38 +96,29 @@ describe("POST /api/webhooks/agent/connectors/auth", () => {
   describe("Validation", () => {
     it("should reject without runId", async () => {
       const response = await POST(
-        makeRequest(
-          { connectorName: "github", base: "https://api.github.com" },
-          testToken,
-        ),
+        makeRequest({ base: "https://api.github.com" }, testToken),
       );
       expect(response.status).toBe(400);
     });
 
-    it("should reject without connectorName", async () => {
-      const response = await POST(
-        makeRequest(
-          { runId: testRunId, base: "https://api.github.com" },
-          testToken,
-        ),
-      );
+    it("should reject without base", async () => {
+      const response = await POST(makeRequest({ runId: testRunId }, testToken));
       expect(response.status).toBe(400);
     });
 
-    it("should reject unknown connector type", async () => {
+    it("should reject unknown base URL", async () => {
       const response = await POST(
         makeRequest(
           {
             runId: testRunId,
-            connectorName: "not-a-connector",
-            base: "https://example.com",
+            base: "https://unknown-api.example.com",
           },
           testToken,
         ),
       );
       expect(response.status).toBe(400);
       const data = await response.json();
-      expect(data.error.message).toContain("Unknown connector type");
+      expect(data.error.message).toContain("No service config matching base");
     });
   });
 
@@ -140,7 +128,6 @@ describe("POST /api/webhooks/agent/connectors/auth", () => {
         makeRequest(
           {
             runId: testRunId,
-            connectorName: "github",
             base: "https://api.github.com",
           },
           testToken,
@@ -166,7 +153,6 @@ describe("POST /api/webhooks/agent/connectors/auth", () => {
         makeRequest(
           {
             runId: testRunId,
-            connectorName: "github",
             base: "https://api.github.com",
           },
           testToken,
@@ -193,7 +179,6 @@ describe("POST /api/webhooks/agent/connectors/auth", () => {
         makeRequest(
           {
             runId: testRunId,
-            connectorName: "slack",
             base: "https://slack.com/api",
           },
           testToken,
@@ -210,7 +195,7 @@ describe("POST /api/webhooks/agent/connectors/auth", () => {
     it("should reject run owned by different user", async () => {
       const otherUser = await context.setupUser({ prefix: "other" });
       const { composeId: otherComposeId } = await createTestCompose(
-        `other-connector-${Date.now()}`,
+        `other-service-auth-${Date.now()}`,
       );
       const { runId: otherRunId } = await createTestRun(
         otherComposeId,
@@ -233,7 +218,6 @@ describe("POST /api/webhooks/agent/connectors/auth", () => {
         makeRequest(
           {
             runId: otherRunId,
-            connectorName: "github",
             base: "https://api.github.com",
           },
           tokenForOtherRun,

--- a/turbo/apps/web/app/api/webhooks/agent/services/auth/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/services/auth/route.ts
@@ -2,10 +2,11 @@ import { NextResponse } from "next/server";
 import { eq, and } from "drizzle-orm";
 import { z } from "zod";
 import {
-  connectorTypeSchema,
+  CONNECTOR_TYPES,
   getConnectorEnvironmentMapping,
-  getConnectorProxyConfig,
+  getServiceConfig,
 } from "@vm0/core";
+import type { ConnectorType, ServiceConfig } from "@vm0/core";
 import { initServices } from "../../../../../../src/lib/init-services";
 import { getSandboxAuthForRun } from "../../../../../../src/lib/auth/get-sandbox-auth";
 import { agentRuns } from "../../../../../../src/db/schema/agent-run";
@@ -17,14 +18,31 @@ import { logger } from "../../../../../../src/lib/logger";
 
 const bodySchema = z.object({
   runId: z.string(),
-  connectorName: z.string(),
   base: z.string(),
 });
 
-const log = logger("webhook:connector-token");
+const log = logger("webhook:service-auth");
 
 type ProviderHandler =
   (typeof PROVIDER_HANDLERS)[keyof typeof PROVIDER_HANDLERS];
+
+/**
+ * Find the connector type and service config that contains an API entry matching the given base URL.
+ */
+function findConnectorByBase(
+  base: string,
+): { connectorType: ConnectorType; config: ServiceConfig } | undefined {
+  const allTypes = Object.keys(CONNECTOR_TYPES) as ConnectorType[];
+  for (const type of allTypes) {
+    const config = getServiceConfig(type);
+    if (!config) continue;
+    const matched = config.apis.find((api) => api.base === base);
+    if (matched) {
+      return { connectorType: type, config };
+    }
+  }
+  return undefined;
+}
 
 /**
  * Attempt to refresh the connector's access token if the handler supports it.
@@ -141,13 +159,13 @@ function resolveAuthHeaders(
 }
 
 /**
- * POST /api/webhooks/agent/connectors/auth
+ * POST /api/webhooks/agent/services/auth
  *
- * Returns resolved auth headers for a connector.
- * Called by the mitmproxy addon when it intercepts a connector-matched request.
+ * Returns resolved auth headers for a service API base URL.
+ * Called by the mitmproxy addon when it intercepts a service-matched request.
  *
  * Auth: Sandbox JWT (same as other webhook/agent endpoints).
- * Body: { runId: string, connectorName: string, base: string }
+ * Body: { runId: string, base: string }
  * Response: { headers: Record<string, string>, expiresIn: number }
  */
 export async function POST(request: Request) {
@@ -173,7 +191,7 @@ export async function POST(request: Request) {
     return NextResponse.json(
       {
         error: {
-          message: "runId and connectorName are required",
+          message: "runId and base are required",
           code: "BAD_REQUEST",
         },
       },
@@ -199,34 +217,20 @@ export async function POST(request: Request) {
     );
   }
 
-  // Validate connector type
-  const connectorParsed = connectorTypeSchema.safeParse(body.connectorName);
-  if (!connectorParsed.success) {
+  // Find connector type by matching base URL against all service configs
+  const match = findConnectorByBase(body.base);
+  if (!match) {
     return NextResponse.json(
       {
         error: {
-          message: `Unknown connector type: "${body.connectorName}"`,
+          message: `No service config matching base "${body.base}"`,
           code: "BAD_REQUEST",
         },
       },
       { status: 400 },
     );
   }
-  const connectorType = connectorParsed.data;
-
-  // Get proxy config (auth header templates)
-  const proxyConfig = getConnectorProxyConfig(connectorType);
-  if (!proxyConfig) {
-    return NextResponse.json(
-      {
-        error: {
-          message: `No proxy config for "${connectorType}"`,
-          code: "BAD_REQUEST",
-        },
-      },
-      { status: 400 },
-    );
-  }
+  const { connectorType, config } = match;
 
   // Look up run to get scopeId
   const [run] = await globalThis.services.db
@@ -293,15 +297,13 @@ export async function POST(request: Request) {
     if (refreshError) return refreshError;
   }
 
-  // Find the matching service by base URL
-  const matchedService = proxyConfig.services.find(
-    (svc) => svc.base === body.base,
-  );
-  if (!matchedService) {
+  // Find the matching API entry by base URL
+  const matchedApi = config.apis.find((api) => api.base === body.base);
+  if (!matchedApi) {
     return NextResponse.json(
       {
         error: {
-          message: `No service matching base "${body.base}" for connector "${connectorType}"`,
+          message: `No API matching base "${body.base}"`,
           code: "BAD_REQUEST",
         },
       },
@@ -312,7 +314,7 @@ export async function POST(request: Request) {
   // Resolve auth header templates with real secret values
   const envMapping = getConnectorEnvironmentMapping(connectorType);
   const resolvedHeaders = resolveAuthHeaders(
-    matchedService.auth.headers,
+    matchedApi.auth.headers,
     envMapping,
     connectorSecrets,
   );
@@ -323,7 +325,7 @@ export async function POST(request: Request) {
     return NextResponse.json(
       {
         error: {
-          message: `No secrets found for "${connectorType}"`,
+          message: `No secrets found for base "${body.base}"`,
           code: "NOT_FOUND",
         },
       },

--- a/turbo/apps/web/app/api/webhooks/agent/services/auth/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/services/auth/route.ts
@@ -29,16 +29,19 @@ type ProviderHandler =
 /**
  * Find the connector type and service config that contains an API entry matching the given base URL.
  */
-function findConnectorByBase(
-  base: string,
-): { connectorType: ConnectorType; config: ServiceConfig } | undefined {
+function findConnectorByBase(base: string):
+  | {
+      connectorType: ConnectorType;
+      api: ServiceConfig["apis"][number];
+    }
+  | undefined {
   const allTypes = Object.keys(CONNECTOR_TYPES) as ConnectorType[];
   for (const type of allTypes) {
     const config = getServiceConfig(type);
     if (!config) continue;
-    const matched = config.apis.find((api) => api.base === base);
-    if (matched) {
-      return { connectorType: type, config };
+    const api = config.apis.find((a) => a.base === base);
+    if (api) {
+      return { connectorType: type, api };
     }
   }
   return undefined;
@@ -230,7 +233,7 @@ export async function POST(request: Request) {
       { status: 400 },
     );
   }
-  const { connectorType, config } = match;
+  const { connectorType, api: matchedApi } = match;
 
   // Look up run to get scopeId
   const [run] = await globalThis.services.db
@@ -295,20 +298,6 @@ export async function POST(request: Request) {
       body.runId,
     );
     if (refreshError) return refreshError;
-  }
-
-  // Find the matching API entry by base URL
-  const matchedApi = config.apis.find((api) => api.base === body.base);
-  if (!matchedApi) {
-    return NextResponse.json(
-      {
-        error: {
-          message: `No API matching base "${body.base}"`,
-          code: "BAD_REQUEST",
-        },
-      },
-      { status: 400 },
-    );
   }
 
   // Resolve auth header templates with real secret values

--- a/turbo/apps/web/src/lib/run/build-context.ts
+++ b/turbo/apps/web/src/lib/run/build-context.ts
@@ -9,10 +9,10 @@ import {
   hasAuthMethods,
   getSecretNamesForAuthMethod,
   getConnectorEnvironmentMapping,
-  getConnectorProxyConfig,
+  getServiceConfig,
   connectorTypeSchema,
   MODEL_PROVIDER_TYPES,
-  type ExperimentalConnectors,
+  type ExperimentalServices,
   type ConnectorType,
   type ModelProviderType,
   type ModelProviderFramework,
@@ -396,7 +396,7 @@ interface ConnectorSecretResult {
   connectorSecrets: Record<string, string> | undefined;
   /** Environment variables mapped from OAuth connectors via environmentMapping */
   injectedEnvVars: Record<string, string> | undefined;
-  /** Connected connector type names (used to filter experimental_connectors placeholders) */
+  /** Connected connector type names (used to filter experimental_services placeholders) */
   connectedTypes: string[];
 }
 
@@ -979,49 +979,50 @@ interface BuildContextResult {
 }
 
 /**
- * Build ExperimentalConnectors manifest from agent compose's experimental_connectors array.
- * Returns null if no connectors are declared.
+ * Build ExperimentalServices manifest from agent compose's experimental_services array.
+ * Returns null if no services are declared.
  *
- * For each declared connector name:
- * 1. Validates it's a known connector type with proxy config
- * 2. Flattens services to one entry per base URL (for runner-side matching)
+ * For each declared service name:
+ * 1. Validates it's a known connector type with service config
+ * 2. Flattens apis to one entry per base URL with auth headers (for runner-side matching)
  *
  * Placeholder env var injection is handled by expandEnvironmentFromCompose.
  */
-function buildExperimentalConnectors(
+function buildExperimentalServices(
   agentCompose: unknown,
-): ExperimentalConnectors | null {
+): ExperimentalServices | null {
   const compose = agentCompose as
-    | { agents?: Record<string, { experimental_connectors?: string[] }> }
+    | { agents?: Record<string, { experimental_services?: string[] }> }
     | undefined;
   if (!compose?.agents) return null;
 
   const firstAgent = Object.values(compose.agents)[0];
-  const connectorNames = firstAgent?.experimental_connectors;
-  if (!connectorNames || connectorNames.length === 0) return null;
+  const serviceNames = firstAgent?.experimental_services;
+  if (!serviceNames || serviceNames.length === 0) return null;
 
-  const entries: { name: string; base: string }[] = [];
+  const entries: { base: string; auth: { headers: Record<string, string> } }[] =
+    [];
 
-  for (const name of connectorNames) {
+  for (const name of serviceNames) {
     const parsed = connectorTypeSchema.safeParse(name);
     if (!parsed.success) {
       throw badRequest(`Unknown connector type: "${name}"`);
     }
     const connectorType = parsed.data;
 
-    const proxyConfig = getConnectorProxyConfig(connectorType);
-    if (!proxyConfig) {
+    const serviceConfig = getServiceConfig(connectorType);
+    if (!serviceConfig) {
       throw badRequest(
         `Connector "${name}" does not support proxy-side token replacement`,
       );
     }
 
-    for (const svc of proxyConfig.services) {
-      entries.push({ name, base: svc.base });
+    for (const api of serviceConfig.apis) {
+      entries.push({ base: api.base, auth: api.auth });
     }
   }
 
-  return { connectors: entries };
+  return { apis: entries };
 }
 
 /**
@@ -1154,9 +1155,9 @@ export async function buildExecutionContext(
     ? { ...platformSecrets, ...secrets }
     : secrets;
 
-  // Build experimental connectors manifest (name + base entries for the runner)
-  const experimentalConnectors =
-    buildExperimentalConnectors(agentCompose) ?? undefined;
+  // Build experimental services manifest (base + auth entries for the runner)
+  const experimentalServices =
+    buildExperimentalServices(agentCompose) ?? undefined;
 
   // Build final execution context
   return {
@@ -1177,7 +1178,7 @@ export async function buildExecutionContext(
       volumeVersions,
       environment,
       userTimezone,
-      experimentalConnectors,
+      experimentalServices,
       resumeSession,
       resumeArtifact,
       // Metadata for vm0_start event

--- a/turbo/apps/web/src/lib/run/context/execution-preparer.ts
+++ b/turbo/apps/web/src/lib/run/context/execution-preparer.ts
@@ -348,8 +348,8 @@ function buildPreparedContext(
     // Experimental firewall configuration (processed with auto-injected rules)
     experimentalFirewall,
 
-    // Experimental connectors for proxy-side token replacement
-    experimentalConnectors: context.experimentalConnectors ?? null,
+    // Experimental services for proxy-side token replacement
+    experimentalServices: context.experimentalServices ?? null,
 
     // Routing
     runnerGroup,

--- a/turbo/apps/web/src/lib/run/environment/__tests__/expand-environment.test.ts
+++ b/turbo/apps/web/src/lib/run/environment/__tests__/expand-environment.test.ts
@@ -1,10 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { expandEnvironmentFromCompose } from "../expand-environment";
 
-function makeCompose(
-  environment: Record<string, string>,
-  connectors?: string[],
-) {
+function makeCompose(environment: Record<string, string>, services?: string[]) {
   return {
     version: "1.0",
     agents: {
@@ -13,14 +10,14 @@ function makeCompose(
         framework: "claude-code" as const,
         working_dir: "/home/user",
         environment,
-        ...(connectors ? { experimental_connectors: connectors } : {}),
+        ...(services ? { experimental_services: services } : {}),
       },
     },
   };
 }
 
-describe("expandEnvironmentFromCompose — connector env vars", () => {
-  it("replaces secret values with connector placeholders when connector is connected", () => {
+describe("expandEnvironmentFromCompose — service env vars", () => {
+  it("replaces secret values with service placeholders when service is connected", () => {
     const compose = makeCompose(
       {
         GH_TOKEN: "${{ secrets.GH_TOKEN }}",
@@ -48,7 +45,7 @@ describe("expandEnvironmentFromCompose — connector env vars", () => {
     );
   });
 
-  it("does not inject placeholders when connector is not connected", () => {
+  it("does not inject placeholders when service is not connected", () => {
     const compose = makeCompose(
       {
         GH_TOKEN: "${{ secrets.GH_TOKEN }}",
@@ -67,16 +64,16 @@ describe("expandEnvironmentFromCompose — connector env vars", () => {
     );
 
     expect(environment).toBeDefined();
-    // Connector not connected → falls back to passed secret
+    // Service not connected → falls back to passed secret
     expect(environment!.GH_TOKEN).toBe("user-provided");
   });
 
-  it("does not inject placeholders when connector is not declared", () => {
+  it("does not inject placeholders when service is not declared", () => {
     const compose = makeCompose(
       {
         GH_TOKEN: "${{ secrets.GH_TOKEN }}",
       },
-      // no experimental_connectors
+      // no experimental_services
     );
 
     const { environment } = expandEnvironmentFromCompose(
@@ -90,11 +87,11 @@ describe("expandEnvironmentFromCompose — connector env vars", () => {
     );
 
     expect(environment).toBeDefined();
-    // Connector not declared → falls back to passed secret
+    // Service not declared → falls back to passed secret
     expect(environment!.GH_TOKEN).toBe("user-provided");
   });
 
-  it("handles multiple connectors with different placeholders", () => {
+  it("handles multiple services with different placeholders", () => {
     const compose = makeCompose(
       {
         GH_TOKEN: "${{ secrets.GH_TOKEN }}",
@@ -120,7 +117,7 @@ describe("expandEnvironmentFromCompose — connector env vars", () => {
     expect(environment!.SLACK_TOKEN).toBe("xoxb-0000-0000-vm0placeholder");
   });
 
-  it("connector placeholder takes precedence over passed secrets", () => {
+  it("service placeholder takes precedence over passed secrets", () => {
     const compose = makeCompose(
       {
         GH_TOKEN: "${{ secrets.GH_TOKEN }}",

--- a/turbo/apps/web/src/lib/run/environment/expand-environment.ts
+++ b/turbo/apps/web/src/lib/run/environment/expand-environment.ts
@@ -4,7 +4,7 @@ import {
   groupVariablesBySource,
   connectorTypeSchema,
   getConnectorEnvironmentMapping,
-  getConnectorProxyConfig,
+  getServiceConfig,
 } from "@vm0/core";
 import { createProxyToken } from "../../proxy/token-service";
 import { badRequest } from "../../errors";
@@ -62,31 +62,31 @@ function processSecretValues(
 }
 
 /**
- * Build connector env var placeholders for experimental_connectors that are actually connected.
+ * Build connector env var placeholders for experimental_services that are actually connected.
  * Returns a map of env var name → placeholder value, or undefined if no connectors qualify.
  */
 function buildConnectorEnvVars(
-  declaredConnectors: string[],
+  declaredServices: string[],
   connectedTypes: string[],
 ): Record<string, string> | undefined {
-  if (declaredConnectors.length === 0 || connectedTypes.length === 0)
+  if (declaredServices.length === 0 || connectedTypes.length === 0)
     return undefined;
 
   const connected = new Set(connectedTypes);
   const envVars: Record<string, string> = {};
 
-  for (const name of declaredConnectors) {
+  for (const name of declaredServices) {
     if (!connected.has(name)) continue;
     const parsed = connectorTypeSchema.safeParse(name);
     if (!parsed.success) continue;
     const connectorType = parsed.data;
-    const proxyConfig = getConnectorProxyConfig(connectorType);
-    if (!proxyConfig) continue;
+    const serviceConfig = getServiceConfig(connectorType);
+    if (!serviceConfig) continue;
 
     const envMapping = getConnectorEnvironmentMapping(connectorType);
     for (const envVar of Object.keys(envMapping)) {
       envVars[envVar] =
-        proxyConfig.placeholders?.[envVar] ?? `VM0_PLACEHOLDER_${envVar}`;
+        serviceConfig.placeholders?.[envVar] ?? `VM0_PLACEHOLDER_${envVar}`;
     }
   }
   return Object.keys(envVars).length > 0 ? envVars : undefined;
@@ -99,7 +99,7 @@ function buildConnectorEnvVars(
  * When experimental_firewall.experimental_seal_secrets is enabled:
  * - Secrets are encrypted into proxy tokens (vm0_enc_xxx)
  *
- * When experimental_connectors is declared:
+ * When experimental_services is declared:
  * - Connector env vars are set to placeholder values (proxy replaces at runtime)
  *
  * @param agentCompose Agent compose configuration
@@ -152,9 +152,9 @@ export function expandEnvironmentFromCompose(
   const sealSecretsEnabled =
     firstAgent?.experimental_firewall?.experimental_seal_secrets ?? false;
 
-  // Build connector env var placeholders from experimental_connectors ∩ connectedTypes
+  // Build connector env var placeholders from experimental_services ∩ connectedTypes
   const connectorEnvVars = buildConnectorEnvVars(
-    firstAgent?.experimental_connectors ?? [],
+    firstAgent?.experimental_services ?? [],
     connectedTypes ?? [],
   );
 

--- a/turbo/apps/web/src/lib/run/executors/runner-executor.ts
+++ b/turbo/apps/web/src/lib/run/executors/runner-executor.ts
@@ -58,7 +58,7 @@ export async function executeRunnerJob(
     encryptedSecrets,
     cliAgentType: context.cliAgentType,
     experimentalFirewall: context.experimentalFirewall ?? undefined,
-    experimentalConnectors: context.experimentalConnectors ?? undefined,
+    experimentalServices: context.experimentalServices ?? undefined,
     debugNoMockClaude: context.debugNoMockClaude || undefined,
     apiStartTime: context.apiStartTime ?? undefined,
     userTimezone: context.userTimezone ?? undefined,

--- a/turbo/apps/web/src/lib/run/executors/types.ts
+++ b/turbo/apps/web/src/lib/run/executors/types.ts
@@ -1,7 +1,7 @@
 import type { StorageManifest } from "../../storage/types";
 import type { ResumeSession } from "../types";
 import type { ArtifactSnapshot } from "../../checkpoint/types";
-import type { ExperimentalFirewall, ExperimentalConnectors } from "@vm0/core";
+import type { ExperimentalFirewall, ExperimentalServices } from "@vm0/core";
 
 /**
  * Prepared execution context for executors
@@ -45,8 +45,8 @@ export interface PreparedContext {
   // Experimental firewall configuration
   experimentalFirewall: ExperimentalFirewall | null;
 
-  // Experimental connectors for proxy-side token replacement
-  experimentalConnectors: ExperimentalConnectors | null;
+  // Experimental services for proxy-side token replacement
+  experimentalServices: ExperimentalServices | null;
 
   // Routing hint (runner group name)
   runnerGroup: string | null;

--- a/turbo/apps/web/src/lib/run/types.ts
+++ b/turbo/apps/web/src/lib/run/types.ts
@@ -1,5 +1,5 @@
 import type { ArtifactSnapshot } from "../checkpoint/types";
-import type { ExperimentalFirewall, ExperimentalConnectors } from "@vm0/core";
+import type { ExperimentalFirewall, ExperimentalServices } from "@vm0/core";
 
 /**
  * Run status values
@@ -79,8 +79,8 @@ export interface ExecutionContext {
   // Experimental firewall configuration for network egress control
   experimentalFirewall?: ExperimentalFirewall;
 
-  // Experimental connectors for proxy-side token replacement
-  experimentalConnectors?: ExperimentalConnectors;
+  // Experimental services for proxy-side token replacement
+  experimentalServices?: ExperimentalServices;
 
   // Resume-specific (optional)
   resumeSession?: ResumeSession;

--- a/turbo/apps/web/src/types/agent-compose.ts
+++ b/turbo/apps/web/src/types/agent-compose.ts
@@ -82,11 +82,11 @@ interface AgentDefinition {
    */
   experimental_firewall?: ExperimentalFirewall;
   /**
-   * Experimental connectors for proxy-side token replacement.
-   * Array of connector type names (e.g., ["gmail", "github"]).
+   * Experimental services for proxy-side token replacement.
+   * Array of service names (e.g., ["gmail", "github"]).
    * Requires experimental_runner to be configured.
    */
-  experimental_connectors?: string[];
+  experimental_services?: string[];
   /**
    * Agent metadata for display and personalization.
    */

--- a/turbo/packages/core/src/contracts/__tests__/connectors.test.ts
+++ b/turbo/packages/core/src/contracts/__tests__/connectors.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   hasRequiredScopes,
-  getConnectorProxyConfig,
+  getServiceConfig,
   CONNECTOR_TYPES,
 } from "../connectors";
 import type { ConnectorType } from "../connectors";
@@ -41,12 +41,12 @@ describe("hasRequiredScopes", () => {
   });
 });
 
-describe("getConnectorProxyConfig", () => {
+describe("getServiceConfig", () => {
   it("returns proxy config for known connector types", () => {
-    const config = getConnectorProxyConfig("github");
+    const config = getServiceConfig("github");
     expect(config).toBeDefined();
-    expect(config!.services[0]!.base).toBe("https://api.github.com");
-    expect(config!.services[0]!.auth.headers.Authorization).toBe(
+    expect(config!.apis[0]!.base).toBe("https://api.github.com");
+    expect(config!.apis[0]!.auth.headers.Authorization).toBe(
       "Bearer ${secrets.GITHUB_TOKEN}",
     );
     expect(config!.placeholders).toEqual({
@@ -56,9 +56,9 @@ describe("getConnectorProxyConfig", () => {
   });
 
   it("returns config with multiple services for slack", () => {
-    const config = getConnectorProxyConfig("slack");
+    const config = getServiceConfig("slack");
     expect(config).toBeDefined();
-    expect(config!.services.map((s) => s.base)).toEqual([
+    expect(config!.apis.map((s) => s.base)).toEqual([
       "https://slack.com/api",
       "https://files.slack.com",
     ]);
@@ -68,15 +68,13 @@ describe("getConnectorProxyConfig", () => {
   });
 
   it("returns config with custom headers for notion", () => {
-    const config = getConnectorProxyConfig("notion");
+    const config = getServiceConfig("notion");
     expect(config).toBeDefined();
-    expect(config!.services[0]!.auth.headers["Notion-Version"]).toBe(
-      "2022-06-28",
-    );
+    expect(config!.apis[0]!.auth.headers["Notion-Version"]).toBe("2022-06-28");
   });
 
   it("returns undefined for computer connector (no proxy support)", () => {
-    const config = getConnectorProxyConfig("computer");
+    const config = getServiceConfig("computer");
     expect(config).toBeUndefined();
   });
 
@@ -84,14 +82,14 @@ describe("getConnectorProxyConfig", () => {
     const allTypes = Object.keys(CONNECTOR_TYPES) as ConnectorType[];
 
     for (const type of allTypes) {
-      const config = getConnectorProxyConfig(type);
+      const config = getServiceConfig(type);
       if (!config) continue;
 
       expect(
-        config.services.length,
+        config.apis.length,
         `${type} should have at least one service`,
       ).toBeGreaterThan(0);
-      for (const svc of config.services) {
+      for (const svc of config.apis) {
         expect(svc.base, `${type} service base should be https URL`).toMatch(
           /^https:\/\//,
         );

--- a/turbo/packages/core/src/contracts/composes.ts
+++ b/turbo/packages/core/src/contracts/composes.ts
@@ -94,11 +94,11 @@ const agentDefinitionSchema = z.object({
    */
   experimental_firewall: experimentalFirewallSchema.optional(),
   /**
-   * External service connectors (e.g., github, slack).
-   * Connector env vars are injected as placeholders; the proxy replaces them at runtime.
+   * External services for proxy-side token replacement (e.g., github, slack).
+   * Service-referenced env vars are replaced with placeholders; the proxy injects real secrets at runtime.
    * Requires experimental_runner to be configured.
    */
-  experimental_connectors: z.array(z.string()).optional(),
+  experimental_services: z.array(z.string()).optional(),
   /**
    * Agent metadata for display and personalization.
    * - displayName: Human-readable name shown in the UI (preserves original casing).

--- a/turbo/packages/core/src/contracts/connectors.ts
+++ b/turbo/packages/core/src/contracts/connectors.ts
@@ -2747,13 +2747,13 @@ const SERVICE_CONFIGS: Partial<Record<ConnectorType, ServiceConfig>> = {
     ],
   },
   jotform: {
-    services: [
-      service("https://api.jotform.com", {
+    apis: [
+      api("https://api.jotform.com", {
         headers: {
           APIKEY: "${secrets.JOTFORM_TOKEN}",
         },
       }),
-      service("https://eu-api.jotform.com", {
+      api("https://eu-api.jotform.com", {
         headers: {
           APIKEY: "${secrets.JOTFORM_TOKEN}",
         },
@@ -2788,8 +2788,8 @@ const SERVICE_CONFIGS: Partial<Record<ConnectorType, ServiceConfig>> = {
     ],
   },
   metabase: {
-    services: [
-      service("https://api.metabase.com", {
+    apis: [
+      api("https://api.metabase.com", {
         headers: {
           "x-api-key": "${secrets.METABASE_TOKEN}",
         },

--- a/turbo/packages/core/src/contracts/connectors.ts
+++ b/turbo/packages/core/src/contracts/connectors.ts
@@ -2602,18 +2602,18 @@ export const CONNECTOR_TYPES: Record<ConnectorType, ConnectorConfig> =
  *
  * `${secrets.XXX}` in header values is replaced by the proxy with the real secret value.
  *
- * NOTE: Currently hardcoded in CONNECTOR_PROXY_CONFIGS below.
+ * NOTE: Currently hardcoded in SERVICE_CONFIGS below.
  * Will be migrated to GitHub-hosted connector.yaml definitions in Phase 2.
  */
-interface ConnectorService {
+interface ServiceApi {
   base: string;
   auth: {
     headers: Record<string, string>;
   };
 }
 
-export interface ConnectorProxyConfig {
-  services: ConnectorService[];
+export interface ServiceConfig {
+  apis: ServiceApi[];
   /** Custom placeholder values per env var (e.g., `{ GITHUB_TOKEN: "gho_..." }`). Falls back to auto-generated `VM0_PLACEHOLDER_{envVar}`. */
   placeholders?: Record<string, string>;
 }
@@ -2623,38 +2623,38 @@ function bearerAuth(secretName: string) {
   return { headers: { Authorization: `Bearer \${secrets.${secretName}}` } };
 }
 
-/** Shorthand: single-base service with bearer auth. */
-function service(
+/** Shorthand: single-base API entry with bearer auth. */
+function api(
   base: string,
-  auth: ConnectorService["auth"],
-): ConnectorService {
+  auth: ServiceApi["auth"],
+): ServiceApi {
   return { base, auth };
 }
 
-const CONNECTOR_PROXY_CONFIGS: Partial<
-  Record<ConnectorType, ConnectorProxyConfig>
+const SERVICE_CONFIGS: Partial<
+  Record<ConnectorType, ServiceConfig>
 > = {
   ahrefs: {
-    services: [service("https://api.ahrefs.com", bearerAuth("AHREFS_TOKEN"))],
+    apis: [api("https://api.ahrefs.com", bearerAuth("AHREFS_TOKEN"))],
   },
   axiom: {
-    services: [service("https://api.axiom.co", bearerAuth("AXIOM_TOKEN"))],
+    apis: [api("https://api.axiom.co", bearerAuth("AXIOM_TOKEN"))],
   },
   airtable: {
-    services: [
-      service("https://api.airtable.com", bearerAuth("AIRTABLE_TOKEN")),
+    apis: [
+      api("https://api.airtable.com", bearerAuth("AIRTABLE_TOKEN")),
     ],
   },
   github: {
-    services: [service("https://api.github.com", bearerAuth("GITHUB_TOKEN"))],
+    apis: [api("https://api.github.com", bearerAuth("GITHUB_TOKEN"))],
     placeholders: {
       GH_TOKEN: "gho_vm0placeholder0000000000000000000000",
       GITHUB_TOKEN: "gho_vm0placeholder0000000000000000000000",
     },
   },
   notion: {
-    services: [
-      service("https://api.notion.com/v1", {
+    apis: [
+      api("https://api.notion.com/v1", {
         headers: {
           Authorization: "Bearer ${secrets.NOTION_TOKEN}",
           "Notion-Version": "2022-06-28",
@@ -2663,99 +2663,99 @@ const CONNECTOR_PROXY_CONFIGS: Partial<
     ],
   },
   gmail: {
-    services: [
-      service(
+    apis: [
+      api(
         "https://gmail.googleapis.com/gmail/v1/users/me",
         bearerAuth("GMAIL_TOKEN"),
       ),
     ],
   },
   "google-sheets": {
-    services: [
-      service(
+    apis: [
+      api(
         "https://sheets.googleapis.com/v4/spreadsheets",
         bearerAuth("GOOGLE_SHEETS_TOKEN"),
       ),
     ],
   },
   "google-docs": {
-    services: [
-      service(
+    apis: [
+      api(
         "https://docs.googleapis.com/v1/documents",
         bearerAuth("GOOGLE_DOCS_TOKEN"),
       ),
     ],
   },
   "google-drive": {
-    services: [
-      service(
+    apis: [
+      api(
         "https://www.googleapis.com/drive/v3",
         bearerAuth("GOOGLE_DRIVE_TOKEN"),
       ),
     ],
   },
   "google-calendar": {
-    services: [
-      service(
+    apis: [
+      api(
         "https://www.googleapis.com/calendar/v3",
         bearerAuth("GOOGLE_CALENDAR_TOKEN"),
       ),
     ],
   },
   "hugging-face": {
-    services: [
-      service("https://huggingface.co/api", bearerAuth("HUGGING_FACE_TOKEN")),
+    apis: [
+      api("https://huggingface.co/api", bearerAuth("HUGGING_FACE_TOKEN")),
     ],
   },
   hume: {
-    services: [
-      service("https://api.hume.ai", {
+    apis: [
+      api("https://api.hume.ai", {
         headers: { "X-Hume-Api-Key": "${secrets.HUME_TOKEN}" },
       }),
     ],
   },
   heygen: {
-    services: [
-      service("https://api.heygen.com", {
+    apis: [
+      api("https://api.heygen.com", {
         headers: { "x-api-key": "${secrets.HEYGEN_TOKEN}" },
       }),
     ],
   },
   hubspot: {
-    services: [service("https://api.hubapi.com", bearerAuth("HUBSPOT_TOKEN"))],
+    apis: [api("https://api.hubapi.com", bearerAuth("HUBSPOT_TOKEN"))],
   },
   slack: {
-    services: [
-      service("https://slack.com/api", bearerAuth("SLACK_TOKEN")),
-      service("https://files.slack.com", bearerAuth("SLACK_TOKEN")),
+    apis: [
+      api("https://slack.com/api", bearerAuth("SLACK_TOKEN")),
+      api("https://files.slack.com", bearerAuth("SLACK_TOKEN")),
     ],
     placeholders: {
       SLACK_TOKEN: "xoxb-0000-0000-vm0placeholder",
     },
   },
   docusign: {
-    services: [
-      service(
+    apis: [
+      api(
         "https://demo.docusign.net/restapi",
         bearerAuth("DOCUSIGN_TOKEN"),
       ),
-      service("https://na1.docusign.net/restapi", bearerAuth("DOCUSIGN_TOKEN")),
+      api("https://na1.docusign.net/restapi", bearerAuth("DOCUSIGN_TOKEN")),
     ],
   },
   dropbox: {
-    services: [
-      service("https://api.dropboxapi.com/2", bearerAuth("DROPBOX_TOKEN")),
-      service("https://content.dropboxapi.com/2", bearerAuth("DROPBOX_TOKEN")),
+    apis: [
+      api("https://api.dropboxapi.com/2", bearerAuth("DROPBOX_TOKEN")),
+      api("https://content.dropboxapi.com/2", bearerAuth("DROPBOX_TOKEN")),
     ],
   },
   linear: {
-    services: [service("https://api.linear.app", bearerAuth("LINEAR_TOKEN"))],
+    apis: [api("https://api.linear.app", bearerAuth("LINEAR_TOKEN"))],
   },
   intercom: {
-    services: [
-      service("https://api.intercom.io", bearerAuth("INTERCOM_TOKEN")),
-      service("https://api.eu.intercom.io", bearerAuth("INTERCOM_TOKEN")),
-      service("https://api.au.intercom.io", bearerAuth("INTERCOM_TOKEN")),
+    apis: [
+      api("https://api.intercom.io", bearerAuth("INTERCOM_TOKEN")),
+      api("https://api.eu.intercom.io", bearerAuth("INTERCOM_TOKEN")),
+      api("https://api.au.intercom.io", bearerAuth("INTERCOM_TOKEN")),
     ],
   },
   jotform: {
@@ -2773,26 +2773,26 @@ const CONNECTOR_PROXY_CONFIGS: Partial<
     ],
   },
   line: {
-    services: [service("https://api.line.me", bearerAuth("LINE_TOKEN"))],
+    apis: [api("https://api.line.me", bearerAuth("LINE_TOKEN"))],
   },
   make: {
-    services: [
-      service("https://eu1.make.com/api/v2", {
+    apis: [
+      api("https://eu1.make.com/api/v2", {
         headers: {
           Authorization: "Token ${secrets.MAKE_TOKEN}",
         },
       }),
-      service("https://eu2.make.com/api/v2", {
+      api("https://eu2.make.com/api/v2", {
         headers: {
           Authorization: "Token ${secrets.MAKE_TOKEN}",
         },
       }),
-      service("https://us1.make.com/api/v2", {
+      api("https://us1.make.com/api/v2", {
         headers: {
           Authorization: "Token ${secrets.MAKE_TOKEN}",
         },
       }),
-      service("https://us2.make.com/api/v2", {
+      api("https://us2.make.com/api/v2", {
         headers: {
           Authorization: "Token ${secrets.MAKE_TOKEN}",
         },
@@ -2809,335 +2809,335 @@ const CONNECTOR_PROXY_CONFIGS: Partial<
     ],
   },
   clickup: {
-    services: [
-      service("https://api.clickup.com/api/v2", bearerAuth("CLICKUP_TOKEN")),
+    apis: [
+      api("https://api.clickup.com/api/v2", bearerAuth("CLICKUP_TOKEN")),
     ],
   },
   cloudflare: {
-    services: [
-      service(
+    apis: [
+      api(
         "https://api.cloudflare.com/client/v4",
         bearerAuth("CLOUDFLARE_TOKEN"),
       ),
     ],
   },
   deel: {
-    services: [service("https://api.deel.com", bearerAuth("DEEL_TOKEN"))],
+    apis: [api("https://api.deel.com", bearerAuth("DEEL_TOKEN"))],
   },
   deepseek: {
-    services: [
-      service("https://api.deepseek.com", bearerAuth("DEEPSEEK_TOKEN")),
+    apis: [
+      api("https://api.deepseek.com", bearerAuth("DEEPSEEK_TOKEN")),
     ],
   },
   dify: {
-    services: [service("https://api.dify.ai/v1", bearerAuth("DIFY_TOKEN"))],
+    apis: [api("https://api.dify.ai/v1", bearerAuth("DIFY_TOKEN"))],
   },
   figma: {
-    services: [service("https://api.figma.com", bearerAuth("FIGMA_TOKEN"))],
+    apis: [api("https://api.figma.com", bearerAuth("FIGMA_TOKEN"))],
   },
   mercury: {
-    services: [service("https://api.mercury.com", bearerAuth("MERCURY_TOKEN"))],
+    apis: [api("https://api.mercury.com", bearerAuth("MERCURY_TOKEN"))],
   },
   minimax: {
-    services: [
-      service("https://api.minimaxi.com/v1", bearerAuth("MINIMAX_TOKEN")),
+    apis: [
+      api("https://api.minimaxi.com/v1", bearerAuth("MINIMAX_TOKEN")),
     ],
   },
   reddit: {
-    services: [service("https://oauth.reddit.com", bearerAuth("REDDIT_TOKEN"))],
+    apis: [api("https://oauth.reddit.com", bearerAuth("REDDIT_TOKEN"))],
   },
   strava: {
-    services: [
-      service("https://www.strava.com/api/v3", bearerAuth("STRAVA_TOKEN")),
+    apis: [
+      api("https://www.strava.com/api/v3", bearerAuth("STRAVA_TOKEN")),
     ],
   },
   x: {
-    services: [service("https://api.x.com/2", bearerAuth("X_ACCESS_TOKEN"))],
+    apis: [api("https://api.x.com/2", bearerAuth("X_ACCESS_TOKEN"))],
   },
   neon: {
-    services: [
-      service("https://console.neon.tech/api/v2", bearerAuth("NEON_TOKEN")),
+    apis: [
+      api("https://console.neon.tech/api/v2", bearerAuth("NEON_TOKEN")),
     ],
   },
   vercel: {
-    services: [service("https://api.vercel.com", bearerAuth("VERCEL_TOKEN"))],
+    apis: [api("https://api.vercel.com", bearerAuth("VERCEL_TOKEN"))],
   },
   sentry: {
-    services: [service("https://sentry.io/api", bearerAuth("SENTRY_TOKEN"))],
+    apis: [api("https://sentry.io/api", bearerAuth("SENTRY_TOKEN"))],
   },
   monday: {
-    services: [
-      service("https://api.monday.com/v2", bearerAuth("MONDAY_TOKEN")),
+    apis: [
+      api("https://api.monday.com/v2", bearerAuth("MONDAY_TOKEN")),
     ],
   },
   canva: {
-    services: [
-      service("https://api.canva.com/rest/v1", bearerAuth("CANVA_TOKEN")),
+    apis: [
+      api("https://api.canva.com/rest/v1", bearerAuth("CANVA_TOKEN")),
     ],
   },
   xero: {
-    services: [service("https://api.xero.com", bearerAuth("XERO_TOKEN"))],
+    apis: [api("https://api.xero.com", bearerAuth("XERO_TOKEN"))],
   },
   supabase: {
-    services: [
-      service("https://api.supabase.com/v1", bearerAuth("SUPABASE_TOKEN")),
+    apis: [
+      api("https://api.supabase.com/v1", bearerAuth("SUPABASE_TOKEN")),
     ],
   },
   todoist: {
-    services: [
-      service("https://api.todoist.com/rest/v2", bearerAuth("TODOIST_TOKEN")),
+    apis: [
+      api("https://api.todoist.com/rest/v2", bearerAuth("TODOIST_TOKEN")),
     ],
   },
   webflow: {
-    services: [
-      service("https://api.webflow.com/v2", bearerAuth("WEBFLOW_TOKEN")),
+    apis: [
+      api("https://api.webflow.com/v2", bearerAuth("WEBFLOW_TOKEN")),
     ],
   },
   asana: {
-    services: [
-      service("https://app.asana.com/api/1.0", bearerAuth("ASANA_TOKEN")),
+    apis: [
+      api("https://app.asana.com/api/1.0", bearerAuth("ASANA_TOKEN")),
     ],
   },
   "meta-ads": {
-    services: [
-      service("https://graph.facebook.com", bearerAuth("META_ADS_TOKEN")),
+    apis: [
+      api("https://graph.facebook.com", bearerAuth("META_ADS_TOKEN")),
     ],
   },
   posthog: {
-    services: [
-      service("https://us.posthog.com/api", bearerAuth("POSTHOG_ACCESS_TOKEN")),
-      service(
+    apis: [
+      api("https://us.posthog.com/api", bearerAuth("POSTHOG_ACCESS_TOKEN")),
+      api(
         "https://app.posthog.com/api",
         bearerAuth("POSTHOG_ACCESS_TOKEN"),
       ),
     ],
   },
   stripe: {
-    services: [service("https://api.stripe.com", bearerAuth("STRIPE_TOKEN"))],
+    apis: [api("https://api.stripe.com", bearerAuth("STRIPE_TOKEN"))],
   },
   productlane: {
-    services: [
-      service(
+    apis: [
+      api(
         "https://productlane.com/api/v1",
         bearerAuth("PRODUCTLANE_TOKEN"),
       ),
     ],
   },
   openai: {
-    services: [service("https://api.openai.com", bearerAuth("OPENAI_TOKEN"))],
+    apis: [api("https://api.openai.com", bearerAuth("OPENAI_TOKEN"))],
   },
   similarweb: {
-    services: [
-      service("https://api.similarweb.com", {
+    apis: [
+      api("https://api.similarweb.com", {
         headers: { "api-key": "${secrets.SIMILARWEB_API_KEY}" },
       }),
     ],
   },
   perplexity: {
-    services: [
-      service("https://api.perplexity.ai", bearerAuth("PERPLEXITY_TOKEN")),
+    apis: [
+      api("https://api.perplexity.ai", bearerAuth("PERPLEXITY_TOKEN")),
     ],
   },
   plausible: {
-    services: [
-      service("https://plausible.io/api", bearerAuth("PLAUSIBLE_TOKEN")),
+    apis: [
+      api("https://plausible.io/api", bearerAuth("PLAUSIBLE_TOKEN")),
     ],
   },
   mailchimp: {
-    services: [
-      service(
+    apis: [
+      api(
         "https://us1.api.mailchimp.com/3.0",
         bearerAuth("MAILCHIMP_TOKEN"),
       ),
-      service(
+      api(
         "https://us2.api.mailchimp.com/3.0",
         bearerAuth("MAILCHIMP_TOKEN"),
       ),
-      service(
+      api(
         "https://us3.api.mailchimp.com/3.0",
         bearerAuth("MAILCHIMP_TOKEN"),
       ),
-      service(
+      api(
         "https://us4.api.mailchimp.com/3.0",
         bearerAuth("MAILCHIMP_TOKEN"),
       ),
-      service(
+      api(
         "https://us5.api.mailchimp.com/3.0",
         bearerAuth("MAILCHIMP_TOKEN"),
       ),
-      service(
+      api(
         "https://us6.api.mailchimp.com/3.0",
         bearerAuth("MAILCHIMP_TOKEN"),
       ),
-      service(
+      api(
         "https://us7.api.mailchimp.com/3.0",
         bearerAuth("MAILCHIMP_TOKEN"),
       ),
-      service(
+      api(
         "https://us8.api.mailchimp.com/3.0",
         bearerAuth("MAILCHIMP_TOKEN"),
       ),
-      service(
+      api(
         "https://us9.api.mailchimp.com/3.0",
         bearerAuth("MAILCHIMP_TOKEN"),
       ),
-      service(
+      api(
         "https://us10.api.mailchimp.com/3.0",
         bearerAuth("MAILCHIMP_TOKEN"),
       ),
-      service(
+      api(
         "https://us11.api.mailchimp.com/3.0",
         bearerAuth("MAILCHIMP_TOKEN"),
       ),
-      service(
+      api(
         "https://us12.api.mailchimp.com/3.0",
         bearerAuth("MAILCHIMP_TOKEN"),
       ),
-      service(
+      api(
         "https://us13.api.mailchimp.com/3.0",
         bearerAuth("MAILCHIMP_TOKEN"),
       ),
-      service(
+      api(
         "https://us14.api.mailchimp.com/3.0",
         bearerAuth("MAILCHIMP_TOKEN"),
       ),
-      service(
+      api(
         "https://us15.api.mailchimp.com/3.0",
         bearerAuth("MAILCHIMP_TOKEN"),
       ),
-      service(
+      api(
         "https://us16.api.mailchimp.com/3.0",
         bearerAuth("MAILCHIMP_TOKEN"),
       ),
-      service(
+      api(
         "https://us17.api.mailchimp.com/3.0",
         bearerAuth("MAILCHIMP_TOKEN"),
       ),
-      service(
+      api(
         "https://us18.api.mailchimp.com/3.0",
         bearerAuth("MAILCHIMP_TOKEN"),
       ),
-      service(
+      api(
         "https://us19.api.mailchimp.com/3.0",
         bearerAuth("MAILCHIMP_TOKEN"),
       ),
-      service(
+      api(
         "https://us20.api.mailchimp.com/3.0",
         bearerAuth("MAILCHIMP_TOKEN"),
       ),
-      service(
+      api(
         "https://us21.api.mailchimp.com/3.0",
         bearerAuth("MAILCHIMP_TOKEN"),
       ),
     ],
   },
   chatwoot: {
-    services: [
-      service("https://app.chatwoot.com", bearerAuth("CHATWOOT_TOKEN")),
+    apis: [
+      api("https://app.chatwoot.com", bearerAuth("CHATWOOT_TOKEN")),
     ],
   },
   resend: {
-    services: [service("https://api.resend.com", bearerAuth("RESEND_TOKEN"))],
+    apis: [api("https://api.resend.com", bearerAuth("RESEND_TOKEN"))],
   },
   revenuecat: {
-    services: [
-      service("https://api.revenuecat.com", bearerAuth("REVENUECAT_TOKEN")),
+    apis: [
+      api("https://api.revenuecat.com", bearerAuth("REVENUECAT_TOKEN")),
     ],
   },
   pdf4me: {
-    services: [
-      service("https://api.pdf4me.com", {
+    apis: [
+      api("https://api.pdf4me.com", {
         headers: { Authorization: "${secrets.PDF4ME_TOKEN}" },
       }),
     ],
   },
   pdfco: {
-    services: [
-      service("https://api.pdf.co/v1", {
+    apis: [
+      api("https://api.pdf.co/v1", {
         headers: { "x-api-key": "${secrets.PDFCO_TOKEN}" },
       }),
     ],
   },
   apify: {
-    services: [service("https://api.apify.com/v2", bearerAuth("APIFY_TOKEN"))],
+    apis: [api("https://api.apify.com/v2", bearerAuth("APIFY_TOKEN"))],
   },
   "bright-data": {
-    services: [
-      service("https://api.brightdata.com", bearerAuth("BRIGHTDATA_TOKEN")),
+    apis: [
+      api("https://api.brightdata.com", bearerAuth("BRIGHTDATA_TOKEN")),
     ],
   },
   browserbase: {
-    services: [
-      service("https://api.browserbase.com/v1", {
+    apis: [
+      api("https://api.browserbase.com/v1", {
         headers: { "X-BB-API-Key": "${secrets.BROWSERBASE_TOKEN}" },
       }),
     ],
   },
   fireflies: {
-    services: [
-      service(
+    apis: [
+      api(
         "https://api.fireflies.ai/graphql",
         bearerAuth("FIREFLIES_TOKEN"),
       ),
     ],
   },
   firecrawl: {
-    services: [
-      service("https://api.firecrawl.dev/v1", bearerAuth("FIRECRAWL_TOKEN")),
+    apis: [
+      api("https://api.firecrawl.dev/v1", bearerAuth("FIRECRAWL_TOKEN")),
     ],
   },
   scrapeninja: {
-    services: [
-      service("https://scrapeninja.p.rapidapi.com", {
+    apis: [
+      api("https://scrapeninja.p.rapidapi.com", {
         headers: { "X-RapidAPI-Key": "${secrets.SCRAPENINJA_TOKEN}" },
       }),
     ],
   },
   elevenlabs: {
-    services: [
-      service("https://api.elevenlabs.io", {
+    apis: [
+      api("https://api.elevenlabs.io", {
         headers: { "xi-api-key": "${secrets.ELEVENLABS_TOKEN}" },
       }),
     ],
   },
   devto: {
-    services: [
-      service("https://dev.to/api", {
+    apis: [
+      api("https://dev.to/api", {
         headers: { "api-key": "${secrets.DEVTO_TOKEN}" },
       }),
     ],
   },
   fal: {
-    services: [service("https://fal.run", bearerAuth("FAL_TOKEN"))],
+    apis: [api("https://fal.run", bearerAuth("FAL_TOKEN"))],
   },
   podchaser: {
-    services: [
-      service("https://api.podchaser.com", bearerAuth("PODCHASER_TOKEN")),
+    apis: [
+      api("https://api.podchaser.com", bearerAuth("PODCHASER_TOKEN")),
     ],
   },
   pushinator: {
-    services: [
-      service("https://api.pushinator.com", bearerAuth("PUSHINATOR_TOKEN")),
+    apis: [
+      api("https://api.pushinator.com", bearerAuth("PUSHINATOR_TOKEN")),
     ],
   },
   qdrant: {
-    services: [
-      service("https://cloud.qdrant.io", {
+    apis: [
+      api("https://cloud.qdrant.io", {
         headers: { "api-key": "${secrets.QDRANT_TOKEN}" },
       }),
     ],
   },
   qiita: {
-    services: [service("https://qiita.com/api/v2", bearerAuth("QIITA_TOKEN"))],
+    apis: [api("https://qiita.com/api/v2", bearerAuth("QIITA_TOKEN"))],
   },
   reportei: {
-    services: [
-      service("https://app.reportei.com/api/v1", bearerAuth("REPORTEI_TOKEN")),
+    apis: [
+      api("https://app.reportei.com/api/v1", bearerAuth("REPORTEI_TOKEN")),
     ],
   },
   zeptomail: {
-    services: [
-      service("https://api.zeptomail.com/v1.1", {
+    apis: [
+      api("https://api.zeptomail.com/v1.1", {
         headers: {
           Authorization: "Zoho-enczapikey ${secrets.ZEPTOMAIL_TOKEN}",
         },
@@ -3145,45 +3145,45 @@ const CONNECTOR_PROXY_CONFIGS: Partial<
     ],
   },
   runway: {
-    services: [
-      service("https://api.dev.runwayml.com/v1", bearerAuth("RUNWAY_TOKEN")),
+    apis: [
+      api("https://api.dev.runwayml.com/v1", bearerAuth("RUNWAY_TOKEN")),
     ],
   },
   shortio: {
-    services: [
-      service("https://api.short.io", {
+    apis: [
+      api("https://api.short.io", {
         headers: { Authorization: "${secrets.SHORTIO_TOKEN}" },
       }),
     ],
   },
   supadata: {
-    services: [
-      service("https://api.supadata.ai/v1", {
+    apis: [
+      api("https://api.supadata.ai/v1", {
         headers: { "x-api-key": "${secrets.SUPADATA_TOKEN}" },
       }),
     ],
   },
   tavily: {
-    services: [service("https://api.tavily.com", bearerAuth("TAVILY_TOKEN"))],
+    apis: [api("https://api.tavily.com", bearerAuth("TAVILY_TOKEN"))],
   },
   tldv: {
-    services: [
-      service("https://pasta.tldv.io", {
+    apis: [
+      api("https://pasta.tldv.io", {
         headers: { "x-api-key": "${secrets.TLDV_TOKEN}" },
       }),
     ],
   },
   twenty: {
-    services: [service("https://api.twenty.com", bearerAuth("TWENTY_TOKEN"))],
+    apis: [api("https://api.twenty.com", bearerAuth("TWENTY_TOKEN"))],
   },
   wrike: {
-    services: [
-      service("https://www.wrike.com/api/v4", bearerAuth("WRIKE_TOKEN")),
+    apis: [
+      api("https://www.wrike.com/api/v4", bearerAuth("WRIKE_TOKEN")),
     ],
   },
   zapsign: {
-    services: [
-      service("https://api.zapsign.com.br/api/v1", bearerAuth("ZAPSIGN_TOKEN")),
+    apis: [
+      api("https://api.zapsign.com.br/api/v1", bearerAuth("ZAPSIGN_TOKEN")),
     ],
   },
 };
@@ -3343,10 +3343,10 @@ export function getConnectorEnvironmentMapping(
  * Get proxy config for a connector type (base URLs + auth headers).
  * Returns undefined if the connector has no proxy config (e.g., computer connector).
  */
-export function getConnectorProxyConfig(
+export function getServiceConfig(
   type: ConnectorType,
-): ConnectorProxyConfig | undefined {
-  return CONNECTOR_PROXY_CONFIGS[type];
+): ServiceConfig | undefined {
+  return SERVICE_CONFIGS[type];
 }
 
 /**

--- a/turbo/packages/core/src/contracts/connectors.ts
+++ b/turbo/packages/core/src/contracts/connectors.ts
@@ -2624,16 +2624,11 @@ function bearerAuth(secretName: string) {
 }
 
 /** Shorthand: single-base API entry with bearer auth. */
-function api(
-  base: string,
-  auth: ServiceApi["auth"],
-): ServiceApi {
+function api(base: string, auth: ServiceApi["auth"]): ServiceApi {
   return { base, auth };
 }
 
-const SERVICE_CONFIGS: Partial<
-  Record<ConnectorType, ServiceConfig>
-> = {
+const SERVICE_CONFIGS: Partial<Record<ConnectorType, ServiceConfig>> = {
   ahrefs: {
     apis: [api("https://api.ahrefs.com", bearerAuth("AHREFS_TOKEN"))],
   },
@@ -2641,9 +2636,7 @@ const SERVICE_CONFIGS: Partial<
     apis: [api("https://api.axiom.co", bearerAuth("AXIOM_TOKEN"))],
   },
   airtable: {
-    apis: [
-      api("https://api.airtable.com", bearerAuth("AIRTABLE_TOKEN")),
-    ],
+    apis: [api("https://api.airtable.com", bearerAuth("AIRTABLE_TOKEN"))],
   },
   github: {
     apis: [api("https://api.github.com", bearerAuth("GITHUB_TOKEN"))],
@@ -2703,9 +2696,7 @@ const SERVICE_CONFIGS: Partial<
     ],
   },
   "hugging-face": {
-    apis: [
-      api("https://huggingface.co/api", bearerAuth("HUGGING_FACE_TOKEN")),
-    ],
+    apis: [api("https://huggingface.co/api", bearerAuth("HUGGING_FACE_TOKEN"))],
   },
   hume: {
     apis: [
@@ -2735,10 +2726,7 @@ const SERVICE_CONFIGS: Partial<
   },
   docusign: {
     apis: [
-      api(
-        "https://demo.docusign.net/restapi",
-        bearerAuth("DOCUSIGN_TOKEN"),
-      ),
+      api("https://demo.docusign.net/restapi", bearerAuth("DOCUSIGN_TOKEN")),
       api("https://na1.docusign.net/restapi", bearerAuth("DOCUSIGN_TOKEN")),
     ],
   },
@@ -2809,9 +2797,7 @@ const SERVICE_CONFIGS: Partial<
     ],
   },
   clickup: {
-    apis: [
-      api("https://api.clickup.com/api/v2", bearerAuth("CLICKUP_TOKEN")),
-    ],
+    apis: [api("https://api.clickup.com/api/v2", bearerAuth("CLICKUP_TOKEN"))],
   },
   cloudflare: {
     apis: [
@@ -2825,9 +2811,7 @@ const SERVICE_CONFIGS: Partial<
     apis: [api("https://api.deel.com", bearerAuth("DEEL_TOKEN"))],
   },
   deepseek: {
-    apis: [
-      api("https://api.deepseek.com", bearerAuth("DEEPSEEK_TOKEN")),
-    ],
+    apis: [api("https://api.deepseek.com", bearerAuth("DEEPSEEK_TOKEN"))],
   },
   dify: {
     apis: [api("https://api.dify.ai/v1", bearerAuth("DIFY_TOKEN"))],
@@ -2839,25 +2823,19 @@ const SERVICE_CONFIGS: Partial<
     apis: [api("https://api.mercury.com", bearerAuth("MERCURY_TOKEN"))],
   },
   minimax: {
-    apis: [
-      api("https://api.minimaxi.com/v1", bearerAuth("MINIMAX_TOKEN")),
-    ],
+    apis: [api("https://api.minimaxi.com/v1", bearerAuth("MINIMAX_TOKEN"))],
   },
   reddit: {
     apis: [api("https://oauth.reddit.com", bearerAuth("REDDIT_TOKEN"))],
   },
   strava: {
-    apis: [
-      api("https://www.strava.com/api/v3", bearerAuth("STRAVA_TOKEN")),
-    ],
+    apis: [api("https://www.strava.com/api/v3", bearerAuth("STRAVA_TOKEN"))],
   },
   x: {
     apis: [api("https://api.x.com/2", bearerAuth("X_ACCESS_TOKEN"))],
   },
   neon: {
-    apis: [
-      api("https://console.neon.tech/api/v2", bearerAuth("NEON_TOKEN")),
-    ],
+    apis: [api("https://console.neon.tech/api/v2", bearerAuth("NEON_TOKEN"))],
   },
   vercel: {
     apis: [api("https://api.vercel.com", bearerAuth("VERCEL_TOKEN"))],
@@ -2866,50 +2844,33 @@ const SERVICE_CONFIGS: Partial<
     apis: [api("https://sentry.io/api", bearerAuth("SENTRY_TOKEN"))],
   },
   monday: {
-    apis: [
-      api("https://api.monday.com/v2", bearerAuth("MONDAY_TOKEN")),
-    ],
+    apis: [api("https://api.monday.com/v2", bearerAuth("MONDAY_TOKEN"))],
   },
   canva: {
-    apis: [
-      api("https://api.canva.com/rest/v1", bearerAuth("CANVA_TOKEN")),
-    ],
+    apis: [api("https://api.canva.com/rest/v1", bearerAuth("CANVA_TOKEN"))],
   },
   xero: {
     apis: [api("https://api.xero.com", bearerAuth("XERO_TOKEN"))],
   },
   supabase: {
-    apis: [
-      api("https://api.supabase.com/v1", bearerAuth("SUPABASE_TOKEN")),
-    ],
+    apis: [api("https://api.supabase.com/v1", bearerAuth("SUPABASE_TOKEN"))],
   },
   todoist: {
-    apis: [
-      api("https://api.todoist.com/rest/v2", bearerAuth("TODOIST_TOKEN")),
-    ],
+    apis: [api("https://api.todoist.com/rest/v2", bearerAuth("TODOIST_TOKEN"))],
   },
   webflow: {
-    apis: [
-      api("https://api.webflow.com/v2", bearerAuth("WEBFLOW_TOKEN")),
-    ],
+    apis: [api("https://api.webflow.com/v2", bearerAuth("WEBFLOW_TOKEN"))],
   },
   asana: {
-    apis: [
-      api("https://app.asana.com/api/1.0", bearerAuth("ASANA_TOKEN")),
-    ],
+    apis: [api("https://app.asana.com/api/1.0", bearerAuth("ASANA_TOKEN"))],
   },
   "meta-ads": {
-    apis: [
-      api("https://graph.facebook.com", bearerAuth("META_ADS_TOKEN")),
-    ],
+    apis: [api("https://graph.facebook.com", bearerAuth("META_ADS_TOKEN"))],
   },
   posthog: {
     apis: [
       api("https://us.posthog.com/api", bearerAuth("POSTHOG_ACCESS_TOKEN")),
-      api(
-        "https://app.posthog.com/api",
-        bearerAuth("POSTHOG_ACCESS_TOKEN"),
-      ),
+      api("https://app.posthog.com/api", bearerAuth("POSTHOG_ACCESS_TOKEN")),
     ],
   },
   stripe: {
@@ -2917,10 +2878,7 @@ const SERVICE_CONFIGS: Partial<
   },
   productlane: {
     apis: [
-      api(
-        "https://productlane.com/api/v1",
-        bearerAuth("PRODUCTLANE_TOKEN"),
-      ),
+      api("https://productlane.com/api/v1", bearerAuth("PRODUCTLANE_TOKEN")),
     ],
   },
   openai: {
@@ -2934,115 +2892,44 @@ const SERVICE_CONFIGS: Partial<
     ],
   },
   perplexity: {
-    apis: [
-      api("https://api.perplexity.ai", bearerAuth("PERPLEXITY_TOKEN")),
-    ],
+    apis: [api("https://api.perplexity.ai", bearerAuth("PERPLEXITY_TOKEN"))],
   },
   plausible: {
-    apis: [
-      api("https://plausible.io/api", bearerAuth("PLAUSIBLE_TOKEN")),
-    ],
+    apis: [api("https://plausible.io/api", bearerAuth("PLAUSIBLE_TOKEN"))],
   },
   mailchimp: {
     apis: [
-      api(
-        "https://us1.api.mailchimp.com/3.0",
-        bearerAuth("MAILCHIMP_TOKEN"),
-      ),
-      api(
-        "https://us2.api.mailchimp.com/3.0",
-        bearerAuth("MAILCHIMP_TOKEN"),
-      ),
-      api(
-        "https://us3.api.mailchimp.com/3.0",
-        bearerAuth("MAILCHIMP_TOKEN"),
-      ),
-      api(
-        "https://us4.api.mailchimp.com/3.0",
-        bearerAuth("MAILCHIMP_TOKEN"),
-      ),
-      api(
-        "https://us5.api.mailchimp.com/3.0",
-        bearerAuth("MAILCHIMP_TOKEN"),
-      ),
-      api(
-        "https://us6.api.mailchimp.com/3.0",
-        bearerAuth("MAILCHIMP_TOKEN"),
-      ),
-      api(
-        "https://us7.api.mailchimp.com/3.0",
-        bearerAuth("MAILCHIMP_TOKEN"),
-      ),
-      api(
-        "https://us8.api.mailchimp.com/3.0",
-        bearerAuth("MAILCHIMP_TOKEN"),
-      ),
-      api(
-        "https://us9.api.mailchimp.com/3.0",
-        bearerAuth("MAILCHIMP_TOKEN"),
-      ),
-      api(
-        "https://us10.api.mailchimp.com/3.0",
-        bearerAuth("MAILCHIMP_TOKEN"),
-      ),
-      api(
-        "https://us11.api.mailchimp.com/3.0",
-        bearerAuth("MAILCHIMP_TOKEN"),
-      ),
-      api(
-        "https://us12.api.mailchimp.com/3.0",
-        bearerAuth("MAILCHIMP_TOKEN"),
-      ),
-      api(
-        "https://us13.api.mailchimp.com/3.0",
-        bearerAuth("MAILCHIMP_TOKEN"),
-      ),
-      api(
-        "https://us14.api.mailchimp.com/3.0",
-        bearerAuth("MAILCHIMP_TOKEN"),
-      ),
-      api(
-        "https://us15.api.mailchimp.com/3.0",
-        bearerAuth("MAILCHIMP_TOKEN"),
-      ),
-      api(
-        "https://us16.api.mailchimp.com/3.0",
-        bearerAuth("MAILCHIMP_TOKEN"),
-      ),
-      api(
-        "https://us17.api.mailchimp.com/3.0",
-        bearerAuth("MAILCHIMP_TOKEN"),
-      ),
-      api(
-        "https://us18.api.mailchimp.com/3.0",
-        bearerAuth("MAILCHIMP_TOKEN"),
-      ),
-      api(
-        "https://us19.api.mailchimp.com/3.0",
-        bearerAuth("MAILCHIMP_TOKEN"),
-      ),
-      api(
-        "https://us20.api.mailchimp.com/3.0",
-        bearerAuth("MAILCHIMP_TOKEN"),
-      ),
-      api(
-        "https://us21.api.mailchimp.com/3.0",
-        bearerAuth("MAILCHIMP_TOKEN"),
-      ),
+      api("https://us1.api.mailchimp.com/3.0", bearerAuth("MAILCHIMP_TOKEN")),
+      api("https://us2.api.mailchimp.com/3.0", bearerAuth("MAILCHIMP_TOKEN")),
+      api("https://us3.api.mailchimp.com/3.0", bearerAuth("MAILCHIMP_TOKEN")),
+      api("https://us4.api.mailchimp.com/3.0", bearerAuth("MAILCHIMP_TOKEN")),
+      api("https://us5.api.mailchimp.com/3.0", bearerAuth("MAILCHIMP_TOKEN")),
+      api("https://us6.api.mailchimp.com/3.0", bearerAuth("MAILCHIMP_TOKEN")),
+      api("https://us7.api.mailchimp.com/3.0", bearerAuth("MAILCHIMP_TOKEN")),
+      api("https://us8.api.mailchimp.com/3.0", bearerAuth("MAILCHIMP_TOKEN")),
+      api("https://us9.api.mailchimp.com/3.0", bearerAuth("MAILCHIMP_TOKEN")),
+      api("https://us10.api.mailchimp.com/3.0", bearerAuth("MAILCHIMP_TOKEN")),
+      api("https://us11.api.mailchimp.com/3.0", bearerAuth("MAILCHIMP_TOKEN")),
+      api("https://us12.api.mailchimp.com/3.0", bearerAuth("MAILCHIMP_TOKEN")),
+      api("https://us13.api.mailchimp.com/3.0", bearerAuth("MAILCHIMP_TOKEN")),
+      api("https://us14.api.mailchimp.com/3.0", bearerAuth("MAILCHIMP_TOKEN")),
+      api("https://us15.api.mailchimp.com/3.0", bearerAuth("MAILCHIMP_TOKEN")),
+      api("https://us16.api.mailchimp.com/3.0", bearerAuth("MAILCHIMP_TOKEN")),
+      api("https://us17.api.mailchimp.com/3.0", bearerAuth("MAILCHIMP_TOKEN")),
+      api("https://us18.api.mailchimp.com/3.0", bearerAuth("MAILCHIMP_TOKEN")),
+      api("https://us19.api.mailchimp.com/3.0", bearerAuth("MAILCHIMP_TOKEN")),
+      api("https://us20.api.mailchimp.com/3.0", bearerAuth("MAILCHIMP_TOKEN")),
+      api("https://us21.api.mailchimp.com/3.0", bearerAuth("MAILCHIMP_TOKEN")),
     ],
   },
   chatwoot: {
-    apis: [
-      api("https://app.chatwoot.com", bearerAuth("CHATWOOT_TOKEN")),
-    ],
+    apis: [api("https://app.chatwoot.com", bearerAuth("CHATWOOT_TOKEN"))],
   },
   resend: {
     apis: [api("https://api.resend.com", bearerAuth("RESEND_TOKEN"))],
   },
   revenuecat: {
-    apis: [
-      api("https://api.revenuecat.com", bearerAuth("REVENUECAT_TOKEN")),
-    ],
+    apis: [api("https://api.revenuecat.com", bearerAuth("REVENUECAT_TOKEN"))],
   },
   pdf4me: {
     apis: [
@@ -3062,9 +2949,7 @@ const SERVICE_CONFIGS: Partial<
     apis: [api("https://api.apify.com/v2", bearerAuth("APIFY_TOKEN"))],
   },
   "bright-data": {
-    apis: [
-      api("https://api.brightdata.com", bearerAuth("BRIGHTDATA_TOKEN")),
-    ],
+    apis: [api("https://api.brightdata.com", bearerAuth("BRIGHTDATA_TOKEN"))],
   },
   browserbase: {
     apis: [
@@ -3075,16 +2960,11 @@ const SERVICE_CONFIGS: Partial<
   },
   fireflies: {
     apis: [
-      api(
-        "https://api.fireflies.ai/graphql",
-        bearerAuth("FIREFLIES_TOKEN"),
-      ),
+      api("https://api.fireflies.ai/graphql", bearerAuth("FIREFLIES_TOKEN")),
     ],
   },
   firecrawl: {
-    apis: [
-      api("https://api.firecrawl.dev/v1", bearerAuth("FIRECRAWL_TOKEN")),
-    ],
+    apis: [api("https://api.firecrawl.dev/v1", bearerAuth("FIRECRAWL_TOKEN"))],
   },
   scrapeninja: {
     apis: [
@@ -3111,14 +2991,10 @@ const SERVICE_CONFIGS: Partial<
     apis: [api("https://fal.run", bearerAuth("FAL_TOKEN"))],
   },
   podchaser: {
-    apis: [
-      api("https://api.podchaser.com", bearerAuth("PODCHASER_TOKEN")),
-    ],
+    apis: [api("https://api.podchaser.com", bearerAuth("PODCHASER_TOKEN"))],
   },
   pushinator: {
-    apis: [
-      api("https://api.pushinator.com", bearerAuth("PUSHINATOR_TOKEN")),
-    ],
+    apis: [api("https://api.pushinator.com", bearerAuth("PUSHINATOR_TOKEN"))],
   },
   qdrant: {
     apis: [
@@ -3145,9 +3021,7 @@ const SERVICE_CONFIGS: Partial<
     ],
   },
   runway: {
-    apis: [
-      api("https://api.dev.runwayml.com/v1", bearerAuth("RUNWAY_TOKEN")),
-    ],
+    apis: [api("https://api.dev.runwayml.com/v1", bearerAuth("RUNWAY_TOKEN"))],
   },
   shortio: {
     apis: [
@@ -3177,9 +3051,7 @@ const SERVICE_CONFIGS: Partial<
     apis: [api("https://api.twenty.com", bearerAuth("TWENTY_TOKEN"))],
   },
   wrike: {
-    apis: [
-      api("https://www.wrike.com/api/v4", bearerAuth("WRIKE_TOKEN")),
-    ],
+    apis: [api("https://www.wrike.com/api/v4", bearerAuth("WRIKE_TOKEN"))],
   },
   zapsign: {
     apis: [

--- a/turbo/packages/core/src/contracts/index.ts
+++ b/turbo/packages/core/src/contracts/index.ts
@@ -299,10 +299,10 @@ export {
   type ResumeSession,
   type FirewallRule,
   type ExperimentalFirewall,
-  connectorEntrySchema,
-  experimentalConnectorsSchema,
-  type ConnectorEntry,
-  type ExperimentalConnectors,
+  serviceApiEntrySchema,
+  experimentalServicesSchema,
+  type ServiceApiEntry,
+  type ExperimentalServices,
 } from "./runners";
 
 export {
@@ -404,7 +404,7 @@ export {
   getConnectorDerivedNames,
   getConnectorProvidedSecretNames,
   getConnectorOAuthConfig,
-  getConnectorProxyConfig,
+  getServiceConfig,
   hasRequiredScopes,
   getApiTokenRequiredSecretNames,
   getApiTokenFieldsByType,
@@ -423,7 +423,7 @@ export {
   type ConnectorSecretConfig,
   type ConnectorAuthMethodConfig,
   type ConnectorOAuthConfig,
-  type ConnectorProxyConfig,
+  type ServiceConfig,
   // Computer connector
   computerConnectorContract,
   computerConnectorCreateResponseSchema,

--- a/turbo/packages/core/src/contracts/runners.ts
+++ b/turbo/packages/core/src/contracts/runners.ts
@@ -80,18 +80,20 @@ export const runnersPollContract = c.router({
 });
 
 /**
- * Connector entry in experimental connectors manifest
+ * Service API entry for proxy-side token replacement
  */
-export const connectorEntrySchema = z.object({
-  name: z.string(),
+export const serviceApiEntrySchema = z.object({
   base: z.string(),
+  auth: z.object({
+    headers: z.record(z.string(), z.string()),
+  }),
 });
 
 /**
- * Experimental connectors configuration for proxy-side token replacement
+ * Experimental services configuration for proxy-side token replacement
  */
-export const experimentalConnectorsSchema = z.object({
-  connectors: z.array(connectorEntrySchema),
+export const experimentalServicesSchema = z.object({
+  apis: z.array(serviceApiEntrySchema),
 });
 
 /**
@@ -153,8 +155,8 @@ export const storedExecutionContextSchema = z.object({
   agentScopeSlug: z.string().optional(),
   // Memory storage name (for first-run when manifest.memory is null)
   memoryName: z.string().optional(),
-  // Experimental connectors for proxy-side token replacement
-  experimentalConnectors: experimentalConnectorsSchema.optional(),
+  // Experimental services for proxy-side token replacement
+  experimentalServices: experimentalServicesSchema.optional(),
 });
 
 /**
@@ -188,8 +190,8 @@ export const executionContextSchema = z.object({
   agentScopeSlug: z.string().optional(),
   // Memory storage name (for first-run when manifest.memory is null)
   memoryName: z.string().optional(),
-  // Experimental connectors for proxy-side token replacement
-  experimentalConnectors: experimentalConnectorsSchema.optional(),
+  // Experimental services for proxy-side token replacement
+  experimentalServices: experimentalServicesSchema.optional(),
 });
 
 /**
@@ -232,7 +234,5 @@ export type StorageManifest = z.infer<typeof storageManifestSchema>;
 export type ResumeSession = z.infer<typeof resumeSessionSchema>;
 export type FirewallRule = z.infer<typeof firewallRuleSchema>;
 export type ExperimentalFirewall = z.infer<typeof experimentalFirewallSchema>;
-export type ConnectorEntry = z.infer<typeof connectorEntrySchema>;
-export type ExperimentalConnectors = z.infer<
-  typeof experimentalConnectorsSchema
->;
+export type ServiceApiEntry = z.infer<typeof serviceApiEntrySchema>;
+export type ExperimentalServices = z.infer<typeof experimentalServicesSchema>;


### PR DESCRIPTION
## Summary
- Rename `ConnectorProxyConfig` → `ServiceConfig`, `ConnectorEntry` → `ServiceApiEntry`, `experimental_connectors` → `experimental_services` across TS, Rust, Python, and E2E
- Change data structure from `{name, base}` to `{base, auth: {headers}}` so auth templates travel with API entries
- Move auth endpoint from `/connectors/auth` to `/services/auth` with base-URL-only lookup (no `connectorName` in request body)

Part of #4318

## Test plan
- [x] Rust: `cargo clippy` passes
- [x] TS: lint, check-types, format, knip all pass
- [x] Python: 23/23 mitm-addon tests pass
- [x] TS: connectors.test (11 tests) + expand-environment.test (6 tests) pass
- [x] Auth endpoint test updated for new API shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)