### PR TITLE
docs: remove outdated e2b references from documentation

### DIFF
--- a/.claude/skills/dev-server/SKILL.md
+++ b/.claude/skills/dev-server/SKILL.md
@@ -16,7 +16,7 @@ Parse the args above to determine which operation to perform:
 - **stop**: Stop the background development server
 - **logs [pattern]**: View development server logs with optional filtering
 - **auth**: Authenticate with local development server and get CLI token
-- **tunnel**: Full setup with tunnel and CLI authentication (for E2B testing)
+- **tunnel**: Full setup with tunnel and CLI authentication
 
 **Note**: As of issue #1726, the web app automatically starts a Cloudflare tunnel when running `pnpm dev`. The tunnel URL is displayed during startup and `VM0_API_URL` is set automatically.
 
@@ -26,7 +26,7 @@ Parse the args above to determine which operation to perform:
 
 Start the Turbo development server in background with stream UI mode.
 
-**Note**: The web app now automatically starts a Cloudflare tunnel during dev startup. This means `VM0_API_URL` is set automatically and E2B webhooks will work out of the box. The web app takes ~15 seconds longer to start than other packages due to tunnel setup.
+**Note**: The web app now automatically starts a Cloudflare tunnel during dev startup. This means `VM0_API_URL` is set automatically and webhooks will work out of the box. The web app takes ~15 seconds longer to start than other packages due to tunnel setup.
 
 ## Workflow
 
@@ -444,7 +444,7 @@ If authentication fails:
 
 # Operation: tunnel
 
-Full development environment setup with Cloudflare tunnel and CLI authentication. Useful for E2B webhook testing.
+Full development environment setup with Cloudflare tunnel and CLI authentication. Useful for webhook testing.
 
 **Note**: Since issue #1726, the web app automatically starts a Cloudflare tunnel when running `pnpm dev`. This operation is useful when you need the **complete setup** including CLI authentication.
 
@@ -567,7 +567,7 @@ VM0_API_URL exported to: <tunnel-url>
 ✅ CLI authentication successful!
 Auth token saved to: ~/.vm0/config.json
 
-You can now test E2B webhooks locally:
+You can now test webhooks locally:
   vm0 run <agent-name> "<prompt>"
 
 Use `/dev-stop` to stop the server.

--- a/.claude/skills/local-testing/skill.md
+++ b/.claude/skills/local-testing/skill.md
@@ -23,7 +23,7 @@ cd turbo && pnpm vitest run
 ### CLI E2E Tests
 
 ```bash
-# 1. Start dev server with tunnel (required for E2B webhooks)
+# 1. Start dev server with tunnel (required for webhooks)
 /dev-start
 
 # 2. Wait for server to be ready, then authenticate CLI
@@ -47,7 +47,6 @@ Ensure the following are set in `turbo/apps/web/.env.local`:
 | `USE_MOCK_CLAUDE` | Enable mock Claude for testing (set to `true`) | Yes for E2E |
 | `CONCURRENT_RUN_LIMIT` | Set to `0` to disable run limits during testing | Yes for E2E |
 | `SECRETS_ENCRYPTION_KEY` | Encryption key for secrets | Yes |
-| `E2B_API_KEY` | E2B sandbox API key | Yes for E2E |
 | `CLERK_SECRET_KEY` | Clerk authentication | Yes |
 | `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` | Clerk authentication | Yes |
 
@@ -81,7 +80,7 @@ This will:
 - Start the Turbo dev server in background
 - Automatically start a Cloudflare tunnel for the web app
 - Set `VM0_API_URL` to the tunnel URL
-- Enable E2B webhooks to reach your local server
+- Enable webhooks to reach your local server
 
 ### Manual Start
 
@@ -96,7 +95,7 @@ Check for these indicators in the logs (`/dev-logs`):
 - `Ready in XXXms` for each app
 - No fatal errors
 
-**Important**: The tunnel URL changes each time you restart. E2B sandbox webhooks use this URL to send events back to your local server.
+**Important**: The tunnel URL changes each time you restart. Sandbox webhooks use this URL to send events back to your local server.
 
 ---
 
@@ -204,12 +203,10 @@ BATS_TEST_TIMEOUT=60 \
 
 When `USE_MOCK_CLAUDE=true`:
 
-1. The web server passes this to E2B sandbox via environment variable
+1. The web server passes this to the sandbox via environment variable
 2. Inside sandbox, `run-agent.ts` checks for `USE_MOCK_CLAUDE`
-3. Instead of running real `claude` CLI, it runs `/usr/local/bin/vm0-agent/mock-claude.mjs`
+3. Instead of running real `claude` CLI, it runs the mock Claude script
 4. Mock Claude executes the prompt as a bash command and outputs Claude-compatible JSONL
-
-Mock Claude location: `turbo/packages/sandbox-scripts/src/scripts/mock-claude.ts`
 
 ---
 
@@ -240,7 +237,7 @@ cd turbo && pnpm vitest run
 
 ### Problem: "Failed to fetch events" or Run Hangs
 
-**Cause**: E2B sandbox cannot reach the tunnel URL (webhooks fail)
+**Cause**: Sandbox cannot reach the tunnel URL (webhooks fail)
 
 **Solution**:
 1. Check if tunnel is active: `/dev-logs tunnel`
@@ -271,7 +268,7 @@ echo "CONCURRENT_RUN_LIMIT=0" >> turbo/apps/web/.env.local
 **Solution**:
 - Ensure `BATS_TEST_TIMEOUT` is set appropriately (60s for parallel tests)
 - Check server logs for errors: `/dev-logs error`
-- Verify E2B sandbox is starting: `/dev-logs sandbox`
+- Verify sandbox is starting: `/dev-logs sandbox`
 
 ### Problem: "SECRETS_ENCRYPTION_KEY" Missing or Other Environment Variables Missing
 
@@ -365,5 +362,4 @@ vm0 run <agent-name> --artifact-name <artifact> "echo hello"
 
 - CLI E2E Testing Patterns: `.claude/skills/cli-e2e-testing/skill.md`
 - Dev Server Management: `.claude/skills/dev-server/skill.md`
-- Mock Claude Source: `turbo/packages/sandbox-scripts/src/scripts/mock-claude.ts`
-- E2B Executor: `turbo/apps/web/src/lib/run/executors/e2b-executor.ts`
+- Runner Executor: `turbo/apps/web/src/lib/run/executors/runner-executor.ts`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,12 +23,6 @@ You need to register the following services and obtain API keys:
 | [Clerk](https://clerk.com) | User authentication and session management | `CLERK_SECRET_KEY`, `CLERK_PUBLISHABLE_KEY` |
 | [Cloudflare R2](https://www.cloudflare.com/products/r2/) | Object storage for user files and artifacts | `R2_ACCOUNT_ID`, `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`, `R2_USER_STORAGES_BUCKET_NAME` |
 
-**Optional** (only needed for specific features):
-
-| Service | Purpose | Keys needed |
-|---------|---------|-------------|
-| [E2B](https://e2b.dev) | Cloud sandbox for running agents | `E2B_API_KEY` |
-
 All other environment variables (OAuth connectors, Slack, Axiom, etc.) can be left empty.
 
 ### SSL Certificates
@@ -75,7 +69,7 @@ cp turbo/apps/platform/.env.local.tpl turbo/apps/platform/.env.local
 
 Then edit the `.env.local` files:
 
-1. Replace `op://...` values for required services (Clerk, E2B, Cloudflare R2) with your actual keys
+1. Replace `op://...` values for required services (Clerk, Cloudflare R2) with your actual keys
 2. For `SECRETS_ENCRYPTION_KEY`, generate one:
    ```bash
    openssl rand -hex 32

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ npm install -g @vm0/cli && vm0 onboard
   </a>
 </p>
 
-- **[Architecture Documentation](./docs/architecture.md)** - Comprehensive technical reference covering sandbox technologies (E2B, Firecracker), infrastructure components and network architecture
+- **[Architecture Documentation](./docs/architecture.md)** - Comprehensive technical reference covering sandbox technologies (Firecracker microVMs), infrastructure components and network architecture
 
 For user-facing guides and tutorials, visit [docs.vm0.ai](https://docs.vm0.ai).
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -8,7 +8,6 @@
   - [Storage](#storage)
   - [Orchestration](#orchestration)
 - [Infrastructure](#infrastructure)
-  - [E2B Sandbox Backend](#e2b-sandbox-backend)
   - [Firecracker Sandbox Backend](#firecracker-sandbox-backend)
   - [Cloudflare R2 Object Storage](#cloudflare-r2-object-storage)
 - [References](#references)
@@ -19,7 +18,7 @@
 
 VM0 is a platform for running AI agent workflows in isolated sandbox environments. The platform consists of three core subsystems:
 
-1. **Compute**: Sandbox execution (E2B or Firecracker microVMs)
+1. **Compute**: Sandbox execution (Firecracker microVMs)
 2. **Storage**: User data persistence (Cloudflare R2)
 3. **Orchestration**: Job queue and runner coordination (PostgreSQL)
 
@@ -31,9 +30,9 @@ User CLI/API Request
   ↓
 Web API (Next.js)
   ↓
-Executor Selection (E2B or Runner)
+Runner Executor (job queue)
   ↓
-Compute Layer (Sandbox)
+Compute Layer (Firecracker microVM)
   ↓ (downloads from)
 Storage Layer (R2)
   ↓ (reports via webhooks)
@@ -50,31 +49,13 @@ User receives results
 
 The compute layer executes agent workflows in isolated sandbox environments.
 
-#### Two Execution Backends
+#### Execution Backend: Firecracker
 
-**1. E2B (Default)**
-- Third-party managed sandbox service (e2b.dev)
-- Container-based isolation
-- Template system for environment configuration
-- 2-hour timeout (production), 1-hour (development)
-- Fire-and-forget execution with webhook callbacks
-
-**2. Firecracker (Experimental)**
 - Self-hosted microVMs on bare metal Linux
 - Hardware-level isolation via KVM
 - 3-5 second boot time
 - Network namespace isolation per VM
-- Requires runner infrastructure
-
-#### Executor Selection
-
-```
-if experimental_runner.group specified:
-  → Queue job in runner_job_queue
-  → Firecracker runner polls and executes
-else:
-  → Execute immediately via E2B
-```
+- Jobs queued in `runner_job_queue`, runners poll and execute
 
 ---
 
@@ -143,27 +124,6 @@ The orchestration layer coordinates job execution between web API and runners.
 ---
 
 ## Infrastructure
-
-### E2B Sandbox Backend
-
-E2B (e2b.dev) is a third-party managed sandbox service that provides containerized execution environments.
-
-#### Integration
-
-- SDK: `@e2b/code-interpreter`
-- Template: Specified via `agent.image` in `vm0.yaml` (defaults to `vm0/claude-code`)
-- Authentication: `E2B_API_KEY`
-
-#### Execution Flow
-
-1. Create sandbox with environment variables
-2. Upload Python/Node.js scripts via tar bundle
-3. Download storages from R2 via presigned URLs
-4. Restore session history (for resume)
-5. Start agent CLI in background (nohup)
-6. Webhook reports progress and completion
-
----
 
 ### Firecracker Sandbox Backend
 
@@ -282,7 +242,6 @@ Sandboxes download directly from R2 (no proxy through VM0 API):
 ### External
 
 - [Firecracker](https://github.com/firecracker-microvm/firecracker)
-- [E2B](https://e2b.dev)
 - [Cloudflare R2](https://developers.cloudflare.com/r2/)
 - [mitmproxy](https://mitmproxy.org/)
 

--- a/docs/bad-smell.md
+++ b/docs/bad-smell.md
@@ -99,15 +99,15 @@ function generateToken() {
 
 // ❌ Bad: Dynamic import for "lazy loading"
 async function handleClick() {
-  const { E2BExecutor } = await import("./e2b-executor");
-  await E2BExecutor.doSomething();
+  const { RunService } = await import("./run-service");
+  await RunService.doSomething();
 }
 
 // ✅ Good: Static import
-import { E2BExecutor } from "./e2b-executor";
+import { RunService } from "./run-service";
 
 async function handleClick() {
-  await E2BExecutor.doSomething();
+  await RunService.doSomething();
 }
 ```
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -62,7 +62,7 @@ Our rule is simple: **mock at the system boundary, nowhere else.**
 
 ```
 External (MOCK):
-├── Third-party services (Clerk, E2B, AWS, Anthropic)
+├── Third-party services (Clerk, AWS, Anthropic)
 ├── External APIs (via MSW)
 └── Node.js built-ins when necessary (child_process)
 
@@ -212,7 +212,6 @@ Test route handlers directly, mock only external services:
 
 ```typescript
 vi.mock("@clerk/nextjs/server");
-vi.mock("@e2b/code-interpreter");
 
 it("should create a run", async () => {
   mockAuth({ userId: "user-123" });
@@ -220,7 +219,7 @@ it("should create a run", async () => {
   const response = await POST(request);
   const data = await response.json();
 
-  expect(data.status).toBe("running");
+  expect(data.status).toBe("pending");
 });
 ```
 

--- a/docs/testing/anti-patterns.md
+++ b/docs/testing/anti-patterns.md
@@ -137,7 +137,6 @@ What should you mock? Only external third-party packages:
 // These are correct
 vi.mock("@clerk/nextjs");
 vi.mock("@aws-sdk/client-s3");
-vi.mock("@e2b/code-interpreter");
 vi.mock("@anthropic-ai/sdk");
 ```
 

--- a/docs/testing/cli-e2e-testing.md
+++ b/docs/testing/cli-e2e-testing.md
@@ -32,7 +32,7 @@ E2E tests verify the system works end-to-end. Error cases belong in CLI Command 
 
 Each `vm0 run` call takes ~15 seconds due to:
 - API call to platform
-- E2B sandbox creation
+- Runner job queuing and sandbox creation
 - Volume/artifact mounting
 - Mock Claude execution
 - Checkpoint creation

--- a/docs/testing/cli-testing.md
+++ b/docs/testing/cli-testing.md
@@ -526,7 +526,7 @@ it("should display schedule details", async () => {
 | Aspect | Web | CLI |
 |--------|-----|-----|
 | **Entry Point** | API route handler | `command.parseAsync()` |
-| **External (Mock)** | Clerk, AWS, E2B | Web API (MSW), Ably |
+| **External (Mock)** | Clerk, AWS | Web API (MSW), Ably |
 | **Internal (Real)** | Database, services | Filesystem, config, validators |
 | **State Storage** | Database | Filesystem (temp dirs) |
 | **User Interface** | HTTP response | Console output + exit codes |

--- a/docs/testing/patterns.md
+++ b/docs/testing/patterns.md
@@ -23,7 +23,6 @@ import { mockClerk } from "../../../../../src/__tests__/clerk-mock";
 // ========== MOCKS SECTION ==========
 // Only mock EXTERNAL third-party packages
 vi.mock("@clerk/nextjs/server");
-vi.mock("@e2b/code-interpreter");
 vi.mock("@aws-sdk/client-s3");
 vi.mock("@aws-sdk/s3-request-presigner");
 vi.mock("@axiomhq/js");
@@ -43,10 +42,10 @@ describe("POST /api/agent/runs", () => {
     testComposeId = composeId;
   });
 
-  it("should create a run with running status", async () => {
+  it("should create a run with pending status", async () => {
     const data = await createTestRun(testComposeId, "Test prompt");
 
-    expect(data.status).toBe("running");
+    expect(data.status).toBe("pending");
     expect(data.runId).toBeDefined();
   });
 });
@@ -56,7 +55,7 @@ The key points:
 
 1. **Mocks at the top, before imports**. Vitest hoists `vi.mock()` calls, so putting them at the top makes the hoisting explicit.
 
-2. **Only mock external dependencies**. Clerk, E2B, S3, Axiom are third-party SaaS requiring API keys. Our internal services use real implementations.
+2. **Only mock external dependencies**. Clerk, S3, Axiom are third-party SaaS requiring API keys. Our internal services use real implementations.
 
 3. **`testContext()` outside describe blocks**. This provides `setupMocks()` for external service mocks and `setupUser()` for isolated user context.
 
@@ -568,7 +567,6 @@ import { mockClerk } from "../../../../../src/__tests__/clerk-mock";
 // ========== MOCKS SECTION ==========
 // Only mock EXTERNAL third-party packages
 vi.mock("@clerk/nextjs/server");
-vi.mock("@e2b/code-interpreter");
 vi.mock("@aws-sdk/client-s3");
 vi.mock("@aws-sdk/s3-request-presigner");
 vi.mock("@axiomhq/js");
@@ -589,14 +587,14 @@ describe("POST /api/agent/runs", () => {
   });
 
   // ========== TEST CASES ==========
-  it("should create a run with running status", async () => {
+  it("should create a run with pending status", async () => {
     // Given - fixtures prepared in beforeEach
 
     // When - execute behavior under test
     const data = await createTestRun(testComposeId, "Test prompt");
 
     // Then - assert the HTTP response
-    expect(data.status).toBe("running");
+    expect(data.status).toBe("pending");
     expect(data.runId).toBeDefined();
   });
 
@@ -631,7 +629,6 @@ Note what's absent compared to older patterns:
 
 - `@clerk/nextjs` - Authentication service
 - `@aws-sdk/client-s3` - Cloud storage
-- `@e2b/code-interpreter` - Sandbox service
 - `@anthropic-ai/sdk` - AI API
 - `@axiomhq/js` - Logging SaaS
 - `@stripe/stripe-js` - Payment API

--- a/docs/testing/web-testing.md
+++ b/docs/testing/web-testing.md
@@ -50,14 +50,14 @@ describe("POST /api/agent/runs", () => {
     testComposeId = composeId;
   });
 
-  it("should create a run with running status", async () => {
+  it("should create a run with pending status", async () => {
     // Given - fixtures prepared in beforeEach
 
     // When - execute the behavior under test
     const data = await createTestRun(testComposeId, "Test prompt");
 
     // Then - assert the result
-    expect(data.status).toBe("running");
+    expect(data.status).toBe("pending");
     expect(data.runId).toBeDefined();
   });
 });
@@ -277,16 +277,11 @@ If you find yourself needing `initServices()`, it's a sign that you're accessing
 Run state transitions should be done via webhook helpers, not direct database modifications:
 
 ```typescript
-// Create run (status automatically set to running)
+// Create run (status automatically set to pending)
 const { runId } = await createTestRun(composeId, "test prompt");
 
 // Complete run (via checkpoint + complete webhook)
 await completeTestRun(user.userId, runId);
-
-// Test failure scenarios - mock Sandbox creation failure
-vi.mocked(Sandbox.create).mockRejectedValueOnce(new Error("Sandbox failed"));
-const data = await createTestRun(composeId, "test");
-expect(data.status).toBe("failed");
 ```
 
 ---

--- a/docs/testing/web-testing.md
+++ b/docs/testing/web-testing.md
@@ -33,7 +33,6 @@ import {
 import { mockClerk } from "../../../../../src/__tests__/clerk-mock";
 
 vi.mock("@clerk/nextjs/server");
-vi.mock("@e2b/code-interpreter");
 vi.mock("@aws-sdk/client-s3");
 vi.mock("@aws-sdk/s3-request-presigner");
 vi.mock("@axiomhq/js");
@@ -130,7 +129,6 @@ vi.mock("../../../lib/agent-session", () => ({
 ```typescript
 // Only mock external services
 vi.mock("@clerk/nextjs/server");
-vi.mock("@e2b/code-interpreter");
 vi.mock("@aws-sdk/client-s3");
 vi.mock("@aws-sdk/s3-request-presigner");
 vi.mock("@axiomhq/js");
@@ -150,7 +148,7 @@ const context = testContext(); // Outside all describe blocks
 
 describe("...", () => {
   beforeEach(() => {
-    context.setupMocks(); // Set up default mock behavior for E2B, S3, Axiom, etc.
+    context.setupMocks(); // Set up default mock behavior for S3, Axiom, etc.
   });
 });
 ```
@@ -694,7 +692,7 @@ it("should run agent", async () => {
 
 ```typescript
 // ✅ Do this - mock only external services, verify behavior through response
-vi.mock("@e2b/code-interpreter"); // External service
+vi.mock("@clerk/nextjs/server"); // External service
 
 it("should run agent", async () => {
   const response = await POST(request);


### PR DESCRIPTION
## Summary
- Remove E2B executor references from architecture docs (runs now use runner executor)
- Update testing docs to remove `@e2b/code-interpreter` mock examples and fix status assertions (`running` → `pending`)
- Update skill files (dev-server, local-testing) to remove E2B-specific language
- Clean up README and CONTRIBUTING to remove E2B as a prerequisite

> E2B references in CI/deployment docs are intentionally kept — compose jobs still use E2B.

Part of #3989 (PR 4: documentation cleanup).

## Test plan
- [x] Documentation-only changes, no code impact
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)