### PR TITLE
fix(core): rename zapier services/service to apis/api

### DIFF
--- a/turbo/packages/core/src/contracts/connectors.ts
+++ b/turbo/packages/core/src/contracts/connectors.ts
@@ -3072,9 +3072,7 @@ const SERVICE_CONFIGS: Partial<Record<ConnectorType, ServiceConfig>> = {
     apis: [api("https://www.wrike.com/api/v4", bearerAuth("WRIKE_TOKEN"))],
   },
   zapier: {
-    services: [
-      service("https://actions.zapier.com", bearerAuth("ZAPIER_TOKEN")),
-    ],
+    apis: [api("https://actions.zapier.com", bearerAuth("ZAPIER_TOKEN"))],
   },
   zapsign: {
     apis: [


### PR DESCRIPTION
## Summary
- Zapier connector (#4401) was merged using old `services`/`service()` naming convention
- The rename refactor (#4388) changed these to `apis`/`api()`, but zapier was added concurrently
- Fixes type check failure on main

## Test plan
- [ ] `lint-types` CI check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)