### PR TITLE
refactor: remove defensive catch-null patterns from org data lookups

### DIFF
--- a/turbo/apps/web/app/api/cron/execute-schedules/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/cron/execute-schedules/__tests__/route.test.ts
@@ -10,7 +10,10 @@ import {
   getTestScheduleRuns,
   disableAllSchedules,
 } from "../../../../../src/__tests__/api-test-helpers";
-import { testContext } from "../../../../../src/__tests__/test-helpers";
+import {
+  testContext,
+  uniqueId,
+} from "../../../../../src/__tests__/test-helpers";
 import { reloadEnv } from "../../../../../src/env";
 
 const context = testContext();
@@ -22,9 +25,7 @@ describe("GET /api/cron/execute-schedules", () => {
     context.setupMocks();
     await context.setupUser();
 
-    const { composeId } = await createTestCompose(
-      `cron-test-agent-${Date.now()}`,
-    );
+    const { composeId } = await createTestCompose(uniqueId("cron-agent"));
     testComposeId = composeId;
   });
 

--- a/turbo/apps/web/app/api/platform/logs/route.ts
+++ b/turbo/apps/web/app/api/platform/logs/route.ts
@@ -21,7 +21,10 @@ import {
   getOrgBySlug,
 } from "../../../../src/lib/scope/org-cache-service";
 import { getUserId } from "../../../../src/lib/auth/get-user-id";
+import { logger } from "../../../../src/lib/logger";
 import { eq, and, desc, lt, or, ilike, count, type SQL } from "drizzle-orm";
+
+const log = logger("api:platform:logs");
 
 // Minimal type for extracting framework from compose content
 interface AgentComposeContent {
@@ -196,19 +199,24 @@ const router = tsr.router(platformLogsListContract, {
       .orderBy(desc(agentRuns.createdAt), desc(agentRuns.id))
       .limit(limit + 1);
 
-    // Resolve scope slugs via org cache
+    // Resolve scope slugs via org cache (skip orgs that fail lookup)
     const uniqueClerkOrgIds = [
       ...new Set(runs.filter((r) => r.clerkOrgId).map((r) => r.clerkOrgId!)),
     ];
-    const orgDataEntries = await Promise.all(
-      uniqueClerkOrgIds.map(
-        async (id) => [id, await getOrgData(id).catch(() => null)] as const,
-      ),
-    );
     const slugMap = new Map<string, string>();
-    for (const [id, data] of orgDataEntries) {
-      if (data) slugMap.set(id, data.slug);
-    }
+    await Promise.all(
+      uniqueClerkOrgIds.map(async (id) => {
+        try {
+          const data = await getOrgData(id);
+          slugMap.set(id, data.slug);
+        } catch (err) {
+          log.warn("failed to resolve org slug for run", {
+            clerkOrgId: id,
+            error: err,
+          });
+        }
+      }),
+    );
 
     const totalCount = await getTotalCount(userId, query, scopeClerkOrgId);
     const totalPages = Math.max(1, Math.ceil(totalCount / limit));

--- a/turbo/apps/web/src/__tests__/test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/test-helpers.ts
@@ -397,6 +397,10 @@ export function testContext(): TestContext {
     // Create new controller for next test
     controller = new AbortController();
 
+    // Restore any stubbed globals (e.g. Date from setSystemTime) so the
+    // next test's beforeEach runs with the real clock.
+    vi.unstubAllGlobals();
+
     // Reset mocks and cached user for next test
     mockHelpers = null;
     mockUser = null;

--- a/turbo/apps/web/src/lib/agent/permission-service.ts
+++ b/turbo/apps/web/src/lib/agent/permission-service.ts
@@ -194,26 +194,31 @@ export async function getEmailSharedAgents(
     .where(and(...conditions))
     .orderBy(desc(agentComposes.createdAt));
 
-  // Resolve scope slugs via org cache
+  // Resolve scope slugs via org cache (skip orgs that fail lookup)
   const uniqueClerkOrgIds = [...new Set(rows.map((r) => r.clerkOrgId))];
   const orgDataResults = await Promise.all(
     uniqueClerkOrgIds.map(async (id) => {
-      const orgData = await getOrgData(id).catch(() => null);
-      return [id, orgData] as const;
+      try {
+        return [id, await getOrgData(id)] as const;
+      } catch (err) {
+        log.warn("failed to resolve org data for shared agent", {
+          clerkOrgId: id,
+          error: err,
+        });
+        return [id, null] as const;
+      }
     }),
   );
-  const orgDataMap = new Map(orgDataResults);
+  const orgDataMap = new Map(orgDataResults.filter(([, v]) => v !== null));
 
-  return rows
-    .filter((row) => orgDataMap.get(row.clerkOrgId) !== null)
-    .map((row) => ({
-      id: row.id,
-      name: row.name,
-      headVersionId: row.headVersionId,
-      createdAt: row.createdAt,
-      updatedAt: row.updatedAt,
-      scopeSlug: orgDataMap.get(row.clerkOrgId)?.slug ?? "",
-    }));
+  return rows.map((row) => ({
+    id: row.id,
+    name: row.name,
+    headVersionId: row.headVersionId,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+    scopeSlug: orgDataMap.get(row.clerkOrgId)?.slug ?? "",
+  }));
 }
 
 /**

--- a/turbo/apps/web/src/lib/run/context/execution-preparer.ts
+++ b/turbo/apps/web/src/lib/run/context/execution-preparer.ts
@@ -220,12 +220,10 @@ export async function prepareForExecution(
     throw badRequest("Agent compose not found");
   }
 
-  const agentOrgData = await getOrgData(agentComposeInfo.clerkOrgId).catch(
-    () => null,
-  );
+  const agentOrgData = await getOrgData(agentComposeInfo.clerkOrgId);
   const agentScopeInfo = {
     clerkOrgId: agentComposeInfo.clerkOrgId,
-    scopeSlug: agentOrgData?.slug ?? "",
+    scopeSlug: agentOrgData.slug,
   };
 
   // Auto-create artifact and memory storages if they don't exist yet

--- a/turbo/apps/web/src/lib/schedule/schedule-service.ts
+++ b/turbo/apps/web/src/lib/schedule/schedule-service.ts
@@ -837,7 +837,7 @@ async function executeSchedule(
   }
 
   // Load org tier and slug from org_cache (Clerk as source of truth)
-  const orgData = await getOrgData(schedule.clerkOrgId).catch(() => null);
+  const orgData = await getOrgData(schedule.clerkOrgId);
 
   // Build callbacks for run completion notifications
   const callbacks: Array<{ url: string; secret: string; payload: unknown }> =
@@ -849,9 +849,7 @@ async function executeSchedule(
     userId: schedule.userId,
   };
 
-  const prefs = orgData
-    ? await getUserPreferences(orgData.clerkOrgId, schedule.userId)
-    : { timezone: null, notifyEmail: false, notifySlack: true };
+  const prefs = await getUserPreferences(orgData.clerkOrgId, schedule.userId);
 
   // Email schedule notification callback (only if Resend is configured AND user opted in)
   if (globalThis.services.env.RESEND_API_KEY && prefs.notifyEmail) {
@@ -898,9 +896,9 @@ async function executeSchedule(
       agentName: compose.name,
       callbacks,
       scopeId: schedule.scopeId,
-      scopeSlug: orgData?.slug,
-      clerkOrgId: orgData?.clerkOrgId,
-      scopeTier: orgData ? scopeTierSchema.parse(orgData.tier) : undefined,
+      scopeSlug: orgData.slug,
+      clerkOrgId: orgData.clerkOrgId,
+      scopeTier: scopeTierSchema.parse(orgData.tier),
     });
     runId = result.runId;
   } catch (error) {


### PR DESCRIPTION
## Summary
- Remove `.catch(() => null)` from `getOrgData` calls in single-entity endpoints (`execution-preparer`, `schedule-service`) where failures should propagate naturally
- Add resilient try/catch with `log.warn` for aggregation endpoints (`permission-service`, `platform/logs`) that should gracefully skip failed org lookups
- Add `vi.unstubAllGlobals()` to test `afterEach` to prevent `Date` stub leaks between tests
- Fix cron test compose naming to use `uniqueId()` instead of `Date.now()` to avoid stale version collisions

## Context
Follow-up cleanup from #4373 (forward + reverse lookup migration). Addresses the review suggestion to remove defensive `.catch(() => null)` wrappers now that `getOrgData` uses the org_cache table with Clerk API fallback.

## Test plan
- [x] All 3696 tests pass (full suite)
- [x] Type check passes
- [x] Lint passes
- [x] Format passes
- [x] Knip passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)