### PR TITLE
refactor: rename clerk identity fields to provider-agnostic names

### DIFF
--- a/docs/resource-model.md
+++ b/docs/resource-model.md
@@ -172,7 +172,7 @@ Phase 2: Prepare for Execution (Agent Org + Runtime Org)
   └── Generate storage manifest with presigned URLs
 ```
 
-All Runtime Org queries use the **(clerkOrgId, userId)** key to locate the correct user-specific resources.
+All Runtime Org queries use the **(orgId, userId)** key to locate the correct user-specific resources.
 
 ---
 
@@ -192,4 +192,4 @@ Runtime Org = org-b, userId = User B
   → User B's artifacts and memories
 ```
 
-This pattern is also used by **scheduled runs**. A schedule carries its own `(clerkOrgId, userId)` pair, which becomes the Runtime Org when the schedule fires. This allows User B to schedule User A's agent while using User B's own credentials and producing User B's own artifacts.
+This pattern is also used by **scheduled runs**. A schedule carries its own `(orgId, userId)` pair, which becomes the Runtime Org when the schedule fires. This allows User B to schedule User A's agent while using User B's own credentials and producing User B's own artifacts.

--- a/turbo/apps/web/app/api/agent/composes/[id]/__tests__/delete-storage-cleanup.test.ts
+++ b/turbo/apps/web/app/api/agent/composes/[id]/__tests__/delete-storage-cleanup.test.ts
@@ -32,10 +32,7 @@ describe("Delete Agent - Instructions Storage Cleanup", () => {
     await createTestVolume(storageName);
 
     // Verify volume exists and get its s3Prefix
-    const storageBefore = await findTestStorageByName(
-      user.clerkOrgId,
-      storageName,
-    );
+    const storageBefore = await findTestStorageByName(user.orgId, storageName);
     expect(storageBefore).toBeDefined();
     const { s3Prefix } = storageBefore!;
 
@@ -54,10 +51,7 @@ describe("Delete Agent - Instructions Storage Cleanup", () => {
     expect(response.status).toBe(204);
 
     // Instructions volume should be deleted from DB
-    const storageAfter = await findTestStorageByName(
-      user.clerkOrgId,
-      storageName,
-    );
+    const storageAfter = await findTestStorageByName(user.orgId, storageName);
     expect(storageAfter).toBeUndefined();
 
     // S3 objects should be listed and deleted
@@ -106,13 +100,13 @@ describe("Delete Agent - Instructions Storage Cleanup", () => {
 
     // Instructions volume should be deleted
     const instructionsAfter = await findTestStorageByName(
-      user.clerkOrgId,
+      user.orgId,
       instructionsName,
     );
     expect(instructionsAfter).toBeUndefined();
 
     // Skill volume should still exist
-    const skillAfter = await findTestStorageByName(user.clerkOrgId, skillName);
+    const skillAfter = await findTestStorageByName(user.orgId, skillName);
     expect(skillAfter).toBeDefined();
   });
 });

--- a/turbo/apps/web/app/api/agent/composes/[id]/__tests__/permission.test.ts
+++ b/turbo/apps/web/app/api/agent/composes/[id]/__tests__/permission.test.ts
@@ -16,12 +16,12 @@ const context = testContext();
 
 describe("Agent Compose Permission Checks", () => {
   let testComposeId: string;
-  let ownerClerkOrgId: string;
+  let ownerOrgId: string;
 
   beforeEach(async () => {
     context.setupMocks();
     const user = await context.setupUser();
-    ownerClerkOrgId = user.clerkOrgId;
+    ownerOrgId = user.orgId;
 
     const { composeId } = await createTestCompose(uniqueId("agent"));
     testComposeId = composeId;
@@ -145,13 +145,13 @@ describe("Agent Compose Permission Checks", () => {
 
     it("should allow access when user is a member of the same org (JWT fast path)", async () => {
       // Switch to another user whose active org matches the compose's org
-      // This exercises the JWT fast path (authResult.orgId === compose.clerkOrgId)
+      // This exercises the JWT fast path (authResult.orgId === compose.orgId)
       mockClerk({
         userId: "other-user-123",
-        orgId: ownerClerkOrgId,
+        orgId: ownerOrgId,
         clerkOrgs: [
           {
-            id: ownerClerkOrgId,
+            id: ownerOrgId,
             slug: "shared-org",
             name: "Shared Org",
           },
@@ -185,7 +185,7 @@ describe("Agent Compose Permission Checks", () => {
             name: "Different Org",
           },
           {
-            id: ownerClerkOrgId,
+            id: ownerOrgId,
             slug: "shared-org",
             name: "Shared Org",
           },
@@ -209,7 +209,7 @@ describe("Agent Compose Permission Checks", () => {
       // If the cache is working, the user gets access without Clerk API finding membership.
       const cacheUserId = "cache-user-789";
       await insertOrgMembersCacheEntry({
-        clerkOrgId: ownerClerkOrgId,
+        orgId: ownerOrgId,
         userId: cacheUserId,
         cachedAt: new Date(), // fresh
       });
@@ -241,7 +241,7 @@ describe("Agent Compose Permission Checks", () => {
       const staleUserId = "stale-cache-user-101";
       const staleCachedAt = new Date(Date.now() - 120_000); // 2 minutes ago
       await insertOrgMembersCacheEntry({
-        clerkOrgId: ownerClerkOrgId,
+        orgId: ownerOrgId,
         userId: staleUserId,
         cachedAt: staleCachedAt,
       });
@@ -253,7 +253,7 @@ describe("Agent Compose Permission Checks", () => {
         orgId: "org_other_active",
         clerkOrgs: [
           { id: "org_other_active", slug: "other", name: "Other Org" },
-          { id: ownerClerkOrgId, slug: "shared-org", name: "Shared Org" },
+          { id: ownerOrgId, slug: "shared-org", name: "Shared Org" },
         ],
       });
 
@@ -275,7 +275,7 @@ describe("Agent Compose Permission Checks", () => {
       const nonMemberUserId = "non-member-user-202";
       const staleCachedAt = new Date(Date.now() - 120_000); // 2 minutes ago
       await insertOrgMembersCacheEntry({
-        clerkOrgId: ownerClerkOrgId,
+        orgId: ownerOrgId,
         userId: nonMemberUserId,
         cachedAt: staleCachedAt,
       });

--- a/turbo/apps/web/app/api/agent/composes/[id]/instructions/route.ts
+++ b/turbo/apps/web/app/api/agent/composes/[id]/instructions/route.ts
@@ -55,7 +55,7 @@ export async function GET(
       id: agentComposes.id,
       userId: agentComposes.userId,
       scopeId: agentComposes.scopeId,
-      clerkOrgId: agentComposes.clerkOrgId,
+      orgId: agentComposes.orgId,
       name: agentComposes.name,
       content: agentComposeVersions.content,
     })
@@ -106,7 +106,7 @@ export async function GET(
     .from(storages)
     .where(
       and(
-        eq(storages.clerkOrgId, result.clerkOrgId),
+        eq(storages.orgId, result.orgId),
         eq(storages.name, storageName),
         eq(storages.type, "volume"),
       ),

--- a/turbo/apps/web/app/api/agent/composes/[id]/route.ts
+++ b/turbo/apps/web/app/api/agent/composes/[id]/route.ts
@@ -40,7 +40,7 @@ const router = tsr.router(composesByIdContract, {
       .select({
         id: agentComposes.id,
         userId: agentComposes.userId,
-        clerkOrgId: agentComposes.clerkOrgId,
+        orgId: agentComposes.orgId,
         name: agentComposes.name,
         headVersionId: agentComposes.headVersionId,
         createdAt: agentComposes.createdAt,
@@ -161,7 +161,7 @@ const router = tsr.router(composesByIdContract, {
       .from(storages)
       .where(
         and(
-          eq(storages.clerkOrgId, compose.clerkOrgId),
+          eq(storages.orgId, compose.orgId),
           eq(storages.name, storageName),
           eq(storages.type, "volume"),
         ),

--- a/turbo/apps/web/app/api/agent/composes/__tests__/get-by-name.test.ts
+++ b/turbo/apps/web/app/api/agent/composes/__tests__/get-by-name.test.ts
@@ -224,9 +224,9 @@ describe("GET /api/agent/composes?name=<name>", () => {
     // Create compose as owner
     const { composeId } = await createTestCompose(agentName);
 
-    // Get the owner's scope slug to derive clerkOrgId
+    // Get the owner's scope slug to derive orgId
     const ownerScope = await getTestScope(user.scopeId);
-    const ownerClerkOrgId = ownerScope.clerkOrgId;
+    const ownerOrgId = ownerScope.orgId;
 
     // Grant email permission to the recipient
     const recipientEmail = "recipient-org@example.com";
@@ -238,7 +238,7 @@ describe("GET /api/agent/composes?name=<name>", () => {
 
     // Access the agent via cross-scope lookup using ?org=
     const getRequest = createTestRequest(
-      `http://localhost:3000/api/agent/composes?name=${agentName}&org=${ownerClerkOrgId}`,
+      `http://localhost:3000/api/agent/composes?name=${agentName}&org=${ownerOrgId}`,
       { method: "GET" },
     );
 
@@ -256,16 +256,16 @@ describe("GET /api/agent/composes?name=<name>", () => {
     // Create compose as owner (no permission granted)
     await createTestCompose(agentName);
 
-    // Get the owner's scope slug to derive clerkOrgId
+    // Get the owner's scope slug to derive orgId
     const ownerScope = await getTestScope(user.scopeId);
-    const ownerClerkOrgId = ownerScope.clerkOrgId;
+    const ownerOrgId = ownerScope.orgId;
 
     // Switch to another user with no permission
     await context.setupUser({ prefix: "unauthorized-org" });
 
     // Try to access via cross-scope lookup using ?org=
     const getRequest = createTestRequest(
-      `http://localhost:3000/api/agent/composes?name=${agentName}&org=${ownerClerkOrgId}`,
+      `http://localhost:3000/api/agent/composes?name=${agentName}&org=${ownerOrgId}`,
       { method: "GET" },
     );
 

--- a/turbo/apps/web/app/api/agent/composes/list/route.ts
+++ b/turbo/apps/web/app/api/agent/composes/list/route.ts
@@ -25,7 +25,7 @@ const router = tsr.router(composesListContract, {
     const { userId, scopeId: tokenScopeId } = authCtx;
 
     // Resolve scope: use ?scope= query param or default scope
-    let clerkOrgId: string;
+    let orgId: string;
     try {
       const { scope: resolvedScope } = await resolveScope(
         userId,
@@ -33,7 +33,7 @@ const router = tsr.router(composesListContract, {
         query.org,
         tokenScopeId,
       );
-      clerkOrgId = resolvedScope.clerkOrgId;
+      orgId = resolvedScope.orgId;
     } catch (error) {
       if (isNotFound(error)) {
         return {
@@ -66,7 +66,7 @@ const router = tsr.router(composesListContract, {
         updatedAt: agentComposes.updatedAt,
       })
       .from(agentComposes)
-      .where(eq(agentComposes.clerkOrgId, clerkOrgId))
+      .where(eq(agentComposes.orgId, orgId))
       .orderBy(desc(agentComposes.updatedAt));
 
     // When using default scope (no ?scope= param), also include email-shared agents

--- a/turbo/apps/web/app/api/agent/composes/route.ts
+++ b/turbo/apps/web/app/api/agent/composes/route.ts
@@ -22,7 +22,7 @@ import { getAuthContext } from "../../../../src/lib/auth/get-user-id";
 import { eq, and } from "drizzle-orm";
 import { computeComposeVersionId } from "../../../../src/lib/agent-compose/content-hash";
 import { resolveScope } from "../../../../src/lib/scope/resolve-scope";
-import { getScopeByClerkOrgId } from "../../../../src/lib/scope/scope-service";
+import { getScopeByOrgId } from "../../../../src/lib/scope/scope-service";
 import { getOrgBySlug } from "../../../../src/lib/scope/org-cache-service";
 import { getUserEmail } from "../../../../src/lib/auth/get-user-email";
 import { canAccessCompose } from "../../../../src/lib/agent/permission-service";
@@ -48,7 +48,7 @@ const router = tsr.router(composesMainContract, {
     // isCrossScopeLookup is true when an explicit scope/org param is provided,
     // which requires canAccessCompose authorization below.
     const isCrossScopeLookup = Boolean(query.scope || query.org);
-    let clerkOrgId: string;
+    let orgId: string;
     if (query.scope) {
       const orgData = await getOrgBySlug(query.scope);
       if (!orgData) {
@@ -62,9 +62,9 @@ const router = tsr.router(composesMainContract, {
           },
         };
       }
-      clerkOrgId = orgData.clerkOrgId;
+      orgId = orgData.orgId;
     } else if (query.org) {
-      const scope = await getScopeByClerkOrgId(query.org);
+      const scope = await getScopeByOrgId(query.org);
       if (!scope) {
         return {
           status: 404 as const,
@@ -76,7 +76,7 @@ const router = tsr.router(composesMainContract, {
           },
         };
       }
-      clerkOrgId = scope.clerkOrgId;
+      orgId = scope.orgId;
     } else {
       const { scope: resolvedScope } = await resolveScope(
         userId,
@@ -84,7 +84,7 @@ const router = tsr.router(composesMainContract, {
         null,
         tokenScopeId,
       );
-      clerkOrgId = resolvedScope.clerkOrgId;
+      orgId = resolvedScope.orgId;
     }
 
     // JOIN compose + version in a single query
@@ -92,7 +92,7 @@ const router = tsr.router(composesMainContract, {
       .select({
         id: agentComposes.id,
         userId: agentComposes.userId,
-        clerkOrgId: agentComposes.clerkOrgId,
+        orgId: agentComposes.orgId,
         name: agentComposes.name,
         headVersionId: agentComposes.headVersionId,
         createdAt: agentComposes.createdAt,
@@ -105,10 +105,7 @@ const router = tsr.router(composesMainContract, {
         eq(agentComposes.headVersionId, agentComposeVersions.id),
       )
       .where(
-        and(
-          eq(agentComposes.clerkOrgId, clerkOrgId),
-          eq(agentComposes.name, query.name),
-        ),
+        and(eq(agentComposes.orgId, orgId), eq(agentComposes.name, query.name)),
       )
       .limit(1);
 
@@ -287,7 +284,7 @@ const router = tsr.router(composesMainContract, {
         .from(agentComposes)
         .where(
           and(
-            eq(agentComposes.clerkOrgId, scope.clerkOrgId),
+            eq(agentComposes.orgId, scope.orgId),
             eq(agentComposes.name, normalizedAgentName),
           ),
         )
@@ -315,7 +312,7 @@ const router = tsr.router(composesMainContract, {
           userId,
           scopeId: scope.id,
           name: normalizedAgentName,
-          clerkOrgId: scope.clerkOrgId,
+          orgId: scope.orgId,
         })
         .returning({ id: agentComposes.id });
 

--- a/turbo/apps/web/app/api/agent/runs/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/route.ts
@@ -485,7 +485,7 @@ const router = tsr.router(runsMainContract, {
         checkEnv: body.checkEnv,
         scopeId: scope.id,
         scopeSlug: scope.slug,
-        clerkOrgId: scope.clerkOrgId,
+        orgId: scope.orgId,
         scopeTier: scopeTierSchema.parse(scope.tier),
       });
 

--- a/turbo/apps/web/app/api/agent/schedules/[name]/disable/route.ts
+++ b/turbo/apps/web/app/api/agent/schedules/[name]/disable/route.ts
@@ -59,7 +59,7 @@ export async function POST(
   try {
     const schedule = await disableSchedule(
       userId,
-      scope.clerkOrgId,
+      scope.orgId,
       body.composeId,
       name,
     );

--- a/turbo/apps/web/app/api/agent/schedules/[name]/enable/route.ts
+++ b/turbo/apps/web/app/api/agent/schedules/[name]/enable/route.ts
@@ -59,7 +59,7 @@ export async function POST(
   try {
     const schedule = await enableSchedule(
       userId,
-      scope.clerkOrgId,
+      scope.orgId,
       body.composeId,
       name,
     );

--- a/turbo/apps/web/app/api/agent/schedules/[name]/route.ts
+++ b/turbo/apps/web/app/api/agent/schedules/[name]/route.ts
@@ -48,7 +48,7 @@ const router = tsr.router(schedulesByNameContract, {
 
       const schedule = await getScheduleByName(
         userId,
-        scope.clerkOrgId,
+        scope.orgId,
         query.composeId,
         params.name,
       );
@@ -100,12 +100,7 @@ const router = tsr.router(schedulesByNameContract, {
         };
       }
 
-      await deleteSchedule(
-        userId,
-        scope.clerkOrgId,
-        query.composeId,
-        params.name,
-      );
+      await deleteSchedule(userId, scope.orgId, query.composeId, params.name);
 
       return {
         status: 204 as const,

--- a/turbo/apps/web/app/api/agent/schedules/[name]/runs/route.ts
+++ b/turbo/apps/web/app/api/agent/schedules/[name]/runs/route.ts
@@ -47,7 +47,7 @@ const router = tsr.router(scheduleRunsContract, {
 
       const runs = await getScheduleRecentRuns(
         userId,
-        scope.clerkOrgId,
+        scope.orgId,
         query.composeId,
         params.name,
         query.limit,

--- a/turbo/apps/web/app/api/agent/schedules/missing-secrets/route.ts
+++ b/turbo/apps/web/app/api/agent/schedules/missing-secrets/route.ts
@@ -9,7 +9,7 @@ import {
   getUserAgents,
   batchFetchVersionContents,
 } from "../../../../../src/lib/agent/get-user-agents";
-import { getDefaultScopeByClerkUserId } from "../../../../../src/lib/scope/scope-service";
+import { getDefaultScopeByUserId } from "../../../../../src/lib/scope/scope-service";
 
 const log = logger("api:agents:missing-secrets");
 
@@ -51,7 +51,7 @@ export async function GET(request: Request) {
   }
 
   // Get user's scope to query configured secrets
-  const runtimeScope = await getDefaultScopeByClerkUserId(userId);
+  const runtimeScope = await getDefaultScopeByUserId(userId);
   if (!runtimeScope) {
     return NextResponse.json({ agents: [] });
   }
@@ -61,7 +61,7 @@ export async function GET(request: Request) {
   const userSecrets = await db
     .select({ name: secrets.name })
     .from(secrets)
-    .where(eq(secrets.clerkOrgId, runtimeScope.clerkOrgId));
+    .where(eq(secrets.orgId, runtimeScope.orgId));
 
   const configuredSecretNames = new Set(userSecrets.map((s) => s.name));
 

--- a/turbo/apps/web/app/api/agent/schedules/route.ts
+++ b/turbo/apps/web/app/api/agent/schedules/route.ts
@@ -45,7 +45,7 @@ const router = tsr.router(schedulesMainContract, {
         };
       }
 
-      const result = await deploySchedule(userId, scope.clerkOrgId, scopeId, {
+      const result = await deploySchedule(userId, scope.orgId, scopeId, {
         name: body.name,
         composeId: body.composeId,
         cronExpression: body.cronExpression,

--- a/turbo/apps/web/app/api/cli/auth/test-connector/route.ts
+++ b/turbo/apps/web/app/api/cli/auth/test-connector/route.ts
@@ -7,7 +7,7 @@ import {
   resolveTestUserId,
   isTestVariant,
 } from "../../../../../src/lib/auth/test-user";
-import { getDefaultScopeByClerkUserId } from "../../../../../src/lib/scope/scope-service";
+import { getDefaultScopeByUserId } from "../../../../../src/lib/scope/scope-service";
 import { env } from "../../../../../src/env";
 
 const bodySchema = z.object({
@@ -91,7 +91,7 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "Test user not found" }, { status: 500 });
   }
 
-  const scope = await getDefaultScopeByClerkUserId(userId);
+  const scope = await getDefaultScopeByUserId(userId);
   if (!scope) {
     return NextResponse.json(
       { error: "Test user has no scope — run test-token first" },
@@ -100,7 +100,7 @@ export async function POST(request: Request) {
   }
 
   await upsertOAuthConnector(
-    scope.clerkOrgId,
+    scope.orgId,
     scope.id,
     userId,
     connectorType,

--- a/turbo/apps/web/app/api/cli/auth/test-token/route.ts
+++ b/turbo/apps/web/app/api/cli/auth/test-token/route.ts
@@ -49,19 +49,19 @@ function isTestTokenAllowed(request: Request): boolean {
  */
 async function ensureTestScope(
   userId: string,
-): Promise<{ scopeId: string; clerkOrgId: string }> {
+): Promise<{ scopeId: string; orgId: string }> {
   let scope;
   try {
     scope = await ensureDefaultScope(userId);
   } catch (error) {
     if (!isNotFound(error)) throw error;
-    // User has no Clerk org — create a test scope with a sentinel clerkOrgId
+    // User has no Clerk org — create a test scope with a sentinel orgId
     const slug = generateDefaultScopeSlug(userId);
     scope = await createScope(userId, slug, {
-      clerkOrgId: `org_test_${userId}`,
+      orgId: `org_test_${userId}`,
     });
   }
-  return { scopeId: scope.id, clerkOrgId: scope.clerkOrgId };
+  return { scopeId: scope.id, orgId: scope.orgId };
 }
 
 /**
@@ -92,7 +92,7 @@ export async function POST(request: Request) {
   }
 
   // Auto-create scope if user doesn't have one (creates real Clerk org)
-  const { scopeId, clerkOrgId } = await ensureTestScope(userId);
+  const { scopeId, orgId } = await ensureTestScope(userId);
 
   // Generate CLI token with scope binding
   const randomBytes = crypto.randomBytes(32);
@@ -105,7 +105,7 @@ export async function POST(request: Request) {
     userId,
     name: "CI Test Token",
     scopeId,
-    clerkOrgId,
+    orgId,
     expiresAt,
     createdAt: now,
   });

--- a/turbo/apps/web/app/api/cli/auth/token/route.ts
+++ b/turbo/apps/web/app/api/cli/auth/token/route.ts
@@ -88,7 +88,7 @@ const router = tsr.router(cliAuthTokenContract, {
           userId,
           name: "CLI Device Flow Authentication",
           scopeId: scope.id,
-          clerkOrgId: scope.clerkOrgId,
+          orgId: scope.orgId,
           expiresAt,
           createdAt: now,
         });

--- a/turbo/apps/web/app/api/connectors/[type]/callback/route.ts
+++ b/turbo/apps/web/app/api/connectors/[type]/callback/route.ts
@@ -202,7 +202,7 @@ export async function GET(
     // may append OAuth scopes as ?scope=... which would be mistaken for an app scope slug.
     const { scope } = await resolveScope(userId, null, null, tokenScopeId);
     const { created } = await upsertOAuthConnector(
-      scope.clerkOrgId,
+      scope.orgId,
       scope.id,
       userId,
       connectorType,

--- a/turbo/apps/web/app/api/connectors/[type]/route.ts
+++ b/turbo/apps/web/app/api/connectors/[type]/route.ts
@@ -30,7 +30,7 @@ const router = tsr.router(connectorsByTypeContract, {
       orgParam,
       tokenScopeId,
     );
-    const connector = await getConnector(scope.clerkOrgId, userId, params.type);
+    const connector = await getConnector(scope.orgId, userId, params.type);
 
     if (!connector) {
       return createErrorResponse("NOT_FOUND", "Connector not found");
@@ -63,7 +63,7 @@ const router = tsr.router(connectorsByTypeContract, {
         orgParam,
         tokenScopeId,
       );
-      await deleteConnector(scope.clerkOrgId, userId, params.type);
+      await deleteConnector(scope.orgId, userId, params.type);
 
       return {
         status: 204 as const,

--- a/turbo/apps/web/app/api/connectors/computer/route.ts
+++ b/turbo/apps/web/app/api/connectors/computer/route.ts
@@ -37,7 +37,7 @@ const router = tsr.router(computerConnectorContract, {
         tokenScopeId,
       );
       const result = await createComputerConnector(
-        scope.clerkOrgId,
+        scope.orgId,
         scope.id,
         userId,
       );
@@ -73,7 +73,7 @@ const router = tsr.router(computerConnectorContract, {
       orgParam,
       tokenScopeId,
     );
-    const connector = await getConnector(scope.clerkOrgId, userId, "computer");
+    const connector = await getConnector(scope.orgId, userId, "computer");
     if (!connector) {
       return createErrorResponse("NOT_FOUND", "Computer connector not found");
     }
@@ -102,7 +102,7 @@ const router = tsr.router(computerConnectorContract, {
         orgParam,
         tokenScopeId,
       );
-      await deleteComputerConnector(scope.clerkOrgId, userId);
+      await deleteComputerConnector(scope.orgId, userId);
       return { status: 204 as const, body: undefined };
     } catch (error) {
       if (isNotFound(error)) {

--- a/turbo/apps/web/app/api/connectors/route.ts
+++ b/turbo/apps/web/app/api/connectors/route.ts
@@ -31,7 +31,7 @@ const router = tsr.router(connectorsMainContract, {
       orgParam,
       tokenScopeId,
     );
-    const connectorList = await listConnectors(scope.clerkOrgId, userId);
+    const connectorList = await listConnectors(scope.orgId, userId);
     const configuredTypes = getConfiguredConnectorTypes(
       globalThis.services.env,
     );

--- a/turbo/apps/web/app/api/integrations/github/route.ts
+++ b/turbo/apps/web/app/api/integrations/github/route.ts
@@ -93,15 +93,13 @@ export async function GET(request: Request) {
       id: agentComposes.id,
       name: agentComposes.name,
       headVersionId: agentComposes.headVersionId,
-      clerkOrgId: agentComposes.clerkOrgId,
+      orgId: agentComposes.orgId,
     })
     .from(agentComposes)
     .where(eq(agentComposes.id, installation.defaultComposeId))
     .limit(1);
 
-  const scopeSlug = compose
-    ? (await getOrgData(compose.clerkOrgId)).slug
-    : null;
+  const scopeSlug = compose ? (await getOrgData(compose.orgId)).slug : null;
 
   // Extract required secrets/vars from agent compose
   let requiredSecrets: string[] = [];
@@ -128,9 +126,9 @@ export async function GET(request: Request) {
 
   // Get user's existing secrets, vars, connectors
   const [userSecrets, userVars, userConnectors] = await Promise.all([
-    listSecrets(scope.clerkOrgId, userId),
-    listVariables(scope.clerkOrgId, userId),
-    listConnectors(scope.clerkOrgId, userId),
+    listSecrets(scope.orgId, userId),
+    listVariables(scope.orgId, userId),
+    listConnectors(scope.orgId, userId),
   ]);
 
   const connectorProvided = getConnectorProvidedSecretNames(
@@ -331,7 +329,7 @@ export async function PATCH(request: Request) {
     slashIndex === -1 ? null : body.agentName.slice(0, slashIndex);
 
   // Resolve target scope
-  let targetClerkOrgId: string;
+  let targetOrgId: string;
   if (scopeSlug) {
     const targetOrg = await getOrgBySlug(scopeSlug);
     if (!targetOrg) {
@@ -340,10 +338,10 @@ export async function PATCH(request: Request) {
         { status: 400 },
       );
     }
-    targetClerkOrgId = targetOrg.clerkOrgId;
+    targetOrgId = targetOrg.orgId;
   } else {
     const { scope } = await resolveScope(userId);
-    targetClerkOrgId = scope.clerkOrgId;
+    targetOrgId = scope.orgId;
   }
 
   // Find agent compose by name in target scope
@@ -352,7 +350,7 @@ export async function PATCH(request: Request) {
     .from(agentComposes)
     .where(
       and(
-        eq(agentComposes.clerkOrgId, targetClerkOrgId),
+        eq(agentComposes.orgId, targetOrgId),
         eq(agentComposes.name, agentName),
       ),
     )

--- a/turbo/apps/web/app/api/integrations/slack/link/route.ts
+++ b/turbo/apps/web/app/api/integrations/slack/link/route.ts
@@ -16,7 +16,7 @@ import {
 } from "../../../../../src/lib/slack/handlers/shared";
 import { getUserEmail } from "../../../../../src/lib/auth/get-user-email";
 import { addPermission } from "../../../../../src/lib/agent/permission-service";
-import { getDefaultScopeByClerkUserId } from "../../../../../src/lib/scope/scope-service";
+import { getDefaultScopeByUserId } from "../../../../../src/lib/scope/scope-service";
 import { agentComposes } from "../../../../../src/db/schema/agent-compose";
 import { logger } from "../../../../../src/lib/logger";
 import { syncWorkspaceAgentPermissions } from "../../../../../src/lib/slack/permission-sync";
@@ -115,12 +115,12 @@ async function buildAgentFields(
 
   let agents: Array<{ id: string; name: string }> = [];
   if (isAdmin) {
-    const defaultScope = await getDefaultScopeByClerkUserId(userId);
+    const defaultScope = await getDefaultScopeByUserId(userId);
     if (defaultScope) {
       const userAgents = await globalThis.services.db
         .select({ id: agentComposes.id, name: agentComposes.name })
         .from(agentComposes)
-        .where(eq(agentComposes.clerkOrgId, defaultScope.clerkOrgId));
+        .where(eq(agentComposes.orgId, defaultScope.orgId));
 
       // Prepend default agent, deduplicate by id
       const seen = new Set<string>();

--- a/turbo/apps/web/app/api/integrations/slack/route.ts
+++ b/turbo/apps/web/app/api/integrations/slack/route.ts
@@ -99,15 +99,13 @@ export async function GET(request: Request) {
       id: agentComposes.id,
       name: agentComposes.name,
       headVersionId: agentComposes.headVersionId,
-      clerkOrgId: agentComposes.clerkOrgId,
+      orgId: agentComposes.orgId,
     })
     .from(agentComposes)
     .where(eq(agentComposes.id, installation.defaultComposeId))
     .limit(1);
 
-  const scopeSlug = compose
-    ? (await getOrgData(compose.clerkOrgId)).slug
-    : null;
+  const scopeSlug = compose ? (await getOrgData(compose.orgId)).slug : null;
 
   // Extract required secrets/vars from agent compose
   let requiredSecrets: string[] = [];
@@ -132,9 +130,9 @@ export async function GET(request: Request) {
   // Get user's existing secrets, vars, connectors
   const { scope } = await resolveScope(userId, null, null, tokenScopeId);
   const [userSecrets, userVars, userConnectors] = await Promise.all([
-    listSecrets(scope.clerkOrgId, userId),
-    listVariables(scope.clerkOrgId, userId),
-    listConnectors(scope.clerkOrgId, userId),
+    listSecrets(scope.orgId, userId),
+    listVariables(scope.orgId, userId),
+    listConnectors(scope.orgId, userId),
   ]);
 
   const connectorProvided = getConnectorProvidedSecretNames(
@@ -323,7 +321,7 @@ export async function PATCH(request: Request) {
     slashIndex === -1 ? null : body.agentName.slice(0, slashIndex);
 
   // Resolve target scope (no membership check - admin can select any agent)
-  let targetClerkOrgId: string;
+  let targetOrgId: string;
   if (scopeSlug) {
     const targetOrg = await getOrgBySlug(scopeSlug);
     if (!targetOrg) {
@@ -332,10 +330,10 @@ export async function PATCH(request: Request) {
         { status: 400 },
       );
     }
-    targetClerkOrgId = targetOrg.clerkOrgId;
+    targetOrgId = targetOrg.orgId;
   } else {
     const { scope } = await resolveScope(userId, null, null, tokenScopeId);
-    targetClerkOrgId = scope.clerkOrgId;
+    targetOrgId = scope.orgId;
   }
 
   // Find agent compose by name in target scope
@@ -344,7 +342,7 @@ export async function PATCH(request: Request) {
     .from(agentComposes)
     .where(
       and(
-        eq(agentComposes.clerkOrgId, targetClerkOrgId),
+        eq(agentComposes.orgId, targetOrgId),
         eq(agentComposes.name, agentName),
       ),
     )

--- a/turbo/apps/web/app/api/integrations/telegram/route.ts
+++ b/turbo/apps/web/app/api/integrations/telegram/route.ts
@@ -95,15 +95,13 @@ export async function GET(request: Request) {
       id: agentComposes.id,
       name: agentComposes.name,
       headVersionId: agentComposes.headVersionId,
-      clerkOrgId: agentComposes.clerkOrgId,
+      orgId: agentComposes.orgId,
     })
     .from(agentComposes)
     .where(eq(agentComposes.id, installation.defaultComposeId))
     .limit(1);
 
-  const scopeSlug = compose
-    ? (await getOrgData(compose.clerkOrgId)).slug
-    : null;
+  const scopeSlug = compose ? (await getOrgData(compose.orgId)).slug : null;
 
   // Extract required secrets/vars from agent compose
   let requiredSecrets: string[] = [];
@@ -128,9 +126,9 @@ export async function GET(request: Request) {
   // Resolve user's default scope and get existing secrets, vars, connectors
   const { scope } = await resolveScope(userId, null, null, tokenScopeId);
   const [userSecrets, userVars, userConnectors] = await Promise.all([
-    listSecrets(scope.clerkOrgId, userId),
-    listVariables(scope.clerkOrgId, userId),
-    listConnectors(scope.clerkOrgId, userId),
+    listSecrets(scope.orgId, userId),
+    listVariables(scope.orgId, userId),
+    listConnectors(scope.orgId, userId),
   ]);
 
   const connectorProvided = getConnectorProvidedSecretNames(
@@ -259,7 +257,7 @@ export async function PATCH(request: Request) {
     slashIndex === -1 ? null : body.agentName.slice(0, slashIndex);
 
   // Resolve target scope
-  let targetScope: { clerkOrgId: string };
+  let targetScope: { orgId: string };
   if (scopeSlug) {
     const targetOrg = await getOrgBySlug(scopeSlug);
     if (!targetOrg) {
@@ -294,7 +292,7 @@ export async function PATCH(request: Request) {
     .from(agentComposes)
     .where(
       and(
-        eq(agentComposes.clerkOrgId, targetScope.clerkOrgId),
+        eq(agentComposes.orgId, targetScope.orgId),
         eq(agentComposes.name, agentName),
       ),
     )

--- a/turbo/apps/web/app/api/model-providers/[type]/model/route.ts
+++ b/turbo/apps/web/app/api/model-providers/[type]/model/route.ts
@@ -41,7 +41,7 @@ const router = tsr.router(modelProvidersUpdateModelContract, {
         tokenScopeId,
       );
       const provider = await updateModelProviderModel(
-        scope.clerkOrgId,
+        scope.orgId,
         userId,
         params.type,
         body.selectedModel,

--- a/turbo/apps/web/app/api/model-providers/[type]/route.ts
+++ b/turbo/apps/web/app/api/model-providers/[type]/route.ts
@@ -33,7 +33,7 @@ const router = tsr.router(modelProvidersByTypeContract, {
         orgParam,
         tokenScopeId,
       );
-      await deleteModelProvider(scope.clerkOrgId, userId, params.type);
+      await deleteModelProvider(scope.orgId, userId, params.type);
 
       return {
         status: 204 as const,

--- a/turbo/apps/web/app/api/model-providers/[type]/set-default/route.ts
+++ b/turbo/apps/web/app/api/model-providers/[type]/set-default/route.ts
@@ -40,7 +40,7 @@ const router = tsr.router(modelProvidersSetDefaultContract, {
         tokenScopeId,
       );
       const provider = await setModelProviderDefault(
-        scope.clerkOrgId,
+        scope.orgId,
         userId,
         params.type,
       );

--- a/turbo/apps/web/app/api/model-providers/check/[type]/route.ts
+++ b/turbo/apps/web/app/api/model-providers/check/[type]/route.ts
@@ -30,11 +30,7 @@ const router = tsr.router(modelProvidersCheckContract, {
       orgParam,
       tokenScopeId,
     );
-    const result = await checkSecretExists(
-      scope.clerkOrgId,
-      userId,
-      params.type,
-    );
+    const result = await checkSecretExists(scope.orgId, userId, params.type);
 
     return {
       status: 200 as const,

--- a/turbo/apps/web/app/api/model-providers/route.ts
+++ b/turbo/apps/web/app/api/model-providers/route.ts
@@ -38,7 +38,7 @@ const router = tsr.router(modelProvidersMainContract, {
       orgParam,
       tokenScopeId,
     );
-    const providers = await listModelProviders(scope.clerkOrgId, userId);
+    const providers = await listModelProviders(scope.orgId, userId);
 
     return {
       status: 200 as const,
@@ -100,7 +100,7 @@ const router = tsr.router(modelProvidersMainContract, {
           );
         }
         const result = await upsertMultiAuthModelProvider(
-          scope.clerkOrgId,
+          scope.orgId,
           scope.id,
           userId,
           type,
@@ -119,7 +119,7 @@ const router = tsr.router(modelProvidersMainContract, {
           );
         }
         const result = await upsertModelProvider(
-          scope.clerkOrgId,
+          scope.orgId,
           scope.id,
           userId,
           type,

--- a/turbo/apps/web/app/api/onboarding/status/route.ts
+++ b/turbo/apps/web/app/api/onboarding/status/route.ts
@@ -43,7 +43,7 @@ const router = tsr.router(onboardingStatusContract, {
       const [provider] = await globalThis.services.db
         .select({ id: modelProviders.id })
         .from(modelProviders)
-        .where(eq(modelProviders.clerkOrgId, scope.clerkOrgId))
+        .where(eq(modelProviders.orgId, scope.orgId))
         .limit(1);
 
       hasModelProvider = provider !== undefined;

--- a/turbo/apps/web/app/api/platform/logs/route.ts
+++ b/turbo/apps/web/app/api/platform/logs/route.ts
@@ -46,14 +46,14 @@ interface LogsQuery {
  */
 function buildAgentFilterConditions(
   query: LogsQuery,
-  scopeClerkOrgId: string | null,
+  scopeOrgId: string | null,
 ): SQL[] {
   const conditions: SQL[] = [];
 
   if (query.name) {
     conditions.push(eq(agentComposes.name, query.name));
-    if (scopeClerkOrgId) {
-      conditions.push(eq(agentComposes.clerkOrgId, scopeClerkOrgId));
+    if (scopeOrgId) {
+      conditions.push(eq(agentComposes.orgId, scopeOrgId));
     }
   } else if (query.agent) {
     conditions.push(eq(agentComposes.name, query.agent));
@@ -88,10 +88,10 @@ function buildCursorCondition(cursor: string): SQL | null {
 async function getTotalCount(
   userId: string,
   query: LogsQuery,
-  scopeClerkOrgId: string | null,
+  scopeOrgId: string | null,
 ): Promise<number> {
   const conditions: SQL[] = [eq(agentRuns.userId, userId)];
-  conditions.push(...buildAgentFilterConditions(query, scopeClerkOrgId));
+  conditions.push(...buildAgentFilterConditions(query, scopeOrgId));
 
   const needsComposeJoin = !!(query.name || query.agent || query.search);
 
@@ -147,12 +147,12 @@ const router = tsr.router(platformLogsListContract, {
 
     const limit = query.limit ?? 20;
 
-    // Resolve scope slug to clerkOrgId for filtering
-    let scopeClerkOrgId: string | null = null;
+    // Resolve scope slug to orgId for filtering
+    let scopeOrgId: string | null = null;
     if (query.scope) {
       const orgData = await getOrgBySlug(query.scope);
-      scopeClerkOrgId = orgData?.clerkOrgId ?? null;
-      if (!scopeClerkOrgId) {
+      scopeOrgId = orgData?.orgId ?? null;
+      if (!scopeOrgId) {
         return {
           status: 200 as const,
           body: {
@@ -173,7 +173,7 @@ const router = tsr.router(platformLogsListContract, {
       }
     }
 
-    conditions.push(...buildAgentFilterConditions(query, scopeClerkOrgId));
+    conditions.push(...buildAgentFilterConditions(query, scopeOrgId));
 
     const runs = await globalThis.services.db
       .select({
@@ -181,7 +181,7 @@ const router = tsr.router(platformLogsListContract, {
         status: agentRuns.status,
         createdAt: agentRuns.createdAt,
         composeName: agentComposes.name,
-        clerkOrgId: agentComposes.clerkOrgId,
+        orgId: agentComposes.orgId,
         sessionId: conversations.cliAgentSessionId,
         composeContent: agentComposeVersions.content,
       })
@@ -200,25 +200,25 @@ const router = tsr.router(platformLogsListContract, {
       .limit(limit + 1);
 
     // Resolve scope slugs via org cache (skip orgs that fail lookup)
-    const uniqueClerkOrgIds = [
-      ...new Set(runs.filter((r) => r.clerkOrgId).map((r) => r.clerkOrgId!)),
+    const uniqueOrgIds = [
+      ...new Set(runs.filter((r) => r.orgId).map((r) => r.orgId!)),
     ];
     const slugMap = new Map<string, string>();
     await Promise.all(
-      uniqueClerkOrgIds.map(async (id) => {
+      uniqueOrgIds.map(async (id) => {
         try {
           const data = await getOrgData(id);
           slugMap.set(id, data.slug);
         } catch (err) {
           log.warn("failed to resolve org slug for run", {
-            clerkOrgId: id,
+            orgId: id,
             error: err,
           });
         }
       }),
     );
 
-    const totalCount = await getTotalCount(userId, query, scopeClerkOrgId);
+    const totalCount = await getTotalCount(userId, query, scopeOrgId);
     const totalPages = Math.max(1, Math.ceil(totalCount / limit));
 
     // Determine pagination info
@@ -239,9 +239,7 @@ const router = tsr.router(platformLogsListContract, {
           id: run.id,
           sessionId: run.sessionId ?? null,
           agentName: run.composeName ?? "unknown",
-          scopeSlug: run.clerkOrgId
-            ? (slugMap.get(run.clerkOrgId) ?? null)
-            : null,
+          scopeSlug: run.orgId ? (slugMap.get(run.orgId) ?? null) : null,
           framework: extractFramework(run.composeContent),
           status: run.status as PlatformLogStatus,
           createdAt: run.createdAt.toISOString(),

--- a/turbo/apps/web/app/api/scope/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/scope/__tests__/route.test.ts
@@ -422,8 +422,8 @@ describe("/api/scope", () => {
     });
   });
 
-  describe("GET /api/scope (clerkOrgId resolution)", () => {
-    it("should resolve scope by clerkOrgId from session", async () => {
+  describe("GET /api/scope (orgId resolution)", () => {
+    it("should resolve scope by orgId from session", async () => {
       const userId = `clerk-org-test-${Date.now()}`;
       const org1Id = `org_first_${Date.now()}`;
       const org2Id = `org_second_${Date.now()}`;
@@ -455,7 +455,7 @@ describe("/api/scope", () => {
       });
       await POST(req2);
 
-      // Set active org to second scope's clerkOrgId
+      // Set active org to second scope's orgId
       mockClerk({ userId, orgId: org2Id });
 
       const request = createTestRequest("http://localhost:3000/api/scope");
@@ -466,13 +466,13 @@ describe("/api/scope", () => {
       expect(data.slug).toBe(slug2);
     });
 
-    it("should fall through to default when clerkOrgId has no matching scope", async () => {
+    it("should fall through to default when orgId has no matching scope", async () => {
       const userId = `no-match-org-${Date.now()}`;
       const clerkOrgs = [
         { id: `org_mock_${userId}`, slug: `default-org`, name: "Default Org" },
       ];
 
-      // Set up Clerk org BEFORE creating scope so POST resolves correct clerkOrgId
+      // Set up Clerk org BEFORE creating scope so POST resolves correct orgId
       mockClerk({ userId, clerkOrgs });
 
       // Create a default scope

--- a/turbo/apps/web/app/api/scope/members/route.ts
+++ b/turbo/apps/web/app/api/scope/members/route.ts
@@ -36,7 +36,7 @@ export async function GET(request: Request) {
     );
     const status = await getScopeMembers(
       userId,
-      scope.clerkOrgId,
+      scope.orgId,
       scope.slug,
       scope.createdAt,
     );

--- a/turbo/apps/web/app/api/scope/route.ts
+++ b/turbo/apps/web/app/api/scope/route.ts
@@ -38,7 +38,7 @@ const router = tsr.router(scopeContract, {
   /**
    * GET /api/scope - Get current user's default scope
    *
-   * Resolves the active scope via clerkOrgId from Clerk session,
+   * Resolves the active scope via orgId from Clerk session,
    * or falls back to the user's default scope (first admin membership).
    */
   get: async ({ headers }) => {
@@ -88,7 +88,7 @@ const router = tsr.router(scopeContract, {
     log.debug("creating scope", { userId, slug });
 
     try {
-      // Resolve clerkOrgId from user's Clerk org memberships
+      // Resolve orgId from user's Clerk org memberships
       const unmatchedOrg = await resolveUnmatchedClerkOrg(userId);
 
       if (!unmatchedOrg) {
@@ -99,7 +99,7 @@ const router = tsr.router(scopeContract, {
       }
 
       const scope = await createScope(userId, slug, {
-        clerkOrgId: unmatchedOrg.organization.id,
+        orgId: unmatchedOrg.organization.id,
       });
 
       return { status: 201 as const, body: scopeToResponseBody(scope) };
@@ -114,7 +114,7 @@ const router = tsr.router(scopeContract, {
   /**
    * PUT /api/scope - Update active scope slug
    *
-   * Resolves the active scope via clerkOrgId from Clerk session,
+   * Resolves the active scope via orgId from Clerk session,
    * or falls back to the user's default scope (first admin membership).
    */
   update: async ({ body, headers }) => {

--- a/turbo/apps/web/app/api/scopes/default-agent/route.ts
+++ b/turbo/apps/web/app/api/scopes/default-agent/route.ts
@@ -55,7 +55,7 @@ const router = tsr.router(scopeDefaultAgentContract, {
         .where(
           and(
             eq(agentComposes.id, agentComposeId),
-            eq(agentComposes.clerkOrgId, scope.clerkOrgId),
+            eq(agentComposes.orgId, scope.orgId),
           ),
         )
         .limit(1);
@@ -81,13 +81,13 @@ const router = tsr.router(scopeDefaultAgentContract, {
     // Dual-write to Clerk org publicMetadata (fire-and-forget)
     try {
       const client = await clerkClient();
-      await client.organizations.updateOrganizationMetadata(scope.clerkOrgId, {
+      await client.organizations.updateOrganizationMetadata(scope.orgId, {
         publicMetadata: { default_agent_compose_id: agentComposeId },
       });
     } catch (err) {
       log.error("Failed to write default agent to Clerk metadata", {
         error: err,
-        clerkOrgId: scope.clerkOrgId,
+        orgId: scope.orgId,
       });
     }
 

--- a/turbo/apps/web/app/api/secrets/[name]/route.ts
+++ b/turbo/apps/web/app/api/secrets/[name]/route.ts
@@ -41,7 +41,7 @@ const router = tsr.router(secretsByNameContract, {
       orgParam,
       tokenScopeId,
     );
-    const secret = await getSecret(scope.clerkOrgId, userId, params.name);
+    const secret = await getSecret(scope.orgId, userId, params.name);
     if (!secret) {
       return createErrorResponse(
         "NOT_FOUND",
@@ -85,7 +85,7 @@ const router = tsr.router(secretsByNameContract, {
         orgParam,
         tokenScopeId,
       );
-      await deleteSecret(scope.clerkOrgId, userId, params.name);
+      await deleteSecret(scope.orgId, userId, params.name);
 
       return {
         status: 204 as const,

--- a/turbo/apps/web/app/api/secrets/route.ts
+++ b/turbo/apps/web/app/api/secrets/route.ts
@@ -34,7 +34,7 @@ const router = tsr.router(secretsMainContract, {
       orgParam,
       tokenScopeId,
     );
-    const secrets = await listSecrets(scope.clerkOrgId, userId);
+    const secrets = await listSecrets(scope.orgId, userId);
 
     return {
       status: 200 as const,
@@ -77,7 +77,7 @@ const router = tsr.router(secretsMainContract, {
         tokenScopeId,
       );
       const secret = await setSecret(
-        scope.clerkOrgId,
+        scope.orgId,
         scope.id,
         userId,
         name,

--- a/turbo/apps/web/app/api/storages/__tests__/per-user-isolation.test.ts
+++ b/turbo/apps/web/app/api/storages/__tests__/per-user-isolation.test.ts
@@ -30,11 +30,7 @@ describe("Storage per-user isolation", () => {
 
     await createTestVolume("shared-vol");
 
-    const record = await findTestStorage(
-      user.clerkOrgId,
-      "shared-vol",
-      "volume",
-    );
+    const record = await findTestStorage(user.orgId, "shared-vol", "volume");
     expect(record).toBeDefined();
     expect(record!.userId).toBe(VOLUME_SCOPE_USER_ID);
   });
@@ -44,11 +40,7 @@ describe("Storage per-user isolation", () => {
 
     await createTestArtifact("my-artifact");
 
-    const record = await findTestStorage(
-      user.clerkOrgId,
-      "my-artifact",
-      "artifact",
-    );
+    const record = await findTestStorage(user.orgId, "my-artifact", "artifact");
     expect(record).toBeDefined();
     expect(record!.userId).toBe(user.userId);
   });
@@ -58,11 +50,7 @@ describe("Storage per-user isolation", () => {
 
     await createTestMemory("my-memory");
 
-    const record = await findTestStorage(
-      user.clerkOrgId,
-      "my-memory",
-      "memory",
-    );
+    const record = await findTestStorage(user.orgId, "my-memory", "memory");
     expect(record).toBeDefined();
     expect(record!.userId).toBe(user.userId);
   });
@@ -154,16 +142,8 @@ describe("Storage per-user isolation", () => {
     expect(userBVolumes[0].name).toBe("shared-data");
 
     // Both volumes use sentinel userId, not the real user
-    const recordA = await findTestStorage(
-      userA.clerkOrgId,
-      "shared-data",
-      "volume",
-    );
-    const recordB = await findTestStorage(
-      userB.clerkOrgId,
-      "shared-data",
-      "volume",
-    );
+    const recordA = await findTestStorage(userA.orgId, "shared-data", "volume");
+    const recordB = await findTestStorage(userB.orgId, "shared-data", "volume");
     expect(recordA!.userId).toBe(VOLUME_SCOPE_USER_ID);
     expect(recordB!.userId).toBe(VOLUME_SCOPE_USER_ID);
   });

--- a/turbo/apps/web/app/api/storages/commit/route.ts
+++ b/turbo/apps/web/app/api/storages/commit/route.ts
@@ -80,7 +80,7 @@ const router = tsr.router(storagesCommitContract, {
       .from(storages)
       .where(
         and(
-          eq(storages.clerkOrgId, runtimeScope.clerkOrgId),
+          eq(storages.orgId, runtimeScope.orgId),
           eq(storages.userId, storageUserId),
           eq(storages.name, storageName),
           eq(storages.type, storageType),

--- a/turbo/apps/web/app/api/storages/download/route.ts
+++ b/turbo/apps/web/app/api/storages/download/route.ts
@@ -58,7 +58,7 @@ const router = tsr.router(storagesDownloadContract, {
       .from(storages)
       .where(
         and(
-          eq(storages.clerkOrgId, runtimeScope.clerkOrgId),
+          eq(storages.orgId, runtimeScope.orgId),
           eq(storages.userId, storageUserId),
           eq(storages.name, storageName),
           eq(storages.type, storageType),

--- a/turbo/apps/web/app/api/storages/list/route.ts
+++ b/turbo/apps/web/app/api/storages/list/route.ts
@@ -58,7 +58,7 @@ const router = tsr.router(storagesListContract, {
       .from(storages)
       .where(
         and(
-          eq(storages.clerkOrgId, runtimeScope.clerkOrgId),
+          eq(storages.orgId, runtimeScope.orgId),
           eq(storages.userId, storageUserId),
           eq(storages.type, storageType),
         ),

--- a/turbo/apps/web/app/api/storages/prepare/route.ts
+++ b/turbo/apps/web/app/api/storages/prepare/route.ts
@@ -150,7 +150,7 @@ const router = tsr.router(storagesPrepareContract, {
       .values({
         userId: storageUserId,
         scopeId: runtimeScope.id,
-        clerkOrgId: runtimeScope.clerkOrgId,
+        orgId: runtimeScope.orgId,
         name: storageName,
         type: storageType,
         s3Prefix: `${runtimeScope.slug}/${storageType}/${storageName}`,
@@ -158,12 +158,7 @@ const router = tsr.router(storagesPrepareContract, {
         fileCount: 0,
       })
       .onConflictDoUpdate({
-        target: [
-          storages.clerkOrgId,
-          storages.userId,
-          storages.name,
-          storages.type,
-        ],
+        target: [storages.orgId, storages.userId, storages.name, storages.type],
         set: { updatedAt: new Date() },
       })
       .returning();

--- a/turbo/apps/web/app/api/user/preferences/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/user/preferences/__tests__/route.test.ts
@@ -30,8 +30,8 @@ describe("GET /api/user/preferences", () => {
   it("should return default preferences for new user", async () => {
     const user = await context.setupUser();
 
-    // Set orgId so the route can resolve clerkOrgId
-    mockClerk({ userId: user.userId, orgId: user.clerkOrgId });
+    // Set orgId so the route can resolve orgId
+    mockClerk({ userId: user.userId, orgId: user.orgId });
 
     const request = createTestRequest(
       "http://localhost:3000/api/user/preferences",
@@ -47,7 +47,7 @@ describe("GET /api/user/preferences", () => {
 
   it("should return saved timezone after update", async () => {
     const user = await context.setupUser();
-    mockClerk({ userId: user.userId, orgId: user.clerkOrgId });
+    mockClerk({ userId: user.userId, orgId: user.orgId });
 
     // Set timezone via PUT (writes to DB + dual-writes to Clerk)
     const putRequest = createTestRequest(
@@ -63,7 +63,7 @@ describe("GET /api/user/preferences", () => {
     // Re-mock with updated metadata to simulate Clerk having the data
     mockClerk({
       userId: user.userId,
-      orgId: user.clerkOrgId,
+      orgId: user.orgId,
       membershipTimezone: "Asia/Shanghai",
     });
 
@@ -89,7 +89,7 @@ describe("GET /api/user/preferences (JWT claims)", () => {
 
     mockClerk({
       userId: user.userId,
-      orgId: user.clerkOrgId,
+      orgId: user.orgId,
       membershipTimezone: "Asia/Tokyo",
       membershipNotifyEmail: true,
       membershipNotifySlack: false,
@@ -111,7 +111,7 @@ describe("GET /api/user/preferences (JWT claims)", () => {
     const user = await context.setupUser();
 
     // orgId set but no membership claims → falls back to Clerk API
-    mockClerk({ userId: user.userId, orgId: user.clerkOrgId });
+    mockClerk({ userId: user.userId, orgId: user.orgId });
 
     const request = createTestRequest(
       "http://localhost:3000/api/user/preferences",
@@ -131,7 +131,7 @@ describe("GET /api/user/preferences (JWT claims)", () => {
     // Only timezone in JWT, no notification claims
     mockClerk({
       userId: user.userId,
-      orgId: user.clerkOrgId,
+      orgId: user.orgId,
       membershipTimezone: "Europe/London",
     });
 
@@ -153,7 +153,7 @@ describe("GET /api/user/preferences (JWT claims)", () => {
     // Set membership metadata in Clerk API (also sets JWT claims)
     mockClerk({
       userId: user.userId,
-      orgId: user.clerkOrgId,
+      orgId: user.orgId,
       membershipTimezone: "America/Chicago",
       membershipNotifyEmail: true,
       membershipNotifySlack: false,
@@ -162,7 +162,7 @@ describe("GET /api/user/preferences (JWT claims)", () => {
     // Clear JWT claims so the code falls through to Clerk API path
     vi.mocked(auth).mockResolvedValue({
       userId: user.userId,
-      orgId: user.clerkOrgId,
+      orgId: user.orgId,
       sessionClaims: {},
     } as Awaited<ReturnType<typeof auth>>);
 
@@ -246,7 +246,7 @@ describe("PUT /api/user/preferences", () => {
 
   it("should update timezone successfully", async () => {
     const user = await context.setupUser();
-    mockClerk({ userId: user.userId, orgId: user.clerkOrgId });
+    mockClerk({ userId: user.userId, orgId: user.orgId });
 
     const request = createTestRequest(
       "http://localhost:3000/api/user/preferences",
@@ -265,7 +265,7 @@ describe("PUT /api/user/preferences", () => {
 
   it("should reject invalid timezone", async () => {
     const user = await context.setupUser();
-    mockClerk({ userId: user.userId, orgId: user.clerkOrgId });
+    mockClerk({ userId: user.userId, orgId: user.orgId });
 
     const request = createTestRequest(
       "http://localhost:3000/api/user/preferences",
@@ -284,7 +284,7 @@ describe("PUT /api/user/preferences", () => {
 
   it("should reject empty timezone", async () => {
     const user = await context.setupUser();
-    mockClerk({ userId: user.userId, orgId: user.clerkOrgId });
+    mockClerk({ userId: user.userId, orgId: user.orgId });
 
     const request = createTestRequest(
       "http://localhost:3000/api/user/preferences",
@@ -301,7 +301,7 @@ describe("PUT /api/user/preferences", () => {
 
   it("should allow updating timezone multiple times", async () => {
     const user = await context.setupUser();
-    mockClerk({ userId: user.userId, orgId: user.clerkOrgId });
+    mockClerk({ userId: user.userId, orgId: user.orgId });
 
     // First update
     const request1 = createTestRequest(
@@ -333,7 +333,7 @@ describe("PUT /api/user/preferences", () => {
 
   it("should update notifyEmail to true", async () => {
     const user = await context.setupUser();
-    mockClerk({ userId: user.userId, orgId: user.clerkOrgId });
+    mockClerk({ userId: user.userId, orgId: user.orgId });
 
     const request = createTestRequest(
       "http://localhost:3000/api/user/preferences",
@@ -352,7 +352,7 @@ describe("PUT /api/user/preferences", () => {
 
   it("should update timezone and notifyEmail together", async () => {
     const user = await context.setupUser();
-    mockClerk({ userId: user.userId, orgId: user.clerkOrgId });
+    mockClerk({ userId: user.userId, orgId: user.orgId });
 
     const request = createTestRequest(
       "http://localhost:3000/api/user/preferences",
@@ -375,7 +375,7 @@ describe("PUT /api/user/preferences", () => {
 
   it("should update only notifyEmail without affecting timezone", async () => {
     const user = await context.setupUser();
-    mockClerk({ userId: user.userId, orgId: user.clerkOrgId });
+    mockClerk({ userId: user.userId, orgId: user.orgId });
 
     // Set timezone first
     const putTz = createTestRequest(
@@ -407,7 +407,7 @@ describe("PUT /api/user/preferences", () => {
 
   it("should update notifySlack to false", async () => {
     const user = await context.setupUser();
-    mockClerk({ userId: user.userId, orgId: user.clerkOrgId });
+    mockClerk({ userId: user.userId, orgId: user.orgId });
 
     const request = createTestRequest(
       "http://localhost:3000/api/user/preferences",
@@ -426,7 +426,7 @@ describe("PUT /api/user/preferences", () => {
 
   it("should update notifySlack independently without affecting other preferences", async () => {
     const user = await context.setupUser();
-    mockClerk({ userId: user.userId, orgId: user.clerkOrgId });
+    mockClerk({ userId: user.userId, orgId: user.orgId });
 
     // Set timezone and notifyEmail first
     const setup = createTestRequest(
@@ -459,7 +459,7 @@ describe("PUT /api/user/preferences", () => {
 
   it("should dual-write timezone to Clerk membership metadata", async () => {
     const user = await context.setupUser();
-    mockClerk({ userId: user.userId, orgId: user.clerkOrgId });
+    mockClerk({ userId: user.userId, orgId: user.orgId });
 
     const request = createTestRequest(
       "http://localhost:3000/api/user/preferences",
@@ -485,7 +485,7 @@ describe("PUT /api/user/preferences", () => {
 
   it("should dual-write notifyEmail and notifySlack to Clerk membership metadata", async () => {
     const user = await context.setupUser();
-    mockClerk({ userId: user.userId, orgId: user.clerkOrgId });
+    mockClerk({ userId: user.userId, orgId: user.orgId });
 
     const request = createTestRequest(
       "http://localhost:3000/api/user/preferences",
@@ -511,7 +511,7 @@ describe("PUT /api/user/preferences", () => {
 
   it("should reject request with no preferences", async () => {
     const user = await context.setupUser();
-    mockClerk({ userId: user.userId, orgId: user.clerkOrgId });
+    mockClerk({ userId: user.userId, orgId: user.orgId });
 
     const request = createTestRequest(
       "http://localhost:3000/api/user/preferences",

--- a/turbo/apps/web/app/api/user/preferences/route.ts
+++ b/turbo/apps/web/app/api/user/preferences/route.ts
@@ -22,20 +22,20 @@ const router = tsr.router(userPreferencesContract, {
       return createErrorResponse("UNAUTHORIZED", "Not authenticated");
     }
 
-    const { sessionClaims, orgId } = await auth();
+    const { sessionClaims, orgId: authOrgId } = await auth();
 
     // Clerk session → orgId from JWT; CLI token → look up from scopeId
-    let clerkOrgId = orgId;
-    if (!clerkOrgId && ctx.scopeId) {
+    let orgId = authOrgId;
+    if (!orgId && ctx.scopeId) {
       const scope = await getScopeById(ctx.scopeId);
-      clerkOrgId = scope?.clerkOrgId ?? null;
+      orgId = scope?.orgId ?? null;
     }
-    if (!clerkOrgId) {
+    if (!orgId) {
       return createErrorResponse("BAD_REQUEST", "No organization context");
     }
 
     const prefs = await getUserPreferences(
-      clerkOrgId,
+      orgId,
       ctx.userId,
       sessionClaims ?? undefined,
     );
@@ -63,17 +63,17 @@ const router = tsr.router(userPreferencesContract, {
 
     // Clerk session → orgId from JWT; CLI token → look up from scopeId
     const { orgId } = await auth();
-    let clerkOrgId = orgId;
-    if (!clerkOrgId && ctx.scopeId) {
+    let resolvedOrgId = orgId;
+    if (!resolvedOrgId && ctx.scopeId) {
       const scope = await getScopeById(ctx.scopeId);
-      clerkOrgId = scope?.clerkOrgId ?? null;
+      resolvedOrgId = scope?.orgId ?? null;
     }
-    if (!clerkOrgId) {
+    if (!resolvedOrgId) {
       return createErrorResponse("BAD_REQUEST", "No organization context");
     }
 
     try {
-      const prefs = await updateUserPreferences(clerkOrgId, ctx.userId, {
+      const prefs = await updateUserPreferences(resolvedOrgId, ctx.userId, {
         timezone: body.timezone,
         notifyEmail: body.notifyEmail,
         notifySlack: body.notifySlack,

--- a/turbo/apps/web/app/api/variables/[name]/route.ts
+++ b/turbo/apps/web/app/api/variables/[name]/route.ts
@@ -41,7 +41,7 @@ const router = tsr.router(variablesByNameContract, {
       orgParam,
       tokenScopeId,
     );
-    const variable = await getVariable(scope.clerkOrgId, userId, params.name);
+    const variable = await getVariable(scope.orgId, userId, params.name);
     if (!variable) {
       return createErrorResponse(
         "NOT_FOUND",
@@ -85,7 +85,7 @@ const router = tsr.router(variablesByNameContract, {
         orgParam,
         tokenScopeId,
       );
-      await deleteVariable(scope.clerkOrgId, userId, params.name);
+      await deleteVariable(scope.orgId, userId, params.name);
 
       return {
         status: 204 as const,

--- a/turbo/apps/web/app/api/variables/route.ts
+++ b/turbo/apps/web/app/api/variables/route.ts
@@ -41,7 +41,7 @@ const router = tsr.router(variablesMainContract, {
       orgParam,
       tokenScopeId,
     );
-    const vars = await listVariables(scope.clerkOrgId, userId);
+    const vars = await listVariables(scope.orgId, userId);
 
     return {
       status: 200 as const,
@@ -84,7 +84,7 @@ const router = tsr.router(variablesMainContract, {
         tokenScopeId,
       );
       const variable = await setVariable(
-        scope.clerkOrgId,
+        scope.orgId,
         scope.id,
         userId,
         name,

--- a/turbo/apps/web/app/api/webhooks/agent/services/auth/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/services/auth/route.ts
@@ -56,8 +56,8 @@ async function refreshConnectorToken(
   connectorType: string,
   connectorSecrets: Record<string, string>,
   accessTokenName: string,
-  clerkOrgId: string,
-  scopeId: string | null,
+  orgId: string,
+  scopeId: string,
   userId: string,
   runId: string,
 ): Promise<Response | null> {
@@ -93,7 +93,7 @@ async function refreshConnectorToken(
       currentRefreshToken,
     );
     await upsertConnectorSecret(
-      clerkOrgId,
+      orgId,
       scopeId,
       userId,
       accessTokenName,
@@ -101,7 +101,7 @@ async function refreshConnectorToken(
     );
     if (result.refreshToken) {
       await upsertConnectorSecret(
-        clerkOrgId,
+        orgId,
         scopeId,
         userId,
         refreshTokenName,
@@ -237,7 +237,7 @@ export async function POST(request: Request) {
 
   // Look up run to get scopeId
   const [run] = await globalThis.services.db
-    .select({ scopeId: agentRuns.scopeId, clerkOrgId: agentRuns.clerkOrgId })
+    .select({ scopeId: agentRuns.scopeId, orgId: agentRuns.orgId })
     .from(agentRuns)
     .where(and(eq(agentRuns.id, body.runId), eq(agentRuns.userId, auth.userId)))
     .limit(1);
@@ -255,7 +255,7 @@ export async function POST(request: Request) {
     .from(connectors)
     .where(
       and(
-        eq(connectors.clerkOrgId, run.clerkOrgId),
+        eq(connectors.orgId, run.orgId),
         eq(connectors.userId, auth.userId),
         eq(connectors.type, connectorType),
       ),
@@ -276,7 +276,7 @@ export async function POST(request: Request) {
 
   // Get connector secrets and refresh if needed
   const connectorSecrets = await getSecretValues(
-    run.clerkOrgId,
+    run.orgId,
     auth.userId,
     "connector",
   );
@@ -292,7 +292,7 @@ export async function POST(request: Request) {
       connectorType,
       connectorSecrets,
       accessTokenName,
-      run.clerkOrgId,
+      run.orgId,
       run.scopeId,
       auth.userId,
       body.runId,

--- a/turbo/apps/web/app/api/webhooks/agent/services/auth/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/services/auth/route.ts
@@ -57,7 +57,7 @@ async function refreshConnectorToken(
   connectorSecrets: Record<string, string>,
   accessTokenName: string,
   orgId: string,
-  scopeId: string,
+  scopeId: string | null,
   userId: string,
   runId: string,
 ): Promise<Response | null> {

--- a/turbo/apps/web/app/api/webhooks/agent/storages/commit/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/storages/commit/route.ts
@@ -12,7 +12,7 @@ import {
 } from "../../../../../../src/db/schema/storage";
 import { eq, and } from "drizzle-orm";
 import { getSandboxAuthForRun } from "../../../../../../src/lib/auth/get-sandbox-auth";
-import { getDefaultScopeByClerkUserId } from "../../../../../../src/lib/scope/scope-service";
+import { getDefaultScopeByUserId } from "../../../../../../src/lib/scope/scope-service";
 import {
   s3ObjectExists,
   verifyS3FilesExist,
@@ -66,7 +66,7 @@ const router = tsr.router(webhookStoragesCommitContract, {
     }
 
     // Resolve Runtime Scope (user's default scope)
-    const runtimeScope = await getDefaultScopeByClerkUserId(userId);
+    const runtimeScope = await getDefaultScopeByUserId(userId);
     if (!runtimeScope) {
       return {
         status: 400 as const,
@@ -89,7 +89,7 @@ const router = tsr.router(webhookStoragesCommitContract, {
       .from(storages)
       .where(
         and(
-          eq(storages.clerkOrgId, runtimeScope.clerkOrgId),
+          eq(storages.orgId, runtimeScope.orgId),
           eq(storages.userId, storageUserId),
           eq(storages.name, storageName),
           eq(storages.type, storageType),

--- a/turbo/apps/web/app/api/webhooks/agent/storages/prepare/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/storages/prepare/route.ts
@@ -15,7 +15,7 @@ import {
 } from "../../../../../../src/db/schema/storage";
 import { eq, and } from "drizzle-orm";
 import { getSandboxAuthForRun } from "../../../../../../src/lib/auth/get-sandbox-auth";
-import { getDefaultScopeByClerkUserId } from "../../../../../../src/lib/scope/scope-service";
+import { getDefaultScopeByUserId } from "../../../../../../src/lib/scope/scope-service";
 import {
   generatePresignedPutUrl,
   downloadManifest,
@@ -78,7 +78,7 @@ const router = tsr.router(webhookStoragesPrepareContract, {
     }
 
     // Resolve Runtime Scope (user's default scope)
-    const runtimeScope = await getDefaultScopeByClerkUserId(userId);
+    const runtimeScope = await getDefaultScopeByUserId(userId);
     if (!runtimeScope) {
       return {
         status: 400 as const,
@@ -101,7 +101,7 @@ const router = tsr.router(webhookStoragesPrepareContract, {
       .values({
         userId: storageUserId,
         scopeId: runtimeScope.id,
-        clerkOrgId: runtimeScope.clerkOrgId,
+        orgId: runtimeScope.orgId,
         name: storageName,
         type: storageType,
         s3Prefix: `${runtimeScope.slug}/${storageType}/${storageName}`,
@@ -109,12 +109,7 @@ const router = tsr.router(webhookStoragesPrepareContract, {
         fileCount: 0,
       })
       .onConflictDoUpdate({
-        target: [
-          storages.clerkOrgId,
-          storages.userId,
-          storages.name,
-          storages.type,
-        ],
+        target: [storages.orgId, storages.userId, storages.name, storages.type],
         set: { updatedAt: new Date() },
       })
       .returning();

--- a/turbo/apps/web/app/slack/link/__tests__/actions.test.ts
+++ b/turbo/apps/web/app/slack/link/__tests__/actions.test.ts
@@ -139,7 +139,7 @@ describe("Slack Link Actions", () => {
       expect(result.success).toBe(true);
 
       // Verify artifact storage was created with a HEAD version
-      const artifactResult = await findTestArtifactStorage(user.clerkOrgId);
+      const artifactResult = await findTestArtifactStorage(user.orgId);
 
       expect(artifactResult).not.toBeNull();
       expect(artifactResult!.storage.headVersionId).toBeTruthy();
@@ -173,7 +173,7 @@ describe("Slack Link Actions", () => {
       expect(result2.alreadyLinked).toBe(true);
 
       // Verify only one artifact storage exists with HEAD version
-      const artifactResult = await findTestArtifactStorage(user.clerkOrgId);
+      const artifactResult = await findTestArtifactStorage(user.orgId);
 
       expect(artifactResult).not.toBeNull();
       expect(artifactResult!.storage.headVersionId).toBeTruthy();

--- a/turbo/apps/web/scripts/migrations/001-backfill-clerk-orgs/backfill.ts
+++ b/turbo/apps/web/scripts/migrations/001-backfill-clerk-orgs/backfill.ts
@@ -151,7 +151,7 @@ async function processScope(
 
     const result = await db
       .update(scopes)
-      .set({ clerkOrgId: orgId, updatedAt: sql`NOW()` })
+      .set({ orgId, updatedAt: sql`NOW()` })
       .where(eq(scopes.id, scope.id))
       .returning({ id: scopes.id });
 
@@ -217,8 +217,8 @@ async function main() {
     // Note: scopes.ownerId was removed from the Drizzle schema (Phase 2),
     // so we use raw SQL column references for this legacy migration script.
     const whereClause = USER_ID
-      ? and(isNull(scopes.clerkOrgId), sql`"scopes"."owner_id" = ${USER_ID}`)
-      : isNull(scopes.clerkOrgId);
+      ? and(isNull(scopes.orgId), sql`"scopes"."owner_id" = ${USER_ID}`)
+      : isNull(scopes.orgId);
 
     const nullScopes: ScopeRow[] = await db
       .select({
@@ -260,7 +260,7 @@ async function main() {
     const [remaining] = await db
       .select({ count: sql<number>`count(*)` })
       .from(scopes)
-      .where(isNull(scopes.clerkOrgId));
+      .where(isNull(scopes.orgId));
 
     console.log("\n=== Summary ===");
     console.log(`Total:     ${stats.total}`);

--- a/turbo/apps/web/scripts/migrations/002-backfill-clerk-metadata/backfill.ts
+++ b/turbo/apps/web/scripts/migrations/002-backfill-clerk-metadata/backfill.ts
@@ -125,7 +125,7 @@ async function backfillScopeTiers(
       id: scopes.id,
       slug: scopes.slug,
       tier: scopes.tier,
-      clerkOrgId: scopes.clerkOrgId,
+      orgId: scopes.orgId,
     })
     .from(scopes)
     .orderBy(asc(scopes.createdAt));
@@ -141,7 +141,7 @@ async function backfillScopeTiers(
 
     if (DRY_RUN) {
       console.log(
-        `${idx} (dry-run) scope "${scope.slug}" — would write tier="${scope.tier}" to Clerk org ${scope.clerkOrgId}`,
+        `${idx} (dry-run) scope "${scope.slug}" — would write tier="${scope.tier}" to Clerk org ${scope.orgId}`,
       );
       stats.success++;
       continue;
@@ -149,7 +149,7 @@ async function backfillScopeTiers(
 
     try {
       await withRetry(() =>
-        client!.organizations.updateOrganizationMetadata(scope.clerkOrgId, {
+        client!.organizations.updateOrganizationMetadata(scope.orgId, {
           publicMetadata: { tier: scope.tier },
         }),
       );
@@ -183,7 +183,7 @@ async function backfillMemberPreferences(
       timezone: scopeMembers.timezone,
       notifyEmail: scopeMembers.notifyEmail,
       notifySlack: scopeMembers.notifySlack,
-      clerkOrgId: scopes.clerkOrgId,
+      orgId: scopes.orgId,
       scopeSlug: scopes.slug,
     })
     .from(scopeMembers)
@@ -229,7 +229,7 @@ async function backfillMemberPreferences(
     try {
       await withRetry(() =>
         client!.organizations.updateOrganizationMembershipMetadata({
-          organizationId: member.clerkOrgId,
+          organizationId: member.orgId,
           userId: member.userId,
           publicMetadata: metadata,
         }),

--- a/turbo/apps/web/scripts/migrations/003-sync-clerk-slugs/sync.ts
+++ b/turbo/apps/web/scripts/migrations/003-sync-clerk-slugs/sync.ts
@@ -29,7 +29,7 @@ import { scopes } from "../../../src/db/schema/scope";
 interface ScopeRow {
   id: string;
   slug: string;
-  clerkOrgId: string;
+  orgId: string;
 }
 
 interface Stats {
@@ -102,10 +102,8 @@ function isSlugConflictError(err: unknown): boolean {
   return status === 422 || status === 400;
 }
 
-function isSentinelClerkOrgId(clerkOrgId: string): boolean {
-  return (
-    clerkOrgId.startsWith("org_backfill_") || clerkOrgId.startsWith("pending_")
-  );
+function isSentinelOrgId(orgId: string): boolean {
+  return orgId.startsWith("org_backfill_") || orgId.startsWith("pending_");
 }
 
 // ---------------------------------------------------------------------------
@@ -114,12 +112,12 @@ function isSentinelClerkOrgId(clerkOrgId: string): boolean {
 
 async function fetchClerkOrg(
   client: ClerkClient,
-  clerkOrgId: string,
+  orgId: string,
 ): Promise<{ slug: string } | null> {
   for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
     try {
       return await client.organizations.getOrganization({
-        organizationId: clerkOrgId,
+        organizationId: orgId,
       });
     } catch (err) {
       if (isNotFoundError(err)) return null;
@@ -139,12 +137,12 @@ async function fetchClerkOrg(
 
 async function updateClerkOrgSlug(
   client: ClerkClient,
-  clerkOrgId: string,
+  orgId: string,
   slug: string,
 ): Promise<"updated" | "conflict"> {
   for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
     try {
-      await client.organizations.updateOrganization(clerkOrgId, { slug });
+      await client.organizations.updateOrganization(orgId, { slug });
       return "updated";
     } catch (err) {
       if (isSlugConflictError(err)) return "conflict";
@@ -173,15 +171,13 @@ async function processScope(
   scope: ScopeRow,
   idx: string,
 ): Promise<ProcessResult> {
-  if (isSentinelClerkOrgId(scope.clerkOrgId)) {
-    console.log(
-      `${idx} ⊘ SKIPPED: scope "${scope.slug}" — sentinel clerkOrgId`,
-    );
+  if (isSentinelOrgId(scope.orgId)) {
+    console.log(`${idx} ⊘ SKIPPED: scope "${scope.slug}" — sentinel orgId`);
     return "skipped";
   }
 
   try {
-    const org = await fetchClerkOrg(client, scope.clerkOrgId);
+    const org = await fetchClerkOrg(client, scope.orgId);
     await sleep(THROTTLE_MS);
 
     if (!org) {
@@ -203,11 +199,7 @@ async function processScope(
       return "mismatched";
     }
 
-    const result = await updateClerkOrgSlug(
-      client,
-      scope.clerkOrgId,
-      scope.slug,
-    );
+    const result = await updateClerkOrgSlug(client, scope.orgId, scope.slug);
     await sleep(THROTTLE_MS);
 
     if (result === "conflict") {
@@ -258,7 +250,7 @@ async function main() {
       .select({
         id: scopes.id,
         slug: scopes.slug,
-        clerkOrgId: scopes.clerkOrgId,
+        orgId: scopes.orgId,
       })
       .from(scopes)
       .orderBy(asc(scopes.createdAt));
@@ -293,7 +285,7 @@ async function main() {
     console.log(`Total:      ${stats.total}`);
     console.log(`Matched:    ${stats.matched}`);
     console.log(`Mismatched: ${stats.mismatched}`);
-    console.log(`Skipped:    ${stats.skipped} (sentinel clerkOrgId)`);
+    console.log(`Skipped:    ${stats.skipped} (sentinel orgId)`);
     console.log(`Not found:  ${stats.notFound} (Clerk org deleted)`);
     console.log(
       `Updated:    ${stats.updated}${DRY_RUN ? " (pass --migrate to sync)" : ""}`,

--- a/turbo/apps/web/scripts/migrations/004-backfill-default-agent/backfill.ts
+++ b/turbo/apps/web/scripts/migrations/004-backfill-default-agent/backfill.ts
@@ -117,7 +117,7 @@ async function backfillDefaultAgents(
     .select({
       id: scopes.id,
       slug: scopes.slug,
-      clerkOrgId: scopes.clerkOrgId,
+      orgId: scopes.orgId,
       defaultAgentComposeId: scopes.defaultAgentComposeId,
     })
     .from(scopes)
@@ -135,7 +135,7 @@ async function backfillDefaultAgents(
 
     if (DRY_RUN) {
       console.log(
-        `${idx} (dry-run) scope "${scope.slug}" — would write default_agent_compose_id="${scope.defaultAgentComposeId}" to Clerk org ${scope.clerkOrgId}`,
+        `${idx} (dry-run) scope "${scope.slug}" — would write default_agent_compose_id="${scope.defaultAgentComposeId}" to Clerk org ${scope.orgId}`,
       );
       stats.success++;
       continue;
@@ -143,7 +143,7 @@ async function backfillDefaultAgents(
 
     try {
       await withRetry(() =>
-        client!.organizations.updateOrganizationMetadata(scope.clerkOrgId, {
+        client!.organizations.updateOrganizationMetadata(scope.orgId, {
           publicMetadata: {
             default_agent_compose_id: scope.defaultAgentComposeId,
           },

--- a/turbo/apps/web/src/__tests__/api-test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers.ts
@@ -334,7 +334,7 @@ export async function createTestScope(
   // organizations from previously created scopes invisible to Clerk mock.
   initServices();
   const [scope] = await globalThis.services.db
-    .select({ clerkOrgId: scopes.clerkOrgId })
+    .select({ orgId: scopes.orgId })
     .from(scopes)
     .where(eq(scopes.id, scopeData.id))
     .limit(1);
@@ -342,13 +342,13 @@ export async function createTestScope(
     await globalThis.services.db
       .insert(orgCache)
       .values({
-        clerkOrgId: scope.clerkOrgId,
+        orgId: scope.orgId,
         slug,
         tier: "free",
         cachedAt: new Date(),
       })
       .onConflictDoUpdate({
-        target: orgCache.clerkOrgId,
+        target: orgCache.orgId,
         set: { slug, tier: "free", cachedAt: new Date() },
       });
   }
@@ -380,13 +380,13 @@ export async function setScopeTier(
  */
 export async function getTestScope(
   scopeId: string,
-): Promise<{ id: string; slug: string; tier: string; clerkOrgId: string }> {
+): Promise<{ id: string; slug: string; tier: string; orgId: string }> {
   const [scope] = await globalThis.services.db
     .select({
       id: scopes.id,
       slug: scopes.slug,
       tier: scopes.tier,
-      clerkOrgId: scopes.clerkOrgId,
+      orgId: scopes.orgId,
     })
     .from(scopes)
     .where(eq(scopes.id, scopeId))
@@ -565,13 +565,13 @@ async function createTestRunDirect(
     continuedFromSessionId?: string;
   },
 ): Promise<{ id: string }> {
-  const clerkOrgId = await getClerkOrgIdFromScope(scopeId);
+  const orgId = await getOrgIdFromScope(scopeId);
   const [run] = await globalThis.services.db
     .insert(agentRuns)
     .values({
       userId,
       scopeId,
-      clerkOrgId,
+      orgId,
       agentComposeVersionId: versionId,
       status: options?.status ?? "running",
       prompt: options?.prompt ?? "test prompt",
@@ -607,11 +607,11 @@ export async function createTestSessionWithConversation(
   userId: string,
   agentComposeId: string,
 ): Promise<{ id: string }> {
-  // Look up scopeId via clerkOrgId from the compose
+  // Look up scopeId via orgId from the compose
   const [compose] = await globalThis.services.db
     .select({ scopeId: scopes.id })
     .from(agentComposes)
-    .innerJoin(scopes, eq(agentComposes.clerkOrgId, scopes.clerkOrgId))
+    .innerJoin(scopes, eq(agentComposes.orgId, scopes.orgId))
     .where(eq(agentComposes.id, agentComposeId))
     .limit(1);
   if (!compose) {
@@ -654,7 +654,7 @@ export async function createTestRunInDb(
   const [compose] = await globalThis.services.db
     .select({ scopeId: scopes.id })
     .from(agentComposes)
-    .innerJoin(scopes, eq(agentComposes.clerkOrgId, scopes.clerkOrgId))
+    .innerJoin(scopes, eq(agentComposes.orgId, scopes.orgId))
     .where(eq(agentComposes.id, agentComposeId))
     .limit(1);
   if (!compose) {
@@ -1475,7 +1475,7 @@ async function getScopeIdFromVersion(versionId: string): Promise<string> {
       agentComposes,
       eq(agentComposes.id, agentComposeVersions.composeId),
     )
-    .innerJoin(scopes, eq(agentComposes.clerkOrgId, scopes.clerkOrgId))
+    .innerJoin(scopes, eq(agentComposes.orgId, scopes.orgId))
     .where(eq(agentComposeVersions.id, versionId))
     .limit(1);
   if (!version) {
@@ -1485,19 +1485,19 @@ async function getScopeIdFromVersion(versionId: string): Promise<string> {
 }
 
 /**
- * Resolve clerkOrgId from a scopeId.
+ * Resolve orgId from a scopeId.
  * Shared by test helpers that insert records into scope-dependent tables.
  */
-async function getClerkOrgIdFromScope(scopeId: string): Promise<string> {
+async function getOrgIdFromScope(scopeId: string): Promise<string> {
   const [scope] = await globalThis.services.db
-    .select({ clerkOrgId: scopes.clerkOrgId })
+    .select({ orgId: scopes.orgId })
     .from(scopes)
     .where(eq(scopes.id, scopeId))
     .limit(1);
   if (!scope) {
     throw new Error(`Scope ${scopeId} not found`);
   }
-  return scope.clerkOrgId;
+  return scope.orgId;
 }
 
 /**
@@ -1517,7 +1517,7 @@ export async function insertStalePendingRun(
   ageMs: number = 20 * 60 * 1000,
 ): Promise<string> {
   const scopeId = await getScopeIdFromVersion(agentComposeVersionId);
-  const clerkOrgId = await getClerkOrgIdFromScope(scopeId);
+  const orgId = await getOrgIdFromScope(scopeId);
 
   const staleCreatedAt = new Date(Date.now() - ageMs);
   const [run] = await globalThis.services.db
@@ -1525,7 +1525,7 @@ export async function insertStalePendingRun(
     .values({
       userId,
       scopeId,
-      clerkOrgId,
+      orgId,
       agentComposeVersionId,
       status: "pending",
       prompt: "Stale pending run",
@@ -1790,13 +1790,13 @@ export async function findTestConnectorSecret(
   secretName: string,
   type: "connector" | "user" = "connector",
 ): Promise<string | undefined> {
-  const clerkOrgId = await getClerkOrgIdFromScope(scopeId);
+  const orgId = await getOrgIdFromScope(scopeId);
   const [storedSecret] = await globalThis.services.db
     .select()
     .from(secrets)
     .where(
       and(
-        eq(secrets.clerkOrgId, clerkOrgId),
+        eq(secrets.orgId, orgId),
         eq(secrets.name, secretName),
         eq(secrets.type, type),
       ),
@@ -1823,13 +1823,11 @@ export async function findTestConnectorTokenExpiresAt(
   scopeId: string,
   type: string,
 ): Promise<Date | null | undefined> {
-  const clerkOrgId = await getClerkOrgIdFromScope(scopeId);
+  const orgId = await getOrgIdFromScope(scopeId);
   const [row] = await globalThis.services.db
     .select({ tokenExpiresAt: connectors.tokenExpiresAt })
     .from(connectors)
-    .where(
-      and(eq(connectors.clerkOrgId, clerkOrgId), eq(connectors.type, type)),
-    )
+    .where(and(eq(connectors.orgId, orgId), eq(connectors.type, type)))
     .limit(1);
 
   if (!row) return undefined;
@@ -1954,14 +1952,14 @@ export async function createCompletedTestRun(options: {
   completedAt: Date;
 }): Promise<string> {
   const scopeId = await getScopeIdFromVersion(options.composeVersionId);
-  const clerkOrgId = await getClerkOrgIdFromScope(scopeId);
+  const orgId = await getOrgIdFromScope(scopeId);
 
   const [row] = await globalThis.services.db
     .insert(agentRuns)
     .values({
       userId: options.userId,
       scopeId,
-      clerkOrgId,
+      orgId,
       agentComposeVersionId: options.composeVersionId,
       status: "completed",
       prompt: "test",
@@ -2012,13 +2010,13 @@ export async function createTestSlackComposeRequest(options: {
 /**
  * Find artifact storage for a scope, including its HEAD version details.
  */
-export async function findTestArtifactStorage(clerkOrgId: string) {
+export async function findTestArtifactStorage(orgId: string) {
   const [storage] = await globalThis.services.db
     .select()
     .from(storages)
     .where(
       and(
-        eq(storages.clerkOrgId, clerkOrgId),
+        eq(storages.orgId, orgId),
         eq(storages.name, "artifact"),
         eq(storages.type, "artifact"),
       ),
@@ -2046,7 +2044,7 @@ export async function findTestArtifactStorage(clerkOrgId: string) {
  * Returns the storage id and name, or undefined if not found.
  */
 export async function findTestStorageByName(
-  clerkOrgId: string,
+  orgId: string,
   name: string,
 ): Promise<{ id: string; name: string; s3Prefix: string } | undefined> {
   const [result] = await globalThis.services.db
@@ -2058,7 +2056,7 @@ export async function findTestStorageByName(
     .from(storages)
     .where(
       and(
-        eq(storages.clerkOrgId, clerkOrgId),
+        eq(storages.orgId, orgId),
         eq(storages.userId, VOLUME_SCOPE_USER_ID),
         eq(storages.name, name),
         eq(storages.type, "volume"),
@@ -2072,7 +2070,7 @@ export async function findTestStorageByName(
  * Returns the storage userId and other details for verification.
  */
 export async function findTestStorage(
-  clerkOrgId: string,
+  orgId: string,
   name: string,
   type: "volume" | "artifact" | "memory",
 ): Promise<
@@ -2088,7 +2086,7 @@ export async function findTestStorage(
     .from(storages)
     .where(
       and(
-        eq(storages.clerkOrgId, clerkOrgId),
+        eq(storages.orgId, orgId),
         eq(storages.name, name),
         eq(storages.type, type),
       ),
@@ -2378,7 +2376,7 @@ export async function findTestComposeWithScope(composeId: string) {
       scopeSlug: scopes.slug,
     })
     .from(agentComposes)
-    .innerJoin(scopes, eq(scopes.clerkOrgId, agentComposes.clerkOrgId))
+    .innerJoin(scopes, eq(scopes.orgId, agentComposes.orgId))
     .where(eq(agentComposes.id, composeId))
     .limit(1);
   return row;
@@ -2400,14 +2398,14 @@ export async function createTestRunnerJob(
   contextOverrides?: Partial<StoredExecutionContext>,
 ): Promise<{ runId: string }> {
   const scopeId = await getScopeIdFromVersion(versionId);
-  const clerkOrgId = await getClerkOrgIdFromScope(scopeId);
+  const orgId = await getOrgIdFromScope(scopeId);
 
   const [run] = await globalThis.services.db
     .insert(agentRuns)
     .values({
       userId,
       scopeId,
-      clerkOrgId,
+      orgId,
       agentComposeVersionId: versionId,
       status: "pending",
       prompt: "test prompt",
@@ -2689,21 +2687,21 @@ export async function createTestTelegramInstallation(options?: {
   const adminUserId = options?.adminUserId ?? uniqueId("test-admin");
 
   const scopeSlug = uniqueId("scope");
-  const clerkOrgId = uniqueId("org");
+  const orgId = uniqueId("org");
   const [scope] = await globalThis.services.db
     .insert(scopes)
     .values({
       slug: scopeSlug,
-      clerkOrgId,
+      orgId,
     })
     .returning();
 
   // Pre-populate org cache for getOrgData()
   await globalThis.services.db
     .insert(orgCache)
-    .values({ clerkOrgId, slug: scopeSlug, tier: "free", cachedAt: new Date() })
+    .values({ orgId, slug: scopeSlug, tier: "free", cachedAt: new Date() })
     .onConflictDoUpdate({
-      target: orgCache.clerkOrgId,
+      target: orgCache.orgId,
       set: { slug: scopeSlug, tier: "free", cachedAt: new Date() },
     });
 
@@ -2712,7 +2710,7 @@ export async function createTestTelegramInstallation(options?: {
     .values({
       userId: adminUserId,
       scopeId: scope!.id,
-      clerkOrgId: scope!.clerkOrgId,
+      orgId: scope!.orgId,
       name: uniqueId("compose"),
     })
     .returning();
@@ -2817,10 +2815,10 @@ export async function insertTestAgentCompose(
   scopeId: string,
   name: string,
 ) {
-  const clerkOrgId = await getClerkOrgIdFromScope(scopeId);
+  const orgId = await getOrgIdFromScope(scopeId);
   const [row] = await globalThis.services.db
     .insert(agentComposes)
-    .values({ userId, scopeId, clerkOrgId, name })
+    .values({ userId, scopeId, orgId, name })
     .returning();
   return row!;
 }
@@ -2836,13 +2834,13 @@ export async function insertTestAgentRun(
   scopeId: string,
   options?: { status?: string; prompt?: string },
 ) {
-  const clerkOrgId = await getClerkOrgIdFromScope(scopeId);
+  const orgId = await getOrgIdFromScope(scopeId);
   const [row] = await globalThis.services.db
     .insert(agentRuns)
     .values({
       userId,
       scopeId,
-      clerkOrgId,
+      orgId,
       status: options?.status ?? "completed",
       prompt: options?.prompt ?? "test prompt",
     })
@@ -3035,7 +3033,7 @@ export async function findTestOutboxItemById(id: string) {
  * Insert a row into org_cache for testing cache behavior.
  */
 export async function insertOrgCacheEntry(entry: {
-  clerkOrgId: string;
+  orgId: string;
   slug: string;
   tier?: string;
   cachedAt?: Date;
@@ -3043,13 +3041,13 @@ export async function insertOrgCacheEntry(entry: {
   await globalThis.services.db
     .insert(orgCache)
     .values({
-      clerkOrgId: entry.clerkOrgId,
+      orgId: entry.orgId,
       slug: entry.slug,
       tier: entry.tier ?? "free",
       cachedAt: entry.cachedAt ?? new Date(),
     })
     .onConflictDoUpdate({
-      target: orgCache.clerkOrgId,
+      target: orgCache.orgId,
       set: {
         slug: entry.slug,
         tier: entry.tier ?? "free",
@@ -3059,23 +3057,23 @@ export async function insertOrgCacheEntry(entry: {
 }
 
 /**
- * Delete an org_cache row by clerkOrgId.
+ * Delete an org_cache row by orgId.
  * Useful for testing cache-miss behavior after createTestScope pre-populates cache.
  */
-export async function deleteOrgCacheEntry(clerkOrgId: string): Promise<void> {
+export async function deleteOrgCacheEntry(orgId: string): Promise<void> {
   await globalThis.services.db
     .delete(orgCache)
-    .where(eq(orgCache.clerkOrgId, clerkOrgId));
+    .where(eq(orgCache.orgId, orgId));
 }
 
 /**
- * Read an org_cache row by clerkOrgId.
+ * Read an org_cache row by orgId.
  */
-export async function getOrgCacheEntry(clerkOrgId: string) {
+export async function getOrgCacheEntry(orgId: string) {
   const [row] = await globalThis.services.db
     .select()
     .from(orgCache)
-    .where(eq(orgCache.clerkOrgId, clerkOrgId))
+    .where(eq(orgCache.orgId, orgId))
     .limit(1);
   return row ?? null;
 }
@@ -3084,13 +3082,13 @@ export async function getOrgCacheEntry(clerkOrgId: string) {
  * Insert an org_members_cache entry for testing cache behavior.
  */
 export async function insertOrgMembersCacheEntry(entry: {
-  clerkOrgId: string;
+  orgId: string;
   userId: string;
   cachedAt?: Date;
 }): Promise<void> {
   initServices();
   await globalThis.services.db.insert(orgMembersCache).values({
-    clerkOrgId: entry.clerkOrgId,
+    orgId: entry.orgId,
     userId: entry.userId,
     cachedAt: entry.cachedAt ?? new Date(),
   });

--- a/turbo/apps/web/src/__tests__/github/api-helpers.ts
+++ b/turbo/apps/web/src/__tests__/github/api-helpers.ts
@@ -53,18 +53,18 @@ export async function givenGitHubInstallation(
   const scopeSlug = uniqueId("scope");
 
   // Create scope
-  const clerkOrgId = uniqueId("org");
+  const orgId = uniqueId("org");
   const [scope] = await globalThis.services.db
     .insert(scopes)
-    .values({ slug: scopeSlug, clerkOrgId })
+    .values({ slug: scopeSlug, orgId })
     .returning();
 
   // Pre-populate org cache for getOrgData()
   await globalThis.services.db
     .insert(orgCache)
-    .values({ clerkOrgId, slug: scopeSlug, tier: "free", cachedAt: new Date() })
+    .values({ orgId, slug: scopeSlug, tier: "free", cachedAt: new Date() })
     .onConflictDoUpdate({
-      target: orgCache.clerkOrgId,
+      target: orgCache.orgId,
       set: { slug: scopeSlug, tier: "free", cachedAt: new Date() },
     });
 
@@ -74,7 +74,7 @@ export async function givenGitHubInstallation(
     .values({
       userId,
       scopeId: scope!.id,
-      clerkOrgId: scope!.clerkOrgId,
+      orgId: scope!.orgId,
       name: uniqueId("gh-agent"),
     })
     .returning();

--- a/turbo/apps/web/src/__tests__/test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/test-helpers.ts
@@ -195,7 +195,7 @@ interface TestContext {
   createAgentCompose(
     vm0UserId: string,
     options?: { name?: string },
-  ): Promise<{ id: string; name: string; scopeId: string; clerkOrgId: string }>;
+  ): Promise<{ id: string; name: string; scopeId: string; orgId: string }>;
   createConnector(
     scopeId: string,
     options: { userId: string; type?: string; authMethod?: string },
@@ -205,7 +205,7 @@ interface TestContext {
 export interface UserContext {
   readonly userId: string;
   readonly scopeId: string;
-  readonly clerkOrgId: string;
+  readonly orgId: string;
 }
 
 /**
@@ -446,9 +446,9 @@ export function testContext(): TestContext {
       const scopeData = await createTestScope(`scope-${suffix}`);
       controller.signal.throwIfAborted();
 
-      // Look up clerkOrgId from the created scope
+      // Look up orgId from the created scope
       const [scope] = await globalThis.services.db
-        .select({ clerkOrgId: scopes.clerkOrgId })
+        .select({ orgId: scopes.orgId })
         .from(scopes)
         .where(eq(scopes.id, scopeData.id))
         .limit(1);
@@ -456,7 +456,7 @@ export function testContext(): TestContext {
       return {
         userId,
         scopeId: scopeData.id,
-        clerkOrgId: scope!.clerkOrgId,
+        orgId: scope!.orgId,
       };
     })();
 
@@ -493,12 +493,12 @@ export function testContext(): TestContext {
     let composeId = options.composeId;
     if (!composeId) {
       const scopeSlug = uniqueId("scope");
-      const clerkOrgId = uniqueId("org");
+      const orgId = uniqueId("org");
       const [scopeData] = await globalThis.services.db
         .insert(scopes)
         .values({
           slug: scopeSlug,
-          clerkOrgId,
+          orgId,
         })
         .returning();
 
@@ -507,14 +507,14 @@ export function testContext(): TestContext {
       }
 
       // Pre-populate org cache for getOrgData()
-      await insertOrgCacheEntry({ clerkOrgId, slug: scopeSlug });
+      await insertOrgCacheEntry({ orgId, slug: scopeSlug });
 
       const [compose] = await globalThis.services.db
         .insert(agentComposes)
         .values({
           userId: adminUserId,
           scopeId: scopeData.id,
-          clerkOrgId: scopeData.clerkOrgId,
+          orgId: scopeData.orgId,
           name: uniqueId("default-agent"),
         })
         .returning();
@@ -593,7 +593,7 @@ export function testContext(): TestContext {
     id: string;
     name: string;
     scopeId: string;
-    clerkOrgId: string;
+    orgId: string;
   }> {
     const { name = uniqueId("test-compose") } = options;
 
@@ -601,12 +601,12 @@ export function testContext(): TestContext {
 
     // Create a scope directly in the database (bypass API to avoid Clerk auth)
     const scopeSlug = uniqueId("scope");
-    const clerkOrgId = uniqueId("org");
+    const orgId = uniqueId("org");
     const [scopeData] = await globalThis.services.db
       .insert(scopes)
       .values({
         slug: scopeSlug,
-        clerkOrgId,
+        orgId,
       })
       .returning();
 
@@ -615,7 +615,7 @@ export function testContext(): TestContext {
     }
 
     // Pre-populate org cache for getOrgData()
-    await insertOrgCacheEntry({ clerkOrgId, slug: scopeSlug });
+    await insertOrgCacheEntry({ orgId, slug: scopeSlug });
 
     // Create a compose for this user
     const [compose] = await globalThis.services.db
@@ -623,7 +623,7 @@ export function testContext(): TestContext {
       .values({
         userId: vm0UserId,
         scopeId: scopeData.id,
-        clerkOrgId: scopeData.clerkOrgId,
+        orgId: scopeData.orgId,
         name,
       })
       .returning();
@@ -636,7 +636,7 @@ export function testContext(): TestContext {
       id: compose.id,
       name: compose.name,
       scopeId: scopeData.id,
-      clerkOrgId: scopeData.clerkOrgId,
+      orgId: scopeData.orgId,
     };
   }
 
@@ -653,7 +653,7 @@ export function testContext(): TestContext {
     initServices();
 
     const [scope] = await globalThis.services.db
-      .select({ clerkOrgId: scopes.clerkOrgId })
+      .select({ orgId: scopes.orgId })
       .from(scopes)
       .where(eq(scopes.id, scopeId))
       .limit(1);
@@ -663,7 +663,7 @@ export function testContext(): TestContext {
       .values({
         scopeId,
         userId,
-        clerkOrgId: scope!.clerkOrgId,
+        orgId: scope!.orgId,
         type,
         authMethod,
       })

--- a/turbo/apps/web/src/db/migrations/0129_rename_clerk_org_id.sql
+++ b/turbo/apps/web/src/db/migrations/0129_rename_clerk_org_id.sql
@@ -27,4 +27,6 @@ ALTER INDEX "idx_secrets_clerk_org_user_name_type" RENAME TO "idx_secrets_org_us
 ALTER INDEX "idx_storages_clerk_org" RENAME TO "idx_storages_org";--> statement-breakpoint
 ALTER INDEX "idx_storages_clerk_org_user_name_type" RENAME TO "idx_storages_org_user_name_type";--> statement-breakpoint
 ALTER INDEX "idx_variables_clerk_org" RENAME TO "idx_variables_org";--> statement-breakpoint
-ALTER INDEX "idx_variables_clerk_org_user_name" RENAME TO "idx_variables_org_user_name";
+ALTER INDEX "idx_variables_clerk_org_user_name" RENAME TO "idx_variables_org_user_name";--> statement-breakpoint
+-- Rename primary key constraint index
+ALTER INDEX "org_members_cache_clerk_org_id_user_id_pk" RENAME TO "org_members_cache_org_id_user_id_pk";

--- a/turbo/apps/web/src/db/migrations/0129_rename_clerk_org_id.sql
+++ b/turbo/apps/web/src/db/migrations/0129_rename_clerk_org_id.sql
@@ -1,0 +1,30 @@
+-- Rename clerk_org_id to org_id across all tables
+ALTER TABLE "scopes" RENAME COLUMN "clerk_org_id" TO "org_id";--> statement-breakpoint
+ALTER TABLE "agent_composes" RENAME COLUMN "clerk_org_id" TO "org_id";--> statement-breakpoint
+ALTER TABLE "agent_runs" RENAME COLUMN "clerk_org_id" TO "org_id";--> statement-breakpoint
+ALTER TABLE "agent_schedules" RENAME COLUMN "clerk_org_id" TO "org_id";--> statement-breakpoint
+ALTER TABLE "cli_tokens" RENAME COLUMN "clerk_org_id" TO "org_id";--> statement-breakpoint
+ALTER TABLE "connectors" RENAME COLUMN "clerk_org_id" TO "org_id";--> statement-breakpoint
+ALTER TABLE "model_providers" RENAME COLUMN "clerk_org_id" TO "org_id";--> statement-breakpoint
+ALTER TABLE "org_cache" RENAME COLUMN "clerk_org_id" TO "org_id";--> statement-breakpoint
+ALTER TABLE "org_members_cache" RENAME COLUMN "clerk_org_id" TO "org_id";--> statement-breakpoint
+ALTER TABLE "secrets" RENAME COLUMN "clerk_org_id" TO "org_id";--> statement-breakpoint
+ALTER TABLE "storages" RENAME COLUMN "clerk_org_id" TO "org_id";--> statement-breakpoint
+ALTER TABLE "variables" RENAME COLUMN "clerk_org_id" TO "org_id";--> statement-breakpoint
+-- Rename indexes
+ALTER INDEX "idx_scopes_clerk_org" RENAME TO "idx_scopes_org";--> statement-breakpoint
+ALTER INDEX "idx_agent_composes_clerk_org" RENAME TO "idx_agent_composes_org";--> statement-breakpoint
+ALTER INDEX "idx_agent_composes_clerk_org_name" RENAME TO "idx_agent_composes_org_name";--> statement-breakpoint
+ALTER INDEX "idx_agent_runs_clerk_org" RENAME TO "idx_agent_runs_org";--> statement-breakpoint
+ALTER INDEX "idx_agent_schedules_clerk_org" RENAME TO "idx_agent_schedules_org";--> statement-breakpoint
+ALTER INDEX "idx_agent_schedules_compose_name_clerk_org_user" RENAME TO "idx_agent_schedules_compose_name_org_user";--> statement-breakpoint
+ALTER INDEX "idx_connectors_clerk_org" RENAME TO "idx_connectors_org";--> statement-breakpoint
+ALTER INDEX "idx_connectors_clerk_org_user_type" RENAME TO "idx_connectors_org_user_type";--> statement-breakpoint
+ALTER INDEX "idx_model_providers_clerk_org" RENAME TO "idx_model_providers_org";--> statement-breakpoint
+ALTER INDEX "idx_model_providers_clerk_org_user_type" RENAME TO "idx_model_providers_org_user_type";--> statement-breakpoint
+ALTER INDEX "idx_secrets_clerk_org" RENAME TO "idx_secrets_org";--> statement-breakpoint
+ALTER INDEX "idx_secrets_clerk_org_user_name_type" RENAME TO "idx_secrets_org_user_name_type";--> statement-breakpoint
+ALTER INDEX "idx_storages_clerk_org" RENAME TO "idx_storages_org";--> statement-breakpoint
+ALTER INDEX "idx_storages_clerk_org_user_name_type" RENAME TO "idx_storages_org_user_name_type";--> statement-breakpoint
+ALTER INDEX "idx_variables_clerk_org" RENAME TO "idx_variables_org";--> statement-breakpoint
+ALTER INDEX "idx_variables_clerk_org_user_name" RENAME TO "idx_variables_org_user_name";

--- a/turbo/apps/web/src/db/migrations/meta/0129_snapshot.json
+++ b/turbo/apps/web/src/db/migrations/meta/0129_snapshot.json
@@ -62,12 +62,8 @@
           "name": "agent_compose_versions_compose_id_agent_composes_id_fk",
           "tableFrom": "agent_compose_versions",
           "tableTo": "agent_composes",
-          "columnsFrom": [
-            "compose_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["compose_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -178,12 +174,8 @@
           "name": "agent_composes_scope_id_scopes_id_fk",
           "tableFrom": "agent_composes",
           "tableTo": "scopes",
-          "columnsFrom": [
-            "scope_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["scope_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -288,12 +280,8 @@
           "name": "agent_permissions_agent_compose_id_agent_composes_id_fk",
           "tableFrom": "agent_permissions",
           "tableTo": "agent_composes",
-          "columnsFrom": [
-            "agent_compose_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_compose_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -303,11 +291,7 @@
         "agent_permissions_compose_type_email_unique": {
           "name": "agent_permissions_compose_type_email_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "agent_compose_id",
-            "grantee_type",
-            "grantee_email"
-          ]
+          "columns": ["agent_compose_id", "grantee_type", "grantee_email"]
         }
       },
       "policies": {},
@@ -427,12 +411,8 @@
           "name": "agent_run_callbacks_run_id_agent_runs_id_fk",
           "tableFrom": "agent_run_callbacks",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -492,12 +472,8 @@
           "name": "agent_run_events_run_id_agent_runs_id_fk",
           "tableFrom": "agent_run_events",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -587,12 +563,8 @@
           "name": "agent_run_queue_run_id_agent_runs_id_fk",
           "tableFrom": "agent_run_queue",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -826,12 +798,8 @@
           "name": "agent_runs_agent_compose_version_id_agent_compose_versions_id_fk",
           "tableFrom": "agent_runs",
           "tableTo": "agent_compose_versions",
-          "columnsFrom": [
-            "agent_compose_version_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_compose_version_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         },
@@ -839,12 +807,8 @@
           "name": "agent_runs_schedule_id_agent_schedules_id_fk",
           "tableFrom": "agent_runs",
           "tableTo": "agent_schedules",
-          "columnsFrom": [
-            "schedule_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["schedule_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -1103,12 +1067,8 @@
           "name": "agent_schedules_compose_id_agent_composes_id_fk",
           "tableFrom": "agent_schedules",
           "tableTo": "agent_composes",
-          "columnsFrom": [
-            "compose_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["compose_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -1116,12 +1076,8 @@
           "name": "agent_schedules_last_run_id_agent_runs_id_fk",
           "tableFrom": "agent_schedules",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "last_run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["last_run_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -1229,12 +1185,8 @@
           "name": "agent_sessions_agent_compose_id_agent_composes_id_fk",
           "tableFrom": "agent_sessions",
           "tableTo": "agent_composes",
-          "columnsFrom": [
-            "agent_compose_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_compose_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -1242,12 +1194,8 @@
           "name": "agent_sessions_conversation_id_conversations_id_fk",
           "tableFrom": "agent_sessions",
           "tableTo": "conversations",
-          "columnsFrom": [
-            "conversation_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -1374,12 +1322,8 @@
           "name": "checkpoints_run_id_agent_runs_id_fk",
           "tableFrom": "checkpoints",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -1387,12 +1331,8 @@
           "name": "checkpoints_conversation_id_conversations_id_fk",
           "tableFrom": "checkpoints",
           "tableTo": "conversations",
-          "columnsFrom": [
-            "conversation_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -1402,9 +1342,7 @@
         "checkpoints_run_id_unique": {
           "name": "checkpoints_run_id_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "run_id"
-          ]
+          "columns": ["run_id"]
         }
       },
       "policies": {},
@@ -1479,9 +1417,7 @@
         "cli_tokens_token_unique": {
           "name": "cli_tokens_token_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "token"
-          ]
+          "columns": ["token"]
         }
       },
       "policies": {},
@@ -1942,12 +1878,8 @@
           "name": "conversations_run_id_agent_runs_id_fk",
           "tableFrom": "conversations",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -1957,9 +1889,7 @@
         "conversations_run_id_unique": {
           "name": "conversations_run_id_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "run_id"
-          ]
+          "columns": ["run_id"]
         }
       },
       "policies": {},
@@ -2234,12 +2164,8 @@
           "name": "email_reply_requests_run_id_agent_runs_id_fk",
           "tableFrom": "email_reply_requests",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -2247,12 +2173,8 @@
           "name": "email_reply_requests_email_thread_session_id_email_thread_sessions_id_fk",
           "tableFrom": "email_reply_requests",
           "tableTo": "email_thread_sessions",
-          "columnsFrom": [
-            "email_thread_session_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["email_thread_session_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -2356,12 +2278,8 @@
           "name": "email_thread_sessions_compose_id_agent_composes_id_fk",
           "tableFrom": "email_thread_sessions",
           "tableTo": "agent_composes",
-          "columnsFrom": [
-            "compose_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["compose_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -2369,12 +2287,8 @@
           "name": "email_thread_sessions_agent_session_id_agent_sessions_id_fk",
           "tableFrom": "email_thread_sessions",
           "tableTo": "agent_sessions",
-          "columnsFrom": [
-            "agent_session_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_session_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -2489,12 +2403,8 @@
           "name": "github_installations_default_compose_id_agent_composes_id_fk",
           "tableFrom": "github_installations",
           "tableTo": "agent_composes",
-          "columnsFrom": [
-            "default_compose_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["default_compose_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -2616,12 +2526,8 @@
           "name": "github_issue_sessions_installation_id_github_installations_id_fk",
           "tableFrom": "github_issue_sessions",
           "tableTo": "github_installations",
-          "columnsFrom": [
-            "installation_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["installation_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -2629,12 +2535,8 @@
           "name": "github_issue_sessions_agent_session_id_agent_sessions_id_fk",
           "tableFrom": "github_issue_sessions",
           "tableTo": "agent_sessions",
-          "columnsFrom": [
-            "agent_session_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_session_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -2710,12 +2612,8 @@
           "name": "github_user_links_installation_id_github_installations_id_fk",
           "tableFrom": "github_user_links",
           "tableTo": "github_installations",
-          "columnsFrom": [
-            "installation_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["installation_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -2865,12 +2763,8 @@
           "name": "model_providers_secret_id_secrets_id_fk",
           "tableFrom": "model_providers",
           "tableTo": "secrets",
-          "columnsFrom": [
-            "secret_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["secret_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -2985,10 +2879,7 @@
       "compositePrimaryKeys": {
         "org_members_cache_org_id_user_id_pk": {
           "name": "org_members_cache_org_id_user_id_pk",
-          "columns": [
-            "org_id",
-            "user_id"
-          ]
+          "columns": ["org_id", "user_id"]
         }
       },
       "uniqueConstraints": {},
@@ -3076,12 +2967,8 @@
           "name": "runner_job_queue_run_id_agent_runs_id_fk",
           "tableFrom": "runner_job_queue",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -3145,12 +3032,8 @@
           "name": "sandbox_telemetry_run_id_agent_runs_id_fk",
           "tableFrom": "sandbox_telemetry",
           "tableTo": "agent_runs",
-          "columnsFrom": [
-            "run_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -3283,12 +3166,8 @@
           "name": "scope_members_scope_id_scopes_id_fk",
           "tableFrom": "scope_members",
           "tableTo": "scopes",
-          "columnsFrom": [
-            "scope_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["scope_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -3377,12 +3256,8 @@
           "name": "scopes_default_agent_compose_id_agent_composes_id_fk",
           "tableFrom": "scopes",
           "tableTo": "agent_composes",
-          "columnsFrom": [
-            "default_agent_compose_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["default_agent_compose_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -3392,9 +3267,7 @@
         "scopes_slug_unique": {
           "name": "scopes_slug_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "slug"
-          ]
+          "columns": ["slug"]
         }
       },
       "policies": {},
@@ -3612,12 +3485,8 @@
           "name": "slack_compose_requests_compose_job_id_compose_jobs_id_fk",
           "tableFrom": "slack_compose_requests",
           "tableTo": "compose_jobs",
-          "columnsFrom": [
-            "compose_job_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["compose_job_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -3696,12 +3565,8 @@
           "name": "slack_installations_default_compose_id_agent_composes_id_fk",
           "tableFrom": "slack_installations",
           "tableTo": "agent_composes",
-          "columnsFrom": [
-            "default_compose_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["default_compose_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -3711,9 +3576,7 @@
         "slack_installations_slack_workspace_id_unique": {
           "name": "slack_installations_slack_workspace_id_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "slack_workspace_id"
-          ]
+          "columns": ["slack_workspace_id"]
         }
       },
       "policies": {},
@@ -3940,12 +3803,8 @@
           "name": "slack_thread_sessions_slack_user_link_id_slack_user_links_id_fk",
           "tableFrom": "slack_thread_sessions",
           "tableTo": "slack_user_links",
-          "columnsFrom": [
-            "slack_user_link_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["slack_user_link_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -3953,12 +3812,8 @@
           "name": "slack_thread_sessions_agent_session_id_agent_sessions_id_fk",
           "tableFrom": "slack_thread_sessions",
           "tableTo": "agent_sessions",
-          "columnsFrom": [
-            "agent_session_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_session_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -4105,12 +3960,8 @@
           "name": "storage_versions_storage_id_storages_id_fk",
           "tableFrom": "storage_versions",
           "tableTo": "storages",
-          "columnsFrom": [
-            "storage_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["storage_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -4259,12 +4110,8 @@
           "name": "storages_head_version_id_storage_versions_id_fk",
           "tableFrom": "storages",
           "tableTo": "storage_versions",
-          "columnsFrom": [
-            "head_version_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["head_version_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -4343,12 +4190,8 @@
           "name": "telegram_installations_default_compose_id_agent_composes_id_fk",
           "tableFrom": "telegram_installations",
           "tableTo": "agent_composes",
-          "columnsFrom": [
-            "default_compose_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["default_compose_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -4358,9 +4201,7 @@
         "telegram_installations_telegram_bot_id_unique": {
           "name": "telegram_installations_telegram_bot_id_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "telegram_bot_id"
-          ]
+          "columns": ["telegram_bot_id"]
         }
       },
       "policies": {},
@@ -4505,12 +4346,8 @@
           "name": "telegram_messages_installation_id_telegram_installations_id_fk",
           "tableFrom": "telegram_messages",
           "tableTo": "telegram_installations",
-          "columnsFrom": [
-            "installation_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["installation_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -4626,12 +4463,8 @@
           "name": "telegram_thread_sessions_telegram_user_link_id_telegram_user_links_id_fk",
           "tableFrom": "telegram_thread_sessions",
           "tableTo": "telegram_user_links",
-          "columnsFrom": [
-            "telegram_user_link_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["telegram_user_link_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -4639,12 +4472,8 @@
           "name": "telegram_thread_sessions_agent_session_id_agent_sessions_id_fk",
           "tableFrom": "telegram_thread_sessions",
           "tableTo": "agent_sessions",
-          "columnsFrom": [
-            "agent_session_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_session_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -4734,12 +4563,8 @@
           "name": "telegram_user_links_installation_id_telegram_installations_id_fk",
           "tableFrom": "telegram_user_links",
           "tableTo": "telegram_installations",
-          "columnsFrom": [
-            "installation_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["installation_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -5022,22 +4847,12 @@
     "public.connector_session_status": {
       "name": "connector_session_status",
       "schema": "public",
-      "values": [
-        "pending",
-        "complete",
-        "expired",
-        "error"
-      ]
+      "values": ["pending", "complete", "expired", "error"]
     },
     "public.device_code_status": {
       "name": "device_code_status",
       "schema": "public",
-      "values": [
-        "pending",
-        "authenticated",
-        "expired",
-        "denied"
-      ]
+      "values": ["pending", "authenticated", "expired", "denied"]
     }
   },
   "schemas": {},

--- a/turbo/apps/web/src/db/migrations/meta/0129_snapshot.json
+++ b/turbo/apps/web/src/db/migrations/meta/0129_snapshot.json
@@ -1,0 +1,5053 @@
+{
+  "id": "a15e5da86f529c0cfa96",
+  "prevId": "07260edd-81cc-431d-a219-ad615ca3cc88",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.agent_compose_versions": {
+      "name": "agent_compose_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "compose_id": {
+          "name": "compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_compose_versions_compose_id": {
+          "name": "idx_agent_compose_versions_compose_id",
+          "columns": [
+            {
+              "expression": "compose_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_compose_versions_compose_id_agent_composes_id_fk": {
+          "name": "agent_compose_versions_compose_id_agent_composes_id_fk",
+          "tableFrom": "agent_compose_versions",
+          "tableTo": "agent_composes",
+          "columnsFrom": [
+            "compose_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_composes": {
+      "name": "agent_composes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "head_version_id": {
+          "name": "head_version_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_composes_org": {
+          "name": "idx_agent_composes_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_composes_org_name": {
+          "name": "idx_agent_composes_org_name",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_composes_scope_id_scopes_id_fk": {
+          "name": "agent_composes_scope_id_scopes_id_fk",
+          "tableFrom": "agent_composes",
+          "tableTo": "scopes",
+          "columnsFrom": [
+            "scope_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_permissions": {
+      "name": "agent_permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "agent_compose_id": {
+          "name": "agent_compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grantee_type": {
+          "name": "grantee_type",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grantee_email": {
+          "name": "grantee_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "permission": {
+          "name": "permission",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'run_view'"
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_permissions_compose": {
+          "name": "idx_agent_permissions_compose",
+          "columns": [
+            {
+              "expression": "agent_compose_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_permissions_email": {
+          "name": "idx_agent_permissions_email",
+          "columns": [
+            {
+              "expression": "grantee_email",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "grantee_email IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_permissions_agent_compose_id_agent_composes_id_fk": {
+          "name": "agent_permissions_agent_compose_id_agent_composes_id_fk",
+          "tableFrom": "agent_permissions",
+          "tableTo": "agent_composes",
+          "columnsFrom": [
+            "agent_compose_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "agent_permissions_compose_type_email_unique": {
+          "name": "agent_permissions_compose_type_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "agent_compose_id",
+            "grantee_type",
+            "grantee_email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_run_callbacks": {
+      "name": "agent_run_callbacks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_secret": {
+          "name": "encrypted_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_attempt_at": {
+          "name": "last_attempt_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_run_callbacks_run_id": {
+          "name": "idx_agent_run_callbacks_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_run_callbacks_pending": {
+          "name": "idx_agent_run_callbacks_pending",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "status = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_run_callbacks_run_id_agent_runs_id_fk": {
+          "name": "agent_run_callbacks_run_id_agent_runs_id_fk",
+          "tableFrom": "agent_run_callbacks",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_run_events": {
+      "name": "agent_run_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence_number": {
+          "name": "sequence_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_data": {
+          "name": "event_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_run_events_run_id_agent_runs_id_fk": {
+          "name": "agent_run_events_run_id_agent_runs_id_fk",
+          "tableFrom": "agent_run_events",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_run_queue": {
+      "name": "agent_run_queue",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_params": {
+          "name": "encrypted_params",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "agent_run_queue_user_created_idx": {
+          "name": "agent_run_queue_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_run_queue_expires_at_idx": {
+          "name": "agent_run_queue_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_run_queue_run_id_agent_runs_id_fk": {
+          "name": "agent_run_queue_run_id_agent_runs_id_fk",
+          "tableFrom": "agent_run_queue",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_runs": {
+      "name": "agent_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_compose_version_id": {
+          "name": "agent_compose_version_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resumed_from_checkpoint_id": {
+          "name": "resumed_from_checkpoint_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "continued_from_session_id": {
+          "name": "continued_from_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vars": {
+          "name": "vars",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "secret_names": {
+          "name": "secret_names",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_heartbeat_at": {
+          "name": "last_heartbeat_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_agent_runs_user_created": {
+          "name": "idx_agent_runs_user_created",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_runs_org": {
+          "name": "idx_agent_runs_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_runs_status_heartbeat": {
+          "name": "idx_agent_runs_status_heartbeat",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_heartbeat_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_runs_running_heartbeat": {
+          "name": "idx_agent_runs_running_heartbeat",
+          "columns": [
+            {
+              "expression": "last_heartbeat_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "status = 'running'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_runs_schedule_created": {
+          "name": "idx_agent_runs_schedule_created",
+          "columns": [
+            {
+              "expression": "schedule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "schedule_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_runs_agent_compose_version_id_agent_compose_versions_id_fk": {
+          "name": "agent_runs_agent_compose_version_id_agent_compose_versions_id_fk",
+          "tableFrom": "agent_runs",
+          "tableTo": "agent_compose_versions",
+          "columnsFrom": [
+            "agent_compose_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "agent_runs_schedule_id_agent_schedules_id_fk": {
+          "name": "agent_runs_schedule_id_agent_schedules_id_fk",
+          "tableFrom": "agent_runs",
+          "tableTo": "agent_schedules",
+          "columnsFrom": [
+            "schedule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_schedules": {
+      "name": "agent_schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "compose_id": {
+          "name": "compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_type": {
+          "name": "trigger_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'cron'"
+        },
+        "cron_expression": {
+          "name": "cron_expression",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "at_time": {
+          "name": "at_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "interval_seconds": {
+          "name": "interval_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vars": {
+          "name": "vars",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_secrets": {
+          "name": "encrypted_secrets",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artifact_name": {
+          "name": "artifact_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artifact_version": {
+          "name": "artifact_version",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "volume_versions": {
+          "name": "volume_versions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_run_id": {
+          "name": "last_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retry_started_at": {
+          "name": "retry_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consecutive_failures": {
+          "name": "consecutive_failures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_schedules_compose": {
+          "name": "idx_agent_schedules_compose",
+          "columns": [
+            {
+              "expression": "compose_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_schedules_org": {
+          "name": "idx_agent_schedules_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_schedules_compose_name_clerk_org_user": {
+          "name": "idx_agent_schedules_compose_name_clerk_org_user",
+          "columns": [
+            {
+              "expression": "compose_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_schedules_next_run": {
+          "name": "idx_agent_schedules_next_run",
+          "columns": [
+            {
+              "expression": "next_run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "enabled = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_schedules_compose_id_agent_composes_id_fk": {
+          "name": "agent_schedules_compose_id_agent_composes_id_fk",
+          "tableFrom": "agent_schedules",
+          "tableTo": "agent_composes",
+          "columnsFrom": [
+            "compose_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_schedules_last_run_id_agent_runs_id_fk": {
+          "name": "agent_schedules_last_run_id_agent_runs_id_fk",
+          "tableFrom": "agent_schedules",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "last_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_sessions": {
+      "name": "agent_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_compose_id": {
+          "name": "agent_compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artifact_name": {
+          "name": "artifact_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_name": {
+          "name": "memory_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chat_messages": {
+          "name": "chat_messages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_sessions_user_compose_artifact": {
+          "name": "idx_agent_sessions_user_compose_artifact",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_compose_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "artifact_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_sessions_agent_compose_id_agent_composes_id_fk": {
+          "name": "agent_sessions_agent_compose_id_agent_composes_id_fk",
+          "tableFrom": "agent_sessions",
+          "tableTo": "agent_composes",
+          "columnsFrom": [
+            "agent_compose_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_sessions_conversation_id_conversations_id_fk": {
+          "name": "agent_sessions_conversation_id_conversations_id_fk",
+          "tableFrom": "agent_sessions",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blobs": {
+      "name": "blobs",
+      "schema": "",
+      "columns": {
+        "hash": {
+          "name": "hash",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref_count": {
+          "name": "ref_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_blobs_ref_count": {
+          "name": "idx_blobs_ref_count",
+          "columns": [
+            {
+              "expression": "ref_count",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.checkpoints": {
+      "name": "checkpoints",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_compose_snapshot": {
+          "name": "agent_compose_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_snapshot": {
+          "name": "artifact_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_snapshot": {
+          "name": "memory_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "volume_versions_snapshot": {
+          "name": "volume_versions_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "checkpoints_run_id_agent_runs_id_fk": {
+          "name": "checkpoints_run_id_agent_runs_id_fk",
+          "tableFrom": "checkpoints",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "checkpoints_conversation_id_conversations_id_fk": {
+          "name": "checkpoints_conversation_id_conversations_id_fk",
+          "tableFrom": "checkpoints",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "checkpoints_run_id_unique": {
+          "name": "checkpoints_run_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "run_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cli_tokens": {
+      "name": "cli_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cli_tokens_token_unique": {
+          "name": "cli_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.compose_jobs": {
+      "name": "compose_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_url": {
+          "name": "github_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "overwrite": {
+          "name": "overwrite",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'github'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_compose_jobs_user_status": {
+          "name": "idx_compose_jobs_user_status",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_compose_jobs_created": {
+          "name": "idx_compose_jobs_created",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_compose_jobs_user_active": {
+          "name": "idx_compose_jobs_user_active",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status IN ('pending', 'running')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.connector_sessions": {
+      "name": "connector_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(9)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "connector_session_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_connector_sessions_code": {
+          "name": "idx_connector_sessions_code",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_connector_sessions_user_status": {
+          "name": "idx_connector_sessions_user_status",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.connectors": {
+      "name": "connectors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_method": {
+          "name": "auth_method",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_username": {
+          "name": "external_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_email": {
+          "name": "external_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_scopes": {
+          "name": "oauth_scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_connectors_org": {
+          "name": "idx_connectors_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_connectors_org_user_type": {
+          "name": "idx_connectors_org_user_type",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversations": {
+      "name": "conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cli_agent_type": {
+          "name": "cli_agent_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cli_agent_session_id": {
+          "name": "cli_agent_session_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cli_agent_session_history": {
+          "name": "cli_agent_session_history",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cli_agent_session_history_hash": {
+          "name": "cli_agent_session_history_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "conversations_run_id_agent_runs_id_fk": {
+          "name": "conversations_run_id_agent_runs_id_fk",
+          "tableFrom": "conversations",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "conversations_run_id_unique": {
+          "name": "conversations_run_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "run_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.device_codes": {
+      "name": "device_codes",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "varchar(9)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "device_code_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_outbox": {
+      "name": "email_outbox",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "from_address": {
+          "name": "from_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_addresses": {
+          "name": "to_addresses",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cc_addresses": {
+          "name": "cc_addresses",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reply_to": {
+          "name": "reply_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headers": {
+          "name": "headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "template": {
+          "name": "template",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_send_action": {
+          "name": "post_send_action",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_retry_at": {
+          "name": "next_retry_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resend_id": {
+          "name": "resend_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_outbox_drain_idx": {
+          "name": "email_outbox_drain_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_retry_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_outbox_created_at_idx": {
+          "name": "email_outbox_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_reply_requests": {
+      "name": "email_reply_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_thread_session_id": {
+          "name": "email_thread_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inbound_email_id": {
+          "name": "inbound_email_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inbound_message_id": {
+          "name": "inbound_message_id",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_email_reply_requests_run": {
+          "name": "idx_email_reply_requests_run",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_reply_requests_run_id_agent_runs_id_fk": {
+          "name": "email_reply_requests_run_id_agent_runs_id_fk",
+          "tableFrom": "email_reply_requests",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "email_reply_requests_email_thread_session_id_email_thread_sessions_id_fk": {
+          "name": "email_reply_requests_email_thread_session_id_email_thread_sessions_id_fk",
+          "tableFrom": "email_reply_requests",
+          "tableTo": "email_thread_sessions",
+          "columnsFrom": [
+            "email_thread_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_thread_sessions": {
+      "name": "email_thread_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "compose_id": {
+          "name": "compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_session_id": {
+          "name": "agent_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_email_message_id": {
+          "name": "last_email_message_id",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_to_token": {
+          "name": "reply_to_token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_email_thread_sessions_reply_token": {
+          "name": "idx_email_thread_sessions_reply_token",
+          "columns": [
+            {
+              "expression": "reply_to_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_email_thread_sessions_user": {
+          "name": "idx_email_thread_sessions_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_thread_sessions_compose_id_agent_composes_id_fk": {
+          "name": "email_thread_sessions_compose_id_agent_composes_id_fk",
+          "tableFrom": "email_thread_sessions",
+          "tableTo": "agent_composes",
+          "columnsFrom": [
+            "compose_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "email_thread_sessions_agent_session_id_agent_sessions_id_fk": {
+          "name": "email_thread_sessions_agent_session_id_agent_sessions_id_fk",
+          "tableFrom": "email_thread_sessions",
+          "tableTo": "agent_sessions",
+          "columnsFrom": [
+            "agent_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_installations": {
+      "name": "github_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_access_token": {
+          "name": "encrypted_access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_name": {
+          "name": "target_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "admin_github_user_id": {
+          "name": "admin_github_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_compose_id": {
+          "name": "default_compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_configs": {
+          "name": "repo_configs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "github_installations_installation_id_unique": {
+          "name": "github_installations_installation_id_unique",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "installation_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_installations_default_compose_id_agent_composes_id_fk": {
+          "name": "github_installations_default_compose_id_agent_composes_id_fk",
+          "tableFrom": "github_installations",
+          "tableTo": "agent_composes",
+          "columnsFrom": [
+            "default_compose_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_issue_sessions": {
+      "name": "github_issue_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo": {
+          "name": "repo",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_number": {
+          "name": "issue_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_session_id": {
+          "name": "agent_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_comment_id": {
+          "name": "last_comment_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_github_issue_sessions_installation_repo_issue": {
+          "name": "idx_github_issue_sessions_installation_repo_issue",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "repo",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "issue_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_github_issue_sessions_installation": {
+          "name": "idx_github_issue_sessions_installation",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_issue_sessions_installation_id_github_installations_id_fk": {
+          "name": "github_issue_sessions_installation_id_github_installations_id_fk",
+          "tableFrom": "github_issue_sessions",
+          "tableTo": "github_installations",
+          "columnsFrom": [
+            "installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_issue_sessions_agent_session_id_agent_sessions_id_fk": {
+          "name": "github_issue_sessions_agent_session_id_agent_sessions_id_fk",
+          "tableFrom": "github_issue_sessions",
+          "tableTo": "agent_sessions",
+          "columnsFrom": [
+            "agent_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_user_links": {
+      "name": "github_user_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "github_user_id": {
+          "name": "github_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vm0_user_id": {
+          "name": "vm0_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_github_user_links_user_installation": {
+          "name": "idx_github_user_links_user_installation",
+          "columns": [
+            {
+              "expression": "github_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_user_links_installation_id_github_installations_id_fk": {
+          "name": "github_user_links_installation_id_github_installations_id_fk",
+          "tableFrom": "github_user_links",
+          "tableTo": "github_installations",
+          "columnsFrom": [
+            "installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_providers": {
+      "name": "model_providers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_id": {
+          "name": "secret_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_method": {
+          "name": "auth_method",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "selected_model": {
+          "name": "selected_model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_model_providers_secret": {
+          "name": "idx_model_providers_secret",
+          "columns": [
+            {
+              "expression": "secret_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_model_providers_org": {
+          "name": "idx_model_providers_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_model_providers_org_user_type": {
+          "name": "idx_model_providers_org_user_type",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "model_providers_secret_id_secrets_id_fk": {
+          "name": "model_providers_secret_id_secrets_id_fk",
+          "tableFrom": "model_providers",
+          "tableTo": "secrets",
+          "columnsFrom": [
+            "secret_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_cache": {
+      "name": "org_cache",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tier": {
+          "name": "tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "cached_at": {
+          "name": "cached_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_org_cache_slug": {
+          "name": "idx_org_cache_slug",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_members_cache": {
+      "name": "org_members_cache",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notify_email": {
+          "name": "notify_email",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "notify_slack": {
+          "name": "notify_slack",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "cached_at": {
+          "name": "cached_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "org_members_cache_org_id_user_id_pk": {
+          "name": "org_members_cache_org_id_user_id_pk",
+          "columns": [
+            "org_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runner_job_queue": {
+      "name": "runner_job_queue",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "runner_group": {
+          "name": "runner_group",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_context": {
+          "name": "execution_context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "runner_job_queue_group_unclaimed_idx": {
+          "name": "runner_job_queue_group_unclaimed_idx",
+          "columns": [
+            {
+              "expression": "runner_group",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "claimed_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runner_job_queue_expires_at_idx": {
+          "name": "runner_job_queue_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "runner_job_queue_run_id_agent_runs_id_fk": {
+          "name": "runner_job_queue_run_id_agent_runs_id_fk",
+          "tableFrom": "runner_job_queue",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sandbox_telemetry": {
+      "name": "sandbox_telemetry",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_sandbox_telemetry_run_id": {
+          "name": "idx_sandbox_telemetry_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sandbox_telemetry_run_id_agent_runs_id_fk": {
+          "name": "sandbox_telemetry_run_id_agent_runs_id_fk",
+          "tableFrom": "sandbox_telemetry",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scope_members": {
+      "name": "scope_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notify_email": {
+          "name": "notify_email",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "notify_slack": {
+          "name": "notify_slack",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_scope_members_scope_user": {
+          "name": "idx_scope_members_scope_user",
+          "columns": [
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_scope_members_scope": {
+          "name": "idx_scope_members_scope",
+          "columns": [
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_scope_members_user": {
+          "name": "idx_scope_members_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scope_members_scope_id_scopes_id_fk": {
+          "name": "scope_members_scope_id_scopes_id_fk",
+          "tableFrom": "scope_members",
+          "tableTo": "scopes",
+          "columnsFrom": [
+            "scope_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "scope_members_role_check": {
+          "name": "scope_members_role_check",
+          "value": "\"scope_members\".\"role\" IN ('admin', 'member')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.scopes": {
+      "name": "scopes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tier": {
+          "name": "tier",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "default_agent_compose_id": {
+          "name": "default_agent_compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_scopes_org": {
+          "name": "idx_scopes_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scopes_default_agent_compose_id_agent_composes_id_fk": {
+          "name": "scopes_default_agent_compose_id_agent_composes_id_fk",
+          "tableFrom": "scopes",
+          "tableTo": "agent_composes",
+          "columnsFrom": [
+            "default_agent_compose_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "scopes_slug_unique": {
+          "name": "scopes_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "scopes_tier_check": {
+          "name": "scopes_tier_check",
+          "value": "\"scopes\".\"tier\" IN ('free', 'pro', 'max')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.secrets": {
+      "name": "secrets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_value": {
+          "name": "encrypted_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_secrets_type": {
+          "name": "idx_secrets_type",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_secrets_org": {
+          "name": "idx_secrets_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_secrets_org_user_name_type": {
+          "name": "idx_secrets_org_user_name_type",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_compose_requests": {
+      "name": "slack_compose_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "compose_job_id": {
+          "name": "compose_job_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_workspace_id": {
+          "name": "slack_workspace_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_user_id": {
+          "name": "slack_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_channel_id": {
+          "name": "slack_channel_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_slack_compose_requests_job": {
+          "name": "idx_slack_compose_requests_job",
+          "columns": [
+            {
+              "expression": "compose_job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "slack_compose_requests_compose_job_id_compose_jobs_id_fk": {
+          "name": "slack_compose_requests_compose_job_id_compose_jobs_id_fk",
+          "tableFrom": "slack_compose_requests",
+          "tableTo": "compose_jobs",
+          "columnsFrom": [
+            "compose_job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_installations": {
+      "name": "slack_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slack_workspace_id": {
+          "name": "slack_workspace_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_workspace_name": {
+          "name": "slack_workspace_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_bot_token": {
+          "name": "encrypted_bot_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bot_user_id": {
+          "name": "bot_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_compose_id": {
+          "name": "default_compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "admin_slack_user_id": {
+          "name": "admin_slack_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "slack_installations_default_compose_id_agent_composes_id_fk": {
+          "name": "slack_installations_default_compose_id_agent_composes_id_fk",
+          "tableFrom": "slack_installations",
+          "tableTo": "agent_composes",
+          "columnsFrom": [
+            "default_compose_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "slack_installations_slack_workspace_id_unique": {
+          "name": "slack_installations_slack_workspace_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slack_workspace_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_pending_questions": {
+      "name": "slack_pending_questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_workspace_id": {
+          "name": "slack_workspace_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_channel_id": {
+          "name": "slack_channel_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_thread_ts": {
+          "name": "slack_thread_ts",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_message_ts": {
+          "name": "slack_message_ts",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_link_id": {
+          "name": "user_link_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "compose_id": {
+          "name": "compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "questions": {
+          "name": "questions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "answered_at": {
+          "name": "answered_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_slack_pending_questions_run_id": {
+          "name": "idx_slack_pending_questions_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_thread_sessions": {
+      "name": "slack_thread_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slack_user_link_id": {
+          "name": "slack_user_link_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_channel_id": {
+          "name": "slack_channel_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_thread_ts": {
+          "name": "slack_thread_ts",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_session_id": {
+          "name": "agent_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_processed_message_ts": {
+          "name": "last_processed_message_ts",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_slack_thread_sessions_thread_user_link": {
+          "name": "idx_slack_thread_sessions_thread_user_link",
+          "columns": [
+            {
+              "expression": "slack_user_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slack_channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slack_thread_ts",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_slack_thread_sessions_user_link": {
+          "name": "idx_slack_thread_sessions_user_link",
+          "columns": [
+            {
+              "expression": "slack_user_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "slack_thread_sessions_slack_user_link_id_slack_user_links_id_fk": {
+          "name": "slack_thread_sessions_slack_user_link_id_slack_user_links_id_fk",
+          "tableFrom": "slack_thread_sessions",
+          "tableTo": "slack_user_links",
+          "columnsFrom": [
+            "slack_user_link_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "slack_thread_sessions_agent_session_id_agent_sessions_id_fk": {
+          "name": "slack_thread_sessions_agent_session_id_agent_sessions_id_fk",
+          "tableFrom": "slack_thread_sessions",
+          "tableTo": "agent_sessions",
+          "columnsFrom": [
+            "agent_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_user_links": {
+      "name": "slack_user_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slack_user_id": {
+          "name": "slack_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_workspace_id": {
+          "name": "slack_workspace_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vm0_user_id": {
+          "name": "vm0_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dm_welcome_sent": {
+          "name": "dm_welcome_sent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_slack_user_links_user_workspace": {
+          "name": "idx_slack_user_links_user_workspace",
+          "columns": [
+            {
+              "expression": "slack_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slack_workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.storage_versions": {
+      "name": "storage_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "storage_id": {
+          "name": "storage_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "file_count": {
+          "name": "file_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "storage_versions_storage_id_storages_id_fk": {
+          "name": "storage_versions_storage_id_storages_id_fk",
+          "tableFrom": "storage_versions",
+          "tableTo": "storages",
+          "columnsFrom": [
+            "storage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.storages": {
+      "name": "storages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'volume'"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "s3_prefix": {
+          "name": "s3_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "file_count": {
+          "name": "file_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "head_version_id": {
+          "name": "head_version_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_storages_org": {
+          "name": "idx_storages_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_storages_org_user_name_type": {
+          "name": "idx_storages_org_user_name_type",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "storages_head_version_id_storage_versions_id_fk": {
+          "name": "storages_head_version_id_storage_versions_id_fk",
+          "tableFrom": "storages",
+          "tableTo": "storage_versions",
+          "columnsFrom": [
+            "head_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_installations": {
+      "name": "telegram_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "telegram_bot_id": {
+          "name": "telegram_bot_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bot_username": {
+          "name": "bot_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_bot_token": {
+          "name": "encrypted_bot_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhook_secret": {
+          "name": "webhook_secret",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_compose_id": {
+          "name": "default_compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "admin_user_id": {
+          "name": "admin_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "telegram_installations_default_compose_id_agent_composes_id_fk": {
+          "name": "telegram_installations_default_compose_id_agent_composes_id_fk",
+          "tableFrom": "telegram_installations",
+          "tableTo": "agent_composes",
+          "columnsFrom": [
+            "default_compose_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "telegram_installations_telegram_bot_id_unique": {
+          "name": "telegram_installations_telegram_bot_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "telegram_bot_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_messages": {
+      "name": "telegram_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_user_id": {
+          "name": "from_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_username": {
+          "name": "from_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_bot": {
+          "name": "is_bot",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_telegram_messages_unique": {
+          "name": "idx_telegram_messages_unique",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_telegram_messages_chat": {
+          "name": "idx_telegram_messages_chat",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_telegram_messages_created_at": {
+          "name": "idx_telegram_messages_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "telegram_messages_installation_id_telegram_installations_id_fk": {
+          "name": "telegram_messages_installation_id_telegram_installations_id_fk",
+          "tableFrom": "telegram_messages",
+          "tableTo": "telegram_installations",
+          "columnsFrom": [
+            "installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_thread_sessions": {
+      "name": "telegram_thread_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "telegram_user_link_id": {
+          "name": "telegram_user_link_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "root_message_id": {
+          "name": "root_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_session_id": {
+          "name": "agent_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_processed_message_id": {
+          "name": "last_processed_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_telegram_thread_sessions_chat_user_link": {
+          "name": "idx_telegram_thread_sessions_chat_user_link",
+          "columns": [
+            {
+              "expression": "telegram_user_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "root_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_telegram_thread_sessions_user_link": {
+          "name": "idx_telegram_thread_sessions_user_link",
+          "columns": [
+            {
+              "expression": "telegram_user_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "telegram_thread_sessions_telegram_user_link_id_telegram_user_links_id_fk": {
+          "name": "telegram_thread_sessions_telegram_user_link_id_telegram_user_links_id_fk",
+          "tableFrom": "telegram_thread_sessions",
+          "tableTo": "telegram_user_links",
+          "columnsFrom": [
+            "telegram_user_link_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "telegram_thread_sessions_agent_session_id_agent_sessions_id_fk": {
+          "name": "telegram_thread_sessions_agent_session_id_agent_sessions_id_fk",
+          "tableFrom": "telegram_thread_sessions",
+          "tableTo": "agent_sessions",
+          "columnsFrom": [
+            "agent_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_user_links": {
+      "name": "telegram_user_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "telegram_user_id": {
+          "name": "telegram_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vm0_user_id": {
+          "name": "vm0_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dm_welcome_sent": {
+          "name": "dm_welcome_sent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_telegram_user_links_user_installation": {
+          "name": "idx_telegram_user_links_user_installation",
+          "columns": [
+            {
+              "expression": "telegram_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "telegram_user_links_installation_id_telegram_installations_id_fk": {
+          "name": "telegram_user_links_installation_id_telegram_installations_id_fk",
+          "tableFrom": "telegram_user_links",
+          "tableTo": "telegram_installations",
+          "columnsFrom": [
+            "installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.usage_daily": {
+      "name": "usage_daily",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_count": {
+          "name": "run_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "run_time_ms": {
+          "name": "run_time_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_usage_daily_user_date": {
+          "name": "uq_usage_daily_user_date",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_cache": {
+      "name": "user_cache",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_list_cached_at": {
+          "name": "org_list_cached_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cached_at": {
+          "name": "cached_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.variables": {
+      "name": "variables",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_variables_org": {
+          "name": "idx_variables_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_variables_org_user_name": {
+          "name": "idx_variables_org_user_name",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.connector_session_status": {
+      "name": "connector_session_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "complete",
+        "expired",
+        "error"
+      ]
+    },
+    "public.device_code_status": {
+      "name": "device_code_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "authenticated",
+        "expired",
+        "denied"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/turbo/apps/web/src/db/migrations/meta/_journal.json
+++ b/turbo/apps/web/src/db/migrations/meta/_journal.json
@@ -904,6 +904,13 @@
       "when": 1773400000031,
       "tag": "0128_overrated_roxanne_simpson",
       "breakpoints": true
+    },
+    {
+      "idx": 129,
+      "version": "7",
+      "when": 1773400000040,
+      "tag": "0129_rename_clerk_org_id",
+      "breakpoints": true
     }
   ]
 }

--- a/turbo/apps/web/src/db/schema/agent-compose.ts
+++ b/turbo/apps/web/src/db/schema/agent-compose.ts
@@ -24,14 +24,14 @@ export const agentComposes = pgTable(
     }), // FK kept for cascade; Phase 5 drops column
     name: varchar("name", { length: 64 }).notNull().default(""), // Agent name from compose
     headVersionId: varchar("head_version_id", { length: 64 }), // Points to latest version hash
-    clerkOrgId: text("clerk_org_id").notNull(),
+    orgId: text("org_id").notNull(),
     createdAt: timestamp("created_at").defaultNow().notNull(),
     updatedAt: timestamp("updated_at").defaultNow().notNull(),
   },
   (table) => ({
-    clerkOrgIdx: index("idx_agent_composes_clerk_org").on(table.clerkOrgId),
-    clerkOrgNameIdx: uniqueIndex("idx_agent_composes_clerk_org_name").on(
-      table.clerkOrgId,
+    orgIdx: index("idx_agent_composes_org").on(table.orgId),
+    orgNameIdx: uniqueIndex("idx_agent_composes_org_name").on(
+      table.orgId,
       table.name,
     ),
   }),

--- a/turbo/apps/web/src/db/schema/agent-run.ts
+++ b/turbo/apps/web/src/db/schema/agent-run.ts
@@ -41,7 +41,7 @@ export const agentRuns = pgTable(
     sandboxId: varchar("sandbox_id", { length: 255 }),
     result: jsonb("result"),
     error: text("error"),
-    clerkOrgId: text("clerk_org_id").notNull(),
+    orgId: text("org_id").notNull(),
     createdAt: timestamp("created_at").defaultNow().notNull(),
     startedAt: timestamp("started_at"),
     completedAt: timestamp("completed_at"),
@@ -53,7 +53,7 @@ export const agentRuns = pgTable(
       table.userId,
       table.createdAt.desc(),
     ),
-    index("idx_agent_runs_clerk_org").on(table.clerkOrgId),
+    index("idx_agent_runs_org").on(table.orgId),
     // Composite index for status-based heartbeat queries
     index("idx_agent_runs_status_heartbeat").on(
       table.status,

--- a/turbo/apps/web/src/db/schema/agent-schedule.ts
+++ b/turbo/apps/web/src/db/schema/agent-schedule.ts
@@ -38,7 +38,7 @@ export const agentSchedules = pgTable(
       .references(() => agentComposes.id, { onDelete: "cascade" }),
     scopeId: uuid("scope_id"),
     userId: text("user_id").notNull(),
-    clerkOrgId: text("clerk_org_id").notNull(),
+    orgId: text("org_id").notNull(),
     name: varchar("name", { length: 64 }).notNull(),
 
     // Trigger type discriminator: 'cron' | 'once' | 'loop'
@@ -80,11 +80,11 @@ export const agentSchedules = pgTable(
   (table) => [
     // Index for finding schedules by compose
     index("idx_agent_schedules_compose").on(table.composeId),
-    index("idx_agent_schedules_clerk_org").on(table.clerkOrgId),
-    uniqueIndex("idx_agent_schedules_compose_name_clerk_org_user").on(
+    index("idx_agent_schedules_org").on(table.orgId),
+    uniqueIndex("idx_agent_schedules_compose_name_org_user").on(
       table.composeId,
       table.name,
-      table.clerkOrgId,
+      table.orgId,
       table.userId,
     ),
     // Partial index for efficient cron polling: enabled schedules with due next_run_at

--- a/turbo/apps/web/src/db/schema/cli-tokens.ts
+++ b/turbo/apps/web/src/db/schema/cli-tokens.ts
@@ -6,7 +6,7 @@ export const cliTokens = pgTable("cli_tokens", {
   userId: text("user_id").notNull(), // Clerk user ID
   name: text("name").notNull(), // User-friendly name
   scopeId: uuid("scope_id"), // Scope bound at token creation (nullable for old tokens)
-  clerkOrgId: text("clerk_org_id"), // Clerk org ID dual-write (nullable for old tokens)
+  orgId: text("org_id"), // Org ID dual-write (nullable for old tokens)
   expiresAt: timestamp("expires_at").notNull(),
   lastUsedAt: timestamp("last_used_at"),
   createdAt: timestamp("created_at").defaultNow().notNull(),

--- a/turbo/apps/web/src/db/schema/connector.ts
+++ b/turbo/apps/web/src/db/schema/connector.ts
@@ -29,15 +29,15 @@ export const connectors = pgTable(
     oauthScopes: text("oauth_scopes"), // JSON array of scopes
     tokenExpiresAt: timestamp("token_expires_at"), // null = non-expiring token
     userId: text("user_id").notNull(),
-    clerkOrgId: text("clerk_org_id").notNull(),
+    orgId: text("org_id").notNull(),
 
     createdAt: timestamp("created_at").defaultNow().notNull(),
     updatedAt: timestamp("updated_at").defaultNow().notNull(),
   },
   (table) => [
-    index("idx_connectors_clerk_org").on(table.clerkOrgId),
-    uniqueIndex("idx_connectors_clerk_org_user_type").on(
-      table.clerkOrgId,
+    index("idx_connectors_org").on(table.orgId),
+    uniqueIndex("idx_connectors_org_user_type").on(
+      table.orgId,
       table.userId,
       table.type,
     ),

--- a/turbo/apps/web/src/db/schema/model-provider.ts
+++ b/turbo/apps/web/src/db/schema/model-provider.ts
@@ -33,15 +33,15 @@ export const modelProviders = pgTable(
     isDefault: boolean("is_default").notNull().default(false),
     selectedModel: varchar("selected_model", { length: 255 }),
     userId: text("user_id").notNull(),
-    clerkOrgId: text("clerk_org_id").notNull(),
+    orgId: text("org_id").notNull(),
     createdAt: timestamp("created_at").defaultNow().notNull(),
     updatedAt: timestamp("updated_at").defaultNow().notNull(),
   },
   (table) => [
     index("idx_model_providers_secret").on(table.secretId),
-    index("idx_model_providers_clerk_org").on(table.clerkOrgId),
-    uniqueIndex("idx_model_providers_clerk_org_user_type").on(
-      table.clerkOrgId,
+    index("idx_model_providers_org").on(table.orgId),
+    uniqueIndex("idx_model_providers_org_user_type").on(
+      table.orgId,
       table.userId,
       table.type,
     ),

--- a/turbo/apps/web/src/db/schema/org-cache.ts
+++ b/turbo/apps/web/src/db/schema/org-cache.ts
@@ -8,7 +8,7 @@ import { pgTable, text, timestamp, index } from "drizzle-orm/pg-core";
 export const orgCache = pgTable(
   "org_cache",
   {
-    clerkOrgId: text("clerk_org_id").primaryKey(),
+    orgId: text("org_id").primaryKey(),
     slug: text("slug").notNull(),
     tier: text("tier").notNull().default("free"),
     cachedAt: timestamp("cached_at").defaultNow().notNull(),

--- a/turbo/apps/web/src/db/schema/org-members-cache.ts
+++ b/turbo/apps/web/src/db/schema/org-members-cache.ts
@@ -14,12 +14,12 @@ import {
 export const orgMembersCache = pgTable(
   "org_members_cache",
   {
-    clerkOrgId: text("clerk_org_id").notNull(),
+    orgId: text("org_id").notNull(),
     userId: text("user_id").notNull(),
     timezone: text("timezone"),
     notifyEmail: boolean("notify_email").notNull().default(false),
     notifySlack: boolean("notify_slack").notNull().default(true),
     cachedAt: timestamp("cached_at").defaultNow().notNull(),
   },
-  (table) => [primaryKey({ columns: [table.clerkOrgId, table.userId] })],
+  (table) => [primaryKey({ columns: [table.orgId, table.userId] })],
 );

--- a/turbo/apps/web/src/db/schema/scope.ts
+++ b/turbo/apps/web/src/db/schema/scope.ts
@@ -21,7 +21,7 @@ export const scopes = pgTable(
   {
     id: uuid("id").defaultRandom().primaryKey(),
     slug: varchar("slug", { length: 64 }).notNull().unique(),
-    clerkOrgId: text("clerk_org_id").notNull(),
+    orgId: text("org_id").notNull(),
     tier: varchar("tier", { length: 16 }).default("free").notNull(),
     defaultAgentComposeId: uuid("default_agent_compose_id").references(
       (): AnyPgColumn => agentComposes.id,
@@ -31,7 +31,7 @@ export const scopes = pgTable(
     updatedAt: timestamp("updated_at").defaultNow().notNull(),
   },
   (table) => ({
-    clerkOrgIdx: index("idx_scopes_clerk_org").on(table.clerkOrgId),
+    orgIdx: index("idx_scopes_org").on(table.orgId),
     tierCheck: check(
       "scopes_tier_check",
       sql`${table.tier} IN ('free', 'pro', 'max')`,

--- a/turbo/apps/web/src/db/schema/secret.ts
+++ b/turbo/apps/web/src/db/schema/secret.ts
@@ -23,15 +23,15 @@ export const secrets = pgTable(
     description: text("description"),
     type: varchar("type", { length: 50 }).notNull().default("user"),
     userId: text("user_id").notNull(),
-    clerkOrgId: text("clerk_org_id").notNull(),
+    orgId: text("org_id").notNull(),
     createdAt: timestamp("created_at").defaultNow().notNull(),
     updatedAt: timestamp("updated_at").defaultNow().notNull(),
   },
   (table) => [
     index("idx_secrets_type").on(table.type),
-    index("idx_secrets_clerk_org").on(table.clerkOrgId),
-    uniqueIndex("idx_secrets_clerk_org_user_name_type").on(
-      table.clerkOrgId,
+    index("idx_secrets_org").on(table.orgId),
+    uniqueIndex("idx_secrets_org_user_name_type").on(
+      table.orgId,
       table.userId,
       table.name,
       table.type,

--- a/turbo/apps/web/src/db/schema/storage.ts
+++ b/turbo/apps/web/src/db/schema/storage.ts
@@ -14,7 +14,7 @@ import {
 /**
  * Storages table
  * Main table for storage with HEAD pointer to current version.
- * Unique constraint: (clerkOrgId, userId, name, type)
+ * Unique constraint: (orgId, userId, name, type)
  * - Volumes use VOLUME_SCOPE_USER_ID ("__scope__") as userId (scope-level shared)
  * - Artifacts and Memory use real userId (per-user isolated)
  */
@@ -26,7 +26,7 @@ export const storages = pgTable(
     scopeId: uuid("scope_id"), // Kept for Phase 5 removal, no longer used for queries
     name: varchar("name", { length: 256 }).notNull(),
     type: varchar("type", { length: 16 }).notNull().default("volume"),
-    clerkOrgId: text("clerk_org_id").notNull(),
+    orgId: text("org_id").notNull(),
     s3Prefix: text("s3_prefix").notNull(),
     size: bigint("size", { mode: "number" }).notNull().default(0),
     fileCount: integer("file_count").notNull().default(0),
@@ -37,10 +37,13 @@ export const storages = pgTable(
     updatedAt: timestamp("updated_at").defaultNow().notNull(),
   },
   (table) => ({
-    clerkOrgIdx: index("idx_storages_clerk_org").on(table.clerkOrgId),
-    clerkOrgUserNameTypeIdx: uniqueIndex(
-      "idx_storages_clerk_org_user_name_type",
-    ).on(table.clerkOrgId, table.userId, table.name, table.type),
+    orgIdx: index("idx_storages_org").on(table.orgId),
+    orgUserNameTypeIdx: uniqueIndex("idx_storages_org_user_name_type").on(
+      table.orgId,
+      table.userId,
+      table.name,
+      table.type,
+    ),
   }),
 );
 

--- a/turbo/apps/web/src/db/schema/variable.ts
+++ b/turbo/apps/web/src/db/schema/variable.ts
@@ -22,14 +22,14 @@ export const variables = pgTable(
     value: text("value").notNull(),
     description: text("description"),
     userId: text("user_id").notNull(),
-    clerkOrgId: text("clerk_org_id").notNull(),
+    orgId: text("org_id").notNull(),
     createdAt: timestamp("created_at").defaultNow().notNull(),
     updatedAt: timestamp("updated_at").defaultNow().notNull(),
   },
   (table) => [
-    index("idx_variables_clerk_org").on(table.clerkOrgId),
-    uniqueIndex("idx_variables_clerk_org_user_name").on(
-      table.clerkOrgId,
+    index("idx_variables_org").on(table.orgId),
+    uniqueIndex("idx_variables_org_user_name").on(
+      table.orgId,
       table.userId,
       table.name,
     ),

--- a/turbo/apps/web/src/lib/agent-compose/resolve-default.ts
+++ b/turbo/apps/web/src/lib/agent-compose/resolve-default.ts
@@ -39,7 +39,7 @@ export async function resolveDefaultAgentComposeId(): Promise<string | null> {
     .from(agentComposes)
     .where(
       and(
-        eq(agentComposes.clerkOrgId, orgData.clerkOrgId),
+        eq(agentComposes.orgId, orgData.orgId),
         eq(agentComposes.name, agentName),
       ),
     )
@@ -49,7 +49,7 @@ export async function resolveDefaultAgentComposeId(): Promise<string | null> {
     log.warn("Agent compose not found for VM0_DEFAULT_AGENT", {
       scopeSlug,
       agentName,
-      clerkOrgId: orgData.clerkOrgId,
+      orgId: orgData.orgId,
     });
     return null;
   }

--- a/turbo/apps/web/src/lib/agent/permission-service.ts
+++ b/turbo/apps/web/src/lib/agent/permission-service.ts
@@ -23,7 +23,7 @@ const CACHE_TTL_MS = 60_000; // 1 minute
 export async function canAccessCompose(
   userId: string,
   userEmail: string,
-  compose: { id: string; userId: string; clerkOrgId: string },
+  compose: { id: string; userId: string; orgId: string },
 ): Promise<boolean> {
   // 1. Owner always has access
   if (compose.userId === userId) return true;
@@ -32,19 +32,19 @@ export async function canAccessCompose(
   const authResult = await auth();
 
   // JWT fast path: active org matches → trust JWT, no API call
-  if (authResult.orgId === compose.clerkOrgId) {
+  if (authResult.orgId === compose.orgId) {
     return true;
   }
 
   // Cache-backed Clerk API fallback for cross-org or non-session contexts
-  if (!compose.clerkOrgId.startsWith("pending_")) {
+  if (!compose.orgId.startsWith("pending_")) {
     // Check org_members_cache first (DB read, no Clerk API call)
     const [cached] = await globalThis.services.db
       .select({ cachedAt: orgMembersCache.cachedAt })
       .from(orgMembersCache)
       .where(
         and(
-          eq(orgMembersCache.clerkOrgId, compose.clerkOrgId),
+          eq(orgMembersCache.orgId, compose.orgId),
           eq(orgMembersCache.userId, userId),
         ),
       )
@@ -61,7 +61,7 @@ export async function canAccessCompose(
       limit: 100,
     });
     const isMember = memberships.data.some(
-      (m) => m.organization.id === compose.clerkOrgId,
+      (m) => m.organization.id === compose.orgId,
     );
     if (isMember) {
       // Fire-and-forget: cache write is non-critical, don't block access
@@ -69,12 +69,12 @@ export async function canAccessCompose(
       void globalThis.services.db
         .insert(orgMembersCache)
         .values({
-          clerkOrgId: compose.clerkOrgId,
+          orgId: compose.orgId,
           userId,
           cachedAt: now,
         })
         .onConflictDoUpdate({
-          target: [orgMembersCache.clerkOrgId, orgMembersCache.userId],
+          target: [orgMembersCache.orgId, orgMembersCache.userId],
           set: { cachedAt: now },
         })
         .catch((err: unknown) => {
@@ -184,7 +184,7 @@ export async function getEmailSharedAgents(
       headVersionId: agentComposes.headVersionId,
       createdAt: agentComposes.createdAt,
       updatedAt: agentComposes.updatedAt,
-      clerkOrgId: agentComposes.clerkOrgId,
+      orgId: agentComposes.orgId,
     })
     .from(agentPermissions)
     .innerJoin(
@@ -195,14 +195,14 @@ export async function getEmailSharedAgents(
     .orderBy(desc(agentComposes.createdAt));
 
   // Resolve scope slugs via org cache (skip orgs that fail lookup)
-  const uniqueClerkOrgIds = [...new Set(rows.map((r) => r.clerkOrgId))];
+  const uniqueOrgIds = [...new Set(rows.map((r) => r.orgId))];
   const orgDataResults = await Promise.all(
-    uniqueClerkOrgIds.map(async (id) => {
+    uniqueOrgIds.map(async (id) => {
       try {
         return [id, await getOrgData(id)] as const;
       } catch (err) {
         log.warn("failed to resolve org data for shared agent", {
-          clerkOrgId: id,
+          orgId: id,
           error: err,
         });
         return [id, null] as const;
@@ -217,7 +217,7 @@ export async function getEmailSharedAgents(
     headVersionId: row.headVersionId,
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
-    scopeSlug: orgDataMap.get(row.clerkOrgId)?.slug ?? "",
+    scopeSlug: orgDataMap.get(row.orgId)?.slug ?? "",
   }));
 }
 

--- a/turbo/apps/web/src/lib/computer-connector/computer-connector-service.ts
+++ b/turbo/apps/web/src/lib/computer-connector/computer-connector-service.ts
@@ -38,7 +38,7 @@ const COMPUTER_SECRETS = [
  * and its 4 secrets (AUTHTOKEN, TOKEN, ENDPOINT, DOMAIN).
  */
 export async function createComputerConnector(
-  clerkOrgId: string,
+  orgId: string,
   scopeId: string,
   userId: string,
 ): Promise<ComputerConnectorCreateResponse> {
@@ -46,12 +46,7 @@ export async function createComputerConnector(
   const [existing] = await globalThis.services.db
     .select({ id: connectors.id })
     .from(connectors)
-    .where(
-      and(
-        eq(connectors.clerkOrgId, clerkOrgId),
-        eq(connectors.type, "computer"),
-      ),
-    )
+    .where(and(eq(connectors.orgId, orgId), eq(connectors.type, "computer")))
     .limit(1);
 
   if (existing) {
@@ -143,7 +138,7 @@ export async function createComputerConnector(
     .values({
       scopeId,
       userId,
-      clerkOrgId,
+      orgId,
       type: "computer",
       authMethod: "api",
       externalId: botUser.id,
@@ -160,7 +155,7 @@ export async function createComputerConnector(
   // Store secrets (ngrok token is one-time use, returned to client only)
   await Promise.all([
     upsertSecretByScope(
-      clerkOrgId,
+      orgId,
       scopeId,
       userId,
       "COMPUTER_CONNECTOR_BRIDGE_TOKEN",
@@ -169,7 +164,7 @@ export async function createComputerConnector(
       "Computer connector: COMPUTER_CONNECTOR_BRIDGE_TOKEN",
     ),
     upsertSecretByScope(
-      clerkOrgId,
+      orgId,
       scopeId,
       userId,
       "COMPUTER_CONNECTOR_DOMAIN_ID",
@@ -178,7 +173,7 @@ export async function createComputerConnector(
       "Computer connector: COMPUTER_CONNECTOR_DOMAIN_ID",
     ),
     upsertSecretByScope(
-      clerkOrgId,
+      orgId,
       scopeId,
       userId,
       "COMPUTER_CONNECTOR_DOMAIN",
@@ -226,7 +221,7 @@ async function safeDeleteNgrokResource(
  * Delete the computer connector and revoke ngrok credentials.
  */
 export async function deleteComputerConnector(
-  clerkOrgId: string,
+  orgId: string,
   userId: string,
 ): Promise<void> {
   const db = globalThis.services.db;
@@ -241,7 +236,7 @@ export async function deleteComputerConnector(
     .from(connectors)
     .where(
       and(
-        eq(connectors.clerkOrgId, clerkOrgId),
+        eq(connectors.orgId, orgId),
         eq(connectors.userId, userId),
         eq(connectors.type, "computer"),
       ),
@@ -278,7 +273,7 @@ export async function deleteComputerConnector(
       .from(secrets)
       .where(
         and(
-          eq(secrets.clerkOrgId, clerkOrgId),
+          eq(secrets.orgId, orgId),
           eq(secrets.userId, userId),
           eq(secrets.name, "COMPUTER_CONNECTOR_DOMAIN_ID"),
           eq(secrets.type, "connector"),
@@ -310,7 +305,7 @@ export async function deleteComputerConnector(
       .delete(secrets)
       .where(
         and(
-          eq(secrets.clerkOrgId, clerkOrgId),
+          eq(secrets.orgId, orgId),
           eq(secrets.userId, userId),
           eq(secrets.name, secretName),
           eq(secrets.type, "connector"),
@@ -318,5 +313,5 @@ export async function deleteComputerConnector(
       );
   }
 
-  log.debug("Computer connector deleted", { clerkOrgId });
+  log.debug("Computer connector deleted", { orgId });
 }

--- a/turbo/apps/web/src/lib/connector/connector-service.ts
+++ b/turbo/apps/web/src/lib/connector/connector-service.ts
@@ -473,7 +473,7 @@ export async function deleteConnector(
  */
 export async function upsertConnectorSecret(
   orgId: string,
-  scopeId: string,
+  scopeId: string | null,
   userId: string,
   secretName: string,
   secretValue: string,

--- a/turbo/apps/web/src/lib/connector/connector-service.ts
+++ b/turbo/apps/web/src/lib/connector/connector-service.ts
@@ -42,7 +42,7 @@ function getSecretNameForConnector(type: ConnectorType): string {
  * based on user secrets that match api-token required secret names.
  */
 export async function listConnectors(
-  clerkOrgId: string,
+  orgId: string,
   userId: string,
 ): Promise<ConnectorResponse[]> {
   const db = globalThis.services.db;
@@ -62,19 +62,14 @@ export async function listConnectors(
         updatedAt: connectors.updatedAt,
       })
       .from(connectors)
-      .where(
-        and(
-          eq(connectors.clerkOrgId, clerkOrgId),
-          eq(connectors.userId, userId),
-        ),
-      )
+      .where(and(eq(connectors.orgId, orgId), eq(connectors.userId, userId)))
       .orderBy(connectors.type),
     db
       .select({ name: secrets.name })
       .from(secrets)
       .where(
         and(
-          eq(secrets.clerkOrgId, clerkOrgId),
+          eq(secrets.orgId, orgId),
           eq(secrets.userId, userId),
           eq(secrets.type, "user"),
         ),
@@ -82,9 +77,7 @@ export async function listConnectors(
     db
       .select({ name: variables.name })
       .from(variables)
-      .where(
-        and(eq(variables.clerkOrgId, clerkOrgId), eq(variables.userId, userId)),
-      ),
+      .where(and(eq(variables.orgId, orgId), eq(variables.userId, userId))),
   ]);
 
   const dbConnectors: ConnectorResponse[] = dbResult.map((row) => ({
@@ -133,7 +126,7 @@ export async function listConnectors(
  * connectors whose required user secrets are all present.
  */
 export async function getConnector(
-  clerkOrgId: string,
+  orgId: string,
   userId: string,
   type: ConnectorType,
 ): Promise<ConnectorResponse | null> {
@@ -152,7 +145,7 @@ export async function getConnector(
     .from(connectors)
     .where(
       and(
-        eq(connectors.clerkOrgId, clerkOrgId),
+        eq(connectors.orgId, orgId),
         eq(connectors.userId, userId),
         eq(connectors.type, type),
       ),
@@ -186,7 +179,7 @@ export async function getConnector(
           .from(secrets)
           .where(
             and(
-              eq(secrets.clerkOrgId, clerkOrgId),
+              eq(secrets.orgId, orgId),
               eq(secrets.userId, userId),
               eq(secrets.type, "user"),
             ),
@@ -196,12 +189,7 @@ export async function getConnector(
       ? globalThis.services.db
           .select({ name: variables.name })
           .from(variables)
-          .where(
-            and(
-              eq(variables.clerkOrgId, clerkOrgId),
-              eq(variables.userId, userId),
-            ),
-          )
+          .where(and(eq(variables.orgId, orgId), eq(variables.userId, userId)))
       : Promise.resolve([]),
   ]);
 
@@ -238,7 +226,7 @@ interface ExternalUserInfo {
  * Also stores the associated secret with type="connector"
  */
 export async function upsertOAuthConnector(
-  clerkOrgId: string,
+  orgId: string,
   scopeId: string,
   userId: string,
   type: ConnectorType,
@@ -264,7 +252,7 @@ export async function upsertOAuthConnector(
     .from(connectors)
     .where(
       and(
-        eq(connectors.clerkOrgId, clerkOrgId),
+        eq(connectors.orgId, orgId),
         eq(connectors.userId, userId),
         eq(connectors.type, type),
       ),
@@ -275,7 +263,7 @@ export async function upsertOAuthConnector(
 
   // Upsert access token secret
   await upsertSecretByScope(
-    clerkOrgId,
+    orgId,
     scopeId,
     userId,
     secretName,
@@ -287,7 +275,7 @@ export async function upsertOAuthConnector(
   // Upsert refresh token secret if provided
   if (options?.refreshToken && options.refreshSecretName) {
     await upsertSecretByScope(
-      clerkOrgId,
+      orgId,
       scopeId,
       userId,
       options.refreshSecretName,
@@ -347,7 +335,7 @@ export async function upsertOAuthConnector(
         externalEmail: userInfo.email,
         oauthScopes: JSON.stringify(oauthScopes),
         tokenExpiresAt,
-        clerkOrgId,
+        orgId,
       })
       .returning();
     if (!created) {
@@ -381,7 +369,7 @@ export async function upsertOAuthConnector(
  * For api-token connectors (no DB record): deletes user secrets matching required api-token secret names.
  */
 export async function deleteConnector(
-  clerkOrgId: string,
+  orgId: string,
   userId: string,
   type: ConnectorType,
 ): Promise<void> {
@@ -393,7 +381,7 @@ export async function deleteConnector(
     .from(connectors)
     .where(
       and(
-        eq(connectors.clerkOrgId, clerkOrgId),
+        eq(connectors.orgId, orgId),
         eq(connectors.userId, userId),
         eq(connectors.type, type),
       ),
@@ -425,7 +413,7 @@ export async function deleteConnector(
         .delete(secrets)
         .where(
           and(
-            eq(secrets.clerkOrgId, clerkOrgId),
+            eq(secrets.orgId, orgId),
             eq(secrets.userId, userId),
             eq(secrets.name, name),
             eq(secrets.type, "connector"),
@@ -433,7 +421,7 @@ export async function deleteConnector(
         );
     }
 
-    log.debug("connector deleted", { clerkOrgId, type });
+    log.debug("connector deleted", { orgId, type });
     return;
   }
 
@@ -446,7 +434,7 @@ export async function deleteConnector(
         .delete(secrets)
         .where(
           and(
-            eq(secrets.clerkOrgId, clerkOrgId),
+            eq(secrets.orgId, orgId),
             eq(secrets.userId, userId),
             eq(secrets.name, name),
             eq(secrets.type, "user"),
@@ -460,7 +448,7 @@ export async function deleteConnector(
         .delete(variables)
         .where(
           and(
-            eq(variables.clerkOrgId, clerkOrgId),
+            eq(variables.orgId, orgId),
             eq(variables.userId, userId),
             eq(variables.name, name),
           ),
@@ -470,7 +458,7 @@ export async function deleteConnector(
     }
     if (deletedAny) {
       log.debug("api-token connector deleted via user secrets/variables", {
-        clerkOrgId,
+        orgId,
         type,
       });
       return;
@@ -484,14 +472,14 @@ export async function deleteConnector(
  * Create or update a connector secret (e.g., refresh token)
  */
 export async function upsertConnectorSecret(
-  clerkOrgId: string,
-  scopeId: string | null,
+  orgId: string,
+  scopeId: string,
   userId: string,
   secretName: string,
   secretValue: string,
 ): Promise<void> {
   await upsertSecretByScope(
-    clerkOrgId,
+    orgId,
     scopeId,
     userId,
     secretName,

--- a/turbo/apps/web/src/lib/email/handlers/inbound-trigger.ts
+++ b/turbo/apps/web/src/lib/email/handlers/inbound-trigger.ts
@@ -15,7 +15,7 @@ import { createRun } from "../../run";
 import { buildIntegrationContext } from "../../integration-context";
 import { generateCallbackSecret, getApiUrl } from "../../callback";
 import { getUserIdByEmail } from "../../auth/get-user-id-by-email";
-import { getDefaultScopeByClerkUserId } from "../../scope/scope-service";
+import { getDefaultScopeByUserId } from "../../scope/scope-service";
 import { canAccessCompose } from "../../agent/permission-service";
 import { getUserEmail } from "../../auth/get-user-email";
 import { logger } from "../../logger";
@@ -100,7 +100,7 @@ async function resolveTrigger(
     };
   }
 
-  const runtimeScope = await getDefaultScopeByClerkUserId(userId);
+  const runtimeScope = await getDefaultScopeByUserId(userId);
   if (!runtimeScope) {
     log.debug("Sender has no scope", { from: senderEmail, userId });
     return {
@@ -167,7 +167,7 @@ export async function handleInboundEmailTrigger(
   const hasAccess = await canAccessCompose(userId, userEmail, {
     id: compose.composeId,
     userId: compose.userId,
-    clerkOrgId: compose.clerkOrgId,
+    orgId: compose.orgId,
   });
 
   if (!hasAccess) {

--- a/turbo/apps/web/src/lib/email/handlers/shared.ts
+++ b/turbo/apps/web/src/lib/email/handlers/shared.ts
@@ -171,7 +171,7 @@ export function computeReplyRecipients(opts: {
 interface ResolvedAgent {
   composeId: string;
   userId: string;
-  clerkOrgId: string;
+  orgId: string;
   scopeSlug: string;
   headVersionId: string;
 }
@@ -188,18 +188,18 @@ export async function resolveAgentByAddress(
   const orgData = await getOrgBySlug(scopeSlug);
   if (!orgData) return null;
 
-  // 2. Find compose by clerkOrgId + name
+  // 2. Find compose by orgId + name
   const [compose] = await globalThis.services.db
     .select({
       id: agentComposes.id,
       userId: agentComposes.userId,
-      clerkOrgId: agentComposes.clerkOrgId,
+      orgId: agentComposes.orgId,
       headVersionId: agentComposes.headVersionId,
     })
     .from(agentComposes)
     .where(
       and(
-        eq(agentComposes.clerkOrgId, orgData.clerkOrgId),
+        eq(agentComposes.orgId, orgData.orgId),
         eq(agentComposes.name, agentName),
       ),
     )
@@ -213,7 +213,7 @@ export async function resolveAgentByAddress(
   return {
     composeId: compose.id,
     userId: compose.userId,
-    clerkOrgId: compose.clerkOrgId,
+    orgId: compose.orgId,
     scopeSlug,
     headVersionId: compose.headVersionId,
   };

--- a/turbo/apps/web/src/lib/model-provider/model-provider-service.ts
+++ b/turbo/apps/web/src/lib/model-provider/model-provider-service.ts
@@ -87,7 +87,7 @@ function getTypesForFramework(framework: ModelProviderFramework): string[] {
  * @returns true if isDefault was set, false if another default already exists
  */
 async function assignDefaultIfFirst(
-  clerkOrgId: string,
+  orgId: string,
   providerId: string,
   framework: ModelProviderFramework,
 ): Promise<boolean> {
@@ -105,7 +105,7 @@ async function assignDefaultIfFirst(
             .from(modelProviders)
             .where(
               and(
-                eq(modelProviders.clerkOrgId, clerkOrgId),
+                eq(modelProviders.orgId, orgId),
                 eq(modelProviders.isDefault, true),
                 ne(modelProviders.id, providerId),
                 inArray(modelProviders.type, frameworkTypes),
@@ -122,7 +122,7 @@ async function assignDefaultIfFirst(
  * List all model providers for a scope
  */
 export async function listModelProviders(
-  clerkOrgId: string,
+  orgId: string,
   userId: string,
 ): Promise<ModelProviderInfo[]> {
   // Use leftJoin to include multi-auth providers that don't have secretId
@@ -140,10 +140,7 @@ export async function listModelProviders(
     .from(modelProviders)
     .leftJoin(secrets, eq(modelProviders.secretId, secrets.id))
     .where(
-      and(
-        eq(modelProviders.clerkOrgId, clerkOrgId),
-        eq(modelProviders.userId, userId),
-      ),
+      and(eq(modelProviders.orgId, orgId), eq(modelProviders.userId, userId)),
     )
     .orderBy(modelProviders.type);
 
@@ -166,7 +163,7 @@ export async function listModelProviders(
  * Note: Multi-auth providers (like aws-bedrock) are not supported by this function
  */
 export async function checkSecretExists(
-  clerkOrgId: string,
+  orgId: string,
   userId: string,
   type: ModelProviderType,
 ): Promise<{ exists: boolean }> {
@@ -186,7 +183,7 @@ export async function checkSecretExists(
     .from(secrets)
     .where(
       and(
-        eq(secrets.clerkOrgId, clerkOrgId),
+        eq(secrets.orgId, orgId),
         eq(secrets.userId, userId),
         eq(secrets.name, secretName),
         eq(secrets.type, "model-provider"),
@@ -207,7 +204,7 @@ export async function checkSecretExists(
  * Note: User secrets and model-provider secrets are isolated by type, so no conflict detection needed
  */
 export async function upsertModelProvider(
-  clerkOrgId: string,
+  orgId: string,
   scopeId: string,
   userId: string,
   type: ModelProviderType,
@@ -230,7 +227,7 @@ export async function upsertModelProvider(
   const encryptedValue = encryptSecretValue(secret, encryptionKey);
 
   log.debug("upserting model provider", {
-    clerkOrgId,
+    orgId,
     type,
     secretName,
   });
@@ -242,7 +239,7 @@ export async function upsertModelProvider(
     .from(modelProviders)
     .where(
       and(
-        eq(modelProviders.clerkOrgId, clerkOrgId),
+        eq(modelProviders.orgId, orgId),
         eq(modelProviders.userId, userId),
         eq(modelProviders.type, type),
       ),
@@ -259,10 +256,10 @@ export async function upsertModelProvider(
       encryptedValue,
       type: "model-provider",
       description: `Model provider secret for ${MODEL_PROVIDER_TYPES[type].label}`,
-      clerkOrgId,
+      orgId,
     })
     .onConflictDoUpdate({
-      target: [secrets.clerkOrgId, secrets.userId, secrets.name, secrets.type],
+      target: [secrets.orgId, secrets.userId, secrets.name, secrets.type],
       set: { encryptedValue, updatedAt: new Date() },
     })
     .returning();
@@ -277,11 +274,11 @@ export async function upsertModelProvider(
       secretId: upsertedSecret!.id,
       isDefault: false,
       selectedModel: selectedModel ?? null,
-      clerkOrgId,
+      orgId,
     })
     .onConflictDoUpdate({
       target: [
-        modelProviders.clerkOrgId,
+        modelProviders.orgId,
         modelProviders.userId,
         modelProviders.type,
       ],
@@ -298,7 +295,7 @@ export async function upsertModelProvider(
   // Assign default if this is a new provider and no other default exists for the framework
   if (wasCreated) {
     const isDefault = await assignDefaultIfFirst(
-      clerkOrgId,
+      orgId,
       provider!.id,
       framework,
     );
@@ -334,7 +331,7 @@ export async function upsertModelProvider(
  * Note: Only targets model-provider type secrets (user secrets are independent)
  */
 async function upsertMultiAuthSecret(
-  clerkOrgId: string,
+  orgId: string,
   scopeId: string,
   userId: string,
   name: string,
@@ -353,10 +350,10 @@ async function upsertMultiAuthSecret(
       encryptedValue,
       type: "model-provider",
       description,
-      clerkOrgId,
+      orgId,
     })
     .onConflictDoUpdate({
-      target: [secrets.clerkOrgId, secrets.userId, secrets.name, secrets.type],
+      target: [secrets.orgId, secrets.userId, secrets.name, secrets.type],
       set: { encryptedValue, description, updatedAt: new Date() },
     });
 }
@@ -365,7 +362,7 @@ async function upsertMultiAuthSecret(
  * Clean up old secrets when switching auth methods
  */
 async function cleanupOldAuthMethodSecrets(
-  clerkOrgId: string,
+  orgId: string,
   userId: string,
   type: ModelProviderType,
   oldAuthMethod: string,
@@ -383,13 +380,13 @@ async function cleanupOldAuthMethodSecrets(
       .delete(secrets)
       .where(
         and(
-          eq(secrets.clerkOrgId, clerkOrgId),
+          eq(secrets.orgId, orgId),
           eq(secrets.userId, userId),
           inArray(secrets.name, secretsToDelete),
         ),
       );
     log.debug("old auth method secrets cleaned up", {
-      clerkOrgId,
+      orgId,
       type,
       oldAuthMethod,
       deletedSecrets: secretsToDelete,
@@ -404,7 +401,7 @@ async function cleanupOldAuthMethodSecrets(
  * @param selectedModel Optional selected model
  */
 export async function upsertMultiAuthModelProvider(
-  clerkOrgId: string,
+  orgId: string,
   scopeId: string,
   userId: string,
   type: ModelProviderType,
@@ -451,7 +448,7 @@ export async function upsertMultiAuthModelProvider(
   const encryptionKey = globalThis.services.env.SECRETS_ENCRYPTION_KEY;
 
   log.debug("upserting multi-auth model provider", {
-    clerkOrgId,
+    orgId,
     type,
     authMethod,
     secretNames: Object.keys(secretValues),
@@ -463,7 +460,7 @@ export async function upsertMultiAuthModelProvider(
     .from(modelProviders)
     .where(
       and(
-        eq(modelProviders.clerkOrgId, clerkOrgId),
+        eq(modelProviders.orgId, orgId),
         eq(modelProviders.userId, userId),
         eq(modelProviders.type, type),
       ),
@@ -473,7 +470,7 @@ export async function upsertMultiAuthModelProvider(
   // If switching auth methods, clean up old secrets that are no longer used
   if (existingProvider && existingProvider.authMethod !== authMethod) {
     await cleanupOldAuthMethodSecrets(
-      clerkOrgId,
+      orgId,
       userId,
       type,
       existingProvider.authMethod ?? "",
@@ -487,7 +484,7 @@ export async function upsertMultiAuthModelProvider(
 
   for (const [name, value] of Object.entries(secretValues)) {
     await upsertMultiAuthSecret(
-      clerkOrgId,
+      orgId,
       scopeId,
       userId,
       name,
@@ -507,11 +504,11 @@ export async function upsertMultiAuthModelProvider(
       authMethod,
       isDefault: false,
       selectedModel: selectedModel ?? null,
-      clerkOrgId,
+      orgId,
     })
     .onConflictDoUpdate({
       target: [
-        modelProviders.clerkOrgId,
+        modelProviders.orgId,
         modelProviders.userId,
         modelProviders.type,
       ],
@@ -528,7 +525,7 @@ export async function upsertMultiAuthModelProvider(
   // Assign default if this is a new provider and no other default exists for the framework
   if (wasCreated) {
     const isDefault = await assignDefaultIfFirst(
-      clerkOrgId,
+      orgId,
       provider!.id,
       framework,
     );
@@ -580,7 +577,7 @@ export async function convertSecretToModelProvider(): Promise<never> {
  * Delete a model provider and its secret
  */
 export async function deleteModelProvider(
-  clerkOrgId: string,
+  orgId: string,
   userId: string,
   type: ModelProviderType,
 ): Promise<void> {
@@ -592,7 +589,7 @@ export async function deleteModelProvider(
     .from(modelProviders)
     .where(
       and(
-        eq(modelProviders.clerkOrgId, clerkOrgId),
+        eq(modelProviders.orgId, orgId),
         eq(modelProviders.userId, userId),
         eq(modelProviders.type, type),
       ),
@@ -623,13 +620,13 @@ export async function deleteModelProvider(
           .delete(secrets)
           .where(
             and(
-              eq(secrets.clerkOrgId, clerkOrgId),
+              eq(secrets.orgId, orgId),
               eq(secrets.userId, userId),
               inArray(secrets.name, secretNames),
             ),
           );
         log.debug("multi-auth secrets deleted", {
-          clerkOrgId,
+          orgId,
           type,
           secretNames,
         });
@@ -641,7 +638,7 @@ export async function deleteModelProvider(
       .where(eq(modelProviders.id, provider.id));
   }
 
-  log.debug("model provider deleted", { clerkOrgId, type });
+  log.debug("model provider deleted", { orgId, type });
 
   // If it was default, assign new default for framework
   if (wasDefault) {
@@ -649,10 +646,7 @@ export async function deleteModelProvider(
       .select({ id: modelProviders.id, type: modelProviders.type })
       .from(modelProviders)
       .where(
-        and(
-          eq(modelProviders.clerkOrgId, clerkOrgId),
-          eq(modelProviders.userId, userId),
-        ),
+        and(eq(modelProviders.orgId, orgId), eq(modelProviders.userId, userId)),
       )
       .orderBy(modelProviders.createdAt);
 
@@ -678,7 +672,7 @@ export async function deleteModelProvider(
  * Set a model provider as default for its framework
  */
 export async function setModelProviderDefault(
-  clerkOrgId: string,
+  orgId: string,
   userId: string,
   type: ModelProviderType,
 ): Promise<ModelProviderInfo> {
@@ -692,7 +686,7 @@ export async function setModelProviderDefault(
     .from(modelProviders)
     .where(
       and(
-        eq(modelProviders.clerkOrgId, clerkOrgId),
+        eq(modelProviders.orgId, orgId),
         eq(modelProviders.userId, userId),
         eq(modelProviders.type, type),
       ),
@@ -721,10 +715,7 @@ export async function setModelProviderDefault(
     .select({ id: modelProviders.id, type: modelProviders.type })
     .from(modelProviders)
     .where(
-      and(
-        eq(modelProviders.clerkOrgId, clerkOrgId),
-        eq(modelProviders.userId, userId),
-      ),
+      and(eq(modelProviders.orgId, orgId), eq(modelProviders.userId, userId)),
     );
 
   const sameFrameworkIds = allProviders
@@ -768,7 +759,7 @@ export async function setModelProviderDefault(
  * Update model selection for an existing provider (keeps secret unchanged)
  */
 export async function updateModelProviderModel(
-  clerkOrgId: string,
+  orgId: string,
   userId: string,
   type: ModelProviderType,
   selectedModel?: string,
@@ -782,7 +773,7 @@ export async function updateModelProviderModel(
     .from(modelProviders)
     .where(
       and(
-        eq(modelProviders.clerkOrgId, clerkOrgId),
+        eq(modelProviders.orgId, orgId),
         eq(modelProviders.userId, userId),
         eq(modelProviders.type, type),
       ),
@@ -825,7 +816,7 @@ export async function updateModelProviderModel(
  * Supports both legacy single-secret and multi-auth providers
  */
 export async function getDefaultModelProvider(
-  clerkOrgId: string,
+  orgId: string,
   userId: string,
   framework: ModelProviderFramework,
 ): Promise<ModelProviderInfo | null> {
@@ -844,10 +835,7 @@ export async function getDefaultModelProvider(
     .from(modelProviders)
     .leftJoin(secrets, eq(modelProviders.secretId, secrets.id))
     .where(
-      and(
-        eq(modelProviders.clerkOrgId, clerkOrgId),
-        eq(modelProviders.userId, userId),
-      ),
+      and(eq(modelProviders.orgId, orgId), eq(modelProviders.userId, userId)),
     );
 
   const defaultProvider = allProviders.find(

--- a/turbo/apps/web/src/lib/run/__tests__/create-run.test.ts
+++ b/turbo/apps/web/src/lib/run/__tests__/create-run.test.ts
@@ -678,7 +678,7 @@ describe("createRun()", () => {
         name: uniqueId("org-agent"),
       });
       const orgScopeId = orgCompose.scopeId;
-      const orgClerkOrgId = orgCompose.clerkOrgId;
+      const orgClerkOrgId = orgCompose.orgId;
 
       // Use the default compose but pass org scope for storage resolution
       const result = await createRun(
@@ -726,7 +726,7 @@ describe("createRun()", () => {
 
       // Verify artifact storage was created in user's default scope
       const artifact = await findTestStorage(
-        user.clerkOrgId,
+        user.orgId,
         "artifact",
         "artifact",
       );
@@ -734,7 +734,7 @@ describe("createRun()", () => {
       expect(artifact!.userId).toBe(user.userId);
 
       // Verify memory storage was created in user's default scope
-      const memory = await findTestStorage(user.clerkOrgId, "memory", "memory");
+      const memory = await findTestStorage(user.orgId, "memory", "memory");
       expect(memory).toBeDefined();
       expect(memory!.userId).toBe(user.userId);
     });

--- a/turbo/apps/web/src/lib/run/build-context.ts
+++ b/turbo/apps/web/src/lib/run/build-context.ts
@@ -183,7 +183,7 @@ interface ModelProviderSecretResult {
  * For providers with environment mapping (e.g., moonshot), resolves all env vars
  */
 async function resolveModelProviderSecrets(
-  clerkOrgId: string,
+  orgId: string,
   userId: string,
   framework: string,
   hasExplicitModelProviderConfig: boolean,
@@ -201,7 +201,7 @@ async function resolveModelProviderSecrets(
 
   // Fetch default provider once (used for type resolution, model selection, and auth method)
   const defaultProvider = await getDefaultModelProvider(
-    clerkOrgId,
+    orgId,
     userId,
     framework as ModelProviderFramework,
   );
@@ -232,7 +232,7 @@ async function resolveModelProviderSecrets(
 
     // Fetch all model-provider secrets by name
     const allSecretValues = await getSecretValues(
-      clerkOrgId,
+      orgId,
       userId,
       "model-provider",
     );
@@ -279,7 +279,7 @@ async function resolveModelProviderSecrets(
   }
 
   const secretValue = await getSecretValue(
-    clerkOrgId,
+    orgId,
     userId,
     secretName,
     "model-provider",
@@ -317,7 +317,7 @@ async function resolveModelProviderSecrets(
  */
 async function refreshConnectorAccessToken(
   connectorType: string,
-  clerkOrgId: string,
+  orgId: string,
   scopeId: string,
   userId: string,
   connectorSecrets: Record<string, string>,
@@ -357,7 +357,7 @@ async function refreshConnectorAccessToken(
 
     // Persist new tokens to database
     await upsertConnectorSecret(
-      clerkOrgId,
+      orgId,
       scopeId,
       userId,
       accessTokenSecret,
@@ -365,7 +365,7 @@ async function refreshConnectorAccessToken(
     );
     if (result.refreshToken) {
       await upsertConnectorSecret(
-        clerkOrgId,
+        orgId,
         scopeId,
         userId,
         refreshTokenSecret,
@@ -406,7 +406,7 @@ interface ConnectorSecretResult {
  * environment variables (e.g., GH_TOKEN, GITHUB_TOKEN for GitHub connector).
  */
 async function resolveConnectorSecrets(
-  clerkOrgId: string,
+  orgId: string,
   scopeId: string,
   userId: string,
 ): Promise<ConnectorSecretResult> {
@@ -414,9 +414,7 @@ async function resolveConnectorSecrets(
   const userConnectors = await globalThis.services.db
     .select({ type: connectors.type, authMethod: connectors.authMethod })
     .from(connectors)
-    .where(
-      and(eq(connectors.clerkOrgId, clerkOrgId), eq(connectors.userId, userId)),
-    );
+    .where(and(eq(connectors.orgId, orgId), eq(connectors.userId, userId)));
 
   if (userConnectors.length === 0) {
     return {
@@ -426,11 +424,7 @@ async function resolveConnectorSecrets(
     };
   }
 
-  const connectorSecrets = await getSecretValues(
-    clerkOrgId,
-    userId,
-    "connector",
-  );
+  const connectorSecrets = await getSecretValues(orgId, userId, "connector");
   if (Object.keys(connectorSecrets).length === 0) {
     return {
       connectorSecrets: undefined,
@@ -464,7 +458,7 @@ async function resolveConnectorSecrets(
       .map(({ type }) =>
         refreshConnectorAccessToken(
           type,
-          clerkOrgId,
+          orgId,
           scopeId,
           userId,
           connectorSecrets,
@@ -507,7 +501,7 @@ async function resolveConnectorSecrets(
  * Fetch secrets referenced in compose environment
  */
 async function fetchReferencedSecrets(
-  clerkOrgId: string,
+  orgId: string,
   userId: string,
   environment: Record<string, string> | undefined,
 ): Promise<Record<string, string> | undefined> {
@@ -526,9 +520,9 @@ async function fetchReferencedSecrets(
   log.debug(`Secrets referenced in environment: ${referencedNames.join(", ")}`);
 
   // Only fetch user secrets for variable expansion (model-provider secrets are isolated)
-  const userSecrets = await getSecretValues(clerkOrgId, userId, "user");
+  const userSecrets = await getSecretValues(orgId, userId, "user");
   log.debug(
-    `Fetched ${Object.keys(userSecrets).length} user secret(s) for org ${clerkOrgId}`,
+    `Fetched ${Object.keys(userSecrets).length} user secret(s) for org ${orgId}`,
   );
   return userSecrets;
 }
@@ -641,17 +635,17 @@ function mergeConnectorSecretsForReferences(
  * @returns Merged variables (CLI takes precedence)
  */
 async function fetchAndMergeVariables(
-  clerkOrgId: string,
+  orgId: string,
   userId: string,
   cliVars: Record<string, string> | undefined,
 ): Promise<Record<string, string> | undefined> {
-  const storedVars = await getVariableValues(clerkOrgId, userId);
+  const storedVars = await getVariableValues(orgId, userId);
   if (Object.keys(storedVars).length === 0) {
     return cliVars;
   }
 
   log.debug(
-    `Fetched ${Object.keys(storedVars).length} stored variable(s) for org ${clerkOrgId}`,
+    `Fetched ${Object.keys(storedVars).length} stored variable(s) for org ${orgId}`,
   );
 
   // Merge: CLI vars override stored vars
@@ -699,7 +693,7 @@ interface BuildContextParams {
   // When not provided, resolved via getDefaultScope fallback.
   scopeId?: string;
   scopeSlug?: string;
-  clerkOrgId?: string;
+  orgId?: string;
 }
 
 /**
@@ -755,7 +749,7 @@ async function loadAgentComposeForNewRun(
  * Extracted from buildExecutionContext to reduce complexity.
  */
 async function resolveSecretsAndEnvironment(
-  clerkOrgId: string,
+  orgId: string,
   scopeId: string,
   agentCompose: unknown,
   firstAgent:
@@ -783,16 +777,16 @@ async function resolveSecretsAndEnvironment(
   // so there is no data dependency between them.
   const [dbSecrets, modelProviderResult, connectorResult, mergedVars] =
     await Promise.all([
-      fetchReferencedSecrets(clerkOrgId, userId, firstAgent?.environment),
+      fetchReferencedSecrets(orgId, userId, firstAgent?.environment),
       resolveModelProviderSecrets(
-        clerkOrgId,
+        orgId,
         userId,
         framework,
         hasExplicitModelProviderConfig,
         modelProvider,
       ),
-      resolveConnectorSecrets(clerkOrgId, scopeId, userId),
-      fetchAndMergeVariables(clerkOrgId, userId, vars),
+      resolveConnectorSecrets(orgId, scopeId, userId),
+      fetchAndMergeVariables(orgId, userId, vars),
     ]);
 
   // Merge platform secrets from all sources for masking.
@@ -916,41 +910,41 @@ async function resolveScopes(params: BuildContextParams): Promise<{
   runtimeScopeId: string;
   runtimeClerkOrgId: string;
   pendingRuntimeScope:
-    | Promise<{ id: string; slug: string; clerkOrgId: string }>
-    | { id: string; slug: string; clerkOrgId: string };
+    | Promise<{ id: string; slug: string; orgId: string }>
+    | { id: string; slug: string; orgId: string };
 }> {
   if (params.scopeId) {
-    if (params.scopeSlug && params.clerkOrgId) {
+    if (params.scopeSlug && params.orgId) {
       return {
         runtimeScopeId: params.scopeId,
-        runtimeClerkOrgId: params.clerkOrgId,
+        runtimeClerkOrgId: params.orgId,
         pendingRuntimeScope: {
           id: params.scopeId,
           slug: params.scopeSlug,
-          clerkOrgId: params.clerkOrgId,
+          orgId: params.orgId,
         },
       };
     }
-    // Fallback: resolve clerkOrgId from scopeId, then slug from org cache
+    // Fallback: resolve orgId from scopeId, then slug from org cache
     const scope = await getScopeById(params.scopeId);
     let resolved;
     if (scope) {
-      const orgData = await getOrgData(scope.clerkOrgId);
+      const orgData = await getOrgData(scope.orgId);
       resolved = {
         id: params.scopeId,
         slug: orgData.slug,
-        clerkOrgId: scope.clerkOrgId,
+        orgId: scope.orgId,
       };
     } else {
       resolved = {
         id: params.scopeId,
         slug: "",
-        clerkOrgId: "",
+        orgId: "",
       };
     }
     return {
       runtimeScopeId: params.scopeId,
-      runtimeClerkOrgId: resolved.clerkOrgId,
+      runtimeClerkOrgId: resolved.orgId,
       pendingRuntimeScope: resolved,
     };
   }
@@ -958,11 +952,11 @@ async function resolveScopes(params: BuildContextParams): Promise<{
   const { scope } = await getDefaultScope(params.userId);
   return {
     runtimeScopeId: scope.id,
-    runtimeClerkOrgId: scope.clerkOrgId,
+    runtimeClerkOrgId: scope.orgId,
     pendingRuntimeScope: {
       id: scope.id,
       slug: scope.slug,
-      clerkOrgId: scope.clerkOrgId,
+      orgId: scope.orgId,
     },
   };
 }

--- a/turbo/apps/web/src/lib/run/context/execution-preparer.ts
+++ b/turbo/apps/web/src/lib/run/context/execution-preparer.ts
@@ -205,7 +205,7 @@ export async function prepareForExecution(
   const scopeStart = Date.now();
   const [agentComposeInfo] = await globalThis.services.db
     .select({
-      clerkOrgId: agentComposes.clerkOrgId,
+      orgId: agentComposes.orgId,
     })
     .from(agentComposeVersions)
     .innerJoin(
@@ -220,9 +220,9 @@ export async function prepareForExecution(
     throw badRequest("Agent compose not found");
   }
 
-  const agentOrgData = await getOrgData(agentComposeInfo.clerkOrgId);
+  const agentOrgData = await getOrgData(agentComposeInfo.orgId);
   const agentScopeInfo = {
-    clerkOrgId: agentComposeInfo.clerkOrgId,
+    orgId: agentComposeInfo.orgId,
     scopeSlug: agentOrgData.slug,
   };
 
@@ -231,7 +231,7 @@ export async function prepareForExecution(
   await Promise.all([
     context.artifactName
       ? ensureStorageExists(
-          runtimeScope.clerkOrgId,
+          runtimeScope.orgId,
           userId,
           context.artifactName,
           runtimeScope.slug,
@@ -241,7 +241,7 @@ export async function prepareForExecution(
       : null,
     context.memoryName
       ? ensureStorageExists(
-          runtimeScope.clerkOrgId,
+          runtimeScope.orgId,
           userId,
           context.memoryName,
           runtimeScope.slug,
@@ -259,8 +259,8 @@ export async function prepareForExecution(
   const storageManifest = await prepareStorageManifest(
     context.agentCompose as AgentComposeYaml,
     context.vars || {},
-    agentScopeInfo.clerkOrgId,
-    runtimeScope.clerkOrgId,
+    agentScopeInfo.orgId,
+    runtimeScope.orgId,
     userId,
     context.artifactName,
     context.artifactVersion,
@@ -272,7 +272,7 @@ export async function prepareForExecution(
   const storageEnd = Date.now();
 
   log.debug(
-    `Storage manifest prepared with dual scopes: agentClerkOrgId=${agentScopeInfo.clerkOrgId}, runtimeClerkOrgId=${runtimeScope.clerkOrgId}, ${storageManifest.storages.length} storages, ${storageManifest.artifact ? "1 artifact" : "no artifact"}`,
+    `Storage manifest prepared with dual scopes: agentClerkOrgId=${agentScopeInfo.orgId}, runtimeClerkOrgId=${runtimeScope.orgId}, ${storageManifest.storages.length} storages, ${storageManifest.artifact ? "1 artifact" : "no artifact"}`,
   );
 
   // Build PreparedContext

--- a/turbo/apps/web/src/lib/run/run-queue-service.ts
+++ b/turbo/apps/web/src/lib/run/run-queue-service.ts
@@ -38,16 +38,16 @@ export async function enqueueRun(
 ): Promise<CreateRunResult> {
   const { userId, agentComposeVersionId, prompt } = params;
 
-  // Resolve scope ID and clerkOrgId (caller should have already resolved it, but fall back)
+  // Resolve scope ID and orgId (caller should have already resolved it, but fall back)
   let scopeId: string;
-  let clerkOrgId: string;
-  if (params.scopeId && params.clerkOrgId) {
+  let orgId: string;
+  if (params.scopeId && params.orgId) {
     scopeId = params.scopeId;
-    clerkOrgId = params.clerkOrgId;
+    orgId = params.orgId;
   } else {
     const { scope } = await getDefaultScope(userId);
     scopeId = scope.id;
-    clerkOrgId = scope.clerkOrgId;
+    orgId = scope.orgId;
   }
 
   // Encrypt the full CreateRunParams for later replay
@@ -66,7 +66,7 @@ export async function enqueueRun(
       .values({
         userId,
         scopeId,
-        clerkOrgId,
+        orgId,
         agentComposeVersionId,
         status: "queued",
         prompt,

--- a/turbo/apps/web/src/lib/run/run-service.ts
+++ b/turbo/apps/web/src/lib/run/run-service.ts
@@ -31,10 +31,7 @@ import { canAccessCompose } from "../agent/permission-service";
 import { getUserEmail } from "../auth/get-user-email";
 import { extractTemplateVars } from "../config-validator";
 
-import {
-  getDefaultScopeByClerkUserId,
-  getScopeById,
-} from "../scope/scope-service";
+import { getDefaultScopeByUserId, getScopeById } from "../scope/scope-service";
 import { getDefaultScope } from "../scope/scope-member-service";
 import { getVariableValues } from "../variable/variable-service";
 import { encryptSecretValue } from "../crypto/secrets-encryption";
@@ -61,13 +58,13 @@ function getConcurrencyLimitForTier(tier: ScopeTier): number {
 /**
  * Check if org has reached concurrent run limit
  *
- * @param clerkOrgId Clerk org ID to check
+ * @param orgId Clerk org ID to check
  * @param scopeTier Scope tier for tier-based limit (default: "free")
  * @param db Optional database instance (for use within transactions)
  * @throws ConcurrentRunLimitError if limit exceeded
  */
 async function checkRunConcurrencyLimit(
-  clerkOrgId: string,
+  orgId: string,
   scopeTier: ScopeTier = "free",
   db?: Database,
 ): Promise<void> {
@@ -96,7 +93,7 @@ async function checkRunConcurrencyLimit(
     .from(agentRuns)
     .where(
       and(
-        eq(agentRuns.clerkOrgId, clerkOrgId),
+        eq(agentRuns.orgId, orgId),
         or(
           eq(agentRuns.status, "running"),
           and(
@@ -111,7 +108,7 @@ async function checkRunConcurrencyLimit(
 
   if (activeRunCount >= effectiveLimit) {
     log.debug(
-      `Org ${clerkOrgId} has ${activeRunCount} active runs, limit is ${effectiveLimit}`,
+      `Org ${orgId} has ${activeRunCount} active runs, limit is ${effectiveLimit}`,
     );
     throw concurrentRunLimit();
   }
@@ -312,7 +309,7 @@ export interface CreateRunParams {
   // When provided, used instead of getDefaultScope fallback.
   scopeId?: string;
   scopeSlug?: string;
-  clerkOrgId?: string;
+  orgId?: string;
   // Caller-resolved scope tier for concurrency limit derivation.
   scopeTier?: ScopeTier;
 }
@@ -335,7 +332,7 @@ async function loadCompose(
   callerComposeId?: string,
 ): Promise<{
   composeContent: AgentComposeYaml;
-  compose: { id: string; userId: string; clerkOrgId: string };
+  compose: { id: string; userId: string; orgId: string };
 }> {
   if (callerComposeId) {
     // When caller provides composeId, both queries are independent — run in parallel
@@ -349,7 +346,7 @@ async function loadCompose(
         .select({
           id: agentComposes.id,
           userId: agentComposes.userId,
-          clerkOrgId: agentComposes.clerkOrgId,
+          orgId: agentComposes.orgId,
         })
         .from(agentComposes)
         .where(eq(agentComposes.id, callerComposeId))
@@ -376,7 +373,7 @@ async function loadCompose(
       content: agentComposeVersions.content,
       composeId: agentComposes.id,
       composeUserId: agentComposes.userId,
-      agentClerkOrgId: agentComposes.clerkOrgId,
+      agentClerkOrgId: agentComposes.orgId,
     })
     .from(agentComposeVersions)
     .leftJoin(
@@ -399,7 +396,7 @@ async function loadCompose(
     compose: {
       id: result.composeId,
       userId: result.composeUserId,
-      clerkOrgId: result.agentClerkOrgId,
+      orgId: result.agentClerkOrgId,
     },
   };
 }
@@ -407,7 +404,7 @@ async function loadCompose(
 async function authorizeCompose(
   userId: string,
   userEmail: string,
-  compose: { id: string; userId: string; clerkOrgId: string },
+  compose: { id: string; userId: string; orgId: string },
 ): Promise<void> {
   const hasAccess = await canAccessCompose(userId, userEmail, compose);
   if (!hasAccess) {
@@ -428,7 +425,7 @@ async function validateComposeRequirements(
   composeContent: AgentComposeYaml,
   vars?: Record<string, string>,
   checkEnv?: boolean,
-  clerkOrgId?: string,
+  orgId?: string,
 ): Promise<void> {
   if (!composeContent?.agents) {
     return;
@@ -439,7 +436,7 @@ async function validateComposeRequirements(
     const requiredVars = extractTemplateVars(composeContent);
     if (requiredVars.length > 0) {
       const resolvedClerkOrgId =
-        clerkOrgId ?? (await getDefaultScopeByClerkUserId(userId))?.clerkOrgId;
+        orgId ?? (await getDefaultScopeByUserId(userId))?.orgId;
       const storedVars = resolvedClerkOrgId
         ? await getVariableValues(resolvedClerkOrgId, userId)
         : {};
@@ -517,7 +514,7 @@ async function buildAndDispatchRun(opts: {
   apiStartTime: number;
   scopeId: string | undefined;
   scopeSlug: string | undefined;
-  clerkOrgId: string | undefined;
+  orgId: string | undefined;
   authorizeTime: number;
   transactionTime: number;
 }): Promise<{ status: string; sandboxId?: string }> {
@@ -529,7 +526,7 @@ async function buildAndDispatchRun(opts: {
     apiStartTime,
     scopeId,
     scopeSlug,
-    clerkOrgId,
+    orgId,
     authorizeTime,
     transactionTime,
   } = opts;
@@ -575,7 +572,7 @@ async function buildAndDispatchRun(opts: {
       apiStartTime,
       scopeId,
       scopeSlug,
-      clerkOrgId,
+      orgId,
     });
     const buildContextTime = Date.now();
 
@@ -681,7 +678,7 @@ export async function createRun(
       composeContent,
       params.vars,
       params.checkEnv,
-      params.clerkOrgId,
+      params.orgId,
     );
   }
 
@@ -695,22 +692,22 @@ export async function createRun(
   // Resolve scope ID and slug for the run record and storage
   let scopeId: string;
   let scopeSlug: string | undefined;
-  let clerkOrgId: string;
+  let orgId: string;
   if (params.scopeId) {
     scopeId = params.scopeId;
     scopeSlug = params.scopeSlug;
-    if (params.clerkOrgId) {
-      clerkOrgId = params.clerkOrgId;
+    if (params.orgId) {
+      orgId = params.orgId;
     } else {
       const scope = await getScopeById(params.scopeId);
       if (!scope) throw badRequest("Scope not found");
-      clerkOrgId = scope.clerkOrgId;
+      orgId = scope.orgId;
     }
   } else {
     const { scope } = await getDefaultScope(userId);
     scopeId = scope.id;
     scopeSlug = scope.slug;
-    clerkOrgId = scope.clerkOrgId;
+    orgId = scope.orgId;
   }
 
   // Step 5: Concurrency check + INSERT in a transaction with advisory lock
@@ -721,16 +718,10 @@ export async function createRun(
   try {
     run = await globalThis.services.db.transaction(async (tx) => {
       // Acquire per-org advisory lock (released when transaction ends)
-      await tx.execute(
-        sql`SELECT pg_advisory_xact_lock(hashtext(${clerkOrgId}))`,
-      );
+      await tx.execute(sql`SELECT pg_advisory_xact_lock(hashtext(${orgId}))`);
 
       // Check concurrent run limit within the serialized transaction
-      await checkRunConcurrencyLimit(
-        clerkOrgId,
-        params.scopeTier ?? "free",
-        tx,
-      );
+      await checkRunConcurrencyLimit(orgId, params.scopeTier ?? "free", tx);
 
       // INSERT within the same transaction
       const [newRun] = await tx
@@ -738,7 +729,7 @@ export async function createRun(
         .values({
           userId,
           scopeId,
-          clerkOrgId,
+          orgId,
           agentComposeVersionId,
           status: "pending",
           prompt,
@@ -759,7 +750,7 @@ export async function createRun(
     });
   } catch (error) {
     if (isConcurrentRunLimit(error)) {
-      return enqueueRun({ ...params, scopeId, scopeSlug, clerkOrgId });
+      return enqueueRun({ ...params, scopeId, scopeSlug, orgId });
     }
     throw error;
   }
@@ -775,7 +766,7 @@ export async function createRun(
     apiStartTime,
     scopeId,
     scopeSlug,
-    clerkOrgId,
+    orgId,
     authorizeTime,
     transactionTime,
   });
@@ -808,12 +799,10 @@ export async function executeQueuedRun(
 
   // Step 1: Re-check concurrency + update status atomically with advisory lock
   // to prevent TOCTOU race where a concurrent createRun claims the slot.
-  const clerkOrgId = params.clerkOrgId ?? "";
+  const orgId = params.orgId ?? "";
   const [run] = await globalThis.services.db.transaction(async (tx) => {
-    await tx.execute(
-      sql`SELECT pg_advisory_xact_lock(hashtext(${clerkOrgId}))`,
-    );
-    await checkRunConcurrencyLimit(clerkOrgId, params.scopeTier ?? "free", tx);
+    await tx.execute(sql`SELECT pg_advisory_xact_lock(hashtext(${orgId}))`);
+    await checkRunConcurrencyLimit(orgId, params.scopeTier ?? "free", tx);
 
     return tx
       .update(agentRuns)
@@ -848,7 +837,7 @@ export async function executeQueuedRun(
       composeContent,
       params.vars,
       params.checkEnv,
-      params.clerkOrgId,
+      params.orgId,
     );
   }
 
@@ -862,7 +851,7 @@ export async function executeQueuedRun(
     apiStartTime,
     scopeId: params.scopeId,
     scopeSlug: params.scopeSlug,
-    clerkOrgId: params.clerkOrgId,
+    orgId: params.orgId,
     authorizeTime,
     transactionTime,
   });

--- a/turbo/apps/web/src/lib/run/types.ts
+++ b/turbo/apps/web/src/lib/run/types.ts
@@ -108,5 +108,5 @@ export interface ExecutionContext {
 export interface RuntimeScope {
   id: string;
   slug: string;
-  clerkOrgId: string;
+  orgId: string;
 }

--- a/turbo/apps/web/src/lib/schedule/schedule-service.ts
+++ b/turbo/apps/web/src/lib/schedule/schedule-service.ts
@@ -219,8 +219,8 @@ async function loadCompose(
 /**
  * Load scope slug by ID
  */
-async function getScopeSlug(clerkOrgId: string): Promise<string> {
-  const orgData = await getOrgData(clerkOrgId);
+async function getScopeSlug(orgId: string): Promise<string> {
+  const orgData = await getOrgData(orgId);
   return orgData.slug;
 }
 
@@ -229,7 +229,7 @@ async function getScopeSlug(clerkOrgId: string): Promise<string> {
  */
 async function verifyScheduleOwnership(
   userId: string,
-  clerkOrgId: string,
+  orgId: string,
   composeId: string,
   name: string,
 ): Promise<{
@@ -244,7 +244,7 @@ async function verifyScheduleOwnership(
       and(
         eq(agentSchedules.composeId, composeId),
         eq(agentSchedules.name, name),
-        eq(agentSchedules.clerkOrgId, clerkOrgId),
+        eq(agentSchedules.orgId, orgId),
         eq(agentSchedules.userId, userId),
       ),
     )
@@ -255,7 +255,7 @@ async function verifyScheduleOwnership(
   }
 
   const compose = await loadCompose(composeId);
-  const scopeSlug = await getScopeSlug(clerkOrgId);
+  const scopeSlug = await getScopeSlug(orgId);
 
   return { schedule, compose, scopeSlug };
 }
@@ -266,7 +266,7 @@ async function verifyScheduleOwnership(
  */
 async function validateRequiredConfig(
   compose: typeof agentComposes.$inferSelect,
-  clerkOrgId: string,
+  orgId: string,
   userId: string,
 ): Promise<void> {
   if (!compose.headVersionId) return;
@@ -282,13 +282,13 @@ async function validateRequiredConfig(
   const required = extractRequiredConfiguration(version.content);
 
   // Fetch platform-managed secrets and vars from schedule's scope + user
-  const platformSecrets = await getSecretValues(clerkOrgId, userId, "user");
+  const platformSecrets = await getSecretValues(orgId, userId, "user");
   const platformSecretNames = Object.keys(platformSecrets);
   log.debug(
     `Fetched ${platformSecretNames.length} platform secret(s) for validation`,
   );
 
-  const platformVars = await getVariableValues(clerkOrgId, userId);
+  const platformVars = await getVariableValues(orgId, userId);
   const platformVarNames = Object.keys(platformVars);
   log.debug(
     `Fetched ${platformVarNames.length} platform variable(s) for validation`,
@@ -298,9 +298,7 @@ async function validateRequiredConfig(
   const userConnectors = await globalThis.services.db
     .select({ type: connectors.type })
     .from(connectors)
-    .where(
-      and(eq(connectors.clerkOrgId, clerkOrgId), eq(connectors.userId, userId)),
-    );
+    .where(and(eq(connectors.orgId, orgId), eq(connectors.userId, userId)));
   const connectorProvidedNames = getConnectorProvidedSecretNames(
     userConnectors.map((c) => c.type),
   );
@@ -349,7 +347,7 @@ function resolveTrigger(request: DeployScheduleRequest): {
  */
 export async function deploySchedule(
   userId: string,
-  clerkOrgId: string,
+  orgId: string,
   scopeId: string,
   request: DeployScheduleRequest,
 ): Promise<{ schedule: ScheduleResponse; created: boolean }> {
@@ -359,7 +357,7 @@ export async function deploySchedule(
 
   // Load compose (access control is handled by the caller/route layer)
   const compose = await loadCompose(request.composeId);
-  const scopeSlug = await getScopeSlug(clerkOrgId);
+  const scopeSlug = await getScopeSlug(orgId);
 
   // Validate timezone
   if (!isValidTimezone(request.timezone)) {
@@ -374,14 +372,14 @@ export async function deploySchedule(
       and(
         eq(agentSchedules.composeId, request.composeId),
         eq(agentSchedules.name, request.name),
-        eq(agentSchedules.clerkOrgId, clerkOrgId),
+        eq(agentSchedules.orgId, orgId),
         eq(agentSchedules.userId, userId),
       ),
     )
     .limit(1);
 
   // Validate required secrets/vars against schedule's scope + user
-  await validateRequiredConfig(compose, clerkOrgId, userId);
+  await validateRequiredConfig(compose, orgId, userId);
 
   const { triggerType, nextRunAt } = resolveTrigger(request);
 
@@ -428,7 +426,7 @@ export async function deploySchedule(
         composeId: request.composeId,
         scopeId,
         userId,
-        clerkOrgId,
+        orgId,
         name: request.name,
         triggerType,
         cronExpression: request.cronExpression ?? null,
@@ -488,10 +486,8 @@ export async function listSchedules(
     .where(inArray(agentComposes.id, composeIds));
   const composeMap = new Map(composeRows.map((c) => [c.id, c]));
 
-  // Load scope slugs via org cache (by clerkOrgId from schedule records)
-  const uniqueClerkOrgIds = [
-    ...new Set(userSchedules.map((s) => s.clerkOrgId)),
-  ];
+  // Load scope slugs via org cache (by orgId from schedule records)
+  const uniqueClerkOrgIds = [...new Set(userSchedules.map((s) => s.orgId))];
   const orgDataEntries = await Promise.all(
     uniqueClerkOrgIds.map(async (id) => [id, await getOrgData(id)] as const),
   );
@@ -505,7 +501,7 @@ export async function listSchedules(
     })
     .map((schedule) => {
       const compose = composeMap.get(schedule.composeId)!;
-      const scopeSlug = orgDataMap.get(schedule.clerkOrgId)?.slug ?? "";
+      const scopeSlug = orgDataMap.get(schedule.orgId)?.slug ?? "";
       return toResponse(schedule, compose.name, scopeSlug);
     });
 }
@@ -515,7 +511,7 @@ export async function listSchedules(
  */
 export async function getScheduleByName(
   userId: string,
-  clerkOrgId: string,
+  orgId: string,
   composeId: string,
   name: string,
 ): Promise<ScheduleResponse> {
@@ -523,7 +519,7 @@ export async function getScheduleByName(
 
   const { schedule, compose, scopeSlug } = await verifyScheduleOwnership(
     userId,
-    clerkOrgId,
+    orgId,
     composeId,
     name,
   );
@@ -536,7 +532,7 @@ export async function getScheduleByName(
  */
 export async function getScheduleRecentRuns(
   userId: string,
-  clerkOrgId: string,
+  orgId: string,
   composeId: string,
   scheduleName: string,
   limit: number,
@@ -547,7 +543,7 @@ export async function getScheduleRecentRuns(
 
   const { schedule } = await verifyScheduleOwnership(
     userId,
-    clerkOrgId,
+    orgId,
     composeId,
     scheduleName,
   );
@@ -580,7 +576,7 @@ export async function getScheduleRecentRuns(
  */
 export async function deleteSchedule(
   userId: string,
-  clerkOrgId: string,
+  orgId: string,
   composeId: string,
   name: string,
 ): Promise<void> {
@@ -588,7 +584,7 @@ export async function deleteSchedule(
 
   const { schedule } = await verifyScheduleOwnership(
     userId,
-    clerkOrgId,
+    orgId,
     composeId,
     name,
   );
@@ -605,7 +601,7 @@ export async function deleteSchedule(
  */
 export async function enableSchedule(
   userId: string,
-  clerkOrgId: string,
+  orgId: string,
   composeId: string,
   name: string,
 ): Promise<ScheduleResponse> {
@@ -613,7 +609,7 @@ export async function enableSchedule(
 
   const { schedule, compose, scopeSlug } = await verifyScheduleOwnership(
     userId,
-    clerkOrgId,
+    orgId,
     composeId,
     name,
   );
@@ -663,7 +659,7 @@ export async function enableSchedule(
  */
 export async function disableSchedule(
   userId: string,
-  clerkOrgId: string,
+  orgId: string,
   composeId: string,
   name: string,
 ): Promise<ScheduleResponse> {
@@ -671,7 +667,7 @@ export async function disableSchedule(
 
   const { schedule, compose, scopeSlug } = await verifyScheduleOwnership(
     userId,
-    clerkOrgId,
+    orgId,
     composeId,
     name,
   );
@@ -837,7 +833,7 @@ async function executeSchedule(
   }
 
   // Load org tier and slug from org_cache (Clerk as source of truth)
-  const orgData = await getOrgData(schedule.clerkOrgId);
+  const orgData = await getOrgData(schedule.orgId);
 
   // Build callbacks for run completion notifications
   const callbacks: Array<{ url: string; secret: string; payload: unknown }> =
@@ -849,7 +845,7 @@ async function executeSchedule(
     userId: schedule.userId,
   };
 
-  const prefs = await getUserPreferences(orgData.clerkOrgId, schedule.userId);
+  const prefs = await getUserPreferences(orgData.orgId, schedule.userId);
 
   // Email schedule notification callback (only if Resend is configured AND user opted in)
   if (globalThis.services.env.RESEND_API_KEY && prefs.notifyEmail) {
@@ -897,7 +893,7 @@ async function executeSchedule(
       callbacks,
       scopeId: schedule.scopeId ?? undefined,
       scopeSlug: orgData.slug,
-      clerkOrgId: orgData.clerkOrgId,
+      orgId: orgData.orgId,
       scopeTier: scopeTierSchema.parse(orgData.tier),
     });
     runId = result.runId;

--- a/turbo/apps/web/src/lib/scope/__tests__/org-cache-service.test.ts
+++ b/turbo/apps/web/src/lib/scope/__tests__/org-cache-service.test.ts
@@ -26,28 +26,28 @@ describe("getOrgData", () => {
       clerkOrgs: [{ id: `org_mock_${slug}`, slug, name: slug }],
     });
     await createTestScope(slug);
-    const clerkOrgId = `org_mock_${slug}`;
+    const orgId = `org_mock_${slug}`;
 
     // Delete pre-populated orgCache to test cache-miss behavior
-    await deleteOrgCacheEntry(clerkOrgId);
+    await deleteOrgCacheEntry(orgId);
 
-    const result = await getOrgData(clerkOrgId);
+    const result = await getOrgData(orgId);
 
     expect(result).toEqual({
-      clerkOrgId,
+      orgId,
       slug,
       tier: "free",
     });
 
     // Verify cache row was created
-    const cached = await getOrgCacheEntry(clerkOrgId);
+    const cached = await getOrgCacheEntry(orgId);
     expect(cached).not.toBeNull();
     expect(cached!.slug).toBe(slug);
 
     // Verify Clerk API was called
     const client = await clerkClient();
     expect(client.organizations.getOrganization).toHaveBeenCalledWith({
-      organizationId: clerkOrgId,
+      organizationId: orgId,
     });
   });
 
@@ -56,19 +56,19 @@ describe("getOrgData", () => {
     const slug = uniqueId("scope");
     mockClerk({ userId });
     await createTestScope(slug);
-    const clerkOrgId = `org_mock_${slug}`;
+    const orgId = `org_mock_${slug}`;
 
     // Pre-populate cache with fresh entry
     await insertOrgCacheEntry({
-      clerkOrgId,
+      orgId,
       slug: "cached-slug",
       tier: "pro",
     });
 
-    const result = await getOrgData(clerkOrgId);
+    const result = await getOrgData(orgId);
 
     expect(result).toEqual({
-      clerkOrgId,
+      orgId,
       slug: "cached-slug",
       tier: "pro",
     });
@@ -87,31 +87,31 @@ describe("getOrgData", () => {
       clerkOrgs: [{ id: `org_mock_${slug}`, slug, name: slug }],
     });
     await createTestScope(slug);
-    const clerkOrgId = `org_mock_${slug}`;
+    const orgId = `org_mock_${slug}`;
 
     // Overwrite the fresh orgCache entry from createTestScope with a stale one
     const twoMinutesAgo = new Date(Date.now() - 120_000);
     await insertOrgCacheEntry({
-      clerkOrgId,
+      orgId,
       slug: "old-slug",
       tier: "free",
       cachedAt: twoMinutesAgo,
     });
 
-    const result = await getOrgData(clerkOrgId);
+    const result = await getOrgData(orgId);
 
     // Should have fresh data from Clerk mock (slug = scope name from createOrganization)
     expect(result.slug).toBe(slug);
-    expect(result.clerkOrgId).toBe(clerkOrgId);
+    expect(result.orgId).toBe(orgId);
 
     // Verify Clerk API was called
     const client = await clerkClient();
     expect(client.organizations.getOrganization).toHaveBeenCalledWith({
-      organizationId: clerkOrgId,
+      organizationId: orgId,
     });
 
     // Verify cache was updated
-    const cached = await getOrgCacheEntry(clerkOrgId);
+    const cached = await getOrgCacheEntry(orgId);
     expect(cached!.slug).toBe(slug);
     expect(cached!.cachedAt.getTime()).toBeGreaterThan(twoMinutesAgo.getTime());
   });
@@ -121,12 +121,12 @@ describe("getOrgData", () => {
     const slug = uniqueId("scope");
     mockClerk({ userId });
     await createTestScope(slug);
-    const clerkOrgId = `org_mock_${slug}`;
+    const orgId = `org_mock_${slug}`;
 
     // Override getOrganization to return tier in publicMetadata
     const client = await clerkClient();
     vi.mocked(client.organizations.getOrganization).mockResolvedValueOnce({
-      id: clerkOrgId,
+      id: orgId,
       slug,
       name: slug,
       publicMetadata: { tier: "pro" },
@@ -134,7 +134,7 @@ describe("getOrgData", () => {
       ReturnType<typeof client.organizations.getOrganization>
     >);
 
-    const result = await getOrgData(clerkOrgId);
+    const result = await getOrgData(orgId);
 
     expect(result.tier).toBe("pro");
   });
@@ -144,12 +144,12 @@ describe("getOrgData", () => {
     const slug = uniqueId("scope");
     mockClerk({ userId });
     await createTestScope(slug);
-    const clerkOrgId = `org_mock_${slug}`;
+    const orgId = `org_mock_${slug}`;
 
     // Override getOrganization to return null slug
     const client = await clerkClient();
     vi.mocked(client.organizations.getOrganization).mockResolvedValueOnce({
-      id: clerkOrgId,
+      id: orgId,
       slug: null,
       name: slug,
       publicMetadata: {},
@@ -157,8 +157,8 @@ describe("getOrgData", () => {
       ReturnType<typeof client.organizations.getOrganization>
     >);
 
-    await expect(getOrgData(clerkOrgId)).rejects.toThrow(
-      `Clerk organization ${clerkOrgId} has no slug`,
+    await expect(getOrgData(orgId)).rejects.toThrow(
+      `Clerk organization ${orgId} has no slug`,
     );
   });
 });
@@ -176,21 +176,21 @@ describe("getOrgBySlug", () => {
       clerkOrgs: [{ id: `org_mock_${slug}`, slug, name: slug }],
     });
     await createTestScope(slug);
-    const clerkOrgId = `org_mock_${slug}`;
+    const orgId = `org_mock_${slug}`;
 
     // Delete pre-populated orgCache to test cache-miss behavior
-    await deleteOrgCacheEntry(clerkOrgId);
+    await deleteOrgCacheEntry(orgId);
 
     const result = await getOrgBySlug(slug);
 
     expect(result).toEqual({
-      clerkOrgId,
+      orgId,
       slug,
       tier: "free",
     });
 
     // Verify cache row was created
-    const cached = await getOrgCacheEntry(clerkOrgId);
+    const cached = await getOrgCacheEntry(orgId);
     expect(cached).not.toBeNull();
     expect(cached!.slug).toBe(slug);
 
@@ -209,14 +209,14 @@ describe("getOrgBySlug", () => {
       clerkOrgs: [{ id: `org_mock_${slug}`, slug, name: slug }],
     });
     await createTestScope(slug);
-    const clerkOrgId = `org_mock_${slug}`;
+    const orgId = `org_mock_${slug}`;
 
     // Overwrite cache with custom tier
-    await insertOrgCacheEntry({ clerkOrgId, slug, tier: "pro" });
+    await insertOrgCacheEntry({ orgId, slug, tier: "pro" });
 
     const result = await getOrgBySlug(slug);
 
-    expect(result).toEqual({ clerkOrgId, slug, tier: "pro" });
+    expect(result).toEqual({ orgId, slug, tier: "pro" });
 
     // Clerk API should NOT have been called
     const client = await clerkClient();
@@ -240,12 +240,12 @@ describe("getOrgBySlug", () => {
       clerkOrgs: [{ id: `org_mock_${slug}`, slug, name: slug }],
     });
     await createTestScope(slug);
-    const clerkOrgId = `org_mock_${slug}`;
+    const orgId = `org_mock_${slug}`;
 
     // Overwrite with stale entry
     const twoMinutesAgo = new Date(Date.now() - 120_000);
     await insertOrgCacheEntry({
-      clerkOrgId,
+      orgId,
       slug,
       tier: "free",
       cachedAt: twoMinutesAgo,
@@ -254,7 +254,7 @@ describe("getOrgBySlug", () => {
     const result = await getOrgBySlug(slug);
 
     expect(result).not.toBeNull();
-    expect(result!.clerkOrgId).toBe(clerkOrgId);
+    expect(result!.orgId).toBe(orgId);
 
     // Verify Clerk API was called with slug param
     const client = await clerkClient();

--- a/turbo/apps/web/src/lib/scope/__tests__/resolve-scope.test.ts
+++ b/turbo/apps/web/src/lib/scope/__tests__/resolve-scope.test.ts
@@ -9,7 +9,7 @@ const context = testContext();
 /**
  * Build clerkOrgs array for scopes created in a test.
  * Must be used BEFORE calling createTestScope() so the POST route
- * resolves the correct clerkOrgId from the user's org memberships.
+ * resolves the correct orgId from the user's org memberships.
  */
 function scopeOrgs(...slugs: string[]) {
   return slugs.map((slug) => ({
@@ -63,11 +63,11 @@ describe("resolveScope", () => {
     const userId = uniqueId("test-user");
     const slug = uniqueId("scope");
 
-    // Set up Clerk org BEFORE creating scope so POST resolves correct clerkOrgId
+    // Set up Clerk org BEFORE creating scope so POST resolves correct orgId
     mockClerk({ userId, clerkOrgs: scopeOrgs(slug) });
     const created = await createTestScope(slug);
 
-    // Mock session with orgId matching the scope's clerkOrgId
+    // Mock session with orgId matching the scope's orgId
     mockClerk({
       userId,
       orgId: `org_mock_${slug}`,
@@ -81,7 +81,7 @@ describe("resolveScope", () => {
     expect(result.scope.slug).toBe(slug);
   });
 
-  it("tier 2: explicit clerkOrgId parameter takes precedence over session", async () => {
+  it("tier 2: explicit orgId parameter takes precedence over session", async () => {
     const userId = uniqueId("test-user");
     const slug = uniqueId("scope");
 
@@ -96,7 +96,7 @@ describe("resolveScope", () => {
       clerkOrgs: scopeOrgs(slug),
     });
 
-    // Pass explicit clerkOrgId matching the scope
+    // Pass explicit orgId matching the scope
     const result = await resolveScope(userId, null, `org_mock_${slug}`);
 
     expect(result.scope.id).toBe(created.id);
@@ -287,7 +287,7 @@ describe("resolveScope", () => {
     );
   });
 
-  it("?org= param resolves scope by clerkOrgId", async () => {
+  it("?org= param resolves scope by orgId", async () => {
     const userId = uniqueId("test-user");
     const slug = uniqueId("scope");
 
@@ -295,14 +295,14 @@ describe("resolveScope", () => {
     mockClerk({ userId, clerkOrgs: scopeOrgs(slug) });
     const created = await createTestScope(slug);
 
-    // Mock session — orgId is different from the explicit clerkOrgId
+    // Mock session — orgId is different from the explicit orgId
     mockClerk({
       userId,
       orgId: "org_session_different",
       clerkOrgs: scopeOrgs(slug),
     });
 
-    // Pass clerkOrgId directly (simulates ?org= being passed as 3rd arg)
+    // Pass orgId directly (simulates ?org= being passed as 3rd arg)
     const result = await resolveScope(userId, null, `org_mock_${slug}`);
 
     expect(result.scope.id).toBe(created.id);
@@ -325,7 +325,7 @@ describe("resolveScope", () => {
       clerkOrgs: scopeOrgs(slug1, slug2),
     });
 
-    // Pass both scopeSlug and clerkOrgId — scopeSlug should win
+    // Pass both scopeSlug and orgId — scopeSlug should win
     const result = await resolveScope(userId, slug1, `org_mock_${slug2}`);
 
     expect(result.scope.id).toBe(scope1.id);

--- a/turbo/apps/web/src/lib/scope/__tests__/scope-service.test.ts
+++ b/turbo/apps/web/src/lib/scope/__tests__/scope-service.test.ts
@@ -3,32 +3,32 @@ import { clerkClient } from "@clerk/nextjs/server";
 import { testContext, uniqueId } from "../../../__tests__/test-helpers";
 import { createTestScope } from "../../../__tests__/api-test-helpers";
 import { mockClerk } from "../../../__tests__/clerk-mock";
-import { getScopeByClerkOrgId, createScope } from "../scope-service";
+import { getScopeByOrgId, createScope } from "../scope-service";
 
 const context = testContext();
 
-describe("getScopeByClerkOrgId", () => {
+describe("getScopeByOrgId", () => {
   beforeEach(() => {
     context.setupMocks();
   });
 
-  it("should return scope for valid clerkOrgId", async () => {
+  it("should return scope for valid orgId", async () => {
     const userId = uniqueId("test-user");
     const slug = uniqueId("scope");
     mockClerk({ userId });
 
     const created = await createTestScope(slug);
 
-    // POST route resolves clerkOrgId from user's Clerk org membership (org_mock_{userId})
-    const result = await getScopeByClerkOrgId(`org_mock_${userId}`);
+    // POST route resolves orgId from user's Clerk org membership (org_mock_{userId})
+    const result = await getScopeByOrgId(`org_mock_${userId}`);
 
     expect(result).not.toBeNull();
     expect(result!.id).toBe(created.id);
     expect(result!.slug).toBe(slug);
   });
 
-  it("should return null for non-existent clerkOrgId", async () => {
-    const result = await getScopeByClerkOrgId("org_nonexistent_xyz");
+  it("should return null for non-existent orgId", async () => {
+    const result = await getScopeByOrgId("org_nonexistent_xyz");
 
     expect(result).toBeNull();
   });
@@ -39,33 +39,33 @@ describe("createScope", () => {
     context.setupMocks();
   });
 
-  it("should use provided clerkOrgId instead of creating a new Clerk org", async () => {
+  it("should use provided orgId instead of creating a new Clerk org", async () => {
     const userId = uniqueId("test-user");
     const slug = uniqueId("scope");
-    const existingClerkOrgId = `org_existing_${slug}`;
+    const existingOrgId = `org_existing_${slug}`;
     mockClerk({ userId });
 
     const scope = await createScope(userId, slug, {
-      clerkOrgId: existingClerkOrgId,
+      orgId: existingOrgId,
     });
 
     expect(scope.slug).toBe(slug);
-    expect(scope.clerkOrgId).toBe(existingClerkOrgId);
+    expect(scope.orgId).toBe(existingOrgId);
 
     // Verify Clerk createOrganization was NOT called
     const client = await clerkClient();
     expect(client.organizations.createOrganization).not.toHaveBeenCalled();
   });
 
-  it("should require clerkOrgId parameter", async () => {
+  it("should require orgId parameter", async () => {
     const userId = uniqueId("test-user");
     const slug = uniqueId("scope");
-    const clerkOrgId = `org_required_${slug}`;
+    const orgId = `org_required_${slug}`;
     mockClerk({ userId });
 
-    const scope = await createScope(userId, slug, { clerkOrgId });
+    const scope = await createScope(userId, slug, { orgId });
 
     expect(scope.slug).toBe(slug);
-    expect(scope.clerkOrgId).toBe(clerkOrgId);
+    expect(scope.orgId).toBe(orgId);
   });
 });

--- a/turbo/apps/web/src/lib/scope/org-cache-service.ts
+++ b/turbo/apps/web/src/lib/scope/org-cache-service.ts
@@ -9,7 +9,7 @@ const log = logger("service:org-cache");
 const CACHE_TTL_MS = 60_000; // 1 minute
 
 interface OrgData {
-  clerkOrgId: string;
+  orgId: string;
   slug: string;
   tier: string;
 }
@@ -17,34 +17,32 @@ interface OrgData {
 /**
  * Get org data from cache or Clerk API.
  *
- * 1. Check org_cache by clerkOrgId
+ * 1. Check org_cache by orgId
  * 2. If fresh (< 1 min): return cached data
  * 3. If miss or stale: call Clerk API, upsert cache, return
  */
-export async function getOrgData(clerkOrgId: string): Promise<OrgData> {
+export async function getOrgData(orgId: string): Promise<OrgData> {
   const db = globalThis.services.db;
 
   // 1. Check cache
   const [cached] = await db
     .select()
     .from(orgCache)
-    .where(eq(orgCache.clerkOrgId, clerkOrgId))
+    .where(eq(orgCache.orgId, orgId))
     .limit(1);
 
   if (cached && Date.now() - cached.cachedAt.getTime() < CACHE_TTL_MS) {
-    return { clerkOrgId, slug: cached.slug, tier: cached.tier };
+    return { orgId, slug: cached.slug, tier: cached.tier };
   }
 
   // 2. Fetch from Clerk (source of truth)
   const client = await clerkClient();
   const org = await client.organizations.getOrganization({
-    organizationId: clerkOrgId,
+    organizationId: orgId,
   });
 
   if (!org.slug) {
-    throw new Error(
-      `Clerk organization ${clerkOrgId} has no slug — cannot cache`,
-    );
+    throw new Error(`Clerk organization ${orgId} has no slug — cannot cache`);
   }
   const slug = org.slug;
   const metadata = org.publicMetadata as Record<string, unknown> | undefined;
@@ -56,15 +54,15 @@ export async function getOrgData(clerkOrgId: string): Promise<OrgData> {
   const now = new Date();
   await db
     .insert(orgCache)
-    .values({ clerkOrgId, slug, tier, cachedAt: now })
+    .values({ orgId, slug, tier, cachedAt: now })
     .onConflictDoUpdate({
-      target: orgCache.clerkOrgId,
+      target: orgCache.orgId,
       set: { slug, tier, cachedAt: now },
     });
 
-  log.debug("org cache refreshed", { clerkOrgId, slug, tier });
+  log.debug("org cache refreshed", { orgId, slug, tier });
 
-  return { clerkOrgId, slug, tier };
+  return { orgId, slug, tier };
 }
 
 /**
@@ -88,7 +86,7 @@ export async function getOrgBySlug(slug: string): Promise<OrgData | null> {
 
   if (cached && Date.now() - cached.cachedAt.getTime() < CACHE_TTL_MS) {
     return {
-      clerkOrgId: cached.clerkOrgId,
+      orgId: cached.orgId,
       slug: cached.slug,
       tier: cached.tier,
     };
@@ -117,17 +115,17 @@ export async function getOrgBySlug(slug: string): Promise<OrgData | null> {
   const now = new Date();
   await db
     .insert(orgCache)
-    .values({ clerkOrgId: org.id, slug: org.slug, tier, cachedAt: now })
+    .values({ orgId: org.id, slug: org.slug, tier, cachedAt: now })
     .onConflictDoUpdate({
-      target: orgCache.clerkOrgId,
+      target: orgCache.orgId,
       set: { slug: org.slug, tier, cachedAt: now },
     });
 
   log.debug("org cache refreshed (by slug)", {
-    clerkOrgId: org.id,
+    orgId: org.id,
     slug: org.slug,
     tier,
   });
 
-  return { clerkOrgId: org.id, slug: org.slug, tier };
+  return { orgId: org.id, slug: org.slug, tier };
 }

--- a/turbo/apps/web/src/lib/scope/resolve-scope.ts
+++ b/turbo/apps/web/src/lib/scope/resolve-scope.ts
@@ -1,7 +1,7 @@
 import { auth, clerkClient } from "@clerk/nextjs/server";
 import { forbidden, badRequest, notFound } from "../errors";
 import { logger } from "../logger";
-import { getScopeByClerkOrgId, getScopeById } from "./scope-service";
+import { getScopeByOrgId, getScopeById } from "./scope-service";
 import { getOrgBySlug } from "./org-cache-service";
 import { getDefaultScope } from "./scope-member-service";
 
@@ -30,7 +30,7 @@ function mapOrgRole(clerkRole: string | undefined | null): ScopeRole {
 /**
  * Verify a user's membership in a Clerk organization.
  *
- * Fast path: if the scope's clerkOrgId matches the JWT's active org,
+ * Fast path: if the scope's orgId matches the JWT's active org,
  * trust the JWT claims and skip the Clerk API call entirely.
  *
  * Slow path: for cross-org access (e.g. ?scope= pointing to a non-active org),
@@ -51,7 +51,7 @@ async function verifyMembership(
   }
 
   // JWT fast path: active org matches → trust JWT, no API call
-  if (scope.clerkOrgId === authResult.orgId) {
+  if (scope.orgId === authResult.orgId) {
     return {
       role: mapOrgRole(authResult.orgRole),
       userId,
@@ -59,7 +59,7 @@ async function verifyMembership(
     };
   }
 
-  if (scope.clerkOrgId.startsWith("pending_")) {
+  if (scope.orgId.startsWith("pending_")) {
     throw forbidden("You are not a member of this scope");
   }
 
@@ -68,7 +68,7 @@ async function verifyMembership(
     const client = await clerkClient();
     const memberships =
       await client.organizations.getOrganizationMembershipList({
-        organizationId: scope.clerkOrgId,
+        organizationId: scope.orgId,
       });
 
     const membership = memberships.data.find(
@@ -92,7 +92,7 @@ async function verifyMembership(
     log.error("verifyMembership failed", {
       scopeId: scope.id,
       userId,
-      clerkOrgId: scope.clerkOrgId,
+      orgId: scope.orgId,
       error,
     });
     throw forbidden("You are not a member of this scope");
@@ -107,10 +107,7 @@ function applyJwtTier(
   scope: Scope,
   authResult: Awaited<ReturnType<typeof auth>>,
 ): Scope {
-  if (
-    scope.clerkOrgId === authResult.orgId &&
-    authResult.sessionClaims?.org_tier
-  ) {
+  if (scope.orgId === authResult.orgId && authResult.sessionClaims?.org_tier) {
     return { ...scope, tier: authResult.sessionClaims.org_tier };
   }
   return scope;
@@ -125,7 +122,7 @@ function applyJwtTier(
  * Resolution order:
  * 1. tokenScopeId (from CLI token) -> direct scope lookup, trusted
  * 2. scopeSlug (?scope=<slug> query param) -> look up scope, verify membership
- * 3. clerkOrgId (from JWT session token) -> look up scope by org ID
+ * 3. orgId (from JWT session token) -> look up scope by org ID
  * 4. Fallback -> user's default scope
  *
  * When the resolved org matches the JWT's active org, `tier` is read from
@@ -134,7 +131,7 @@ function applyJwtTier(
 export async function resolveScope(
   userId: string,
   scopeSlug?: string | null,
-  clerkOrgId?: string | null,
+  orgId?: string | null,
   tokenScopeId?: string | null,
 ) {
   const authResult = await auth();
@@ -143,7 +140,7 @@ export async function resolveScope(
   if (scopeSlug) {
     const orgData = await getOrgBySlug(scopeSlug);
     if (!orgData) throw notFound("Scope not found");
-    const scope = await getScopeByClerkOrgId(orgData.clerkOrgId);
+    const scope = await getScopeByOrgId(orgData.orgId);
     if (!scope) throw notFound("Scope not found");
 
     const member = await verifyMembership(
@@ -169,9 +166,9 @@ export async function resolveScope(
   // 3. Clerk org ID — use provided value or auto-detect from JWT session token.
   // For CLI tokens, auth().orgId returns null (no Clerk session),
   // so this tier is skipped and we fall through to the default scope.
-  const effectiveOrgId = clerkOrgId ?? authResult.orgId ?? null;
+  const effectiveOrgId = orgId ?? authResult.orgId ?? null;
   if (effectiveOrgId) {
-    const scope = await getScopeByClerkOrgId(effectiveOrgId);
+    const scope = await getScopeByOrgId(effectiveOrgId);
     if (scope) {
       const member = await verifyMembership(
         scope,
@@ -181,7 +178,7 @@ export async function resolveScope(
       );
       return { scope: applyJwtTier(scope, authResult), member };
     }
-    // Scope not found for this clerkOrgId — fall through to default
+    // Scope not found for this orgId — fall through to default
     // (scope may not be created yet in the migration period)
   }
 
@@ -210,10 +207,10 @@ export async function requireScopeFromRequest(
   if (scopeSlug) {
     const orgData = await getOrgBySlug(scopeSlug);
     if (orgData) {
-      scope = await getScopeByClerkOrgId(orgData.clerkOrgId);
+      scope = await getScopeByOrgId(orgData.orgId);
     }
   } else if (orgParam) {
-    scope = await getScopeByClerkOrgId(orgParam);
+    scope = await getScopeByOrgId(orgParam);
   } else {
     throw badRequest("scope or org query parameter is required");
   }

--- a/turbo/apps/web/src/lib/scope/scope-member-service.ts
+++ b/turbo/apps/web/src/lib/scope/scope-member-service.ts
@@ -3,7 +3,7 @@ import { eq } from "drizzle-orm";
 import { scopes } from "../../db/schema/scope";
 import { badRequest, forbidden, notFound } from "../errors";
 import { logger } from "../logger";
-import { getScopeByClerkOrgId, getScopesByClerkOrgIds } from "./scope-service";
+import { getScopeByOrgId, getScopesByOrgIds } from "./scope-service";
 import type { ScopeRole } from "@vm0/core";
 
 const log = logger("service:scope-member");
@@ -19,13 +19,13 @@ export async function requireScopeMember(scopeId: string, userId: string) {
     .where(eq(scopes.id, scopeId))
     .limit(1);
 
-  if (!scope?.clerkOrgId || scope.clerkOrgId.startsWith("pending_")) {
+  if (!scope?.orgId || scope.orgId.startsWith("pending_")) {
     throw forbidden("You are not a member of this scope");
   }
 
   const client = await clerkClient();
   const memberships = await client.organizations.getOrganizationMembershipList({
-    organizationId: scope.clerkOrgId,
+    organizationId: scope.orgId,
   });
 
   const membership = memberships.data.find(
@@ -55,7 +55,7 @@ export async function getDefaultScope(userId: string) {
   // JWT fast path: use active org from session token
   const authResult = await auth();
   if (authResult.orgId) {
-    const scope = await getScopeByClerkOrgId(authResult.orgId);
+    const scope = await getScopeByOrgId(authResult.orgId);
     if (scope) {
       return {
         scope,
@@ -84,8 +84,8 @@ export async function getDefaultScope(userId: string) {
     : memberships.data;
 
   // Batch-fetch all scopes by Clerk org IDs in a single query
-  const clerkOrgIds = candidates.map((m) => m.organization.id);
-  const scopeMap = await getScopesByClerkOrgIds(clerkOrgIds);
+  const orgIds = candidates.map((m) => m.organization.id);
+  const scopeMap = await getScopesByOrgIds(orgIds);
 
   for (const membership of candidates) {
     const scope = scopeMap.get(membership.organization.id);
@@ -140,11 +140,11 @@ async function getScopeWithClerkOrg(scopeId: string) {
     .where(eq(scopes.id, scopeId))
     .limit(1);
 
-  if (!scope?.clerkOrgId) {
+  if (!scope?.orgId) {
     throw notFound("Scope not found");
   }
 
-  return scope as typeof scope & { clerkOrgId: string };
+  return scope as typeof scope & { orgId: string };
 }
 
 /**
@@ -152,15 +152,15 @@ async function getScopeWithClerkOrg(scopeId: string) {
  * Reads membership data directly from Clerk API.
  */
 export async function getScopeMembers(
-  clerkUserId: string,
-  clerkOrgId: string,
+  userId: string,
+  orgId: string,
   scopeSlug: string,
   createdAt: Date,
 ) {
   // Get members from Clerk
   const client = await clerkClient();
   const memberships = await client.organizations.getOrganizationMembershipList({
-    organizationId: clerkOrgId,
+    organizationId: orgId,
   });
 
   // Batch-resolve emails for all members in a single Clerk API call
@@ -193,7 +193,7 @@ export async function getScopeMembers(
 
   // Determine caller's role
   const callerMembership = memberships.data.find(
-    (m) => m.publicUserData?.userId === clerkUserId,
+    (m) => m.publicUserData?.userId === userId,
   );
   const callerRole = callerMembership
     ? mapClerkRole(callerMembership.role)
@@ -225,7 +225,7 @@ export async function inviteMember(
 
   const client = await clerkClient();
   await client.organizations.createOrganizationInvitation({
-    organizationId: scope.clerkOrgId,
+    organizationId: scope.orgId,
     emailAddress: email,
     inviterUserId: callerUserId,
     role: "org:member",
@@ -267,7 +267,7 @@ export async function removeMember(
 
   // Find membership to get membershipId
   const memberships = await client.organizations.getOrganizationMembershipList({
-    organizationId: scope.clerkOrgId,
+    organizationId: scope.orgId,
   });
 
   const membership = memberships.data.find(
@@ -280,7 +280,7 @@ export async function removeMember(
 
   // Remove from Clerk
   await client.organizations.deleteOrganizationMembership({
-    organizationId: scope.clerkOrgId,
+    organizationId: scope.orgId,
     userId: targetUserId,
   });
 
@@ -292,7 +292,7 @@ export async function removeMember(
  * Admins cannot leave (they must add another admin or delete the scope).
  */
 export async function leaveScope(
-  clerkUserId: string,
+  userId: string,
   scopeId: string,
   role: ScopeRole,
 ) {
@@ -307,22 +307,22 @@ export async function leaveScope(
   // Remove own membership from Clerk
   const client = await clerkClient();
   await client.organizations.deleteOrganizationMembership({
-    organizationId: scope.clerkOrgId,
-    userId: clerkUserId,
+    organizationId: scope.orgId,
+    userId: userId,
   });
 
-  log.debug("User left scope", { scopeId, clerkUserId });
+  log.debug("User left scope", { scopeId, userId });
 }
 
 /**
  * Get all scopes accessible to a user (via Clerk organization memberships).
  */
 export async function getUserAccessibleScopes(
-  clerkUserId: string,
+  userId: string,
 ): Promise<Array<{ slug: string; role: string }>> {
   const client = await clerkClient();
   const memberships = await client.users.getOrganizationMembershipList({
-    userId: clerkUserId,
+    userId: userId,
   });
   return memberships.data.map((m) => ({
     slug: m.organization.slug,

--- a/turbo/apps/web/src/lib/scope/scope-service.ts
+++ b/turbo/apps/web/src/lib/scope/scope-service.ts
@@ -32,11 +32,11 @@ const SLUG_REGEX = /^[a-z0-9][a-z0-9-]*[a-z0-9]$|^[a-z0-9]{1,2}$/;
  * Generate a deterministic default scope slug from Clerk user ID.
  * Format: user-{8 hex chars from SHA-256 hash}
  *
- * @param clerkUserId - The Clerk user ID to hash
+ * @param userId - The Clerk user ID to hash
  * @returns A slug in format "user-xxxxxxxx" (13 chars total)
  */
-export function generateDefaultScopeSlug(clerkUserId: string): string {
-  const hash = createHash("sha256").update(clerkUserId).digest("hex");
+export function generateDefaultScopeSlug(userId: string): string {
+  const hash = createHash("sha256").update(userId).digest("hex");
   return `user-${hash.slice(0, 8)}`;
 }
 
@@ -89,11 +89,11 @@ async function getScopeBySlug(slug: string) {
 /**
  * Get a scope by its Clerk organization ID
  */
-export async function getScopeByClerkOrgId(clerkOrgId: string) {
+export async function getScopeByOrgId(orgId: string) {
   const result = await globalThis.services.db
     .select()
     .from(scopes)
-    .where(eq(scopes.clerkOrgId, clerkOrgId))
+    .where(eq(scopes.orgId, orgId))
     .limit(1);
 
   return result[0] ?? null;
@@ -101,17 +101,17 @@ export async function getScopeByClerkOrgId(clerkOrgId: string) {
 
 /**
  * Get scopes by multiple Clerk organization IDs in a single query.
- * Returns a Map from clerkOrgId to scope record.
+ * Returns a Map from orgId to scope record.
  */
-export async function getScopesByClerkOrgIds(
-  clerkOrgIds: string[],
+export async function getScopesByOrgIds(
+  orgIds: string[],
 ): Promise<Map<string, typeof scopes.$inferSelect>> {
-  if (clerkOrgIds.length === 0) return new Map();
+  if (orgIds.length === 0) return new Map();
   const results = await globalThis.services.db
     .select()
     .from(scopes)
-    .where(inArray(scopes.clerkOrgId, clerkOrgIds));
-  return new Map(results.map((s) => [s.clerkOrgId, s]));
+    .where(inArray(scopes.orgId, orgIds));
+  return new Map(results.map((s) => [s.orgId, s]));
 }
 
 /**
@@ -119,12 +119,12 @@ export async function getScopesByClerkOrgIds(
  *
  * Handles slug validation and scope creation.
  *
- * @param options.clerkOrgId - Clerk org ID to bind the scope to
+ * @param options.orgId - Clerk org ID to bind the scope to
  */
 export async function createScope(
-  clerkUserId: string,
+  userId: string,
   slug: string,
-  options: { clerkOrgId: string },
+  options: { orgId: string },
 ) {
   validateScopeSlug(slug);
 
@@ -134,13 +134,13 @@ export async function createScope(
     throw badRequest(`Scope "${slug}" already exists`);
   }
 
-  const { clerkOrgId } = options;
+  const { orgId } = options;
 
   const [newScope] = await globalThis.services.db
     .insert(scopes)
     .values({
       slug,
-      clerkOrgId,
+      orgId,
     })
     .onConflictDoNothing({ target: scopes.slug })
     .returning();
@@ -150,10 +150,10 @@ export async function createScope(
   }
 
   log.debug("scope created", {
-    clerkUserId,
+    userId,
     scopeId: newScope.id,
     slug,
-    clerkOrgId,
+    orgId,
   });
 
   return newScope;
@@ -164,9 +164,9 @@ export async function createScope(
  * Finds the first scope where the user is an admin member.
  * Returns the scope record or null if none found.
  */
-export async function getDefaultScopeByClerkUserId(clerkUserId: string) {
+export async function getDefaultScopeByUserId(userId: string) {
   try {
-    const { scope } = await getDefaultScope(clerkUserId);
+    const { scope } = await getDefaultScope(userId);
     return scope;
   } catch (error) {
     if (isNotFound(error)) return null;
@@ -185,11 +185,11 @@ export async function getDefaultScopeByClerkUserId(clerkUserId: string) {
  *
  * @returns The existing or newly created scope
  */
-export async function ensureDefaultScope(clerkUserId: string) {
-  const existing = await getDefaultScopeByClerkUserId(clerkUserId);
+export async function ensureDefaultScope(userId: string) {
+  const existing = await getDefaultScopeByUserId(userId);
   if (existing) return existing;
 
-  return await discoverAndCreateScope(clerkUserId);
+  return await discoverAndCreateScope(userId);
 }
 
 /**
@@ -211,10 +211,10 @@ function isValidSlug(slug: string): boolean {
  * Fetches the user's Clerk org memberships, batch-queries existing scopes, and
  * returns the first unmatched membership (or null if all orgs are already bound).
  */
-export async function resolveUnmatchedClerkOrg(clerkUserId: string) {
+export async function resolveUnmatchedClerkOrg(userId: string) {
   const client = await clerkClient();
   const memberships = await client.users.getOrganizationMembershipList({
-    userId: clerkUserId,
+    userId: userId,
   });
 
   if (memberships.data.length === 0) {
@@ -223,10 +223,10 @@ export async function resolveUnmatchedClerkOrg(clerkUserId: string) {
 
   const orgIds = memberships.data.map((m) => m.organization.id);
   const matchedScopes = await globalThis.services.db
-    .select({ clerkOrgId: scopes.clerkOrgId })
+    .select({ orgId: scopes.orgId })
     .from(scopes)
-    .where(inArray(scopes.clerkOrgId, orgIds));
-  const existingOrgIds = new Set(matchedScopes.map((s) => s.clerkOrgId));
+    .where(inArray(scopes.orgId, orgIds));
+  const existingOrgIds = new Set(matchedScopes.map((s) => s.orgId));
 
   return (
     memberships.data.find((m) => !existingOrgIds.has(m.organization.id)) ?? null
@@ -238,8 +238,8 @@ export async function resolveUnmatchedClerkOrg(clerkUserId: string) {
  * Queries the Clerk API for the user's org memberships, finds the first org
  * without a matching local scope, and creates a scope record.
  */
-async function discoverAndCreateScope(clerkUserId: string) {
-  const unmatchedMembership = await resolveUnmatchedClerkOrg(clerkUserId);
+async function discoverAndCreateScope(userId: string) {
+  const unmatchedMembership = await resolveUnmatchedClerkOrg(userId);
 
   if (!unmatchedMembership) {
     throw notFound(
@@ -247,29 +247,29 @@ async function discoverAndCreateScope(clerkUserId: string) {
     );
   }
 
-  const clerkOrgId = unmatchedMembership.organization.id;
+  const orgId = unmatchedMembership.organization.id;
 
   // Prefer Clerk org slug, fall back to deterministic user-{hash}
   const clerkSlug = unmatchedMembership.organization.slug;
   let slug: string;
   if (clerkSlug && isValidSlug(clerkSlug)) {
     const taken = await getScopeBySlug(clerkSlug);
-    slug = taken ? generateDefaultScopeSlug(clerkUserId) : clerkSlug;
+    slug = taken ? generateDefaultScopeSlug(userId) : clerkSlug;
   } else {
-    slug = generateDefaultScopeSlug(clerkUserId);
+    slug = generateDefaultScopeSlug(userId);
   }
 
   try {
-    return await createScope(clerkUserId, slug, { clerkOrgId });
+    return await createScope(userId, slug, { orgId });
   } catch (error) {
     if (isBadRequest(error) && error.message.includes("already exists")) {
       // Re-check: another concurrent request may have created this scope
-      const raceScope = await getScopeByClerkOrgId(clerkOrgId);
+      const raceScope = await getScopeByOrgId(orgId);
       if (raceScope) return raceScope;
 
       // Slug collision with unrelated scope — retry with random slug
       const fallbackSlug = `user-${randomBytes(4).toString("hex")}`;
-      return await createScope(clerkUserId, fallbackSlug, { clerkOrgId });
+      return await createScope(userId, fallbackSlug, { orgId });
     }
     throw error;
   }
@@ -282,7 +282,7 @@ async function discoverAndCreateScope(clerkUserId: string) {
 export async function updateScopeSlug(
   scopeId: string,
   newSlug: string,
-  clerkUserId: string,
+  userId: string,
   force: boolean = false,
 ) {
   // Get the scope
@@ -292,7 +292,7 @@ export async function updateScopeSlug(
   }
 
   // Verify membership (requireScopeMember throws 403 if not a member)
-  await requireScopeMember(scopeId, clerkUserId);
+  await requireScopeMember(scopeId, userId);
 
   // Require force flag for slug changes
   if (!force) {
@@ -329,13 +329,13 @@ export async function updateScopeSlug(
   // Dual-write: sync slug to Clerk org (fire-and-forget)
   try {
     const client = await clerkClient();
-    await client.organizations.updateOrganization(scope.clerkOrgId, {
+    await client.organizations.updateOrganization(scope.orgId, {
       slug: newSlug,
     });
   } catch (err) {
     log.error("failed to write slug to Clerk org", {
       error: err,
-      clerkOrgId: scope.clerkOrgId,
+      orgId: scope.orgId,
       scopeId,
       newSlug,
     });
@@ -367,7 +367,7 @@ export function isOfficialRunnerGroup(group: string): boolean {
  * @throws ForbiddenError if scope doesn't match (for non-official groups)
  */
 export async function validateRunnerGroupScope(
-  clerkUserId: string,
+  userId: string,
   group: string,
   tokenScopeId?: string | null,
 ): Promise<void> {
@@ -392,7 +392,7 @@ export async function validateRunnerGroupScope(
     );
   }
 
-  const defaultScope = await getDefaultScopeByClerkUserId(clerkUserId);
+  const defaultScope = await getDefaultScopeByUserId(userId);
   if (!defaultScope) {
     throw forbidden(
       `Runner group scope "${scopeSlug}" requires you to have a scope configured`,

--- a/turbo/apps/web/src/lib/secret/secret-service.ts
+++ b/turbo/apps/web/src/lib/secret/secret-service.ts
@@ -180,7 +180,7 @@ export async function getSecretValues(
  */
 export async function upsertSecretByScope(
   orgId: string,
-  scopeId: string,
+  scopeId: string | null,
   userId: string,
   name: string,
   value: string,

--- a/turbo/apps/web/src/lib/secret/secret-service.ts
+++ b/turbo/apps/web/src/lib/secret/secret-service.ts
@@ -44,7 +44,7 @@ interface SecretInfo {
  * List all secrets for a scope (metadata only, no values)
  */
 export async function listSecrets(
-  clerkOrgId: string,
+  orgId: string,
   userId: string,
 ): Promise<SecretInfo[]> {
   const result = await globalThis.services.db
@@ -57,7 +57,7 @@ export async function listSecrets(
       updatedAt: secrets.updatedAt,
     })
     .from(secrets)
-    .where(and(eq(secrets.clerkOrgId, clerkOrgId), eq(secrets.userId, userId)))
+    .where(and(eq(secrets.orgId, orgId), eq(secrets.userId, userId)))
     .orderBy(secrets.name);
 
   return result.map((row) => ({
@@ -71,7 +71,7 @@ export async function listSecrets(
  * Only returns user-type secrets; model-provider secrets are managed via model-provider commands
  */
 export async function getSecret(
-  clerkOrgId: string,
+  orgId: string,
   userId: string,
   name: string,
 ): Promise<SecretInfo | null> {
@@ -87,7 +87,7 @@ export async function getSecret(
     .from(secrets)
     .where(
       and(
-        eq(secrets.clerkOrgId, clerkOrgId),
+        eq(secrets.orgId, orgId),
         eq(secrets.userId, userId),
         eq(secrets.name, name),
         eq(secrets.type, "user"),
@@ -111,13 +111,13 @@ export async function getSecret(
  * @param type - Optional type filter to isolate user vs model-provider secrets
  */
 export async function getSecretValue(
-  clerkOrgId: string,
+  orgId: string,
   userId: string,
   name: string,
   type?: SecretType,
 ): Promise<string | null> {
   const conditions = [
-    eq(secrets.clerkOrgId, clerkOrgId),
+    eq(secrets.orgId, orgId),
     eq(secrets.userId, userId),
     eq(secrets.name, name),
   ];
@@ -147,14 +147,11 @@ export async function getSecretValue(
  * @param type - Optional type filter to isolate user vs model-provider secrets
  */
 export async function getSecretValues(
-  clerkOrgId: string,
+  orgId: string,
   userId: string,
   type?: SecretType,
 ): Promise<Record<string, string>> {
-  const conditions = [
-    eq(secrets.clerkOrgId, clerkOrgId),
-    eq(secrets.userId, userId),
-  ];
+  const conditions = [eq(secrets.orgId, orgId), eq(secrets.userId, userId)];
   if (type) {
     conditions.push(eq(secrets.type, type));
   }
@@ -182,8 +179,8 @@ export async function getSecretValues(
  * Used internally by connector services for managing connector/model-provider secrets.
  */
 export async function upsertSecretByScope(
-  clerkOrgId: string,
-  scopeId: string | null,
+  orgId: string,
+  scopeId: string,
   userId: string,
   name: string,
   value: string,
@@ -198,7 +195,7 @@ export async function upsertSecretByScope(
     .from(secrets)
     .where(
       and(
-        eq(secrets.clerkOrgId, clerkOrgId),
+        eq(secrets.orgId, orgId),
         eq(secrets.userId, userId),
         eq(secrets.name, name),
         eq(secrets.type, type),
@@ -219,7 +216,7 @@ export async function upsertSecretByScope(
       encryptedValue,
       type,
       description,
-      clerkOrgId,
+      orgId,
     });
   }
 }
@@ -228,7 +225,7 @@ export async function upsertSecretByScope(
  * Create or update a secret (upsert)
  */
 export async function setSecret(
-  clerkOrgId: string,
+  orgId: string,
   scopeId: string,
   userId: string,
   name: string,
@@ -240,7 +237,7 @@ export async function setSecret(
   const encryptionKey = globalThis.services.env.SECRETS_ENCRYPTION_KEY;
   const encryptedValue = encryptSecretValue(value, encryptionKey);
 
-  log.debug("setting secret", { clerkOrgId, name });
+  log.debug("setting secret", { orgId, name });
 
   // Check if user secret exists with same name
   // Note: We only check for user type to allow coexistence with model-provider secrets
@@ -249,7 +246,7 @@ export async function setSecret(
     .from(secrets)
     .where(
       and(
-        eq(secrets.clerkOrgId, clerkOrgId),
+        eq(secrets.orgId, orgId),
         eq(secrets.userId, userId),
         eq(secrets.name, name),
         eq(secrets.type, "user"),
@@ -292,7 +289,7 @@ export async function setSecret(
       encryptedValue,
       description: description ?? null,
       userId,
-      clerkOrgId,
+      orgId,
     })
     .returning({
       id: secrets.id,
@@ -315,7 +312,7 @@ export async function setSecret(
  * Note: Model-provider secrets are managed via model-provider commands
  */
 export async function deleteSecret(
-  clerkOrgId: string,
+  orgId: string,
   userId: string,
   name: string,
 ): Promise<void> {
@@ -325,7 +322,7 @@ export async function deleteSecret(
     .from(secrets)
     .where(
       and(
-        eq(secrets.clerkOrgId, clerkOrgId),
+        eq(secrets.orgId, orgId),
         eq(secrets.userId, userId),
         eq(secrets.name, name),
         eq(secrets.type, "user"),
@@ -339,5 +336,5 @@ export async function deleteSecret(
 
   await globalThis.services.db.delete(secrets).where(eq(secrets.id, secret.id));
 
-  log.debug("secret deleted", { clerkOrgId, name });
+  log.debug("secret deleted", { orgId, name });
 }

--- a/turbo/apps/web/src/lib/slack/handlers/shared.ts
+++ b/turbo/apps/web/src/lib/slack/handlers/shared.ts
@@ -232,7 +232,7 @@ export async function ensureScopeAndArtifact(vm0UserId: string): Promise<void> {
   // Slack callers (server actions, OAuth callback) don't have error handling for this.
   try {
     await ensureStorageExists(
-      scope.clerkOrgId,
+      scope.orgId,
       vm0UserId,
       "artifact",
       scope.slug,

--- a/turbo/apps/web/src/lib/storage/storage-service.ts
+++ b/turbo/apps/web/src/lib/storage/storage-service.ts
@@ -31,7 +31,7 @@ function createEmptyTarGz(): Buffer {
  * (both manifest.json and archive.tar.gz so download.ts can create the mount directory).
  * If it already has a HEAD version, this is a no-op.
  *
- * @param clerkOrgId - Clerk org ID for storage access
+ * @param orgId - Clerk org ID for storage access
  * @param userId - User ID for storage record ownership
  * @param storageName - Storage name
  * @param scopeSlug - Scope slug for S3 prefix construction
@@ -39,7 +39,7 @@ function createEmptyTarGz(): Buffer {
  * @param scopeId - Scope ID for INSERT only (removed in Phase 5)
  */
 export async function ensureStorageExists(
-  clerkOrgId: string,
+  orgId: string,
   userId: string,
   storageName: string,
   scopeSlug: string,
@@ -52,7 +52,7 @@ export async function ensureStorageExists(
     .from(storages)
     .where(
       and(
-        eq(storages.clerkOrgId, clerkOrgId),
+        eq(storages.orgId, orgId),
         eq(storages.userId, userId),
         eq(storages.name, storageName),
         eq(storages.type, storageType),
@@ -71,7 +71,7 @@ export async function ensureStorageExists(
         s3Prefix: `${scopeSlug}/${storageType}/${storageName}`,
         size: 0,
         fileCount: 0,
-        clerkOrgId,
+        orgId,
       })
       .onConflictDoNothing()
       .returning();
@@ -83,7 +83,7 @@ export async function ensureStorageExists(
         .from(storages)
         .where(
           and(
-            eq(storages.clerkOrgId, clerkOrgId),
+            eq(storages.orgId, orgId),
             eq(storages.userId, userId),
             eq(storages.name, storageName),
             eq(storages.type, storageType),
@@ -94,7 +94,7 @@ export async function ensureStorageExists(
     } else {
       storage = newStorage;
     }
-    log.info("Auto-created storage", { storageName, storageType, clerkOrgId });
+    log.info("Auto-created storage", { storageName, storageType, orgId });
   }
 
   if (!storage) {
@@ -179,7 +179,7 @@ export async function ensureStorageExists(
 
 /**
  * Resolve version ID from version string
- * @param clerkOrgId - Clerk org ID for storage access
+ * @param orgId - Clerk org ID for storage access
  * @param storageName - Storage name
  * @param storageType - Storage type ("volume", "artifact", or "memory")
  * @param version - Version string ("latest" or specific hash)
@@ -187,7 +187,7 @@ export async function ensureStorageExists(
  * @returns Version ID and S3 key
  */
 async function resolveVersion(
-  clerkOrgId: string,
+  orgId: string,
   storageName: string,
   storageType: "volume" | "artifact" | "memory",
   version: string,
@@ -205,7 +205,7 @@ async function resolveVersion(
       .leftJoin(storageVersions, eq(storages.headVersionId, storageVersions.id))
       .where(
         and(
-          eq(storages.clerkOrgId, clerkOrgId),
+          eq(storages.orgId, orgId),
           eq(storages.userId, userId),
           eq(storages.name, storageName),
           eq(storages.type, storageType),
@@ -234,7 +234,7 @@ async function resolveVersion(
     .from(storages)
     .where(
       and(
-        eq(storages.clerkOrgId, clerkOrgId),
+        eq(storages.orgId, orgId),
         eq(storages.userId, userId),
         eq(storages.name, storageName),
         eq(storages.type, storageType),

--- a/turbo/apps/web/src/lib/telegram/__tests__/helpers.ts
+++ b/turbo/apps/web/src/lib/telegram/__tests__/helpers.ts
@@ -23,7 +23,7 @@ export async function createTelegramInstallation(): Promise<string> {
     .insert(scopes)
     .values({
       slug: suffix,
-      clerkOrgId: uniqueId("org"),
+      orgId: uniqueId("org"),
     })
     .returning();
 
@@ -32,7 +32,7 @@ export async function createTelegramInstallation(): Promise<string> {
     .values({
       userId: uniqueId("test-user"),
       scopeId: scope!.id,
-      clerkOrgId: scope!.clerkOrgId,
+      orgId: scope!.orgId,
       name: uniqueId("test-compose"),
     })
     .returning();

--- a/turbo/apps/web/src/lib/telegram/handlers/shared.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/shared.ts
@@ -245,7 +245,7 @@ export async function ensureScopeAndArtifact(vm0UserId: string): Promise<void> {
   const scope = await ensureDefaultScope(vm0UserId);
 
   await ensureStorageExists(
-    scope.clerkOrgId,
+    scope.orgId,
     vm0UserId,
     "artifact",
     scope.slug,

--- a/turbo/apps/web/src/lib/user/user-preferences-service.ts
+++ b/turbo/apps/web/src/lib/user/user-preferences-service.ts
@@ -31,7 +31,7 @@ function isValidTimezone(timezone: string): boolean {
  * Read preferences from org_members_cache, falling back to Clerk API on miss/stale.
  */
 async function getCachedMemberPreferences(
-  clerkOrgId: string,
+  orgId: string,
   userId: string,
 ): Promise<UserPreferences> {
   const db = globalThis.services.db;
@@ -41,10 +41,7 @@ async function getCachedMemberPreferences(
     .select()
     .from(orgMembersCache)
     .where(
-      and(
-        eq(orgMembersCache.clerkOrgId, clerkOrgId),
-        eq(orgMembersCache.userId, userId),
-      ),
+      and(eq(orgMembersCache.orgId, orgId), eq(orgMembersCache.userId, userId)),
     )
     .limit(1);
 
@@ -59,7 +56,7 @@ async function getCachedMemberPreferences(
   // 2. Fetch from Clerk API (source of truth)
   const client = await clerkClient();
   const memberships = await client.organizations.getOrganizationMembershipList({
-    organizationId: clerkOrgId,
+    organizationId: orgId,
   });
 
   const membership = memberships.data.find(
@@ -83,7 +80,7 @@ async function getCachedMemberPreferences(
   await db
     .insert(orgMembersCache)
     .values({
-      clerkOrgId,
+      orgId,
       userId,
       timezone: prefs.timezone,
       notifyEmail: prefs.notifyEmail,
@@ -91,7 +88,7 @@ async function getCachedMemberPreferences(
       cachedAt: now,
     })
     .onConflictDoUpdate({
-      target: [orgMembersCache.clerkOrgId, orgMembersCache.userId],
+      target: [orgMembersCache.orgId, orgMembersCache.userId],
       set: {
         timezone: prefs.timezone,
         notifyEmail: prefs.notifyEmail,
@@ -100,7 +97,7 @@ async function getCachedMemberPreferences(
       },
     });
 
-  log.debug("org members cache refreshed", { clerkOrgId, userId });
+  log.debug("org members cache refreshed", { orgId, userId });
 
   return prefs;
 }
@@ -109,7 +106,7 @@ async function getCachedMemberPreferences(
  * Upsert preferences into org_members_cache.
  */
 async function upsertMemberCache(
-  clerkOrgId: string,
+  orgId: string,
   userId: string,
   prefs: Partial<UserPreferences>,
 ): Promise<void> {
@@ -119,7 +116,7 @@ async function upsertMemberCache(
   await db
     .insert(orgMembersCache)
     .values({
-      clerkOrgId,
+      orgId,
       userId,
       timezone: prefs.timezone ?? null,
       notifyEmail: prefs.notifyEmail ?? false,
@@ -127,7 +124,7 @@ async function upsertMemberCache(
       cachedAt: now,
     })
     .onConflictDoUpdate({
-      target: [orgMembersCache.clerkOrgId, orgMembersCache.userId],
+      target: [orgMembersCache.orgId, orgMembersCache.userId],
       set: {
         ...(prefs.timezone !== undefined && { timezone: prefs.timezone }),
         ...(prefs.notifyEmail !== undefined && {
@@ -170,7 +167,7 @@ function buildClerkMetadata(prefs: {
  * org_members_cache (DB-backed read-through cache of Clerk membership data).
  */
 export async function getUserPreferences(
-  clerkOrgId: string,
+  orgId: string,
   userId: string,
   sessionClaims?: CustomJwtSessionClaims,
 ): Promise<UserPreferences> {
@@ -189,14 +186,14 @@ export async function getUserPreferences(
   }
 
   // Cache-backed Clerk API fallback
-  return getCachedMemberPreferences(clerkOrgId, userId);
+  return getCachedMemberPreferences(orgId, userId);
 }
 
 /**
  * Update user preferences in Clerk membership metadata and local cache.
  */
 export async function updateUserPreferences(
-  clerkOrgId: string,
+  orgId: string,
   userId: string,
   prefs: { timezone?: string; notifyEmail?: boolean; notifySlack?: boolean },
 ): Promise<UserPreferences> {
@@ -207,7 +204,7 @@ export async function updateUserPreferences(
   }
 
   // Read existing preferences to merge with partial update
-  const existing = await getCachedMemberPreferences(clerkOrgId, userId);
+  const existing = await getCachedMemberPreferences(orgId, userId);
 
   const merged: UserPreferences = {
     timezone: prefs.timezone !== undefined ? prefs.timezone : existing.timezone,
@@ -224,13 +221,13 @@ export async function updateUserPreferences(
   // Write to Clerk membership metadata
   const client = await clerkClient();
   await client.organizations.updateOrganizationMembershipMetadata({
-    organizationId: clerkOrgId,
+    organizationId: orgId,
     userId,
     publicMetadata: buildClerkMetadata(prefs),
   });
 
   // Update local cache with merged result
-  await upsertMemberCache(clerkOrgId, userId, merged);
+  await upsertMemberCache(orgId, userId, merged);
 
   return merged;
 }
@@ -240,7 +237,7 @@ export async function updateUserPreferences(
  * Writes to Clerk membership metadata and local cache.
  */
 export async function setTimezoneIfNotSet(
-  clerkOrgId: string,
+  orgId: string,
   userId: string,
   timezone: string,
   sessionClaims?: CustomJwtSessionClaims,
@@ -250,7 +247,7 @@ export async function setTimezoneIfNotSet(
   }
 
   const { timezone: existingTimezone } = await getUserPreferences(
-    clerkOrgId,
+    orgId,
     userId,
     sessionClaims,
   );
@@ -259,12 +256,12 @@ export async function setTimezoneIfNotSet(
     try {
       const client = await clerkClient();
       await client.organizations.updateOrganizationMembershipMetadata({
-        organizationId: clerkOrgId,
+        organizationId: orgId,
         userId,
         publicMetadata: { timezone },
       });
 
-      await upsertMemberCache(clerkOrgId, userId, { timezone });
+      await upsertMemberCache(orgId, userId, { timezone });
     } catch (err) {
       log.error("Failed to write timezone to Clerk metadata", {
         error: err,

--- a/turbo/apps/web/src/lib/variable/variable-service.ts
+++ b/turbo/apps/web/src/lib/variable/variable-service.ts
@@ -42,7 +42,7 @@ interface VariableInfo {
  * List all variables for a scope (includes values)
  */
 export async function listVariables(
-  clerkOrgId: string,
+  orgId: string,
   userId: string,
 ): Promise<VariableInfo[]> {
   const result = await globalThis.services.db
@@ -55,9 +55,7 @@ export async function listVariables(
       updatedAt: variables.updatedAt,
     })
     .from(variables)
-    .where(
-      and(eq(variables.clerkOrgId, clerkOrgId), eq(variables.userId, userId)),
-    )
+    .where(and(eq(variables.orgId, orgId), eq(variables.userId, userId)))
     .orderBy(variables.name);
 
   return result;
@@ -67,7 +65,7 @@ export async function listVariables(
  * Get a variable by name for a scope (includes value)
  */
 export async function getVariable(
-  clerkOrgId: string,
+  orgId: string,
   userId: string,
   name: string,
 ): Promise<VariableInfo | null> {
@@ -83,7 +81,7 @@ export async function getVariable(
     .from(variables)
     .where(
       and(
-        eq(variables.clerkOrgId, clerkOrgId),
+        eq(variables.orgId, orgId),
         eq(variables.userId, userId),
         eq(variables.name, name),
       ),
@@ -102,7 +100,7 @@ export async function getVariable(
  * Used for batch variable resolution during agent execution
  */
 export async function getVariableValues(
-  clerkOrgId: string,
+  orgId: string,
   userId: string,
 ): Promise<Record<string, string>> {
   const result = await globalThis.services.db
@@ -111,9 +109,7 @@ export async function getVariableValues(
       value: variables.value,
     })
     .from(variables)
-    .where(
-      and(eq(variables.clerkOrgId, clerkOrgId), eq(variables.userId, userId)),
-    );
+    .where(and(eq(variables.orgId, orgId), eq(variables.userId, userId)));
 
   const values: Record<string, string> = {};
   for (const row of result) {
@@ -127,7 +123,7 @@ export async function getVariableValues(
  * Create or update a variable (upsert)
  */
 export async function setVariable(
-  clerkOrgId: string,
+  orgId: string,
   scopeId: string,
   userId: string,
   name: string,
@@ -136,7 +132,7 @@ export async function setVariable(
 ): Promise<VariableInfo> {
   validateVariableName(name);
 
-  log.debug("setting variable", { clerkOrgId, name });
+  log.debug("setting variable", { orgId, name });
 
   // Check if variable exists
   const existing = await globalThis.services.db
@@ -144,7 +140,7 @@ export async function setVariable(
     .from(variables)
     .where(
       and(
-        eq(variables.clerkOrgId, clerkOrgId),
+        eq(variables.orgId, orgId),
         eq(variables.userId, userId),
         eq(variables.name, name),
       ),
@@ -183,7 +179,7 @@ export async function setVariable(
       value,
       description: description ?? null,
       userId,
-      clerkOrgId,
+      orgId,
     })
     .returning({
       id: variables.id,
@@ -202,7 +198,7 @@ export async function setVariable(
  * Delete a variable by name
  */
 export async function deleteVariable(
-  clerkOrgId: string,
+  orgId: string,
   userId: string,
   name: string,
 ): Promise<void> {
@@ -212,7 +208,7 @@ export async function deleteVariable(
     .from(variables)
     .where(
       and(
-        eq(variables.clerkOrgId, clerkOrgId),
+        eq(variables.orgId, orgId),
         eq(variables.userId, userId),
         eq(variables.name, name),
       ),
@@ -227,5 +223,5 @@ export async function deleteVariable(
     .delete(variables)
     .where(eq(variables.id, variable.id));
 
-  log.debug("variable deleted", { clerkOrgId, name });
+  log.debug("variable deleted", { orgId, name });
 }


### PR DESCRIPTION
## Summary

- Rename DB column `clerk_org_id` → `org_id` across 12 tables with 16 index renames
- Rename `clerkOrgId` → `orgId` and `clerkUserId` → `userId` across ~100 TypeScript files (services, API routes, tests, docs)
- Rename exported functions (e.g., `getScopeByClerkOrgId` → `getScopeByOrgId`)
- Add migration `0128_rename_clerk_org_id.sql` with column and index renames

Closes #4405

## Test plan

- [x] All 164 test files pass (1872 tests)
- [x] Lint: 0 warnings, 0 errors
- [x] Knip: no unused code found
- [x] Format: all files clean
- [x] Pre-commit hooks pass (prettier, knip, commitlint)
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)