### PR TITLE
refactor: remove all scope_members reads/writes (phase 5b-2)

### DIFF
--- a/turbo/apps/web/app/api/user/preferences/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/user/preferences/__tests__/route.test.ts
@@ -224,8 +224,29 @@ describe("PUT /api/user/preferences", () => {
     expect(data.error.message).toContain("Not authenticated");
   });
 
+  it("should return BAD_REQUEST when no organization context is available", async () => {
+    const user = await context.setupUser();
+    // No orgId in session and no scopeId in auth context
+    mockClerk({ userId: user.userId });
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/user/preferences",
+      {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ timezone: "America/New_York" }),
+      },
+    );
+    const response = await PUT(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.error.message).toContain("No organization context");
+  });
+
   it("should update timezone successfully", async () => {
-    await context.setupUser();
+    const user = await context.setupUser();
+    mockClerk({ userId: user.userId, orgId: user.clerkOrgId });
 
     const request = createTestRequest(
       "http://localhost:3000/api/user/preferences",
@@ -243,7 +264,8 @@ describe("PUT /api/user/preferences", () => {
   });
 
   it("should reject invalid timezone", async () => {
-    await context.setupUser();
+    const user = await context.setupUser();
+    mockClerk({ userId: user.userId, orgId: user.clerkOrgId });
 
     const request = createTestRequest(
       "http://localhost:3000/api/user/preferences",
@@ -261,7 +283,8 @@ describe("PUT /api/user/preferences", () => {
   });
 
   it("should reject empty timezone", async () => {
-    await context.setupUser();
+    const user = await context.setupUser();
+    mockClerk({ userId: user.userId, orgId: user.clerkOrgId });
 
     const request = createTestRequest(
       "http://localhost:3000/api/user/preferences",
@@ -277,7 +300,8 @@ describe("PUT /api/user/preferences", () => {
   });
 
   it("should allow updating timezone multiple times", async () => {
-    await context.setupUser();
+    const user = await context.setupUser();
+    mockClerk({ userId: user.userId, orgId: user.clerkOrgId });
 
     // First update
     const request1 = createTestRequest(
@@ -308,7 +332,8 @@ describe("PUT /api/user/preferences", () => {
   });
 
   it("should update notifyEmail to true", async () => {
-    await context.setupUser();
+    const user = await context.setupUser();
+    mockClerk({ userId: user.userId, orgId: user.clerkOrgId });
 
     const request = createTestRequest(
       "http://localhost:3000/api/user/preferences",
@@ -326,7 +351,8 @@ describe("PUT /api/user/preferences", () => {
   });
 
   it("should update timezone and notifyEmail together", async () => {
-    await context.setupUser();
+    const user = await context.setupUser();
+    mockClerk({ userId: user.userId, orgId: user.clerkOrgId });
 
     const request = createTestRequest(
       "http://localhost:3000/api/user/preferences",
@@ -348,7 +374,8 @@ describe("PUT /api/user/preferences", () => {
   });
 
   it("should update only notifyEmail without affecting timezone", async () => {
-    await context.setupUser();
+    const user = await context.setupUser();
+    mockClerk({ userId: user.userId, orgId: user.clerkOrgId });
 
     // Set timezone first
     const putTz = createTestRequest(
@@ -379,7 +406,8 @@ describe("PUT /api/user/preferences", () => {
   });
 
   it("should update notifySlack to false", async () => {
-    await context.setupUser();
+    const user = await context.setupUser();
+    mockClerk({ userId: user.userId, orgId: user.clerkOrgId });
 
     const request = createTestRequest(
       "http://localhost:3000/api/user/preferences",
@@ -397,7 +425,8 @@ describe("PUT /api/user/preferences", () => {
   });
 
   it("should update notifySlack independently without affecting other preferences", async () => {
-    await context.setupUser();
+    const user = await context.setupUser();
+    mockClerk({ userId: user.userId, orgId: user.clerkOrgId });
 
     // Set timezone and notifyEmail first
     const setup = createTestRequest(
@@ -430,6 +459,7 @@ describe("PUT /api/user/preferences", () => {
 
   it("should dual-write timezone to Clerk membership metadata", async () => {
     const user = await context.setupUser();
+    mockClerk({ userId: user.userId, orgId: user.clerkOrgId });
 
     const request = createTestRequest(
       "http://localhost:3000/api/user/preferences",
@@ -455,6 +485,7 @@ describe("PUT /api/user/preferences", () => {
 
   it("should dual-write notifyEmail and notifySlack to Clerk membership metadata", async () => {
     const user = await context.setupUser();
+    mockClerk({ userId: user.userId, orgId: user.clerkOrgId });
 
     const request = createTestRequest(
       "http://localhost:3000/api/user/preferences",
@@ -479,7 +510,8 @@ describe("PUT /api/user/preferences", () => {
   });
 
   it("should reject request with no preferences", async () => {
-    await context.setupUser();
+    const user = await context.setupUser();
+    mockClerk({ userId: user.userId, orgId: user.clerkOrgId });
 
     const request = createTestRequest(
       "http://localhost:3000/api/user/preferences",

--- a/turbo/apps/web/app/api/user/preferences/route.ts
+++ b/turbo/apps/web/app/api/user/preferences/route.ts
@@ -61,8 +61,19 @@ const router = tsr.router(userPreferencesContract, {
       return createErrorResponse("UNAUTHORIZED", "Not authenticated");
     }
 
+    // Clerk session → orgId from JWT; CLI token → look up from scopeId
+    const { orgId } = await auth();
+    let clerkOrgId = orgId;
+    if (!clerkOrgId && ctx.scopeId) {
+      const scope = await getScopeById(ctx.scopeId);
+      clerkOrgId = scope?.clerkOrgId ?? null;
+    }
+    if (!clerkOrgId) {
+      return createErrorResponse("BAD_REQUEST", "No organization context");
+    }
+
     try {
-      const prefs = await updateUserPreferences(ctx.userId, {
+      const prefs = await updateUserPreferences(clerkOrgId, ctx.userId, {
         timezone: body.timezone,
         notifyEmail: body.notifyEmail,
         notifySlack: body.notifySlack,

--- a/turbo/apps/web/src/__tests__/api-test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers.ts
@@ -92,7 +92,6 @@ import {
 } from "../db/schema/agent-compose";
 import { agentPermissions } from "../db/schema/agent-permission";
 import { scopes } from "../db/schema/scope";
-import { scopeMembers } from "../db/schema/scope-member";
 import { conversations } from "../db/schema/conversation";
 import { uniqueId } from "./test-helpers";
 
@@ -2707,12 +2706,6 @@ export async function createTestTelegramInstallation(options?: {
       target: orgCache.clerkOrgId,
       set: { slug: scopeSlug, tier: "free", cachedAt: new Date() },
     });
-
-  await globalThis.services.db.insert(scopeMembers).values({
-    scopeId: scope!.id,
-    userId: adminUserId,
-    role: "admin",
-  });
 
   const [compose] = await globalThis.services.db
     .insert(agentComposes)

--- a/turbo/apps/web/src/__tests__/github/api-helpers.ts
+++ b/turbo/apps/web/src/__tests__/github/api-helpers.ts
@@ -13,7 +13,6 @@ import { env } from "../../env";
 import { encryptSecretValue } from "../../lib/crypto/secrets-encryption";
 import { scopes } from "../../db/schema/scope";
 import { orgCache } from "../../db/schema/org-cache";
-import { scopeMembers } from "../../db/schema/scope-member";
 import {
   agentComposes,
   agentComposeVersions,
@@ -68,12 +67,6 @@ export async function givenGitHubInstallation(
       target: orgCache.clerkOrgId,
       set: { slug: scopeSlug, tier: "free", cachedAt: new Date() },
     });
-
-  await globalThis.services.db.insert(scopeMembers).values({
-    scopeId: scope!.id,
-    userId,
-    role: "admin",
-  });
 
   // Create compose
   const [compose] = await globalThis.services.db

--- a/turbo/apps/web/src/__tests__/test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/test-helpers.ts
@@ -48,7 +48,6 @@ import { slackUserLinks } from "../db/schema/slack-user-link";
 import { agentComposes } from "../db/schema/agent-compose";
 import { connectors } from "../db/schema/connector";
 import { scopes } from "../db/schema/scope";
-import { scopeMembers } from "../db/schema/scope-member";
 import { userCache } from "../db/schema/user-cache";
 import { encryptSecretValue } from "../lib/crypto/secrets-encryption";
 import { env } from "../env";
@@ -199,7 +198,7 @@ interface TestContext {
   ): Promise<{ id: string; name: string; scopeId: string; clerkOrgId: string }>;
   createConnector(
     scopeId: string,
-    options?: { type?: string; authMethod?: string },
+    options: { userId: string; type?: string; authMethod?: string },
   ): Promise<{ id: string; type: string }>;
 }
 
@@ -510,12 +509,6 @@ export function testContext(): TestContext {
       // Pre-populate org cache for getOrgData()
       await insertOrgCacheEntry({ clerkOrgId, slug: scopeSlug });
 
-      await globalThis.services.db.insert(scopeMembers).values({
-        scopeId: scopeData.id,
-        userId: adminUserId,
-        role: "admin",
-      });
-
       const [compose] = await globalThis.services.db
         .insert(agentComposes)
         .values({
@@ -624,12 +617,6 @@ export function testContext(): TestContext {
     // Pre-populate org cache for getOrgData()
     await insertOrgCacheEntry({ clerkOrgId, slug: scopeSlug });
 
-    await globalThis.services.db.insert(scopeMembers).values({
-      scopeId: scopeData.id,
-      userId: vm0UserId,
-      role: "admin",
-    });
-
     // Create a compose for this user
     const [compose] = await globalThis.services.db
       .insert(agentComposes)
@@ -659,21 +646,12 @@ export function testContext(): TestContext {
    */
   async function createConnector(
     scopeId: string,
-    options: { type?: string; authMethod?: string } = {},
+    options: { userId: string; type?: string; authMethod?: string },
   ): Promise<{ id: string; type: string }> {
-    const { type = "github", authMethod = "oauth" } = options;
+    const { userId, type = "github", authMethod = "oauth" } = options;
 
     initServices();
 
-    // Look up userId and clerkOrgId from scope_members + scopes
-    const [member] = await globalThis.services.db
-      .select({ userId: scopeMembers.userId })
-      .from(scopeMembers)
-      .where(eq(scopeMembers.scopeId, scopeId))
-      .limit(1);
-    if (!member) {
-      throw new Error(`No scope member found for scope ${scopeId}`);
-    }
     const [scope] = await globalThis.services.db
       .select({ clerkOrgId: scopes.clerkOrgId })
       .from(scopes)
@@ -684,7 +662,7 @@ export function testContext(): TestContext {
       .insert(connectors)
       .values({
         scopeId,
-        userId: member.userId,
+        userId,
         clerkOrgId: scope!.clerkOrgId,
         type,
         authMethod,

--- a/turbo/apps/web/src/lib/scope/scope-member-service.ts
+++ b/turbo/apps/web/src/lib/scope/scope-member-service.ts
@@ -1,6 +1,5 @@
 import { auth, clerkClient } from "@clerk/nextjs/server";
-import { eq, and, asc } from "drizzle-orm";
-import { scopeMembers } from "../../db/schema/scope-member";
+import { eq } from "drizzle-orm";
 import { scopes } from "../../db/schema/scope";
 import { badRequest, forbidden, notFound } from "../errors";
 import { logger } from "../logger";
@@ -41,20 +40,6 @@ export async function requireScopeMember(scopeId: string, userId: string) {
     userId,
     scopeId,
   };
-}
-
-/**
- * Find the user's primary admin membership (first admin membership by creation date).
- * Returns the raw scope_members record, or null if none found.
- */
-export async function getPrimaryAdminMembership(userId: string) {
-  const [record] = await globalThis.services.db
-    .select()
-    .from(scopeMembers)
-    .where(and(eq(scopeMembers.userId, userId), eq(scopeMembers.role, "admin")))
-    .orderBy(asc(scopeMembers.createdAt))
-    .limit(1);
-  return record ?? null;
 }
 
 /**

--- a/turbo/apps/web/src/lib/scope/scope-service.ts
+++ b/turbo/apps/web/src/lib/scope/scope-service.ts
@@ -166,16 +166,14 @@ export async function createScope(
     throw badRequest(`Scope "${slug}" already exists`);
   }
 
-  const scope = newScope;
-
   log.debug("scope created", {
     clerkUserId,
-    scopeId: scope.id,
+    scopeId: newScope.id,
     slug,
     clerkOrgId,
   });
 
-  return scope;
+  return newScope;
 }
 
 /**

--- a/turbo/apps/web/src/lib/scope/scope-service.ts
+++ b/turbo/apps/web/src/lib/scope/scope-service.ts
@@ -2,7 +2,6 @@ import { createHash, randomBytes } from "crypto";
 import { eq, inArray } from "drizzle-orm";
 import { clerkClient } from "@clerk/nextjs/server";
 import { scopes } from "../../db/schema/scope";
-import { scopeMembers } from "../../db/schema/scope-member";
 import { requireScopeMember, getDefaultScope } from "./scope-member-service";
 import {
   badRequest,
@@ -129,14 +128,12 @@ export async function getScopesByClerkOrgIds(
 }
 
 /**
- * Create a scope for a user with an admin membership.
+ * Create a scope for a user.
  *
- * Merges the former scope creation and organization setup functions.
- * Handles Clerk org creation, slug validation,
- * one-admin-per-user constraint, and atomic scope + membership creation.
+ * Handles slug validation and scope creation.
  *
  * @param options.skipSlugValidation - Skip reserved-slug checks (for vm0-admin bypass)
- * @param options.clerkOrgId - Use existing Clerk org instead of creating one (JIT discovery path)
+ * @param options.clerkOrgId - Clerk org ID to bind the scope to
  */
 export async function createScope(
   clerkUserId: string,
@@ -156,29 +153,20 @@ export async function createScope(
 
   const { clerkOrgId } = options;
 
-  // Create scope + admin membership atomically
-  const scope = await globalThis.services.db.transaction(async (tx) => {
-    const [newScope] = await tx
-      .insert(scopes)
-      .values({
-        slug,
-        clerkOrgId,
-      })
-      .onConflictDoNothing({ target: scopes.slug })
-      .returning();
+  const [newScope] = await globalThis.services.db
+    .insert(scopes)
+    .values({
+      slug,
+      clerkOrgId,
+    })
+    .onConflictDoNothing({ target: scopes.slug })
+    .returning();
 
-    if (!newScope) {
-      throw badRequest(`Scope "${slug}" already exists`);
-    }
+  if (!newScope) {
+    throw badRequest(`Scope "${slug}" already exists`);
+  }
 
-    await tx.insert(scopeMembers).values({
-      scopeId: newScope.id,
-      userId: clerkUserId,
-      role: "admin",
-    });
-
-    return newScope;
-  });
+  const scope = newScope;
 
   log.debug("scope created", {
     clerkUserId,

--- a/turbo/apps/web/src/lib/telegram/__tests__/helpers.ts
+++ b/turbo/apps/web/src/lib/telegram/__tests__/helpers.ts
@@ -6,7 +6,6 @@ import { telegramMessages } from "../../../db/schema/telegram-message";
 import { telegramThreadSessions } from "../../../db/schema/telegram-thread-session";
 import { agentComposes } from "../../../db/schema/agent-compose";
 import { scopes } from "../../../db/schema/scope";
-import { scopeMembers } from "../../../db/schema/scope-member";
 import { encryptSecretValue } from "../../crypto/secrets-encryption";
 import { PENDING_TELEGRAM_USER_ID } from "../handlers/shared";
 import { uniqueId } from "../../../__tests__/test-helpers";
@@ -20,7 +19,6 @@ export async function createTelegramInstallation(): Promise<string> {
 
   const suffix = uniqueId("tg");
 
-  const adminUserId = uniqueId("test-admin");
   const [scope] = await globalThis.services.db
     .insert(scopes)
     .values({
@@ -28,12 +26,6 @@ export async function createTelegramInstallation(): Promise<string> {
       clerkOrgId: uniqueId("org"),
     })
     .returning();
-
-  await globalThis.services.db.insert(scopeMembers).values({
-    scopeId: scope!.id,
-    userId: adminUserId,
-    role: "admin",
-  });
 
   const [compose] = await globalThis.services.db
     .insert(agentComposes)

--- a/turbo/apps/web/src/lib/user/user-preferences-service.ts
+++ b/turbo/apps/web/src/lib/user/user-preferences-service.ts
@@ -1,10 +1,7 @@
 import { eq, and } from "drizzle-orm";
 import { clerkClient } from "@clerk/nextjs/server";
-import { scopeMembers } from "../../db/schema/scope-member";
-import { scopes } from "../../db/schema/scope";
 import { orgMembersCache } from "../../db/schema/org-members-cache";
 import { badRequest } from "../errors";
-import { getPrimaryAdminMembership } from "../scope/scope-member-service";
 import { logger } from "../logger";
 
 const log = logger("service:user-preferences");
@@ -164,40 +161,6 @@ function buildClerkMetadata(prefs: {
 }
 
 /**
- * Dual-write preferences to Clerk metadata + local cache (fire-and-forget).
- */
-async function dualWriteToClerk(
-  scopeId: string,
-  userId: string,
-  prefs: { timezone?: string; notifyEmail?: boolean; notifySlack?: boolean },
-  result: UserPreferences,
-): Promise<void> {
-  try {
-    const [scope] = await globalThis.services.db
-      .select({ clerkOrgId: scopes.clerkOrgId })
-      .from(scopes)
-      .where(eq(scopes.id, scopeId))
-      .limit(1);
-
-    if (scope) {
-      const client = await clerkClient();
-      await client.organizations.updateOrganizationMembershipMetadata({
-        organizationId: scope.clerkOrgId,
-        userId,
-        publicMetadata: buildClerkMetadata(prefs),
-      });
-
-      await upsertMemberCache(scope.clerkOrgId, userId, result);
-    }
-  } catch (err) {
-    log.error("Failed to write preferences to Clerk metadata", {
-      error: err,
-      userId,
-    });
-  }
-}
-
-/**
  * Get user preferences from Clerk membership metadata.
  *
  * Fast path: when sessionClaims are provided (JWT context), reads from
@@ -230,9 +193,10 @@ export async function getUserPreferences(
 }
 
 /**
- * Update user preferences on scope_members (primary admin membership)
+ * Update user preferences in Clerk membership metadata and local cache.
  */
 export async function updateUserPreferences(
+  clerkOrgId: string,
   userId: string,
   prefs: { timezone?: string; notifyEmail?: boolean; notifySlack?: boolean },
 ): Promise<UserPreferences> {
@@ -242,46 +206,38 @@ export async function updateUserPreferences(
     }
   }
 
-  const memberRecord = await getPrimaryAdminMembership(userId);
+  // Read existing preferences to merge with partial update
+  const existing = await getCachedMemberPreferences(clerkOrgId, userId);
 
-  if (!memberRecord) {
-    throw badRequest("User has no scope membership");
-  }
-
-  const setValues: Record<string, unknown> = { updatedAt: new Date() };
-  if (prefs.timezone !== undefined) {
-    setValues.timezone = prefs.timezone;
-  }
-  if (prefs.notifyEmail !== undefined) {
-    setValues.notifyEmail = prefs.notifyEmail;
-  }
-  if (prefs.notifySlack !== undefined) {
-    setValues.notifySlack = prefs.notifySlack;
-  }
-
-  const [updated] = await globalThis.services.db
-    .update(scopeMembers)
-    .set(setValues)
-    .where(eq(scopeMembers.id, memberRecord.id))
-    .returning({
-      timezone: scopeMembers.timezone,
-      notifyEmail: scopeMembers.notifyEmail,
-      notifySlack: scopeMembers.notifySlack,
-    });
-
-  const result: UserPreferences = {
-    timezone: updated?.timezone ?? null,
-    notifyEmail: updated?.notifyEmail ?? false,
-    notifySlack: updated?.notifySlack ?? true,
+  const merged: UserPreferences = {
+    timezone: prefs.timezone !== undefined ? prefs.timezone : existing.timezone,
+    notifyEmail:
+      prefs.notifyEmail !== undefined
+        ? prefs.notifyEmail
+        : existing.notifyEmail,
+    notifySlack:
+      prefs.notifySlack !== undefined
+        ? prefs.notifySlack
+        : existing.notifySlack,
   };
 
-  await dualWriteToClerk(memberRecord.scopeId, userId, prefs, result);
+  // Write to Clerk membership metadata
+  const client = await clerkClient();
+  await client.organizations.updateOrganizationMembershipMetadata({
+    organizationId: clerkOrgId,
+    userId,
+    publicMetadata: buildClerkMetadata(prefs),
+  });
 
-  return result;
+  // Update local cache with merged result
+  await upsertMemberCache(clerkOrgId, userId, merged);
+
+  return merged;
 }
 
 /**
- * Set user timezone if not already set (for auto-detection on first login)
+ * Set user timezone if not already set (for auto-detection on first login).
+ * Writes to Clerk membership metadata and local cache.
  */
 export async function setTimezoneIfNotSet(
   clerkOrgId: string,
@@ -300,33 +256,20 @@ export async function setTimezoneIfNotSet(
   );
 
   if (existingTimezone === null) {
-    const memberRecord = await getPrimaryAdminMembership(userId);
+    try {
+      const client = await clerkClient();
+      await client.organizations.updateOrganizationMembershipMetadata({
+        organizationId: clerkOrgId,
+        userId,
+        publicMetadata: { timezone },
+      });
 
-    if (memberRecord) {
-      await globalThis.services.db
-        .update(scopeMembers)
-        .set({
-          timezone,
-          updatedAt: new Date(),
-        })
-        .where(eq(scopeMembers.id, memberRecord.id));
-
-      // Dual-write timezone to Clerk membership publicMetadata + local cache
-      try {
-        const client = await clerkClient();
-        await client.organizations.updateOrganizationMembershipMetadata({
-          organizationId: clerkOrgId,
-          userId,
-          publicMetadata: { timezone },
-        });
-
-        await upsertMemberCache(clerkOrgId, userId, { timezone });
-      } catch (err) {
-        log.error("Failed to write timezone to Clerk metadata", {
-          error: err,
-          userId,
-        });
-      }
+      await upsertMemberCache(clerkOrgId, userId, { timezone });
+    } catch (err) {
+      log.error("Failed to write timezone to Clerk metadata", {
+        error: err,
+        userId,
+      });
     }
   }
 }


### PR DESCRIPTION
## Summary

- Remove all 4 remaining production touchpoints on the `scope_members` table (3 writes, 1 read)
- Refactor `updateUserPreferences()` to accept `clerkOrgId` param and use read-modify-return pattern (Clerk + `org_members_cache` only)
- Remove `scope_members` INSERT from `createScope()` and unwrap unnecessary transaction
- Delete `dualWriteToClerk()` and `getPrimaryAdminMembership()` (zero callers after refactor)
- Update PUT `/api/user/preferences` route to resolve `clerkOrgId` from auth context
- Clean up test helpers: remove dead `scope_members` inserts, refactor `createConnector()` to accept `userId`

After this change, `scope_members` has zero production reads/writes and is ready for Phase 6 (DROP TABLE).

Closes #4410

## Test plan

- [x] All 22 preference route tests pass (including new PUT error path test)
- [x] All 4 scope-service tests pass
- [x] TypeScript type check passes (no new errors)
- [x] ESLint passes with 0 warnings
- [x] Knip finds no unused exports/imports
- [x] Prettier formatting verified
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)