### PR TITLE
fix: disable process exporter child tracking for accurate process counts

### DIFF
--- a/ansible/playbooks/provision-monitoring.yml
+++ b/ansible/playbooks/provision-monitoring.yml
@@ -102,9 +102,14 @@
 
           // Count vm0 processes (separate pipeline, only keep num_procs)
           prometheus.exporter.process "vm0" {
+            track_children = false
             matcher {
               name = "runner"
               comm = ["runner"]
+            }
+            matcher {
+              name = "mitmdump"
+              comm = ["mitmdump"]
             }
             matcher {
               name = "firecracker"


### PR DESCRIPTION
## Summary

- Set `track_children = false` on `prometheus.exporter.process` to prevent child processes (mitmdump) from inflating runner's `num_procs`
- Add `mitmdump` as a separate matcher for independent monitoring

## Context

`num_procs{groupname="runner"}` was reporting 3 on prod-3 when only 1 runner process existed. The process exporter was including mitmdump child processes (runner → mitmdump → mitmdump fork) in the runner group.

## Test plan

- [ ] After deploy, verify `num_procs{groupname="runner"}` matches actual runner process count (`ps -eo comm= | grep -x runner | wc -l`)
- [ ] Verify `num_procs{groupname="mitmdump"}` appears as a new metric

🤖 Generated with [Claude Code](https://claude.com/claude-code)