### PR TITLE
fix: sanitize api error responses to prevent information leakage

### DIFF
--- a/turbo/apps/web/app/api/connectors/[type]/callback/route.ts
+++ b/turbo/apps/web/app/api/connectors/[type]/callback/route.ts
@@ -257,25 +257,30 @@ export async function GET(
     );
     return response;
   } catch (err) {
-    const errorMessage = err instanceof Error ? err.message : "OAuth failed";
+    const internalMessage = err instanceof Error ? err.message : "OAuth failed";
     log.error("OAuth callback error", {
       type,
-      error: errorMessage,
+      error: internalMessage,
       sessionId,
     });
 
-    // Mark session as error if present
+    // Mark session as error if present (store full error server-side only)
     if (sessionId) {
       await globalThis.services.db
         .update(connectorSessions)
         .set({
           status: "error",
-          errorMessage,
+          errorMessage: internalMessage,
         })
         .where(eq(connectorSessions.id, sessionId));
     }
 
-    return redirectWithError(origin, type, errorMessage, true);
+    return redirectWithError(
+      origin,
+      type,
+      "OAuth authorization failed. Please try again.",
+      true,
+    );
   }
 }
 

--- a/turbo/apps/web/app/api/connectors/[type]/sessions/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/connectors/[type]/sessions/__tests__/route.test.ts
@@ -48,8 +48,8 @@ describe("POST /api/connectors/:type/sessions - Create Session", () => {
     const data = await response.json();
 
     expect(response.status).toBe(400);
-    // ts-rest validates connector type at contract level
-    expect(data.message).toMatch(/validation failed/i);
+    // ts-rest validates connector type at contract level, error is sanitized
+    expect(data.error.code).toBe("BAD_REQUEST");
   });
 
   it("should create session successfully", async () => {

--- a/turbo/apps/web/app/api/slack/oauth/callback/route.ts
+++ b/turbo/apps/web/app/api/slack/oauth/callback/route.ts
@@ -226,11 +226,9 @@ export async function GET(request: Request) {
     };
     return buildPostInstallRedirect(baseUrl, result, state);
   } catch (err) {
-    const errorMessage =
-      err instanceof Error ? err.message : "Failed to complete installation";
     console.error("Slack OAuth callback error:", err);
     return NextResponse.redirect(
-      `${baseUrl}/slack/failed?error=${encodeURIComponent(errorMessage)}`,
+      `${baseUrl}/slack/failed?error=${encodeURIComponent("Failed to complete Slack installation. Please try again.")}`,
     );
   }
 }

--- a/turbo/apps/web/app/api/storages/commit/route.ts
+++ b/turbo/apps/web/app/api/storages/commit/route.ts
@@ -1,7 +1,7 @@
 import {
   createHandler,
   tsr,
-  TsRestResponse,
+  createSafeErrorHandler,
 } from "../../../../src/lib/ts-rest-handler";
 import { storagesCommitContract, VOLUME_SCOPE_USER_ID } from "@vm0/core";
 import { initServices } from "../../../../src/lib/init-services";
@@ -134,7 +134,7 @@ const router = tsr.router(storagesCommitContract, {
           status: 500 as const,
           body: {
             error: {
-              message: "R2_USER_STORAGES_BUCKET_NAME not configured",
+              message: "Storage service is not properly configured",
               code: "INTERNAL_ERROR",
             },
           },
@@ -197,7 +197,7 @@ const router = tsr.router(storagesCommitContract, {
         status: 500 as const,
         body: {
           error: {
-            message: "R2_USER_STORAGES_BUCKET_NAME not configured",
+            message: "Storage service is not properly configured",
             code: "INTERNAL_ERROR",
           },
         },
@@ -308,49 +308,8 @@ const router = tsr.router(storagesCommitContract, {
   },
 });
 
-/**
- * Custom error handler to convert Zod validation errors to API error format
- */
-function errorHandler(err: unknown): TsRestResponse | void {
-  if (
-    err &&
-    typeof err === "object" &&
-    "bodyError" in err &&
-    "queryError" in err
-  ) {
-    const validationError = err as {
-      bodyError: { issues: Array<{ path: string[]; message: string }> } | null;
-      queryError: { issues: Array<{ path: string[]; message: string }> } | null;
-    };
-
-    if (validationError.bodyError) {
-      const issue = validationError.bodyError.issues[0];
-      if (issue) {
-        const path = issue.path.join(".");
-        const message = path ? `${path}: ${issue.message}` : issue.message;
-        return TsRestResponse.fromJson(
-          { error: { message, code: "BAD_REQUEST" } },
-          { status: 400 },
-        );
-      }
-    }
-  }
-
-  // Log unexpected errors
-  log.error("Commit error:", err);
-  return TsRestResponse.fromJson(
-    {
-      error: {
-        message: err instanceof Error ? err.message : "Commit failed",
-        code: "INTERNAL_ERROR",
-      },
-    },
-    { status: 500 },
-  );
-}
-
 const handler = createHandler(storagesCommitContract, router, {
-  errorHandler,
+  errorHandler: createSafeErrorHandler("storages:commit"),
 });
 
 export { handler as POST };

--- a/turbo/apps/web/app/api/storages/download/route.ts
+++ b/turbo/apps/web/app/api/storages/download/route.ts
@@ -1,7 +1,7 @@
 import {
   createHandler,
   tsr,
-  TsRestResponse,
+  createSafeErrorHandler,
 } from "../../../../src/lib/ts-rest-handler";
 import { storagesDownloadContract, VOLUME_SCOPE_USER_ID } from "@vm0/core";
 import { initServices } from "../../../../src/lib/init-services";
@@ -154,7 +154,7 @@ const router = tsr.router(storagesDownloadContract, {
         status: 500 as const,
         body: {
           error: {
-            message: "R2_USER_STORAGES_BUCKET_NAME not configured",
+            message: "Storage service is not properly configured",
             code: "INTERNAL_ERROR",
           },
         },
@@ -185,49 +185,8 @@ const router = tsr.router(storagesDownloadContract, {
   },
 });
 
-/**
- * Custom error handler to convert Zod validation errors to API error format
- */
-function errorHandler(err: unknown): TsRestResponse | void {
-  if (
-    err &&
-    typeof err === "object" &&
-    "bodyError" in err &&
-    "queryError" in err
-  ) {
-    const validationError = err as {
-      bodyError: { issues: Array<{ path: string[]; message: string }> } | null;
-      queryError: { issues: Array<{ path: string[]; message: string }> } | null;
-    };
-
-    if (validationError.queryError) {
-      const issue = validationError.queryError.issues[0];
-      if (issue) {
-        const path = issue.path.join(".");
-        const message = path ? `${path}: ${issue.message}` : issue.message;
-        return TsRestResponse.fromJson(
-          { error: { message, code: "BAD_REQUEST" } },
-          { status: 400 },
-        );
-      }
-    }
-  }
-
-  // Log unexpected errors
-  log.error("Download error:", err);
-  return TsRestResponse.fromJson(
-    {
-      error: {
-        message: err instanceof Error ? err.message : "Download failed",
-        code: "INTERNAL_ERROR",
-      },
-    },
-    { status: 500 },
-  );
-}
-
 const handler = createHandler(storagesDownloadContract, router, {
-  errorHandler,
+  errorHandler: createSafeErrorHandler("storages:download"),
 });
 
 export { handler as GET };

--- a/turbo/apps/web/app/api/storages/list/route.ts
+++ b/turbo/apps/web/app/api/storages/list/route.ts
@@ -1,7 +1,7 @@
 import {
   createHandler,
   tsr,
-  TsRestResponse,
+  createSafeErrorHandler,
 } from "../../../../src/lib/ts-rest-handler";
 import { storagesListContract, VOLUME_SCOPE_USER_ID } from "@vm0/core";
 import { initServices } from "../../../../src/lib/init-services";
@@ -79,49 +79,8 @@ const router = tsr.router(storagesListContract, {
   },
 });
 
-/**
- * Custom error handler to convert Zod validation errors to API error format
- */
-function errorHandler(err: unknown): TsRestResponse | void {
-  if (
-    err &&
-    typeof err === "object" &&
-    "bodyError" in err &&
-    "queryError" in err
-  ) {
-    const validationError = err as {
-      bodyError: { issues: Array<{ path: string[]; message: string }> } | null;
-      queryError: { issues: Array<{ path: string[]; message: string }> } | null;
-    };
-
-    if (validationError.queryError) {
-      const issue = validationError.queryError.issues[0];
-      if (issue) {
-        const path = issue.path.join(".");
-        const message = path ? `${path}: ${issue.message}` : issue.message;
-        return TsRestResponse.fromJson(
-          { error: { message, code: "BAD_REQUEST" } },
-          { status: 400 },
-        );
-      }
-    }
-  }
-
-  // Log unexpected errors
-  log.error("List error:", err);
-  return TsRestResponse.fromJson(
-    {
-      error: {
-        message: err instanceof Error ? err.message : "List failed",
-        code: "INTERNAL_ERROR",
-      },
-    },
-    { status: 500 },
-  );
-}
-
 const handler = createHandler(storagesListContract, router, {
-  errorHandler,
+  errorHandler: createSafeErrorHandler("storages:list"),
 });
 
 export { handler as GET };

--- a/turbo/apps/web/app/api/storages/prepare/route.ts
+++ b/turbo/apps/web/app/api/storages/prepare/route.ts
@@ -1,7 +1,7 @@
 import {
   createHandler,
   tsr,
-  TsRestResponse,
+  createSafeErrorHandler,
 } from "../../../../src/lib/ts-rest-handler";
 import { storagesPrepareContract, VOLUME_SCOPE_USER_ID } from "@vm0/core";
 import { initServices } from "../../../../src/lib/init-services";
@@ -32,7 +32,7 @@ async function mergeWithBaseVersion(
 ): Promise<Array<{ path: string; hash: string; size: number }>> {
   const bucketName = env().R2_USER_STORAGES_BUCKET_NAME;
   if (!bucketName) {
-    throw new Error("R2_USER_STORAGES_BUCKET_NAME not configured");
+    throw new Error("Storage service is not properly configured");
   }
 
   // Get base version
@@ -211,7 +211,7 @@ const router = tsr.router(storagesPrepareContract, {
         status: 500 as const,
         body: {
           error: {
-            message: "R2_USER_STORAGES_BUCKET_NAME not configured",
+            message: "Storage service is not properly configured",
             code: "INTERNAL_ERROR",
           },
         },
@@ -301,49 +301,8 @@ const router = tsr.router(storagesPrepareContract, {
   },
 });
 
-/**
- * Custom error handler to convert Zod validation errors to API error format
- */
-function errorHandler(err: unknown): TsRestResponse | void {
-  if (
-    err &&
-    typeof err === "object" &&
-    "bodyError" in err &&
-    "queryError" in err
-  ) {
-    const validationError = err as {
-      bodyError: { issues: Array<{ path: string[]; message: string }> } | null;
-      queryError: { issues: Array<{ path: string[]; message: string }> } | null;
-    };
-
-    if (validationError.bodyError) {
-      const issue = validationError.bodyError.issues[0];
-      if (issue) {
-        const path = issue.path.join(".");
-        const message = path ? `${path}: ${issue.message}` : issue.message;
-        return TsRestResponse.fromJson(
-          { error: { message, code: "BAD_REQUEST" } },
-          { status: 400 },
-        );
-      }
-    }
-  }
-
-  // Log unexpected errors
-  log.error("Prepare error:", err);
-  return TsRestResponse.fromJson(
-    {
-      error: {
-        message: err instanceof Error ? err.message : "Prepare failed",
-        code: "INTERNAL_ERROR",
-      },
-    },
-    { status: 500 },
-  );
-}
-
 const handler = createHandler(storagesPrepareContract, router, {
-  errorHandler,
+  errorHandler: createSafeErrorHandler("storages:prepare"),
 });
 
 export { handler as POST };

--- a/turbo/apps/web/app/api/webhooks/agent/proxy/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/proxy/__tests__/route.test.ts
@@ -573,7 +573,7 @@ describe("POST /api/webhooks/agent/proxy", () => {
       expect(response.status).toBe(401);
       const data = await response.json();
       expect(data.error.code).toBe("UNAUTHORIZED");
-      expect(data.error.message).toContain("decryption failed");
+      expect(data.error.message).toContain("invalid or expired");
       expect(data.error.header).toBe("x-api-key");
 
       // Should NOT have called fetch since decryption failed
@@ -615,7 +615,7 @@ describe("POST /api/webhooks/agent/proxy", () => {
       expect(response.status).toBe(401);
       const data = await response.json();
       expect(data.error.code).toBe("UNAUTHORIZED");
-      expect(data.error.message).toContain("decryption failed");
+      expect(data.error.message).toContain("invalid or expired");
 
       // Should NOT have called fetch
       expect(fetchCalled).toBe(false);

--- a/turbo/apps/web/app/api/webhooks/agent/proxy/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/proxy/route.ts
@@ -92,7 +92,7 @@ async function handleProxyRequest(request: Request) {
       return NextResponse.json(
         {
           error: {
-            message: err.message,
+            message: "Authentication token is invalid or expired",
             code: "UNAUTHORIZED",
             header: err.header,
           },
@@ -101,15 +101,15 @@ async function handleProxyRequest(request: Request) {
       );
     }
 
-    const message = err instanceof Error ? err.message : "Unknown error";
-    log.error(`Proxy request failed for ${targetUrl}: ${message}`);
+    const internalMessage =
+      err instanceof Error ? err.message : "Unknown error";
+    log.error(`Proxy request failed for ${targetUrl}: ${internalMessage}`);
 
     return NextResponse.json(
       {
         error: {
-          message: `Failed to reach target: ${message}`,
+          message: "Proxy request failed",
           code: "BAD_GATEWAY",
-          targetUrl,
         },
       },
       { status: 502 },

--- a/turbo/apps/web/app/api/webhooks/agent/storages/commit/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/storages/commit/route.ts
@@ -1,7 +1,7 @@
 import {
   createHandler,
   tsr,
-  TsRestResponse,
+  createSafeErrorHandler,
 } from "../../../../../../src/lib/ts-rest-handler";
 import { webhookStoragesCommitContract, VOLUME_SCOPE_USER_ID } from "@vm0/core";
 import { initServices } from "../../../../../../src/lib/init-services";
@@ -143,7 +143,7 @@ const router = tsr.router(webhookStoragesCommitContract, {
           status: 500 as const,
           body: {
             error: {
-              message: "R2_USER_STORAGES_BUCKET_NAME not configured",
+              message: "Storage service is not properly configured",
               code: "INTERNAL_ERROR",
             },
           },
@@ -206,7 +206,7 @@ const router = tsr.router(webhookStoragesCommitContract, {
         status: 500 as const,
         body: {
           error: {
-            message: "R2_USER_STORAGES_BUCKET_NAME not configured",
+            message: "Storage service is not properly configured",
             code: "INTERNAL_ERROR",
           },
         },
@@ -315,49 +315,8 @@ const router = tsr.router(webhookStoragesCommitContract, {
   },
 });
 
-/**
- * Custom error handler to convert Zod validation errors to API error format
- */
-function errorHandler(err: unknown): TsRestResponse | void {
-  if (
-    err &&
-    typeof err === "object" &&
-    "bodyError" in err &&
-    "queryError" in err
-  ) {
-    const validationError = err as {
-      bodyError: { issues: Array<{ path: string[]; message: string }> } | null;
-      queryError: { issues: Array<{ path: string[]; message: string }> } | null;
-    };
-
-    if (validationError.bodyError) {
-      const issue = validationError.bodyError.issues[0];
-      if (issue) {
-        const path = issue.path.join(".");
-        const message = path ? `${path}: ${issue.message}` : issue.message;
-        return TsRestResponse.fromJson(
-          { error: { message, code: "BAD_REQUEST" } },
-          { status: 400 },
-        );
-      }
-    }
-  }
-
-  // Log unexpected errors
-  log.error("Commit error:", err);
-  return TsRestResponse.fromJson(
-    {
-      error: {
-        message: err instanceof Error ? err.message : "Commit failed",
-        code: "INTERNAL_ERROR",
-      },
-    },
-    { status: 500 },
-  );
-}
-
 const handler = createHandler(webhookStoragesCommitContract, router, {
-  errorHandler,
+  errorHandler: createSafeErrorHandler("webhook:storages:commit"),
 });
 
 export { handler as POST };

--- a/turbo/apps/web/app/api/webhooks/agent/storages/prepare/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/storages/prepare/route.ts
@@ -1,7 +1,7 @@
 import {
   createHandler,
   tsr,
-  TsRestResponse,
+  createSafeErrorHandler,
 } from "../../../../../../src/lib/ts-rest-handler";
 import {
   webhookStoragesPrepareContract,
@@ -139,7 +139,7 @@ const router = tsr.router(webhookStoragesPrepareContract, {
       try {
         const bucketName = env().R2_USER_STORAGES_BUCKET_NAME;
         if (!bucketName) {
-          throw new Error("R2_USER_STORAGES_BUCKET_NAME not configured");
+          throw new Error("Storage service is not properly configured");
         }
 
         // Get base version
@@ -207,7 +207,7 @@ const router = tsr.router(webhookStoragesPrepareContract, {
         status: 500 as const,
         body: {
           error: {
-            message: "R2_USER_STORAGES_BUCKET_NAME not configured",
+            message: "Storage service is not properly configured",
             code: "INTERNAL_ERROR",
           },
         },
@@ -290,49 +290,8 @@ const router = tsr.router(webhookStoragesPrepareContract, {
   },
 });
 
-/**
- * Custom error handler to convert Zod validation errors to API error format
- */
-function errorHandler(err: unknown): TsRestResponse | void {
-  if (
-    err &&
-    typeof err === "object" &&
-    "bodyError" in err &&
-    "queryError" in err
-  ) {
-    const validationError = err as {
-      bodyError: { issues: Array<{ path: string[]; message: string }> } | null;
-      queryError: { issues: Array<{ path: string[]; message: string }> } | null;
-    };
-
-    if (validationError.bodyError) {
-      const issue = validationError.bodyError.issues[0];
-      if (issue) {
-        const path = issue.path.join(".");
-        const message = path ? `${path}: ${issue.message}` : issue.message;
-        return TsRestResponse.fromJson(
-          { error: { message, code: "BAD_REQUEST" } },
-          { status: 400 },
-        );
-      }
-    }
-  }
-
-  // Log unexpected errors
-  log.error("Prepare error:", err);
-  return TsRestResponse.fromJson(
-    {
-      error: {
-        message: err instanceof Error ? err.message : "Prepare failed",
-        code: "INTERNAL_ERROR",
-      },
-    },
-    { status: 500 },
-  );
-}
-
 const handler = createHandler(webhookStoragesPrepareContract, router, {
-  errorHandler,
+  errorHandler: createSafeErrorHandler("webhook:storages:prepare"),
 });
 
 export { handler as POST };

--- a/turbo/apps/web/src/lib/ts-rest-handler.ts
+++ b/turbo/apps/web/src/lib/ts-rest-handler.ts
@@ -16,7 +16,7 @@ import { createNextHandler, tsr } from "@ts-rest/serverless/next";
 import { TsRestResponse } from "@ts-rest/serverless";
 import type { TsRestRequest } from "@ts-rest/serverless";
 import type { AppRouter } from "@ts-rest/core";
-import { flushLogs } from "./logger";
+import { flushLogs, logger } from "./logger";
 import { ingestRequestLog } from "./axiom";
 
 // Re-export tsr and TsRestResponse for convenience
@@ -27,6 +27,65 @@ export { tsr, TsRestResponse };
  * This is the return type of `tsr.router(contract, { ... })`.
  */
 type TsRestRouter<T extends AppRouter> = ReturnType<typeof tsr.router<T>>;
+
+/**
+ * Create a safe error handler that sanitizes error messages for API responses.
+ *
+ * - Zod validation errors (bodyError/queryError) are safe to return as-is
+ * - All other errors are logged server-side with full details but return
+ *   a generic message to the client (CWE-209, OWASP ASVS V7.4.1)
+ *
+ * @param routeName - Route identifier for server-side logging
+ */
+export function createSafeErrorHandler(
+  routeName: string,
+): (err: unknown) => TsRestResponse | void {
+  const log = logger(`api:${routeName}`);
+
+  return function safeErrorHandler(err: unknown): TsRestResponse | void {
+    // Zod validation errors are safe to return (field names + validation messages)
+    if (
+      err &&
+      typeof err === "object" &&
+      "bodyError" in err &&
+      "queryError" in err
+    ) {
+      const validationError = err as {
+        bodyError: {
+          issues: Array<{ path: string[]; message: string }>;
+        } | null;
+        queryError: {
+          issues: Array<{ path: string[]; message: string }>;
+        } | null;
+      };
+
+      const source = validationError.bodyError ?? validationError.queryError;
+      if (source) {
+        const issue = source.issues[0];
+        if (issue) {
+          const path = issue.path.join(".");
+          const message = path ? `${path}: ${issue.message}` : issue.message;
+          return TsRestResponse.fromJson(
+            { error: { message, code: "BAD_REQUEST" } },
+            { status: 400 },
+          );
+        }
+      }
+    }
+
+    // Non-validation errors: log full details server-side, return generic message
+    log.error(`${routeName} error:`, err);
+    return TsRestResponse.fromJson(
+      {
+        error: {
+          message: "An internal error occurred. Please try again later.",
+          code: "INTERNAL_ERROR",
+        },
+      },
+      { status: 500 },
+    );
+  };
+}
 
 /**
  * Options for createHandler.
@@ -54,12 +113,18 @@ export function createHandler<T extends AppRouter>(
   router: TsRestRouter<T>,
   options?: CreateHandlerOptions,
 ) {
+  const resolvedOptions = {
+    ...options,
+    errorHandler:
+      options?.errorHandler ?? createSafeErrorHandler("unknown-route"),
+  };
+
   return createNextHandler(contract, router, {
     handlerType: "app-router",
     // jsonQuery is intentionally disabled: JSON.parse() misinterprets hex strings
     // like "846e3519" as scientific notation, corrupting version query params (#2666)
     jsonQuery: false,
-    ...options,
+    ...resolvedOptions,
     requestMiddleware: [
       (request) => {
         // Record request start time

--- a/turbo/apps/web/src/lib/ts-rest-handler.ts
+++ b/turbo/apps/web/src/lib/ts-rest-handler.ts
@@ -43,32 +43,39 @@ export function createSafeErrorHandler(
   const log = logger(`api:${routeName}`);
 
   return function safeErrorHandler(err: unknown): TsRestResponse | void {
-    // Zod validation errors are safe to return (field names + validation messages)
-    if (
-      err &&
-      typeof err === "object" &&
-      "bodyError" in err &&
-      "queryError" in err
-    ) {
-      const validationError = err as {
-        bodyError: {
-          issues: Array<{ path: string[]; message: string }>;
-        } | null;
-        queryError: {
-          issues: Array<{ path: string[]; message: string }>;
-        } | null;
-      };
+    // Zod/standard-schema validation errors are safe to return (field names + validation messages)
+    if (err && typeof err === "object") {
+      // ts-rest validation errors have bodyError, queryError, and/or pathParamsError
+      const hasValidationFields =
+        "bodyError" in err || "queryError" in err || "pathParamsError" in err;
 
-      const source = validationError.bodyError ?? validationError.queryError;
-      if (source) {
-        const issue = source.issues[0];
-        if (issue) {
-          const path = issue.path.join(".");
-          const message = path ? `${path}: ${issue.message}` : issue.message;
-          return TsRestResponse.fromJson(
-            { error: { message, code: "BAD_REQUEST" } },
-            { status: 400 },
-          );
+      if (hasValidationFields) {
+        const validationError = err as {
+          bodyError?: {
+            issues: Array<{ path: string[]; message: string }>;
+          } | null;
+          queryError?: {
+            issues: Array<{ path: string[]; message: string }>;
+          } | null;
+          pathParamsError?: {
+            issues: Array<{ path: string[]; message: string }>;
+          } | null;
+        };
+
+        const source =
+          validationError.pathParamsError ??
+          validationError.bodyError ??
+          validationError.queryError;
+        if (source) {
+          const issue = source.issues[0];
+          if (issue) {
+            const path = issue.path.join(".");
+            const message = path ? `${path}: ${issue.message}` : issue.message;
+            return TsRestResponse.fromJson(
+              { error: { message, code: "BAD_REQUEST" } },
+              { status: 400 },
+            );
+          }
         }
       }
     }


### PR DESCRIPTION
## Summary

- Add centralized `createSafeErrorHandler()` to `ts-rest-handler.ts` that returns generic error messages to clients while logging full details server-side
- Replace 6 duplicate per-route `errorHandler` functions across storage routes with the centralized handler
- Sanitize environment variable names (e.g., `R2_USER_STORAGES_BUCKET_NAME`) from error responses
- Sanitize OAuth callback error messages (connector and Slack OAuth routes)
- Sanitize proxy route error messages (token decryption and general proxy errors)

Addresses CWE-209 (Error Message Containing Sensitive Information) and OWASP ASVS V7.4.1.

Closes #4390

## Test plan

- [ ] Verify storage routes return generic "An internal error occurred" for 500 errors
- [ ] Verify Zod validation errors still return specific field-level messages (unchanged behavior)
- [ ] Verify OAuth callback errors show generic messages in redirect URLs
- [ ] Verify proxy route errors no longer expose internal error details or target URLs
- [ ] Verify server-side logs still contain full error details for debugging

🤖 Generated with [Claude Code](https://claude.com/claude-code)