### PR TITLE
fix: add runner default group to preview deployments

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -444,6 +444,7 @@ jobs:
           R2_USER_STORAGES_BUCKET_NAME: ${{ vars.R2_USER_STORAGES_BUCKET_NAME }}
           SECRETS_ENCRYPTION_KEY: ${{ secrets.SECRETS_ENCRYPTION_KEY }}
           OFFICIAL_RUNNER_SECRET: ${{ secrets.OFFICIAL_RUNNER_SECRET }}
+          RUNNER_DEFAULT_GROUP: vm0/development-${{ needs.prepare.outputs.job-ref }}
           AXIOM_TOKEN_SESSIONS: ${{ secrets.AXIOM_TOKEN_SESSIONS }}
           AXIOM_TOKEN_TELEMETRY: ${{ secrets.AXIOM_TOKEN_TELEMETRY }}
           AXIOM_DATASET_SUFFIX: dev
@@ -635,6 +636,7 @@ jobs:
             R2_USER_STORAGES_BUCKET_NAME=${{ vars.R2_USER_STORAGES_BUCKET_NAME }}
             SECRETS_ENCRYPTION_KEY=${{ secrets.SECRETS_ENCRYPTION_KEY }}
             OFFICIAL_RUNNER_SECRET=${{ secrets.OFFICIAL_RUNNER_SECRET }}
+            RUNNER_DEFAULT_GROUP=vm0/development-${{ needs.prepare.outputs.job-ref }}
             AXIOM_TOKEN_SESSIONS=${{ secrets.AXIOM_TOKEN_SESSIONS }}
             AXIOM_TOKEN_TELEMETRY=${{ secrets.AXIOM_TOKEN_TELEMETRY }}
             AXIOM_DATASET_SUFFIX=dev


### PR DESCRIPTION
## Summary
- Add `RUNNER_DEFAULT_GROUP` environment variable to preview deployments in CI workflow
- Uses dynamic group `vm0/development-{job-ref}` matching the runner's group registration
- Without this, preview deployments fail with `"No executor configured: set RUNNER_DEFAULT_GROUP"`

Fixes #4423

## Test plan
- [ ] Verify preview deployment starts successfully after merge
- [ ] Confirm `dispatchRun` no longer throws executor error in preview environments

🤖 Generated with [Claude Code](https://claude.com/claude-code)