### PR TITLE
refactor: remove redundant experimental_runner from e2e tests

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1447,7 +1447,7 @@ jobs:
           [ "$PARALLEL" -lt 1 ] && PARALLEL=1
           echo "=== Running Runner E2E Tests (Chunk ${{ matrix.index }}, ${PARALLEL} parallel, total capacity ${RUNNER_TOTAL_CAPACITY}) ==="
           echo "Files: ${{ matrix.files }}"
-          BATS_TEST_TIMEOUT=60 RUNNER_GROUP="vm0/development-${JOB_REF}" ./e2e/test/libs/bats/bin/bats -T -j "${PARALLEL}" --no-parallelize-within-files ${{ matrix.files }}
+          BATS_TEST_TIMEOUT=60 ./e2e/test/libs/bats/bin/bats -T -j "${PARALLEL}" --no-parallelize-within-files ${{ matrix.files }}
           echo "✅ Chunk ${{ matrix.index }} tests passed"
         env:
           RUNNER_TOTAL_CAPACITY: ${{ needs.deploy-runner-start.outputs.total-capacity }}
@@ -1456,7 +1456,6 @@ jobs:
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
           USE_MOCK_CLAUDE: "true"
           ANTHROPIC_API_KEY: ${{ secrets.CI_ANTHROPIC_API_KEY }}
-          JOB_REF: ${{ needs.prepare.outputs.job-ref }}
           OFFICIAL_RUNNER_SECRET: ${{ secrets.OFFICIAL_RUNNER_SECRET }}
           CI_GITHUB_TOKEN: ${{ github.token }}
 
@@ -1541,8 +1540,6 @@ jobs:
             ${AGENT_NAME}:
               description: "Stress test agent"
               framework: claude-code
-              experimental_runner:
-                group: vm0/development-${JOB_REF}
           EOF
           vm0 compose /tmp/stress-agent.yaml
           echo "agent-name=${AGENT_NAME}" >> "$GITHUB_OUTPUT"

--- a/e2e/tests/03-experimental-runner/t04-vm0-artifact-checkpoint.bats
+++ b/e2e/tests/03-experimental-runner/t04-vm0-artifact-checkpoint.bats
@@ -37,8 +37,6 @@ agents:
   ${AGENT_NAME}:
     description: "E2E test agent for checkpoint testing"
     framework: claude-code
-    experimental_runner:
-      group: ${RUNNER_GROUP}
     volumes:
       - claude-files:/home/user/.claude
     working_dir: /home/user/workspace

--- a/e2e/tests/03-experimental-runner/t05-vm0-artifact-mount.bats
+++ b/e2e/tests/03-experimental-runner/t05-vm0-artifact-mount.bats
@@ -26,8 +26,6 @@ agents:
   ${AGENT_NAME}:
     description: "E2E test agent for artifact mount testing"
     framework: claude-code
-    experimental_runner:
-      group: ${RUNNER_GROUP}
     volumes:
       - claude-files:/home/user/.claude
     working_dir: /home/user/workspace

--- a/e2e/tests/03-experimental-runner/t06-vm0-agent-session.bats
+++ b/e2e/tests/03-experimental-runner/t06-vm0-agent-session.bats
@@ -42,8 +42,6 @@ agents:
   ${AGENT_NAME}:
     description: "E2E test agent for session testing"
     framework: claude-code
-    experimental_runner:
-      group: ${RUNNER_GROUP}
     volumes:
       - claude-files:/home/user/.claude
     working_dir: /home/user/workspace
@@ -248,8 +246,6 @@ agents:
   ${ENV_AGENT_NAME}:
     description: "Test agent for environment variable expansion"
     framework: claude-code
-    experimental_runner:
-      group: ${RUNNER_GROUP}
     working_dir: /home/user/workspace
     environment:
       TEST_VAR: "\${{ vars.testVar }}"

--- a/e2e/tests/03-experimental-runner/t07-vm0-volume-version-override.bats
+++ b/e2e/tests/03-experimental-runner/t07-vm0-volume-version-override.bats
@@ -44,8 +44,6 @@ agents:
   ${AGENT_NAME}:
     description: "Test agent with volume for override testing"
     framework: claude-code
-    experimental_runner:
-      group: ${RUNNER_GROUP}
     volumes:
       - test-volume:/home/user/data
       - claude-files:/home/user/.config/claude

--- a/e2e/tests/03-experimental-runner/t08-vm0-conversation-fork.bats
+++ b/e2e/tests/03-experimental-runner/t08-vm0-conversation-fork.bats
@@ -38,8 +38,6 @@ agents:
   ${AGENT_NAME}:
     description: "E2E test agent for conversation fork testing"
     framework: claude-code
-    experimental_runner:
-      group: ${RUNNER_GROUP}
     volumes:
       - claude-files:/home/user/.claude
     working_dir: /home/user/workspace

--- a/e2e/tests/03-experimental-runner/t09-vm0-artifact-empty.bats
+++ b/e2e/tests/03-experimental-runner/t09-vm0-artifact-empty.bats
@@ -29,8 +29,6 @@ agents:
   ${AGENT_NAME}:
     description: "E2E test agent for empty artifact testing"
     framework: claude-code
-    experimental_runner:
-      group: ${RUNNER_GROUP}
     volumes:
       - claude-files:/home/user/.claude
     working_dir: /home/user/workspace

--- a/e2e/tests/03-experimental-runner/t11-vm0-compose-versioning.bats
+++ b/e2e/tests/03-experimental-runner/t11-vm0-compose-versioning.bats
@@ -31,8 +31,6 @@ agents:
   $AGENT_NAME:
     description: "Test agent for version display"
     framework: claude-code
-    experimental_runner:
-      group: ${RUNNER_GROUP}
     working_dir: /home/user/workspace
 EOF
 
@@ -55,8 +53,6 @@ agents:
   $AGENT_NAME:
     description: "Initial description"
     framework: claude-code
-    experimental_runner:
-      group: ${RUNNER_GROUP}
     working_dir: /home/user/workspace
 EOF
 
@@ -74,8 +70,6 @@ agents:
   $AGENT_NAME:
     description: "Updated description"
     framework: claude-code
-    experimental_runner:
-      group: ${RUNNER_GROUP}
     working_dir: /home/user/workspace
 EOF
 
@@ -112,8 +106,6 @@ agents:
   $AGENT_NAME:
     description: "Version 1"
     framework: claude-code
-    experimental_runner:
-      group: ${RUNNER_GROUP}
     working_dir: /home/user/workspace
 EOF
 
@@ -131,8 +123,6 @@ agents:
   $AGENT_NAME:
     description: "Version 2"
     framework: claude-code
-    experimental_runner:
-      group: ${RUNNER_GROUP}
     working_dir: /home/user/workspace
 EOF
 
@@ -167,8 +157,6 @@ agents:
   $AGENT_NAME:
     description: "Latest version test"
     framework: claude-code
-    experimental_runner:
-      group: ${RUNNER_GROUP}
     working_dir: /home/user/workspace
 EOF
 
@@ -201,8 +189,6 @@ agents:
   $AGENT_NAME:
     description: "Backward compatibility test"
     framework: claude-code
-    experimental_runner:
-      group: ${RUNNER_GROUP}
     working_dir: /home/user/workspace
 EOF
 

--- a/e2e/tests/03-experimental-runner/t12-vm0-env-expansion.bats
+++ b/e2e/tests/03-experimental-runner/t12-vm0-env-expansion.bats
@@ -25,8 +25,6 @@ agents:
   ${AGENT_NAME}:
     description: "Test agent for environment variable expansion"
     framework: claude-code
-    experimental_runner:
-      group: ${RUNNER_GROUP}
     working_dir: /home/user/workspace
     environment:
       TEST_VAR: "\${{ vars.testVar }}"

--- a/e2e/tests/03-experimental-runner/t13-vm0-cook.bats
+++ b/e2e/tests/03-experimental-runner/t13-vm0-cook.bats
@@ -34,8 +34,6 @@ agents:
   $AGENT_NAME:
     description: "E2E test agent for cook command"
     framework: claude-code
-    experimental_runner:
-      group: ${RUNNER_GROUP}
     volumes:
       - ${VOLUME_NAME}:/home/user/data
     working_dir: /home/user/workspace
@@ -108,8 +106,6 @@ agents:
   $AGENT_NAME:
     description: "E2E test agent for env check"
     framework: claude-code
-    experimental_runner:
-      group: ${RUNNER_GROUP}
     working_dir: /home/user/workspace
     environment:
       API_KEY: \${{ vars.E2E_TEST_VAR }}
@@ -146,8 +142,6 @@ agents:
   $AGENT_NAME:
     description: "E2E test agent for cook with skills"
     framework: claude-code
-    experimental_runner:
-      group: ${RUNNER_GROUP}
     skills:
       - https://github.com/vm0-ai/vm0-skills/tree/main/github
 EOF

--- a/e2e/tests/03-experimental-runner/t15-vm0-telemetry.bats
+++ b/e2e/tests/03-experimental-runner/t15-vm0-telemetry.bats
@@ -28,8 +28,6 @@ agents:
   ${AGENT_NAME}:
     description: "E2E test agent for telemetry testing"
     framework: claude-code
-    experimental_runner:
-      group: ${RUNNER_GROUP}
     volumes:
       - claude-files:/home/user/.claude
     working_dir: /home/user/workspace

--- a/e2e/tests/03-experimental-runner/t17-vm0-simplified-compose.bats
+++ b/e2e/tests/03-experimental-runner/t17-vm0-simplified-compose.bats
@@ -28,8 +28,6 @@ agents:
   $AGENT_NAME:
     description: "Test agent with provider auto-config"
     framework: claude-code
-    experimental_runner:
-      group: ${RUNNER_GROUP}
 EOF
 
     echo "# Running vm0 compose..."
@@ -49,8 +47,6 @@ agents:
   $AGENT_NAME:
     description: "Test agent with explicit config"
     framework: claude-code
-    experimental_runner:
-      group: ${RUNNER_GROUP}
     working_dir: /custom/path
 EOF
 
@@ -71,8 +67,6 @@ agents:
   $AGENT_NAME:
     description: "Test agent with legacy apps field"
     framework: claude-code
-    experimental_runner:
-      group: ${RUNNER_GROUP}
     apps:
       - github
 EOF
@@ -97,8 +91,6 @@ version: "1.0"
 agents:
   $AGENT_NAME:
     framework: claude-code
-    experimental_runner:
-      group: ${RUNNER_GROUP}
     instructions: AGENTS.md
 EOF
 
@@ -127,8 +119,6 @@ version: "1.0"
 agents:
   $AGENT_NAME:
     framework: claude-code
-    experimental_runner:
-      group: ${RUNNER_GROUP}
     instructions: AGENTS.md
 EOF
 
@@ -164,8 +154,6 @@ version: "1.0"
 agents:
   $AGENT_NAME:
     framework: claude-code
-    experimental_runner:
-      group: ${RUNNER_GROUP}
     skills:
       - https://github.com/vm0-ai/vm0-skills/tree/main/github
 EOF
@@ -188,8 +176,6 @@ version: "1.0"
 agents:
   $AGENT_NAME:
     framework: claude-code
-    experimental_runner:
-      group: ${RUNNER_GROUP}
     skills:
       - https://github.com/vm0-ai/vm0-skills/tree/main/github
 EOF
@@ -217,8 +203,6 @@ version: "1.0"
 agents:
   $AGENT_NAME:
     framework: claude-code
-    experimental_runner:
-      group: ${RUNNER_GROUP}
     instructions: AGENTS.md
     skills:
       - https://github.com/vm0-ai/vm0-skills/tree/main/github
@@ -253,8 +237,6 @@ version: "1.0"
 agents:
   $AGENT_NAME:
     framework: claude-code
-    experimental_runner:
-      group: ${RUNNER_GROUP}
     instructions: AGENTS.md
 EOF
 
@@ -297,8 +279,6 @@ version: "1.0"
 agents:
   $AGENT_NAME:
     framework: claude-code
-    experimental_runner:
-      group: ${RUNNER_GROUP}
     skills:
       - https://github.com/vm0-ai/vm0-skills/tree/main/github
 EOF
@@ -335,8 +315,6 @@ version: "1.0"
 agents:
   $AGENT_NAME:
     framework: claude-code
-    experimental_runner:
-      group: ${RUNNER_GROUP}
 EOF
 
     echo "# Running vm0 compose..."

--- a/e2e/tests/03-experimental-runner/t19-vm0-optional-artifact.bats
+++ b/e2e/tests/03-experimental-runner/t19-vm0-optional-artifact.bats
@@ -27,8 +27,6 @@ agents:
   ${AGENT_NAME}:
     description: "E2E test agent for optional artifact testing"
     framework: claude-code
-    experimental_runner:
-      group: ${RUNNER_GROUP}
     volumes:
       - claude-files:/home/user/.claude
     working_dir: /home/user/workspace

--- a/e2e/tests/03-experimental-runner/t20-vm0-schedule.bats
+++ b/e2e/tests/03-experimental-runner/t20-vm0-schedule.bats
@@ -32,8 +32,6 @@ agents:
   ${AGENT_NAME}:
     description: "E2E schedule test agent"
     framework: claude-code
-    experimental_runner:
-      group: ${RUNNER_GROUP}
     working_dir: /home/user/workspace
 EOF
 
@@ -168,8 +166,6 @@ agents:
   ${LOOP_AGENT_NAME}:
     description: "E2E loop schedule test agent"
     framework: claude-code
-    experimental_runner:
-      group: ${RUNNER_GROUP}
     working_dir: /home/user/workspace
 EOF
 
@@ -252,8 +248,6 @@ agents:
   ${CONFIG_AGENT_NAME}:
     description: "Test agent with configuration requirements"
     framework: claude-code
-    experimental_runner:
-      group: ${RUNNER_GROUP}
     working_dir: /home/user/workspace
     environment:
       SCHEDULE_TEST_API_KEY: "\${{ secrets.${SECRET_NAME} }}"

--- a/e2e/tests/03-experimental-runner/t22-vm0-compose-scope.bats
+++ b/e2e/tests/03-experimental-runner/t22-vm0-compose-scope.bats
@@ -37,8 +37,6 @@ agents:
   $AGENT_NAME:
     description: "Test agent for run instructions"
     framework: claude-code
-    experimental_runner:
-      group: ${RUNNER_GROUP}
     working_dir: /home/user/workspace
 EOF
 
@@ -76,8 +74,6 @@ agents:
   $AGENT_NAME:
     description: "Test agent for scope/name run"
     framework: claude-code
-    experimental_runner:
-      group: ${RUNNER_GROUP}
     working_dir: /home/user/workspace
 EOF
 
@@ -128,8 +124,6 @@ agents:
   $AGENT_NAME:
     description: "Test agent for default file behavior"
     framework: claude-code
-    experimental_runner:
-      group: ${RUNNER_GROUP}
     working_dir: /home/user/workspace
 EOF
 

--- a/e2e/tests/03-experimental-runner/t24-vm0-skill-frontmatter.bats
+++ b/e2e/tests/03-experimental-runner/t24-vm0-skill-frontmatter.bats
@@ -48,8 +48,6 @@ agents:
   $AGENT_NAME:
     description: "Test agent with --yes flag"
     framework: claude-code
-    experimental_runner:
-      group: ${RUNNER_GROUP}
     skills:
       - https://github.com/vm0-ai/vm0-skills/tree/main/github
 EOF
@@ -69,8 +67,6 @@ agents:
   $AGENT_NAME_2:
     description: "Test agent with -y short flag"
     framework: claude-code
-    experimental_runner:
-      group: ${RUNNER_GROUP}
     skills:
       - https://github.com/vm0-ai/vm0-skills/tree/main/github
 EOF
@@ -90,8 +86,6 @@ agents:
   $AGENT_NAME:
     description: "Test agent in non-TTY"
     framework: claude-code
-    experimental_runner:
-      group: ${RUNNER_GROUP}
 EOF
 
     echo "# Step 2: Compose with --yes flag and piped input (non-TTY)"
@@ -115,8 +109,6 @@ agents:
   $AGENT_NAME:
     description: "Test agent with skill and environment"
     framework: claude-code
-    experimental_runner:
-      group: ${RUNNER_GROUP}
     skills:
       - https://github.com/vm0-ai/vm0-skills/tree/main/github
     environment:
@@ -141,8 +133,6 @@ agents:
   $AGENT_NAME:
     description: "Test agent with skill"
     framework: claude-code
-    experimental_runner:
-      group: ${RUNNER_GROUP}
     skills:
       - https://github.com/vm0-ai/vm0-skills/tree/main/github
 EOF
@@ -172,8 +162,6 @@ agents:
   $AGENT_NAME:
     description: "Test agent with skill upload"
     framework: claude-code
-    experimental_runner:
-      group: ${RUNNER_GROUP}
     skills:
       - https://github.com/vm0-ai/vm0-skills/tree/main/github
 EOF
@@ -198,8 +186,6 @@ agents:
   $AGENT_NAME:
     description: "Test agent with multiple skills"
     framework: claude-code
-    experimental_runner:
-      group: ${RUNNER_GROUP}
     skills:
       - https://github.com/vm0-ai/vm0-skills/tree/main/github
       - https://github.com/vm0-ai/vm0-skills/tree/main/axiom

--- a/e2e/tests/03-experimental-runner/t26-vm0-agent-list-status.bats
+++ b/e2e/tests/03-experimental-runner/t26-vm0-agent-list-status.bats
@@ -41,8 +41,6 @@ agents:
   $AGENT_NAME:
     description: "Test agent for list command"
     framework: claude-code
-    experimental_runner:
-      group: ${RUNNER_GROUP}
     working_dir: /home/user/workspace
 EOF
 
@@ -68,8 +66,6 @@ agents:
   $AGENT_NAME:
     description: "Test agent for version format"
     framework: claude-code
-    experimental_runner:
-      group: ${RUNNER_GROUP}
     working_dir: /home/user/workspace
 EOF
 
@@ -97,8 +93,6 @@ agents:
   $AGENT_NAME:
     description: "Test agent for status command"
     framework: claude-code
-    experimental_runner:
-      group: ${RUNNER_GROUP}
     working_dir: /home/user/workspace
 EOF
 
@@ -124,8 +118,6 @@ agents:
   $AGENT_NAME:
     description: "Test agent for version specifier"
     framework: claude-code
-    experimental_runner:
-      group: ${RUNNER_GROUP}
     working_dir: /home/user/workspace
 EOF
 
@@ -150,8 +142,6 @@ agents:
   $AGENT_NAME:
     description: "Test agent for latest tag"
     framework: claude-code
-    experimental_runner:
-      group: ${RUNNER_GROUP}
     working_dir: /home/user/workspace
 EOF
 
@@ -175,8 +165,6 @@ agents:
   $AGENT_NAME:
     description: "Test agent for no-sources flag"
     framework: claude-code
-    experimental_runner:
-      group: ${RUNNER_GROUP}
     working_dir: /home/user/workspace
 EOF
 
@@ -202,14 +190,12 @@ version: "1.0"
 agents:
   $AGENT_NAME:
     framework: claude-code
-    experimental_runner:
-      group: ${RUNNER_GROUP}
     environment:
       API_KEY: "${{ secrets.MY_API_KEY }}"
       AUTH_TOKEN: "${{ secrets.AUTH_TOKEN }}"
 EOF
     # Replace $AGENT_NAME in the file
-    sed -i "s|\$AGENT_NAME|$AGENT_NAME|g; s|\${RUNNER_GROUP}|$RUNNER_GROUP|g" "$TEST_DIR/vm0.yaml"
+    sed -i "s|\$AGENT_NAME|$AGENT_NAME|g" "$TEST_DIR/vm0.yaml"
 
     echo "# Step 2: Run vm0 compose"
     run $CLI_COMMAND compose "$TEST_DIR/vm0.yaml" --yes
@@ -231,14 +217,12 @@ version: "1.0"
 agents:
   $AGENT_NAME:
     framework: claude-code
-    experimental_runner:
-      group: ${RUNNER_GROUP}
     environment:
       DEBUG_MODE: "${{ vars.DEBUG }}"
       LOG_LEVEL: "${{ vars.LOG_LEVEL }}"
 EOF
     # Replace $AGENT_NAME in the file
-    sed -i "s|\$AGENT_NAME|$AGENT_NAME|g; s|\${RUNNER_GROUP}|$RUNNER_GROUP|g" "$TEST_DIR/vm0.yaml"
+    sed -i "s|\$AGENT_NAME|$AGENT_NAME|g" "$TEST_DIR/vm0.yaml"
 
     echo "# Step 2: Run vm0 compose"
     run $CLI_COMMAND compose "$TEST_DIR/vm0.yaml"
@@ -260,15 +244,13 @@ version: "1.0"
 agents:
   $AGENT_NAME:
     framework: claude-code
-    experimental_runner:
-      group: ${RUNNER_GROUP}
     environment:
       API_KEY: "${{ secrets.API_KEY }}"
       DEBUG: "${{ vars.DEBUG }}"
       STATIC_VALUE: "hardcoded"
 EOF
     # Replace $AGENT_NAME in the file
-    sed -i "s|\$AGENT_NAME|$AGENT_NAME|g; s|\${RUNNER_GROUP}|$RUNNER_GROUP|g" "$TEST_DIR/vm0.yaml"
+    sed -i "s|\$AGENT_NAME|$AGENT_NAME|g" "$TEST_DIR/vm0.yaml"
 
     echo "# Step 2: Run vm0 compose"
     run $CLI_COMMAND compose "$TEST_DIR/vm0.yaml" --yes
@@ -296,8 +278,6 @@ agents:
   $AGENT_NAME:
     description: "Test agent for delete command"
     framework: claude-code
-    experimental_runner:
-      group: ${RUNNER_GROUP}
 EOF
 
     echo "# Step 2: Run vm0 compose to create the agent"
@@ -329,8 +309,6 @@ agents:
   $AGENT_NAME:
     description: "Test agent for rm alias"
     framework: claude-code
-    experimental_runner:
-      group: ${RUNNER_GROUP}
 EOF
 
     echo "# Step 2: Run vm0 compose to create the agent"

--- a/e2e/tests/03-experimental-runner/t27-real-claude-smoke.bats
+++ b/e2e/tests/03-experimental-runner/t27-real-claude-smoke.bats
@@ -38,8 +38,6 @@ agents:
   $AGENT_NAME:
     description: "Real Claude smoke test"
     framework: claude-code
-    experimental_runner:
-      group: ${RUNNER_GROUP}
     working_dir: /home/user/workspace
     environment:
       ANTHROPIC_API_KEY: \${{ secrets.ANTHROPIC_API_KEY }}

--- a/e2e/tests/03-experimental-runner/t29-vm0-secret.bats
+++ b/e2e/tests/03-experimental-runner/t29-vm0-secret.bats
@@ -112,8 +112,6 @@ agents:
   ${agent_name}:
     description: "E2E test agent for secret masking"
     framework: claude-code
-    experimental_runner:
-      group: ${RUNNER_GROUP}
     working_dir: /home/user/workspace
     environment:
       MY_SECRET: "\${{ secrets.MY_SECRET }}"
@@ -182,8 +180,6 @@ agents:
   ${agent_name}:
     description: "E2E test agent for multiple secrets"
     framework: claude-code
-    experimental_runner:
-      group: ${RUNNER_GROUP}
     working_dir: /home/user/workspace
     environment:
       API_KEY: "\${{ secrets.API_KEY }}"

--- a/e2e/tests/03-experimental-runner/t30-vm0-model-provider-inject.bats
+++ b/e2e/tests/03-experimental-runner/t30-vm0-model-provider-inject.bats
@@ -32,8 +32,6 @@ agents:
   ${AGENT_NAME}:
     description: "Test model-provider injection"
     framework: claude-code
-    experimental_runner:
-      group: ${RUNNER_GROUP}
     working_dir: /home/user/workspace
     volumes:
       - claude-files:/home/user/.claude

--- a/e2e/tests/03-experimental-runner/t31-vm0-variable.bats
+++ b/e2e/tests/03-experimental-runner/t31-vm0-variable.bats
@@ -118,8 +118,6 @@ agents:
   ${agent_name}:
     description: "E2E test agent for variable expansion"
     framework: claude-code
-    experimental_runner:
-      group: ${RUNNER_GROUP}
     working_dir: /home/user/workspace
     environment:
       MY_VAR: "\${{ vars.$TEST_VAR_NAME }}"
@@ -189,8 +187,6 @@ agents:
   ${agent_name}:
     description: "E2E test agent for variable override"
     framework: claude-code
-    experimental_runner:
-      group: ${RUNNER_GROUP}
     working_dir: /home/user/workspace
     environment:
       MY_VAR: "\${{ vars.$TEST_VAR_NAME }}"

--- a/e2e/tests/03-experimental-runner/t32-vm0-timezone.bats
+++ b/e2e/tests/03-experimental-runner/t32-vm0-timezone.bats
@@ -43,8 +43,6 @@ agents:
   ${AGENT_NAME}:
     description: "E2E timezone test agent"
     framework: claude-code
-    experimental_runner:
-      group: ${RUNNER_GROUP}
     working_dir: /home/user/workspace
     volumes:
       - claude-files:/home/user/.claude
@@ -130,8 +128,6 @@ agents:
   ${OVERRIDE_AGENT_NAME}:
     description: "Agent with explicit TZ"
     framework: claude-code
-    experimental_runner:
-      group: ${RUNNER_GROUP}
     working_dir: /home/user/workspace
     environment:
       TZ: "Europe/London"

--- a/e2e/tests/03-experimental-runner/t33-vm0-optional-volume.bats
+++ b/e2e/tests/03-experimental-runner/t33-vm0-optional-volume.bats
@@ -49,8 +49,6 @@ agents:
   ${AGENT_NAME}:
     description: "Test agent with optional volume"
     framework: claude-code
-    experimental_runner:
-      group: ${RUNNER_GROUP}
     volumes:
       - optional-data:/home/user/optional-data
       - claude-files:/home/user/.config/claude
@@ -77,8 +75,6 @@ agents:
   ${AGENT_NAME}:
     description: "Test agent with optional volume"
     framework: claude-code
-    experimental_runner:
-      group: ${RUNNER_GROUP}
     volumes:
       - optional-data:/home/user/optional-data
       - claude-files:/home/user/.config/claude
@@ -133,8 +129,6 @@ agents:
   ${AGENT_NAME}-mixed:
     description: "Test agent with mixed volumes"
     framework: claude-code
-    experimental_runner:
-      group: ${RUNNER_GROUP}
     volumes:
       - required-data:/home/user/required-data
       - optional-data:/home/user/optional-data

--- a/e2e/tests/03-experimental-runner/t34-vm0-memory.bats
+++ b/e2e/tests/03-experimental-runner/t34-vm0-memory.bats
@@ -39,8 +39,6 @@ agents:
   ${AGENT_NAME}:
     description: "E2E test agent for memory flag testing"
     framework: claude-code
-    experimental_runner:
-      group: ${RUNNER_GROUP}
     volumes:
       - claude-files:/home/user/.claude
     working_dir: /home/user/workspace

--- a/e2e/tests/03-experimental-runner/t36-vm0-logs-search.bats
+++ b/e2e/tests/03-experimental-runner/t36-vm0-logs-search.bats
@@ -26,8 +26,6 @@ agents:
   ${AGENT_NAME}:
     description: "E2E test agent for logs search testing"
     framework: claude-code
-    experimental_runner:
-      group: ${RUNNER_GROUP}
     volumes:
       - claude-files:/home/user/.claude
     working_dir: /home/user/workspace

--- a/e2e/tests/03-experimental-runner/t40-firewall-sni.bats
+++ b/e2e/tests/03-experimental-runner/t40-firewall-sni.bats
@@ -17,10 +17,6 @@ setup() {
         fail "VM0_API_URL not set"
     fi
 
-    if [[ -z "$RUNNER_GROUP" ]]; then
-        fail "RUNNER_GROUP not set - runner was not started by workflow"
-    fi
-
     export TEST_DIR="$(mktemp -d)"
     export UNIQUE_ID="$(date +%s%3N)-$RANDOM"
     export AGENT_NAME="e2e-sni-${UNIQUE_ID}"
@@ -52,8 +48,6 @@ agents:
     description: "SNI-only firewall test"
     framework: claude-code
     working_dir: /home/user/workspace
-    experimental_runner:
-      group: ${RUNNER_GROUP}
     experimental_firewall:
       enabled: true
       experimental_mitm: false
@@ -76,8 +70,6 @@ agents:
     description: "SNI allow test"
     framework: claude-code
     working_dir: /home/user/workspace
-    experimental_runner:
-      group: ${RUNNER_GROUP}
     experimental_firewall:
       enabled: true
       experimental_mitm: false
@@ -131,8 +123,6 @@ agents:
     description: "SNI block test"
     framework: claude-code
     working_dir: /home/user/workspace
-    experimental_runner:
-      group: ${RUNNER_GROUP}
     experimental_firewall:
       enabled: true
       experimental_mitm: false

--- a/e2e/tests/03-experimental-runner/t41-firewall-mitm.bats
+++ b/e2e/tests/03-experimental-runner/t41-firewall-mitm.bats
@@ -17,10 +17,6 @@ setup() {
         fail "VM0_API_URL not set"
     fi
 
-    if [[ -z "$RUNNER_GROUP" ]]; then
-        fail "RUNNER_GROUP not set - runner was not started by workflow"
-    fi
-
     export TEST_DIR="$(mktemp -d)"
     export UNIQUE_ID="$(date +%s%3N)-$RANDOM"
     export AGENT_NAME="e2e-mitm-${UNIQUE_ID}"
@@ -52,8 +48,6 @@ agents:
     description: "MITM firewall test"
     framework: claude-code
     working_dir: /home/user/workspace
-    experimental_runner:
-      group: ${RUNNER_GROUP}
     experimental_firewall:
       enabled: true
       experimental_mitm: true
@@ -76,8 +70,6 @@ agents:
     description: "MITM allow test"
     framework: claude-code
     working_dir: /home/user/workspace
-    experimental_runner:
-      group: ${RUNNER_GROUP}
     experimental_firewall:
       enabled: true
       experimental_mitm: true
@@ -131,8 +123,6 @@ agents:
     description: "MITM block test"
     framework: claude-code
     working_dir: /home/user/workspace
-    experimental_runner:
-      group: ${RUNNER_GROUP}
     experimental_firewall:
       enabled: true
       experimental_mitm: true
@@ -170,8 +160,6 @@ agents:
     description: "MITM seal_secrets test"
     framework: claude-code
     working_dir: /home/user/workspace
-    experimental_runner:
-      group: ${RUNNER_GROUP}
     experimental_firewall:
       enabled: true
       experimental_mitm: true
@@ -219,8 +207,6 @@ agents:
     description: "MITM without seal_secrets"
     framework: claude-code
     working_dir: /home/user/workspace
-    experimental_runner:
-      group: ${RUNNER_GROUP}
     experimental_firewall:
       enabled: true
       experimental_mitm: true

--- a/e2e/tests/03-experimental-runner/t42-connector-placeholder.bats
+++ b/e2e/tests/03-experimental-runner/t42-connector-placeholder.bats
@@ -18,10 +18,6 @@ setup() {
         fail "VM0_API_URL not set"
     fi
 
-    if [[ -z "$RUNNER_GROUP" ]]; then
-        fail "RUNNER_GROUP not set - runner was not started by workflow"
-    fi
-
     export TEST_DIR="$(mktemp -d)"
     export UNIQUE_ID="$(date +%s%3N)-$RANDOM"
     export AGENT_NAME="e2e-connector-${UNIQUE_ID}"
@@ -82,8 +78,6 @@ agents:
     description: "Connector placeholder test"
     framework: claude-code
     working_dir: /home/user/workspace
-    experimental_runner:
-      group: ${RUNNER_GROUP}
     experimental_services:
       - github
 EOF
@@ -103,8 +97,6 @@ agents:
     description: "GitHub connector placeholder test"
     framework: claude-code
     working_dir: /home/user/workspace
-    experimental_runner:
-      group: ${RUNNER_GROUP}
     experimental_services:
       - github
     environment:
@@ -145,8 +137,6 @@ agents:
     description: "Multi-connector placeholder test"
     framework: claude-code
     working_dir: /home/user/workspace
-    experimental_runner:
-      group: ${RUNNER_GROUP}
     experimental_services:
       - github
       - slack
@@ -194,8 +184,6 @@ agents:
     description: "Token replacement test"
     framework: claude-code
     working_dir: /home/user/workspace
-    experimental_runner:
-      group: ${RUNNER_GROUP}
     experimental_services:
       - github
     environment:

--- a/turbo/apps/web/src/lib/run/context/execution-preparer.ts
+++ b/turbo/apps/web/src/lib/run/context/execution-preparer.ts
@@ -63,13 +63,6 @@ function processFirewallConfig(
     firstAgent.experimental_firewall as ExperimentalFirewall;
   if (!firewallConfig.enabled) return null;
 
-  // Validate experimental_runner is configured (firewall requires runner)
-  if (!firstAgent.experimental_runner?.group) {
-    throw badRequest(
-      "experimental_firewall requires experimental_runner to be configured",
-    );
-  }
-
   // Validate experimental_seal_secrets requires experimental_mitm
   if (
     firewallConfig.experimental_seal_secrets &&


### PR DESCRIPTION
## Summary
- Remove `experimental_runner` blocks from all E2E test YAML configs — server falls back to `RUNNER_DEFAULT_GROUP` env var
- Remove `RUNNER_GROUP` and `JOB_REF` env vars from bats runner step (no longer consumed by tests)
- Remove firewall validation that required `experimental_runner` — all runs use runner now
- Keep `experimental_runner` in schema/types/contracts for future use (custom runner groups)

## Test plan
- [ ] Verify E2E tests pass without `experimental_runner` in compose configs
- [ ] Verify firewall E2E tests pass without `experimental_runner` validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)