### PR TITLE
refactor(web): remove defensive try-catch in axiom client query

### DIFF
--- a/turbo/apps/web/app/api/agent/runs/[id]/events/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/events/route.ts
@@ -79,13 +79,7 @@ const router = tsr.router(runEventsContract, {
 | limit ${limit}`;
 
     // Query Axiom for agent events
-    const axiomEvents = await queryAxiom<AxiomAgentEvent>(apl);
-
-    if (!axiomEvents) {
-      throw new Error(`Axiom returned null for run ${params.id}`);
-    }
-
-    const rawEvents: AxiomAgentEvent[] = axiomEvents;
+    const rawEvents = await queryAxiom<AxiomAgentEvent>(apl);
 
     // Filter to only consecutive events to handle Axiom's eventual consistency.
     const events = filterConsecutiveEvents(rawEvents, since);

--- a/turbo/apps/web/app/api/agent/runs/[id]/telemetry/agent/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/telemetry/agent/__tests__/route.test.ts
@@ -136,7 +136,7 @@ describe("GET /api/agent/runs/:id/telemetry/agent", () => {
     });
 
     it("should return empty events when Axiom is not configured", async () => {
-      context.mocks.axiom.queryAxiom.mockResolvedValue(null);
+      context.mocks.axiom.queryAxiom.mockResolvedValue([]);
 
       const request = createTestRequest(
         `http://localhost:3000/api/agent/runs/${testRunId}/telemetry/agent`,
@@ -396,7 +396,7 @@ describe("GET /api/agent/runs/:id/telemetry/agent", () => {
 
   describe("DB fallback (Axiom not configured)", () => {
     it("should return empty events from DB fallback when Axiom is not configured", async () => {
-      context.mocks.axiom.queryAxiom.mockResolvedValue(null);
+      context.mocks.axiom.queryAxiom.mockResolvedValue([]);
 
       const request = createTestRequest(
         `http://localhost:3000/api/agent/runs/${testRunId}/telemetry/agent`,

--- a/turbo/apps/web/app/api/agent/runs/[id]/telemetry/agent/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/telemetry/agent/route.ts
@@ -83,13 +83,9 @@ ${sinceFilter}
     // Query Axiom for agent events
     const events = await queryAxiom<AxiomAgentEvent>(apl);
 
-    const resolvedEvents = events ?? [];
-
     // Check if there are more events
-    const hasMore = resolvedEvents.length > limit;
-    const resultEvents = hasMore
-      ? resolvedEvents.slice(0, limit)
-      : resolvedEvents;
+    const hasMore = events.length > limit;
+    const resultEvents = hasMore ? events.slice(0, limit) : events;
 
     return {
       status: 200 as const,

--- a/turbo/apps/web/app/api/agent/runs/[id]/telemetry/metrics/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/telemetry/metrics/__tests__/route.test.ts
@@ -134,7 +134,7 @@ describe("GET /api/agent/runs/:id/telemetry/metrics", () => {
     });
 
     it("should return empty metrics when Axiom is not configured", async () => {
-      context.mocks.axiom.queryAxiom.mockResolvedValue(null);
+      context.mocks.axiom.queryAxiom.mockResolvedValue([]);
 
       const request = createTestRequest(
         `http://localhost:3000/api/agent/runs/${testRunId}/telemetry/metrics`,
@@ -306,7 +306,7 @@ describe("GET /api/agent/runs/:id/telemetry/metrics", () => {
 
   describe("DB fallback (Axiom not configured)", () => {
     it("should return empty metrics from DB fallback when Axiom is not configured", async () => {
-      context.mocks.axiom.queryAxiom.mockResolvedValue(null);
+      context.mocks.axiom.queryAxiom.mockResolvedValue([]);
 
       const request = createTestRequest(
         `http://localhost:3000/api/agent/runs/${testRunId}/telemetry/metrics`,

--- a/turbo/apps/web/app/api/agent/runs/[id]/telemetry/metrics/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/telemetry/metrics/route.ts
@@ -70,11 +70,9 @@ ${sinceFilter}
     // Query Axiom for metrics
     const events = await queryAxiom<AxiomMetricEvent>(apl);
 
-    const resolvedEvents = events ?? [];
-
     // Check if there are more records
-    const hasMore = resolvedEvents.length > limit;
-    const records = hasMore ? resolvedEvents.slice(0, limit) : resolvedEvents;
+    const hasMore = events.length > limit;
+    const records = hasMore ? events.slice(0, limit) : events;
 
     // Transform to API response format
     const metrics = records.map((e) => ({

--- a/turbo/apps/web/app/api/agent/runs/[id]/telemetry/network/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/telemetry/network/__tests__/route.test.ts
@@ -138,7 +138,7 @@ describe("GET /api/agent/runs/:id/telemetry/network", () => {
     });
 
     it("should return empty network logs when Axiom is not configured", async () => {
-      context.mocks.axiom.queryAxiom.mockResolvedValue(null);
+      context.mocks.axiom.queryAxiom.mockResolvedValue([]);
 
       const request = createTestRequest(
         `http://localhost:3000/api/agent/runs/${testRunId}/telemetry/network`,
@@ -332,7 +332,7 @@ describe("GET /api/agent/runs/:id/telemetry/network", () => {
 
   describe("DB fallback (Axiom not configured)", () => {
     it("should return empty network logs from DB fallback when Axiom is not configured", async () => {
-      context.mocks.axiom.queryAxiom.mockResolvedValue(null);
+      context.mocks.axiom.queryAxiom.mockResolvedValue([]);
 
       const request = createTestRequest(
         `http://localhost:3000/api/agent/runs/${testRunId}/telemetry/network`,

--- a/turbo/apps/web/app/api/agent/runs/[id]/telemetry/network/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/telemetry/network/route.ts
@@ -83,11 +83,9 @@ ${sinceFilter}
     // Query Axiom for network logs
     const events = await queryAxiom<AxiomNetworkEvent>(apl);
 
-    const resolvedEvents = events ?? [];
-
     // Check if there are more records
-    const hasMore = resolvedEvents.length > limit;
-    const records = hasMore ? resolvedEvents.slice(0, limit) : resolvedEvents;
+    const hasMore = events.length > limit;
+    const records = hasMore ? events.slice(0, limit) : events;
 
     // Transform to API response format (supports both SNI-only and MITM modes)
     const networkLogs = records.map((e) => ({

--- a/turbo/apps/web/app/api/agent/runs/[id]/telemetry/system-log/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/telemetry/system-log/__tests__/route.test.ts
@@ -165,8 +165,8 @@ describe("GET /api/agent/runs/:id/telemetry/system-log", () => {
       expect(data.hasMore).toBe(false);
     });
 
-    it("should return empty when Axiom returns null and no DB data exists", async () => {
-      context.mocks.axiom.queryAxiom.mockResolvedValue(null);
+    it("should return empty when Axiom is not configured and no DB data exists", async () => {
+      context.mocks.axiom.queryAxiom.mockResolvedValue([]);
 
       const request = createTestRequest(
         `http://localhost:3000/api/agent/runs/${testRunId}/telemetry/system-log?limit=10`,

--- a/turbo/apps/web/app/api/agent/runs/[id]/telemetry/system-log/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/telemetry/system-log/route.ts
@@ -66,11 +66,9 @@ ${sinceFilter}
     // Query Axiom for system logs
     const events = await queryAxiom<AxiomSystemLogEvent>(apl);
 
-    const resolvedEvents = events ?? [];
-
     // Check if there are more records
-    const hasMore = resolvedEvents.length > limit;
-    const records = hasMore ? resolvedEvents.slice(0, limit) : resolvedEvents;
+    const hasMore = events.length > limit;
+    const records = hasMore ? events.slice(0, limit) : events;
 
     // Aggregate system logs from records
     const aggregatedSystemLog = records.map((r) => r.log).join("");

--- a/turbo/apps/web/app/api/logs/search/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/logs/search/__tests__/route.test.ts
@@ -82,7 +82,7 @@ describe("GET /api/logs/search", () => {
   });
 
   it("should return empty results when Axiom is not configured", async () => {
-    context.mocks.axiom.queryAxiom.mockResolvedValue(null);
+    context.mocks.axiom.queryAxiom.mockResolvedValue([]);
 
     const request = createTestRequest(
       "http://localhost:3000/api/logs/search?keyword=test",

--- a/turbo/apps/web/app/api/logs/search/route.ts
+++ b/turbo/apps/web/app/api/logs/search/route.ts
@@ -114,7 +114,7 @@ async function searchEventsInAxiom(
   runIdFilter: string,
   keyword: string,
   limit: number,
-): Promise<AxiomAgentEvent[] | null> {
+): Promise<AxiomAgentEvent[]> {
   const apl = `['${dataset}']
 | where _time > datetime("${sinceISO}")
 ${runIdFilter}
@@ -148,10 +148,8 @@ async function fetchContextEvents(
 | order by runId asc, sequenceNumber asc`;
 
   const contextEvents = await queryAxiom<AxiomAgentEvent>(apl);
-  if (contextEvents) {
-    for (const event of contextEvents) {
-      contextMap.set(`${event.runId}:${event.sequenceNumber}`, event);
-    }
+  for (const event of contextEvents) {
+    contextMap.set(`${event.runId}:${event.sequenceNumber}`, event);
   }
 
   return contextMap;
@@ -222,7 +220,7 @@ const router = tsr.router(logsSearchContract, {
       limit,
     );
 
-    if (matchedEvents === null || matchedEvents.length === 0) {
+    if (matchedEvents.length === 0) {
       return {
         status: 200 as const,
         body: { results: [], hasMore: false },

--- a/turbo/apps/web/src/__tests__/test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/test-helpers.ts
@@ -311,14 +311,10 @@ export function testContext(): TestContext {
       query: vi.fn().mockResolvedValue({ matches: [] }),
       ingest: vi.fn(),
       flush: vi.fn().mockResolvedValue(undefined),
-      queryAxiom: vi
-        .spyOn(axiomClient, "queryAxiom")
-        .mockResolvedValue([]) as MockInstance<typeof axiomClient.queryAxiom>,
+      queryAxiom: vi.spyOn(axiomClient, "queryAxiom").mockResolvedValue([]),
       ingestToAxiom: vi
         .spyOn(axiomClient, "ingestToAxiom")
-        .mockResolvedValue(true) as MockInstance<
-        typeof axiomClient.ingestToAxiom
-      >,
+        .mockResolvedValue(true),
     };
     // Use try/catch since Axiom may not be mocked in all test files
     try {

--- a/turbo/apps/web/src/lib/axiom/client.ts
+++ b/turbo/apps/web/src/lib/axiom/client.ts
@@ -105,30 +105,25 @@ export async function ingestToAxiom(
 /**
  * Query events from Axiom dataset using APL.
  * Automatically routes to the correct client based on the dataset in the APL query.
- * Returns null if Axiom is not configured or query fails.
+ * Returns empty array if Axiom is not configured.
  */
 export async function queryAxiom<T = Record<string, unknown>>(
   apl: string,
-): Promise<T[] | null> {
+): Promise<T[]> {
   const dataset = extractDatasetFromApl(apl);
   // If we can't determine the dataset, default to telemetry client (broader scope)
   const client = dataset ? getClientForDataset(dataset) : getTelemetryClient();
   if (!client) {
     log.debug("Axiom not configured, skipping query");
-    return null;
+    return [];
   }
 
-  try {
-    const result = await client.query(apl);
-    // Axiom stores _time separately from data, merge them for the response
-    return (
-      result.matches?.map((m: Entry) => ({ _time: m._time, ...m.data }) as T) ??
-      []
-    );
-  } catch (error) {
-    log.error("Axiom query failed:", error);
-    return null;
-  }
+  const result = await client.query(apl);
+  // Axiom stores _time separately from data, merge them for the response
+  return (
+    result.matches?.map((m: Entry) => ({ _time: m._time, ...m.data }) as T) ??
+    []
+  );
 }
 
 interface RequestLogEntry {

--- a/turbo/apps/web/src/lib/slack/handlers/run-agent.ts
+++ b/turbo/apps/web/src/lib/slack/handlers/run-agent.ts
@@ -190,7 +190,7 @@ export async function getRunResultData(
   }
 
   const events = await queryAxiom<ResultEvent>(apl);
-  if (!events || events.length === 0) {
+  if (events.length === 0) {
     return undefined;
   }
 


### PR DESCRIPTION
## Summary

- Remove defensive try-catch from `queryAxiom` in `apps/web/src/lib/axiom/client.ts` — let exceptions propagate naturally per CLAUDE.md's "Avoid Defensive Programming" principle
- Change return type from `T[] | null` to `T[]` (return empty array when Axiom is not configured instead of null)
- Remove all downstream null-coalescing (`?? []`) and null-guard patterns from 6 route handlers and 1 Slack handler
- Update 8 test files to mock `queryAxiom` with `[]` instead of `null`

Closes #4432

## Test plan

- [x] All 14 modified files pass TypeScript type checking (`pnpm check-types`)
- [x] All 14 modified files pass lint (`pnpm turbo run lint`)
- [x] All 108 affected tests pass (agent events, telemetry agent/network/system-log/metrics, logs/search, email reply callbacks)
- [x] Knip reports no unused code issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)