### PR TITLE
refactor(web): remove defensive try-catch in runner group token generation

### DIFF
--- a/turbo/apps/web/app/api/runners/realtime/token/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/runners/realtime/token/__tests__/route.test.ts
@@ -207,8 +207,10 @@ describe("POST /api/runners/realtime/token", () => {
       );
       const data = await response.json();
 
+      // Exception propagates to createHandler's error handler which returns
+      // a generic 500 message (no defensive catch in generateRunnerGroupToken)
       expect(response.status).toBe(500);
-      expect(data.error.message).toContain("Realtime service unavailable");
+      expect(data.error.message).toContain("An internal error occurred");
     });
   });
 });

--- a/turbo/apps/web/src/lib/realtime/client.ts
+++ b/turbo/apps/web/src/lib/realtime/client.ts
@@ -45,20 +45,15 @@ export async function generateRunnerGroupToken(
     return null;
   }
 
-  try {
-    const channelName = getRunnerGroupChannelName(group);
-    const tokenRequest = await client.auth.createTokenRequest({
-      capability: {
-        [channelName]: ["subscribe"],
-      },
-      ttl: 3600000, // 1 hour
-    });
-    log.debug(`Generated token for runner-group:${group}`);
-    return tokenRequest;
-  } catch (error) {
-    log.error(`Ably token generation failed for runner-group:${group}:`, error);
-    return null;
-  }
+  const channelName = getRunnerGroupChannelName(group);
+  const tokenRequest = await client.auth.createTokenRequest({
+    capability: {
+      [channelName]: ["subscribe"],
+    },
+    ttl: 3600000, // 1 hour
+  });
+  log.debug(`Generated token for runner-group:${group}`);
+  return tokenRequest;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Remove the defensive try-catch in `generateRunnerGroupToken` that was hiding Ably token generation failures by returning `null`
- Let exceptions propagate naturally to the route handler's `createHandler` error handler, which returns a generic 500 response and logs full error details server-side
- The `null` return for "Ably not configured" remains unchanged — it is semantically correct since Ably is optional
- Update test assertion to match the new error message from `createSafeErrorHandler`

Closes #4434

## Test plan

- [x] All 10 existing tests pass (including the updated token generation failure test)
- [x] Lint passes
- [x] Type check passes
- [x] Knip finds no unused code

Generated with [Claude Code](https://claude.com/claude-code)