### PR TITLE
chore: audit api-token connector help texts

### DIFF
--- a/turbo/packages/core/src/contracts/connectors.ts
+++ b/turbo/packages/core/src/contracts/connectors.ts
@@ -724,8 +724,6 @@ const CONNECTOR_TYPES_DEF = {
     authMethods: {
       "api-token": {
         label: "Personal Access Token",
-        helpText:
-          "1. Log in to [Jam](https://jam.dev)\n2. Go to **Settings** → **API**\n3. Create a new **Personal Access Token**\n4. Copy the token (starts with `jam_pat_`)",
         secrets: {
           JAM_TOKEN: {
             label: "Personal Access Token",
@@ -2448,8 +2446,6 @@ const CONNECTOR_TYPES_DEF = {
     authMethods: {
       "api-token": {
         label: "API Key",
-        helpText:
-          "1. Sign up at [Short.io](https://short.io/)\n2. Go to **Integrations & API** in Settings\n3. Copy your API key",
         secrets: {
           SHORTIO_TOKEN: {
             label: "API Key",


### PR DESCRIPTION
## Summary

- Audited all 19 api-token connectors that have `helpText` in their `authMethods["api-token"]` configuration against official documentation
- Removed `helpText` from 2 connectors where instructions could not be verified (Jam, Short.io)
- Confirmed 17 connectors have accurate help texts

## Verification Details

### Verified as Accurate (17 connectors)
| Connector | Verification Method | Result |
|-----------|-------------------|--------|
| AgentMail | Jina Reader: agentmail.to/docs/quickstart | Steps confirmed: Console > API Keys > Create |
| Apify | Jina Reader: docs.apify.com/platform/integrations/api | Confirmed: Settings > Integrations |
| Atlassian | Jina Reader: id.atlassian.com/manage-profile/security/api-tokens | URL and steps confirmed |
| Axiom | Jina Reader: docs.axiom.co/reference/tokens | Confirmed: Settings > API Tokens |
| Bright Data | Jina Reader: docs.brightdata.com/api-reference/authentication | Confirmed: Account settings > Add API key |
| Cloudflare | Jina Reader: developers.cloudflare.com/fundamentals/api/get-started/create-token/ | Confirmed: My Profile > API Tokens |
| Firecrawl | Jina Reader: docs.firecrawl.dev/introduction | Confirmed: Dashboard > API Key |
| Hugging Face | Jina Reader: huggingface.co/docs/hub/en/security-tokens | Confirmed: Settings > Access Tokens |
| Hume | Jina Reader: dev.hume.ai/docs/introduction/api-key | Confirmed: app.hume.ai > API Keys page |
| Jotform | Jina Reader: api.jotform.com/docs/ | Confirmed: My Account > API section |
| LINE | Jina Reader: developers.line.biz/en/docs/messaging-api/channel-access-tokens/ | Confirmed: Messaging API tab > Channel access token |
| Mercury | Jina Reader: docs.mercury.com/reference/authentication | Confirmed: Settings > Tokens (mercury.com/settings/tokens) |
| Metabase | Jina Reader: metabase.com/docs/latest/people-and-groups/api-keys | Confirmed: Admin > Settings > Authentication > API Keys |
| Plausible | Jina Reader: plausible.io/docs/stats-api | Confirmed: Account Settings > API Keys > Stats API |
| Qdrant | Jina Reader: qdrant.tech/documentation/cloud/authentication/ | Confirmed: Cluster detail page > API Keys |
| YouTube | Jina Reader: console.cloud.google.com YouTube Data API v3 page | Confirmed: Enable API > Credentials > API Key |
| Zendesk | Jina Reader: support.zendesk.com/hc/en-us/articles/4408889192858 | Confirmed: Apps and integrations > APIs > API tokens |

### Removed helpText (2 connectors)
| Connector | Verification Attempts | Result |
|-----------|----------------------|--------|
| **Jam** | Direct: jam.dev/docs/product-features/api/personal-access-tokens (404), jam.dev/docs/integrations/api (404), jam.dev/docs/api (404), jam.dev/docs/product-features/integrations (404). Jina Reader: all same URLs returned 404 | Cannot verify Settings > API path or jam_pat_ token prefix |
| **Short.io** | Direct: short.io/developers (404 content), docs.short.io/reference/getting-started (no API key info), docs.short.io/docs/getting-started (404), developers.short.io/docs/getting-started (no key info), help.short.io/en/articles/4065870 (404). Jina Reader: all same results | Cannot verify "Integrations & API" location in Settings |

## Test plan
- [x] TypeScript type check passes for `@vm0/core`
- [x] Lint passes for `@vm0/core`
- [x] Knip finds no issues
- [x] Formatting unchanged

Closes #4386

🤖 Generated with [Claude Code](https://claude.com/claude-code)