### PR TITLE
refactor(web): remove defensive catch in enrichMessageContent

### DIFF
--- a/turbo/apps/web/app/api/slack/events/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/slack/events/__tests__/route.test.ts
@@ -555,7 +555,7 @@ describe("POST /api/slack/events", () => {
 
       // Then the message should be routed to the agent (runAgentForSlack called)
       expect(runAgentSpy).toHaveBeenCalledTimes(1);
-      expect(runAgentSpy.mock.calls[0]![0].prompt).toBe("hello");
+      expect(runAgentSpy.mock.calls[0]![0].prompt).toContain("hello");
 
       // And no immediate response should be posted (callback handles that)
       expect(mockClient.chat.postMessage).not.toHaveBeenCalled();

--- a/turbo/apps/web/src/__tests__/setup.ts
+++ b/turbo/apps/web/src/__tests__/setup.ts
@@ -145,6 +145,16 @@ vi.mock("@slack/web-api", () => {
       replies: vi.fn().mockResolvedValue({ ok: true, messages: [] }),
       history: vi.fn().mockResolvedValue({ ok: true, messages: [] }),
     },
+    users: {
+      info: vi.fn().mockResolvedValue({
+        ok: true,
+        user: {
+          id: "U-mock",
+          name: "mockuser",
+          profile: { display_name: "Mock User" },
+        },
+      }),
+    },
     reactions: {
       add: vi.fn().mockResolvedValue({ ok: true }),
       remove: vi.fn().mockResolvedValue({ ok: true }),

--- a/turbo/apps/web/src/lib/slack/__tests__/client.test.ts
+++ b/turbo/apps/web/src/lib/slack/__tests__/client.test.ts
@@ -78,6 +78,18 @@ describe("Feature: Fetch Slack User Info", () => {
     expect(result).toBeUndefined();
   });
 
+  it("should propagate error when API call throws", async () => {
+    const client = {
+      users: {
+        info: vi.fn().mockRejectedValue(new Error("network_error")),
+      },
+    } as unknown as WebClient;
+
+    await expect(fetchSlackUserInfo(client, "U999")).rejects.toThrow(
+      "network_error",
+    );
+  });
+
   it("should omit name when no name fields are available", async () => {
     const client = createMockClient({
       ok: true,

--- a/turbo/apps/web/src/lib/slack/client.ts
+++ b/turbo/apps/web/src/lib/slack/client.ts
@@ -123,7 +123,12 @@ export async function fetchSlackUserInfo(
   client: WebClient,
   userId: string,
 ): Promise<string | undefined> {
-  const result = await client.users.info({ user: userId });
+  let result;
+  try {
+    result = await client.users.info({ user: userId });
+  } catch {
+    return undefined;
+  }
   if (!result.ok || !result.user) return undefined;
 
   const u = result.user;

--- a/turbo/apps/web/src/lib/slack/client.ts
+++ b/turbo/apps/web/src/lib/slack/client.ts
@@ -123,12 +123,7 @@ export async function fetchSlackUserInfo(
   client: WebClient,
   userId: string,
 ): Promise<string | undefined> {
-  let result;
-  try {
-    result = await client.users.info({ user: userId });
-  } catch {
-    return undefined;
-  }
+  const result = await client.users.info({ user: userId });
   if (!result.ok || !result.user) return undefined;
 
   const u = result.user;

--- a/turbo/apps/web/src/lib/slack/handlers/shared.ts
+++ b/turbo/apps/web/src/lib/slack/handlers/shared.ts
@@ -314,15 +314,7 @@ export async function enrichMessageContent(opts: {
   }
 
   // Prepend Slack user info to the prompt
-  const userInfo = await fetchSlackUserInfo(opts.client, opts.userId).catch(
-    (err) => {
-      log.warn("Failed to fetch Slack user info", {
-        userId: opts.userId,
-        error: err,
-      });
-      return undefined;
-    },
-  );
+  const userInfo = await fetchSlackUserInfo(opts.client, opts.userId);
   if (userInfo) {
     content = `[Slack User]\n${userInfo}\n\n${content}`;
   }


### PR DESCRIPTION
## Summary

- Remove defensive `.catch()` on `fetchSlackUserInfo` in `enrichMessageContent` that silently converted Slack API errors into `undefined`, hiding real failures (auth issues, rate limiting, network problems)
- Let errors propagate naturally per the project's "Avoid Defensive Programming" principle

Closes #4435

## Test plan

- [ ] Verify lint, type-check, and knip pass (confirmed locally)
- [ ] CI pipeline passes all checks
- [ ] Slack message handling continues to work when `fetchSlackUserInfo` succeeds
- [ ] Slack API errors now propagate instead of being silently swallowed

🤖 Generated with [Claude Code](https://claude.com/claude-code)