### PR TITLE
refactor(web): remove defensive catch in enrich-message-content

### DIFF
--- a/turbo/apps/web/src/__tests__/setup.ts
+++ b/turbo/apps/web/src/__tests__/setup.ts
@@ -149,6 +149,9 @@ vi.mock("@slack/web-api", () => {
       add: vi.fn().mockResolvedValue({ ok: true }),
       remove: vi.fn().mockResolvedValue({ ok: true }),
     },
+    users: {
+      info: vi.fn().mockResolvedValue({ ok: true, user: undefined }),
+    },
     assistant: {
       threads: {
         setStatus: vi.fn().mockResolvedValue({ ok: true }),

--- a/turbo/apps/web/src/lib/slack/handlers/shared.ts
+++ b/turbo/apps/web/src/lib/slack/handlers/shared.ts
@@ -314,15 +314,7 @@ export async function enrichMessageContent(opts: {
   }
 
   // Prepend Slack user info to the prompt
-  const userInfo = await fetchSlackUserInfo(opts.client, opts.userId).catch(
-    (err) => {
-      log.warn("Failed to fetch Slack user info", {
-        userId: opts.userId,
-        error: err,
-      });
-      return undefined;
-    },
-  );
+  const userInfo = await fetchSlackUserInfo(opts.client, opts.userId);
   if (userInfo) {
     content = `[Slack User]\n${userInfo}\n\n${content}`;
   }


### PR DESCRIPTION
## Summary

- Remove defensive `.catch()` on `fetchSlackUserInfo` in `enrichMessageContent` that silently converted Slack API failures into `undefined`
- Let errors propagate naturally per the project's "avoid defensive programming" principle (CLAUDE.md)

Closes #4435

## Test plan

- [ ] Verify type check passes (`pnpm check-types`)
- [ ] Verify lint passes (`pnpm turbo run lint`)
- [ ] Verify Slack message handling still works when user info is available
- [ ] Verify errors propagate correctly when Slack API fails (no silent swallowing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)