### PR TITLE
refactor(web): remove dead code and defensive try-catch in slack shared.ts

### DIFF
--- a/turbo/apps/web/src/lib/slack/handlers/shared.ts
+++ b/turbo/apps/web/src/lib/slack/handlers/shared.ts
@@ -21,25 +21,6 @@ const log = logger("slack:shared");
 export type SlackClient = ReturnType<typeof createSlackClient>;
 
 /**
- * Remove the thinking reaction from a message
- */
-export async function removeThinkingReaction(
-  client: SlackClient,
-  channelId: string,
-  messageTs: string,
-): Promise<void> {
-  await client.reactions
-    .remove({
-      channel: channelId,
-      timestamp: messageTs,
-      name: "thought_balloon",
-    })
-    .catch(() => {
-      // Ignore errors when removing reaction
-    });
-}
-
-/**
  * Fetch conversation context with deduplication support.
  * Returns separate contexts for routing (text-only, full history) and
  * execution (with images, only new messages since lastProcessedMessageTs).
@@ -228,22 +209,13 @@ export function buildAgentLogsUrl(agentName: string): string {
 export async function ensureScopeAndArtifact(vm0UserId: string): Promise<void> {
   const scope = await ensureDefaultScope(vm0UserId);
 
-  // Preserve original Slack behavior: log but don't throw on artifact creation failure.
-  // Slack callers (server actions, OAuth callback) don't have error handling for this.
-  try {
-    await ensureStorageExists(
-      scope.orgId,
-      vm0UserId,
-      "artifact",
-      scope.slug,
-      "artifact",
-    );
-  } catch (err) {
-    log.error("Failed to ensure artifact exists for Slack user", {
-      userId: vm0UserId,
-      err,
-    });
-  }
+  await ensureStorageExists(
+    scope.orgId,
+    vm0UserId,
+    "artifact",
+    scope.slug,
+    "artifact",
+  );
 }
 
 /**


### PR DESCRIPTION
## Summary
- Delete unused `removeThinkingReaction` export (zero callers in codebase)
- Remove defensive try-catch in `ensureScopeAndArtifact` — let `ensureStorageExists` errors propagate naturally to callers

## Test plan
- [x] Type check passes (`pnpm check-types`)
- [x] Lint passes (`pnpm turbo run lint`)
- [x] Knip passes (`pnpm knip`)
- [x] All tests pass (`pnpm vitest run`)
- [x] Verified `removeThinkingReaction` has zero callers via codebase grep
- [x] Verified all `ensureScopeAndArtifact` callers are in API routes/server actions with framework-level error handling

Closes #4436

🤖 Generated with [Claude Code](https://claude.com/claude-code)