### PR TITLE
feat: fix agent connections page to handle api-token connectors and unify layout

### DIFF
--- a/turbo/apps/platform/src/signals/agent-detail/agent-connections-page.ts
+++ b/turbo/apps/platform/src/signals/agent-detail/agent-connections-page.ts
@@ -3,10 +3,8 @@ import { createElement } from "react";
 import { AgentConnectionsPage } from "../../views/agent-detail-page/agent-connections-page.tsx";
 import { updatePage$ } from "../react-router.ts";
 import { fetchAgentDetail$ } from "./agent-detail.ts";
-import { initConnectionsTabs$ } from "./connections.ts";
 
 export const setupAgentConnectionsPage$ = command(async ({ set }) => {
   set(updatePage$, createElement(AgentConnectionsPage));
-  set(initConnectionsTabs$);
   await set(fetchAgentDetail$);
 });

--- a/turbo/apps/platform/src/signals/agent-detail/connections.ts
+++ b/turbo/apps/platform/src/signals/agent-detail/connections.ts
@@ -1,15 +1,14 @@
-import { computed, state, command } from "ccstate";
+import { computed } from "ccstate";
 import {
   extractVariableReferences,
   groupVariablesBySource,
-  getConnectorProvidedSecretNames,
-  getConnectorEnvironmentMapping,
+  getConnectorManagedSecretNames,
+  getConnectorTypeForSecretName,
   CONNECTOR_TYPES,
   type ConnectorType,
   type SecretResponse,
   type VariableResponse,
 } from "@vm0/core";
-import { searchParams$, updateSearchParams$ } from "../route.ts";
 import { agentDetail$ } from "./agent-detail.ts";
 import { connectors$ } from "../external/connectors.ts";
 import { secrets$ } from "../settings-page/secrets.ts";
@@ -83,22 +82,16 @@ export const agentRequiredConnectorTypes$ = computed(
       return required;
     }
 
-    // From environment field — match env var names against connector environmentMappings
+    // From environment field — match env var names against all connector secret names
+    // (including api-token auth method secrets and OAuth environmentMapping keys)
     if (firstAgent.environment) {
       const refs = extractVariableReferences(firstAgent.environment);
       const grouped = groupVariablesBySource(refs);
-      const envVarNames = new Set(grouped.secrets.map((r) => r.name));
 
-      for (const type of Object.keys(CONNECTOR_TYPES) as ConnectorType[]) {
-        if (type === "computer") {
-          continue;
-        }
-        const mapping = getConnectorEnvironmentMapping(type);
-        for (const envKey of Object.keys(mapping)) {
-          if (envVarNames.has(envKey)) {
-            required.add(type);
-            break;
-          }
+      for (const ref of grouped.secrets) {
+        const connectorType = getConnectorTypeForSecretName(ref.name);
+        if (connectorType && connectorType !== "computer") {
+          required.add(connectorType);
         }
       }
     }
@@ -150,7 +143,7 @@ export const agentMergedItems$ = computed(async (get) => {
     get(variables$),
   ]);
 
-  const allConnectorEnvVars = getConnectorProvidedSecretNames(
+  const allConnectorEnvVars = getConnectorManagedSecretNames(
     Object.keys(CONNECTOR_TYPES) as ConnectorType[],
   );
 
@@ -202,48 +195,4 @@ export const agentMergedItems$ = computed(async (get) => {
   }
 
   return items;
-});
-
-// ---------------------------------------------------------------------------
-// Active tab state
-// ---------------------------------------------------------------------------
-
-type ConnectionsTab = "connectors" | "secrets";
-
-const internalActiveTab$ = state<ConnectionsTab>("connectors");
-
-export const connectionsActiveTab$ = computed((get) => get(internalActiveTab$));
-
-function isConnectionsTab(v: string): v is ConnectionsTab {
-  return v === "connectors" || v === "secrets";
-}
-
-/**
- * Initialize tab state from URL search params.
- * Called during connections page setup.
- */
-export const initConnectionsTabs$ = command(({ get, set }) => {
-  const params = get(searchParams$);
-  const tab = params.get("tab");
-  if (tab && isConnectionsTab(tab)) {
-    set(internalActiveTab$, tab);
-  }
-});
-
-/**
- * Switch active tab and sync to URL.
- */
-export const setConnectionsActiveTab$ = command(({ get, set }, tab: string) => {
-  if (!isConnectionsTab(tab)) {
-    return;
-  }
-  set(internalActiveTab$, tab);
-
-  const params = new URLSearchParams(get(searchParams$));
-  if (tab === "connectors") {
-    params.delete("tab");
-  } else {
-    params.set("tab", tab);
-  }
-  set(updateSearchParams$, params);
 });

--- a/turbo/apps/platform/src/signals/settings-page/secrets-and-variables.ts
+++ b/turbo/apps/platform/src/signals/settings-page/secrets-and-variables.ts
@@ -1,6 +1,6 @@
 import { computed } from "ccstate";
 import {
-  CONNECTOR_TYPES,
+  getConnectorManagedSecretNames,
   type ConnectorType,
   type SecretResponse,
   type VariableResponse,
@@ -25,24 +25,6 @@ export type MergedItem =
       data: VariableResponse;
     };
 
-/**
- * Collect all secret and variable names managed by connected connectors.
- */
-function getConnectorManagedNames(
-  connectedTypes: ConnectorType[],
-): Set<string> {
-  const managed = new Set<string>();
-  for (const type of connectedTypes) {
-    const config = CONNECTOR_TYPES[type];
-    for (const method of Object.values(config.authMethods)) {
-      for (const name of Object.keys(method.secrets)) {
-        managed.add(name);
-      }
-    }
-  }
-  return managed;
-}
-
 export const mergedItems$ = computed(async (get) => {
   const [secretsList, variablesList, connectorsData] = await Promise.all([
     get(secrets$),
@@ -53,7 +35,7 @@ export const mergedItems$ = computed(async (get) => {
   const connectedTypes = connectorsData.connectors.map(
     (c) => c.type as ConnectorType,
   );
-  const managedNames = getConnectorManagedNames(connectedTypes);
+  const managedNames = getConnectorManagedSecretNames(connectedTypes);
 
   const items: MergedItem[] = [];
 

--- a/turbo/apps/platform/src/views/agent-detail-page/__tests__/agent-connections-page.test.tsx
+++ b/turbo/apps/platform/src/views/agent-detail-page/__tests__/agent-connections-page.test.tsx
@@ -1,7 +1,7 @@
 import { setupPage } from "../../../__tests__/page-helper.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { describe, expect, it, vi } from "vitest";
-import { screen, within, fireEvent } from "@testing-library/react";
+import { screen, within } from "@testing-library/react";
 import { server } from "../../../mocks/server.ts";
 import { http, HttpResponse } from "msw";
 
@@ -106,7 +106,7 @@ describe("agent connections page", () => {
     ).toBeInTheDocument();
   });
 
-  it("should show connectors and secrets tabs", async () => {
+  it("should show connectors and secrets sections", async () => {
     mockAgentDetailAPI({
       environment: {
         GH_TOKEN: SECRET_REF_GH_TOKEN,
@@ -124,11 +124,13 @@ describe("agent connections page", () => {
 
     await vi.waitFor(() => {
       expect(
-        screen.getByRole("tab", { name: "Connectors" }),
+        screen.getByRole("heading", { name: "Connectors" }),
       ).toBeInTheDocument();
     });
 
-    expect(screen.getByRole("tab", { name: "Custom API" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "Secrets & Variables" }),
+    ).toBeInTheDocument();
   });
 
   it("should show connectors tab by default with connector types", async () => {
@@ -209,7 +211,7 @@ describe("agent connections page", () => {
     expect(connectButtons.length).toBeGreaterThan(0);
   });
 
-  it("should switch to secrets tab and show add row when no secrets required", async () => {
+  it("should show secrets and variables section alongside connectors", async () => {
     mockAgentDetailAPI({
       environment: {
         GH_TOKEN: SECRET_REF_GH_TOKEN,
@@ -226,17 +228,13 @@ describe("agent connections page", () => {
 
     await vi.waitFor(() => {
       expect(
-        screen.getByRole("tab", { name: "Custom API" }),
+        screen.getByRole("heading", { name: "Connectors" }),
       ).toBeInTheDocument();
     });
 
-    fireEvent.click(screen.getByRole("tab", { name: "Custom API" }));
-
-    await vi.waitFor(() => {
-      expect(
-        screen.getByRole("tab", { name: "Custom API" }),
-      ).toBeInTheDocument();
-    });
+    expect(
+      screen.getByRole("heading", { name: "Secrets & Variables" }),
+    ).toBeInTheDocument();
   });
 
   it("should show required secrets with configured and missing rows", async () => {

--- a/turbo/apps/platform/src/views/agent-detail-page/agent-connections-page.tsx
+++ b/turbo/apps/platform/src/views/agent-detail-page/agent-connections-page.tsx
@@ -6,7 +6,6 @@ import {
   IconPlus,
 } from "@tabler/icons-react";
 import { Button } from "@vm0/ui/components/ui/button";
-import { Tabs, TabsList, TabsTrigger } from "@vm0/ui/components/ui/tabs";
 import { Skeleton } from "@vm0/ui/components/ui/skeleton";
 import {
   Popover,
@@ -30,8 +29,6 @@ import {
   agentConnectorStatus$,
   agentMergedItems$,
   agentRequiredConnectorTypes$,
-  connectionsActiveTab$,
-  setConnectionsActiveTab$,
   type AgentConnectorStatus,
   type AgentMergedItem,
 } from "../../signals/agent-detail/connections.ts";
@@ -432,7 +429,9 @@ function SecretsAndVariablesTab() {
 
   return (
     <div className="flex flex-col gap-4">
-      <h3 className="text-base font-medium text-foreground">Custom API</h3>
+      <h3 className="text-base font-medium text-foreground">
+        Secrets & Variables
+      </h3>
       <div className="flex flex-col">
         {items.map((item, index) => (
           <ItemRow
@@ -456,11 +455,8 @@ export function AgentConnectionsPage() {
   const agentName = useGet(agentName$);
   const detail = useGet(agentDetail$);
   const loading = useGet(agentDetailLoading$);
-  const activeTab = useGet(connectionsActiveTab$);
-  const setActiveTab = useSet(setConnectionsActiveTab$);
   const requiredConnectors = useGet(agentRequiredConnectorTypes$);
   const hasConnectors = requiredConnectors.size > 0;
-  const effectiveTab = hasConnectors ? activeTab : "secrets";
 
   return (
     <AppShell
@@ -499,16 +495,8 @@ export function AgentConnectionsPage() {
                 Add connection
               </Button>
             </div>
-            {hasConnectors ? (
-              <Tabs value={effectiveTab} onValueChange={setActiveTab}>
-                <TabsList className="w-fit">
-                  <TabsTrigger value="connectors">Connectors</TabsTrigger>
-                  <TabsTrigger value="secrets">Custom API</TabsTrigger>
-                </TabsList>
-              </Tabs>
-            ) : null}
-            {effectiveTab === "connectors" && <ConnectorsTab />}
-            {effectiveTab === "secrets" && <SecretsAndVariablesTab />}
+            {hasConnectors && <ConnectorsTab />}
+            <SecretsAndVariablesTab />
             <AddConnectionDialog
               open={addDialogOpen}
               onOpenChange={setAddDialogOpen}

--- a/turbo/packages/core/src/contracts/__tests__/connectors.test.ts
+++ b/turbo/packages/core/src/contracts/__tests__/connectors.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { hasRequiredScopes, CONNECTOR_TYPES } from "../connectors";
+import {
+  hasRequiredScopes,
+  CONNECTOR_TYPES,
+  getConnectorManagedSecretNames,
+  getConnectorTypeForSecretName,
+} from "../connectors";
 import type { ConnectorType } from "../connectors";
 import { getServiceConfig } from "../services";
 
@@ -35,6 +40,56 @@ describe("hasRequiredScopes", () => {
     expect(
       hasRequiredScopes("github", ["repo", "project", "read:org", "user"]),
     ).toBe(true);
+  });
+});
+
+describe("getConnectorManagedSecretNames", () => {
+  it("includes OAuth environmentMapping keys for OAuth connectors", () => {
+    const managed = getConnectorManagedSecretNames(["github"]);
+    // OAuth env mapping keys
+    expect(managed.has("GH_TOKEN")).toBe(true);
+    expect(managed.has("GITHUB_TOKEN")).toBe(true);
+    // OAuth auth method secret
+    expect(managed.has("GITHUB_ACCESS_TOKEN")).toBe(true);
+  });
+
+  it("includes api-token auth method secrets for api-token-only connectors", () => {
+    const managed = getConnectorManagedSecretNames(["atlassian"]);
+    expect(managed.has("ATLASSIAN_TOKEN")).toBe(true);
+    expect(managed.has("ATLASSIAN_EMAIL")).toBe(true);
+    expect(managed.has("ATLASSIAN_DOMAIN")).toBe(true);
+  });
+
+  it("returns empty set for empty input", () => {
+    const managed = getConnectorManagedSecretNames([]);
+    expect(managed.size).toBe(0);
+  });
+
+  it("combines managed names across multiple connector types", () => {
+    const managed = getConnectorManagedSecretNames(["github", "atlassian"]);
+    expect(managed.has("GH_TOKEN")).toBe(true);
+    expect(managed.has("ATLASSIAN_TOKEN")).toBe(true);
+  });
+});
+
+describe("getConnectorTypeForSecretName", () => {
+  it("finds connector type for OAuth env mapping key", () => {
+    expect(getConnectorTypeForSecretName("GH_TOKEN")).toBe("github");
+    expect(getConnectorTypeForSecretName("GITHUB_TOKEN")).toBe("github");
+  });
+
+  it("finds connector type for api-token auth method secret", () => {
+    expect(getConnectorTypeForSecretName("ATLASSIAN_TOKEN")).toBe("atlassian");
+    expect(getConnectorTypeForSecretName("ATLASSIAN_EMAIL")).toBe("atlassian");
+    expect(getConnectorTypeForSecretName("ATLASSIAN_DOMAIN")).toBe("atlassian");
+  });
+
+  it("finds connector type for OAuth auth method secret", () => {
+    expect(getConnectorTypeForSecretName("GITHUB_ACCESS_TOKEN")).toBe("github");
+  });
+
+  it("returns null for unknown secret name", () => {
+    expect(getConnectorTypeForSecretName("UNKNOWN_SECRET")).toBeNull();
   });
 });
 

--- a/turbo/packages/core/src/contracts/connectors.ts
+++ b/turbo/packages/core/src/contracts/connectors.ts
@@ -2918,6 +2918,59 @@ export function hasRequiredScopes(
 }
 
 /**
+ * Get all secret/variable names managed by connectors across ALL auth methods.
+ * Unlike `getConnectorProvidedSecretNames` (which only reads environmentMapping),
+ * this function also includes api-token auth method secrets.
+ *
+ * Used to hide connector-managed secrets from the secrets & variables list.
+ */
+export function getConnectorManagedSecretNames(
+  types: ConnectorType[],
+): Set<string> {
+  const managed = new Set<string>();
+  for (const type of types) {
+    const config = CONNECTOR_TYPES[type];
+    for (const method of Object.values(config.authMethods)) {
+      for (const name of Object.keys(method.secrets)) {
+        managed.add(name);
+      }
+    }
+    // Also include environmentMapping keys (OAuth-derived env vars like GH_TOKEN)
+    const mapping = getConnectorEnvironmentMapping(type);
+    for (const envVar of Object.keys(mapping)) {
+      managed.add(envVar);
+    }
+  }
+  return managed;
+}
+
+/**
+ * Reverse lookup: given a secret/env-var name, find which connector type manages it.
+ * Checks both authMethods.secrets keys and environmentMapping keys.
+ * Returns null if no connector manages this name.
+ */
+export function getConnectorTypeForSecretName(
+  name: string,
+): ConnectorType | null {
+  const allTypes = Object.keys(CONNECTOR_TYPES) as ConnectorType[];
+  for (const type of allTypes) {
+    const config = CONNECTOR_TYPES[type];
+    // Check authMethods secrets
+    for (const method of Object.values(config.authMethods)) {
+      if (name in method.secrets) {
+        return type;
+      }
+    }
+    // Check environmentMapping keys
+    const mapping = getConnectorEnvironmentMapping(type);
+    if (name in mapping) {
+      return type;
+    }
+  }
+  return null;
+}
+
+/**
  * Get required secret names for a connector's api-token auth method.
  * Returns null if the connector type does not support api-token auth.
  * Note: Returns ALL required field names regardless of storage type (secret or variable).

--- a/turbo/packages/core/src/contracts/index.ts
+++ b/turbo/packages/core/src/contracts/index.ts
@@ -405,6 +405,8 @@ export {
   getConnectorEnvironmentMapping,
   getConnectorDerivedNames,
   getConnectorProvidedSecretNames,
+  getConnectorManagedSecretNames,
+  getConnectorTypeForSecretName,
   getConnectorOAuthConfig,
   hasRequiredScopes,
   getApiTokenRequiredSecretNames,


### PR DESCRIPTION
## Summary

- Add `getConnectorManagedSecretNames()` and `getConnectorTypeForSecretName()` to `@vm0/core` to properly detect api-token connector secrets (not just OAuth environmentMapping)
- Fix `agentRequiredConnectorTypes$` so api-token connectors (e.g., Atlassian) appear in the connectors section when their secrets are referenced
- Fix `agentMergedItems$` so api-token managed secrets are hidden from the secrets/variables list
- Remove tab layout from agent connections page — connectors and secrets/variables are now stacked vertically
- Migrate settings page `secrets-and-variables.ts` to use the shared core function, removing its local `getConnectorManagedNames`

Closes #4471

## Test plan

- [x] Integration tests added for `getConnectorManagedSecretNames` (OAuth + api-token connectors)
- [x] Integration tests added for `getConnectorTypeForSecretName` (reverse lookup)
- [ ] Verify Atlassian connector appears when agent compose references `ATLASSIAN_TOKEN`
- [ ] Verify `ATLASSIAN_TOKEN`, `ATLASSIAN_EMAIL`, `ATLASSIAN_DOMAIN` are hidden from secrets section when Atlassian connector exists
- [ ] Verify OAuth connectors (GitHub) still work correctly
- [ ] Verify settings page behavior unchanged
- [ ] Verify agent connections page shows single-page layout without tabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)