### PR TITLE
fix: address semgrep sast findings for casa tier 2 compliance

### DIFF
--- a/turbo/apps/platform/index.html
+++ b/turbo/apps/platform/index.html
@@ -24,6 +24,8 @@
     <div id="root"></div>
     <script
       src="https://api.dashboard.instatus.com/widget?host=status.vm0.ai&code=02c0ef5a&locale=en"
+      integrity="sha384-PeueJ613SmtgegJQz/JL0K6uh1Q5Q4os+b/FZsvK9GoMFvyFlyBv8FiP62B3rilT"
+      crossorigin="anonymous"
       defer
     ></script>
   </body>

--- a/turbo/apps/web/src/lib/email/sender-auth.ts
+++ b/turbo/apps/web/src/lib/email/sender-auth.ts
@@ -69,17 +69,16 @@ function parseAuthenticationResults(
 ): AuthenticationResults {
   const lower = headerValue.toLowerCase();
 
-  function extractResult(method: string): AuthResult {
-    const regex = new RegExp(`${method}\\s*=\\s*(\\w+)`);
-    const match = lower.match(regex);
+  function extractResult(method: RegExp): AuthResult {
+    const match = lower.match(method);
     if (!match?.[1]) return null;
     return isAuthResultValue(match[1]) ? match[1] : null;
   }
 
   return {
-    dmarc: extractResult("dmarc"),
-    dkim: extractResult("dkim"),
-    spf: extractResult("spf"),
+    dmarc: extractResult(/dmarc\s*=\s*(\w+)/),
+    dkim: extractResult(/dkim\s*=\s*(\w+)/),
+    spf: extractResult(/spf\s*=\s*(\w+)/),
   };
 }
 

--- a/turbo/apps/web/src/lib/proxy/token-service.ts
+++ b/turbo/apps/web/src/lib/proxy/token-service.ts
@@ -78,7 +78,9 @@ export function createProxyToken(
 
   const key = getEncryptionKey();
   const iv = randomBytes(IV_LENGTH);
-  const cipher = createCipheriv(ALGORITHM, key, iv);
+  const cipher = createCipheriv(ALGORITHM, key, iv, {
+    authTagLength: AUTH_TAG_LENGTH,
+  });
 
   const plaintext = JSON.stringify(payload);
   const encrypted = Buffer.concat([
@@ -123,7 +125,9 @@ export function decryptProxyToken(
     const ciphertext = combined.subarray(IV_LENGTH + AUTH_TAG_LENGTH);
 
     const key = getEncryptionKey();
-    const decipher = createDecipheriv(ALGORITHM, key, iv);
+    const decipher = createDecipheriv(ALGORITHM, key, iv, {
+      authTagLength: AUTH_TAG_LENGTH,
+    });
     decipher.setAuthTag(authTag);
 
     const decrypted = Buffer.concat([

--- a/turbo/apps/web/src/lib/slack/context.ts
+++ b/turbo/apps/web/src/lib/slack/context.ts
@@ -649,6 +649,8 @@ export async function formatCurrentMessageFiles(
  */
 export function extractMessageContent(text: string, botUserId: string): string {
   // Slack mentions look like: <@U12345678> message
-  const mentionPattern = new RegExp(`^<@${botUserId}>\\s*`, "i");
+  // Escape botUserId to prevent ReDoS from non-literal RegExp
+  const escapedId = botUserId.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const mentionPattern = new RegExp(`^<@${escapedId}>\\s*`, "i");
   return text.replace(mentionPattern, "").trim();
 }


### PR DESCRIPTION
## Summary
- **gcm-no-tag-length**: Add explicit `authTagLength: 16` to `createCipheriv`/`createDecipheriv` in token-service.ts for GCM crypto safety
- **missing-integrity**: Add SRI `integrity` and `crossorigin` attributes to external instatus widget script in platform index.html
- **detect-non-literal-regexp**: Refactor sender-auth.ts to use literal RegExp instead of constructing from string; escape `botUserId` in slack context.ts before RegExp construction
- **False positives confirmed**: highlight-text.tsx, cook/utils.ts, and telegram mention.ts already escape user input before RegExp. spawn-shell-true uses `shell: isWindows` with fixed commands only. Path traversal findings are CLI-internal paths from config, not untrusted user input.

Closes #4422

## Test plan
- [x] Existing token-service tests pass (19/19)
- [ ] CI lint, type-check, and build pass
- [ ] Verify platform loads correctly with SRI attribute on instatus script

🤖 Generated with [Claude Code](https://claude.com/claude-code)