### PR TITLE
refactor: remove secret names from build context and resolvers

### DIFF
--- a/turbo/apps/web/src/lib/run/build-context.ts
+++ b/turbo/apps/web/src/lib/run/build-context.ts
@@ -848,7 +848,6 @@ function applyResolutionDefaults(
   artifactVersion: string | undefined;
   memoryName: string | undefined;
   vars: Record<string, string> | undefined;
-  secretNames: string[] | undefined;
   volumeVersions: Record<string, string> | undefined;
   resumeSession: ResumeSession;
   resumeArtifact: ArtifactSnapshot | undefined;
@@ -873,7 +872,6 @@ function applyResolutionDefaults(
     artifactVersion,
     memoryName: params.memoryName || resolution.memoryName,
     vars: params.vars || resolution.vars,
-    secretNames: resolution.secretNames,
     volumeVersions: params.volumeVersions || resolution.volumeVersions,
     resumeSession: {
       sessionId: resolution.conversationData.cliAgentSessionId,
@@ -1008,7 +1006,6 @@ export async function buildExecutionContext(
   let artifactVersion: string | undefined = params.artifactVersion;
   let vars: Record<string, string> | undefined = params.vars;
   let secrets: Record<string, string> | undefined = params.secrets;
-  let secretNames: string[] | undefined;
   let memoryName: string | undefined = params.memoryName;
   let volumeVersions: Record<string, string> | undefined =
     params.volumeVersions;
@@ -1033,7 +1030,6 @@ export async function buildExecutionContext(
     artifactVersion = defaults.artifactVersion;
     memoryName = defaults.memoryName;
     vars = defaults.vars;
-    secretNames = defaults.secretNames;
     volumeVersions = defaults.volumeVersions;
     resumeSession = defaults.resumeSession;
     resumeArtifact = defaults.resumeArtifact;
@@ -1047,11 +1043,6 @@ export async function buildExecutionContext(
     agentCompose =
       params.agentCompose ??
       (await loadAgentComposeForNewRun(agentComposeVersionId));
-
-    // For new runs, derive secretNames from provided secrets
-    if (secrets) {
-      secretNames = Object.keys(secrets);
-    }
   }
 
   // Validate required fields
@@ -1128,7 +1119,6 @@ export async function buildExecutionContext(
       prompt: params.prompt,
       vars,
       secrets: mergedSecrets,
-      secretNames,
       sandboxToken: params.sandboxToken,
       artifactName,
       artifactVersion,

--- a/turbo/apps/web/src/lib/run/resolvers/resolve-checkpoint.ts
+++ b/turbo/apps/web/src/lib/run/resolvers/resolve-checkpoint.ts
@@ -60,9 +60,6 @@ export async function resolveCheckpoint(
     throw badRequest("Invalid checkpoint: missing agentComposeVersionId");
   }
 
-  // Get secret names from snapshot (values are NEVER stored)
-  const secretNames = agentComposeSnapshot.secretNames as string[] | undefined;
-
   // Verify checkpoint belongs to user (must complete before doing further work)
   const [originalRun] = await globalThis.services.db
     .select()
@@ -128,7 +125,6 @@ export async function resolveCheckpoint(
     artifactVersion: checkpointArtifact?.artifactVersion,
     memoryName: checkpointMemory?.memoryName,
     vars: agentComposeSnapshot.vars || {},
-    secretNames,
     volumeVersions: checkpointVolumeVersions?.versions,
     buildResumeArtifact: !!checkpointArtifact, // Only build resumeArtifact if checkpoint has artifact
   };

--- a/turbo/apps/web/src/lib/run/resolvers/resolve-session.ts
+++ b/turbo/apps/web/src/lib/run/resolvers/resolve-session.ts
@@ -132,7 +132,6 @@ export async function resolveSession(
     artifactVersion: session.artifactName ? "latest" : undefined,
     memoryName: session.memoryName ?? undefined,
     vars: lastRunVars,
-    secretNames: undefined,
     volumeVersions: undefined,
     buildResumeArtifact: !!session.artifactName,
   };

--- a/turbo/apps/web/src/lib/run/resolvers/types.ts
+++ b/turbo/apps/web/src/lib/run/resolvers/types.ts
@@ -17,8 +17,6 @@ export interface ConversationResolution {
   artifactVersion?: string;
   memoryName?: string;
   vars?: Record<string, string>;
-  /** Secret names required for this run (values must be provided at runtime) */
-  secretNames?: string[];
   volumeVersions?: Record<string, string>;
   buildResumeArtifact: boolean;
 }

--- a/turbo/apps/web/src/lib/run/types.ts
+++ b/turbo/apps/web/src/lib/run/types.ts
@@ -55,7 +55,6 @@ export interface ExecutionContext {
   prompt: string;
   vars?: Record<string, string>;
   secrets?: Record<string, string>; // Decrypted secrets for environment expansion
-  secretNames?: string[]; // Secret names for validation (values from secrets param are used for client-side masking)
   sandboxToken: string;
 
   // Artifact settings (new runs only)


### PR DESCRIPTION
Follow-up to #4489.

## Summary

- Remove `secretNames` from `ExecutionContext` type, `ConversationResolution`, and `applyResolutionDefaults`
- Remove `secretNames` collection in `buildContext` (variable, assignment from defaults, derivation from secrets)
- Remove `secretNames` from `resolve-checkpoint.ts` and `resolve-session.ts`

These were the upstream producers of `secretNames` that fed into the execution context path cleaned in #4489. No downstream consumer remains.

`secretNames` in DB (`agent_runs.secret_names`) and checkpoint/resume API responses are unaffected.

## Test plan

- [x] `pnpm vitest` — 3630 passed
- [x] `pnpm check-types` — all packages pass
- [ ] CI pipeline green

🤖 Generated with [Claude Code](https://claude.com/claude-code)