### PR TITLE
chore: add sarif files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -186,3 +186,5 @@ debug-*.png
 
 .claude/scheduled_tasks.lock
 tmp/
+
+*.sarif


### PR DESCRIPTION
## Summary
- Add `*.sarif` pattern to `.gitignore` to exclude SARIF (Static Analysis Results Interchange Format) files from version control

## Test plan
- [x] Verify `.gitignore` correctly ignores `.sarif` files

🤖 Generated with [Claude Code](https://claude.com/claude-code)