### PR TITLE
ci: skip runner cleanup on test failure to enable re-run

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1585,6 +1585,14 @@ jobs:
       github.event_name != 'push' &&
       needs.deploy-runner-prepare.outputs.bin-dir != ''
     steps:
+      # Guard: if any test/deploy job didn't succeed, fail this job WITHOUT
+      # cleaning up. This makes "Re-run failed jobs" include cleanup-runner,
+      # so on successful retry the cleanup runs automatically.
+      #
+      # - deploy-runner-start != success (not just failure/cancelled):
+      #   covers deploy-web failure → start is "skipped" but binaries exist
+      # - cli-e2e-03-runner / runner-stress-test failure/cancelled:
+      #   the main re-run scenario — keep runner alive for E2E retry
       - name: Fail if tests failed (keep runner for re-run)
         if: |
           needs.deploy-runner-start.result != 'success' ||

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1573,8 +1573,10 @@ jobs:
             echo "Cron simulator stopped"
           fi
 
-  # Stop runner service and clean up after cli-e2e-03-runner completes (or fails/times out)
-  # Skip on push to main - runner deployment is only needed for PRs
+  # Stop runner service and clean up after tests complete.
+  # When tests fail/cancel, this job fails WITHOUT cleaning up so that
+  # "Re-run failed jobs" includes it — on successful retry it will clean up.
+  # cleanup.yml (pull_request_target:closed) is the safety net.
   cleanup-runner:
     runs-on: ubuntu-latest
     needs: [prepare, deploy-runner-prepare, deploy-runner-start, cli-e2e-03-runner, runner-stress-test]
@@ -1583,6 +1585,17 @@ jobs:
       github.event_name != 'push' &&
       needs.deploy-runner-prepare.outputs.bin-dir != ''
     steps:
+      - name: Fail if tests failed (keep runner for re-run)
+        if: |
+          needs.deploy-runner-start.result != 'success' ||
+          needs.cli-e2e-03-runner.result == 'failure' ||
+          needs.cli-e2e-03-runner.result == 'cancelled' ||
+          needs.runner-stress-test.result == 'failure' ||
+          needs.runner-stress-test.result == 'cancelled'
+        run: |
+          echo "::error::Tests failed or cancelled — keeping runner alive for re-run"
+          exit 1
+
       - uses: actions/checkout@v6
 
       - name: Install Ansible


### PR DESCRIPTION
## Summary

- When E2E tests fail, `cleanup-runner` now **fails without cleaning up**, so "Re-run failed jobs" includes it and the runner stays alive for retry
- On successful retry, cleanup proceeds normally
- `cleanup.yml` (PR close) remains the safety net for all cases

## Problem

Previously `cleanup-runner` ran with `always()` after every CI run. When E2E tests failed and you clicked "Re-run failed jobs", the runner was already gone — forcing a full "Re-run all jobs" to redeploy.

## How it works

A guard step is added before cleanup that checks upstream job results:

```yaml
- name: Fail if tests failed (keep runner for re-run)
  if: |
    needs.deploy-runner-start.result != 'success' ||
    needs.cli-e2e-03-runner.result == 'failure' ||
    needs.cli-e2e-03-runner.result == 'cancelled' ||
    needs.runner-stress-test.result == 'failure' ||
    needs.runner-stress-test.result == 'cancelled'
  run: exit 1
```

`deploy-runner-start != success` (not just `failure/cancelled`) covers the edge case where `deploy-web` fails → `deploy-runner-start` is **skipped** → binaries exist but shouldn't be cleaned up.

## Scenario matrix

| Scenario | cleanup-runner | Re-run failed jobs |
|----------|---------------|--------------------|
| E2E passes | ✅ cleans up | — |
| E2E fails | ❌ fails (no cleanup) | ✅ re-runs e2e + cleanup |
| E2E cancelled | ❌ fails (no cleanup) | ✅ re-runs e2e + cleanup |
| stress test fails | ❌ fails (no cleanup) | ✅ re-runs stress + cleanup |
| deploy-runner-start fails | ❌ fails (no cleanup) | ✅ re-runs start + e2e + cleanup |
| deploy-web fails (start skipped) | ❌ fails (no cleanup) | ✅ re-runs web + start + e2e + cleanup |
| deploy-runner-prepare fails | skipped (bin-dir='') | — |
| PR closed | — | cleanup.yml handles it |

## Test plan

- [ ] Verify CI passes on this PR (cleanup-runner should succeed since E2E passes)
- [ ] On a future PR with E2E failure, verify cleanup-runner shows as failed
- [ ] Verify "Re-run failed jobs" re-runs E2E + cleanup without needing full redeploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)