### PR TITLE
feat(zero): add settings page, deferred skill saving, and onboarding improvements

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-meet.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-meet.test.ts
@@ -7,6 +7,9 @@ import {
   zeroAddedSkills$,
   addZeroSkill$,
   removeZeroSkill$,
+  saveZeroSkills$,
+  discardZeroSkills$,
+  zeroSkillsDirty$,
   zeroUpdateSettings$,
   zeroSettingsSaving$,
 } from "../zero-meet.ts";
@@ -96,7 +99,7 @@ describe("zeroAddedSkills$", () => {
 });
 
 describe("addZeroSkill$", () => {
-  it("should add a skill and sync to compose", async () => {
+  it("should add a skill locally and save to compose", async () => {
     let postedContent: Record<string, unknown> | null = null;
 
     mockComposeApi({
@@ -129,9 +132,18 @@ describe("addZeroSkill$", () => {
 
     await setupPage({ context, path: "/", withoutRender: true });
 
+    // Add skill locally (deferred save pattern)
     await context.store.set(addZeroSkill$, "github");
 
-    // Verify the compose job was triggered with updated skills
+    // Local state should include both skills
+    const skills = await context.store.get(zeroAddedSkills$);
+    expect(skills).toContain("slack");
+    expect(skills).toContain("github");
+    await expect(context.store.get(zeroSkillsDirty$)).resolves.toBeTruthy();
+
+    // Save triggers the compose job
+    await context.store.set(saveZeroSkills$);
+
     expect(postedContent).toBeTruthy();
     const content = getComposeContent(postedContent!);
     const agentKey = Object.keys(content.agents)[0];
@@ -143,7 +155,7 @@ describe("addZeroSkill$", () => {
     );
   });
 
-  it("should rollback on compose job failure", async () => {
+  it("should discard local skill changes", async () => {
     mockComposeApi({
       agents: {
         zero: {
@@ -153,28 +165,21 @@ describe("addZeroSkill$", () => {
       },
     });
 
-    server.use(
-      http.post("*/api/compose/jobs", () => {
-        return HttpResponse.json(
-          { error: { message: "Build failed" } },
-          { status: 500 },
-        );
-      }),
-    );
-
     await setupPage({ context, path: "/", withoutRender: true });
 
     await context.store.set(addZeroSkill$, "github");
+    await expect(context.store.get(zeroSkillsDirty$)).resolves.toBeTruthy();
 
-    // Should have rolled back -- github should not be in the list
+    // Discard reverts to seeded skills
+    await context.store.set(discardZeroSkills$);
     const skills = await context.store.get(zeroAddedSkills$);
-    expect(skills).not.toContain("github");
-    expect(skills).toContain("slack");
+    expect(skills).toStrictEqual(["slack"]);
+    await expect(context.store.get(zeroSkillsDirty$)).resolves.toBeFalsy();
   });
 });
 
 describe("removeZeroSkill$", () => {
-  it("should remove a skill and sync to compose", async () => {
+  it("should remove a skill locally and save to compose", async () => {
     let postedContent: Record<string, unknown> | null = null;
 
     mockComposeApi({
@@ -210,9 +215,18 @@ describe("removeZeroSkill$", () => {
 
     await setupPage({ context, path: "/", withoutRender: true });
 
+    // Remove skill locally (deferred save pattern)
     await context.store.set(removeZeroSkill$, "slack");
 
-    // Verify compose job was triggered with only github
+    // Local state should only have github
+    const skills = await context.store.get(zeroAddedSkills$);
+    expect(skills).toContain("github");
+    expect(skills).not.toContain("slack");
+    await expect(context.store.get(zeroSkillsDirty$)).resolves.toBeTruthy();
+
+    // Save triggers the compose job
+    await context.store.set(saveZeroSkills$);
+
     expect(postedContent).toBeTruthy();
     const content = getComposeContent(postedContent!);
     const agentKey = Object.keys(content.agents)[0];
@@ -224,7 +238,7 @@ describe("removeZeroSkill$", () => {
     );
   });
 
-  it("should rollback on compose job failure", async () => {
+  it("should discard removal and restore original skills", async () => {
     mockComposeApi({
       agents: {
         zero: {
@@ -237,23 +251,17 @@ describe("removeZeroSkill$", () => {
       },
     });
 
-    server.use(
-      http.post("*/api/compose/jobs", () => {
-        return HttpResponse.json(
-          { error: { message: "Build failed" } },
-          { status: 500 },
-        );
-      }),
-    );
-
     await setupPage({ context, path: "/", withoutRender: true });
 
     await context.store.set(removeZeroSkill$, "slack");
+    await expect(context.store.get(zeroSkillsDirty$)).resolves.toBeTruthy();
 
-    // Should have rolled back -- slack should still be in the list
+    // Discard reverts to seeded skills
+    await context.store.set(discardZeroSkills$);
     const skills = await context.store.get(zeroAddedSkills$);
     expect(skills).toContain("slack");
     expect(skills).toContain("github");
+    await expect(context.store.get(zeroSkillsDirty$)).resolves.toBeFalsy();
   });
 });
 

--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-onboarding.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-onboarding.test.ts
@@ -19,11 +19,13 @@ interface ComposePayload {
       string,
       {
         framework: string;
+        instructions?: string;
         metadata?: { displayName?: string; sound?: string };
         skills?: string[];
       }
     >;
   };
+  instructions?: string;
 }
 
 describe("completeZeroOnboarding$", () => {
@@ -31,11 +33,15 @@ describe("completeZeroOnboarding$", () => {
     let capturedPayload: ComposePayload | null = null;
 
     server.use(
-      http.post("*/api/agent/composes", async ({ request }) => {
+      http.post("*/api/compose/jobs", async ({ request }) => {
         capturedPayload = (await request.json()) as ComposePayload;
         return HttpResponse.json({
-          composeId: "new-compose-id",
-          name: "test-compose",
+          jobId: "test-job-id",
+          status: "completed",
+          result: {
+            composeId: "new-compose-id",
+            composeName: "test-compose",
+          },
         });
       }),
       http.put("*/api/scopes/default-agent", () => {
@@ -74,10 +80,14 @@ describe("completeZeroOnboarding$", () => {
     let defaultAgentBody: Record<string, unknown> | null = null;
 
     server.use(
-      http.post("*/api/agent/composes", () => {
+      http.post("*/api/compose/jobs", () => {
         return HttpResponse.json({
-          composeId: "new-compose-id",
-          name: "test-compose",
+          jobId: "test-job-id",
+          status: "completed",
+          result: {
+            composeId: "new-compose-id",
+            composeName: "test-compose",
+          },
         });
       }),
       http.put("*/api/scopes/default-agent", async ({ request }) => {
@@ -97,10 +107,14 @@ describe("completeZeroOnboarding$", () => {
 
   it("should set step to done and saving to false after completion", async () => {
     server.use(
-      http.post("*/api/agent/composes", () => {
+      http.post("*/api/compose/jobs", () => {
         return HttpResponse.json({
-          composeId: "new-compose-id",
-          name: "test-compose",
+          jobId: "test-job-id",
+          status: "completed",
+          result: {
+            composeId: "new-compose-id",
+            composeName: "test-compose",
+          },
         });
       }),
       http.put("*/api/scopes/default-agent", () => {

--- a/turbo/apps/platform/src/signals/zero-page/zero-meet.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-meet.ts
@@ -248,9 +248,10 @@ export const zeroSettingsSaving$ = computed((get) => get(internalSaving$));
 // Skills list: derived from compose content, synced via compose jobs
 // ---------------------------------------------------------------------------
 
-const internalAddedSkills$ = state<string[]>([]);
+// null = not initialized (fallback to seeded), string[] = user's local draft
+const internalAddedSkills$ = state<string[] | null>(null);
 
-/** Skills seeded from compose content. Returns compose skills when local list is empty. */
+/** Skills seeded from compose content. */
 const seededSkills$ = computed(async (get) => {
   const compose = await get(zeroCompose$);
   if (!compose?.content) {
@@ -264,69 +265,65 @@ const seededSkills$ = computed(async (get) => {
   return (agent?.skills ?? []).map(skillUrlToValue);
 });
 
-/** Added skills: local overrides take precedence, otherwise seeded from compose. */
+/** Added skills: local draft takes precedence, otherwise seeded from compose. */
 export const zeroAddedSkills$ = computed(async (get) => {
   const local = get(internalAddedSkills$);
-  if (local.length > 0) {
+  if (local !== null) {
     return local;
   }
   return await get(seededSkills$);
 });
 
-/** Add a skill: update compose content and trigger compose job. */
-export const addZeroSkill$ = command(async ({ get, set }, name: string) => {
-  // Ensure internal state is populated from compose before mutating
-  if (get(internalAddedSkills$).length === 0) {
-    const seeded = await get(seededSkills$);
-    if (seeded.length > 0) {
-      set(internalAddedSkills$, seeded);
-    }
+/** Whether local skills differ from the saved compose skills. */
+export const zeroSkillsDirty$ = computed(async (get) => {
+  const local = get(internalAddedSkills$);
+  if (local === null) {
+    return false;
   }
-  // Optimistic update
-  set(internalAddedSkills$, (prev) => [...prev, name]);
-
-  set(internalSaving$, true);
-  try {
-    const newSkills = get(internalAddedSkills$);
-    await set(syncSkillsToCompose$, newSkills);
-  } catch (error) {
-    throwIfAbort(error);
-    // Rollback on failure
-    set(internalAddedSkills$, (prev) => prev.filter((s) => s !== name));
-    L.error("Failed to add skill:", error);
-    toast.error(error instanceof Error ? error.message : "Failed to add skill");
-  } finally {
-    set(internalSaving$, false);
+  const seeded = await get(seededSkills$);
+  if (local.length !== seeded.length) {
+    return true;
   }
+  const sorted = [...local].sort();
+  const seededSorted = [...seeded].sort();
+  return sorted.some((s, i) => s !== seededSorted[i]);
 });
 
-/** Remove a skill: update compose content and trigger compose job. */
-export const removeZeroSkill$ = command(async ({ get, set }, name: string) => {
-  // Ensure internal state is populated from compose before mutating
-  if (get(internalAddedSkills$).length === 0) {
-    const seeded = await get(seededSkills$);
-    if (seeded.length > 0) {
-      set(internalAddedSkills$, seeded);
-    }
+/** Add a skill (local only, no compose job). */
+export const addZeroSkill$ = command(async ({ get, set }, name: string) => {
+  if (get(internalAddedSkills$) === null) {
+    set(internalAddedSkills$, await get(seededSkills$));
   }
-  const prev = get(internalAddedSkills$);
-  // Optimistic update
-  set(
-    internalAddedSkills$,
-    prev.filter((s) => s !== name),
-  );
+  set(internalAddedSkills$, (prev) => [...(prev ?? []), name]);
+});
 
+/** Remove a skill (local only, no compose job). */
+export const removeZeroSkill$ = command(async ({ get, set }, name: string) => {
+  if (get(internalAddedSkills$) === null) {
+    set(internalAddedSkills$, await get(seededSkills$));
+  }
+  set(internalAddedSkills$, (prev) => (prev ?? []).filter((s) => s !== name));
+});
+
+/** Discard local skill changes and revert to saved compose skills. */
+export const discardZeroSkills$ = command(({ set }) => {
+  set(internalAddedSkills$, null);
+});
+
+/** Save skill changes: trigger compose job and wait for completion. */
+export const saveZeroSkills$ = command(async ({ get, set }) => {
   set(internalSaving$, true);
   try {
-    const newSkills = get(internalAddedSkills$);
+    const newSkills = get(internalAddedSkills$) ?? [];
     await set(syncSkillsToCompose$, newSkills);
+    // Reset to null so seeded picks up the new compose state
+    set(internalAddedSkills$, null);
+    toast.success("Skills saved");
   } catch (error) {
     throwIfAbort(error);
-    // Rollback on failure
-    set(internalAddedSkills$, prev);
-    L.error("Failed to remove skill:", error);
+    L.error("Failed to save skills:", error);
     toast.error(
-      error instanceof Error ? error.message : "Failed to remove skill",
+      error instanceof Error ? error.message : "Failed to save skills",
     );
   } finally {
     set(internalSaving$, false);
@@ -373,9 +370,12 @@ async function buildAndSetDefaultAgent(
   newContent: ZeroComposeContent,
   instructions?: string,
 ): Promise<void> {
-  // Ensure compose content includes instructions field so the CLI uploads it
+  // Ensure instructions field is present when we have content to write.
+  // Fall back to empty string so the server creates a CLAUDE.md with
+  // metadata frontmatter even when there are no user-written instructions.
   const agentKey = Object.keys(newContent.agents)[0];
   const agent = agentKey ? newContent.agents[agentKey] : undefined;
+  const resolvedInstructions = instructions ?? "";
   const contentWithInstructions: ZeroComposeContent =
     agentKey && agent && !("instructions" in agent)
       ? {
@@ -393,7 +393,7 @@ async function buildAndSetDefaultAgent(
   const job = await triggerAndPollComposeJob(
     fetchFn,
     contentWithInstructions,
-    instructions,
+    resolvedInstructions,
   );
   if (!job.result) {
     throw new Error("Build completed without result");

--- a/turbo/apps/platform/src/signals/zero-page/zero-nav.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-nav.ts
@@ -11,6 +11,7 @@ function isValidTab(tab: string): tab is ZeroNavId {
     tab === "production" ||
     tab === "activity" ||
     tab === "works" ||
+    tab === "settings" ||
     tab === "account"
   );
 }

--- a/turbo/apps/platform/src/signals/zero-page/zero-onboarding.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-onboarding.ts
@@ -341,7 +341,9 @@ export const completeZeroOnboarding$ = command(
 
       // Force JWT refresh so updated org metadata is available immediately
       const clerk = await get(clerk$);
+      signal.throwIfAborted();
       await clerk.session?.getToken({ skipCache: true });
+      signal.throwIfAborted();
 
       // Reload status and mark done
       set(internalReload$, (x) => x + 1);

--- a/turbo/apps/platform/src/signals/zero-page/zero-onboarding.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-onboarding.ts
@@ -3,16 +3,19 @@ import {
   type ModelProviderType,
   getDefaultAuthMethod,
   getDefaultModel,
+  getInstructionsFilename,
   getSecretsForAuthMethod,
   hasAuthMethods,
   hasModelSelection,
   onboardingStatusResponseSchema,
 } from "@vm0/core";
 import { fetch$ } from "../fetch.ts";
+import { clerk$ } from "../auth.ts";
 import { initScope$, hasScope$ } from "../scope.ts";
 import { createModelProvider$ } from "../external/model-providers.ts";
 import { getProviderShape } from "../../views/settings-page/provider-ui-config.ts";
 import { skillValueToUrl } from "../../data/skills.ts";
+import { triggerAndPollComposeJob } from "../agent-detail/compose-job.ts";
 import { logger } from "../log.ts";
 
 const L = logger("ZeroOnboarding");
@@ -291,6 +294,7 @@ export const completeZeroOnboarding$ = command(
       // Build agent definition with optional skills and metadata
       const agentDef: Record<string, unknown> = {
         framework: "claude-code",
+        instructions: getInstructionsFilename("claude-code"),
         metadata: {
           displayName,
           sound: "professional",
@@ -300,39 +304,28 @@ export const completeZeroOnboarding$ = command(
         agentDef.skills = selectedSkills.map(skillValueToUrl);
       }
 
-      // Create agent compose
-      const composeResp = await fetchFn("/api/agent/composes", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          content: {
-            version: "1",
-            agents: {
-              [agentId]: agentDef,
-            },
-          },
-        }),
-      });
-      signal.throwIfAborted();
-
-      if (!composeResp.ok) {
-        throw new Error(
-          `Failed to create agent compose: ${composeResp.status}`,
-        );
-      }
-
-      const composeData = (await composeResp.json()) as {
-        composeId: string;
-        name: string;
+      const content = {
+        version: "1",
+        agents: {
+          [agentId]: agentDef,
+        },
       };
+
+      // Run compose job (CLI processes skills, uploads assets)
+      // Pass empty instructions so the server creates a CLAUDE.md with metadata frontmatter
+      const job = await triggerAndPollComposeJob(fetchFn, content, "");
       signal.throwIfAborted();
+
+      if (!job.result) {
+        throw new Error("Compose job completed without result");
+      }
 
       // Set as default agent
       const defaultResp = await fetchFn("/api/scopes/default-agent", {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          agentComposeId: composeData.composeId,
+          agentComposeId: job.result.composeId,
         }),
       });
       signal.throwIfAborted();
@@ -342,9 +335,13 @@ export const completeZeroOnboarding$ = command(
       }
 
       L.debug("Zero onboarding completed", {
-        agentName: composeData.name,
-        composeId: composeData.composeId,
+        agentName: job.result.composeName,
+        composeId: job.result.composeId,
       });
+
+      // Force JWT refresh so updated org metadata is available immediately
+      const clerk = await get(clerk$);
+      await clerk.session?.getToken({ skipCache: true });
 
       // Reload status and mark done
       set(internalReload$, (x) => x + 1);

--- a/turbo/apps/platform/src/views/main.tsx
+++ b/turbo/apps/platform/src/views/main.tsx
@@ -14,7 +14,7 @@ export const setupRouter = (
         <ErrorBoundary>
           <Router />
         </ErrorBoundary>
-        <Toaster position="top-center" />
+        <Toaster position="top-center" visibleToasts={1} />
       </StoreWrapper>
     </StrictMode>,
   );

--- a/turbo/apps/platform/src/views/settings-page/__tests__/settings-page.test.tsx
+++ b/turbo/apps/platform/src/views/settings-page/__tests__/settings-page.test.tsx
@@ -99,15 +99,14 @@ describe("settings page", () => {
     const anthropicCard = within(addProviderDialog).getByTestId(
       "provider-card-anthropic-api-key",
     );
-    await user.click(
-      within(anthropicCard).getByRole("button", { name: /^add$/i }),
-    );
+    await user.click(anthropicCard);
 
     // Provider form dialog should open with API key input
-    const dialog = await screen.findByRole("dialog");
-    expect(
-      within(dialog).getByText("Add your Anthropic API key"),
-    ).toBeInTheDocument();
+    const providerFormTitle = await screen.findByText(
+      "Add your Anthropic API key",
+    );
+    const dialog = providerFormTitle.closest("[role='dialog']") as HTMLElement;
+    expect(dialog).toBeTruthy();
 
     // Fill in the API key
     const input = within(dialog).getByPlaceholderText("Enter your API key");
@@ -120,13 +119,19 @@ describe("settings page", () => {
     });
     await user.click(addProviderButton);
 
-    // Verify request was sent with correct data and dialog closed
+    // Verify request was sent with correct data and provider form closed
     await vi.waitFor(() => {
       expect(capturedBody).toBeTruthy();
-      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
     });
     expect(capturedBody!.type).toBe("anthropic-api-key");
     expect(capturedBody!.secret).toBe("sk-ant-api-key-12345");
+
+    // Provider form dialog should close; add provider dialog may remain open
+    await vi.waitFor(() => {
+      expect(
+        screen.queryByText("Add your Anthropic API key"),
+      ).not.toBeInTheDocument();
+    });
   });
 
   it("persists selected model when adding a provider with model selection", async () => {
@@ -172,10 +177,14 @@ describe("settings page", () => {
     const zaiCard = within(addProviderDialog).getByTestId(
       "provider-card-zai-api-key",
     );
-    await user.click(within(zaiCard).getByRole("button", { name: /^add$/i }));
+    await user.click(zaiCard);
 
     // Provider form dialog should open with model selector
-    const dialog = await screen.findByRole("dialog");
+    const providerFormTitle = await screen.findByText(
+      /^Add your Z\.AI \(GLM\)$/,
+    );
+    const dialog = providerFormTitle.closest("[role='dialog']") as HTMLElement;
+    expect(dialog).toBeTruthy();
 
     // Select glm-5 model via store (Radix Select doesn't render options in jsdom)
     context.store.set(updateFormModel$, "glm-5");
@@ -194,7 +203,6 @@ describe("settings page", () => {
     // Verify selectedModel was included in the request
     await vi.waitFor(() => {
       expect(capturedBody).toBeTruthy();
-      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
     });
     expect(capturedBody!.type).toBe("zai-api-key");
     expect(capturedBody!.secret).toBe("test-zai-api-key");

--- a/turbo/apps/platform/src/views/settings-page/add-provider-dialog.tsx
+++ b/turbo/apps/platform/src/views/settings-page/add-provider-dialog.tsx
@@ -19,19 +19,19 @@ function getProviderTypes(): ModelProviderType[] {
 
 function ProviderCardInDialog({
   type,
-  configured,
   onAdd,
 }: {
   type: ModelProviderType;
-  configured: boolean;
   onAdd: () => void;
 }) {
   const label = getUILabel(type);
   const description = getUIDescription(type);
 
   return (
-    <div
-      className="flex flex-col gap-3 rounded-xl border border-border bg-card p-4 transition-colors hover:bg-muted/50"
+    <button
+      type="button"
+      onClick={onAdd}
+      className="flex flex-col gap-3 rounded-xl border border-border bg-card p-4 text-left transition-colors hover:bg-muted/50"
       data-testid={`provider-card-${type}`}
     >
       <div className="flex items-center gap-3">
@@ -50,19 +50,11 @@ function ProviderCardInDialog({
         </div>
       )}
       <div className="mt-auto">
-        {configured ? (
-          <span className="text-xs text-muted-foreground">Configured</span>
-        ) : (
-          <button
-            type="button"
-            onClick={onAdd}
-            className="w-full rounded-md border border-border bg-background px-2 py-1.5 text-xs font-medium text-foreground hover:bg-muted transition-colors"
-          >
-            Add
-          </button>
-        )}
+        <span className="w-full rounded-md border border-border bg-background px-2 py-1.5 text-xs font-medium text-foreground text-center block">
+          Add
+        </span>
       </div>
-    </div>
+    </button>
   );
 }
 
@@ -79,8 +71,11 @@ export function AddProviderDialog({
 
   const handleAdd = (type: ModelProviderType) => {
     openAdd(type);
-    onOpenChange(false);
   };
+
+  const availableTypes = getProviderTypes().filter(
+    (type) => !configuredSet.has(type),
+  );
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -90,16 +85,21 @@ export function AddProviderDialog({
         </DialogHeader>
         <div className="flex-1 min-h-0 overflow-y-auto">
           <div className="pt-4 pb-6 pr-6">
-            <div className="grid grid-cols-2 gap-3">
-              {getProviderTypes().map((type) => (
-                <ProviderCardInDialog
-                  key={type}
-                  type={type}
-                  configured={configuredSet.has(type)}
-                  onAdd={() => handleAdd(type)}
-                />
-              ))}
-            </div>
+            {availableTypes.length === 0 ? (
+              <p className="text-sm text-muted-foreground py-8 text-center">
+                All providers have been configured.
+              </p>
+            ) : (
+              <div className="grid grid-cols-2 gap-3">
+                {availableTypes.map((type) => (
+                  <ProviderCardInDialog
+                    key={type}
+                    type={type}
+                    onAdd={() => handleAdd(type)}
+                  />
+                ))}
+              </div>
+            )}
           </div>
         </div>
       </DialogContent>

--- a/turbo/apps/platform/src/views/settings-page/provider-list.tsx
+++ b/turbo/apps/platform/src/views/settings-page/provider-list.tsx
@@ -2,6 +2,7 @@ import { useGet, useLastResolved, useSet } from "ccstate-react";
 import { Button } from "@vm0/ui/components/ui/button";
 import { Skeleton } from "@vm0/ui/components/ui/skeleton";
 import { IconPlus } from "@tabler/icons-react";
+import { MODEL_PROVIDER_TYPES } from "@vm0/core";
 import {
   addProviderDialogOpen$,
   setAddProviderDialogOpen$,
@@ -14,6 +15,9 @@ export function ProviderList() {
   const addDialogOpen = useGet(addProviderDialogOpen$);
   const setAddDialogOpen = useSet(setAddProviderDialogOpen$);
   const providers = useLastResolved(configuredProviders$);
+  const allConfigured =
+    providers !== undefined &&
+    providers.length >= Object.keys(MODEL_PROVIDER_TYPES).length;
 
   return (
     <div className="flex flex-col gap-4">
@@ -31,15 +35,17 @@ export function ProviderList() {
             <h3 className="text-base font-medium text-foreground">
               Configured model providers
             </h3>
-            <Button
-              variant="outline"
-              size="sm"
-              className="shrink-0 gap-2"
-              onClick={() => setAddDialogOpen(true)}
-            >
-              <IconPlus size={16} stroke={1.5} />
-              Add model provider
-            </Button>
+            {!allConfigured && (
+              <Button
+                variant="outline"
+                size="sm"
+                className="shrink-0 gap-2"
+                onClick={() => setAddDialogOpen(true)}
+              >
+                <IconPlus size={16} stroke={1.5} />
+                Add model provider
+              </Button>
+            )}
           </div>
           <div className="flex flex-col">
             {providers.length === 0 ? (

--- a/turbo/apps/platform/src/views/zero-page/zero-content.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-content.tsx
@@ -9,6 +9,7 @@ import { ZeroProductionPage } from "./zero-production-page.tsx";
 import { ZeroActivityPage } from "./zero-activity-page.tsx";
 import { ZeroWorksPage } from "./zero-works-page.tsx";
 import { ZeroSchedulePage } from "./zero-schedule-page.tsx";
+import { ZeroSettingsPage } from "./zero-settings-page.tsx";
 import { agentDisplayName$ } from "../../signals/zero-page/zero-agent-name.ts";
 
 interface ZeroContentProps {
@@ -38,6 +39,7 @@ function getSectionTitles(
     production: "Documents",
     activity: "Activities",
     works: `Where ${agentName} works`,
+    settings: "Settings",
     account: "Account",
   };
 }
@@ -105,6 +107,9 @@ export function ZeroContent({
   }
   if (sectionId === "works") {
     return <ZeroWorksPage />;
+  }
+  if (sectionId === "settings") {
+    return <ZeroSettingsPage />;
   }
   if (sectionId === "account") {
     return <ZeroAccountPage accountSubId={accountSubId ?? null} />;

--- a/turbo/apps/platform/src/views/zero-page/zero-job-detail-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-job-detail-page.tsx
@@ -7,11 +7,10 @@ import {
   IconSettings,
   IconPlug,
   IconSparkles,
-  IconX,
   IconPlus,
-  IconTool,
   IconCalendar,
   IconPencil,
+  IconDotsVertical,
 } from "@tabler/icons-react";
 import {
   Button,
@@ -21,14 +20,13 @@ import {
   Card,
   CardContent,
   Input,
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
   cn,
 } from "@vm0/ui";
-import { CONNECTOR_TYPES, type ConnectorType } from "@vm0/core";
+import type { ConnectorType } from "@vm0/core";
 import { ConnectorIcon } from "../settings-page/connector-icons";
 import { ZeroScheduleCard, DUMMY_AGENT_SCHEDULE } from "./zero-schedule-card";
 
@@ -40,35 +38,134 @@ export interface JobItem {
   scope: "personal" | "team";
 }
 
-const WORKFLOW_SKILLS_OPTIONS = [
-  "Slack",
-  "Notion",
-  "GitHub",
-  "Gmail",
-  "Data Analysis",
-  "Content Summarization",
-  "Linear",
-] as const;
-
-const INITIAL_SKILLS = [
-  "Slack",
-  "Data Analysis",
-  "Content Summarization",
-] as const;
-
-const CONNECTOR_LIST: readonly ConnectorType[] = [
-  "github",
-  "linear",
-  "notion",
-  "gmail",
-  "slack",
+const DUMMY_SKILLS: {
+  type: ConnectorType;
+  label: string;
+  connected: boolean;
+  statusText: string;
+}[] = [
+  {
+    type: "notion",
+    label: "Notion",
+    connected: true,
+    statusText: "Connected",
+  },
+  { type: "github", label: "GitHub", connected: false, statusText: "" },
+  {
+    type: "axiom",
+    label: "Axiom",
+    connected: true,
+    statusText: "Connected",
+  },
+  { type: "slack", label: "Slack", connected: false, statusText: "" },
 ];
 
-function skillToConnectorType(skill: string): ConnectorType | null {
-  const lower = skill.toLowerCase();
-  return CONNECTOR_LIST.includes(lower as ConnectorType)
-    ? (lower as ConnectorType)
-    : null;
+function SubAgentSkillsTab() {
+  const removedTypes$ = useCCState<ConnectorType[]>([]);
+  const removedTypes = useGet(removedTypes$);
+  const setRemovedTypes = useSet(removedTypes$);
+  const displayItems = DUMMY_SKILLS.filter(
+    (item) => !removedTypes.includes(item.type),
+  );
+
+  return (
+    <div className="flex flex-col gap-4">
+      <p className="text-sm text-muted-foreground">
+        Skills manage your connections and help you get more out of these
+        services.
+      </p>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+        {/* Add skill */}
+        <button
+          type="button"
+          className="flex flex-col rounded-[var(--zero-card-radius)] border border-dashed border-border/80 transition-colors hover:border-border hover:bg-muted/30 group"
+        >
+          <div className="flex h-14 items-center gap-2.5 px-5">
+            <span className="flex h-7 w-7 shrink-0 items-center justify-center">
+              <IconPlus
+                size={18}
+                stroke={2}
+                className="text-muted-foreground group-hover:text-foreground"
+              />
+            </span>
+            <span className="text-sm font-medium text-muted-foreground group-hover:text-foreground">
+              Add skill
+            </span>
+          </div>
+          <div className="flex h-11 items-center border-t border-dashed border-border/80 px-5 group-hover:border-border">
+            <span className="text-xs text-muted-foreground/70">
+              Browse 100+ popular skills
+            </span>
+          </div>
+        </button>
+
+        {/* Skill cards */}
+        {displayItems.map((item) => (
+          <div
+            key={item.type}
+            className="flex flex-col rounded-[var(--zero-card-radius)] border border-[var(--zero-card-border)] bg-card shadow-[var(--zero-card-shadow)]"
+          >
+            <div className="flex h-14 items-center gap-2.5 px-5">
+              <span className="flex h-7 w-7 shrink-0 items-center justify-center">
+                <ConnectorIcon type={item.type} size={22} />
+              </span>
+              <span className="min-w-0 flex-1 text-sm font-medium text-foreground truncate">
+                {item.label}
+              </span>
+            </div>
+
+            <div className="flex h-11 items-center justify-between border-t border-border/50 pl-5 pr-2">
+              <div className="flex items-center gap-2 min-w-0">
+                {item.connected ? (
+                  <span className="flex items-center gap-2 text-xs text-muted-foreground truncate">
+                    <span className="h-1.5 w-1.5 rounded-full bg-emerald-500 shrink-0" />
+                    {item.statusText}
+                  </span>
+                ) : (
+                  <button
+                    type="button"
+                    className="text-xs font-medium text-primary hover:text-primary/80 transition-colors"
+                  >
+                    Connect
+                  </button>
+                )}
+              </div>
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-7 w-7 shrink-0 rounded-lg text-muted-foreground hover:text-foreground"
+                    aria-label="More options"
+                  >
+                    <IconDotsVertical size={14} stroke={1.5} />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end" className="w-40">
+                  {item.connected ? (
+                    <DropdownMenuItem>Disconnect</DropdownMenuItem>
+                  ) : (
+                    <DropdownMenuItem
+                      onClick={() =>
+                        setRemovedTypes((prev) =>
+                          prev.includes(item.type)
+                            ? prev
+                            : [...prev, item.type],
+                        )
+                      }
+                    >
+                      Remove skill
+                    </DropdownMenuItem>
+                  )}
+                </DropdownMenuContent>
+              </DropdownMenu>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
 }
 
 interface ZeroJobDetailPageProps {
@@ -86,66 +183,32 @@ export function ZeroJobDetailPage({ job, onBack }: ZeroJobDetailPageProps) {
   const settingsDescription$ = useCCState(job.description);
   const settingsDescription = useGet(settingsDescription$);
   const setSettingsDescription = useSet(settingsDescription$);
-  const skills$ = useCCState<string[]>([...INITIAL_SKILLS]);
-  const skills = useGet(skills$);
-  const setSkills = useSet(skills$);
-  const ADD_SKILL_PLACEHOLDER = "__add_skill__";
-  const addSkillValue$ = useCCState(ADD_SKILL_PLACEHOLDER);
-  const addSkillValue = useGet(addSkillValue$);
-  const setAddSkillValue = useSet(addSkillValue$);
-  const connectedConnectors$ = useCCState<ConnectorType[]>(["github", "slack"]);
-  const connectedConnectors = useGet(connectedConnectors$);
-  const setConnectedConnectors = useSet(connectedConnectors$);
-
-  const removeSkill = (s: string) =>
-    setSkills((prev) => prev.filter((x) => x !== s));
-  const toggleConnector = (type: ConnectorType) => {
-    setConnectedConnectors((prev) =>
-      prev.includes(type) ? prev.filter((t) => t !== type) : [...prev, type],
-    );
-  };
-  const addSkill = (s: string) => {
-    if (!skills.includes(s)) {
-      setSkills((prev) => [...prev, s].sort());
-    }
-    setAddSkillValue(ADD_SKILL_PLACEHOLDER);
-  };
-  const availableSkills = WORKFLOW_SKILLS_OPTIONS.filter(
-    (s) => !skills.includes(s),
-  );
 
   const savedSettings$ = useCCState<{
     name: string;
     description: string;
-    skills: string[];
   }>({
     name: job.title,
     description: job.description,
-    skills: [...INITIAL_SKILLS],
   });
   const savedSettings = useGet(savedSettings$);
   const setSavedSettings = useSet(savedSettings$);
 
   const isSettingsDirty =
     settingsName !== savedSettings.name ||
-    settingsDescription !== savedSettings.description ||
-    JSON.stringify([...skills].sort()) !==
-      JSON.stringify([...savedSettings.skills].sort());
+    settingsDescription !== savedSettings.description;
   const showSaveBar = isSettingsDirty;
 
   const handleReset = () => {
     setSettingsName(savedSettings.name);
     setSettingsDescription(savedSettings.description);
-    setSkills([...savedSettings.skills]);
   };
 
   const handleSave = () => {
     setSavedSettings({
       name: settingsName,
       description: settingsDescription,
-      skills: [...skills],
     });
-    // API persist would go here
   };
 
   return (
@@ -197,7 +260,7 @@ export function ZeroJobDetailPage({ job, onBack }: ZeroJobDetailPageProps) {
                 className="gap-1.5 text-sm data-[state=active]:bg-background px-3"
               >
                 <IconPlug size={14} stroke={1.5} />
-                Connectors
+                Skills
               </TabsTrigger>
               <TabsTrigger
                 value="schedule"
@@ -328,131 +391,11 @@ export function ZeroJobDetailPage({ job, onBack }: ZeroJobDetailPageProps) {
                     className="w-full rounded-lg border border-border bg-input px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground outline-none transition-colors focus:border-primary focus:ring-[3px] focus:ring-primary/10 resize-y min-h-[72px]"
                   />
                 </div>
-                <div className="flex flex-col gap-3">
-                  <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                    Skills
-                  </span>
-                  <ul className="flex flex-wrap gap-2" role="list">
-                    {skills.map((skill) => {
-                      const connectorType = skillToConnectorType(skill);
-                      return (
-                        <li
-                          key={skill}
-                          className="flex min-w-[120px] max-w-[220px] flex-1 basis-[120px]"
-                        >
-                          <span className="zero-chip flex w-full min-w-0 items-center gap-2 rounded-2xl border px-3 py-2.5 text-sm text-foreground transition-colors duration-200">
-                            {connectorType ? (
-                              <ConnectorIcon type={connectorType} size={16} />
-                            ) : (
-                              <IconTool
-                                size={16}
-                                stroke={1.5}
-                                className="shrink-0 text-muted-foreground"
-                              />
-                            )}
-                            <span className="min-w-0 truncate font-medium">
-                              {skill}
-                            </span>
-                            <button
-                              type="button"
-                              onClick={() => removeSkill(skill)}
-                              className="ml-auto shrink-0 rounded p-1 text-muted-foreground hover:bg-muted hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-                              aria-label={`Remove ${skill}`}
-                            >
-                              <IconX size={12} stroke={2} />
-                            </button>
-                          </span>
-                        </li>
-                      );
-                    })}
-                    {availableSkills.length > 0 && (
-                      <li className="flex shrink-0">
-                        <Select
-                          value={addSkillValue}
-                          onValueChange={(v) => {
-                            setAddSkillValue(ADD_SKILL_PLACEHOLDER);
-                            if (v && v !== ADD_SKILL_PLACEHOLDER) {
-                              addSkill(v);
-                            }
-                          }}
-                        >
-                          <SelectTrigger className="zero-chip h-10 min-w-[120px] gap-2 rounded-2xl border px-3 py-2.5 text-sm text-foreground transition-colors duration-200">
-                            <IconPlus size={14} stroke={2} />
-                            <SelectValue placeholder="Add skill" />
-                          </SelectTrigger>
-                          <SelectContent>
-                            <SelectItem value={ADD_SKILL_PLACEHOLDER}>
-                              Add skill
-                            </SelectItem>
-                            {availableSkills.map((s) => (
-                              <SelectItem key={s} value={s}>
-                                {s}
-                              </SelectItem>
-                            ))}
-                          </SelectContent>
-                        </Select>
-                      </li>
-                    )}
-                  </ul>
-                </div>
               </CardContent>
             </Card>
           )}
 
-          {activeTab === "connectors" && (
-            <div className="flex flex-col gap-6">
-              <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
-                <div>
-                  <h2 className="text-sm font-semibold tracking-tight text-foreground">
-                    Connectors
-                  </h2>
-                  <p className="text-sm text-muted-foreground">
-                    Third-party services this workflow can use
-                  </p>
-                </div>
-                <Button size="sm" className="h-9 shrink-0 gap-2 rounded-lg">
-                  <IconPlus size={16} stroke={2} />
-                  Add Connector
-                </Button>
-              </div>
-              <ul className="flex flex-col gap-3">
-                {CONNECTOR_LIST.map((type) => {
-                  const config = CONNECTOR_TYPES[type];
-                  const connected = connectedConnectors.includes(type);
-                  return (
-                    <li key={type}>
-                      <Card className="zero-card">
-                        <CardContent className="flex items-center gap-4 px-4 py-3">
-                          <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-muted overflow-hidden">
-                            <ConnectorIcon type={type} size={24} />
-                          </span>
-                          <div className="min-w-0 flex-1">
-                            <p className="text-sm font-medium text-foreground">
-                              {config.label}
-                            </p>
-                            <p className="text-xs text-muted-foreground">
-                              {config.helpText}
-                            </p>
-                          </div>
-                          <Button
-                            size="sm"
-                            variant={connected ? "secondary" : "outline"}
-                            className={cn(
-                              "h-8 shrink-0 rounded-lg px-3",
-                              !connected && "zero-btn-morandi border",
-                            )}
-                            onClick={() => toggleConnector(type)}
-                          >
-                            {connected ? "Connected" : "Connect"}
-                          </Button>
-                        </CardContent>
-                      </Card>
-                    </li>
-                  );
-                })}
-              </ul>
-            </div>
-          )}
+          {activeTab === "connectors" && <SubAgentSkillsTab />}
 
           {activeTab !== "instructions" &&
             activeTab !== "settings" &&

--- a/turbo/apps/platform/src/views/zero-page/zero-job-detail-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-job-detail-page.tsx
@@ -38,27 +38,32 @@ export interface JobItem {
   scope: "personal" | "team";
 }
 
-const DUMMY_SKILLS: {
-  type: ConnectorType;
-  label: string;
-  connected: boolean;
-  statusText: string;
-}[] = [
+const DUMMY_SKILLS = [
   {
-    type: "notion",
+    type: "notion" as ConnectorType,
     label: "Notion",
     connected: true,
     statusText: "Connected",
   },
-  { type: "github", label: "GitHub", connected: false, statusText: "" },
   {
-    type: "axiom",
+    type: "github" as ConnectorType,
+    label: "GitHub",
+    connected: false,
+    statusText: "",
+  },
+  {
+    type: "axiom" as ConnectorType,
     label: "Axiom",
     connected: true,
     statusText: "Connected",
   },
-  { type: "slack", label: "Slack", connected: false, statusText: "" },
-];
+  {
+    type: "slack" as ConnectorType,
+    label: "Slack",
+    connected: false,
+    statusText: "",
+  },
+] as const;
 
 function SubAgentSkillsTab() {
   const removedTypes$ = useCCState<ConnectorType[]>([]);

--- a/turbo/apps/platform/src/views/zero-page/zero-meet-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-meet-page.tsx
@@ -85,6 +85,9 @@ import {
   zeroAddedSkills$,
   addZeroSkill$,
   removeZeroSkill$,
+  zeroSkillsDirty$,
+  saveZeroSkills$,
+  discardZeroSkills$,
 } from "../../signals/zero-page/zero-meet.ts";
 
 /** Stored as lowercase in metadata.sound. */
@@ -130,10 +133,10 @@ const TONE_SAMPLES: Readonly<
 };
 
 // ---------------------------------------------------------------------------
-// Skill item — a single row in the skills list
+// Skill card — a single card in the skills grid
 // ---------------------------------------------------------------------------
 
-function ZeroSkillItem({
+function ZeroSkillCard({
   name,
   label,
   iconUrl,
@@ -142,7 +145,6 @@ function ZeroSkillItem({
   onConnect,
   onDisconnect,
   onRemove,
-  isLast,
 }: {
   name: string;
   label: string;
@@ -152,114 +154,84 @@ function ZeroSkillItem({
   onConnect: () => void;
   onDisconnect: () => void;
   onRemove: () => void;
-  isLast: boolean;
 }) {
   const isPolling = pollingType === name;
 
   return (
-    <div
-      className={cn(
-        "flex items-center gap-4 px-4 py-3",
-        !isLast && "border-b border-border/60",
-      )}
-    >
-      <span className="flex h-10 w-10 shrink-0 items-center justify-center">
-        {name in CONNECTOR_TYPES ? (
-          <ConnectorIcon type={name as ConnectorType} size={24} />
-        ) : iconUrl ? (
-          <img src={iconUrl} alt="" className="h-6 w-6 object-contain" />
-        ) : (
-          <IconPlug size={20} stroke={1.5} className="text-muted-foreground" />
-        )}
-      </span>
-      <div className="min-w-0 flex-1">
-        <p className="text-sm font-medium text-foreground">{label}</p>
+    <div className="flex flex-col rounded-[var(--zero-card-radius)] border border-[var(--zero-card-border)] bg-card shadow-[var(--zero-card-shadow)]">
+      <div className="flex h-14 items-center gap-2.5 px-5">
+        <span className="flex h-7 w-7 shrink-0 items-center justify-center">
+          {name in CONNECTOR_TYPES ? (
+            <ConnectorIcon type={name as ConnectorType} size={22} />
+          ) : iconUrl ? (
+            <img src={iconUrl} alt="" className="h-5 w-5 object-contain" />
+          ) : (
+            <IconPlug
+              size={18}
+              stroke={1.5}
+              className="text-muted-foreground"
+            />
+          )}
+        </span>
+        <span className="min-w-0 flex-1 text-sm font-medium text-foreground truncate">
+          {label}
+        </span>
       </div>
-      {connector &&
-        (isPolling ? (
-          <span className="flex h-8 items-center gap-1.5 rounded-lg border px-3 text-xs text-muted-foreground">
-            <IconLoader2 size={14} stroke={1.5} className="animate-spin" />
-            Connecting…
-          </span>
-        ) : connector.connected ? (
-          <>
-            <span className="text-xs text-muted-foreground shrink-0">
-              {connector.connector?.externalUsername
-                ? `Connected as @${connector.connector.externalUsername}`
-                : connector.connector?.authMethod === "api-token"
-                  ? "Connected via API key"
-                  : "Connected"}
-            </span>
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="h-8 w-8 shrink-0 rounded-lg text-muted-foreground hover:text-foreground"
-                  aria-label="More options"
-                >
-                  <IconDotsVertical size={16} stroke={1.5} />
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end" className="w-40">
-                <DropdownMenuItem onClick={onDisconnect}>
-                  Disconnect
-                </DropdownMenuItem>
-                <DropdownMenuItem onClick={onRemove}>
-                  Remove skill
-                </DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
-          </>
-        ) : (
-          <div className="flex h-8 shrink-0 items-center gap-2">
-            <Button
-              size="sm"
-              variant="outline"
-              className="h-8 rounded-lg px-3 zero-btn-morandi border"
-              onClick={onConnect}
-            >
-              {connector.availableAuthMethods.length === 1 &&
-              connector.availableAuthMethods[0] === "api-token"
-                ? "Add API key"
-                : "Connect"}
-            </Button>
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="h-8 w-8 shrink-0 rounded-lg text-muted-foreground hover:text-foreground"
-                  aria-label="More options"
-                >
-                  <IconDotsVertical size={16} stroke={1.5} />
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end" className="w-40">
-                <DropdownMenuItem onClick={onRemove}>
-                  Remove skill
-                </DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
-          </div>
-        ))}
-      {!connector && (
+
+      <div className="flex h-11 items-center justify-between border-t border-border/50 pl-5 pr-2">
+        <div className="flex items-center gap-2 min-w-0">
+          {connector &&
+            (isPolling ? (
+              <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                <IconLoader2 size={12} stroke={1.5} className="animate-spin" />
+                Connecting…
+              </span>
+            ) : connector.connected ? (
+              <span className="flex items-center gap-2 text-xs text-muted-foreground truncate">
+                <span className="h-1.5 w-1.5 rounded-full bg-emerald-500 shrink-0" />
+                {connector.connector?.externalUsername
+                  ? `@${connector.connector.externalUsername}`
+                  : connector.connector?.authMethod === "api-token"
+                    ? "API key"
+                    : "Connected"}
+              </span>
+            ) : (
+              <button
+                type="button"
+                onClick={onConnect}
+                className="text-xs font-medium text-primary hover:text-primary/80 transition-colors"
+              >
+                {connector.availableAuthMethods.length === 1 &&
+                connector.availableAuthMethods[0] === "api-token"
+                  ? "Add API key"
+                  : "Connect"}
+              </button>
+            ))}
+          {!connector && (
+            <span className="text-xs text-muted-foreground">Added</span>
+          )}
+        </div>
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <Button
               variant="ghost"
               size="icon"
-              className="h-8 w-8 shrink-0 rounded-lg text-muted-foreground hover:text-foreground"
+              className="h-7 w-7 shrink-0 rounded-lg text-muted-foreground hover:text-foreground"
               aria-label="More options"
             >
-              <IconDotsVertical size={16} stroke={1.5} />
+              <IconDotsVertical size={14} stroke={1.5} />
             </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end" className="w-40">
+            {connector?.connected && (
+              <DropdownMenuItem onClick={onDisconnect}>
+                Disconnect
+              </DropdownMenuItem>
+            )}
             <DropdownMenuItem onClick={onRemove}>Remove skill</DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>
-      )}
+      </div>
     </div>
   );
 }
@@ -333,13 +305,19 @@ function ZeroSkillsTab() {
   const selectedType = useGet(selectedConnectorType$);
   const setSelected = useSet(setSelectedConnectorType$);
 
-  // Skills list: auto-seeded from compose content, synced via compose jobs
+  // Skills list: local draft, saved via compose jobs on explicit Save
   const addedSkillsLoadable = useLastLoadable(zeroAddedSkills$);
   const addedSkills =
     addedSkillsLoadable.state === "hasData" ? addedSkillsLoadable.data : [];
   const allSkills = useGet(skills$);
   const addSkill = useSet(addZeroSkill$);
   const removeSkill = useSet(removeZeroSkill$);
+  const skillsDirtyLoadable = useLastLoadable(zeroSkillsDirty$);
+  const skillsDirty =
+    skillsDirtyLoadable.state === "hasData" ? skillsDirtyLoadable.data : false;
+  const saveSkills = useSet(saveZeroSkills$);
+  const discardSkills = useSet(discardZeroSkills$);
+  const skillsSaving = useGet(zeroSettingsSaving$);
 
   // Optimistic connected state — set by connectConnector$/submitApiToken$
   // so the skill shows "Connected" immediately without waiting for refetch.
@@ -378,110 +356,103 @@ function ZeroSkillsTab() {
   };
 
   return (
-    <div className="mx-auto max-w-[900px] px-7 flex flex-col gap-6">
-      <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
-        <div>
-          <h2 className="text-base font-semibold tracking-tight text-foreground">
-            Add skills
-          </h2>
-          <p className="text-sm text-muted-foreground">
-            Skills manage your connections and help you get more out of these
-            services.
-          </p>
-        </div>
-        <Button
-          size="sm"
-          className="h-9 shrink-0 gap-2 rounded-lg"
-          onClick={() => setAddDialogOpen(true)}
-        >
-          <IconPlus size={16} stroke={2} />
-          Add skill
-        </Button>
-      </div>
+    <div className="mx-auto max-w-[900px] px-7 flex flex-col gap-4">
+      <p className="text-sm text-muted-foreground">
+        Skills manage your connections and help you get more out of these
+        services.
+      </p>
 
-      {addedSkillsLoadable.state !== "hasData" && addedSkills.length === 0 ? (
-        <Card className="zero-card">
-          <CardContent className="p-0">
-            {Array.from({ length: 3 }, (_, i) => (
-              <div
-                key={i}
-                className={cn(
-                  "flex items-center gap-4 px-4 py-3",
-                  i < 2 && "border-b border-border/60",
-                )}
-              >
-                <span className="h-10 w-10 shrink-0 rounded-lg bg-muted/50 animate-pulse" />
-                <div className="min-w-0 flex-1">
-                  <div
-                    className="h-4 rounded bg-muted/50 animate-pulse"
-                    style={{ width: `${80 + ((i * 37) % 60)}px` }}
-                  />
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+        {/* Add skill */}
+        <button
+          type="button"
+          onClick={() => setAddDialogOpen(true)}
+          className="flex flex-col rounded-[var(--zero-card-radius)] border border-dashed border-border/80 transition-colors hover:border-border hover:bg-muted/30 group"
+        >
+          <div className="flex h-14 items-center gap-2.5 px-5">
+            <span className="flex h-7 w-7 shrink-0 items-center justify-center">
+              <IconPlus
+                size={18}
+                stroke={2}
+                className="text-muted-foreground group-hover:text-foreground"
+              />
+            </span>
+            <span className="text-sm font-medium text-muted-foreground group-hover:text-foreground">
+              Add skill
+            </span>
+          </div>
+          <div className="flex h-11 items-center border-t border-dashed border-border/80 px-5 group-hover:border-border">
+            <span className="text-xs text-muted-foreground/70">
+              Browse 100+ popular skills
+            </span>
+          </div>
+        </button>
+
+        {/* Skeleton cards while loading */}
+        {addedSkillsLoadable.state !== "hasData" &&
+          addedSkills.length === 0 && (
+            <>
+              {Array.from({ length: 3 }, (_, i) => (
+                <div
+                  key={i}
+                  className="flex flex-col rounded-[var(--zero-card-radius)] border border-border/50 bg-card animate-pulse"
+                >
+                  <div className="flex h-14 items-center gap-2.5 px-5">
+                    <span className="h-7 w-7 shrink-0 rounded-lg bg-muted/50" />
+                    <span className="h-4 w-24 rounded bg-muted/50" />
+                  </div>
+                  <div className="flex h-11 items-center border-t border-border/30 px-5">
+                    <span className="h-3 w-16 rounded bg-muted/30" />
+                  </div>
                 </div>
-                <div className="h-8 w-20 shrink-0 rounded-lg bg-muted/30 animate-pulse" />
-              </div>
-            ))}
-          </CardContent>
-        </Card>
-      ) : addedSkills.length === 0 ? (
-        <div className="flex flex-col items-center gap-3 rounded-xl border border-dashed border-border/60 py-12">
-          <IconPlug
-            size={32}
-            stroke={1.2}
-            className="text-muted-foreground/50"
-          />
-          <p className="text-sm text-muted-foreground">
-            No skills yet. Add one to get started.
-          </p>
-        </div>
-      ) : (
-        <Card className="zero-card">
-          <CardContent className="p-0">
-            {addedSkills.map((name, index) => {
-              const skill = skillMap.get(name);
-              const connector = connectorMap.get(name as ConnectorType) ?? null;
-              const effectiveConnector =
-                optimisticConnected.has(name) &&
-                connector &&
-                !connector.connected
-                  ? { ...connector, connected: true }
-                  : connector;
-              return (
-                <ZeroSkillItem
-                  key={name}
-                  name={name}
-                  label={skill?.label ?? name}
-                  iconUrl={skill?.icon}
-                  connector={effectiveConnector}
-                  pollingType={pollingType}
-                  onConnect={() => {
-                    const ct = connectorMap.get(name as ConnectorType);
-                    if (
-                      ct &&
-                      ct.availableAuthMethods.length === 1 &&
-                      ct.availableAuthMethods[0] === "api-token"
-                    ) {
-                      setSelected(name as ConnectorType);
-                    } else {
-                      detach(
-                        connect(name as ConnectorType, signal),
-                        Reason.DomCallback,
-                      );
-                    }
-                  }}
-                  onDisconnect={() =>
-                    detach(
-                      disconnect(name as ConnectorType),
-                      Reason.DomCallback,
-                    )
-                  }
-                  onRemove={() => handleRemoveSkill(name)}
-                  isLast={index === addedSkills.length - 1}
-                />
-              );
-            })}
-          </CardContent>
-        </Card>
-      )}
+              ))}
+            </>
+          )}
+
+        {/* Skill cards */}
+        {addedSkills.map((name) => {
+          const skill = skillMap.get(name);
+          const connector = connectorMap.get(name as ConnectorType) ?? null;
+          const effectiveConnector =
+            optimisticConnected.has(name) && connector && !connector.connected
+              ? { ...connector, connected: true }
+              : connector;
+          return (
+            <ZeroSkillCard
+              key={name}
+              name={name}
+              label={skill?.label ?? name}
+              iconUrl={skill?.icon}
+              connector={effectiveConnector}
+              pollingType={pollingType}
+              onConnect={() => {
+                const ct = connectorMap.get(name as ConnectorType);
+                if (
+                  ct &&
+                  ct.availableAuthMethods.length === 1 &&
+                  ct.availableAuthMethods[0] === "api-token"
+                ) {
+                  setSelected(name as ConnectorType);
+                } else {
+                  detach(
+                    connect(name as ConnectorType, signal),
+                    Reason.DomCallback,
+                  );
+                }
+              }}
+              onDisconnect={() => {
+                detach(disconnect(name as ConnectorType), Reason.DomCallback);
+                const label =
+                  skillMap.get(name)?.label ??
+                  connectorMap.get(name as ConnectorType)?.label ??
+                  name;
+                toast.success(`${label} disconnected`);
+              }}
+              onRemove={() => handleRemoveSkill(name)}
+            />
+          );
+        })}
+      </div>
 
       <AddConnectionDialog
         open={addDialogOpen}
@@ -502,6 +473,49 @@ function ZeroSkillsTab() {
           }}
         />
       )}
+
+      {(skillsDirty || skillsSaving) &&
+        createPortal(
+          <div className="zero-app fixed bottom-6 left-0 right-0 z-40 flex justify-center px-4 sm:left-[255px]">
+            <div className="zero-card flex max-w-md items-center justify-between gap-4 rounded-xl border border-border bg-card px-5 py-4 shadow-lg">
+              <div className="flex items-center gap-2 text-sm text-foreground">
+                <IconPencil
+                  size={18}
+                  stroke={1.5}
+                  className="shrink-0 text-muted-foreground"
+                />
+                <span>You have unsaved changes</span>
+              </div>
+              <div className="flex items-center gap-2 shrink-0">
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="text-destructive hover:bg-destructive/10 hover:text-destructive"
+                  onClick={() => discardSkills()}
+                  disabled={skillsSaving}
+                >
+                  Discard
+                </Button>
+                <Button
+                  size="sm"
+                  className="h-9 rounded-lg px-4 bg-primary text-primary-foreground hover:bg-primary/90"
+                  onClick={() => detach(saveSkills(), Reason.DomCallback)}
+                  disabled={skillsSaving}
+                >
+                  {skillsSaving ? (
+                    <IconLoader2
+                      size={14}
+                      stroke={1.5}
+                      className="animate-spin mr-1.5"
+                    />
+                  ) : null}
+                  Save
+                </Button>
+              </div>
+            </div>
+          </div>,
+          document.body,
+        )}
     </div>
   );
 }
@@ -589,9 +603,9 @@ function ZeroInstructionsTab() {
         </CardContent>
       </Card>
 
-      {isDirty &&
+      {(isDirty || isBuilding) &&
         createPortal(
-          <div className="zero-app fixed bottom-6 left-0 right-0 z-50 flex justify-center px-4 sm:left-[255px]">
+          <div className="zero-app fixed bottom-6 left-0 right-0 z-40 flex justify-center px-4 sm:left-[255px]">
             <div className="zero-card flex max-w-md items-center justify-between gap-4 rounded-xl border border-border bg-card px-5 py-4 shadow-lg">
               <div className="flex items-center gap-2 text-sm text-foreground">
                 <IconPencil
@@ -757,7 +771,7 @@ function ZeroSettingsTab({
 
       {isSettingsDirty &&
         createPortal(
-          <div className="zero-app fixed bottom-6 left-0 right-0 z-50 flex justify-center px-4 sm:left-[255px]">
+          <div className="zero-app fixed bottom-6 left-0 right-0 z-40 flex justify-center px-4 sm:left-[255px]">
             <div className="zero-card flex max-w-md items-center justify-between gap-4 rounded-xl border border-border bg-card px-5 py-4 shadow-lg">
               <div className="flex items-center gap-2 text-sm text-foreground">
                 <IconPencil

--- a/turbo/apps/platform/src/views/zero-page/zero-settings-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-settings-page.tsx
@@ -1,0 +1,283 @@
+import { useGet, useSet, useLoadable } from "ccstate-react";
+import { IconPlus, IconDotsVertical } from "@tabler/icons-react";
+import { MODEL_PROVIDER_TYPES, type ModelProviderType } from "@vm0/core";
+import {
+  Button,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+} from "@vm0/ui";
+import {
+  addProviderDialogOpen$,
+  setAddProviderDialogOpen$,
+  configuredProviders$,
+  defaultProvider$,
+  setDefaultProvider$,
+  openEditDialog$,
+  openDeleteDialog$,
+} from "../../signals/settings-page/model-providers.ts";
+import { getUILabel } from "../settings-page/provider-ui-config.ts";
+import { ProviderIcon } from "../settings-page/provider-icons.tsx";
+import { AddProviderDialog } from "../settings-page/add-provider-dialog.tsx";
+import { ProviderDialog } from "../settings-page/provider-dialog.tsx";
+import { DeleteProviderDialog } from "../settings-page/delete-provider-dialog.tsx";
+import { detach, Reason } from "../../signals/utils.ts";
+import { pageSignal$ } from "../../signals/page-signal.ts";
+
+export function ZeroSettingsPage() {
+  return (
+    <div className="flex flex-1 flex-col min-h-0 overflow-auto [scrollbar-gutter:stable]">
+      <header className="shrink-0 bg-transparent px-4 pt-10 pb-4 sm:px-6">
+        <div className="mx-auto max-w-[900px] px-7">
+          <div className="flex items-center">
+            <h1 className="text-xl font-semibold tracking-tight text-foreground">
+              Settings
+            </h1>
+          </div>
+          <p className="text-sm text-muted-foreground mt-1">
+            Configure model providers for your agents.
+          </p>
+        </div>
+      </header>
+
+      <main className="shrink-0 px-4 sm:px-6 pt-4 pb-16">
+        <div className="mx-auto max-w-[900px] px-7 flex flex-col gap-8">
+          <ZeroDefaultProvider />
+          <ZeroProviderList />
+        </div>
+      </main>
+
+      <DeleteProviderDialog />
+      <ProviderDialog />
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Skeleton card — matches the real card dimensions
+// ---------------------------------------------------------------------------
+
+function SkeletonCard() {
+  return (
+    <div className="flex flex-col rounded-[var(--zero-card-radius)] border border-border/50 bg-card animate-pulse">
+      <div className="flex h-14 items-center gap-2.5 px-5">
+        <span className="h-7 w-7 shrink-0 rounded-lg bg-muted/50" />
+        <span className="h-4 w-24 rounded bg-muted/50" />
+      </div>
+      <div className="flex h-11 items-center border-t border-border/30 px-5">
+        <span className="h-3 w-16 rounded bg-muted/30" />
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Default provider selector
+// ---------------------------------------------------------------------------
+
+function ZeroDefaultProvider() {
+  const providersLoadable = useLoadable(configuredProviders$);
+  const defaultProviderLoadable = useLoadable(defaultProvider$);
+  const setDefault = useSet(setDefaultProvider$);
+  const pageSignal = useGet(pageSignal$);
+
+  const isLoading =
+    providersLoadable.state === "loading" ||
+    defaultProviderLoadable.state === "loading";
+  const providers =
+    providersLoadable.state === "hasData" ? providersLoadable.data : [];
+  const defaultProvider =
+    defaultProviderLoadable.state === "hasData"
+      ? defaultProviderLoadable.data
+      : null;
+
+  const selectItems = providers.map((p) => ({
+    type: p.type,
+    label: getUILabel(p.type),
+  }));
+  const currentDefault = defaultProvider?.type ?? selectItems[0]?.type ?? "";
+
+  const handleChange = (value: string) => {
+    if (providers.length > 0) {
+      detach(
+        setDefault(value as ModelProviderType, pageSignal),
+        Reason.DomCallback,
+      );
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-3">
+      <h2 className="text-base font-semibold tracking-tight text-foreground">
+        Default model provider
+      </h2>
+      <div className="flex flex-col rounded-[var(--zero-card-radius)] border border-[var(--zero-card-border)] bg-card shadow-[var(--zero-card-shadow)]">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-center px-5 py-4">
+          <div className="flex flex-1 flex-col gap-1 min-w-0">
+            <span className="text-sm font-medium text-foreground">
+              Default provider
+            </span>
+            <span className="text-xs text-muted-foreground">
+              The provider used by default when running agents.
+            </span>
+          </div>
+          {isLoading ? (
+            <div className="w-full sm:w-[260px] h-9 shrink-0 rounded-lg bg-muted/50 animate-pulse" />
+          ) : selectItems.length === 0 ? (
+            <span className="text-sm text-muted-foreground">
+              No providers configured
+            </span>
+          ) : (
+            <Select value={currentDefault} onValueChange={handleChange}>
+              <SelectTrigger className="w-full sm:w-[260px] h-9 shrink-0 rounded-lg border-border/70">
+                <SelectValue placeholder="Select a default provider" />
+              </SelectTrigger>
+              <SelectContent>
+                {selectItems.map((item) => (
+                  <SelectItem key={item.type} value={item.type}>
+                    <div className="flex items-center gap-2">
+                      <ProviderIcon type={item.type} size={16} />
+                      <span>{item.label}</span>
+                    </div>
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Provider list
+// ---------------------------------------------------------------------------
+
+function ZeroProviderList() {
+  const providersLoadable = useLoadable(configuredProviders$);
+  const addDialogOpen = useGet(addProviderDialogOpen$);
+  const setAddDialogOpen = useSet(setAddProviderDialogOpen$);
+  const openEdit = useSet(openEditDialog$);
+  const openDelete = useSet(openDeleteDialog$);
+
+  const isLoading = providersLoadable.state === "loading";
+  const providers =
+    providersLoadable.state === "hasData" ? providersLoadable.data : [];
+  const totalProviderTypes = Object.keys(MODEL_PROVIDER_TYPES).length;
+  const allConfigured = !isLoading && providers.length >= totalProviderTypes;
+
+  return (
+    <div className="flex flex-col gap-3">
+      <h2 className="text-base font-semibold tracking-tight text-foreground">
+        Model providers
+      </h2>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+        {/* Add provider — hidden when all types are configured */}
+        {!allConfigured && (
+          <button
+            type="button"
+            onClick={() => setAddDialogOpen(true)}
+            className="flex flex-col rounded-[var(--zero-card-radius)] border border-dashed border-border/80 transition-colors hover:border-border hover:bg-muted/30 group"
+          >
+            <div className="flex h-14 items-center gap-2.5 px-5">
+              <span className="flex h-7 w-7 shrink-0 items-center justify-center">
+                <IconPlus
+                  size={18}
+                  stroke={2}
+                  className="text-muted-foreground group-hover:text-foreground"
+                />
+              </span>
+              <span className="text-sm font-medium text-muted-foreground group-hover:text-foreground">
+                Add provider
+              </span>
+            </div>
+            <div className="flex h-11 items-center border-t border-dashed border-border/80 px-5 group-hover:border-border">
+              <span className="text-xs text-muted-foreground/70">
+                Browse supported providers
+              </span>
+            </div>
+          </button>
+        )}
+
+        {/* Skeleton cards while loading */}
+        {isLoading && (
+          <>
+            <SkeletonCard />
+            <SkeletonCard />
+            <SkeletonCard />
+          </>
+        )}
+
+        {/* Real provider cards */}
+        {!isLoading &&
+          providers.map((p) => (
+            <div
+              key={p.type}
+              role="button"
+              tabIndex={0}
+              onClick={() => openEdit(p)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  openEdit(p);
+                }
+              }}
+              className="flex flex-col rounded-[var(--zero-card-radius)] border border-[var(--zero-card-border)] bg-card shadow-[var(--zero-card-shadow)] cursor-pointer transition-colors hover:bg-muted/50"
+            >
+              <div className="flex h-14 items-center gap-2.5 px-5">
+                <span className="flex h-7 w-7 shrink-0 items-center justify-center">
+                  <ProviderIcon type={p.type} size={22} />
+                </span>
+                <span className="min-w-0 flex-1 text-sm font-medium text-foreground truncate">
+                  {getUILabel(p.type)}
+                </span>
+              </div>
+
+              <div
+                className="flex h-11 items-center justify-between border-t border-border/50 pl-5 pr-2"
+                onClick={(e) => e.stopPropagation()}
+              >
+                <span className="flex items-center gap-2 text-xs text-muted-foreground truncate">
+                  <span className="h-1.5 w-1.5 rounded-full bg-emerald-500 shrink-0" />
+                  Configured
+                </span>
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-7 w-7 shrink-0 rounded-lg text-muted-foreground hover:text-foreground"
+                      aria-label="More options"
+                    >
+                      <IconDotsVertical size={14} stroke={1.5} />
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end" className="w-40">
+                    <DropdownMenuItem onClick={() => openEdit(p)}>
+                      Edit
+                    </DropdownMenuItem>
+                    <DropdownMenuItem
+                      className="text-destructive"
+                      onClick={() => openDelete(p.type)}
+                    >
+                      Delete
+                    </DropdownMenuItem>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </div>
+            </div>
+          ))}
+      </div>
+
+      <AddProviderDialog open={addDialogOpen} onOpenChange={setAddDialogOpen} />
+    </div>
+  );
+}

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -14,6 +14,7 @@ import {
   IconPlus,
   IconChevronRight,
   IconSwitchHorizontal,
+  IconSettings,
   IconLoader2,
   IconRefresh,
 } from "@tabler/icons-react";
@@ -42,6 +43,7 @@ export type ZeroNavId =
   | "production"
   | "activity"
   | "works"
+  | "settings"
   | "account";
 
 type NavIcon = (props: { size?: number; className?: string }) => ReactNode;
@@ -60,6 +62,12 @@ const FOOTER_NAV = [
     label: "Where Zero works",
     icon: IconLayoutGrid as NavIcon,
     iconImg: slackIcon,
+  },
+  {
+    id: "settings" as const satisfies ZeroNavId,
+    label: "Settings",
+    icon: IconSettings as NavIcon,
+    iconImg: undefined,
   },
 ] as const;
 
@@ -323,7 +331,7 @@ function AccountDropdown({
           <IconUser size={18} stroke={1.5} />
           <span>Manage account</span>
         </DropdownMenuItem>
-        {import.meta.env.DEV && onResetAgent && (
+        {onResetAgent && (
           <>
             <DropdownMenuSeparator />
             <DropdownMenuItem

--- a/turbo/apps/web/app/api/onboarding/status/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/onboarding/status/__tests__/route.test.ts
@@ -85,7 +85,7 @@ describe("GET /api/onboarding/status", () => {
   });
 
   it("should return needsOnboarding=false when all conditions met", async () => {
-    await context.setupUser();
+    const user = await context.setupUser();
     await createTestModelProvider("anthropic-api-key", "test-secret-key");
 
     // Create a compose and set as default via API
@@ -101,6 +101,13 @@ describe("GET /api/onboarding/status", () => {
     );
     const setDefaultResponse = await setDefaultAgent(setDefaultRequest);
     expect(setDefaultResponse.status).toBe(200);
+
+    // Re-mock Clerk so the JWT session claim includes the compose ID
+    // (in production, Clerk propagates org metadata to JWT claims)
+    mockClerk({
+      userId: user.userId,
+      orgDefaultAgentComposeId: compose.composeId,
+    });
 
     const request = createTestRequest(
       "http://localhost:3000/api/onboarding/status",
@@ -121,7 +128,7 @@ describe("GET /api/onboarding/status", () => {
   });
 
   it("should return defaultAgentMetadata when compose has metadata", async () => {
-    await context.setupUser();
+    const user = await context.setupUser();
     await createTestModelProvider("anthropic-api-key", "test-secret-key");
 
     // Create a compose with metadata
@@ -139,6 +146,12 @@ describe("GET /api/onboarding/status", () => {
     );
     const setDefaultResponse = await setDefaultAgent(setDefaultRequest);
     expect(setDefaultResponse.status).toBe(200);
+
+    // Re-mock Clerk so the JWT session claim includes the compose ID
+    mockClerk({
+      userId: user.userId,
+      orgDefaultAgentComposeId: compose.composeId,
+    });
 
     const request = createTestRequest(
       "http://localhost:3000/api/onboarding/status",

--- a/turbo/apps/web/app/api/onboarding/status/route.ts
+++ b/turbo/apps/web/app/api/onboarding/status/route.ts
@@ -3,7 +3,6 @@ import { onboardingStatusContract } from "@vm0/core";
 import { initServices } from "../../../../src/lib/init-services";
 import { getUserId } from "../../../../src/lib/auth/get-user-id";
 import { resolveScope } from "../../../../src/lib/scope/resolve-scope";
-import { getScopeByOrgId } from "../../../../src/lib/scope/scope-service";
 import { isNotFound } from "../../../../src/lib/errors";
 import { modelProviders } from "../../../../src/db/schema/model-provider";
 import {
@@ -12,6 +11,7 @@ import {
 } from "../../../../src/db/schema/agent-compose";
 import { eq } from "drizzle-orm";
 import { agentComposeContentSchema } from "@vm0/core";
+import { auth } from "@clerk/nextjs/server";
 
 const router = tsr.router(onboardingStatusContract, {
   getStatus: async ({ headers }) => {
@@ -49,11 +49,12 @@ const router = tsr.router(onboardingStatusContract, {
 
       hasModelProvider = provider !== undefined;
 
-      // Query the scope record to get defaultAgentComposeId
-      const scopeRecord = await getScopeByOrgId(resolvedScope.orgId);
+      // Read default agent compose ID from Clerk JWT session claims
+      const authResult = await auth();
+      const claimAgentComposeId =
+        authResult.sessionClaims?.org_default_agent_compose_id ?? null;
 
-      // Check default agent and get its name + metadata
-      if (scopeRecord?.defaultAgentComposeId) {
+      if (claimAgentComposeId) {
         const [compose] = await globalThis.services.db
           .select({
             name: agentComposes.name,
@@ -65,13 +66,13 @@ const router = tsr.router(onboardingStatusContract, {
             agentComposeVersions,
             eq(agentComposes.headVersionId, agentComposeVersions.id),
           )
-          .where(eq(agentComposes.id, scopeRecord.defaultAgentComposeId))
+          .where(eq(agentComposes.id, claimAgentComposeId))
           .limit(1);
 
         if (compose) {
           hasDefaultAgent = true;
           defaultAgentName = compose.name;
-          defaultAgentComposeId = scopeRecord.defaultAgentComposeId;
+          defaultAgentComposeId = claimAgentComposeId;
 
           // Extract metadata from compose content
           const parsed = agentComposeContentSchema.safeParse(compose.content);

--- a/turbo/apps/web/app/api/scopes/default-agent/route.ts
+++ b/turbo/apps/web/app/api/scopes/default-agent/route.ts
@@ -4,12 +4,8 @@ import { initServices } from "../../../../src/lib/init-services";
 import { getAuthContext } from "../../../../src/lib/auth/get-user-id";
 import { resolveScope } from "../../../../src/lib/scope/resolve-scope";
 import { agentComposes } from "../../../../src/db/schema/agent-compose";
-import { scopes } from "../../../../src/db/schema/scope";
 import { eq, and } from "drizzle-orm";
 import { clerkClient } from "@clerk/nextjs/server";
-import { logger } from "../../../../src/lib/logger";
-
-const log = logger("api:scopes:default-agent");
 
 const router = tsr.router(scopeDefaultAgentContract, {
   setDefaultAgent: async ({ query, body, headers }) => {
@@ -73,23 +69,10 @@ const router = tsr.router(scopeDefaultAgentContract, {
       }
     }
 
-    await globalThis.services.db
-      .update(scopes)
-      .set({ defaultAgentComposeId: agentComposeId })
-      .where(eq(scopes.orgId, scope.orgId));
-
-    // Dual-write to Clerk org publicMetadata (fire-and-forget)
-    try {
-      const client = await clerkClient();
-      await client.organizations.updateOrganizationMetadata(scope.orgId, {
-        publicMetadata: { default_agent_compose_id: agentComposeId },
-      });
-    } catch (err) {
-      log.error("Failed to write default agent to Clerk metadata", {
-        error: err,
-        orgId: scope.orgId,
-      });
-    }
+    const client = await clerkClient();
+    await client.organizations.updateOrganizationMetadata(scope.orgId, {
+      publicMetadata: { default_agent_compose_id: agentComposeId },
+    });
 
     return {
       status: 200 as const,

--- a/turbo/apps/web/src/__tests__/clerk-mock.ts
+++ b/turbo/apps/web/src/__tests__/clerk-mock.ts
@@ -51,6 +51,7 @@ let createdOrgs: Array<{
  * @param options.membershipTimezone - Timezone to include in JWT sessionClaims.membership_timezone (optional)
  * @param options.membershipNotifyEmail - Flag to include in JWT sessionClaims.membership_notify_email (optional)
  * @param options.membershipNotifySlack - Flag to include in JWT sessionClaims.membership_notify_slack (optional)
+ * @param options.orgDefaultAgentComposeId - Default agent compose ID to include in JWT sessionClaims.org_default_agent_compose_id (optional)
  */
 export function mockClerk(options: {
   userId: string | null;
@@ -62,6 +63,7 @@ export function mockClerk(options: {
   membershipTimezone?: string;
   membershipNotifyEmail?: boolean;
   membershipNotifySlack?: boolean;
+  orgDefaultAgentComposeId?: string | null;
   clerkOrgs?: Array<{ id: string; slug: string; name: string; role?: string }>;
 }) {
   const email = options.email ?? "test@example.com";
@@ -107,6 +109,9 @@ export function mockClerk(options: {
       }),
       ...(options.membershipNotifySlack !== undefined && {
         membership_notify_slack: options.membershipNotifySlack,
+      }),
+      ...(options.orgDefaultAgentComposeId !== undefined && {
+        org_default_agent_compose_id: options.orgDefaultAgentComposeId,
       }),
     },
   } as Awaited<ReturnType<typeof auth>>);

--- a/turbo/apps/web/src/lib/compose/trigger-compose-job.ts
+++ b/turbo/apps/web/src/lib/compose/trigger-compose-job.ts
@@ -300,7 +300,7 @@ async function spawnComposeJobSandbox(
     await sandbox.files.write("/tmp/compose/vm0.yaml", yamlContent);
 
     // Write instructions file if provided, with metadata frontmatter injected
-    if (params.instructions) {
+    if (params.instructions !== undefined) {
       const instructionsFilename = getInstructionsFilename(params.content);
       if (instructionsFilename) {
         const metadata = getAgentMetadata(params.content);


### PR DESCRIPTION
## Summary
- Add a dedicated **zero settings page** (`/settings` tab) with provider management UI (default provider selector, provider cards with add/edit/delete)
- Refactor skills management to use a **local draft pattern** with explicit save/discard instead of saving on every add/remove — adds `zeroSkillsDirty$`, `saveZeroSkills$`, and `discardZeroSkills$` signals
- Replace raw API calls in onboarding with `triggerAndPollComposeJob` so the CLI processes skills and uploads assets correctly
- Read default agent compose ID from **Clerk JWT session claims** instead of querying the scopes table, and remove the dual-write pattern from the default-agent route
- Write instructions file even when empty so metadata frontmatter is always created
- Force JWT refresh after onboarding completion so updated org metadata is available immediately
- Limit visible toasts to 1 and update test assertions for the new add-provider dialog flow

## Test plan
- [ ] Verify the new `/settings` tab appears in the zero sidebar and renders the provider management UI
- [ ] Test adding, editing, and deleting model providers from the settings page
- [ ] Test skill add/remove shows dirty state, save persists via compose job, discard reverts
- [ ] Run onboarding flow end-to-end and verify compose job runs and default agent is set
- [ ] Verify `pnpm vitest` passes (settings-page tests updated)
- [ ] Verify `pnpm turbo run lint` and `pnpm check-types` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)