### PR TITLE
feat(web): add cookie consent banner via termly

### DIFF
--- a/turbo/apps/web/app/components/Footer.tsx
+++ b/turbo/apps/web/app/components/Footer.tsx
@@ -53,6 +53,21 @@ export default function Footer() {
               <Link href="/privacy-policy" className="footer-legal-link">
                 {t("privacyPolicy")}
               </Link>
+              <span className="footer-legal-separator">•</span>
+              <button
+                type="button"
+                className="footer-legal-link"
+                onClick={() => {
+                  if (
+                    "displayPreferenceModal" in window &&
+                    typeof window.displayPreferenceModal === "function"
+                  ) {
+                    (window.displayPreferenceModal as () => void)();
+                  }
+                }}
+              >
+                {t("cookieSettings")}
+              </button>
             </div>
           </div>
           <div className="footer-right">

--- a/turbo/apps/web/app/layout.tsx
+++ b/turbo/apps/web/app/layout.tsx
@@ -142,6 +142,10 @@ export default function RootLayout({
     >
       <html lang="en" data-theme="dark" suppressHydrationWarning>
         <head>
+          <Script
+            src="https://app.termly.io/resource-blocker/058a3478-08ac-4f2f-a9c4-5b357bbe7433?autoBlock=on"
+            strategy="beforeInteractive"
+          />
           <link rel="preconnect" href="https://fonts.googleapis.com" />
           <link
             rel="preconnect"

--- a/turbo/apps/web/messages/de.json
+++ b/turbo/apps/web/messages/de.json
@@ -97,7 +97,8 @@
     "language": "Sprache",
     "status": "Status",
     "termsOfUse": "Nutzungsbedingungen",
-    "privacyPolicy": "Datenschutzrichtlinie"
+    "privacyPolicy": "Datenschutzrichtlinie",
+    "cookieSettings": "Cookie-Einstellungen"
   },
   "skills": {
     "hero": {

--- a/turbo/apps/web/messages/en.json
+++ b/turbo/apps/web/messages/en.json
@@ -97,7 +97,8 @@
     "language": "Language",
     "status": "Status",
     "termsOfUse": "Terms of Use",
-    "privacyPolicy": "Privacy Policy"
+    "privacyPolicy": "Privacy Policy",
+    "cookieSettings": "Cookie Settings"
   },
   "skills": {
     "hero": {

--- a/turbo/apps/web/messages/es.json
+++ b/turbo/apps/web/messages/es.json
@@ -97,7 +97,8 @@
     "language": "Idioma",
     "status": "Estado",
     "termsOfUse": "Términos de Uso",
-    "privacyPolicy": "Política de Privacidad"
+    "privacyPolicy": "Política de Privacidad",
+    "cookieSettings": "Configuración de Cookies"
   },
   "skills": {
     "hero": {

--- a/turbo/apps/web/messages/ja.json
+++ b/turbo/apps/web/messages/ja.json
@@ -97,7 +97,8 @@
     "language": "言語",
     "status": "ステータス",
     "termsOfUse": "利用規約",
-    "privacyPolicy": "プライバシーポリシー"
+    "privacyPolicy": "プライバシーポリシー",
+    "cookieSettings": "Cookie設定"
   },
   "skills": {
     "hero": {


### PR DESCRIPTION
## Summary
- Add Termly CMP resource-blocker script to `layout.tsx` `<head>` before all other scripts, enabling Auto Blocker to intercept third-party scripts before execution
- Add "Cookie Settings" button to the footer that opens Termly's preference center modal, allowing users to manage consent preferences
- Add i18n translations for the cookie settings link in all four supported languages (en, de, es, ja)

Closes #4509

## Test plan
- [ ] Verify Termly banner appears on the web app (may require EU geo-targeting config in Termly dashboard)
- [ ] Verify "Cookie Settings" button in footer opens the Termly preference center modal
- [ ] Verify the button renders correctly in all four languages
- [ ] Verify existing functionality (Clerk auth, Plausible analytics) is not affected by the resource blocker

🤖 Generated with [Claude Code](https://claude.com/claude-code)