### PR TITLE
fix(web): add quote character escaping to telegram html output

### DIFF
--- a/turbo/apps/web/src/lib/telegram/format.ts
+++ b/turbo/apps/web/src/lib/telegram/format.ts
@@ -10,7 +10,9 @@ export function escapeHtml(text: string): string {
   return text
     .replace(/&/g, "&amp;")
     .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;");
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#x27;");
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add `"` and `'` character escaping to the `escapeHtml` function in the Telegram formatter
- Prevents potential XSS via unescaped quote characters in HTML attributes (e.g., `href` values)
- Aligns with OWASP recommendation to escape all five HTML special characters (`& < > " '`)

## Test plan
- [ ] Verify existing Telegram format tests still pass
- [ ] Confirm quote characters in user input are properly escaped in HTML output

🤖 Generated with [Claude Code](https://claude.com/claude-code)