### PR TITLE
chore: add turbo-reset skill for clean reinstall

### DIFF
--- a/.claude/skills/turbo-reset/SKILL.md
+++ b/.claude/skills/turbo-reset/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: turbo-reset
+description: Reset turbo environment (clean node_modules, reinstall, sync DB)
+user-invocable: true
+---
+
+# Turbo Reset
+
+Reset the turbo development environment to a clean state.
+
+## Steps
+
+1. Remove `node_modules` across the monorepo:
+   ```bash
+   cd turbo && rm -rf node_modules apps/*/node_modules packages/*/node_modules
+   ```
+
+2. Clear turbo cache:
+   ```bash
+   cd turbo && rm -rf .turbo apps/*/.turbo packages/*/.turbo
+   ```
+
+3. Reinstall dependencies:
+   ```bash
+   cd turbo && pnpm install
+   ```
+
+4. Sync database migrations:
+   ```bash
+   cd turbo/apps/web && pnpm db:migrate
+   ```
+
+Run all steps sequentially. Report success or failure after each step.


### PR DESCRIPTION
## Summary
- Add `/turbo-reset` slash command to reset the turbo dev environment
- Cleans node_modules, turbo cache, reinstalls deps, and syncs DB migrations

Closes #4518

## Test plan
- [x] Tested `/turbo-reset` locally — all 4 steps pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)