### PR TITLE
refactor: add extract-and-group-variables convenience function

### DIFF
--- a/turbo/apps/cli/src/commands/compose/index.ts
+++ b/turbo/apps/cli/src/commands/compose/index.ts
@@ -6,8 +6,7 @@ import { dirname, join } from "path";
 import { parse as parseYaml } from "yaml";
 import {
   getLegacySystemTemplateWarning,
-  extractVariableReferences,
-  groupVariablesBySource,
+  extractAndGroupVariables,
   resolveSkillRef,
 } from "@vm0/core";
 import {
@@ -50,8 +49,7 @@ function isGitHubUrl(input: string): boolean {
  * Looks for ${{ secrets.XXX }} patterns in the compose.
  */
 export function getSecretsFromComposeContent(content: unknown): Set<string> {
-  const refs = extractVariableReferences(content);
-  const grouped = groupVariablesBySource(refs);
+  const grouped = extractAndGroupVariables(content);
   return new Set(grouped.secrets.map((r) => r.name));
 }
 
@@ -60,8 +58,7 @@ export function getSecretsFromComposeContent(content: unknown): Set<string> {
  * Looks for ${{ vars.XXX }} patterns in the compose.
  */
 function getVarsFromComposeContent(content: unknown): Set<string> {
-  const refs = extractVariableReferences(content);
-  const grouped = groupVariablesBySource(refs);
+  const grouped = extractAndGroupVariables(content);
   return new Set(grouped.vars.map((r) => r.name));
 }
 

--- a/turbo/apps/cli/src/commands/run/shared.ts
+++ b/turbo/apps/cli/src/commands/run/shared.ts
@@ -5,7 +5,7 @@ import { getEvents } from "../../lib/api";
 import { parseEvent } from "../../lib/events/event-parser-factory";
 import { EventRenderer } from "../../lib/events/event-renderer";
 import { CodexEventRenderer } from "../../lib/events/codex-event-renderer";
-import { extractVariableReferences, groupVariablesBySource } from "@vm0/core";
+import { extractAndGroupVariables } from "@vm0/core";
 /**
  * Collector for --secrets and --vars flags
  * Format: KEY=value
@@ -52,8 +52,7 @@ export function isUUID(str: string): boolean {
  * Extract var names from compose config
  */
 export function extractVarNames(composeContent: unknown): string[] {
-  const refs = extractVariableReferences(composeContent);
-  const grouped = groupVariablesBySource(refs);
+  const grouped = extractAndGroupVariables(composeContent);
   return grouped.vars.map((r) => r.name);
 }
 
@@ -61,8 +60,7 @@ export function extractVarNames(composeContent: unknown): string[] {
  * Extract secret names from compose config
  */
 export function extractSecretNames(composeContent: unknown): string[] {
-  const refs = extractVariableReferences(composeContent);
-  const grouped = groupVariablesBySource(refs);
+  const grouped = extractAndGroupVariables(composeContent);
   return grouped.secrets.map((r) => r.name);
 }
 

--- a/turbo/apps/cli/src/lib/domain/schedule-utils.ts
+++ b/turbo/apps/cli/src/lib/domain/schedule-utils.ts
@@ -1,6 +1,6 @@
 import { existsSync, readFileSync } from "fs";
 import { parse as parseYaml } from "yaml";
-import { extractVariableReferences, groupVariablesBySource } from "@vm0/core";
+import { extractAndGroupVariables } from "@vm0/core";
 import { listSchedules, getScope } from "../api";
 
 const CONFIG_FILE = "vm0.yaml";
@@ -304,8 +304,7 @@ export function extractRequiredConfiguration(
     return result;
   }
 
-  const refs = extractVariableReferences(composeContent);
-  const grouped = groupVariablesBySource(refs);
+  const grouped = extractAndGroupVariables(composeContent);
 
   result.secrets = grouped.secrets.map((r) => r.name);
   result.vars = grouped.vars.map((r) => r.name);

--- a/turbo/apps/cli/src/lib/domain/source-derivation.ts
+++ b/turbo/apps/cli/src/lib/domain/source-derivation.ts
@@ -1,10 +1,7 @@
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import * as os from "node:os";
-import {
-  extractVariableReferences as extractVariableReferencesCore,
-  groupVariablesBySource,
-} from "@vm0/core";
+import { extractAndGroupVariables } from "@vm0/core";
 import {
   parseGitHubTreeUrl,
   downloadGitHubSkill,
@@ -93,10 +90,7 @@ async function deriveAgentVariableSources(
   options?: { skipNetwork?: boolean },
 ): Promise<AgentVariableSources> {
   // Extract all variable references from environment using @vm0/core
-  const refs = agent.environment
-    ? extractVariableReferencesCore(agent.environment)
-    : [];
-  const grouped = groupVariablesBySource(refs);
+  const grouped = extractAndGroupVariables(agent.environment ?? {});
 
   // Initialize all sources as "agent environment"
   const secretSources = new Map<string, VariableSource>();

--- a/turbo/apps/platform/src/signals/agent-detail/connections.ts
+++ b/turbo/apps/platform/src/signals/agent-detail/connections.ts
@@ -1,7 +1,6 @@
 import { computed } from "ccstate";
 import {
-  extractVariableReferences,
-  groupVariablesBySource,
+  extractAndGroupVariables,
   getConnectorManagedSecretNames,
   getConnectorTypeForSecretName,
   CONNECTOR_TYPES,
@@ -36,8 +35,7 @@ const agentRequiredEnv$ = computed((get): AgentRequiredEnv => {
     return { requiredSecrets: [], requiredVariables: [] };
   }
 
-  const refs = extractVariableReferences(firstAgent.environment);
-  const grouped = groupVariablesBySource(refs);
+  const grouped = extractAndGroupVariables(firstAgent.environment);
 
   return {
     requiredSecrets: grouped.secrets.map((r) => r.name),
@@ -85,8 +83,7 @@ export const agentRequiredConnectorTypes$ = computed(
     // From environment field — match env var names against all connector secret names
     // (including api-token auth method secrets and OAuth environmentMapping keys)
     if (firstAgent.environment) {
-      const refs = extractVariableReferences(firstAgent.environment);
-      const grouped = groupVariablesBySource(refs);
+      const grouped = extractAndGroupVariables(firstAgent.environment);
 
       for (const ref of grouped.secrets) {
         const connectorType = getConnectorTypeForSecretName(ref.name);

--- a/turbo/apps/web/app/api/agent/required-env/route.ts
+++ b/turbo/apps/web/app/api/agent/required-env/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 import { initServices } from "../../../../src/lib/init-services";
 import { getUserId } from "../../../../src/lib/auth/get-user-id";
 import { logger } from "../../../../src/lib/logger";
-import { extractVariableReferences, groupVariablesBySource } from "@vm0/core";
+import { extractAndGroupVariables } from "@vm0/core";
 import {
   getUserAgents,
   batchFetchVersionContents,
@@ -68,8 +68,7 @@ export async function GET(request: Request) {
       continue;
     }
 
-    const refs = extractVariableReferences(firstAgent.environment);
-    const grouped = groupVariablesBySource(refs);
+    const grouped = extractAndGroupVariables(firstAgent.environment);
 
     const requiredSecrets = grouped.secrets.map((r) => r.name);
     const requiredVariables = grouped.vars.map((r) => r.name);

--- a/turbo/apps/web/app/api/agent/schedules/missing-secrets/route.ts
+++ b/turbo/apps/web/app/api/agent/schedules/missing-secrets/route.ts
@@ -4,7 +4,7 @@ import { getUserId } from "../../../../../src/lib/auth/get-user-id";
 import { logger } from "../../../../../src/lib/logger";
 import { eq } from "drizzle-orm";
 import { secrets } from "../../../../../src/db/schema/secret";
-import { extractVariableReferences, groupVariablesBySource } from "@vm0/core";
+import { extractAndGroupVariables } from "@vm0/core";
 import {
   getUserAgents,
   batchFetchVersionContents,
@@ -92,8 +92,7 @@ export async function GET(request: Request) {
       continue;
     }
 
-    const refs = extractVariableReferences(firstAgent.environment);
-    const grouped = groupVariablesBySource(refs);
+    const grouped = extractAndGroupVariables(firstAgent.environment);
 
     const requiredSecrets = grouped.secrets.map((r) => r.name);
 

--- a/turbo/apps/web/app/api/agent/sessions/[id]/route.ts
+++ b/turbo/apps/web/app/api/agent/sessions/[id]/route.ts
@@ -3,11 +3,7 @@ import {
   tsr,
   TsRestResponse,
 } from "../../../../../src/lib/ts-rest-handler";
-import {
-  sessionsByIdContract,
-  extractVariableReferences,
-  groupVariablesBySource,
-} from "@vm0/core";
+import { sessionsByIdContract, extractAndGroupVariables } from "@vm0/core";
 import { eq } from "drizzle-orm";
 import { initServices } from "../../../../../src/lib/init-services";
 import { agentSessions } from "../../../../../src/db/schema/agent-session";
@@ -75,8 +71,7 @@ const router = tsr.router(sessionsByIdContract, {
         .limit(1);
 
       if (version?.content) {
-        const refs = extractVariableReferences(version.content);
-        const grouped = groupVariablesBySource(refs);
+        const grouped = extractAndGroupVariables(version.content);
         const names = grouped.secrets.map((ref) => ref.name);
         secretNames = names.length > 0 ? names : null;
       }

--- a/turbo/apps/web/app/api/integrations/github/route.ts
+++ b/turbo/apps/web/app/api/integrations/github/route.ts
@@ -1,8 +1,7 @@
 import { NextResponse } from "next/server";
 import { and, eq } from "drizzle-orm";
 import {
-  extractVariableReferences,
-  groupVariablesBySource,
+  extractAndGroupVariables,
   getConnectorProvidedSecretNames,
 } from "@vm0/core";
 import { initServices } from "../../../../src/lib/init-services";
@@ -114,8 +113,7 @@ export async function GET(request: Request) {
 
     if (version) {
       const content = version.content as AgentComposeYaml;
-      const refs = extractVariableReferences(content);
-      const grouped = groupVariablesBySource(refs);
+      const grouped = extractAndGroupVariables(content);
       requiredSecrets = grouped.secrets.map((s) => s.name);
       requiredVars = grouped.vars.map((v) => v.name);
     }

--- a/turbo/apps/web/app/api/integrations/slack/route.ts
+++ b/turbo/apps/web/app/api/integrations/slack/route.ts
@@ -1,8 +1,7 @@
 import { NextResponse } from "next/server";
 import { and, desc, eq } from "drizzle-orm";
 import {
-  extractVariableReferences,
-  groupVariablesBySource,
+  extractAndGroupVariables,
   getConnectorProvidedSecretNames,
 } from "@vm0/core";
 import { initServices } from "../../../../src/lib/init-services";
@@ -120,8 +119,7 @@ export async function GET(request: Request) {
 
     if (version) {
       const content = version.content as AgentComposeYaml;
-      const refs = extractVariableReferences(content);
-      const grouped = groupVariablesBySource(refs);
+      const grouped = extractAndGroupVariables(content);
       requiredSecrets = grouped.secrets.map((s) => s.name);
       requiredVars = grouped.vars.map((v) => v.name);
     }

--- a/turbo/apps/web/app/api/integrations/telegram/route.ts
+++ b/turbo/apps/web/app/api/integrations/telegram/route.ts
@@ -2,8 +2,7 @@ import { NextResponse } from "next/server";
 import { and, eq, desc } from "drizzle-orm";
 import { z } from "zod";
 import {
-  extractVariableReferences,
-  groupVariablesBySource,
+  extractAndGroupVariables,
   getConnectorProvidedSecretNames,
 } from "@vm0/core";
 import { initServices } from "../../../../src/lib/init-services";
@@ -116,8 +115,7 @@ export async function GET(request: Request) {
 
     if (version) {
       const content = version.content as AgentComposeYaml;
-      const refs = extractVariableReferences(content);
-      const grouped = groupVariablesBySource(refs);
+      const grouped = extractAndGroupVariables(content);
       requiredSecrets = grouped.secrets.map((s) => s.name);
       requiredVars = grouped.vars.map((v) => v.name);
     }

--- a/turbo/apps/web/src/lib/config-validator.ts
+++ b/turbo/apps/web/src/lib/config-validator.ts
@@ -1,4 +1,4 @@
-import { extractVariableReferences, groupVariablesBySource } from "@vm0/core";
+import { extractAndGroupVariables } from "@vm0/core";
 
 /**
  * Extract all ${{ vars.xxx }} template variable references from a config object
@@ -7,7 +7,6 @@ import { extractVariableReferences, groupVariablesBySource } from "@vm0/core";
  * @returns Array of unique template variable names (just the name, not full syntax)
  */
 export function extractTemplateVars(obj: unknown): string[] {
-  const refs = extractVariableReferences(obj);
-  const grouped = groupVariablesBySource(refs);
+  const grouped = extractAndGroupVariables(obj);
   return grouped.vars.map((ref) => ref.name);
 }

--- a/turbo/apps/web/src/lib/run/build-context.ts
+++ b/turbo/apps/web/src/lib/run/build-context.ts
@@ -1,7 +1,6 @@
 import { eq, and } from "drizzle-orm";
 import {
-  extractVariableReferences,
-  groupVariablesBySource,
+  extractAndGroupVariables,
   getFrameworkForType,
   getSecretNameForType,
   getEnvironmentMapping,
@@ -498,8 +497,7 @@ async function fetchReferencedSecrets(
     return undefined;
   }
 
-  const refs = extractVariableReferences(environment);
-  const grouped = groupVariablesBySource(refs);
+  const grouped = extractAndGroupVariables(environment);
 
   if (grouped.secrets.length === 0) {
     return undefined;
@@ -585,8 +583,7 @@ function mergeConnectorSecretsForReferences(
   }
 
   // Extract ${{ secrets.* }} references from compose environment
-  const refs = extractVariableReferences(composeEnvironment);
-  const grouped = groupVariablesBySource(refs);
+  const grouped = extractAndGroupVariables(composeEnvironment);
 
   if (grouped.secrets.length === 0) {
     return existingSecrets;

--- a/turbo/apps/web/src/lib/run/environment/expand-environment.ts
+++ b/turbo/apps/web/src/lib/run/environment/expand-environment.ts
@@ -1,7 +1,6 @@
 import {
   expandVariables,
-  extractVariableReferences,
-  groupVariablesBySource,
+  extractAndGroupVariables,
   connectorTypeSchema,
   getConnectorEnvironmentMapping,
   getServiceConfig,
@@ -136,8 +135,7 @@ export function expandEnvironmentFromCompose(
   const environment = firstAgent.environment;
 
   // Extract all variable references to determine what we need
-  const refs = extractVariableReferences(environment);
-  const grouped = groupVariablesBySource(refs);
+  const grouped = extractAndGroupVariables(environment);
 
   // Check for unsupported env references
   if (grouped.env.length > 0) {

--- a/turbo/apps/web/src/lib/schedule/schedule-service.ts
+++ b/turbo/apps/web/src/lib/schedule/schedule-service.ts
@@ -1,8 +1,7 @@
 import { eq, and, lte, inArray, desc } from "drizzle-orm";
 import { Cron } from "croner";
 import {
-  extractVariableReferences,
-  groupVariablesBySource,
+  extractAndGroupVariables,
   getConnectorProvidedSecretNames,
   scopeTierSchema,
 } from "@vm0/core";
@@ -110,8 +109,7 @@ function extractRequiredConfiguration(composeContent: unknown): {
   };
   if (!composeContent) return result;
 
-  const refs = extractVariableReferences(composeContent);
-  const grouped = groupVariablesBySource(refs);
+  const grouped = extractAndGroupVariables(composeContent);
 
   result.secrets = grouped.secrets.map((r) => r.name);
   result.vars = grouped.vars.map((r) => r.name);

--- a/turbo/packages/core/src/variable-expander.ts
+++ b/turbo/packages/core/src/variable-expander.ts
@@ -218,6 +218,31 @@ export function groupVariablesBySource(refs: VariableReference[]): {
 }
 
 /**
+ * Extract all variable references from an object and group them by source.
+ * Convenience wrapper combining extractVariableReferences + groupVariablesBySource.
+ *
+ * @example
+ * ```ts
+ * const env = {
+ *   API_KEY: "${{ secrets.OPENAI_KEY }}",
+ *   REGION: "${{ vars.AWS_REGION }}",
+ *   STATIC: "hello",
+ * };
+ * const grouped = extractAndGroupVariables(env);
+ * // grouped.secrets => [{ source: "secrets", name: "OPENAI_KEY", fullMatch: "${{ secrets.OPENAI_KEY }}" }]
+ * // grouped.vars    => [{ source: "vars", name: "AWS_REGION", fullMatch: "${{ vars.AWS_REGION }}" }]
+ * // grouped.env     => []
+ * ```
+ */
+export function extractAndGroupVariables(obj: unknown): {
+  env: VariableReference[];
+  vars: VariableReference[];
+  secrets: VariableReference[];
+} {
+  return groupVariablesBySource(extractVariableReferences(obj));
+}
+
+/**
  * Format missing variables for error messages
  * @param missing - Array of missing variable references
  * @returns Formatted error message


### PR DESCRIPTION
## Summary
- Add `extractAndGroupVariables` convenience function that combines `extractVariableReferences` + `groupVariablesBySource` into a single call
- Replace all 15 consumer call sites that always used these two functions together
- Reduces boilerplate imports and improves readability without changing behavior

## Test plan
- [ ] CI passes (lint, type check, tests)
- [ ] Existing tests cover all modified call sites — no behavioral change

🤖 Generated with [Claude Code](https://claude.com/claude-code)