### PR TITLE
docs: add rust and python testing guides

### DIFF
--- a/.claude/skills/testing/SKILL.md
+++ b/.claude/skills/testing/SKILL.md
@@ -21,6 +21,8 @@ Read the testing guide and relevant reference based on context:
 | CLI E2E (`e2e/tests/`) | [docs/testing.md](../../../docs/testing.md) | [cli-e2e-testing.md](../../../docs/testing/cli-e2e-testing.md) |
 | Web (`turbo/apps/web`) | [docs/testing.md](../../../docs/testing.md) | [web-testing.md](../../../docs/testing/web-testing.md) |
 | Platform (`turbo/apps/platform`) | [docs/testing.md](../../../docs/testing.md) | [platform-testing.md](../../../docs/testing/platform-testing.md) |
+| Rust (`crates/`) | [docs/testing.md](../../../docs/testing.md) | [rust-testing.md](../../../docs/testing/rust-testing.md) |
+| Python addon (`crates/runner/mitm-addon`) | [docs/testing.md](../../../docs/testing.md) | [mitm-addon-testing.md](../../../docs/testing/mitm-addon-testing.md) |
 
 ## Key Principles
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -259,5 +259,7 @@ Don't render components directly—use `setupPage()` which mirrors `main.ts` sta
 | CLI E2E (BATS) | [cli-e2e-testing.md](./testing/cli-e2e-testing.md) |
 | Web routes | [web-testing.md](./testing/web-testing.md) |
 | Platform UI | [platform-testing.md](./testing/platform-testing.md) |
+| Rust crates | [rust-testing.md](./testing/rust-testing.md) |
+| Python addon | [mitm-addon-testing.md](./testing/mitm-addon-testing.md) |
 
 For general code quality rules (no `any`, no lint suppressions, etc.), see [bad-smell.md](./bad-smell.md).

--- a/docs/testing/mitm-addon-testing.md
+++ b/docs/testing/mitm-addon-testing.md
@@ -1,0 +1,150 @@
+# mitmproxy Addon Testing Guide
+
+## Overview
+
+The mitmproxy addon (`crates/runner/mitm-addon/`) is a Python module that intercepts HTTPS requests inside sandboxes. Tests live in `tests/` and use pytest.
+
+## Running Tests
+
+```bash
+cd crates/runner/mitm-addon
+
+# All tests
+pytest tests/
+
+# Specific file
+pytest tests/test_handlers.py
+
+# Specific test
+pytest tests/test_handlers.py::TestRequestHandler::test_denied_flow_returns_403
+
+# Verbose
+pytest -v tests/
+```
+
+Pre-commit hooks run `pytest` on staged Python files in the addon.
+
+## Test Files
+
+| File | Tests |
+|------|-------|
+| `test_handlers.py` | Request routing, service auth, cache invalidation |
+| `test_firewall.py` | Domain matching, firewall rules, ALLOW/DENY |
+| `test_registry.py` | Registry loading, caching, file watching |
+| `test_connectors.py` | Service URL matching, token handling |
+| `test_utils.py` | Utility functions |
+
+## Patterns
+
+### Fixtures (conftest.py)
+
+Shared test data via pytest fixtures:
+
+```python
+@pytest.fixture
+def registry_file(tmp_path):
+    """Create a sample proxy registry JSON file."""
+    registry = {
+        "vms": {
+            "10.200.0.1": {
+                "runId": "run-abc-123",
+                "sandboxToken": "tok-xyz",
+                "mitmEnabled": True,
+                "firewallRules": [
+                    {"domain": "*.vm0.ai", "action": "ALLOW"},
+                ],
+            },
+        },
+    }
+    path = tmp_path / "proxy-registry.json"
+    path.write_text(json.dumps(registry))
+    return path
+```
+
+### Mock HTTP Flows
+
+Build mock mitmproxy flow objects for testing:
+
+```python
+def _make_http_flow(client_ip="10.200.0.1", host="example.com", port=443, path="/"):
+    flow = MagicMock()
+    flow.client_conn.peername = (client_ip, 12345)
+    flow.request.pretty_host = host
+    flow.request.port = port
+    flow.request.path = path
+    flow.request.pretty_url = f"https://{host}{path}"
+    flow.request.method = "GET"
+    flow.request.content = b""
+    flow.request.headers = {}
+    flow.metadata = {}
+    flow.response = None
+    return flow
+```
+
+### Module State Reset
+
+The addon uses module-level caches. Reset between tests:
+
+```python
+def _reset():
+    mitm_addon._request_start_times.clear()
+    mitm_addon._registry_cache = {}
+    mitm_addon._registry_cache_key = (0, 0)
+    mitm_addon._service_token_cache.clear()
+
+class TestRequestHandler:
+    def setup_method(self):
+        _reset()
+```
+
+### Mocking with patch
+
+Use `unittest.mock.patch` for module-level functions:
+
+```python
+from unittest.mock import MagicMock, patch
+
+def test_service_match_calls_handler(self, registry_file):
+    flow = _make_http_flow(host="api.github.com", path="/repos")
+
+    with (
+        patch.object(mitm_addon, "get_registry_path", return_value=str(registry_file)),
+        patch.object(mitm_addon, "handle_service_request") as mock_handler,
+    ):
+        mitm_addon.request(flow)
+
+    mock_handler.assert_called_once()
+    call_args = mock_handler.call_args
+    assert call_args[0][0] is flow
+    assert call_args[0][1]["base"] == "https://api.github.com"
+```
+
+### Asserting Flow State
+
+Check flow metadata and response after handler execution:
+
+```python
+# Firewall blocked
+assert flow.response is not None
+assert flow.response.status_code == 403
+assert flow.metadata["firewall_action"] == "DENY"
+
+# Service auth injected
+assert flow.request.headers["Authorization"] == "Bearer real-token"
+assert flow.metadata["firewall_action"] == "ALLOW"
+assert flow.metadata["service_base"] == "https://api.github.com"
+```
+
+## What to Test
+
+- **URL matching**: `match_service()` with various URLs, path boundaries
+- **Firewall rules**: domain/IP matching, rule ordering, wildcards
+- **Request routing**: correct handler called based on registry state
+- **Cache behavior**: token caching, expiry, invalidation on 401
+- **Registry loading**: valid JSON, missing file, cache refresh
+
+## What NOT to Test
+
+- Real mitmproxy interception (requires running proxy)
+- Real HTTP calls to auth endpoint (mock with `patch`)
+- TLS certificate handling (mitmproxy internals)

--- a/docs/testing/mitm-addon-testing.md
+++ b/docs/testing/mitm-addon-testing.md
@@ -90,7 +90,6 @@ def _reset():
     mitm_addon._request_start_times.clear()
     mitm_addon._registry_cache = {}
     mitm_addon._registry_cache_key = (0, 0)
-    mitm_addon._service_token_cache.clear()
 
 class TestRequestHandler:
     def setup_method(self):

--- a/docs/testing/rust-testing.md
+++ b/docs/testing/rust-testing.md
@@ -1,0 +1,183 @@
+# Rust Testing Guide
+
+## Overview
+
+Rust crates live in `crates/` and use `cargo test` for testing. The same principles from [testing.md](../testing.md) apply: integration tests are primary, mock at the boundary, use real infrastructure.
+
+## Running Tests
+
+```bash
+# All crates
+cargo test --manifest-path crates/Cargo.toml
+
+# Specific crate
+cargo test --manifest-path crates/Cargo.toml -p guest-agent
+
+# Specific test by name
+cargo test --manifest-path crates/Cargo.toml -p runner config::tests::load_full_config
+
+# With output (for debugging)
+cargo test --manifest-path crates/Cargo.toml -- --nocapture
+```
+
+Pre-commit hooks run `cargo-clippy` and `cargo-fmt` on staged Rust files.
+
+## Test Organization
+
+### Integration Tests (`tests/`)
+
+Preferred for testing public APIs and cross-module behavior:
+
+```
+crates/guest-agent/
+  src/
+    http.rs
+    masker.rs
+  tests/
+    integration.rs     # Integration tests
+```
+
+### Inline Tests (`#[cfg(test)]`)
+
+For testing module-internal logic that isn't exposed publicly:
+
+```rust
+// src/config.rs
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn load_full_config() {
+        let dir = tempfile::tempdir().unwrap();
+        // ... setup and assertions
+    }
+}
+```
+
+## Patterns
+
+### HTTP Mocking with httpmock
+
+Use `httpmock` for mocking external HTTP services:
+
+```rust
+use httpmock::prelude::*;
+
+static MOCK_SERVER: LazyLock<MockServer> = LazyLock::new(|| {
+    let server = MockServer::start();
+    unsafe {
+        std::env::set_var("VM0_API_URL", server.base_url());
+    }
+    server
+});
+
+#[tokio::test]
+async fn post_json_success() {
+    let server = &*MOCK_SERVER;
+    let mock = server.mock(|when, then| {
+        when.method(POST).path("/test");
+        then.status(200).json_body(json!({"status": "ok"}));
+    });
+
+    let result = http::post_json(&format!("{}/test", server.base_url()), &json!({}), 1).await;
+
+    mock.assert_calls_async(1).await;
+    assert_eq!(result.unwrap().unwrap()["status"], "ok");
+    mock.delete_async().await;
+}
+```
+
+### Test Serialization
+
+When tests share mutable state (env vars, global server), use `std::sync::Mutex`:
+
+```rust
+// Use std::sync::Mutex, not tokio::sync::Mutex
+// Each #[tokio::test] runs in its own runtime, so tokio Mutex won't work across tests
+static TEST_MUTEX: Mutex<()> = Mutex::new(());
+
+#[tokio::test]
+async fn test_with_shared_state() {
+    let _guard = TEST_MUTEX.lock().unwrap();
+    // ... test body
+}
+```
+
+### Temp Directories
+
+Use `tempfile` crate (auto-cleanup via `Drop`):
+
+```rust
+let dir = tempfile::tempdir().unwrap();
+let config_path = dir.path().join("runner.yaml");
+tokio::fs::write(&config_path, yaml).await.unwrap();
+
+let config = load(&config_path).await.unwrap();
+assert_eq!(config.name, "test-runner");
+// dir is cleaned up when dropped
+```
+
+### Test Harness for Complex Setup
+
+When multiple tests need shared setup/teardown:
+
+```rust
+struct Harness {
+    dir: PathBuf,
+    host: Option<VsockHost>,
+}
+
+impl Harness {
+    async fn new() -> Self {
+        let dir = std::env::temp_dir().join(format!("test-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("create temp dir");
+        Self { dir, host: None }
+    }
+}
+
+impl Drop for Harness {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.dir);
+    }
+}
+```
+
+### Async Tests
+
+Use `#[tokio::test]` for async code:
+
+```rust
+#[tokio::test]
+async fn downloads_and_extracts() {
+    let dir = tempfile::tempdir().unwrap();
+    // ... async operations with .await
+}
+```
+
+For sync-only logic, plain `#[test]` is fine:
+
+```rust
+#[test]
+fn masks_nested_json() {
+    let masker = SecretMasker { patterns: vec!["secret".into()] };
+    let mut val = json!({"key": "has secret inside"});
+    masker.mask_value(&mut val);
+    assert_eq!(val["key"], "has *** inside");
+}
+```
+
+## What to Test
+
+- **Config parsing**: round-trip (generate → load), validation of invalid inputs
+- **HTTP clients**: success, retry, error responses (via httpmock)
+- **Serialization**: serde round-trips for protocol types
+- **Business logic**: masking, matching, path manipulation
+
+## What NOT to Test
+
+- Firecracker VM creation (requires root + KVM)
+- Network namespace operations (requires root)
+- Sandbox lifecycle (requires full runner environment)
+
+These are covered by E2E tests in CI with real runner infrastructure.


### PR DESCRIPTION
## Summary
- Add `docs/testing/rust-testing.md` — Rust crate testing guide (cargo test, httpmock, tempfile, async patterns)
- Add `docs/testing/mitm-addon-testing.md` — Python addon testing guide (pytest, fixtures, mock flows, state reset)
- Update `docs/testing.md` reference table with Rust and Python entries
- Update `.claude/skills/testing/SKILL.md` context table with Rust and Python entries

## Test plan
- [ ] Verify all doc links resolve correctly
- [ ] Verify commands in guides work (`cargo test`, `pytest tests/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)