### PR TITLE
fix: add input validation and request-target safeguards for external integrations

### DIFF
--- a/turbo/apps/web/app/api/github/oauth/callback/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/github/oauth/callback/__tests__/route.test.ts
@@ -13,6 +13,7 @@ import {
 import {
   testContext,
   uniqueId,
+  uniqueNumericId,
 } from "../../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
 import { env } from "../../../../../../src/env";
@@ -118,7 +119,7 @@ describe("/api/github/oauth/callback", () => {
     await createTestScope(uniqueId("gh-scope"));
     const { composeId } = await createTestCompose("gh-test-agent");
 
-    const installationId = uniqueId("install");
+    const installationId = uniqueNumericId();
     server.use(
       http.get(
         `https://api.github.com/app/installations/${installationId}`,
@@ -147,7 +148,7 @@ describe("/api/github/oauth/callback", () => {
     await createTestScope(uniqueId("gh-scope"));
     const { composeId } = await createTestCompose("gh-test-agent");
 
-    const installationId = uniqueId("install");
+    const installationId = uniqueNumericId();
     setupGitHubMocks(installationId);
 
     const state = buildSignedState(userId, composeId);
@@ -220,7 +221,7 @@ describe("/api/github/oauth/callback", () => {
     await createTestScope(uniqueId("gh-scope"));
     const { composeId } = await createTestCompose("gh-test-agent");
 
-    const installationId = uniqueId("install");
+    const installationId = uniqueNumericId();
     setupGitHubMocks(installationId);
 
     const state = buildSignedState(userId, composeId);

--- a/turbo/apps/web/src/__tests__/api-test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers.ts
@@ -93,7 +93,7 @@ import {
 import { agentPermissions } from "../db/schema/agent-permission";
 import { scopes } from "../db/schema/scope";
 import { conversations } from "../db/schema/conversation";
-import { uniqueId } from "./test-helpers";
+import { uniqueId, uniqueNumericId } from "./test-helpers";
 
 /**
  * Helper to create a NextRequest for testing.
@@ -2500,7 +2500,7 @@ export async function insertTestGitHubInstallation(
   composeId: string,
   installationId?: string,
 ) {
-  const id = installationId ?? uniqueId("gh-install");
+  const id = installationId ?? uniqueNumericId();
   const encryptedToken = encryptSecretValue(
     "ghs_test_token",
     globalThis.services.env.SECRETS_ENCRYPTION_KEY,

--- a/turbo/apps/web/src/__tests__/test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/test-helpers.ts
@@ -36,6 +36,14 @@ export function uniqueId(prefix: string): string {
   return `${prefix}-${uniqueSuffix()}`;
 }
 
+/**
+ * Generate a unique numeric ID string for test isolation.
+ * Useful for external IDs that must be numeric (e.g., GitHub installation IDs).
+ */
+export function uniqueNumericId(): string {
+  return String(Math.floor(Math.random() * 900_000_000) + 100_000_000);
+}
+
 import { eq } from "drizzle-orm";
 import { Axiom } from "@axiomhq/js";
 import { mockClerk, clearClerkMock } from "./clerk-mock";

--- a/turbo/apps/web/src/lib/github/github-app.ts
+++ b/turbo/apps/web/src/lib/github/github-app.ts
@@ -147,10 +147,11 @@ export async function deleteInstallation(
   privateKeyBase64: string,
   installationId: string,
 ): Promise<void> {
+  const safeId = validateInstallationId(installationId);
   const jwt = createAppJWT(appId, privateKeyBase64);
 
   const res = await fetch(
-    `https://api.github.com/app/installations/${installationId}`,
+    `https://api.github.com/app/installations/${safeId}`,
     {
       method: "DELETE",
       headers: {

--- a/turbo/apps/web/src/lib/github/github-app.ts
+++ b/turbo/apps/web/src/lib/github/github-app.ts
@@ -7,6 +7,20 @@
 
 import { createSign } from "node:crypto";
 
+const INSTALLATION_ID_RE = /^\d+$/;
+
+/**
+ * Validate that an installation ID is a numeric string to prevent URL injection.
+ */
+function validateInstallationId(installationId: string): string {
+  if (!INSTALLATION_ID_RE.test(installationId)) {
+    throw new Error(
+      `Invalid GitHub installation ID: expected numeric string, got "${installationId}"`,
+    );
+  }
+  return installationId;
+}
+
 /**
  * Create a JWT for authenticating as a GitHub App.
  *
@@ -49,10 +63,11 @@ export async function getInstallationAccessToken(
   privateKeyBase64: string,
   installationId: string,
 ): Promise<{ token: string; expiresAt: string }> {
+  const safeId = validateInstallationId(installationId);
   const jwt = createAppJWT(appId, privateKeyBase64);
 
   const res = await fetch(
-    `https://api.github.com/app/installations/${installationId}/access_tokens`,
+    `https://api.github.com/app/installations/${safeId}/access_tokens`,
     {
       method: "POST",
       headers: {
@@ -89,10 +104,11 @@ export async function getInstallationInfo(
   targetId: string;
   targetName: string;
 }> {
+  const safeId = validateInstallationId(installationId);
   const jwt = createAppJWT(appId, privateKeyBase64);
 
   const res = await fetch(
-    `https://api.github.com/app/installations/${installationId}`,
+    `https://api.github.com/app/installations/${safeId}`,
     {
       headers: {
         Authorization: `Bearer ${jwt}`,

--- a/turbo/apps/web/src/lib/proxy/proxy-service.ts
+++ b/turbo/apps/web/src/lib/proxy/proxy-service.ts
@@ -79,6 +79,17 @@ export async function forwardRequest(
   targetUrl: string,
   runId?: string,
 ): Promise<ProxyResult> {
+  // Validate target URL to prevent SSRF (defense-in-depth, caller should also validate)
+  const parsed = new URL(targetUrl);
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new Error(`Invalid target URL protocol: ${parsed.protocol}`);
+  }
+  if (isPrivateOrInternalHost(parsed.hostname)) {
+    throw new Error(
+      `Blocked request to private/internal address: ${parsed.hostname}`,
+    );
+  }
+
   log.debug(`Forwarding request to ${targetUrl}`);
 
   // Build headers to forward (excluding hop-by-hop headers)

--- a/turbo/apps/web/src/lib/slack/context.ts
+++ b/turbo/apps/web/src/lib/slack/context.ts
@@ -5,6 +5,31 @@ import { env } from "../../env";
 
 const log = logger("slack:context");
 
+/**
+ * Validate that a Slack file download URL is from a trusted Slack domain.
+ */
+function isValidSlackDownloadUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    return (
+      parsed.protocol === "https:" && parsed.hostname.endsWith(".slack.com")
+    );
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Check if a buffer starts with known image magic bytes.
+ */
+function hasImageMagicBytes(buffer: Buffer): boolean {
+  const isPng = buffer[0] === 0x89 && buffer[1] === 0x50;
+  const isJpeg = buffer[0] === 0xff && buffer[1] === 0xd8;
+  const isGif = buffer[0] === 0x47 && buffer[1] === 0x49;
+  const isWebp = buffer[0] === 0x52 && buffer[1] === 0x49;
+  return isPng || isJpeg || isGif || isWebp;
+}
+
 /** Maximum file size to download and upload (10MB) */
 const MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024;
 
@@ -261,8 +286,8 @@ async function downloadAndUploadSlackFile(
   sessionId: string,
 ): Promise<string | null> {
   const downloadUrl = file.url_private_download;
-  if (!downloadUrl) {
-    log.debug("No url_private_download available", { fileId: file.id });
+  if (!downloadUrl || !isValidSlackDownloadUrl(downloadUrl)) {
+    log.debug("No valid Slack download URL available", { fileId: file.id });
     return null;
   }
 
@@ -317,13 +342,7 @@ async function downloadAndUploadSlackFile(
     const buffer = Buffer.from(arrayBuffer);
 
     // Verify the content is actually an image (check magic bytes)
-    // PNG: 89 50 4E 47, JPEG: FF D8 FF, GIF: 47 49 46, WebP: 52 49 46 46
-    const isPng = buffer[0] === 0x89 && buffer[1] === 0x50;
-    const isJpeg = buffer[0] === 0xff && buffer[1] === 0xd8;
-    const isGif = buffer[0] === 0x47 && buffer[1] === 0x49;
-    const isWebp = buffer[0] === 0x52 && buffer[1] === 0x49;
-
-    if (!isPng && !isJpeg && !isGif && !isWebp) {
+    if (!hasImageMagicBytes(buffer)) {
       log.debug("Downloaded content is not a valid image", {
         fileId: file.id,
         firstBytes: buffer.slice(0, 10).toString("hex"),


### PR DESCRIPTION
## Summary
- Add numeric validation for GitHub installation IDs to prevent URL injection in `github-app.ts`
- Add SSRF prevention in `proxy-service.ts` by validating target URL protocol and blocking private/internal hosts
- Add Slack download URL domain validation and extract image magic-byte check into reusable helper in `context.ts`
- Introduce `uniqueNumericId()` test helper and update GitHub OAuth callback tests to use numeric installation IDs

## Test plan
- [ ] Verify existing GitHub OAuth callback tests pass with numeric installation IDs
- [ ] Verify proxy service rejects non-HTTP protocols and private addresses
- [ ] Verify Slack file download rejects non-Slack URLs
- [ ] Run full test suite: `cd turbo && pnpm vitest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)