### PR TITLE
ci: stop existing runner service before starting on deploy

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1278,6 +1278,10 @@ jobs:
               --api-url ${PREVIEW_URL} \
               --token vm0_official_${OFFICIAL_RUNNER_SECRET}"
 
+            # Stop any existing service from a previous run (e.g., re-run after test failure
+            # where cleanup-runner preserved the runner). Ignore errors if not running.
+            ssh $REMOTE "${BIN_DIR}/runner service stop --name ${RUNNER_NAME}" 2>/dev/null || true
+
             # Start as systemd transient service
             ssh $REMOTE "${BIN_DIR}/runner service start \
               --name ${RUNNER_NAME} \

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1585,6 +1585,14 @@ jobs:
       github.event_name != 'push' &&
       needs.deploy-runner-prepare.outputs.bin-dir != ''
     steps:
+      # Guard: if any test/deploy job didn't succeed, fail this job WITHOUT
+      # cleaning up. This makes "Re-run failed jobs" include cleanup-runner,
+      # so on successful retry the cleanup runs automatically.
+      #
+      # - deploy-runner-start != success (not just failure/cancelled):
+      #   covers deploy-web failure → start is "skipped" but binaries exist
+      # - cli-e2e-03-runner / runner-stress-test failure/cancelled:
+      #   the main re-run scenario — keep runner alive for E2E retry
       - name: Fail if tests failed (keep runner for re-run)
         if: |
           needs.deploy-runner-start.result != 'success' ||

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1573,8 +1573,10 @@ jobs:
             echo "Cron simulator stopped"
           fi
 
-  # Stop runner service and clean up after cli-e2e-03-runner completes (or fails/times out)
-  # Skip on push to main - runner deployment is only needed for PRs
+  # Stop runner service and clean up after tests complete.
+  # When tests fail/cancel, this job fails WITHOUT cleaning up so that
+  # "Re-run failed jobs" includes it — on successful retry it will clean up.
+  # cleanup.yml (pull_request_target:closed) is the safety net.
   cleanup-runner:
     runs-on: ubuntu-latest
     needs: [prepare, deploy-runner-prepare, deploy-runner-start, cli-e2e-03-runner, runner-stress-test]
@@ -1583,6 +1585,17 @@ jobs:
       github.event_name != 'push' &&
       needs.deploy-runner-prepare.outputs.bin-dir != ''
     steps:
+      - name: Fail if tests failed (keep runner for re-run)
+        if: |
+          needs.deploy-runner-start.result != 'success' ||
+          needs.cli-e2e-03-runner.result == 'failure' ||
+          needs.cli-e2e-03-runner.result == 'cancelled' ||
+          needs.runner-stress-test.result == 'failure' ||
+          needs.runner-stress-test.result == 'cancelled'
+        run: |
+          echo "::error::Tests failed or cancelled — keeping runner alive for re-run"
+          exit 1
+
       - uses: actions/checkout@v6
 
       - name: Install Ansible


### PR DESCRIPTION
## Summary
- Adds `runner service stop` before `runner service start` in `deploy-runner-start` to handle re-runs where the previous runner was preserved
- Fixes CI failure when "Re-run failed jobs" is used after test failure (cleanup-runner now preserves the runner per #4497)
- The stop command ignores errors if no service is running

## Context
After merging #4497 (skip runner cleanup on test failure), re-running failed jobs causes `deploy-runner-start` to fail with `unit vm0-runner-pr-XXXX-N is already running` because the systemd transient service from the previous attempt is still active.

## Test plan
- [ ] Re-run a failed CI job on a PR where the runner was preserved — deploy-runner-start should succeed
- [ ] Fresh CI run (no existing service) should still work normally (stop returns 0 via `|| true`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)