### PR TITLE
fix(web): add worker-src CSP directive and disable termly autoBlock

### DIFF
--- a/turbo/apps/web/__tests__/security-headers.test.ts
+++ b/turbo/apps/web/__tests__/security-headers.test.ts
@@ -102,5 +102,13 @@ describe("Security Response Headers", () => {
 
       expect(csp).toContain("default-src *");
     });
+
+    it("should allow blob: URLs in worker-src for third-party scripts", async () => {
+      const headers = await getSecurityHeaders();
+      const csp = findHeader(headers, "Content-Security-Policy");
+
+      expect(csp).toContain("worker-src");
+      expect(csp).toContain("blob:");
+    });
   });
 });

--- a/turbo/apps/web/app/layout.tsx
+++ b/turbo/apps/web/app/layout.tsx
@@ -143,7 +143,7 @@ export default function RootLayout({
       <html lang="en" data-theme="dark" suppressHydrationWarning>
         <head>
           <Script
-            src="https://app.termly.io/resource-blocker/058a3478-08ac-4f2f-a9c4-5b357bbe7433?autoBlock=on"
+            src="https://app.termly.io/resource-blocker/058a3478-08ac-4f2f-a9c4-5b357bbe7433?autoBlock=off"
             strategy="beforeInteractive"
           />
           <link rel="preconnect" href="https://fonts.googleapis.com" />

--- a/turbo/apps/web/next.config.js
+++ b/turbo/apps/web/next.config.js
@@ -29,7 +29,7 @@ const nextConfig = {
           {
             key: "Content-Security-Policy",
             value:
-              "default-src * 'unsafe-inline'; script-src * 'unsafe-inline'; style-src * 'unsafe-inline'; frame-ancestors 'none';",
+              "default-src * 'unsafe-inline'; script-src * 'unsafe-inline'; style-src * 'unsafe-inline'; worker-src * blob:; frame-ancestors 'none';",
           },
         ],
       },


### PR DESCRIPTION
## Summary
- Add `worker-src * blob:` to the Content-Security-Policy header to allow Termly's cookie consent banner to spawn web workers
- Switch Termly's `autoBlock` parameter from `on` to `off` to prevent resource blocking issues
- Add integration test verifying the `worker-src` and `blob:` directives are present in CSP headers

## Test plan
- [ ] Verify Termly cookie consent banner loads correctly in preview deployment
- [ ] Confirm no CSP violations appear in browser console
- [ ] Check that `worker-src` and `blob:` directives are present in response headers

🤖 Generated with [Claude Code](https://claude.com/claude-code)