### PR TITLE
refactor: remove unused full-match field from variable reference

### DIFF
--- a/turbo/packages/core/src/__tests__/variable-expander.spec.ts
+++ b/turbo/packages/core/src/__tests__/variable-expander.spec.ts
@@ -16,7 +16,6 @@ describe("extractVariableReferencesFromString", () => {
     expect(refs[0]).toEqual({
       source: "env",
       name: "MY_VAR",
-      fullMatch: "${{ env.MY_VAR }}",
     });
   });
 
@@ -26,7 +25,6 @@ describe("extractVariableReferencesFromString", () => {
     expect(refs[0]).toEqual({
       source: "vars",
       name: "myVar",
-      fullMatch: "${{ vars.myVar }}",
     });
   });
 
@@ -36,7 +34,6 @@ describe("extractVariableReferencesFromString", () => {
     expect(refs[0]).toEqual({
       source: "secrets",
       name: "apiKey",
-      fullMatch: "${{ secrets.apiKey }}",
     });
   });
 
@@ -295,9 +292,7 @@ describe("expandVariables", () => {
 
 describe("validateRequiredVariables", () => {
   test("returns empty for all present", () => {
-    const refs = [
-      { source: "env" as const, name: "VAR", fullMatch: "${{ env.VAR }}" },
-    ];
+    const refs = [{ source: "env" as const, name: "VAR" }];
     const missing = validateRequiredVariables(refs, {
       env: { VAR: "value" },
     });
@@ -305,9 +300,7 @@ describe("validateRequiredVariables", () => {
   });
 
   test("returns missing variables", () => {
-    const refs = [
-      { source: "env" as const, name: "MISS", fullMatch: "${{ env.MISS }}" },
-    ];
+    const refs = [{ source: "env" as const, name: "MISS" }];
     const missing = validateRequiredVariables(refs, {
       env: {},
     });
@@ -320,7 +313,6 @@ describe("validateRequiredVariables", () => {
       {
         source: "secrets" as const,
         name: "KEY",
-        fullMatch: "${{ secrets.KEY }}",
       },
     ];
     const missing = validateRequiredVariables(refs, {
@@ -333,11 +325,11 @@ describe("validateRequiredVariables", () => {
 describe("groupVariablesBySource", () => {
   test("groups variables correctly", () => {
     const refs = [
-      { source: "env" as const, name: "A", fullMatch: "" },
-      { source: "vars" as const, name: "B", fullMatch: "" },
-      { source: "secrets" as const, name: "C", fullMatch: "" },
-      { source: "secrets" as const, name: "D", fullMatch: "" },
-      { source: "env" as const, name: "E", fullMatch: "" },
+      { source: "env" as const, name: "A" },
+      { source: "vars" as const, name: "B" },
+      { source: "secrets" as const, name: "C" },
+      { source: "secrets" as const, name: "D" },
+      { source: "env" as const, name: "E" },
     ];
     const grouped = groupVariablesBySource(refs);
     expect(grouped.env).toHaveLength(2);
@@ -349,9 +341,9 @@ describe("groupVariablesBySource", () => {
 describe("formatMissingVariables", () => {
   test("formats all sources", () => {
     const missing = [
-      { source: "env" as const, name: "A", fullMatch: "" },
-      { source: "vars" as const, name: "b", fullMatch: "" },
-      { source: "secrets" as const, name: "c", fullMatch: "" },
+      { source: "env" as const, name: "A" },
+      { source: "vars" as const, name: "b" },
+      { source: "secrets" as const, name: "c" },
     ];
     const msg = formatMissingVariables(missing);
     expect(msg).toContain("Environment variables: A");
@@ -361,8 +353,8 @@ describe("formatMissingVariables", () => {
 
   test("lists multiple vars per source", () => {
     const missing = [
-      { source: "env" as const, name: "A", fullMatch: "" },
-      { source: "env" as const, name: "B", fullMatch: "" },
+      { source: "env" as const, name: "A" },
+      { source: "env" as const, name: "B" },
     ];
     const msg = formatMissingVariables(missing);
     expect(msg).toContain("Environment variables: A, B");

--- a/turbo/packages/core/src/variable-expander.ts
+++ b/turbo/packages/core/src/variable-expander.ts
@@ -10,7 +10,6 @@
 export interface VariableReference {
   source: "env" | "vars" | "secrets";
   name: string;
-  fullMatch: string;
 }
 
 /**
@@ -51,11 +50,7 @@ export function extractVariableReferencesFromString(
   for (const match of matches) {
     const source = match[1] as "env" | "vars" | "secrets";
     const name = match[2]!;
-    refs.push({
-      source,
-      name,
-      fullMatch: match[0]!,
-    });
+    refs.push({ source, name });
   }
 
   return refs;
@@ -116,7 +111,7 @@ export function expandVariablesInString(
       const key = `${typedSource}.${name}`;
       if (!seenMissing.has(key)) {
         seenMissing.add(key);
-        missingVars.push({ source: typedSource, name, fullMatch });
+        missingVars.push({ source: typedSource, name });
       }
       return fullMatch;
     }
@@ -229,8 +224,8 @@ export function groupVariablesBySource(refs: VariableReference[]): {
  *   STATIC: "hello",
  * };
  * const grouped = extractAndGroupVariables(env);
- * // grouped.secrets => [{ source: "secrets", name: "OPENAI_KEY", fullMatch: "${{ secrets.OPENAI_KEY }}" }]
- * // grouped.vars    => [{ source: "vars", name: "AWS_REGION", fullMatch: "${{ vars.AWS_REGION }}" }]
+ * // grouped.secrets => [{ source: "secrets", name: "OPENAI_KEY" }]
+ * // grouped.vars    => [{ source: "vars", name: "AWS_REGION" }]
  * // grouped.env     => []
  * ```
  */


### PR DESCRIPTION
## Summary
- Remove `fullMatch` field from `VariableReference` interface — it was populated but never read by any consumer
- The `expandVariablesInString` function uses `fullMatch` as a `String.replace` callback parameter name, not the interface field
- Clean up all test fixtures that included the field

## Test plan
- [x] All 34 variable-expander tests pass
- [x] Type check passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)