### PR TITLE
fix(test): scope user_cache cleanup to tracked userids in testcontext

### DIFF
--- a/turbo/apps/web/src/__tests__/clerk-mock.ts
+++ b/turbo/apps/web/src/__tests__/clerk-mock.ts
@@ -46,6 +46,11 @@ let createdOrgs: Array<{
 let orgSlugOverrides = new Map<string, string>();
 let orgMetadataOverrides = new Map<string, Record<string, unknown>>();
 
+// Module-level tracking of all userIds configured via mockClerk().
+// Used by testContext afterEach to scope user_cache cleanup to rows created
+// by this test, avoiding cross-file interference in parallel test runs.
+let mockUserIds: string[] = [];
+
 /**
  * Configure Clerk auth mock
  * @param options - Auth configuration
@@ -74,6 +79,11 @@ export function mockClerk(options: {
   clerkOrgs?: Array<{ id: string; slug: string; name: string; role?: string }>;
 }) {
   const email = options.email ?? "test@example.com";
+
+  // Track userId for scoped user_cache cleanup in testContext afterEach
+  if (options.userId) {
+    mockUserIds.push(options.userId);
+  }
 
   // Default: one org per user (simulates signup-created org).
   // The org ID is derived from userId to ensure uniqueness across tests.
@@ -303,12 +313,17 @@ export function mockClerk(options: {
 }
 
 /**
- * Clear all Clerk mock calls and reset to default state
+ * Clear all Clerk mock calls and reset to default state.
+ * Returns the list of userIds that were configured via mockClerk() since
+ * the last clear, so callers can scope DB cleanup (e.g. user_cache).
  */
-export function clearClerkMock() {
+export function clearClerkMock(): string[] {
+  const userIds = [...mockUserIds];
   mockAuth.mockClear();
   mockClerkClient.mockClear();
   createdOrgs = [];
   orgSlugOverrides = new Map();
   orgMetadataOverrides = new Map();
+  mockUserIds = [];
+  return userIds;
 }

--- a/turbo/apps/web/src/__tests__/test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/test-helpers.ts
@@ -44,7 +44,7 @@ export function uniqueNumericId(): string {
   return String(Math.floor(Math.random() * 900_000_000) + 100_000_000);
 }
 
-import { eq } from "drizzle-orm";
+import { eq, inArray } from "drizzle-orm";
 import { Axiom } from "@axiomhq/js";
 import { mockClerk, clearClerkMock } from "./clerk-mock";
 import { initServices } from "../lib/init-services";
@@ -242,6 +242,7 @@ export function testContext(): TestContext {
   let controller = new AbortController();
   let mockHelpers: MockHelpers | null = null;
   let mockUser: Promise<UserContext> | null = null;
+  const trackedUserIds: string[] = [];
 
   /**
    * Creates mock helpers (called by getter or setupMocks)
@@ -390,12 +391,20 @@ export function testContext(): TestContext {
   }
 
   afterEach(async () => {
-    // Clear Clerk mock
-    clearClerkMock();
+    // Clear Clerk mock and collect all userIds it was configured with.
+    // These include both setupUser() IDs and hardcoded IDs from direct
+    // mockClerk() calls in tests (e.g. "different-user-id" in email tests).
+    const clerkUserIds = clearClerkMock();
 
-    // Clear user_cache to prevent cross-test contamination via shared emails
+    // Scope user_cache cleanup to IDs used in this test only, so parallel
+    // test files don't wipe each other's cache entries (the original flaky bug).
     if (globalThis.services?.db) {
-      await globalThis.services.db.delete(userCache);
+      const allIds = [...new Set([...trackedUserIds, ...clerkUserIds])];
+      if (allIds.length > 0) {
+        await globalThis.services.db
+          .delete(userCache)
+          .where(inArray(userCache.userId, allIds));
+      }
     }
 
     // Abort the signal to trigger any cleanup handlers
@@ -410,9 +419,10 @@ export function testContext(): TestContext {
     // next test's beforeEach runs with the real clock.
     vi.unstubAllGlobals();
 
-    // Reset mocks and cached user for next test
+    // Reset mocks, cached user, and tracked IDs for next test
     mockHelpers = null;
     mockUser = null;
+    trackedUserIds.length = 0;
   });
 
   /**
@@ -442,6 +452,7 @@ export function testContext(): TestContext {
       // This allows tests to derive scope slug from userId if needed
       const suffix = uniqueSuffix();
       const userId = `${prefix}-${suffix}`;
+      trackedUserIds.push(userId);
 
       // Mock Clerk for this user
       mockClerk({ userId });


### PR DESCRIPTION
## Summary

- Fix flaky `user-cache-service.test.ts` caused by parallel test files deleting shared `user_cache` table
- Replace unconditional `DELETE FROM user_cache` in `testContext().afterEach` with scoped delete using `inArray(userCache.userId, trackedUserIds)`
- Track userIds created via `setupUser()` and only clean up those specific rows

## Root Cause

`testContext()` ran `db.delete(userCache)` (no WHERE clause) in `afterEach`, wiping **all** rows. Since Vitest runs test files in parallel sharing the same PostgreSQL database, another file's cleanup could delete cache entries mid-test, causing the "fetches from Clerk and caches on miss" test to intermittently fail.

## Test plan

- [x] `user-cache-service.test.ts` passes (7/7)
- [x] Full web test suite: only pre-existing `email/inbound` failures remain (unrelated MSW issue)

Closes #4527

🤖 Generated with [Claude Code](https://claude.com/claude-code)