### PR TITLE
fix: resolve 5 codeql code scanning alerts

### DIFF
--- a/turbo/apps/cli/src/commands/cook/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/cook/__tests__/index.test.ts
@@ -556,9 +556,9 @@ agents:
         .map((call) => call[0])
         .filter((log): log is string => typeof log === "string");
 
-      // Should show escaped rerun command
+      // Should show escaped rerun command (single-quote escaping)
       expect(
-        allLogs.some((log) => log.includes('vm0 cook "say \\"hello\\""')),
+        allLogs.some((log) => log.includes("vm0 cook 'say \"hello\"'")),
       ).toBe(true);
     });
 

--- a/turbo/apps/cli/src/lib/utils/update-checker.ts
+++ b/turbo/apps/cli/src/lib/utils/update-checker.ts
@@ -91,11 +91,13 @@ export function getManualUpgradeCommand(pm: PackageManager): string {
 }
 
 /**
- * Escape a string for use in shell command display
- * Uses double quotes and escapes internal double quotes
+ * Escape a string for use in shell command display.
+ * Uses single quotes which don't interpret any special characters.
+ * Embedded single quotes are handled via the '\'' idiom
+ * (end quote, escaped literal quote, start quote).
  */
 function escapeForShell(str: string): string {
-  return `"${str.replace(/"/g, '\\"')}"`;
+  return `'${str.replace(/'/g, "'\\''")}'`;
 }
 
 /**

--- a/turbo/apps/web/app/api/cli/auth/device/route.ts
+++ b/turbo/apps/web/app/api/cli/auth/device/route.ts
@@ -1,32 +1,14 @@
 import { createHandler, tsr } from "../../../../../src/lib/ts-rest-handler";
 import { cliAuthDeviceContract } from "@vm0/core";
-import crypto from "crypto";
 import { initServices } from "../../../../../src/lib/init-services";
 import { deviceCodes } from "../../../../../src/db/schema/device-codes";
-
-// Characters that are easy to read (excluding 0/O, 1/I/L)
-const CHARS = "ABCDEFGHJKMNPQRSTUVWXYZ23456789";
-
-function generateDeviceCode(): string {
-  const randomBytes = crypto.randomBytes(8);
-  let code = "";
-
-  for (let i = 0; i < 8; i++) {
-    if (i === 4) code += "-";
-    const byte = randomBytes[i];
-    if (byte !== undefined) {
-      code += CHARS[byte % CHARS.length];
-    }
-  }
-
-  return code;
-}
+import { generateCode } from "../../../../../src/lib/crypto";
 
 const router = tsr.router(cliAuthDeviceContract, {
   create: async () => {
     initServices();
 
-    const deviceCode = generateDeviceCode();
+    const deviceCode = generateCode();
     const expiresAt = new Date(Date.now() + 900 * 1000); // 15 minutes
 
     await globalThis.services.db.insert(deviceCodes).values({

--- a/turbo/apps/web/app/api/connectors/[type]/sessions/route.ts
+++ b/turbo/apps/web/app/api/connectors/[type]/sessions/route.ts
@@ -1,4 +1,3 @@
-import crypto from "crypto";
 import { createHandler, tsr } from "../../../../../src/lib/ts-rest-handler";
 import {
   connectorSessionsContract,
@@ -9,26 +8,9 @@ import { initServices } from "../../../../../src/lib/init-services";
 import { getUserId } from "../../../../../src/lib/auth/get-user-id";
 import { connectorSessions } from "../../../../../src/db/schema/connector-session";
 import { logger } from "../../../../../src/lib/logger";
+import { generateCode } from "../../../../../src/lib/crypto";
 
 const log = logger("api:connectors:sessions");
-
-// Characters that are easy to read (excluding 0/O, 1/I/L)
-const CHARS = "ABCDEFGHJKMNPQRSTUVWXYZ23456789";
-
-function generateSessionCode(): string {
-  const randomBytes = crypto.randomBytes(8);
-  let code = "";
-
-  for (let i = 0; i < 8; i++) {
-    if (i === 4) code += "-";
-    const byte = randomBytes[i];
-    if (byte !== undefined) {
-      code += CHARS[byte % CHARS.length];
-    }
-  }
-
-  return code;
-}
 
 const router = tsr.router(connectorSessionsContract, {
   create: async ({ params, headers }) => {
@@ -50,7 +32,7 @@ const router = tsr.router(connectorSessionsContract, {
       return createErrorResponse("UNAUTHORIZED", "Authentication required");
     }
 
-    const code = generateSessionCode();
+    const code = generateCode();
     const expiresAt = new Date(Date.now() + 15 * 60 * 1000); // 15 minutes
 
     const [session] = await globalThis.services.db

--- a/turbo/apps/web/src/lib/crypto/generate-code.ts
+++ b/turbo/apps/web/src/lib/crypto/generate-code.ts
@@ -1,0 +1,23 @@
+import crypto from "crypto";
+
+// Characters that are easy to read (excluding 0/O, 1/I/L)
+const CHARS = "ABCDEFGHJKMNPQRSTUVWXYZ23456789";
+
+/**
+ * Generate a random code using unbiased cryptographic randomness.
+ * Format: XXXX-XXXX (8 characters with a dash in the middle)
+ *
+ * Uses crypto.randomInt() which provides unbiased sampling,
+ * unlike randomBytes + modulo which introduces bias when the
+ * byte range (256) is not evenly divisible by the character set size.
+ */
+export function generateCode(): string {
+  let code = "";
+
+  for (let i = 0; i < 8; i++) {
+    if (i === 4) code += "-";
+    code += CHARS[crypto.randomInt(CHARS.length)];
+  }
+
+  return code;
+}

--- a/turbo/apps/web/src/lib/crypto/index.ts
+++ b/turbo/apps/web/src/lib/crypto/index.ts
@@ -3,3 +3,4 @@ export {
   encryptSecretValue,
   decryptSecretValue,
 } from "./secrets-encryption";
+export { generateCode } from "./generate-code";

--- a/turbo/packages/core/src/github-url.ts
+++ b/turbo/packages/core/src/github-url.ts
@@ -27,7 +27,10 @@ export interface ParsedGitHubTreeUrl {
  */
 export function parseGitHubTreeUrl(url: string): ParsedGitHubTreeUrl | null {
   // Normalize: strip trailing slashes for consistent matching
-  const normalizedUrl = url.replace(/\/+$/, "");
+  let normalizedUrl = url;
+  while (normalizedUrl.endsWith("/")) {
+    normalizedUrl = normalizedUrl.slice(0, -1);
+  }
 
   // First, extract the full path after github.com/ (always correct)
   const fullPathMatch = normalizedUrl.match(/^https:\/\/github\.com\/(.+)$/);
@@ -96,7 +99,10 @@ export interface ParsedGitHubUrl {
  */
 export function parseGitHubUrl(url: string): ParsedGitHubUrl | null {
   // Normalize: strip trailing slashes for consistent matching
-  const normalizedUrl = url.replace(/\/+$/, "");
+  let normalizedUrl = url;
+  while (normalizedUrl.endsWith("/")) {
+    normalizedUrl = normalizedUrl.slice(0, -1);
+  }
 
   // Extract full path after github.com/
   const fullPathMatch = normalizedUrl.match(/^https:\/\/github\.com\/(.+)$/);


### PR DESCRIPTION
## Summary

Fixes 5 CodeQL code scanning alerts across 3 categories:

- **Polynomial ReDoS** (`js/polynomial-redos`): Replaced `/\/+$/` regex with `while (endsWith("/"))` loop in `github-url.ts` (2 alerts at lines 30, 99)
- **Biased cryptographic random** (`js/biased-cryptographic-random`): Replaced `crypto.randomBytes` + modulo with `crypto.randomInt()` for unbiased sampling, and deduplicated identical code into shared `generateCode()` utility (2 alerts in device route and connector sessions route)
- **Incomplete string escaping** (`js/incomplete-sanitization`): Switched from double-quote wrapping to single-quote wrapping with `'\''` idiom in `escapeForShell()` (1 alert in update-checker.ts)

Closes #4529

## Test plan

- [x] Type check passes (`pnpm check-types`)
- [x] Lint passes (`pnpm turbo run lint`)
- [x] Formatting passes (`pnpm format`)
- [x] Knip passes (no unused exports/dependencies)
- [x] Existing upgrade tests pass (8/8)
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)