### PR TITLE
refactor(web): use react component for termly consent management

### DIFF
--- a/turbo/apps/web/__tests__/security-headers.test.ts
+++ b/turbo/apps/web/__tests__/security-headers.test.ts
@@ -103,12 +103,11 @@ describe("Security Response Headers", () => {
       expect(csp).toContain("default-src *");
     });
 
-    it("should allow blob: URLs in worker-src for third-party scripts", async () => {
+    it("should restrict worker-src to self and blob: only", async () => {
       const headers = await getSecurityHeaders();
       const csp = findHeader(headers, "Content-Security-Policy");
 
-      expect(csp).toContain("worker-src");
-      expect(csp).toContain("blob:");
+      expect(csp).toContain("worker-src 'self' blob:");
     });
   });
 });

--- a/turbo/apps/web/app/components/Footer.tsx
+++ b/turbo/apps/web/app/components/Footer.tsx
@@ -54,20 +54,12 @@ export default function Footer() {
                 {t("privacyPolicy")}
               </Link>
               <span className="footer-legal-separator">•</span>
-              <button
-                type="button"
-                className="footer-legal-link"
-                onClick={() => {
-                  if (
-                    "displayPreferenceModal" in window &&
-                    typeof window.displayPreferenceModal === "function"
-                  ) {
-                    (window.displayPreferenceModal as () => void)();
-                  }
-                }}
+              <a
+                href="#"
+                className="footer-legal-link termly-display-preferences"
               >
-                {t("cookieSettings")}
-              </button>
+                {t("consentPreferences")}
+              </a>
             </div>
           </div>
           <div className="footer-right">

--- a/turbo/apps/web/app/components/TermlyCMP.tsx
+++ b/turbo/apps/web/app/components/TermlyCMP.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { useEffect, useMemo, useRef } from "react";
+import { usePathname, useSearchParams } from "next/navigation";
+
+const SCRIPT_SRC_BASE = "https://app.termly.io";
+
+/**
+ * Custom blocking map: categorize third-party domains for Termly Auto Blocker.
+ * Must be set on window before the Termly script loads.
+ * Categories: essential, performance, analytics, advertising, social_networking
+ * @see https://support.termly.io/hc/en-us/articles/30710543325329
+ */
+const CUSTOM_BLOCKING_MAP: Record<string, string> = {
+  "vm0.ai": "essential",
+  "vm6.ai": "essential",
+  "vm7.ai": "essential",
+  "clerk.accounts.dev": "essential",
+  "plausible.io": "analytics",
+  "instatus.com": "essential",
+};
+
+interface TermlyCMPProps {
+  websiteUUID: string;
+  autoBlock?: boolean;
+  masterConsentsOrigin?: string;
+}
+
+declare global {
+  interface Window {
+    Termly?: {
+      initialize: () => void;
+    };
+    TERMLY_CUSTOM_BLOCKING_MAP?: Record<string, string>;
+  }
+}
+
+export default function TermlyCMP({
+  websiteUUID,
+  autoBlock,
+  masterConsentsOrigin,
+}: TermlyCMPProps) {
+  const scriptSrc = useMemo(() => {
+    const src = new URL(SCRIPT_SRC_BASE);
+    src.pathname = `/resource-blocker/${websiteUUID}`;
+    if (autoBlock) {
+      src.searchParams.set("autoBlock", "on");
+    }
+    if (masterConsentsOrigin) {
+      src.searchParams.set("masterConsentsOrigin", masterConsentsOrigin);
+    }
+    return src.toString();
+  }, [autoBlock, masterConsentsOrigin, websiteUUID]);
+
+  const isScriptAdded = useRef(false);
+
+  useEffect(() => {
+    if (isScriptAdded.current) return;
+    window.TERMLY_CUSTOM_BLOCKING_MAP = CUSTOM_BLOCKING_MAP;
+    const script = document.createElement("script");
+    script.src = scriptSrc;
+    document.head.appendChild(script);
+    isScriptAdded.current = true;
+  }, [scriptSrc]);
+
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  useEffect(() => {
+    window.Termly?.initialize();
+  }, [pathname, searchParams]);
+
+  return null;
+}

--- a/turbo/apps/web/app/layout.tsx
+++ b/turbo/apps/web/app/layout.tsx
@@ -1,6 +1,7 @@
 // Root layout for the web application
 import type { Metadata } from "next";
 import Script from "next/script";
+import { Suspense } from "react";
 import {
   Noto_Sans,
   Fira_Code,
@@ -245,10 +246,12 @@ export default function RootLayout({
               }),
             }}
           />
-          <TermlyCMP
-            websiteUUID="058a3478-08ac-4f2f-a9c4-5b357bbe7433"
-            autoBlock
-          />
+          <Suspense>
+            <TermlyCMP
+              websiteUUID="058a3478-08ac-4f2f-a9c4-5b357bbe7433"
+              autoBlock
+            />
+          </Suspense>
           <ThemeProvider>{children}</ThemeProvider>
           <Script
             src="https://api.dashboard.instatus.com/widget?host=status.vm0.ai&code=02c0ef5a&locale=en"

--- a/turbo/apps/web/app/layout.tsx
+++ b/turbo/apps/web/app/layout.tsx
@@ -11,6 +11,7 @@ import { ClerkProvider } from "@clerk/nextjs";
 import { getClerkPublishableKey } from "../src/lib/clerk-config";
 import { getPlatformUrl } from "../src/lib/url";
 import { ThemeProvider } from "./components/ThemeProvider";
+import TermlyCMP from "./components/TermlyCMP";
 import "./globals.css";
 import "./landing.css";
 import "./blog.css";
@@ -142,10 +143,6 @@ export default function RootLayout({
     >
       <html lang="en" data-theme="dark" suppressHydrationWarning>
         <head>
-          <Script
-            src="https://app.termly.io/resource-blocker/058a3478-08ac-4f2f-a9c4-5b357bbe7433?autoBlock=off"
-            strategy="beforeInteractive"
-          />
           <link rel="preconnect" href="https://fonts.googleapis.com" />
           <link
             rel="preconnect"
@@ -247,6 +244,10 @@ export default function RootLayout({
                 image: "https://vm0.ai/og-image.png",
               }),
             }}
+          />
+          <TermlyCMP
+            websiteUUID="058a3478-08ac-4f2f-a9c4-5b357bbe7433"
+            autoBlock
           />
           <ThemeProvider>{children}</ThemeProvider>
           <Script

--- a/turbo/apps/web/messages/de.json
+++ b/turbo/apps/web/messages/de.json
@@ -98,7 +98,7 @@
     "status": "Status",
     "termsOfUse": "Nutzungsbedingungen",
     "privacyPolicy": "Datenschutzrichtlinie",
-    "cookieSettings": "Cookie-Einstellungen"
+    "consentPreferences": "Einwilligungseinstellungen"
   },
   "skills": {
     "hero": {

--- a/turbo/apps/web/messages/en.json
+++ b/turbo/apps/web/messages/en.json
@@ -98,7 +98,7 @@
     "status": "Status",
     "termsOfUse": "Terms of Use",
     "privacyPolicy": "Privacy Policy",
-    "cookieSettings": "Cookie Settings"
+    "consentPreferences": "Consent Preferences"
   },
   "skills": {
     "hero": {

--- a/turbo/apps/web/messages/es.json
+++ b/turbo/apps/web/messages/es.json
@@ -98,7 +98,7 @@
     "status": "Estado",
     "termsOfUse": "Términos de Uso",
     "privacyPolicy": "Política de Privacidad",
-    "cookieSettings": "Configuración de Cookies"
+    "consentPreferences": "Preferencias de Consentimiento"
   },
   "skills": {
     "hero": {

--- a/turbo/apps/web/messages/ja.json
+++ b/turbo/apps/web/messages/ja.json
@@ -98,7 +98,7 @@
     "status": "ステータス",
     "termsOfUse": "利用規約",
     "privacyPolicy": "プライバシーポリシー",
-    "cookieSettings": "Cookie設定"
+    "consentPreferences": "同意設定"
   },
   "skills": {
     "hero": {

--- a/turbo/apps/web/next.config.js
+++ b/turbo/apps/web/next.config.js
@@ -29,7 +29,7 @@ const nextConfig = {
           {
             key: "Content-Security-Policy",
             value:
-              "default-src * 'unsafe-inline'; script-src * 'unsafe-inline'; style-src * 'unsafe-inline'; worker-src * blob:; frame-ancestors 'none';",
+              "default-src * 'unsafe-inline'; script-src * 'unsafe-inline'; style-src * 'unsafe-inline'; worker-src 'self' blob:; frame-ancestors 'none';",
           },
         ],
       },


### PR DESCRIPTION
## Summary
- Replace static Termly `<Script>` tag with a `TermlyCMP` React client component that dynamically injects the script, sets a custom blocking map for first-party domains, and re-initializes on route changes
- Enable Termly autoBlock so cookie consent is managed automatically instead of being disabled
- Tighten `worker-src` CSP directive from wildcard (`*`) to `'self' blob:` only
- Rename footer link from "Cookie Settings" to "Consent Preferences" across all locales (en, de, es, ja) and switch from JS button to Termly's built-in `.termly-display-preferences` anchor class

## Test plan
- [ ] Verify Termly consent banner appears on page load
- [ ] Verify "Consent Preferences" link in footer opens Termly preferences modal
- [ ] Verify autoBlock prevents third-party cookies until consent is given
- [ ] Verify no CSP violations in browser console
- [ ] Confirm existing security-headers test passes with updated worker-src assertion

🤖 Generated with [Claude Code](https://claude.com/claude-code)