### PR TITLE
chore: fix code scanning quality alerts for unused imports and unclosed files

### DIFF
--- a/crates/runner/mitm-addon/tests/conftest.py
+++ b/crates/runner/mitm-addon/tests/conftest.py
@@ -1,6 +1,5 @@
 import json
 import pytest
-from pathlib import Path
 
 
 @pytest.fixture

--- a/crates/runner/mitm-addon/tests/test_handlers.py
+++ b/crates/runner/mitm-addon/tests/test_handlers.py
@@ -1,6 +1,7 @@
 """Tests for HTTP/TLS handlers."""
 import json
 import time
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import mitm_addon
@@ -270,7 +271,7 @@ class TestResponseHandler:
         assert flow.id not in mitm_addon._request_start_times
 
         # Network log should be written
-        lines = open(log_path).readlines()
+        lines = Path(log_path).read_text().splitlines()
         assert len(lines) == 1
         entry = json.loads(lines[0])
         assert entry["action"] == "ALLOW"

--- a/crates/runner/mitm-addon/tests/test_registry.py
+++ b/crates/runner/mitm-addon/tests/test_registry.py
@@ -1,6 +1,6 @@
 """Tests for registry loading, caching, and network logging."""
 import json
-import time
+from pathlib import Path
 from unittest.mock import patch, MagicMock
 
 import mitm_addon
@@ -81,7 +81,7 @@ class TestLogNetworkEntry:
         with patch.object(mitm_addon.ctx, "log", MagicMock(), create=True):
             mitm_addon.log_network_entry(vm_info, entry)
 
-        lines = open(log_path).readlines()
+        lines = Path(log_path).read_text().splitlines()
         assert len(lines) == 1
         parsed = json.loads(lines[0])
         assert parsed["action"] == "ALLOW"
@@ -95,7 +95,7 @@ class TestLogNetworkEntry:
             mitm_addon.log_network_entry(vm_info, {"n": 1})
             mitm_addon.log_network_entry(vm_info, {"n": 2})
 
-        lines = open(log_path).readlines()
+        lines = Path(log_path).read_text().splitlines()
         assert len(lines) == 2
 
     def test_no_path_is_noop(self):

--- a/turbo/apps/platform/src/signals/agent-detail/schedule.ts
+++ b/turbo/apps/platform/src/signals/agent-detail/schedule.ts
@@ -221,7 +221,7 @@ function parseCronExpression(cron: string): {
   const dayOfMonth = parts[2] ?? "*";
   const dayOfWeek = parts[4] ?? "*";
 
-  let timeOption: CronTimeOption = "every-day";
+  let timeOption: CronTimeOption;
 
   if (dayOfMonth !== "*") {
     timeOption = "every-month";

--- a/turbo/apps/platform/src/views/logs-page/components/json-viewer.tsx
+++ b/turbo/apps/platform/src/views/logs-page/components/json-viewer.tsx
@@ -85,8 +85,8 @@ function valueContainsSearch(value: unknown, searchTerm: string): boolean {
   if (Array.isArray(value)) {
     return value.some((item) => valueContainsSearch(item, searchTerm));
   }
-  if (typeof value === "object" && value !== null) {
-    return Object.entries(value).some(
+  if (typeof value === "object") {
+    return Object.entries(value as Record<string, unknown>).some(
       ([key, val]) =>
         key.toLowerCase().includes(lowerSearch) ||
         valueContainsSearch(val, searchTerm),

--- a/turbo/vitest.config.ts
+++ b/turbo/vitest.config.ts
@@ -1,5 +1,4 @@
 import { defineConfig } from "vitest/config";
-import { resolve } from "path";
 
 export default defineConfig({
   test: {


### PR DESCRIPTION
## Summary
- Fix 8 CodeQL quality alerts across Python and TypeScript code
- Replace bare `open().readlines()` with `Path().read_text().splitlines()` to properly close file handles (3 alerts)
- Remove unused imports in Python tests and `vitest.config.ts` (3 alerts)
- Remove redundant `value !== null` guard in `json-viewer.tsx` (1 alert)
- Remove useless initial value assignment in `schedule.ts` (1 alert)

## Test plan
- [x] All 82 Python mitm-addon tests pass
- [x] TypeScript lint passes (0 warnings, 0 errors)
- [x] Knip finds no issues
- [x] Prettier formatting unchanged

Closes #4535

🤖 Generated with [Claude Code](https://claude.com/claude-code)