### PR TITLE
refactor: remove residual scope-id writes and reads (5c-2)

### DIFF
--- a/turbo/apps/web/app/api/agent/composes/[id]/instructions/route.ts
+++ b/turbo/apps/web/app/api/agent/composes/[id]/instructions/route.ts
@@ -54,7 +54,6 @@ export async function GET(
     .select({
       id: agentComposes.id,
       userId: agentComposes.userId,
-      scopeId: agentComposes.scopeId,
       orgId: agentComposes.orgId,
       name: agentComposes.name,
       content: agentComposeVersions.content,

--- a/turbo/apps/web/app/api/cli/auth/test-token/route.ts
+++ b/turbo/apps/web/app/api/cli/auth/test-token/route.ts
@@ -102,7 +102,6 @@ export async function POST(request: Request) {
     token,
     userId,
     name: "CI Test Token",
-    scopeId: null,
     orgId,
     expiresAt,
     createdAt: now,

--- a/turbo/apps/web/app/api/cli/auth/token/route.ts
+++ b/turbo/apps/web/app/api/cli/auth/token/route.ts
@@ -87,7 +87,6 @@ const router = tsr.router(cliAuthTokenContract, {
           token: cliToken,
           userId,
           name: "CLI Device Flow Authentication",
-          scopeId: null,
           orgId: scope.orgId,
           expiresAt,
           createdAt: now,

--- a/turbo/apps/web/app/api/webhooks/agent/storages/prepare/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/storages/prepare/route.ts
@@ -100,7 +100,6 @@ const router = tsr.router(webhookStoragesPrepareContract, {
       .insert(storages)
       .values({
         userId: storageUserId,
-        scopeId: null,
         orgId: resolvedScope.orgId,
         name: storageName,
         type: storageType,


### PR DESCRIPTION
## Summary
- Remove `scopeId: null` from 3 INSERT operations (`cli/auth/token`, `cli/auth/test-token`, `webhooks/agent/storages/prepare`)
- Remove unused `scopeId` SELECT field from `agent/composes/[id]/instructions` route

Part of scope-to-org migration (Phase 5c-2). All changes are no-op dead code removal — writing `null` to nullable columns and selecting an unused field.

Closes #4537

## Test plan
- [x] Existing tests pass (20/20 across 3 test files)
- [x] Lint passes (0 warnings, 0 errors)
- [x] Knip passes (no unused code)
- [x] Grep confirms zero `scopeId` references in all 4 modified route files

🤖 Generated with [Claude Code](https://claude.com/claude-code)