### PR TITLE
refactor(auth): remove scope-id from auth context types (5c-1)

### DIFF
--- a/turbo/apps/web/src/lib/auth/get-user-id.ts
+++ b/turbo/apps/web/src/lib/auth/get-user-id.ts
@@ -8,12 +8,10 @@ const log = logger("auth:user");
 
 /**
  * Authentication context returned by getAuthContext.
- * - scopeId: present when auth is via a CLI token that has a stored scope (legacy, prefer orgId)
  * - orgId: present when auth is via a CLI token that has a stored org
  */
 type AuthContext = {
   userId: string;
-  scopeId: string | null;
   orgId: string | null;
 };
 
@@ -21,8 +19,8 @@ type AuthContext = {
  * Get the full authentication context from CLI token or Clerk session.
  * Returns null if not authenticated.
  *
- * For Clerk sessions, scopeId is null (scope is resolved from JWT orgId).
- * For CLI tokens with scope_id, returns the stored scopeId.
+ * For Clerk sessions, orgId is null (org is resolved from Clerk JWT).
+ * For CLI tokens with org_id, returns the stored orgId.
  *
  * IMPORTANT: This function rejects sandbox JWT tokens.
  * Sandbox tokens can only be used on webhook endpoints via getSandboxAuth().
@@ -33,7 +31,7 @@ export async function getAuthContext(
   // Session auth via Clerk
   const { userId } = await auth();
   if (userId) {
-    return { userId, scopeId: null, orgId: null };
+    return { userId, orgId: null };
   }
 
   if (!authHeader?.startsWith("Bearer ")) {
@@ -72,7 +70,6 @@ export async function getAuthContext(
 
   return {
     userId: tokenRecord.userId,
-    scopeId: tokenRecord.scopeId,
     orgId: tokenRecord.orgId,
   };
 }
@@ -81,7 +78,7 @@ export async function getAuthContext(
  * Get the current user ID from CLI token or Clerk session.
  * Returns null if not authenticated.
  *
- * Use getAuthContext() when you also need the CLI token's scopeId.
+ * Use getAuthContext() when you also need the CLI token's orgId.
  */
 export async function getUserId(authHeader?: string): Promise<string | null> {
   const ctx = await getAuthContext(authHeader);

--- a/turbo/apps/web/src/lib/auth/runner-auth.ts
+++ b/turbo/apps/web/src/lib/auth/runner-auth.ts
@@ -28,7 +28,6 @@ type RunnerAuthContext =
   | {
       type: "user";
       userId: string;
-      scopeId: string | null;
       orgId: string | null;
     }
   | { type: "official-runner" };
@@ -128,7 +127,6 @@ export async function getRunnerAuth(
       return {
         type: "user",
         userId: tokenRecord.userId,
-        scopeId: tokenRecord.scopeId,
         orgId: tokenRecord.orgId,
       };
     }

--- a/turbo/apps/web/src/lib/run/build-context.ts
+++ b/turbo/apps/web/src/lib/run/build-context.ts
@@ -1064,7 +1064,7 @@ export async function buildExecutionContext(
     : undefined;
 
   // Step 4: Resolve secrets, user preferences, and runtime scope in parallel.
-  // pendingRuntimeScope may already be resolved (when scopeId was not explicit).
+  // pendingRuntimeScope may already be resolved (when orgId was not explicit).
   const resolveSecretsStart = Date.now();
   const [secretsResult, userPrefs, runtimeScope] = await Promise.all([
     resolveSecretsAndEnvironment(

--- a/turbo/apps/web/src/lib/schedule/schedule-service.ts
+++ b/turbo/apps/web/src/lib/schedule/schedule-service.ts
@@ -224,7 +224,7 @@ async function getScopeSlug(orgId: string): Promise<string> {
 }
 
 /**
- * Verify the user owns this schedule (by composeId + name + scopeId + userId)
+ * Verify the user owns this schedule (by composeId + name + orgId + userId)
  */
 async function verifyScheduleOwnership(
   userId: string,
@@ -261,7 +261,7 @@ async function verifyScheduleOwnership(
 
 /**
  * Validate that all required secrets/vars are available in platform tables.
- * Uses the schedule's scopeId + userId (not compose's) for cross-scope support.
+ * Uses the schedule's orgId + userId (not compose's) for cross-org support.
  */
 async function validateRequiredConfig(
   compose: typeof agentComposes.$inferSelect,


### PR DESCRIPTION
## Summary
- Remove dead `scopeId` field from `AuthContext` and `RunnerAuthContext` types
- Remove `scopeId` assignments from `getAuthContext()` and `getRunnerAuth()` return values
- Fix 3 stale comments that referenced `scopeId` where code uses `orgId`

Part of scope-to-org migration Phase 5c-1.

Closes #4536

## Test plan
- [x] `pnpm check-types` passes (pre-existing `archiver` type error unrelated)
- [x] `pnpm turbo run lint` passes
- [x] `pnpm knip` finds no issues
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)