### PR TITLE
fix: update stale scope-id comment in preferences test

### DIFF
--- a/turbo/apps/web/app/api/user/preferences/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/user/preferences/__tests__/route.test.ts
@@ -187,7 +187,7 @@ describe("GET /api/user/preferences (error paths)", () => {
   it("should return BAD_REQUEST when no organization context is available", async () => {
     const user = await context.setupUser();
 
-    // No orgId in session and no scopeId in auth context
+    // No orgId in session and no orgId in auth context
     mockClerk({ userId: user.userId });
 
     const request = createTestRequest(
@@ -226,7 +226,7 @@ describe("PUT /api/user/preferences", () => {
 
   it("should return BAD_REQUEST when no organization context is available", async () => {
     const user = await context.setupUser();
-    // No orgId in session and no scopeId in auth context
+    // No orgId in session and no orgId in auth context
     mockClerk({ userId: user.userId });
 
     const request = createTestRequest(


### PR DESCRIPTION
## Summary
- Update 2 stale comments in `preferences/route.test.ts` that referenced `scopeId in auth context` — `scopeId` was removed from `AuthContext` in 5c-1 (PR #4541)

Part of scope-to-org migration (#4146).

## Test plan
- [x] Comment-only change, no behavioral impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)