### PR TITLE
refactor(services): expand service configs at compose stage with secret-name keyed placeholders

### DIFF
--- a/e2e/tests/03-experimental-runner/t42-connector-placeholder.bats
+++ b/e2e/tests/03-experimental-runner/t42-connector-placeholder.bats
@@ -7,9 +7,6 @@
 # 2. Placeholder env vars replace secret values in the sandbox (with custom formats)
 # 3. Multiple connectors work together
 # 4. Proxy replaces placeholder tokens with real tokens (via test-connector API)
-#
-# All tests require test-connector setup so the connector is "connected" in the DB,
-# which is needed for placeholder injection via buildConnectorEnvVars.
 
 load '../../helpers/setup'
 
@@ -100,7 +97,6 @@ agents:
     experimental_services:
       - github
     environment:
-      GH_TOKEN: \${{ secrets.GH_TOKEN }}
       GITHUB_TOKEN: \${{ secrets.GITHUB_TOKEN }}
 EOF
 
@@ -109,19 +105,18 @@ EOF
     run $CLI_COMMAND compose "$TEST_DIR/vm0.yaml"
     assert_success
 
-    # Verify GITHUB_TOKEN and GH_TOKEN are set to the connector placeholder.
+    # Verify GITHUB_TOKEN is set to the connector placeholder.
     # Full values are masked by the runner (***), so we compare sha256 hashes.
     local expected_gh_hash
     expected_gh_hash=$(echo -n "gho_vm0placeholder0000000000000000000000" | sha256sum | cut -d' ' -f1)
     run $CLI_COMMAND run "${AGENT_NAME}-github" \
         --artifact-name "$ARTIFACT_NAME-github" \
-        "echo \"GH_HASH=\$(echo -n \$GH_TOKEN | sha256sum | cut -d' ' -f1)\" && echo \"GITHUB_HASH=\$(echo -n \$GITHUB_TOKEN | sha256sum | cut -d' ' -f1)\""
+        "echo \"GITHUB_HASH=\$(echo -n \$GITHUB_TOKEN | sha256sum | cut -d' ' -f1)\""
 
     echo "$output"
     assert_success
     assert_output --partial "Run completed successfully"
 
-    assert_output --partial "GH_HASH=${expected_gh_hash}"
     assert_output --partial "GITHUB_HASH=${expected_gh_hash}"
 }
 
@@ -141,7 +136,7 @@ agents:
       - github
       - slack
     environment:
-      GH_TOKEN: \${{ secrets.GH_TOKEN }}
+      GITHUB_TOKEN: \${{ secrets.GITHUB_TOKEN }}
       SLACK_TOKEN: \${{ secrets.SLACK_TOKEN }}
 EOF
 
@@ -157,13 +152,13 @@ EOF
     expected_slack_hash=$(echo -n "xoxb-0000-0000-vm0placeholder" | sha256sum | cut -d' ' -f1)
     run $CLI_COMMAND run "${AGENT_NAME}-multi" \
         --artifact-name "$ARTIFACT_NAME-multi" \
-        "echo \"GH_HASH=\$(echo -n \$GH_TOKEN | sha256sum | cut -d' ' -f1)\" && echo \"SLACK_HASH=\$(echo -n \$SLACK_TOKEN | sha256sum | cut -d' ' -f1)\""
+        "echo \"GITHUB_HASH=\$(echo -n \$GITHUB_TOKEN | sha256sum | cut -d' ' -f1)\" && echo \"SLACK_HASH=\$(echo -n \$SLACK_TOKEN | sha256sum | cut -d' ' -f1)\""
 
     echo "$output"
     assert_success
     assert_output --partial "Run completed successfully"
 
-    assert_output --partial "GH_HASH=${expected_gh_hash}"
+    assert_output --partial "GITHUB_HASH=${expected_gh_hash}"
     assert_output --partial "SLACK_HASH=${expected_slack_hash}"
 }
 

--- a/turbo/apps/cli/src/commands/compose/index.ts
+++ b/turbo/apps/cli/src/commands/compose/index.ts
@@ -399,9 +399,7 @@ function expandServiceConfigs(config: unknown): void {
       return {
         name,
         apis: serviceConfig.apis,
-        ...(serviceConfig.placeholders
-          ? { placeholders: serviceConfig.placeholders }
-          : {}),
+        placeholders: serviceConfig.placeholders,
       };
     });
   }

--- a/turbo/apps/cli/src/commands/compose/index.ts
+++ b/turbo/apps/cli/src/commands/compose/index.ts
@@ -8,7 +8,10 @@ import {
   getLegacySystemTemplateWarning,
   extractAndGroupVariables,
   resolveSkillRef,
+  connectorTypeSchema,
+  getServiceConfig,
 } from "@vm0/core";
+import type { ExpandedServiceConfig } from "@vm0/core";
 import {
   getComposeByName,
   createOrUpdateCompose,
@@ -68,6 +71,7 @@ interface AgentConfig {
   skills?: string[];
   environment?: Record<string, string>;
   metadata?: { displayName?: string; sound?: string };
+  experimental_services?: string[];
 }
 
 interface LoadedConfig {
@@ -360,6 +364,50 @@ function mergeSkillVariables(
 }
 
 /**
+ * Expand experimental_services from string[] to ExpandedServiceConfig[] in-place.
+ * Mutates the config object so the API receives pre-expanded service objects.
+ *
+ * TODO: Support resolving services from GitHub URLs (like skills).
+ * Currently only resolves from built-in SERVICE_CONFIGS via connectorTypeSchema.
+ */
+function expandServiceConfigs(config: unknown): void {
+  const compose = config as {
+    agents?: Record<
+      string,
+      { experimental_services?: string[] | ExpandedServiceConfig[] }
+    >;
+  };
+  if (!compose?.agents) return;
+
+  for (const agent of Object.values(compose.agents)) {
+    const services = agent.experimental_services;
+    if (!services || services.length === 0) continue;
+    // Skip if already expanded (object array, not string array)
+    if (typeof services[0] !== "string") continue;
+
+    agent.experimental_services = (services as string[]).map((name) => {
+      const parsed = connectorTypeSchema.safeParse(name);
+      if (!parsed.success) {
+        throw new Error(`Unknown service: "${name}"`);
+      }
+      const serviceConfig = getServiceConfig(parsed.data);
+      if (!serviceConfig) {
+        throw new Error(
+          `Service "${name}" does not support proxy-side token replacement`,
+        );
+      }
+      return {
+        name,
+        apis: serviceConfig.apis,
+        ...(serviceConfig.placeholders
+          ? { placeholders: serviceConfig.placeholders }
+          : {}),
+      };
+    });
+  }
+}
+
+/**
  * Derive the platform URL from the API URL by replacing "www" with "platform" in the hostname.
  */
 function getPlatformUrl(apiUrl: string): string {
@@ -477,6 +525,9 @@ async function finalizeCompose(
 
   // Merge skill variables into environment
   mergeSkillVariables(agent, variables);
+
+  // Expand experimental_services from names to full configs before sending to API
+  expandServiceConfigs(config);
 
   // Call API
   if (!options.json) {

--- a/turbo/apps/cli/src/lib/api/api-client.ts
+++ b/turbo/apps/cli/src/lib/api/api-client.ts
@@ -21,7 +21,7 @@ import {
   schedulesByNameContract,
   schedulesEnableContract,
   scheduleRunsContract,
-  agentComposeContentSchema,
+  agentComposeApiContentSchema,
   type ApiErrorResponse,
   type ScheduleResponse,
   type ScheduleListResponse,
@@ -247,7 +247,7 @@ class ApiClient {
     });
 
     const result = await client.create({
-      body: body as { content: z.infer<typeof agentComposeContentSchema> },
+      body: body as { content: z.infer<typeof agentComposeApiContentSchema> },
     });
 
     // ts-rest returns discriminated union based on status code

--- a/turbo/apps/cli/src/lib/api/domains/composes.ts
+++ b/turbo/apps/cli/src/lib/api/domains/composes.ts
@@ -3,7 +3,7 @@ import {
   composesMainContract,
   composesByIdContract,
   composesVersionsContract,
-  agentComposeContentSchema,
+  agentComposeApiContentSchema,
 } from "@vm0/core";
 import type { z } from "zod";
 import { getClientConfig, handleError } from "../core/client-factory";
@@ -79,7 +79,7 @@ export async function createOrUpdateCompose(body: {
   const client = initClient(composesMainContract, config);
 
   const result = await client.create({
-    body: body as { content: z.infer<typeof agentComposeContentSchema> },
+    body: body as { content: z.infer<typeof agentComposeApiContentSchema> },
   });
 
   // Both 200 and 201 are success cases

--- a/turbo/apps/web/app/api/onboarding/status/route.ts
+++ b/turbo/apps/web/app/api/onboarding/status/route.ts
@@ -10,7 +10,7 @@ import {
   agentComposeVersions,
 } from "../../../../src/db/schema/agent-compose";
 import { eq } from "drizzle-orm";
-import { agentComposeContentSchema } from "@vm0/core";
+import { agentComposeApiContentSchema } from "@vm0/core";
 import { auth } from "@clerk/nextjs/server";
 
 const router = tsr.router(onboardingStatusContract, {
@@ -75,7 +75,9 @@ const router = tsr.router(onboardingStatusContract, {
           defaultAgentComposeId = claimAgentComposeId;
 
           // Extract metadata from compose content
-          const parsed = agentComposeContentSchema.safeParse(compose.content);
+          const parsed = agentComposeApiContentSchema.safeParse(
+            compose.content,
+          );
           if (parsed.success) {
             const agentKey = Object.keys(parsed.data.agents)[0];
             const agentDef = agentKey

--- a/turbo/apps/web/src/lib/run/build-context.ts
+++ b/turbo/apps/web/src/lib/run/build-context.ts
@@ -8,7 +8,6 @@ import {
   hasAuthMethods,
   getSecretNamesForAuthMethod,
   getConnectorEnvironmentMapping,
-  getServiceConfig,
   connectorTypeSchema,
   MODEL_PROVIDER_TYPES,
   type ExperimentalServices,
@@ -17,6 +16,7 @@ import {
   type ModelProviderFramework,
 } from "@vm0/core";
 import { agentComposeVersions } from "../../db/schema/agent-compose";
+import type { AgentComposeYaml } from "../../types/agent-compose";
 import { badRequest, notFound } from "../errors";
 import { getOrgData } from "../scope/org-cache-service";
 import { logger } from "../logger";
@@ -391,8 +391,6 @@ interface ConnectorSecretResult {
   connectorSecrets: Record<string, string> | undefined;
   /** Environment variables mapped from OAuth connectors via environmentMapping */
   injectedEnvVars: Record<string, string> | undefined;
-  /** Connected connector type names (used to filter experimental_services placeholders) */
-  connectedTypes: string[];
 }
 
 /**
@@ -414,7 +412,6 @@ async function resolveConnectorSecrets(
     return {
       connectorSecrets: undefined,
       injectedEnvVars: undefined,
-      connectedTypes: [],
     };
   }
 
@@ -423,7 +420,6 @@ async function resolveConnectorSecrets(
     return {
       connectorSecrets: undefined,
       injectedEnvVars: undefined,
-      connectedTypes: [],
     };
   }
 
@@ -481,7 +477,6 @@ async function resolveConnectorSecrets(
   return {
     connectorSecrets,
     injectedEnvVars: allInjectedEnvVars,
-    connectedTypes: validConnectors.map((c) => c.type),
   };
 }
 
@@ -815,7 +810,6 @@ async function resolveSecretsAndEnvironment(
     mergedVars,
     secrets,
     checkEnv,
-    connectorResult.connectedTypes,
   );
 
   // Auto-inject model provider env vars into environment
@@ -932,46 +926,30 @@ interface BuildContextResult {
 }
 
 /**
- * Build ExperimentalServices manifest from agent compose's experimental_services array.
+ * Build ExperimentalServices manifest from agent compose's expanded experimental_services.
  * Returns null if no services are declared.
  *
- * For each declared service name:
- * 1. Validates it's a known connector type with service config
- * 2. Flattens apis to one entry per base URL with auth headers (for runner-side matching)
+ * Reads pre-expanded ExpandedServiceConfig objects (resolved at compose time)
+ * and flattens apis to one entry per base URL with auth headers (for runner-side matching).
  *
  * Placeholder env var injection is handled by expandEnvironmentFromCompose.
  */
 function buildExperimentalServices(
   agentCompose: unknown,
 ): ExperimentalServices | null {
-  const compose = agentCompose as
-    | { agents?: Record<string, { experimental_services?: string[] }> }
-    | undefined;
+  const compose = agentCompose as AgentComposeYaml | undefined;
   if (!compose?.agents) return null;
 
   const firstAgent = Object.values(compose.agents)[0];
-  const serviceNames = firstAgent?.experimental_services;
-  if (!serviceNames || serviceNames.length === 0) return null;
+  const services = firstAgent?.experimental_services;
+  if (!services || services.length === 0) return null;
 
   const entries: { base: string; auth: { headers: Record<string, string> } }[] =
     [];
 
-  for (const name of serviceNames) {
-    const parsed = connectorTypeSchema.safeParse(name);
-    if (!parsed.success) {
-      throw badRequest(`Unknown connector type: "${name}"`);
-    }
-    const connectorType = parsed.data;
-
-    const serviceConfig = getServiceConfig(connectorType);
-    if (!serviceConfig) {
-      throw badRequest(
-        `Connector "${name}" does not support proxy-side token replacement`,
-      );
-    }
-
-    for (const api of serviceConfig.apis) {
-      entries.push({ base: api.base, auth: api.auth });
+  for (const service of services) {
+    for (const serviceApi of service.apis) {
+      entries.push({ base: serviceApi.base, auth: serviceApi.auth });
     }
   }
 

--- a/turbo/apps/web/src/lib/run/environment/__tests__/expand-environment.test.ts
+++ b/turbo/apps/web/src/lib/run/environment/__tests__/expand-environment.test.ts
@@ -1,7 +1,11 @@
 import { describe, it, expect } from "vitest";
 import { expandEnvironmentFromCompose } from "../expand-environment";
+import type { ExpandedServiceConfig } from "@vm0/core";
 
-function makeCompose(environment: Record<string, string>, services?: string[]) {
+function makeCompose(
+  environment: Record<string, string>,
+  services?: ExpandedServiceConfig[],
+) {
   return {
     version: "1.0",
     agents: {
@@ -16,14 +20,46 @@ function makeCompose(environment: Record<string, string>, services?: string[]) {
   };
 }
 
+const githubService: ExpandedServiceConfig = {
+  name: "github",
+  apis: [
+    {
+      base: "https://api.github.com",
+      auth: { headers: { Authorization: "Bearer ${secrets.GITHUB_TOKEN}" } },
+    },
+  ],
+  placeholders: { GITHUB_TOKEN: "gho_vm0placeholder0000000000000000000000" },
+};
+
+const slackService: ExpandedServiceConfig = {
+  name: "slack",
+  apis: [
+    {
+      base: "https://slack.com/api",
+      auth: { headers: { Authorization: "Bearer ${secrets.SLACK_TOKEN}" } },
+    },
+  ],
+  placeholders: { SLACK_TOKEN: "xoxb-0000-0000-vm0placeholder" },
+};
+
+const airtableService: ExpandedServiceConfig = {
+  name: "airtable",
+  apis: [
+    {
+      base: "https://api.airtable.com",
+      auth: { headers: { Authorization: "Bearer ${secrets.AIRTABLE_TOKEN}" } },
+    },
+  ],
+};
+
 describe("expandEnvironmentFromCompose — service env vars", () => {
-  it("replaces secret values with service placeholders when service is connected", () => {
+  it("replaces secret values with service placeholders", () => {
     const compose = makeCompose(
       {
-        GH_TOKEN: "${{ secrets.GH_TOKEN }}",
-        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}",
+        GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}",
+        MY_GH: "${{ secrets.GITHUB_TOKEN }}",
       },
-      ["github"],
+      [githubService],
     );
 
     const { environment } = expandEnvironmentFromCompose(
@@ -31,67 +67,38 @@ describe("expandEnvironmentFromCompose — service env vars", () => {
       undefined,
       undefined,
       false,
-      ["github"],
     );
 
     expect(environment).toBeDefined();
     expect(environment!.GH_TOKEN).toBe(
       "gho_vm0placeholder0000000000000000000000",
     );
-    expect(environment!.GITHUB_TOKEN).toBe(
-      "gho_vm0placeholder0000000000000000000000",
-    );
-  });
-
-  it("does not inject placeholders when service is not connected", () => {
-    const compose = makeCompose(
-      {
-        GH_TOKEN: "${{ secrets.GH_TOKEN }}",
-      },
-      ["github"],
-    );
-
-    const { environment } = expandEnvironmentFromCompose(
-      compose,
-      undefined,
-      { GH_TOKEN: "user-provided" },
-      false,
-      [], // no connected types
-    );
-
-    expect(environment).toBeDefined();
-    // Service not connected → falls back to passed secret
-    expect(environment!.GH_TOKEN).toBe("user-provided");
+    expect(environment!.MY_GH).toBe("gho_vm0placeholder0000000000000000000000");
   });
 
   it("does not inject placeholders when service is not declared", () => {
-    const compose = makeCompose(
-      {
-        GH_TOKEN: "${{ secrets.GH_TOKEN }}",
-      },
-      // no experimental_services
-    );
+    const compose = makeCompose({
+      GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}",
+    });
 
     const { environment } = expandEnvironmentFromCompose(
       compose,
       undefined,
-      { GH_TOKEN: "user-provided" },
+      { GITHUB_TOKEN: "user-provided" },
       false,
-      ["github"],
     );
 
     expect(environment).toBeDefined();
-    // Service not declared → falls back to passed secret
     expect(environment!.GH_TOKEN).toBe("user-provided");
   });
 
   it("handles multiple services with different placeholders", () => {
     const compose = makeCompose(
       {
-        GH_TOKEN: "${{ secrets.GH_TOKEN }}",
+        GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}",
         SLACK_TOKEN: "${{ secrets.SLACK_TOKEN }}",
       },
-      ["github", "slack"],
+      [githubService, slackService],
     );
 
     const { environment } = expandEnvironmentFromCompose(
@@ -99,7 +106,6 @@ describe("expandEnvironmentFromCompose — service env vars", () => {
       undefined,
       undefined,
       false,
-      ["github", "slack"],
     );
 
     expect(environment).toBeDefined();
@@ -112,17 +118,16 @@ describe("expandEnvironmentFromCompose — service env vars", () => {
   it("service placeholder takes precedence over passed secrets", () => {
     const compose = makeCompose(
       {
-        GH_TOKEN: "${{ secrets.GH_TOKEN }}",
+        GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}",
       },
-      ["github"],
+      [githubService],
     );
 
     const { environment } = expandEnvironmentFromCompose(
       compose,
       undefined,
-      { GH_TOKEN: "user-provided-token" },
+      { GITHUB_TOKEN: "user-provided-token" },
       false,
-      ["github"],
     );
 
     expect(environment).toBeDefined();
@@ -136,7 +141,7 @@ describe("expandEnvironmentFromCompose — service env vars", () => {
       {
         AIRTABLE_TOKEN: "${{ secrets.AIRTABLE_TOKEN }}",
       },
-      ["airtable"],
+      [airtableService],
     );
 
     const { environment } = expandEnvironmentFromCompose(
@@ -144,11 +149,9 @@ describe("expandEnvironmentFromCompose — service env vars", () => {
       undefined,
       undefined,
       false,
-      ["airtable"],
     );
 
     expect(environment).toBeDefined();
-    // Airtable has no custom placeholder → uses default VM0_PLACEHOLDER_ prefix
     expect(environment!.AIRTABLE_TOKEN).toBe("VM0_PLACEHOLDER_AIRTABLE_TOKEN");
   });
 });

--- a/turbo/apps/web/src/lib/run/environment/expand-environment.ts
+++ b/turbo/apps/web/src/lib/run/environment/expand-environment.ts
@@ -119,9 +119,7 @@ export function expandEnvironmentFromCompose(
   }
 
   const servicePlaceholders = buildServicePlaceholders(
-    (firstAgent?.experimental_services as
-      | ExpandedServiceConfig[]
-      | undefined) ?? [],
+    firstAgent?.experimental_services ?? [],
   );
 
   // Process secrets if needed

--- a/turbo/apps/web/src/lib/run/environment/expand-environment.ts
+++ b/turbo/apps/web/src/lib/run/environment/expand-environment.ts
@@ -1,10 +1,9 @@
 import {
   expandVariables,
   extractAndGroupVariables,
-  connectorTypeSchema,
-  getConnectorEnvironmentMapping,
-  getServiceConfig,
+  extractSecretNamesFromApis,
 } from "@vm0/core";
+import type { ExpandedServiceConfig } from "@vm0/core";
 import { badRequest } from "../../errors";
 import { logger } from "../../logger";
 import type { AgentComposeYaml } from "../../../types/agent-compose";
@@ -19,13 +18,13 @@ interface ExpandedEnvironmentResult {
 }
 
 /**
- * Process secret values: validate and resolve from passed secrets or connector placeholders.
+ * Process secret values: validate and resolve from passed secrets or service placeholders.
  */
 function processSecretValues(
   secretNames: string[],
   passedSecrets: Record<string, string> | undefined,
   checkEnv: boolean | undefined,
-  connectorEnvVars?: Record<string, string>,
+  servicePlaceholders?: Record<string, string>,
 ): Record<string, string> | undefined {
   if (secretNames.length === 0) return undefined;
 
@@ -42,8 +41,8 @@ function processSecretValues(
 
   const secrets: Record<string, string> = {};
   for (const name of secretNames) {
-    if (connectorEnvVars?.[name]) {
-      secrets[name] = connectorEnvVars[name];
+    if (servicePlaceholders?.[name]) {
+      secrets[name] = servicePlaceholders[name];
     } else {
       secrets[name] = passedSecrets![name]!;
     }
@@ -52,34 +51,25 @@ function processSecretValues(
 }
 
 /**
- * Build connector env var placeholders for experimental_services that are actually connected.
- * Returns a map of env var name → placeholder value, or undefined if no connectors qualify.
+ * Build service placeholder map keyed by canonical secret name.
+ * Reads pre-expanded service configs and extracts secret names from auth templates
+ * (`${secrets.XXX}`), then maps each to a placeholder value (custom or auto-generated).
  */
-function buildConnectorEnvVars(
-  declaredServices: string[],
-  connectedTypes: string[],
+function buildServicePlaceholders(
+  expandedServices: ExpandedServiceConfig[],
 ): Record<string, string> | undefined {
-  if (declaredServices.length === 0 || connectedTypes.length === 0)
-    return undefined;
+  if (expandedServices.length === 0) return undefined;
 
-  const connected = new Set(connectedTypes);
-  const envVars: Record<string, string> = {};
+  const placeholders: Record<string, string> = {};
 
-  for (const name of declaredServices) {
-    if (!connected.has(name)) continue;
-    const parsed = connectorTypeSchema.safeParse(name);
-    if (!parsed.success) continue;
-    const connectorType = parsed.data;
-    const serviceConfig = getServiceConfig(connectorType);
-    if (!serviceConfig) continue;
-
-    const envMapping = getConnectorEnvironmentMapping(connectorType);
-    for (const envVar of Object.keys(envMapping)) {
-      envVars[envVar] =
-        serviceConfig.placeholders?.[envVar] ?? `VM0_PLACEHOLDER_${envVar}`;
+  for (const service of expandedServices) {
+    const secretNames = extractSecretNamesFromApis(service.apis);
+    for (const secretName of secretNames) {
+      placeholders[secretName] =
+        service.placeholders?.[secretName] ?? `VM0_PLACEHOLDER_${secretName}`;
     }
   }
-  return Object.keys(envVars).length > 0 ? envVars : undefined;
+  return Object.keys(placeholders).length > 0 ? placeholders : undefined;
 }
 
 /**
@@ -87,7 +77,7 @@ function buildConnectorEnvVars(
  * Expands ${{ vars.xxx }} and ${{ secrets.xxx }} references
  *
  * When experimental_services is declared:
- * - Connector env vars are set to placeholder values (proxy replaces at runtime)
+ * - Service secret values are replaced with placeholders (proxy resolves real secrets at runtime)
  *
  * @param agentCompose Agent compose configuration
  * @param vars Variables for expansion (from --vars CLI param)
@@ -100,8 +90,6 @@ export function expandEnvironmentFromCompose(
   vars: Record<string, string> | undefined,
   passedSecrets: Record<string, string> | undefined,
   checkEnv?: boolean,
-  /** Connected connector type names — only these get placeholder injection. */
-  connectedTypes?: string[],
 ): ExpandedEnvironmentResult {
   const compose = agentCompose as AgentComposeYaml | undefined;
   if (!compose?.agents) {
@@ -130,10 +118,10 @@ export function expandEnvironmentFromCompose(
     );
   }
 
-  // Build connector env var placeholders from experimental_services ∩ connectedTypes
-  const connectorEnvVars = buildConnectorEnvVars(
-    firstAgent?.experimental_services ?? [],
-    connectedTypes ?? [],
+  const servicePlaceholders = buildServicePlaceholders(
+    (firstAgent?.experimental_services as
+      | ExpandedServiceConfig[]
+      | undefined) ?? [],
   );
 
   // Process secrets if needed
@@ -142,7 +130,7 @@ export function expandEnvironmentFromCompose(
     secretNames,
     passedSecrets,
     checkEnv,
-    connectorEnvVars,
+    servicePlaceholders,
   );
 
   // Build sources for expansion

--- a/turbo/apps/web/src/types/agent-compose.ts
+++ b/turbo/apps/web/src/types/agent-compose.ts
@@ -2,6 +2,8 @@
  * Agent compose types matching agent.yaml format
  */
 
+import type { ExpandedServiceConfig } from "@vm0/core";
+
 /**
  * Volume configuration for static dependencies
  * Each volume requires explicit name and version
@@ -84,14 +86,7 @@ interface AgentDefinition {
    * Resolved from service names at compose time, stored as full objects.
    * Input format (CLI): string[] — expanded server-side before storage.
    */
-  experimental_services?: Array<{
-    name: string;
-    apis: Array<{
-      base: string;
-      auth: { headers: Record<string, string> };
-    }>;
-    placeholders?: Record<string, string>;
-  }>;
+  experimental_services?: ExpandedServiceConfig[];
   /**
    * Agent metadata for display and personalization.
    */

--- a/turbo/apps/web/src/types/agent-compose.ts
+++ b/turbo/apps/web/src/types/agent-compose.ts
@@ -80,11 +80,18 @@ interface AgentDefinition {
    */
   experimental_firewall?: ExperimentalFirewall;
   /**
-   * Experimental services for proxy-side token replacement.
-   * Array of service names (e.g., ["gmail", "github"]).
-   * Requires experimental_runner to be configured.
+   * Expanded service configs for proxy-side token replacement.
+   * Resolved from service names at compose time, stored as full objects.
+   * Input format (CLI): string[] — expanded server-side before storage.
    */
-  experimental_services?: string[];
+  experimental_services?: Array<{
+    name: string;
+    apis: Array<{
+      base: string;
+      auth: { headers: Record<string, string> };
+    }>;
+    placeholders?: Record<string, string>;
+  }>;
   /**
    * Agent metadata for display and personalization.
    */

--- a/turbo/packages/core/src/contracts/__tests__/connectors.test.ts
+++ b/turbo/packages/core/src/contracts/__tests__/connectors.test.ts
@@ -102,7 +102,6 @@ describe("getServiceConfig", () => {
       "Bearer ${secrets.GITHUB_TOKEN}",
     );
     expect(config!.placeholders).toEqual({
-      GH_TOKEN: "gho_vm0placeholder0000000000000000000000",
       GITHUB_TOKEN: "gho_vm0placeholder0000000000000000000000",
     });
   });

--- a/turbo/packages/core/src/contracts/composes.ts
+++ b/turbo/packages/core/src/contracts/composes.ts
@@ -94,9 +94,8 @@ const agentDefinitionSchema = z.object({
    */
   experimental_firewall: experimentalFirewallSchema.optional(),
   /**
-   * External services for proxy-side token replacement (e.g., github, slack).
-   * Service-referenced env vars are replaced with placeholders; the proxy injects real secrets at runtime.
-   * Requires experimental_runner to be configured.
+   * External services for proxy-side token replacement.
+   * CLI input: string[] (e.g., ["github", "slack"]) — expanded by CLI to full objects before API call.
    */
   experimental_services: z.array(z.string()).optional(),
   /**
@@ -123,11 +122,42 @@ const agentDefinitionSchema = z.object({
 });
 
 /**
- * Agent compose YAML content schema
+ * Agent compose YAML content schema (CLI input — experimental_services is string[])
  */
 const agentComposeContentSchema = z.object({
   version: z.string().min(1, "Version is required"),
   agents: z.record(z.string(), agentDefinitionSchema),
+  volumes: z.record(z.string(), volumeConfigSchema).optional(),
+});
+
+/**
+ * Expanded service config schema (after CLI expansion)
+ */
+const expandedServiceConfigSchema = z.object({
+  name: z.string(),
+  apis: z.array(
+    z.object({
+      base: z.string(),
+      auth: z.object({
+        headers: z.record(z.string(), z.string()),
+      }),
+    }),
+  ),
+  placeholders: z.record(z.string(), z.string()).optional(),
+});
+
+/**
+ * Agent compose content schema for API requests.
+ * Same as agentComposeContentSchema but experimental_services is pre-expanded by CLI.
+ */
+const agentComposeApiContentSchema = z.object({
+  version: z.string().min(1, "Version is required"),
+  agents: z.record(
+    z.string(),
+    agentDefinitionSchema.extend({
+      experimental_services: z.array(expandedServiceConfigSchema).optional(),
+    }),
+  ),
   volumes: z.record(z.string(), volumeConfigSchema).optional(),
 });
 
@@ -138,7 +168,7 @@ const composeResponseSchema = z.object({
   id: z.string(),
   name: z.string(),
   headVersionId: z.string().nullable(),
-  content: agentComposeContentSchema.nullable(),
+  content: agentComposeApiContentSchema.nullable(),
   createdAt: z.string(),
   updatedAt: z.string(),
 });
@@ -193,7 +223,7 @@ export const composesMainContract = c.router({
     path: "/api/agent/composes",
     headers: authHeadersSchema,
     body: z.object({
-      content: agentComposeContentSchema,
+      content: agentComposeApiContentSchema,
     }),
     responses: {
       200: createComposeResponseSchema,
@@ -329,6 +359,7 @@ export {
   volumeConfigSchema,
   agentDefinitionSchema,
   agentComposeContentSchema,
+  agentComposeApiContentSchema,
   composeResponseSchema,
   composeListItemSchema,
 };

--- a/turbo/packages/core/src/contracts/index.ts
+++ b/turbo/packages/core/src/contracts/index.ts
@@ -33,6 +33,7 @@ export {
   volumeConfigSchema,
   agentDefinitionSchema,
   agentComposeContentSchema,
+  agentComposeApiContentSchema,
   composeResponseSchema,
   composeListItemSchema,
   // Inferred types
@@ -425,7 +426,12 @@ export {
   type ComputerConnectorCreateResponse,
 } from "./connectors";
 
-export { getServiceConfig, type ServiceConfig } from "./services";
+export {
+  getServiceConfig,
+  extractSecretNamesFromApis,
+  type ServiceConfig,
+  type ExpandedServiceConfig,
+} from "./services";
 
 export {
   userPreferencesContract,

--- a/turbo/packages/core/src/contracts/services.ts
+++ b/turbo/packages/core/src/contracts/services.ts
@@ -21,8 +21,35 @@ interface ServiceApi {
 
 export interface ServiceConfig {
   apis: ServiceApi[];
-  /** Custom placeholder values per env var (e.g., `{ GITHUB_TOKEN: "gho_..." }`). Falls back to auto-generated `VM0_PLACEHOLDER_{envVar}`. */
+  /**
+   * Custom placeholder values keyed by secret name (matching `${secrets.XXX}` in auth templates).
+   * Falls back to auto-generated `VM0_PLACEHOLDER_{secretName}`.
+   * Only needed when the service requires a specific credential format (e.g., GitHub's `gho_` prefix).
+   */
   placeholders?: Record<string, string>;
+}
+
+/**
+ * Regex pattern matching `${secrets.XXX}` references in auth header templates.
+ */
+const AUTH_SECRET_PATTERN = /\$\{secrets\.([^}]+)\}/g;
+
+/**
+ * Extract all secret names referenced in service API auth header templates.
+ * E.g., `Bearer ${secrets.GITHUB_TOKEN}` → `["GITHUB_TOKEN"]`
+ */
+export function extractSecretNamesFromApis(
+  apis: ServiceConfig["apis"],
+): string[] {
+  const names = new Set<string>();
+  for (const entry of apis) {
+    for (const value of Object.values(entry.auth.headers)) {
+      for (const match of value.matchAll(AUTH_SECRET_PATTERN)) {
+        names.add(match[1]!);
+      }
+    }
+  }
+  return [...names];
 }
 
 /** Helper to build standard Bearer auth header with a secret reference. */
@@ -48,7 +75,6 @@ const SERVICE_CONFIGS: Partial<Record<ConnectorType, ServiceConfig>> = {
   github: {
     apis: [api("https://api.github.com", bearerAuth("GITHUB_TOKEN"))],
     placeholders: {
-      GH_TOKEN: "gho_vm0placeholder0000000000000000000000",
       GITHUB_TOKEN: "gho_vm0placeholder0000000000000000000000",
     },
   },
@@ -479,6 +505,16 @@ const SERVICE_CONFIGS: Partial<Record<ConnectorType, ServiceConfig>> = {
     ],
   },
 };
+
+/**
+ * Expanded service config stored in compose content.
+ * Resolved from service name + ServiceConfig at compose time, then frozen.
+ */
+export interface ExpandedServiceConfig {
+  name: string;
+  apis: ServiceApi[];
+  placeholders?: Record<string, string>;
+}
 
 /**
  * Get service config for a connector type (base URLs + auth headers).


### PR DESCRIPTION
## Summary

- Move `experimental_services` expansion from compose API to CLI, consistent with skills pattern (CLI resolves → API stores)
- Change placeholder keying from env-var-name to canonical secret-name extracted from auth templates (`${secrets.XXX}`)
- Split compose schema: `agentComposeContentSchema` (CLI yaml input, `string[]`) vs `agentComposeApiContentSchema` (API contract, expanded objects)
- Remove `connectedTypes` filtering — declared services always get placeholder injection

Closes #4420

## Test plan

- [x] `expand-environment.test.ts` — 5/5 passing
- [x] Type check (core, web, cli) passing
- [x] Lint, knip, format passing
- [ ] CI pipeline green

🤖 Generated with [Claude Code](https://claude.com/claude-code)