### PR TITLE
test: remove css class assertions from button test (ap-7)

### DIFF
--- a/turbo/packages/ui/src/components/ui/__tests__/button.test.tsx
+++ b/turbo/packages/ui/src/components/ui/__tests__/button.test.tsx
@@ -8,36 +8,6 @@ describe("Button", () => {
     expect(screen.getByRole("button")).toHaveTextContent("Click me");
   });
 
-  it("applies default variant classes", () => {
-    render(<Button>Default</Button>);
-    const button = screen.getByRole("button");
-    expect(button).toHaveClass("bg-primary");
-  });
-
-  it("applies destructive variant classes", () => {
-    render(<Button variant="destructive">Delete</Button>);
-    const button = screen.getByRole("button");
-    expect(button).toHaveClass("bg-destructive");
-  });
-
-  it("applies outline variant classes", () => {
-    render(<Button variant="outline">Outline</Button>);
-    const button = screen.getByRole("button");
-    expect(button).toHaveClass("border");
-  });
-
-  it("applies size classes", () => {
-    render(<Button size="sm">Small</Button>);
-    const button = screen.getByRole("button");
-    expect(button).toHaveClass("h-9");
-  });
-
-  it("applies large size classes", () => {
-    render(<Button size="lg">Large</Button>);
-    const button = screen.getByRole("button");
-    expect(button).toHaveClass("h-11");
-  });
-
   it("forwards ref", () => {
     const ref = { current: null as HTMLButtonElement | null };
     render(<Button ref={ref}>Ref test</Button>);


### PR DESCRIPTION
## Summary
- Remove 5 test cases from `button.test.tsx` that asserted on Tailwind CSS class names (`bg-primary`, `bg-destructive`, `border`, `h-9`, `h-11`)
- These violate AP-7 (testing implementation details) — they break when CSS classes are renamed even if visual behavior is unchanged
- Retain 4 behavioral tests: renders children, forwards ref, merges custom className, handles disabled state

## Test plan
- [x] UI package tests pass (`pnpm vitest run packages/ui` — 2 files, 9 tests)
- [x] Knip reports no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)