### PR TITLE
chore: remove unused auth-url variable in cli-auth-automation

### DIFF
--- a/e2e/cli-auth-automation.ts
+++ b/e2e/cli-auth-automation.ts
@@ -100,7 +100,7 @@ export async function automateCliAuth(apiHost?: string) {
     });
 
     // Wait for device code
-    const { deviceCode, authUrl } = await new Promise<{ deviceCode: string; authUrl: string }>((resolve, reject) => {
+    const { deviceCode } = await new Promise<{ deviceCode: string }>((resolve, reject) => {
       const timeout = setTimeout(() => {
         reject(new Error("Timeout: Unable to get device code"));
       }, 10000);
@@ -108,14 +108,12 @@ export async function automateCliAuth(apiHost?: string) {
       // Poll for device code in accumulated output
       const checkInterval = setInterval(() => {
         const codeMatch = cliOutput.match(/enter this code:\s*([A-Z0-9]{4}-[A-Z0-9]{4})/i);
-        const urlMatch = cliOutput.match(/visit:\s*(https?:\/\/[^\s]+\/cli-auth)/i);
 
         if (codeMatch) {
           clearTimeout(timeout);
           clearInterval(checkInterval);
           resolve({
             deviceCode: codeMatch[1],
-            authUrl: urlMatch ? urlMatch[1] : `${apiUrl}/cli-auth`
           });
         }
       }, 100);


### PR DESCRIPTION
## Summary

- Remove unused `authUrl` variable from `e2e/cli-auth-automation.ts` that was destructured but never referenced
- The browser navigation already uses a separately constructed URL (`${baseUrl}/cli-auth`), making `authUrl` dead code
- Cleans up the Promise type signature and resolve call accordingly

Closes #4557

## Test plan

- [ ] Verify CI passes (no runtime impact — only removes unused code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)