### PR TITLE
fix(cli): handle broken pipe error on stdout gracefully

### DIFF
--- a/turbo/apps/cli/src/index.ts
+++ b/turbo/apps/cli/src/index.ts
@@ -68,6 +68,16 @@ if (
   process.argv[1]?.endsWith("index.ts") ||
   process.argv[1]?.endsWith("vm0")
 ) {
+  // Handle EPIPE gracefully (e.g., `vm0 logs ... | head`)
+  process.stdout.on("error", (err) => {
+    if (err.code === "EPIPE") process.exit(0);
+    throw err;
+  });
+  process.stderr.on("error", (err) => {
+    if (err.code === "EPIPE") process.exit(0);
+    throw err;
+  });
+
   configureGlobalProxyFromEnv();
   program.parse();
 }


### PR DESCRIPTION
## Summary
- Add EPIPE error handlers on `process.stdout` and `process.stderr` in the CLI entry point
- When pipe is broken (e.g., `vm0 logs --all | head`), exit cleanly with code 0 instead of crashing
- Resolves Sentry issue CLI-E (6 fatal occurrences since 2026-02-12)

## Test plan
- [ ] Run `vm0 logs --all | head -5` and verify no error is thrown
- [ ] Run `vm0 --help | head -1` and verify clean exit
- [ ] Verify non-EPIPE stdout errors still propagate normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)