### PR TITLE
fix: eliminate shell injection in start-caddy script

### DIFF
--- a/turbo/packages/proxy/scripts/start-caddy.js
+++ b/turbo/packages/proxy/scripts/start-caddy.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-const { execSync, spawn } = require("child_process");
+const { execFileSync, spawn } = require("child_process");
 const path = require("path");
 
 const CADDYFILE = path.join(__dirname, "../Caddyfile");
@@ -9,7 +9,7 @@ console.log("🚀 Starting Caddy reverse proxy...\n");
 
 // Check if certificates exist
 try {
-  execSync("node " + path.join(__dirname, "check-certs.js"), {
+  execFileSync(process.execPath, [path.join(__dirname, "check-certs.js")], {
     stdio: "inherit",
   });
 } catch (error) {
@@ -20,7 +20,7 @@ try {
 // Stop any existing Caddy instance
 try {
   console.log("Stopping any existing Caddy instances...");
-  execSync("pkill -9 caddy 2>/dev/null || true", { stdio: "pipe" });
+  execFileSync("pkill", ["-9", "caddy"], { stdio: "pipe" });
 } catch (error) {
   // Ignore errors if no Caddy is running
 }


### PR DESCRIPTION
## Summary

- Replace `execSync` with `execFileSync` in `start-caddy.js` to eliminate shell injection (CodeQL alert #74, CWE-78). Arguments are now passed as arrays, bypassing the shell entirely.
- Alert #97 (SSRF in `proxy-service.ts`) was already resolved by the removal of the proxy rewrite endpoint in #4539 — no additional changes needed.

Closes #4554

## Test plan

- [ ] Verify CodeQL alert #74 is resolved on next security scan
- [ ] Verify `start-caddy.js` still works correctly (certificate check + pkill + caddy start)

🤖 Generated with [Claude Code](https://claude.com/claude-code)