### PR TITLE
fix: resolve 9 semgrep code scanning alerts on main

### DIFF
--- a/.github/actions/setup-ssh-tunnel/action.yml
+++ b/.github/actions/setup-ssh-tunnel/action.yml
@@ -21,9 +21,10 @@ runs:
   steps:
     - name: Install cloudflared
       shell: bash
-      # nosemgrep: run-shell-injection -- inputs.cloudflared-version is a hardcoded default, not attacker-controlled
+      env:
+        CLOUDFLARED_VERSION: ${{ inputs.cloudflared-version }}
       run: |
-        curl -sfL "https://github.com/cloudflare/cloudflared/releases/download/${{ inputs.cloudflared-version }}/cloudflared-linux-amd64.deb" -o /tmp/cloudflared.deb
+        curl -sfL "https://github.com/cloudflare/cloudflared/releases/download/${CLOUDFLARED_VERSION}/cloudflared-linux-amd64.deb" -o /tmp/cloudflared.deb
         if command -v sudo &>/dev/null; then
           sudo dpkg -i /tmp/cloudflared.deb
         else

--- a/.github/actions/vercel-alias/action.yml
+++ b/.github/actions/vercel-alias/action.yml
@@ -40,17 +40,23 @@ runs:
     - name: Create Vercel alias
       id: alias
       shell: bash
-      # nosemgrep: run-shell-injection -- all inputs (job-ref, app-name, etc.) come from our own workflow, not attacker-controlled
+      env:
+        VERCEL_TOKEN: ${{ inputs.vercel-token }}
+        VERCEL_ORG_ID: ${{ inputs.vercel-org-id }}
+        DEPLOYMENT_URL: ${{ inputs.deployment-url }}
+        APP_NAME: ${{ inputs.app-name }}
+        JOB_REF: ${{ inputs.job-ref }}
+        PREVIEW_DOMAIN: ${{ inputs.preview-domain }}
       run: |
         # Build alias URL: {job-ref}-{app}.{preview-domain}
-        ALIAS_URL="${{ inputs.job-ref }}-${{ inputs.app-name }}.${{ inputs.preview-domain }}"
+        ALIAS_URL="${JOB_REF}-${APP_NAME}.${PREVIEW_DOMAIN}"
 
-        echo "Creating alias: ${ALIAS_URL} -> ${{ inputs.deployment-url }}"
+        echo "Creating alias: ${ALIAS_URL} -> ${DEPLOYMENT_URL}"
 
         # Set the alias using Vercel CLI
-        vercel alias set "${{ inputs.deployment-url }}" "${ALIAS_URL}" \
-          --token="${{ inputs.vercel-token }}" \
-          --scope="${{ inputs.vercel-org-id }}"
+        vercel alias set "${DEPLOYMENT_URL}" "${ALIAS_URL}" \
+          --token="${VERCEL_TOKEN}" \
+          --scope="${VERCEL_ORG_ID}"
 
         # Output the full URL
         FULL_URL="https://${ALIAS_URL}"

--- a/.github/actions/vercel-setup/action.yml
+++ b/.github/actions/vercel-setup/action.yml
@@ -32,9 +32,12 @@ runs:
 
     - name: Prepare Vercel configuration
       shell: bash
-      # nosemgrep: run-shell-injection -- inputs are secrets/IDs from workflow, not attacker-controlled
+      env:
+        VERCEL_TOKEN: ${{ inputs.vercel-token }}
+        VERCEL_ORG_ID: ${{ inputs.vercel-org-id }}
+        VERCEL_PROJECT_ID: ${{ inputs.vercel-project-id }}
       run: |
         # Initialize Vercel project configuration
         mkdir -p .vercel
-        echo '{"orgId":"${{ inputs.vercel-org-id }}","projectId":"${{ inputs.vercel-project-id }}"}' > .vercel/project.json
-        vercel pull --token=${{ inputs.vercel-token }}
+        echo "{\"orgId\":\"${VERCEL_ORG_ID}\",\"projectId\":\"${VERCEL_PROJECT_ID}\"}" > .vercel/project.json
+        vercel pull --token="${VERCEL_TOKEN}"

--- a/turbo/apps/cli/src/commands/cook/utils.ts
+++ b/turbo/apps/cli/src/commands/cook/utils.ts
@@ -1,6 +1,6 @@
 import chalk from "chalk";
-import { spawn } from "child_process";
 import { existsSync } from "fs";
+import { safeSpawn } from "../../lib/utils/spawn";
 
 export const CONFIG_FILE = "vm0.yaml";
 export const ARTIFACT_DIR = "artifact";
@@ -28,11 +28,9 @@ export function execVm0Command(
     // - default: inherit all (full terminal passthrough, allows prompts)
     const stdio: "pipe" | "inherit" = options.silent ? "pipe" : "inherit";
 
-    // nosemgrep: spawn-shell-true -- shell only enabled on Windows for hardcoded "vm0" command
-    const proc = spawn("vm0", args, {
+    const proc = safeSpawn("vm0", args, {
       cwd: options.cwd,
       stdio,
-      shell: process.platform === "win32",
     });
 
     let stdout = "";
@@ -76,12 +74,10 @@ export function execVm0RunWithCapture(
       ? { ...process.env, FORCE_COLOR: "1" }
       : process.env;
 
-    // nosemgrep: spawn-shell-true -- shell only enabled on Windows for hardcoded "vm0" command
-    const proc = spawn("vm0", args, {
+    const proc = safeSpawn("vm0", args, {
       cwd: options.cwd,
       env,
       stdio: ["inherit", "pipe", "pipe"],
-      shell: process.platform === "win32",
     });
 
     let stdout = "";

--- a/turbo/apps/cli/src/lib/utils/spawn.ts
+++ b/turbo/apps/cli/src/lib/utils/spawn.ts
@@ -1,0 +1,27 @@
+import { spawn, type SpawnOptions } from "child_process";
+import type { ChildProcess } from "child_process";
+
+/**
+ * Spawn a child process with safe Windows shell handling.
+ *
+ * On Windows, `shell: true` is required to resolve `.cmd` extensions for
+ * commands like `npm`, `pnpm`, etc. On other platforms, shell is disabled
+ * to avoid unnecessary shell interpretation. Commands passed to this
+ * function must be hardcoded strings (not user input), and arguments
+ * must use array form to prevent shell injection.
+ *
+ * nosemgrep: spawn-shell-true, detect-child-process -- shell only on Windows; callers pass hardcoded command names
+ */
+export function safeSpawn(
+  command: string,
+  args: string[],
+  options?: Omit<SpawnOptions, "shell">,
+): ChildProcess {
+  const isWindows = process.platform === "win32";
+  const resolvedCommand = isWindows ? `${command}.cmd` : command;
+
+  return spawn(resolvedCommand, args, {
+    ...options,
+    shell: isWindows,
+  });
+}

--- a/turbo/apps/cli/src/lib/utils/spawn.ts
+++ b/turbo/apps/cli/src/lib/utils/spawn.ts
@@ -10,7 +10,6 @@ import type { ChildProcess } from "child_process";
  * function must be hardcoded strings (not user input), and arguments
  * must use array form to prevent shell injection.
  *
- * nosemgrep: spawn-shell-true, detect-child-process -- shell only on Windows; callers pass hardcoded command names
  */
 export function safeSpawn(
   command: string,
@@ -20,6 +19,7 @@ export function safeSpawn(
   const isWindows = process.platform === "win32";
   const resolvedCommand = isWindows ? `${command}.cmd` : command;
 
+  // nosemgrep: javascript.lang.security.audit.spawn-shell-true.spawn-shell-true, javascript.lang.security.detect-child-process.detect-child-process
   return spawn(resolvedCommand, args, {
     ...options,
     shell: isWindows,

--- a/turbo/apps/cli/src/lib/utils/update-checker.ts
+++ b/turbo/apps/cli/src/lib/utils/update-checker.ts
@@ -1,5 +1,6 @@
-import { spawn, ChildProcess } from "child_process";
+import type { ChildProcess } from "child_process";
 import chalk from "chalk";
+import { safeSpawn } from "./spawn";
 
 const PACKAGE_NAME = "@vm0/cli";
 const NPM_REGISTRY_URL = `https://registry.npmjs.org/${encodeURIComponent(PACKAGE_NAME)}/latest`;
@@ -146,17 +147,13 @@ export function performUpgrade(
   packageManager: "npm" | "pnpm",
 ): Promise<boolean> {
   return new Promise((resolve) => {
-    const isWindows = process.platform === "win32";
-    const command = isWindows ? `${packageManager}.cmd` : packageManager;
     const args =
       packageManager === "pnpm"
         ? ["add", "-g", `${PACKAGE_NAME}@latest`]
         : ["install", "-g", `${PACKAGE_NAME}@latest`];
 
-    // nosemgrep: spawn-shell-true, detect-child-process -- shell only on Windows; command is hardcoded package manager name
-    const child = spawn(command, args, {
+    const child = safeSpawn(packageManager, args, {
       stdio: "inherit",
-      shell: isWindows,
     });
 
     child.on("close", (code) => {
@@ -280,17 +277,14 @@ export async function startSilentUpgrade(
 
   // Spawn upgrade process (don't wait for completion)
   const isWindows = process.platform === "win32";
-  const command = isWindows ? `${packageManager}.cmd` : packageManager;
   const args =
     packageManager === "pnpm"
       ? ["add", "-g", `${PACKAGE_NAME}@latest`]
       : ["install", "-g", `${PACKAGE_NAME}@latest`];
 
-  // nosemgrep: spawn-shell-true, detect-child-process -- shell only on Windows; command is hardcoded package manager name
-  const child = spawn(command, args, {
-    stdio: "pipe", // Capture output instead of inheriting
-    shell: isWindows,
-    detached: !isWindows, // Detach on non-Windows
+  const child = safeSpawn(packageManager, args, {
+    stdio: "pipe",
+    detached: !isWindows,
     windowsHide: true,
   });
 

--- a/turbo/apps/web/src/lib/slack/__tests__/verify.test.ts
+++ b/turbo/apps/web/src/lib/slack/__tests__/verify.test.ts
@@ -3,8 +3,7 @@ import { createHmac } from "crypto";
 import { verifySlackSignature, getSlackSignatureHeaders } from "../verify";
 
 describe("verifySlackSignature", () => {
-  // nosemgrep: detected-generic-secret -- test fixture, not a real secret
-  const signingSecret = "8f742231b10e8888abcd99yyyzzz85a5";
+  const signingSecret = "test-slack-signing-secret-not-real";
 
   it("should return true for valid signature", () => {
     const timestamp = Math.floor(Date.now() / 1000).toString();


### PR DESCRIPTION
## Summary

- Replace hex-like test signing secret with an obviously fake string to dismiss the `detected-generic-secret` false positive (Alert #60)
- Extract a shared `safeSpawn` helper in `turbo/apps/cli/src/lib/utils/spawn.ts` that encapsulates the `shell: process.platform === "win32"` pattern with nosemgrep justification, and refactor `update-checker.ts` and `cook/utils.ts` to use it (Alerts #33, #34, #52, #53, #54)
- Replace `${{ inputs.* }}` interpolation in GitHub Actions `run:` blocks with `env:` blocks to prevent shell injection in `vercel-setup`, `vercel-alias`, and `setup-ssh-tunnel` actions (Alerts #3, #4, #6)

Closes #4561

## Test plan

- [x] Slack verify tests pass (7 tests) with the new non-hex signing secret
- [x] Cook command tests pass (37 tests) with the safeSpawn refactor
- [x] TypeScript type checking passes for CLI package
- [x] Lint passes with no warnings
- [x] Knip finds no unused exports or files
- [x] GitHub Actions YAML syntax verified (env blocks properly structured)

🤖 Generated with [Claude Code](https://claude.com/claude-code)