### PR TITLE
test: remove console mocking without assertions (ap-9)

### DIFF
--- a/turbo/apps/platform/src/__tests__/setup-page.test.ts
+++ b/turbo/apps/platform/src/__tests__/setup-page.test.ts
@@ -1,16 +1,10 @@
 import { testContext } from "../signals/__tests__/test-helpers";
 import { setupPage } from "./page-helper";
-import { expect, it, describe, beforeAll, vi } from "vitest";
+import { expect, it, describe } from "vitest";
 import { Level, logger } from "../signals/log";
 import { localStorageSignals } from "../signals/external/local-storage";
 
 const context = testContext();
-
-beforeAll(() => {
-  // suppress console logs because these cases are not intented to test logging functionality
-  vi.spyOn(console, "log").mockImplementation(() => {});
-  vi.spyOn(console, "info").mockImplementation(() => {});
-});
 
 describe("setupPage", () => {
   it("should set debug loggers correctly", async () => {

--- a/turbo/apps/platform/src/signals/__tests__/global-method.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/global-method.test.ts
@@ -1,13 +1,8 @@
-import { beforeAll, describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import { testContext } from "./test-helpers";
 import { setupPage } from "../../__tests__/page-helper";
 
 const context = testContext();
-beforeAll(() => {
-  // suppress console logs because these cases are not intented to test logging functionality
-  vi.spyOn(console, "log").mockImplementation(() => {});
-  vi.spyOn(console, "info").mockImplementation(() => {});
-});
 
 describe("global debug loggers", () => {
   it("should has vm0 method after init", async () => {


### PR DESCRIPTION
## Summary
- Remove `console.log`/`console.info` spies from 2 platform test files that suppressed output without any assertions
- Per AP-9, mocking console without asserting on it just hinders debugging without adding test value
- Files modified:
  - `turbo/apps/platform/src/__tests__/setup-page.test.ts`
  - `turbo/apps/platform/src/signals/__tests__/global-method.test.ts`

## Test plan
- [x] Both modified test files pass (8 tests total)
- [x] Knip reports no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)