### PR TITLE
ci: remove sbom release upload and reduce permissions to read-only

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -832,7 +832,7 @@ jobs:
     container:
       image: ghcr.io/vm0-ai/vm0-toolchain:20260310
     permissions:
-      contents: write
+      contents: read
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/toolchain-init
@@ -869,18 +869,4 @@ jobs:
         with:
           name: sbom
           path: sbom.json
-
-      - name: Attach SBOM to GitHub releases
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          # Upload SBOM to each release created in this run
-          for tag in $(gh release list --limit 10 --json tagName,createdAt --jq 'sort_by(.createdAt) | reverse | .[0:5] | .[].tagName'); do
-            # Only attach to releases created today
-            CREATED=$(gh release view "$tag" --json createdAt --jq '.createdAt[:10]')
-            TODAY=$(date -u +%Y-%m-%d)
-            if [ "$CREATED" = "$TODAY" ]; then
-              gh release upload "$tag" sbom.json --clobber
-            fi
-          done
 


### PR DESCRIPTION
## Summary
- Remove the "Attach SBOM to GitHub releases" step from the release-please workflow since SBOM is already preserved as a workflow artifact
- Downgrade the `sbom` job permissions from `contents: write` to `contents: read` (principle of least privilege)

## Test plan
- [ ] Verify the `sbom` job still generates and uploads the SBOM as a workflow artifact
- [ ] Confirm no other jobs depend on the removed release upload step

🤖 Generated with [Claude Code](https://claude.com/claude-code)