### PR TITLE
test: remove redundant vi.clearallmocks from 14 test files

### DIFF
--- a/turbo/apps/cli/src/commands/auth/__tests__/login-with-proxy.test.ts
+++ b/turbo/apps/cli/src/commands/auth/__tests__/login-with-proxy.test.ts
@@ -31,7 +31,6 @@ describe("auth login: proxy configuration", () => {
   vi.spyOn(process.stdout, "write").mockImplementation(() => true);
 
   beforeEach(async () => {
-    vi.clearAllMocks();
     vi.resetModules();
     chalk.level = 0;
 

--- a/turbo/apps/cli/src/commands/memory/__tests__/list.test.ts
+++ b/turbo/apps/cli/src/commands/memory/__tests__/list.test.ts
@@ -24,7 +24,6 @@ describe("memory list", () => {
     .mockImplementation(() => {});
 
   beforeEach(() => {
-    vi.clearAllMocks();
     chalk.level = 0;
     vi.stubEnv("VM0_API_URL", "http://localhost:3000");
     vi.stubEnv("VM0_TOKEN", "test-token");

--- a/turbo/apps/cli/src/commands/memory/__tests__/pull.test.ts
+++ b/turbo/apps/cli/src/commands/memory/__tests__/pull.test.ts
@@ -40,7 +40,6 @@ describe("memory pull", () => {
     .mockImplementation(() => {});
 
   beforeEach(() => {
-    vi.clearAllMocks();
     chalk.level = 0;
     vi.stubEnv("VM0_API_URL", "http://localhost:3000");
     vi.stubEnv("VM0_TOKEN", "test-token");

--- a/turbo/apps/cli/src/commands/scope/__tests__/set.test.ts
+++ b/turbo/apps/cli/src/commands/scope/__tests__/set.test.ts
@@ -13,7 +13,6 @@ describe("scope set command", () => {
     .mockImplementation(() => {});
 
   beforeEach(() => {
-    vi.clearAllMocks();
     vi.stubEnv("VM0_API_URL", "http://localhost:3000");
     vi.stubEnv("VM0_TOKEN", "test-token");
   });

--- a/turbo/apps/platform/src/views/logs-page/log-detail/__tests__/utils.test.ts
+++ b/turbo/apps/platform/src/views/logs-page/log-detail/__tests__/utils.test.ts
@@ -291,7 +291,6 @@ describe("log-detail utils", () => {
     let container: HTMLDivElement;
 
     beforeEach(() => {
-      vi.clearAllMocks();
       container = document.createElement("div");
       container.id = EVENTS_CONTAINER_ID;
       container.style.height = "200px";

--- a/turbo/apps/web/app/api/agent/runs/[id]/events/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/events/__tests__/route.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { GET } from "../route";
 import { filterConsecutiveEvents } from "../filter-events";
 import {

--- a/turbo/apps/web/app/api/agent/runs/[id]/events/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/events/__tests__/route.test.ts
@@ -46,7 +46,6 @@ describe("GET /api/agent/runs/:id/events", () => {
   let testRunId: string;
 
   beforeEach(async () => {
-    vi.clearAllMocks();
     context.setupMocks();
     user = await context.setupUser();
 

--- a/turbo/apps/web/app/api/agent/runs/[id]/telemetry/agent/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/telemetry/agent/__tests__/route.test.ts
@@ -46,7 +46,6 @@ describe("GET /api/agent/runs/:id/telemetry/agent", () => {
   let testRunId: string;
 
   beforeEach(async () => {
-    vi.clearAllMocks();
     context.setupMocks();
     user = await context.setupUser();
 

--- a/turbo/apps/web/app/api/logs/search/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/logs/search/__tests__/route.test.ts
@@ -42,7 +42,6 @@ describe("GET /api/logs/search", () => {
   let testRunId: string;
 
   beforeEach(async () => {
-    vi.clearAllMocks();
     context.setupMocks();
     await context.setupUser();
 

--- a/turbo/apps/web/app/api/runners/realtime/token/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/runners/realtime/token/__tests__/route.test.ts
@@ -61,7 +61,6 @@ describe("POST /api/runners/realtime/token", () => {
   let user: UserContext;
 
   beforeEach(async () => {
-    vi.clearAllMocks();
     context.setupMocks();
     user = await context.setupUser();
   });

--- a/turbo/apps/web/app/api/webhooks/agent/events/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/events/__tests__/route.test.ts
@@ -34,7 +34,6 @@ describe("POST /api/webhooks/agent/events", () => {
   let ingestToAxiomSpy: MockInstance<typeof axiomModule.ingestToAxiom>;
 
   beforeEach(async () => {
-    vi.clearAllMocks();
     context.setupMocks();
     user = await context.setupUser();
 

--- a/turbo/apps/web/app/api/webhooks/agent/heartbeat/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/heartbeat/__tests__/route.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach } from "vitest";
 import { POST } from "../route";
 import {
   createTestRequest,

--- a/turbo/apps/web/app/api/webhooks/agent/heartbeat/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/heartbeat/__tests__/route.test.ts
@@ -24,7 +24,6 @@ describe("POST /api/webhooks/agent/heartbeat", () => {
   let testToken: string;
 
   beforeEach(async () => {
-    vi.clearAllMocks();
     context.setupMocks();
     user = await context.setupUser();
 

--- a/turbo/apps/web/app/api/webhooks/agent/services/auth/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/services/auth/__tests__/route.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach } from "vitest";
 import { POST } from "../route";
 import {
   createTestRequest,

--- a/turbo/apps/web/app/api/webhooks/agent/services/auth/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/services/auth/__tests__/route.test.ts
@@ -37,7 +37,6 @@ describe("POST /api/webhooks/agent/services/auth", () => {
   let testToken: string;
 
   beforeEach(async () => {
-    vi.clearAllMocks();
     context.setupMocks();
     user = await context.setupUser();
 

--- a/turbo/apps/web/src/lib/auth/__tests__/get-user-id.spec.ts
+++ b/turbo/apps/web/src/lib/auth/__tests__/get-user-id.spec.ts
@@ -1,13 +1,9 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { auth } from "@clerk/nextjs/server";
 import { getUserId } from "../get-user-id";
 
 describe("getUserId", () => {
   const mockAuth = vi.mocked(auth);
-
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
 
   it("should return userId from auth provider session", async () => {
     const testUserId = "user_123";

--- a/turbo/apps/web/src/lib/crypto/__tests__/secrets-encryption.test.ts
+++ b/turbo/apps/web/src/lib/crypto/__tests__/secrets-encryption.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   encryptSecrets,
   decryptSecrets,
@@ -11,10 +11,6 @@ const TEST_KEY =
   "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
 
 describe("secrets-encryption", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
   describe("encryptSecrets (array)", () => {
     it("should return null for null input", () => {
       const result = encryptSecrets(null, TEST_KEY);


### PR DESCRIPTION
## Summary
- Remove `vi.clearAllMocks()` calls from 14 test files across cli, web, and platform apps
- Vitest is configured with `clearMocks: true` (in vitest config), which automatically clears all mocks between tests — making these explicit calls redundant
- For 2 files where `vi.clearAllMocks()` was the only statement in `beforeEach`, the entire empty `beforeEach` block was removed along with unused imports

## Files modified
- `apps/cli`: 4 files (scope/set, auth/login-with-proxy, memory/list, memory/pull)
- `apps/web`: 9 files (7 route tests + secrets-encryption + get-user-id)
- `apps/platform`: 1 file (log-detail/utils)

## Test plan
- [x] CLI, platform, and non-DB web tests pass locally (105 tests in batch 1)
- [x] Knip reports no issues
- [x] Prettier formatting unchanged
- [x] This is a no-op change — `clearMocks: true` already does the same thing

🤖 Generated with [Claude Code](https://claude.com/claude-code)