### PR TITLE
feat(zero): add recent chat sidebar, file attachments, and session switching

### DIFF
--- a/turbo/apps/platform/src/signals/bootstrap.ts
+++ b/turbo/apps/platform/src/signals/bootstrap.ts
@@ -46,6 +46,10 @@ const ROUTE_CONFIG = [
     setup: setupAuthPageWrapper(setupSelectOrgPage$),
   },
   {
+    path: "/zero/chat/:sessionId",
+    setup: setupAuthPageWrapper(setupZeroPage$),
+  },
+  {
     path: "/zero/:tab/:sub",
     setup: setupAuthPageWrapper(setupZeroPage$),
   },

--- a/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
@@ -5,6 +5,7 @@ import { throwIfAbort } from "../utils.ts";
 import { logger } from "../log.ts";
 import { setupPollingLoop$, type PageResult } from "../agent-detail/polling.ts";
 import { zeroOnboardingStatus$ } from "./zero-onboarding.ts";
+import { navigateToZeroSession$ } from "./zero-nav.ts";
 import type { SessionListItem } from "@vm0/core";
 
 const L = logger("ZeroChat");
@@ -73,6 +74,13 @@ async function startAgentRun(
 // Chat message types
 // ---------------------------------------------------------------------------
 
+interface ZeroChatMessageAttachment {
+  filename: string;
+  contentType: string;
+  size: number;
+  url: string;
+}
+
 export interface ZeroChatMessage {
   id: string;
   role: "user" | "assistant";
@@ -80,6 +88,7 @@ export interface ZeroChatMessage {
   runId?: string;
   status?: LogStatus;
   error?: string;
+  attachments?: ZeroChatMessageAttachment[];
 }
 
 // ---------------------------------------------------------------------------
@@ -119,6 +128,11 @@ export const zeroSessionListError$ = computed((get) =>
 const internalSessionError$ = state<string | null>(null);
 export const zeroSessionError$ = computed((get) => get(internalSessionError$));
 
+const internalSessionSwitching$ = state(false);
+export const zeroSessionSwitching$ = computed((get) =>
+  get(internalSessionSwitching$),
+);
+
 // Chat input
 const internalChatInput$ = state("");
 export const zeroChatInput$ = computed((get) => get(internalChatInput$));
@@ -129,6 +143,81 @@ export const setZeroChatInput$ = command(({ set }, value: string) => {
 
 export const clearZeroChatInput$ = command(({ set }) => {
   set(internalChatInput$, "");
+});
+
+// Attachments
+export interface ZeroChatAttachment {
+  id: string;
+  filename: string;
+  contentType: string;
+  size: number;
+  url: string;
+  uploading?: boolean;
+}
+
+const internalAttachments$ = state<ZeroChatAttachment[]>([]);
+export const zeroChatAttachments$ = computed((get) =>
+  get(internalAttachments$),
+);
+
+export const uploadZeroAttachment$ = command(
+  async ({ get, set }, file: File) => {
+    const id = crypto.randomUUID();
+    const placeholder: ZeroChatAttachment = {
+      id,
+      filename: file.name,
+      contentType: file.type,
+      size: file.size,
+      url: "",
+      uploading: true,
+    };
+    set(internalAttachments$, (prev) => [...prev, placeholder]);
+
+    try {
+      const fetchFn = get(fetch$);
+      const formData = new FormData();
+      formData.append("file", file);
+
+      const res = await fetchFn("/api/agent/uploads", {
+        method: "POST",
+        body: formData,
+      });
+
+      if (!res.ok) {
+        const err = (await res.json().catch(() => null)) as {
+          error?: { message?: string };
+        } | null;
+        throw new Error(
+          err?.error?.message ?? `Upload failed: ${res.statusText}`,
+        );
+      }
+
+      const data = (await res.json()) as {
+        id: string;
+        filename: string;
+        contentType: string;
+        size: number;
+        url: string;
+      };
+
+      set(internalAttachments$, (prev) =>
+        prev.map((a) =>
+          a.id === id
+            ? { ...a, url: data.url, id: data.id, uploading: false }
+            : a,
+        ),
+      );
+    } catch (error) {
+      throwIfAbort(error);
+      L.error("Upload failed:", error);
+      // Remove the failed placeholder
+      set(internalAttachments$, (prev) => prev.filter((a) => a.id !== id));
+    }
+  },
+);
+
+export const removeZeroAttachment$ = command(({ set }, id: string) => {
+  set(internalAttachments$, (prev) => prev.filter((a) => a.id !== id));
 });
 
 // ---------------------------------------------------------------------------
@@ -180,6 +269,7 @@ export const switchZeroSession$ = command(
     set(internalRunError$, null);
     set(internalSending$, false);
     set(internalSessionError$, null);
+    set(internalSessionSwitching$, true);
 
     try {
       const fetchFn = get(fetch$);
@@ -214,6 +304,8 @@ export const switchZeroSession$ = command(
         error instanceof Error ? error.message : "Failed to load session";
       set(internalSessionError$, msg);
       L.error("Failed to switch session:", error);
+    } finally {
+      set(internalSessionSwitching$, false);
     }
   },
 );
@@ -243,13 +335,34 @@ export const sendZeroChatMessage$ = command(
 
     set(internalSending$, true);
 
-    // Add user message
+    // Build full prompt with attachments
+    const attachments = get(internalAttachments$).filter((a) => !a.uploading);
+    let fullPrompt = prompt.trim();
+    if (attachments.length > 0) {
+      const attachmentLines = attachments.map(
+        (a) =>
+          `[Attached file: ${a.filename}](${a.url})\nDownload with: curl -sL -o "${a.filename}" "${a.url}"`,
+      );
+      fullPrompt = `${fullPrompt}\n\n${attachmentLines.join("\n")}`;
+    }
+
+    // Add user message (show original prompt + attachment names in UI)
     const userMessage: ZeroChatMessage = {
       id: crypto.randomUUID(),
       role: "user",
       content: prompt.trim(),
+      attachments:
+        attachments.length > 0
+          ? attachments.map((a) => ({
+              filename: a.filename,
+              contentType: a.contentType,
+              size: a.size,
+              url: a.url,
+            }))
+          : undefined,
     };
     set(internalMessages$, (prev) => [...prev, userMessage]);
+    set(internalAttachments$, []);
 
     // Add placeholder assistant message
     const assistantPlaceholder: ZeroChatMessage = {
@@ -263,7 +376,12 @@ export const sendZeroChatMessage$ = command(
       const fetchFn = get(fetch$);
       const sessionId = get(internalSessionId$);
 
-      const runId = await startAgentRun(fetchFn, composeId, prompt, sessionId);
+      const runId = await startAgentRun(
+        fetchFn,
+        composeId,
+        fullPrompt,
+        sessionId,
+      );
 
       if (!runId) {
         set(internalMessages$, (prev) => {
@@ -381,7 +499,12 @@ const onZeroRunComplete$ = command(async ({ get, set }, runId: string) => {
         result?: { output?: string; agentSessionId?: string };
       };
       if (data.result?.agentSessionId) {
+        const prevSessionId = get(internalSessionId$);
         set(internalSessionId$, data.result.agentSessionId);
+        // Update URL when a new session is created
+        if (!prevSessionId) {
+          set(navigateToZeroSession$, data.result.agentSessionId);
+        }
       }
     }
 
@@ -403,43 +526,11 @@ const onZeroRunComplete$ = command(async ({ get, set }, runId: string) => {
       });
     }
 
-    // Persist messages to server, then refresh session list
-    const sessionId = get(internalSessionId$);
-    const currentMessages = get(internalMessages$);
-    const assistantIdx = sessionId
-      ? currentMessages.findIndex(
-          (m) => m.role === "assistant" && m.runId === runId,
-        )
-      : -1;
-    const userMsg =
-      assistantIdx > 0 ? currentMessages[assistantIdx - 1] : undefined;
-    const assistantMsg =
-      assistantIdx > 0 ? currentMessages[assistantIdx] : undefined;
-
-    if (sessionId && userMsg?.role === "user" && assistantMsg) {
-      const persistRes = await fetchFn(
-        `/api/agent/sessions/${sessionId}/messages`,
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            messages: [
-              { role: "user", content: userMsg.content },
-              { role: "assistant", content: assistantMsg.content, runId },
-            ],
-          }),
-        },
-      );
-      if (!persistRes.ok) {
-        L.error("Failed to persist messages:", persistRes.statusText);
-      }
-
-      // Refresh session list
-      set(fetchZeroSessionList$).catch((error: unknown) => {
-        throwIfAbort(error);
-        L.error("Failed to refresh session list:", error);
-      });
-    }
+    // Refresh session list (messages are persisted server-side via webhook)
+    set(fetchZeroSessionList$).catch((error: unknown) => {
+      throwIfAbort(error);
+      L.error("Failed to refresh session list:", error);
+    });
   } catch (error) {
     throwIfAbort(error);
     L.error("Failed to extract run result:", error);

--- a/turbo/apps/platform/src/signals/zero-page/zero-meet.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-meet.ts
@@ -344,21 +344,23 @@ async function resolveInstructionsContent(
   composeId: string | undefined,
   localContent: string | null | undefined,
 ): Promise<string | undefined> {
+  let raw: string | undefined;
   if (localContent) {
-    return localContent;
+    raw = localContent;
+  } else if (composeId) {
+    const resp = await fetchFn(`/api/agent/composes/${composeId}/instructions`);
+    if (!resp.ok) {
+      L.warn(
+        `Failed to fetch instructions for compose ${composeId}: ${resp.status} ${resp.statusText}`,
+      );
+      return undefined;
+    }
+    const data = (await resp.json()) as AgentInstructions;
+    raw = data.content ?? undefined;
   }
-  if (!composeId) {
-    return undefined;
-  }
-  const resp = await fetchFn(`/api/agent/composes/${composeId}/instructions`);
-  if (!resp.ok) {
-    L.warn(
-      `Failed to fetch instructions for compose ${composeId}: ${resp.status} ${resp.statusText}`,
-    );
-    return undefined;
-  }
-  const data = (await resp.json()) as AgentInstructions;
-  return data.content ?? undefined;
+  // Strip any existing metadata (legacy frontmatter or profile block)
+  // so the server can inject a clean copy from compose metadata.
+  return raw ? stripMetadataFrontmatter(raw) : undefined;
 }
 
 // ---------------------------------------------------------------------------
@@ -372,7 +374,7 @@ async function buildAndSetDefaultAgent(
 ): Promise<void> {
   // Ensure instructions field is present when we have content to write.
   // Fall back to empty string so the server creates a CLAUDE.md with
-  // metadata frontmatter even when there are no user-written instructions.
+  // agent profile even when there are no user-written instructions.
   const agentKey = Object.keys(newContent.agents)[0];
   const agent = agentKey ? newContent.agents[agentKey] : undefined;
   const resolvedInstructions = instructions ?? "";
@@ -513,6 +515,8 @@ export const zeroUpdateSettings$ = command(
 
       await set(reloadOnboardingStatus$);
       set(internalComposeReload$, (x) => x + 1);
+      // Refresh instructions so the profile block reflects the new settings
+      await set(fetchZeroInstructions$);
       toast.success("Settings saved");
     } catch (error) {
       throwIfAbort(error);

--- a/turbo/apps/platform/src/signals/zero-page/zero-nav.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-nav.ts
@@ -18,7 +18,7 @@ function isValidTab(tab: string): tab is ZeroNavId {
 
 /**
  * Active zero nav id, derived from the URL path `/zero/:tab`.
- * `/zero` and `/zero/chat` both resolve to "chat".
+ * `/zero`, `/zero/chat`, and `/zero/chat/:sessionId` all resolve to "chat".
  */
 export const zeroActiveId$ = computed((get): ZeroNavId => {
   const path = get(pathname$);
@@ -27,6 +27,24 @@ export const zeroActiveId$ = computed((get): ZeroNavId => {
     return segment;
   }
   return "chat";
+});
+
+/**
+ * Whether the user is on a chat page — `/zero/chat` or `/zero/chat/:sessionId`.
+ */
+export const zeroInChat$ = computed((get): boolean => {
+  const path = get(pathname$);
+  return /^\/zero\/chat(\/|$)/.test(path);
+});
+
+/**
+ * Session ID extracted from `/zero/chat/:sessionId`.
+ * Returns null when on `/zero` or `/zero/chat` (no active session).
+ */
+export const zeroSessionId$ = computed((get): string | null => {
+  const path = get(pathname$);
+  const match = /^\/zero\/chat\/([^/]+)$/.exec(path);
+  return match ? match[1] : null;
 });
 
 /**
@@ -46,4 +64,18 @@ export const zeroTabSub$ = computed((get): string | null => {
   const path = get(pathname$);
   const parts = path.replace(/^\/zero\/?/, "").split("/");
   return parts[1] || null;
+});
+
+/**
+ * Navigate to a specific chat session — `/zero/chat/:sessionId`.
+ */
+export const navigateToZeroSession$ = command(({ set }, sessionId: string) => {
+  set(updatePathname$, `/zero/chat/${sessionId}`);
+});
+
+/**
+ * Navigate back from a chat session to the chat home — `/zero`.
+ */
+export const navigateFromZeroSession$ = command(({ set }) => {
+  set(updatePathname$, "/zero");
 });

--- a/turbo/apps/platform/src/signals/zero-page/zero-onboarding.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-onboarding.ts
@@ -312,7 +312,7 @@ export const completeZeroOnboarding$ = command(
       };
 
       // Run compose job (CLI processes skills, uploads assets)
-      // Pass empty instructions so the server creates a CLAUDE.md with metadata frontmatter
+      // Pass empty instructions so the server creates a CLAUDE.md with agent profile
       const job = await triggerAndPollComposeJob(fetchFn, content, "");
       signal.throwIfAborted();
 

--- a/turbo/apps/platform/src/types/route.ts
+++ b/turbo/apps/platform/src/types/route.ts
@@ -3,6 +3,7 @@ export type RoutePath =
   | "/select-org"
   | "/zero"
   | "/zero/:tab"
+  | "/zero/chat/:sessionId"
   | "/logs"
   | "/logs/:id"
   | "/settings"

--- a/turbo/apps/platform/src/views/zero-page/zero-app-shell.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-app-shell.tsx
@@ -17,9 +17,13 @@ import { resetDefaultAgent$ } from "../../signals/zero-page/zero-dev-tools.ts";
 import { detach, Reason } from "../../signals/utils.ts";
 import {
   zeroActiveId$,
+  zeroInChat$,
+  zeroSessionId$,
   setZeroActiveId$,
+  navigateToZeroSession$,
+  navigateFromZeroSession$,
 } from "../../signals/zero-page/zero-nav.ts";
-import { updateSearchParams$ } from "../../signals/route.ts";
+import { updateSearchParams$, updatePathname$ } from "../../signals/route.ts";
 import {
   zeroSessionList$,
   zeroSessionListLoading$,
@@ -206,8 +210,9 @@ export function ZeroAppShell() {
   });
   const cycleAvatar = useSet(cycleAvatar$);
 
-  const inSession$ = useCCState(false);
-  const inSession = useGet(inSession$);
+  const inChat = useGet(zeroInChat$);
+  const urlSessionId = useGet(zeroSessionId$);
+  const inSession = inChat;
   const currentSessionId = useGet(zeroCurrentSessionId$);
   const switchSession = useSet(switchZeroSession$);
   const startNewSession = useSet(startNewZeroSession$);
@@ -216,35 +221,50 @@ export function ZeroAppShell() {
   const { recentSessions, recentSessionsLoading, recentSessionsError } =
     useSessionLifecycle(isLoggedIn, onboardingReady, needsOnboarding);
 
+  // Sync URL session ID to chat signal (skip if signal already matches)
+  const prevUrlSessionId$ = useCCState<string | null>(null);
+  const prevUrlSessionId = useGet(prevUrlSessionId$);
+  const setPrevUrlSessionId = useSet(prevUrlSessionId$);
+  if (
+    urlSessionId &&
+    urlSessionId !== prevUrlSessionId &&
+    urlSessionId !== currentSessionId
+  ) {
+    queueMicrotask(() => {
+      setPrevUrlSessionId(urlSessionId);
+      detach(switchSession(urlSessionId), Reason.DomCallback);
+    });
+  } else if (urlSessionId && urlSessionId !== prevUrlSessionId) {
+    queueMicrotask(() => setPrevUrlSessionId(urlSessionId));
+  } else if (!urlSessionId && prevUrlSessionId) {
+    queueMicrotask(() => setPrevUrlSessionId(null));
+  }
+
   const handleRecentSelect$ = useCommand(({ set }, sessionId: string) => {
-    set(setZeroActiveId$, "chat");
-    set(inSession$, true);
-    detach(switchSession(sessionId), Reason.DomCallback);
+    set(navigateToZeroSession$, sessionId);
   });
   const handleRecentSelect = useSet(handleRecentSelect$);
 
   const handleNewChat$ = useCommand(({ set }) => {
-    set(setZeroActiveId$, "chat");
-    set(inSession$, true);
+    set(updatePathname$, "/zero/chat");
     startNewSession();
   });
   const handleNewChat = useSet(handleNewChat$);
 
   const handleSendFromDemo$ = useCommand(({ set }, message: string) => {
-    set(inSession$, true);
+    set(updatePathname$, "/zero/chat");
     startNewSession();
     detach(sendMessage(message), Reason.DomCallback);
   });
   const handleSendFromDemo = useSet(handleSendFromDemo$);
 
   const handleBackFromSession$ = useCommand(({ set }) => {
-    set(inSession$, false);
+    set(navigateFromZeroSession$);
   });
   const handleBackFromSession = useSet(handleBackFromSession$);
 
   const handleNavSelect$ = useCommand(({ set }, id: ZeroNavId) => {
     set(setZeroActiveId$, id);
-    set(inSession$, false);
     set(showAboutPage$, false);
   });
   const handleNavSelect = useSet(handleNavSelect$);
@@ -280,9 +300,7 @@ export function ZeroAppShell() {
         agentName={agentDisplayName}
         onSelect={handleNavSelect}
         onRecentSelect={handleRecentSelect}
-        selectedRecentId={
-          activeId === "chat" && inSession ? currentSessionId : null
-        }
+        selectedRecentId={urlSessionId}
         onAccountAction={handleAccountAction}
         recentSessions={recentSessions}
         recentSessionsLoading={recentSessionsLoading}

--- a/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
@@ -1,0 +1,150 @@
+import { IconFile, IconPhoto, IconLoader2, IconX } from "@tabler/icons-react";
+import type { ZeroChatAttachment } from "../../signals/zero-page/zero-chat.ts";
+
+/**
+ * Return the icon path for a known file extension, or null for unknown types.
+ */
+function getFileTypeIcon(filename: string): string | null {
+  const ext = filename.split(".").pop()?.toLowerCase();
+  switch (ext) {
+    case "pdf": {
+      return "/doc-types/PDF.svg";
+    }
+    case "doc":
+    case "docx":
+    case "md":
+    case "txt":
+    case "json":
+    case "html": {
+      return "/doc-types/DOC.svg";
+    }
+    case "csv": {
+      return "/doc-types/CSV.svg";
+    }
+    default: {
+      return null;
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// FileAttachmentChip — compact chip shown inside sent message bubbles
+// ---------------------------------------------------------------------------
+
+export function FileAttachmentChip({
+  filename,
+  url,
+}: {
+  filename: string;
+  url: string;
+}) {
+  const iconSrc = getFileTypeIcon(filename);
+  return (
+    <a
+      href={url}
+      download={filename}
+      title={filename}
+      className="inline-flex items-center justify-center rounded-md hover:bg-foreground/10 transition-colors p-0.5"
+    >
+      {iconSrc ? (
+        <img
+          alt=""
+          className="h-6 w-6 object-contain opacity-80"
+          aria-hidden="true"
+          src={iconSrc}
+        />
+      ) : (
+        <IconFile size={20} stroke={1.5} className="text-muted-foreground" />
+      )}
+    </a>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// AttachmentChip — chip shown in the composer before the message is sent
+// ---------------------------------------------------------------------------
+
+export function AttachmentChip({
+  attachment,
+  onRemove,
+}: {
+  attachment: ZeroChatAttachment;
+  onRemove: () => void;
+}) {
+  const isImage = attachment.contentType.startsWith("image/");
+  const iconSrc = isImage ? null : getFileTypeIcon(attachment.filename);
+  return (
+    <div
+      className="relative inline-flex items-center justify-center"
+      title={attachment.filename}
+    >
+      {isImage ? (
+        <div className="relative h-6 w-6 rounded-md overflow-hidden border border-foreground/10">
+          {attachment.url ? (
+            <img
+              src={attachment.url}
+              alt=""
+              className="h-full w-full object-cover"
+            />
+          ) : (
+            <IconPhoto
+              size={16}
+              stroke={1.5}
+              className="text-muted-foreground m-auto h-full"
+            />
+          )}
+        </div>
+      ) : iconSrc ? (
+        <img
+          alt=""
+          className="h-6 w-6 object-contain opacity-80"
+          aria-hidden="true"
+          src={iconSrc}
+        />
+      ) : (
+        <IconFile size={20} stroke={1.5} className="text-muted-foreground" />
+      )}
+      {attachment.uploading ? (
+        <span className="absolute -top-1 -right-1 flex h-3.5 w-3.5 items-center justify-center rounded-full bg-background">
+          <IconLoader2
+            size={10}
+            className="animate-spin text-muted-foreground"
+          />
+        </span>
+      ) : (
+        <button
+          type="button"
+          onClick={onRemove}
+          className="absolute -top-1 -right-1 flex h-3.5 w-3.5 items-center justify-center rounded-full bg-muted hover:bg-destructive hover:text-destructive-foreground transition-colors"
+          aria-label={`Remove ${attachment.filename}`}
+        >
+          <IconX size={9} stroke={2.5} />
+        </button>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// AttachmentChips — wrapper that renders a list of AttachmentChip items
+// ---------------------------------------------------------------------------
+
+export function AttachmentChips({
+  attachments,
+  onRemove,
+}: {
+  attachments: ZeroChatAttachment[];
+  onRemove: (id: string) => void;
+}) {
+  return (
+    <div className="flex flex-wrap gap-2 px-4 pt-3">
+      {attachments.map((a) => (
+        <AttachmentChip
+          key={a.id}
+          attachment={a}
+          onRemove={() => onRemove(a.id)}
+        />
+      ))}
+    </div>
+  );
+}

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-page.tsx
@@ -6,15 +6,10 @@ import {
   zeroChatAttachments$,
   uploadZeroAttachment$,
   removeZeroAttachment$,
-  type ZeroChatAttachment,
 } from "../../signals/zero-page/zero-chat.ts";
 import {
   IconSend,
   IconPaperclip,
-  IconX,
-  IconFile,
-  IconPhoto,
-  IconLoader2,
   IconBriefcase,
   IconSettings,
   IconPlug,
@@ -31,6 +26,7 @@ import {
 import { Button, Card, CardContent, cn } from "@vm0/ui";
 import { ZERO_TEAM_JOBS } from "./zero-jobs-page";
 import { agentDisplayName$ } from "../../signals/zero-page/zero-agent-name.ts";
+import { AttachmentChips } from "./zero-attachment-chips.tsx";
 
 type DemoScenarioId =
   | "hello-from-zero"
@@ -1219,101 +1215,6 @@ export function ZeroChatPage({
           </div>
         </div>
       </main>
-    </div>
-  );
-}
-
-function getFileTypeIcon(filename: string): string | null {
-  const ext = filename.split(".").pop()?.toLowerCase();
-  switch (ext) {
-    case "pdf": {
-      return "/doc-types/PDF.svg";
-    }
-    case "doc":
-    case "docx":
-    case "md":
-    case "txt":
-    case "json":
-    case "html": {
-      return "/doc-types/DOC.svg";
-    }
-    case "csv": {
-      return "/doc-types/CSV.svg";
-    }
-    default: {
-      return null;
-    }
-  }
-}
-
-function AttachmentChips({
-  attachments,
-  onRemove,
-}: {
-  attachments: ZeroChatAttachment[];
-  onRemove: (id: string) => void;
-}) {
-  return (
-    <div className="flex flex-wrap gap-2 px-4 pt-3">
-      {attachments.map((a) => {
-        const isImage = a.contentType.startsWith("image/");
-        const iconSrc = isImage ? null : getFileTypeIcon(a.filename);
-        return (
-          <div
-            key={a.id}
-            className="relative inline-flex items-center justify-center"
-            title={a.filename}
-          >
-            {isImage ? (
-              <div className="relative h-6 w-6 rounded-md overflow-hidden border border-foreground/10">
-                {a.url ? (
-                  <img
-                    src={a.url}
-                    alt=""
-                    className="h-full w-full object-cover"
-                  />
-                ) : (
-                  <IconPhoto
-                    size={16}
-                    stroke={1.5}
-                    className="text-muted-foreground m-auto h-full"
-                  />
-                )}
-              </div>
-            ) : iconSrc ? (
-              <img
-                alt=""
-                className="h-6 w-6 object-contain opacity-80"
-                aria-hidden="true"
-                src={iconSrc}
-              />
-            ) : (
-              <IconFile
-                size={20}
-                stroke={1.5}
-                className="text-muted-foreground"
-              />
-            )}
-            {a.uploading ? (
-              <span className="absolute -top-1 -right-1 flex h-3.5 w-3.5 items-center justify-center rounded-full bg-background">
-                <IconLoader2
-                  size={10}
-                  className="animate-spin text-muted-foreground"
-                />
-              </span>
-            ) : (
-              <button
-                type="button"
-                onClick={() => onRemove(a.id)}
-                className="absolute -top-1 -right-1 flex h-3.5 w-3.5 items-center justify-center rounded-full bg-muted hover:bg-destructive hover:text-destructive-foreground transition-colors"
-                aria-label={`Remove ${a.filename}`}
-              >
-                <IconX size={9} stroke={2.5} />
-              </button>
-            )}
-          </div>
-        );
-      })}
     </div>
   );
 }

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-page.tsx
@@ -1,13 +1,21 @@
 import type { ReactNode, KeyboardEvent } from "react";
+import { useRef } from "react";
 import { useCCState, useCommand } from "ccstate-react/experimental";
 import { useGet, useSet, useLoadable } from "ccstate-react";
-import { onRef } from "../../signals/utils.ts";
+import { onRef, detach, Reason } from "../../signals/utils.ts";
+import {
+  zeroChatAttachments$,
+  uploadZeroAttachment$,
+  removeZeroAttachment$,
+  type ZeroChatAttachment,
+} from "../../signals/zero-page/zero-chat.ts";
 import {
   IconSend,
   IconPaperclip,
-  IconMoodSmile,
-  IconMicrophone,
-  IconPlus,
+  IconX,
+  IconFile,
+  IconPhoto,
+  IconLoader2,
   IconBriefcase,
   IconSettings,
   IconPlug,
@@ -672,6 +680,10 @@ export function ZeroChatPage({
   const input$ = useCCState("");
   const input = useGet(input$);
   const setInput = useSet(input$);
+  const attachments = useGet(zeroChatAttachments$);
+  const uploadAttachment = useSet(uploadZeroAttachment$);
+  const removeAttachment = useSet(removeZeroAttachment$);
+  const fileInputRef = useRef<HTMLInputElement>(null);
   const conversationActive$ = useCCState(false);
   const conversationActive = useGet(conversationActive$);
   const setConversationActive = useSet(conversationActive$);
@@ -797,6 +809,19 @@ export function ZeroChatPage({
     }
   };
 
+  const handleFileSelect = () => {
+    fileInputRef.current?.click();
+  };
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = e.target.files;
+    if (!files) return;
+    for (const file of files) {
+      detach(uploadAttachment(file), Reason.DomCallback);
+    }
+    e.target.value = "";
+  };
+
   const streamedScenarios = getStreamedScenarios(agentName);
   const scenariosToShow = initialScenarioId
     ? streamedScenarios.filter((s) => s.id === initialScenarioId)
@@ -807,6 +832,17 @@ export function ZeroChatPage({
     (initialScenarioId !== undefined && scenariosToShow.length > 0) ||
     conversationActive;
 
+  const fileInput = (
+    <input
+      ref={fileInputRef}
+      type="file"
+      className="hidden"
+      accept="image/*,.pdf,.txt,.csv,.md,.json"
+      multiple
+      onChange={handleFileChange}
+    />
+  );
+
   if (showConversation && scenariosToShow.length > 0) {
     const isScenarioFromSidebar = initialScenarioId !== undefined;
     return (
@@ -814,6 +850,7 @@ export function ZeroChatPage({
         ref={streamCleanupRef}
         className="flex flex-1 flex-col min-h-0 bg-transparent"
       >
+        {fileInput}
         <header className="shrink-0 bg-transparent px-4 sm:px-6 py-3 flex items-center justify-between">
           <div className="flex items-center gap-3">
             <Button
@@ -991,6 +1028,12 @@ export function ZeroChatPage({
             <Card className="zero-composer w-full min-w-0 overflow-hidden transition-colors duration-200">
               <CardContent className="p-0">
                 <div className="flex flex-col">
+                  {attachments.length > 0 && (
+                    <AttachmentChips
+                      attachments={attachments}
+                      onRemove={removeAttachment}
+                    />
+                  )}
                   <textarea
                     className="w-full resize-none bg-transparent px-5 pt-4 pb-2 text-sm text-foreground placeholder:text-muted-foreground border-0 min-h-[88px] focus:outline-none focus:ring-0"
                     rows={3}
@@ -1000,47 +1043,23 @@ export function ZeroChatPage({
                     onKeyDown={handleKeyDown}
                   />
                   <div className="flex items-center justify-between gap-2 px-4 py-3 border-t border-border/50">
-                    <div className="flex items-center gap-1 text-muted-foreground">
-                      <button
-                        type="button"
-                        className="p-2 rounded-lg hover:bg-muted/60 hover:text-foreground transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-                        aria-label="Add"
-                      >
-                        <IconPlus size={18} stroke={1.5} />
-                      </button>
-                      <button
-                        type="button"
-                        className="p-2 rounded-lg hover:bg-muted/60 hover:text-foreground transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-                        aria-label="Attach"
-                      >
-                        <IconPaperclip size={18} stroke={1.5} />
-                      </button>
-                      <button
-                        type="button"
-                        className="p-2 rounded-lg hover:bg-muted/60 hover:text-foreground transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-                        aria-label="Emoji"
-                      >
-                        <IconMoodSmile size={18} stroke={1.5} />
-                      </button>
-                    </div>
-                    <div className="flex items-center gap-1">
-                      <button
-                        type="button"
-                        className="p-2 rounded-lg text-muted-foreground hover:bg-muted/60 hover:text-foreground transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-                        aria-label="Voice input"
-                      >
-                        <IconMicrophone size={18} stroke={1.5} />
-                      </button>
-                      <Button
-                        size="sm"
-                        className="rounded-lg h-9 w-9 p-0 shrink-0"
-                        onClick={() => handleSend()}
-                        disabled={!input.trim()}
-                        aria-label="Send"
-                      >
-                        <IconSend size={16} stroke={2} />
-                      </Button>
-                    </div>
+                    <button
+                      type="button"
+                      className="p-2 rounded-lg text-muted-foreground hover:bg-muted/60 hover:text-foreground transition-colors duration-200"
+                      aria-label="Attach"
+                      onClick={handleFileSelect}
+                    >
+                      <IconPaperclip size={18} stroke={1.5} />
+                    </button>
+                    <Button
+                      size="sm"
+                      className="rounded-lg h-9 w-9 p-0 shrink-0"
+                      onClick={() => handleSend()}
+                      disabled={!input.trim()}
+                      aria-label="Send"
+                    >
+                      <IconSend size={16} stroke={2} />
+                    </Button>
                   </div>
                 </div>
               </CardContent>
@@ -1054,6 +1073,7 @@ export function ZeroChatPage({
   // Landing page: full content (title, triggers, composer, actions, prompts)
   return (
     <div ref={carouselRef} className="flex flex-1 flex-col min-h-0">
+      {fileInput}
       <header
         className="shrink-0 bg-transparent px-4 sm:px-6 pt-10 pb-2"
         aria-hidden="true"
@@ -1089,6 +1109,12 @@ export function ZeroChatPage({
           <Card className="zero-composer w-full overflow-hidden transition-colors duration-200">
             <CardContent className="p-0">
               <div className="flex flex-col">
+                {attachments.length > 0 && (
+                  <AttachmentChips
+                    attachments={attachments}
+                    onRemove={removeAttachment}
+                  />
+                )}
                 <textarea
                   className="w-full resize-none bg-transparent px-5 pt-4 pb-2 text-sm text-foreground placeholder:text-muted-foreground border-0 min-h-[88px] focus:outline-none focus:ring-0"
                   rows={3}
@@ -1098,47 +1124,23 @@ export function ZeroChatPage({
                   onKeyDown={handleKeyDown}
                 />
                 <div className="flex items-center justify-between gap-2 px-4 py-3 border-t border-border/50">
-                  <div className="flex items-center gap-1 text-muted-foreground">
-                    <button
-                      type="button"
-                      className="p-2 rounded-lg hover:bg-muted/60 hover:text-foreground transition-colors"
-                      aria-label="Add"
-                    >
-                      <IconPlus size={18} stroke={1.5} />
-                    </button>
-                    <button
-                      type="button"
-                      className="p-2 rounded-lg hover:bg-muted/60 hover:text-foreground transition-colors"
-                      aria-label="Attach"
-                    >
-                      <IconPaperclip size={18} stroke={1.5} />
-                    </button>
-                    <button
-                      type="button"
-                      className="p-2 rounded-lg hover:bg-muted/60 hover:text-foreground transition-colors"
-                      aria-label="Emoji"
-                    >
-                      <IconMoodSmile size={18} stroke={1.5} />
-                    </button>
-                  </div>
-                  <div className="flex items-center gap-1">
-                    <button
-                      type="button"
-                      className="p-2 rounded-lg text-muted-foreground hover:bg-muted/60 hover:text-foreground transition-colors"
-                      aria-label="Voice input"
-                    >
-                      <IconMicrophone size={18} stroke={1.5} />
-                    </button>
-                    <Button
-                      size="sm"
-                      className="rounded-lg h-9 w-9 p-0 shrink-0"
-                      onClick={() => handleSend()}
-                      disabled={!input.trim()}
-                      aria-label="Send"
-                    >
-                      <IconSend size={16} stroke={2} />
-                    </Button>
-                  </div>
+                  <button
+                    type="button"
+                    className="p-2 rounded-lg text-muted-foreground hover:bg-muted/60 hover:text-foreground transition-colors duration-200"
+                    aria-label="Attach"
+                    onClick={handleFileSelect}
+                  >
+                    <IconPaperclip size={18} stroke={1.5} />
+                  </button>
+                  <Button
+                    size="sm"
+                    className="rounded-lg h-9 w-9 p-0 shrink-0"
+                    onClick={() => handleSend()}
+                    disabled={!input.trim()}
+                    aria-label="Send"
+                  >
+                    <IconSend size={16} stroke={2} />
+                  </Button>
                 </div>
               </div>
             </CardContent>
@@ -1214,6 +1216,47 @@ export function ZeroChatPage({
           </div>
         </div>
       </main>
+    </div>
+  );
+}
+
+function AttachmentChips({
+  attachments,
+  onRemove,
+}: {
+  attachments: ZeroChatAttachment[];
+  onRemove: (id: string) => void;
+}) {
+  return (
+    <div className="flex flex-wrap gap-1.5 px-4 pt-3">
+      {attachments.map((a) => {
+        const isImage = a.contentType.startsWith("image/");
+        return (
+          <div
+            key={a.id}
+            className="inline-flex items-center gap-1.5 rounded-lg bg-muted/60 pl-2.5 pr-1.5 py-1.5 text-xs text-muted-foreground"
+          >
+            {isImage ? (
+              <IconPhoto size={14} stroke={1.5} />
+            ) : (
+              <IconFile size={14} stroke={1.5} />
+            )}
+            <span className="truncate max-w-[120px]">{a.filename}</span>
+            {a.uploading ? (
+              <IconLoader2 size={12} className="animate-spin ml-0.5" />
+            ) : (
+              <button
+                type="button"
+                onClick={() => onRemove(a.id)}
+                className="p-0.5 rounded hover:bg-muted transition-colors"
+                aria-label={`Remove ${a.filename}`}
+              >
+                <IconX size={12} stroke={2} />
+              </button>
+            )}
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-page.tsx
@@ -1,5 +1,4 @@
-import type { ReactNode, KeyboardEvent } from "react";
-import { useRef } from "react";
+import type { ReactNode, KeyboardEvent, ChangeEvent } from "react";
 import { useCCState, useCommand } from "ccstate-react/experimental";
 import { useGet, useSet, useLoadable } from "ccstate-react";
 import { onRef, detach, Reason } from "../../signals/utils.ts";
@@ -683,7 +682,9 @@ export function ZeroChatPage({
   const attachments = useGet(zeroChatAttachments$);
   const uploadAttachment = useSet(uploadZeroAttachment$);
   const removeAttachment = useSet(removeZeroAttachment$);
-  const fileInputRef = useRef<HTMLInputElement>(null);
+  const fileInputEl$ = useCCState<HTMLInputElement | null>(null);
+  const fileInputEl = useGet(fileInputEl$);
+  const setFileInputEl = useSet(fileInputEl$);
   const conversationActive$ = useCCState(false);
   const conversationActive = useGet(conversationActive$);
   const setConversationActive = useSet(conversationActive$);
@@ -810,12 +811,14 @@ export function ZeroChatPage({
   };
 
   const handleFileSelect = () => {
-    fileInputRef.current?.click();
+    fileInputEl?.click();
   };
 
-  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleFileChange = (e: ChangeEvent<HTMLInputElement>) => {
     const files = e.target.files;
-    if (!files) return;
+    if (!files) {
+      return;
+    }
     for (const file of files) {
       detach(uploadAttachment(file), Reason.DomCallback);
     }
@@ -834,7 +837,7 @@ export function ZeroChatPage({
 
   const fileInput = (
     <input
-      ref={fileInputRef}
+      ref={setFileInputEl}
       type="file"
       className="hidden"
       accept="image/*,.pdf,.txt,.csv,.md,.json"
@@ -1223,19 +1226,23 @@ export function ZeroChatPage({
 function getFileTypeIcon(filename: string): string | null {
   const ext = filename.split(".").pop()?.toLowerCase();
   switch (ext) {
-    case "pdf":
+    case "pdf": {
       return "/doc-types/PDF.svg";
+    }
     case "doc":
     case "docx":
     case "md":
     case "txt":
     case "json":
-    case "html":
+    case "html": {
       return "/doc-types/DOC.svg";
-    case "csv":
+    }
+    case "csv": {
       return "/doc-types/CSV.svg";
-    default:
+    }
+    default: {
       return null;
+    }
   }
 }
 

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-page.tsx
@@ -1220,6 +1220,25 @@ export function ZeroChatPage({
   );
 }
 
+function getFileTypeIcon(filename: string): string | null {
+  const ext = filename.split(".").pop()?.toLowerCase();
+  switch (ext) {
+    case "pdf":
+      return "/doc-types/PDF.svg";
+    case "doc":
+    case "docx":
+    case "md":
+    case "txt":
+    case "json":
+    case "html":
+      return "/doc-types/DOC.svg";
+    case "csv":
+      return "/doc-types/CSV.svg";
+    default:
+      return null;
+  }
+}
+
 function AttachmentChips({
   attachments,
   onRemove,
@@ -1228,30 +1247,61 @@ function AttachmentChips({
   onRemove: (id: string) => void;
 }) {
   return (
-    <div className="flex flex-wrap gap-1.5 px-4 pt-3">
+    <div className="flex flex-wrap gap-2 px-4 pt-3">
       {attachments.map((a) => {
         const isImage = a.contentType.startsWith("image/");
+        const iconSrc = isImage ? null : getFileTypeIcon(a.filename);
         return (
           <div
             key={a.id}
-            className="inline-flex items-center gap-1.5 rounded-lg bg-muted/60 pl-2.5 pr-1.5 py-1.5 text-xs text-muted-foreground"
+            className="relative inline-flex items-center justify-center"
+            title={a.filename}
           >
             {isImage ? (
-              <IconPhoto size={14} stroke={1.5} />
+              <div className="relative h-6 w-6 rounded-md overflow-hidden border border-foreground/10">
+                {a.url ? (
+                  <img
+                    src={a.url}
+                    alt=""
+                    className="h-full w-full object-cover"
+                  />
+                ) : (
+                  <IconPhoto
+                    size={16}
+                    stroke={1.5}
+                    className="text-muted-foreground m-auto h-full"
+                  />
+                )}
+              </div>
+            ) : iconSrc ? (
+              <img
+                alt=""
+                className="h-6 w-6 object-contain opacity-80"
+                aria-hidden="true"
+                src={iconSrc}
+              />
             ) : (
-              <IconFile size={14} stroke={1.5} />
+              <IconFile
+                size={20}
+                stroke={1.5}
+                className="text-muted-foreground"
+              />
             )}
-            <span className="truncate max-w-[120px]">{a.filename}</span>
             {a.uploading ? (
-              <IconLoader2 size={12} className="animate-spin ml-0.5" />
+              <span className="absolute -top-1 -right-1 flex h-3.5 w-3.5 items-center justify-center rounded-full bg-background">
+                <IconLoader2
+                  size={10}
+                  className="animate-spin text-muted-foreground"
+                />
+              </span>
             ) : (
               <button
                 type="button"
                 onClick={() => onRemove(a.id)}
-                className="p-0.5 rounded hover:bg-muted transition-colors"
+                className="absolute -top-1 -right-1 flex h-3.5 w-3.5 items-center justify-center rounded-full bg-muted hover:bg-destructive hover:text-destructive-foreground transition-colors"
                 aria-label={`Remove ${a.filename}`}
               >
-                <IconX size={12} stroke={2} />
+                <IconX size={9} stroke={2.5} />
               </button>
             )}
           </div>

--- a/turbo/apps/platform/src/views/zero-page/zero-meet-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-meet-page.tsx
@@ -671,7 +671,24 @@ function ZeroSettingsTab({
     tone: initialSound,
   });
   const savedSettings = useGet(savedSettings$);
+  const setSavedSettings = useSet(savedSettings$);
   const saving = useGet(zeroSettingsSaving$);
+
+  // Sync local state when props change (e.g. metadata finishes loading)
+  const prevProps$ = useCCState({
+    name: resolvedAgentName,
+    tone: initialSound,
+  });
+  const prevProps = useGet(prevProps$);
+  const setPrevProps = useSet(prevProps$);
+  if (resolvedAgentName !== prevProps.name || initialSound !== prevProps.tone) {
+    queueMicrotask(() => {
+      setPrevProps({ name: resolvedAgentName, tone: initialSound });
+      setAgentName(resolvedAgentName);
+      setTone(initialSound);
+      setSavedSettings({ name: resolvedAgentName, tone: initialSound });
+    });
+  }
 
   const isSettingsDirty =
     agentName !== savedSettings.name || tone !== savedSettings.tone;

--- a/turbo/apps/platform/src/views/zero-page/zero-session-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-session-chat-page.tsx
@@ -1,15 +1,20 @@
 import type { KeyboardEvent } from "react";
+import { useRef } from "react";
 import { useCCState } from "ccstate-react/experimental";
 import { useGet, useSet, useLoadable } from "ccstate-react";
 import {
   IconSend,
+  IconPaperclip,
   IconAlertCircle,
   IconLoader2,
   IconArrowLeft,
   IconUsers,
   IconCalendar,
+  IconX,
+  IconFile,
+  IconPhoto,
 } from "@tabler/icons-react";
-import { Button, Card, CardContent } from "@vm0/ui";
+import { Button, Card, CardContent, Skeleton } from "@vm0/ui";
 import { Markdown } from "../components/markdown.tsx";
 import { detach, Reason } from "../../signals/utils.ts";
 import { agentDisplayName$ } from "../../signals/zero-page/zero-agent-name.ts";
@@ -17,11 +22,16 @@ import {
   zeroChatMessages$,
   zeroChatSending$,
   zeroChatInput$,
+  zeroChatAttachments$,
   zeroSessionError$,
+  zeroSessionSwitching$,
   setZeroChatInput$,
   clearZeroChatInput$,
   sendZeroChatMessage$,
+  uploadZeroAttachment$,
+  removeZeroAttachment$,
   type ZeroChatMessage,
+  type ZeroChatAttachment,
 } from "../../signals/zero-page/zero-chat.ts";
 
 // ---------------------------------------------------------------------------
@@ -49,10 +59,15 @@ export function ZeroSessionChatPage({
   const messages = useGet(zeroChatMessages$);
   const sending = useGet(zeroChatSending$);
   const sessionError = useGet(zeroSessionError$);
+  const sessionSwitching = useGet(zeroSessionSwitching$);
   const input = useGet(zeroChatInput$);
   const setInput = useSet(setZeroChatInput$);
   const clearInput = useSet(clearZeroChatInput$);
   const send = useSet(sendZeroChatMessage$);
+  const attachments = useGet(zeroChatAttachments$);
+  const uploadAttachment = useSet(uploadZeroAttachment$);
+  const removeAttachment = useSet(removeZeroAttachment$);
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
   const messagesEndEl$ = useCCState<HTMLDivElement | null>(null);
   const messagesEndEl = useGet(messagesEndEl$);
@@ -79,6 +94,20 @@ export function ZeroSessionChatPage({
       e.preventDefault();
       handleSend();
     }
+  };
+
+  const handleFileSelect = () => {
+    fileInputRef.current?.click();
+  };
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = e.target.files;
+    if (!files) return;
+    for (const file of files) {
+      detach(uploadAttachment(file), Reason.DomCallback);
+    }
+    // Reset so same file can be selected again
+    e.target.value = "";
   };
 
   return (
@@ -143,7 +172,10 @@ export function ZeroSessionChatPage({
               </div>
             </div>
           )}
-          {!sessionError && messages.length === 0 && (
+          {!sessionError && messages.length === 0 && sessionSwitching && (
+            <ChatSkeleton />
+          )}
+          {!sessionError && messages.length === 0 && !sessionSwitching && (
             <div className="flex-1 flex items-center justify-center py-16">
               <p className="text-sm text-muted-foreground">
                 Send a message to start the conversation
@@ -169,6 +201,17 @@ export function ZeroSessionChatPage({
           <Card className="zero-composer w-full min-w-0 overflow-hidden transition-colors duration-200">
             <CardContent className="p-0">
               <div className="flex flex-col">
+                {attachments.length > 0 && (
+                  <div className="flex flex-wrap gap-2 px-5 pt-3">
+                    {attachments.map((a) => (
+                      <AttachmentChip
+                        key={a.id}
+                        attachment={a}
+                        onRemove={() => removeAttachment(a.id)}
+                      />
+                    ))}
+                  </div>
+                )}
                 <textarea
                   className="w-full resize-none bg-transparent px-5 pt-4 pb-2 text-sm text-foreground placeholder:text-muted-foreground border-0 min-h-[88px] focus:outline-none focus:ring-0"
                   rows={3}
@@ -178,7 +221,25 @@ export function ZeroSessionChatPage({
                   onKeyDown={handleKeyDown}
                   disabled={sending}
                 />
-                <div className="flex items-center justify-end gap-2 px-4 py-3 border-t border-border/50">
+                <div className="flex items-center justify-between gap-2 px-4 py-3 border-t border-border/50">
+                  <div className="flex items-center gap-1 text-muted-foreground">
+                    <input
+                      ref={fileInputRef}
+                      type="file"
+                      className="hidden"
+                      accept="image/*,.pdf,.txt,.csv,.md,.json"
+                      multiple
+                      onChange={handleFileChange}
+                    />
+                    <button
+                      type="button"
+                      className="p-2 rounded-lg hover:bg-muted/60 hover:text-foreground transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                      aria-label="Attach file"
+                      onClick={handleFileSelect}
+                    >
+                      <IconPaperclip size={18} stroke={1.5} />
+                    </button>
+                  </div>
                   <Button
                     size="sm"
                     className="rounded-lg h-9 w-9 p-0 shrink-0"
@@ -203,6 +264,48 @@ export function ZeroSessionChatPage({
 }
 
 // ---------------------------------------------------------------------------
+// Skeleton placeholder while session loads
+// ---------------------------------------------------------------------------
+
+function ChatSkeleton() {
+  return (
+    <>
+      {/* User bubble skeleton */}
+      <div className="grid grid-cols-[48px_1fr] gap-3 items-start">
+        <div className="w-9 h-9 shrink-0" />
+        <div className="flex min-w-0 justify-end">
+          <Skeleton className="h-10 w-[60%] rounded-2xl" />
+        </div>
+      </div>
+      {/* Assistant bubble skeleton */}
+      <div className="grid grid-cols-[48px_1fr] gap-3 items-start">
+        <Skeleton className="h-9 w-9 rounded-xl" />
+        <div className="flex flex-col gap-2">
+          <Skeleton className="h-4 w-[90%] rounded-lg" />
+          <Skeleton className="h-4 w-[75%] rounded-lg" />
+          <Skeleton className="h-4 w-[40%] rounded-lg" />
+        </div>
+      </div>
+      {/* User bubble skeleton */}
+      <div className="grid grid-cols-[48px_1fr] gap-3 items-start">
+        <div className="w-9 h-9 shrink-0" />
+        <div className="flex min-w-0 justify-end">
+          <Skeleton className="h-10 w-[45%] rounded-2xl" />
+        </div>
+      </div>
+      {/* Assistant bubble skeleton */}
+      <div className="grid grid-cols-[48px_1fr] gap-3 items-start">
+        <Skeleton className="h-9 w-9 rounded-xl" />
+        <div className="flex flex-col gap-2">
+          <Skeleton className="h-4 w-[85%] rounded-lg" />
+          <Skeleton className="h-4 w-[60%] rounded-lg" />
+        </div>
+      </div>
+    </>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Chat message components
 // ---------------------------------------------------------------------------
 
@@ -218,7 +321,7 @@ function ChatMessageRow({
   onAvatarClick,
 }: ChatMessageRowProps) {
   if (message.role === "user") {
-    return <UserMessage content={message.content} />;
+    return <UserMessage message={message} />;
   }
   return (
     <AssistantMessage
@@ -229,13 +332,33 @@ function ChatMessageRow({
   );
 }
 
-function UserMessage({ content }: { content: string }) {
+function UserMessage({ message }: { message: ZeroChatMessage }) {
   return (
     <div className="grid grid-cols-[48px_1fr] gap-3 items-start animate-in fade-in slide-in-from-bottom-2 duration-300">
       <div className="w-9 h-9 shrink-0" />
-      <div className="flex min-w-0 justify-end">
+      <div className="flex flex-col items-end gap-2 min-w-0">
+        {message.attachments && message.attachments.length > 0 && (
+          <div className="flex flex-wrap justify-end gap-2 max-w-[85%]">
+            {message.attachments.map((a, i) => (
+              <a
+                key={i}
+                href={a.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1.5 rounded-lg bg-muted/60 px-2.5 py-1.5 text-xs text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
+              >
+                {a.contentType.startsWith("image/") ? (
+                  <IconPhoto size={14} stroke={1.5} />
+                ) : (
+                  <IconFile size={14} stroke={1.5} />
+                )}
+                <span className="truncate max-w-[120px]">{a.filename}</span>
+              </a>
+            ))}
+          </div>
+        )}
         <div className="zero-chat-bubble-user rounded-2xl px-4 py-3 max-w-[85%] text-sm leading-relaxed">
-          {content}
+          {message.content}
         </div>
       </div>
     </div>
@@ -307,6 +430,42 @@ function AssistantMessage({
           <span className="text-muted-foreground">Thinking...</span>
         </div>
       </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Attachment chip (shown in composer before sending)
+// ---------------------------------------------------------------------------
+
+function AttachmentChip({
+  attachment,
+  onRemove,
+}: {
+  attachment: ZeroChatAttachment;
+  onRemove: () => void;
+}) {
+  const isImage = attachment.contentType.startsWith("image/");
+  return (
+    <div className="inline-flex items-center gap-1.5 rounded-lg bg-muted/60 pl-2.5 pr-1.5 py-1.5 text-xs text-muted-foreground">
+      {isImage ? (
+        <IconPhoto size={14} stroke={1.5} />
+      ) : (
+        <IconFile size={14} stroke={1.5} />
+      )}
+      <span className="truncate max-w-[120px]">{attachment.filename}</span>
+      {attachment.uploading ? (
+        <IconLoader2 size={12} className="animate-spin ml-0.5" />
+      ) : (
+        <button
+          type="button"
+          onClick={onRemove}
+          className="p-0.5 rounded hover:bg-muted transition-colors"
+          aria-label={`Remove ${attachment.filename}`}
+        >
+          <IconX size={12} stroke={2} />
+        </button>
+      )}
     </div>
   );
 }

--- a/turbo/apps/platform/src/views/zero-page/zero-session-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-session-chat-page.tsx
@@ -10,12 +10,15 @@ import {
   IconUsers,
   IconCalendar,
   IconX,
-  IconFile,
   IconPhoto,
 } from "@tabler/icons-react";
 import { Button, Card, CardContent, Skeleton } from "@vm0/ui";
 import { Markdown } from "../components/markdown.tsx";
 import { detach, Reason } from "../../signals/utils.ts";
+import {
+  FileAttachmentChip,
+  AttachmentChip,
+} from "./zero-attachment-chips.tsx";
 import { agentDisplayName$ } from "../../signals/zero-page/zero-agent-name.ts";
 import {
   zeroChatMessages$,
@@ -30,7 +33,6 @@ import {
   uploadZeroAttachment$,
   removeZeroAttachment$,
   type ZeroChatMessage,
-  type ZeroChatAttachment,
 } from "../../signals/zero-page/zero-chat.ts";
 
 // ---------------------------------------------------------------------------
@@ -359,29 +361,6 @@ function isImageFilename(filename: string): boolean {
   return /\.(png|jpe?g|gif|webp|svg)$/i.test(filename);
 }
 
-function getFileTypeIcon(filename: string): string | null {
-  const ext = filename.split(".").pop()?.toLowerCase();
-  switch (ext) {
-    case "pdf": {
-      return "/doc-types/PDF.svg";
-    }
-    case "doc":
-    case "docx":
-    case "md":
-    case "txt":
-    case "json":
-    case "html": {
-      return "/doc-types/DOC.svg";
-    }
-    case "csv": {
-      return "/doc-types/CSV.svg";
-    }
-    default: {
-      return null;
-    }
-  }
-}
-
 function UserMessage({ message }: { message: ZeroChatMessage }) {
   const { cleanContent, parsed } = parseInlineAttachments(message.content);
   const lightboxUrl$ = useCCState<string | null>(null);
@@ -554,104 +533,6 @@ function AssistantMessage({
           <span className="text-muted-foreground">Thinking...</span>
         </div>
       </div>
-    </div>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// File attachment chip (shown in sent messages)
-// ---------------------------------------------------------------------------
-
-function FileAttachmentChip({
-  filename,
-  url,
-}: {
-  filename: string;
-  url: string;
-}) {
-  const iconSrc = getFileTypeIcon(filename);
-  return (
-    <a
-      href={url}
-      download={filename}
-      title={filename}
-      className="inline-flex items-center justify-center rounded-md hover:bg-foreground/10 transition-colors p-0.5"
-    >
-      {iconSrc ? (
-        <img
-          alt=""
-          className="h-6 w-6 object-contain opacity-80"
-          aria-hidden="true"
-          src={iconSrc}
-        />
-      ) : (
-        <IconFile size={20} stroke={1.5} className="text-muted-foreground" />
-      )}
-    </a>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Attachment chip (shown in composer before sending)
-// ---------------------------------------------------------------------------
-
-function AttachmentChip({
-  attachment,
-  onRemove,
-}: {
-  attachment: ZeroChatAttachment;
-  onRemove: () => void;
-}) {
-  const isImage = attachment.contentType.startsWith("image/");
-  const iconSrc = isImage ? null : getFileTypeIcon(attachment.filename);
-  return (
-    <div
-      className="relative inline-flex items-center justify-center"
-      title={attachment.filename}
-    >
-      {isImage ? (
-        <div className="relative h-6 w-6 rounded-md overflow-hidden border border-foreground/10">
-          {attachment.url ? (
-            <img
-              src={attachment.url}
-              alt=""
-              className="h-full w-full object-cover"
-            />
-          ) : (
-            <IconPhoto
-              size={16}
-              stroke={1.5}
-              className="text-muted-foreground m-auto h-full"
-            />
-          )}
-        </div>
-      ) : iconSrc ? (
-        <img
-          alt=""
-          className="h-6 w-6 object-contain opacity-80"
-          aria-hidden="true"
-          src={iconSrc}
-        />
-      ) : (
-        <IconFile size={20} stroke={1.5} className="text-muted-foreground" />
-      )}
-      {attachment.uploading ? (
-        <span className="absolute -top-1 -right-1 flex h-3.5 w-3.5 items-center justify-center rounded-full bg-background">
-          <IconLoader2
-            size={10}
-            className="animate-spin text-muted-foreground"
-          />
-        </span>
-      ) : (
-        <button
-          type="button"
-          onClick={onRemove}
-          className="absolute -top-1 -right-1 flex h-3.5 w-3.5 items-center justify-center rounded-full bg-muted hover:bg-destructive hover:text-destructive-foreground transition-colors"
-          aria-label={`Remove ${attachment.filename}`}
-        >
-          <IconX size={9} stroke={2.5} />
-        </button>
-      )}
     </div>
   );
 }

--- a/turbo/apps/platform/src/views/zero-page/zero-session-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-session-chat-page.tsx
@@ -1,5 +1,5 @@
 import type { KeyboardEvent } from "react";
-import { useRef } from "react";
+import { useRef, useState, useCallback } from "react";
 import { useCCState } from "ccstate-react/experimental";
 import { useGet, useSet, useLoadable } from "ccstate-react";
 import {
@@ -332,35 +332,151 @@ function ChatMessageRow({
   );
 }
 
+/**
+ * Parse inline attachment lines from message content.
+ * Matches `[Attached file: name](url)` optionally followed by a curl line.
+ * Returns the cleaned content and parsed attachments.
+ */
+function parseInlineAttachments(content: string): {
+  cleanContent: string;
+  parsed: { filename: string; url: string }[];
+} {
+  const parsed: { filename: string; url: string }[] = [];
+  const cleaned = content.replace(
+    /\[Attached file: ([^\]]+)\]\(([^)]+)\)(?:\nDownload with: curl [^\n]*)?\n?/g,
+    (_match, filename: string, url: string) => {
+      parsed.push({ filename, url });
+      return "";
+    },
+  );
+  return { cleanContent: cleaned.trim(), parsed };
+}
+
+function isImageFilename(filename: string): boolean {
+  return /\.(png|jpe?g|gif|webp|svg)$/i.test(filename);
+}
+
+function getFileTypeIcon(filename: string): string | null {
+  const ext = filename.split(".").pop()?.toLowerCase();
+  switch (ext) {
+    case "pdf":
+      return "/doc-types/PDF.svg";
+    case "doc":
+    case "docx":
+    case "md":
+    case "txt":
+    case "json":
+    case "html":
+      return "/doc-types/DOC.svg";
+    case "csv":
+      return "/doc-types/CSV.svg";
+    default:
+      return null;
+  }
+}
+
 function UserMessage({ message }: { message: ZeroChatMessage }) {
+  const { cleanContent, parsed } = parseInlineAttachments(message.content);
+  const [lightboxUrl, setLightboxUrl] = useState<string | null>(null);
+
+  // Merge explicit attachments with those parsed from content
+  const allAttachments = [
+    ...(message.attachments ?? []).map((a) => ({
+      filename: a.filename,
+      url: a.url,
+      isImage: a.contentType.startsWith("image/"),
+    })),
+    ...parsed
+      .filter(
+        (p) =>
+          !(message.attachments ?? []).some((a) => a.filename === p.filename),
+      )
+      .map((p) => ({
+        filename: p.filename,
+        url: p.url,
+        isImage: isImageFilename(p.filename),
+      })),
+  ];
+
   return (
-    <div className="grid grid-cols-[48px_1fr] gap-3 items-start animate-in fade-in slide-in-from-bottom-2 duration-300">
-      <div className="w-9 h-9 shrink-0" />
-      <div className="flex flex-col items-end gap-2 min-w-0">
-        {message.attachments && message.attachments.length > 0 && (
-          <div className="flex flex-wrap justify-end gap-2 max-w-[85%]">
-            {message.attachments.map((a, i) => (
-              <a
-                key={i}
-                href={a.url}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="inline-flex items-center gap-1.5 rounded-lg bg-muted/60 px-2.5 py-1.5 text-xs text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
-              >
-                {a.contentType.startsWith("image/") ? (
-                  <IconPhoto size={14} stroke={1.5} />
-                ) : (
-                  <IconFile size={14} stroke={1.5} />
+    <>
+      <div className="grid grid-cols-[48px_1fr] gap-3 items-start animate-in fade-in slide-in-from-bottom-2 duration-300">
+        <div className="w-9 h-9 shrink-0" />
+        <div className="flex flex-col items-end min-w-0">
+          <div className="zero-chat-bubble-user rounded-2xl max-w-[85%] text-sm leading-relaxed break-words overflow-hidden">
+            <div className="px-4 py-3">
+              <Markdown source={cleanContent} />
+            </div>
+            {allAttachments.length > 0 && (
+              <div className="border-t border-foreground/10 px-3 py-2.5 flex flex-wrap gap-2">
+                {allAttachments.map((a, i) =>
+                  a.isImage ? (
+                    <button
+                      key={i}
+                      type="button"
+                      onClick={() => setLightboxUrl(a.url)}
+                      className="group relative rounded-lg overflow-hidden border border-foreground/10 hover:border-foreground/25 transition-colors"
+                    >
+                      <img
+                        src={a.url}
+                        alt={a.filename}
+                        className="h-7 max-w-[56px] object-cover"
+                      />
+                      <span className="absolute inset-0 flex items-center justify-center bg-black/0 group-hover:bg-black/30 transition-colors">
+                        <IconPhoto
+                          size={18}
+                          className="text-white opacity-0 group-hover:opacity-100 transition-opacity drop-shadow"
+                        />
+                      </span>
+                    </button>
+                  ) : (
+                    <FileAttachmentChip
+                      key={i}
+                      filename={a.filename}
+                      url={a.url}
+                    />
+                  ),
                 )}
-                <span className="truncate max-w-[120px]">{a.filename}</span>
-              </a>
-            ))}
+              </div>
+            )}
           </div>
-        )}
-        <div className="zero-chat-bubble-user rounded-2xl px-4 py-3 max-w-[85%] text-sm leading-relaxed">
-          {message.content}
         </div>
       </div>
+      {lightboxUrl && (
+        <ImageLightbox url={lightboxUrl} onClose={() => setLightboxUrl(null)} />
+      )}
+    </>
+  );
+}
+
+function ImageLightbox({ url, onClose }: { url: string; onClose: () => void }) {
+  const handleBackdropClick = useCallback(
+    (e: React.MouseEvent) => {
+      if (e.target === e.currentTarget) onClose();
+    },
+    [onClose],
+  );
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 backdrop-blur-sm animate-in fade-in duration-200"
+      onClick={handleBackdropClick}
+      role="dialog"
+      aria-modal="true"
+    >
+      <button
+        type="button"
+        onClick={onClose}
+        className="absolute top-4 right-4 p-2 rounded-full bg-black/50 text-white hover:bg-black/70 transition-colors"
+        aria-label="Close"
+      >
+        <IconX size={20} stroke={2} />
+      </button>
+      <img
+        src={url}
+        alt=""
+        className="max-h-[85vh] max-w-[90vw] rounded-lg shadow-2xl object-contain animate-in zoom-in-95 duration-200"
+      />
     </div>
   );
 }
@@ -396,7 +512,7 @@ function AssistantMessage({
     return (
       <div className="grid grid-cols-[48px_1fr] gap-3 items-start animate-in fade-in slide-in-from-bottom-2 duration-300">
         {avatarButton}
-        <div className="zero-chat-bubble-assistant rounded-2xl border backdrop-blur-sm px-4 py-4 text-sm leading-relaxed min-w-0">
+        <div className="zero-chat-bubble-assistant rounded-2xl border backdrop-blur-sm px-4 py-4 text-sm leading-relaxed min-w-0 break-words overflow-hidden">
           <div className="flex items-start gap-1.5 text-destructive">
             <IconAlertCircle size={14} className="shrink-0 mt-0.5" />
             <span>{message.error}</span>
@@ -410,7 +526,7 @@ function AssistantMessage({
     return (
       <div className="grid grid-cols-[48px_1fr] gap-3 items-start animate-in fade-in slide-in-from-bottom-2 duration-300">
         {avatarButton}
-        <div className="zero-chat-bubble-assistant rounded-2xl border backdrop-blur-sm px-4 py-4 text-sm leading-relaxed min-w-0">
+        <div className="zero-chat-bubble-assistant rounded-2xl border backdrop-blur-sm px-4 py-4 text-sm leading-relaxed min-w-0 break-words overflow-hidden">
           <Markdown source={message.content} />
         </div>
       </div>
@@ -421,7 +537,7 @@ function AssistantMessage({
   return (
     <div className="grid grid-cols-[48px_1fr] gap-3 items-start animate-in fade-in slide-in-from-bottom-2 duration-300">
       {avatarButton}
-      <div className="zero-chat-bubble-assistant rounded-2xl border backdrop-blur-sm px-4 py-4 text-sm leading-relaxed min-w-0">
+      <div className="zero-chat-bubble-assistant rounded-2xl border backdrop-blur-sm px-4 py-4 text-sm leading-relaxed min-w-0 break-words overflow-hidden">
         <div className="flex items-center gap-2">
           <IconLoader2
             size={14}
@@ -431,6 +547,39 @@ function AssistantMessage({
         </div>
       </div>
     </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// File attachment chip (shown in sent messages)
+// ---------------------------------------------------------------------------
+
+function FileAttachmentChip({
+  filename,
+  url,
+}: {
+  filename: string;
+  url: string;
+}) {
+  const iconSrc = getFileTypeIcon(filename);
+  return (
+    <a
+      href={url}
+      download={filename}
+      title={filename}
+      className="inline-flex items-center justify-center rounded-md hover:bg-foreground/10 transition-colors p-0.5"
+    >
+      {iconSrc ? (
+        <img
+          alt=""
+          className="h-6 w-6 object-contain opacity-80"
+          aria-hidden="true"
+          src={iconSrc}
+        />
+      ) : (
+        <IconFile size={20} stroke={1.5} className="text-muted-foreground" />
+      )}
+    </a>
   );
 }
 
@@ -446,24 +595,53 @@ function AttachmentChip({
   onRemove: () => void;
 }) {
   const isImage = attachment.contentType.startsWith("image/");
+  const iconSrc = isImage ? null : getFileTypeIcon(attachment.filename);
   return (
-    <div className="inline-flex items-center gap-1.5 rounded-lg bg-muted/60 pl-2.5 pr-1.5 py-1.5 text-xs text-muted-foreground">
+    <div
+      className="relative inline-flex items-center justify-center"
+      title={attachment.filename}
+    >
       {isImage ? (
-        <IconPhoto size={14} stroke={1.5} />
+        <div className="relative h-6 w-6 rounded-md overflow-hidden border border-foreground/10">
+          {attachment.url ? (
+            <img
+              src={attachment.url}
+              alt=""
+              className="h-full w-full object-cover"
+            />
+          ) : (
+            <IconPhoto
+              size={16}
+              stroke={1.5}
+              className="text-muted-foreground m-auto h-full"
+            />
+          )}
+        </div>
+      ) : iconSrc ? (
+        <img
+          alt=""
+          className="h-6 w-6 object-contain opacity-80"
+          aria-hidden="true"
+          src={iconSrc}
+        />
       ) : (
-        <IconFile size={14} stroke={1.5} />
+        <IconFile size={20} stroke={1.5} className="text-muted-foreground" />
       )}
-      <span className="truncate max-w-[120px]">{attachment.filename}</span>
       {attachment.uploading ? (
-        <IconLoader2 size={12} className="animate-spin ml-0.5" />
+        <span className="absolute -top-1 -right-1 flex h-3.5 w-3.5 items-center justify-center rounded-full bg-background">
+          <IconLoader2
+            size={10}
+            className="animate-spin text-muted-foreground"
+          />
+        </span>
       ) : (
         <button
           type="button"
           onClick={onRemove}
-          className="p-0.5 rounded hover:bg-muted transition-colors"
+          className="absolute -top-1 -right-1 flex h-3.5 w-3.5 items-center justify-center rounded-full bg-muted hover:bg-destructive hover:text-destructive-foreground transition-colors"
           aria-label={`Remove ${attachment.filename}`}
         >
-          <IconX size={12} stroke={2} />
+          <IconX size={9} stroke={2.5} />
         </button>
       )}
     </div>

--- a/turbo/apps/platform/src/views/zero-page/zero-session-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-session-chat-page.tsx
@@ -1,5 +1,4 @@
-import type { KeyboardEvent } from "react";
-import { useRef, useState, useCallback } from "react";
+import type { KeyboardEvent, ChangeEvent, MouseEvent } from "react";
 import { useCCState } from "ccstate-react/experimental";
 import { useGet, useSet, useLoadable } from "ccstate-react";
 import {
@@ -67,7 +66,9 @@ export function ZeroSessionChatPage({
   const attachments = useGet(zeroChatAttachments$);
   const uploadAttachment = useSet(uploadZeroAttachment$);
   const removeAttachment = useSet(removeZeroAttachment$);
-  const fileInputRef = useRef<HTMLInputElement>(null);
+  const fileInputEl$ = useCCState<HTMLInputElement | null>(null);
+  const fileInputEl = useGet(fileInputEl$);
+  const setFileInputEl = useSet(fileInputEl$);
 
   const messagesEndEl$ = useCCState<HTMLDivElement | null>(null);
   const messagesEndEl = useGet(messagesEndEl$);
@@ -97,12 +98,14 @@ export function ZeroSessionChatPage({
   };
 
   const handleFileSelect = () => {
-    fileInputRef.current?.click();
+    fileInputEl?.click();
   };
 
-  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleFileChange = (e: ChangeEvent<HTMLInputElement>) => {
     const files = e.target.files;
-    if (!files) return;
+    if (!files) {
+      return;
+    }
     for (const file of files) {
       detach(uploadAttachment(file), Reason.DomCallback);
     }
@@ -224,7 +227,7 @@ export function ZeroSessionChatPage({
                 <div className="flex items-center justify-between gap-2 px-4 py-3 border-t border-border/50">
                   <div className="flex items-center gap-1 text-muted-foreground">
                     <input
-                      ref={fileInputRef}
+                      ref={setFileInputEl}
                       type="file"
                       className="hidden"
                       accept="image/*,.pdf,.txt,.csv,.md,.json"
@@ -359,25 +362,31 @@ function isImageFilename(filename: string): boolean {
 function getFileTypeIcon(filename: string): string | null {
   const ext = filename.split(".").pop()?.toLowerCase();
   switch (ext) {
-    case "pdf":
+    case "pdf": {
       return "/doc-types/PDF.svg";
+    }
     case "doc":
     case "docx":
     case "md":
     case "txt":
     case "json":
-    case "html":
+    case "html": {
       return "/doc-types/DOC.svg";
-    case "csv":
+    }
+    case "csv": {
       return "/doc-types/CSV.svg";
-    default:
+    }
+    default: {
       return null;
+    }
   }
 }
 
 function UserMessage({ message }: { message: ZeroChatMessage }) {
   const { cleanContent, parsed } = parseInlineAttachments(message.content);
-  const [lightboxUrl, setLightboxUrl] = useState<string | null>(null);
+  const lightboxUrl$ = useCCState<string | null>(null);
+  const lightboxUrl = useGet(lightboxUrl$);
+  const setLightboxUrl = useSet(lightboxUrl$);
 
   // Merge explicit attachments with those parsed from content
   const allAttachments = [
@@ -409,10 +418,10 @@ function UserMessage({ message }: { message: ZeroChatMessage }) {
             </div>
             {allAttachments.length > 0 && (
               <div className="border-t border-foreground/10 px-3 py-2.5 flex flex-wrap gap-2">
-                {allAttachments.map((a, i) =>
+                {allAttachments.map((a) =>
                   a.isImage ? (
                     <button
-                      key={i}
+                      key={a.url}
                       type="button"
                       onClick={() => setLightboxUrl(a.url)}
                       className="group relative rounded-lg overflow-hidden border border-foreground/10 hover:border-foreground/25 transition-colors"
@@ -431,7 +440,7 @@ function UserMessage({ message }: { message: ZeroChatMessage }) {
                     </button>
                   ) : (
                     <FileAttachmentChip
-                      key={i}
+                      key={a.url}
                       filename={a.filename}
                       url={a.url}
                     />
@@ -450,12 +459,11 @@ function UserMessage({ message }: { message: ZeroChatMessage }) {
 }
 
 function ImageLightbox({ url, onClose }: { url: string; onClose: () => void }) {
-  const handleBackdropClick = useCallback(
-    (e: React.MouseEvent) => {
-      if (e.target === e.currentTarget) onClose();
-    },
-    [onClose],
-  );
+  const handleBackdropClick = (e: MouseEvent<HTMLDivElement>) => {
+    if (e.target === e.currentTarget) {
+      onClose();
+    }
+  };
 
   return (
     <div

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -1,5 +1,6 @@
-import { type ReactNode, useState, useMemo } from "react";
-import { useLoadable } from "ccstate-react";
+import type { ReactNode } from "react";
+import { useLoadable, useGet, useSet } from "ccstate-react";
+import { useCCState } from "ccstate-react/experimental";
 import {
   IconMessageCircle,
   IconRobot,
@@ -373,18 +374,19 @@ function RecentChatSection({
   onRecentSelect?: (id: string) => void;
   onNewChat?: () => void;
 }) {
-  const [searchOpen, setSearchOpen] = useState(false);
-  const [searchTerm, setSearchTerm] = useState("");
+  const searchOpen$ = useCCState(false);
+  const searchOpen = useGet(searchOpen$);
+  const setSearchOpen = useSet(searchOpen$);
+  const searchTerm$ = useCCState("");
+  const searchTerm = useGet(searchTerm$);
+  const setSearchTerm = useSet(searchTerm$);
 
-  const filteredSessions = useMemo(() => {
-    const term = searchTerm.trim().toLowerCase();
-    if (!term) {
-      return recentSessions;
-    }
-    return recentSessions.filter((s) =>
-      (s.preview ?? "").toLowerCase().includes(term),
-    );
-  }, [recentSessions, searchTerm]);
+  const trimmedTerm = searchTerm.trim().toLowerCase();
+  const filteredSessions = trimmedTerm
+    ? recentSessions.filter((s) =>
+        (s.preview ?? "").toLowerCase().includes(trimmedTerm),
+      )
+    : recentSessions;
 
   return (
     <div className="mt-4 flex flex-col min-h-0 flex-1">

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react";
+import { type ReactNode, useState, useMemo } from "react";
 import { useLoadable } from "ccstate-react";
 import {
   IconMessageCircle,
@@ -17,6 +17,8 @@ import {
   IconSettings,
   IconLoader2,
   IconRefresh,
+  IconSearch,
+  IconX,
 } from "@tabler/icons-react";
 import type { SessionListItem } from "@vm0/core";
 import {
@@ -356,6 +358,131 @@ function AccountDropdown({
   );
 }
 
+function RecentChatSection({
+  recentSessions,
+  recentSessionsLoading,
+  recentSessionsError,
+  selectedRecentId,
+  onRecentSelect,
+  onNewChat,
+}: {
+  recentSessions: SessionListItem[];
+  recentSessionsLoading: boolean;
+  recentSessionsError: string | null;
+  selectedRecentId: string | null;
+  onRecentSelect?: (id: string) => void;
+  onNewChat?: () => void;
+}) {
+  const [searchOpen, setSearchOpen] = useState(false);
+  const [searchTerm, setSearchTerm] = useState("");
+
+  const filteredSessions = useMemo(() => {
+    const term = searchTerm.trim().toLowerCase();
+    if (!term) {
+      return recentSessions;
+    }
+    return recentSessions.filter((s) =>
+      (s.preview ?? "").toLowerCase().includes(term),
+    );
+  }, [recentSessions, searchTerm]);
+
+  return (
+    <div className="mt-4 flex flex-col min-h-0 flex-1">
+      {searchOpen ? (
+        <div className="shrink-0 flex items-center gap-2 h-8 rounded-lg p-2 bg-sidebar-accent/50">
+          <IconSearch
+            size={13}
+            stroke={1.5}
+            className="shrink-0 text-sidebar-foreground/70"
+          />
+          <input
+            type="text"
+            value={searchTerm}
+            onChange={(e) => setSearchTerm(e.target.value)}
+            placeholder="Search chats..."
+            autoFocus
+            className="flex-1 min-w-0 bg-transparent text-sm leading-5 text-sidebar-foreground placeholder:text-sidebar-foreground/40 focus:outline-none"
+          />
+          <button
+            type="button"
+            onClick={() => {
+              setSearchOpen(false);
+              setSearchTerm("");
+            }}
+            className="shrink-0 text-sidebar-foreground/50 hover:text-sidebar-foreground transition-colors"
+            aria-label="Close search"
+          >
+            <IconX size={13} stroke={1.5} />
+          </button>
+        </div>
+      ) : (
+        <div className="shrink-0 zero-nav-recent-label h-8 flex items-center justify-between px-2">
+          <span className="text-xs leading-4 text-sidebar-foreground uppercase tracking-wider">
+            recent chat
+          </span>
+          <div className="flex items-center gap-1">
+            <button
+              type="button"
+              onClick={() => setSearchOpen(true)}
+              className="text-sidebar-foreground/60 hover:text-sidebar-foreground transition-colors"
+              aria-label="Search chats"
+            >
+              <IconSearch size={14} />
+            </button>
+            {onNewChat && (
+              <button
+                type="button"
+                onClick={onNewChat}
+                className="text-sidebar-foreground/60 hover:text-sidebar-foreground transition-colors"
+                aria-label="New chat"
+              >
+                <IconPlus size={14} />
+              </button>
+            )}
+          </div>
+        </div>
+      )}
+      <div className="flex-1 min-h-0 overflow-y-auto overflow-x-hidden">
+        <div className="flex flex-col gap-1">
+          {recentSessionsLoading ? (
+            <div className="flex items-center justify-center py-3">
+              <IconLoader2
+                size={14}
+                className="animate-spin text-muted-foreground"
+              />
+            </div>
+          ) : recentSessionsError ? (
+            <p className="px-2 py-2 text-xs text-destructive">
+              {recentSessionsError}
+            </p>
+          ) : filteredSessions.length === 0 ? (
+            <p className="px-2 py-2 text-xs text-muted-foreground">
+              {searchTerm.trim() ? "No matching chats" : "No recent chats"}
+            </p>
+          ) : (
+            filteredSessions.map((session) => (
+              <button
+                key={session.id}
+                type="button"
+                onClick={() => onRecentSelect?.(session.id)}
+                className={`flex h-8 items-center gap-2 rounded-lg p-2 text-left text-sm leading-5 transition-colors ${
+                  selectedRecentId === session.id
+                    ? "bg-sidebar-active text-sidebar-primary"
+                    : "text-sidebar-foreground hover:bg-sidebar-accent"
+                }`}
+              >
+                <span className="truncate min-w-0 flex-1">
+                  {session.preview ?? "New chat"}
+                </span>
+              </button>
+            ))
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export function ZeroSidebar({
   activeId,
   agentName,
@@ -390,78 +517,38 @@ export function ZeroSidebar({
         </div>
 
         {/* Main nav */}
-        <nav className="flex-1 overflow-y-auto overflow-x-hidden p-2">
-          <div className="flex flex-col gap-1">
-            {mainNav.map(({ id, label, icon: Icon }) => (
-              <button
-                key={id}
-                type="button"
-                onClick={() => onSelect(id)}
-                className={`flex w-full h-8 items-center gap-2 rounded-lg p-2 text-left text-sm leading-5 transition-colors duration-200 ${
-                  activeId === id
-                    ? "bg-sidebar-active text-sidebar-primary font-medium"
-                    : "text-sidebar-foreground hover:bg-sidebar-accent"
-                }`}
-              >
-                <Icon size={16} className="shrink-0" />
-                <span className="truncate">{label}</span>
-              </button>
-            ))}
+        <nav className="flex-1 flex flex-col min-h-0 overflow-hidden p-2">
+          <div className="shrink-0 flex flex-col gap-1">
+            {mainNav.map(({ id, label, icon: Icon }) => {
+              const isActive =
+                activeId === id && !(id === "chat" && selectedRecentId);
+              return (
+                <button
+                  key={id}
+                  type="button"
+                  onClick={() => onSelect(id)}
+                  className={`flex w-full h-8 items-center gap-2 rounded-lg p-2 text-left text-sm leading-5 transition-colors duration-200 ${
+                    isActive
+                      ? "bg-sidebar-active text-sidebar-primary font-medium"
+                      : "text-sidebar-foreground hover:bg-sidebar-accent"
+                  }`}
+                >
+                  <Icon size={16} className="shrink-0" />
+                  <span className="truncate">{label}</span>
+                </button>
+              );
+            })}
           </div>
 
           {/* Recent chat sessions */}
-          <div className="mt-4">
-            <div className="zero-nav-recent-label h-8 flex items-center justify-between px-2">
-              <span className="text-xs leading-4 text-sidebar-foreground uppercase tracking-wider">
-                recent chat
-              </span>
-              {onNewChat && (
-                <button
-                  type="button"
-                  onClick={onNewChat}
-                  className="text-sidebar-foreground/60 hover:text-sidebar-foreground transition-colors"
-                  aria-label="New chat"
-                >
-                  <IconPlus size={14} />
-                </button>
-              )}
-            </div>
-            <div className="flex flex-col gap-1">
-              {recentSessionsLoading ? (
-                <div className="flex items-center justify-center py-3">
-                  <IconLoader2
-                    size={14}
-                    className="animate-spin text-muted-foreground"
-                  />
-                </div>
-              ) : recentSessionsError ? (
-                <p className="px-2 py-2 text-xs text-destructive">
-                  {recentSessionsError}
-                </p>
-              ) : recentSessions.length === 0 ? (
-                <p className="px-2 py-2 text-xs text-muted-foreground">
-                  No recent chats
-                </p>
-              ) : (
-                recentSessions.map((session) => (
-                  <button
-                    key={session.id}
-                    type="button"
-                    onClick={() => onRecentSelect?.(session.id)}
-                    className={`flex h-8 items-center gap-2 rounded-lg p-2 text-left text-sm leading-5 transition-colors ${
-                      selectedRecentId === session.id
-                        ? "bg-sidebar-active text-sidebar-primary"
-                        : "text-sidebar-foreground hover:bg-sidebar-accent"
-                    }`}
-                  >
-                    <span className="truncate min-w-0 flex-1">
-                      {session.preview ?? "New chat"}
-                    </span>
-                  </button>
-                ))
-              )}
-            </div>
-          </div>
+          <RecentChatSection
+            recentSessions={recentSessions}
+            recentSessionsLoading={recentSessionsLoading}
+            recentSessionsError={recentSessionsError}
+            selectedRecentId={selectedRecentId}
+            onRecentSelect={onRecentSelect}
+            onNewChat={onNewChat}
+          />
         </nav>
 
         {/* Footer nav */}

--- a/turbo/apps/web/app/api/agent/uploads/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/uploads/__tests__/route.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+import { POST } from "../route";
+import {
+  testContext,
+  type UserContext,
+} from "../../../../../src/__tests__/test-helpers";
+
+const context = testContext();
+
+function createUploadRequest(
+  file: File | null,
+  userId?: string | null,
+): NextRequest {
+  const formData = new FormData();
+  if (file) {
+    formData.append("file", file);
+  }
+
+  const headers: Record<string, string> = {};
+  // Clerk mock handles auth — no explicit header needed when userId is set
+  if (userId === null) {
+    // explicitly unauthenticated
+    headers["x-no-auth"] = "true";
+  }
+
+  return new NextRequest("http://localhost:3000/api/agent/uploads", {
+    method: "POST",
+    body: formData,
+    headers,
+  });
+}
+
+describe("POST /api/agent/uploads", () => {
+  let user: UserContext;
+
+  beforeEach(async () => {
+    context.setupMocks();
+    user = await context.setupUser();
+  });
+
+  describe("Authentication", () => {
+    it("should reject unauthenticated requests", async () => {
+      const { mockClerk } = await import(
+        "../../../../../src/__tests__/clerk-mock"
+      );
+      mockClerk({ userId: null });
+
+      const file = new File(["hello"], "test.txt", { type: "text/plain" });
+      const request = createUploadRequest(file, null);
+
+      const response = await POST(request);
+
+      expect(response.status).toBe(401);
+      const data = await response.json();
+      expect(data.error.code).toBe("UNAUTHORIZED");
+    });
+  });
+
+  describe("Validation", () => {
+    it("should reject request without file", async () => {
+      const request = createUploadRequest(null);
+
+      const response = await POST(request);
+
+      expect(response.status).toBe(400);
+      const data = await response.json();
+      expect(data.error.code).toBe("BAD_REQUEST");
+      expect(data.error.message).toContain("No file");
+    });
+
+    it("should reject file exceeding 10 MB", async () => {
+      // Create a file slightly over 10 MB
+      const largeBuffer = new ArrayBuffer(10 * 1024 * 1024 + 1);
+      const file = new File([largeBuffer], "large.txt", {
+        type: "text/plain",
+      });
+      const request = createUploadRequest(file);
+
+      const response = await POST(request);
+
+      expect(response.status).toBe(400);
+      const data = await response.json();
+      expect(data.error.message).toContain("File too large");
+    });
+
+    it("should reject unsupported file types", async () => {
+      const file = new File(["data"], "script.exe", {
+        type: "application/x-msdownload",
+      });
+      const request = createUploadRequest(file);
+
+      const response = await POST(request);
+
+      expect(response.status).toBe(400);
+      const data = await response.json();
+      expect(data.error.message).toContain("Unsupported file type");
+    });
+  });
+
+  describe("Success", () => {
+    it("should upload a valid text file and return metadata", async () => {
+      const content = "Hello, world!";
+      const file = new File([content], "hello.txt", { type: "text/plain" });
+      const request = createUploadRequest(file);
+
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.id).toBeDefined();
+      expect(data.filename).toBe("hello.txt");
+      expect(data.contentType).toBe("text/plain");
+      expect(data.size).toBe(content.length);
+      expect(data.url).toBe("https://mock-presigned-url");
+
+      // Verify S3 was called
+      expect(context.mocks.s3.uploadS3Buffer).toHaveBeenCalledOnce();
+      expect(context.mocks.s3.generatePresignedUrl).toHaveBeenCalledOnce();
+    });
+
+    it("should upload a valid image file", async () => {
+      const file = new File([new ArrayBuffer(100)], "photo.png", {
+        type: "image/png",
+      });
+      const request = createUploadRequest(file);
+
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.filename).toBe("photo.png");
+      expect(data.contentType).toBe("image/png");
+    });
+
+    it("should upload a valid PDF file", async () => {
+      const file = new File([new ArrayBuffer(50)], "document.pdf", {
+        type: "application/pdf",
+      });
+      const request = createUploadRequest(file);
+
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.contentType).toBe("application/pdf");
+    });
+
+    it("should sanitize filenames with special characters", async () => {
+      const file = new File(["data"], "my file (1).txt", {
+        type: "text/plain",
+      });
+      const request = createUploadRequest(file);
+
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+
+      // Verify the S3 key uses sanitized name
+      const uploadCall = context.mocks.s3.uploadS3Buffer.mock.calls[0];
+      const s3Key = uploadCall?.[1] as string;
+      expect(s3Key).toContain("my_file__1_.txt");
+      expect(s3Key).toContain(`uploads/${user.userId}/`);
+    });
+  });
+});

--- a/turbo/apps/web/app/api/agent/uploads/route.ts
+++ b/turbo/apps/web/app/api/agent/uploads/route.ts
@@ -1,0 +1,91 @@
+import { NextRequest, NextResponse } from "next/server";
+import { initServices } from "../../../../src/lib/init-services";
+import { getUserId } from "../../../../src/lib/auth/get-user-id";
+import {
+  uploadS3Buffer,
+  generatePresignedUrl,
+} from "../../../../src/lib/s3/s3-client";
+import { env } from "../../../../src/env";
+import { logger } from "../../../../src/lib/logger";
+
+const log = logger("api:agent:uploads");
+
+const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10 MB
+const ALLOWED_TYPES = new Set([
+  "image/png",
+  "image/jpeg",
+  "image/gif",
+  "image/webp",
+  "image/svg+xml",
+  "application/pdf",
+  "text/plain",
+  "text/csv",
+  "text/markdown",
+  "application/json",
+]);
+
+export async function POST(request: NextRequest) {
+  initServices();
+
+  const userId = await getUserId(
+    request.headers.get("authorization") ?? undefined,
+  );
+  if (!userId) {
+    return NextResponse.json(
+      { error: { message: "Not authenticated", code: "UNAUTHORIZED" } },
+      { status: 401 },
+    );
+  }
+
+  const formData = await request.formData();
+  const file = formData.get("file");
+
+  if (!file || !(file instanceof File)) {
+    return NextResponse.json(
+      { error: { message: "No file provided", code: "BAD_REQUEST" } },
+      { status: 400 },
+    );
+  }
+
+  if (file.size > MAX_FILE_SIZE) {
+    return NextResponse.json(
+      { error: { message: "File too large (max 10 MB)", code: "BAD_REQUEST" } },
+      { status: 400 },
+    );
+  }
+
+  if (!ALLOWED_TYPES.has(file.type)) {
+    return NextResponse.json(
+      {
+        error: {
+          message: `Unsupported file type: ${file.type}`,
+          code: "BAD_REQUEST",
+        },
+      },
+      { status: 400 },
+    );
+  }
+
+  const id = crypto.randomUUID();
+  const sanitizedName = file.name.replace(/[^a-zA-Z0-9._-]/g, "_");
+  const s3Key = `uploads/${userId}/${id}/${sanitizedName}`;
+  const bucket = env().R2_USER_STORAGES_BUCKET_NAME;
+
+  const buffer = Buffer.from(await file.arrayBuffer());
+  await uploadS3Buffer(bucket, s3Key, buffer, file.type);
+
+  // Generate a presigned GET URL valid for 24 hours
+  const url = await generatePresignedUrl(bucket, s3Key, 86400, sanitizedName);
+
+  log.debug(
+    `Uploaded ${sanitizedName} (${file.size} bytes) for user ${userId}`,
+  );
+
+  return NextResponse.json({
+    id,
+    filename: file.name,
+    contentType: file.type,
+    size: file.size,
+    url,
+  });
+}

--- a/turbo/apps/web/app/api/webhooks/agent/complete/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/complete/__tests__/route.test.ts
@@ -17,9 +17,10 @@ import {
   findTestQueueEntry,
 } from "../../../../../../src/__tests__/api-test-helpers";
 import { reloadEnv } from "../../../../../../src/env";
-import { getAgentSessionWithConversation } from "../../../../../../src/lib/agent-session";
-import { agentSessions } from "../../../../../../src/db/schema/agent-session";
-import { eq } from "drizzle-orm";
+import {
+  getAgentSessionWithConversation,
+  getSessionChatMessages,
+} from "../../../../../../src/lib/agent-session";
 import {
   testContext,
   uniqueId,
@@ -458,16 +459,11 @@ describe("POST /api/webhooks/agent/complete", () => {
       // Flush after() callbacks which trigger persistChatMessages
       await context.mocks.flushAfter();
 
-      // Verify session now has chat messages by querying DB directly
-      const [sessionRow] = await globalThis.services.db
-        .select({ chatMessages: agentSessions.chatMessages })
-        .from(agentSessions)
-        .where(eq(agentSessions.id, checkpointData.agentSessionId))
-        .limit(1);
-      expect(sessionRow).toBeDefined();
-
+      // Verify session now has chat messages
       type StoredMessage = { role: string; content: string; runId?: string };
-      const chatMessages = (sessionRow!.chatMessages ?? []) as StoredMessage[];
+      const chatMessages = (await getSessionChatMessages(
+        checkpointData.agentSessionId,
+      )) as StoredMessage[];
       expect(chatMessages.length).toBeGreaterThanOrEqual(2);
 
       // Verify user message from prompt
@@ -534,16 +530,11 @@ describe("POST /api/webhooks/agent/complete", () => {
 
       await context.mocks.flushAfter();
 
-      // Verify session has only user message by querying DB directly
-      const [sessionRow] = await globalThis.services.db
-        .select({ chatMessages: agentSessions.chatMessages })
-        .from(agentSessions)
-        .where(eq(agentSessions.id, checkpointData.agentSessionId))
-        .limit(1);
-      expect(sessionRow).toBeDefined();
-
+      // Verify session has only user message
       type StoredMessage = { role: string; content: string };
-      const chatMessages = (sessionRow!.chatMessages ?? []) as StoredMessage[];
+      const chatMessages = (await getSessionChatMessages(
+        checkpointData.agentSessionId,
+      )) as StoredMessage[];
       expect(chatMessages).toHaveLength(1);
       expect(chatMessages[0]!.role).toBe("user");
       expect(chatMessages[0]!.content).toBe("Test prompt");

--- a/turbo/apps/web/app/api/webhooks/agent/complete/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/complete/__tests__/route.test.ts
@@ -18,6 +18,8 @@ import {
 } from "../../../../../../src/__tests__/api-test-helpers";
 import { reloadEnv } from "../../../../../../src/env";
 import { getAgentSessionWithConversation } from "../../../../../../src/lib/agent-session";
+import { agentSessions } from "../../../../../../src/db/schema/agent-session";
+import { eq } from "drizzle-orm";
 import {
   testContext,
   uniqueId,
@@ -395,6 +397,156 @@ describe("POST /api/webhooks/agent/complete", () => {
       const data = await response.json();
       expect(data.success).toBe(true);
       expect(data.status).toBe("failed");
+    });
+  });
+
+  describe("Chat Persistence", () => {
+    it("should persist chat messages to session after successful completion", async () => {
+      // Create checkpoint (which creates a session)
+      const checkpointRequest = createTestRequest(
+        "http://localhost:3000/api/webhooks/agent/checkpoints",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${testToken}`,
+          },
+          body: JSON.stringify({
+            runId: testRunId,
+            cliAgentType: "claude-code",
+            cliAgentSessionId: "test-session-chat",
+            cliAgentSessionHistory: JSON.stringify({ type: "test" }),
+            artifactSnapshot: {
+              artifactName: "test-artifact",
+              artifactVersion: "v1",
+            },
+          }),
+        },
+      );
+      const checkpointResponse = await checkpointWebhook(checkpointRequest);
+      expect(checkpointResponse.status).toBe(200);
+      const checkpointData = (await checkpointResponse.json()) as {
+        agentSessionId: string;
+      };
+
+      // Mock Axiom to return a result event for this run
+      context.mocks.axiom.queryAxiom.mockResolvedValueOnce([
+        {
+          eventData: { result: "Here is the agent response." },
+        },
+      ]);
+
+      // Complete the run
+      const request = createTestRequest(
+        "http://localhost:3000/api/webhooks/agent/complete",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${testToken}`,
+          },
+          body: JSON.stringify({
+            runId: testRunId,
+            exitCode: 0,
+          }),
+        },
+      );
+
+      const response = await POST(request);
+      expect(response.status).toBe(200);
+
+      // Flush after() callbacks which trigger persistChatMessages
+      await context.mocks.flushAfter();
+
+      // Verify session now has chat messages by querying DB directly
+      const [sessionRow] = await globalThis.services.db
+        .select({ chatMessages: agentSessions.chatMessages })
+        .from(agentSessions)
+        .where(eq(agentSessions.id, checkpointData.agentSessionId))
+        .limit(1);
+      expect(sessionRow).toBeDefined();
+
+      type StoredMessage = { role: string; content: string; runId?: string };
+      const chatMessages = (sessionRow!.chatMessages ?? []) as StoredMessage[];
+      expect(chatMessages.length).toBeGreaterThanOrEqual(2);
+
+      // Verify user message from prompt
+      const userMsg = chatMessages.find((m) => m.role === "user");
+      expect(userMsg).toBeDefined();
+      expect(userMsg!.content).toBe("Test prompt");
+
+      // Verify assistant message from Axiom result
+      const assistantMsg = chatMessages.find((m) => m.role === "assistant");
+      expect(assistantMsg).toBeDefined();
+      expect(assistantMsg!.content).toBe("Here is the agent response.");
+      expect(assistantMsg!.runId).toBe(testRunId);
+    });
+
+    it("should persist only user message when no result found in Axiom", async () => {
+      // Create checkpoint
+      const checkpointRequest = createTestRequest(
+        "http://localhost:3000/api/webhooks/agent/checkpoints",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${testToken}`,
+          },
+          body: JSON.stringify({
+            runId: testRunId,
+            cliAgentType: "claude-code",
+            cliAgentSessionId: "test-session-no-result",
+            cliAgentSessionHistory: JSON.stringify({ type: "test" }),
+            artifactSnapshot: {
+              artifactName: "test-artifact",
+              artifactVersion: "v1",
+            },
+          }),
+        },
+      );
+      const checkpointResponse = await checkpointWebhook(checkpointRequest);
+      expect(checkpointResponse.status).toBe(200);
+      const checkpointData = (await checkpointResponse.json()) as {
+        agentSessionId: string;
+      };
+
+      // Axiom returns no events (default mock)
+      context.mocks.axiom.queryAxiom.mockResolvedValueOnce([]);
+
+      // Complete the run
+      const request = createTestRequest(
+        "http://localhost:3000/api/webhooks/agent/complete",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${testToken}`,
+          },
+          body: JSON.stringify({
+            runId: testRunId,
+            exitCode: 0,
+          }),
+        },
+      );
+
+      const response = await POST(request);
+      expect(response.status).toBe(200);
+
+      await context.mocks.flushAfter();
+
+      // Verify session has only user message by querying DB directly
+      const [sessionRow] = await globalThis.services.db
+        .select({ chatMessages: agentSessions.chatMessages })
+        .from(agentSessions)
+        .where(eq(agentSessions.id, checkpointData.agentSessionId))
+        .limit(1);
+      expect(sessionRow).toBeDefined();
+
+      type StoredMessage = { role: string; content: string };
+      const chatMessages = (sessionRow!.chatMessages ?? []) as StoredMessage[];
+      expect(chatMessages).toHaveLength(1);
+      expect(chatMessages[0]!.role).toBe("user");
+      expect(chatMessages[0]!.content).toBe("Test prompt");
     });
   });
 

--- a/turbo/apps/web/app/api/webhooks/agent/complete/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/complete/route.ts
@@ -19,6 +19,12 @@ import { logger } from "../../../../../src/lib/logger";
 import { dispatchCallbacks } from "../../../../../src/lib/callback";
 import { drainUserQueue } from "../../../../../src/lib/run/run-queue-service";
 import { executeQueuedRun } from "../../../../../src/lib/run/run-service";
+import { appendChatMessages } from "../../../../../src/lib/agent-session/agent-session-service";
+import {
+  queryAxiom,
+  getDatasetName,
+  DATASETS,
+} from "../../../../../src/lib/axiom";
 import { after } from "next/server";
 
 const log = logger("webhook:complete");
@@ -48,6 +54,52 @@ async function atomicTransition(
     )
     .returning({ id: agentRuns.id });
   return !!updated;
+}
+
+/**
+ * Query Axiom for the last "result" event of a run.
+ * Returns the result string or null if not found.
+ */
+async function extractResultFromAxiom(runId: string): Promise<string | null> {
+  const dataset = getDatasetName(DATASETS.AGENT_RUN_EVENTS);
+  const apl = `['${dataset}']
+| where runId == "${runId}"
+| where eventType == "result"
+| order by sequenceNumber desc
+| limit 1`;
+
+  const events = await queryAxiom<{
+    eventData: { result?: string };
+  }>(apl);
+
+  const result = events[0]?.eventData?.result;
+  return typeof result === "string" ? result : null;
+}
+
+/**
+ * Persist user prompt and assistant result as chat messages on the session.
+ * Runs in after() — best-effort, errors are logged but not propagated.
+ */
+async function persistChatMessages(
+  runId: string,
+  sessionId: string,
+  userId: string,
+  prompt: string,
+): Promise<void> {
+  const result = await extractResultFromAxiom(runId);
+
+  const messages: Array<{
+    role: "user" | "assistant";
+    content: string;
+    runId?: string;
+  }> = [{ role: "user", content: prompt }];
+
+  if (result) {
+    messages.push({ role: "assistant", content: result, runId });
+  }
+
+  await appendChatMessages(sessionId, userId, messages);
+  log.debug(`Persisted ${messages.length} chat messages for run ${runId}`);
 }
 
 /**
@@ -228,6 +280,20 @@ const router = tsr.router(webhookCompleteContract, {
 
       finalStatus = "completed";
       log.debug(`Run ${body.runId} completed successfully`);
+
+      // Persist chat messages to session (non-blocking)
+      if (session) {
+        after(async () => {
+          await persistChatMessages(
+            body.runId,
+            session.id,
+            userId,
+            run.prompt,
+          ).catch((err) =>
+            log.error("Failed to persist chat messages", { err }),
+          );
+        });
+      }
     } else {
       // Failure: store error in run table
       const errorMessage =

--- a/turbo/apps/web/src/lib/agent-session/agent-session-service.ts
+++ b/turbo/apps/web/src/lib/agent-session/agent-session-service.ts
@@ -145,6 +145,25 @@ export async function listAgentSessions(
 }
 
 /**
+ * Get chat messages for a session by ID.
+ */
+export async function getSessionChatMessages(
+  sessionId: string,
+): Promise<StoredChatMessage[]> {
+  const [row] = await globalThis.services.db
+    .select({ chatMessages: agentSessions.chatMessages })
+    .from(agentSessions)
+    .where(eq(agentSessions.id, sessionId))
+    .limit(1);
+
+  if (!row) {
+    return [];
+  }
+
+  return (row.chatMessages ?? []) as StoredChatMessage[];
+}
+
+/**
  * Append chat messages to a session's chatMessages JSONB array.
  * Adds server-side createdAt timestamp to each message.
  */

--- a/turbo/apps/web/src/lib/agent-session/index.ts
+++ b/turbo/apps/web/src/lib/agent-session/index.ts
@@ -4,4 +4,5 @@ export {
   updateAgentSession,
   listAgentSessions,
   appendChatMessages,
+  getSessionChatMessages,
 } from "./agent-session-service";

--- a/turbo/apps/web/src/lib/compose/trigger-compose-job.ts
+++ b/turbo/apps/web/src/lib/compose/trigger-compose-job.ts
@@ -299,7 +299,7 @@ async function spawnComposeJobSandbox(
     const yamlContent = JSON.stringify(params.content, null, 2);
     await sandbox.files.write("/tmp/compose/vm0.yaml", yamlContent);
 
-    // Write instructions file if provided, with metadata frontmatter injected
+    // Write instructions file if provided, with agent profile injected
     if (params.instructions !== undefined) {
       const instructionsFilename = getInstructionsFilename(params.content);
       if (instructionsFilename) {

--- a/turbo/packages/core/src/__tests__/instructions-frontmatter.spec.ts
+++ b/turbo/packages/core/src/__tests__/instructions-frontmatter.spec.ts
@@ -27,110 +27,133 @@ describe("injectMetadataFrontmatter", () => {
     ).toBe(content);
   });
 
-  it("should prepend frontmatter with full metadata", () => {
+  it("should append profile block with full metadata as natural language", () => {
     const content = "# Instructions\nDo stuff.";
     const result = injectMetadataFrontmatter(content, {
       displayName: "Aria",
       sound: "professional",
     });
     expect(result).toBe(
-      "---\nname: Aria\ntone: professional\n---\n\n# Instructions\nDo stuff.",
+      "# Instructions\nDo stuff.\n\n<!-- ZERO_PROFILE\nYour name is Aria. Communicate in a clear, polished, and business-appropriate tone. This should be reflected in all your responses.\nZERO_PROFILE -->\n",
     );
   });
 
-  it("should prepend frontmatter with only displayName", () => {
+  it("should append profile block with only displayName", () => {
     const content = "# Instructions";
     const result = injectMetadataFrontmatter(content, {
       displayName: "Aria",
     });
-    expect(result).toBe("---\nname: Aria\n---\n\n# Instructions");
+    expect(result).toBe(
+      "# Instructions\n\n<!-- ZERO_PROFILE\nYour name is Aria.\nZERO_PROFILE -->\n",
+    );
   });
 
-  it("should prepend frontmatter with only sound", () => {
+  it("should append profile block with only sound", () => {
     const content = "# Instructions";
     const result = injectMetadataFrontmatter(content, {
       sound: "friendly",
     });
-    expect(result).toBe("---\ntone: friendly\n---\n\n# Instructions");
-  });
-
-  it("should merge with existing frontmatter preserving other fields", () => {
-    const content =
-      "---\nvm0_secrets:\n  - API_KEY\n---\n\n# Instructions\nDo stuff.";
-    const result = injectMetadataFrontmatter(content, {
-      displayName: "Aria",
-      sound: "professional",
-    });
     expect(result).toBe(
-      "---\nvm0_secrets:\n  - API_KEY\nname: Aria\ntone: professional\n---\n\n# Instructions\nDo stuff.",
+      "# Instructions\n\n<!-- ZERO_PROFILE\nCommunicate in a warm, approachable, and conversational tone. This should be reflected in all your responses.\nZERO_PROFILE -->\n",
     );
   });
 
-  it("should overwrite existing name and tone in frontmatter", () => {
-    const content = "---\nname: OldName\ntone: casual\n---\n\n# Instructions";
+  it("should use sound value directly for unknown tones", () => {
+    const content = "# Instructions";
+    const result = injectMetadataFrontmatter(content, {
+      sound: "playful",
+    });
+    expect(result).toContain("Communicate in a playful tone.");
+  });
+
+  it("should replace existing profile block", () => {
+    const content =
+      "# Instructions\nDo stuff.\n\n<!-- ZERO_PROFILE\nYour name is OldName.\nZERO_PROFILE -->\n";
     const result = injectMetadataFrontmatter(content, {
       displayName: "NewName",
-      sound: "formal",
+      sound: "direct",
+    });
+    expect(result).toContain("Your name is NewName.");
+    expect(result).toContain("concise, to the point, and no-nonsense");
+    expect(result).not.toContain("OldName");
+  });
+
+  it("should handle empty content with metadata", () => {
+    const result = injectMetadataFrontmatter("", {
+      displayName: "Aria",
     });
     expect(result).toBe(
-      "---\nname: NewName\ntone: formal\n---\n\n# Instructions",
+      "<!-- ZERO_PROFILE\nYour name is Aria.\nZERO_PROFILE -->\n",
     );
   });
 
-  it("should handle frontmatter with no trailing content", () => {
-    const content = "---\nkey: value\n---\n";
-    const result = injectMetadataFrontmatter(content, {
-      displayName: "Aria",
-    });
-    expect(result).toBe("---\nkey: value\nname: Aria\n---\n");
+  it("should describe all known tones correctly", () => {
+    for (const tone of ["professional", "friendly", "direct", "supportive"]) {
+      const result = injectMetadataFrontmatter("test", { sound: tone });
+      expect(result).toContain("Communicate in a ");
+      expect(result).toContain("tone.");
+    }
   });
 });
 
 describe("stripMetadataFrontmatter", () => {
-  it("should return content unchanged when no frontmatter", () => {
+  it("should return content unchanged when no profile block", () => {
     const content = "# Instructions\nDo stuff.";
     expect(stripMetadataFrontmatter(content)).toBe(content);
   });
 
-  it("should strip name and tone from frontmatter", () => {
+  it("should strip profile block", () => {
     const content =
-      "---\nname: Aria\ntone: professional\n---\n\n# Instructions";
+      "# Instructions\n\n<!-- ZERO_PROFILE\nYour name is Aria. Communicate in a clear, polished, and business-appropriate tone. This should be reflected in all your responses.\nZERO_PROFILE -->\n";
     expect(stripMetadataFrontmatter(content)).toBe("# Instructions");
   });
 
-  it("should preserve non-metadata frontmatter fields", () => {
+  it("should preserve content before profile block", () => {
     const content =
-      "---\nname: Aria\nvm0_secrets:\n  - API_KEY\ntone: friendly\n---\n\n# Instructions";
-    expect(stripMetadataFrontmatter(content)).toBe(
-      "---\nvm0_secrets:\n  - API_KEY\n---\n# Instructions",
-    );
+      "# Instructions\nDo stuff.\n\n<!-- ZERO_PROFILE\nYour name is Aria.\nZERO_PROFILE -->\n";
+    expect(stripMetadataFrontmatter(content)).toBe("# Instructions\nDo stuff.");
   });
 
-  it("should strip only metadata keys and keep the rest intact", () => {
-    const content = "---\ncustom: value\nname: Aria\n---\n\nBody text here.";
-    expect(stripMetadataFrontmatter(content)).toBe(
-      "---\ncustom: value\n---\nBody text here.",
-    );
+  it("should handle content with only profile block", () => {
+    const content = "<!-- ZERO_PROFILE\nYour name is Aria.\nZERO_PROFILE -->\n";
+    expect(stripMetadataFrontmatter(content)).toBe("");
   });
 
-  it("should handle frontmatter with only non-metadata keys", () => {
-    const content = "---\nvm0_secrets:\n  - KEY\n---\n\n# Instructions";
-    expect(stripMetadataFrontmatter(content)).toBe(
-      "---\nvm0_secrets:\n  - KEY\n---\n# Instructions",
-    );
-  });
-
-  it("should handle CRLF line endings in frontmatter delimiter", () => {
-    const content = "---\r\nname: Aria\r\n---\r\n\n# Instructions";
-    expect(stripMetadataFrontmatter(content)).toBe("# Instructions");
-  });
-
-  it("should be the inverse of injectMetadataFrontmatter for simple cases", () => {
+  it("should be the inverse of injectMetadataFrontmatter", () => {
     const original = "# Instructions\nDo stuff.";
     const injected = injectMetadataFrontmatter(original, {
       displayName: "Aria",
       sound: "professional",
     });
     expect(stripMetadataFrontmatter(injected)).toBe(original);
+  });
+
+  it("should strip legacy YAML frontmatter with name and tone", () => {
+    const content =
+      "---\nname: Boss\ntone: friendly\n---\n\n# Instructions\nDo stuff.";
+    expect(stripMetadataFrontmatter(content)).toBe("# Instructions\nDo stuff.");
+  });
+
+  it("should preserve non-metadata keys in legacy frontmatter", () => {
+    const content =
+      "---\nname: Boss\nvm0_secrets:\n  - API_KEY\ntone: friendly\n---\n\n# Instructions";
+    expect(stripMetadataFrontmatter(content)).toBe(
+      "---\nvm0_secrets:\n  - API_KEY\n---\n# Instructions",
+    );
+  });
+});
+
+describe("legacy migration", () => {
+  it("should replace old frontmatter with new profile block on inject", () => {
+    const content =
+      "---\nname: OldName\ntone: casual\n---\n\n# Instructions\nDo stuff.";
+    const result = injectMetadataFrontmatter(content, {
+      displayName: "NewName",
+      sound: "professional",
+    });
+    expect(result).not.toContain("---");
+    expect(result).toContain("<!-- ZERO_PROFILE");
+    expect(result).toContain("Your name is NewName.");
+    expect(result).toContain("# Instructions\nDo stuff.");
   });
 });

--- a/turbo/packages/core/src/instructions-frontmatter.ts
+++ b/turbo/packages/core/src/instructions-frontmatter.ts
@@ -5,8 +5,7 @@ interface AgentMetadata {
 
 const PROFILE_START = "<!-- ZERO_PROFILE";
 const PROFILE_END = "ZERO_PROFILE -->";
-const PROFILE_REGEX =
-  /<!-- ZERO_PROFILE\r?\n[\s\S]*?\r?\nZERO_PROFILE -->\r?\n?/g;
+const PROFILE_REGEX = /<!-- ZERO_PROFILE\n(?:[^\n]*\n)*?ZERO_PROFILE -->\n?/g;
 
 /** Keys used by the legacy YAML frontmatter format. */
 const LEGACY_METADATA_KEYS = new Set(["name", "tone"]);

--- a/turbo/packages/core/src/instructions-frontmatter.ts
+++ b/turbo/packages/core/src/instructions-frontmatter.ts
@@ -1,70 +1,21 @@
-import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
-
 interface AgentMetadata {
   displayName?: string;
   sound?: string;
 }
 
-const METADATA_KEY_MAP: Record<string, string> = {
-  displayName: "name",
-  sound: "tone",
-};
+const PROFILE_START = "<!-- ZERO_PROFILE";
+const PROFILE_END = "ZERO_PROFILE -->";
+const PROFILE_REGEX =
+  /<!-- ZERO_PROFILE\r?\n[\s\S]*?\r?\nZERO_PROFILE -->\r?\n?/g;
+
+/** Keys used by the legacy YAML frontmatter format. */
+const LEGACY_METADATA_KEYS = new Set(["name", "tone"]);
 
 /**
- * Inject agent metadata into instructions content as YAML frontmatter.
- *
- * - If metadata is undefined/null or has no truthy fields, returns content unchanged.
- * - If content already has frontmatter, merges metadata fields into it.
- * - If no existing frontmatter, prepends a new frontmatter block.
- *
- * Key mapping: displayName → name, sound → tone
+ * Strip legacy `---` YAML frontmatter that only contains our metadata keys
+ * (name, tone). If user-defined keys exist, only our keys are removed.
  */
-export function injectMetadataFrontmatter(
-  content: string,
-  metadata?: AgentMetadata | null,
-): string {
-  if (!metadata) {
-    return content;
-  }
-
-  const fields: Record<string, string> = {};
-  for (const [key, value] of Object.entries(metadata)) {
-    if (value && METADATA_KEY_MAP[key]) {
-      fields[METADATA_KEY_MAP[key]] = value;
-    }
-  }
-
-  if (Object.keys(fields).length === 0) {
-    return content;
-  }
-
-  const frontmatterMatch = content.match(
-    /^---\r?\n([\s\S]*?)\r?\n---(\r?\n|$)/,
-  );
-
-  if (frontmatterMatch) {
-    const existingYaml = frontmatterMatch[1] ?? "";
-    const parsed = (parseYaml(existingYaml) ?? {}) as Record<string, unknown>;
-    const merged = { ...parsed, ...fields };
-    const newYaml = stringifyYaml(merged).trimEnd();
-    const rest = content.slice(frontmatterMatch[0].length);
-    return `---\n${newYaml}\n---\n${rest}`;
-  }
-
-  const yaml = stringifyYaml(fields).trimEnd();
-  return `---\n${yaml}\n---\n\n${content}`;
-}
-
-/** Frontmatter keys injected by {@link injectMetadataFrontmatter}. */
-const METADATA_FRONTMATTER_KEYS: ReadonlySet<string> = Object.freeze(
-  new Set(Object.values(METADATA_KEY_MAP)),
-);
-
-/**
- * Strip only our metadata keys (name, tone) from frontmatter.
- * User-defined frontmatter fields are preserved.
- */
-export function stripMetadataFrontmatter(content: string): string {
+function stripLegacyFrontmatter(content: string): string {
   const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---(\r?\n|$)/);
   if (!match) {
     return content;
@@ -76,7 +27,7 @@ export function stripMetadataFrontmatter(content: string): string {
     .split("\n")
     .filter((line) => {
       const key = line.split(":")[0]?.trim();
-      return !key || !METADATA_FRONTMATTER_KEYS.has(key);
+      return !key || !LEGACY_METADATA_KEYS.has(key);
     })
     .join("\n")
     .trim();
@@ -85,4 +36,85 @@ export function stripMetadataFrontmatter(content: string): string {
     return body.replace(/^\n/, "");
   }
   return `---\n${remaining}\n---${body}`;
+}
+
+const TONE_DESCRIPTIONS: Record<string, string> = {
+  professional: "clear, polished, and business-appropriate",
+  friendly: "warm, approachable, and conversational",
+  direct: "concise, to the point, and no-nonsense",
+  supportive: "encouraging, empathetic, and reassuring",
+};
+
+function buildProfileParagraph(metadata: AgentMetadata): string | null {
+  const parts: string[] = [];
+
+  if (metadata.displayName) {
+    parts.push(`Your name is ${metadata.displayName}.`);
+  }
+
+  if (metadata.sound) {
+    const desc = TONE_DESCRIPTIONS[metadata.sound] ?? metadata.sound;
+    parts.push(
+      `Communicate in a ${desc} tone. This should be reflected in all your responses.`,
+    );
+  }
+
+  if (parts.length === 0) {
+    return null;
+  }
+
+  return parts.join(" ");
+}
+
+/**
+ * Inject agent metadata into instructions content as a hidden profile block.
+ *
+ * The block uses HTML comment syntax so it can be stripped before displaying
+ * in the instructions editor, while remaining readable to the agent at runtime.
+ *
+ * Format:
+ * ```
+ * <!-- ZERO_PROFILE
+ * Your name is Aria. Communicate in a clear, polished, and business-appropriate tone.
+ * This should be reflected in all your responses.
+ * ZERO_PROFILE -->
+ * ```
+ *
+ * - If metadata is undefined/null or has no truthy fields, returns content unchanged.
+ * - If content already has a profile block, replaces it.
+ * - Otherwise appends it at the end.
+ */
+export function injectMetadataFrontmatter(
+  content: string,
+  metadata?: AgentMetadata | null,
+): string {
+  if (!metadata) {
+    return content;
+  }
+
+  const paragraph = buildProfileParagraph(metadata);
+  if (!paragraph) {
+    return content;
+  }
+
+  const block = `${PROFILE_START}\n${paragraph}\n${PROFILE_END}`;
+
+  // Remove any existing profile block and legacy frontmatter first
+  const stripped = stripLegacyFrontmatter(content)
+    .replace(PROFILE_REGEX, "")
+    .trimEnd();
+
+  if (!stripped) {
+    return `${block}\n`;
+  }
+
+  return `${stripped}\n\n${block}\n`;
+}
+
+/**
+ * Strip the hidden profile block (and legacy YAML frontmatter) from
+ * instructions content for display in the editor.
+ */
+export function stripMetadataFrontmatter(content: string): string {
+  return stripLegacyFrontmatter(content).replace(PROFILE_REGEX, "").trim();
 }


### PR DESCRIPTION
## Summary

- Add searchable recent chat list in the Zero sidebar with session navigation and filtering
- Implement file upload/attachment support via new `/api/agent/uploads` endpoint using S3 presigned URLs
- Add session switching with loading states and chat history restoration
- Improve agent complete webhook to update session preview text
- Enhance instructions frontmatter parsing robustness

## Test plan

- [ ] Verify recent chat list appears in sidebar and sessions are clickable
- [ ] Test search/filter functionality in recent chats
- [ ] Test file attachment upload flow (drag-and-drop / button)
- [ ] Verify session switching loads correct chat history
- [ ] Confirm agent complete webhook updates session preview
- [ ] Test instructions frontmatter parsing with edge cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)