### PR TITLE
fix: add explicit file size limits to storage upload handlers

### DIFF
--- a/crates/guest-agent/src/http.rs
+++ b/crates/guest-agent/src/http.rs
@@ -58,14 +58,34 @@ pub async fn post_json(
             }
             Ok(resp) => {
                 let status = resp.status();
+                // 4xx errors (except 429) are deterministic — retrying won't help
+                if status.is_client_error() && status.as_u16() != HTTP_TOO_MANY_REQUESTS {
+                    // Try to extract error message from response body
+                    let error_msg = resp
+                        .text()
+                        .await
+                        .ok()
+                        .and_then(|body| serde_json::from_str::<Value>(&body).ok())
+                        .and_then(|v| v.get("error")?.get("message")?.as_str().map(String::from));
+
+                    return match error_msg {
+                        Some(msg) => {
+                            log_warn!(LOG_TAG, "HTTP POST failed: HTTP {status} — {msg}",);
+                            Err(AgentError::Http(format!("POST {url}: {msg}")))
+                        }
+                        None => {
+                            log_warn!(
+                                LOG_TAG,
+                                "HTTP POST failed (attempt {attempt}/{max_retries}): HTTP {status}",
+                            );
+                            Err(AgentError::Http(format!("POST {url}: HTTP {status}")))
+                        }
+                    };
+                }
                 log_warn!(
                     LOG_TAG,
                     "HTTP POST failed (attempt {attempt}/{max_retries}): HTTP {status}",
                 );
-                // 4xx errors (except 429) are deterministic — retrying won't help
-                if status.is_client_error() && status.as_u16() != HTTP_TOO_MANY_REQUESTS {
-                    return Err(AgentError::Http(format!("POST {url}: HTTP {status}")));
-                }
             }
             Err(e) => {
                 log_warn!(

--- a/turbo/apps/web/app/api/storages/prepare/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/storages/prepare/__tests__/route.test.ts
@@ -206,6 +206,83 @@ describe("POST /api/storages/prepare", () => {
     );
   });
 
+  describe("file size limits", () => {
+    it("should return 413 when a single file exceeds 100MB", async () => {
+      const storageName = `oversize-single-${Date.now()}`;
+
+      const request = createTestRequest(
+        "http://localhost:3000/api/storages/prepare",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            storageName,
+            storageType: "artifact",
+            files: [
+              {
+                path: "large-file.bin",
+                hash: "f".repeat(64),
+                size: 104_857_601,
+              },
+            ],
+          }),
+        },
+      );
+
+      const response = await POST(request);
+      expect(response.status).toBe(400);
+    });
+
+    it("should return 413 when total file size exceeds 100MB", async () => {
+      const storageName = `oversize-total-${Date.now()}`;
+
+      const request = createTestRequest(
+        "http://localhost:3000/api/storages/prepare",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            storageName,
+            storageType: "artifact",
+            files: [
+              { path: "file1.bin", hash: "a".repeat(64), size: 60_000_000 },
+              { path: "file2.bin", hash: "b".repeat(64), size: 60_000_000 },
+            ],
+          }),
+        },
+      );
+
+      const response = await POST(request);
+      expect(response.status).toBe(413);
+      const json = await response.json();
+      expect(json.error.code).toBe("PAYLOAD_TOO_LARGE");
+      expect(json.error.message).toContain("100MB");
+    });
+
+    it("should accept files within the 100MB limit", async () => {
+      const storageName = `within-limit-${Date.now()}`;
+
+      const request = createTestRequest(
+        "http://localhost:3000/api/storages/prepare",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            storageName,
+            storageType: "artifact",
+            files: [
+              { path: "file1.bin", hash: "a".repeat(64), size: 50_000_000 },
+              { path: "file2.bin", hash: "b".repeat(64), size: 50_000_000 },
+            ],
+          }),
+        },
+      );
+
+      const response = await POST(request);
+      expect(response.status).toBe(200);
+    });
+  });
+
   describe("content hash behavior", () => {
     it("should produce same version ID regardless of file order", async () => {
       const storageName = `order-independent-${Date.now()}`;

--- a/turbo/apps/web/app/api/storages/prepare/route.ts
+++ b/turbo/apps/web/app/api/storages/prepare/route.ts
@@ -3,7 +3,11 @@ import {
   tsr,
   createSafeErrorHandler,
 } from "../../../../src/lib/ts-rest-handler";
-import { storagesPrepareContract, VOLUME_SCOPE_USER_ID } from "@vm0/core";
+import {
+  storagesPrepareContract,
+  VOLUME_SCOPE_USER_ID,
+  MAX_FILE_SIZE_BYTES,
+} from "@vm0/core";
 import { initServices } from "../../../../src/lib/init-services";
 import { agentRuns } from "../../../../src/db/schema/agent-run";
 import { storages, storageVersions } from "../../../../src/db/schema/storage";
@@ -117,6 +121,23 @@ const router = tsr.router(storagesPrepareContract, {
       baseVersion,
       changes,
     } = body;
+
+    // Validate total declared file size (100MB per-file limit is enforced by schema)
+    const totalDeclaredSize = files.reduce(
+      (sum: number, f: { size: number }) => sum + f.size,
+      0,
+    );
+    if (totalDeclaredSize > MAX_FILE_SIZE_BYTES) {
+      return {
+        status: 413 as const,
+        body: {
+          error: {
+            message: "Upload rejected: total file size exceeds 100MB limit",
+            code: "PAYLOAD_TOO_LARGE",
+          },
+        },
+      };
+    }
 
     log.debug(
       `Preparing upload for "${storageName}" (type: ${storageType}), ${files.length} files`,

--- a/turbo/apps/web/app/api/webhooks/agent/storages/prepare/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/storages/prepare/__tests__/route.test.ts
@@ -115,6 +115,39 @@ describe("POST /api/webhooks/agent/storages/prepare", () => {
     );
   });
 
+  it("should return 413 when total file size exceeds 100MB", async () => {
+    const storageName = uniqueId("webhook-oversize");
+
+    const request = makePrepareRequest(testRunId, testToken, {
+      storageName,
+      storageType: "volume",
+      files: [
+        { path: "file1.bin", hash: "a".repeat(64), size: 60_000_000 },
+        { path: "file2.bin", hash: "b".repeat(64), size: 60_000_000 },
+      ],
+    });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(413);
+    const json = await response.json();
+    expect(json.error.code).toBe("PAYLOAD_TOO_LARGE");
+    expect(json.error.message).toContain("100MB");
+  });
+
+  it("should reject single file exceeding 100MB via schema validation", async () => {
+    const storageName = uniqueId("webhook-single-oversize");
+
+    const request = makePrepareRequest(testRunId, testToken, {
+      storageName,
+      storageType: "volume",
+      files: [{ path: "huge.bin", hash: "f".repeat(64), size: 104_857_601 }],
+    });
+
+    const response = await POST(request);
+    expect(response.status).toBe(400);
+  });
+
   it("should return existing=true for deduplicated version", async () => {
     const storageName = uniqueId("webhook-dedup");
     const files = [{ path: "test.txt", hash: "b".repeat(64), size: 100 }];

--- a/turbo/apps/web/app/api/webhooks/agent/storages/prepare/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/storages/prepare/route.ts
@@ -6,6 +6,7 @@ import {
 import {
   webhookStoragesPrepareContract,
   VOLUME_SCOPE_USER_ID,
+  MAX_FILE_SIZE_BYTES,
 } from "@vm0/core";
 import { initServices } from "../../../../../../src/lib/init-services";
 import { agentRuns } from "../../../../../../src/db/schema/agent-run";
@@ -56,6 +57,23 @@ const router = tsr.router(webhookStoragesPrepareContract, {
     }
 
     const { userId } = auth;
+
+    // Validate total declared file size (100MB per-file limit is enforced by schema)
+    const totalDeclaredSize = files.reduce(
+      (sum: number, f: { size: number }) => sum + f.size,
+      0,
+    );
+    if (totalDeclaredSize > MAX_FILE_SIZE_BYTES) {
+      return {
+        status: 413 as const,
+        body: {
+          error: {
+            message: "Upload rejected: total file size exceeds 100MB limit",
+            code: "PAYLOAD_TOO_LARGE",
+          },
+        },
+      };
+    }
 
     log.debug(
       `Preparing upload for "${storageName}" (type: ${storageType}), ${files.length} files, run: ${runId}`,

--- a/turbo/packages/core/src/contracts/errors.ts
+++ b/turbo/packages/core/src/contracts/errors.ts
@@ -10,6 +10,7 @@ export const ApiError = {
   FORBIDDEN: { status: 403 as const, code: "FORBIDDEN" },
   NOT_FOUND: { status: 404 as const, code: "NOT_FOUND" },
   CONFLICT: { status: 409 as const, code: "CONFLICT" },
+  PAYLOAD_TOO_LARGE: { status: 413 as const, code: "PAYLOAD_TOO_LARGE" },
   TOO_MANY_REQUESTS: { status: 429 as const, code: "TOO_MANY_REQUESTS" },
   INTERNAL_SERVER_ERROR: {
     status: 500 as const,

--- a/turbo/packages/core/src/contracts/index.ts
+++ b/turbo/packages/core/src/contracts/index.ts
@@ -108,6 +108,7 @@ export {
   storageTypeSchema,
   uploadStorageResponseSchema,
   // Direct upload schemas (shared with webhooks)
+  MAX_FILE_SIZE_BYTES,
   fileEntryWithHashSchema,
   storageChangesSchema,
   presignedUploadSchema,

--- a/turbo/packages/core/src/contracts/storages.ts
+++ b/turbo/packages/core/src/contracts/storages.ts
@@ -108,12 +108,21 @@ export type StoragesContract = typeof storagesContract;
 // ============================================================================
 
 /**
+ * Maximum file size per file in bytes (100MB)
+ */
+export const MAX_FILE_SIZE_BYTES = 104_857_600;
+
+/**
  * File entry with hash for content-addressable storage
  */
 export const fileEntryWithHashSchema = z.object({
   path: z.string().min(1, "File path is required"),
   hash: z.string().length(64, "Hash must be SHA-256 (64 hex chars)"),
-  size: z.number().int().min(0, "Size must be non-negative"),
+  size: z
+    .number()
+    .int()
+    .min(0, "Size must be non-negative")
+    .max(MAX_FILE_SIZE_BYTES, "File size exceeds 100MB limit"),
 });
 
 /**
@@ -173,6 +182,7 @@ export const storagesPrepareContract = c.router({
       400: apiErrorSchema,
       401: apiErrorSchema,
       404: apiErrorSchema,
+      413: apiErrorSchema,
       500: apiErrorSchema,
     },
     summary: "Prepare for direct S3 upload",
@@ -213,6 +223,7 @@ export const storagesCommitContract = c.router({
       401: apiErrorSchema,
       404: apiErrorSchema,
       409: apiErrorSchema, // S3 files missing
+      413: apiErrorSchema,
       500: apiErrorSchema,
     },
     summary: "Commit uploaded storage",

--- a/turbo/packages/core/src/contracts/webhooks.ts
+++ b/turbo/packages/core/src/contracts/webhooks.ts
@@ -381,6 +381,7 @@ export const webhookStoragesPrepareContract = c.router({
       400: apiErrorSchema,
       401: apiErrorSchema,
       404: apiErrorSchema,
+      413: apiErrorSchema,
       500: apiErrorSchema,
     },
     summary: "Prepare for direct S3 upload from sandbox",
@@ -419,6 +420,7 @@ export const webhookStoragesCommitContract = c.router({
       401: apiErrorSchema,
       404: apiErrorSchema,
       409: apiErrorSchema, // S3 files missing
+      413: apiErrorSchema,
       500: apiErrorSchema,
     },
     summary: "Commit uploaded storage from sandbox",


### PR DESCRIPTION
## Summary
- Add per-file (100MB) size limit to `fileEntryWithHashSchema` via Zod `.max()` — enforced across all 4 storage endpoints automatically
- Add total declared size validation in both CLI and webhook prepare handlers, returning 413 with actionable error message
- Add `413: apiErrorSchema` response to all 4 ts-rest contracts (prepare + commit, CLI + webhook)
- Add `PAYLOAD_TOO_LARGE` to the `ApiError` error map
- Update guest-agent `post_json()` to parse error response bodies on 4xx, propagating API error messages instead of bare HTTP status codes
- Add integration tests for size limit enforcement (over-limit rejected, under-limit accepted) for both CLI and webhook variants

Closes #4576

## Test plan
- [x] CLI prepare: single file exceeding 100MB returns 400 (schema validation)
- [x] CLI prepare: total size exceeding 100MB returns 413
- [x] CLI prepare: files within limit return 200
- [x] Webhook prepare: total size exceeding 100MB returns 413
- [x] Webhook prepare: single file exceeding 100MB returns 400 (schema validation)
- [x] All existing prepare/commit tests continue to pass
- [x] Rust guest-agent compiles and passes clippy

🤖 Generated with [Claude Code](https://claude.com/claude-code)