### PR TITLE
refactor: remove sni mode dead code from network logging

### DIFF
--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -1,14 +1,13 @@
 #!/usr/bin/env python3
 """
-mitmproxy addon for VM0 runner-level network security mode.
+mitmproxy addon for VM0 runner-level network proxy.
 
 This addon runs on the runner HOST (not inside VMs) and:
 1. Intercepts all HTTPS requests from VMs
 2. Looks up the source VM's runId and firewall rules from the proxy registry
 3. Evaluates firewall rules (first-match-wins) to ALLOW or DENY
-4. For MITM mode: Rewrites requests to go through VM0 Proxy endpoint
-5. For SNI-only mode: Passes through or blocks without decryption
-6. Logs network activity per-run to JSONL files
+4. Injects auth headers for configured services (proxy-side token replacement)
+5. Logs network activity per-run to JSONL files
 """
 import os
 import json

--- a/crates/runner/src/network_logs.rs
+++ b/crates/runner/src/network_logs.rs
@@ -112,16 +112,6 @@ mod tests {
     use super::*;
 
     #[test]
-    fn network_log_deserializes_sni() {
-        let json = r#"{"timestamp":"2026-02-15T10:00:00","mode":"sni","action":"ALLOW","host":"example.com","port":443,"rule_matched":"domain:*.example.com"}"#;
-        let log: NetworkLog = serde_json::from_str(json).unwrap();
-        assert_eq!(log.timestamp, "2026-02-15T10:00:00");
-        assert_eq!(log.mode.as_deref(), Some("sni"));
-        assert_eq!(log.host.as_deref(), Some("example.com"));
-        assert!(log.method.is_none());
-    }
-
-    #[test]
     fn network_log_deserializes_mitm() {
         let json = r#"{"timestamp":"2026-02-15T10:00:00","mode":"mitm","action":"ALLOW","host":"api.example.com","port":443,"rule_matched":"domain:*.example.com","method":"GET","url":"https://api.example.com/data","status":200,"latency_ms":150,"request_size":0,"response_size":1024,"resp_content_type":"application/json","resp_content_encoding":"gzip","resp_transfer_encoding":"chunked"}"#;
         let log: NetworkLog = serde_json::from_str(json).unwrap();
@@ -135,12 +125,13 @@ mod tests {
 
     #[test]
     fn network_log_round_trip() {
-        let json = r#"{"timestamp":"2026-02-15T10:00:00","mode":"sni","action":"DENY","host":"evil.com","port":443,"rule_matched":"final"}"#;
+        let json = r#"{"timestamp":"2026-02-15T10:00:00","mode":"mitm","action":"DENY","host":"evil.com","port":443,"rule_matched":"final","method":"GET","url":"https://evil.com","status":403,"latency_ms":5,"request_size":0,"response_size":0}"#;
         let log: NetworkLog = serde_json::from_str(json).unwrap();
         let reserialized = serde_json::to_value(&log).unwrap();
         assert_eq!(reserialized["timestamp"], "2026-02-15T10:00:00");
         assert_eq!(reserialized["action"], "DENY");
-        assert!(reserialized.get("method").is_none());
+        assert_eq!(reserialized["mode"], "mitm");
+        assert_eq!(reserialized["method"], "GET");
     }
 
     #[test]

--- a/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
@@ -735,36 +735,7 @@ describe("logs command", () => {
   });
 
   describe("network logs", () => {
-    it("should display SNI network logs with --network flag", async () => {
-      server.use(
-        http.get(
-          "http://localhost:3000/api/agent/runs/:id/telemetry/network",
-          () => {
-            return HttpResponse.json({
-              networkLogs: [
-                {
-                  timestamp: "2024-01-15T10:30:00Z",
-                  mode: "sni",
-                  host: "api.example.com",
-                  port: 443,
-                  action: "ALLOW",
-                  rule_matched: "allowlist",
-                },
-              ],
-              hasMore: false,
-            });
-          },
-        ),
-      );
-
-      await logsCommand.parseAsync(["node", "cli", "run-123", "--network"]);
-
-      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
-      expect(logCalls).toContain("api.example.com");
-      expect(logCalls).toContain("443");
-    });
-
-    it("should display MITM network logs", async () => {
+    it("should display network logs with --network flag", async () => {
       server.use(
         http.get(
           "http://localhost:3000/api/agent/runs/:id/telemetry/network",
@@ -813,7 +784,6 @@ describe("logs command", () => {
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("No network logs found");
-      expect(logCalls).toContain("experimental_firewall");
     });
   });
 
@@ -1095,7 +1065,9 @@ describe("logs command", () => {
               networkLogs: [
                 {
                   timestamp: "2024-01-15T10:30:00Z",
-                  mode: "sni",
+                  mode: "mitm",
+                  method: "GET",
+                  status: 200,
                   host: "api.example.com",
                   port: 443,
                   action: "ALLOW",

--- a/turbo/apps/cli/src/commands/logs/index.ts
+++ b/turbo/apps/cli/src/commands/logs/index.ts
@@ -64,19 +64,9 @@ function formatMetric(metric: TelemetryMetric): string {
 }
 
 /**
- * Format an SNI-mode network log entry (no HTTPS decryption, only host/port/action)
+ * Format a network log entry with full HTTP details
  */
-function formatSniLog(entry: NetworkLogEntry): string {
-  const actionColor = entry.action === "ALLOW" ? chalk.green : chalk.red;
-  const host = entry.host || "unknown";
-  const port = entry.port || 443;
-  return `[${entry.timestamp}] ${chalk.cyan("SNI")} ${actionColor(entry.action || "ALLOW")} ${host}:${port} ${chalk.dim(entry.rule_matched || "")}`;
-}
-
-/**
- * Format a MITM-mode network log entry (full HTTP details including method, status, latency, sizes)
- */
-function formatMitmLog(entry: NetworkLogEntry): string {
+function formatNetworkLog(entry: NetworkLogEntry): string {
   // Color status code based on HTTP status
   let statusColor: typeof chalk.green;
   const status = entry.status || 0;
@@ -107,16 +97,6 @@ function formatMitmLog(entry: NetworkLogEntry): string {
   const url = entry.url || entry.host || "unknown";
 
   return `[${entry.timestamp}] ${method.padEnd(6)} ${statusColor(status)} ${latencyColor(latencyMs + "ms")} ${formatBytes(requestSize)}/${formatBytes(responseSize)} ${chalk.dim(url)}`;
-}
-
-/**
- * Format a single network log entry
- */
-function formatNetworkLog(entry: NetworkLogEntry): string {
-  if (entry.mode === "sni" || !entry.method) {
-    return formatSniLog(entry);
-  }
-  return formatMitmLog(entry);
 }
 
 /**
@@ -510,7 +490,7 @@ async function showNetworkLogs(
   if (firstResponse.networkLogs.length === 0) {
     console.log(
       chalk.yellow(
-        "No network logs found for this run. Network logs are only captured when experimental_firewall is enabled on an experimental_runner",
+        "No network logs found for this run. Network logs are only captured when using a runner with proxy enabled",
       ),
     );
     return;

--- a/turbo/apps/web/app/api/agent/runs/[id]/telemetry/network/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/telemetry/network/route.ts
@@ -14,21 +14,17 @@ import {
   DATASETS,
 } from "../../../../../../../src/lib/axiom";
 /**
- * Axiom network event supports two modes:
- * - sni: SNI-only mode (no HTTPS decryption, only host/port/action)
- * - mitm: MITM mode (full HTTP details including method, status, latency, sizes)
+ * Axiom network event (MITM proxy)
  */
 interface AxiomNetworkEvent {
   _time: string;
   runId: string;
   userId: string;
-  // Common fields (all modes)
-  mode?: "mitm" | "sni";
+  mode?: "mitm";
   action?: "ALLOW" | "DENY";
   host?: string;
   port?: number;
   rule_matched?: string | null;
-  // MITM-only fields (optional)
   method?: string;
   url?: string;
   status?: number;
@@ -87,16 +83,13 @@ ${sinceFilter}
     const hasMore = events.length > limit;
     const records = hasMore ? events.slice(0, limit) : events;
 
-    // Transform to API response format (supports both SNI-only and MITM modes)
     const networkLogs = records.map((e) => ({
       timestamp: e._time,
-      // Common fields (all modes)
       mode: e.mode,
       action: e.action,
       host: e.host,
       port: e.port,
       rule_matched: e.rule_matched,
-      // MITM-only fields (may be undefined for SNI-only mode)
       method: e.method,
       url: e.url,
       status: e.status,

--- a/turbo/apps/web/app/api/webhooks/agent/telemetry/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/telemetry/route.ts
@@ -108,22 +108,18 @@ const router = tsr.router(webhookTelemetryContract, {
     }
 
     // Ingest network logs to Axiom (fire-and-forget)
-    // Supports both SNI-only mode (basic connection info) and MITM mode (full HTTP details)
     if (body.networkLogs && body.networkLogs.length > 0) {
       const axiomDataset = getDatasetName(DATASETS.SANDBOX_TELEMETRY_NETWORK);
-      // Network logs are already masked by client
       const axiomEvents = body.networkLogs.map(
         (netLog: Record<string, unknown>) => ({
           _time: netLog.timestamp,
           runId: body.runId,
           userId: auth.userId,
-          // Common fields (all modes)
           mode: netLog.mode,
           action: netLog.action,
           host: netLog.host,
           port: netLog.port,
           rule_matched: netLog.rule_matched,
-          // MITM-only fields (may be undefined for SNI-only mode)
           method: netLog.method,
           url: netLog.url,
           status: netLog.status,

--- a/turbo/packages/core/src/contracts/runs.ts
+++ b/turbo/packages/core/src/contracts/runs.ts
@@ -321,21 +321,15 @@ const agentEventsResponseSchema = z.object({
 });
 
 /**
- * Network log entry schema
- *
- * Supports two modes:
- * - sni: SNI-only mode (no HTTPS decryption, only host/port/action)
- * - mitm: MITM mode (full HTTP details including method, status, latency, sizes)
+ * Network log entry schema (MITM proxy)
  */
 const networkLogEntrySchema = z.object({
   timestamp: z.string(),
-  // Common fields (all modes)
-  mode: z.enum(["mitm", "sni"]).optional(),
+  mode: z.literal("mitm").optional(),
   action: z.enum(["ALLOW", "DENY"]).optional(),
   host: z.string().optional(),
   port: z.number().optional(),
   rule_matched: z.string().nullable().optional(),
-  // MITM-only fields (optional)
   method: z.string().optional(),
   url: z.string().optional(),
   status: z.number().optional(),

--- a/turbo/packages/core/src/contracts/webhooks.ts
+++ b/turbo/packages/core/src/contracts/webhooks.ts
@@ -288,20 +288,14 @@ const sandboxOperationSchema = z.object({
 
 /**
  * Network log entry schema (from mitmproxy addon)
- *
- * Supports two modes:
- * - sni: SNI-only mode (no HTTPS decryption, only host/port/action)
- * - mitm: MITM mode (full HTTP details including method, status, latency, sizes)
  */
 const networkLogSchema = z.object({
   timestamp: z.string(),
-  // Common fields (all modes)
-  mode: z.enum(["mitm", "sni"]).optional(),
+  mode: z.literal("mitm").optional(),
   action: z.enum(["ALLOW", "DENY"]).optional(),
   host: z.string().optional(),
   port: z.number().optional(),
   rule_matched: z.string().nullable().optional(),
-  // MITM-only fields (optional)
   method: z.string().optional(),
   url: z.string().optional(),
   status: z.number().optional(),


### PR DESCRIPTION
## Summary
- Remove `formatSniLog()` function from CLI — proxy always runs in MITM mode now
- Change `mode` from `z.enum(["mitm", "sni"])` to `z.literal("mitm")` in network log contracts
- Remove SNI-specific test fixtures and Rust deserialization test
- Update empty network logs message to not reference `experimental_firewall`
- Clean up "two modes" comments across contracts and API routes

Follows phase 2 (#4568) which removed `experimental_mitm` toggle. SNI mode is no longer produced by the proxy, so all SNI code paths are dead.

## Test plan
- [x] Rust `cargo test network_log` — 4 passed
- [x] CLI `logs/__tests__/index.test.ts` — 40 passed
- [x] Knip — no unused exports
- [x] Lint (core, cli) — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)