### PR TITLE
fix(cli): handle epipe gracefully when piped output closes early

### DIFF
--- a/turbo/apps/cli/src/__tests__/instrument.test.ts
+++ b/turbo/apps/cli/src/__tests__/instrument.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Tests for instrument.ts EPIPE handling
+ *
+ * Tests process-level behavior following CLI testing principles:
+ * - Entry point: instrument.ts side-effect import (CLI initialization)
+ * - Mock (external): None
+ * - Real (internal): process.stdout/stderr error event handlers
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Import instrument.ts to register the EPIPE handler as a side effect
+import "../instrument";
+
+describe("EPIPE handling", () => {
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+
+  beforeEach(() => {
+    mockExit.mockClear();
+  });
+
+  it("should exit cleanly when stdout encounters EPIPE", () => {
+    const epipeError: NodeJS.ErrnoException = new Error("write EPIPE");
+    epipeError.code = "EPIPE";
+
+    expect(() => {
+      process.stdout.emit("error", epipeError);
+    }).toThrow("process.exit called");
+
+    expect(mockExit).toHaveBeenCalledWith(0);
+  });
+
+  it("should exit cleanly when stderr encounters EPIPE", () => {
+    const epipeError: NodeJS.ErrnoException = new Error("write EPIPE");
+    epipeError.code = "EPIPE";
+
+    expect(() => {
+      process.stderr.emit("error", epipeError);
+    }).toThrow("process.exit called");
+
+    expect(mockExit).toHaveBeenCalledWith(0);
+  });
+
+  it("should re-throw non-EPIPE errors on stdout", () => {
+    const otherError: NodeJS.ErrnoException = new Error("some other error");
+    otherError.code = "EACCES";
+
+    expect(() => {
+      process.stdout.emit("error", otherError);
+    }).toThrow("some other error");
+
+    expect(mockExit).not.toHaveBeenCalled();
+  });
+
+  it("should re-throw non-EPIPE errors on stderr", () => {
+    const otherError: NodeJS.ErrnoException = new Error("permission denied");
+    otherError.code = "EACCES";
+
+    expect(() => {
+      process.stderr.emit("error", otherError);
+    }).toThrow("permission denied");
+
+    expect(mockExit).not.toHaveBeenCalled();
+  });
+});

--- a/turbo/apps/cli/src/instrument.ts
+++ b/turbo/apps/cli/src/instrument.ts
@@ -93,3 +93,15 @@ if (DSN) {
     os_release: os.release(),
   });
 }
+
+// Handle EPIPE gracefully — occurs when piped output is closed early
+// (e.g., `vm0 logs ... | head`). Exit cleanly per Unix convention.
+function handleEpipe(err: NodeJS.ErrnoException) {
+  if (err.code === "EPIPE") {
+    process.exit(0);
+  }
+  throw err;
+}
+
+process.stdout.on("error", handleEpipe);
+process.stderr.on("error", handleEpipe);


### PR DESCRIPTION
## Summary

- Add process-level EPIPE error handler for stdout/stderr in CLI instrument setup
- When pipe reader closes early (e.g., `vm0 logs ... | head`), exit cleanly with code 0 instead of crashing with uncaught exception
- Standard Unix behavior for broken pipes

## Test plan

- [x] All 921 CLI tests pass
- [ ] Manual: `vm0 logs <run-id> --all | head -5` exits cleanly without error

Fixes CLI-E

🤖 Generated with [Claude Code](https://claude.com/claude-code)