### PR TITLE
refactor(services): pass encryptedSecrets in claim response to runner

### DIFF
--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -652,6 +652,7 @@ mod tests {
             environment: None,
             resume_session: None,
             secret_values: None,
+            encrypted_secrets: None,
             cli_agent_type: String::new(),
             experimental_firewall: None,
             debug_no_mock_claude: None,

--- a/crates/runner/src/provider/local.rs
+++ b/crates/runner/src/provider/local.rs
@@ -149,6 +149,7 @@ impl JobProvider for LocalProvider {
             environment: req.environment,
             resume_session: None,
             secret_values: None,
+            encrypted_secrets: None,
             cli_agent_type: req.cli_agent_type,
             experimental_firewall: None,
             debug_no_mock_claude: None,

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -51,6 +51,10 @@ pub struct ExecutionContext {
     pub resume_session: Option<ResumeSession>,
     #[serde(default)]
     pub secret_values: Option<Vec<String>>,
+    // Not yet used by runner — forwarded to mitm-addon for auth resolution
+    #[allow(dead_code)]
+    #[serde(default)]
+    pub encrypted_secrets: Option<String>,
     pub cli_agent_type: String,
     #[serde(default)]
     pub experimental_firewall: Option<ExperimentalFirewall>,

--- a/turbo/apps/web/app/api/runners/jobs/[id]/claim/route.ts
+++ b/turbo/apps/web/app/api/runners/jobs/[id]/claim/route.ts
@@ -194,7 +194,8 @@ const router = tsr.router(runnersJobClaimContract, {
         storageManifest: storedContext.storageManifest,
         environment: storedContext.environment,
         resumeSession: storedContext.resumeSession,
-        secretValues, // Decrypted secrets
+        secretValues, // Decrypted secret values for log masking
+        encryptedSecrets: storedContext.encryptedSecrets, // Encrypted blob for auth resolution
         cliAgentType: storedContext.cliAgentType,
         experimentalFirewall: storedContext.experimentalFirewall,
         experimentalServices: storedContext.experimentalServices,

--- a/turbo/packages/core/src/contracts/runners.ts
+++ b/turbo/packages/core/src/contracts/runners.ts
@@ -174,6 +174,8 @@ export const executionContextSchema = z.object({
   environment: z.record(z.string(), z.string()).nullable(),
   resumeSession: resumeSessionSchema.nullable(),
   secretValues: z.array(z.string()).nullable(),
+  // AES-256-GCM encrypted Record<string, string> — passed through to mitm-addon for auth resolution
+  encryptedSecrets: z.string().nullable(),
   cliAgentType: z.string(),
   // Experimental firewall configuration
   experimentalFirewall: experimentalFirewallSchema.optional(),


### PR DESCRIPTION
## Summary

- Add `encryptedSecrets` field to `executionContextSchema` (claim response) so the runner receives the encrypted secrets blob
- Claim endpoint now returns `storedContext.encryptedSecrets` alongside `secretValues`
- Add `encrypted_secrets: Option<String>` to Rust `ExecutionContext` struct
- Update test helper and local provider constructions

Part of #4593 (PR 1/4). Closes #4595.

## Test plan

- [x] Rust `cargo check -p runner` passes
- [x] Rust `cargo test -p runner` — 188 tests pass
- [x] TS secrets encryption tests — 10 tests pass
- [x] All pre-commit hooks pass (fmt, clippy, prettier, knip, commitlint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)