### PR TITLE
refactor(services): forward encryptedSecrets through proxy registry

### DIFF
--- a/crates/runner/src/cmd/benchmark.rs
+++ b/crates/runner/src/cmd/benchmark.rs
@@ -176,6 +176,7 @@ async fn run_sandbox(
         firewall_rules: &[],
         network_log_path: &network_log_path,
         services: None,
+        encrypted_secrets: None,
     };
     if let Err(e) = mitm.register_vm(&source_ip, &registration).await {
         warn!(error = %e, "failed to register VM in proxy");

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -129,6 +129,7 @@ async fn execute_inner(
             firewall_rules: fw.and_then(|f| f.rules.as_deref()).unwrap_or(&[]),
             network_log_path: &network_log_path,
             services: context.experimental_services.as_ref(),
+            encrypted_secrets: context.encrypted_secrets.as_deref(),
         };
         if let Err(e) = config.registry.register_vm(&source_ip, &registration).await {
             warn!(run_id = %context.run_id, error = %e, "failed to register VM in proxy");

--- a/crates/runner/src/proxy.rs
+++ b/crates/runner/src/proxy.rs
@@ -807,4 +807,50 @@ mod tests {
             "https://gmail.googleapis.com/gmail/v1/users/me"
         );
     }
+
+    #[tokio::test]
+    async fn register_vm_stores_encrypted_secrets() {
+        let dir = tempfile::tempdir().unwrap();
+        let registry_path = dir.path().join("proxy-registry.json");
+        let lock_path = dir.path().join("proxy-registry.lock");
+
+        let empty = ProxyRegistry {
+            vms: HashMap::new(),
+            updated_at: 0,
+        };
+        write_registry(&registry_path, &empty).await.unwrap();
+
+        let handle = ProxyRegistryHandle {
+            registry_path: registry_path.clone(),
+            lock_path,
+        };
+
+        let registration = VmRegistration {
+            run_id: "run-enc",
+            sandbox_token: "tok",
+            firewall_rules: &[],
+            network_log_path: std::path::Path::new("/tmp/network-run-enc.jsonl"),
+            services: None,
+            encrypted_secrets: Some("iv_b64:tag_b64:data_b64"),
+        };
+        handle
+            .register_vm("10.200.0.6", &registration)
+            .await
+            .unwrap();
+
+        let loaded = read_registry(&registry_path).await.unwrap();
+        let vm = loaded.vms.get("10.200.0.6").unwrap();
+        assert_eq!(
+            vm.encrypted_secrets.as_deref(),
+            Some("iv_b64:tag_b64:data_b64")
+        );
+
+        // Verify JSON key name matches what the Python addon expects.
+        let raw = tokio::fs::read_to_string(&registry_path).await.unwrap();
+        let value: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        assert_eq!(
+            value["vms"]["10.200.0.6"]["encryptedSecrets"],
+            "iv_b64:tag_b64:data_b64"
+        );
+    }
 }

--- a/crates/runner/src/proxy.rs
+++ b/crates/runner/src/proxy.rs
@@ -27,6 +27,7 @@ struct VmEntry {
     firewall_rules: Vec<FirewallRule>,
     network_log_path: String,
     services: Option<crate::types::ExperimentalServices>,
+    encrypted_secrets: Option<String>,
 }
 
 /// Firewall rule for network filtering (first-match-wins).
@@ -63,6 +64,7 @@ pub struct VmRegistration<'a> {
     pub firewall_rules: &'a [FirewallRule],
     pub network_log_path: &'a std::path::Path,
     pub services: Option<&'a crate::types::ExperimentalServices>,
+    pub encrypted_secrets: Option<&'a str>,
 }
 
 /// Embedded mitmproxy addon script (compiled into the binary).
@@ -432,6 +434,7 @@ impl ProxyRegistryHandle {
                 firewall_rules: registration.firewall_rules.to_vec(),
                 network_log_path: registration.network_log_path.to_string_lossy().into_owned(),
                 services: registration.services.cloned(),
+                encrypted_secrets: registration.encrypted_secrets.map(String::from),
             },
         );
         registry.updated_at = now;
@@ -507,6 +510,7 @@ mod tests {
 
                 network_log_path: "/tmp/network-test-run.jsonl".to_string(),
                 services: None,
+                encrypted_secrets: None,
             },
         );
         write_registry(&registry_path, &registry).await.unwrap();
@@ -610,6 +614,7 @@ mod tests {
 
             network_log_path: std::path::Path::new("/tmp/network-run-1.jsonl"),
             services: None,
+            encrypted_secrets: None,
         };
         handle
             .register_vm("10.200.0.2", &registration)
@@ -627,6 +632,7 @@ mod tests {
             firewall_rules: &[],
             network_log_path: std::path::Path::new("/tmp/network-run-2.jsonl"),
             services: None,
+            encrypted_secrets: None,
         };
         handle
             .register_vm("10.200.0.2", &registration2)
@@ -677,6 +683,7 @@ mod tests {
                     firewall_rules: &[],
                     network_log_path: &log_path,
                     services: None,
+                    encrypted_secrets: None,
                 };
                 h.register_vm(&ip, &registration).await.unwrap();
             });
@@ -722,6 +729,7 @@ mod tests {
 
                 network_log_path: "/tmp/network-run-1.jsonl".to_string(),
                 services: None,
+                encrypted_secrets: None,
             },
         );
         write_registry(&registry_path, &registry).await.unwrap();
@@ -772,6 +780,7 @@ mod tests {
 
             network_log_path: std::path::Path::new("/tmp/network-run-svc.jsonl"),
             services: Some(&services),
+            encrypted_secrets: None,
         };
         handle
             .register_vm("10.200.0.5", &registration)

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -51,8 +51,7 @@ pub struct ExecutionContext {
     pub resume_session: Option<ResumeSession>,
     #[serde(default)]
     pub secret_values: Option<Vec<String>>,
-    // Not yet used by runner — forwarded to mitm-addon for auth resolution
-    #[allow(dead_code)]
+    // Forwarded to mitm-addon via proxy registry for auth resolution
     #[serde(default)]
     pub encrypted_secrets: Option<String>,
     pub cli_agent_type: String,


### PR DESCRIPTION
## Summary

- Add `encrypted_secrets` field to `VmEntry` and `VmRegistration` in proxy registry
- Executor passes `context.encrypted_secrets` to proxy registration
- Registry JSON now includes `encryptedSecrets` for mitm-addon to read

Part of #4593 (PR 2/4). Closes #4596.

## Test plan

- [x] `cargo test -p runner` — 187 tests pass
- [x] All pre-commit hooks pass (cargo-fmt, cargo-clippy, commitlint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)