### PR TITLE
refactor: update scope to org in env.ts comment and resolve-default.ts logs

### DIFF
--- a/turbo/apps/web/src/env.ts
+++ b/turbo/apps/web/src/env.ts
@@ -56,7 +56,7 @@ function initEnv() {
       SLACK_CLIENT_SECRET: z.string().min(1).optional(),
       SLACK_SIGNING_SECRET: z.string().min(1).optional(),
       SLACK_REDIRECT_BASE_URL: z.string().url().optional(), // Override base URL for OAuth redirects (e.g., tunnel URL)
-      VM0_DEFAULT_AGENT: z.string().min(1).optional(), // Default agent for new integrations (format: "scope/name")
+      VM0_DEFAULT_AGENT: z.string().min(1).optional(), // Default agent for new integrations (format: "org/name")
       VM0_TUNNEL_URL: z.string().url().optional(), // Tunnel URL for local development webhooks
       // LLM API
       OPENROUTER_API_KEY: z.string().min(1).optional(), // OpenRouter API key for logged-in users

--- a/turbo/apps/web/src/lib/agent-compose/resolve-default.ts
+++ b/turbo/apps/web/src/lib/agent-compose/resolve-default.ts
@@ -8,7 +8,7 @@ const log = logger("agent-compose:resolve-default");
 
 /**
  * Resolve the default agent compose ID from VM0_DEFAULT_AGENT env var.
- * Format: "scope-slug/agent-name" (e.g. "yuma/deep-dive")
+ * Format: "org-slug/agent-name" (e.g. "yuma/deep-dive")
  *
  * Returns the compose ID if found, or null.
  */
@@ -21,7 +21,7 @@ export async function resolveDefaultAgentComposeId(): Promise<string | null> {
 
   const [orgSlug, agentName] = VM0_DEFAULT_AGENT.split("/");
   if (!orgSlug || !agentName) {
-    log.warn("VM0_DEFAULT_AGENT has invalid format, expected 'scope/name'", {
+    log.warn("VM0_DEFAULT_AGENT has invalid format, expected 'org/name'", {
       value: VM0_DEFAULT_AGENT,
     });
     return null;
@@ -30,7 +30,7 @@ export async function resolveDefaultAgentComposeId(): Promise<string | null> {
   const orgData = await getOrgBySlug(orgSlug);
 
   if (!orgData) {
-    log.warn("Scope not found for VM0_DEFAULT_AGENT", { orgSlug });
+    log.warn("Org not found for VM0_DEFAULT_AGENT", { orgSlug });
     return null;
   }
 


### PR DESCRIPTION
## Summary

- Update `VM0_DEFAULT_AGENT` comment in `env.ts` from `"scope/name"` to `"org/name"`
- Update JSDoc and log messages in `resolve-default.ts` to use "org" instead of "scope"

Closes #4610

## Test plan

- [ ] Verify lint passes (`pnpm turbo run lint`)
- [ ] Verify type check passes (`pnpm check-types`)
- [ ] No behavioral changes — only comments and log strings updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)