### PR TITLE
feat(platform): improve zero activity, schedule, and meet pages

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-activity.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-activity.test.ts
@@ -74,19 +74,14 @@ async function setup() {
 
 describe("zero-activity signals", () => {
   describe("zeroActivityData$", () => {
-    it("should fetch logs for the default agent", async () => {
+    it("should fetch logs for all agents in scope", async () => {
       server.use(
         http.get("http://localhost:3000/api/platform/logs", ({ request }) => {
           const url = new URL(request.url);
-          const name = url.searchParams.get("name");
-          if (name === "zero") {
-            return HttpResponse.json({
-              data: createMockLogs(),
-              pagination: { hasMore: false, nextCursor: null, totalPages: 1 },
-            });
-          }
+          // No name filter → returns all agents' logs
+          expect(url.searchParams.has("name")).toBeFalsy();
           return HttpResponse.json({
-            data: [],
+            data: createMockLogs(),
             pagination: { hasMore: false, nextCursor: null, totalPages: 1 },
           });
         }),

--- a/turbo/apps/platform/src/signals/zero-page/zero-activity.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-activity.ts
@@ -5,6 +5,7 @@ import type {
   AgentEventsResponse,
   LogStatus,
 } from "../logs-page/types.ts";
+import type { ComposeListItem } from "@vm0/core";
 import { fetch$ } from "../fetch.ts";
 import { searchParams$, updateSearchParams$ } from "../route.ts";
 import { createCursorPagination } from "../cursor-pagination.ts";
@@ -31,21 +32,52 @@ export const zeroActivityStatusFilter$ = computed((get) => {
 });
 
 // ---------------------------------------------------------------------------
+// Scope agents — fetch all composes for name → displayName mapping
+// ---------------------------------------------------------------------------
+
+interface AgentOption {
+  name: string;
+  displayName: string;
+}
+
+const internalScopeAgents$ = state<AgentOption[]>([]);
+
+/** All agents in the current scope with display names. */
+export const zeroActivityScopeAgents$ = computed((get) =>
+  get(internalScopeAgents$),
+);
+
+const fetchScopeAgents$ = command(async ({ get, set }) => {
+  const fetchFn = get(fetch$);
+  const resp = await fetchFn("/api/agent/composes/list");
+  if (!resp.ok) {
+    return;
+  }
+  const data = (await resp.json()) as { composes: ComposeListItem[] };
+  const agents: AgentOption[] = data.composes.map((c) => ({
+    name: c.name,
+    displayName:
+      c.displayName ?? c.name.charAt(0).toUpperCase() + c.name.slice(1),
+  }));
+  set(internalScopeAgents$, agents);
+});
+
+// ---------------------------------------------------------------------------
 // List — cursor pagination with URL-synced limit/cursor/filters
 // ---------------------------------------------------------------------------
 
 /** Agent name from onboarding (cached so pagination factory can read it). */
 const internalAgentName$ = state<string | null>(null);
-const cachedAgentName$ = computed((get) => get(internalAgentName$));
 
 export const initZeroActivityAgentName$ = command(async ({ get, set }) => {
   const status = await get(zeroOnboardingStatus$);
   set(internalAgentName$, status.defaultAgentName);
 });
 
-/** Initialize activity page: load agent name and seed cursor history. */
+/** Initialize activity page: load agent name, scope agents, and seed cursor history. */
 export const initZeroActivity$ = command(async ({ set }) => {
   await set(initZeroActivityAgentName$);
+  await set(fetchScopeAgents$);
   set(seedZeroActivityCursorHistory$);
 });
 
@@ -63,15 +95,16 @@ export const {
   resetPaginationState$: resetZeroActivityPagination$,
 } = createCursorPagination({
   buildFetchParams: (limit, cursor, get) => {
-    const agentName = get(cachedAgentName$);
-    if (!agentName) {
-      return null;
-    }
-
     const params = new URLSearchParams({
       limit: String(limit),
-      name: agentName,
     });
+
+    // Filter by specific agent when selected, otherwise fetch all
+    const agentFilter = get(zeroActivityAgentFilter$);
+    if (agentFilter !== "all") {
+      params.set("name", agentFilter);
+    }
+
     if (cursor) {
       params.set("cursor", cursor);
     }

--- a/turbo/apps/platform/src/signals/zero-page/zero-activity.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-activity.ts
@@ -51,7 +51,7 @@ const fetchScopeAgents$ = command(async ({ get, set }) => {
   const fetchFn = get(fetch$);
   const resp = await fetchFn("/api/agent/composes/list");
   if (!resp.ok) {
-    return;
+    throw new Error(`Failed to fetch scope agents: ${resp.statusText}`);
   }
   const data = (await resp.json()) as { composes: ComposeListItem[] };
   const agents: AgentOption[] = data.composes.map((c) => ({

--- a/turbo/apps/platform/src/signals/zero-page/zero-schedule.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-schedule.ts
@@ -364,6 +364,12 @@ export interface ScopeScheduleEntry {
 }
 
 const internalAllSchedules$ = state<ScheduleResponse[]>([]);
+const internalAllSchedulesLoaded$ = state(false);
+
+/** Whether the scope schedules have been loaded at least once. */
+export const allScopeSchedulesLoaded$ = computed((get) =>
+  get(internalAllSchedulesLoaded$),
+);
 
 export const allScopeScheduleEntries$ = computed((get) => {
   const schedules = get(internalAllSchedules$);
@@ -399,6 +405,8 @@ export const fetchAllScopeSchedules$ = command(async ({ get, set }) => {
     throwIfAbort(error);
     L.error("Failed to fetch all scope schedules:", error);
     set(internalAllSchedules$, []);
+  } finally {
+    set(internalAllSchedulesLoaded$, true);
   }
 });
 

--- a/turbo/apps/platform/src/views/zero-page/zero-activity-detail-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-activity-detail-page.tsx
@@ -143,6 +143,11 @@ export function ZeroActivityDetailPage({
                 Download
               </Button>
             </div>
+            {detail?.error && status === "failed" && (
+              <div className="mt-2 rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive">
+                {detail.error}
+              </div>
+            )}
           </div>
 
           {/* Steps section */}

--- a/turbo/apps/platform/src/views/zero-page/zero-activity-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-activity-page.tsx
@@ -17,10 +17,10 @@ import type { LogEntry } from "../../signals/logs-page/types.ts";
 import { StatusBadge } from "../logs-page/status-badge.tsx";
 import { Pagination } from "../components/pagination.tsx";
 import { ZeroActivityDetailPage } from "./zero-activity-detail-page.tsx";
-import { agentDisplayName$ } from "../../signals/zero-page/zero-agent-name.ts";
 import {
   zeroActivityAgentFilter$,
   zeroActivityStatusFilter$,
+  zeroActivityScopeAgents$,
   setZeroActivityFilter$,
   zeroActivityData$,
   zeroActivityLimit$,
@@ -115,10 +115,6 @@ function ActivityRow({
 }
 
 export function ZeroActivityPage() {
-  const agentNameLoadable = useLoadable(agentDisplayName$);
-  const agentName =
-    agentNameLoadable.state === "hasData" ? agentNameLoadable.data : "Zero";
-
   const dataLoadable = useLoadable(zeroActivityData$);
   const hasPrev = useGet(zeroActivityHasPrev$);
   const currentPage = useGet(zeroActivityCurrentPage$);
@@ -138,6 +134,7 @@ export function ZeroActivityPage() {
   const agentFilter = useGet(zeroActivityAgentFilter$);
   const statusFilter = useGet(zeroActivityStatusFilter$);
   const setFilter = useSet(setZeroActivityFilter$);
+  const scopeAgents = useGet(zeroActivityScopeAgents$);
 
   const logs = dataLoadable.state === "hasData" ? dataLoadable.data.data : [];
   const hasNext =
@@ -148,12 +145,15 @@ export function ZeroActivityPage() {
       : undefined;
   const isLoading = dataLoadable.state === "loading";
 
-  // Derive unique agent names for the filter dropdown (show display name)
+  // Build name → displayName lookup from scope agents
+  const nameToDisplay = new Map(
+    scopeAgents.map((a) => [a.name, a.displayName]),
+  );
+
+  // Agent filter options: show display names, map back to compose name
   const agentOptions = [
     { value: "all", label: "All Agents" },
-    ...Array.from(new Set(logs.map((e) => e.agentName)))
-      .sort()
-      .map((name) => ({ value: name, label: name })),
+    ...scopeAgents.map((a) => ({ value: a.name, label: a.displayName })),
   ];
 
   // Detail view when sub-route is present
@@ -163,6 +163,7 @@ export function ZeroActivityPage() {
 
   return (
     <div className="flex flex-1 flex-col min-h-0">
+      {/* Fixed header: title + filters */}
       <header className="shrink-0 bg-transparent px-4 sm:px-6 pt-10 pb-3">
         <div className="mx-auto max-w-[900px]">
           <div>
@@ -170,7 +171,7 @@ export function ZeroActivityPage() {
               Activity
             </h1>
             <p className="text-sm text-muted-foreground">
-              Logs and runs from {agentName} and your workflows.
+              Logs and runs from your agents.
             </p>
           </div>
 
@@ -219,69 +220,74 @@ export function ZeroActivityPage() {
         </div>
       </header>
 
-      <main className="flex-1 overflow-auto px-4 sm:px-6 pt-2 pb-8">
+      {/* Scrollable table area */}
+      <div className="flex-1 min-h-0 overflow-auto px-4 sm:px-6">
         <div className="mx-auto max-w-[900px]">
-          {logs.length > 0 && (
-            <div>
-              <div
-                className={cn(
-                  ROW_GRID,
-                  "zero-activity-header py-2 pb-1.5 border-b text-sm font-medium text-muted-foreground",
-                )}
-              >
-                <div className="text-left">Agent</div>
-                <div className="text-left">Status</div>
-                <div className="text-left">Start Time</div>
-                <div className="text-left">Duration</div>
-                <div />
-              </div>
+          {(logs.length > 0 || isLoading) && (
+            <div
+              className={cn(
+                ROW_GRID,
+                "sticky top-0 z-10 py-2 pb-1.5 border-b text-sm font-medium text-muted-foreground backdrop-blur-md bg-background/60",
+              )}
+            >
+              <div className="text-left">Agent</div>
+              <div className="text-left">Status</div>
+              <div className="text-left">Start Time</div>
+              <div className="text-left">Duration</div>
+              <div />
             </div>
           )}
-          {logs.map((entry) => (
-            <ActivityRow
-              key={entry.id}
-              entry={entry}
-              onSelect={(id) => navigate(`/zero/activity/${id}`)}
-              agentName={agentName}
-            />
-          ))}
-          {logs.length === 0 && !isLoading && (
-            <p className="text-sm text-muted-foreground py-8 text-center">
-              {agentFilter === "all" && statusFilter === "all"
-                ? "No activity found."
-                : "No activity matches your filters."}
-            </p>
-          )}
-          {isLoading && (
-            <div className="flex justify-center py-8">
+          {isLoading ? (
+            <div className="flex items-center justify-center min-h-[20rem]">
               <IconLoader2
                 size={20}
                 stroke={1.5}
                 className="animate-spin text-muted-foreground"
               />
             </div>
+          ) : logs.length === 0 ? (
+            <div className="flex items-center justify-center min-h-[20rem]">
+              <p className="text-sm text-muted-foreground">
+                {agentFilter === "all" && statusFilter === "all"
+                  ? "No activity found."
+                  : "No activity matches your filters."}
+              </p>
+            </div>
+          ) : (
+            logs.map((entry) => (
+              <ActivityRow
+                key={entry.id}
+                entry={entry}
+                onSelect={(id) => navigate(`/zero/activity/${id}`)}
+                agentName={
+                  nameToDisplay.get(entry.agentName) ?? entry.agentName
+                }
+              />
+            ))
           )}
-          <div className="pt-8">
-            <Pagination
-              currentPage={currentPage}
-              totalPages={totalPages}
-              rowsPerPage={rowsPerPage}
-              hasNext={hasNext}
-              hasPrev={hasPrev}
-              isLoading={isLoading}
-              labelClassName="font-normal text-muted-foreground"
-              buttonClassName="bg-transparent border-border/70"
-              onNextPage={() => detach(goToNext(), Reason.DomCallback)}
-              onPrevPage={() => goToPrev()}
-              onForwardTwoPages={() =>
-                detach(goForwardTwo(), Reason.DomCallback)
-              }
-              onBackTwoPages={() => goBackTwo()}
-              onRowsPerPageChange={(limit) => setRowsPerPage(limit)}
-            />
-          </div>
         </div>
-      </main>
+      </div>
+
+      {/* Fixed pagination footer */}
+      <div className="shrink-0 px-4 sm:px-6 py-4">
+        <div className="mx-auto max-w-[900px]">
+          <Pagination
+            currentPage={currentPage}
+            totalPages={totalPages}
+            rowsPerPage={rowsPerPage}
+            hasNext={hasNext}
+            hasPrev={hasPrev}
+            isLoading={isLoading}
+            labelClassName="font-normal text-muted-foreground"
+            buttonClassName="bg-transparent border-border/70"
+            onNextPage={() => detach(goToNext(), Reason.DomCallback)}
+            onPrevPage={() => goToPrev()}
+            onForwardTwoPages={() => detach(goForwardTwo(), Reason.DomCallback)}
+            onBackTwoPages={() => goBackTwo()}
+            onRowsPerPageChange={(limit) => setRowsPerPage(limit)}
+          />
+        </div>
+      </div>
     </div>
   );
 }

--- a/turbo/apps/platform/src/views/zero-page/zero-meet-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-meet-page.tsx
@@ -61,6 +61,7 @@ import {
 } from "../../signals/settings-page/connectors.ts";
 import { deleteConnector$ } from "../../signals/external/connectors.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
+import { updatePathname$ } from "../../signals/route.ts";
 import {
   AddConnectionDialog,
   ConnectModal,
@@ -847,6 +848,7 @@ export function ZeroMeetPage({
   zeroAvatarSrc = "/zero-avatar.png",
   onAvatarClick,
 }: ZeroMeetPageProps) {
+  const navigate = useSet(updatePathname$);
   const agentNameLoadable = useLoadable(agentDisplayName$);
   const resolvedAgentName =
     agentNameLoadable.state === "hasData" ? agentNameLoadable.data : "Zero";
@@ -963,6 +965,7 @@ export function ZeroMeetPage({
               variant="outline"
               size="sm"
               className="zero-btn-morandi h-9 shrink-0 gap-2 rounded-lg border px-4"
+              onClick={() => navigate("/zero/chat")}
             >
               <IconMessageCircle size={14} stroke={1.5} />
               Just ask

--- a/turbo/apps/platform/src/views/zero-page/zero-schedule-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-schedule-page.tsx
@@ -51,6 +51,7 @@ import { COMMON_TIMEZONES } from "../../signals/agent-detail/cron.ts";
 import { detach, Reason } from "../../signals/utils.ts";
 import {
   allScopeScheduleEntries$,
+  allScopeSchedulesLoaded$,
   fetchAllScopeSchedules$,
   saveScopeSchedule$,
   toggleScopeScheduleEnabled$,
@@ -778,8 +779,8 @@ export function ZeroSchedulePage() {
   const entriesLoadable = useLastLoadable(allScopeScheduleEntries$);
   const entries: ScopeScheduleEntry[] =
     entriesLoadable.state === "hasData" ? entriesLoadable.data : [];
-  const isInitialLoading =
-    entriesLoadable.state === "loading" && entries.length === 0;
+  const loaded = useGet(allScopeSchedulesLoaded$);
+  const isInitialLoading = !loaded;
 
   const fetchSchedules = useSet(fetchAllScopeSchedules$);
   const saveSchedule = useSet(saveScopeSchedule$);

--- a/turbo/apps/platform/src/views/zero-page/zero-schedule-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-schedule-page.tsx
@@ -22,6 +22,7 @@ import {
   SelectValue,
   cn,
 } from "@vm0/ui";
+import { Skeleton } from "@vm0/ui/components/ui/skeleton";
 import {
   Popover,
   PopoverContent,
@@ -603,6 +604,70 @@ function ScheduleEditDialog(props: ScheduleEditDialogProps) {
 }
 
 // ---------------------------------------------------------------------------
+// Skeleton
+// ---------------------------------------------------------------------------
+
+const SKELETON_LIST_KEYS = ["s-0", "s-1", "s-2", "s-3", "s-4"] as const;
+const SKELETON_ROW_KEYS = ["r-0", "r-1", "r-2", "r-3"] as const;
+
+function ScheduleListSkeleton() {
+  return (
+    <ul className="flex flex-col" role="list">
+      {SKELETON_LIST_KEYS.map((key) => (
+        <li
+          key={key}
+          className="flex items-center gap-3 py-2.5 border-b border-border/50 last:border-b-0 -mx-1 px-1"
+        >
+          <Skeleton className="h-5 w-9 rounded-full shrink-0" />
+          <Skeleton className="h-3.5 w-[100px] shrink-0" />
+          <Skeleton className="h-3.5 w-[120px] shrink-0" />
+          <Skeleton className="h-3.5 flex-1" />
+          <Skeleton className="h-6 w-6 rounded shrink-0" />
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function ScheduleCalendarSkeleton() {
+  return (
+    <section className="flex flex-col gap-2">
+      <Skeleton className="h-4 w-20" />
+      <div className="rounded-xl border border-border/70 bg-muted/20 overflow-hidden">
+        <div className="grid grid-cols-8">
+          <div className="bg-muted/50 p-2 border-b border-r border-border/60 h-9" />
+          {WEEKDAY_LABELS.map((d) => (
+            <div
+              key={d}
+              className="bg-muted/50 p-2 border-b border-border/60 flex justify-center"
+            >
+              <Skeleton className="h-4 w-8" />
+            </div>
+          ))}
+          {SKELETON_ROW_KEYS.map((rowKey, row) => (
+            <div key={rowKey} className="contents">
+              <div className="bg-muted/30 p-2 border-r border-b border-border/60 flex items-center">
+                <Skeleton className="h-3 w-12" />
+              </div>
+              {WEEKDAY_LABELS.map((day, col) => (
+                <div
+                  key={`${rowKey}-${day}`}
+                  className="min-h-[52px] p-1.5 border-r border-b border-border/60 flex items-center justify-center"
+                >
+                  {(row + col) % 3 === 0 && (
+                    <Skeleton className="h-6 w-full rounded" />
+                  )}
+                </div>
+              ))}
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // List view
 // ---------------------------------------------------------------------------
 
@@ -713,6 +778,8 @@ export function ZeroSchedulePage() {
   const entriesLoadable = useLastLoadable(allScopeScheduleEntries$);
   const entries: ScopeScheduleEntry[] =
     entriesLoadable.state === "hasData" ? entriesLoadable.data : [];
+  const isInitialLoading =
+    entriesLoadable.state === "loading" && entries.length === 0;
 
   const fetchSchedules = useSet(fetchAllScopeSchedules$);
   const saveSchedule = useSet(saveScopeSchedule$);
@@ -830,16 +897,20 @@ export function ZeroSchedulePage() {
         <div className="mx-auto max-w-[900px]">
           <Card className="zero-card">
             <CardContent className="py-5 flex flex-col gap-6">
-              {scheduleViewMode === "list" && (
+              {isInitialLoading ? (
+                scheduleViewMode === "calendar" ? (
+                  <ScheduleCalendarSkeleton />
+                ) : (
+                  <ScheduleListSkeleton />
+                )
+              ) : scheduleViewMode === "list" ? (
                 <ScheduleListView
                   combinedSchedule={combinedSchedule}
                   onEdit={openEditSchedule}
                   onToggle={handleToggle}
                   onDelete={handleDelete}
                 />
-              )}
-
-              {scheduleViewMode === "calendar" && (
+              ) : (
                 <ScheduleCalendarView
                   combinedSchedule={combinedSchedule}
                   agentOrder={agentOrder}

--- a/turbo/apps/web/app/api/agent/composes/list/route.ts
+++ b/turbo/apps/web/app/api/agent/composes/list/route.ts
@@ -12,16 +12,43 @@ import { resolveOrg } from "../../../../../src/lib/scope/resolve-org";
 import { isNotFound, isForbidden } from "../../../../../src/lib/errors";
 import { getEmailSharedAgents } from "../../../../../src/lib/agent/permission-service";
 
-interface ComposeContent {
-  agents?: Record<string, { metadata?: { displayName?: string } }>;
-}
-
 function extractDisplayName(content: unknown): string | null {
-  const c = content as ComposeContent | null;
-  if (!c?.agents) return null;
-  const agentKeys = Object.keys(c.agents);
+  if (
+    content === null ||
+    content === undefined ||
+    typeof content !== "object"
+  ) {
+    return null;
+  }
+  const record = content as Record<string, unknown>;
+  const agents = record["agents"];
+  if (agents === null || agents === undefined || typeof agents !== "object") {
+    return null;
+  }
+  const agentKeys = Object.keys(agents);
   if (agentKeys.length === 0) return null;
-  return c.agents[agentKeys[0]!]?.metadata?.displayName ?? null;
+  const agentsRecord = agents as Record<string, unknown>;
+  const firstAgent = agentsRecord[agentKeys[0]!];
+  if (
+    firstAgent === null ||
+    firstAgent === undefined ||
+    typeof firstAgent !== "object"
+  ) {
+    return null;
+  }
+  const agentRecord = firstAgent as Record<string, unknown>;
+  const metadata = agentRecord["metadata"];
+  if (
+    metadata === null ||
+    metadata === undefined ||
+    typeof metadata !== "object"
+  ) {
+    return null;
+  }
+  const metadataRecord = metadata as Record<string, unknown>;
+  const displayName = metadataRecord["displayName"];
+  if (typeof displayName !== "string") return null;
+  return displayName;
 }
 
 const router = tsr.router(composesListContract, {

--- a/turbo/apps/web/app/api/agent/composes/list/route.ts
+++ b/turbo/apps/web/app/api/agent/composes/list/route.ts
@@ -1,13 +1,28 @@
 import { createHandler, tsr } from "../../../../../src/lib/ts-rest-handler";
 import { composesListContract } from "@vm0/core";
 import { initServices } from "../../../../../src/lib/init-services";
-import { agentComposes } from "../../../../../src/db/schema/agent-compose";
+import {
+  agentComposes,
+  agentComposeVersions,
+} from "../../../../../src/db/schema/agent-compose";
 import { getAuthContext } from "../../../../../src/lib/auth/get-user-id";
 import { getUserEmail } from "../../../../../src/lib/auth/get-user-email";
 import { eq, desc } from "drizzle-orm";
 import { resolveOrg } from "../../../../../src/lib/scope/resolve-org";
 import { isNotFound, isForbidden } from "../../../../../src/lib/errors";
 import { getEmailSharedAgents } from "../../../../../src/lib/agent/permission-service";
+
+interface ComposeContent {
+  agents?: Record<string, { metadata?: { displayName?: string } }>;
+}
+
+function extractDisplayName(content: unknown): string | null {
+  const c = content as ComposeContent | null;
+  if (!c?.agents) return null;
+  const agentKeys = Object.keys(c.agents);
+  if (agentKeys.length === 0) return null;
+  return c.agents[agentKeys[0]!]?.metadata?.displayName ?? null;
+}
 
 const router = tsr.router(composesListContract, {
   list: async ({ query, headers }) => {
@@ -57,15 +72,20 @@ const router = tsr.router(composesListContract, {
       throw error;
     }
 
-    // Query own composes for this scope
+    // Query own composes for this scope (join head version for displayName)
     const ownComposes = await globalThis.services.db
       .select({
         id: agentComposes.id,
         name: agentComposes.name,
         headVersionId: agentComposes.headVersionId,
         updatedAt: agentComposes.updatedAt,
+        headContent: agentComposeVersions.content,
       })
       .from(agentComposes)
+      .leftJoin(
+        agentComposeVersions,
+        eq(agentComposes.headVersionId, agentComposeVersions.id),
+      )
       .where(eq(agentComposes.orgId, orgId))
       .orderBy(desc(agentComposes.updatedAt));
 
@@ -87,12 +107,14 @@ const router = tsr.router(composesListContract, {
     const allComposes = [
       ...ownComposes.map((c) => ({
         name: c.name,
+        displayName: extractDisplayName(c.headContent),
         headVersionId: c.headVersionId,
         updatedAt: c.updatedAt.toISOString(),
         isOwner: true,
       })),
       ...sharedComposes.map((c) => ({
         name: `${c.orgSlug}/${c.name}`,
+        displayName: null as string | null,
         headVersionId: c.headVersionId,
         updatedAt: c.updatedAt.toISOString(),
         isOwner: false,

--- a/turbo/packages/core/src/contracts/composes.ts
+++ b/turbo/packages/core/src/contracts/composes.ts
@@ -315,6 +315,7 @@ export const composesVersionsContract = c.router({
  */
 const composeListItemSchema = z.object({
   name: z.string(),
+  displayName: z.string().nullable().optional(),
   headVersionId: z.string().nullable(),
   updatedAt: z.string(),
   isOwner: z.boolean(),


### PR DESCRIPTION
## Summary
- Activity page now searches all agents in scope (not just default agent), with display names in the agent filter dropdown mapped back to compose names
- Activity table layout restructured: fixed header/filters + scrollable table + fixed pagination footer, with stable height during loading
- Activity detail page shows error reason banner for failed runs
- Schedule page shows skeleton screens (list & calendar) during initial data load
- Meet page "Just ask" button navigates directly to `/zero/chat`
- Composes list API (`/api/agent/composes/list`) now returns `displayName` extracted from agent metadata in compose content

## Test plan
- [ ] Open Activity page — verify all agents' logs are shown, not just the default agent
- [ ] Use agent filter dropdown — verify display names are shown and filtering works
- [ ] Scroll the activity table — verify header stays sticky with frosted glass effect, pagination stays at bottom
- [ ] Click into a failed activity detail — verify error reason is displayed
- [ ] Open Schedule page — verify skeleton loading appears before data loads
- [ ] Switch between list/calendar view while loading — verify correct skeleton variant
- [ ] Click "Just ask" on Meet page — verify navigation to `/zero/chat`

🤖 Generated with [Claude Code](https://claude.com/claude-code)