### PR TITLE
refactor: rename scope to org in test helpers and test descriptions

### DIFF
--- a/turbo/apps/web/app/api/agent/composes/list/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/composes/list/__tests__/route.test.ts
@@ -43,7 +43,7 @@ describe("GET /api/agent/composes/list", () => {
   it("should return no own composes when none exist in scope", async () => {
     // Use explicit scope param to only get own agents (excludes shared)
     const uniqueSuffix = user.userId.replace("test-user-", "");
-    const orgSlug = `scope-${uniqueSuffix}`;
+    const orgSlug = `org-${uniqueSuffix}`;
 
     const request = createTestRequest(
       `http://localhost:3000/api/agent/composes/list?scope=${orgSlug}`,
@@ -65,7 +65,7 @@ describe("GET /api/agent/composes/list", () => {
 
     // Use explicit scope param to get only own agents
     const uniqueSuffix = user.userId.replace("test-user-", "");
-    const orgSlug = `scope-${uniqueSuffix}`;
+    const orgSlug = `org-${uniqueSuffix}`;
 
     const request = createTestRequest(
       `http://localhost:3000/api/agent/composes/list?scope=${orgSlug}`,
@@ -149,14 +149,14 @@ describe("GET /api/agent/composes/list", () => {
 
     // Derive the other user's scope slug from their userId
     // userId format: {prefix}-{timestamp}-{uuid}
-    // scope slug format: scope-{timestamp}-{uuid}
+    // scope slug format: org-{timestamp}-{uuid}
     const uniqueSuffix = otherUser.userId.replace("forbidden-user-", "");
-    const otherScopeSlug = `scope-${uniqueSuffix}`;
+    const otherOrgSlug = `org-${uniqueSuffix}`;
 
     // Switch back to original user and try to access the other user's scope
     mockClerk({ userId: user.userId });
     const request = createTestRequest(
-      `http://localhost:3000/api/agent/composes/list?scope=${otherScopeSlug}`,
+      `http://localhost:3000/api/agent/composes/list?scope=${otherOrgSlug}`,
     );
     const response = await GET(request);
     const data = await response.json();
@@ -173,9 +173,9 @@ describe("GET /api/agent/composes/list", () => {
 
     // Derive the user's scope slug from their userId
     // userId format: test-user-{timestamp}-{uuid}
-    // scope slug format: scope-{timestamp}-{uuid}
+    // scope slug format: org-{timestamp}-{uuid}
     const uniqueSuffix = user.userId.replace("test-user-", "");
-    const orgSlug = `scope-${uniqueSuffix}`;
+    const orgSlug = `org-${uniqueSuffix}`;
 
     // List by scope slug
     const request = createTestRequest(
@@ -199,7 +199,7 @@ describe("GET /api/agent/composes/list", () => {
 
       // Derive the Agent Scope slug
       const ownerSuffix = owner.userId.replace("owner-", "");
-      const agentScopeSlug = `scope-${ownerSuffix}`;
+      const agentOrgSlug = `org-${ownerSuffix}`;
 
       // Switch to recipient (original user) and list
       mockClerk({ userId: user.userId });
@@ -211,7 +211,7 @@ describe("GET /api/agent/composes/list", () => {
 
       expect(response.status).toBe(200);
       const names = data.composes.map((c: { name: string }) => c.name);
-      expect(names).toContain(`${agentScopeSlug}/${agentName}`);
+      expect(names).toContain(`${agentOrgSlug}/${agentName}`);
     });
 
     it("should not show unshared agents from other users", async () => {
@@ -246,7 +246,7 @@ describe("GET /api/agent/composes/list", () => {
       await createTestPermission(composeId, "email", MOCK_USER_EMAIL);
 
       const ownerSuffix = owner.userId.replace("combo-owner-", "");
-      const agentScopeSlug = `scope-${ownerSuffix}`;
+      const agentOrgSlug = `org-${ownerSuffix}`;
 
       // Switch back to original user
       mockClerk({ userId: user.userId });
@@ -261,7 +261,7 @@ describe("GET /api/agent/composes/list", () => {
       // Own agent has plain name
       expect(names).toContain(ownAgentName);
       // Shared agent has scope/name format
-      expect(names).toContain(`${agentScopeSlug}/${sharedAgentName}`);
+      expect(names).toContain(`${agentOrgSlug}/${sharedAgentName}`);
     });
 
     it("should not include shared agents when scope param is provided", async () => {
@@ -274,7 +274,7 @@ describe("GET /api/agent/composes/list", () => {
       // Switch back to original user, list with explicit scope
       mockClerk({ userId: user.userId });
       const uniqueSuffix = user.userId.replace("test-user-", "");
-      const orgSlug = `scope-${uniqueSuffix}`;
+      const orgSlug = `org-${uniqueSuffix}`;
 
       const request = createTestRequest(
         `http://localhost:3000/api/agent/composes/list?scope=${orgSlug}`,

--- a/turbo/apps/web/app/api/agent/required-env/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/required-env/__tests__/route.test.ts
@@ -78,7 +78,7 @@ describe("GET /api/agent/required-env", () => {
     await createTestPermission(composeId, "email", MOCK_USER_EMAIL);
 
     const ownerSuffix = owner.userId.replace("env-owner-", "");
-    const agentScopeSlug = `scope-${ownerSuffix}`;
+    const agentOrgSlug = `org-${ownerSuffix}`;
 
     // Switch to recipient and fetch required env
     mockClerk({ userId: user.userId });
@@ -91,7 +91,7 @@ describe("GET /api/agent/required-env", () => {
     expect(response.status).toBe(200);
     const agent = data.agents.find(
       (a: { agentName: string }) =>
-        a.agentName === `${agentScopeSlug}/${agentName}`,
+        a.agentName === `${agentOrgSlug}/${agentName}`,
     );
     expect(agent).toBeDefined();
     expect(agent.requiredSecrets).toContain("SHARED_SECRET");

--- a/turbo/apps/web/app/api/agent/schedules/missing-secrets/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/schedules/missing-secrets/__tests__/route.test.ts
@@ -134,7 +134,7 @@ describe("GET /api/agent/schedules/missing-secrets", () => {
     await createTestPermission(composeId, "email", MOCK_USER_EMAIL);
 
     const ownerSuffix = owner.userId.replace("ms-owner-", "");
-    const agentScopeSlug = `scope-${ownerSuffix}`;
+    const agentOrgSlug = `org-${ownerSuffix}`;
 
     // Switch to recipient — they don't have SHARED_KEY configured
     mockClerk({ userId: user.userId });
@@ -147,7 +147,7 @@ describe("GET /api/agent/schedules/missing-secrets", () => {
     expect(response.status).toBe(200);
     const agent = data.agents.find(
       (a: { agentName: string }) =>
-        a.agentName === `${agentScopeSlug}/${agentName}`,
+        a.agentName === `${agentOrgSlug}/${agentName}`,
     );
     expect(agent).toBeDefined();
     expect(agent.missingSecrets).toContain("SHARED_KEY");

--- a/turbo/apps/web/app/api/github/oauth/callback/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/github/oauth/callback/__tests__/route.test.ts
@@ -5,7 +5,7 @@ import { server } from "../../../../../../src/mocks/server";
 import { GET } from "../route";
 import {
   createTestRequest,
-  createTestScope,
+  createTestOrg,
   createTestCompose,
   findTestGitHubInstallations,
   findTestGitHubInstallationsByTargetId,
@@ -68,7 +68,7 @@ describe("/api/github/oauth/callback", () => {
   it("should redirect with error when installation_id is missing for install action", async () => {
     const userId = uniqueId("gh-user");
     mockClerk({ userId });
-    await createTestScope(uniqueId("gh-scope"));
+    await createTestOrg(uniqueId("gh-org"));
     const { composeId } = await createTestCompose("gh-test-agent");
 
     const state = buildSignedState(userId, composeId);
@@ -116,7 +116,7 @@ describe("/api/github/oauth/callback", () => {
   it("should propagate error when GitHub API fails", async () => {
     const userId = uniqueId("gh-user");
     mockClerk({ userId });
-    await createTestScope(uniqueId("gh-scope"));
+    await createTestOrg(uniqueId("gh-org"));
     const { composeId } = await createTestCompose("gh-test-agent");
 
     const installationId = uniqueNumericId();
@@ -145,7 +145,7 @@ describe("/api/github/oauth/callback", () => {
   it("should create installation on valid callback", async () => {
     const userId = uniqueId("gh-user");
     mockClerk({ userId });
-    await createTestScope(uniqueId("gh-scope"));
+    await createTestOrg(uniqueId("gh-org"));
     const { composeId } = await createTestCompose("gh-test-agent");
 
     const installationId = uniqueNumericId();
@@ -175,7 +175,7 @@ describe("/api/github/oauth/callback", () => {
   it("should create pending record when setup_action is request", async () => {
     const userId = uniqueId("gh-user");
     mockClerk({ userId });
-    await createTestScope(uniqueId("gh-scope"));
+    await createTestOrg(uniqueId("gh-org"));
     const { composeId } = await createTestCompose("gh-test-agent");
 
     const state = buildSignedState(userId, composeId);
@@ -218,7 +218,7 @@ describe("/api/github/oauth/callback", () => {
   it("should skip creation when installation already exists", async () => {
     const userId = uniqueId("gh-user");
     mockClerk({ userId });
-    await createTestScope(uniqueId("gh-scope"));
+    await createTestOrg(uniqueId("gh-org"));
     const { composeId } = await createTestCompose("gh-test-agent");
 
     const installationId = uniqueNumericId();

--- a/turbo/apps/web/app/api/integrations/github/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/integrations/github/__tests__/route.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach } from "vitest";
 import { GET, DELETE, PATCH } from "../route";
 import {
   createTestRequest,
-  createTestScope,
+  createTestOrg,
   createTestCompose,
   insertTestGitHubInstallation,
   insertTestGitHubInstallationWithAdmin,
@@ -38,7 +38,7 @@ describe("/api/integrations/github", () => {
     it("should return 404 with installUrl when no installation exists", async () => {
       const userId = uniqueId("gh-user");
       mockClerk({ userId });
-      await createTestScope(uniqueId("gh-scope"));
+      await createTestOrg(uniqueId("gh-org"));
 
       const request = createTestRequest(
         "http://localhost:3000/api/integrations/github",
@@ -55,7 +55,7 @@ describe("/api/integrations/github", () => {
     it("should return installation data when installed", async () => {
       const userId = uniqueId("gh-user");
       mockClerk({ userId });
-      await createTestScope(uniqueId("gh-scope"));
+      await createTestOrg(uniqueId("gh-org"));
       const { composeId } = await createTestCompose("gh-agent");
 
       await insertTestGitHubInstallationWithAdmin(composeId, userId);
@@ -77,7 +77,7 @@ describe("/api/integrations/github", () => {
     it("should return environment data in response", async () => {
       const userId = uniqueId("gh-user");
       mockClerk({ userId });
-      await createTestScope(uniqueId("gh-scope"));
+      await createTestOrg(uniqueId("gh-org"));
       const { composeId } = await createTestCompose("gh-agent");
 
       await insertTestGitHubInstallationWithAdmin(composeId, userId);
@@ -114,7 +114,7 @@ describe("/api/integrations/github", () => {
     it("should return 404 when no installation exists", async () => {
       const userId = uniqueId("gh-user");
       mockClerk({ userId });
-      await createTestScope(uniqueId("gh-scope"));
+      await createTestOrg(uniqueId("gh-org"));
 
       const request = createTestRequest(
         "http://localhost:3000/api/integrations/github",
@@ -131,7 +131,7 @@ describe("/api/integrations/github", () => {
     it("should delete installation and return ok", async () => {
       const userId = uniqueId("gh-user");
       mockClerk({ userId });
-      await createTestScope(uniqueId("gh-scope"));
+      await createTestOrg(uniqueId("gh-org"));
       const { composeId } = await createTestCompose("gh-agent");
 
       const { installation } = await insertTestGitHubInstallationWithAdmin(
@@ -161,7 +161,7 @@ describe("/api/integrations/github", () => {
       // Create installation WITHOUT setting an admin (simulates org install where admin is unset)
       const userId = uniqueId("gh-user");
       mockClerk({ userId });
-      await createTestScope(uniqueId("gh-scope"));
+      await createTestOrg(uniqueId("gh-org"));
       const { composeId } = await createTestCompose("gh-agent");
 
       const installation = await insertTestGitHubInstallation(composeId);
@@ -194,7 +194,7 @@ describe("/api/integrations/github", () => {
       // Create installation with admin user
       const adminUserId = uniqueId("admin-user");
       mockClerk({ userId: adminUserId });
-      await createTestScope(uniqueId("gh-scope"));
+      await createTestOrg(uniqueId("gh-org"));
       const { composeId } = await createTestCompose("gh-agent");
       const { installation } = await insertTestGitHubInstallationWithAdmin(
         composeId,
@@ -204,7 +204,7 @@ describe("/api/integrations/github", () => {
       // Create a non-admin user linked to the same installation
       const nonAdminUserId = uniqueId("nonadmin-user");
       mockClerk({ userId: nonAdminUserId });
-      await createTestScope(uniqueId("gh-scope"));
+      await createTestOrg(uniqueId("gh-org"));
       await insertTestGitHubUserLink(
         uniqueId("gh-other-uid"),
         installation.id,
@@ -250,7 +250,7 @@ describe("/api/integrations/github", () => {
     it("should return 400 when agentName is missing", async () => {
       const userId = uniqueId("gh-user");
       mockClerk({ userId });
-      await createTestScope(uniqueId("gh-scope"));
+      await createTestOrg(uniqueId("gh-org"));
       const { composeId } = await createTestCompose("gh-agent");
       await insertTestGitHubInstallationWithAdmin(composeId, userId);
 
@@ -275,7 +275,7 @@ describe("/api/integrations/github", () => {
     it("should return 404 when no installation exists", async () => {
       const userId = uniqueId("gh-user");
       mockClerk({ userId });
-      await createTestScope(uniqueId("gh-scope"));
+      await createTestOrg(uniqueId("gh-org"));
 
       const request = createTestRequest(
         "http://localhost:3000/api/integrations/github",
@@ -297,7 +297,7 @@ describe("/api/integrations/github", () => {
       // Create installation WITHOUT setting an admin (simulates org install where admin is unset)
       const userId = uniqueId("gh-user");
       mockClerk({ userId });
-      await createTestScope(uniqueId("gh-scope"));
+      await createTestOrg(uniqueId("gh-org"));
       const { composeId } = await createTestCompose("gh-agent");
 
       const installation = await insertTestGitHubInstallation(composeId);
@@ -330,7 +330,7 @@ describe("/api/integrations/github", () => {
       // Create installation with admin user
       const adminUserId = uniqueId("admin-user");
       mockClerk({ userId: adminUserId });
-      await createTestScope(uniqueId("gh-scope"));
+      await createTestOrg(uniqueId("gh-org"));
       const { composeId } = await createTestCompose("gh-agent");
       const { installation } = await insertTestGitHubInstallationWithAdmin(
         composeId,
@@ -340,7 +340,7 @@ describe("/api/integrations/github", () => {
       // Create a non-admin user linked to the same installation
       const nonAdminUserId = uniqueId("nonadmin-user");
       mockClerk({ userId: nonAdminUserId });
-      await createTestScope(uniqueId("gh-scope"));
+      await createTestOrg(uniqueId("gh-org"));
       await insertTestGitHubUserLink(
         uniqueId("gh-other-uid"),
         installation.id,
@@ -368,7 +368,7 @@ describe("/api/integrations/github", () => {
     it("should return 404 when agent does not exist", async () => {
       const userId = uniqueId("gh-user");
       mockClerk({ userId });
-      await createTestScope(uniqueId("gh-scope"));
+      await createTestOrg(uniqueId("gh-org"));
       const { composeId } = await createTestCompose("gh-agent");
       await insertTestGitHubInstallationWithAdmin(composeId, userId);
 
@@ -393,7 +393,7 @@ describe("/api/integrations/github", () => {
     it("should update default agent successfully", async () => {
       const userId = uniqueId("gh-user");
       mockClerk({ userId });
-      await createTestScope(uniqueId("gh-scope"));
+      await createTestOrg(uniqueId("gh-org"));
       const { composeId } = await createTestCompose("gh-agent");
       await insertTestGitHubInstallationWithAdmin(composeId, userId);
 
@@ -431,14 +431,14 @@ describe("/api/integrations/github", () => {
     it("should update default agent with scoped name", async () => {
       const userId = uniqueId("gh-user");
       mockClerk({ userId });
-      await createTestScope(uniqueId("gh-scope"));
+      await createTestOrg(uniqueId("gh-org"));
       const { composeId } = await createTestCompose("gh-agent");
       await insertTestGitHubInstallationWithAdmin(composeId, userId);
 
       // Create a compose in a different scope (simulating a shared agent)
       const otherUserId = uniqueId("other-user");
       mockClerk({ userId: otherUserId });
-      await createTestScope(uniqueId("other-scope"));
+      await createTestOrg(uniqueId("other-org"));
       const { composeId: otherComposeId } =
         await createTestCompose("shared-agent");
 

--- a/turbo/apps/web/app/api/integrations/slack/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/integrations/slack/__tests__/route.test.ts
@@ -12,7 +12,7 @@ import {
 } from "../../../../../src/__tests__/slack/api-helpers";
 import {
   createTestCompose,
-  createTestScope,
+  createTestOrg,
   findTestAgentPermissions,
   findTestComposeWithScope,
   insertTestAgentPermission,
@@ -362,7 +362,7 @@ describe("/api/integrations/slack", () => {
       // Create a compose in a different scope (simulating a shared agent)
       const otherUserId = uniqueId("other-user");
       mockClerk({ userId: otherUserId });
-      await createTestScope(uniqueId("other-scope"));
+      await createTestOrg(uniqueId("other-org"));
       const { composeId: otherComposeId } =
         await createTestCompose("shared-agent");
 

--- a/turbo/apps/web/app/api/internal/callbacks/github/issues/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/github/issues/__tests__/route.test.ts
@@ -8,7 +8,7 @@ import {
 } from "../../../../../../../src/__tests__/test-helpers";
 import {
   createTestRequest,
-  createTestScope,
+  createTestOrg,
   createTestCompose,
   createTestRun,
   createTestCallback,
@@ -117,7 +117,7 @@ async function givenGitHubCallbackSetup(overrides?: {
 }) {
   const userId = uniqueId("gh-cb-user");
   mockClerk({ userId });
-  await createTestScope(uniqueId("gh-cb-scope"));
+  await createTestOrg(uniqueId("gh-cb-org"));
   const { composeId } = await createTestCompose("gh-callback-agent");
 
   const { runId } = await createTestRun(composeId, "Test GitHub prompt");
@@ -330,7 +330,7 @@ describe("POST /api/internal/callbacks/github/issues", () => {
     it("should return 404 when GitHub installation is missing", async () => {
       const userId = uniqueId("gh-missing-user");
       mockClerk({ userId });
-      await createTestScope(uniqueId("gh-missing-scope"));
+      await createTestOrg(uniqueId("gh-missing-org"));
       const { composeId } = await createTestCompose("gh-missing-agent");
 
       const { runId } = await createTestRun(composeId, "Test prompt");

--- a/turbo/apps/web/app/api/internal/callbacks/telegram/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/telegram/__tests__/route.test.ts
@@ -113,7 +113,7 @@ async function setupTelegramCallback() {
   const userId = uniqueId("user");
   mockClerk({ userId });
 
-  // Create scope + compose (with version) through API
+  // Create org + compose (with version) through API
   await createTestOrg(uniqueId("org"));
   const { composeId } = await createTestCompose("test-agent");
 

--- a/turbo/apps/web/app/api/internal/callbacks/telegram/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/telegram/__tests__/route.test.ts
@@ -10,7 +10,7 @@ import {
   createTestCallback,
   createTestAgentSession,
   createTestRequest,
-  createTestScope,
+  createTestOrg,
   createTestCompose,
 } from "../../../../../../src/__tests__/api-test-helpers";
 import { computeHmacSignature } from "../../../../../../src/lib/callback/hmac";
@@ -114,7 +114,7 @@ async function setupTelegramCallback() {
   mockClerk({ userId });
 
   // Create scope + compose (with version) through API
-  await createTestScope(uniqueId("scope"));
+  await createTestOrg(uniqueId("org"));
   const { composeId } = await createTestCompose("test-agent");
 
   // Create installation with encrypted bot token + user link via helper

--- a/turbo/apps/web/app/api/runners/realtime/token/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/runners/realtime/token/__tests__/route.test.ts
@@ -163,9 +163,9 @@ describe("POST /api/runners/realtime/token", () => {
       reloadEnv();
       const token = await createTestCliToken(user.userId);
 
-      // Derive scope slug from user context - setupUser creates scope-{suffix}
+      // Derive scope slug from user context - setupUser creates org-{suffix}
       const suffix = user.userId.replace("test-user-", "");
-      const orgSlug = `scope-${suffix}`;
+      const orgSlug = `org-${suffix}`;
 
       const response = await POST(
         makeRequest({ group: `${orgSlug}/default` }, `Bearer ${token}`),

--- a/turbo/apps/web/app/api/scope/__tests__/invite.test.ts
+++ b/turbo/apps/web/app/api/scope/__tests__/invite.test.ts
@@ -3,7 +3,7 @@ import { POST } from "../invite/route";
 import { GET as getMembersRoute } from "../members/route";
 import {
   createTestRequest,
-  createTestScope as createTestScopeHelper,
+  createTestOrg as createTestOrgHelper,
 } from "../../../../src/__tests__/api-test-helpers";
 import { testContext, uniqueId } from "../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../src/__tests__/clerk-mock";
@@ -12,10 +12,10 @@ import { setupClerkOrgMock } from "../../../../src/__tests__/clerk-org-mock";
 const context = testContext();
 
 /**
- * Helper to create a scope and return its slug.
+ * Helper to create an org and return its slug.
  */
-async function createTestScope(userId: string) {
-  const slug = uniqueId("scope");
+async function createTestOrg(userId: string) {
+  const slug = uniqueId("org");
   const orgId = `org_mock_${userId}`;
   setupClerkOrgMock({
     userId,
@@ -24,7 +24,7 @@ async function createTestScope(userId: string) {
     memberships: [{ userId, role: "org:admin" }],
   });
 
-  await createTestScopeHelper(slug);
+  await createTestOrgHelper(slug);
 
   return { slug, orgId };
 }
@@ -52,7 +52,7 @@ describe("POST /api/scope/invite - Invite Member", () => {
     expect(data.error.message).toContain("Not authenticated");
   });
 
-  it("should require scope query parameter", async () => {
+  it("should require org query parameter", async () => {
     const userId = uniqueId("invite-user");
     mockClerk({ userId });
 
@@ -73,7 +73,7 @@ describe("POST /api/scope/invite - Invite Member", () => {
 
   it("should invite member and return success message", async () => {
     const userId = uniqueId("invite-admin");
-    const { slug } = await createTestScope(userId);
+    const { slug } = await createTestOrg(userId);
 
     const inviteReq = createTestRequest(
       `http://localhost:3000/api/scope/invite?scope=${slug}`,
@@ -90,11 +90,11 @@ describe("POST /api/scope/invite - Invite Member", () => {
     expect(inviteData.message).toContain("new-member@example.com");
   });
 
-  it("should make invited member visible in scope members list", async () => {
+  it("should make invited member visible in org members list", async () => {
     const adminUserId = uniqueId("invite-admin2");
     const memberUserId = "user_new-member";
     const memberEmail = "new-member@example.com";
-    const { slug, orgId } = await createTestScope(adminUserId);
+    const { slug, orgId } = await createTestOrg(adminUserId);
 
     // Invite the member
     const inviteReq = createTestRequest(

--- a/turbo/apps/web/app/api/scope/__tests__/leave.test.ts
+++ b/turbo/apps/web/app/api/scope/__tests__/leave.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach } from "vitest";
 import { POST } from "../leave/route";
 import {
   createTestRequest,
-  createTestScope as createTestScopeHelper,
+  createTestOrg as createTestOrgHelper,
 } from "../../../../src/__tests__/api-test-helpers";
 import { testContext, uniqueId } from "../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../src/__tests__/clerk-mock";
@@ -10,7 +10,7 @@ import { setupClerkOrgMock } from "../../../../src/__tests__/clerk-org-mock";
 
 const context = testContext();
 
-describe("POST /api/scope/leave - Leave Scope", () => {
+describe("POST /api/scope/leave - Leave Org", () => {
   beforeEach(() => {
     context.setupMocks();
   });
@@ -33,7 +33,7 @@ describe("POST /api/scope/leave - Leave Scope", () => {
     expect(data.error.message).toContain("Not authenticated");
   });
 
-  it("should require scope query parameter", async () => {
+  it("should require org query parameter", async () => {
     const userId = uniqueId("leave-user");
     mockClerk({ userId });
 
@@ -51,7 +51,7 @@ describe("POST /api/scope/leave - Leave Scope", () => {
 
   it("should prevent admin from leaving", async () => {
     const userId = uniqueId("leave-admin");
-    const slug = uniqueId("scope");
+    const slug = uniqueId("org");
     const orgId = `org_${userId}`;
     setupClerkOrgMock({
       userId,
@@ -60,8 +60,8 @@ describe("POST /api/scope/leave - Leave Scope", () => {
       memberships: [{ userId, role: "org:admin" }],
     });
 
-    // Create scope
-    await createTestScopeHelper(slug);
+    // Create org
+    await createTestOrgHelper(slug);
 
     // Try to leave as admin
     const leaveReq = createTestRequest(

--- a/turbo/apps/web/app/api/scope/__tests__/list.test.ts
+++ b/turbo/apps/web/app/api/scope/__tests__/list.test.ts
@@ -6,7 +6,7 @@ import { mockClerk } from "../../../../src/__tests__/clerk-mock";
 
 const context = testContext();
 
-describe("GET /api/scope/list - Scope List", () => {
+describe("GET /api/scope/list - Org List", () => {
   beforeEach(() => {
     context.setupMocks();
   });
@@ -22,9 +22,9 @@ describe("GET /api/scope/list - Scope List", () => {
     expect(data.error.message).toContain("Not authenticated");
   });
 
-  it("should return personal scope from Clerk memberships", async () => {
+  it("should return personal org from Clerk memberships", async () => {
     const userId = uniqueId("list-user");
-    const orgSlug = uniqueId("scope");
+    const orgSlug = uniqueId("org");
 
     mockClerk({
       userId,
@@ -43,7 +43,7 @@ describe("GET /api/scope/list - Scope List", () => {
 
   it("should return org scopes with correct roles", async () => {
     const memberUserId = uniqueId("list-member");
-    const orgSlug = uniqueId("scope");
+    const orgSlug = uniqueId("org");
     const orgId = uniqueId("org");
 
     // Mock Clerk to return the member's org membership with "member" role
@@ -64,9 +64,9 @@ describe("GET /api/scope/list - Scope List", () => {
     expect(data.scopes[0].role).toBe("member");
   });
 
-  it("should only return scopes the user is a Clerk member of", async () => {
+  it("should only return orgs the user is a Clerk member of", async () => {
     const userBId = uniqueId("user-b");
-    const userBOrgSlug = uniqueId("scope-b");
+    const userBOrgSlug = uniqueId("org-b");
 
     // User B only has their own org
     mockClerk({

--- a/turbo/apps/web/app/api/scope/__tests__/members.test.ts
+++ b/turbo/apps/web/app/api/scope/__tests__/members.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 import { GET } from "../members/route";
 import {
   createTestRequest,
-  createTestScope as createTestScopeHelper,
+  createTestOrg as createTestOrgHelper,
 } from "../../../../src/__tests__/api-test-helpers";
 import { testContext, uniqueId } from "../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../src/__tests__/clerk-mock";
@@ -12,10 +12,10 @@ import { clerkClient } from "@clerk/nextjs/server";
 const context = testContext();
 
 /**
- * Helper to create a scope via the test helper
+ * Helper to create an org via the test helper
  */
-async function createTestScope(userId: string) {
-  const slug = uniqueId("scope");
+async function createTestOrg(userId: string) {
+  const slug = uniqueId("org");
   setupClerkOrgMock({
     userId,
     orgId: `org_mock_${userId}`,
@@ -23,11 +23,11 @@ async function createTestScope(userId: string) {
     memberships: [{ userId, role: "org:admin" }],
   });
 
-  await createTestScopeHelper(slug);
+  await createTestOrgHelper(slug);
   return { slug, orgId: `org_mock_${userId}` };
 }
 
-describe("GET /api/scope/members - Scope Members", () => {
+describe("GET /api/scope/members - Org Members", () => {
   beforeEach(() => {
     context.setupMocks();
   });
@@ -45,7 +45,7 @@ describe("GET /api/scope/members - Scope Members", () => {
     expect(data.error.message).toContain("Not authenticated");
   });
 
-  it("should require scope query parameter", async () => {
+  it("should require org query parameter", async () => {
     const userId = uniqueId("members-user");
     mockClerk({ userId });
 
@@ -59,9 +59,9 @@ describe("GET /api/scope/members - Scope Members", () => {
     expect(data.error.code).toBe("BAD_REQUEST");
   });
 
-  it("should return scope members", async () => {
+  it("should return org members", async () => {
     const userId = uniqueId("members-admin");
-    const { slug, orgId } = await createTestScope(userId);
+    const { slug, orgId } = await createTestOrg(userId);
 
     setupClerkOrgMock({
       userId,
@@ -87,7 +87,7 @@ describe("GET /api/scope/members - Scope Members", () => {
     it("should auto-sync org membership from Clerk when user is not yet known locally", async () => {
       const adminUserId = uniqueId("admin");
       const memberUserId = uniqueId("member");
-      const { slug, orgId } = await createTestScope(adminUserId);
+      const { slug, orgId } = await createTestOrg(adminUserId);
 
       // Switch to member user who is in Clerk org but not yet synced locally
       setupClerkOrgMock({
@@ -114,7 +114,7 @@ describe("GET /api/scope/members - Scope Members", () => {
     it("should return 403 when user is not in Clerk org", async () => {
       const adminUserId = uniqueId("admin");
       const outsiderUserId = uniqueId("outsider");
-      const { slug, orgId } = await createTestScope(adminUserId);
+      const { slug, orgId } = await createTestOrg(adminUserId);
 
       setupClerkOrgMock({
         userId: outsiderUserId,
@@ -133,7 +133,7 @@ describe("GET /api/scope/members - Scope Members", () => {
     it("should return 403 when Clerk API fails during lazy sync", async () => {
       const adminUserId = uniqueId("admin");
       const memberUserId = uniqueId("member");
-      const { slug, orgId } = await createTestScope(adminUserId);
+      const { slug, orgId } = await createTestOrg(adminUserId);
 
       setupClerkOrgMock({
         userId: memberUserId,

--- a/turbo/apps/web/app/api/scope/__tests__/remove-member.test.ts
+++ b/turbo/apps/web/app/api/scope/__tests__/remove-member.test.ts
@@ -4,7 +4,7 @@ import { DELETE } from "../members/route";
 import { GET as getMembersRoute } from "../members/route";
 import {
   createTestRequest,
-  createTestScope as createTestScopeHelper,
+  createTestOrg as createTestOrgHelper,
 } from "../../../../src/__tests__/api-test-helpers";
 import { testContext, uniqueId } from "../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../src/__tests__/clerk-mock";
@@ -14,10 +14,10 @@ import { clerkClient } from "@clerk/nextjs/server";
 const context = testContext();
 
 /**
- * Helper to create a scope with a fresh user.
+ * Helper to create an org with a fresh user.
  */
-async function createTestScope(userId: string) {
-  const slug = uniqueId("scope");
+async function createTestOrg(userId: string) {
+  const slug = uniqueId("org");
   const orgId = `org_mock_${userId}`;
   setupClerkOrgMock({
     userId,
@@ -26,7 +26,7 @@ async function createTestScope(userId: string) {
     memberships: [{ userId, role: "org:admin" }],
   });
 
-  await createTestScopeHelper(slug);
+  await createTestOrgHelper(slug);
 
   return { slug, orgId };
 }
@@ -89,7 +89,7 @@ describe("DELETE /api/scope/members - Remove Member", () => {
     expect(data.error.message).toContain("Not authenticated");
   });
 
-  it("should require scope query parameter", async () => {
+  it("should require org query parameter", async () => {
     const userId = uniqueId("members-user");
     mockClerk({ userId });
 
@@ -113,7 +113,7 @@ describe("DELETE /api/scope/members - Remove Member", () => {
     const memberEmail = "member@example.com";
     // Clerk mock maps "member@example.com" -> "user_member"
     const memberUserId = "user_member";
-    const { slug, orgId } = await createTestScope(adminUserId);
+    const { slug, orgId } = await createTestOrg(adminUserId);
 
     // Add member via invite API
     await addMember(adminUserId, memberUserId, memberEmail, slug, orgId);
@@ -150,7 +150,7 @@ describe("DELETE /api/scope/members - Remove Member", () => {
     const memberEmail = "member-revoke@example.com";
     // Clerk mock maps "member-revoke@example.com" -> "user_member-revoke"
     const memberUserId = "user_member-revoke";
-    const { slug, orgId } = await createTestScope(adminUserId);
+    const { slug, orgId } = await createTestOrg(adminUserId);
 
     // Add member via invite API
     await addMember(adminUserId, memberUserId, memberEmail, slug, orgId);

--- a/turbo/apps/web/app/api/scope/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/scope/__tests__/route.test.ts
@@ -24,7 +24,7 @@ describe("/api/scope", () => {
       expect(data.error.message).toContain("Not authenticated");
     });
 
-    it("should return user's default scope from org_cache", async () => {
+    it("should return user's default org from org_cache", async () => {
       await context.setupUser();
 
       const request = createTestRequest("http://localhost:3000/api/scope");
@@ -80,7 +80,7 @@ describe("/api/scope", () => {
       expect(data.error.code).toBe("BAD_REQUEST");
     });
 
-    it("should update scope slug with force flag", async () => {
+    it("should update org slug with force flag", async () => {
       const newSlug = `updated-${Date.now()}`;
 
       const request = createTestRequest("http://localhost:3000/api/scope", {

--- a/turbo/apps/web/app/api/slack/oauth/callback/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/slack/oauth/callback/__tests__/route.test.ts
@@ -3,7 +3,7 @@ import { WebClient } from "@slack/web-api";
 import { GET } from "../route";
 import {
   createTestRequest,
-  createTestScope,
+  createTestOrg,
   createTestCompose,
   findTestSlackInstallation,
 } from "../../../../../../src/__tests__/api-test-helpers";
@@ -52,7 +52,7 @@ describe("/api/slack/oauth/callback", () => {
       // Create a compose to use as the default workspace agent
       const adminUserId = uniqueId("admin");
       mockClerk({ userId: adminUserId });
-      await createTestScope(uniqueId("scope"));
+      await createTestOrg(uniqueId("org"));
       const { composeId } = await createTestCompose("test-agent");
 
       // Configure the WebClient singleton's oauth.v2.access to return expected values
@@ -146,7 +146,7 @@ describe("/api/slack/oauth/callback", () => {
       // First install: admin is U-admin-original
       const adminUserId = uniqueId("admin");
       mockClerk({ userId: adminUserId });
-      await createTestScope(uniqueId("scope"));
+      await createTestOrg(uniqueId("org"));
       const { composeId } = await createTestCompose("original-agent");
 
       const mockClient = vi.mocked(new WebClient(), true);

--- a/turbo/apps/web/app/api/webhooks/email/inbound/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/email/inbound/__tests__/route.test.ts
@@ -518,13 +518,13 @@ describe("POST /api/webhooks/email/inbound", () => {
     it("should dispatch agent run for valid trigger email", async () => {
       // Given a user with a scope and compose
       // setupUser creates a user with userId = "trigger-user-{suffix}" and
-      // scope slug = "scope-{suffix}" using the same suffix
+      // scope slug = "org-{suffix}" using the same suffix
       const user = await context.setupUser({ prefix: "trigger-user" });
 
       // Extract suffix from userId to derive scope slug
       // userId format: "{prefix}-{suffix}" where suffix is an 8-char UUID
       const suffix = user.userId.slice("trigger-user-".length);
-      const orgSlug = `scope-${suffix}`;
+      const orgSlug = `org-${suffix}`;
       const agentName = uniqueId("trigger-agent");
 
       // Create compose (automatically associates with user's scope)
@@ -659,7 +659,7 @@ describe("POST /api/webhooks/email/inbound", () => {
       // Create a compose owned by user A
       const ownerUser = await context.setupUser({ prefix: "perm-owner" });
       const suffix = ownerUser.userId.slice("perm-owner-".length);
-      const orgSlug = `scope-${suffix}`;
+      const orgSlug = `org-${suffix}`;
       const agentName = uniqueId("perm-agent");
       await createTestCompose(agentName);
 
@@ -698,7 +698,7 @@ describe("POST /api/webhooks/email/inbound", () => {
     it("should send error reply when DMARC fails", async () => {
       const user = await context.setupUser({ prefix: "dmarc-fail" });
       const suffix = user.userId.slice("dmarc-fail-".length);
-      const orgSlug = `scope-${suffix}`;
+      const orgSlug = `org-${suffix}`;
       const agentName = uniqueId("dmarc-agent");
       await createTestCompose(agentName);
 
@@ -752,7 +752,7 @@ describe("POST /api/webhooks/email/inbound", () => {
     it("should send error reply when DMARC is none even if DKIM passes", async () => {
       const user = await context.setupUser({ prefix: "dkim-pass" });
       const suffix = user.userId.slice("dkim-pass-".length);
-      const orgSlug = `scope-${suffix}`;
+      const orgSlug = `org-${suffix}`;
       const agentName = uniqueId("dkim-agent");
       await createTestCompose(agentName);
 
@@ -804,7 +804,7 @@ describe("POST /api/webhooks/email/inbound", () => {
     it("should send error reply when authentication-results header is missing", async () => {
       const user = await context.setupUser({ prefix: "no-auth" });
       const suffix = user.userId.slice("no-auth-".length);
-      const orgSlug = `scope-${suffix}`;
+      const orgSlug = `org-${suffix}`;
       const agentName = uniqueId("noauth-agent");
       await createTestCompose(agentName);
 
@@ -853,7 +853,7 @@ describe("POST /api/webhooks/email/inbound", () => {
     it("should send error reply when all authentication methods fail", async () => {
       const user = await context.setupUser({ prefix: "all-fail" });
       const suffix = user.userId.slice("all-fail-".length);
-      const orgSlug = `scope-${suffix}`;
+      const orgSlug = `org-${suffix}`;
       const agentName = uniqueId("allfail-agent");
       await createTestCompose(agentName);
 
@@ -905,7 +905,7 @@ describe("POST /api/webhooks/email/inbound", () => {
     it("should send error reply when email body is empty", async () => {
       const user = await context.setupUser({ prefix: "empty-trigger" });
       const suffix = user.userId.slice("empty-trigger-".length);
-      const orgSlug = `scope-${suffix}`;
+      const orgSlug = `org-${suffix}`;
       const agentName = uniqueId("empty-body-agent");
       await createTestCompose(agentName);
 
@@ -952,7 +952,7 @@ describe("POST /api/webhooks/email/inbound", () => {
     it("should extract content from HTML when text is empty", async () => {
       const user = await context.setupUser({ prefix: "html-trigger" });
       const suffix = user.userId.slice("html-trigger-".length);
-      const orgSlug = `scope-${suffix}`;
+      const orgSlug = `org-${suffix}`;
       const agentName = uniqueId("html-agent");
       await createTestCompose(agentName);
 
@@ -1061,7 +1061,7 @@ describe("POST /api/webhooks/email/inbound", () => {
     it("should include attachment URLs in prompt when email has attachments", async () => {
       const user = await context.setupUser({ prefix: "att-trigger" });
       const suffix = user.userId.slice("att-trigger-".length);
-      const orgSlug = `scope-${suffix}`;
+      const orgSlug = `org-${suffix}`;
       const agentName = uniqueId("att-agent");
       await createTestCompose(agentName);
 
@@ -1156,7 +1156,7 @@ describe("POST /api/webhooks/email/inbound", () => {
     it("should skip oversized attachment with 'exceeds size limit' message", async () => {
       const user = await context.setupUser({ prefix: "att-oversize" });
       const suffix = user.userId.slice("att-oversize-".length);
-      const orgSlug = `scope-${suffix}`;
+      const orgSlug = `org-${suffix}`;
       const agentName = uniqueId("oversize-agent");
       await createTestCompose(agentName);
 
@@ -1217,7 +1217,7 @@ describe("POST /api/webhooks/email/inbound", () => {
     it("should skip attachment with 'download failed' when download returns error", async () => {
       const user = await context.setupUser({ prefix: "att-dl-fail" });
       const suffix = user.userId.slice("att-dl-fail-".length);
-      const orgSlug = `scope-${suffix}`;
+      const orgSlug = `org-${suffix}`;
       const agentName = uniqueId("dlfail-agent");
       await createTestCompose(agentName);
 
@@ -1286,7 +1286,7 @@ describe("POST /api/webhooks/email/inbound", () => {
     it("should handle multiple attachments with mixed results", async () => {
       const user = await context.setupUser({ prefix: "att-mixed" });
       const suffix = user.userId.slice("att-mixed-".length);
-      const orgSlug = `scope-${suffix}`;
+      const orgSlug = `org-${suffix}`;
       const agentName = uniqueId("mixed-agent");
       await createTestCompose(agentName);
 
@@ -1392,7 +1392,7 @@ describe("POST /api/webhooks/email/inbound", () => {
     it("should replace inline image data URI with placeholder in prompt", async () => {
       const user = await context.setupUser({ prefix: "inline-img" });
       const suffix = user.userId.slice("inline-img-".length);
-      const orgSlug = `scope-${suffix}`;
+      const orgSlug = `org-${suffix}`;
       const agentName = uniqueId("inline-agent");
       await createTestCompose(agentName);
 
@@ -1475,7 +1475,7 @@ describe("POST /api/webhooks/email/inbound", () => {
     it("should handle inline image without alt text", async () => {
       const user = await context.setupUser({ prefix: "inline-noalt" });
       const suffix = user.userId.slice("inline-noalt-".length);
-      const orgSlug = `scope-${suffix}`;
+      const orgSlug = `org-${suffix}`;
       const agentName = uniqueId("noalt-agent");
       await createTestCompose(agentName);
 
@@ -1878,7 +1878,7 @@ describe("POST /api/webhooks/email/inbound", () => {
     // Set up a valid trigger scenario so the handler proceeds past address parsing
     const user = await context.setupUser({ prefix: "crash-user" });
     const suffix = user.userId.slice("crash-user-".length);
-    const orgSlug = `scope-${suffix}`;
+    const orgSlug = `org-${suffix}`;
     const agentName = uniqueId("crash-agent");
     await createTestCompose(agentName);
 

--- a/turbo/apps/web/app/api/webhooks/github/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/github/__tests__/route.test.ts
@@ -8,7 +8,7 @@ import {
 } from "../../../../../src/__tests__/test-helpers";
 import { givenGitHubInstallation } from "../../../../../src/__tests__/github/api-helpers";
 import {
-  createTestScope,
+  createTestOrg,
   createTestCompose,
   insertTestPendingGitHubInstallation,
   findTestGitHubInstallationsByTargetId,
@@ -583,7 +583,7 @@ describe("POST /api/webhooks/github", () => {
     it("should activate pending installation on installation.created event", async () => {
       const userId = uniqueId("gh-user");
       mockClerk({ userId });
-      await createTestScope(uniqueId("gh-scope"));
+      await createTestOrg(uniqueId("gh-scope"));
       const { composeId } = await createTestCompose("gh-webhook-agent");
 
       const targetId = String(Math.floor(Math.random() * 1_000_000_000));

--- a/turbo/apps/web/app/api/webhooks/github/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/github/__tests__/route.test.ts
@@ -583,7 +583,7 @@ describe("POST /api/webhooks/github", () => {
     it("should activate pending installation on installation.created event", async () => {
       const userId = uniqueId("gh-user");
       mockClerk({ userId });
-      await createTestOrg(uniqueId("gh-scope"));
+      await createTestOrg(uniqueId("gh-org"));
       const { composeId } = await createTestCompose("gh-webhook-agent");
 
       const targetId = String(Math.floor(Math.random() * 1_000_000_000));

--- a/turbo/apps/web/src/__tests__/api-test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers.ts
@@ -311,15 +311,15 @@ export async function findTestCliToken(token: string) {
 }
 
 /**
- * Create a test scope by inserting into org_cache.
+ * Create a test org by inserting into org_cache.
  *
  * Pre-populates org_cache so getOrgData() works without Clerk API calls.
  * The scopes table has been dropped (Phase 6 🆉).
  *
- * @param slug - The scope slug
- * @returns The created scope with id and slug
+ * @param slug - The org slug
+ * @returns The created org with id and slug
  */
-export async function createTestScope(
+export async function createTestOrg(
   slug: string,
 ): Promise<{ id: string; slug: string }> {
   initServices();
@@ -1957,7 +1957,7 @@ export async function findTestArtifactStorage(orgId: string) {
 
 /**
  * Find a storage volume by clerk org and name.
- * Volumes use the sentinel VOLUME_SCOPE_USER_ID for scope-level sharing.
+ * Volumes use the sentinel VOLUME_SCOPE_USER_ID for org-level sharing.
  * Returns the storage id and name, or undefined if not found.
  */
 export async function findTestStorageByName(
@@ -2304,7 +2304,7 @@ export async function findTestComposeWithScope(composeId: string) {
  *
  * @param userId - The user who owns the run
  * @param versionId - The agent compose version ID
- * @param runnerGroup - The runner group (e.g., "scope-slug/default")
+ * @param runnerGroup - The runner group (e.g., "org-slug/default")
  * @param contextOverrides - Optional overrides for the stored execution context
  * @returns The created run ID
  */
@@ -2601,7 +2601,7 @@ export async function createTestTelegramInstallation(options?: {
   const suffix = uniqueId("tg");
   const adminUserId = options?.adminUserId ?? uniqueId("test-admin");
 
-  const orgSlug = uniqueId("scope");
+  const orgSlug = uniqueId("org");
   const orgId = uniqueId("org");
 
   // Pre-populate org cache for getOrgData()
@@ -2823,7 +2823,7 @@ export async function insertOrgCacheEntry(entry: {
 
 /**
  * Delete an org_cache row by orgId.
- * Useful for testing cache-miss behavior after createTestScope pre-populates cache.
+ * Useful for testing cache-miss behavior after createTestOrg pre-populates cache.
  */
 export async function deleteOrgCacheEntry(orgId: string): Promise<void> {
   await globalThis.services.db

--- a/turbo/apps/web/src/__tests__/clerk-mock.ts
+++ b/turbo/apps/web/src/__tests__/clerk-mock.ts
@@ -31,7 +31,7 @@ const mockClerkClient = vi.mocked(clerkClient);
 
 // Module-level tracking of orgs created via createOrganization.
 // Persists across mockClerk() calls so that re-mocking (e.g. to set orgId)
-// doesn't lose orgs created by earlier API calls (like createTestScope).
+// doesn't lose orgs created by earlier API calls (like createTestOrg).
 let createdOrgs: Array<{
   id: string;
   slug: string;
@@ -107,9 +107,9 @@ export function mockClerk(options: {
 
   // Note: createdOrgs is module-level (declared above) so it persists across
   // mockClerk() calls. This is critical: setupUser() calls mockClerk() then
-  // createTestScope() (which calls createOrganization), and tests often call
+  // createTestOrg() (which calls createOrganization), and tests often call
   // mockClerk() again to configure orgId — without module-level tracking,
-  // the org from createTestScope would be lost.
+  // the org from createTestOrg would be lost.
 
   mockAuth.mockResolvedValue({
     userId: options.userId,

--- a/turbo/apps/web/src/__tests__/github/api-helpers.ts
+++ b/turbo/apps/web/src/__tests__/github/api-helpers.ts
@@ -49,7 +49,7 @@ export async function givenGitHubInstallation(
 
   const userId = uniqueId("gh-user");
   const githubUserId = String(Math.floor(Math.random() * 1_000_000_000));
-  const orgSlug = uniqueId("scope");
+  const orgSlug = uniqueId("org");
 
   // Pre-populate org cache for getOrgData()
   const orgId = uniqueId("org");

--- a/turbo/apps/web/src/__tests__/slack/api-helpers.ts
+++ b/turbo/apps/web/src/__tests__/slack/api-helpers.ts
@@ -105,7 +105,7 @@ export async function givenSlackWorkspaceInstalled(
   const accessToken = `xoxb-test-${uniqueId("token")}`;
   const adminSlackUserId = uniqueId("admin-slack");
 
-  // Create admin scope + compose for the workspace agent
+  // Create admin org + compose for the workspace agent
   const adminUserId = options.adminUserId ?? uniqueId("admin");
   mockClerk({ userId: adminUserId });
   await createTestOrg(uniqueId("admin-org"));
@@ -152,7 +152,7 @@ export async function givenSlackWorkspaceInstalled(
 
 /**
  * Given a Slack user has linked their account to VM0.
- * Creates installation, user link, and scope via API endpoints.
+ * Creates installation, user link, and org via API endpoints.
  */
 export async function givenLinkedSlackUser(
   options: LinkedUserOptions = {},
@@ -174,7 +174,7 @@ export async function givenLinkedSlackUser(
   // Restore Clerk mock to the linking user (givenSlackWorkspaceInstalled sets it to admin)
   mockClerk({ userId: vm0UserId });
 
-  // Create scope for the user (required for compose creation)
+  // Create org for the user (required for compose creation)
   const orgSlug = uniqueId("org");
   await createTestOrg(orgSlug);
 

--- a/turbo/apps/web/src/__tests__/slack/api-helpers.ts
+++ b/turbo/apps/web/src/__tests__/slack/api-helpers.ts
@@ -12,7 +12,7 @@ import { vi } from "vitest";
 import { WebClient } from "@slack/web-api";
 import { eq, and, sql } from "drizzle-orm";
 import { mockClerk } from "../clerk-mock";
-import { createTestCompose, createTestScope } from "../api-test-helpers";
+import { createTestCompose, createTestOrg } from "../api-test-helpers";
 import { uniqueId } from "../test-helpers";
 import { initServices } from "../../lib/init-services";
 import { slackUserLinks } from "../../db/schema/slack-user-link";
@@ -108,7 +108,7 @@ export async function givenSlackWorkspaceInstalled(
   // Create admin scope + compose for the workspace agent
   const adminUserId = options.adminUserId ?? uniqueId("admin");
   mockClerk({ userId: adminUserId });
-  await createTestScope(uniqueId("admin-scope"));
+  await createTestOrg(uniqueId("admin-org"));
   const { composeId } = await createTestCompose(
     options.agentName ?? "default-agent",
   );
@@ -175,8 +175,8 @@ export async function givenLinkedSlackUser(
   mockClerk({ userId: vm0UserId });
 
   // Create scope for the user (required for compose creation)
-  const orgSlug = uniqueId("scope");
-  await createTestScope(orgSlug);
+  const orgSlug = uniqueId("org");
+  await createTestOrg(orgSlug);
 
   // WebClient methods (views.publish, chat.postEphemeral) are already mocked in setup.ts
   // so linking triggers (refreshAppHome, postEphemeral) will use those mocks.

--- a/turbo/apps/web/src/__tests__/test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/test-helpers.ts
@@ -447,7 +447,7 @@ export function testContext(): TestContext {
       initServices();
 
       // Generate unique suffix shared between userId and scope
-      // This allows tests to derive scope slug from userId if needed
+      // This allows tests to derive org slug from userId if needed
       const suffix = uniqueSuffix();
       const userId = `${prefix}-${suffix}`;
       trackedUserIds.push(userId);
@@ -457,10 +457,10 @@ export function testContext(): TestContext {
 
       // Pre-populate org_cache for the default Clerk org so that
       // getOrgData() works without hitting the Clerk API mock.
-      // Use scope-${suffix} as slug to match test conventions that derive
-      // scope slug from userId suffix.
+      // Use org-${suffix} as slug to match test conventions that derive
+      // org slug from userId suffix.
       const defaultOrgId = `org_mock_${userId}`;
-      const defaultOrgSlug = `scope-${suffix}`;
+      const defaultOrgSlug = `org-${suffix}`;
       await insertOrgCacheEntry({ orgId: defaultOrgId, slug: defaultOrgSlug });
       controller.signal.throwIfAborted();
 
@@ -502,7 +502,7 @@ export function testContext(): TestContext {
     const adminUserId = optVm0UserId ?? uniqueId("test-admin");
     let composeId = options.composeId;
     if (!composeId) {
-      const orgSlug = uniqueId("scope");
+      const orgSlug = uniqueId("org");
       const orgId = uniqueId("org");
 
       // Pre-populate org cache for getOrgData()
@@ -597,7 +597,7 @@ export function testContext(): TestContext {
     initServices();
 
     // Create org cache and compose for this user
-    const orgSlug = uniqueId("scope");
+    const orgSlug = uniqueId("org");
     const orgId = uniqueId("org");
 
     // Pre-populate org cache for getOrgData()

--- a/turbo/apps/web/src/lib/auth/__tests__/user-cache-service.test.ts
+++ b/turbo/apps/web/src/lib/auth/__tests__/user-cache-service.test.ts
@@ -3,7 +3,7 @@ import { clerkClient } from "@clerk/nextjs/server";
 import { testContext, uniqueId } from "../../../__tests__/test-helpers";
 import { mockClerk } from "../../../__tests__/clerk-mock";
 import {
-  createTestScope,
+  createTestOrg,
   insertUserCacheEntry,
 } from "../../../__tests__/api-test-helpers";
 import { getCachedUser, getCachedUserIdByEmail } from "../user-cache-service";
@@ -19,8 +19,8 @@ describe("getCachedUser", () => {
     const userId = uniqueId("test-user");
     const email = `${userId}@example.com`;
     mockClerk({ userId, email });
-    // createTestScope triggers initServices() via the route handler
-    await createTestScope(uniqueId("scope"));
+    // createTestOrg triggers initServices() via the route handler
+    await createTestOrg(uniqueId("org"));
 
     const result = await getCachedUser(userId);
 
@@ -41,7 +41,7 @@ describe("getCachedUser", () => {
     const userId = uniqueId("test-user");
     const email = `${userId}@cached.com`;
     mockClerk({ userId });
-    await createTestScope(uniqueId("scope"));
+    await createTestOrg(uniqueId("org"));
 
     // Pre-populate cache with fresh entry
     await insertUserCacheEntry({ userId, email });
@@ -59,7 +59,7 @@ describe("getCachedUser", () => {
     const userId = uniqueId("test-user");
     const freshEmail = `${userId}@example.com`;
     mockClerk({ userId, email: freshEmail });
-    await createTestScope(uniqueId("scope"));
+    await createTestOrg(uniqueId("org"));
 
     // Pre-populate cache with stale entry (2 minutes ago)
     const twoMinutesAgo = new Date(Date.now() - 120_000);
@@ -88,7 +88,7 @@ describe("getCachedUser", () => {
   it("throws when user has no primary email", async () => {
     const userId = uniqueId("test-user");
     mockClerk({ userId });
-    await createTestScope(uniqueId("scope"));
+    await createTestOrg(uniqueId("org"));
 
     // Override getUser to return no primary email
     const client = await clerkClient();
@@ -112,7 +112,7 @@ describe("getCachedUserIdByEmail", () => {
     const userId = uniqueId("test-user");
     const email = `${userId}@cached.com`;
     mockClerk({ userId });
-    await createTestScope(uniqueId("scope"));
+    await createTestOrg(uniqueId("org"));
 
     // Pre-populate cache
     await insertUserCacheEntry({ userId, email });
@@ -130,7 +130,7 @@ describe("getCachedUserIdByEmail", () => {
     const userId = uniqueId("test-user");
     const email = `${userId}@example.com`;
     mockClerk({ userId, email });
-    await createTestScope(uniqueId("scope"));
+    await createTestOrg(uniqueId("org"));
 
     const result = await getCachedUserIdByEmail(email);
 
@@ -150,7 +150,7 @@ describe("getCachedUserIdByEmail", () => {
   it("returns null when user not found", async () => {
     const userId = uniqueId("test-user");
     mockClerk({ userId });
-    await createTestScope(uniqueId("scope"));
+    await createTestOrg(uniqueId("org"));
 
     const result = await getCachedUserIdByEmail("nonexistent@example.com");
 

--- a/turbo/apps/web/src/lib/scope/__tests__/org-cache-service.test.ts
+++ b/turbo/apps/web/src/lib/scope/__tests__/org-cache-service.test.ts
@@ -3,7 +3,7 @@ import { clerkClient } from "@clerk/nextjs/server";
 import { testContext, uniqueId } from "../../../__tests__/test-helpers";
 import { mockClerk } from "../../../__tests__/clerk-mock";
 import {
-  createTestScope,
+  createTestOrg,
   insertOrgCacheEntry,
   deleteOrgCacheEntry,
   getOrgCacheEntry,
@@ -19,13 +19,13 @@ describe("getOrgData", () => {
 
   it("fetches from Clerk and caches on miss", async () => {
     const userId = uniqueId("test-user");
-    const slug = uniqueId("scope");
+    const slug = uniqueId("org");
     // Set up Clerk org with slug-based ID BEFORE creating scope
     mockClerk({
       userId,
       clerkOrgs: [{ id: `org_mock_${slug}`, slug, name: slug }],
     });
-    await createTestScope(slug);
+    await createTestOrg(slug);
     const orgId = `org_mock_${slug}`;
 
     // Delete pre-populated orgCache to test cache-miss behavior
@@ -53,9 +53,9 @@ describe("getOrgData", () => {
 
   it("returns cached data without Clerk call when fresh", async () => {
     const userId = uniqueId("test-user");
-    const slug = uniqueId("scope");
+    const slug = uniqueId("org");
     mockClerk({ userId });
-    await createTestScope(slug);
+    await createTestOrg(slug);
     const orgId = `org_mock_${slug}`;
 
     // Pre-populate cache with fresh entry
@@ -80,16 +80,16 @@ describe("getOrgData", () => {
 
   it("refetches from Clerk when cache is stale", async () => {
     const userId = uniqueId("test-user");
-    const slug = uniqueId("scope");
+    const slug = uniqueId("org");
     // Set up Clerk org with slug-based ID BEFORE creating scope
     mockClerk({
       userId,
       clerkOrgs: [{ id: `org_mock_${slug}`, slug, name: slug }],
     });
-    await createTestScope(slug);
+    await createTestOrg(slug);
     const orgId = `org_mock_${slug}`;
 
-    // Overwrite the fresh orgCache entry from createTestScope with a stale one
+    // Overwrite the fresh orgCache entry from createTestOrg with a stale one
     const twoMinutesAgo = new Date(Date.now() - 120_000);
     await insertOrgCacheEntry({
       orgId,
@@ -118,9 +118,9 @@ describe("getOrgData", () => {
 
   it("reads tier from Clerk publicMetadata", async () => {
     const userId = uniqueId("test-user");
-    const slug = uniqueId("scope");
+    const slug = uniqueId("org");
     mockClerk({ userId });
-    await createTestScope(slug);
+    await createTestOrg(slug);
     const orgId = `org_mock_${slug}`;
 
     // Override getOrganization to return tier in publicMetadata
@@ -141,9 +141,9 @@ describe("getOrgData", () => {
 
   it("throws when Clerk org has no slug", async () => {
     const userId = uniqueId("test-user");
-    const slug = uniqueId("scope");
+    const slug = uniqueId("org");
     mockClerk({ userId });
-    await createTestScope(slug);
+    await createTestOrg(slug);
     const orgId = `org_mock_${slug}`;
 
     // Override getOrganization to return null slug
@@ -170,7 +170,7 @@ describe("getOrgBySlug", () => {
 
   it("fetches from Clerk by slug and caches on miss", async () => {
     const userId = uniqueId("test-user");
-    const slug = uniqueId("scope");
+    const slug = uniqueId("org");
     const orgId = `org_mock_${slug}`;
     mockClerk({
       userId,
@@ -200,7 +200,7 @@ describe("getOrgBySlug", () => {
 
   it("returns cached data without Clerk call when fresh", async () => {
     const userId = uniqueId("test-user");
-    const slug = uniqueId("scope");
+    const slug = uniqueId("org");
     const orgId = `org_mock_${slug}`;
     mockClerk({
       userId,
@@ -230,7 +230,7 @@ describe("getOrgBySlug", () => {
 
   it("refetches from Clerk when cache is stale", async () => {
     const userId = uniqueId("test-user");
-    const slug = uniqueId("scope");
+    const slug = uniqueId("org");
     const orgId = `org_mock_${slug}`;
     mockClerk({
       userId,

--- a/turbo/apps/web/src/lib/scope/__tests__/org-service.test.ts
+++ b/turbo/apps/web/src/lib/scope/__tests__/org-service.test.ts
@@ -11,7 +11,7 @@ describe("getDefaultOrgByUserId", () => {
     context.setupMocks();
   });
 
-  it("should return null when user has no scope", async () => {
+  it("should return null when user has no org", async () => {
     const userId = uniqueId("no-scope-user");
     mockClerk({ userId, clerkOrgs: [] });
 
@@ -20,10 +20,10 @@ describe("getDefaultOrgByUserId", () => {
     expect(result).toBeNull();
   });
 
-  it("should return scope from org_cache for user with Clerk org", async () => {
+  it("should return org from org_cache for user with Clerk org", async () => {
     const userId = uniqueId("test-user");
     const orgId = `org_mock_${userId}`;
-    const slug = uniqueId("scope");
+    const slug = uniqueId("org");
     mockClerk({ userId });
 
     // Pre-populate org_cache

--- a/turbo/apps/web/src/lib/scope/__tests__/resolve-org.test.ts
+++ b/turbo/apps/web/src/lib/scope/__tests__/resolve-org.test.ts
@@ -1,17 +1,17 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { testContext, uniqueId } from "../../../__tests__/test-helpers";
-import { createTestScope } from "../../../__tests__/api-test-helpers";
+import { createTestOrg } from "../../../__tests__/api-test-helpers";
 import { mockClerk } from "../../../__tests__/clerk-mock";
 import { resolveOrg, requireOrgFromRequest } from "../resolve-org";
 
 const context = testContext();
 
 /**
- * Build clerkOrgs array for scopes created in a test.
- * Must be used BEFORE calling createTestScope() so the POST route
+ * Build clerkOrgs array for orgs created in a test.
+ * Must be used BEFORE calling createTestOrg() so the POST route
  * resolves the correct orgId from the user's org memberships.
  */
-function scopeOrgs(...slugs: string[]) {
+function testOrgs(...slugs: string[]) {
   return slugs.map((slug) => ({
     id: `org_mock_${slug}`,
     slug,
@@ -28,8 +28,8 @@ describe("resolveOrg", () => {
     const { userId } = await context.setupUser();
 
     // Create two additional scopes — set up Clerk orgs BEFORE creating scopes
-    const slug1 = uniqueId("scope");
-    const slug2 = uniqueId("scope");
+    const slug1 = uniqueId("org");
+    const slug2 = uniqueId("org");
     mockClerk({
       userId,
       clerkOrgs: [
@@ -39,17 +39,17 @@ describe("resolveOrg", () => {
           slug: `org-${userId}`,
           name: `org-${userId}`,
         },
-        ...scopeOrgs(slug1, slug2),
+        ...testOrgs(slug1, slug2),
       ],
     });
-    await createTestScope(slug1);
-    await createTestScope(slug2);
+    await createTestOrg(slug1);
+    await createTestOrg(slug2);
 
     // Mock session with orgId pointing to scope2
     mockClerk({
       userId,
       orgId: `org_mock_${slug2}`,
-      clerkOrgs: scopeOrgs(slug1, slug2),
+      clerkOrgs: testOrgs(slug1, slug2),
     });
 
     // Resolve with explicit slug for scope1 — should return scope1, not scope2
@@ -61,17 +61,17 @@ describe("resolveOrg", () => {
 
   it("tier 2: auto-detects orgId from Clerk session", async () => {
     const userId = uniqueId("test-user");
-    const slug = uniqueId("scope");
+    const slug = uniqueId("org");
 
     // Set up Clerk org BEFORE creating scope so POST resolves correct orgId
-    mockClerk({ userId, clerkOrgs: scopeOrgs(slug) });
-    await createTestScope(slug);
+    mockClerk({ userId, clerkOrgs: testOrgs(slug) });
+    await createTestOrg(slug);
 
     // Mock session with orgId matching the scope's orgId
     mockClerk({
       userId,
       orgId: `org_mock_${slug}`,
-      clerkOrgs: scopeOrgs(slug),
+      clerkOrgs: testOrgs(slug),
     });
 
     // Resolve without slug or explicit orgId — should auto-detect from session
@@ -83,17 +83,17 @@ describe("resolveOrg", () => {
 
   it("tier 2: explicit orgId parameter takes precedence over session", async () => {
     const userId = uniqueId("test-user");
-    const slug = uniqueId("scope");
+    const slug = uniqueId("org");
 
     // Set up Clerk org BEFORE creating scope
-    mockClerk({ userId, clerkOrgs: scopeOrgs(slug) });
-    await createTestScope(slug);
+    mockClerk({ userId, clerkOrgs: testOrgs(slug) });
+    await createTestOrg(slug);
 
     // Mock session with a different orgId (should NOT be used)
     mockClerk({
       userId,
       orgId: "org_session_different",
-      clerkOrgs: scopeOrgs(slug),
+      clerkOrgs: testOrgs(slug),
     });
 
     // Pass explicit orgId matching the scope
@@ -105,17 +105,17 @@ describe("resolveOrg", () => {
 
   it("tier 3: falls through when no Clerk session (CLI token)", async () => {
     const userId = uniqueId("test-user");
-    const slug = uniqueId("scope");
+    const slug = uniqueId("org");
 
     // Set up Clerk org BEFORE creating scope
-    mockClerk({ userId, clerkOrgs: scopeOrgs(slug) });
-    await createTestScope(slug);
+    mockClerk({ userId, clerkOrgs: testOrgs(slug) });
+    await createTestOrg(slug);
 
     // Mock as CLI token — no orgId in session, but Clerk API returns user's orgs
     mockClerk({
       userId,
       orgId: null,
-      clerkOrgs: scopeOrgs(slug),
+      clerkOrgs: testOrgs(slug),
     });
 
     // Resolve without slug — should fall through to getDefaultOrg (Clerk API)
@@ -126,17 +126,17 @@ describe("resolveOrg", () => {
 
   it("tier 3: falls through when orgId has no matching scope", async () => {
     const userId = uniqueId("test-user");
-    const slug = uniqueId("scope");
+    const slug = uniqueId("org");
 
     // Set up Clerk org BEFORE creating scope
-    mockClerk({ userId, clerkOrgs: scopeOrgs(slug) });
-    await createTestScope(slug);
+    mockClerk({ userId, clerkOrgs: testOrgs(slug) });
+    await createTestOrg(slug);
 
     // Mock session with an orgId that doesn't match any scope
     mockClerk({
       userId,
       orgId: "org_nonexistent_xyz",
-      clerkOrgs: scopeOrgs(slug),
+      clerkOrgs: testOrgs(slug),
     });
 
     // Resolve without slug — orgId lookup returns null, falls to default
@@ -147,26 +147,26 @@ describe("resolveOrg", () => {
 
   it("tier 2: resolves correct scope when user has multiple scopes", async () => {
     const userId = uniqueId("test-user");
-    const slug1 = uniqueId("scope");
-    const slug2 = uniqueId("scope");
+    const slug1 = uniqueId("org");
+    const slug2 = uniqueId("org");
 
     // Set up two Clerk orgs BEFORE creating scopes
     mockClerk({
       userId,
-      clerkOrgs: scopeOrgs(slug1, slug2),
+      clerkOrgs: testOrgs(slug1, slug2),
     });
 
     // Create first scope (will be the default — earliest createdAt)
-    await createTestScope(slug1);
+    await createTestOrg(slug1);
 
     // Create second scope
-    await createTestScope(slug2);
+    await createTestOrg(slug2);
 
     // Mock session with orgId matching the SECOND scope
     mockClerk({
       userId,
       orgId: `org_mock_${slug2}`,
-      clerkOrgs: scopeOrgs(slug1, slug2),
+      clerkOrgs: testOrgs(slug1, slug2),
     });
 
     // Resolve without slug — should return scope2 (from orgId), not scope1 (default)
@@ -179,18 +179,18 @@ describe("resolveOrg", () => {
 
   it("reads tier from JWT sessionClaims when org matches", async () => {
     const userId = uniqueId("test-user");
-    const slug = uniqueId("scope");
+    const slug = uniqueId("org");
 
     // Set up Clerk org BEFORE creating scope
-    mockClerk({ userId, clerkOrgs: scopeOrgs(slug) });
-    await createTestScope(slug);
+    mockClerk({ userId, clerkOrgs: testOrgs(slug) });
+    await createTestOrg(slug);
 
     // Mock session with orgTier in JWT claims
     mockClerk({
       userId,
       orgId: `org_mock_${slug}`,
       orgTier: "pro",
-      clerkOrgs: scopeOrgs(slug),
+      clerkOrgs: testOrgs(slug),
     });
 
     const result = await resolveOrg(userId);
@@ -202,17 +202,17 @@ describe("resolveOrg", () => {
 
   it("falls back to DB tier when JWT org_tier claim is missing", async () => {
     const userId = uniqueId("test-user");
-    const slug = uniqueId("scope");
+    const slug = uniqueId("org");
 
     // Set up Clerk org BEFORE creating scope
-    mockClerk({ userId, clerkOrgs: scopeOrgs(slug) });
-    await createTestScope(slug);
+    mockClerk({ userId, clerkOrgs: testOrgs(slug) });
+    await createTestOrg(slug);
 
     // Mock session WITHOUT orgTier
     mockClerk({
       userId,
       orgId: `org_mock_${slug}`,
-      clerkOrgs: scopeOrgs(slug),
+      clerkOrgs: testOrgs(slug),
     });
 
     const result = await resolveOrg(userId);
@@ -223,20 +223,20 @@ describe("resolveOrg", () => {
 
   it("does not override tier when resolving non-active org via explicit slug", async () => {
     const userId = uniqueId("test-user");
-    const slug1 = uniqueId("scope");
-    const slug2 = uniqueId("scope");
+    const slug1 = uniqueId("org");
+    const slug2 = uniqueId("org");
 
     // Set up two Clerk orgs BEFORE creating scopes
-    mockClerk({ userId, clerkOrgs: scopeOrgs(slug1, slug2) });
-    await createTestScope(slug1);
-    await createTestScope(slug2);
+    mockClerk({ userId, clerkOrgs: testOrgs(slug1, slug2) });
+    await createTestOrg(slug1);
+    await createTestOrg(slug2);
 
     // JWT active org is scope2, but resolving scope1 via explicit slug
     mockClerk({
       userId,
       orgId: `org_mock_${slug2}`,
       orgTier: "max",
-      clerkOrgs: scopeOrgs(slug1, slug2),
+      clerkOrgs: testOrgs(slug1, slug2),
     });
 
     const result = await resolveOrg(userId, slug1);
@@ -247,16 +247,16 @@ describe("resolveOrg", () => {
 
   it("returns member with correct role", async () => {
     const userId = uniqueId("test-user");
-    const slug = uniqueId("scope");
+    const slug = uniqueId("org");
 
     // Set up Clerk org BEFORE creating scope
-    mockClerk({ userId, clerkOrgs: scopeOrgs(slug) });
-    await createTestScope(slug);
+    mockClerk({ userId, clerkOrgs: testOrgs(slug) });
+    await createTestOrg(slug);
 
     mockClerk({
       userId,
       orgId: `org_mock_${slug}`,
-      clerkOrgs: scopeOrgs(slug),
+      clerkOrgs: testOrgs(slug),
     });
 
     const result = await resolveOrg(userId);
@@ -268,11 +268,11 @@ describe("resolveOrg", () => {
   it("throws 403 when user is not a Clerk org member", async () => {
     const userId = uniqueId("test-user");
     const otherUserId = uniqueId("other-user");
-    const slug = uniqueId("scope");
+    const slug = uniqueId("org");
 
     // Set up Clerk org BEFORE creating scope
-    mockClerk({ userId, clerkOrgs: scopeOrgs(slug) });
-    await createTestScope(slug);
+    mockClerk({ userId, clerkOrgs: testOrgs(slug) });
+    await createTestOrg(slug);
 
     // Mock as different user who is NOT in the org
     mockClerk({
@@ -288,17 +288,17 @@ describe("resolveOrg", () => {
 
   it("?org= param resolves scope by orgId", async () => {
     const userId = uniqueId("test-user");
-    const slug = uniqueId("scope");
+    const slug = uniqueId("org");
 
     // Set up Clerk org BEFORE creating scope
-    mockClerk({ userId, clerkOrgs: scopeOrgs(slug) });
-    await createTestScope(slug);
+    mockClerk({ userId, clerkOrgs: testOrgs(slug) });
+    await createTestOrg(slug);
 
     // Mock session — orgId is different from the explicit orgId
     mockClerk({
       userId,
       orgId: "org_session_different",
-      clerkOrgs: scopeOrgs(slug),
+      clerkOrgs: testOrgs(slug),
     });
 
     // Pass orgId directly (simulates ?org= being passed as 3rd arg)
@@ -310,18 +310,18 @@ describe("resolveOrg", () => {
 
   it("?scope= takes priority over ?org=", async () => {
     const userId = uniqueId("test-user");
-    const slug1 = uniqueId("scope");
-    const slug2 = uniqueId("scope");
+    const slug1 = uniqueId("org");
+    const slug2 = uniqueId("org");
 
     // Set up two Clerk orgs BEFORE creating scopes
-    mockClerk({ userId, clerkOrgs: scopeOrgs(slug1, slug2) });
-    await createTestScope(slug1);
-    await createTestScope(slug2);
+    mockClerk({ userId, clerkOrgs: testOrgs(slug1, slug2) });
+    await createTestOrg(slug1);
+    await createTestOrg(slug2);
 
     mockClerk({
       userId,
       orgId: `org_mock_${slug1}`,
-      clerkOrgs: scopeOrgs(slug1, slug2),
+      clerkOrgs: testOrgs(slug1, slug2),
     });
 
     // Pass both orgSlug and orgId — orgSlug should win
@@ -339,16 +339,16 @@ describe("requireOrgFromRequest", () => {
 
   it("resolves scope via ?org= param", async () => {
     const userId = uniqueId("test-user");
-    const slug = uniqueId("scope");
+    const slug = uniqueId("org");
 
     // Set up Clerk org BEFORE creating scope
-    mockClerk({ userId, clerkOrgs: scopeOrgs(slug) });
-    await createTestScope(slug);
+    mockClerk({ userId, clerkOrgs: testOrgs(slug) });
+    await createTestOrg(slug);
 
     mockClerk({
       userId,
       orgId: `org_mock_${slug}`,
-      clerkOrgs: scopeOrgs(slug),
+      clerkOrgs: testOrgs(slug),
     });
 
     const request = new Request(
@@ -362,18 +362,18 @@ describe("requireOrgFromRequest", () => {
 
   it("?scope= takes priority over ?org=", async () => {
     const userId = uniqueId("test-user");
-    const slug1 = uniqueId("scope");
-    const slug2 = uniqueId("scope");
+    const slug1 = uniqueId("org");
+    const slug2 = uniqueId("org");
 
     // Set up two Clerk orgs BEFORE creating scopes
-    mockClerk({ userId, clerkOrgs: scopeOrgs(slug1, slug2) });
-    await createTestScope(slug1);
-    await createTestScope(slug2);
+    mockClerk({ userId, clerkOrgs: testOrgs(slug1, slug2) });
+    await createTestOrg(slug1);
+    await createTestOrg(slug2);
 
     mockClerk({
       userId,
       orgId: `org_mock_${slug1}`,
-      clerkOrgs: scopeOrgs(slug1, slug2),
+      clerkOrgs: testOrgs(slug1, slug2),
     });
 
     // Both ?scope= and ?org= provided — ?scope= should win

--- a/turbo/apps/web/src/lib/slack/handlers/__tests__/run-agent.test.ts
+++ b/turbo/apps/web/src/lib/slack/handlers/__tests__/run-agent.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { testContext, uniqueId } from "../../../../__tests__/test-helpers";
 import {
   createTestCompose,
-  createTestScope,
+  createTestOrg,
 } from "../../../../__tests__/api-test-helpers";
 import { mockClerk } from "../../../../__tests__/clerk-mock";
 import * as runModule from "../../../run";
@@ -20,7 +20,7 @@ describe("runAgentForSlack", () => {
     // Given a user with an agent compose (created via API so it has a version)
     const userId = uniqueId("test-user");
     mockClerk({ userId });
-    await createTestScope(uniqueId("scope"));
+    await createTestOrg(uniqueId("org"));
     const { composeId } = await createTestCompose("test-agent");
 
     // And createRun is spied on to capture the call without executing


### PR DESCRIPTION
## Summary

- Rename `createTestScope()` → `createTestOrg()` across 18 test files (definition + all imports/call sites)
- Rename `scopeOrgs()` → `testOrgs()` in resolve-org.test.ts
- Replace all `uniqueId("scope*")` → `uniqueId("org*")` prefixes (~40+ occurrences)
- Update test descriptions (`describe`/`it` strings) from "scope" to "org" terminology (~15 occurrences)
- Update `setupUser()` slug convention from `scope-${suffix}` to `org-${suffix}` and all matching hardcoded references
- Update comments referencing old function names and terminology

## Test plan

- [x] All renamed tests pass locally (verified individually and in batches)
- [x] Pre-existing test failures confirmed identical on `main` branch (email/inbound, composes/list, integrations — unrelated to this PR)
- [x] Lint passes (`pnpm turbo run lint --filter=web`)
- [x] Prettier formatting passes (no changes needed)
- [x] Knip finds no unused exports/dependencies
- [x] Commitlint passes

Closes #4609

🤖 Generated with [Claude Code](https://claude.com/claude-code)