### PR TITLE
refactor: reorder mitm-addon request handling to enforce firewall before services

### DIFF
--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -352,8 +352,12 @@ def tls_clienthello(data: tls.ClientHelloData) -> None:
 
 def request(flow: http.HTTPFlow) -> None:
     """
-    Intercept request and apply firewall rules.
-    For MITM mode, rewrites allowed requests to VM0 Proxy.
+    Intercept request: enforce firewall rules, then inject service auth headers.
+
+    Order:
+    1. VM0 API auto-allow (agent must always reach the platform)
+    2. Firewall rules (security boundary — nothing bypasses this)
+    3. Service match (inject auth headers for allowed requests)
     """
     # Track request start time
     _request_start_times[flow.id] = time.time()
@@ -381,21 +385,12 @@ def request(flow: http.HTTPFlow) -> None:
     flow.metadata["vm_client_ip"] = client_ip
     flow.metadata["vm_network_log_path"] = vm_info.get("networkLogPath", "")
 
-    # Check service match BEFORE firewall rules.
-    # Service requests go directly to the target API with real tokens injected.
-    vm_services = vm_info.get("services")
-    if vm_services:
-        original_url = get_original_url(flow)
-        api_entry = match_service(original_url, vm_services)
-        if api_entry:
-            handle_service_request(flow, api_entry, vm_info)
-            return
-
     # Get target hostname
     hostname = flow.request.pretty_host.lower()
 
-    # Auto-allow VM0 API requests - the agent MUST be able to communicate with VM0
-    # This is checked before user firewall rules to ensure agent functionality
+    # --- Step 1: Auto-allow VM0 API requests ---
+    # The agent MUST be able to communicate with the platform.
+    # Checked before firewall rules to ensure agent functionality.
     api_url = get_api_url()
     if api_url:
         parsed_api = urllib.parse.urlparse(api_url)
@@ -404,18 +399,17 @@ def request(flow: http.HTTPFlow) -> None:
             ctx.log.info(f"[{run_id}] Auto-allow VM0 API: {hostname}")
             flow.metadata["firewall_action"] = "ALLOW"
             flow.metadata["firewall_rule"] = "vm0-api"
-            # Continue to skip rewrite check below
             flow.metadata["original_url"] = get_original_url(flow)
             return
 
-    # Evaluate firewall rules
+    # --- Step 2: Evaluate firewall rules (security boundary) ---
+    # Nothing bypasses the firewall — including service-matched requests.
     action, matched_rule = evaluate_rules(rules, hostname)
     flow.metadata["firewall_action"] = action
     flow.metadata["firewall_rule"] = matched_rule
 
     if action == "DENY":
         ctx.log.warn(f"[{run_id}] Firewall DENY: {hostname} (rule: {matched_rule})")
-        # Kill the flow and return error response
         flow.response = http.Response.make(
             403,
             b"Blocked by firewall",
@@ -423,7 +417,17 @@ def request(flow: http.HTTPFlow) -> None:
         )
         return
 
-    # Request is ALLOWED - pass through directly
+    # --- Step 3: Service match (only for allowed requests) ---
+    # Inject auth headers for configured API services.
+    vm_services = vm_info.get("services")
+    if vm_services:
+        original_url = get_original_url(flow)
+        api_entry = match_service(original_url, vm_services)
+        if api_entry:
+            handle_service_request(flow, api_entry, vm_info)
+            return
+
+    # Request is ALLOWED, no service match — pass through directly
     flow.metadata["original_url"] = get_original_url(flow)
     ctx.log.info(f"[{run_id}] Firewall ALLOW: {hostname}")
 

--- a/crates/runner/mitm-addon/tests/test_handlers.py
+++ b/crates/runner/mitm-addon/tests/test_handlers.py
@@ -125,7 +125,48 @@ class TestRequestHandler:
         assert flow.metadata.get("original_url") == "https://api.anthropic.com/v1/messages"
 
     def test_service_match_calls_handler(self, tmp_path):
-        """When URL matches a service, handle_service_request is called."""
+        """When URL matches a service and firewall allows, handle_service_request is called."""
+        registry = {
+            "vms": {
+                "10.200.0.5": {
+                    "runId": "run-conn-1",
+                    "sandboxToken": "tok-conn",
+                    "firewallRules": [
+                        {"domain": "*.github.com", "action": "ALLOW"},
+                        {"final": "DENY"},
+                    ],
+                    "networkLogPath": str(tmp_path / "net.jsonl"),
+                    "services": {
+                        "apis": [
+                            {"base": "https://api.github.com", "auth": {"headers": {"Authorization": "Bearer ${secrets.GITHUB_TOKEN}"}}},
+                        ]
+                    },
+                    "encryptedSecrets": "iv:tag:data",
+                }
+            }
+        }
+        reg_path = tmp_path / "registry.json"
+        reg_path.write_text(json.dumps(registry))
+
+        flow = _make_http_flow(
+            client_ip="10.200.0.5", host="api.github.com", path="/repos"
+        )
+
+        with (
+            patch.object(mitm_addon, "get_registry_path", return_value=str(reg_path)),
+            patch.object(mitm_addon, "get_api_url", return_value="https://api.vm0.ai"),
+            patch.object(mitm_addon.ctx, "log", MagicMock(), create=True),
+            patch.object(mitm_addon, "handle_service_request") as mock_handler,
+        ):
+            mitm_addon.request(flow)
+
+        mock_handler.assert_called_once()
+        call_args = mock_handler.call_args
+        assert call_args[0][0] is flow
+        assert call_args[0][1]["base"] == "https://api.github.com"
+
+    def test_firewall_denies_service_domain(self, tmp_path):
+        """Firewall DENY blocks service-matched domains — firewall is the security boundary."""
         registry = {
             "vms": {
                 "10.200.0.5": {
@@ -157,10 +198,11 @@ class TestRequestHandler:
         ):
             mitm_addon.request(flow)
 
-        mock_handler.assert_called_once()
-        call_args = mock_handler.call_args
-        assert call_args[0][0] is flow
-        assert call_args[0][1]["base"] == "https://api.github.com"
+        # Firewall should block before service matching
+        mock_handler.assert_not_called()
+        assert flow.response is not None
+        assert flow.response.status_code == 403
+        assert flow.metadata["firewall_action"] == "DENY"
 
     def test_no_rules_allows_through(self, registry_file):
         """VM with no firewall rules allows all requests through."""


### PR DESCRIPTION
## Summary

- Reorder MITM addon `request()` handler: **VM0 API auto-allow → firewall rules → service match**
- Previously services bypassed firewall entirely; now firewall is the security boundary
- Add test for firewall blocking service-matched domains

Closes #4624

## Test plan

- [x] Python mitm-addon tests pass (78 passed)
- [x] Rust runner tests pass (188 passed)
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)