### PR TITLE
refactor: update user-facing error messages from scope to org

### DIFF
--- a/docs/cli-design-guideline.md
+++ b/docs/cli-design-guideline.md
@@ -667,7 +667,7 @@ if (!isValid(value)) {
 }
 
 // Configuration
-if (error.message.includes("No scope configured")) {
+if (error.message.includes("No org configured")) {
   console.log(chalk.yellow("No organization configured"));
   console.log();
   console.log("Set your organization with:");

--- a/turbo/apps/cli/src/commands/org/__tests__/set.test.ts
+++ b/turbo/apps/cli/src/commands/org/__tests__/set.test.ts
@@ -95,7 +95,7 @@ describe("org set command", () => {
       }),
       http.put("http://localhost:3000/api/scope", () => {
         return HttpResponse.json(
-          { error: { message: "Scope already exists", code: "CONFLICT" } },
+          { error: { message: "Org already exists", code: "CONFLICT" } },
           { status: 409 },
         );
       }),

--- a/turbo/apps/cli/src/commands/org/__tests__/status.test.ts
+++ b/turbo/apps/cli/src/commands/org/__tests__/status.test.ts
@@ -44,7 +44,7 @@ describe("org status command", () => {
       server.use(
         http.get("http://localhost:3000/api/scope", () => {
           return HttpResponse.json(
-            { error: { message: "No scope configured", code: "NOT_FOUND" } },
+            { error: { message: "No org configured", code: "NOT_FOUND" } },
             { status: 404 },
           );
         }),

--- a/turbo/apps/cli/src/commands/org/status.ts
+++ b/turbo/apps/cli/src/commands/org/status.ts
@@ -16,7 +16,7 @@ export const statusCommand = new Command()
       } catch (error) {
         if (
           error instanceof Error &&
-          error.message.includes("No scope configured")
+          error.message.includes("No org configured")
         ) {
           throw new Error("No organization configured", {
             cause: new Error("Set your organization with: vm0 org set <slug>"),

--- a/turbo/apps/web/app/api/agent/composes/list/route.ts
+++ b/turbo/apps/web/app/api/agent/composes/list/route.ts
@@ -66,7 +66,7 @@ const router = tsr.router(composesListContract, {
     }
     const { userId, orgId: tokenOrgId } = authCtx;
 
-    // Resolve scope: use ?scope= query param or default scope
+    // Resolve org: use ?scope= query param or default org
     let orgId: string;
     try {
       const { org: resolvedOrg } = await resolveOrg(
@@ -90,7 +90,7 @@ const router = tsr.router(composesListContract, {
           status: 403 as const,
           body: {
             error: {
-              message: "You don't have access to this scope",
+              message: "You don't have access to this org",
               code: "FORBIDDEN",
             },
           },
@@ -99,7 +99,7 @@ const router = tsr.router(composesListContract, {
       throw error;
     }
 
-    // Query own composes for this scope (join head version for displayName)
+    // Query own composes for this org (join head version for displayName)
     const ownComposes = await globalThis.services.db
       .select({
         id: agentComposes.id,
@@ -116,7 +116,7 @@ const router = tsr.router(composesListContract, {
       .where(eq(agentComposes.orgId, orgId))
       .orderBy(desc(agentComposes.updatedAt));
 
-    // When using default scope (no ?scope= param), also include email-shared agents
+    // When using default org (no ?scope= param), also include email-shared agents
     let sharedComposes: {
       name: string;
       headVersionId: string | null;
@@ -130,7 +130,7 @@ const router = tsr.router(composesListContract, {
       sharedComposes = shared;
     }
 
-    // Combine: own agents first, then shared agents with scope/name format
+    // Combine: own agents first, then shared agents with org/name format
     const allComposes = [
       ...ownComposes.map((c) => ({
         name: c.name,

--- a/turbo/apps/web/app/api/integrations/github/route.ts
+++ b/turbo/apps/web/app/api/integrations/github/route.ts
@@ -122,7 +122,7 @@ export async function GET(request: Request) {
     }
   }
 
-  // Resolve user's scope for resource queries
+  // Resolve user's org for resource queries
   const { org } = await resolveOrg(userId, null, null, tokenOrgId);
 
   // Get user's existing secrets, vars, connectors
@@ -325,20 +325,20 @@ export async function PATCH(request: Request) {
     );
   }
 
-  // Parse scope/agentName format (shared agents use "orgSlug/agentName")
+  // Parse org/agentName format (shared agents use "orgSlug/agentName")
   const slashIndex = body.agentName.indexOf("/");
   const agentName =
     slashIndex === -1 ? body.agentName : body.agentName.slice(slashIndex + 1);
   const orgSlug =
     slashIndex === -1 ? null : body.agentName.slice(0, slashIndex);
 
-  // Resolve target scope
+  // Resolve target org
   let targetOrgId: string;
   if (orgSlug) {
     const targetOrg = await getOrgBySlug(orgSlug);
     if (!targetOrg) {
       return NextResponse.json(
-        { error: { message: "Scope not found", code: "BAD_REQUEST" } },
+        { error: { message: "Org not found", code: "BAD_REQUEST" } },
         { status: 400 },
       );
     }
@@ -348,7 +348,7 @@ export async function PATCH(request: Request) {
     targetOrgId = org.orgId;
   }
 
-  // Find agent compose by name in target scope
+  // Find agent compose by name in target org
   const [compose] = await db
     .select({ id: agentComposes.id })
     .from(agentComposes)

--- a/turbo/apps/web/app/api/integrations/slack/route.ts
+++ b/turbo/apps/web/app/api/integrations/slack/route.ts
@@ -95,7 +95,7 @@ export async function GET(request: Request) {
     );
   }
 
-  // Get workspace agent with scope info for navigation
+  // Get workspace agent with org info for navigation
   const [compose] = await db
     .select({
       id: agentComposes.id,
@@ -317,20 +317,20 @@ export async function PATCH(request: Request) {
     );
   }
 
-  // Parse scope/agentName format (shared agents use "orgSlug/agentName")
+  // Parse org/agentName format (shared agents use "orgSlug/agentName")
   const slashIndex = body.agentName.indexOf("/");
   const agentName =
     slashIndex === -1 ? body.agentName : body.agentName.slice(slashIndex + 1);
   const orgSlug =
     slashIndex === -1 ? null : body.agentName.slice(0, slashIndex);
 
-  // Resolve target scope (no membership check - admin can select any agent)
+  // Resolve target org (no membership check - admin can select any agent)
   let targetOrgId: string;
   if (orgSlug) {
     const targetOrg = await getOrgBySlug(orgSlug);
     if (!targetOrg) {
       return NextResponse.json(
-        { error: { message: "Scope not found", code: "BAD_REQUEST" } },
+        { error: { message: "Org not found", code: "BAD_REQUEST" } },
         { status: 400 },
       );
     }
@@ -340,7 +340,7 @@ export async function PATCH(request: Request) {
     targetOrgId = org.orgId;
   }
 
-  // Find agent compose by name in target scope
+  // Find agent compose by name in target org
   const [compose] = await db
     .select({ id: agentComposes.id })
     .from(agentComposes)

--- a/turbo/apps/web/app/api/integrations/telegram/route.ts
+++ b/turbo/apps/web/app/api/integrations/telegram/route.ts
@@ -88,7 +88,7 @@ export async function GET(request: Request) {
     );
   }
 
-  // Get default agent with scope info
+  // Get default agent with org info
   const [compose] = await db
     .select({
       id: agentComposes.id,
@@ -121,7 +121,7 @@ export async function GET(request: Request) {
     }
   }
 
-  // Resolve user's default scope and get existing secrets, vars, connectors
+  // Resolve user's default org and get existing secrets, vars, connectors
   const { org } = await resolveOrg(userId, null, null, tokenOrgId);
   const [userSecrets, userVars, userConnectors] = await Promise.all([
     listSecrets(org.orgId, userId),
@@ -247,7 +247,7 @@ export async function PATCH(request: Request) {
     );
   }
 
-  // Parse scope/agentName format
+  // Parse org/agentName format
   const slashIndex = body.agentName.indexOf("/");
   const agentName =
     slashIndex === -1 ? body.agentName : body.agentName.slice(slashIndex + 1);
@@ -260,7 +260,7 @@ export async function PATCH(request: Request) {
     const resolved = await getOrgBySlug(orgSlug);
     if (!resolved) {
       return NextResponse.json(
-        { error: { message: "Scope not found", code: "BAD_REQUEST" } },
+        { error: { message: "Org not found", code: "BAD_REQUEST" } },
         { status: 400 },
       );
     }
@@ -271,7 +271,7 @@ export async function PATCH(request: Request) {
     } catch (error) {
       if (isNotFound(error)) {
         return NextResponse.json(
-          { error: { message: "No scope configured", code: "BAD_REQUEST" } },
+          { error: { message: "No org configured", code: "BAD_REQUEST" } },
           { status: 400 },
         );
       }

--- a/turbo/apps/web/app/api/scope/__tests__/remove-member.test.ts
+++ b/turbo/apps/web/app/api/scope/__tests__/remove-member.test.ts
@@ -155,7 +155,7 @@ describe("DELETE /api/scope/members - Remove Member", () => {
     // Add member via invite API
     await addMember(adminUserId, memberUserId, memberEmail, slug, orgId);
 
-    // Verify member can access scope members
+    // Verify member can access org members
     setupClerkOrgMock({
       userId: memberUserId,
       orgId,
@@ -206,7 +206,7 @@ describe("DELETE /api/scope/members - Remove Member", () => {
     expect(removeRes.status).toBe(200);
 
     // Verify member is no longer in the Clerk org membership list.
-    // Use admin user to check — the removed member can no longer access the scope.
+    // Use admin user to check — the removed member can no longer access the org.
     setupClerkOrgMock({
       userId: adminUserId,
       orgId,

--- a/turbo/apps/web/app/api/scope/leave/route.ts
+++ b/turbo/apps/web/app/api/scope/leave/route.ts
@@ -10,7 +10,7 @@ import {
 } from "../../../../src/lib/errors";
 
 /**
- * POST /api/scope/leave - Leave the current scope
+ * POST /api/scope/leave - Leave the current org
  */
 export async function POST(request: Request) {
   initServices();
@@ -32,7 +32,7 @@ export async function POST(request: Request) {
       tokenOrgId,
     );
     await leaveOrg(userId, org.orgId, member.role);
-    return NextResponse.json({ message: "Left scope" });
+    return NextResponse.json({ message: "Left org" });
   } catch (error) {
     if (isBadRequest(error)) {
       return NextResponse.json(

--- a/turbo/apps/web/app/api/scope/route.ts
+++ b/turbo/apps/web/app/api/scope/route.ts
@@ -24,10 +24,10 @@ function resolvedOrgToResponse(resolved: ResolvedOrg) {
 
 const router = tsr.router(scopeContract, {
   /**
-   * GET /api/scope - Get current user's default scope
+   * GET /api/scope - Get current user's default org
    *
-   * Resolves the active scope via orgId from Clerk session,
-   * or falls back to the user's default scope (first admin membership).
+   * Resolves the active org via orgId from Clerk session,
+   * or falls back to the user's default org (first admin membership).
    */
   get: async ({ headers }) => {
     initServices();
@@ -59,10 +59,10 @@ const router = tsr.router(scopeContract, {
   },
 
   /**
-   * PUT /api/scope - Update active scope slug
+   * PUT /api/scope - Update active org slug
    *
-   * Resolves the active scope via orgId from Clerk session,
-   * or falls back to the user's default scope (first admin membership).
+   * Resolves the active org via orgId from Clerk session,
+   * or falls back to the user's default org (first admin membership).
    */
   update: async ({ body, headers }) => {
     initServices();
@@ -75,7 +75,7 @@ const router = tsr.router(scopeContract, {
 
     const { slug, force } = body;
 
-    log.debug("updating scope", { userId, slug, force });
+    log.debug("updating org", { userId, slug, force });
 
     let resolvedOrg;
     try {
@@ -84,7 +84,7 @@ const router = tsr.router(scopeContract, {
       if (isNotFound(error)) {
         return createErrorResponse(
           "NOT_FOUND",
-          "No scope configured. Set your scope with: vm0 scope set <slug>",
+          "No org configured. Set your org with: vm0 org set <slug>",
         );
       }
       throw error;

--- a/turbo/apps/web/app/api/storages/list/route.ts
+++ b/turbo/apps/web/app/api/storages/list/route.ts
@@ -31,7 +31,7 @@ const router = tsr.router(storagesListContract, {
 
     const { type: storageType } = query;
 
-    // Resolve user's default scope
+    // Resolve user's default org
     const orgSlug = new URL(request.url).searchParams.get("scope");
     const orgParam = new URL(request.url).searchParams.get("org");
     const { org: runtimeOrg } = await resolveOrg(
@@ -45,9 +45,9 @@ const router = tsr.router(storagesListContract, {
     const storageUserId =
       storageType === "volume" ? VOLUME_SCOPE_USER_ID : userId;
 
-    log.debug(`Listing ${storageType}s for scope ${runtimeOrg.slug}`);
+    log.debug(`Listing ${storageType}s for org ${runtimeOrg.slug}`);
 
-    // Query storages filtered by scope, userId, and type
+    // Query storages filtered by org, userId, and type
     const results = await globalThis.services.db
       .select({
         name: storages.name,

--- a/turbo/apps/web/src/lib/email/handlers/__tests__/shared.test.ts
+++ b/turbo/apps/web/src/lib/email/handlers/__tests__/shared.test.ts
@@ -7,24 +7,24 @@ import {
 } from "../shared";
 
 describe("parseEmailTriggerAddress", () => {
-  it("should parse valid scope+agent address", () => {
+  it("should parse valid org+agent address", () => {
     const result = parseEmailTriggerAddress("lancy+my-agent@vm0.bot");
-    expect(result).toEqual({ scope: "lancy", agent: "my-agent" });
+    expect(result).toEqual({ org: "lancy", agent: "my-agent" });
   });
 
   it("should normalize to lowercase", () => {
     const result = parseEmailTriggerAddress("LANCY+MY-AGENT@vm0.bot");
-    expect(result).toEqual({ scope: "lancy", agent: "my-agent" });
+    expect(result).toEqual({ org: "lancy", agent: "my-agent" });
   });
 
-  it("should handle scope and agent with numbers", () => {
+  it("should handle org and agent with numbers", () => {
     const result = parseEmailTriggerAddress("user123+agent456@vm0.bot");
-    expect(result).toEqual({ scope: "user123", agent: "agent456" });
+    expect(result).toEqual({ org: "user123", agent: "agent456" });
   });
 
-  it("should handle scope and agent with hyphens", () => {
+  it("should handle org and agent with hyphens", () => {
     const result = parseEmailTriggerAddress("my-scope+my-agent@vm0.bot");
-    expect(result).toEqual({ scope: "my-scope", agent: "my-agent" });
+    expect(result).toEqual({ org: "my-scope", agent: "my-agent" });
   });
 
   it("should return null for reply address", () => {
@@ -37,7 +37,7 @@ describe("parseEmailTriggerAddress", () => {
     expect(result).toBeNull();
   });
 
-  it("should return null for address with only scope", () => {
+  it("should return null for address with only org", () => {
     const result = parseEmailTriggerAddress("scope+@vm0.bot");
     expect(result).toBeNull();
   });
@@ -47,7 +47,7 @@ describe("parseEmailTriggerAddress", () => {
     expect(result).toBeNull();
   });
 
-  it("should return null for scope starting with hyphen", () => {
+  it("should return null for org starting with hyphen", () => {
     const result = parseEmailTriggerAddress("-invalid+agent@vm0.bot");
     expect(result).toBeNull();
   });

--- a/turbo/apps/web/src/lib/email/handlers/inbound-trigger.ts
+++ b/turbo/apps/web/src/lib/email/handlers/inbound-trigger.ts
@@ -34,7 +34,7 @@ interface InboundEmailEvent {
 }
 
 interface ResolvedTrigger {
-  triggerAddress: { scope: string; agent: string };
+  triggerAddress: { org: string; agent: string };
   triggerLocalPart: string;
   userId: string;
 }
@@ -42,14 +42,14 @@ interface ResolvedTrigger {
 /**
  * Parse trigger address from recipients and resolve the sender's user ID.
  * Supports two formats:
- * - scope+agent@domain (explicit scope)
- * - agent@domain (scope auto-detected from sender's personal scope)
+ * - org+agent@domain (explicit org)
+ * - agent@domain (org auto-detected from sender's personal org)
  */
 async function resolveTrigger(
   to: string[],
   senderEmail: string,
 ): Promise<ResolvedTrigger | HandlerResult> {
-  // 1a. Try scope+agent format first
+  // 1a. Try org+agent format first
   for (const addr of to) {
     const parsed = parseEmailTriggerAddress(addr);
     if (parsed) {
@@ -65,7 +65,7 @@ async function resolveTrigger(
       }
       return {
         triggerAddress: parsed,
-        triggerLocalPart: `${parsed.scope}+${parsed.agent}`,
+        triggerLocalPart: `${parsed.org}+${parsed.agent}`,
         userId,
       };
     }
@@ -90,7 +90,7 @@ async function resolveTrigger(
     };
   }
 
-  // For agent-only format, we need the sender's scope
+  // For agent-only format, we need the sender's org
   const userId = await getUserIdByEmail(senderEmail);
   if (!userId) {
     log.debug("Sender email not registered", { from: senderEmail });
@@ -102,7 +102,7 @@ async function resolveTrigger(
 
   const runtimeOrg = await getDefaultOrgByUserId(userId);
   if (!runtimeOrg) {
-    log.debug("Sender has no scope", { from: senderEmail, userId });
+    log.debug("Sender has no org", { from: senderEmail, userId });
     return {
       ok: false,
       errorMessage: "Your account does not have a workspace configured.",
@@ -110,7 +110,7 @@ async function resolveTrigger(
   }
 
   return {
-    triggerAddress: { scope: runtimeOrg.slug, agent: agentName },
+    triggerAddress: { org: runtimeOrg.slug, agent: agentName },
     triggerLocalPart: agentName,
     userId,
   };
@@ -120,9 +120,9 @@ async function resolveTrigger(
  * Handle an inbound email that triggers an agent run.
  *
  * Flow:
- * 1. Parse trigger address from recipients (scope+agent or agent-only)
+ * 1. Parse trigger address from recipients (org+agent or agent-only)
  * 2. Look up sender email in Clerk to get user ID
- * 3. Resolve agent by scope slug + agent name
+ * 3. Resolve agent by org slug + agent name
  * 4. Check if user has permission to access the agent
  * 5. Fetch full email and verify sender via DMARC
  * 6. Create agent run with callback for response delivery
@@ -141,24 +141,24 @@ export async function handleInboundEmailTrigger(
   const { triggerAddress, triggerLocalPart, userId } = resolved;
 
   log.debug("Processing email trigger", {
-    scope: triggerAddress.scope,
+    org: triggerAddress.org,
     agent: triggerAddress.agent,
     from: senderEmail,
   });
 
   // 3. Resolve agent
   const compose = await resolveAgentByAddress(
-    triggerAddress.scope,
+    triggerAddress.org,
     triggerAddress.agent,
   );
   if (!compose) {
     log.debug("Agent not found", {
-      scope: triggerAddress.scope,
+      org: triggerAddress.org,
       agent: triggerAddress.agent,
     });
     return {
       ok: false,
-      errorMessage: `Agent "${triggerAddress.agent}" was not found in scope "${triggerAddress.scope}".`,
+      errorMessage: `Agent "${triggerAddress.agent}" was not found in org "${triggerAddress.org}".`,
     };
   }
 
@@ -282,7 +282,7 @@ export async function handleInboundEmailTrigger(
   log.info("Dispatched agent run from email trigger", {
     runId: result.runId,
     emailId,
-    scope: triggerAddress.scope,
+    org: triggerAddress.org,
     agent: triggerAddress.agent,
   });
 

--- a/turbo/apps/web/src/lib/email/handlers/shared.ts
+++ b/turbo/apps/web/src/lib/email/handlers/shared.ts
@@ -18,36 +18,36 @@ export type HandlerResult = { ok: true } | { ok: false; errorMessage: string };
 // ============================================================================
 
 interface EmailTriggerAddress {
-  scope: string;
+  org: string;
   agent: string;
 }
 
 /**
- * Parse a trigger email address in the format: scope+agent@domain
+ * Parse a trigger email address in the format: org+agent@domain
  * Returns null if the address doesn't match the expected format.
  *
  * Examples:
- * - "lancy+my-agent@vm0.bot" → { scope: "lancy", agent: "my-agent" }
+ * - "lancy+my-agent@vm0.bot" → { org: "lancy", agent: "my-agent" }
  * - "reply+token@vm0.bot" → null (reply address, not trigger)
  * - "invalid@vm0.bot" → null (no plus sign)
  */
 export function parseEmailTriggerAddress(
   toAddress: string,
 ): EmailTriggerAddress | null {
-  // Match: scope+agent@domain (case-insensitive)
-  // Scope and agent must start with alphanumeric, can contain hyphens
+  // Match: org+agent@domain (case-insensitive)
+  // Org and agent must start with alphanumeric, can contain hyphens
   const match = toAddress.match(
     /^([a-z0-9][a-z0-9-]*)\+([a-z0-9][a-z0-9-]*)@/i,
   );
   if (!match || !match[1] || !match[2]) return null;
 
-  const scope = match[1].toLowerCase();
+  const org = match[1].toLowerCase();
   const agent = match[2].toLowerCase();
 
   // Exclude reply addresses (reply+token@domain)
-  if (scope === "reply") return null;
+  if (org === "reply") return null;
 
-  return { scope, agent };
+  return { org, agent };
 }
 
 /**
@@ -57,7 +57,7 @@ export function parseEmailTriggerAddress(
  *
  * Examples:
  * - "my-agent@vm0.bot" → "my-agent"
- * - "scope+agent@vm0.bot" → null (has plus sign, use parseEmailTriggerAddress)
+ * - "org+agent@vm0.bot" → null (has plus sign, use parseEmailTriggerAddress)
  * - "reply+token@vm0.bot" → null (has plus sign)
  * - "@vm0.bot" → null (empty local part)
  */
@@ -177,7 +177,7 @@ interface ResolvedAgent {
 }
 
 /**
- * Resolve an agent compose by scope slug and agent name.
+ * Resolve an agent compose by org slug and agent name.
  * Returns compose details if found, null otherwise.
  */
 export async function resolveAgentByAddress(

--- a/turbo/apps/web/src/lib/scope/__tests__/resolve-org.test.ts
+++ b/turbo/apps/web/src/lib/scope/__tests__/resolve-org.test.ts
@@ -392,7 +392,7 @@ describe("requireOrgFromRequest", () => {
     const request = new Request("http://localhost/api/test");
 
     await expect(requireOrgFromRequest(request, userId)).rejects.toThrow(
-      "scope or org query parameter is required",
+      "org query parameter is required",
     );
   });
 
@@ -405,7 +405,7 @@ describe("requireOrgFromRequest", () => {
     );
 
     await expect(requireOrgFromRequest(request, userId)).rejects.toThrow(
-      "Scope not found",
+      "Org not found",
     );
   });
 });

--- a/turbo/apps/web/src/lib/scope/org-member-service.ts
+++ b/turbo/apps/web/src/lib/scope/org-member-service.ts
@@ -230,7 +230,7 @@ export async function removeMember(
 
   // Cannot remove self
   if (targetUserId === callerUserId) {
-    throw badRequest("Cannot remove yourself. Use 'scope leave' instead.");
+    throw badRequest("Cannot remove yourself. Use 'org leave' instead.");
   }
 
   // Find membership to get membershipId
@@ -257,12 +257,12 @@ export async function removeMember(
 
 /**
  * Leave the org.
- * Admins cannot leave (they must add another admin or delete the scope).
+ * Admins cannot leave (they must add another admin or delete the org).
  */
 export async function leaveOrg(userId: string, orgId: string, role: OrgRole) {
   if (role === "admin") {
     throw forbidden(
-      "Admins cannot leave a scope. Add another admin or delete the scope.",
+      "Admins cannot leave an org. Add another admin or delete the org.",
     );
   }
 
@@ -273,7 +273,7 @@ export async function leaveOrg(userId: string, orgId: string, role: OrgRole) {
     userId: userId,
   });
 
-  log.debug("User left scope", { orgId, userId });
+  log.debug("User left org", { orgId, userId });
 }
 
 /**

--- a/turbo/apps/web/src/lib/scope/org-service.ts
+++ b/turbo/apps/web/src/lib/scope/org-service.ts
@@ -34,7 +34,7 @@ const SLUG_REGEX = /^[a-z0-9][a-z0-9-]*[a-z0-9]$|^[a-z0-9]{1,2}$/;
  * @returns A slug in format "user-xxxxxxxx" (13 chars total)
  */
 export function generateDefaultOrgSlug(userId: string): string {
-  const hash = createHmac("sha256", "scope-slug").update(userId).digest("hex");
+  const hash = createHmac("sha256", "org-slug").update(userId).digest("hex");
   return `user-${hash.slice(0, 8)}`;
 }
 
@@ -101,7 +101,7 @@ export async function updateOrgSlug(
   // Check if new slug already exists via org_cache
   const existing = await getOrgBySlug(newSlug);
   if (existing && existing.orgId !== orgId) {
-    throw badRequest(`Scope "${newSlug}" already exists`);
+    throw badRequest(`Org "${newSlug}" already exists`);
   }
 
   log.debug("updating org slug", { orgId, newSlug });
@@ -123,7 +123,7 @@ export async function updateOrgSlug(
  * Check if a runner group belongs to the official vm0 org.
  * Official runner groups (vm0/production, vm0/development) can be used by any user.
  *
- * @param group - Runner group in format "scope/name"
+ * @param group - Runner group in format "org/name"
  * @returns true if the group is an official runner group (vm0/*)
  */
 export function isOfficialRunnerGroup(group: string): boolean {
@@ -134,12 +134,12 @@ export function isOfficialRunnerGroup(group: string): boolean {
 
 /**
  * Validate that a runner group's org matches the user's org.
- * Runner groups are in format "scope/name" (e.g., "e2e-stable/pr-851").
+ * Runner groups are in format "org/name" (e.g., "e2e-stable/pr-851").
  *
  * For official runner groups (vm0/*), any authenticated user is allowed.
- * For user runner groups, the org part must match the user's personal scope slug.
+ * For user runner groups, the org part must match the user's personal org slug.
  *
- * @throws ForbiddenError if scope doesn't match (for non-official groups)
+ * @throws ForbiddenError if org doesn't match (for non-official groups)
  */
 export async function validateRunnerGroupOrg(
   userId: string,
@@ -162,19 +162,19 @@ export async function validateRunnerGroupOrg(
     if (orgData.slug === orgSlug) {
       return;
     }
-    throw forbidden(`Runner group org "${orgSlug}" does not match your scope`);
+    throw forbidden(`Runner group org "${orgSlug}" does not match your org`);
   }
 
-  const defaultScope = await getDefaultOrgByUserId(userId);
-  if (!defaultScope) {
+  const defaultOrg = await getDefaultOrgByUserId(userId);
+  if (!defaultOrg) {
     throw forbidden(
-      `Runner group org "${orgSlug}" requires you to have a scope configured`,
+      `Runner group org "${orgSlug}" requires you to have an org configured`,
     );
   }
 
-  if (defaultScope.slug !== orgSlug) {
+  if (defaultOrg.slug !== orgSlug) {
     throw forbidden(
-      `Runner group org "${orgSlug}" does not match your scope "${defaultScope.slug}"`,
+      `Runner group org "${orgSlug}" does not match your org "${defaultOrg.slug}"`,
     );
   }
 }

--- a/turbo/apps/web/src/lib/scope/resolve-org.ts
+++ b/turbo/apps/web/src/lib/scope/resolve-org.ts
@@ -35,13 +35,13 @@ function mapOrgRole(clerkRole: string | undefined | null): OrgRole {
 /**
  * Verify a user's membership in a Clerk organization.
  *
- * Fast path: if the scope's orgId matches the JWT's active org,
+ * Fast path: if the org's orgId matches the JWT's active org,
  * trust the JWT claims and skip the Clerk API call entirely.
  *
  * Slow path: for cross-org access (e.g. ?scope= pointing to a non-active org),
  * fall back to Clerk Backend API.
  *
- * CLI token path: if tokenOrgId is provided and matches the scope,
+ * CLI token path: if tokenOrgId is provided and matches the org,
  * trust the token (membership was verified at token creation time).
  */
 async function verifyMembership(
@@ -143,7 +143,7 @@ export async function resolveOrg(
   // 1. Explicit org selection via ?scope= query param (highest priority)
   if (orgSlug) {
     const orgData = await getOrgBySlug(orgSlug);
-    if (!orgData) throw notFound("Scope not found");
+    if (!orgData) throw notFound("Org not found");
 
     const member = await verifyMembership(
       orgData,
@@ -173,7 +173,7 @@ export async function resolveOrg(
       if (error instanceof Error && error.message.includes("not a member")) {
         throw error;
       }
-      // Org not found in Clerk — fall through to default scope
+      // Org not found in Clerk — fall through to default org
       log.debug("orgId lookup failed, falling through to default", {
         orgId: effectiveOrgId,
       });
@@ -186,10 +186,10 @@ export async function resolveOrg(
 
 /**
  * Extract and validate org from a request's ?scope= or ?org= query parameter.
- * Throws if the scope param is missing, the scope doesn't exist, or the user
+ * Throws if the param is missing, the org doesn't exist, or the user
  * is not a member.
  *
- * Use this in org routes that always require an explicit scope parameter.
+ * Use this in org routes that always require an explicit org parameter.
  */
 export async function requireOrgFromRequest(
   request: Request,
@@ -211,11 +211,11 @@ export async function requireOrgFromRequest(
       orgData = null;
     }
   } else {
-    throw badRequest("scope or org query parameter is required");
+    throw badRequest("org query parameter is required");
   }
 
   if (!orgData) {
-    throw notFound("Scope not found");
+    throw notFound("Org not found");
   }
 
   const authResult = await auth();


### PR DESCRIPTION
## Summary

- Replace "scope" terminology with "org" in all user-facing error messages, log strings, and comments
- Update HMAC key from `"scope-slug"` to `"org-slug"` for consistency (non-production only)
- Rename `triggerAddress.scope` → `triggerAddress.org` in email handler interface
- Sync CLI error message matching (`"No scope configured"` → `"No org configured"`)
- Update all test assertions to match new error strings

Closes #4607

## Files Changed (18)

**Core libraries:** `org-member-service.ts`, `resolve-org.ts`, `org-service.ts`
**API routes:** `scope/route.ts`, `scope/leave/route.ts`, integrations (GitHub, Slack, Telegram), `storages/list`, `composes/list`
**Email handler:** `inbound-trigger.ts`, `shared.ts`
**CLI:** `org/status.ts`
**Tests:** `status.test.ts`, `shared.test.ts`, `resolve-org.test.ts`, `remove-member.test.ts`
**Docs:** `cli-design-guideline.md`

## Test plan

- [x] Type check passes (`pnpm check-types`)
- [x] Lint passes (`pnpm turbo run lint`)
- [x] Format passes (`pnpm format`)
- [x] All tests pass (`pnpm vitest --run` — 3513/3514 pass, 1 pre-existing flaky test unrelated)
- [x] Knip passes (no unused exports/dependencies)
- [x] Grep verified no remaining user-facing "scope" strings in changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)