### PR TITLE
refactor(cli): rename internal scope variables and comments to org

### DIFF
--- a/turbo/apps/cli/src/commands/agent/__tests__/sharing.test.ts
+++ b/turbo/apps/cli/src/commands/agent/__tests__/sharing.test.ts
@@ -28,7 +28,7 @@ describe("Agent Sharing Commands", () => {
 
   const testComposeId = "test-compose-123";
   const testAgentName = "my-agent";
-  const testScopeSlug = "test-user";
+  const testOrgSlug = "test-user";
 
   beforeEach(() => {
     chalk.level = 0;
@@ -51,11 +51,11 @@ describe("Agent Sharing Commands", () => {
           { status: 404 },
         );
       }),
-      // Default handler for scope API
+      // Default handler for org API
       http.get("http://localhost:3000/api/scope", () => {
         return HttpResponse.json({
-          id: "scope-123",
-          slug: testScopeSlug,
+          id: "org-123",
+          slug: testOrgSlug,
           createdAt: new Date().toISOString(),
           updatedAt: new Date().toISOString(),
         });
@@ -108,7 +108,7 @@ describe("Agent Sharing Commands", () => {
       // Check for run command hint with experimental flag
       expect(mockConsoleLog).toHaveBeenCalledWith(
         expect.stringContaining(
-          `vm0 run ${testScopeSlug}/${testAgentName} --experimental-shared-agent`,
+          `vm0 run ${testOrgSlug}/${testAgentName} --experimental-shared-agent`,
         ),
       );
     });
@@ -287,7 +287,7 @@ describe("Agent Sharing Commands", () => {
       // Check for run command hint with experimental flag
       expect(mockConsoleLog).toHaveBeenCalledWith(
         expect.stringContaining(
-          `vm0 run ${testScopeSlug}/${testAgentName} --experimental-shared-agent`,
+          `vm0 run ${testOrgSlug}/${testAgentName} --experimental-shared-agent`,
         ),
       );
     });

--- a/turbo/apps/cli/src/commands/agent/public.ts
+++ b/turbo/apps/cli/src/commands/agent/public.ts
@@ -37,8 +37,8 @@ export const publicCommand = new Command()
           throw new Error(`Agent not found: ${name}`);
         }
 
-        // Get scope for display
-        const scope = await getOrg();
+        // Get org for display
+        const org = await getOrg();
 
         // Add public permission
         const response = await httpPost(
@@ -57,7 +57,7 @@ export const publicCommand = new Command()
           );
         }
 
-        const fullName = `${scope.slug}/${name}`;
+        const fullName = `${org.slug}/${name}`;
         console.log(chalk.green(`✓ Agent "${name}" is now public`));
         console.log();
         console.log("Others can now run your agent with:");

--- a/turbo/apps/cli/src/commands/agent/share.ts
+++ b/turbo/apps/cli/src/commands/agent/share.ts
@@ -41,8 +41,8 @@ export const shareCommand = new Command()
           throw new Error(`Agent not found: ${name}`);
         }
 
-        // Get scope for display
-        const scope = await getOrg();
+        // Get org for display
+        const org = await getOrg();
 
         // Add email permission
         const response = await httpPost(
@@ -63,7 +63,7 @@ export const shareCommand = new Command()
           throw new Error(error.error?.message || "Failed to share agent");
         }
 
-        const fullName = `${scope.slug}/${name}`;
+        const fullName = `${org.slug}/${name}`;
         console.log(
           chalk.green(`✓ Agent "${name}" shared with ${options.email}`),
         );

--- a/turbo/apps/cli/src/commands/org/__tests__/leave.test.ts
+++ b/turbo/apps/cli/src/commands/org/__tests__/leave.test.ts
@@ -51,7 +51,7 @@ describe("org leave command", () => {
 
     const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
     expect(logCalls).toContain("Left organization");
-    expect(logCalls).toContain("personal scope");
+    expect(logCalls).toContain("personal org");
   });
 
   it("should handle admin-cannot-leave error", async () => {

--- a/turbo/apps/cli/src/commands/org/__tests__/use.test.ts
+++ b/turbo/apps/cli/src/commands/org/__tests__/use.test.ts
@@ -54,11 +54,11 @@ describe("org use command", () => {
     expect(logCalls).toContain("my-org");
   });
 
-  it("should switch to personal scope with --personal flag", async () => {
+  it("should switch to personal org with --personal flag", async () => {
     await useCommand.parseAsync(["node", "cli", "--personal"]);
 
     const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
-    expect(logCalls).toContain("personal scope");
+    expect(logCalls).toContain("personal org");
   });
 
   it("should require slug argument without --personal", async () => {

--- a/turbo/apps/cli/src/commands/org/leave.ts
+++ b/turbo/apps/cli/src/commands/org/leave.ts
@@ -12,7 +12,7 @@ export const leaveCommand = new Command()
       await leaveOrg();
       await saveConfig({ activeScope: undefined });
       console.log(
-        chalk.green("✓ Left organization. Switched to personal scope."),
+        chalk.green("✓ Left organization. Switched to personal org."),
       );
     }),
   );

--- a/turbo/apps/cli/src/commands/org/list.ts
+++ b/turbo/apps/cli/src/commands/org/list.ts
@@ -14,12 +14,12 @@ export const listCommand = new Command()
       const activeScope = config.activeScope;
 
       console.log(chalk.bold("Available organizations:"));
-      for (const scope of result.scopes) {
-        const isCurrent = scope.slug === activeScope;
+      for (const org of result.scopes) {
+        const isCurrent = org.slug === activeScope;
         const marker = isCurrent ? chalk.green("* ") : "  ";
-        const roleLabel = scope.role ? ` (${scope.role})` : "";
+        const roleLabel = org.role ? ` (${org.role})` : "";
         const currentLabel = isCurrent ? chalk.dim(" ← current") : "";
-        console.log(`${marker}${scope.slug}${roleLabel}${currentLabel}`);
+        console.log(`${marker}${org.slug}${roleLabel}${currentLabel}`);
       }
     }),
   );

--- a/turbo/apps/cli/src/commands/org/set.ts
+++ b/turbo/apps/cli/src/commands/org/set.ts
@@ -14,22 +14,22 @@ export const setCommand = new Command()
   .action(
     withErrorHandler(async (slug: string, options: { force?: boolean }) => {
       try {
-        const existingScope = await getOrg();
+        const existingOrg = await getOrg();
 
         if (!options.force) {
           throw new Error(
-            `You already have an organization: ${existingScope.slug}`,
+            `You already have an organization: ${existingOrg.slug}`,
             {
               cause: new Error(`To change, use: vm0 org set ${slug} --force`),
             },
           );
         }
 
-        const scope = await updateOrg({ slug, force: true });
-        console.log(chalk.green(`✓ Organization updated to ${scope.slug}`));
+        const org = await updateOrg({ slug, force: true });
+        console.log(chalk.green(`✓ Organization updated to ${org.slug}`));
         console.log();
         console.log("Your agents will now be namespaced as:");
-        console.log(chalk.cyan(`  ${scope.slug}/<agent-name>`));
+        console.log(chalk.cyan(`  ${org.slug}/<agent-name>`));
       } catch (error) {
         if (
           error instanceof Error &&

--- a/turbo/apps/cli/src/commands/org/status.ts
+++ b/turbo/apps/cli/src/commands/org/status.ts
@@ -9,10 +9,10 @@ export const statusCommand = new Command()
   .action(
     withErrorHandler(async () => {
       try {
-        const scope = await getOrg();
+        const org = await getOrg();
 
         console.log(chalk.bold("Organization Information:"));
-        console.log(`  Slug: ${chalk.green(scope.slug)}`);
+        console.log(`  Slug: ${chalk.green(org.slug)}`);
       } catch (error) {
         if (
           error instanceof Error &&

--- a/turbo/apps/cli/src/commands/org/use.ts
+++ b/turbo/apps/cli/src/commands/org/use.ts
@@ -8,19 +8,19 @@ export const useCommand = new Command()
   .name("use")
   .description("Switch to a different organization")
   .argument("[slug]", "Organization slug to switch to")
-  .option("--personal", "Switch to personal scope")
+  .option("--personal", "Switch to personal org")
   .action(
     withErrorHandler(
       async (slug: string | undefined, options: { personal?: boolean }) => {
         if (options.personal) {
           await saveConfig({ activeScope: undefined });
-          console.log(chalk.green("✓ Switched to personal scope."));
+          console.log(chalk.green("✓ Switched to personal org."));
           return;
         }
 
         if (!slug) {
           throw new Error(
-            "Organization slug is required. Use --personal to switch to personal scope.",
+            "Organization slug is required. Use --personal to switch to personal org.",
           );
         }
 

--- a/turbo/apps/cli/src/lib/api/api-client.ts
+++ b/turbo/apps/cli/src/lib/api/api-client.ts
@@ -479,7 +479,7 @@ class ApiClient {
   }
 
   /**
-   * Get current user's default scope
+   * Get current user's default org
    */
   async getScope(): Promise<ScopeResponse> {
     const baseUrl = await this.getBaseUrl();
@@ -501,12 +501,12 @@ class ApiClient {
 
     // Error cases
     const errorBody = result.body as ApiErrorResponse;
-    const message = errorBody.error?.message || "Failed to get scope";
+    const message = errorBody.error?.message || "Failed to get org";
     throw new Error(message);
   }
 
   /**
-   * Update user's default scope slug
+   * Update user's default org slug
    */
   async updateScope(body: {
     slug: string;
@@ -531,7 +531,7 @@ class ApiClient {
 
     // Error cases
     const errorBody = result.body as ApiErrorResponse;
-    const message = errorBody.error?.message || "Failed to update scope";
+    const message = errorBody.error?.message || "Failed to update org";
     throw new Error(message);
   }
 


### PR DESCRIPTION
## Summary

- Rename ~25 internal `scope` variable names, comments, and user messages to `org` in CLI code
- Part of scope-to-org terminology migration (#4146)
- No API wire format changes (`activeScope` config, `?scope=` query param, API response fields all unchanged)

Closes #4632

## Changes

**Source files (6):**
- `status.ts`, `set.ts`, `list.ts` — rename local variables (`scope` → `org`, `existingScope` → `existingOrg`)
- `use.ts`, `leave.ts` — update user messages ("personal scope" → "personal org")
- `agent/share.ts`, `agent/public.ts` — rename variables and comments
- `api-client.ts` — update JSDoc comments and fallback error messages

**Test files (3):**
- `use.test.ts`, `leave.test.ts` — update string assertions to match new messages
- `sharing.test.ts` — rename `testScopeSlug` → `testOrgSlug` and related test identifiers

## Test plan

- [x] `pnpm check-types` passes
- [x] `pnpm turbo run lint` passes (0 warnings, 0 errors)
- [x] `pnpm format` — no changes needed
- [x] `pnpm vitest run` — all 307 test files, 3514 tests pass
- [x] `pnpm knip` — no unused exports/files
- [x] `grep -r "scope" turbo/apps/cli/src/commands/org/` — only wire format references remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)