### PR TITLE
refactor(platform): rename internal scope variables and signals to org

### DIFF
--- a/turbo/apps/platform/src/mocks/handlers/api-org.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-org.ts
@@ -1,7 +1,7 @@
 /**
  * Org API Handlers
  *
- * Mock handlers for /api/scope endpoint.
+ * Mock handlers for /api/scope endpoint (org API).
  * Default behavior: user always has an org (for tests that need auth to work).
  */
 
@@ -10,7 +10,7 @@ import type { Org } from "../../signals/org.ts";
 
 // Mock org data
 const mockOrg: Org = {
-  id: "scope_1",
+  id: "org_1",
   slug: "user-12345678",
   createdAt: "2024-01-01T00:00:00Z",
   updatedAt: "2024-01-01T00:00:00Z",

--- a/turbo/apps/platform/src/signals/__tests__/onboarding.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/onboarding.test.ts
@@ -19,7 +19,7 @@ import { act } from "@testing-library/react";
 const context = testContext();
 
 describe("startOnboarding$", () => {
-  it("visit a scope protected page without a scope will redirect to the onboarding page", async () => {
+  it("visit an org protected page without an org will redirect to the onboarding page", async () => {
     server.use(
       http.get("/api/scope", () => {
         return new HttpResponse(null, { status: 404 });
@@ -40,7 +40,7 @@ describe("startOnboarding$", () => {
 });
 
 describe("needsOnboarding$", () => {
-  it("should return true when no scope exists", async () => {
+  it("should return true when no org exists", async () => {
     server.use(
       http.get("/api/scope", () => {
         return new HttpResponse(null, { status: 404 });
@@ -69,8 +69,8 @@ describe("needsOnboarding$", () => {
     expect(needsOnboarding).toBeTruthy();
   });
 
-  it("should return false when both scope and a model provider exist", async () => {
-    // Default mocks have both scope and oauth token
+  it("should return false when both org and a model provider exist", async () => {
+    // Default mocks have both org and oauth token
     await setupPage({ context, path: "/", withoutRender: true });
 
     const needsOnboarding = await context.store.get(needsOnboarding$);
@@ -79,8 +79,8 @@ describe("needsOnboarding$", () => {
 });
 
 describe("saveOnboardingConfig$", () => {
-  it("should send slug with user- prefix when creating scope", async () => {
-    let scopeSlug: string | undefined;
+  it("should send slug with user- prefix when creating org", async () => {
+    let orgSlug: string | undefined;
 
     server.use(
       http.get("/api/scope", () => {
@@ -88,7 +88,7 @@ describe("saveOnboardingConfig$", () => {
       }),
       http.post("/api/scope", async ({ request }) => {
         const body = (await request.json()) as { slug: string };
-        scopeSlug = body.slug;
+        orgSlug = body.slug;
         return HttpResponse.json({}, { status: 201 });
       }),
     );
@@ -103,12 +103,12 @@ describe("saveOnboardingConfig$", () => {
       await context.store.set(saveOnboardingConfig$, context.signal);
     });
 
-    expect(scopeSlug).toBeDefined();
-    expect(scopeSlug).toMatch(/^user-[0-9a-f]{8}$/);
+    expect(orgSlug).toBeDefined();
+    expect(orgSlug).toMatch(/^user-[0-9a-f]{8}$/);
   });
 
-  it("should create scope and model provider when saving with oauth token", async () => {
-    let scopeCreated = false;
+  it("should create org and model provider when saving with oauth token", async () => {
+    let orgCreated = false;
     let providerCreated = false;
 
     server.use(
@@ -116,7 +116,7 @@ describe("saveOnboardingConfig$", () => {
         return new HttpResponse(null, { status: 404 });
       }),
       http.post("/api/scope", () => {
-        scopeCreated = true;
+        orgCreated = true;
         return HttpResponse.json({}, { status: 201 });
       }),
       http.put("/api/model-providers", () => {
@@ -149,7 +149,7 @@ describe("saveOnboardingConfig$", () => {
       await context.store.set(saveOnboardingConfig$, context.signal);
     });
 
-    expect(scopeCreated).toBeTruthy();
+    expect(orgCreated).toBeTruthy();
     expect(providerCreated).toBeTruthy();
     expect(context.store.get(showOnboardingModal$)).toBeFalsy();
   });
@@ -279,8 +279,8 @@ describe("saveOnboardingConfig$", () => {
 });
 
 describe("closeOnboardingModal$", () => {
-  it("should create scope when closing without saving", async () => {
-    let scopeCreated = false;
+  it("should create org when closing without saving", async () => {
+    let orgCreated = false;
     let providerCreated = false;
 
     server.use(
@@ -288,7 +288,7 @@ describe("closeOnboardingModal$", () => {
         return new HttpResponse(null, { status: 404 });
       }),
       http.post("/api/scope", () => {
-        scopeCreated = true;
+        orgCreated = true;
         return HttpResponse.json({}, { status: 201 });
       }),
       http.put("/api/model-providers", () => {
@@ -303,29 +303,29 @@ describe("closeOnboardingModal$", () => {
       context.store.set(closeOnboardingModal$);
     });
 
-    expect(scopeCreated).toBeTruthy();
+    expect(orgCreated).toBeTruthy();
     expect(providerCreated).toBeFalsy();
     expect(context.store.get(showOnboardingModal$)).toBeFalsy();
   });
 
-  it("should not create scope if it already exists", async () => {
-    let scopeCreated = false;
+  it("should not create org if it already exists", async () => {
+    let orgCreated = false;
 
     server.use(
       http.post("/api/scope", () => {
-        scopeCreated = true;
+        orgCreated = true;
         return HttpResponse.json({}, { status: 201 });
       }),
     );
 
-    // Default mock has scope
+    // Default mock has org
     await setupPage({ context, path: "/", withoutRender: true });
 
     act(() => {
       context.store.set(closeOnboardingModal$);
     });
 
-    expect(scopeCreated).toBeFalsy();
+    expect(orgCreated).toBeFalsy();
     expect(context.store.get(showOnboardingModal$)).toBeFalsy();
   });
 });

--- a/turbo/apps/platform/src/signals/agent-detail/agent-detail.ts
+++ b/turbo/apps/platform/src/signals/agent-detail/agent-detail.ts
@@ -59,15 +59,15 @@ export const fetchAgentDetail$ = command(async ({ get, set }) => {
   try {
     const fetchFn = get(fetch$);
 
-    // Shared agents have scope/agentName format; split for the API
+    // Shared agents have org/agentName format; split for the API
     const slashIndex = name.indexOf("/");
     const isOwner = slashIndex === -1;
     const agentName = isOwner ? name : name.slice(slashIndex + 1);
-    const scope = isOwner ? undefined : name.slice(0, slashIndex);
+    const org = isOwner ? undefined : name.slice(0, slashIndex);
 
     const params = new URLSearchParams({ name: agentName });
-    if (scope) {
-      params.set("scope", scope);
+    if (org) {
+      params.set("scope", org);
     }
 
     const response = await fetchFn(`/api/agent/composes?${params.toString()}`);

--- a/turbo/apps/platform/src/signals/agent-detail/agent-logs.ts
+++ b/turbo/apps/platform/src/signals/agent-detail/agent-logs.ts
@@ -23,18 +23,18 @@ export const {
       return null;
     }
 
-    // Split scoped name (e.g., "e7h4n/agent0") into name and scope
+    // Split qualified name (e.g., "e7h4n/agent0") into name and org
     const slashIndex = rawName.indexOf("/");
     const isOwner = slashIndex === -1;
     const name = isOwner ? rawName : rawName.slice(slashIndex + 1);
-    const scope = isOwner ? undefined : rawName.slice(0, slashIndex);
+    const org = isOwner ? undefined : rawName.slice(0, slashIndex);
 
     const params = new URLSearchParams({
       limit: String(limit),
       name,
     });
-    if (scope) {
-      params.set("scope", scope);
+    if (org) {
+      params.set("scope", org);
     }
     if (cursor) {
       params.set("cursor", cursor);

--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-activity.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-activity.test.ts
@@ -74,7 +74,7 @@ async function setup() {
 
 describe("zero-activity signals", () => {
   describe("zeroActivityData$", () => {
-    it("should fetch logs for all agents in scope", async () => {
+    it("should fetch logs for all agents in org", async () => {
       server.use(
         http.get("http://localhost:3000/api/platform/logs", ({ request }) => {
           const url = new URL(request.url);

--- a/turbo/apps/platform/src/signals/zero-page/zero-activity.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-activity.ts
@@ -32,7 +32,7 @@ export const zeroActivityStatusFilter$ = computed((get) => {
 });
 
 // ---------------------------------------------------------------------------
-// Scope agents — fetch all composes for name → displayName mapping
+// Org agents — fetch all composes for name → displayName mapping
 // ---------------------------------------------------------------------------
 
 interface AgentOption {
@@ -40,18 +40,18 @@ interface AgentOption {
   displayName: string;
 }
 
-const internalScopeAgents$ = state<AgentOption[]>([]);
+const internalOrgAgents$ = state<AgentOption[]>([]);
 
-/** All agents in the current scope with display names. */
-export const zeroActivityScopeAgents$ = computed((get) =>
-  get(internalScopeAgents$),
+/** All agents in the current org with display names. */
+export const zeroActivityOrgAgents$ = computed((get) =>
+  get(internalOrgAgents$),
 );
 
-const fetchScopeAgents$ = command(async ({ get, set }) => {
+const fetchOrgAgents$ = command(async ({ get, set }) => {
   const fetchFn = get(fetch$);
   const resp = await fetchFn("/api/agent/composes/list");
   if (!resp.ok) {
-    throw new Error(`Failed to fetch scope agents: ${resp.statusText}`);
+    throw new Error(`Failed to fetch org agents: ${resp.statusText}`);
   }
   const data = (await resp.json()) as { composes: ComposeListItem[] };
   const agents: AgentOption[] = data.composes.map((c) => ({
@@ -59,7 +59,7 @@ const fetchScopeAgents$ = command(async ({ get, set }) => {
     displayName:
       c.displayName ?? c.name.charAt(0).toUpperCase() + c.name.slice(1),
   }));
-  set(internalScopeAgents$, agents);
+  set(internalOrgAgents$, agents);
 });
 
 // ---------------------------------------------------------------------------
@@ -74,10 +74,10 @@ export const initZeroActivityAgentName$ = command(async ({ get, set }) => {
   set(internalAgentName$, status.defaultAgentName);
 });
 
-/** Initialize activity page: load agent name, scope agents, and seed cursor history. */
+/** Initialize activity page: load agent name, org agents, and seed cursor history. */
 export const initZeroActivity$ = command(async ({ set }) => {
   await set(initZeroActivityAgentName$);
-  await set(fetchScopeAgents$);
+  await set(fetchOrgAgents$);
   set(seedZeroActivityCursorHistory$);
 });
 

--- a/turbo/apps/platform/src/views/agent-detail-page/__tests__/agent-detail-page.test.tsx
+++ b/turbo/apps/platform/src/views/agent-detail-page/__tests__/agent-detail-page.test.tsx
@@ -459,7 +459,7 @@ describe("agent detail page", () => {
 
     await setupPage({
       context,
-      path: `/agents/${encodeURIComponent("other-scope/shared-agent")}`,
+      path: `/agents/${encodeURIComponent("other-org/shared-agent")}`,
     });
 
     await vi.waitFor(() => {
@@ -778,7 +778,7 @@ describe("agent detail page", () => {
   });
 
   it("should show read-only pre for shared (non-owner) agents", async () => {
-    // Shared agent path has scope/name format
+    // Shared agent path has org/name format
     server.use(
       http.get("/api/agent/composes", ({ request }) => {
         const url = new URL(request.url);
@@ -813,7 +813,7 @@ describe("agent detail page", () => {
 
     await setupPage({
       context,
-      path: `/agents/${encodeURIComponent("other-scope/shared-agent")}`,
+      path: `/agents/${encodeURIComponent("other-org/shared-agent")}`,
     });
 
     await vi.waitFor(() => {

--- a/turbo/apps/platform/src/views/home/__tests__/home-page.test.tsx
+++ b/turbo/apps/platform/src/views/home/__tests__/home-page.test.tsx
@@ -34,7 +34,7 @@ describe("home page", () => {
     expect(mockedClerk.redirectToSignIn).toHaveBeenCalledWith();
   });
 
-  it("should show onboarding modal when scope returns 404", async () => {
+  it("should show onboarding modal when org returns 404", async () => {
     server.use(
       http.get("/api/scope", () => {
         return new HttpResponse(null, { status: 404 });
@@ -86,8 +86,8 @@ describe("home page", () => {
     expect(screen.getByText(/Define your model provider/)).toBeDefined();
   });
 
-  it("should not show onboarding modal when both scope and a model provider exist", async () => {
-    // Default mocks have both scope and oauth token
+  it("should not show onboarding modal when both org and a model provider exist", async () => {
+    // Default mocks have both org and oauth token
     await setupPage({
       context,
       path: "/",

--- a/turbo/apps/platform/src/views/integrations-page/github-settings-page.tsx
+++ b/turbo/apps/platform/src/views/integrations-page/github-settings-page.tsx
@@ -139,9 +139,9 @@ export function GitHubSettingsPage() {
   const openConfirm = useSet(openGithubDisconnectDialog$);
   const closeConfirm = useSet(closeGithubDisconnectDialog$);
 
-  // Construct scoped agent name that matches the format used in agentsList$
-  // (shared agents use "scope/name", owned agents use just "name").
-  const scopedAgentName = (() => {
+  // Construct qualified agent name that matches the format used in agentsList$
+  // (shared agents use "org/name", owned agents use just "name").
+  const qualifiedAgentName = (() => {
     if (!data?.agent) {
       return undefined;
     }
@@ -157,15 +157,15 @@ export function GitHubSettingsPage() {
   // Ensure the current agent appears in the dropdown even if
   // it isn't in the user's own agents list (e.g. shared by another user).
   const agentOptions = (() => {
-    if (!scopedAgentName) {
+    if (!qualifiedAgentName) {
       return agents;
     }
-    const hasCurrentAgent = agents.some((a) => a.name === scopedAgentName);
+    const hasCurrentAgent = agents.some((a) => a.name === qualifiedAgentName);
     if (hasCurrentAgent) {
       return agents;
     }
     return [
-      { name: scopedAgentName, headVersionId: null, updatedAt: "" },
+      { name: qualifiedAgentName, headVersionId: null, updatedAt: "" },
       ...agents,
     ];
   })();
@@ -235,7 +235,7 @@ export function GitHubSettingsPage() {
                   </p>
                 </div>
                 <Select
-                  value={scopedAgentName ?? ""}
+                  value={qualifiedAgentName ?? ""}
                   onValueChange={handleAgentChange}
                   disabled={!isAdmin}
                 >
@@ -254,7 +254,7 @@ export function GitHubSettingsPage() {
             </div>
 
             <MissingEnvBanner
-              agentName={scopedAgentName}
+              agentName={qualifiedAgentName}
               missingSecrets={data?.environment.missingSecrets ?? []}
               missingVars={data?.environment.missingVars ?? []}
             />

--- a/turbo/apps/platform/src/views/integrations-page/github-settings-page.tsx
+++ b/turbo/apps/platform/src/views/integrations-page/github-settings-page.tsx
@@ -146,7 +146,7 @@ export function GitHubSettingsPage() {
       return undefined;
     }
     const fullName = `${data.agent.scopeSlug}/${data.agent.name}`;
-    // If the scoped name exists in agents list, use it (shared agent)
+    // If the qualified name exists in agents list, use it (shared agent)
     if (agents.some((a) => a.name === fullName)) {
       return fullName;
     }

--- a/turbo/apps/platform/src/views/integrations-page/slack-settings-page.tsx
+++ b/turbo/apps/platform/src/views/integrations-page/slack-settings-page.tsx
@@ -204,9 +204,9 @@ export function SlackSettingsPage() {
   const openConfirm = useSet(openSlackDisconnectDialog$);
   const closeConfirm = useSet(closeSlackDisconnectDialog$);
 
-  // Construct scoped agent name that matches the format used in agentsList$
-  // (shared agents use "scope/name", owned agents use just "name").
-  const scopedAgentName = (() => {
+  // Construct qualified agent name that matches the format used in agentsList$
+  // (shared agents use "org/name", owned agents use just "name").
+  const qualifiedAgentName = (() => {
     if (!data?.agent) {
       return undefined;
     }
@@ -222,15 +222,15 @@ export function SlackSettingsPage() {
   // Ensure the current workspace agent appears in the dropdown even if
   // it isn't in the user's own agents list (e.g. shared by another user).
   const agentOptions = (() => {
-    if (!scopedAgentName) {
+    if (!qualifiedAgentName) {
       return agents;
     }
-    const hasCurrentAgent = agents.some((a) => a.name === scopedAgentName);
+    const hasCurrentAgent = agents.some((a) => a.name === qualifiedAgentName);
     if (hasCurrentAgent) {
       return agents;
     }
     return [
-      { name: scopedAgentName, headVersionId: null, updatedAt: "" },
+      { name: qualifiedAgentName, headVersionId: null, updatedAt: "" },
       ...agents,
     ];
   })();
@@ -276,13 +276,13 @@ export function SlackSettingsPage() {
           <>
             <DefaultAgentSection
               isAdmin={data?.isAdmin ?? false}
-              agentName={scopedAgentName}
+              agentName={qualifiedAgentName}
               agentOptions={agentOptions}
               onAgentChange={handleAgentChange}
             />
 
             <MissingEnvBanner
-              agentName={scopedAgentName}
+              agentName={qualifiedAgentName}
               missingSecrets={data?.environment.missingSecrets ?? []}
               missingVars={data?.environment.missingVars ?? []}
             />

--- a/turbo/apps/platform/src/views/integrations-page/slack-settings-page.tsx
+++ b/turbo/apps/platform/src/views/integrations-page/slack-settings-page.tsx
@@ -211,7 +211,7 @@ export function SlackSettingsPage() {
       return undefined;
     }
     const fullName = `${data.agent.scopeSlug}/${data.agent.name}`;
-    // If the scoped name exists in agents list, use it (shared agent)
+    // If the qualified name exists in agents list, use it (shared agent)
     if (agents.some((a) => a.name === fullName)) {
       return fullName;
     }

--- a/turbo/apps/platform/src/views/integrations-page/telegram-settings-page.tsx
+++ b/turbo/apps/platform/src/views/integrations-page/telegram-settings-page.tsx
@@ -309,8 +309,8 @@ export function TelegramSettingsPage() {
   const copyToClipboard = useSet(copyToClipboard$);
   const openPopup = useSet(openTelegramLoginPopup$);
 
-  // Construct scoped agent name that matches the format used in agentsList$
-  const scopedAgentName = (() => {
+  // Construct qualified agent name that matches the format used in agentsList$
+  const qualifiedAgentName = (() => {
     if (!data?.agent) {
       return undefined;
     }
@@ -323,15 +323,15 @@ export function TelegramSettingsPage() {
 
   // Ensure the current agent appears in the dropdown
   const agentOptions = (() => {
-    if (!scopedAgentName) {
+    if (!qualifiedAgentName) {
       return agents;
     }
-    const hasCurrentAgent = agents.some((a) => a.name === scopedAgentName);
+    const hasCurrentAgent = agents.some((a) => a.name === qualifiedAgentName);
     if (hasCurrentAgent) {
       return agents;
     }
     return [
-      { name: scopedAgentName, headVersionId: null, updatedAt: "" },
+      { name: qualifiedAgentName, headVersionId: null, updatedAt: "" },
       ...agents,
     ];
   })();
@@ -402,13 +402,13 @@ export function TelegramSettingsPage() {
 
             <DefaultAgentSection
               isAdmin={data?.isAdmin ?? false}
-              agentName={scopedAgentName}
+              agentName={qualifiedAgentName}
               agentOptions={agentOptions}
               onAgentChange={handleAgentChange}
             />
 
             <MissingEnvBanner
-              agentName={scopedAgentName}
+              agentName={qualifiedAgentName}
               missingSecrets={data?.environment.missingSecrets ?? []}
               missingVars={data?.environment.missingVars ?? []}
             />

--- a/turbo/apps/platform/src/views/settings-page/__tests__/settings-page.test.tsx
+++ b/turbo/apps/platform/src/views/settings-page/__tests__/settings-page.test.tsx
@@ -12,7 +12,7 @@ const context = testContext();
 const user = userEvent.setup();
 
 describe("settings page", () => {
-  it("should be redirect if user has no scope", async () => {
+  it("should be redirect if user has no org", async () => {
     server.use(
       http.get("/api/scope", () => {
         return new HttpResponse(null, { status: 404 });

--- a/turbo/apps/platform/src/views/zero-page/zero-activity-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-activity-page.tsx
@@ -20,7 +20,7 @@ import { ZeroActivityDetailPage } from "./zero-activity-detail-page.tsx";
 import {
   zeroActivityAgentFilter$,
   zeroActivityStatusFilter$,
-  zeroActivityScopeAgents$,
+  zeroActivityOrgAgents$,
   setZeroActivityFilter$,
   zeroActivityData$,
   zeroActivityLimit$,
@@ -134,7 +134,7 @@ export function ZeroActivityPage() {
   const agentFilter = useGet(zeroActivityAgentFilter$);
   const statusFilter = useGet(zeroActivityStatusFilter$);
   const setFilter = useSet(setZeroActivityFilter$);
-  const scopeAgents = useGet(zeroActivityScopeAgents$);
+  const orgAgents = useGet(zeroActivityOrgAgents$);
 
   const logs = dataLoadable.state === "hasData" ? dataLoadable.data.data : [];
   const hasNext =
@@ -145,15 +145,13 @@ export function ZeroActivityPage() {
       : undefined;
   const isLoading = dataLoadable.state === "loading";
 
-  // Build name → displayName lookup from scope agents
-  const nameToDisplay = new Map(
-    scopeAgents.map((a) => [a.name, a.displayName]),
-  );
+  // Build name → displayName lookup from org agents
+  const nameToDisplay = new Map(orgAgents.map((a) => [a.name, a.displayName]));
 
   // Agent filter options: show display names, map back to compose name
   const agentOptions = [
     { value: "all", label: "All Agents" },
-    ...scopeAgents.map((a) => ({ value: a.name, label: a.displayName })),
+    ...orgAgents.map((a) => ({ value: a.name, label: a.displayName })),
   ];
 
   // Detail view when sub-route is present

--- a/turbo/apps/platform/src/views/zero-page/zero-onboarding.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-onboarding.tsx
@@ -199,7 +199,7 @@ function OnboardingSkillsStep({
   );
 }
 
-/** Zero onboarding: creates scope, model provider, and default agent. */
+/** Zero onboarding: creates org, model provider, and default agent. */
 export function ZeroOnboarding({
   zeroAvatarSrc = "/zero-avatar.png",
   onAvatarClick,

--- a/turbo/apps/platform/src/views/zero-page/zero-schedule-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-schedule-page.tsx
@@ -866,7 +866,7 @@ export function ZeroSchedulePage() {
               Schedule
             </h1>
             <p className="mt-0.5 text-sm text-muted-foreground">
-              Schedules for all agents in this scope.
+              Schedules for all agents in this org.
             </p>
           </div>
           <Tabs

--- a/turbo/apps/platform/src/views/zero-page/zero-slack-config-content.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-slack-config-content.tsx
@@ -116,7 +116,7 @@ export function ZeroSlackConfigContent({
   const openConfirm = useSet(openSlackDisconnectDialog$);
   const closeConfirm = useSet(closeSlackDisconnectDialog$);
 
-  const scopedAgentName = (() => {
+  const qualifiedAgentName = (() => {
     if (!data?.agent) {
       return undefined;
     }
@@ -128,15 +128,15 @@ export function ZeroSlackConfigContent({
   })();
 
   const agentOptions = (() => {
-    if (!scopedAgentName) {
+    if (!qualifiedAgentName) {
       return agents;
     }
-    const hasCurrentAgent = agents.some((a) => a.name === scopedAgentName);
+    const hasCurrentAgent = agents.some((a) => a.name === qualifiedAgentName);
     if (hasCurrentAgent) {
       return agents;
     }
     return [
-      { name: scopedAgentName, headVersionId: null, updatedAt: "" },
+      { name: qualifiedAgentName, headVersionId: null, updatedAt: "" },
       ...agents,
     ];
   })();
@@ -202,7 +202,7 @@ export function ZeroSlackConfigContent({
                 </div>
                 {data?.isAdmin ? (
                   <Select
-                    value={scopedAgentName ?? ""}
+                    value={qualifiedAgentName ?? ""}
                     onValueChange={handleAgentChange}
                   >
                     <SelectTrigger className="w-full sm:w-[280px] sm:shrink-0">
@@ -219,7 +219,7 @@ export function ZeroSlackConfigContent({
                 ) : (
                   <div className="flex h-9 w-full items-center justify-between rounded-lg border border-border bg-muted px-3 py-2 sm:w-[280px] sm:shrink-0">
                     <span className="truncate text-sm">
-                      {scopedAgentName ?? "No agent"}
+                      {qualifiedAgentName ?? "No agent"}
                     </span>
                     <IconChevronDown
                       size={16}
@@ -231,7 +231,7 @@ export function ZeroSlackConfigContent({
             </div>
 
             <MissingEnvBanner
-              agentName={scopedAgentName}
+              agentName={qualifiedAgentName}
               missingSecrets={data?.environment.missingSecrets ?? []}
               missingVars={data?.environment.missingVars ?? []}
             />


### PR DESCRIPTION
## Summary

- Rename ~90 internal "scope" references across 16 platform frontend files as part of scope-to-org terminology migration (#4146)
- Signal names: `internalScopeAgents$` → `internalOrgAgents$`, `zeroActivityScopeAgents$` → `zeroActivityOrgAgents$`, `fetchScopeAgents$` → `fetchOrgAgents$`
- View variables: `scopedAgentName` → `qualifiedAgentName` in 4 integration settings pages
- Local variables, test descriptions, comments, and mock ID updated from "scope" to "org"
- No API wire format changes — endpoint paths, query params, and response field names preserved

## Test plan

- [x] `pnpm check-types` — all type checks pass
- [x] `pnpm turbo run lint` — zero warnings/errors
- [x] `pnpm format` — all files formatted
- [x] `pnpm vitest run` — 307 test files, 3514 tests pass
- [x] `pnpm knip` — no unused exports/files
- [x] grep audit confirms only wire format `/api/scope` and unrelated `scope` (job scope, module scope) references remain

Closes #4633

🤖 Generated with [Claude Code](https://claude.com/claude-code)