### PR TITLE
refactor(web): rename internal scope references in service layer to org

### DIFF
--- a/turbo/apps/web/app/api/internal/callbacks/email/trigger/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/email/trigger/__tests__/route.test.ts
@@ -150,7 +150,7 @@ describe("POST /api/internal/callbacks/email/trigger", () => {
 
       const replyToken = generateReplyToken(crypto.randomUUID());
       const senderEmail = "sender@example.com";
-      const triggerLocalPart = `my-scope+${agentName}`;
+      const triggerLocalPart = `my-org+${agentName}`;
       const payload: TriggerCallbackPayload = {
         senderEmail,
         composeId,

--- a/turbo/apps/web/src/db/schema/secret.ts
+++ b/turbo/apps/web/src/db/schema/secret.ts
@@ -10,7 +10,7 @@ import {
 
 /**
  * Secrets table
- * Stores encrypted third-party service secrets per user within a scope
+ * Stores encrypted third-party service secrets per user within an org
  * Values encrypted with AES-256-GCM using SECRETS_ENCRYPTION_KEY
  */
 export const secrets = pgTable(

--- a/turbo/apps/web/src/db/schema/storage.ts
+++ b/turbo/apps/web/src/db/schema/storage.ts
@@ -15,7 +15,7 @@ import {
  * Storages table
  * Main table for storage with HEAD pointer to current version.
  * Unique constraint: (orgId, userId, name, type)
- * - Volumes use VOLUME_SCOPE_USER_ID ("__scope__") as userId (scope-level shared)
+ * - Volumes use VOLUME_SCOPE_USER_ID ("__scope__") as userId (org-level shared)
  * - Artifacts and Memory use real userId (per-user isolated)
  */
 export const storages = pgTable(

--- a/turbo/apps/web/src/db/schema/variable.ts
+++ b/turbo/apps/web/src/db/schema/variable.ts
@@ -10,7 +10,7 @@ import {
 
 /**
  * Variables table
- * Stores non-sensitive configuration variables per user within a scope
+ * Stores non-sensitive configuration variables per user within an org
  * Values are stored in plaintext (unlike secrets which are encrypted)
  */
 export const variables = pgTable(

--- a/turbo/apps/web/src/lib/computer-connector/computer-connector-service.ts
+++ b/turbo/apps/web/src/lib/computer-connector/computer-connector-service.ts
@@ -12,7 +12,7 @@ import { secrets } from "../../db/schema/secret";
 import { decryptSecretValue } from "../crypto";
 import { badRequest, conflict, notFound } from "../errors";
 import { logger } from "../logger";
-import { upsertSecretByScope } from "../secret/secret-service";
+import { upsertSecretByOrg } from "../secret/secret-service";
 import {
   findOrCreateBotUser,
   createCredential,
@@ -152,7 +152,7 @@ export async function createComputerConnector(
 
   // Store secrets (ngrok token is one-time use, returned to client only)
   await Promise.all([
-    upsertSecretByScope(
+    upsertSecretByOrg(
       orgId,
       userId,
       "COMPUTER_CONNECTOR_BRIDGE_TOKEN",
@@ -160,7 +160,7 @@ export async function createComputerConnector(
       "connector",
       "Computer connector: COMPUTER_CONNECTOR_BRIDGE_TOKEN",
     ),
-    upsertSecretByScope(
+    upsertSecretByOrg(
       orgId,
       userId,
       "COMPUTER_CONNECTOR_DOMAIN_ID",
@@ -168,7 +168,7 @@ export async function createComputerConnector(
       "connector",
       "Computer connector: COMPUTER_CONNECTOR_DOMAIN_ID",
     ),
-    upsertSecretByScope(
+    upsertSecretByOrg(
       orgId,
       userId,
       "COMPUTER_CONNECTOR_DOMAIN",

--- a/turbo/apps/web/src/lib/connector/connector-service.ts
+++ b/turbo/apps/web/src/lib/connector/connector-service.ts
@@ -12,7 +12,7 @@ import { secrets } from "../../db/schema/secret";
 import { variables } from "../../db/schema/variable";
 import { notFound, badRequest } from "../errors";
 import { logger } from "../logger";
-import { upsertSecretByScope } from "../secret/secret-service";
+import { upsertSecretByOrg } from "../secret/secret-service";
 import { PROVIDER_HANDLERS } from "./provider-registry";
 
 const log = logger("service:connector");
@@ -37,7 +37,7 @@ function getSecretNameForConnector(type: ConnectorType): string {
 }
 
 /**
- * List all connectors for a scope.
+ * List all connectors for an org.
  * Returns OAuth connectors from DB plus derived api-token connectors
  * based on user secrets that match api-token required secret names.
  */
@@ -261,7 +261,7 @@ export async function upsertOAuthConnector(
   const isUpdate = existingConnector.length > 0;
 
   // Upsert access token secret
-  await upsertSecretByScope(
+  await upsertSecretByOrg(
     orgId,
     userId,
     secretName,
@@ -272,7 +272,7 @@ export async function upsertOAuthConnector(
 
   // Upsert refresh token secret if provided
   if (options?.refreshToken && options.refreshSecretName) {
-    await upsertSecretByScope(
+    await upsertSecretByOrg(
       orgId,
       userId,
       options.refreshSecretName,
@@ -473,7 +473,7 @@ export async function upsertConnectorSecret(
   secretName: string,
   secretValue: string,
 ): Promise<void> {
-  await upsertSecretByScope(
+  await upsertSecretByOrg(
     orgId,
     userId,
     secretName,

--- a/turbo/apps/web/src/lib/email/handlers/__tests__/shared.test.ts
+++ b/turbo/apps/web/src/lib/email/handlers/__tests__/shared.test.ts
@@ -23,8 +23,8 @@ describe("parseEmailTriggerAddress", () => {
   });
 
   it("should handle org and agent with hyphens", () => {
-    const result = parseEmailTriggerAddress("my-scope+my-agent@vm0.bot");
-    expect(result).toEqual({ org: "my-scope", agent: "my-agent" });
+    const result = parseEmailTriggerAddress("my-org+my-agent@vm0.bot");
+    expect(result).toEqual({ org: "my-org", agent: "my-agent" });
   });
 
   it("should return null for reply address", () => {

--- a/turbo/apps/web/src/lib/model-provider/model-provider-service.ts
+++ b/turbo/apps/web/src/lib/model-provider/model-provider-service.ts
@@ -119,7 +119,7 @@ async function assignDefaultIfFirst(
 }
 
 /**
- * List all model providers for a scope
+ * List all model providers for an org
  */
 export async function listModelProviders(
   orgId: string,

--- a/turbo/apps/web/src/lib/run/build-context.ts
+++ b/turbo/apps/web/src/lib/run/build-context.ts
@@ -608,7 +608,7 @@ interface BuildContextParams {
   checkEnv?: boolean;
   // API start time for E2E timing metrics
   apiStartTime?: number;
-  // Caller-resolved scope slug and orgId for secret/variable/storage resolution.
+  // Caller-resolved org slug and orgId for secret/variable/storage resolution.
   // When provided, used for both secrets and storage (artifacts/memory).
   // When not provided, resolved via getDefaultOrg fallback.
   orgSlug?: string;
@@ -795,13 +795,13 @@ function applyResolutionDefaults(
 }
 
 /**
- * Resolve the Runtime Scope for this execution.
+ * Resolve the Runtime Org for this execution.
  *
- * The Runtime Scope (orgId + userId) determines secrets, variables,
+ * The Runtime Org (orgId + userId) determines secrets, variables,
  * connectors, model providers, artifacts, and memories.
  * See docs/resource-model.md for the full resource model.
  *
- * When params.orgId is not provided, the user's default scope is used.
+ * When params.orgId is not provided, the user's default org is used.
  */
 async function resolveOrgs(params: BuildContextParams): Promise<{
   runtimeClerkOrgId: string;
@@ -827,7 +827,7 @@ async function resolveOrgs(params: BuildContextParams): Promise<{
       },
     };
   }
-  // No explicit scope — default scope is used
+  // No explicit org — default org is used
   const { org } = await getDefaultOrg(params.userId);
   return {
     runtimeClerkOrgId: org.orgId,
@@ -907,9 +907,9 @@ export async function buildExecutionContext(
   let resumeSession: ResumeSession | undefined;
   let resumeArtifact: ArtifactSnapshot | undefined;
 
-  // Step 1: Resolve source and scopes in parallel (independent operations).
+  // Step 1: Resolve source and orgs in parallel (independent operations).
   // resolveSource loads checkpoint/session/conversation data.
-  // resolveOrgs resolves the runtime scope for secrets and storage.
+  // resolveOrgs resolves the runtime org for secrets and storage.
   const resolveStart = Date.now();
   const [resolution, { runtimeClerkOrgId, pendingRuntimeScope }] =
     await Promise.all([resolveSource(params), resolveOrgs(params)]);

--- a/turbo/apps/web/src/lib/run/context/execution-preparer.ts
+++ b/turbo/apps/web/src/lib/run/context/execution-preparer.ts
@@ -179,8 +179,8 @@ export async function prepareForExecution(
     `Extracted config: workingDir=${workingDir}, cliAgentType=${cliAgentType}, runnerGroup=${runnerGroup}, firewall=${experimentalFirewall ? "enabled" : "disabled"}`,
   );
 
-  // Resolve the Agent Scope for volume resolution.
-  // Runtime Scope (for artifacts/memory) is pre-resolved by buildExecutionContext.
+  // Resolve the Agent Org for volume resolution.
+  // Runtime Org (for artifacts/memory) is pre-resolved by buildExecutionContext.
   const userId = context.userId || "";
   const scopeStart = Date.now();
   const [agentComposeInfo] = await globalThis.services.db
@@ -230,9 +230,9 @@ export async function prepareForExecution(
   ]);
   const ensureEnd = Date.now();
 
-  // Prepare storage manifest with dual scopes (see docs/resource-model.md)
-  // - Volumes: resolved from Agent Scope
-  // - Artifacts/Memory: resolved from Runtime Scope
+  // Prepare storage manifest with dual orgs (see docs/resource-model.md)
+  // - Volumes: resolved from Agent Org
+  // - Artifacts/Memory: resolved from Runtime Org
   const storageStart = Date.now();
   const storageManifest = await prepareStorageManifest(
     context.agentCompose as AgentComposeYaml,
@@ -250,7 +250,7 @@ export async function prepareForExecution(
   const storageEnd = Date.now();
 
   log.debug(
-    `Storage manifest prepared with dual scopes: agentClerkOrgId=${agentScopeInfo.orgId}, runtimeClerkOrgId=${runtimeOrg.orgId}, ${storageManifest.storages.length} storages, ${storageManifest.artifact ? "1 artifact" : "no artifact"}`,
+    `Storage manifest prepared with dual orgs: agentClerkOrgId=${agentScopeInfo.orgId}, runtimeClerkOrgId=${runtimeOrg.orgId}, ${storageManifest.storages.length} storages, ${storageManifest.artifact ? "1 artifact" : "no artifact"}`,
   );
 
   // Build PreparedContext
@@ -271,7 +271,7 @@ export async function prepareForExecution(
   };
 
   log.debug(
-    `PreparedContext built for run ${context.runId} (scopes=${timings.resolveOrgs}ms, ensure=${timings.ensureStorage}ms, storage=${timings.storageManifest}ms)`,
+    `PreparedContext built for run ${context.runId} (orgs=${timings.resolveOrgs}ms, ensure=${timings.ensureStorage}ms, storage=${timings.storageManifest}ms)`,
   );
 
   return { context: preparedContext, timings };
@@ -287,7 +287,7 @@ function buildPreparedContext(
   runnerGroup: string | null,
   storageManifest: StorageManifest,
   experimentalFirewall: CoreExperimentalFirewall | null,
-  agentScopeSlug: string | null,
+  agentOrgSlug: string | null,
 ): PreparedContext {
   return {
     // Identity
@@ -330,7 +330,7 @@ function buildPreparedContext(
 
     // Metadata
     agentName: context.agentName || null,
-    agentScopeSlug,
+    agentOrgSlug,
     resumedFromCheckpointId: context.resumedFromCheckpointId || null,
     continuedFromSessionId: context.continuedFromSessionId || null,
 

--- a/turbo/apps/web/src/lib/run/executors/runner-executor.ts
+++ b/turbo/apps/web/src/lib/run/executors/runner-executor.ts
@@ -38,7 +38,7 @@ export async function executeRunnerJob(
 
   log.debug(`Queueing run ${context.runId} for runner group: ${runnerGroup}`);
 
-  // Validate runner group scope matches user's scope
+  // Validate runner group org matches user's org
   await validateRunnerGroupOrg(context.userId, runnerGroup);
 
   // Encrypt secrets map (key-value pairs) before storing
@@ -62,7 +62,7 @@ export async function executeRunnerJob(
     apiStartTime: context.apiStartTime ?? undefined,
     userTimezone: context.userTimezone ?? undefined,
     agentName: context.agentName ?? undefined,
-    agentScopeSlug: context.agentScopeSlug ?? undefined,
+    agentScopeSlug: context.agentOrgSlug ?? undefined,
     memoryName: context.memoryName ?? undefined,
   };
 

--- a/turbo/apps/web/src/lib/run/executors/types.ts
+++ b/turbo/apps/web/src/lib/run/executors/types.ts
@@ -52,7 +52,7 @@ export interface PreparedContext {
 
   // Metadata for vm0_start event
   agentName: string | null;
-  agentScopeSlug: string | null;
+  agentOrgSlug: string | null;
   resumedFromCheckpointId: string | null;
   continuedFromSessionId: string | null;
 

--- a/turbo/apps/web/src/lib/run/run-service.ts
+++ b/turbo/apps/web/src/lib/run/run-service.ts
@@ -593,7 +593,7 @@ async function buildAndDispatchRun(opts: {
       { op: "api_step_dispatch", ms: dispatchTime - prepareTime },
       // Sub-step timings within buildExecutionContext
       {
-        op: "api_build_resolve_source_and_org",
+        op: "api_build_resolve_source_and_scope",
         ms: buildContextTimings.resolveSourceAndScope,
       },
       {
@@ -602,7 +602,7 @@ async function buildAndDispatchRun(opts: {
       },
       // Sub-step timings within prepareForExecution
       {
-        op: "api_prepare_resolve_orgs",
+        op: "api_prepare_resolve_scopes",
         ms: prepareResult.timings.resolveOrgs,
       },
       {

--- a/turbo/apps/web/src/lib/run/run-service.ts
+++ b/turbo/apps/web/src/lib/run/run-service.ts
@@ -44,7 +44,7 @@ const log = logger("service:run");
 // so this TTL only matters if the cron job fails to run.
 export const PENDING_RUN_TTL_MS = 15 * 60 * 1000; // 15 minutes
 
-/** Concurrent run limits by scope tier */
+/** Concurrent run limits by org tier */
 const TIER_CONCURRENCY_LIMITS: Record<OrgTier, number> = {
   free: 1,
   pro: 2,
@@ -59,7 +59,7 @@ function getConcurrencyLimitForTier(tier: OrgTier): number {
  * Check if org has reached concurrent run limit
  *
  * @param orgId Clerk org ID to check
- * @param orgTier Scope tier for tier-based limit (default: "free")
+ * @param orgTier Org tier for tier-based limit (default: "free")
  * @param db Optional database instance (for use within transactions)
  * @throws ConcurrentRunLimitError if limit exceeded
  */
@@ -305,11 +305,11 @@ export interface CreateRunParams {
   modelProvider?: string;
   debugNoMockClaude?: boolean;
   checkEnv?: boolean;
-  // Caller-resolved scope slug and orgId for variable/storage resolution (org-aware).
+  // Caller-resolved org slug and orgId for variable/storage resolution.
   // When provided, used instead of getDefaultOrg fallback.
   orgSlug?: string;
   orgId?: string;
-  // Caller-resolved scope tier for concurrency limit derivation.
+  // Caller-resolved org tier for concurrency limit derivation.
   orgTier?: OrgTier;
 }
 
@@ -593,7 +593,7 @@ async function buildAndDispatchRun(opts: {
       { op: "api_step_dispatch", ms: dispatchTime - prepareTime },
       // Sub-step timings within buildExecutionContext
       {
-        op: "api_build_resolve_source_and_scope",
+        op: "api_build_resolve_source_and_org",
         ms: buildContextTimings.resolveSourceAndScope,
       },
       {
@@ -602,7 +602,7 @@ async function buildAndDispatchRun(opts: {
       },
       // Sub-step timings within prepareForExecution
       {
-        op: "api_prepare_resolve_scopes",
+        op: "api_prepare_resolve_orgs",
         ms: prepareResult.timings.resolveOrgs,
       },
       {
@@ -685,7 +685,7 @@ export async function createRun(
     );
   }
 
-  // Resolve scope slug and orgId for the run record and storage
+  // Resolve org slug and orgId for the run record and storage
   let orgSlug: string | undefined;
   let orgId: string;
   if (params.orgId) {

--- a/turbo/apps/web/src/lib/run/types.ts
+++ b/turbo/apps/web/src/lib/run/types.ts
@@ -98,7 +98,7 @@ export interface ExecutionContext {
 }
 
 /**
- * Runtime Scope — the scope of the user who triggers an agent run.
+ * Runtime Org — the org of the user who triggers an agent run.
  * Combined with userId, determines artifacts, memories, secrets, variables,
  * connectors, and model providers. See docs/resource-model.md.
  *

--- a/turbo/apps/web/src/lib/schedule/schedule-service.ts
+++ b/turbo/apps/web/src/lib/schedule/schedule-service.ts
@@ -154,7 +154,7 @@ function calculateNextRun(
 function toResponse(
   schedule: typeof agentSchedules.$inferSelect,
   composeName: string,
-  scopeSlug: string,
+  orgSlug: string,
 ): ScheduleResponse {
   // Extract secret names from encrypted secrets (values are never returned)
   let secretNames: string[] | null = null;
@@ -172,7 +172,7 @@ function toResponse(
     id: schedule.id,
     composeId: schedule.composeId,
     composeName,
-    scopeSlug,
+    scopeSlug: orgSlug,
     userId: schedule.userId,
     name: schedule.name,
     triggerType: schedule.triggerType as "cron" | "once" | "loop",
@@ -216,9 +216,9 @@ async function loadCompose(
 }
 
 /**
- * Load scope slug by ID
+ * Load org slug by ID
  */
-async function getScopeSlug(orgId: string): Promise<string> {
+async function getOrgSlug(orgId: string): Promise<string> {
   const orgData = await getOrgData(orgId);
   return orgData.slug;
 }
@@ -234,7 +234,7 @@ async function verifyScheduleOwnership(
 ): Promise<{
   schedule: typeof agentSchedules.$inferSelect;
   compose: typeof agentComposes.$inferSelect;
-  scopeSlug: string;
+  orgSlug: string;
 }> {
   const [schedule] = await globalThis.services.db
     .select()
@@ -254,9 +254,9 @@ async function verifyScheduleOwnership(
   }
 
   const compose = await loadCompose(composeId);
-  const scopeSlug = await getScopeSlug(orgId);
+  const orgSlug = await getOrgSlug(orgId);
 
-  return { schedule, compose, scopeSlug };
+  return { schedule, compose, orgSlug };
 }
 
 /**
@@ -280,7 +280,7 @@ async function validateRequiredConfig(
 
   const required = extractRequiredConfiguration(version.content);
 
-  // Fetch platform-managed secrets and vars from schedule's scope + user
+  // Fetch platform-managed secrets and vars from schedule's org + user
   const platformSecrets = await getSecretValues(orgId, userId, "user");
   const platformSecretNames = Object.keys(platformSecrets);
   log.debug(
@@ -373,7 +373,7 @@ export async function deploySchedule(
 
   // Load compose (access control is handled by the caller/route layer)
   const compose = await loadCompose(request.composeId);
-  const scopeSlug = await getScopeSlug(orgId);
+  const orgSlug = await getOrgSlug(orgId);
 
   // Validate timezone
   if (!isValidTimezone(request.timezone)) {
@@ -397,7 +397,7 @@ export async function deploySchedule(
     )
     .limit(1);
 
-  // Validate required secrets/vars against schedule's scope + user
+  // Validate required secrets/vars against schedule's org + user
   await validateRequiredConfig(compose, orgId, userId);
 
   const { triggerType, nextRunAt } = resolveTrigger(request);
@@ -434,7 +434,7 @@ export async function deploySchedule(
     log.debug(`Updated schedule ${request.name} (${existing.id})`);
 
     return {
-      schedule: toResponse(updated, compose.name, scopeSlug),
+      schedule: toResponse(updated, compose.name, orgSlug),
       created: false,
     };
   } else {
@@ -472,7 +472,7 @@ export async function deploySchedule(
     log.debug(`Created schedule ${request.name} (${created.id})`);
 
     return {
-      schedule: toResponse(created, compose.name, scopeSlug),
+      schedule: toResponse(created, compose.name, orgSlug),
       created: true,
     };
   }
@@ -504,7 +504,7 @@ export async function listSchedules(
     .where(inArray(agentComposes.id, composeIds));
   const composeMap = new Map(composeRows.map((c) => [c.id, c]));
 
-  // Load scope slugs via org cache (by orgId from schedule records)
+  // Load org slugs via org cache (by orgId from schedule records)
   const uniqueClerkOrgIds = [...new Set(userSchedules.map((s) => s.orgId))];
   const orgDataEntries = await Promise.all(
     uniqueClerkOrgIds.map(async (id) => [id, await getOrgData(id)] as const),
@@ -519,13 +519,13 @@ export async function listSchedules(
     })
     .map((schedule) => {
       const compose = composeMap.get(schedule.composeId)!;
-      const scopeSlug = orgDataMap.get(schedule.orgId)?.slug ?? "";
-      return toResponse(schedule, compose.name, scopeSlug);
+      const orgSlug = orgDataMap.get(schedule.orgId)?.slug ?? "";
+      return toResponse(schedule, compose.name, orgSlug);
     });
 }
 
 /**
- * Get schedule by name, compose ID, and scope+user
+ * Get schedule by name, compose ID, and org+user
  */
 export async function getScheduleByName(
   userId: string,
@@ -535,14 +535,14 @@ export async function getScheduleByName(
 ): Promise<ScheduleResponse> {
   log.debug(`Getting schedule ${name} for compose ${composeId}`);
 
-  const { schedule, compose, scopeSlug } = await verifyScheduleOwnership(
+  const { schedule, compose, orgSlug } = await verifyScheduleOwnership(
     userId,
     orgId,
     composeId,
     name,
   );
 
-  return toResponse(schedule, compose.name, scopeSlug);
+  return toResponse(schedule, compose.name, orgSlug);
 }
 
 /**
@@ -590,7 +590,7 @@ export async function getScheduleRecentRuns(
 }
 
 /**
- * Delete schedule by name, compose ID, and scope+user
+ * Delete schedule by name, compose ID, and org+user
  */
 export async function deleteSchedule(
   userId: string,
@@ -625,7 +625,7 @@ export async function enableSchedule(
 ): Promise<ScheduleResponse> {
   log.debug(`Enabling schedule ${name} for compose ${composeId}`);
 
-  const { schedule, compose, scopeSlug } = await verifyScheduleOwnership(
+  const { schedule, compose, orgSlug } = await verifyScheduleOwnership(
     userId,
     orgId,
     composeId,
@@ -669,7 +669,7 @@ export async function enableSchedule(
 
   log.debug(`Enabled schedule ${name}`);
 
-  return toResponse(updated, compose.name, scopeSlug);
+  return toResponse(updated, compose.name, orgSlug);
 }
 
 /**
@@ -683,7 +683,7 @@ export async function disableSchedule(
 ): Promise<ScheduleResponse> {
   log.debug(`Disabling schedule ${name} for compose ${composeId}`);
 
-  const { schedule, compose, scopeSlug } = await verifyScheduleOwnership(
+  const { schedule, compose, orgSlug } = await verifyScheduleOwnership(
     userId,
     orgId,
     composeId,
@@ -706,7 +706,7 @@ export async function disableSchedule(
 
   log.debug(`Disabled schedule ${name}`);
 
-  return toResponse(updated, compose.name, scopeSlug);
+  return toResponse(updated, compose.name, orgSlug);
 }
 
 /**

--- a/turbo/apps/web/src/lib/secret/secret-service.ts
+++ b/turbo/apps/web/src/lib/secret/secret-service.ts
@@ -41,7 +41,7 @@ interface SecretInfo {
 }
 
 /**
- * List all secrets for a scope (metadata only, no values)
+ * List all secrets for an org (metadata only, no values)
  */
 export async function listSecrets(
   orgId: string,
@@ -67,7 +67,7 @@ export async function listSecrets(
 }
 
 /**
- * Get a secret by name for a user's default scope (metadata only)
+ * Get a secret by name for a user's default org (metadata only)
  * Only returns user-type secrets; model-provider secrets are managed via model-provider commands
  */
 export async function getSecret(
@@ -142,7 +142,7 @@ export async function getSecretValue(
 }
 
 /**
- * Get all secret values for a scope as a map
+ * Get all secret values for an org as a map
  * Used for batch secret resolution during variable expansion
  * @param type - Optional type filter to isolate user vs model-provider secrets
  */
@@ -175,10 +175,10 @@ export async function getSecretValues(
 }
 
 /**
- * Upsert a secret by scope ID, name, and type.
+ * Upsert a secret by org ID, name, and type.
  * Used internally by connector services for managing connector/model-provider secrets.
  */
-export async function upsertSecretByScope(
+export async function upsertSecretByOrg(
   orgId: string,
   userId: string,
   name: string,

--- a/turbo/apps/web/src/lib/variable/variable-service.ts
+++ b/turbo/apps/web/src/lib/variable/variable-service.ts
@@ -39,7 +39,7 @@ interface VariableInfo {
 }
 
 /**
- * List all variables for a scope (includes values)
+ * List all variables for an org (includes values)
  */
 export async function listVariables(
   orgId: string,
@@ -62,7 +62,7 @@ export async function listVariables(
 }
 
 /**
- * Get a variable by name for a scope (includes value)
+ * Get a variable by name for an org (includes value)
  */
 export async function getVariable(
   orgId: string,
@@ -96,7 +96,7 @@ export async function getVariable(
 }
 
 /**
- * Get all variable values for a scope as a map
+ * Get all variable values for an org as a map
  * Used for batch variable resolution during agent execution
  */
 export async function getVariableValues(


### PR DESCRIPTION
## Summary
- Continue scope-to-org terminology migration (#4146) in web service layer
- Rename ~120 internal "scope" references across 17 files: JSDoc comments, function names (`upsertSecretByScope` → `upsertSecretByOrg`, `getScopeSlug` → `getOrgSlug`), local variables (`scopeSlug` → `orgSlug`, `agentScopeSlug` → `agentOrgSlug`), DB schema comments, and email handler test data
- No API wire format changes — `ScheduleResponse.scopeSlug`, OAuth scopes, `VOLUME_SCOPE_USER_ID`, and import paths from `lib/scope/` are all preserved

## Test plan
- [x] `pnpm check-types` — only pre-existing errors (archiver, radix-ui), no new type errors
- [x] `pnpm turbo run lint --filter=web` — 0 warnings, 0 errors
- [x] `pnpm format` — all files unchanged
- [x] `pnpm knip` — no unused exports
- [x] Email handler tests pass (shared.test.ts, route.test.ts)
- [x] Runner claim tests pass (agentScopeSlug wire format preserved)
- [x] Service directory tests pass (secret, variable, connector, schedule, run, model-provider)
- [x] Grep audit confirms only expected "scope" references remain (wire format, OAuth, JWT, import paths)

Closes #4634

🤖 Generated with [Claude Code](https://claude.com/claude-code)