### PR TITLE
refactor(web): rename internal scope references to org in route handlers and tests

### DIFF
--- a/turbo/apps/web/app/api/agent/composes/__tests__/get-by-name.test.ts
+++ b/turbo/apps/web/app/api/agent/composes/__tests__/get-by-name.test.ts
@@ -142,14 +142,14 @@ describe("GET /api/agent/composes?name=<name>", () => {
     expect(getData.error.message).toContain("Not authenticated");
   });
 
-  it("should return shared agent via cross-scope lookup with ?scope=", async () => {
+  it("should return shared agent via cross-org lookup with ?scope=", async () => {
     const agentName = `test-shared-agent-${Date.now()}`;
 
     // Create compose as owner
     const { composeId } = await createTestCompose(agentName);
 
-    // Get the owner's scope slug
-    const ownerScope = (await getOrgCacheEntry(user.orgId))!;
+    // Get the owner's org slug
+    const ownerOrg = (await getOrgCacheEntry(user.orgId))!;
 
     // Grant email permission to the recipient
     const recipientEmail = "recipient@example.com";
@@ -159,9 +159,9 @@ describe("GET /api/agent/composes?name=<name>", () => {
     const recipient = await context.setupUser({ prefix: "recipient" });
     mockClerk({ userId: recipient.userId, email: recipientEmail });
 
-    // Access the agent via cross-scope lookup
+    // Access the agent via cross-org lookup
     const getRequest = createTestRequest(
-      `http://localhost:3000/api/agent/composes?name=${agentName}&scope=${ownerScope.slug}`,
+      `http://localhost:3000/api/agent/composes?name=${agentName}&scope=${ownerOrg.slug}`,
       { method: "GET" },
     );
 
@@ -173,21 +173,21 @@ describe("GET /api/agent/composes?name=<name>", () => {
     expect(getData.name).toBe(agentName);
   });
 
-  it("should return 404 for non-shared agent via cross-scope lookup", async () => {
+  it("should return 404 for non-shared agent via cross-org lookup", async () => {
     const agentName = `test-not-shared-${Date.now()}`;
 
     // Create compose as owner (no permission granted)
     await createTestCompose(agentName);
 
-    // Get the owner's scope slug
-    const ownerScope = (await getOrgCacheEntry(user.orgId))!;
+    // Get the owner's org slug
+    const ownerOrg = (await getOrgCacheEntry(user.orgId))!;
 
     // Switch to another user with no permission
     await context.setupUser({ prefix: "unauthorized" });
 
-    // Try to access via cross-scope lookup
+    // Try to access via cross-org lookup
     const getRequest = createTestRequest(
-      `http://localhost:3000/api/agent/composes?name=${agentName}&scope=${ownerScope.slug}`,
+      `http://localhost:3000/api/agent/composes?name=${agentName}&scope=${ownerOrg.slug}`,
       { method: "GET" },
     );
 
@@ -218,15 +218,15 @@ describe("GET /api/agent/composes?name=<name>", () => {
     expect(getData.name).toBe(agentName);
   });
 
-  it("should return shared agent via cross-scope lookup with ?org=", async () => {
+  it("should return shared agent via cross-org lookup with ?org=", async () => {
     const agentName = `test-shared-org-${Date.now()}`;
 
     // Create compose as owner
     const { composeId } = await createTestCompose(agentName);
 
-    // Get the owner's scope slug to derive orgId
-    const ownerScope = (await getOrgCacheEntry(user.orgId))!;
-    const ownerOrgId = ownerScope.orgId;
+    // Get the owner's org slug to derive orgId
+    const ownerOrg = (await getOrgCacheEntry(user.orgId))!;
+    const ownerOrgId = ownerOrg.orgId;
 
     // Grant email permission to the recipient
     const recipientEmail = "recipient-org@example.com";
@@ -236,7 +236,7 @@ describe("GET /api/agent/composes?name=<name>", () => {
     const recipient = await context.setupUser({ prefix: "recipient-org" });
     mockClerk({ userId: recipient.userId, email: recipientEmail });
 
-    // Access the agent via cross-scope lookup using ?org=
+    // Access the agent via cross-org lookup using ?org=
     const getRequest = createTestRequest(
       `http://localhost:3000/api/agent/composes?name=${agentName}&org=${ownerOrgId}`,
       { method: "GET" },
@@ -250,20 +250,20 @@ describe("GET /api/agent/composes?name=<name>", () => {
     expect(getData.name).toBe(agentName);
   });
 
-  it("should return 404 for non-shared agent via cross-scope lookup with ?org=", async () => {
+  it("should return 404 for non-shared agent via cross-org lookup with ?org=", async () => {
     const agentName = `test-not-shared-org-${Date.now()}`;
 
     // Create compose as owner (no permission granted)
     await createTestCompose(agentName);
 
-    // Get the owner's scope slug to derive orgId
-    const ownerScope = (await getOrgCacheEntry(user.orgId))!;
-    const ownerOrgId = ownerScope.orgId;
+    // Get the owner's org slug to derive orgId
+    const ownerOrg = (await getOrgCacheEntry(user.orgId))!;
+    const ownerOrgId = ownerOrg.orgId;
 
     // Switch to another user with no permission
     await context.setupUser({ prefix: "unauthorized-org" });
 
-    // Try to access via cross-scope lookup using ?org=
+    // Try to access via cross-org lookup using ?org=
     const getRequest = createTestRequest(
       `http://localhost:3000/api/agent/composes?name=${agentName}&org=${ownerOrgId}`,
       { method: "GET" },
@@ -276,7 +276,7 @@ describe("GET /api/agent/composes?name=<name>", () => {
     expect(getData.error.message).toContain("Agent compose not found");
   });
 
-  it("should return 404 for invalid scope slug in cross-scope lookup", async () => {
+  it("should return 404 for invalid scope slug in cross-org lookup", async () => {
     const getRequest = createTestRequest(
       "http://localhost:3000/api/agent/composes?name=any-agent&scope=nonexistent-scope",
       { method: "GET" },

--- a/turbo/apps/web/app/api/agent/composes/list/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/composes/list/__tests__/route.test.ts
@@ -40,7 +40,7 @@ describe("GET /api/agent/composes/list", () => {
     expect(data.error.message).toBe("Not authenticated");
   });
 
-  it("should return no own composes when none exist in scope", async () => {
+  it("should return no own composes when none exist in org", async () => {
     // Use explicit scope param to only get own agents (excludes shared)
     const uniqueSuffix = user.userId.replace("test-user-", "");
     const orgSlug = `org-${uniqueSuffix}`;
@@ -55,7 +55,7 @@ describe("GET /api/agent/composes/list", () => {
     expect(data.composes).toEqual([]);
   });
 
-  it("should return all composes for the user's default scope", async () => {
+  it("should return all composes for the user's default org", async () => {
     // Create two test composes via API
     const agentName1 = `test-list-agent-1-${Date.now()}`;
     const agentName2 = `test-list-agent-2-${Date.now()}`;
@@ -91,7 +91,7 @@ describe("GET /api/agent/composes/list", () => {
     }
   });
 
-  it("should filter by scope correctly - not show other user's composes", async () => {
+  it("should filter by org correctly - not show other user's composes", async () => {
     // Create compose for current user
     const userAgentName = `test-user-agent-${Date.now()}`;
     await createTestCompose(userAgentName);
@@ -129,7 +129,7 @@ describe("GET /api/agent/composes/list", () => {
     expect(otherNames).not.toContain(userAgentName);
   });
 
-  it("should return 400 for non-existent scope", async () => {
+  it("should return 400 for non-existent org", async () => {
     const request = createTestRequest(
       "http://localhost:3000/api/agent/composes/list?scope=nonexistent-scope",
     );
@@ -140,20 +140,20 @@ describe("GET /api/agent/composes/list", () => {
     expect(data.error.code).toBe("BAD_REQUEST");
   });
 
-  it("should return 403 when user tries to access another user's scope", async () => {
-    // Create another user with their own scope
+  it("should return 403 when user tries to access another user's org", async () => {
+    // Create another user with their own org
     const otherUser = await context.setupUser({ prefix: "forbidden-user" });
 
     // Create a compose for the other user
     await createTestCompose(uniqueId("forbidden-compose"));
 
-    // Derive the other user's scope slug from their userId
+    // Derive the other user's org slug from their userId
     // userId format: {prefix}-{timestamp}-{uuid}
-    // scope slug format: org-{timestamp}-{uuid}
+    // org slug format: org-{timestamp}-{uuid}
     const uniqueSuffix = otherUser.userId.replace("forbidden-user-", "");
     const otherOrgSlug = `org-${uniqueSuffix}`;
 
-    // Switch back to original user and try to access the other user's scope
+    // Switch back to original user and try to access the other user's org
     mockClerk({ userId: user.userId });
     const request = createTestRequest(
       `http://localhost:3000/api/agent/composes/list?scope=${otherOrgSlug}`,
@@ -166,14 +166,14 @@ describe("GET /api/agent/composes/list", () => {
     expect(data.error.message).toContain("don't have access");
   });
 
-  it("should list composes by specified scope slug", async () => {
+  it("should list composes by specified org slug", async () => {
     // Create a compose first
     const agentName = `test-scope-agent-${Date.now()}`;
     await createTestCompose(agentName);
 
-    // Derive the user's scope slug from their userId
+    // Derive the user's org slug from their userId
     // userId format: test-user-{timestamp}-{uuid}
-    // scope slug format: org-{timestamp}-{uuid}
+    // org slug format: org-{timestamp}-{uuid}
     const uniqueSuffix = user.userId.replace("test-user-", "");
     const orgSlug = `org-${uniqueSuffix}`;
 

--- a/turbo/apps/web/app/api/agent/composes/list/route.ts
+++ b/turbo/apps/web/app/api/agent/composes/list/route.ts
@@ -66,7 +66,7 @@ const router = tsr.router(composesListContract, {
     }
     const { userId, orgId: tokenOrgId } = authCtx;
 
-    // Resolve org: use ?scope= query param or default org
+    // Resolve org: use ?scope= query param or default
     let orgId: string;
     try {
       const { org: resolvedOrg } = await resolveOrg(

--- a/turbo/apps/web/app/api/agent/composes/list/route.ts
+++ b/turbo/apps/web/app/api/agent/composes/list/route.ts
@@ -66,7 +66,7 @@ const router = tsr.router(composesListContract, {
     }
     const { userId, orgId: tokenOrgId } = authCtx;
 
-    // Resolve org: use ?scope= query param or default
+    // Resolve org: use ?scope= query param or default org
     let orgId: string;
     try {
       const { org: resolvedOrg } = await resolveOrg(

--- a/turbo/apps/web/app/api/agent/composes/route.ts
+++ b/turbo/apps/web/app/api/agent/composes/route.ts
@@ -42,11 +42,11 @@ const router = tsr.router(composesMainContract, {
     }
     const { userId, orgId: tokenOrgId } = authCtx;
 
-    // Resolve scope: for cross-scope lookups (shared agents), skip membership
+    // Resolve org: for cross-org lookups (shared agents), skip membership
     // check and rely on canAccessCompose for authorization instead.
-    // isCrossScopeLookup is true when an explicit scope/org param is provided,
+    // isCrossOrgLookup is true when an explicit scope/org param is provided,
     // which requires canAccessCompose authorization below.
-    const isCrossScopeLookup = Boolean(query.scope || query.org);
+    const isCrossOrgLookup = Boolean(query.scope || query.org);
     let orgId: string;
     if (query.scope) {
       const orgData = await getOrgBySlug(query.scope);
@@ -108,8 +108,8 @@ const router = tsr.router(composesMainContract, {
       };
     }
 
-    // Check permission to access this compose (for cross-scope lookups)
-    if (isCrossScopeLookup) {
+    // Check permission to access this compose (for cross-org lookups)
+    if (isCrossOrgLookup) {
       const userEmail = await getUserEmail(userId);
       const hasAccess = await canAccessCompose(userId, userEmail, result);
       if (!hasAccess) {
@@ -261,7 +261,7 @@ const router = tsr.router(composesMainContract, {
     // Compute content-addressable version ID from resolved content
     const versionId = computeComposeVersionId(resolvedContent);
 
-    // Get user's scope (required for compose creation)
+    // Get user's org (required for compose creation)
     const { org } = await resolveOrg(userId, null, null, tokenOrgId);
 
     // Check compose and version existence in parallel

--- a/turbo/apps/web/app/api/agent/runs/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/__tests__/route.test.ts
@@ -649,8 +649,8 @@ describe("POST /api/agent/runs - Internal Runs API", () => {
       expect(run2.status).toBe("pending");
     });
 
-    it("should allow 2 concurrent runs for pro tier scopes", async () => {
-      // Set scope to pro tier (allows 2 concurrent runs)
+    it("should allow 2 concurrent runs for pro tier orgs", async () => {
+      // Set org to pro tier (allows 2 concurrent runs)
       const orgEntry = (await getOrgCacheEntry(user.orgId))!;
       await insertOrgCacheEntry({
         orgId: user.orgId,
@@ -665,7 +665,7 @@ describe("POST /api/agent/runs - Internal Runs API", () => {
       expect(run2.status).toBe("pending");
     });
 
-    it("should queue 3rd concurrent run for pro tier scopes", async () => {
+    it("should queue 3rd concurrent run for pro tier orgs", async () => {
       // Pro tier only allows 2 concurrent runs
       const orgEntry = (await getOrgCacheEntry(user.orgId))!;
       await insertOrgCacheEntry({

--- a/turbo/apps/web/app/api/agent/runs/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/route.ts
@@ -444,7 +444,7 @@ const router = tsr.router(runsMainContract, {
       `Resolved agentComposeVersionId: ${resolved.agentComposeVersionId}`,
     );
 
-    // Resolve scope for variable/secret resolution.
+    // Resolve org for variable/secret resolution.
     // The actual variable fetching happens in build-context.ts.
     const orgSlug = new URL(request.url).searchParams.get("scope");
     const orgParam = new URL(request.url).searchParams.get("org");

--- a/turbo/apps/web/app/api/agent/schedules/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/schedules/__tests__/route.test.ts
@@ -311,7 +311,7 @@ describe("POST /api/agent/schedules - Deploy Schedule", () => {
       expect(data.error.code).toBe("NOT_FOUND");
     });
 
-    it("should allow scheduling another user's compose (cross-scope sharing)", async () => {
+    it("should allow scheduling another user's compose (cross-org sharing)", async () => {
       // Create another user and their compose
       await context.setupUser({ prefix: "other" });
       const { composeId: otherComposeId } = await createTestCompose(
@@ -339,7 +339,7 @@ describe("POST /api/agent/schedules - Deploy Schedule", () => {
       const response = await POST(request);
       const data = await response.json();
 
-      // Cross-scope sharing: user can schedule another user's agent
+      // Cross-org sharing: user can schedule another user's agent
       // The schedule is associated with the caller's orgId + userId
       expect(response.status).toBe(201);
       expect(data.created).toBe(true);

--- a/turbo/apps/web/app/api/agent/schedules/missing-secrets/route.ts
+++ b/turbo/apps/web/app/api/agent/schedules/missing-secrets/route.ts
@@ -50,7 +50,7 @@ export async function GET(request: Request) {
     return NextResponse.json({ agents: [] });
   }
 
-  // Get user's scope to query configured secrets
+  // Get user's org to query configured secrets
   const runtimeOrg = await getDefaultOrgByUserId(userId);
   if (!runtimeOrg) {
     return NextResponse.json({ agents: [] });

--- a/turbo/apps/web/app/api/cli/auth/test-connector/route.ts
+++ b/turbo/apps/web/app/api/cli/auth/test-connector/route.ts
@@ -94,7 +94,7 @@ export async function POST(request: Request) {
   const org = await getDefaultOrgByUserId(userId);
   if (!org) {
     return NextResponse.json(
-      { error: "Test user has no scope — run test-token first" },
+      { error: "Test user has no org — run test-token first" },
       { status: 400 },
     );
   }

--- a/turbo/apps/web/app/api/cli/auth/test-token/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/cli/auth/test-token/__tests__/route.test.ts
@@ -37,7 +37,7 @@ describe("/api/cli/auth/test-token", () => {
     mockGetUserList.mockResolvedValue({
       data: [{ id: "user_test123" }],
     });
-    // Return a Clerk org membership so ensureDefaultScope can discover/create a local scope
+    // Return a Clerk org membership so ensureDefaultOrg can discover/create a local org
     mockGetOrganizationMembershipList.mockResolvedValue({
       data: [
         {

--- a/turbo/apps/web/app/api/cli/auth/test-token/route.ts
+++ b/turbo/apps/web/app/api/cli/auth/test-token/route.ts
@@ -39,7 +39,7 @@ function isTestTokenAllowed(request: Request): boolean {
 }
 
 /**
- * Ensure the test user has an org_cache entry for scope resolution.
+ * Ensure the test user has an org_cache entry for org resolution.
  * Uses the same flow as production (getDefaultOrg) so that
  * Clerk API membership verification works during E2E tests.
  *
@@ -89,7 +89,7 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "Test user not found" }, { status: 500 });
   }
 
-  // Auto-create scope if user doesn't have one (creates real Clerk org or sentinel)
+  // Auto-create org if user doesn't have one (creates real Clerk org or sentinel)
   const { orgId } = await ensureTestScope(userId);
 
   // Generate CLI token with org binding

--- a/turbo/apps/web/app/api/cli/auth/token/route.ts
+++ b/turbo/apps/web/app/api/cli/auth/token/route.ts
@@ -74,7 +74,7 @@ const router = tsr.router(cliAuthTokenContract, {
       case "authenticated": {
         const userId = session.userId as string;
 
-        // Resolve user's default scope from org_cache
+        // Resolve user's default org from org_cache
         const { org } = await getDefaultOrg(userId);
 
         // Generate CLI token with org binding

--- a/turbo/apps/web/app/api/integrations/github/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/integrations/github/__tests__/route.test.ts
@@ -435,7 +435,7 @@ describe("/api/integrations/github", () => {
       const { composeId } = await createTestCompose("gh-agent");
       await insertTestGitHubInstallationWithAdmin(composeId, userId);
 
-      // Create a compose in a different scope (simulating a shared agent)
+      // Create a compose in a different org (simulating a shared agent)
       const otherUserId = uniqueId("other-user");
       mockClerk({ userId: otherUserId });
       await createTestOrg(uniqueId("other-org"));
@@ -445,7 +445,7 @@ describe("/api/integrations/github", () => {
       // Switch back to original user
       mockClerk({ userId });
 
-      // Look up the other scope's slug for the scoped name
+      // Look up the other org's slug for the scoped name
       const otherCompose = await findTestComposeWithScope(otherComposeId);
 
       const request = createTestRequest(

--- a/turbo/apps/web/app/api/integrations/slack/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/integrations/slack/__tests__/route.test.ts
@@ -314,7 +314,7 @@ describe("/api/integrations/slack", () => {
 
       mockClerk({ userId: userLink.vm0UserId });
 
-      // Find the scope slug and name used for the default agent
+      // Find the org slug and name used for the default agent
       const defaultCompose = await findTestComposeWithScope(
         installation.defaultComposeId,
       );
@@ -359,7 +359,7 @@ describe("/api/integrations/slack", () => {
     it("updates the default agent with scoped name (scope/agentName)", async () => {
       const { userLink } = await givenLinkedSlackUser({ isAdmin: true });
 
-      // Create a compose in a different scope (simulating a shared agent)
+      // Create a compose in a different org (simulating a shared agent)
       const otherUserId = uniqueId("other-user");
       mockClerk({ userId: otherUserId });
       await createTestOrg(uniqueId("other-org"));
@@ -369,7 +369,7 @@ describe("/api/integrations/slack", () => {
       // Switch back to admin user
       mockClerk({ userId: userLink.vm0UserId });
 
-      // Look up the other scope's slug for the scoped name
+      // Look up the other org's slug for the scoped name
       const otherCompose = await findTestComposeWithScope(otherComposeId);
 
       const request = new Request(
@@ -398,7 +398,7 @@ describe("/api/integrations/slack", () => {
       expect(getData.agent.orgSlug).toBe(otherCompose!.orgSlug);
     });
 
-    it("returns 400 when scoped name has invalid scope slug", async () => {
+    it("returns 400 when scoped name has invalid org slug", async () => {
       const { userLink } = await givenLinkedSlackUser({ isAdmin: true });
       mockClerk({ userId: userLink.vm0UserId });
 

--- a/turbo/apps/web/app/api/integrations/slack/link/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/integrations/slack/link/__tests__/route.test.ts
@@ -206,7 +206,7 @@ describe("/api/integrations/slack/link", () => {
       const { installation } = await givenSlackWorkspaceInstalled();
       mockClerk({ userId: user.userId });
 
-      // Create an additional agent for the user (scope already exists from setupUser)
+      // Create an additional agent for the user (org already exists from setupUser)
       const { composeId: customAgentId } =
         await createTestCompose("custom-agent");
 

--- a/turbo/apps/web/app/api/integrations/slack/link/route.ts
+++ b/turbo/apps/web/app/api/integrations/slack/link/route.ts
@@ -278,7 +278,7 @@ export async function POST(request: Request) {
     );
   }
 
-  // Ensure scope and artifact exist for the user
+  // Ensure org and artifact exist for the user
   await ensureScopeAndArtifact(userId);
 
   // Create the link

--- a/turbo/apps/web/app/api/internal/callbacks/email/trigger/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/email/trigger/__tests__/route.test.ts
@@ -150,7 +150,7 @@ describe("POST /api/internal/callbacks/email/trigger", () => {
 
       const replyToken = generateReplyToken(crypto.randomUUID());
       const senderEmail = "sender@example.com";
-      const triggerLocalPart = `my-scope+${agentName}`;
+      const triggerLocalPart = `my-org+${agentName}`;
       const payload: TriggerCallbackPayload = {
         senderEmail,
         composeId,

--- a/turbo/apps/web/app/api/internal/callbacks/github/issues/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/github/issues/__tests__/route.test.ts
@@ -110,7 +110,7 @@ function setupGitHubApiMocks(installationId: string) {
 }
 
 /**
- * Create a full test setup: user, scope, compose, run, GitHub installation, and callback.
+ * Create a full test setup: user, org, compose, run, GitHub installation, and callback.
  */
 async function givenGitHubCallbackSetup(overrides?: {
   existingSessionId?: string;

--- a/turbo/apps/web/app/api/internal/callbacks/telegram/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/telegram/__tests__/route.test.ts
@@ -106,7 +106,7 @@ function createCallbackRequest(
 }
 
 /**
- * Set up a full Telegram test context: scope, compose (with version),
+ * Set up a full Telegram test context: org, compose (with version),
  * installation (encrypted token), user link, run, callback.
  */
 async function setupTelegramCallback() {

--- a/turbo/apps/web/app/api/onboarding/status/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/onboarding/status/__tests__/route.test.ts
@@ -29,7 +29,7 @@ describe("GET /api/onboarding/status", () => {
     expect(data.error.code).toBe("UNAUTHORIZED");
   });
 
-  it("should return needsOnboarding=true when user has no scope", async () => {
+  it("should return needsOnboarding=true when user has no org", async () => {
     const userId = `no-scope-user-${Date.now()}`;
     mockClerk({ userId, clerkOrgs: [] });
 
@@ -51,7 +51,7 @@ describe("GET /api/onboarding/status", () => {
     });
   });
 
-  it("should return hasScope=true, hasModelProvider=false when scope exists but no provider", async () => {
+  it("should return hasOrg=true, hasModelProvider=false when org exists but no provider", async () => {
     await context.setupUser();
 
     const request = createTestRequest(

--- a/turbo/apps/web/app/api/onboarding/status/route.ts
+++ b/turbo/apps/web/app/api/onboarding/status/route.ts
@@ -27,8 +27,8 @@ const router = tsr.router(onboardingStatusContract, {
       };
     }
 
-    // Check if scope exists
-    let hasScope = false;
+    // Check if org exists
+    let hasOrg = false;
     let hasModelProvider = false;
     let hasDefaultAgent = false;
     let defaultAgentName: string | null = null;
@@ -38,7 +38,7 @@ const router = tsr.router(onboardingStatusContract, {
 
     try {
       const { org: resolvedOrg } = await resolveOrg(userId);
-      hasScope = true;
+      hasOrg = true;
 
       // Check model provider
       const [provider] = await globalThis.services.db
@@ -93,16 +93,16 @@ const router = tsr.router(onboardingStatusContract, {
       if (!isNotFound(error)) {
         throw error;
       }
-      // Scope not found — all flags stay false
+      // Org not found — all flags stay false
     }
 
-    const needsOnboarding = !hasScope || !hasModelProvider || !hasDefaultAgent;
+    const needsOnboarding = !hasOrg || !hasModelProvider || !hasDefaultAgent;
 
     return {
       status: 200 as const,
       body: {
         needsOnboarding,
-        hasScope,
+        hasScope: hasOrg,
         hasModelProvider,
         hasDefaultAgent,
         defaultAgentName,

--- a/turbo/apps/web/app/api/platform/logs/route.ts
+++ b/turbo/apps/web/app/api/platform/logs/route.ts
@@ -42,19 +42,19 @@ interface LogsQuery {
 }
 
 /**
- * Build agent name/scope filter conditions from query params.
+ * Build agent name/org filter conditions from query params.
  * name+scope take precedence over legacy agent param, which takes precedence over search.
  */
 function buildAgentFilterConditions(
   query: LogsQuery,
-  scopeOrgId: string | null,
+  orgId: string | null,
 ): SQL[] {
   const conditions: SQL[] = [];
 
   if (query.name) {
     conditions.push(eq(agentComposes.name, query.name));
-    if (scopeOrgId) {
-      conditions.push(eq(agentComposes.orgId, scopeOrgId));
+    if (orgId) {
+      conditions.push(eq(agentComposes.orgId, orgId));
     }
   } else if (query.agent) {
     conditions.push(eq(agentComposes.name, query.agent));
@@ -89,10 +89,10 @@ function buildCursorCondition(cursor: string): SQL | null {
 async function getTotalCount(
   userId: string,
   query: LogsQuery,
-  scopeOrgId: string | null,
+  orgId: string | null,
 ): Promise<number> {
   const conditions: SQL[] = [eq(agentRuns.userId, userId)];
-  conditions.push(...buildAgentFilterConditions(query, scopeOrgId));
+  conditions.push(...buildAgentFilterConditions(query, orgId));
   if (query.status) {
     conditions.push(eq(agentRuns.status, query.status));
   }
@@ -151,12 +151,12 @@ const router = tsr.router(platformLogsListContract, {
 
     const limit = query.limit ?? 20;
 
-    // Resolve scope slug to orgId for filtering
-    let scopeOrgId: string | null = null;
+    // Resolve org slug to orgId for filtering
+    let orgId: string | null = null;
     if (query.scope) {
       const orgData = await getOrgBySlug(query.scope);
-      scopeOrgId = orgData?.orgId ?? null;
-      if (!scopeOrgId) {
+      orgId = orgData?.orgId ?? null;
+      if (!orgId) {
         return {
           status: 200 as const,
           body: {
@@ -177,7 +177,7 @@ const router = tsr.router(platformLogsListContract, {
       }
     }
 
-    conditions.push(...buildAgentFilterConditions(query, scopeOrgId));
+    conditions.push(...buildAgentFilterConditions(query, orgId));
 
     if (query.status) {
       conditions.push(eq(agentRuns.status, query.status));
@@ -209,7 +209,7 @@ const router = tsr.router(platformLogsListContract, {
       .orderBy(desc(agentRuns.createdAt), desc(agentRuns.id))
       .limit(limit + 1);
 
-    // Resolve scope slugs via org cache (skip orgs that fail lookup)
+    // Resolve org slugs via org cache (skip orgs that fail lookup)
     const uniqueOrgIds = [
       ...new Set(runs.filter((r) => r.orgId).map((r) => r.orgId!)),
     ];
@@ -228,7 +228,7 @@ const router = tsr.router(platformLogsListContract, {
       }),
     );
 
-    const totalCount = await getTotalCount(userId, query, scopeOrgId);
+    const totalCount = await getTotalCount(userId, query, orgId);
     const totalPages = Math.max(1, Math.ceil(totalCount / limit));
 
     // Determine pagination info

--- a/turbo/apps/web/app/api/runners/jobs/[id]/claim/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/runners/jobs/[id]/claim/__tests__/route.test.ts
@@ -234,7 +234,7 @@ describe("POST /api/runners/jobs/:id/claim", () => {
 
   describe("Claim flow - Agent metadata", () => {
     it("should return agentName and agentScopeSlug in claim response", async () => {
-      // Create compose and look up scope slug
+      // Create compose and look up org slug
       const { composeId, versionId } = await createTestCompose("test-agent");
       const composeInfo = await findTestComposeWithScope(composeId);
       const orgSlug = composeInfo!.orgSlug;
@@ -273,7 +273,7 @@ describe("POST /api/runners/jobs/:id/claim", () => {
     });
 
     it("should omit agentName and agentScopeSlug when not set in stored context", async () => {
-      // Create compose and look up scope slug
+      // Create compose and look up org slug
       const { composeId, versionId } =
         await createTestCompose("test-agent-no-meta");
       const composeInfo = await findTestComposeWithScope(composeId);

--- a/turbo/apps/web/app/api/runners/jobs/[id]/claim/route.ts
+++ b/turbo/apps/web/app/api/runners/jobs/[id]/claim/route.ts
@@ -78,7 +78,7 @@ const router = tsr.router(runnersJobClaimContract, {
         `Official runner claiming job from ${jobWithRun.job.runnerGroup}`,
       );
     } else {
-      // User runners: verify job ownership and scope
+      // User runners: verify job ownership and org
       if (jobWithRun.runUserId !== auth.userId) {
         return createErrorResponse("FORBIDDEN", "Job does not belong to user");
       }

--- a/turbo/apps/web/app/api/runners/poll/route.ts
+++ b/turbo/apps/web/app/api/runners/poll/route.ts
@@ -46,7 +46,7 @@ const router = tsr.router(runnersPollContract, {
       ];
       log.debug(`Official runner polling group: ${group}`);
     } else {
-      // User runners: validate scope and filter by userId
+      // User runners: validate org and filter by userId
       try {
         await validateRunnerGroupOrg(auth.userId, group, auth.orgId);
       } catch {

--- a/turbo/apps/web/app/api/runners/realtime/token/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/runners/realtime/token/__tests__/route.test.ts
@@ -118,7 +118,7 @@ describe("POST /api/runners/realtime/token", () => {
       const token = `vm0_official_${OFFICIAL_RUNNER_SECRET}`;
 
       const response = await POST(
-        makeRequest({ group: "other-scope/default" }, `Bearer ${token}`),
+        makeRequest({ group: "other-org/default" }, `Bearer ${token}`),
       );
       const data = await response.json();
 
@@ -128,11 +128,11 @@ describe("POST /api/runners/realtime/token", () => {
       );
     });
 
-    it("should return 403 when user runner requests group from wrong scope", async () => {
+    it("should return 403 when user runner requests group from wrong org", async () => {
       const token = await createTestCliToken(user.userId);
 
       const response = await POST(
-        makeRequest({ group: "wrong-scope/default" }, `Bearer ${token}`),
+        makeRequest({ group: "wrong-org/default" }, `Bearer ${token}`),
       );
       const data = await response.json();
 
@@ -158,12 +158,12 @@ describe("POST /api/runners/realtime/token", () => {
       expect(data.mac).toBe("test-mac");
     });
 
-    it("should return Ably TokenRequest for user runner with matching scope group", async () => {
+    it("should return Ably TokenRequest for user runner with matching org group", async () => {
       vi.stubEnv("ABLY_API_KEY", "test-api-key");
       reloadEnv();
       const token = await createTestCliToken(user.userId);
 
-      // Derive scope slug from user context - setupUser creates org-{suffix}
+      // Derive org slug from user context - setupUser creates org-{suffix}
       const suffix = user.userId.replace("test-user-", "");
       const orgSlug = `org-${suffix}`;
 

--- a/turbo/apps/web/app/api/runners/realtime/token/route.ts
+++ b/turbo/apps/web/app/api/runners/realtime/token/route.ts
@@ -33,7 +33,7 @@ const router = tsr.router(runnerRealtimeTokenContract, {
       }
       log.debug(`Official runner requesting token for ${group}`);
     } else {
-      // User runners: validate scope
+      // User runners: validate org
       try {
         await validateRunnerGroupOrg(auth.userId, group, auth.orgId);
       } catch {

--- a/turbo/apps/web/app/api/secrets/[name]/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/secrets/[name]/__tests__/route.test.ts
@@ -194,7 +194,7 @@ describe("DELETE /api/secrets/:name - Delete Secret", () => {
     expect(getResponse.status).toBe(200);
   });
 
-  it("should return 404 for user without scope", async () => {
+  it("should return 404 for user without org", async () => {
     mockClerk({ userId: `user-no-scope-${Date.now()}` });
 
     const request = createTestRequest(

--- a/turbo/apps/web/app/api/slack/oauth/callback/route.ts
+++ b/turbo/apps/web/app/api/slack/oauth/callback/route.ts
@@ -262,7 +262,7 @@ async function createUserLink(
 
   if (existing) return;
 
-  // Ensure scope and artifact exist
+  // Ensure org and artifact exist
   await ensureScopeAndArtifact(vm0UserId);
 
   // Create the link

--- a/turbo/apps/web/app/api/storages/__tests__/per-user-isolation.test.ts
+++ b/turbo/apps/web/app/api/storages/__tests__/per-user-isolation.test.ts
@@ -64,7 +64,7 @@ describe("Storage per-user isolation", () => {
     expect(userAArtifacts).toHaveLength(1);
     expect(userAArtifacts[0].name).toBe("shared-name");
 
-    // User B (different scope) should not see User A's artifact
+    // User B (different org) should not see User A's artifact
     const userB = await context.setupUser({ prefix: "other-user" });
     mockClerk({ userId: userB.userId });
 
@@ -129,13 +129,13 @@ describe("Storage per-user isolation", () => {
     expect(userAVolumes).toHaveLength(1);
     expect(userAVolumes[0].name).toBe("shared-data");
 
-    // User B (different scope) creates volume with same name in their scope
+    // User B (different org) creates volume with same name in their org
     const userB = await context.setupUser({ prefix: "other-user" });
     mockClerk({ userId: userB.userId });
 
     await createTestVolume("shared-data");
 
-    // User B should see their scope's volume
+    // User B should see their org's volume
     const userBResponse = await listStorages("volume");
     const userBVolumes = await userBResponse.json();
     expect(userBVolumes).toHaveLength(1);

--- a/turbo/apps/web/app/api/storages/commit/route.ts
+++ b/turbo/apps/web/app/api/storages/commit/route.ts
@@ -36,7 +36,7 @@ const router = tsr.router(storagesCommitContract, {
     }
     const { userId, orgId: tokenOrgId } = authCtx;
 
-    // Resolve user's default scope
+    // Resolve user's default org
     const orgSlug = new URL(request.url).searchParams.get("scope");
     const orgParam = new URL(request.url).searchParams.get("org");
     const { org: runtimeOrg } = await resolveOrg(

--- a/turbo/apps/web/app/api/storages/download/route.ts
+++ b/turbo/apps/web/app/api/storages/download/route.ts
@@ -32,7 +32,7 @@ const router = tsr.router(storagesDownloadContract, {
     }
     const { userId, orgId: tokenOrgId } = authCtx;
 
-    // Resolve user's default scope
+    // Resolve user's default org
     const orgSlug = new URL(request.url).searchParams.get("scope");
     const orgParam = new URL(request.url).searchParams.get("org");
     const { org: runtimeOrg } = await resolveOrg(
@@ -45,14 +45,14 @@ const router = tsr.router(storagesDownloadContract, {
     const { name: storageName, type: storageType, version: versionId } = query;
 
     log.debug(
-      `Getting download URL for "${storageName}" (type: ${storageType})${versionId ? ` version ${versionId}` : ""} for scope ${runtimeOrg.slug}`,
+      `Getting download URL for "${storageName}" (type: ${storageType})${versionId ? ` version ${versionId}` : ""} for org ${runtimeOrg.slug}`,
     );
 
-    // Volumes use sentinel userId (scope-shared); artifacts/memory use real userId
+    // Volumes use sentinel userId (org-shared); artifacts/memory use real userId
     const storageUserId =
       storageType === "volume" ? VOLUME_SCOPE_USER_ID : userId;
 
-    // Check if storage exists and belongs to user's default scope
+    // Check if storage exists and belongs to user's default org
     const [storage] = await globalThis.services.db
       .select()
       .from(storages)

--- a/turbo/apps/web/app/api/storages/list/route.ts
+++ b/turbo/apps/web/app/api/storages/list/route.ts
@@ -41,7 +41,7 @@ const router = tsr.router(storagesListContract, {
       tokenOrgId,
     );
 
-    // Volumes use sentinel userId (scope-shared); artifacts/memory use real userId
+    // Volumes use sentinel userId (org-shared); artifacts/memory use real userId
     const storageUserId =
       storageType === "volume" ? VOLUME_SCOPE_USER_ID : userId;
 

--- a/turbo/apps/web/app/api/storages/prepare/route.ts
+++ b/turbo/apps/web/app/api/storages/prepare/route.ts
@@ -102,7 +102,7 @@ const router = tsr.router(storagesPrepareContract, {
     }
     const { userId, orgId: tokenOrgId } = authCtx;
 
-    // Resolve user's default scope
+    // Resolve user's default org
     const orgSlug = new URL(request.url).searchParams.get("scope");
     const orgParam = new URL(request.url).searchParams.get("org");
     const { org: runtimeOrg } = await resolveOrg(
@@ -161,7 +161,7 @@ const router = tsr.router(storagesPrepareContract, {
       }
     }
 
-    // Volumes use sentinel userId (scope-level shared); artifacts/memory use real userId
+    // Volumes use sentinel userId (org-level shared); artifacts/memory use real userId
     const storageUserId =
       storageType === "volume" ? VOLUME_SCOPE_USER_ID : userId;
 

--- a/turbo/apps/web/app/api/variables/[name]/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/variables/[name]/__tests__/route.test.ts
@@ -193,7 +193,7 @@ describe("DELETE /api/variables/:name - Delete Variable", () => {
     expect(getResponse.status).toBe(200);
   });
 
-  it("should return 404 for user without scope", async () => {
+  it("should return 404 for user without org", async () => {
     mockClerk({ userId: `user-no-scope-${Date.now()}` });
 
     const request = createTestRequest(

--- a/turbo/apps/web/app/api/webhooks/agent/storages/commit/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/storages/commit/route.ts
@@ -65,14 +65,14 @@ const router = tsr.router(webhookStoragesCommitContract, {
       };
     }
 
-    // Resolve Runtime Scope (user's default scope)
+    // Resolve Runtime Org (user's default org)
     const runtimeOrg = await getDefaultOrgByUserId(userId);
     if (!runtimeOrg) {
       return {
         status: 400 as const,
         body: {
           error: {
-            message: "User's default scope not found",
+            message: "User's default org not found",
             code: "BAD_REQUEST",
           },
         },

--- a/turbo/apps/web/app/api/webhooks/agent/storages/prepare/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/storages/prepare/route.ts
@@ -95,21 +95,21 @@ const router = tsr.router(webhookStoragesPrepareContract, {
       };
     }
 
-    // Resolve Runtime Scope (user's default scope)
+    // Resolve Runtime Org (user's default org)
     const resolvedOrg = await getDefaultOrgByUserId(userId);
     if (!resolvedOrg) {
       return {
         status: 400 as const,
         body: {
           error: {
-            message: "User's default scope not found",
+            message: "User's default org not found",
             code: "BAD_REQUEST",
           },
         },
       };
     }
 
-    // Volumes use sentinel userId (scope-level shared); artifacts/memory use real userId
+    // Volumes use sentinel userId (org-level shared); artifacts/memory use real userId
     const storageUserId =
       storageType === "volume" ? VOLUME_SCOPE_USER_ID : userId;
 

--- a/turbo/apps/web/app/api/webhooks/email/inbound/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/email/inbound/__tests__/route.test.ts
@@ -514,27 +514,27 @@ describe("POST /api/webhooks/email/inbound", () => {
     expect(JSON.stringify(args?.react)).toContain("DMARC verification failed");
   });
 
-  describe("Email Trigger (scope+agent@domain)", () => {
+  describe("Email Trigger (org+agent@domain)", () => {
     it("should dispatch agent run for valid trigger email", async () => {
-      // Given a user with a scope and compose
+      // Given a user with an org and compose
       // setupUser creates a user with userId = "trigger-user-{suffix}" and
-      // scope slug = "org-{suffix}" using the same suffix
+      // org slug = "org-{suffix}" using the same suffix
       const user = await context.setupUser({ prefix: "trigger-user" });
 
-      // Extract suffix from userId to derive scope slug
+      // Extract suffix from userId to derive org slug
       // userId format: "{prefix}-{suffix}" where suffix is an 8-char UUID
       const suffix = user.userId.slice("trigger-user-".length);
       const orgSlug = `org-${suffix}`;
       const agentName = uniqueId("trigger-agent");
 
-      // Create compose (automatically associates with user's scope)
+      // Create compose (automatically associates with user's org)
       const { composeId } = await createTestCompose(agentName);
 
       // Mock Clerk to return the user when looking up by email
       const senderEmail = "sender@example.com";
       mockClerk({ userId: user.userId, email: senderEmail });
 
-      // Build inbound email webhook payload with scope+agent format
+      // Build inbound email webhook payload with org+agent format
       const payload = JSON.stringify({
         type: "email.received",
         data: {
@@ -625,7 +625,7 @@ describe("POST /api/webhooks/email/inbound", () => {
       const senderEmail = "sender@example.com";
       mockClerk({ userId: "some-user-id", email: senderEmail });
 
-      // Send email to non-existent scope/agent
+      // Send email to non-existent org/agent
       const payload = JSON.stringify({
         type: "email.received",
         data: {
@@ -664,7 +664,7 @@ describe("POST /api/webhooks/email/inbound", () => {
       await createTestCompose(agentName);
 
       // Mock Clerk to return a DIFFERENT user when looking up sender email.
-      // This user is not the compose owner, not in the scope, and has no ACL entry.
+      // This user is not the compose owner, not in the org, and has no ACL entry.
       const senderEmail = "unauthorized@example.com";
       mockClerk({ userId: "unauthorized-user-id", email: senderEmail });
 
@@ -1647,8 +1647,8 @@ describe("POST /api/webhooks/email/inbound", () => {
     });
   });
 
-  describe("Email Trigger (agent@domain, auto-detect scope)", () => {
-    it("should dispatch agent run for agent-only email (auto-detect scope)", async () => {
+  describe("Email Trigger (agent@domain, auto-detect org)", () => {
+    it("should dispatch agent run for agent-only email (auto-detect org)", async () => {
       const user = await context.setupUser({ prefix: "auto-scope" });
       const agentName = uniqueId("auto-agent");
       await createTestCompose(agentName);
@@ -1656,7 +1656,7 @@ describe("POST /api/webhooks/email/inbound", () => {
       const senderEmail = "sender@example.com";
       mockClerk({ userId: user.userId, email: senderEmail });
 
-      // Send to agentname@domain (no scope, no plus sign)
+      // Send to agentname@domain (no org, no plus sign)
       const payload = JSON.stringify({
         type: "email.received",
         data: {
@@ -1726,10 +1726,10 @@ describe("POST /api/webhooks/email/inbound", () => {
       expect(getErrorReplyArgs()?.to).toBe(senderEmail);
     });
 
-    it("should send error reply for agent-only email when sender has no scope", async () => {
+    it("should send error reply for agent-only email when sender has no org", async () => {
       mockResend.emails.receiving.get.mockClear();
 
-      // Mock Clerk to return a userId that has no scope in the database
+      // Mock Clerk to return a userId that has no org in the database
       const senderEmail = "noscopeuser@example.com";
       mockClerk({ userId: "no-scope-user-id", email: senderEmail });
 
@@ -1750,7 +1750,7 @@ describe("POST /api/webhooks/email/inbound", () => {
       expect(response.status).toBe(200);
       await context.mocks.flushAfter();
 
-      // No email fetch should have happened (early return after scope lookup failed)
+      // No email fetch should have happened (early return after org lookup failed)
       expect(mockResend.emails.receiving.get).not.toHaveBeenCalled();
 
       // Error reply should have been sent
@@ -1765,7 +1765,7 @@ describe("POST /api/webhooks/email/inbound", () => {
       const senderEmail = "sender@example.com";
       mockClerk({ userId: user.userId, email: senderEmail });
 
-      // Send to an agent that doesn't exist in the sender's scope
+      // Send to an agent that doesn't exist in the sender's org
       const payload = JSON.stringify({
         type: "email.received",
         data: {

--- a/turbo/apps/web/app/api/webhooks/email/inbound/route.ts
+++ b/turbo/apps/web/app/api/webhooks/email/inbound/route.ts
@@ -22,8 +22,8 @@ const log = logger("webhook:email:inbound");
  * Receives inbound email events from Resend via Svix.
  * Routes to appropriate handler based on email address type:
  * - reply+{token}@domain → handleInboundEmailReply (continue conversation)
- * - {scope}+{agent}@domain → handleInboundEmailTrigger (new agent run, explicit scope)
- * - {agent}@domain → handleInboundEmailTrigger (new agent run, scope from sender)
+ * - {org}+{agent}@domain → handleInboundEmailTrigger (new agent run, explicit org)
+ * - {agent}@domain → handleInboundEmailTrigger (new agent run, org from sender)
  *
  * Verifies the webhook signature and dispatches handling in the background.
  * Returns 200 immediately to acknowledge receipt.

--- a/turbo/apps/web/app/slack/link/actions.ts
+++ b/turbo/apps/web/app/slack/link/actions.ts
@@ -139,7 +139,7 @@ export async function linkSlackAccount(
     };
   }
 
-  // Ensure scope and artifact exist for the user
+  // Ensure org and artifact exist for the user
   await ensureScopeAndArtifact(userId);
 
   // Create the link


### PR DESCRIPTION
## Summary

Part of the scope-to-org terminology migration (#4146). Renames ~130 internal "scope" references across 40 files in `turbo/apps/web/app/`:

- **Variable renames**: `scopeOrgId`→`orgId`, `isCrossScopeLookup`→`isCrossOrgLookup`, `hasScope`→`hasOrg` (wire format key preserved via explicit mapping)
- **Comments and error messages**: "scope" → "org" where referring to org context
- **Test descriptions, comments, and variable names**: updated consistently across ~20 test files

**No API wire format changes. No breaking changes.**

### Exclusions (intentionally unchanged)
- `agentScopeSlug` (wire format in runners contract)
- `VOLUME_SCOPE_USER_ID` (constant from @vm0/core)
- `searchParams.get("scope")` (query parameter)
- `/api/scope/` path strings
- Import paths from `../../lib/scope/`
- `scopeSlug` from API response JSON reads
- `hasScope` as response body key in onboarding schema

Closes #4635

## Test plan
- [x] `pnpm turbo run lint` passes (0 warnings, 0 errors)
- [x] `pnpm format` — no changes needed
- [x] `pnpm knip` — no unused exports/deps found
- [x] Pre-commit hooks all pass (prettier, knip, commitlint)
- [ ] CI: check-types, lint, test, cli-e2e pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)