### PR TITLE
feat(platform): refactor preferences into standalone zero route with loading states

### DIFF
--- a/turbo/apps/platform/src/signals/settings-page/notification-settings.ts
+++ b/turbo/apps/platform/src/signals/settings-page/notification-settings.ts
@@ -5,6 +5,7 @@ import type {
   UpdateUserPreferencesRequest,
 } from "@vm0/core";
 import { fetch$ } from "../fetch.ts";
+import { clerk$ } from "../auth.ts";
 
 // ---------------------------------------------------------------------------
 // Reload trigger
@@ -41,6 +42,10 @@ export const updateNotificationPreference$ = command(
       toast.error("Failed to update notification preference");
       return;
     }
+
+    // Force JWT refresh so updated membership metadata is available immediately
+    const clerk = await get(clerk$);
+    await clerk.session?.getToken({ skipCache: true });
 
     set(internalReloadPreferences$, (x) => x + 1);
   },

--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-nav.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-nav.test.ts
@@ -48,9 +48,12 @@ describe("zero-nav", () => {
       expect(context.store.get(zeroActiveId$)).toBe("works");
     });
 
-    it("should resolve /zero/account to 'account'", () => {
-      mockLocation({ pathname: "/zero/account", search: "" }, context.signal);
-      expect(context.store.get(zeroActiveId$)).toBe("account");
+    it("should resolve /zero/preferences to 'preferences'", () => {
+      mockLocation(
+        { pathname: "/zero/preferences", search: "" },
+        context.signal,
+      );
+      expect(context.store.get(zeroActiveId$)).toBe("preferences");
     });
 
     it("should fall back to 'chat' for invalid tab", () => {

--- a/turbo/apps/platform/src/signals/zero-page/zero-nav.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-nav.ts
@@ -11,7 +11,7 @@ function isValidTab(tab: string): tab is ZeroNavId {
     tab === "activity" ||
     tab === "works" ||
     tab === "settings" ||
-    tab === "account"
+    tab === "preferences"
   );
 }
 

--- a/turbo/apps/platform/src/views/settings-page/notification-settings.tsx
+++ b/turbo/apps/platform/src/views/settings-page/notification-settings.tsx
@@ -1,11 +1,11 @@
-import { useLastResolved, useSet } from "ccstate-react";
-import { Switch } from "@vm0/ui/components/ui/switch";
+import { useCCState } from "ccstate-react/experimental";
+import { useGet, useLastResolved, useSet } from "ccstate-react";
 import { Skeleton } from "@vm0/ui/components/ui/skeleton";
 import {
   notificationPreferences$,
   updateNotificationPreference$,
 } from "../../signals/settings-page/notification-settings.ts";
-import { detach, Reason } from "../../signals/utils.ts";
+import { LoadingSwitch } from "../components/loading-switch.tsx";
 import emailIcon from "./icons/email.svg";
 import slackIcon from "./icons/slack.svg";
 
@@ -13,31 +13,37 @@ export function NotificationSettings() {
   const preferences = useLastResolved(notificationPreferences$);
   const updatePreference = useSet(updateNotificationPreference$);
 
+  const loadingKeys$ = useCCState<Set<string>>(new Set());
+  const loadingKeys = useGet(loadingKeys$);
+  const setLoadingKeys = useSet(loadingKeys$);
+
+  const handleToggle = (key: string, update: Record<string, boolean>) => {
+    setLoadingKeys((prev) => new Set([...prev, key]));
+    updatePreference(update)
+      .finally(() => {
+        setLoadingKeys((prev) => {
+          const next = new Set(prev);
+          next.delete(key);
+          return next;
+        });
+      })
+      .catch(() => {});
+  };
+
   if (!preferences) {
     return (
-      <div className="flex flex-col gap-4">
-        <div className="flex flex-col gap-1">
-          <Skeleton className="h-5 w-32 rounded" />
-          <Skeleton className="h-4 w-80 rounded" />
-        </div>
-        <div className="flex flex-col">
-          <Skeleton className="h-[76px] w-full rounded-t-xl rounded-b-none" />
-          <Skeleton className="h-[76px] w-full rounded-t-none rounded-b-xl border-t border-background" />
-        </div>
+      <div className="flex flex-col">
+        <Skeleton className="h-[76px] w-full rounded-t-xl rounded-b-none" />
+        <Skeleton className="h-[76px] w-full rounded-t-none rounded-b-xl border-t border-background" />
       </div>
     );
   }
 
   return (
-    <div className="flex flex-col gap-4">
-      <div className="flex flex-col gap-1">
-        <h3 className="text-base font-medium text-foreground">Notifications</h3>
-        <p className="text-sm text-muted-foreground">
-          Choose how you get notified when scheduled agent runs complete or
-          fail.
-        </p>
-      </div>
-
+    <div className="flex flex-col gap-3">
+      <p className="text-sm text-muted-foreground">
+        Choose how you get notified when scheduled agent runs complete or fail.
+      </p>
       <div className="flex flex-col">
         <div className="flex items-center gap-4 border-l border-r border-t border-border bg-card p-4 rounded-t-xl">
           <div className="shrink-0">
@@ -57,18 +63,14 @@ export function NotificationSettings() {
               Receive an email when a scheduled agent run completes or fails.
             </div>
           </div>
-          <div className="shrink-0">
-            <Switch
-              checked={preferences.notifyEmail}
-              onCheckedChange={(checked) =>
-                detach(
-                  updatePreference({ notifyEmail: checked }),
-                  Reason.DomCallback,
-                )
-              }
-              aria-label="Toggle email notifications"
-            />
-          </div>
+          <LoadingSwitch
+            checked={preferences.notifyEmail}
+            loading={loadingKeys.has("email")}
+            onCheckedChange={(checked) =>
+              handleToggle("email", { notifyEmail: checked })
+            }
+            ariaLabel="Toggle email notifications"
+          />
         </div>
 
         <div className="flex items-center gap-4 border border-border bg-card p-4 rounded-b-xl">
@@ -83,18 +85,14 @@ export function NotificationSettings() {
               Get a Slack DM when a scheduled agent run completes or fails.
             </div>
           </div>
-          <div className="shrink-0">
-            <Switch
-              checked={preferences.notifySlack}
-              onCheckedChange={(checked) =>
-                detach(
-                  updatePreference({ notifySlack: checked }),
-                  Reason.DomCallback,
-                )
-              }
-              aria-label="Toggle Slack notifications"
-            />
-          </div>
+          <LoadingSwitch
+            checked={preferences.notifySlack}
+            loading={loadingKeys.has("slack")}
+            onCheckedChange={(checked) =>
+              handleToggle("slack", { notifySlack: checked })
+            }
+            ariaLabel="Toggle Slack notifications"
+          />
         </div>
       </div>
     </div>

--- a/turbo/apps/platform/src/views/settings-page/notification-settings.tsx
+++ b/turbo/apps/platform/src/views/settings-page/notification-settings.tsx
@@ -1,6 +1,7 @@
 import { useCCState } from "ccstate-react/experimental";
 import { useGet, useLastResolved, useSet } from "ccstate-react";
 import { Skeleton } from "@vm0/ui/components/ui/skeleton";
+import { toast } from "@vm0/ui/components/ui/sonner";
 import {
   notificationPreferences$,
   updateNotificationPreference$,
@@ -27,7 +28,7 @@ export function NotificationSettings() {
           return next;
         });
       })
-      .catch(() => {});
+      .catch(() => toast.error("Failed to update preference"));
   };
 
   if (!preferences) {

--- a/turbo/apps/platform/src/views/settings-page/timezone-settings.tsx
+++ b/turbo/apps/platform/src/views/settings-page/timezone-settings.tsx
@@ -8,6 +8,7 @@ import {
   SelectValue,
 } from "@vm0/ui/components/ui/select";
 import { Skeleton } from "@vm0/ui/components/ui/skeleton";
+import { toast } from "@vm0/ui/components/ui/sonner";
 import { IconClock, IconLoader2 } from "@tabler/icons-react";
 import {
   notificationPreferences$,
@@ -48,7 +49,7 @@ export function TimezoneSettings() {
     setLoading(true);
     updatePreference({ timezone: value })
       .finally(() => setLoading(false))
-      .catch(() => {});
+      .catch(() => toast.error("Failed to update timezone"));
   };
 
   if (!preferences) {

--- a/turbo/apps/platform/src/views/settings-page/timezone-settings.tsx
+++ b/turbo/apps/platform/src/views/settings-page/timezone-settings.tsx
@@ -1,4 +1,5 @@
-import { useLastResolved, useSet } from "ccstate-react";
+import { useCCState } from "ccstate-react/experimental";
+import { useGet, useLastResolved, useSet } from "ccstate-react";
 import {
   Select,
   SelectContent,
@@ -7,12 +8,11 @@ import {
   SelectValue,
 } from "@vm0/ui/components/ui/select";
 import { Skeleton } from "@vm0/ui/components/ui/skeleton";
-import { IconClock } from "@tabler/icons-react";
+import { IconClock, IconLoader2 } from "@tabler/icons-react";
 import {
   notificationPreferences$,
   updateNotificationPreference$,
 } from "../../signals/settings-page/notification-settings.ts";
-import { detach, Reason } from "../../signals/utils.ts";
 
 function getCommonTimezones() {
   return [
@@ -40,27 +40,26 @@ export function TimezoneSettings() {
   const preferences = useLastResolved(notificationPreferences$);
   const updatePreference = useSet(updateNotificationPreference$);
 
+  const loading$ = useCCState(false);
+  const loading = useGet(loading$);
+  const setLoading = useSet(loading$);
+
+  const handleChange = (value: string) => {
+    setLoading(true);
+    updatePreference({ timezone: value })
+      .finally(() => setLoading(false))
+      .catch(() => {});
+  };
+
   if (!preferences) {
-    return (
-      <div className="flex flex-col gap-4">
-        <div className="flex flex-col gap-1">
-          <Skeleton className="h-5 w-32 rounded" />
-          <Skeleton className="h-4 w-80 rounded" />
-        </div>
-        <Skeleton className="h-[76px] w-full rounded-xl" />
-      </div>
-    );
+    return <Skeleton className="h-[76px] w-full rounded-xl" />;
   }
 
   return (
-    <div className="flex flex-col gap-4">
-      <div className="flex flex-col gap-1">
-        <h3 className="text-base font-medium text-foreground">Time Zone</h3>
-        <p className="text-sm text-muted-foreground">
-          Sets the TZ environment variable for your agent sandbox at runtime.
-        </p>
-      </div>
-
+    <div className="flex flex-col gap-3">
+      <p className="text-sm text-muted-foreground">
+        Sets the TZ environment variable for your agent sandbox at runtime.
+      </p>
       <div className="flex items-center gap-4 border border-border bg-card p-4 rounded-xl">
         <div className="shrink-0">
           <div className="flex h-7 w-7 items-center justify-center">
@@ -73,12 +72,11 @@ export function TimezoneSettings() {
             Your agents will use this time zone during runs
           </div>
         </div>
-        <div className="shrink-0 w-64">
+        <div className="relative shrink-0 w-64">
           <Select
             value={preferences.timezone ?? "UTC"}
-            onValueChange={(value) =>
-              detach(updatePreference({ timezone: value }), Reason.DomCallback)
-            }
+            onValueChange={handleChange}
+            disabled={loading}
           >
             <SelectTrigger>
               <SelectValue />
@@ -91,6 +89,14 @@ export function TimezoneSettings() {
               ))}
             </SelectContent>
           </Select>
+          {loading && (
+            <div className="absolute inset-0 flex items-center justify-end pr-8">
+              <IconLoader2
+                size={16}
+                className="animate-spin text-muted-foreground"
+              />
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/turbo/apps/platform/src/views/zero-page/zero-account-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-account-page.tsx
@@ -1,101 +1,49 @@
 import { useCCState } from "ccstate-react/experimental";
 import { useGet, useSet } from "ccstate-react";
 import { Tabs, TabsList, TabsTrigger } from "@vm0/ui/components/ui/tabs";
-import { Card, CardContent } from "@vm0/ui/components/ui/card";
-import type { ZeroAccountSubId } from "./zero-sidebar.tsx";
+import { NotificationSettings } from "../settings-page/notification-settings.tsx";
+import { TimezoneSettings } from "../settings-page/timezone-settings.tsx";
 
-interface ZeroAccountPageProps {
-  accountSubId: ZeroAccountSubId;
-}
-
-export function ZeroAccountPage({ accountSubId }: ZeroAccountPageProps) {
-  if (accountSubId === "preferences") {
-    return <ZeroPreferencesSubPage />;
-  }
-  return <ZeroAccountOverview />;
-}
-
-function ZeroAccountOverview() {
-  return (
-    <div className="flex flex-1 flex-col min-h-0">
-      <header className="shrink-0 border-b border-divider bg-transparent px-4 sm:px-6 pt-6 sm:pt-6 pb-4 sm:pb-5">
-        <h1 className="text-lg font-semibold tracking-tight text-foreground">
-          Account
-        </h1>
-        <p className="mt-0.5 text-sm text-muted-foreground">
-          Use the account menu in the sidebar to open Preferences or Manage
-          account.
-        </p>
-      </header>
-      <main className="flex-1 overflow-auto px-4 sm:px-6 pb-8">
-        <div className="mx-auto max-w-[900px]">
-          <div className="zero-card p-6">
-            <p className="text-sm text-muted-foreground">
-              Your profile and settings are available from the account dropdown
-              at the bottom of the sidebar.
-            </p>
-          </div>
-        </div>
-      </main>
-    </div>
-  );
-}
-
-function ZeroPreferencesSubPage() {
+export function ZeroPreferencesPage() {
   const tab$ = useCCState("notifications");
   const tab = useGet(tab$);
   const setTab = useSet(tab$);
 
   return (
-    <div className="flex flex-1 flex-col min-h-0">
-      <header className="shrink-0 border-b border-divider bg-transparent px-4 sm:px-6 pt-6 sm:pt-6 pb-4 sm:pb-5">
-        <h1 className="text-lg font-semibold tracking-tight text-foreground">
-          Preferences
-        </h1>
-        <p className="mt-0.5 text-sm text-muted-foreground">
-          Manage your notification and agent runtime preferences
-        </p>
+    <div className="flex flex-1 flex-col min-h-0 overflow-auto [scrollbar-gutter:stable]">
+      <header className="shrink-0 bg-transparent px-4 pt-10 pb-4 sm:px-6">
+        <div className="mx-auto max-w-[900px] px-7">
+          <h1 className="text-xl font-semibold tracking-tight text-foreground">
+            Preferences
+          </h1>
+          <p className="text-sm text-muted-foreground mt-1">
+            Manage your notification and agent runtime preferences
+          </p>
+        </div>
       </header>
-      <main className="flex-1 overflow-auto px-4 sm:px-6 pb-8">
-        <div className="mx-auto max-w-[900px] flex flex-col gap-6">
-          <Tabs value={tab} onValueChange={setTab}>
+
+      <main className="shrink-0 px-4 sm:px-6 pt-4 pb-16">
+        <div className="mx-auto max-w-[900px] px-7 flex flex-col gap-8">
+          <Tabs value={tab} onValueChange={(v) => setTab(v)}>
             <TabsList className="zero-tabs h-9 gap-1 px-1 py-1">
-              <TabsTrigger value="notifications">Notifications</TabsTrigger>
-              <TabsTrigger value="timezone">Time Zone</TabsTrigger>
+              <TabsTrigger
+                value="notifications"
+                className="gap-1.5 text-sm data-[state=active]:bg-background px-3"
+              >
+                Notifications
+              </TabsTrigger>
+              <TabsTrigger
+                value="timezone"
+                className="gap-1.5 text-sm data-[state=active]:bg-background px-3"
+              >
+                Time Zone
+              </TabsTrigger>
             </TabsList>
 
-            {tab === "notifications" && (
-              <Card className="zero-card">
-                <CardContent className="p-6">
-                  <h2 className="text-sm font-medium text-foreground mb-1">
-                    Notifications
-                  </h2>
-                  <p className="text-sm text-muted-foreground mb-4">
-                    Choose how you get notified when scheduled agent runs
-                    complete or fail.
-                  </p>
-                  <p className="text-sm text-muted-foreground">
-                    Notification preferences will appear here.
-                  </p>
-                </CardContent>
-              </Card>
-            )}
-
-            {tab === "timezone" && (
-              <Card className="zero-card">
-                <CardContent className="p-6">
-                  <h2 className="text-sm font-medium text-foreground mb-1">
-                    Time Zone
-                  </h2>
-                  <p className="text-sm text-muted-foreground mb-4">
-                    Set your time zone for schedules and activity logs.
-                  </p>
-                  <p className="text-sm text-muted-foreground">
-                    Time zone settings will appear here.
-                  </p>
-                </CardContent>
-              </Card>
-            )}
+            <div className="mt-4">
+              {tab === "notifications" && <NotificationSettings />}
+              {tab === "timezone" && <TimezoneSettings />}
+            </div>
           </Tabs>
         </div>
       </main>

--- a/turbo/apps/platform/src/views/zero-page/zero-app-shell.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-app-shell.tsx
@@ -4,7 +4,6 @@ import {
   ZeroSidebar,
   type ZeroNavId,
   type ZeroAccountAction,
-  type ZeroAccountSubId,
 } from "./zero-sidebar.tsx";
 import { Button } from "@vm0/ui";
 import { ZeroAboutPage } from "./zero-about-page.tsx";
@@ -197,8 +196,6 @@ export function ZeroAppShell() {
     : "Zero";
   const activeId = useGet(zeroActiveId$);
   const setActiveId = useSet(setZeroActiveId$);
-  const accountSubId$ = useCCState<ZeroAccountSubId>(null);
-  const accountSubId = useGet(accountSubId$);
   const avatarIndex$ = useCCState(0);
   const avatarIndex = useGet(avatarIndex$);
   const showAboutPage$ = useCCState(false);
@@ -274,8 +271,9 @@ export function ZeroAppShell() {
       if (action === "signout" || action === "manage") {
         return;
       }
-      set(setZeroActiveId$, "account");
-      set(accountSubId$, action as ZeroAccountSubId);
+      if (action === "preferences") {
+        set(setZeroActiveId$, "preferences");
+      }
     },
   );
   const handleAccountAction = useSet(handleAccountAction$);
@@ -346,7 +344,6 @@ export function ZeroAppShell() {
         ) : (
           <ZeroContent
             sectionId={activeId}
-            accountSubId={accountSubId}
             inSession={inSession}
             onSendMessage={handleSendFromDemo}
             onNavigateToActivity={() => setActiveId("activity")}

--- a/turbo/apps/platform/src/views/zero-page/zero-content.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-content.tsx
@@ -1,8 +1,8 @@
 import { useLoadable } from "ccstate-react";
-import type { ZeroNavId, ZeroAccountSubId } from "./zero-sidebar.tsx";
+import type { ZeroNavId } from "./zero-sidebar.tsx";
 import { ZeroChatPage } from "./zero-chat-page.tsx";
 import { ZeroSessionChatPage } from "./zero-session-chat-page.tsx";
-import { ZeroAccountPage } from "./zero-account-page.tsx";
+import { ZeroPreferencesPage } from "./zero-account-page.tsx";
 import { ZeroJobsPage } from "./zero-jobs-page.tsx";
 import { ZeroMeetPage } from "./zero-meet-page.tsx";
 import { ZeroActivityPage } from "./zero-activity-page.tsx";
@@ -13,7 +13,6 @@ import { agentDisplayName$ } from "../../signals/zero-page/zero-agent-name.ts";
 
 interface ZeroContentProps {
   sectionId: ZeroNavId;
-  accountSubId?: ZeroAccountSubId | null;
   /** When set, shows the real session chat page instead of the demo page. */
   inSession?: boolean;
   onSendMessage?: (message: string) => void;
@@ -38,13 +37,12 @@ function getSectionTitles(
     activity: "Activities",
     works: `Where ${agentName} works`,
     settings: "Settings",
-    account: "Account",
+    preferences: "Preferences",
   };
 }
 
 export function ZeroContent({
   sectionId,
-  accountSubId = null,
   inSession = false,
   onSendMessage,
   onNavigateToActivity,
@@ -106,8 +104,8 @@ export function ZeroContent({
   if (sectionId === "settings") {
     return <ZeroSettingsPage />;
   }
-  if (sectionId === "account") {
-    return <ZeroAccountPage accountSubId={accountSubId ?? null} />;
+  if (sectionId === "preferences") {
+    return <ZeroPreferencesPage />;
   }
 
   const title = getSectionTitles(agentName)[sectionId];

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -45,7 +45,7 @@ export type ZeroNavId =
   | "activity"
   | "works"
   | "settings"
-  | "account";
+  | "preferences";
 
 type NavIcon = (props: { size?: number; className?: string }) => ReactNode;
 const MAIN_NAV = [
@@ -72,8 +72,6 @@ const FOOTER_NAV = [
 ] as const;
 
 export type ZeroAccountAction = "preferences" | "manage" | "signout";
-
-export type ZeroAccountSubId = "preferences" | null;
 
 interface SessionAccount {
   sessionId: string;
@@ -193,7 +191,7 @@ function AccountDropdown({
         <button
           type="button"
           className={`flex w-full items-center gap-2 rounded-lg p-2 text-left transition-colors duration-200 ${
-            activeId === "account"
+            activeId === "preferences"
               ? "bg-sidebar-active"
               : "hover:bg-sidebar-accent/50"
           }`}
@@ -206,7 +204,7 @@ function AccountDropdown({
           <div className="flex-1 min-w-0">
             <p
               className={`text-sm font-medium leading-tight truncate ${
-                activeId === "account"
+                activeId === "preferences"
                   ? "text-sidebar-primary"
                   : "text-sidebar-foreground"
               }`}
@@ -215,7 +213,7 @@ function AccountDropdown({
             </p>
             <p
               className={`text-xs leading-tight truncate mt-px ${
-                activeId === "account"
+                activeId === "preferences"
                   ? "text-sidebar-primary/80"
                   : "text-sidebar-foreground opacity-70"
               }`}


### PR DESCRIPTION
## Summary
- Make `/zero/preferences` a first-class route instead of an account sub-page, removing the orphaned account route and `ZeroAccountSubId` type
- Replace plain `Switch` with `LoadingSwitch` for notification toggles with spinner animation during async operations
- Add loading spinner to timezone `Select` during async updates
- Fix stale GET after PUT by refreshing JWT cache with `clerk.session?.getToken({ skipCache: true })`
- Match settings page layout structure (spacing, scrollbar-gutter, consistent padding)

## Test plan
- [ ] Navigate to `/zero/preferences` and verify it renders correctly
- [ ] Toggle email/slack notifications and confirm loading spinner appears during request
- [ ] Change timezone and confirm loading spinner + disabled state during request
- [ ] Verify toggling notifications reflects the updated value after request completes (no stale data)
- [ ] Verify account dropdown "Preferences" option navigates to `/zero/preferences`
- [ ] Verify no regression on `/zero/settings` page

🤖 Generated with [Claude Code](https://claude.com/claude-code)