### PR TITLE
refactor: remove dead org creation and slug generation code

### DIFF
--- a/turbo/apps/platform/src/mocks/handlers/api-org.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-org.ts
@@ -1,7 +1,7 @@
 /**
  * Org API Handlers
  *
- * Mock handlers for /api/scope endpoint (org API).
+ * Mock handlers for /api/scope endpoint.
  * Default behavior: user always has an org (for tests that need auth to work).
  */
 
@@ -20,14 +20,5 @@ export const apiOrgHandlers = [
   // GET /api/scope - Get current user's default org
   http.get("/api/scope", () => {
     return HttpResponse.json(mockOrg);
-  }),
-
-  // POST /api/scope - Create an org
-  // Always returns 409 since mock user always has org
-  http.post("/api/scope", () => {
-    return HttpResponse.json(
-      { error: { message: "You already have an org", code: "CONFLICT" } },
-      { status: 409 },
-    );
   }),
 ];

--- a/turbo/apps/platform/src/signals/__tests__/onboarding.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/onboarding.test.ts
@@ -24,9 +24,6 @@ describe("startOnboarding$", () => {
       http.get("/api/scope", () => {
         return new HttpResponse(null, { status: 404 });
       }),
-      http.post("/api/scope", () => {
-        return HttpResponse.json({}, { status: 201 });
-      }),
     );
 
     await setupPage({
@@ -44,9 +41,6 @@ describe("needsOnboarding$", () => {
     server.use(
       http.get("/api/scope", () => {
         return new HttpResponse(null, { status: 404 });
-      }),
-      http.post("/api/scope", () => {
-        return new HttpResponse(null, { status: 201 });
       }),
     );
 
@@ -79,46 +73,10 @@ describe("needsOnboarding$", () => {
 });
 
 describe("saveOnboardingConfig$", () => {
-  it("should send slug with user- prefix when creating org", async () => {
-    let orgSlug: string | undefined;
-
-    server.use(
-      http.get("/api/scope", () => {
-        return new HttpResponse(null, { status: 404 });
-      }),
-      http.post("/api/scope", async ({ request }) => {
-        const body = (await request.json()) as { slug: string };
-        orgSlug = body.slug;
-        return HttpResponse.json({}, { status: 201 });
-      }),
-    );
-
-    await setupPage({ context, path: "/", withoutRender: true });
-
-    act(() => {
-      context.store.set(setOnboardingSecret$, "test-oauth-token");
-    });
-
-    await act(async () => {
-      await context.store.set(saveOnboardingConfig$, context.signal);
-    });
-
-    expect(orgSlug).toBeDefined();
-    expect(orgSlug).toMatch(/^user-[0-9a-f]{8}$/);
-  });
-
-  it("should create org and model provider when saving with oauth token", async () => {
-    let orgCreated = false;
+  it("should create model provider when saving with oauth token", async () => {
     let providerCreated = false;
 
     server.use(
-      http.get("/api/scope", () => {
-        return new HttpResponse(null, { status: 404 });
-      }),
-      http.post("/api/scope", () => {
-        orgCreated = true;
-        return HttpResponse.json({}, { status: 201 });
-      }),
       http.put("/api/model-providers", () => {
         providerCreated = true;
         return HttpResponse.json(
@@ -149,7 +107,6 @@ describe("saveOnboardingConfig$", () => {
       await context.store.set(saveOnboardingConfig$, context.signal);
     });
 
-    expect(orgCreated).toBeTruthy();
     expect(providerCreated).toBeTruthy();
     expect(context.store.get(showOnboardingModal$)).toBeFalsy();
   });
@@ -279,53 +236,13 @@ describe("saveOnboardingConfig$", () => {
 });
 
 describe("closeOnboardingModal$", () => {
-  it("should create org when closing without saving", async () => {
-    let orgCreated = false;
-    let providerCreated = false;
-
-    server.use(
-      http.get("/api/scope", () => {
-        return new HttpResponse(null, { status: 404 });
-      }),
-      http.post("/api/scope", () => {
-        orgCreated = true;
-        return HttpResponse.json({}, { status: 201 });
-      }),
-      http.put("/api/model-providers", () => {
-        providerCreated = true;
-        return HttpResponse.json({}, { status: 201 });
-      }),
-    );
-
+  it("should close modal and reset form", async () => {
     await setupPage({ context, path: "/", withoutRender: true });
 
     act(() => {
       context.store.set(closeOnboardingModal$);
     });
 
-    expect(orgCreated).toBeTruthy();
-    expect(providerCreated).toBeFalsy();
-    expect(context.store.get(showOnboardingModal$)).toBeFalsy();
-  });
-
-  it("should not create org if it already exists", async () => {
-    let orgCreated = false;
-
-    server.use(
-      http.post("/api/scope", () => {
-        orgCreated = true;
-        return HttpResponse.json({}, { status: 201 });
-      }),
-    );
-
-    // Default mock has org
-    await setupPage({ context, path: "/", withoutRender: true });
-
-    act(() => {
-      context.store.set(closeOnboardingModal$);
-    });
-
-    expect(orgCreated).toBeFalsy();
     expect(context.store.get(showOnboardingModal$)).toBeFalsy();
   });
 });

--- a/turbo/apps/platform/src/signals/home/home-page.ts
+++ b/turbo/apps/platform/src/signals/home/home-page.ts
@@ -23,7 +23,7 @@ export const setupHomePage$ = command(
     signal.throwIfAborted();
 
     if (needsOnboarding) {
-      await set(startOnboarding$, signal);
+      set(startOnboarding$);
     }
   },
 );

--- a/turbo/apps/platform/src/signals/onboarding.ts
+++ b/turbo/apps/platform/src/signals/onboarding.ts
@@ -7,7 +7,7 @@ import {
   hasModelSelection,
   type ModelProviderType,
 } from "@vm0/core";
-import { initOrg$, hasOrg$ } from "./org.ts";
+import { hasOrg$ } from "./org.ts";
 import {
   hasAnyModelProvider$,
   createModelProvider$,
@@ -208,23 +208,11 @@ export const copyToClipboard$ = command(({ get, set }, text: string) => {
 // ---------------------------------------------------------------------------
 
 /**
- * Start the onboarding flow - show modal only.
- * Org creation is deferred to save action.
+ * Start the onboarding flow - show modal.
  */
-export const startOnboarding$ = command(
-  async ({ get, set }, signal: AbortSignal) => {
-    set(internalShowOnboardingModal$, true);
-
-    // Create org if it doesn't exist
-    const orgExists = await get(hasOrg$);
-    signal.throwIfAborted();
-
-    if (!orgExists) {
-      await set(initOrg$, signal);
-      signal.throwIfAborted();
-    }
-  },
-);
+export const startOnboarding$ = command(({ set }) => {
+  set(internalShowOnboardingModal$, true);
+});
 
 /**
  * Close the onboarding modal (Cancel / Add it later).
@@ -237,7 +225,7 @@ export const closeOnboardingModal$ = command(({ set }) => {
 
 /**
  * Save the onboarding configuration.
- * Creates org if needed and creates the model provider.
+ * Creates the model provider.
  */
 export const saveOnboardingConfig$ = command(
   async ({ get, set }, signal: AbortSignal) => {
@@ -261,15 +249,6 @@ export const saveOnboardingConfig$ = command(
         }
       } else if (!formValues.secret.trim()) {
         return;
-      }
-
-      // Create org if it doesn't exist
-      const orgExists = await get(hasOrg$);
-      signal.throwIfAborted();
-
-      if (!orgExists) {
-        await set(initOrg$, signal);
-        signal.throwIfAborted();
       }
 
       // Build request based on provider shape

--- a/turbo/apps/platform/src/signals/org.ts
+++ b/turbo/apps/platform/src/signals/org.ts
@@ -1,15 +1,9 @@
-import { computed, state } from "ccstate";
+import { computed } from "ccstate";
 import { user$ } from "./auth.ts";
 import { fetch$ } from "./fetch.ts";
 import { logger } from "./log.ts";
 
 const L = logger("Org");
-
-/**
- * Reload trigger for org signals.
- * Increment to force recomputation of org$.
- */
-const internalReloadOrg$ = state(0);
 
 /**
  * Org response type from API
@@ -26,7 +20,6 @@ export interface Org {
  * Returns undefined if user has no org or is not authenticated.
  */
 export const org$ = computed(async (get) => {
-  get(internalReloadOrg$); // Subscribe to reload trigger
   const user = await get(user$);
   if (!user) {
     return undefined;

--- a/turbo/apps/platform/src/signals/org.ts
+++ b/turbo/apps/platform/src/signals/org.ts
@@ -1,4 +1,4 @@
-import { command, computed, state } from "ccstate";
+import { computed, state } from "ccstate";
 import { user$ } from "./auth.ts";
 import { fetch$ } from "./fetch.ts";
 import { logger } from "./log.ts";
@@ -53,49 +53,4 @@ export const org$ = computed(async (get) => {
 export const hasOrg$ = computed(async (get) => {
   const org = await get(org$);
   return org !== undefined;
-});
-
-/**
- * Generate a deterministic org slug from user ID.
- * Uses SubtleCrypto (browser-compatible) to hash the user ID.
- */
-async function generateDefaultSlug(userId: string): Promise<string> {
-  const encoder = new TextEncoder();
-  const data = encoder.encode(userId);
-  const hashBuffer = await crypto.subtle.digest("SHA-256", data);
-  const hashArray = Array.from(new Uint8Array(hashBuffer));
-  const hashHex = hashArray
-    .map((b) => b.toString(16).padStart(2, "0"))
-    .join("");
-  return `user-${hashHex.slice(0, 8)}`;
-}
-
-/**
- * Create org for current user with auto-generated slug.
- * Triggers reload after successful creation.
- */
-export const initOrg$ = command(async ({ get, set }, signal: AbortSignal) => {
-  const user = await get(user$);
-  signal.throwIfAborted();
-
-  if (!user) {
-    throw new Error("User must be authenticated to create org");
-  }
-
-  const slug = await generateDefaultSlug(user.id);
-  signal.throwIfAborted();
-
-  const fetchFn = get(fetch$);
-  const response = await fetchFn("/api/scope", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ slug }),
-  });
-  signal.throwIfAborted();
-
-  if (!response.ok) {
-    throw new Error(`Failed to create org: ${response.status}`);
-  }
-
-  set(internalReloadOrg$, (x) => x + 1);
 });

--- a/turbo/apps/platform/src/signals/zero-page/zero-onboarding.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-onboarding.ts
@@ -11,7 +11,6 @@ import {
 } from "@vm0/core";
 import { fetch$ } from "../fetch.ts";
 import { clerk$ } from "../auth.ts";
-import { initOrg$, hasOrg$ } from "../org.ts";
 import { createModelProvider$ } from "../external/model-providers.ts";
 import { getProviderShape } from "../../views/settings-page/provider-ui-config.ts";
 import { skillValueToUrl } from "../../data/skills.ts";
@@ -225,7 +224,6 @@ export const initZeroOnboarding$ = command(
 
 /**
  * Save model provider (step 2 completion).
- * Creates org if needed, then creates model provider.
  */
 export const saveZeroModelProvider$ = command(
   async ({ get, set }, signal: AbortSignal) => {
@@ -235,15 +233,6 @@ export const saveZeroModelProvider$ = command(
       const providerType = get(internalProviderType$);
       const formValues = get(internalFormValues$);
       const shape = getProviderShape(providerType);
-
-      // Create org if needed
-      const orgExists = await get(hasOrg$);
-      signal.throwIfAborted();
-
-      if (!orgExists) {
-        await set(initOrg$, signal);
-        signal.throwIfAborted();
-      }
 
       // Build request based on provider shape
       const request: Record<string, unknown> = { type: providerType };

--- a/turbo/apps/platform/src/views/home/__tests__/home-page.test.tsx
+++ b/turbo/apps/platform/src/views/home/__tests__/home-page.test.tsx
@@ -39,9 +39,6 @@ describe("home page", () => {
       http.get("/api/scope", () => {
         return new HttpResponse(null, { status: 404 });
       }),
-      http.post("/api/scope", () => {
-        return HttpResponse.json({}, { status: 201 });
-      }),
     );
 
     await setupPage({
@@ -104,9 +101,6 @@ describe("home page", () => {
       http.get("/api/scope", () => {
         return new HttpResponse(null, { status: 404 });
       }),
-      http.post("/api/scope", () => {
-        return HttpResponse.json({}, { status: 201 });
-      }),
       http.put("/api/model-providers", async ({ request }) => {
         providerCreated = true;
         const body = (await request.json()) as {
@@ -162,9 +156,6 @@ describe("home page", () => {
     server.use(
       http.get("/api/scope", () => {
         return new HttpResponse(null, { status: 404 });
-      }),
-      http.post("/api/scope", () => {
-        return HttpResponse.json({}, { status: 201 });
       }),
       http.put("/api/model-providers", async ({ request }) => {
         await uploadDeferred;

--- a/turbo/apps/platform/src/views/settings-page/__tests__/settings-page.test.tsx
+++ b/turbo/apps/platform/src/views/settings-page/__tests__/settings-page.test.tsx
@@ -17,9 +17,6 @@ describe("settings page", () => {
       http.get("/api/scope", () => {
         return new HttpResponse(null, { status: 404 });
       }),
-      http.post("/api/scope", () => {
-        return new HttpResponse(null, { status: 201 });
-      }),
     );
 
     await setupPage({ context, path: "/settings" });

--- a/turbo/apps/web/app/api/cli/auth/test-token/route.ts
+++ b/turbo/apps/web/app/api/cli/auth/test-token/route.ts
@@ -2,7 +2,6 @@ import { NextResponse } from "next/server";
 import crypto from "crypto";
 import { initServices } from "../../../../../src/lib/init-services";
 import { cliTokens } from "../../../../../src/db/schema/cli-tokens";
-import { generateDefaultOrgSlug } from "../../../../../src/lib/org/org-service";
 import { getDefaultOrg } from "../../../../../src/lib/org/org-member-service";
 import { orgCache } from "../../../../../src/db/schema/org-cache";
 import { isNotFound } from "../../../../../src/lib/errors";
@@ -53,7 +52,7 @@ async function ensureTestScope(userId: string): Promise<{ orgId: string }> {
     if (!isNotFound(error)) throw error;
     // User has no Clerk org — use sentinel orgId with org_cache entry
     const sentinelOrgId = `org_test_${userId}`;
-    const slug = generateDefaultOrgSlug(userId);
+    const slug = "test-org";
     await globalThis.services.db
       .insert(orgCache)
       .values({ orgId: sentinelOrgId, slug, tier: "free" })

--- a/turbo/apps/web/src/lib/org/__tests__/org-service.test.ts
+++ b/turbo/apps/web/src/lib/org/__tests__/org-service.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach } from "vitest";
 import { testContext, uniqueId } from "../../../__tests__/test-helpers";
 import { insertOrgCacheEntry } from "../../../__tests__/api-test-helpers";
 import { mockClerk } from "../../../__tests__/clerk-mock";
-import { getDefaultOrgByUserId, generateDefaultOrgSlug } from "../org-service";
+import { getDefaultOrgByUserId } from "../org-service";
 
 const context = testContext();
 
@@ -34,20 +34,5 @@ describe("getDefaultOrgByUserId", () => {
     expect(result).not.toBeNull();
     expect(result!.orgId).toBe(orgId);
     expect(result!.slug).toBe(slug);
-  });
-});
-
-describe("generateDefaultOrgSlug", () => {
-  it("should generate deterministic slug from userId", () => {
-    const slug1 = generateDefaultOrgSlug("user_abc");
-    const slug2 = generateDefaultOrgSlug("user_abc");
-    expect(slug1).toBe(slug2);
-    expect(slug1).toMatch(/^user-[a-f0-9]{8}$/);
-  });
-
-  it("should generate different slugs for different userIds", () => {
-    const slug1 = generateDefaultOrgSlug("user_abc");
-    const slug2 = generateDefaultOrgSlug("user_xyz");
-    expect(slug1).not.toBe(slug2);
   });
 });

--- a/turbo/apps/web/src/lib/org/org-service.ts
+++ b/turbo/apps/web/src/lib/org/org-service.ts
@@ -1,4 +1,3 @@
-import { createHmac } from "crypto";
 import { clerkClient } from "@clerk/nextjs/server";
 import { requireOrgMember, getDefaultOrg } from "./org-member-service";
 import {
@@ -25,18 +24,6 @@ const RESERVED_SLUGS = ["vm0", "system", "admin", "api", "app", "www"];
  * - must start and end with alphanumeric
  */
 const SLUG_REGEX = /^[a-z0-9][a-z0-9-]*[a-z0-9]$|^[a-z0-9]{1,2}$/;
-
-/**
- * Generate a deterministic default org slug from Clerk user ID.
- * Format: user-{8 hex chars from SHA-256 hash}
- *
- * @param userId - The Clerk user ID to hash
- * @returns A slug in format "user-xxxxxxxx" (13 chars total)
- */
-export function generateDefaultOrgSlug(userId: string): string {
-  const hash = createHmac("sha256", "org-slug").update(userId).digest("hex");
-  return `user-${hash.slice(0, 8)}`;
-}
 
 /**
  * Validate org slug format


### PR DESCRIPTION
## Summary

Closes #4650

With the Clerk-as-source-of-truth migration (#4023), Clerk now forces org creation at signup. This makes VM0's client-side org creation (`initOrg$`) and slug generation functions dead code:

- **`initOrg$` was already broken** — it POSTs to `/api/scope`, but backend has no POST handler
- **`generateDefaultSlug` (frontend) and `generateDefaultOrgSlug` (backend) are unnecessary** — Clerk is the sole source of slugs
- The two functions used different hash algorithms (SHA-256 vs HMAC-SHA256), confirming this code path was unused

Changes:
- Remove `initOrg$` command and `generateDefaultSlug` from platform signals
- Remove `generateDefaultOrgSlug` and `createHmac` import from web org-service
- Simplify `startOnboarding$` to synchronous (no more async org creation guard)
- Remove org creation guards from `saveOnboardingConfig$` and `saveZeroModelProvider$`
- Remove POST `/api/scope` mock handler from platform mocks
- Clean up tests: delete 3 org-creation test cases, remove POST mocks from 6 test files
- Use fixed `"test-org"` slug in test-token endpoint

**11 files changed, +13 −223 lines**

## Test plan

- [x] `pnpm check-types` passes (platform + cli + core; web has pre-existing archiver issue on main)
- [x] `pnpm turbo run lint` passes (0 warnings, 0 errors)
- [x] `pnpm knip` passes (no unused exports/files)
- [x] All 24 affected tests pass (onboarding, home-page, settings-page, org-service)
- [x] `grep -rn "initOrg\$\|generateDefaultSlug\|generateDefaultOrgSlug"` returns zero results

🤖 Generated with [Claude Code](https://claude.com/claude-code)