### PR TITLE
fix(platform): increase compose job polling timeout and handle onboarding errors

### DIFF
--- a/turbo/apps/platform/src/signals/agent-detail/compose-job.ts
+++ b/turbo/apps/platform/src/signals/agent-detail/compose-job.ts
@@ -52,8 +52,10 @@ export async function triggerAndPollComposeJob(
     return job;
   }
 
-  // Poll until done (2s intervals, up to 3 minutes)
-  const maxAttempts = 90;
+  // Poll until done (2s intervals, up to ~5.5 minutes)
+  // Must exceed the 5-minute E2B sandbox timeout to allow for sandbox creation,
+  // script startup, and webhook delivery overhead.
+  const maxAttempts = 165;
   for (let i = 0; i < maxAttempts; i++) {
     await delay(2000);
 

--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-onboarding.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-onboarding.test.ts
@@ -6,7 +6,9 @@ import { setupPage } from "../../../__tests__/page-helper.ts";
 import {
   completeZeroOnboarding$,
   setZeroAgentName$,
+  setZeroStep$,
   zeroOnboardingStep$,
+  zeroOnboardingError$,
   zeroSaving$,
 } from "../zero-onboarding.ts";
 
@@ -128,5 +130,70 @@ describe("completeZeroOnboarding$", () => {
 
     expect(context.store.get(zeroOnboardingStep$)).toBe("done");
     expect(context.store.get(zeroSaving$)).toBeFalsy();
+  });
+
+  it("should set error state and reset saving on build failure", async () => {
+    server.use(
+      http.post("*/api/compose/jobs", () => {
+        return HttpResponse.json(
+          { error: { message: "Build failed: sandbox error" } },
+          { status: 500 },
+        );
+      }),
+    );
+
+    await setupPage({ context, path: "/", withoutRender: true });
+
+    // Set step to "4" so we can verify it doesn't change to "done"
+    context.store.set(setZeroStep$, "4");
+
+    // Should NOT throw — error is caught internally
+    await context.store.set(completeZeroOnboarding$, context.signal);
+
+    expect(context.store.get(zeroOnboardingError$)).toBe(
+      "Build failed: sandbox error",
+    );
+    expect(context.store.get(zeroSaving$)).toBeFalsy();
+    expect(context.store.get(zeroOnboardingStep$)).toBe("4");
+  });
+
+  it("should clear error state on successful retry", async () => {
+    // First call: fail
+    server.use(
+      http.post("*/api/compose/jobs", () => {
+        return HttpResponse.json(
+          { error: { message: "Build failed" } },
+          { status: 500 },
+        );
+      }),
+    );
+
+    await setupPage({ context, path: "/", withoutRender: true });
+    context.store.set(setZeroStep$, "4");
+
+    await context.store.set(completeZeroOnboarding$, context.signal);
+    expect(context.store.get(zeroOnboardingError$)).toBeTruthy();
+
+    // Second call: succeed
+    server.use(
+      http.post("*/api/compose/jobs", () => {
+        return HttpResponse.json({
+          jobId: "test-job-id",
+          status: "completed",
+          result: {
+            composeId: "new-compose-id",
+            composeName: "test-compose",
+          },
+        });
+      }),
+      http.put("*/api/scopes/default-agent", () => {
+        return HttpResponse.json({ ok: true });
+      }),
+    );
+
+    await context.store.set(completeZeroOnboarding$, context.signal);
+
+    expect(context.store.get(zeroOnboardingError$)).toBeNull();
+    expect(context.store.get(zeroOnboardingStep$)).toBe("done");
   });
 });

--- a/turbo/apps/platform/src/signals/zero-page/zero-onboarding.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-onboarding.ts
@@ -16,6 +16,7 @@ import { createModelProvider$ } from "../external/model-providers.ts";
 import { getProviderShape } from "../../views/settings-page/provider-ui-config.ts";
 import { skillValueToUrl } from "../../data/skills.ts";
 import { triggerAndPollComposeJob } from "../agent-detail/compose-job.ts";
+import { throwIfAbort } from "../utils.ts";
 import { logger } from "../log.ts";
 
 const L = logger("ZeroOnboarding");
@@ -84,6 +85,7 @@ function defaultFormValues(): ZeroFormValues {
 const internalFormValues$ = state<ZeroFormValues>(defaultFormValues());
 const internalSaving$ = state(false);
 const internalSelectedSkills$ = state<string[]>([]);
+const internalOnboardingError$ = state<string | null>(null);
 
 // ---------------------------------------------------------------------------
 // Exported computed state
@@ -97,6 +99,14 @@ export const zeroSaving$ = computed((get) => get(internalSaving$));
 export const zeroSelectedSkills$ = computed((get) =>
   get(internalSelectedSkills$),
 );
+
+export const zeroOnboardingError$ = computed((get) =>
+  get(internalOnboardingError$),
+);
+
+export const clearZeroOnboardingError$ = command(({ set }) => {
+  set(internalOnboardingError$, null);
+});
 
 export const zeroCanSave$ = computed((get) => {
   const providerType = get(internalProviderType$);
@@ -282,6 +292,7 @@ export const saveZeroModelProvider$ = command(
 export const completeZeroOnboarding$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     set(internalSaving$, true);
+    set(internalOnboardingError$, null);
 
     try {
       const displayName = get(internalAgentName$);
@@ -348,6 +359,12 @@ export const completeZeroOnboarding$ = command(
       // Reload status and mark done
       set(internalReload$, (x) => x + 1);
       set(internalStep$, "done");
+    } catch (error) {
+      throwIfAbort(error);
+      const message =
+        error instanceof Error ? error.message : "Failed to complete setup";
+      L.error("Failed to complete onboarding:", error);
+      set(internalOnboardingError$, message);
     } finally {
       set(internalSaving$, false);
     }

--- a/turbo/apps/platform/src/views/zero-page/zero-onboarding.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-onboarding.tsx
@@ -38,6 +38,8 @@ import {
   zeroHasModelProvider$,
   zeroSelectedSkills$,
   toggleZeroSkill$,
+  zeroOnboardingError$,
+  clearZeroOnboardingError$,
 } from "../../signals/zero-page/zero-onboarding.ts";
 import { fetchSlackIntegration$ } from "../../signals/integrations-page/slack-integration.ts";
 import {
@@ -231,6 +233,8 @@ export function ZeroOnboarding({
   const hasModelProvider =
     hasModelProviderLoadable.state === "hasData" &&
     hasModelProviderLoadable.data === true;
+  const onboardingError = useGet(zeroOnboardingError$);
+  const clearOnboardingError = useSet(clearZeroOnboardingError$);
   const selectedConnectorType = useGet(selectedConnectorType$);
   const setSelected = useSet(setSelectedConnectorType$);
 
@@ -280,6 +284,7 @@ export function ZeroOnboarding({
   };
 
   const handleAddToSlack = () => {
+    clearOnboardingError();
     const controller = new AbortController();
     detach(
       (async () => {
@@ -295,6 +300,7 @@ export function ZeroOnboarding({
   };
 
   const handleContinueWithWeb = () => {
+    clearOnboardingError();
     const controller = new AbortController();
     detach(completeOnboarding(controller.signal), Reason.DomCallback);
   };
@@ -508,6 +514,13 @@ export function ZeroOnboarding({
             <p className="text-sm text-muted-foreground leading-relaxed max-w-[400px] mt-1 mb-6">
               Choose how you&apos;d like to interact with your agent.
             </p>
+            {onboardingError && (
+              <div className="w-full max-w-[560px] mb-4 rounded-lg border border-destructive/30 bg-destructive/5 px-4 py-3 text-sm text-destructive">
+                {onboardingError === "Build timed out"
+                  ? "Setup is taking longer than expected. Please try again."
+                  : onboardingError}
+              </div>
+            )}
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 w-full max-w-[560px]">
               <div className="zero-card flex flex-col items-center text-center rounded-xl border border-border p-5">
                 <span className="flex h-12 w-12 shrink-0 items-center justify-center mb-3 overflow-hidden">


### PR DESCRIPTION
## Summary

- **Increase frontend polling timeout** from 3 min (90 * 2s) to ~5.5 min (165 * 2s) to exceed the 5 min E2B sandbox timeout, fixing the zero-margin timing mismatch that caused `Build timed out` errors
- **Catch build errors in `completeZeroOnboarding$`** and surface them via `zeroOnboardingError$` state instead of letting them propagate as unhandled rejections
- **Show error banner in onboarding step 4** with a user-friendly message and retry capability

Fixes #4654

## Test plan

- [x] Existing onboarding tests pass (3 tests)
- [x] New test: build failure sets error state, resets saving, preserves step
- [x] New test: successful retry clears error state
- [x] Lint, type check, knip all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)