### PR TITLE
feat(services): add permission type definitions

### DIFF
--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -967,6 +967,7 @@ mod tests {
                         "Bearer ${secrets.GMAIL_TOKEN}".into(),
                     )]),
                 },
+                permissions: None,
             }],
         });
         let env = build_env_json(&ctx, "http://localhost");

--- a/crates/runner/src/proxy.rs
+++ b/crates/runner/src/proxy.rs
@@ -780,6 +780,7 @@ mod tests {
                         "Bearer ${secrets.GMAIL_TOKEN}".to_string(),
                     )]),
                 },
+                permissions: None,
             }],
         };
 

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -104,6 +104,17 @@ pub struct ServiceApiEntry {
     pub id: String,
     pub base: String,
     pub auth: ServiceApiAuth,
+    #[serde(default)]
+    pub permissions: Option<Vec<ServiceApiPermission>>,
+}
+
+/// A named permission group with matching rules for request authorization.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct ServiceApiPermission {
+    pub name: String,
+    #[serde(default)]
+    pub description: Option<String>,
+    pub rules: Vec<String>,
 }
 
 /// Auth configuration for a service API entry.

--- a/turbo/packages/core/src/contracts/runners.ts
+++ b/turbo/packages/core/src/contracts/runners.ts
@@ -79,11 +79,18 @@ export const runnersPollContract = c.router({
 /**
  * Service API entry for proxy-side token replacement
  */
+const servicePermissionSchema = z.object({
+  name: z.string(),
+  description: z.string().optional(),
+  rules: z.array(z.string()),
+});
+
 export const serviceApiEntrySchema = z.object({
   base: z.string(),
   auth: z.object({
     headers: z.record(z.string(), z.string()),
   }),
+  permissions: z.array(servicePermissionSchema).optional(),
 });
 
 /**

--- a/turbo/packages/core/src/contracts/services.ts
+++ b/turbo/packages/core/src/contracts/services.ts
@@ -12,14 +12,26 @@ import type { ConnectorType } from "./connectors";
  * NOTE: Currently hardcoded in SERVICE_CONFIGS below.
  * Will be migrated to GitHub-hosted connector.yaml definitions in Phase 2.
  */
+/**
+ * A named permission group with matching rules for request authorization.
+ * Rules use the format `METHOD /path` where path is relative to the api entry's base URL.
+ */
+interface ServicePermission {
+  name: string;
+  description?: string;
+  rules: string[];
+}
+
 interface ServiceApi {
   base: string;
   auth: {
     headers: Record<string, string>;
   };
+  permissions?: ServicePermission[];
 }
 
 export interface ServiceConfig {
+  description?: string;
   apis: ServiceApi[];
   /**
    * Custom placeholder values keyed by secret name (matching `${secrets.XXX}` in auth templates).


### PR DESCRIPTION
## Summary

- Add `ServicePermission` type (`name`, `description?`, `rules`) across TypeScript, Zod schema, and Rust
- Add `permissions?` field to `ServiceApi` / `ServiceApiEntry`
- Add `description?` field to `ServiceConfig`
- All fields optional — zero behavior change, full backward compatibility

PR 1/5 of #4626.

## Test plan

- [x] TypeScript type check passes
- [x] Rust compiles (188 tests pass)
- [x] Knip reports no unused exports
- [x] Pre-commit hooks pass (clippy, prettier, commitlint)
- [x] Existing behavior completely unchanged

Closes #4658

🤖 Generated with [Claude Code](https://claude.com/claude-code)