### PR TITLE
fix(cli): add path traversal guard to agent clone

### DIFF
--- a/turbo/apps/cli/src/commands/agent/__tests__/clone.test.ts
+++ b/turbo/apps/cli/src/commands/agent/__tests__/clone.test.ts
@@ -445,6 +445,51 @@ describe("agent clone command", () => {
       expect(logCalls).toContain("Instructions volume is empty");
     });
 
+    it("should reject path traversal in instructions path", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/agent/composes", ({ request }) => {
+          const url = new URL(request.url);
+          if (url.searchParams.get("name") === "test-agent") {
+            return HttpResponse.json({
+              id: "cmp-123",
+              name: "test-agent",
+              headVersionId:
+                "abc123def456789012345678901234567890123456789012345678901234",
+              content: {
+                version: "1",
+                agents: {
+                  "test-agent": {
+                    framework: "claude-code",
+                    instructions: "../../../../.ssh/authorized_keys",
+                  },
+                },
+              },
+              createdAt: new Date().toISOString(),
+              updatedAt: new Date().toISOString(),
+            });
+          }
+          return HttpResponse.json(
+            { error: { message: "Not found", code: "NOT_FOUND" } },
+            { status: 400 },
+          );
+        }),
+      );
+
+      const dest = path.join(tempDir, "test-agent");
+      await cloneCommand.parseAsync(["node", "cli", "test-agent", dest]);
+
+      // Should still succeed with vm0.yaml (instructions failure is non-fatal)
+      expect(fs.existsSync(path.join(dest, "vm0.yaml"))).toBe(true);
+
+      // Should show warning about path traversal
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("Could not download instructions");
+      expect(logCalls).toContain("path traversal");
+
+      // Verify no file was written outside destination
+      expect(fs.existsSync(path.join(dest, ".ssh"))).toBe(false);
+    });
+
     it("should continue when instructions download fails", async () => {
       server.use(
         http.get("http://localhost:3000/api/agent/composes", ({ request }) => {

--- a/turbo/apps/cli/src/commands/agent/clone.ts
+++ b/turbo/apps/cli/src/commands/agent/clone.ts
@@ -3,7 +3,7 @@ import chalk from "chalk";
 import { mkdtempSync } from "fs";
 import { mkdir, writeFile, readdir, copyFile, rm } from "fs/promises";
 import { checkDirectoryStatus } from "../../lib/utils/file-utils";
-import { join, dirname } from "path";
+import { join, dirname, resolve, sep } from "path";
 import { tmpdir } from "os";
 import * as tar from "tar";
 import { stringify as yamlStringify } from "yaml";
@@ -47,6 +47,17 @@ async function downloadInstructions(
   instructionsPath: string,
   destination: string,
 ): Promise<boolean> {
+  // Validate that instructionsPath doesn't escape the destination directory
+  const destPath = join(destination, instructionsPath);
+  const resolvedDest = resolve(destPath);
+  const resolvedBase = resolve(destination);
+  if (
+    resolvedDest !== resolvedBase &&
+    !resolvedDest.startsWith(resolvedBase + sep)
+  ) {
+    throw new Error("Invalid instructions path: path traversal detected");
+  }
+
   const volumeName = getInstructionsStorageName(agentName);
 
   console.log(chalk.dim("Downloading instructions..."));
@@ -86,8 +97,7 @@ async function downloadInstructions(
     return false;
   }
 
-  // Determine destination path (preserve original path from YAML)
-  const destPath = join(destination, instructionsPath);
+  // destPath was already validated at the top of this function
   await mkdir(dirname(destPath), { recursive: true });
 
   // Copy file to destination with original filename

--- a/turbo/packages/core/src/contracts/composes.ts
+++ b/turbo/packages/core/src/contracts/composes.ts
@@ -67,6 +67,11 @@ const agentDefinitionSchema = z.object({
   instructions: z
     .string()
     .min(1, "Instructions path cannot be empty")
+    .refine(
+      (val) =>
+        !val.includes("..") && !val.startsWith("/") && !val.startsWith("\\"),
+      "Instructions path must be a relative path without '..' segments",
+    )
     .optional(),
   /**
    * Array of GitHub tree URLs for agent skills.


### PR DESCRIPTION
## Summary
- Fixes CWE-22 path traversal vulnerability in `agent clone` command where `instructionsPath` from server-stored compose content could escape the destination directory
- Adds runtime validation in `downloadInstructions()` to verify resolved path stays within destination before any file I/O
- Adds schema-level validation on the `instructions` field to reject paths containing `..` segments or absolute prefixes

Closes #4620

## Test plan
- [x] Existing clone tests pass (13/13)
- [x] New test verifies path traversal attempt (e.g. `../../../../.ssh/authorized_keys`) is caught and reported as non-fatal warning
- [x] Type check, lint, knip all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)