### PR TITLE
fix: default coding-assign max workers to 4 when no argument provided

### DIFF
--- a/.claude/skills/coding-assign/SKILL.md
+++ b/.claude/skills/coding-assign/SKILL.md
@@ -12,14 +12,17 @@ Assigns the current working issue to a coding worker label (`vm01`–`vm0N`) usi
 
 Your args are: `$ARGUMENTS`
 
-The first argument is the **maximum number of workers** (required). For example, `coding-assign 8` means workers `vm01` through `vm08`.
+The first argument is the **maximum number of workers** (optional, defaults to **4**). For example, `coding-assign 8` means workers `vm01` through `vm08`.
 
 ```bash
 # Example: /coding-assign 8
 MAX_WORKERS=8
+
+# Example: /coding-assign  (no args — defaults to 4)
+MAX_WORKERS=4
 ```
 
-If no argument is provided, ask the user and exit.
+If no argument is provided, default to `MAX_WORKERS=4` (uniform distribution across `vm01`–`vm04`).
 
 ## Prerequisites
 


### PR DESCRIPTION
## Summary

- Updates the `coding-assign` skill to default `MAX_WORKERS` to 4 when no argument is provided, instead of requiring the user to specify it
- Adds documentation example showing the default behavior

## Test plan

- [ ] Run `/coding-assign` with no arguments and verify it defaults to 4 workers (vm01–vm04)
- [ ] Run `/coding-assign 8` and verify it still uses 8 workers as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)