### PR TITLE
feat(services): add full-access catch-all permissions to all service configs

### DIFF
--- a/turbo/packages/core/src/contracts/services.ts
+++ b/turbo/packages/core/src/contracts/services.ts
@@ -69,9 +69,15 @@ function bearerAuth(secretName: string) {
   return { headers: { Authorization: `Bearer \${secrets.${secretName}}` } };
 }
 
+/** Default catch-all permission for services without granular permissions. */
+const FULL_ACCESS_PERMISSION: ServicePermission = {
+  name: "full-access",
+  rules: ["ANY /{path+}"],
+};
+
 /** Shorthand: single-base API entry with bearer auth. */
 function api(base: string, auth: ServiceApi["auth"]): ServiceApi {
-  return { base, auth };
+  return { base, auth, permissions: [FULL_ACCESS_PERMISSION] };
 }
 
 const SERVICE_CONFIGS: Partial<Record<ConnectorType, ServiceConfig>> = {


### PR DESCRIPTION
## Summary

- Add `FULL_ACCESS_PERMISSION` constant (`ANY /{path+}`) to the `api()` helper, automatically giving every service api entry a default catch-all permission
- Covers all 75 services / 120+ api entries with a single-line change in the helper
- Zero behavior change — existing code doesn't read `permissions`, all 3513 tests pass

Part of #4626 (PR 2 of 5). Closes #4664.

## Test plan

- [x] All 3513 existing tests pass (zero modifications needed)
- [x] Verified permissions present on sample services (github, slack, mailchimp, notion)
- [ ] CI passes (lint, type-check, knip, tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)