### PR TITLE
chore: remove strava connector feature switch

### DIFF
--- a/turbo/apps/platform/src/signals/settings-page/__tests__/connectors.test.ts
+++ b/turbo/apps/platform/src/signals/settings-page/__tests__/connectors.test.ts
@@ -211,22 +211,6 @@ describe("allConnectorTypes$", () => {
     expect(mercuryConnector?.availableAuthMethods).toStrictEqual(["api-token"]);
   });
 
-  it("should hide strava connector when OAuth feature flag is disabled", async () => {
-    const { store } = context;
-
-    await setupPage({
-      context,
-      path: "/",
-      withoutRender: true,
-      featureSwitches: { stravaConnector: false },
-    });
-
-    const types = await store.get(allConnectorTypes$);
-    const stravaConnector = types.find((t) => t.type === "strava");
-
-    expect(stravaConnector).toBeUndefined();
-  });
-
   it("should hide garmin-connect connector when OAuth feature flag is disabled", async () => {
     const { store } = context;
 

--- a/turbo/packages/core/src/contracts/connectors.ts
+++ b/turbo/packages/core/src/contracts/connectors.ts
@@ -1111,7 +1111,6 @@ const CONNECTOR_TYPES_DEF = {
   },
   strava: {
     label: "Strava",
-    featureFlag: FeatureSwitchKey.StravaConnector,
     helpText:
       "Connect your Strava account to access activities and athlete data",
     authMethods: {

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -23,7 +23,6 @@ export enum FeatureSwitchKey {
   GoogleDriveConnector = "googleDriveConnector",
   GoogleCalendarConnector = "googleCalendarConnector",
   MercuryConnector = "mercuryConnector",
-  StravaConnector = "stravaConnector",
   NeonConnector = "neonConnector",
   GarminConnectConnector = "garminConnectConnector",
   RedditConnector = "redditConnector",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -129,11 +129,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledUserHashes: STAFF_USER_HASHES,
   },
-  [FeatureSwitchKey.StravaConnector]: {
-    maintainer: "ethan@vm0.ai",
-    enabled: false,
-    enabledUserHashes: STAFF_USER_HASHES,
-  },
   [FeatureSwitchKey.NeonConnector]: {
     maintainer: "ethan@vm0.ai",
     enabled: false,


### PR DESCRIPTION
## Summary
- Remove `StravaConnector` feature flag so the Strava OAuth connector is visible to all users
- Delete enum value from `feature-switch-key.ts`, config block from `feature-switch.ts`, `featureFlag` property from connector definition in `connectors.ts`
- Remove now-irrelevant test that verified strava was hidden when feature flag was disabled

Closes #4673

## Test plan
- [x] All 17 connector tests pass (removed 1 obsolete test)
- [x] Lint passes
- [x] Knip finds no unused code
- [x] Type check passes (pre-existing `archiver` error in `web` unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)