### PR TITLE
fix: add sshd feature to devcontainer for gh cs ssh support

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,6 +4,9 @@
   "features": {
     "ghcr.io/itsmechlark/features/postgresql:1": {
       "version": "17"
+    },
+    "ghcr.io/devcontainers/features/sshd:1": {
+      "version": "latest"
     }
   },
   "remoteUser": "vscode",


### PR DESCRIPTION
## Summary

- Add `ghcr.io/devcontainers/features/sshd:1` to `.devcontainer/devcontainer.json` features to enable SSH server in codespaces
- This fixes `gh cs ssh` failing with "failed to start SSH server" error

Closes #4681

## Test plan

- [ ] Rebuild codespace and verify `gh cs ssh` connects successfully
- [ ] Verify existing PostgreSQL feature still works after rebuild

🤖 Generated with [Claude Code](https://claude.com/claude-code)