### PR TITLE
fix(web): filter secret values to only include environment-present values

### DIFF
--- a/turbo/apps/web/app/api/runners/jobs/[id]/claim/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/runners/jobs/[id]/claim/__tests__/route.test.ts
@@ -12,6 +12,7 @@ import {
   testContext,
   type UserContext,
 } from "../../../../../../../src/__tests__/test-helpers";
+import { encryptSecretsMap } from "../../../../../../../src/lib/crypto/secrets-encryption";
 
 const context = testContext();
 
@@ -306,6 +307,133 @@ describe("POST /api/runners/jobs/:id/claim", () => {
       const data = await response.json();
       expect(data.agentName).toBeUndefined();
       expect(data.agentScopeSlug).toBeUndefined();
+    });
+  });
+
+  describe("Claim flow - secretValues filtering", () => {
+    it("should only include secret values present in environment", async () => {
+      const { composeId, versionId } =
+        await createTestCompose("test-secret-filter");
+      const composeInfo = await findTestComposeWithScope(composeId);
+      const orgSlug = composeInfo!.orgSlug;
+
+      const encryptedSecrets = encryptSecretsMap(
+        {
+          API_KEY: "sk-real-key",
+          AUTH_TOKEN: "placeholder-token",
+          UNUSED_SECRET: "should-not-appear",
+        },
+        globalThis.services.env.SECRETS_ENCRYPTION_KEY,
+      );
+
+      const { runId } = await createTestRunnerJob(
+        user.userId,
+        versionId,
+        `${orgSlug}/default`,
+        {
+          encryptedSecrets,
+          environment: {
+            API_KEY: "sk-real-key",
+            AUTH_TOKEN: "placeholder-token",
+            LITERAL_VAR: "not-a-secret",
+          },
+        },
+      );
+
+      const token = await createTestCliToken(user.userId);
+      const request = createTestRequest(
+        `http://localhost:3000/api/runners/jobs/${runId}/claim`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({}),
+        },
+      );
+
+      const response = await POST(request);
+      expect(response.status).toBe(200);
+
+      const data = await response.json();
+      // Values present in environment are included
+      expect(data.secretValues).toContain("sk-real-key");
+      expect(data.secretValues).toContain("placeholder-token");
+      // Values NOT in environment are excluded
+      expect(data.secretValues).not.toContain("should-not-appear");
+    });
+
+    it("should return empty array when no secrets match environment", async () => {
+      const { composeId, versionId } = await createTestCompose("test-no-match");
+      const composeInfo = await findTestComposeWithScope(composeId);
+      const orgSlug = composeInfo!.orgSlug;
+
+      const encryptedSecrets = encryptSecretsMap(
+        { SECRET: "not-in-env" },
+        globalThis.services.env.SECRETS_ENCRYPTION_KEY,
+      );
+
+      const { runId } = await createTestRunnerJob(
+        user.userId,
+        versionId,
+        `${orgSlug}/default`,
+        {
+          encryptedSecrets,
+          environment: { SOME_VAR: "other-value" },
+        },
+      );
+
+      const token = await createTestCliToken(user.userId);
+      const request = createTestRequest(
+        `http://localhost:3000/api/runners/jobs/${runId}/claim`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({}),
+        },
+      );
+
+      const response = await POST(request);
+      expect(response.status).toBe(200);
+
+      const data = await response.json();
+      expect(data.secretValues).toEqual([]);
+    });
+
+    it("should return null when no encrypted secrets exist", async () => {
+      const { composeId, versionId } =
+        await createTestCompose("test-no-secrets");
+      const composeInfo = await findTestComposeWithScope(composeId);
+      const orgSlug = composeInfo!.orgSlug;
+
+      const { runId } = await createTestRunnerJob(
+        user.userId,
+        versionId,
+        `${orgSlug}/default`,
+      );
+
+      const token = await createTestCliToken(user.userId);
+      const request = createTestRequest(
+        `http://localhost:3000/api/runners/jobs/${runId}/claim`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({}),
+        },
+      );
+
+      const response = await POST(request);
+      expect(response.status).toBe(200);
+
+      const data = await response.json();
+      expect(data.secretValues).toBeNull();
     });
   });
 });

--- a/turbo/apps/web/app/api/runners/jobs/[id]/claim/route.ts
+++ b/turbo/apps/web/app/api/runners/jobs/[id]/claim/route.ts
@@ -168,12 +168,19 @@ const router = tsr.router(runnersJobClaimContract, {
 
     log.debug(`Deleted job queue entry for ${runId}`);
 
-    // Decrypt secrets map and extract values for runner log masking
+    // Decrypt secrets map and extract values for runner log masking.
+    // Only include secret values that actually appear in the environment —
+    // secrets replaced with service placeholders should not be exposed via VM0_SECRET_VALUES.
     const secretsMap = decryptSecretsMap(
       storedContext.encryptedSecrets,
       globalThis.services.env.SECRETS_ENCRYPTION_KEY,
     );
-    const secretValues = secretsMap ? Object.values(secretsMap) : null;
+    const envValues = storedContext.environment
+      ? new Set(Object.values(storedContext.environment))
+      : new Set<string>();
+    const secretValues = secretsMap
+      ? Object.values(secretsMap).filter((v) => envValues.has(v))
+      : null;
 
     // Return execution context (context already prepared at job creation)
     // Note: apiUrl is not returned - runner uses its configured server.url


### PR DESCRIPTION
## Summary

- Filter `secretValues` (used for `VM0_SECRET_VALUES` log masking) to only include values actually present in the VM's environment
- Secrets replaced with service placeholders are no longer exposed to the sandbox

Closes #4647

## Test plan

- [x] Type check passes
- [x] `claim/route.test.ts` passes (11 tests)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)