### PR TITLE
refactor: rename remaining scope variables and remove dead scope field

### DIFF
--- a/turbo/apps/cli/src/commands/run/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/run/__tests__/index.test.ts
@@ -1324,7 +1324,7 @@ describe("run command", () => {
   });
 
   describe("--experimental-shared-agent flag", () => {
-    it("should require flag when running agent from another user's scope", async () => {
+    it("should require flag when running agent from another user's org", async () => {
       await expect(async () => {
         await runCommand.parseAsync([
           "node",
@@ -1376,7 +1376,7 @@ describe("run command", () => {
         }),
       );
 
-      // Should not throw - own scope doesn't require the flag
+      // Should not throw - own org doesn't require the flag
       await runCommand.parseAsync([
         "node",
         "cli",
@@ -1480,7 +1480,7 @@ describe("run command", () => {
       expect(mockExit).toHaveBeenCalledWith(1);
     });
 
-    it("should provide helpful error message for non-existent scope", async () => {
+    it("should provide helpful error message for non-existent org", async () => {
       server.use(
         http.get("http://localhost:3000/api/agent/composes", () => {
           return HttpResponse.json(
@@ -1635,7 +1635,7 @@ describe("run command", () => {
       expect(mockExit).toHaveBeenCalledWith(1);
     });
 
-    it("should treat scope isolation as not found rather than forbidden", async () => {
+    it("should treat org isolation as not found rather than forbidden", async () => {
       server.use(
         http.get("http://localhost:3000/api/agent/composes", () => {
           return HttpResponse.json(

--- a/turbo/apps/cli/src/commands/run/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/run/__tests__/index.test.ts
@@ -1349,14 +1349,14 @@ describe("run command", () => {
       expect(mockExit).toHaveBeenCalledWith(1);
     });
 
-    it("should allow running agent from own scope without flag", async () => {
+    it("should allow running agent from own org without flag", async () => {
       server.use(
         http.get("http://localhost:3000/api/agent/composes", ({ request }) => {
           const url = new URL(request.url);
           const name = url.searchParams.get("name");
-          const scope = url.searchParams.get("org");
+          const org = url.searchParams.get("org");
 
-          if (scope === "test-user" && name === "my-agent") {
+          if (org === "test-user" && name === "my-agent") {
             return HttpResponse.json({
               id: "compose-123",
               name: "my-agent",
@@ -1392,14 +1392,14 @@ describe("run command", () => {
       );
     });
 
-    it("should allow running agent from another scope with flag", async () => {
+    it("should allow running agent from another org with flag", async () => {
       server.use(
         http.get("http://localhost:3000/api/agent/composes", ({ request }) => {
           const url = new URL(request.url);
           const name = url.searchParams.get("name");
-          const scope = url.searchParams.get("org");
+          const org = url.searchParams.get("org");
 
-          if (scope === "other-user" && name === "shared-agent") {
+          if (org === "other-user" && name === "shared-agent") {
             return HttpResponse.json({
               id: "compose-456",
               name: "shared-agent",
@@ -1437,14 +1437,14 @@ describe("run command", () => {
     });
   });
 
-  describe("scope error handling", () => {
-    it("should show error when scope does not exist", async () => {
+  describe("org error handling", () => {
+    it("should show error when org does not exist", async () => {
       server.use(
         http.get("http://localhost:3000/api/agent/composes", ({ request }) => {
           const url = new URL(request.url);
-          const scope = url.searchParams.get("org");
+          const org = url.searchParams.get("org");
 
-          if (scope === "nonexistent-scope-xyz123") {
+          if (org === "nonexistent-scope-xyz123") {
             return HttpResponse.json(
               {
                 error: {
@@ -1515,17 +1515,14 @@ describe("run command", () => {
       );
     });
 
-    it("should show error when agent does not exist in valid scope", async () => {
+    it("should show error when agent does not exist in valid org", async () => {
       server.use(
         http.get("http://localhost:3000/api/agent/composes", ({ request }) => {
           const url = new URL(request.url);
           const name = url.searchParams.get("name");
-          const scope = url.searchParams.get("org");
+          const org = url.searchParams.get("org");
 
-          if (
-            scope === "user-abc12345" &&
-            name === "nonexistent-agent-xyz123"
-          ) {
+          if (org === "user-abc12345" && name === "nonexistent-agent-xyz123") {
             return HttpResponse.json(
               {
                 error: {
@@ -1594,14 +1591,14 @@ describe("run command", () => {
       );
     });
 
-    it("should not allow access to agent from different scope", async () => {
+    it("should not allow access to agent from different org", async () => {
       server.use(
         http.get("http://localhost:3000/api/agent/composes", ({ request }) => {
           const url = new URL(request.url);
           const name = url.searchParams.get("name");
-          const scope = url.searchParams.get("org");
+          const org = url.searchParams.get("org");
 
-          if (scope === "other-user-scope" && name === "my-agent") {
+          if (org === "other-user-scope" && name === "my-agent") {
             return HttpResponse.json(
               {
                 error: {

--- a/turbo/apps/web/app/api/platform/logs/route.ts
+++ b/turbo/apps/web/app/api/platform/logs/route.ts
@@ -33,7 +33,6 @@ interface AgentComposeContent {
 
 interface LogsQuery {
   name?: string;
-  scope?: string;
   agent?: string;
   search?: string;
   status?: PlatformLogStatus;
@@ -43,7 +42,7 @@ interface LogsQuery {
 
 /**
  * Build agent name/org filter conditions from query params.
- * name+scope take precedence over legacy agent param, which takes precedence over search.
+ * name takes precedence over legacy agent param, which takes precedence over search.
  */
 function buildAgentFilterConditions(
   query: LogsQuery,


### PR DESCRIPTION
## Summary

Follow-up cleanup from #4656. Fixes leftover scope references caught in review:

- Rename 5 local `scope` variables to `org` in `run/__tests__/index.test.ts` and update test descriptions
- Remove unused `scope` field from `LogsQuery` interface in `platform/logs/route.ts`

**Not changed:** CLI config migration (`activeScope` → `activeOrg`) is intentionally in-memory only — disk migration happens naturally on next `vm0 org set/use`.

## Test plan

- [x] CLI run tests (51 tests) pass
- [x] Web logs route tests (18 tests) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)