### PR TITLE
fix: resolve redos vulnerability in profile regex

### DIFF
--- a/turbo/packages/core/src/__tests__/instructions-frontmatter.spec.ts
+++ b/turbo/packages/core/src/__tests__/instructions-frontmatter.spec.ts
@@ -143,6 +143,60 @@ describe("stripMetadataFrontmatter", () => {
   });
 });
 
+describe("ReDoS regression", () => {
+  it("should handle opening marker with no closing marker in linear time", () => {
+    const malicious = "<!-- ZERO_PROFILE\n" + "a\n".repeat(10000);
+    const start = performance.now();
+    const result = stripMetadataFrontmatter(malicious);
+    const elapsed = performance.now() - start;
+    expect(elapsed).toBeLessThan(100);
+    expect(result).toBe(malicious.trim());
+  });
+
+  it("should handle repeated opening markers in linear time", () => {
+    const malicious = "<!-- ZERO_PROFILE\n".repeat(10000);
+    const start = performance.now();
+    const result = stripMetadataFrontmatter(malicious);
+    const elapsed = performance.now() - start;
+    expect(elapsed).toBeLessThan(100);
+    expect(result).toBe(malicious.trim());
+  });
+
+  it("should handle nested-looking markers with one closer", () => {
+    const malicious =
+      "<!-- ZERO_PROFILE\n".repeat(100) + "payload\n" + "ZERO_PROFILE -->\n";
+    const start = performance.now();
+    const result = stripMetadataFrontmatter(malicious);
+    const elapsed = performance.now() - start;
+    expect(elapsed).toBeLessThan(100);
+    // The regex matches from the first opener to the closer
+    expect(result).toBe("");
+  });
+
+  it("should correctly strip a valid block in large content", () => {
+    const prefix = "line\n".repeat(5000);
+    const block = "<!-- ZERO_PROFILE\nYour name is Aria.\nZERO_PROFILE -->\n";
+    const suffix = "line\n".repeat(5000);
+    const content = prefix + block + suffix;
+    const start = performance.now();
+    const result = stripMetadataFrontmatter(content);
+    const elapsed = performance.now() - start;
+    expect(elapsed).toBeLessThan(100);
+    expect(result).not.toContain("ZERO_PROFILE");
+  });
+
+  it("should handle injectMetadataFrontmatter with repeated markers in linear time", () => {
+    const malicious = "<!-- ZERO_PROFILE\n".repeat(10000);
+    const start = performance.now();
+    const result = injectMetadataFrontmatter(malicious, {
+      displayName: "Test",
+    });
+    const elapsed = performance.now() - start;
+    expect(elapsed).toBeLessThan(100);
+    expect(result).toContain("Your name is Test.");
+  });
+});
+
 describe("legacy migration", () => {
   it("should replace old frontmatter with new profile block on inject", () => {
     const content =

--- a/turbo/packages/core/src/instructions-frontmatter.ts
+++ b/turbo/packages/core/src/instructions-frontmatter.ts
@@ -5,7 +5,44 @@ interface AgentMetadata {
 
 const PROFILE_START = "<!-- ZERO_PROFILE";
 const PROFILE_END = "ZERO_PROFILE -->";
-const PROFILE_REGEX = /<!-- ZERO_PROFILE\n(?:[^\n]*\n)*?ZERO_PROFILE -->\n?/g;
+
+/**
+ * Remove all ZERO_PROFILE blocks from content in O(n) time.
+ * Uses indexOf instead of regex to avoid ReDoS with nested/repeated markers.
+ */
+function stripProfileBlocks(content: string): string {
+  let result = "";
+  let searchFrom = 0;
+
+  while (searchFrom < content.length) {
+    const startIdx = content.indexOf(PROFILE_START + "\n", searchFrom);
+    if (startIdx === -1) {
+      result += content.slice(searchFrom);
+      break;
+    }
+
+    result += content.slice(searchFrom, startIdx);
+
+    const endIdx = content.indexOf(
+      PROFILE_END,
+      startIdx + PROFILE_START.length + 1,
+    );
+    if (endIdx === -1) {
+      // No closing marker — keep the rest as-is
+      result += content.slice(startIdx);
+      break;
+    }
+
+    // Skip past the end marker and optional trailing newline
+    let afterEnd = endIdx + PROFILE_END.length;
+    if (content[afterEnd] === "\n") {
+      afterEnd++;
+    }
+    searchFrom = afterEnd;
+  }
+
+  return result;
+}
 
 /** Keys used by the legacy YAML frontmatter format. */
 const LEGACY_METADATA_KEYS = new Set(["name", "tone"]);
@@ -99,9 +136,9 @@ export function injectMetadataFrontmatter(
   const block = `${PROFILE_START}\n${paragraph}\n${PROFILE_END}`;
 
   // Remove any existing profile block and legacy frontmatter first
-  const stripped = stripLegacyFrontmatter(content)
-    .replace(PROFILE_REGEX, "")
-    .trimEnd();
+  const stripped = stripProfileBlocks(
+    stripLegacyFrontmatter(content),
+  ).trimEnd();
 
   if (!stripped) {
     return `${block}\n`;
@@ -115,5 +152,5 @@ export function injectMetadataFrontmatter(
  * instructions content for display in the editor.
  */
 export function stripMetadataFrontmatter(content: string): string {
-  return stripLegacyFrontmatter(content).replace(PROFILE_REGEX, "").trim();
+  return stripProfileBlocks(stripLegacyFrontmatter(content)).trim();
 }


### PR DESCRIPTION
## Summary

- Replace regex-based ZERO_PROFILE block stripping with an `indexOf`-based `stripProfileBlocks` function to eliminate ReDoS vulnerability (CWE-1333)
- The original `PROFILE_REGEX` with nested quantifiers `(?:[^\n]*\n)*?` caused O(n^2) backtracking when the closing marker was missing
- Add 5 ReDoS regression tests that verify linear-time performance (< 100ms) on adversarial inputs up to 10k repetitions

Closes #4692

## Test plan

- [x] All 24 existing + new tests pass (8ms total vs 448ms+ before)
- [x] ReDoS tests with 10k repeated opening markers complete in < 100ms
- [x] Functional behavior unchanged for valid profile blocks
- [x] Lint, type-check, knip, and format all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)