### PR TITLE
refactor: rename remaining scope references to org in contracts

### DIFF
--- a/crates/runner/src/cmd/config.rs
+++ b/crates/runner/src/cmd/config.rs
@@ -22,7 +22,7 @@ pub struct ConfigArgs {
     /// Runner logical name
     #[arg(long)]
     name: String,
-    /// Runner group in scope/name format (e.g. "acme/production")
+    /// Runner group in org/name format (e.g. "acme/production")
     #[arg(long)]
     group: String,
     /// Runner directory name (under ~/.vm0-runner/runners/)

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -660,7 +660,7 @@ mod tests {
             api_start_time: None,
             user_timezone: None,
             agent_name: None,
-            agent_scope_slug: None,
+            agent_org_slug: None,
             memory_name: None,
             experimental_services: None,
         }

--- a/crates/runner/src/provider/local.rs
+++ b/crates/runner/src/provider/local.rs
@@ -156,7 +156,7 @@ impl JobProvider for LocalProvider {
             api_start_time: None,
             user_timezone: req.user_timezone,
             agent_name: None,
-            agent_scope_slug: None,
+            agent_org_slug: None,
             memory_name: None,
             experimental_services: None,
         })

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -70,7 +70,7 @@ pub struct ExecutionContext {
     // Not yet used by runner — org/agent slug for scoping
     #[allow(dead_code)]
     #[serde(default)]
-    pub agent_scope_slug: Option<String>,
+    pub agent_org_slug: Option<String>,
     // Not yet used by runner — memory storage name for first-run init
     #[allow(dead_code)]
     #[serde(default)]

--- a/e2e/tests/03-experimental-runner/t22-vm0-compose-scope.bats
+++ b/e2e/tests/03-experimental-runner/t22-vm0-compose-scope.bats
@@ -1,12 +1,12 @@
 #!/usr/bin/env bats
 
-# Test VM0 compose with scope support (E2E happy path only)
-# Tests the scope/name:version naming convention for agent composes
+# Test VM0 compose with org support (E2E happy path only)
+# Tests the org/name:version naming convention for agent composes
 #
 # This test covers issue #757: Add scope support to agent compose
 #
-# Note: Identifier format parsing and error handling (scope/name, scope/name:version, name:version,
-# backward compat, scope errors) are tested via CLI Command Integration Tests
+# Note: Identifier format parsing and error handling (org/name, org/name:version, name:version,
+# backward compat, org errors) are tested via CLI Command Integration Tests
 # (see run/__tests__/index.test.ts, "scope error handling" section).
 
 load '../../helpers/setup'
@@ -25,10 +25,10 @@ teardown() {
 }
 
 # ============================================
-# vm0 compose displays scope/name format
+# vm0 compose displays org/name format
 # ============================================
 
-@test "t22-1: vm0 compose shows scope/name:version in run instructions" {
+@test "t22-1: vm0 compose shows org/name:version in run instructions" {
     echo "# Creating config file..."
     cat > "$TEST_DIR/vm0.yaml" <<EOF
 version: "1.0"
@@ -44,7 +44,7 @@ EOF
     run $CLI_COMMAND compose "$TEST_DIR/vm0.yaml"
     assert_success
 
-    echo "# Verifying output contains scope/name format..."
+    echo "# Verifying output contains org/name format..."
     # Output should show something like "Compose created: user-abc12345/e2e-scope-compose-xxxx"
     assert_output --regexp "Compose (created|version exists): [a-z0-9-]+/$AGENT_NAME"
 
@@ -52,18 +52,18 @@ EOF
     assert_output --partial "Version:"
     assert_output --regexp "Version:[ ]+[0-9a-f]{8}"
 
-    echo "# Verifying run instructions include scope/name:version format..."
-    # Output should show: vm0 run scope/name:version
+    echo "# Verifying run instructions include org/name:version format..."
+    # Output should show: vm0 run org/name:version
     assert_output --regexp "vm0 run [a-z0-9-]+/$AGENT_NAME:[0-9a-f]{8}"
 }
 
 # ============================================
-# vm0 run with scope/name format (E2E happy path)
+# vm0 run with org/name format (E2E happy path)
 # ============================================
 
-@test "t22-2: vm0 run with scope/name format resolves agent correctly" {
-    # This test verifies the end-to-end happy path for scope/name format.
-    # Other identifier formats (scope/name:version, name:version, backward compat)
+@test "t22-2: vm0 run with org/name format resolves agent correctly" {
+    # This test verifies the end-to-end happy path for org/name format.
+    # Other identifier formats (org/name:version, name:version, backward compat)
     # are tested via CLI Command Integration Tests in run/__tests__/index.test.ts.
 
     echo "# Step 1: Creating agent config..."
@@ -72,7 +72,7 @@ version: "1.0"
 
 agents:
   $AGENT_NAME:
-    description: "Test agent for scope/name run"
+    description: "Test agent for org/name run"
     framework: claude-code
     working_dir: /home/user/workspace
 EOF
@@ -99,7 +99,7 @@ EOF
     run $CLI_COMMAND artifact push
     assert_success
 
-    echo "# Step 4: Running with scope/name format..."
+    echo "# Step 4: Running with org/name format..."
     run $CLI_COMMAND run "$USER_SCOPE/$AGENT_NAME" \
         --artifact-name "$ARTIFACT_NAME" \
         "echo hello from scope test"

--- a/turbo/apps/cli/src/commands/compose/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/compose/__tests__/index.test.ts
@@ -896,7 +896,7 @@ agents:
   });
 
   describe("runner group validation", () => {
-    it("should accept valid runner group format (scope/name)", async () => {
+    it("should accept valid runner group format (org/name)", async () => {
       await fs.writeFile(
         path.join(tempDir, "vm0.yaml"),
         `version: "1.0"
@@ -949,7 +949,7 @@ agents:
         (call) => call[0] as string,
       );
       const hasFormatError = allErrors.some(
-        (err) => err.includes("scope/name") || err.includes("format"),
+        (err) => err.includes("org/name") || err.includes("format"),
       );
       expect(hasFormatError).toBe(true);
       expect(mockExit).toHaveBeenCalledWith(1);

--- a/turbo/apps/cli/src/commands/run/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/run/__tests__/index.test.ts
@@ -420,7 +420,7 @@ describe("run command", () => {
       expect(mockExit).toHaveBeenCalledWith(1);
     });
 
-    it("should parse scope/name format", async () => {
+    it("should parse org/name format", async () => {
       let capturedQueryParams:
         | { name: string | null; org: string | null }
         | undefined;
@@ -489,7 +489,7 @@ describe("run command", () => {
       );
     });
 
-    it("should parse scope/name:version format", async () => {
+    it("should parse org/name:version format", async () => {
       let capturedVersionParams:
         | { composeId: string | null; version: string | null }
         | undefined;

--- a/turbo/apps/docs/content/docs/reference/configuration/vm0-yaml.mdx
+++ b/turbo/apps/docs/content/docs/reference/configuration/vm0-yaml.mdx
@@ -71,7 +71,7 @@ Each agent key must be a valid agent name: 3-64 characters, starting and ending 
 | `skills`                 | array  | No       | `[]`           | List of skill references. Supports bare names (e.g., `"slack"`) which resolve to `https://github.com/vm0-ai/vm0-skills/tree/main/slack`, or full GitHub URLs. See [Skills](/docs/core-concept/skills) |
 | `volumes`                | array  | No       | `[]`           | Volume mounts in format `name:path`. See [Volume](/docs/core-concept/volume)                      |
 | `environment`            | object | No       | `{}`           | Environment variables. See [Environment Variables](/docs/core-concept/environment-variable)       |
-| `experimental_runner`    | object | No       | -              | Self-hosted runner configuration. Object with `group` field in `scope/name` format (e.g., `acme/production`) |
+| `experimental_runner`    | object | No       | -              | Self-hosted runner configuration. Object with `group` field in `org/name` format (e.g., `acme/production`) |
 | `experimental_firewall`  | object | No       | -              | Firewall configuration for network access control. See [Firewall](/docs/experimental/firewall) for details |
 
 ## Volume Fields

--- a/turbo/apps/web/app/api/runners/jobs/[id]/claim/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/runners/jobs/[id]/claim/__tests__/route.test.ts
@@ -233,7 +233,7 @@ describe("POST /api/runners/jobs/:id/claim", () => {
   });
 
   describe("Claim flow - Agent metadata", () => {
-    it("should return agentName and agentScopeSlug in claim response", async () => {
+    it("should return agentName and agentOrgSlug in claim response", async () => {
       // Create compose and look up org slug
       const { composeId, versionId } = await createTestCompose("test-agent");
       const composeInfo = await findTestComposeWithScope(composeId);
@@ -246,7 +246,7 @@ describe("POST /api/runners/jobs/:id/claim", () => {
         `${orgSlug}/default`,
         {
           agentName: "test-agent",
-          agentScopeSlug: orgSlug,
+          agentOrgSlug: orgSlug,
         },
       );
 
@@ -269,10 +269,10 @@ describe("POST /api/runners/jobs/:id/claim", () => {
 
       const data = await response.json();
       expect(data.agentName).toBe("test-agent");
-      expect(data.agentScopeSlug).toBe(orgSlug);
+      expect(data.agentOrgSlug).toBe(orgSlug);
     });
 
-    it("should omit agentName and agentScopeSlug when not set in stored context", async () => {
+    it("should omit agentName and agentOrgSlug when not set in stored context", async () => {
       // Create compose and look up org slug
       const { composeId, versionId } =
         await createTestCompose("test-agent-no-meta");
@@ -305,7 +305,7 @@ describe("POST /api/runners/jobs/:id/claim", () => {
 
       const data = await response.json();
       expect(data.agentName).toBeUndefined();
-      expect(data.agentScopeSlug).toBeUndefined();
+      expect(data.agentOrgSlug).toBeUndefined();
     });
   });
 });

--- a/turbo/apps/web/app/api/runners/jobs/[id]/claim/route.ts
+++ b/turbo/apps/web/app/api/runners/jobs/[id]/claim/route.ts
@@ -200,7 +200,7 @@ const router = tsr.router(runnersJobClaimContract, {
         apiStartTime: storedContext.apiStartTime,
         userTimezone: storedContext.userTimezone,
         agentName: storedContext.agentName,
-        agentScopeSlug: storedContext.agentScopeSlug,
+        agentOrgSlug: storedContext.agentOrgSlug,
         memoryName: storedContext.memoryName,
       },
     };

--- a/turbo/apps/web/src/lib/run/executors/runner-executor.ts
+++ b/turbo/apps/web/src/lib/run/executors/runner-executor.ts
@@ -62,7 +62,7 @@ export async function executeRunnerJob(
     apiStartTime: context.apiStartTime ?? undefined,
     userTimezone: context.userTimezone ?? undefined,
     agentName: context.agentName ?? undefined,
-    agentScopeSlug: context.agentOrgSlug ?? undefined,
+    agentOrgSlug: context.agentOrgSlug ?? undefined,
     memoryName: context.memoryName ?? undefined,
   };
 

--- a/turbo/packages/core/src/contracts/composes.ts
+++ b/turbo/packages/core/src/contracts/composes.ts
@@ -88,7 +88,7 @@ const agentDefinitionSchema = z.object({
         .string()
         .regex(
           /^[a-z0-9-]+\/[a-z0-9-]+$/,
-          "Runner group must be in scope/name format (e.g., acme/production)",
+          "Runner group must be in org/name format (e.g., acme/production)",
         ),
     })
     .optional(),

--- a/turbo/packages/core/src/contracts/runners.ts
+++ b/turbo/packages/core/src/contracts/runners.ts
@@ -29,13 +29,13 @@ export const experimentalFirewallSchema = z.object({
 });
 
 /**
- * Runner group format: scope/name (e.g., "acme/production")
+ * Runner group format: org/name (e.g., "acme/production")
  */
 export const runnerGroupSchema = z
   .string()
   .regex(
     /^[a-z0-9-]+\/[a-z0-9-]+$/,
-    "Runner group must be in scope/name format (e.g., acme/production)",
+    "Runner group must be in org/name format (e.g., acme/production)",
   );
 
 /**
@@ -154,9 +154,9 @@ export const storedExecutionContextSchema = z.object({
   apiStartTime: z.number().optional(),
   // User's timezone preference (IANA format, e.g., "Asia/Shanghai")
   userTimezone: z.string().optional(),
-  // Agent metadata for VM0_AGENT_NAME and VM0_AGENT_SCOPE env vars
+  // Agent metadata for VM0_AGENT_NAME and VM0_AGENT_ORG env vars
   agentName: z.string().optional(),
-  agentScopeSlug: z.string().optional(),
+  agentOrgSlug: z.string().optional(),
   // Memory storage name (for first-run when manifest.memory is null)
   memoryName: z.string().optional(),
   // Experimental services for proxy-side token replacement
@@ -194,7 +194,7 @@ export const executionContextSchema = z.object({
   userTimezone: z.string().optional(),
   // Agent metadata
   agentName: z.string().optional(),
-  agentScopeSlug: z.string().optional(),
+  agentOrgSlug: z.string().optional(),
   // Memory storage name (for first-run when manifest.memory is null)
   memoryName: z.string().optional(),
   // Experimental services for proxy-side token replacement

--- a/turbo/packages/core/src/contracts/schedules.ts
+++ b/turbo/packages/core/src/contracts/schedules.ts
@@ -70,7 +70,7 @@ const deployScheduleRequestSchema = z
     artifactName: z.string().optional(),
     artifactVersion: z.string().optional(),
     volumeVersions: z.record(z.string(), z.string()).optional(),
-    // Resolved agent compose ID (CLI resolves scope/name:version → composeId)
+    // Resolved agent compose ID (CLI resolves org/name:version → composeId)
     composeId: z.string().uuid("Invalid compose ID"),
     // Enable schedule immediately upon creation
     enabled: z.boolean().optional(),


### PR DESCRIPTION
## Summary

- Rename `agentScopeSlug` → `agentOrgSlug` in wire format schemas (`storedExecutionContextSchema`, `executionContextSchema`)
- Update `scope/name` → `org/name` in error messages, comments, and documentation
- Sync Rust runner struct field `agent_scope_slug` → `agent_org_slug`

Follow-up to #4656. Closes #4688.

## Test plan

- [x] TypeScript type check passes (`pnpm check-types`)
- [x] All claim route tests pass (11 tests)
- [x] CLI compose tests pass (96 tests)
- [x] CLI run tests pass (51 tests)
- [x] Lint passes across all packages
- [x] Knip finds no unused exports
- [x] Rust compiles and passes clippy

🤖 Generated with [Claude Code](https://claude.com/claude-code)