### PR TITLE
feat(slack): add org-aware oauth install and callback routes

### DIFF
--- a/turbo/apps/web/app/api/slack/org/oauth/callback/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/slack/org/oauth/callback/__tests__/route.test.ts
@@ -117,7 +117,33 @@ describe("/api/slack/org/oauth/callback", () => {
     expect(connection!.orgId).toBe(orgId);
   });
 
-  it("should reject user who is not an org member", async () => {
+  it("should reject org member who is not an admin", async () => {
+    const userId = uniqueId("member");
+    const orgId = uniqueId("org");
+
+    // User is a member of this org but with "member" role, not "admin"
+    mockClerk({
+      userId,
+      clerkOrgs: [{ id: orgId, slug: orgId, name: orgId, role: "org:member" }],
+    });
+    await createTestOrg(orgId);
+
+    mockOAuthSuccess();
+
+    const state = JSON.stringify({ orgId, vm0UserId: userId });
+    const request = createTestRequest(
+      `http://localhost:3000/api/slack/org/oauth/callback?code=valid-code&state=${encodeURIComponent(state)}`,
+    );
+    const response = await GET(request);
+
+    // Non-admin member should be redirected to failed page
+    expect(response.status).toBe(307);
+    const location = response.headers.get("Location");
+    expect(location).toContain("/slack/failed");
+    expect(location).toContain("Only%20org%20admins");
+  });
+
+  it("should throw when user is not an org member", async () => {
     const userId = uniqueId("outsider");
     const orgId = uniqueId("org");
 
@@ -130,12 +156,11 @@ describe("/api/slack/org/oauth/callback", () => {
     const request = createTestRequest(
       `http://localhost:3000/api/slack/org/oauth/callback?code=valid-code&state=${encodeURIComponent(state)}`,
     );
-    const response = await GET(request);
 
-    // requireOrgMember throws 403 → caught by catch block → redirect to failed
-    expect(response.status).toBe(307);
-    const location = response.headers.get("Location");
-    expect(location).toContain("/slack/failed");
+    // requireOrgMember throws ForbiddenError — let it propagate to framework
+    await expect(GET(request)).rejects.toThrow(
+      "You are not a member of this organization",
+    );
   });
 
   it("should create installation with null org_id for slack-initiated flow", async () => {
@@ -168,7 +193,10 @@ describe("/api/slack/org/oauth/callback", () => {
     const orgId = uniqueId("org");
     const workspaceId = uniqueId("ws");
 
-    mockClerk({ userId: adminUserId });
+    mockClerk({
+      userId: adminUserId,
+      clerkOrgs: [{ id: orgId, slug: orgId, name: orgId }],
+    });
     await createTestOrg(orgId);
 
     // First install (platform flow)

--- a/turbo/apps/web/app/api/slack/org/oauth/callback/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/slack/org/oauth/callback/__tests__/route.test.ts
@@ -1,0 +1,286 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { WebClient } from "@slack/web-api";
+import { GET } from "../route";
+import {
+  createTestRequest,
+  createTestOrg,
+  findTestSlackOrgInstallation,
+  findTestSlackOrgConnection,
+  findTestSlackOrgConnections,
+} from "../../../../../../../src/__tests__/api-test-helpers";
+import {
+  testContext,
+  uniqueId,
+} from "../../../../../../../src/__tests__/test-helpers";
+import { mockClerk } from "../../../../../../../src/__tests__/clerk-mock";
+import { decryptSecretValue } from "../../../../../../../src/lib/crypto/secrets-encryption";
+import { env } from "../../../../../../../src/env";
+
+const context = testContext();
+
+function mockOAuthSuccess(overrides?: {
+  accessToken?: string;
+  botUserId?: string;
+  teamId?: string;
+  teamName?: string;
+  authedUserId?: string;
+}) {
+  const mockClient = vi.mocked(new WebClient(), true);
+  mockClient.oauth.v2.access.mockResolvedValueOnce({
+    ok: true,
+    access_token: overrides?.accessToken ?? "xoxb-test-token",
+    bot_user_id: overrides?.botUserId ?? "B123456",
+    team: {
+      id: overrides?.teamId ?? "T123456",
+      name: overrides?.teamName ?? "Test Workspace",
+    },
+    authed_user: { id: overrides?.authedUserId ?? "U-installer" },
+  } as never);
+  return mockClient;
+}
+
+describe("/api/slack/org/oauth/callback", () => {
+  beforeEach(() => {
+    context.setupMocks();
+  });
+
+  it("should redirect to failed page when error parameter is present", async () => {
+    const request = createTestRequest(
+      "http://localhost:3000/api/slack/org/oauth/callback?error=access_denied",
+    );
+    const response = await GET(request);
+
+    expect(response.status).toBe(307);
+    const location = response.headers.get("Location");
+    expect(location).toBe(
+      "http://localhost:3001/slack/failed?error=access_denied",
+    );
+  });
+
+  it("should return 400 when code parameter is missing", async () => {
+    const request = createTestRequest(
+      "http://localhost:3000/api/slack/org/oauth/callback",
+    );
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.error).toBe("Missing authorization code");
+  });
+
+  it("should create installation with org_id for platform flow (first install)", async () => {
+    const adminUserId = uniqueId("admin");
+    const orgId = uniqueId("org");
+    const workspaceId = uniqueId("ws");
+
+    mockClerk({
+      userId: adminUserId,
+      clerkOrgs: [{ id: orgId, slug: orgId, name: orgId }],
+    });
+    await createTestOrg(orgId);
+
+    mockOAuthSuccess({ teamId: workspaceId, authedUserId: "U-slack-admin" });
+
+    const state = JSON.stringify({ orgId, vm0UserId: adminUserId });
+    const request = createTestRequest(
+      `http://localhost:3000/api/slack/org/oauth/callback?code=valid-code&state=${encodeURIComponent(state)}`,
+    );
+    const response = await GET(request);
+
+    // Should redirect to /zero/works
+    expect(response.status).toBe(307);
+    expect(response.headers.get("Location")).toBe(
+      "http://localhost:3001/zero/works",
+    );
+
+    // Verify installation was created with org_id
+    const installation = await findTestSlackOrgInstallation(workspaceId);
+    expect(installation).toBeDefined();
+    expect(installation!.orgId).toBe(orgId);
+    expect(installation!.installedByUserId).toBe(adminUserId);
+    expect(installation!.botUserId).toBe("B123456");
+
+    // Verify bot token is encrypted and decryptable
+    const decrypted = decryptSecretValue(
+      installation!.encryptedBotToken,
+      env().SECRETS_ENCRYPTION_KEY,
+    );
+    expect(decrypted).toBe("xoxb-test-token");
+
+    // Verify connection was created
+    const connection = await findTestSlackOrgConnection(
+      "U-slack-admin",
+      workspaceId,
+    );
+    expect(connection).toBeDefined();
+    expect(connection!.vm0UserId).toBe(adminUserId);
+    expect(connection!.orgId).toBe(orgId);
+  });
+
+  it("should reject user who is not an org member", async () => {
+    const userId = uniqueId("outsider");
+    const orgId = uniqueId("org");
+
+    // User is not a member of this org (no clerkOrgs match)
+    mockClerk({ userId });
+
+    mockOAuthSuccess();
+
+    const state = JSON.stringify({ orgId, vm0UserId: userId });
+    const request = createTestRequest(
+      `http://localhost:3000/api/slack/org/oauth/callback?code=valid-code&state=${encodeURIComponent(state)}`,
+    );
+    const response = await GET(request);
+
+    // requireOrgMember throws 403 → caught by catch block → redirect to failed
+    expect(response.status).toBe(307);
+    const location = response.headers.get("Location");
+    expect(location).toContain("/slack/failed");
+  });
+
+  it("should create installation with null org_id for slack-initiated flow", async () => {
+    const workspaceId = uniqueId("ws");
+    mockOAuthSuccess({
+      teamId: workspaceId,
+      teamName: "Slack Workspace",
+    });
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/slack/org/oauth/callback?code=valid-code",
+    );
+    const response = await GET(request);
+
+    // Should redirect to installed page
+    expect(response.status).toBe(307);
+    const location = response.headers.get("Location");
+    expect(location).toContain("/slack/installed");
+    expect(location).toContain("workspace=Slack%20Workspace");
+
+    // Verify installation was created with null org_id
+    const installation = await findTestSlackOrgInstallation(workspaceId);
+    expect(installation).toBeDefined();
+    expect(installation!.orgId).toBeNull();
+    expect(installation!.installedByUserId).toBeNull();
+  });
+
+  it("should update bot token on re-install and preserve org binding", async () => {
+    const adminUserId = uniqueId("admin");
+    const orgId = uniqueId("org");
+    const workspaceId = uniqueId("ws");
+
+    mockClerk({ userId: adminUserId });
+    await createTestOrg(orgId);
+
+    // First install (platform flow)
+    mockOAuthSuccess({
+      teamId: workspaceId,
+      accessToken: "xoxb-original-token",
+      botUserId: "B-original",
+      authedUserId: "U-original",
+    });
+
+    const state = JSON.stringify({ orgId, vm0UserId: adminUserId });
+    const firstRequest = createTestRequest(
+      `http://localhost:3000/api/slack/org/oauth/callback?code=first-code&state=${encodeURIComponent(state)}`,
+    );
+    await GET(firstRequest);
+
+    // Re-install (slack-initiated, no state)
+    mockOAuthSuccess({
+      teamId: workspaceId,
+      accessToken: "xoxb-new-token",
+      botUserId: "B-new",
+      teamName: "Renamed Workspace",
+      authedUserId: "U-different",
+    });
+
+    const secondRequest = createTestRequest(
+      `http://localhost:3000/api/slack/org/oauth/callback?code=second-code`,
+    );
+    const response = await GET(secondRequest);
+
+    // Re-install without state redirects to installed page
+    expect(response.status).toBe(307);
+    expect(response.headers.get("Location")).toContain("/slack/installed");
+
+    // Verify bot token updated, org binding preserved
+    const installation = await findTestSlackOrgInstallation(workspaceId);
+    expect(installation).toBeDefined();
+    expect(installation!.orgId).toBe(orgId);
+    expect(installation!.installedByUserId).toBe(adminUserId);
+    expect(installation!.botUserId).toBe("B-new");
+    expect(installation!.slackWorkspaceName).toBe("Renamed Workspace");
+
+    // Verify new token is encrypted correctly
+    const decrypted = decryptSecretValue(
+      installation!.encryptedBotToken,
+      env().SECRETS_ENCRYPTION_KEY,
+    );
+    expect(decrypted).toBe("xoxb-new-token");
+  });
+
+  it("should redirect to failed page when OAuth exchange fails", async () => {
+    const mockClient = vi.mocked(new WebClient(), true);
+    mockClient.oauth.v2.access.mockResolvedValueOnce({
+      ok: false,
+      error: "invalid_code",
+    } as never);
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/slack/org/oauth/callback?code=expired-code",
+    );
+    const response = await GET(request);
+
+    expect(response.status).toBe(307);
+    const location = response.headers.get("Location");
+    expect(location).toContain("/slack/failed");
+    expect(location).toContain("error=");
+  });
+
+  it("should create connection idempotently on duplicate platform flow", async () => {
+    const adminUserId = uniqueId("admin");
+    const orgId = uniqueId("org");
+    const workspaceId = uniqueId("ws");
+
+    mockClerk({
+      userId: adminUserId,
+      clerkOrgs: [{ id: orgId, slug: orgId, name: orgId }],
+    });
+    await createTestOrg(orgId);
+
+    // First install
+    mockOAuthSuccess({
+      teamId: workspaceId,
+      authedUserId: "U-slack-admin",
+    });
+
+    const state = JSON.stringify({ orgId, vm0UserId: adminUserId });
+    const firstRequest = createTestRequest(
+      `http://localhost:3000/api/slack/org/oauth/callback?code=first-code&state=${encodeURIComponent(state)}`,
+    );
+    await GET(firstRequest);
+
+    // Second install with same state (re-install with platform flow)
+    mockOAuthSuccess({
+      teamId: workspaceId,
+      authedUserId: "U-slack-admin",
+    });
+
+    const secondRequest = createTestRequest(
+      `http://localhost:3000/api/slack/org/oauth/callback?code=second-code&state=${encodeURIComponent(state)}`,
+    );
+    const response = await GET(secondRequest);
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("Location")).toBe(
+      "http://localhost:3001/zero/works",
+    );
+
+    // Should still have exactly one connection (onConflictDoNothing)
+    const connections = await findTestSlackOrgConnections(
+      "U-slack-admin",
+      workspaceId,
+    );
+    expect(connections).toHaveLength(1);
+  });
+});

--- a/turbo/apps/web/app/api/slack/org/oauth/callback/route.ts
+++ b/turbo/apps/web/app/api/slack/org/oauth/callback/route.ts
@@ -92,96 +92,97 @@ export async function GET(request: Request) {
   const state = parseOAuthState(url.searchParams.get("state"));
   const redirectUri = `${baseUrl}/api/slack/org/oauth/callback`;
 
+  let oauthResult;
   try {
-    const oauthResult = await exchangeOAuthCode(
+    oauthResult = await exchangeOAuthCode(
       SLACK_CLIENT_ID,
       SLACK_CLIENT_SECRET,
       code,
       redirectUri,
     );
-
-    const encryptedBotToken = encryptSecretValue(
-      oauthResult.accessToken,
-      SECRETS_ENCRYPTION_KEY,
-    );
-
-    const db = globalThis.services.db;
-
-    // Check existing installation
-    const existing = await db
-      .select()
-      .from(slackOrgInstallations)
-      .where(eq(slackOrgInstallations.slackWorkspaceId, oauthResult.teamId))
-      .limit(1)
-      .then((rows) => rows[0] ?? null);
-
-    if (existing) {
-      // Re-install: update bot token, preserve org binding
-      await db
-        .update(slackOrgInstallations)
-        .set({
-          encryptedBotToken,
-          botUserId: oauthResult.botUserId,
-          slackWorkspaceName: oauthResult.teamName,
-          updatedAt: new Date(),
-        })
-        .where(eq(slackOrgInstallations.slackWorkspaceId, oauthResult.teamId));
-
-      log.debug("Re-installed Slack workspace, bot token updated", {
-        workspaceId: oauthResult.teamId,
-        orgId: existing.orgId,
-      });
-    } else {
-      // First install
-      const isPlatformFlow = state.orgId && state.vm0UserId;
-
-      await db.insert(slackOrgInstallations).values({
-        slackWorkspaceId: oauthResult.teamId,
-        slackWorkspaceName: oauthResult.teamName,
-        orgId: isPlatformFlow ? state.orgId : null,
-        encryptedBotToken,
-        botUserId: oauthResult.botUserId,
-        installedByUserId: isPlatformFlow ? state.vm0UserId : null,
-      });
-
-      log.debug("New Slack workspace installed", {
-        workspaceId: oauthResult.teamId,
-        orgId: isPlatformFlow ? state.orgId : null,
-      });
-    }
-
-    // Platform flow: verify admin and create connection
-    if (state.orgId && state.vm0UserId) {
-      // Verify user is org admin
-      const member = await requireOrgMember(state.orgId, state.vm0UserId);
-      if (member.role !== "admin") {
-        return NextResponse.redirect(
-          `${platformUrl}/slack/failed?error=${encodeURIComponent("Only org admins can install Slack for an organization.")}`,
-        );
-      }
-
-      // Create connection (idempotent via unique constraint)
-      await db
-        .insert(slackOrgConnections)
-        .values({
-          slackUserId: oauthResult.authedUserId,
-          slackWorkspaceId: oauthResult.teamId,
-          vm0UserId: state.vm0UserId,
-          orgId: state.orgId,
-        })
-        .onConflictDoNothing();
-
-      return NextResponse.redirect(`${platformUrl}/zero/works`);
-    }
-
-    // Slack flow: redirect to success page
-    return NextResponse.redirect(
-      `${platformUrl}/slack/installed?workspace=${encodeURIComponent(oauthResult.teamName)}`,
-    );
   } catch (err) {
-    log.error("Slack OAuth callback error", { error: err });
+    log.error("Slack OAuth exchange failed", { error: err });
     return NextResponse.redirect(
       `${platformUrl}/slack/failed?error=${encodeURIComponent("Failed to complete Slack installation. Please try again.")}`,
     );
   }
+
+  const encryptedBotToken = encryptSecretValue(
+    oauthResult.accessToken,
+    SECRETS_ENCRYPTION_KEY,
+  );
+
+  const db = globalThis.services.db;
+
+  // Check existing installation
+  const existing = await db
+    .select()
+    .from(slackOrgInstallations)
+    .where(eq(slackOrgInstallations.slackWorkspaceId, oauthResult.teamId))
+    .limit(1)
+    .then((rows) => rows[0] ?? null);
+
+  if (existing) {
+    // Re-install: update bot token, preserve org binding
+    await db
+      .update(slackOrgInstallations)
+      .set({
+        encryptedBotToken,
+        botUserId: oauthResult.botUserId,
+        slackWorkspaceName: oauthResult.teamName,
+        updatedAt: new Date(),
+      })
+      .where(eq(slackOrgInstallations.slackWorkspaceId, oauthResult.teamId));
+
+    log.debug("Re-installed Slack workspace, bot token updated", {
+      workspaceId: oauthResult.teamId,
+      orgId: existing.orgId,
+    });
+  } else {
+    // First install
+    const isPlatformFlow = state.orgId && state.vm0UserId;
+
+    await db.insert(slackOrgInstallations).values({
+      slackWorkspaceId: oauthResult.teamId,
+      slackWorkspaceName: oauthResult.teamName,
+      orgId: isPlatformFlow ? state.orgId : null,
+      encryptedBotToken,
+      botUserId: oauthResult.botUserId,
+      installedByUserId: isPlatformFlow ? state.vm0UserId : null,
+    });
+
+    log.debug("New Slack workspace installed", {
+      workspaceId: oauthResult.teamId,
+      orgId: isPlatformFlow ? state.orgId : null,
+    });
+  }
+
+  // Platform flow: verify admin and create connection
+  if (state.orgId && state.vm0UserId) {
+    // Verify user is org admin
+    const member = await requireOrgMember(state.orgId, state.vm0UserId);
+    if (member.role !== "admin") {
+      return NextResponse.redirect(
+        `${platformUrl}/slack/failed?error=${encodeURIComponent("Only org admins can install Slack for an organization.")}`,
+      );
+    }
+
+    // Create connection (idempotent via unique constraint)
+    await db
+      .insert(slackOrgConnections)
+      .values({
+        slackUserId: oauthResult.authedUserId,
+        slackWorkspaceId: oauthResult.teamId,
+        vm0UserId: state.vm0UserId,
+        orgId: state.orgId,
+      })
+      .onConflictDoNothing();
+
+    return NextResponse.redirect(`${platformUrl}/zero/works`);
+  }
+
+  // Slack flow: redirect to success page
+  return NextResponse.redirect(
+    `${platformUrl}/slack/installed?workspace=${encodeURIComponent(oauthResult.teamName)}`,
+  );
 }

--- a/turbo/apps/web/app/api/slack/org/oauth/callback/route.ts
+++ b/turbo/apps/web/app/api/slack/org/oauth/callback/route.ts
@@ -1,0 +1,187 @@
+import { NextResponse } from "next/server";
+import { eq } from "drizzle-orm";
+import { initServices } from "../../../../../../src/lib/init-services";
+import { env } from "../../../../../../src/env";
+import {
+  exchangeOAuthCode,
+  getSlackRedirectBaseUrl,
+} from "../../../../../../src/lib/slack";
+import { encryptSecretValue } from "../../../../../../src/lib/crypto/secrets-encryption";
+import { slackOrgInstallations } from "../../../../../../src/db/schema/slack-org-installation";
+import { slackOrgConnections } from "../../../../../../src/db/schema/slack-org-connection";
+import { requireOrgMember } from "../../../../../../src/lib/org/org-member-service";
+import { getPlatformUrl } from "../../../../../../src/lib/url";
+import { logger } from "../../../../../../src/lib/logger";
+
+const log = logger("slack-org:oauth-callback");
+
+interface OAuthState {
+  orgId: string | null;
+  vm0UserId: string | null;
+}
+
+function parseOAuthState(state: string | null): OAuthState {
+  if (!state) return { orgId: null, vm0UserId: null };
+  try {
+    const parsed = JSON.parse(state) as {
+      orgId?: string;
+      vm0UserId?: string;
+    };
+    return {
+      orgId: parsed.orgId ?? null,
+      vm0UserId: parsed.vm0UserId ?? null,
+    };
+  } catch {
+    return { orgId: null, vm0UserId: null };
+  }
+}
+
+/**
+ * Org-aware Slack OAuth Callback
+ *
+ * GET /api/slack/org/oauth/callback
+ *
+ * Handles the OAuth redirect from Slack after authorization.
+ *
+ * Platform flow (state has orgId + vm0UserId):
+ *   - Verify user is org admin via Clerk
+ *   - Upsert installation with org_id and installed_by_user_id
+ *   - Create connection record
+ *   - Redirect to platform settings
+ *
+ * Slack flow (no orgId in state):
+ *   - Upsert installation with org_id = NULL
+ *   - Redirect to "workspace installed, ask admin to connect" page
+ *
+ * Re-install (installation exists with org_id):
+ *   - Preserve org_id and installed_by_user_id
+ *   - Update bot token only
+ */
+export async function GET(request: Request) {
+  initServices();
+
+  const { SLACK_CLIENT_ID, SLACK_CLIENT_SECRET, SECRETS_ENCRYPTION_KEY } =
+    env();
+
+  if (!SLACK_CLIENT_ID || !SLACK_CLIENT_SECRET) {
+    return NextResponse.json(
+      { error: "Slack integration is not configured" },
+      { status: 503 },
+    );
+  }
+
+  const url = new URL(request.url);
+  const code = url.searchParams.get("code");
+  const error = url.searchParams.get("error");
+  const baseUrl = getSlackRedirectBaseUrl(request.url);
+  const platformUrl = getPlatformUrl();
+
+  if (error) {
+    return NextResponse.redirect(
+      `${platformUrl}/slack/failed?error=${encodeURIComponent(error)}`,
+    );
+  }
+
+  if (!code) {
+    return NextResponse.json(
+      { error: "Missing authorization code" },
+      { status: 400 },
+    );
+  }
+
+  const state = parseOAuthState(url.searchParams.get("state"));
+  const redirectUri = `${baseUrl}/api/slack/org/oauth/callback`;
+
+  try {
+    const oauthResult = await exchangeOAuthCode(
+      SLACK_CLIENT_ID,
+      SLACK_CLIENT_SECRET,
+      code,
+      redirectUri,
+    );
+
+    const encryptedBotToken = encryptSecretValue(
+      oauthResult.accessToken,
+      SECRETS_ENCRYPTION_KEY,
+    );
+
+    const db = globalThis.services.db;
+
+    // Check existing installation
+    const existing = await db
+      .select()
+      .from(slackOrgInstallations)
+      .where(eq(slackOrgInstallations.slackWorkspaceId, oauthResult.teamId))
+      .limit(1)
+      .then((rows) => rows[0] ?? null);
+
+    if (existing) {
+      // Re-install: update bot token, preserve org binding
+      await db
+        .update(slackOrgInstallations)
+        .set({
+          encryptedBotToken,
+          botUserId: oauthResult.botUserId,
+          slackWorkspaceName: oauthResult.teamName,
+          updatedAt: new Date(),
+        })
+        .where(eq(slackOrgInstallations.slackWorkspaceId, oauthResult.teamId));
+
+      log.debug("Re-installed Slack workspace, bot token updated", {
+        workspaceId: oauthResult.teamId,
+        orgId: existing.orgId,
+      });
+    } else {
+      // First install
+      const isPlatformFlow = state.orgId && state.vm0UserId;
+
+      await db.insert(slackOrgInstallations).values({
+        slackWorkspaceId: oauthResult.teamId,
+        slackWorkspaceName: oauthResult.teamName,
+        orgId: isPlatformFlow ? state.orgId : null,
+        encryptedBotToken,
+        botUserId: oauthResult.botUserId,
+        installedByUserId: isPlatformFlow ? state.vm0UserId : null,
+      });
+
+      log.debug("New Slack workspace installed", {
+        workspaceId: oauthResult.teamId,
+        orgId: isPlatformFlow ? state.orgId : null,
+      });
+    }
+
+    // Platform flow: verify admin and create connection
+    if (state.orgId && state.vm0UserId) {
+      // Verify user is org admin
+      const member = await requireOrgMember(state.orgId, state.vm0UserId);
+      if (member.role !== "admin") {
+        return NextResponse.redirect(
+          `${platformUrl}/slack/failed?error=${encodeURIComponent("Only org admins can install Slack for an organization.")}`,
+        );
+      }
+
+      // Create connection (idempotent via unique constraint)
+      await db
+        .insert(slackOrgConnections)
+        .values({
+          slackUserId: oauthResult.authedUserId,
+          slackWorkspaceId: oauthResult.teamId,
+          vm0UserId: state.vm0UserId,
+          orgId: state.orgId,
+        })
+        .onConflictDoNothing();
+
+      return NextResponse.redirect(`${platformUrl}/zero/works`);
+    }
+
+    // Slack flow: redirect to success page
+    return NextResponse.redirect(
+      `${platformUrl}/slack/installed?workspace=${encodeURIComponent(oauthResult.teamName)}`,
+    );
+  } catch (err) {
+    log.error("Slack OAuth callback error", { error: err });
+    return NextResponse.redirect(
+      `${platformUrl}/slack/failed?error=${encodeURIComponent("Failed to complete Slack installation. Please try again.")}`,
+    );
+  }
+}

--- a/turbo/apps/web/app/api/slack/org/oauth/install/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/slack/org/oauth/install/__tests__/route.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi } from "vitest";
+import { GET } from "../route";
+import { createTestRequest } from "../../../../../../../src/__tests__/api-test-helpers";
+import { reloadEnv } from "../../../../../../../src/env";
+
+describe("/api/slack/org/oauth/install", () => {
+  it("should redirect to Slack OAuth URL with correct parameters", async () => {
+    const request = createTestRequest(
+      "http://localhost:3000/api/slack/org/oauth/install",
+    );
+    const response = await GET(request);
+
+    expect(response.status).toBe(307);
+
+    const locationHeader = response.headers.get("Location");
+    expect(locationHeader).toBeDefined();
+
+    const redirectUrl = new URL(locationHeader!);
+    expect(redirectUrl.origin).toBe("https://slack.com");
+    expect(redirectUrl.pathname).toBe("/oauth/v2/authorize");
+    expect(redirectUrl.searchParams.get("client_id")).toBe(
+      "test-slack-client-id",
+    );
+    expect(redirectUrl.searchParams.get("redirect_uri")).toBe(
+      "https://test.example.com/api/slack/org/oauth/callback",
+    );
+  });
+
+  it("should include all required bot scopes", async () => {
+    const request = createTestRequest(
+      "http://localhost:3000/api/slack/org/oauth/install",
+    );
+    const response = await GET(request);
+
+    const locationHeader = response.headers.get("Location");
+    const redirectUrl = new URL(locationHeader!);
+    const scopes = redirectUrl.searchParams.get("scope")!.split(",");
+
+    expect(scopes).toContain("app_mentions:read");
+    expect(scopes).toContain("assistant:write");
+    expect(scopes).toContain("chat:write");
+    expect(scopes).toContain("channels:history");
+    expect(scopes).toContain("im:history");
+    expect(scopes).toContain("commands");
+    expect(scopes).toContain("users:read");
+    expect(scopes).toContain("files:read");
+    expect(scopes).toContain("files:write");
+  });
+
+  it("should pass orgId and vm0UserId in state for platform flow", async () => {
+    const request = createTestRequest(
+      "http://localhost:3000/api/slack/org/oauth/install?orgId=org_123&vm0UserId=user_456",
+    );
+    const response = await GET(request);
+
+    const locationHeader = response.headers.get("Location");
+    const redirectUrl = new URL(locationHeader!);
+    const state = JSON.parse(redirectUrl.searchParams.get("state")!);
+
+    expect(state.orgId).toBe("org_123");
+    expect(state.vm0UserId).toBe("user_456");
+  });
+
+  it("should not include state parameter for slack-initiated flow", async () => {
+    const request = createTestRequest(
+      "http://localhost:3000/api/slack/org/oauth/install",
+    );
+    const response = await GET(request);
+
+    const locationHeader = response.headers.get("Location");
+    const redirectUrl = new URL(locationHeader!);
+
+    expect(redirectUrl.searchParams.get("state")).toBeNull();
+  });
+
+  it("should use SLACK_REDIRECT_BASE_URL for redirect_uri when configured", async () => {
+    vi.stubEnv("SLACK_REDIRECT_BASE_URL", "https://tunnel.example.com");
+    reloadEnv();
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/slack/org/oauth/install",
+    );
+    const response = await GET(request);
+
+    const locationHeader = response.headers.get("Location");
+    const redirectUrl = new URL(locationHeader!);
+    expect(redirectUrl.searchParams.get("redirect_uri")).toBe(
+      "https://tunnel.example.com/api/slack/org/oauth/callback",
+    );
+  });
+
+  it("should return 503 when Slack is not configured", async () => {
+    vi.stubEnv("SLACK_CLIENT_ID", "");
+    reloadEnv();
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/slack/org/oauth/install",
+    );
+    const response = await GET(request);
+
+    expect(response.status).toBe(503);
+    const data = await response.json();
+    expect(data.error).toBe("Slack integration is not configured");
+  });
+});

--- a/turbo/apps/web/app/api/slack/org/oauth/install/route.ts
+++ b/turbo/apps/web/app/api/slack/org/oauth/install/route.ts
@@ -1,0 +1,68 @@
+import { NextResponse } from "next/server";
+import { env } from "../../../../../../src/env";
+import { getSlackRedirectBaseUrl } from "../../../../../../src/lib/slack";
+
+/**
+ * Org-aware Slack OAuth Install Endpoint
+ *
+ * GET /api/slack/org/oauth/install
+ *
+ * Redirects to Slack's OAuth authorization page.
+ *
+ * Query params:
+ * - orgId:     VM0 org ID (Platform flow — admin installs from platform)
+ * - vm0UserId: VM0 user ID (Platform flow)
+ *
+ * Without orgId: Slack-initiated install → installation created with org_id = NULL.
+ */
+
+const SLACK_OAUTH_URL = "https://slack.com/oauth/v2/authorize";
+
+const BOT_SCOPES = [
+  "app_mentions:read",
+  "assistant:write",
+  "chat:write",
+  "channels:history",
+  "groups:history",
+  "im:history",
+  "im:write",
+  "commands",
+  "users:read",
+  "reactions:write",
+  "files:read",
+  "files:write",
+].join(",");
+
+export async function GET(request: Request) {
+  const { SLACK_CLIENT_ID } = env();
+
+  if (!SLACK_CLIENT_ID) {
+    return NextResponse.json(
+      { error: "Slack integration is not configured" },
+      { status: 503 },
+    );
+  }
+
+  const url = new URL(request.url);
+  const baseUrl = getSlackRedirectBaseUrl(request.url);
+  const redirectUri = `${baseUrl}/api/slack/org/oauth/callback`;
+
+  const orgId = url.searchParams.get("orgId");
+  const vm0UserId = url.searchParams.get("vm0UserId");
+
+  const stateObj: { orgId?: string; vm0UserId?: string } = {};
+  if (orgId) stateObj.orgId = orgId;
+  if (vm0UserId) stateObj.vm0UserId = vm0UserId;
+  const state =
+    Object.keys(stateObj).length > 0 ? JSON.stringify(stateObj) : "";
+
+  const authUrl = new URL(SLACK_OAUTH_URL);
+  authUrl.searchParams.set("client_id", SLACK_CLIENT_ID);
+  authUrl.searchParams.set("scope", BOT_SCOPES);
+  authUrl.searchParams.set("redirect_uri", redirectUri);
+  if (state) {
+    authUrl.searchParams.set("state", state);
+  }
+
+  return NextResponse.redirect(authUrl.toString());
+}

--- a/turbo/apps/web/src/__tests__/api-test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers.ts
@@ -25,6 +25,8 @@ import { storages, storageVersions } from "../db/schema/storage";
 import { usageDaily } from "../db/schema/usage-daily";
 import { slackComposeRequests } from "../db/schema/slack-compose-request";
 import { slackInstallations } from "../db/schema/slack-installation";
+import { slackOrgInstallations } from "../db/schema/slack-org-installation";
+import { slackOrgConnections } from "../db/schema/slack-org-connection";
 import { githubInstallations } from "../db/schema/github-installation";
 import { githubUserLinks } from "../db/schema/github-user-link";
 import { githubIssueSessions } from "../db/schema/github-issue-session";
@@ -2232,6 +2234,46 @@ export async function findTestSlackInstallation(workspaceId: string) {
     .where(eq(slackInstallations.slackWorkspaceId, workspaceId))
     .limit(1);
   return row;
+}
+
+export async function findTestSlackOrgInstallation(workspaceId: string) {
+  const [row] = await globalThis.services.db
+    .select()
+    .from(slackOrgInstallations)
+    .where(eq(slackOrgInstallations.slackWorkspaceId, workspaceId))
+    .limit(1);
+  return row;
+}
+
+export async function findTestSlackOrgConnection(
+  slackUserId: string,
+  workspaceId: string,
+) {
+  const [row] = await globalThis.services.db
+    .select()
+    .from(slackOrgConnections)
+    .where(
+      and(
+        eq(slackOrgConnections.slackUserId, slackUserId),
+        eq(slackOrgConnections.slackWorkspaceId, workspaceId),
+      ),
+    );
+  return row;
+}
+
+export async function findTestSlackOrgConnections(
+  slackUserId: string,
+  workspaceId: string,
+) {
+  return globalThis.services.db
+    .select()
+    .from(slackOrgConnections)
+    .where(
+      and(
+        eq(slackOrgConnections.slackUserId, slackUserId),
+        eq(slackOrgConnections.slackWorkspaceId, workspaceId),
+      ),
+    );
 }
 
 /**

--- a/turbo/apps/web/src/__tests__/clerk-mock.ts
+++ b/turbo/apps/web/src/__tests__/clerk-mock.ts
@@ -208,12 +208,14 @@ export function mockClerk(options: {
             // Return members of this org.
             // For clerkOrgs: session user is a member.
             // For createdOrgs: the creator is a member (regardless of session).
-            const inClerkOrgs = clerkOrgs.some((o) => o.id === organizationId);
-            if (inClerkOrgs && options.userId) {
+            const matchedClerkOrg = clerkOrgs.find(
+              (o) => o.id === organizationId,
+            );
+            if (matchedClerkOrg && options.userId) {
               return Promise.resolve({
                 data: [
                   {
-                    role: "org:admin",
+                    role: matchedClerkOrg.role ?? "org:admin",
                     publicUserData: { userId: options.userId },
                     publicMetadata,
                     createdAt: Date.now(),


### PR DESCRIPTION
## Summary
- Implements org-aware Slack OAuth install route (`GET /api/slack/org/oauth/install`) that redirects to Slack authorization with orgId/vm0UserId in state
- Implements org-aware Slack OAuth callback route (`GET /api/slack/org/oauth/callback`) that handles token exchange, installation upsert, admin verification, and connection creation
- Adds test helpers `findTestSlackOrgInstallation`, `findTestSlackOrgConnection`, `findTestSlackOrgConnections` to api-test-helpers

Closes #4667

## Test plan
- [x] Install route redirects to Slack OAuth URL with correct parameters and scopes
- [x] Install route passes orgId/vm0UserId in state for platform flow
- [x] Install route omits state for slack-initiated flow
- [x] Callback handles error parameter redirect
- [x] Callback returns 400 for missing code
- [x] Callback creates installation with org_id for platform flow (first install)
- [x] Callback rejects non-org-member users
- [x] Callback creates installation with null org_id for slack-initiated flow
- [x] Callback updates bot token on re-install, preserves org binding
- [x] Callback creates connection idempotently (onConflictDoNothing)
- [x] Callback redirects to failed page when OAuth exchange fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)