### PR TITLE
refactor: eliminate remaining scope references

### DIFF
--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -660,7 +660,7 @@ mod tests {
             api_start_time: None,
             user_timezone: None,
             agent_name: None,
-            agent_scope_slug: None,
+            agent_org_slug: None,
             memory_name: None,
             experimental_services: None,
         }

--- a/crates/runner/src/provider/local.rs
+++ b/crates/runner/src/provider/local.rs
@@ -156,7 +156,7 @@ impl JobProvider for LocalProvider {
             api_start_time: None,
             user_timezone: req.user_timezone,
             agent_name: None,
-            agent_scope_slug: None,
+            agent_org_slug: None,
             memory_name: None,
             experimental_services: None,
         })

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -67,10 +67,10 @@ pub struct ExecutionContext {
     #[allow(dead_code)]
     #[serde(default)]
     pub agent_name: Option<String>,
-    // Not yet used by runner — org/agent slug for scoping
+    // Not yet used by runner — org slug for agent
     #[allow(dead_code)]
     #[serde(default)]
-    pub agent_scope_slug: Option<String>,
+    pub agent_org_slug: Option<String>,
     // Not yet used by runner — memory storage name for first-run init
     #[allow(dead_code)]
     #[serde(default)]

--- a/turbo/apps/cli/src/lib/api/config.ts
+++ b/turbo/apps/cli/src/lib/api/config.ts
@@ -9,13 +9,6 @@ interface CliConfig {
   activeOrg?: string;
 }
 
-/**
- * Legacy config shape for migration from activeScope to activeOrg
- */
-interface LegacyCliConfig extends CliConfig {
-  activeScope?: string;
-}
-
 // Use functions for lazy evaluation (enables testing with mocked homedir)
 function getConfigDir(): string {
   return join(homedir(), ".vm0");
@@ -31,15 +24,7 @@ export async function loadConfig(): Promise<CliConfig> {
     return {};
   }
   const content = await readFile(configFile, "utf8");
-  const raw = JSON.parse(content) as LegacyCliConfig;
-
-  // Migrate activeScope → activeOrg
-  if (raw.activeScope !== undefined && raw.activeOrg === undefined) {
-    raw.activeOrg = raw.activeScope;
-    delete raw.activeScope;
-  }
-
-  return raw;
+  return JSON.parse(content) as CliConfig;
 }
 
 export async function saveConfig(config: CliConfig): Promise<void> {

--- a/turbo/apps/cli/src/lib/api/core/http.ts
+++ b/turbo/apps/cli/src/lib/api/core/http.ts
@@ -53,9 +53,9 @@ async function getRawHeaders(): Promise<Record<string, string>> {
 export async function httpGet(path: string): Promise<Response> {
   const baseUrl = await getBaseUrl();
   const headers = await getRawHeaders();
-  const scopedPath = await appendOrgParam(path);
+  const orgPath = await appendOrgParam(path);
 
-  return fetch(`${baseUrl}${scopedPath}`, {
+  return fetch(`${baseUrl}${orgPath}`, {
     method: "GET",
     headers,
   });
@@ -67,9 +67,9 @@ export async function httpGet(path: string): Promise<Response> {
 export async function httpPost(path: string, body: unknown): Promise<Response> {
   const baseUrl = await getBaseUrl();
   const headers = await getRawHeaders();
-  const scopedPath = await appendOrgParam(path);
+  const orgPath = await appendOrgParam(path);
 
-  return fetch(`${baseUrl}${scopedPath}`, {
+  return fetch(`${baseUrl}${orgPath}`, {
     method: "POST",
     headers: {
       ...headers,
@@ -85,9 +85,9 @@ export async function httpPost(path: string, body: unknown): Promise<Response> {
 export async function httpDelete(path: string): Promise<Response> {
   const baseUrl = await getBaseUrl();
   const headers = await getRawHeaders();
-  const scopedPath = await appendOrgParam(path);
+  const orgPath = await appendOrgParam(path);
 
-  return fetch(`${baseUrl}${scopedPath}`, {
+  return fetch(`${baseUrl}${orgPath}`, {
     method: "DELETE",
     headers,
   });

--- a/turbo/apps/docs/content/docs/reference/configuration/vm0-yaml.mdx
+++ b/turbo/apps/docs/content/docs/reference/configuration/vm0-yaml.mdx
@@ -71,7 +71,7 @@ Each agent key must be a valid agent name: 3-64 characters, starting and ending 
 | `skills`                 | array  | No       | `[]`           | List of skill references. Supports bare names (e.g., `"slack"`) which resolve to `https://github.com/vm0-ai/vm0-skills/tree/main/slack`, or full GitHub URLs. See [Skills](/docs/core-concept/skills) |
 | `volumes`                | array  | No       | `[]`           | Volume mounts in format `name:path`. See [Volume](/docs/core-concept/volume)                      |
 | `environment`            | object | No       | `{}`           | Environment variables. See [Environment Variables](/docs/core-concept/environment-variable)       |
-| `experimental_runner`    | object | No       | -              | Self-hosted runner configuration. Object with `group` field in `scope/name` format (e.g., `acme/production`) |
+| `experimental_runner`    | object | No       | -              | Self-hosted runner configuration. Object with `group` field in `org/name` format (e.g., `acme/production`) |
 | `experimental_firewall`  | object | No       | -              | Firewall configuration for network access control. See [Firewall](/docs/experimental/firewall) for details |
 
 ## Volume Fields

--- a/turbo/apps/platform/src/signals/agent-detail/agent-detail.ts
+++ b/turbo/apps/platform/src/signals/agent-detail/agent-detail.ts
@@ -67,7 +67,7 @@ export const fetchAgentDetail$ = command(async ({ get, set }) => {
 
     const params = new URLSearchParams({ name: agentName });
     if (org) {
-      params.set("scope", org);
+      params.set("org", org);
     }
 
     const response = await fetchFn(`/api/agent/composes?${params.toString()}`);

--- a/turbo/apps/platform/src/signals/agent-detail/agent-logs.ts
+++ b/turbo/apps/platform/src/signals/agent-detail/agent-logs.ts
@@ -34,7 +34,7 @@ export const {
       name,
     });
     if (org) {
-      params.set("scope", org);
+      params.set("org", org);
     }
     if (cursor) {
       params.set("cursor", cursor);

--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-job-detail.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-job-detail.test.ts
@@ -241,10 +241,10 @@ describe("zero-job-detail signals", () => {
         http.get("http://localhost:3000/api/agent/composes", ({ request }) => {
           const url = new URL(request.url);
           const name = url.searchParams.get("name");
-          const scope = url.searchParams.get("scope");
+          const org = url.searchParams.get("org");
 
           expect(name).toBe("sub-agent");
-          expect(scope).toBe("my-org");
+          expect(org).toBe("my-org");
 
           return HttpResponse.json({
             ...mockAgentResponse(),

--- a/turbo/apps/platform/src/signals/zero-page/zero-job-detail.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-job-detail.ts
@@ -62,11 +62,11 @@ const fetchZeroJobDetail$ = command(async ({ get, set }) => {
     const slashIndex = name.indexOf("/");
     const isOwner = slashIndex === -1;
     const agentName = isOwner ? name : name.slice(slashIndex + 1);
-    const scope = isOwner ? undefined : name.slice(0, slashIndex);
+    const org = isOwner ? undefined : name.slice(0, slashIndex);
 
     const params = new URLSearchParams({ name: agentName });
-    if (scope) {
-      params.set("scope", scope);
+    if (org) {
+      params.set("org", org);
     }
 
     const response = await fetchFn(`/api/agent/composes?${params.toString()}`);

--- a/turbo/apps/web/app/api/agent/runs/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/__tests__/route.test.ts
@@ -395,7 +395,7 @@ describe("POST /api/agent/runs - Internal Runs API", () => {
       mockClerk({ userId: ownerUser.userId });
     });
 
-    it("should resolve model provider from Runtime Scope for shared agent", async () => {
+    it("should resolve model provider from Runtime Org for shared agent", async () => {
       // User A (owner) creates an agent without explicit API key
       const ownerUser = user;
       const { composeId: sharedComposeId } = await createTestCompose(

--- a/turbo/apps/web/app/api/agent/schedules/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/schedules/__tests__/route.test.ts
@@ -328,10 +328,10 @@ describe("POST /api/agent/schedules - Deploy Schedule", () => {
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
             composeId: otherComposeId,
-            name: "cross-scope-schedule",
+            name: "cross-org-schedule",
             cronExpression: "0 9 * * *",
             timezone: "UTC",
-            prompt: "Test cross-scope",
+            prompt: "Test cross-org",
           }),
         },
       );

--- a/turbo/apps/web/app/api/cli/auth/test-token/route.ts
+++ b/turbo/apps/web/app/api/cli/auth/test-token/route.ts
@@ -44,7 +44,7 @@ function isTestTokenAllowed(request: Request): boolean {
  *
  * If the user has no Clerk org yet, creates an org_cache entry with a sentinel orgId.
  */
-async function ensureTestScope(userId: string): Promise<{ orgId: string }> {
+async function ensureTestOrg(userId: string): Promise<{ orgId: string }> {
   try {
     const { org } = await getDefaultOrg(userId);
     return { orgId: org.orgId };
@@ -89,7 +89,7 @@ export async function POST(request: Request) {
   }
 
   // Auto-create org if user doesn't have one (creates real Clerk org or sentinel)
-  const { orgId } = await ensureTestScope(userId);
+  const { orgId } = await ensureTestOrg(userId);
 
   // Generate CLI token with org binding
   const randomBytes = crypto.randomBytes(32);

--- a/turbo/apps/web/app/api/integrations/github/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/integrations/github/__tests__/route.test.ts
@@ -8,7 +8,7 @@ import {
   insertTestGitHubInstallationWithAdmin,
   insertTestGitHubUserLink,
   findTestGitHubInstallationById,
-  findTestComposeWithScope,
+  findTestComposeWithOrg,
 } from "../../../../../src/__tests__/api-test-helpers";
 import {
   testContext,
@@ -446,7 +446,7 @@ describe("/api/integrations/github", () => {
       mockClerk({ userId });
 
       // Look up the other org's slug for the scoped name
-      const otherCompose = await findTestComposeWithScope(otherComposeId);
+      const otherCompose = await findTestComposeWithOrg(otherComposeId);
 
       const request = createTestRequest(
         "http://localhost:3000/api/integrations/github",

--- a/turbo/apps/web/app/api/integrations/slack/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/integrations/slack/__tests__/route.test.ts
@@ -14,7 +14,7 @@ import {
   createTestCompose,
   createTestOrg,
   findTestAgentPermissions,
-  findTestComposeWithScope,
+  findTestComposeWithOrg,
   insertTestAgentPermission,
 } from "../../../../../src/__tests__/api-test-helpers";
 import { uniqueId } from "../../../../../src/__tests__/test-helpers";
@@ -315,7 +315,7 @@ describe("/api/integrations/slack", () => {
       mockClerk({ userId: userLink.vm0UserId });
 
       // Find the org slug and name used for the default agent
-      const defaultCompose = await findTestComposeWithScope(
+      const defaultCompose = await findTestComposeWithOrg(
         installation.defaultComposeId,
       );
 
@@ -370,7 +370,7 @@ describe("/api/integrations/slack", () => {
       mockClerk({ userId: userLink.vm0UserId });
 
       // Look up the other org's slug for the scoped name
-      const otherCompose = await findTestComposeWithScope(otherComposeId);
+      const otherCompose = await findTestComposeWithOrg(otherComposeId);
 
       const request = new Request(
         "http://localhost:3000/api/integrations/slack",

--- a/turbo/apps/web/app/api/integrations/slack/link/route.ts
+++ b/turbo/apps/web/app/api/integrations/slack/link/route.ts
@@ -12,7 +12,7 @@ import {
   refreshAppHome,
 } from "../../../../../src/lib/slack";
 import {
-  ensureScopeAndArtifact,
+  ensureOrgAndArtifact,
   getWorkspaceAgent,
 } from "../../../../../src/lib/slack/handlers/shared";
 import { getUserEmail } from "../../../../../src/lib/auth/get-user-email";
@@ -279,7 +279,7 @@ export async function POST(request: Request) {
   }
 
   // Ensure org and artifact exist for the user
-  await ensureScopeAndArtifact(userId);
+  await ensureOrgAndArtifact(userId);
 
   // Create the link
   await globalThis.services.db

--- a/turbo/apps/web/app/api/integrations/slack/link/route.ts
+++ b/turbo/apps/web/app/api/integrations/slack/link/route.ts
@@ -130,12 +130,12 @@ async function buildAgentFields(
 
   let agents: Array<{ id: string; name: string }> = [];
   if (isAdmin) {
-    const defaultScope = await getDefaultOrgByUserId(userId);
-    if (defaultScope) {
+    const defaultOrg = await getDefaultOrgByUserId(userId);
+    if (defaultOrg) {
       const userAgents = await globalThis.services.db
         .select({ id: agentComposes.id, name: agentComposes.name })
         .from(agentComposes)
-        .where(eq(agentComposes.orgId, defaultScope.orgId));
+        .where(eq(agentComposes.orgId, defaultOrg.orgId));
 
       // Prepend default agent, deduplicate by id
       const seen = new Set<string>();

--- a/turbo/apps/web/app/api/integrations/telegram/link/route.ts
+++ b/turbo/apps/web/app/api/integrations/telegram/link/route.ts
@@ -7,7 +7,7 @@ import { getUserId } from "../../../../../src/lib/auth/get-user-id";
 import { telegramUserLinks } from "../../../../../src/db/schema/telegram-user-link";
 import { telegramInstallations } from "../../../../../src/db/schema/telegram-installation";
 import {
-  ensureScopeAndArtifact,
+  ensureOrgAndArtifact,
   getWorkspaceAgent,
 } from "../../../../../src/lib/telegram/handlers/shared";
 import { decryptSecretValue } from "../../../../../src/lib/crypto/secrets-encryption";
@@ -231,7 +231,7 @@ export async function POST(request: Request) {
         ],
         set: { vm0UserId: userId, updatedAt: new Date() },
       });
-    await ensureScopeAndArtifact(userId);
+    await ensureOrgAndArtifact(userId);
 
     return NextResponse.json({
       botUsername: installation.botUsername,
@@ -283,7 +283,7 @@ export async function POST(request: Request) {
         ],
         set: { vm0UserId: userId, updatedAt: new Date() },
       });
-    await ensureScopeAndArtifact(userId);
+    await ensureOrgAndArtifact(userId);
 
     // Send success message to user in Telegram (non-blocking)
     const client = createTelegramClient(botToken);

--- a/turbo/apps/web/app/api/org/members/route.ts
+++ b/turbo/apps/web/app/api/org/members/route.ts
@@ -93,7 +93,7 @@ export async function DELETE(request: Request) {
     );
     await removeMember(userId, org.orgId, member.role, body.email);
     return NextResponse.json({
-      message: `Removed ${body.email} from scope`,
+      message: `Removed ${body.email} from org`,
     });
   } catch (error) {
     if (isBadRequest(error)) {

--- a/turbo/apps/web/app/api/org/route.ts
+++ b/turbo/apps/web/app/api/org/route.ts
@@ -12,7 +12,7 @@ import type { ResolvedOrg } from "../../../src/lib/org/resolve-org";
 import { logger } from "../../../src/lib/logger";
 import { isBadRequest, isForbidden, isNotFound } from "../../../src/lib/errors";
 
-const log = logger("api:scope");
+const log = logger("api:org");
 
 function resolvedOrgToResponse(resolved: ResolvedOrg) {
   return {
@@ -91,9 +91,9 @@ const router = tsr.router(orgContract, {
     }
 
     try {
-      const scope = await updateOrgSlug(resolvedOrg.orgId, slug, userId, force);
+      const org = await updateOrgSlug(resolvedOrg.orgId, slug, userId, force);
 
-      return { status: 200 as const, body: resolvedOrgToResponse(scope) };
+      return { status: 200 as const, body: resolvedOrgToResponse(org) };
     } catch (error) {
       if (isBadRequest(error)) {
         // Check if it's a conflict error (slug already exists)
@@ -119,7 +119,7 @@ const router = tsr.router(orgContract, {
 });
 
 /**
- * Custom error handler for scope API
+ * Custom error handler for org API
  */
 function errorHandler(err: unknown): TsRestResponse | void {
   // Handle ts-rest RequestValidationError

--- a/turbo/apps/web/app/api/runners/jobs/[id]/claim/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/runners/jobs/[id]/claim/__tests__/route.test.ts
@@ -6,7 +6,7 @@ import {
   createTestCliToken,
   createTestCompose,
   createTestRunnerJob,
-  findTestComposeWithScope,
+  findTestComposeWithOrg,
 } from "../../../../../../../src/__tests__/api-test-helpers";
 import {
   testContext,
@@ -234,10 +234,10 @@ describe("POST /api/runners/jobs/:id/claim", () => {
   });
 
   describe("Claim flow - Agent metadata", () => {
-    it("should return agentName and agentScopeSlug in claim response", async () => {
+    it("should return agentName and agentOrgSlug in claim response", async () => {
       // Create compose and look up org slug
       const { composeId, versionId } = await createTestCompose("test-agent");
-      const composeInfo = await findTestComposeWithScope(composeId);
+      const composeInfo = await findTestComposeWithOrg(composeId);
       const orgSlug = composeInfo!.orgSlug;
 
       // Create runner job with agent metadata in stored context
@@ -247,7 +247,7 @@ describe("POST /api/runners/jobs/:id/claim", () => {
         `${orgSlug}/default`,
         {
           agentName: "test-agent",
-          agentScopeSlug: orgSlug,
+          agentOrgSlug: orgSlug,
         },
       );
 
@@ -270,14 +270,14 @@ describe("POST /api/runners/jobs/:id/claim", () => {
 
       const data = await response.json();
       expect(data.agentName).toBe("test-agent");
-      expect(data.agentScopeSlug).toBe(orgSlug);
+      expect(data.agentOrgSlug).toBe(orgSlug);
     });
 
-    it("should omit agentName and agentScopeSlug when not set in stored context", async () => {
+    it("should omit agentName and agentOrgSlug when not set in stored context", async () => {
       // Create compose and look up org slug
       const { composeId, versionId } =
         await createTestCompose("test-agent-no-meta");
-      const composeInfo = await findTestComposeWithScope(composeId);
+      const composeInfo = await findTestComposeWithOrg(composeId);
       const orgSlug = composeInfo!.orgSlug;
 
       // Create runner job WITHOUT agent metadata
@@ -306,7 +306,7 @@ describe("POST /api/runners/jobs/:id/claim", () => {
 
       const data = await response.json();
       expect(data.agentName).toBeUndefined();
-      expect(data.agentScopeSlug).toBeUndefined();
+      expect(data.agentOrgSlug).toBeUndefined();
     });
   });
 
@@ -314,7 +314,7 @@ describe("POST /api/runners/jobs/:id/claim", () => {
     it("should only include secret values present in environment", async () => {
       const { composeId, versionId } =
         await createTestCompose("test-secret-filter");
-      const composeInfo = await findTestComposeWithScope(composeId);
+      const composeInfo = await findTestComposeWithOrg(composeId);
       const orgSlug = composeInfo!.orgSlug;
 
       const encryptedSecrets = encryptSecretsMap(
@@ -366,7 +366,7 @@ describe("POST /api/runners/jobs/:id/claim", () => {
 
     it("should return empty array when no secrets match environment", async () => {
       const { composeId, versionId } = await createTestCompose("test-no-match");
-      const composeInfo = await findTestComposeWithScope(composeId);
+      const composeInfo = await findTestComposeWithOrg(composeId);
       const orgSlug = composeInfo!.orgSlug;
 
       const encryptedSecrets = encryptSecretsMap(
@@ -407,7 +407,7 @@ describe("POST /api/runners/jobs/:id/claim", () => {
     it("should return null when no encrypted secrets exist", async () => {
       const { composeId, versionId } =
         await createTestCompose("test-no-secrets");
-      const composeInfo = await findTestComposeWithScope(composeId);
+      const composeInfo = await findTestComposeWithOrg(composeId);
       const orgSlug = composeInfo!.orgSlug;
 
       const { runId } = await createTestRunnerJob(

--- a/turbo/apps/web/app/api/runners/jobs/[id]/claim/route.ts
+++ b/turbo/apps/web/app/api/runners/jobs/[id]/claim/route.ts
@@ -207,7 +207,7 @@ const router = tsr.router(runnersJobClaimContract, {
         apiStartTime: storedContext.apiStartTime,
         userTimezone: storedContext.userTimezone,
         agentName: storedContext.agentName,
-        agentScopeSlug: storedContext.agentScopeSlug,
+        agentOrgSlug: storedContext.agentOrgSlug,
         memoryName: storedContext.memoryName,
       },
     };

--- a/turbo/apps/web/app/api/secrets/[name]/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/secrets/[name]/__tests__/route.test.ts
@@ -195,7 +195,7 @@ describe("DELETE /api/secrets/:name - Delete Secret", () => {
   });
 
   it("should return 404 for user without org", async () => {
-    mockClerk({ userId: `user-no-scope-${Date.now()}` });
+    mockClerk({ userId: `user-no-org-${Date.now()}` });
 
     const request = createTestRequest(
       "http://localhost:3000/api/secrets/ANY_KEY",

--- a/turbo/apps/web/app/api/slack/oauth/callback/route.ts
+++ b/turbo/apps/web/app/api/slack/oauth/callback/route.ts
@@ -15,7 +15,7 @@ import {
 } from "../../../../../src/lib/crypto/secrets-encryption";
 import { slackInstallations } from "../../../../../src/db/schema/slack-installation";
 import { slackUserLinks } from "../../../../../src/db/schema/slack-user-link";
-import { ensureScopeAndArtifact } from "../../../../../src/lib/slack/handlers/shared";
+import { ensureOrgAndArtifact } from "../../../../../src/lib/slack/handlers/shared";
 import { getUserEmail } from "../../../../../src/lib/auth/get-user-email";
 import { addPermission } from "../../../../../src/lib/agent/permission-service";
 import { getPlatformUrl } from "../../../../../src/lib/url";
@@ -263,7 +263,7 @@ async function createUserLink(
   if (existing) return;
 
   // Ensure org and artifact exist
-  await ensureScopeAndArtifact(vm0UserId);
+  await ensureOrgAndArtifact(vm0UserId);
 
   // Create the link
   await db.insert(slackUserLinks).values({

--- a/turbo/apps/web/app/api/variables/[name]/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/variables/[name]/__tests__/route.test.ts
@@ -194,7 +194,7 @@ describe("DELETE /api/variables/:name - Delete Variable", () => {
   });
 
   it("should return 404 for user without org", async () => {
-    mockClerk({ userId: `user-no-scope-${Date.now()}` });
+    mockClerk({ userId: `user-no-org-${Date.now()}` });
 
     const request = createTestRequest(
       "http://localhost:3000/api/variables/ANY_VAR",

--- a/turbo/apps/web/app/slack/link/actions.ts
+++ b/turbo/apps/web/app/slack/link/actions.ts
@@ -9,7 +9,7 @@ import { slackInstallations } from "../../../src/db/schema/slack-installation";
 import { decryptSecretValue } from "../../../src/lib/crypto/secrets-encryption";
 import { createSlackClient, refreshAppHome } from "../../../src/lib/slack";
 import {
-  ensureScopeAndArtifact,
+  ensureOrgAndArtifact,
   getWorkspaceAgent,
 } from "../../../src/lib/slack/handlers/shared";
 import { getUserEmail } from "../../../src/lib/auth/get-user-email";
@@ -140,7 +140,7 @@ export async function linkSlackAccount(
   }
 
   // Ensure org and artifact exist for the user
-  await ensureScopeAndArtifact(userId);
+  await ensureOrgAndArtifact(userId);
 
   // Create the link
   await globalThis.services.db

--- a/turbo/apps/web/src/__tests__/api-test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers.ts
@@ -2280,12 +2280,12 @@ export async function insertTestAgentPermission(
 }
 
 /**
- * Find a compose record with its scope details.
+ * Find a compose record with its org details.
  *
  * Direct DB read is required because the compose API does not expose
- * scope slug in its response — it only returns compose-level fields.
+ * org slug in its response — it only returns compose-level fields.
  */
-export async function findTestComposeWithScope(composeId: string) {
+export async function findTestComposeWithOrg(composeId: string) {
   const [row] = await globalThis.services.db
     .select({
       composeId: agentComposes.id,

--- a/turbo/apps/web/src/__tests__/setup.ts
+++ b/turbo/apps/web/src/__tests__/setup.ts
@@ -45,7 +45,7 @@ const resetEnv = vi.hoisted(() => {
     vi.stubEnv("NGROK_API_KEY", "test-ngrok-api-key");
     vi.stubEnv("NGROK_COMPUTER_CONNECTOR_DOMAIN", "computer.test.vm0.io");
     // Runner executor default group (runs dispatch to runner)
-    // Uses "vm0" scope which is hardcoded as public in validateRunnerGroupOrg
+    // Uses "vm0" org which is hardcoded as public in validateRunnerGroupOrg
     vi.stubEnv("RUNNER_DEFAULT_GROUP", "vm0/default");
     // API URL for compose job webhooks
     vi.stubEnv("VM0_API_URL", "http://localhost:3000");

--- a/turbo/apps/web/src/lib/run/executors/runner-executor.ts
+++ b/turbo/apps/web/src/lib/run/executors/runner-executor.ts
@@ -62,7 +62,7 @@ export async function executeRunnerJob(
     apiStartTime: context.apiStartTime ?? undefined,
     userTimezone: context.userTimezone ?? undefined,
     agentName: context.agentName ?? undefined,
-    agentScopeSlug: context.agentOrgSlug ?? undefined,
+    agentOrgSlug: context.agentOrgSlug ?? undefined,
     memoryName: context.memoryName ?? undefined,
   };
 

--- a/turbo/apps/web/src/lib/slack/handlers/shared.ts
+++ b/turbo/apps/web/src/lib/slack/handlers/shared.ts
@@ -206,7 +206,7 @@ export function buildAgentLogsUrl(agentName: string): string {
  * 1. Find-or-create storage record
  * 2. If no HEAD version, create an empty initial version (upload manifest to S3 + commit)
  */
-export async function ensureScopeAndArtifact(vm0UserId: string): Promise<void> {
+export async function ensureOrgAndArtifact(vm0UserId: string): Promise<void> {
   const org = await getDefaultOrgByUserId(vm0UserId);
   if (!org) return;
 

--- a/turbo/apps/web/src/lib/telegram/handlers/shared.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/shared.ts
@@ -241,7 +241,7 @@ async function completePendingLink(
 /**
  * Ensure scope and artifact storage exist for a user.
  */
-export async function ensureScopeAndArtifact(vm0UserId: string): Promise<void> {
+export async function ensureOrgAndArtifact(vm0UserId: string): Promise<void> {
   const org = await getDefaultOrgByUserId(vm0UserId);
   if (!org) return;
 

--- a/turbo/apps/web/src/lib/telegram/handlers/start.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/start.ts
@@ -5,7 +5,7 @@ import { decryptSecretValue } from "../../crypto/secrets-encryption";
 import { env } from "../../../env";
 import { createTelegramClient, sendMessage } from "../client";
 import {
-  ensureScopeAndArtifact,
+  ensureOrgAndArtifact,
   resolveUserLink,
   buildConnectUrl,
 } from "./shared";
@@ -121,7 +121,7 @@ export async function handleStartCommand(
     .onConflictDoNothing();
 
   // Auto-grant permission
-  await ensureScopeAndArtifact(payload.vm0UserId);
+  await ensureOrgAndArtifact(payload.vm0UserId);
 
   await sendMessage(
     client,

--- a/turbo/packages/core/src/__tests__/org-reference.spec.ts
+++ b/turbo/packages/core/src/__tests__/org-reference.spec.ts
@@ -18,7 +18,7 @@ describe("isLegacySystemTemplate", () => {
 
   it("returns false for non-vm0 prefix", () => {
     expect(isLegacySystemTemplate("my-image")).toBe(false);
-    expect(isLegacySystemTemplate("scope/vm0-image")).toBe(false);
+    expect(isLegacySystemTemplate("org/vm0-image")).toBe(false);
     expect(isLegacySystemTemplate("vm1-image")).toBe(false);
   });
 });

--- a/turbo/packages/core/src/contracts/runners.ts
+++ b/turbo/packages/core/src/contracts/runners.ts
@@ -154,9 +154,9 @@ export const storedExecutionContextSchema = z.object({
   apiStartTime: z.number().optional(),
   // User's timezone preference (IANA format, e.g., "Asia/Shanghai")
   userTimezone: z.string().optional(),
-  // Agent metadata for VM0_AGENT_NAME and VM0_AGENT_SCOPE env vars
+  // Agent metadata for VM0_AGENT_NAME and VM0_AGENT_ORG env vars
   agentName: z.string().optional(),
-  agentScopeSlug: z.string().optional(),
+  agentOrgSlug: z.string().optional(),
   // Memory storage name (for first-run when manifest.memory is null)
   memoryName: z.string().optional(),
   // Experimental services for proxy-side token replacement
@@ -194,7 +194,7 @@ export const executionContextSchema = z.object({
   userTimezone: z.string().optional(),
   // Agent metadata
   agentName: z.string().optional(),
-  agentScopeSlug: z.string().optional(),
+  agentOrgSlug: z.string().optional(),
   // Memory storage name (for first-run when manifest.memory is null)
   memoryName: z.string().optional(),
   // Experimental services for proxy-side token replacement

--- a/turbo/packages/core/src/contracts/secrets.ts
+++ b/turbo/packages/core/src/contracts/secrets.ts
@@ -68,7 +68,7 @@ export type SetSecretRequest = z.infer<typeof setSecretRequestSchema>;
 export const secretsMainContract = c.router({
   /**
    * GET /api/secrets
-   * List all secrets for the current user's scope (metadata only)
+   * List all secrets for the current user's org (metadata only)
    */
   list: {
     method: "GET",

--- a/turbo/packages/core/src/contracts/variables.ts
+++ b/turbo/packages/core/src/contracts/variables.ts
@@ -61,7 +61,7 @@ export type SetVariableRequest = z.infer<typeof setVariableRequestSchema>;
 export const variablesMainContract = c.router({
   /**
    * GET /api/variables
-   * List all variables for the current user's scope (includes values)
+   * List all variables for the current user's org (includes values)
    */
   list: {
     method: "GET",


### PR DESCRIPTION
## Summary

Closes #4696

- Rename `ensureScopeAndArtifact` → `ensureOrgAndArtifact` and `ensureTestScope` → `ensureTestOrg` across web app
- Rename scope variables and strings to org in API routes (logger, comments, error messages)
- Remove CLI `activeScope` legacy migration code and rename `scopedPath` → `orgPath`
- **Fix**: Platform was sending `?scope=` but API expects `?org=`, causing cross-org lookups to silently fail
- Rename `agentScopeSlug` → `agentOrgSlug` in TS contracts and `agent_scope_slug` → `agent_org_slug` in Rust runner (wire-format, both sides updated atomically)
- Rename `findTestComposeWithScope` → `findTestComposeWithOrg` and update all test scope references
- Update contract comments and documentation to use org terminology

## Test plan

- [x] All 3557 tests pass (307 test files)
- [x] Lint passes across all packages
- [x] TypeScript type checking passes for web, cli, platform, core
- [x] Cargo clippy passes for Rust crates
- [x] Knip finds no unused exports/dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)