### PR TITLE
refactor: fix remaining scope references in org route and test comments

### DIFF
--- a/turbo/apps/web/app/api/integrations/github/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/integrations/github/__tests__/route.test.ts
@@ -445,7 +445,7 @@ describe("/api/integrations/github", () => {
       // Switch back to original user
       mockClerk({ userId });
 
-      // Look up the other org's slug for the scoped name
+      // Look up the other org's slug for the org-qualified name
       const otherCompose = await findTestComposeWithOrg(otherComposeId);
 
       const request = createTestRequest(

--- a/turbo/apps/web/app/api/integrations/slack/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/integrations/slack/__tests__/route.test.ts
@@ -369,7 +369,7 @@ describe("/api/integrations/slack", () => {
       // Switch back to admin user
       mockClerk({ userId: userLink.vm0UserId });
 
-      // Look up the other org's slug for the scoped name
+      // Look up the other org's slug for the org-qualified name
       const otherCompose = await findTestComposeWithOrg(otherComposeId);
 
       const request = new Request(

--- a/turbo/apps/web/app/api/org/route.ts
+++ b/turbo/apps/web/app/api/org/route.ts
@@ -91,9 +91,9 @@ const router = tsr.router(orgContract, {
     }
 
     try {
-      const org = await updateOrgSlug(resolvedOrg.orgId, slug, userId, force);
+      const updatedOrg = await updateOrgSlug(resolvedOrg.orgId, slug, userId, force);
 
-      return { status: 200 as const, body: resolvedOrgToResponse(org) };
+      return { status: 200 as const, body: resolvedOrgToResponse(updatedOrg) };
     } catch (error) {
       if (isBadRequest(error)) {
         // Check if it's a conflict error (slug already exists)

--- a/turbo/apps/web/app/api/org/route.ts
+++ b/turbo/apps/web/app/api/org/route.ts
@@ -91,7 +91,12 @@ const router = tsr.router(orgContract, {
     }
 
     try {
-      const updatedOrg = await updateOrgSlug(resolvedOrg.orgId, slug, userId, force);
+      const updatedOrg = await updateOrgSlug(
+        resolvedOrg.orgId,
+        slug,
+        userId,
+        force,
+      );
 
       return { status: 200 as const, body: resolvedOrgToResponse(updatedOrg) };
     } catch (error) {


### PR DESCRIPTION
## Summary

- Rename `scope` variable to `updatedOrg` in org route PATCH handler
- Update "scoped name" comments to "org-qualified name" in Slack/GitHub integration test files

Follow-up to #4693 / #4700

## Test plan

- [x] Pre-commit hooks pass (prettier, knip, commitlint)
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)