### PR TITLE
feat(slack): add org-aware slack integration

### DIFF
--- a/turbo/apps/web/app/api/integrations/slack/org/connect/route.ts
+++ b/turbo/apps/web/app/api/integrations/slack/org/connect/route.ts
@@ -1,0 +1,212 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { eq, and } from "drizzle-orm";
+import { initServices } from "../../../../../../src/lib/init-services";
+import { getAuthContext } from "../../../../../../src/lib/auth/get-user-id";
+import { resolveOrg } from "../../../../../../src/lib/org/resolve-org";
+import { slackOrgInstallations } from "../../../../../../src/db/schema/slack-org-installation";
+import { slackOrgConnections } from "../../../../../../src/db/schema/slack-org-connection";
+import {
+  adminConnect,
+  memberConnect,
+} from "../../../../../../src/lib/slack-org/connect-service";
+import {
+  resolveDefaultComposeId,
+  getWorkspaceAgent,
+} from "../../../../../../src/lib/slack-org/handlers/shared";
+import { logger } from "../../../../../../src/lib/logger";
+
+const log = logger("api:slack-org:connect");
+
+const connectBodySchema = z.object({
+  workspaceId: z.string().min(1),
+  slackUserId: z.string().min(1),
+});
+
+/**
+ * GET /api/integrations/slack/org/connect
+ *
+ * Check connection status for the authenticated user.
+ */
+export async function GET(request: Request) {
+  initServices();
+
+  const authHeader = request.headers.get("authorization");
+  const authCtx = await getAuthContext(authHeader ?? undefined);
+  if (!authCtx) {
+    return NextResponse.json(
+      { error: { message: "Not authenticated", code: "UNAUTHORIZED" } },
+      { status: 401 },
+    );
+  }
+
+  const { userId, orgId: tokenOrgId } = authCtx;
+  const { org, member } = await resolveOrg(userId, null, null, tokenOrgId);
+
+  // Find user's connection in any workspace bound to this org
+  const [connection] = await globalThis.services.db
+    .select()
+    .from(slackOrgConnections)
+    .where(
+      and(
+        eq(slackOrgConnections.vm0UserId, userId),
+        eq(slackOrgConnections.orgId, org.orgId),
+      ),
+    )
+    .limit(1);
+
+  if (!connection) {
+    return NextResponse.json({
+      isConnected: false,
+      isAdmin: member.role === "admin",
+    });
+  }
+
+  // Get workspace info
+  const [installation] = await globalThis.services.db
+    .select()
+    .from(slackOrgInstallations)
+    .where(
+      eq(slackOrgInstallations.slackWorkspaceId, connection.slackWorkspaceId),
+    )
+    .limit(1);
+
+  // Get default agent name
+  let defaultAgentName: string | null = null;
+  const composeId = await resolveDefaultComposeId(org.orgId);
+  if (composeId) {
+    const agent = await getWorkspaceAgent(composeId);
+    defaultAgentName = agent?.name ?? null;
+  }
+
+  return NextResponse.json({
+    isConnected: true,
+    workspaceName: installation?.slackWorkspaceName ?? null,
+    isAdmin: member.role === "admin",
+    defaultAgentName,
+  });
+}
+
+/**
+ * POST /api/integrations/slack/org/connect
+ *
+ * Connect user to Slack workspace (admin or member flow).
+ */
+export async function POST(request: Request) {
+  initServices();
+
+  const authHeader = request.headers.get("authorization");
+  const authCtx = await getAuthContext(authHeader ?? undefined);
+  if (!authCtx) {
+    return NextResponse.json(
+      { error: { message: "Not authenticated", code: "UNAUTHORIZED" } },
+      { status: 401 },
+    );
+  }
+
+  const { userId, orgId: tokenOrgId } = authCtx;
+
+  const parseResult = connectBodySchema.safeParse(
+    await request.json().catch(() => undefined),
+  );
+  if (!parseResult.success) {
+    return NextResponse.json(
+      {
+        error: {
+          message: "Missing workspaceId or slackUserId",
+          code: "BAD_REQUEST",
+        },
+      },
+      { status: 400 },
+    );
+  }
+
+  const { workspaceId, slackUserId } = parseResult.data;
+
+  // Resolve org and check membership
+  const { org, member } = await resolveOrg(userId, null, null, tokenOrgId);
+
+  // Check installation exists
+  const [installation] = await globalThis.services.db
+    .select()
+    .from(slackOrgInstallations)
+    .where(eq(slackOrgInstallations.slackWorkspaceId, workspaceId))
+    .limit(1);
+
+  if (!installation) {
+    return NextResponse.json(
+      {
+        error: {
+          message: "Workspace not found. Please install the Slack app first.",
+          code: "NOT_FOUND",
+        },
+      },
+      { status: 404 },
+    );
+  }
+
+  try {
+    if (!installation.orgId) {
+      // Unbound workspace — requires admin
+      if (member.role !== "admin") {
+        return NextResponse.json(
+          {
+            error: {
+              message:
+                "Only org admins can connect an unconfigured workspace. Ask your org admin to connect first.",
+              code: "FORBIDDEN",
+            },
+          },
+          { status: 403 },
+        );
+      }
+
+      const result = await adminConnect({
+        userId,
+        orgId: org.orgId,
+        workspaceId,
+        slackUserId,
+      });
+
+      return NextResponse.json({
+        success: true,
+        connectionId: result.connection.id,
+        role: "admin",
+      });
+    }
+
+    // Already bound — member connect
+    if (installation.orgId !== org.orgId) {
+      return NextResponse.json(
+        {
+          error: {
+            message: "This workspace is connected to a different org",
+            code: "FORBIDDEN",
+          },
+        },
+        { status: 403 },
+      );
+    }
+
+    const result = await memberConnect({
+      userId,
+      orgId: org.orgId,
+      workspaceId,
+      slackUserId,
+    });
+
+    return NextResponse.json({
+      success: true,
+      connectionId: result.connection.id,
+      role: member.role,
+    });
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Connection failed";
+    log.error("Connect failed", { error, userId, workspaceId });
+    return NextResponse.json(
+      { error: { message, code: "INTERNAL_ERROR" } },
+      { status: 500 },
+    );
+  }
+}

--- a/turbo/apps/web/app/api/integrations/slack/org/connect/route.ts
+++ b/turbo/apps/web/app/api/integrations/slack/org/connect/route.ts
@@ -14,9 +14,6 @@ import {
   resolveDefaultComposeId,
   getWorkspaceAgent,
 } from "../../../../../../src/lib/slack-org/handlers/shared";
-import { logger } from "../../../../../../src/lib/logger";
-
-const log = logger("api:slack-org:connect");
 
 const connectBodySchema = z.object({
   workspaceId: z.string().min(1),
@@ -145,42 +142,14 @@ export async function POST(request: Request) {
     );
   }
 
-  try {
-    if (!installation.orgId) {
-      // Unbound workspace — requires admin
-      if (member.role !== "admin") {
-        return NextResponse.json(
-          {
-            error: {
-              message:
-                "Only org admins can connect an unconfigured workspace. Ask your org admin to connect first.",
-              code: "FORBIDDEN",
-            },
-          },
-          { status: 403 },
-        );
-      }
-
-      const result = await adminConnect({
-        userId,
-        orgId: org.orgId,
-        workspaceId,
-        slackUserId,
-      });
-
-      return NextResponse.json({
-        success: true,
-        connectionId: result.connection.id,
-        role: "admin",
-      });
-    }
-
-    // Already bound — member connect
-    if (installation.orgId !== org.orgId) {
+  if (!installation.orgId) {
+    // Unbound workspace — requires admin
+    if (member.role !== "admin") {
       return NextResponse.json(
         {
           error: {
-            message: "This workspace is connected to a different org",
+            message:
+              "Only org admins can connect an unconfigured workspace. Ask your org admin to connect first.",
             code: "FORBIDDEN",
           },
         },
@@ -188,7 +157,7 @@ export async function POST(request: Request) {
       );
     }
 
-    const result = await memberConnect({
+    const result = await adminConnect({
       userId,
       orgId: org.orgId,
       workspaceId,
@@ -198,15 +167,33 @@ export async function POST(request: Request) {
     return NextResponse.json({
       success: true,
       connectionId: result.connection.id,
-      role: member.role,
+      role: "admin",
     });
-  } catch (error) {
-    const message =
-      error instanceof Error ? error.message : "Connection failed";
-    log.error("Connect failed", { error, userId, workspaceId });
+  }
+
+  // Already bound — member connect
+  if (installation.orgId !== org.orgId) {
     return NextResponse.json(
-      { error: { message, code: "INTERNAL_ERROR" } },
-      { status: 500 },
+      {
+        error: {
+          message: "This workspace is connected to a different org",
+          code: "FORBIDDEN",
+        },
+      },
+      { status: 403 },
     );
   }
+
+  const result = await memberConnect({
+    userId,
+    orgId: org.orgId,
+    workspaceId,
+    slackUserId,
+  });
+
+  return NextResponse.json({
+    success: true,
+    connectionId: result.connection.id,
+    role: member.role,
+  });
 }

--- a/turbo/apps/web/app/api/internal/callbacks/slack/org/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/slack/org/route.ts
@@ -1,0 +1,334 @@
+import { NextRequest, NextResponse } from "next/server";
+import { eq, and, gte, desc } from "drizzle-orm";
+import { initServices } from "../../../../../../src/lib/init-services";
+import { verifyCallback } from "../../../../../../src/lib/callback";
+import { decryptSecretValue } from "../../../../../../src/lib/crypto/secrets-encryption";
+import { slackOrgInstallations } from "../../../../../../src/db/schema/slack-org-installation";
+import { slackOrgPendingQuestions } from "../../../../../../src/db/schema/slack-org-pending-question";
+import { agentSessions } from "../../../../../../src/db/schema/agent-session";
+import { agentRuns } from "../../../../../../src/db/schema/agent-run";
+import {
+  createSlackClient,
+  postMessage,
+  setThreadStatus,
+} from "../../../../../../src/lib/slack/client";
+import {
+  buildAgentResponseMessage,
+  buildAskUserQuestionBlocks,
+  detectDeepLinks,
+} from "../../../../../../src/lib/slack/blocks";
+import type { AskUserQuestion } from "../../../../../../src/lib/slack/blocks";
+import {
+  getRunResultData,
+  formatAskUserDenials,
+} from "../../../../../../src/lib/slack/handlers/run-agent";
+import {
+  saveThreadSession,
+  buildLogsUrl,
+} from "../../../../../../src/lib/slack-org/handlers/shared";
+import { getPlatformUrl } from "../../../../../../src/lib/url";
+import { env } from "../../../../../../src/env";
+import { logger } from "../../../../../../src/lib/logger";
+import type { WebClient } from "@slack/web-api";
+import type { PermissionDenial } from "../../../../../../src/lib/slack/handlers/run-agent";
+
+const log = logger("callback:slack-org");
+
+interface CallbackPayload {
+  workspaceId: string;
+  channelId: string;
+  threadTs: string;
+  messageTs: string;
+  connectionId: string;
+  orgId: string;
+  agentName: string;
+  composeId: string;
+  existingSessionId?: string;
+}
+
+function parsePayload(payload: unknown): CallbackPayload | null {
+  if (!payload || typeof payload !== "object") return null;
+  const p = payload as Record<string, unknown>;
+  if (
+    typeof p.workspaceId !== "string" ||
+    typeof p.channelId !== "string" ||
+    typeof p.threadTs !== "string" ||
+    typeof p.messageTs !== "string" ||
+    typeof p.connectionId !== "string" ||
+    typeof p.orgId !== "string" ||
+    typeof p.agentName !== "string" ||
+    typeof p.composeId !== "string"
+  ) {
+    return null;
+  }
+  return p as unknown as CallbackPayload;
+}
+
+function errorResponse(message: string, status: number): NextResponse {
+  return NextResponse.json({ error: message }, { status });
+}
+
+async function findNewSessionId(
+  userId: string,
+  composeId: string,
+  runCreatedAt: Date,
+): Promise<string | undefined> {
+  const [newSession] = await globalThis.services.db
+    .select({ id: agentSessions.id })
+    .from(agentSessions)
+    .where(
+      and(
+        eq(agentSessions.userId, userId),
+        eq(agentSessions.agentComposeId, composeId),
+        gte(agentSessions.updatedAt, runCreatedAt),
+      ),
+    )
+    .orderBy(desc(agentSessions.updatedAt))
+    .limit(1);
+  return newSession?.id;
+}
+
+/**
+ * Post an interactive Block Kit card for askUserQuestion denials.
+ */
+async function postAskUserInteractiveCard(
+  client: WebClient,
+  resultData: { askUserDenials: PermissionDenial[] },
+  payload: CallbackPayload,
+  runId: string,
+  resolvedSessionId: string | undefined,
+): Promise<void> {
+  const allQuestions: AskUserQuestion[] = [];
+  for (const denial of resultData.askUserDenials) {
+    const questions = denial.tool_input?.questions;
+    if (questions) {
+      allQuestions.push(...questions);
+    }
+  }
+
+  if (allQuestions.length === 0) {
+    return;
+  }
+
+  const expiresAt = new Date(Date.now() + 60 * 60 * 1000);
+  const [pending] = await globalThis.services.db
+    .insert(slackOrgPendingQuestions)
+    .values({
+      runId,
+      slackWorkspaceId: payload.workspaceId,
+      slackChannelId: payload.channelId,
+      slackThreadTs: payload.threadTs,
+      connectionId: payload.connectionId,
+      orgId: payload.orgId,
+      composeId: payload.composeId,
+      agentName: payload.agentName,
+      sessionId: resolvedSessionId,
+      questions: allQuestions,
+      expiresAt,
+    })
+    .returning({ id: slackOrgPendingQuestions.id });
+
+  if (!pending) {
+    return;
+  }
+
+  const fallbackText = formatAskUserDenials(resultData.askUserDenials);
+  const cardBlocks = buildAskUserQuestionBlocks(allQuestions, pending.id);
+
+  const cardResult = await postMessage(
+    client,
+    payload.channelId,
+    fallbackText ?? "The agent needs your input.",
+    { threadTs: payload.threadTs, blocks: cardBlocks },
+  );
+
+  if (cardResult.ts) {
+    await globalThis.services.db
+      .update(slackOrgPendingQuestions)
+      .set({ slackMessageTs: cardResult.ts })
+      .where(eq(slackOrgPendingQuestions.id, pending.id));
+  }
+}
+
+function buildResponseText(
+  status: string,
+  error: string | undefined,
+  resultData: Awaited<ReturnType<typeof getRunResultData>>,
+): string {
+  if (status !== "completed") {
+    return `Error: ${error ?? "Agent execution failed."}`;
+  }
+  if (resultData && resultData.askUserDenials.length > 0) {
+    return resultData.result ?? "";
+  }
+  return resultData?.result ?? "Task completed successfully.";
+}
+
+/**
+ * Save or update the org-aware thread session mapping.
+ * Returns the resolved session ID.
+ */
+async function saveOrgThreadSession(
+  payload: CallbackPayload,
+  runId: string,
+  status: string,
+): Promise<string | undefined> {
+  const {
+    connectionId,
+    channelId,
+    threadTs,
+    messageTs,
+    composeId,
+    existingSessionId,
+  } = payload;
+
+  const [run] = await globalThis.services.db
+    .select({ userId: agentRuns.userId, createdAt: agentRuns.createdAt })
+    .from(agentRuns)
+    .where(eq(agentRuns.id, runId))
+    .limit(1);
+
+  if (!run) {
+    return existingSessionId;
+  }
+
+  const newSessionId = !existingSessionId
+    ? await findNewSessionId(run.userId, composeId, run.createdAt)
+    : undefined;
+
+  await saveThreadSession({
+    connectionId,
+    channelId,
+    threadTs,
+    existingSessionId,
+    newSessionId,
+    messageTs,
+    runStatus: status,
+  });
+
+  return newSessionId ?? existingSessionId;
+}
+
+/**
+ * POST /api/internal/callbacks/slack/org
+ *
+ * Org-aware Slack callback handler for agent run completion.
+ */
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  initServices();
+
+  const result = await verifyCallback<CallbackPayload>(request, log);
+  if (!result.ok) return result.response;
+
+  const { runId, status, error } = result.data;
+
+  const payload = parsePayload(result.data.payload);
+  if (!payload) {
+    return errorResponse("Invalid or missing payload", 400);
+  }
+
+  log.debug("Processing org Slack callback", {
+    runId,
+    status,
+    channelId: payload.channelId,
+  });
+
+  const { SECRETS_ENCRYPTION_KEY } = env();
+
+  // Handle progress notifications
+  if (status === "progress") {
+    const [inst] = await globalThis.services.db
+      .select()
+      .from(slackOrgInstallations)
+      .where(eq(slackOrgInstallations.slackWorkspaceId, payload.workspaceId))
+      .limit(1);
+
+    if (inst) {
+      const token = decryptSecretValue(
+        inst.encryptedBotToken,
+        SECRETS_ENCRYPTION_KEY,
+      );
+      const slackClient = createSlackClient(token);
+      try {
+        await setThreadStatus(
+          slackClient,
+          payload.channelId,
+          payload.threadTs,
+          "is thinking...",
+        );
+      } catch (err) {
+        log.debug("Failed to refresh thread status", { runId, error: err });
+      }
+    }
+
+    return NextResponse.json({ success: true });
+  }
+
+  // Get installation for bot token
+  const [installation] = await globalThis.services.db
+    .select()
+    .from(slackOrgInstallations)
+    .where(eq(slackOrgInstallations.slackWorkspaceId, payload.workspaceId))
+    .limit(1);
+
+  if (!installation) {
+    log.error("Slack org installation not found", {
+      workspaceId: payload.workspaceId,
+    });
+    return errorResponse("Slack installation not found", 404);
+  }
+
+  const botToken = decryptSecretValue(
+    installation.encryptedBotToken,
+    SECRETS_ENCRYPTION_KEY,
+  );
+  const client = createSlackClient(botToken);
+
+  const resultData =
+    status === "completed" ? await getRunResultData(runId) : undefined;
+  const hasAskUserDenials = resultData && resultData.askUserDenials.length > 0;
+  const responseText = buildResponseText(status, error, resultData);
+
+  // Resolve session before posting interactive card
+  const resolvedSessionId = await saveOrgThreadSession(payload, runId, status);
+
+  // Post text response
+  if (responseText) {
+    const logsUrl = buildLogsUrl(runId, payload.agentName);
+    const deepLinks = detectDeepLinks(
+      responseText,
+      getPlatformUrl(),
+      payload.agentName,
+    );
+    await postMessage(client, payload.channelId, responseText, {
+      threadTs: payload.threadTs,
+      blocks: buildAgentResponseMessage(
+        responseText,
+        payload.agentName,
+        logsUrl,
+        deepLinks,
+      ),
+    });
+  }
+
+  // Post interactive card for askUserQuestion denials
+  if (hasAskUserDenials) {
+    await postAskUserInteractiveCard(
+      client,
+      resultData,
+      payload,
+      runId,
+      resolvedSessionId,
+    );
+  }
+
+  // Clear assistant thinking status
+  try {
+    await setThreadStatus(client, payload.channelId, payload.threadTs, "");
+  } catch (err) {
+    log.debug("Failed to clear thread status", { runId, error: err });
+  }
+
+  log.debug("Slack org callback processed successfully", { runId });
+  return NextResponse.json({ success: true });
+}

--- a/turbo/apps/web/app/api/internal/callbacks/slack/org/schedule/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/slack/org/schedule/route.ts
@@ -1,0 +1,226 @@
+import { NextRequest, NextResponse } from "next/server";
+import { eq } from "drizzle-orm";
+import { initServices } from "../../../../../../../src/lib/init-services";
+import { verifyCallback } from "../../../../../../../src/lib/callback";
+import { decryptSecretValue } from "../../../../../../../src/lib/crypto/secrets-encryption";
+import { agentRuns } from "../../../../../../../src/db/schema/agent-run";
+import { slackOrgConnections } from "../../../../../../../src/db/schema/slack-org-connection";
+import { slackOrgInstallations } from "../../../../../../../src/db/schema/slack-org-installation";
+import {
+  createSlackClient,
+  postMessage,
+} from "../../../../../../../src/lib/slack/client";
+import { getRunOutput } from "../../../../../../../src/lib/slack/handlers/run-agent";
+import {
+  saveThreadSession,
+  buildLogsUrl,
+} from "../../../../../../../src/lib/slack-org/handlers/shared";
+import { env } from "../../../../../../../src/env";
+import { logger } from "../../../../../../../src/lib/logger";
+
+const log = logger("callback:slack-org:schedule");
+
+interface CallbackPayload {
+  scheduleId: string;
+  composeId: string;
+  composeName: string;
+  userId: string;
+  orgId: string;
+}
+
+function parsePayload(payload: unknown): CallbackPayload | null {
+  if (!payload || typeof payload !== "object") return null;
+  const p = payload as Record<string, unknown>;
+  if (
+    typeof p.scheduleId !== "string" ||
+    typeof p.composeId !== "string" ||
+    typeof p.composeName !== "string" ||
+    typeof p.userId !== "string" ||
+    typeof p.orgId !== "string"
+  ) {
+    return null;
+  }
+  return p as unknown as CallbackPayload;
+}
+
+function errorResponse(message: string, status: number): NextResponse {
+  return NextResponse.json({ error: message }, { status });
+}
+
+function extractAgentSessionId(result: unknown): string | undefined {
+  if (
+    result &&
+    typeof result === "object" &&
+    "agentSessionId" in result &&
+    typeof result.agentSessionId === "string"
+  ) {
+    return result.agentSessionId;
+  }
+  return undefined;
+}
+
+/**
+ * POST /api/internal/callbacks/slack/org/schedule
+ *
+ * Org-aware schedule callback for Slack notifications.
+ */
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  initServices();
+
+  const result = await verifyCallback<CallbackPayload>(request, log);
+  if (!result.ok) return result.response;
+
+  const { runId, status, error } = result.data;
+
+  const payload = parsePayload(result.data.payload);
+  if (!payload) {
+    return errorResponse("Invalid or missing payload", 400);
+  }
+
+  const { composeName, userId } = payload;
+
+  log.debug("Processing Slack org schedule callback", { runId, status });
+
+  const { SECRETS_ENCRYPTION_KEY } = env();
+
+  // Find connection for this VM0 user
+  const [connection] = await globalThis.services.db
+    .select({
+      id: slackOrgConnections.id,
+      slackUserId: slackOrgConnections.slackUserId,
+      slackWorkspaceId: slackOrgConnections.slackWorkspaceId,
+    })
+    .from(slackOrgConnections)
+    .where(eq(slackOrgConnections.vm0UserId, userId))
+    .limit(1);
+
+  if (!connection) {
+    log.debug("No Slack org connection found, skipping notification", {
+      userId,
+    });
+    return NextResponse.json({ success: true, skipped: true });
+  }
+
+  // Get installation and decrypt bot token
+  const [installation] = await globalThis.services.db
+    .select()
+    .from(slackOrgInstallations)
+    .where(
+      eq(slackOrgInstallations.slackWorkspaceId, connection.slackWorkspaceId),
+    )
+    .limit(1);
+
+  if (!installation) {
+    log.warn("No Slack org installation found for workspace", {
+      workspaceId: connection.slackWorkspaceId,
+    });
+    return errorResponse("Slack installation not found", 404);
+  }
+
+  const botToken = decryptSecretValue(
+    installation.encryptedBotToken,
+    SECRETS_ENCRYPTION_KEY,
+  );
+  const client = createSlackClient(botToken);
+
+  const logsUrl = buildLogsUrl(runId, composeName);
+
+  if (status === "completed") {
+    const rawOutput = await getRunOutput(runId);
+    const truncatedOutput = rawOutput
+      ? rawOutput.length > 2000
+        ? `${rawOutput.slice(0, 2000)}…`
+        : rawOutput
+      : "Task completed successfully.";
+
+    const { ts: messageTs, channel: dmChannelId } = await postMessage(
+      client,
+      connection.slackUserId,
+      `Scheduled run for "${composeName}" completed`,
+      {
+        blocks: [
+          {
+            type: "section",
+            text: {
+              type: "mrkdwn",
+              text: `:white_check_mark: *Scheduled run for \`${composeName}\` completed*`,
+            },
+          },
+          {
+            type: "section",
+            text: {
+              type: "mrkdwn",
+              text: truncatedOutput,
+            },
+          },
+          {
+            type: "context",
+            elements: [
+              {
+                type: "mrkdwn",
+                text: `<${logsUrl}|Audit> · Reply in this thread to continue the conversation`,
+              },
+            ],
+          },
+        ],
+      },
+    );
+
+    // Create thread session so user can reply to continue
+    const [run] = await globalThis.services.db
+      .select({ result: agentRuns.result })
+      .from(agentRuns)
+      .where(eq(agentRuns.id, runId))
+      .limit(1);
+
+    const agentSessionId = extractAgentSessionId(run?.result);
+
+    if (messageTs && dmChannelId && agentSessionId) {
+      await saveThreadSession({
+        connectionId: connection.id,
+        channelId: dmChannelId,
+        threadTs: messageTs,
+        existingSessionId: undefined,
+        newSessionId: agentSessionId,
+        messageTs,
+        runStatus: "completed",
+      });
+    }
+  } else {
+    // Failed run
+    const errMsg = error ?? "Unknown error";
+    await postMessage(
+      client,
+      connection.slackUserId,
+      `Scheduled run for "${composeName}" failed`,
+      {
+        blocks: [
+          {
+            type: "section",
+            text: {
+              type: "mrkdwn",
+              text: `:x: *Scheduled run for \`${composeName}\` failed*\n\n${errMsg}`,
+            },
+          },
+          {
+            type: "context",
+            elements: [
+              {
+                type: "mrkdwn",
+                text: `<${logsUrl}|Audit>`,
+              },
+            ],
+          },
+        ],
+      },
+    );
+  }
+
+  log.info("Sent Slack org schedule notification", {
+    runId,
+    status,
+    agentName: composeName,
+  });
+
+  return NextResponse.json({ success: true });
+}

--- a/turbo/apps/web/app/api/slack/org/commands/route.ts
+++ b/turbo/apps/web/app/api/slack/org/commands/route.ts
@@ -1,0 +1,288 @@
+import { NextResponse } from "next/server";
+import { eq, and } from "drizzle-orm";
+import { initServices } from "../../../../../src/lib/init-services";
+import { env } from "../../../../../src/env";
+import {
+  verifySlackSignature,
+  getSlackSignatureHeaders,
+} from "../../../../../src/lib/slack/verify";
+import { slackOrgInstallations } from "../../../../../src/db/schema/slack-org-installation";
+import { slackOrgConnections } from "../../../../../src/db/schema/slack-org-connection";
+import { decryptSecretValue } from "../../../../../src/lib/crypto/secrets-encryption";
+import { createSlackClient } from "../../../../../src/lib/slack/client";
+import {
+  buildHelpMessage,
+  buildErrorMessage,
+  buildSuccessMessage,
+  buildLoginMessage,
+} from "../../../../../src/lib/slack/blocks";
+import { disconnect } from "../../../../../src/lib/slack-org/connect-service";
+import { refreshOrgAppHome } from "../../../../../src/lib/slack-org/handlers/app-home";
+import {
+  resolveDefaultComposeId,
+  buildOrgConnectUrl,
+  getWorkspaceAgent,
+} from "../../../../../src/lib/slack-org/handlers/shared";
+import { getPlatformUrl } from "../../../../../src/lib/url";
+import { logger } from "../../../../../src/lib/logger";
+import { removePermission } from "../../../../../src/lib/agent/permission-service";
+import { getUserEmail } from "../../../../../src/lib/auth/get-user-email";
+
+const log = logger("slack-org:commands");
+
+interface SlackCommandPayload {
+  token: string;
+  team_id: string;
+  team_domain: string;
+  channel_id: string;
+  channel_name: string;
+  user_id: string;
+  user_name: string;
+  command: string;
+  text: string;
+  response_url: string;
+  trigger_id: string;
+  api_app_id: string;
+}
+
+function parseCommandPayload(body: string): SlackCommandPayload {
+  const params = new URLSearchParams(body);
+  return {
+    token: params.get("token") ?? "",
+    team_id: params.get("team_id") ?? "",
+    team_domain: params.get("team_domain") ?? "",
+    channel_id: params.get("channel_id") ?? "",
+    channel_name: params.get("channel_name") ?? "",
+    user_id: params.get("user_id") ?? "",
+    user_name: params.get("user_name") ?? "",
+    command: params.get("command") ?? "",
+    text: params.get("text") ?? "",
+    response_url: params.get("response_url") ?? "",
+    trigger_id: params.get("trigger_id") ?? "",
+    api_app_id: params.get("api_app_id") ?? "",
+  };
+}
+
+function ephemeral(blocks: unknown[]) {
+  return NextResponse.json({ response_type: "ephemeral", blocks });
+}
+
+/**
+ * Handle /vm0 connect command.
+ */
+async function handleConnect(
+  payload: SlackCommandPayload,
+  installation: typeof slackOrgInstallations.$inferSelect,
+): Promise<NextResponse> {
+  // Check if already connected
+  const [existingConnection] = await globalThis.services.db
+    .select()
+    .from(slackOrgConnections)
+    .where(
+      and(
+        eq(slackOrgConnections.slackUserId, payload.user_id),
+        eq(slackOrgConnections.slackWorkspaceId, payload.team_id),
+      ),
+    )
+    .limit(1);
+
+  if (existingConnection) {
+    let agentName: string | undefined;
+    if (installation.orgId) {
+      const composeId = await resolveDefaultComposeId(installation.orgId);
+      if (composeId) {
+        const agent = await getWorkspaceAgent(composeId);
+        agentName = agent?.name;
+      }
+    }
+
+    const agentLine = agentName
+      ? `Your workspace agent is *${agentName}*.`
+      : `No workspace agent configured yet.`;
+
+    return ephemeral(
+      buildSuccessMessage(
+        `You are already connected.\n\n${agentLine}\nMention \`@VM0\` in any channel or send a DM to start chatting with your agent.`,
+      ),
+    );
+  }
+
+  const connectUrl = buildOrgConnectUrl(
+    payload.team_id,
+    payload.user_id,
+    payload.channel_id,
+  );
+  return ephemeral(buildLoginMessage(connectUrl));
+}
+
+/**
+ * Handle /vm0 disconnect command.
+ */
+async function handleDisconnect(
+  payload: SlackCommandPayload,
+  installation: typeof slackOrgInstallations.$inferSelect,
+  connection: typeof slackOrgConnections.$inferSelect,
+): Promise<NextResponse> {
+  // Revoke agent permission
+  if (installation.orgId) {
+    const composeId = await resolveDefaultComposeId(installation.orgId);
+    if (composeId) {
+      const email = await getUserEmail(connection.vm0UserId);
+      if (email) {
+        await removePermission(composeId, "email", email);
+      }
+    }
+  }
+
+  await disconnect({
+    connectionId: connection.id,
+    userId: connection.vm0UserId,
+  });
+
+  // Refresh App Home
+  const { SECRETS_ENCRYPTION_KEY } = env();
+  const botToken = decryptSecretValue(
+    installation.encryptedBotToken,
+    SECRETS_ENCRYPTION_KEY,
+  );
+  const client = createSlackClient(botToken);
+  await refreshOrgAppHome(client, installation, payload.user_id).catch((e) =>
+    log.warn("Failed to refresh App Home after disconnect", { error: e }),
+  );
+
+  return ephemeral(
+    buildSuccessMessage(
+      "You have been disconnected and your agent access has been revoked.",
+    ),
+  );
+}
+
+/**
+ * POST /api/slack/org/commands
+ *
+ * Org-aware slash commands handler.
+ * Handles /vm0 connect, disconnect, settings, help.
+ */
+export async function POST(request: Request) {
+  const { SLACK_SIGNING_SECRET } = env();
+
+  if (!SLACK_SIGNING_SECRET) {
+    return NextResponse.json(
+      { error: "Slack integration is not configured" },
+      { status: 503 },
+    );
+  }
+
+  const body = await request.text();
+  const headers = getSlackSignatureHeaders(request.headers);
+  if (!headers) {
+    return NextResponse.json(
+      { error: "Missing Slack signature headers" },
+      { status: 401 },
+    );
+  }
+
+  const isValid = verifySlackSignature(
+    SLACK_SIGNING_SECRET,
+    headers.signature,
+    headers.timestamp,
+    body,
+  );
+
+  if (!isValid) {
+    return NextResponse.json({ error: "Invalid signature" }, { status: 401 });
+  }
+
+  const payload = parseCommandPayload(body);
+
+  initServices();
+
+  const args = payload.text.trim().split(/\s+/);
+  const subCommand = args[0]?.toLowerCase() ?? "";
+
+  // Get workspace installation
+  const [installation] = await globalThis.services.db
+    .select()
+    .from(slackOrgInstallations)
+    .where(eq(slackOrgInstallations.slackWorkspaceId, payload.team_id))
+    .limit(1);
+
+  // Handle help command (doesn't require installation)
+  if (subCommand === "help" || subCommand === "") {
+    return ephemeral(buildHelpMessage({ isAdmin: false }));
+  }
+
+  // Handle connect command
+  if (subCommand === "connect") {
+    if (!installation) {
+      return ephemeral(
+        buildErrorMessage(
+          "The VM0 Slack app is not installed in this workspace. Please ask your workspace admin to install it first.",
+        ),
+      );
+    }
+    return handleConnect(payload, installation);
+  }
+
+  // Other commands require installation
+  if (!installation) {
+    return ephemeral(
+      buildErrorMessage(
+        "The VM0 Slack app is not installed in this workspace.",
+      ),
+    );
+  }
+
+  // Check if user is connected
+  const [connection] = await globalThis.services.db
+    .select()
+    .from(slackOrgConnections)
+    .where(
+      and(
+        eq(slackOrgConnections.slackUserId, payload.user_id),
+        eq(slackOrgConnections.slackWorkspaceId, payload.team_id),
+      ),
+    )
+    .limit(1);
+
+  // Handle disconnect command
+  if (subCommand === "disconnect") {
+    if (!connection) {
+      return ephemeral(buildErrorMessage("You are not connected."));
+    }
+    return handleDisconnect(payload, installation, connection);
+  }
+
+  // Check connection for remaining commands
+  if (!connection) {
+    const connectUrl = buildOrgConnectUrl(
+      payload.team_id,
+      payload.user_id,
+      payload.channel_id,
+    );
+    return ephemeral(buildLoginMessage(connectUrl));
+  }
+
+  // Handle settings command
+  if (subCommand === "settings") {
+    const platformUrl = getPlatformUrl();
+    return ephemeral([
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: `:gear: *Settings*\nConfigure your workspace agent and settings on the VM0 platform.`,
+        },
+        accessory: {
+          type: "button",
+          text: { type: "plain_text", text: "Open Platform" },
+          url: `${platformUrl}/settings/slack`,
+          action_id: "open_platform_settings",
+        },
+      },
+    ]);
+  }
+
+  // Unknown command
+  return ephemeral(buildHelpMessage({ isAdmin: false }));
+}

--- a/turbo/apps/web/app/api/slack/org/events/route.ts
+++ b/turbo/apps/web/app/api/slack/org/events/route.ts
@@ -1,0 +1,193 @@
+import { NextResponse, after } from "next/server";
+import { initServices } from "../../../../../src/lib/init-services";
+import { env } from "../../../../../src/env";
+import {
+  verifySlackSignature,
+  getSlackSignatureHeaders,
+} from "../../../../../src/lib/slack/verify";
+import { handleOrgMention } from "../../../../../src/lib/slack-org/handlers/mention";
+import { handleOrgDirectMessage } from "../../../../../src/lib/slack-org/handlers/direct-message";
+import {
+  handleOrgAppHomeOpened,
+  handleOrgMessagesTabOpened,
+} from "../../../../../src/lib/slack-org/handlers/app-home";
+import type { SlackFile } from "../../../../../src/lib/slack/context";
+import { logger } from "../../../../../src/lib/logger";
+
+const log = logger("slack-org:events");
+
+interface SlackUrlVerificationEvent {
+  type: "url_verification";
+  challenge: string;
+  token: string;
+}
+
+interface SlackAppMentionEvent {
+  type: "app_mention";
+  user: string;
+  text: string;
+  ts: string;
+  channel: string;
+  event_ts: string;
+  thread_ts?: string;
+  files?: SlackFile[];
+}
+
+interface SlackDirectMessageEvent {
+  type: "message";
+  channel_type: "im";
+  user: string;
+  text: string;
+  ts: string;
+  channel: string;
+  event_ts: string;
+  thread_ts?: string;
+  subtype?: string;
+  bot_id?: string;
+  files?: SlackFile[];
+}
+
+interface SlackAppHomeOpenedEvent {
+  type: "app_home_opened";
+  user: string;
+  tab: "home" | "messages";
+  channel: string;
+}
+
+interface SlackEventCallback {
+  type: "event_callback";
+  token: string;
+  team_id: string;
+  api_app_id: string;
+  event:
+    | SlackAppMentionEvent
+    | SlackDirectMessageEvent
+    | SlackAppHomeOpenedEvent;
+  event_id: string;
+  event_time: number;
+}
+
+type SlackEvent = SlackUrlVerificationEvent | SlackEventCallback;
+
+/**
+ * POST /api/slack/org/events
+ *
+ * Org-aware Slack Events API endpoint.
+ * Must respond within 3 seconds to avoid Slack retries.
+ */
+export async function POST(request: Request) {
+  const { SLACK_SIGNING_SECRET } = env();
+
+  if (!SLACK_SIGNING_SECRET) {
+    return NextResponse.json(
+      { error: "Slack integration is not configured" },
+      { status: 503 },
+    );
+  }
+
+  const body = await request.text();
+  const headers = getSlackSignatureHeaders(request.headers);
+  if (!headers) {
+    return NextResponse.json(
+      { error: "Missing Slack signature headers" },
+      { status: 401 },
+    );
+  }
+
+  const isValid = verifySlackSignature(
+    SLACK_SIGNING_SECRET,
+    headers.signature,
+    headers.timestamp,
+    body,
+  );
+
+  if (!isValid) {
+    return NextResponse.json({ error: "Invalid signature" }, { status: 401 });
+  }
+
+  let payload: SlackEvent;
+  try {
+    payload = JSON.parse(body) as SlackEvent;
+  } catch {
+    return NextResponse.json(
+      { error: "Invalid JSON payload" },
+      { status: 400 },
+    );
+  }
+
+  if (payload.type === "url_verification") {
+    return NextResponse.json({ challenge: payload.challenge });
+  }
+
+  if (payload.type === "event_callback") {
+    const event = payload.event;
+
+    if (event.type === "app_mention") {
+      initServices();
+      after(
+        handleOrgMention({
+          workspaceId: payload.team_id,
+          channelId: event.channel,
+          userId: event.user,
+          messageText: event.text,
+          messageTs: event.ts,
+          threadTs: event.thread_ts,
+          files: event.files,
+        }).catch((error) => {
+          log.error("Error handling org app_mention", { error });
+        }),
+      );
+    }
+
+    if (
+      event.type === "message" &&
+      event.channel_type === "im" &&
+      (!event.subtype || event.subtype === "file_share") &&
+      !event.bot_id
+    ) {
+      initServices();
+      after(
+        handleOrgDirectMessage({
+          workspaceId: payload.team_id,
+          channelId: event.channel,
+          userId: event.user,
+          messageText: event.text,
+          files: event.files,
+          messageTs: event.ts,
+          threadTs: event.thread_ts,
+        }).catch((error) => {
+          log.error("Error handling org direct_message", { error });
+        }),
+      );
+    }
+
+    if (event.type === "app_home_opened" && event.tab === "home") {
+      initServices();
+      after(
+        handleOrgAppHomeOpened({
+          workspaceId: payload.team_id,
+          userId: event.user,
+        }).catch((error) => {
+          log.error("Error handling org app_home_opened", { error });
+        }),
+      );
+    }
+
+    if (event.type === "app_home_opened" && event.tab === "messages") {
+      initServices();
+      after(
+        handleOrgMessagesTabOpened({
+          workspaceId: payload.team_id,
+          userId: event.user,
+          channelId: event.channel,
+        }).catch((error) => {
+          log.error("Error handling org messages_tab_opened", { error });
+        }),
+      );
+    }
+
+    return new Response("OK", { status: 200 });
+  }
+
+  return new Response("OK", { status: 200 });
+}

--- a/turbo/apps/web/app/api/slack/org/interactive/route.ts
+++ b/turbo/apps/web/app/api/slack/org/interactive/route.ts
@@ -1,0 +1,571 @@
+import { NextResponse } from "next/server";
+import { eq, and, isNull, gte } from "drizzle-orm";
+import { z } from "zod";
+import { initServices } from "../../../../../src/lib/init-services";
+import { env } from "../../../../../src/env";
+import {
+  verifySlackSignature,
+  getSlackSignatureHeaders,
+} from "../../../../../src/lib/slack/verify";
+import { slackOrgInstallations } from "../../../../../src/db/schema/slack-org-installation";
+import { slackOrgConnections } from "../../../../../src/db/schema/slack-org-connection";
+import { slackOrgPendingQuestions } from "../../../../../src/db/schema/slack-org-pending-question";
+import { decryptSecretValue } from "../../../../../src/lib/crypto/secrets-encryption";
+import {
+  createSlackClient,
+  updateMessage,
+  setThreadStatus,
+} from "../../../../../src/lib/slack/client";
+import {
+  buildAskUserAnsweredBlocks,
+  buildErrorMessage,
+} from "../../../../../src/lib/slack/blocks";
+import type { AskUserQuestion } from "../../../../../src/lib/slack/blocks";
+import { runAgentForSlackOrg } from "../../../../../src/lib/slack-org/handlers/run-agent";
+import type { SlackOrgCallbackContext } from "../../../../../src/lib/slack-org/handlers/run-agent";
+import { refreshOrgAppHome } from "../../../../../src/lib/slack-org/handlers/app-home";
+import { disconnect } from "../../../../../src/lib/slack-org/connect-service";
+import { logger } from "../../../../../src/lib/logger";
+
+const askUserQuestionSchema = z.array(
+  z.object({
+    question: z.string(),
+    header: z.string().optional(),
+    options: z
+      .array(
+        z.object({
+          label: z.string(),
+          description: z.string().optional(),
+        }),
+      )
+      .optional(),
+    multiSelect: z.boolean().optional(),
+  }),
+);
+
+const log = logger("slack-org:interactive");
+
+interface SlackInteractivePayload {
+  type: "view_submission" | "block_actions" | "shortcut";
+  user: {
+    id: string;
+    username: string;
+    team_id: string;
+  };
+  team: {
+    id: string;
+    domain: string;
+  };
+  channel?: {
+    id: string;
+  };
+  message?: {
+    ts: string;
+  };
+  trigger_id?: string;
+  actions?: Array<{
+    action_id: string;
+    block_id: string;
+    value?: string;
+    selected_option?: { value: string };
+    selected_options?: Array<{ value: string }>;
+  }>;
+  state?: {
+    values: Record<
+      string,
+      Record<
+        string,
+        {
+          type: string;
+          selected_options?: Array<{ value: string }>;
+        }
+      >
+    >;
+  };
+}
+
+/**
+ * POST /api/slack/org/interactive
+ *
+ * Org-aware interactive component handler.
+ */
+export async function POST(request: Request) {
+  const { SLACK_SIGNING_SECRET } = env();
+
+  if (!SLACK_SIGNING_SECRET) {
+    return NextResponse.json(
+      { error: "Slack integration is not configured" },
+      { status: 503 },
+    );
+  }
+
+  const body = await request.text();
+  const headers = getSlackSignatureHeaders(request.headers);
+  if (!headers) {
+    return NextResponse.json(
+      { error: "Missing Slack signature headers" },
+      { status: 401 },
+    );
+  }
+
+  const isValid = verifySlackSignature(
+    SLACK_SIGNING_SECRET,
+    headers.signature,
+    headers.timestamp,
+    body,
+  );
+
+  if (!isValid) {
+    return NextResponse.json({ error: "Invalid signature" }, { status: 401 });
+  }
+
+  const params = new URLSearchParams(body);
+  const payloadStr = params.get("payload");
+
+  if (!payloadStr) {
+    return NextResponse.json({ error: "Missing payload" }, { status: 400 });
+  }
+
+  let payload: SlackInteractivePayload;
+  try {
+    payload = JSON.parse(payloadStr) as SlackInteractivePayload;
+  } catch {
+    return NextResponse.json({ error: "Invalid payload" }, { status: 400 });
+  }
+
+  initServices();
+
+  if (payload.type === "block_actions") {
+    const action = payload.actions?.[0];
+    if (!action) {
+      return new Response("", { status: 200 });
+    }
+
+    if (action.action_id === "home_disconnect") {
+      await handleHomeDisconnect(payload);
+    } else if (action.action_id === "ask_user_submit") {
+      handleAskUserSubmit(payload).catch((err: unknown) => {
+        log.error("Failed to handle askUserQuestion submit:", err);
+      });
+    } else if (/^ask_user_pick_q\d+_o\d+$/.test(action.action_id)) {
+      handleDirectPick(payload, action).catch((err: unknown) => {
+        log.error("Failed to handle direct pick:", err);
+      });
+    }
+  }
+
+  return new Response("", { status: 200 });
+}
+
+/**
+ * Handle disconnect button click from App Home.
+ */
+async function handleHomeDisconnect(
+  payload: SlackInteractivePayload,
+): Promise<void> {
+  const [connection] = await globalThis.services.db
+    .select()
+    .from(slackOrgConnections)
+    .where(
+      and(
+        eq(slackOrgConnections.slackUserId, payload.user.id),
+        eq(slackOrgConnections.slackWorkspaceId, payload.team.id),
+      ),
+    )
+    .limit(1);
+
+  if (!connection) {
+    return;
+  }
+
+  await disconnect({
+    connectionId: connection.id,
+    userId: connection.vm0UserId,
+  });
+
+  // Refresh App Home to show disconnected state
+  const { SECRETS_ENCRYPTION_KEY } = env();
+  const [installation] = await globalThis.services.db
+    .select()
+    .from(slackOrgInstallations)
+    .where(eq(slackOrgInstallations.slackWorkspaceId, payload.team.id))
+    .limit(1);
+
+  if (!installation) {
+    return;
+  }
+
+  const botToken = decryptSecretValue(
+    installation.encryptedBotToken,
+    SECRETS_ENCRYPTION_KEY,
+  );
+  const client = createSlackClient(botToken);
+  await refreshOrgAppHome(client, installation, payload.user.id);
+}
+
+// ---------------------------------------------------------------------------
+// askUserQuestion interactive card handling
+// ---------------------------------------------------------------------------
+
+type SlackAction = NonNullable<SlackInteractivePayload["actions"]>[number];
+
+/**
+ * Verify the submitting user is the initiator of the pending question.
+ */
+async function validateSubmitter(
+  claimed: typeof slackOrgPendingQuestions.$inferSelect,
+  slackUserId: string,
+): Promise<boolean> {
+  const [connection] = await globalThis.services.db
+    .select({ slackUserId: slackOrgConnections.slackUserId })
+    .from(slackOrgConnections)
+    .where(eq(slackOrgConnections.id, claimed.connectionId))
+    .limit(1);
+
+  if (connection && connection.slackUserId === slackUserId) {
+    return true;
+  }
+
+  // Roll back answeredAt so the real user can still answer
+  await globalThis.services.db
+    .update(slackOrgPendingQuestions)
+    .set({ answeredAt: null })
+    .where(eq(slackOrgPendingQuestions.id, claimed.id));
+
+  // Post ephemeral rejection
+  const { SECRETS_ENCRYPTION_KEY } = env();
+  const [installation] = await globalThis.services.db
+    .select()
+    .from(slackOrgInstallations)
+    .where(eq(slackOrgInstallations.slackWorkspaceId, claimed.slackWorkspaceId))
+    .limit(1);
+
+  if (installation) {
+    const botToken = decryptSecretValue(
+      installation.encryptedBotToken,
+      SECRETS_ENCRYPTION_KEY,
+    );
+    const client = createSlackClient(botToken);
+    await client.chat.postEphemeral({
+      channel: claimed.slackChannelId,
+      user: slackUserId,
+      text: "Only the person who started this conversation can answer this question.",
+    });
+  }
+
+  log.warn("Unauthorized ask-user submit attempt", {
+    pendingId: claimed.id,
+    expectedConnectionId: claimed.connectionId,
+    actualSlackUserId: slackUserId,
+  });
+
+  return false;
+}
+
+/**
+ * Handle direct-submit button click (single question, single-select).
+ */
+async function handleDirectPick(
+  payload: SlackInteractivePayload,
+  action: SlackAction,
+): Promise<void> {
+  const pendingId = action.value;
+  if (!pendingId) return;
+
+  const match = action.action_id.match(/^ask_user_pick_q(\d+)_o(\d+)$/);
+  if (!match) return;
+
+  const qIdx = parseInt(match[1]!, 10);
+  const oIdx = parseInt(match[2]!, 10);
+
+  const now = new Date();
+  const [claimed] = await globalThis.services.db
+    .update(slackOrgPendingQuestions)
+    .set({ answeredAt: now })
+    .where(
+      and(
+        eq(slackOrgPendingQuestions.id, pendingId),
+        isNull(slackOrgPendingQuestions.answeredAt),
+        gte(slackOrgPendingQuestions.expiresAt, now),
+      ),
+    )
+    .returning();
+
+  if (!claimed) return;
+
+  const authorized = await validateSubmitter(claimed, payload.user.id);
+  if (!authorized) return;
+
+  const parsed = askUserQuestionSchema.safeParse(claimed.questions);
+  if (!parsed.success) return;
+
+  const questions: AskUserQuestion[] = parsed.data;
+  const opt = questions[qIdx]?.options?.[oIdx];
+  if (!opt) return;
+
+  const answers = new Map<number, string[]>();
+  answers.set(qIdx, [opt.label]);
+  const answerPrompt = buildAnswerPrompt(questions, answers);
+
+  await finishSubmit(payload, claimed, questions, answers, answerPrompt);
+}
+
+function collectAnswersFromState(
+  stateValues: NonNullable<SlackInteractivePayload["state"]>["values"],
+  questions: AskUserQuestion[],
+): Map<number, string[]> {
+  const answers = new Map<number, string[]>();
+
+  for (const [blockId, actions] of Object.entries(stateValues)) {
+    const blockMatch = blockId.match(/^ask_user_block_q(\d+)$/);
+    if (!blockMatch) continue;
+
+    const qIdx = parseInt(blockMatch[1]!, 10);
+    const q = questions[qIdx];
+    if (!q) continue;
+
+    for (const element of Object.values(actions)) {
+      if (element.selected_options && element.selected_options.length > 0) {
+        const labels: string[] = [];
+        for (const selOpt of element.selected_options) {
+          const optMatch = selOpt.value.match(/^q\d+_o(\d+)$/);
+          if (optMatch) {
+            const opt = q.options?.[parseInt(optMatch[1]!, 10)];
+            if (opt) {
+              labels.push(opt.label);
+            }
+          }
+        }
+        if (labels.length > 0) {
+          answers.set(qIdx, labels);
+        }
+      }
+    }
+  }
+
+  return answers;
+}
+
+function buildAnswerPrompt(
+  questions: AskUserQuestion[],
+  answers: Map<number, string[]>,
+): string {
+  const items: string[] = [];
+  for (let qIdx = 0; qIdx < questions.length; qIdx++) {
+    const selected = answers.get(qIdx);
+    if (selected) {
+      for (const label of selected) {
+        items.push(`- ${label}`);
+      }
+    }
+  }
+  return items.length > 0
+    ? `User selected:\n${items.join("\n")}`
+    : "The user submitted the form without making a selection.";
+}
+
+async function updateCardWithError(
+  channelId: string,
+  messageTs: string | null,
+  workspaceId: string,
+  errorText: string,
+): Promise<void> {
+  if (!messageTs) {
+    return;
+  }
+  const { SECRETS_ENCRYPTION_KEY } = env();
+  const [installation] = await globalThis.services.db
+    .select()
+    .from(slackOrgInstallations)
+    .where(eq(slackOrgInstallations.slackWorkspaceId, workspaceId))
+    .limit(1);
+  if (!installation) {
+    return;
+  }
+  const botToken = decryptSecretValue(
+    installation.encryptedBotToken,
+    SECRETS_ENCRYPTION_KEY,
+  );
+  const client = createSlackClient(botToken);
+  await updateMessage(
+    client,
+    channelId,
+    messageTs,
+    errorText,
+    buildErrorMessage(errorText),
+  );
+}
+
+async function handleAskUserSubmit(
+  payload: SlackInteractivePayload,
+): Promise<void> {
+  const action = payload.actions?.find(
+    (a) => a.action_id === "ask_user_submit",
+  );
+  const pendingId = action?.value;
+
+  if (!pendingId) {
+    log.warn("ask_user_submit missing pendingId");
+    return;
+  }
+
+  const now = new Date();
+  const [claimed] = await globalThis.services.db
+    .update(slackOrgPendingQuestions)
+    .set({ answeredAt: now })
+    .where(
+      and(
+        eq(slackOrgPendingQuestions.id, pendingId),
+        isNull(slackOrgPendingQuestions.answeredAt),
+        gte(slackOrgPendingQuestions.expiresAt, now),
+      ),
+    )
+    .returning();
+
+  if (!claimed) {
+    log.warn("Pending question not found, already answered, or expired", {
+      pendingId,
+    });
+    return;
+  }
+
+  const authorized = await validateSubmitter(claimed, payload.user.id);
+  if (!authorized) return;
+
+  const parsed = askUserQuestionSchema.safeParse(claimed.questions);
+  if (!parsed.success) {
+    log.error("Invalid questions data in pending question", {
+      pendingId,
+      error: parsed.error,
+    });
+    await updateCardWithError(
+      claimed.slackChannelId,
+      claimed.slackMessageTs,
+      claimed.slackWorkspaceId,
+      "Something went wrong processing your answer. Please try again.",
+    );
+    return;
+  }
+
+  const questions: AskUserQuestion[] = parsed.data;
+
+  const answers = collectAnswersFromState(
+    payload.state?.values ?? {},
+    questions,
+  );
+  const answerPrompt = buildAnswerPrompt(questions, answers);
+
+  await finishSubmit(payload, claimed, questions, answers, answerPrompt);
+}
+
+/**
+ * Shared post-submit logic: update the card, set thinking status, dispatch run.
+ */
+async function finishSubmit(
+  payload: SlackInteractivePayload,
+  claimed: typeof slackOrgPendingQuestions.$inferSelect,
+  questions: AskUserQuestion[],
+  answers: Map<number, string[]>,
+  answerPrompt: string,
+): Promise<void> {
+  const pendingId = claimed.id;
+
+  const { SECRETS_ENCRYPTION_KEY } = env();
+  const [installation] = await globalThis.services.db
+    .select()
+    .from(slackOrgInstallations)
+    .where(eq(slackOrgInstallations.slackWorkspaceId, claimed.slackWorkspaceId))
+    .limit(1);
+
+  if (!installation) {
+    log.error("Installation not found for pending question", { pendingId });
+    await updateCardWithError(
+      claimed.slackChannelId,
+      claimed.slackMessageTs,
+      claimed.slackWorkspaceId,
+      "Slack installation not found. Please reconnect the VM0 app.",
+    );
+    return;
+  }
+
+  const botToken = decryptSecretValue(
+    installation.encryptedBotToken,
+    SECRETS_ENCRYPTION_KEY,
+  );
+  const client = createSlackClient(botToken);
+
+  // Replace interactive card with answered summary
+  if (claimed.slackMessageTs) {
+    const answeredBlocks = buildAskUserAnsweredBlocks(
+      questions,
+      answers,
+      claimed.agentName,
+    );
+    await updateMessage(
+      client,
+      claimed.slackChannelId,
+      claimed.slackMessageTs,
+      answerPrompt,
+      answeredBlocks,
+    );
+  }
+
+  // Set thinking status
+  try {
+    await setThreadStatus(
+      client,
+      claimed.slackChannelId,
+      claimed.slackThreadTs,
+      "is thinking...",
+    );
+  } catch (err) {
+    log.debug("Failed to set thread status", { error: err });
+  }
+
+  // Look up connection to get userId for the run
+  const [connection] = await globalThis.services.db
+    .select()
+    .from(slackOrgConnections)
+    .where(eq(slackOrgConnections.id, claimed.connectionId))
+    .limit(1);
+
+  if (!connection) {
+    log.error("Connection not found for pending question", { pendingId });
+    await updateCardWithError(
+      claimed.slackChannelId,
+      claimed.slackMessageTs,
+      claimed.slackWorkspaceId,
+      "Your VM0 account connection was not found. Please reconnect your account.",
+    );
+    return;
+  }
+
+  // Dispatch new agent run with the user's answer
+  const callbackContext: SlackOrgCallbackContext = {
+    workspaceId: claimed.slackWorkspaceId,
+    channelId: claimed.slackChannelId,
+    threadTs: claimed.slackThreadTs,
+    messageTs: claimed.slackThreadTs,
+    connectionId: claimed.connectionId,
+    orgId: claimed.orgId,
+    agentName: claimed.agentName,
+    composeId: claimed.composeId,
+    existingSessionId: claimed.sessionId ?? undefined,
+  };
+
+  await runAgentForSlackOrg({
+    composeId: claimed.composeId,
+    agentName: claimed.agentName,
+    sessionId: claimed.sessionId ?? undefined,
+    prompt: answerPrompt,
+    threadContext: "",
+    userId: connection.vm0UserId,
+    orgId: claimed.orgId,
+    callbackContext,
+  });
+
+  log.debug("askUserQuestion answer dispatched", {
+    pendingId,
+    answerPrompt,
+  });
+}

--- a/turbo/apps/web/src/lib/slack-org/connect-service.ts
+++ b/turbo/apps/web/src/lib/slack-org/connect-service.ts
@@ -1,0 +1,233 @@
+import { eq, and, isNull } from "drizzle-orm";
+import { slackOrgInstallations } from "../../db/schema/slack-org-installation";
+import { slackOrgConnections } from "../../db/schema/slack-org-connection";
+import { addPermission } from "../agent/permission-service";
+import { getUserEmail } from "../auth/get-user-email";
+import { resolveDefaultComposeId, ensureOrgArtifact } from "./handlers/shared";
+import { getOrgData } from "../org/org-cache-service";
+import { logger } from "../logger";
+
+const log = logger("slack-org:connect");
+
+/**
+ * Admin connect: bind an unbound workspace to an org.
+ *
+ * Uses atomic UPDATE ... WHERE org_id IS NULL to prevent race conditions.
+ * If the workspace is already bound to the same org, treats as idempotent success.
+ */
+export async function adminConnect(params: {
+  userId: string;
+  orgId: string;
+  workspaceId: string;
+  slackUserId: string;
+}): Promise<{
+  connection: typeof slackOrgConnections.$inferSelect;
+  installation: typeof slackOrgInstallations.$inferSelect;
+}> {
+  const { userId, orgId, workspaceId, slackUserId } = params;
+  const db = globalThis.services.db;
+
+  // Atomic bind: only succeeds if org_id is currently NULL
+  const updated = await db
+    .update(slackOrgInstallations)
+    .set({
+      orgId,
+      installedByUserId: userId,
+      updatedAt: new Date(),
+    })
+    .where(
+      and(
+        eq(slackOrgInstallations.slackWorkspaceId, workspaceId),
+        isNull(slackOrgInstallations.orgId),
+      ),
+    )
+    .returning();
+
+  let installation: typeof slackOrgInstallations.$inferSelect;
+
+  if (updated.length === 0) {
+    // Workspace already bound — check if it's the same org (idempotent)
+    const [existing] = await db
+      .select()
+      .from(slackOrgInstallations)
+      .where(eq(slackOrgInstallations.slackWorkspaceId, workspaceId))
+      .limit(1);
+
+    if (!existing) {
+      throw new Error("Workspace installation not found");
+    }
+
+    if (existing.orgId !== orgId) {
+      throw new Error("Workspace is already connected to a different org");
+    }
+
+    installation = existing;
+  } else {
+    installation = updated[0]!;
+  }
+
+  // Create connection (upsert to handle idempotent admin reconnect)
+  const [connection] = await db
+    .insert(slackOrgConnections)
+    .values({
+      slackUserId,
+      slackWorkspaceId: workspaceId,
+      vm0UserId: userId,
+      orgId,
+    })
+    .onConflictDoNothing({
+      target: [
+        slackOrgConnections.slackUserId,
+        slackOrgConnections.slackWorkspaceId,
+      ],
+    })
+    .returning();
+
+  // If conflict (already exists), fetch the existing connection
+  const finalConnection =
+    connection ??
+    (
+      await db
+        .select()
+        .from(slackOrgConnections)
+        .where(
+          and(
+            eq(slackOrgConnections.slackUserId, slackUserId),
+            eq(slackOrgConnections.slackWorkspaceId, workspaceId),
+          ),
+        )
+        .limit(1)
+    )[0]!;
+
+  // Grant agent permission via email
+  await grantAgentPermission(userId, orgId);
+
+  // Ensure artifact storage
+  const orgData = await getOrgData(orgId);
+  await ensureOrgArtifact(userId, orgId, orgData.slug);
+
+  log.info("Admin connected workspace to org", {
+    workspaceId,
+    orgId,
+    userId,
+  });
+
+  return { connection: finalConnection, installation };
+}
+
+/**
+ * Member connect: join an already-bound workspace.
+ *
+ * Requires that an admin has already connected (org_id is set on installation).
+ */
+export async function memberConnect(params: {
+  userId: string;
+  orgId: string;
+  workspaceId: string;
+  slackUserId: string;
+}): Promise<{ connection: typeof slackOrgConnections.$inferSelect }> {
+  const { userId, orgId, workspaceId, slackUserId } = params;
+  const db = globalThis.services.db;
+
+  // Verify installation is bound to this org
+  const [installation] = await db
+    .select()
+    .from(slackOrgInstallations)
+    .where(eq(slackOrgInstallations.slackWorkspaceId, workspaceId))
+    .limit(1);
+
+  if (!installation) {
+    throw new Error("Workspace installation not found");
+  }
+
+  if (!installation.orgId) {
+    throw new Error(
+      "Org admin must connect first. Ask your org admin to run /vm0 connect.",
+    );
+  }
+
+  if (installation.orgId !== orgId) {
+    throw new Error("Workspace is connected to a different org");
+  }
+
+  // Create connection
+  const [connection] = await db
+    .insert(slackOrgConnections)
+    .values({
+      slackUserId,
+      slackWorkspaceId: workspaceId,
+      vm0UserId: userId,
+      orgId,
+    })
+    .onConflictDoNothing({
+      target: [
+        slackOrgConnections.slackUserId,
+        slackOrgConnections.slackWorkspaceId,
+      ],
+    })
+    .returning();
+
+  const finalConnection =
+    connection ??
+    (
+      await db
+        .select()
+        .from(slackOrgConnections)
+        .where(
+          and(
+            eq(slackOrgConnections.slackUserId, slackUserId),
+            eq(slackOrgConnections.slackWorkspaceId, workspaceId),
+          ),
+        )
+        .limit(1)
+    )[0]!;
+
+  // Grant agent permission
+  await grantAgentPermission(userId, orgId);
+
+  // Ensure artifact storage
+  const orgData = await getOrgData(orgId);
+  await ensureOrgArtifact(userId, orgId, orgData.slug);
+
+  log.info("Member connected to workspace", {
+    workspaceId,
+    orgId,
+    userId,
+  });
+
+  return { connection: finalConnection };
+}
+
+/**
+ * Disconnect a user from Slack.
+ */
+export async function disconnect(params: {
+  connectionId: string;
+  userId: string;
+}): Promise<void> {
+  const { connectionId } = params;
+
+  await globalThis.services.db
+    .delete(slackOrgConnections)
+    .where(eq(slackOrgConnections.id, connectionId));
+
+  log.info("User disconnected from Slack", params);
+}
+
+/**
+ * Grant agent permission to user via email for the org's default agent.
+ */
+async function grantAgentPermission(
+  userId: string,
+  orgId: string,
+): Promise<void> {
+  const email = await getUserEmail(userId);
+  if (!email) return;
+
+  const composeId = await resolveDefaultComposeId(orgId);
+  if (!composeId) return;
+
+  await addPermission(composeId, "email", userId, email).catch((error) => {
+    log.warn("Failed to grant agent permission", { error, userId, orgId });
+  });
+}

--- a/turbo/apps/web/src/lib/slack-org/handlers/app-home.ts
+++ b/turbo/apps/web/src/lib/slack-org/handlers/app-home.ts
@@ -1,0 +1,200 @@
+import { eq, and } from "drizzle-orm";
+import { slackOrgInstallations } from "../../../db/schema/slack-org-installation";
+import { slackOrgConnections } from "../../../db/schema/slack-org-connection";
+import { decryptSecretValue } from "../../crypto/secrets-encryption";
+import { env } from "../../../env";
+import { getUserEmail } from "../../auth/get-user-email";
+import {
+  createSlackClient,
+  publishAppHome,
+  postMessage,
+} from "../../slack/client";
+import { buildAppHomeView, buildWelcomeMessage } from "../../slack/blocks";
+import {
+  resolveDefaultComposeId,
+  getWorkspaceAgent,
+  buildOrgConnectUrl,
+} from "./shared";
+
+interface OrgAppHomeContext {
+  workspaceId: string;
+  userId: string;
+}
+
+/**
+ * Handle app_home_opened event for org-aware Slack.
+ */
+export async function handleOrgAppHomeOpened(
+  context: OrgAppHomeContext,
+): Promise<void> {
+  const { SECRETS_ENCRYPTION_KEY } = env();
+
+  const [installation] = await globalThis.services.db
+    .select()
+    .from(slackOrgInstallations)
+    .where(eq(slackOrgInstallations.slackWorkspaceId, context.workspaceId))
+    .limit(1);
+
+  if (!installation) {
+    return;
+  }
+
+  const botToken = decryptSecretValue(
+    installation.encryptedBotToken,
+    SECRETS_ENCRYPTION_KEY,
+  );
+  const client = createSlackClient(botToken);
+
+  await refreshOrgAppHome(client, installation, context.userId);
+}
+
+/**
+ * Refresh the App Home tab for an org-aware Slack workspace.
+ */
+export async function refreshOrgAppHome(
+  client: ReturnType<typeof createSlackClient>,
+  installation: typeof slackOrgInstallations.$inferSelect,
+  slackUserId: string,
+): Promise<void> {
+  const workspaceId = installation.slackWorkspaceId;
+
+  // Check if user is connected
+  const [connection] = await globalThis.services.db
+    .select()
+    .from(slackOrgConnections)
+    .where(
+      and(
+        eq(slackOrgConnections.slackUserId, slackUserId),
+        eq(slackOrgConnections.slackWorkspaceId, workspaceId),
+      ),
+    )
+    .limit(1);
+
+  if (!connection) {
+    // User not connected — show connect prompt
+    const connectUrl = buildOrgConnectUrl(workspaceId, slackUserId, "");
+    const view = buildAppHomeView({
+      isLinked: false,
+      loginUrl: connectUrl,
+    });
+    await publishAppHome(client, slackUserId, view);
+    return;
+  }
+
+  // Get agent name from org's default compose
+  let agentName: string | undefined;
+  if (installation.orgId) {
+    const composeId = await resolveDefaultComposeId(installation.orgId);
+    if (composeId) {
+      const agent = await getWorkspaceAgent(composeId);
+      agentName = agent?.name;
+    }
+  }
+
+  // Get user email for display
+  const userEmail = await getUserEmail(connection.vm0UserId);
+
+  // Determine admin status from Clerk (not from DB column)
+  let isAdmin = false;
+  if (installation.orgId) {
+    try {
+      const { requireOrgMember } = await import("../../org/org-member-service");
+      const member = await requireOrgMember(
+        installation.orgId,
+        connection.vm0UserId,
+      );
+      isAdmin = member.role === "admin";
+    } catch {
+      // Not a member or error — treat as non-admin
+    }
+  }
+
+  const view = buildAppHomeView({
+    isLinked: true,
+    vm0UserId: connection.vm0UserId,
+    userEmail,
+    agentName,
+    isAdmin,
+  });
+  await publishAppHome(client, slackUserId, view);
+}
+
+interface OrgMessagesTabContext {
+  workspaceId: string;
+  userId: string;
+  channelId: string;
+}
+
+/**
+ * Handle messages tab opened for org-aware Slack.
+ * Sends one-time welcome message to connected users.
+ */
+export async function handleOrgMessagesTabOpened(
+  context: OrgMessagesTabContext,
+): Promise<void> {
+  const { SECRETS_ENCRYPTION_KEY } = env();
+
+  const [installation] = await globalThis.services.db
+    .select()
+    .from(slackOrgInstallations)
+    .where(eq(slackOrgInstallations.slackWorkspaceId, context.workspaceId))
+    .limit(1);
+
+  if (!installation) {
+    return;
+  }
+
+  // Check connection
+  const [connection] = await globalThis.services.db
+    .select({ id: slackOrgConnections.id })
+    .from(slackOrgConnections)
+    .where(
+      and(
+        eq(slackOrgConnections.slackUserId, context.userId),
+        eq(slackOrgConnections.slackWorkspaceId, context.workspaceId),
+      ),
+    )
+    .limit(1);
+
+  if (!connection) {
+    return;
+  }
+
+  // Atomic flag: only send welcome once
+  const updated = await globalThis.services.db
+    .update(slackOrgConnections)
+    .set({ dmWelcomeSent: true })
+    .where(
+      and(
+        eq(slackOrgConnections.id, connection.id),
+        eq(slackOrgConnections.dmWelcomeSent, false),
+      ),
+    );
+
+  if (updated.rowCount === 0) {
+    return;
+  }
+
+  // Get agent name
+  let agentName: string | undefined;
+  if (installation.orgId) {
+    const composeId = await resolveDefaultComposeId(installation.orgId);
+    if (composeId) {
+      const agent = await getWorkspaceAgent(composeId);
+      agentName = agent?.name;
+    }
+  }
+
+  const botToken = decryptSecretValue(
+    installation.encryptedBotToken,
+    SECRETS_ENCRYPTION_KEY,
+  );
+  const client = createSlackClient(botToken);
+
+  await postMessage(
+    client,
+    context.channelId,
+    "Hi! I'm VM0. I can connect you to AI agents to help with your tasks.",
+    { blocks: buildWelcomeMessage(agentName) },
+  );
+}

--- a/turbo/apps/web/src/lib/slack-org/handlers/app-home.ts
+++ b/turbo/apps/web/src/lib/slack-org/handlers/app-home.ts
@@ -10,6 +10,7 @@ import {
   postMessage,
 } from "../../slack/client";
 import { buildAppHomeView, buildWelcomeMessage } from "../../slack/blocks";
+import { requireOrgMember } from "../../org/org-member-service";
 import {
   resolveDefaultComposeId,
   getWorkspaceAgent,
@@ -98,7 +99,6 @@ export async function refreshOrgAppHome(
   let isAdmin = false;
   if (installation.orgId) {
     try {
-      const { requireOrgMember } = await import("../../org/org-member-service");
       const member = await requireOrgMember(
         installation.orgId,
         connection.vm0UserId,

--- a/turbo/apps/web/src/lib/slack-org/handlers/direct-message.ts
+++ b/turbo/apps/web/src/lib/slack-org/handlers/direct-message.ts
@@ -1,0 +1,215 @@
+import { decryptSecretValue } from "../../crypto/secrets-encryption";
+import { env } from "../../../env";
+import {
+  createSlackClient,
+  postMessage,
+  setThreadStatus,
+} from "../../slack/client";
+import {
+  buildAgentResponseMessage,
+  buildLoginPromptMessage,
+  detectDeepLinks,
+} from "../../slack/blocks";
+import type { SlackFile } from "../../slack/context";
+import { runAgentForSlackOrg } from "./run-agent";
+import type { SlackOrgCallbackContext } from "./run-agent";
+import {
+  resolveOrgFromWorkspace,
+  resolveConnectionFromSlackUser,
+  resolveDefaultComposeId,
+  lookupThreadSession,
+  enrichMessageContent,
+  fetchConversationContexts,
+  buildOrgConnectUrl,
+  buildLogsUrl,
+  buildAgentLogsUrl,
+  getWorkspaceAgent,
+  resolveSessionCompose,
+} from "./shared";
+import { getPlatformUrl } from "../../url";
+import { logger } from "../../logger";
+
+const log = logger("slack-org:dm");
+
+interface OrgDirectMessageContext {
+  workspaceId: string;
+  channelId: string;
+  userId: string;
+  messageText: string;
+  messageTs: string;
+  threadTs?: string;
+  files?: SlackFile[];
+}
+
+/**
+ * Handle a direct message event in an org-aware Slack workspace.
+ *
+ * Same as mention handler with DM-specific differences:
+ * 1. No mention prefix stripping
+ * 2. Login prompt uses postMessage (DMs are already private)
+ */
+export async function handleOrgDirectMessage(
+  context: OrgDirectMessageContext,
+): Promise<void> {
+  const { SECRETS_ENCRYPTION_KEY } = env();
+
+  // 1. Resolve workspace + org
+  const resolved = await resolveOrgFromWorkspace(context.workspaceId);
+  if (!resolved) {
+    return;
+  }
+  const { installation, orgId } = resolved;
+
+  const botToken = decryptSecretValue(
+    installation.encryptedBotToken,
+    SECRETS_ENCRYPTION_KEY,
+  );
+  const client = createSlackClient(botToken);
+  const botUserId = installation.botUserId;
+  const threadTs = context.threadTs ?? context.messageTs;
+
+  // 2. Check if user is connected
+  const connection = await resolveConnectionFromSlackUser(
+    context.userId,
+    context.workspaceId,
+  );
+
+  if (!connection) {
+    const connectUrl = buildOrgConnectUrl(
+      context.workspaceId,
+      context.userId,
+      context.channelId,
+    );
+    await postMessage(
+      client,
+      context.channelId,
+      "Please connect your account first",
+      { blocks: buildLoginPromptMessage(connectUrl) },
+    );
+    return;
+  }
+
+  // 3. Resolve default agent
+  const composeId = await resolveDefaultComposeId(orgId);
+  if (!composeId) {
+    await postMessage(
+      client,
+      context.channelId,
+      "No agent is configured for this org. Please ask your org admin to set a default agent.",
+      { threadTs },
+    );
+    return;
+  }
+
+  const agent = await getWorkspaceAgent(composeId);
+  if (!agent) {
+    await postMessage(
+      client,
+      context.channelId,
+      "The configured agent could not be found. Please contact your org admin.",
+      { threadTs },
+    );
+    return;
+  }
+  const agentName = agent.name;
+
+  // 4. Show thinking indicator
+  await setThreadStatus(client, context.channelId, threadTs, "is thinking...");
+
+  // 5. Enrich message
+  const messageContent = await enrichMessageContent({
+    messageContent: context.messageText,
+    files: context.files,
+    botToken,
+    channelId: context.channelId,
+    threadTs,
+    client,
+    userId: context.userId,
+  });
+
+  // 6. Look up existing thread session
+  let existingSessionId: string | undefined;
+  let lastProcessedMessageTs: string | undefined;
+  if (threadTs) {
+    const session = await lookupThreadSession(
+      context.channelId,
+      threadTs,
+      connection.id,
+    );
+    existingSessionId = session.existingSessionId;
+    lastProcessedMessageTs = session.lastProcessedMessageTs;
+  }
+
+  if (existingSessionId) {
+    const sessionCompose = await resolveSessionCompose(
+      existingSessionId,
+      connection.vm0UserId,
+    );
+    if (sessionCompose && sessionCompose.composeId !== composeId) {
+      existingSessionId = undefined;
+      lastProcessedMessageTs = undefined;
+    }
+  }
+
+  // 7. Fetch conversation context
+  const { executionContext } = await fetchConversationContexts(
+    client,
+    context.channelId,
+    context.threadTs,
+    botUserId,
+    botToken,
+    lastProcessedMessageTs,
+    context.messageTs,
+  );
+
+  // 8. Dispatch agent run
+  const callbackContext: SlackOrgCallbackContext = {
+    workspaceId: context.workspaceId,
+    channelId: context.channelId,
+    threadTs,
+    messageTs: context.messageTs,
+    connectionId: connection.id,
+    orgId,
+    agentName,
+    composeId,
+    existingSessionId,
+  };
+
+  const { status, response, runId } = await runAgentForSlackOrg({
+    composeId,
+    agentName,
+    sessionId: existingSessionId,
+    prompt: messageContent,
+    threadContext: executionContext,
+    userId: connection.vm0UserId,
+    orgId,
+    callbackContext,
+  });
+
+  if (status === "queued") {
+    await client.chat.postEphemeral({
+      channel: context.channelId,
+      user: context.userId,
+      thread_ts: threadTs,
+      text: "⚠ Run queued — concurrency limit reached. Will start automatically when a slot is available.",
+    });
+  } else if (status === "failed") {
+    const errorText = response ?? "Sorry, an error occurred. Please try again.";
+    const logsUrl = runId
+      ? buildLogsUrl(runId, agentName)
+      : buildAgentLogsUrl(agentName);
+    const deepLinks = detectDeepLinks(errorText, getPlatformUrl(), agentName);
+    await postMessage(client, context.channelId, errorText, {
+      threadTs,
+      blocks: buildAgentResponseMessage(
+        errorText,
+        agentName,
+        logsUrl,
+        deepLinks,
+      ),
+    });
+    await setThreadStatus(client, context.channelId, threadTs, "").catch(
+      (err) => log.warn("Failed to clear thread status", { error: err }),
+    );
+  }
+}

--- a/turbo/apps/web/src/lib/slack-org/handlers/mention.ts
+++ b/turbo/apps/web/src/lib/slack-org/handlers/mention.ts
@@ -1,0 +1,218 @@
+import { decryptSecretValue } from "../../crypto/secrets-encryption";
+import { env } from "../../../env";
+import { createSlackClient, setThreadStatus } from "../../slack/client";
+import {
+  buildAgentResponseMessage,
+  buildLoginPromptMessage,
+  detectDeepLinks,
+} from "../../slack/blocks";
+import type { SlackFile } from "../../slack/context";
+import { runAgentForSlackOrg } from "./run-agent";
+import type { SlackOrgCallbackContext } from "./run-agent";
+import {
+  resolveOrgFromWorkspace,
+  resolveConnectionFromSlackUser,
+  resolveDefaultComposeId,
+  lookupThreadSession,
+  enrichMessageContent,
+  fetchConversationContexts,
+  buildOrgConnectUrl,
+  buildLogsUrl,
+  buildAgentLogsUrl,
+  getWorkspaceAgent,
+  resolveSessionCompose,
+} from "./shared";
+import { getPlatformUrl } from "../../url";
+import { logger } from "../../logger";
+
+const log = logger("slack-org:mention");
+
+interface OrgMentionContext {
+  workspaceId: string;
+  channelId: string;
+  userId: string;
+  messageText: string;
+  messageTs: string;
+  threadTs?: string;
+  files?: SlackFile[];
+}
+
+/**
+ * Handle an @mention event in an org-aware Slack workspace.
+ */
+export async function handleOrgMention(
+  context: OrgMentionContext,
+): Promise<void> {
+  const { SECRETS_ENCRYPTION_KEY } = env();
+
+  // 1. Resolve workspace installation + org
+  const resolved = await resolveOrgFromWorkspace(context.workspaceId);
+  if (!resolved) {
+    log.debug("Workspace not configured for org", {
+      workspaceId: context.workspaceId,
+    });
+    return;
+  }
+  const { installation, orgId } = resolved;
+
+  // Decrypt bot token
+  const botToken = decryptSecretValue(
+    installation.encryptedBotToken,
+    SECRETS_ENCRYPTION_KEY,
+  );
+  const client = createSlackClient(botToken);
+  const botUserId = installation.botUserId;
+  const threadTs = context.threadTs ?? context.messageTs;
+
+  // 2. Check if user is connected
+  const connection = await resolveConnectionFromSlackUser(
+    context.userId,
+    context.workspaceId,
+  );
+
+  if (!connection) {
+    // Post ephemeral login prompt
+    const connectUrl = buildOrgConnectUrl(
+      context.workspaceId,
+      context.userId,
+      context.channelId,
+    );
+    await client.chat.postEphemeral({
+      channel: context.channelId,
+      user: context.userId,
+      thread_ts: threadTs,
+      text: "Please connect your account first",
+      blocks: buildLoginPromptMessage(connectUrl),
+    });
+    return;
+  }
+
+  // 3. Resolve default agent
+  const composeId = await resolveDefaultComposeId(orgId);
+  if (!composeId) {
+    await client.chat.postEphemeral({
+      channel: context.channelId,
+      user: context.userId,
+      thread_ts: threadTs,
+      text: "No agent is configured for this org. Please ask your org admin to set a default agent.",
+    });
+    return;
+  }
+
+  const agent = await getWorkspaceAgent(composeId);
+  if (!agent) {
+    await client.chat.postEphemeral({
+      channel: context.channelId,
+      user: context.userId,
+      thread_ts: threadTs,
+      text: "The configured agent could not be found. Please contact your org admin.",
+    });
+    return;
+  }
+  const agentName = agent.name;
+
+  // 4. Show thinking indicator
+  await setThreadStatus(client, context.channelId, threadTs, "is thinking...");
+
+  // 5. Enrich message content
+  const messageContent = await enrichMessageContent({
+    messageContent: context.messageText,
+    files: context.files,
+    botToken,
+    channelId: context.channelId,
+    threadTs,
+    client,
+    userId: context.userId,
+  });
+
+  // 6. Look up existing thread session
+  let existingSessionId: string | undefined;
+  let lastProcessedMessageTs: string | undefined;
+  if (threadTs) {
+    const session = await lookupThreadSession(
+      context.channelId,
+      threadTs,
+      connection.id,
+    );
+    existingSessionId = session.existingSessionId;
+    lastProcessedMessageTs = session.lastProcessedMessageTs;
+  }
+
+  // 6b. Validate session agent matches current default
+  if (existingSessionId) {
+    const sessionCompose = await resolveSessionCompose(
+      existingSessionId,
+      connection.vm0UserId,
+    );
+    if (sessionCompose && sessionCompose.composeId !== composeId) {
+      log.debug("Agent changed, starting new session");
+      existingSessionId = undefined;
+      lastProcessedMessageTs = undefined;
+    }
+  }
+
+  // 7. Fetch conversation context
+  const { executionContext } = await fetchConversationContexts(
+    client,
+    context.channelId,
+    context.threadTs,
+    botUserId,
+    botToken,
+    lastProcessedMessageTs,
+    context.messageTs,
+  );
+
+  // 8. Dispatch agent run with explicit orgId
+  const callbackContext: SlackOrgCallbackContext = {
+    workspaceId: context.workspaceId,
+    channelId: context.channelId,
+    threadTs,
+    messageTs: context.messageTs,
+    connectionId: connection.id,
+    orgId,
+    agentName,
+    composeId,
+    existingSessionId,
+  };
+
+  const { status, response, runId } = await runAgentForSlackOrg({
+    composeId,
+    agentName,
+    sessionId: existingSessionId,
+    prompt: messageContent,
+    threadContext: executionContext,
+    userId: connection.vm0UserId,
+    orgId,
+    callbackContext,
+  });
+
+  if (status === "queued") {
+    await client.chat.postEphemeral({
+      channel: context.channelId,
+      user: context.userId,
+      thread_ts: threadTs,
+      text: "⚠ Run queued — concurrency limit reached. Will start automatically when a slot is available.",
+    });
+  } else if (status === "failed") {
+    log.error("Failed to dispatch agent run", { response });
+    const errorText = response ?? "Sorry, an error occurred. Please try again.";
+    const logsUrl = runId
+      ? buildLogsUrl(runId, agentName)
+      : buildAgentLogsUrl(agentName);
+    const deepLinks = detectDeepLinks(errorText, getPlatformUrl(), agentName);
+    await client.chat.postMessage({
+      channel: context.channelId,
+      thread_ts: threadTs,
+      text: errorText,
+      blocks: buildAgentResponseMessage(
+        errorText,
+        agentName,
+        logsUrl,
+        deepLinks,
+      ),
+    });
+    await setThreadStatus(client, context.channelId, threadTs, "").catch(
+      (err) => log.warn("Failed to clear thread status", { error: err }),
+    );
+  }
+}

--- a/turbo/apps/web/src/lib/slack-org/handlers/run-agent.ts
+++ b/turbo/apps/web/src/lib/slack-org/handlers/run-agent.ts
@@ -1,0 +1,156 @@
+import { eq, desc } from "drizzle-orm";
+import {
+  agentComposes,
+  agentComposeVersions,
+} from "../../../db/schema/agent-compose";
+import { createRun, isRunDispatchError } from "../../run";
+import { buildIntegrationContext } from "../../integration-context";
+import { generateCallbackSecret, getApiUrl } from "../../callback";
+import { getOrgData } from "../../org/org-cache-service";
+import { orgTierSchema } from "@vm0/core";
+import { logger } from "../../logger";
+
+const log = logger("slack-org:run-agent");
+
+/**
+ * Org-aware callback context for Slack
+ */
+export interface SlackOrgCallbackContext {
+  workspaceId: string;
+  channelId: string;
+  threadTs: string;
+  messageTs: string;
+  connectionId: string;
+  orgId: string;
+  agentName: string;
+  composeId: string;
+  existingSessionId?: string;
+}
+
+interface RunAgentParams {
+  composeId: string;
+  agentName: string;
+  sessionId: string | undefined;
+  prompt: string;
+  threadContext: string;
+  userId: string;
+  orgId: string;
+  callbackContext: SlackOrgCallbackContext;
+}
+
+interface RunAgentResult {
+  status: "dispatched" | "queued" | "failed";
+  response?: string;
+  runId: string | undefined;
+}
+
+/**
+ * Execute an agent run for org-aware Slack integration.
+ *
+ * Key difference from legacy: passes orgId, orgSlug, orgTier explicitly
+ * to createRun() instead of relying on getDefaultOrg().
+ */
+export async function runAgentForSlackOrg(
+  params: RunAgentParams,
+): Promise<RunAgentResult> {
+  const {
+    composeId,
+    agentName,
+    sessionId,
+    prompt,
+    threadContext,
+    userId,
+    orgId,
+    callbackContext,
+  } = params;
+
+  try {
+    // Get compose and latest version
+    const [compose] = await globalThis.services.db
+      .select({
+        id: agentComposes.id,
+        headVersionId: agentComposes.headVersionId,
+      })
+      .from(agentComposes)
+      .where(eq(agentComposes.id, composeId))
+      .limit(1);
+
+    if (!compose) {
+      return {
+        status: "failed",
+        response: "Error: Agent configuration not found.",
+        runId: undefined,
+      };
+    }
+
+    // Get latest version
+    let versionId = compose.headVersionId;
+    if (!versionId) {
+      const [latestVersion] = await globalThis.services.db
+        .select({ id: agentComposeVersions.id })
+        .from(agentComposeVersions)
+        .where(eq(agentComposeVersions.composeId, compose.id))
+        .orderBy(desc(agentComposeVersions.createdAt))
+        .limit(1);
+
+      if (!latestVersion) {
+        return {
+          status: "failed",
+          response: "Error: Agent has no versions configured.",
+          runId: undefined,
+        };
+      }
+      versionId = latestVersion.id;
+    }
+
+    // Build prompt with integration context
+    const integrationContext = buildIntegrationContext("Slack");
+    const fullPrompt = threadContext
+      ? `${integrationContext}\n\n${threadContext}\n\n# User Prompt\n\n${prompt}`
+      : `${integrationContext}\n\n# User Prompt\n\n${prompt}`;
+
+    // Build callback
+    const callbackUrl = `${getApiUrl()}/api/internal/callbacks/slack/org`;
+    const callbackSecret = generateCallbackSecret();
+
+    // Resolve org context for explicit passing
+    const orgData = await getOrgData(orgId);
+    const orgTier = orgTierSchema.parse(orgData.tier);
+
+    // Create run with EXPLICIT org context
+    const result = await createRun({
+      userId,
+      agentComposeVersionId: versionId,
+      prompt: fullPrompt,
+      composeId: compose.id,
+      sessionId,
+      agentName,
+      artifactName: "artifact",
+      memoryName: "memory",
+      orgId,
+      orgSlug: orgData.slug,
+      orgTier,
+      callbacks: [
+        {
+          url: callbackUrl,
+          secret: callbackSecret,
+          payload: callbackContext,
+        },
+      ],
+    });
+
+    const status = result.status === "queued" ? "queued" : "dispatched";
+    log.debug(`Run ${result.runId} ${status} for Slack org agent ${agentName}`);
+
+    return { status, runId: result.runId };
+  } catch (error) {
+    const runId = isRunDispatchError(error) ? error.runId : undefined;
+    log.error("Error running agent for Slack org:", error);
+    return {
+      status: "failed",
+      response:
+        "Something went wrong while starting the agent. Please try again later.",
+      runId,
+    };
+  }
+}

--- a/turbo/apps/web/src/lib/slack-org/handlers/shared.ts
+++ b/turbo/apps/web/src/lib/slack-org/handlers/shared.ts
@@ -1,8 +1,11 @@
 import { eq, and } from "drizzle-orm";
+import { clerkClient } from "@clerk/nextjs/server";
 import { slackOrgInstallations } from "../../../db/schema/slack-org-installation";
 import { slackOrgConnections } from "../../../db/schema/slack-org-connection";
 import { slackOrgThreadSessions } from "../../../db/schema/slack-org-thread-session";
 import { getPlatformUrl } from "../../url";
+import { resolveDefaultAgentComposeId } from "../../agent-compose/resolve-default";
+import { ensureStorageExists } from "../../storage/storage-service";
 
 /**
  * Resolve installation and org from a Slack workspace ID.
@@ -56,10 +59,8 @@ export async function resolveDefaultComposeId(
   // For now, read from Clerk org metadata via org cache
   // The publicMetadata.default_agent_compose_id field may not yet exist,
   // so we read it via getOrgData which fetches from Clerk API
-  const clerkClient = (await import("@clerk/nextjs/server")).clerkClient();
-  const org = await (
-    await clerkClient
-  ).organizations.getOrganization({
+  const clerk = await clerkClient();
+  const org = await clerk.organizations.getOrganization({
     organizationId: orgId,
   });
 
@@ -71,9 +72,6 @@ export async function resolveDefaultComposeId(
   }
 
   // Fallback: resolve from VM0_DEFAULT_AGENT env var
-  const { resolveDefaultAgentComposeId } = await import(
-    "../../agent-compose/resolve-default"
-  );
   return resolveDefaultAgentComposeId();
 }
 
@@ -205,7 +203,6 @@ export async function ensureOrgArtifact(
   orgId: string,
   orgSlug: string,
 ): Promise<void> {
-  const { ensureStorageExists } = await import("../../storage/storage-service");
   await ensureStorageExists(orgId, userId, "artifact", orgSlug, "artifact");
 }
 

--- a/turbo/apps/web/src/lib/slack-org/handlers/shared.ts
+++ b/turbo/apps/web/src/lib/slack-org/handlers/shared.ts
@@ -1,0 +1,220 @@
+import { eq, and } from "drizzle-orm";
+import { slackOrgInstallations } from "../../../db/schema/slack-org-installation";
+import { slackOrgConnections } from "../../../db/schema/slack-org-connection";
+import { slackOrgThreadSessions } from "../../../db/schema/slack-org-thread-session";
+import { getPlatformUrl } from "../../url";
+
+/**
+ * Resolve installation and org from a Slack workspace ID.
+ * Returns null if the workspace is not installed or not bound to an org.
+ */
+export async function resolveOrgFromWorkspace(workspaceId: string): Promise<{
+  installation: typeof slackOrgInstallations.$inferSelect;
+  orgId: string;
+} | null> {
+  const [installation] = await globalThis.services.db
+    .select()
+    .from(slackOrgInstallations)
+    .where(eq(slackOrgInstallations.slackWorkspaceId, workspaceId))
+    .limit(1);
+
+  if (!installation?.orgId) {
+    return null;
+  }
+
+  return { installation, orgId: installation.orgId };
+}
+
+/**
+ * Resolve a connection from a Slack user in a workspace.
+ */
+export async function resolveConnectionFromSlackUser(
+  slackUserId: string,
+  workspaceId: string,
+): Promise<typeof slackOrgConnections.$inferSelect | null> {
+  const [connection] = await globalThis.services.db
+    .select()
+    .from(slackOrgConnections)
+    .where(
+      and(
+        eq(slackOrgConnections.slackUserId, slackUserId),
+        eq(slackOrgConnections.slackWorkspaceId, workspaceId),
+      ),
+    )
+    .limit(1);
+
+  return connection ?? null;
+}
+
+/**
+ * Resolve default agent compose ID from Clerk org metadata.
+ * Falls back to VM0_DEFAULT_AGENT env var if not set.
+ */
+export async function resolveDefaultComposeId(
+  orgId: string,
+): Promise<string | null> {
+  // For now, read from Clerk org metadata via org cache
+  // The publicMetadata.default_agent_compose_id field may not yet exist,
+  // so we read it via getOrgData which fetches from Clerk API
+  const clerkClient = (await import("@clerk/nextjs/server")).clerkClient();
+  const org = await (
+    await clerkClient
+  ).organizations.getOrganization({
+    organizationId: orgId,
+  });
+
+  const metadata = org.publicMetadata as Record<string, unknown> | undefined;
+  const composeId = metadata?.default_agent_compose_id;
+
+  if (typeof composeId === "string" && composeId.length > 0) {
+    return composeId;
+  }
+
+  // Fallback: resolve from VM0_DEFAULT_AGENT env var
+  const { resolveDefaultAgentComposeId } = await import(
+    "../../agent-compose/resolve-default"
+  );
+  return resolveDefaultAgentComposeId();
+}
+
+/**
+ * Look up an existing thread session for deduplication.
+ */
+export async function lookupThreadSession(
+  channelId: string,
+  threadTs: string,
+  connectionId: string,
+): Promise<{
+  existingSessionId: string | undefined;
+  lastProcessedMessageTs: string | undefined;
+}> {
+  const [session] = await globalThis.services.db
+    .select({
+      agentSessionId: slackOrgThreadSessions.agentSessionId,
+      lastProcessedMessageTs: slackOrgThreadSessions.lastProcessedMessageTs,
+    })
+    .from(slackOrgThreadSessions)
+    .where(
+      and(
+        eq(slackOrgThreadSessions.connectionId, connectionId),
+        eq(slackOrgThreadSessions.slackChannelId, channelId),
+        eq(slackOrgThreadSessions.slackThreadTs, threadTs),
+      ),
+    )
+    .limit(1);
+
+  return {
+    existingSessionId: session?.agentSessionId ?? undefined,
+    lastProcessedMessageTs: session?.lastProcessedMessageTs ?? undefined,
+  };
+}
+
+/**
+ * Save or update a thread session mapping after agent execution.
+ */
+export async function saveThreadSession(opts: {
+  connectionId: string;
+  channelId: string;
+  threadTs: string;
+  existingSessionId: string | undefined;
+  newSessionId: string | undefined;
+  messageTs: string;
+  runStatus: string;
+}): Promise<void> {
+  const {
+    connectionId,
+    channelId,
+    threadTs,
+    existingSessionId,
+    newSessionId,
+    messageTs,
+    runStatus,
+  } = opts;
+
+  const agentSessionId = newSessionId ?? existingSessionId;
+
+  // Skip update on failed runs — allows retry with same context
+  if (runStatus === "failed") {
+    return;
+  }
+
+  if (!existingSessionId && agentSessionId) {
+    // Create new mapping
+    await globalThis.services.db
+      .insert(slackOrgThreadSessions)
+      .values({
+        connectionId,
+        slackChannelId: channelId,
+        slackThreadTs: threadTs,
+        agentSessionId,
+        lastProcessedMessageTs: messageTs,
+      })
+      .onConflictDoUpdate({
+        target: [
+          slackOrgThreadSessions.connectionId,
+          slackOrgThreadSessions.slackChannelId,
+          slackOrgThreadSessions.slackThreadTs,
+        ],
+        set: {
+          agentSessionId,
+          lastProcessedMessageTs: messageTs,
+          updatedAt: new Date(),
+        },
+      });
+  } else if (existingSessionId) {
+    // Update existing mapping
+    await globalThis.services.db
+      .update(slackOrgThreadSessions)
+      .set({
+        lastProcessedMessageTs: messageTs,
+        updatedAt: new Date(),
+      })
+      .where(
+        and(
+          eq(slackOrgThreadSessions.connectionId, connectionId),
+          eq(slackOrgThreadSessions.slackChannelId, channelId),
+          eq(slackOrgThreadSessions.slackThreadTs, threadTs),
+        ),
+      );
+  }
+}
+
+/**
+ * Build the org connect URL for Slack users.
+ */
+export function buildOrgConnectUrl(
+  workspaceId: string,
+  slackUserId: string,
+  channelId: string,
+): string {
+  const baseUrl = getPlatformUrl();
+  const params = new URLSearchParams({
+    w: workspaceId,
+    u: slackUserId,
+    c: channelId,
+  });
+  return `${baseUrl}/integrations/slack/org/connect?${params.toString()}`;
+}
+
+/**
+ * Ensure artifact storage exists for a user in a specific org.
+ * Unlike the legacy version, this takes explicit org context.
+ */
+export async function ensureOrgArtifact(
+  userId: string,
+  orgId: string,
+  orgSlug: string,
+): Promise<void> {
+  const { ensureStorageExists } = await import("../../storage/storage-service");
+  await ensureStorageExists(orgId, userId, "artifact", orgSlug, "artifact");
+}
+
+// Re-export pure functions from legacy shared module
+export {
+  fetchConversationContexts,
+  enrichMessageContent,
+  buildLogsUrl,
+  buildAgentLogsUrl,
+  getWorkspaceAgent,
+  resolveSessionCompose,
+} from "../../slack/handlers/shared";


### PR DESCRIPTION
## Summary
- Implements org-aware Slack integration as a parallel module (`src/lib/slack-org/`) alongside existing legacy integration — zero risk to existing users
- Adds connect service (admin-first flow with atomic workspace binding), event handlers (mention, DM, app home), slash commands, interactive actions (askUserQuestion), and callback routes
- All handlers pass explicit `orgId` context through to `createRun()` instead of relying on `getDefaultOrg()`, and derive admin status from Clerk at runtime

Builds on the schema from #4670.

Closes #4668

## Test plan
- [ ] Verify type checking passes (`pnpm check-types`)
- [ ] Verify lint passes (`pnpm turbo run lint`)
- [ ] Verify knip finds no unused exports
- [ ] Integration tests for connect, events, commands, interactive, and callback routes (follow-up PR)
- [ ] Manual testing with Slack workspace once deployed to staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)