### PR TITLE
refactor(cli): rename scope references to org in cli package (#4691)

### DIFF
--- a/turbo/apps/cli/src/commands/run/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/run/__tests__/index.test.ts
@@ -1578,7 +1578,7 @@ describe("run command", () => {
         await runCommand.parseAsync([
           "node",
           "cli",
-          "user-scope/missing-agent",
+          "user-org/missing-agent",
           "--experimental-shared-agent",
           "test prompt",
           "--artifact-name",
@@ -1598,12 +1598,11 @@ describe("run command", () => {
           const name = url.searchParams.get("name");
           const org = url.searchParams.get("org");
 
-          if (org === "other-user-scope" && name === "my-agent") {
+          if (org === "other-user-org" && name === "my-agent") {
             return HttpResponse.json(
               {
                 error: {
-                  message:
-                    "Compose not found: my-agent in scope other-user-scope",
+                  message: "Compose not found: my-agent in org other-user-org",
                   code: "NOT_FOUND",
                 },
               },
@@ -1621,7 +1620,7 @@ describe("run command", () => {
         await runCommand.parseAsync([
           "node",
           "cli",
-          "other-user-scope/my-agent",
+          "other-user-org/my-agent",
           "--experimental-shared-agent",
           "test prompt",
           "--artifact-name",
@@ -1654,7 +1653,7 @@ describe("run command", () => {
         await runCommand.parseAsync([
           "node",
           "cli",
-          "another-scope/secret-agent",
+          "another-org/secret-agent",
           "--experimental-shared-agent",
           "test prompt",
           "--artifact-name",

--- a/turbo/apps/cli/src/commands/run/run.ts
+++ b/turbo/apps/cli/src/commands/run/run.ts
@@ -31,7 +31,7 @@ export const mainRunCommand = new Command()
   .description("Run an agent")
   .argument(
     "<agent-name>",
-    "Agent reference: [scope/]name[:version] (e.g., 'my-agent', 'lancy/my-agent:abc123', 'my-agent:latest')",
+    "Agent reference: [org/]name[:version] (e.g., 'my-agent', 'lancy/my-agent:abc123', 'my-agent:latest')",
   )
   .argument("<prompt>", "Prompt for the agent")
   .option(
@@ -73,7 +73,7 @@ export const mainRunCommand = new Command()
   .option("--verbose", "Show full tool inputs and outputs")
   .option(
     "--experimental-shared-agent",
-    "Allow running agents shared by other users (required when running scope/agent format)",
+    "Allow running agents shared by other users (required when running org/agent format)",
   )
   .option("--check-env", "Validate secrets and vars before running")
   .addOption(new Option("--debug-no-mock-claude").hideHelp())
@@ -105,16 +105,16 @@ export const mainRunCommand = new Command()
           await startSilentUpgrade(__CLI_VERSION__);
         }
 
-        // 1. Parse identifier for optional scope and version specifier
-        const { scope, name, version } = parseIdentifier(identifier);
+        // 1. Parse identifier for optional org and version specifier
+        const { org, name, version } = parseIdentifier(identifier);
 
         // 1.5. Validate: running another user's agent requires explicit opt-in
-        if (scope && !options.experimentalSharedAgent) {
-          // Check if it's the user's own scope
-          const defaultScope = await getOrg();
-          const isOwnScope = defaultScope.slug === scope;
+        if (org && !options.experimentalSharedAgent) {
+          // Check if it's the user's own org
+          const defaultOrg = await getOrg();
+          const isOwnOrg = defaultOrg.slug === org;
 
-          if (!isOwnScope) {
+          if (!isOwnOrg) {
             throw new Error(
               "Running shared agents requires --experimental-shared-agent flag",
               {
@@ -137,7 +137,7 @@ export const mainRunCommand = new Command()
           composeContent = compose.content;
         } else {
           // It's an agent name - resolve to compose ID
-          const compose = await getComposeByName(name, scope);
+          const compose = await getComposeByName(name, org);
           if (!compose) {
             throw new Error(`Agent not found: ${identifier}`, {
               cause: new Error(

--- a/turbo/apps/cli/src/commands/run/shared.ts
+++ b/turbo/apps/cli/src/commands/run/shared.ts
@@ -128,17 +128,17 @@ export function loadValues(
 }
 
 /**
- * Parse identifier with optional scope and version specifier
- * Format: [scope/]name[:version]
+ * Parse identifier with optional org and version specifier
+ * Format: [org/]name[:version]
  * Examples:
  *   "demo:d084948d"      → { name: "demo", version: "d084948d" }
  *   "demo:latest"        → { name: "demo", version: "latest" }
  *   "demo"               → { name: "demo" }
- *   "lancy/demo"         → { scope: "lancy", name: "demo" }
- *   "lancy/demo:abc123"  → { scope: "lancy", name: "demo", version: "abc123" }
+ *   "lancy/demo"         → { org: "lancy", name: "demo" }
+ *   "lancy/demo:abc123"  → { org: "lancy", name: "demo", version: "abc123" }
  */
 export function parseIdentifier(identifier: string): {
-  scope?: string;
+  org?: string;
   name: string;
   version?: string;
 } {
@@ -147,13 +147,13 @@ export function parseIdentifier(identifier: string): {
     return { name: identifier };
   }
 
-  let scope: string | undefined;
+  let org: string | undefined;
   let rest = identifier;
 
-  // Check for scope (contains "/")
+  // Check for org (contains "/")
   const slashIndex = identifier.indexOf("/");
   if (slashIndex > 0) {
-    scope = identifier.slice(0, slashIndex);
+    org = identifier.slice(0, slashIndex);
     rest = identifier.slice(slashIndex + 1);
   }
 
@@ -161,13 +161,13 @@ export function parseIdentifier(identifier: string): {
   const colonIndex = rest.indexOf(":");
   if (colonIndex > 0 && colonIndex < rest.length - 1) {
     return {
-      scope,
+      org,
       name: rest.slice(0, colonIndex),
       version: rest.slice(colonIndex + 1),
     };
   }
 
-  return { scope, name: rest };
+  return { org, name: rest };
 }
 
 /**

--- a/turbo/apps/cli/src/index.ts
+++ b/turbo/apps/cli/src/index.ts
@@ -12,7 +12,7 @@ import { artifactCommand } from "./commands/artifact";
 import { memoryCommand } from "./commands/memory";
 import { cookCommand } from "./commands/cook";
 import { logsCommand } from "./commands/logs";
-import chalk from "chalk";
+
 import { orgCommand } from "./commands/org";
 import { agentCommand } from "./commands/agent";
 import { initCommand } from "./commands/init";
@@ -49,20 +49,6 @@ program.addCommand(cookCommand);
 program.addCommand(logsCommand);
 program.addCommand(orgCommand);
 
-// Deprecated scope command alias — shows deprecation warning
-const deprecatedScopeCommand = new Command("scope")
-  .allowUnknownOption()
-  .allowExcessArguments()
-  .action((_options: unknown, command: Command) => {
-    const args = command.args.join(" ");
-    console.error(
-      chalk.yellow(
-        `⚠ 'vm0 scope' is deprecated. Use 'vm0 org${args ? " " + args : ""}' instead.`,
-      ),
-    );
-    process.exit(1);
-  });
-program.addCommand(deprecatedScopeCommand, { hidden: true });
 program.addCommand(agentCommand);
 program.addCommand(initCommand);
 program.addCommand(scheduleCommand);


### PR DESCRIPTION
## Summary

- Remove deprecated `vm0 scope` command entirely (no backward compatibility needed)
- Rename `scope` → `org` in `parseIdentifier()` return type, variables, and comments
- Update user-facing text in run command (`[scope/]` → `[org/]`)
- Update test data strings from `*-scope` to `*-org` patterns

Closes #4691

## Test plan

- [x] All 51 existing run command tests pass
- [x] Lint passes (`oxlint` + `eslint`)
- [x] Type check passes
- [x] Knip finds no unused code
- [x] Verified no remaining scope references in CLI package (excluding unrelated `PluginScope`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)