### PR TITLE
refactor: update remaining scope comments to use org terminology

### DIFF
--- a/turbo/apps/web/src/__tests__/api-test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers.ts
@@ -316,7 +316,7 @@ export async function findTestCliToken(token: string) {
  * Create a test org by inserting into org_cache.
  *
  * Pre-populates org_cache so getOrgData() works without Clerk API calls.
- * The legacy scopes table was dropped and replaced by orgs (Phase 6 🆉).
+ * The legacy scopes table was dropped and replaced by orgs.
  *
  * @param slug - The org slug
  * @returns The created org with id and slug

--- a/turbo/apps/web/src/__tests__/github/api-helpers.ts
+++ b/turbo/apps/web/src/__tests__/github/api-helpers.ts
@@ -35,7 +35,7 @@ interface GitHubInstallationResult {
 /**
  * Given a GitHub App installation exists in the database.
  *
- * Creates all prerequisite records (scope, compose, version, installation, user link)
+ * Creates all prerequisite records (org, compose, version, installation, user link)
  * needed for webhook handler tests.
  */
 export async function givenGitHubInstallation(

--- a/turbo/apps/web/src/__tests__/test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/test-helpers.ts
@@ -425,7 +425,7 @@ export function testContext(): TestContext {
 
   /**
    * Creates an isolated user context for a single test.
-   * Each call creates a unique user ID and scope.
+   * Each call creates a unique user ID and org.
    *
    * Usage:
    *   const user = await context.setupUser();
@@ -446,7 +446,7 @@ export function testContext(): TestContext {
     const userPromise = (async () => {
       initServices();
 
-      // Generate unique suffix shared between userId and scope
+      // Generate unique suffix shared between userId and org
       // This allows tests to derive org slug from userId if needed
       const suffix = uniqueSuffix();
       const userId = `${prefix}-${suffix}`;

--- a/turbo/apps/web/src/lib/org/__tests__/resolve-org.test.ts
+++ b/turbo/apps/web/src/lib/org/__tests__/resolve-org.test.ts
@@ -45,14 +45,14 @@ describe("resolveOrg", () => {
     await createTestOrg(slug1);
     await createTestOrg(slug2);
 
-    // Mock session with orgId pointing to scope2
+    // Mock session with orgId pointing to org2
     mockClerk({
       userId,
       orgId: `org_mock_${slug2}`,
       clerkOrgs: testOrgs(slug1, slug2),
     });
 
-    // Resolve with explicit slug for scope1 — should return scope1, not scope2
+    // Resolve with explicit slug for org1 — should return org1, not org2
     const result = await resolveOrg(userId, slug1);
 
     expect(result.org.orgId).toBe(`org_mock_${slug1}`);
@@ -169,7 +169,7 @@ describe("resolveOrg", () => {
       clerkOrgs: testOrgs(slug1, slug2),
     });
 
-    // Resolve without slug — should return scope2 (from orgId), not scope1 (default)
+    // Resolve without slug — should return org2 (from orgId), not org1 (default)
     const result = await resolveOrg(userId);
 
     expect(result.org.orgId).toBe(`org_mock_${slug2}`);
@@ -231,7 +231,7 @@ describe("resolveOrg", () => {
     await createTestOrg(slug1);
     await createTestOrg(slug2);
 
-    // JWT active org is scope2, but resolving scope1 via explicit slug
+    // JWT active org is org2, but resolving org1 via explicit slug
     mockClerk({
       userId,
       orgId: `org_mock_${slug2}`,


### PR DESCRIPTION
## Summary

- Replace the last 7 comments that still referenced "scope" as a domain concept with "org"
- This completes the scope→org migration across the entire codebase

## Changes

| File | Change |
|------|--------|
| `web/src/__tests__/api-test-helpers.ts` | `"legacy scopes table"` — historical comment, kept factual |
| `web/src/__tests__/github/api-helpers.ts` | `"prerequisite records (scope, ...)"` → `"(org, ...)"` |
| `web/src/__tests__/test-helpers.ts` | `"unique user ID and scope"` → `"and org"` (2 comments) |
| `web/src/lib/org/__tests__/resolve-org.test.ts` | `scope1/scope2` → `org1/org2` in 4 comments |

## Verification

After this PR, searching the codebase for "scope" returns **only**:
- OAuth permission scopes (`oauthScopes`, `hasRequiredScopes`, `BOT_SCOPES`)
- Sentry SDK `initialScope`
- Claude plugin `PluginScope` (`--scope user|project`)
- English adjective "scoped" (e.g., "scoped to the active organization")
- UI display concept `scope: "personal" | "team"`

## Test plan

- [x] Pure comment changes, no behavior change
- [x] All pre-commit checks pass (format, knip, commitlint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)