### PR TITLE
feat: remove org_id from cli_tokens, use org_members_cache for verification

### DIFF
--- a/e2e/scripts/generate-test-token.sh
+++ b/e2e/scripts/generate-test-token.sh
@@ -111,8 +111,9 @@ call_test_token_endpoint() {
 # Call endpoint with retry
 BODY=$(call_test_token_endpoint) || exit 1
 
-# Extract token from response
+# Extract token and org_slug from response
 TOKEN=$(echo "$BODY" | grep -o '"access_token":"[^"]*"' | cut -d'"' -f4)
+ORG_SLUG=$(echo "$BODY" | grep -o '"org_slug":"[^"]*"' | cut -d'"' -f4)
 
 if [[ -z "$TOKEN" ]]; then
   echo "Error: Failed to extract token from response"
@@ -123,6 +124,7 @@ fi
 # Mask token in logs (show first 10 and last 4 chars)
 MASKED_TOKEN="${TOKEN:0:10}...${TOKEN: -4}"
 echo "Got token: $MASKED_TOKEN"
+echo "Org slug: ${ORG_SLUG:-<none>}"
 
 # Create config directory and file
 CONFIG_DIR="$HOME/.vm0"
@@ -130,13 +132,23 @@ CONFIG_FILE="$CONFIG_DIR/config.json"
 
 mkdir -p "$CONFIG_DIR"
 
-# Write config file
-cat > "$CONFIG_FILE" << EOF
+# Write config file (include activeOrg if returned by server)
+if [[ -n "$ORG_SLUG" ]]; then
+  cat > "$CONFIG_FILE" << EOF
+{
+  "token": "$TOKEN",
+  "apiUrl": "$VM0_API_URL",
+  "activeOrg": "$ORG_SLUG"
+}
+EOF
+else
+  cat > "$CONFIG_FILE" << EOF
 {
   "token": "$TOKEN",
   "apiUrl": "$VM0_API_URL"
 }
 EOF
+fi
 
 echo ""
 echo "=== Token generated successfully ==="

--- a/turbo/apps/cli/src/commands/org/set.ts
+++ b/turbo/apps/cli/src/commands/org/set.ts
@@ -1,6 +1,7 @@
 import { Command } from "commander";
 import chalk from "chalk";
 import { getOrg, updateOrg } from "../../lib/api";
+import { saveConfig } from "../../lib/api/config";
 import { withErrorHandler } from "../../lib/command";
 
 export const setCommand = new Command()
@@ -26,6 +27,7 @@ export const setCommand = new Command()
         }
 
         const org = await updateOrg({ slug, force: true });
+        await saveConfig({ activeOrg: org.slug });
         console.log(chalk.green(`✓ Organization updated to ${org.slug}`));
         console.log();
         console.log("Your agents will now be namespaced as:");

--- a/turbo/apps/cli/src/lib/api/auth.ts
+++ b/turbo/apps/cli/src/lib/api/auth.ts
@@ -62,6 +62,7 @@ async function exchangeToken(
   refresh_token?: string;
   token_type?: string;
   expires_in?: number;
+  org_slug?: string;
   error?: string;
   error_description?: string;
 }> {
@@ -76,6 +77,7 @@ async function exchangeToken(
     refresh_token?: string;
     token_type?: string;
     expires_in?: number;
+    org_slug?: string;
     error?: string;
     error_description?: string;
   }>;
@@ -125,10 +127,11 @@ export async function authenticate(apiUrl?: string): Promise<void> {
     );
 
     if (tokenResult.access_token) {
-      // Success! Store the token
+      // Success! Store the token and org context
       await saveConfig({
         token: tokenResult.access_token,
         apiUrl: targetApiUrl,
+        ...(tokenResult.org_slug && { activeOrg: tokenResult.org_slug }),
       });
 
       console.log(chalk.green("\nAuthentication successful!"));

--- a/turbo/apps/web/app/api/agent/composes/list/route.ts
+++ b/turbo/apps/web/app/api/agent/composes/list/route.ts
@@ -74,17 +74,12 @@ const router = tsr.router(composesListContract, {
         },
       };
     }
-    const { userId, orgId: tokenOrgId } = authCtx;
+    const { userId } = authCtx;
 
     // Resolve org: use ?org= query param or default org
     let orgId: string;
     try {
-      const { org: resolvedOrg } = await resolveOrg(
-        userId,
-        query.org,
-        undefined,
-        tokenOrgId,
-      );
+      const { org: resolvedOrg } = await resolveOrg(userId, query.org);
       orgId = resolvedOrg.orgId;
     } catch (error) {
       if (isNotFound(error)) {

--- a/turbo/apps/web/app/api/agent/composes/route.ts
+++ b/turbo/apps/web/app/api/agent/composes/route.ts
@@ -43,7 +43,7 @@ const router = tsr.router(composesMainContract, {
         },
       };
     }
-    const { userId, orgId: tokenOrgId } = authCtx;
+    const { userId } = authCtx;
 
     // Resolve org: for cross-org lookups (shared agents), skip membership
     // check and rely on canAccessCompose for authorization instead.
@@ -68,12 +68,7 @@ const router = tsr.router(composesMainContract, {
       }
       orgId = orgData.orgId;
     } else {
-      const { org: resolvedOrg } = await resolveOrg(
-        userId,
-        null,
-        null,
-        tokenOrgId,
-      );
+      const { org: resolvedOrg } = await resolveOrg(userId);
       orgId = resolvedOrg.orgId;
     }
 
@@ -153,7 +148,7 @@ const router = tsr.router(composesMainContract, {
         },
       };
     }
-    const { userId, orgId: tokenOrgId } = authCtx;
+    const { userId } = authCtx;
 
     const { content } = body;
 
@@ -265,7 +260,7 @@ const router = tsr.router(composesMainContract, {
     const versionId = computeComposeVersionId(resolvedContent);
 
     // Get user's org (required for compose creation)
-    const { org } = await resolveOrg(userId, null, null, tokenOrgId);
+    const { org } = await resolveOrg(userId);
 
     // Check compose and version existence in parallel
     const [existingComposes, existingVersions] = await Promise.all([

--- a/turbo/apps/web/app/api/agent/runs/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/route.ts
@@ -398,7 +398,7 @@ const router = tsr.router(runsMainContract, {
         },
       };
     }
-    const { userId, orgId: tokenOrgId } = authCtx;
+    const { userId } = authCtx;
 
     // Validate mutually exclusive shortcuts
     if (body.checkpointId && body.sessionId) {
@@ -447,7 +447,7 @@ const router = tsr.router(runsMainContract, {
     // Resolve org for variable/secret resolution.
     // The actual variable fetching happens in build-context.ts.
     const orgSlug = new URL(request.url).searchParams.get("org");
-    const { org } = await resolveOrg(userId, orgSlug, null, tokenOrgId);
+    const { org } = await resolveOrg(userId, orgSlug);
 
     // Delegate run creation, validation, and dispatch to createRun()
     try {

--- a/turbo/apps/web/app/api/agent/schedules/[name]/disable/route.ts
+++ b/turbo/apps/web/app/api/agent/schedules/[name]/disable/route.ts
@@ -28,7 +28,7 @@ export async function POST(
       { status: 401 },
     );
   }
-  const { userId, orgId: tokenOrgId } = authCtx;
+  const { userId } = authCtx;
 
   const { name } = await params;
 
@@ -48,7 +48,7 @@ export async function POST(
   }
   const body = parseResult.data;
 
-  const orgId = await resolveOrgId(userId, undefined, tokenOrgId);
+  const orgId = await resolveOrgId(userId);
 
   log.debug(`Disabling schedule ${name} for compose ${body.composeId}`);
 

--- a/turbo/apps/web/app/api/agent/schedules/[name]/enable/route.ts
+++ b/turbo/apps/web/app/api/agent/schedules/[name]/enable/route.ts
@@ -28,7 +28,7 @@ export async function POST(
       { status: 401 },
     );
   }
-  const { userId, orgId: tokenOrgId } = authCtx;
+  const { userId } = authCtx;
 
   const { name } = await params;
 
@@ -48,7 +48,7 @@ export async function POST(
   }
   const body = parseResult.data;
 
-  const orgId = await resolveOrgId(userId, undefined, tokenOrgId);
+  const orgId = await resolveOrgId(userId);
 
   log.debug(`Enabling schedule ${name} for compose ${body.composeId}`);
 

--- a/turbo/apps/web/app/api/agent/schedules/[name]/route.ts
+++ b/turbo/apps/web/app/api/agent/schedules/[name]/route.ts
@@ -29,12 +29,12 @@ const router = tsr.router(schedulesByNameContract, {
         },
       };
     }
-    const { userId, orgId: tokenOrgId } = authCtx;
+    const { userId } = authCtx;
 
     log.debug(`Getting schedule ${params.name} for compose ${query.composeId}`);
 
     try {
-      const orgId = await resolveOrgId(userId, undefined, tokenOrgId);
+      const orgId = await resolveOrgId(userId);
 
       const schedule = await getScheduleByName(
         userId,
@@ -72,14 +72,14 @@ const router = tsr.router(schedulesByNameContract, {
         },
       };
     }
-    const { userId, orgId: tokenOrgId } = authCtx;
+    const { userId } = authCtx;
 
     log.debug(
       `Deleting schedule ${params.name} for compose ${query.composeId}`,
     );
 
     try {
-      const orgId = await resolveOrgId(userId, undefined, tokenOrgId);
+      const orgId = await resolveOrgId(userId);
 
       await deleteSchedule(userId, orgId, query.composeId, params.name);
 

--- a/turbo/apps/web/app/api/agent/schedules/[name]/runs/route.ts
+++ b/turbo/apps/web/app/api/agent/schedules/[name]/runs/route.ts
@@ -26,14 +26,14 @@ const router = tsr.router(scheduleRunsContract, {
         },
       };
     }
-    const { userId, orgId: tokenOrgId } = authCtx;
+    const { userId } = authCtx;
 
     log.debug(
       `Listing runs for schedule ${params.name} (limit: ${query.limit})`,
     );
 
     try {
-      const orgId = await resolveOrgId(userId, undefined, tokenOrgId);
+      const orgId = await resolveOrgId(userId);
 
       const runs = await getScheduleRecentRuns(
         userId,

--- a/turbo/apps/web/app/api/agent/schedules/route.ts
+++ b/turbo/apps/web/app/api/agent/schedules/route.ts
@@ -26,14 +26,14 @@ const router = tsr.router(schedulesMainContract, {
         },
       };
     }
-    const { userId, orgId: tokenOrgId } = authCtx;
+    const { userId } = authCtx;
 
     log.debug(`Deploying schedule ${body.name} for compose ${body.composeId}`);
 
     try {
       // Note: vars and secrets are no longer accepted via API
       // They must be managed via platform tables (vm0 secret set, vm0 var set)
-      const orgId = await resolveOrgId(userId, undefined, tokenOrgId);
+      const orgId = await resolveOrgId(userId);
 
       const result = await deploySchedule(userId, orgId, {
         name: body.name,

--- a/turbo/apps/web/app/api/cli/auth/test-token/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/cli/auth/test-token/__tests__/route.test.ts
@@ -192,7 +192,7 @@ describe("/api/cli/auth/test-token", () => {
       reloadEnv();
     });
 
-    it("returns token with correct format", async () => {
+    it("returns token with correct format and org_slug", async () => {
       const request = createTestRequest(
         "http://localhost:3000/api/cli/auth/test-token",
         { method: "POST" },
@@ -205,6 +205,7 @@ describe("/api/cli/auth/test-token", () => {
       expect(data.token_type).toBe("Bearer");
       expect(data.expires_in).toBe(90 * 24 * 60 * 60);
       expect(data.user_id).toBe("user_test123");
+      expect(data.org_slug).toBe("test-token-org");
     });
 
     it("returns 500 when test user is not found", async () => {

--- a/turbo/apps/web/app/api/cli/auth/test-token/route.ts
+++ b/turbo/apps/web/app/api/cli/auth/test-token/route.ts
@@ -4,6 +4,7 @@ import { initServices } from "../../../../../src/lib/init-services";
 import { cliTokens } from "../../../../../src/db/schema/cli-tokens";
 import { getDefaultOrg } from "../../../../../src/lib/org/org-member-service";
 import { orgCache } from "../../../../../src/db/schema/org-cache";
+import { orgMembersCache } from "../../../../../src/db/schema/org-members-cache";
 import { isNotFound } from "../../../../../src/lib/errors";
 import {
   resolveTestUserId,
@@ -42,22 +43,30 @@ function isTestTokenAllowed(request: Request): boolean {
  * Uses the same flow as production (getDefaultOrg) so that
  * Clerk API membership verification works during E2E tests.
  *
- * If the user has no Clerk org yet, creates an org_cache entry with a sentinel orgId.
+ * If the user has no Clerk org yet, creates org_cache and org_members_cache
+ * entries with a sentinel orgId.
  */
-async function ensureTestOrg(userId: string): Promise<{ orgId: string }> {
+async function ensureTestOrg(userId: string): Promise<void> {
   try {
-    const { org } = await getDefaultOrg(userId);
-    return { orgId: org.orgId };
+    await getDefaultOrg(userId);
   } catch (error) {
     if (!isNotFound(error)) throw error;
-    // User has no Clerk org — use sentinel orgId with org_cache entry
+    // User has no Clerk org — use sentinel orgId with org_cache + membership cache
     const sentinelOrgId = `org_test_${userId}`;
     const slug = "test-org";
     await globalThis.services.db
       .insert(orgCache)
       .values({ orgId: sentinelOrgId, slug, tier: "free" })
       .onConflictDoNothing();
-    return { orgId: sentinelOrgId };
+    await globalThis.services.db
+      .insert(orgMembersCache)
+      .values({
+        orgId: sentinelOrgId,
+        userId,
+        role: "admin",
+        cachedAt: new Date(),
+      })
+      .onConflictDoNothing();
   }
 }
 
@@ -89,9 +98,9 @@ export async function POST(request: Request) {
   }
 
   // Auto-create org if user doesn't have one (creates real Clerk org or sentinel)
-  const { orgId } = await ensureTestOrg(userId);
+  await ensureTestOrg(userId);
 
-  // Generate CLI token with org binding
+  // Generate CLI token
   const randomBytes = crypto.randomBytes(32);
   const token = `vm0_live_${randomBytes.toString("base64url")}`;
   const now = new Date();
@@ -101,7 +110,6 @@ export async function POST(request: Request) {
     token,
     userId,
     name: "CI Test Token",
-    orgId,
     expiresAt,
     createdAt: now,
   });

--- a/turbo/apps/web/app/api/cli/auth/test-token/route.ts
+++ b/turbo/apps/web/app/api/cli/auth/test-token/route.ts
@@ -46,9 +46,10 @@ function isTestTokenAllowed(request: Request): boolean {
  * If the user has no Clerk org yet, creates org_cache and org_members_cache
  * entries with a sentinel orgId.
  */
-async function ensureTestOrg(userId: string): Promise<void> {
+async function ensureTestOrg(userId: string): Promise<{ slug: string }> {
   try {
-    await getDefaultOrg(userId);
+    const { org } = await getDefaultOrg(userId);
+    return { slug: org.slug };
   } catch (error) {
     if (!isNotFound(error)) throw error;
     // User has no Clerk org — use sentinel orgId with org_cache + membership cache
@@ -67,6 +68,7 @@ async function ensureTestOrg(userId: string): Promise<void> {
         cachedAt: new Date(),
       })
       .onConflictDoNothing();
+    return { slug };
   }
 }
 
@@ -98,7 +100,7 @@ export async function POST(request: Request) {
   }
 
   // Auto-create org if user doesn't have one (creates real Clerk org or sentinel)
-  await ensureTestOrg(userId);
+  const { slug: orgSlug } = await ensureTestOrg(userId);
 
   // Generate CLI token
   const randomBytes = crypto.randomBytes(32);
@@ -119,5 +121,6 @@ export async function POST(request: Request) {
     token_type: "Bearer",
     expires_in: 90 * 24 * 60 * 60,
     user_id: userId,
+    org_slug: orgSlug,
   });
 }

--- a/turbo/apps/web/app/api/cli/auth/test-token/route.ts
+++ b/turbo/apps/web/app/api/cli/auth/test-token/route.ts
@@ -48,7 +48,18 @@ function isTestTokenAllowed(request: Request): boolean {
  */
 async function ensureTestOrg(userId: string): Promise<{ slug: string }> {
   try {
-    const { org } = await getDefaultOrg(userId);
+    const { org, member } = await getDefaultOrg(userId);
+    // Pre-populate org_members_cache so verifyMembershipCached hits cache
+    // instead of calling Clerk API on every request (avoids 429 rate limits)
+    await globalThis.services.db
+      .insert(orgMembersCache)
+      .values({
+        orgId: org.orgId,
+        userId,
+        role: member.role,
+        cachedAt: new Date(),
+      })
+      .onConflictDoNothing();
     return { slug: org.slug };
   } catch (error) {
     if (!isNotFound(error)) throw error;

--- a/turbo/apps/web/app/api/cli/auth/token/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/cli/auth/token/__tests__/route.test.ts
@@ -106,6 +106,33 @@ describe("POST /api/cli/auth/token", () => {
     expect(found).toBeUndefined();
   });
 
+  it("should return org_slug when device code has org context", async () => {
+    const code = await createTestDeviceCode({
+      status: "authenticated",
+      userId: user.userId,
+      orgSlug: "my-test-org",
+    });
+
+    const response = await POST(makeTokenRequest(code));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.org_slug).toBe("my-test-org");
+  });
+
+  it("should not return org_slug when device code has no org context", async () => {
+    const code = await createTestDeviceCode({
+      status: "authenticated",
+      userId: user.userId,
+    });
+
+    const response = await POST(makeTokenRequest(code));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).not.toHaveProperty("org_slug");
+  });
+
   it("should return 400 when device_code is missing from body", async () => {
     const request = createTestRequest(
       "http://localhost:3000/api/cli/auth/token",

--- a/turbo/apps/web/app/api/cli/auth/token/route.ts
+++ b/turbo/apps/web/app/api/cli/auth/token/route.ts
@@ -9,7 +9,6 @@ import { eq } from "drizzle-orm";
 import { initServices } from "../../../../../src/lib/init-services";
 import { deviceCodes } from "../../../../../src/db/schema/device-codes";
 import { cliTokens } from "../../../../../src/db/schema/cli-tokens";
-import { getDefaultOrg } from "../../../../../src/lib/org/org-member-service";
 
 const router = tsr.router(cliAuthTokenContract, {
   exchange: async ({ body }) => {
@@ -74,10 +73,7 @@ const router = tsr.router(cliAuthTokenContract, {
       case "authenticated": {
         const userId = session.userId as string;
 
-        // Resolve user's default org from org_cache
-        const { org } = await getDefaultOrg(userId);
-
-        // Generate CLI token with org binding
+        // Generate CLI token (no org binding — org context comes from client-side activeOrg)
         const randomBytes = crypto.randomBytes(32);
         const cliToken = `vm0_live_${randomBytes.toString("base64url")}`;
         const now = new Date();
@@ -87,7 +83,6 @@ const router = tsr.router(cliAuthTokenContract, {
           token: cliToken,
           userId,
           name: "CLI Device Flow Authentication",
-          orgId: org.orgId,
           expiresAt,
           createdAt: now,
         });
@@ -103,6 +98,7 @@ const router = tsr.router(cliAuthTokenContract, {
             access_token: cliToken,
             token_type: "Bearer" as const,
             expires_in: 90 * 24 * 60 * 60, // 90 days in seconds
+            org_slug: session.orgSlug ?? undefined,
           },
         };
       }

--- a/turbo/apps/web/app/api/compose/jobs/route.ts
+++ b/turbo/apps/web/app/api/compose/jobs/route.ts
@@ -55,10 +55,10 @@ const router = tsr.router(composeJobsMainContract, {
         },
       };
     }
-    const { userId, orgId: tokenOrgId } = authCtx;
+    const { userId } = authCtx;
 
-    // Resolve the caller's org so the CLI token carries the correct orgId
-    const { org } = await resolveOrg(userId, null, null, tokenOrgId);
+    // Resolve the caller's org
+    const { org } = await resolveOrg(userId);
 
     // Dispatch based on input type: GitHub URL or platform content
     const isGitHubInput = "githubUrl" in body;

--- a/turbo/apps/web/app/api/connectors/[type]/callback/route.ts
+++ b/turbo/apps/web/app/api/connectors/[type]/callback/route.ts
@@ -181,7 +181,7 @@ export async function GET(
         codeVerifier,
       );
 
-    const { userId, orgId: tokenOrgId } = authCtx;
+    const { userId } = authCtx;
 
     log.debug("Storing connector", {
       userId,
@@ -200,7 +200,7 @@ export async function GET(
     // when the code adds new scopes and prompt users to re-authorize.
     // Note: do not read "scope" from the callback URL — OAuth providers (e.g., Monday.com)
     // may append OAuth scopes as ?scope=... which would be mistaken for an app scope slug.
-    const { org } = await resolveOrg(userId, null, null, tokenOrgId);
+    const { org } = await resolveOrg(userId);
     const { created } = await upsertOAuthConnector(
       org.orgId,
       userId,

--- a/turbo/apps/web/app/api/connectors/[type]/route.ts
+++ b/turbo/apps/web/app/api/connectors/[type]/route.ts
@@ -20,10 +20,10 @@ const router = tsr.router(connectorsByTypeContract, {
     if (!authCtx) {
       return createErrorResponse("UNAUTHORIZED", "Not authenticated");
     }
-    const { userId, orgId: tokenOrgId } = authCtx;
+    const { userId } = authCtx;
 
     const orgSlug = new URL(request.url).searchParams.get("org");
-    const { org } = await resolveOrg(userId, orgSlug, null, tokenOrgId);
+    const { org } = await resolveOrg(userId, orgSlug);
     const connector = await getConnector(org.orgId, userId, params.type);
 
     if (!connector) {
@@ -46,11 +46,11 @@ const router = tsr.router(connectorsByTypeContract, {
     if (!authCtx) {
       return createErrorResponse("UNAUTHORIZED", "Not authenticated");
     }
-    const { userId, orgId: tokenOrgId } = authCtx;
+    const { userId } = authCtx;
 
     try {
       const orgSlug = new URL(request.url).searchParams.get("org");
-      const { org } = await resolveOrg(userId, orgSlug, null, tokenOrgId);
+      const { org } = await resolveOrg(userId, orgSlug);
       await deleteConnector(org.orgId, userId, params.type);
 
       return {

--- a/turbo/apps/web/app/api/connectors/computer/route.ts
+++ b/turbo/apps/web/app/api/connectors/computer/route.ts
@@ -25,11 +25,11 @@ const router = tsr.router(computerConnectorContract, {
     if (!authCtx) {
       return createErrorResponse("UNAUTHORIZED", "Not authenticated");
     }
-    const { userId, orgId: tokenOrgId } = authCtx;
+    const { userId } = authCtx;
 
     try {
       const orgSlug = new URL(request.url).searchParams.get("org");
-      const { org } = await resolveOrg(userId, orgSlug, null, tokenOrgId);
+      const { org } = await resolveOrg(userId, orgSlug);
       const result = await createComputerConnector(org.orgId, userId);
       return { status: 200 as const, body: result };
     } catch (error) {
@@ -53,10 +53,10 @@ const router = tsr.router(computerConnectorContract, {
     if (!authCtx) {
       return createErrorResponse("UNAUTHORIZED", "Not authenticated");
     }
-    const { userId, orgId: tokenOrgId } = authCtx;
+    const { userId } = authCtx;
 
     const orgSlug = new URL(request.url).searchParams.get("org");
-    const { org } = await resolveOrg(userId, orgSlug, null, tokenOrgId);
+    const { org } = await resolveOrg(userId, orgSlug);
     const connector = await getConnector(org.orgId, userId, "computer");
     if (!connector) {
       return createErrorResponse("NOT_FOUND", "Computer connector not found");
@@ -75,11 +75,11 @@ const router = tsr.router(computerConnectorContract, {
     if (!authCtx) {
       return createErrorResponse("UNAUTHORIZED", "Not authenticated");
     }
-    const { userId, orgId: tokenOrgId } = authCtx;
+    const { userId } = authCtx;
 
     try {
       const orgSlug = new URL(request.url).searchParams.get("org");
-      const { org } = await resolveOrg(userId, orgSlug, null, tokenOrgId);
+      const { org } = await resolveOrg(userId, orgSlug);
       await deleteComputerConnector(org.orgId, userId);
       return { status: 204 as const, body: undefined };
     } catch (error) {

--- a/turbo/apps/web/app/api/connectors/route.ts
+++ b/turbo/apps/web/app/api/connectors/route.ts
@@ -21,10 +21,10 @@ const router = tsr.router(connectorsMainContract, {
     if (!authCtx) {
       return createErrorResponse("UNAUTHORIZED", "Not authenticated");
     }
-    const { userId, orgId: tokenOrgId } = authCtx;
+    const { userId } = authCtx;
 
     const orgSlug = new URL(request.url).searchParams.get("org");
-    const { org } = await resolveOrg(userId, orgSlug, null, tokenOrgId);
+    const { org } = await resolveOrg(userId, orgSlug);
     const connectorList = await listConnectors(org.orgId, userId);
     const configuredTypes = getConfiguredConnectorTypes(
       globalThis.services.env,

--- a/turbo/apps/web/app/api/integrations/github/route.ts
+++ b/turbo/apps/web/app/api/integrations/github/route.ts
@@ -48,7 +48,7 @@ export async function GET(request: Request) {
       { status: 401 },
     );
   }
-  const { userId, orgId: tokenOrgId } = authCtx;
+  const { userId } = authCtx;
 
   const db = globalThis.services.db;
 
@@ -123,7 +123,7 @@ export async function GET(request: Request) {
   }
 
   // Resolve user's org for resource queries
-  const { org } = await resolveOrg(userId, null, null, tokenOrgId);
+  const { org } = await resolveOrg(userId);
 
   // Get user's existing secrets, vars, connectors
   const [userSecrets, userVars, userConnectors] = await Promise.all([

--- a/turbo/apps/web/app/api/integrations/slack/org/connect/route.ts
+++ b/turbo/apps/web/app/api/integrations/slack/org/connect/route.ts
@@ -37,8 +37,8 @@ export async function GET(request: Request) {
     );
   }
 
-  const { userId, orgId: tokenOrgId } = authCtx;
-  const { org, member } = await resolveOrg(userId, null, null, tokenOrgId);
+  const { userId } = authCtx;
+  const { org, member } = await resolveOrg(userId);
 
   // Find user's connection in any workspace bound to this org
   const [connection] = await globalThis.services.db
@@ -101,7 +101,7 @@ export async function POST(request: Request) {
     );
   }
 
-  const { userId, orgId: tokenOrgId } = authCtx;
+  const { userId } = authCtx;
 
   const parseResult = connectBodySchema.safeParse(
     await request.json().catch(() => undefined),
@@ -121,7 +121,7 @@ export async function POST(request: Request) {
   const { workspaceId, slackUserId } = parseResult.data;
 
   // Resolve org and check membership
-  const { org, member } = await resolveOrg(userId, null, null, tokenOrgId);
+  const { org, member } = await resolveOrg(userId);
 
   // Check installation exists
   const [installation] = await globalThis.services.db

--- a/turbo/apps/web/app/api/integrations/slack/route.ts
+++ b/turbo/apps/web/app/api/integrations/slack/route.ts
@@ -56,7 +56,7 @@ export async function GET(request: Request) {
       { status: 401 },
     );
   }
-  const { userId, orgId: tokenOrgId } = authCtx;
+  const { userId } = authCtx;
 
   const db = globalThis.services.db;
 
@@ -129,7 +129,7 @@ export async function GET(request: Request) {
   }
 
   // Get user's existing secrets, vars, connectors
-  const { org } = await resolveOrg(userId, null, null, tokenOrgId);
+  const { org } = await resolveOrg(userId);
   const [userSecrets, userVars, userConnectors] = await Promise.all([
     listSecrets(org.orgId, userId),
     listVariables(org.orgId, userId),
@@ -260,7 +260,7 @@ export async function PATCH(request: Request) {
       { status: 401 },
     );
   }
-  const { userId, orgId: tokenOrgId } = authCtx;
+  const { userId } = authCtx;
 
   const parseResult = patchSlackBodySchema.safeParse(
     await request.json().catch(() => undefined),
@@ -336,7 +336,7 @@ export async function PATCH(request: Request) {
     }
     targetOrgId = targetOrg.orgId;
   } else {
-    const { org } = await resolveOrg(userId, null, null, tokenOrgId);
+    const { org } = await resolveOrg(userId);
     targetOrgId = org.orgId;
   }
 

--- a/turbo/apps/web/app/api/integrations/telegram/route.ts
+++ b/turbo/apps/web/app/api/integrations/telegram/route.ts
@@ -53,7 +53,7 @@ export async function GET(request: Request) {
       { status: 401 },
     );
   }
-  const { userId, orgId: tokenOrgId } = authCtx;
+  const { userId } = authCtx;
 
   const db = globalThis.services.db;
 
@@ -122,7 +122,7 @@ export async function GET(request: Request) {
   }
 
   // Resolve user's default org and get existing secrets, vars, connectors
-  const { org } = await resolveOrg(userId, null, null, tokenOrgId);
+  const { org } = await resolveOrg(userId);
   const [userSecrets, userVars, userConnectors] = await Promise.all([
     listSecrets(org.orgId, userId),
     listVariables(org.orgId, userId),
@@ -192,7 +192,7 @@ export async function PATCH(request: Request) {
       { status: 401 },
     );
   }
-  const { userId, orgId: tokenOrgId } = authCtx;
+  const { userId } = authCtx;
 
   const parseResult = patchBodySchema.safeParse(await request.json());
   if (!parseResult.success) {
@@ -267,7 +267,7 @@ export async function PATCH(request: Request) {
     targetOrg = resolved;
   } else {
     try {
-      ({ org: targetOrg } = await resolveOrg(userId, null, null, tokenOrgId));
+      ({ org: targetOrg } = await resolveOrg(userId));
     } catch (error) {
       if (isNotFound(error)) {
         return NextResponse.json(

--- a/turbo/apps/web/app/api/model-providers/[type]/model/route.ts
+++ b/turbo/apps/web/app/api/model-providers/[type]/model/route.ts
@@ -23,7 +23,7 @@ const router = tsr.router(modelProvidersUpdateModelContract, {
     if (!authCtx) {
       return createErrorResponse("UNAUTHORIZED", "Not authenticated");
     }
-    const { userId, orgId: tokenOrgId } = authCtx;
+    const { userId } = authCtx;
 
     log.debug("updating model provider model", {
       userId,
@@ -33,7 +33,7 @@ const router = tsr.router(modelProvidersUpdateModelContract, {
 
     try {
       const orgSlug = new URL(request.url).searchParams.get("org");
-      const { org } = await resolveOrg(userId, orgSlug, null, tokenOrgId);
+      const { org } = await resolveOrg(userId, orgSlug);
       const provider = await updateModelProviderModel(
         org.orgId,
         userId,

--- a/turbo/apps/web/app/api/model-providers/[type]/route.ts
+++ b/turbo/apps/web/app/api/model-providers/[type]/route.ts
@@ -20,13 +20,13 @@ const router = tsr.router(modelProvidersByTypeContract, {
     if (!authCtx) {
       return createErrorResponse("UNAUTHORIZED", "Not authenticated");
     }
-    const { userId, orgId: tokenOrgId } = authCtx;
+    const { userId } = authCtx;
 
     log.debug("deleting model provider", { userId, type: params.type });
 
     try {
       const orgSlug = new URL(request.url).searchParams.get("org");
-      const { org } = await resolveOrg(userId, orgSlug, null, tokenOrgId);
+      const { org } = await resolveOrg(userId, orgSlug);
       await deleteModelProvider(org.orgId, userId, params.type);
 
       return {

--- a/turbo/apps/web/app/api/model-providers/[type]/set-default/route.ts
+++ b/turbo/apps/web/app/api/model-providers/[type]/set-default/route.ts
@@ -23,7 +23,7 @@ const router = tsr.router(modelProvidersSetDefaultContract, {
     if (!authCtx) {
       return createErrorResponse("UNAUTHORIZED", "Not authenticated");
     }
-    const { userId, orgId: tokenOrgId } = authCtx;
+    const { userId } = authCtx;
 
     log.debug("setting model provider as default", {
       userId,
@@ -32,7 +32,7 @@ const router = tsr.router(modelProvidersSetDefaultContract, {
 
     try {
       const orgSlug = new URL(request.url).searchParams.get("org");
-      const { org } = await resolveOrg(userId, orgSlug, null, tokenOrgId);
+      const { org } = await resolveOrg(userId, orgSlug);
       const provider = await setModelProviderDefault(
         org.orgId,
         userId,

--- a/turbo/apps/web/app/api/model-providers/check/[type]/route.ts
+++ b/turbo/apps/web/app/api/model-providers/check/[type]/route.ts
@@ -20,10 +20,10 @@ const router = tsr.router(modelProvidersCheckContract, {
     if (!authCtx) {
       return createErrorResponse("UNAUTHORIZED", "Not authenticated");
     }
-    const { userId, orgId: tokenOrgId } = authCtx;
+    const { userId } = authCtx;
 
     const orgSlug = new URL(request.url).searchParams.get("org");
-    const { org } = await resolveOrg(userId, orgSlug, null, tokenOrgId);
+    const { org } = await resolveOrg(userId, orgSlug);
     const result = await checkSecretExists(org.orgId, userId, params.type);
 
     return {

--- a/turbo/apps/web/app/api/model-providers/route.ts
+++ b/turbo/apps/web/app/api/model-providers/route.ts
@@ -28,10 +28,10 @@ const router = tsr.router(modelProvidersMainContract, {
     if (!authCtx) {
       return createErrorResponse("UNAUTHORIZED", "Not authenticated");
     }
-    const { userId, orgId: tokenOrgId } = authCtx;
+    const { userId } = authCtx;
 
     const orgSlug = new URL(request.url).searchParams.get("org");
-    const { org } = await resolveOrg(userId, orgSlug, null, tokenOrgId);
+    const { org } = await resolveOrg(userId, orgSlug);
     const providers = await listModelProviders(org.orgId, userId);
 
     return {
@@ -63,7 +63,7 @@ const router = tsr.router(modelProvidersMainContract, {
     if (!authCtx) {
       return createErrorResponse("UNAUTHORIZED", "Not authenticated");
     }
-    const { userId, orgId: tokenOrgId } = authCtx;
+    const { userId } = authCtx;
 
     const { type, secret, authMethod, secrets, selectedModel } = body;
 
@@ -71,7 +71,7 @@ const router = tsr.router(modelProvidersMainContract, {
 
     try {
       const orgSlug = new URL(request.url).searchParams.get("org");
-      const { org } = await resolveOrg(userId, orgSlug, null, tokenOrgId);
+      const { org } = await resolveOrg(userId, orgSlug);
 
       // Determine if this is a multi-auth provider or legacy provider
       const isMultiAuth = hasAuthMethods(type);

--- a/turbo/apps/web/app/api/org/__tests__/members.test.ts
+++ b/turbo/apps/web/app/api/org/__tests__/members.test.ts
@@ -128,7 +128,7 @@ describe("GET /api/org/members - Org Members", () => {
       expect(statusRes.status).toBe(403);
     });
 
-    it("should return 403 when Clerk API fails during lazy sync", async () => {
+    it("should propagate Clerk API errors during lazy sync", async () => {
       const adminUserId = uniqueId("admin");
       const memberUserId = uniqueId("member");
       const { slug, orgId } = await createTestOrg(adminUserId);
@@ -147,8 +147,7 @@ describe("GET /api/org/members - Org Members", () => {
       const statusReq = createTestRequest(
         `http://localhost:3000/api/org/members?org=${slug}`,
       );
-      const statusRes = await GET(statusReq);
-      expect(statusRes.status).toBe(403);
+      await expect(GET(statusReq)).rejects.toThrow("Clerk API unavailable");
     });
   });
 });

--- a/turbo/apps/web/app/api/org/__tests__/members.test.ts
+++ b/turbo/apps/web/app/api/org/__tests__/members.test.ts
@@ -140,9 +140,9 @@ describe("GET /api/org/members - Org Members", () => {
         memberships: [],
       });
       const client = await clerkClient();
-      vi.mocked(
-        client.organizations.getOrganizationMembershipList,
-      ).mockRejectedValue(new Error("Clerk API unavailable"));
+      vi.mocked(client.users.getOrganizationMembershipList).mockRejectedValue(
+        new Error("Clerk API unavailable"),
+      );
 
       const statusReq = createTestRequest(
         `http://localhost:3000/api/org/members?org=${slug}`,

--- a/turbo/apps/web/app/api/org/invite/route.ts
+++ b/turbo/apps/web/app/api/org/invite/route.ts
@@ -26,7 +26,7 @@ export async function POST(request: Request) {
       { status: 401 },
     );
   }
-  const { userId, orgId: tokenOrgId } = authCtx;
+  const { userId } = authCtx;
 
   const parseResult = inviteBodySchema.safeParse(
     await request.json().catch(() => undefined),
@@ -40,11 +40,7 @@ export async function POST(request: Request) {
   const body = parseResult.data;
 
   try {
-    const { org, member } = await requireOrgFromRequest(
-      request,
-      userId,
-      tokenOrgId,
-    );
+    const { org, member } = await requireOrgFromRequest(request, userId);
     await inviteMember(userId, org.orgId, member.role, body.email);
     return NextResponse.json({ message: `Invitation sent to ${body.email}` });
   } catch (error) {

--- a/turbo/apps/web/app/api/org/leave/route.ts
+++ b/turbo/apps/web/app/api/org/leave/route.ts
@@ -23,14 +23,10 @@ export async function POST(request: Request) {
       { status: 401 },
     );
   }
-  const { userId, orgId: tokenOrgId } = authCtx;
+  const { userId } = authCtx;
 
   try {
-    const { org, member } = await requireOrgFromRequest(
-      request,
-      userId,
-      tokenOrgId,
-    );
+    const { org, member } = await requireOrgFromRequest(request, userId);
     await leaveOrg(userId, org.orgId, member.role);
     return NextResponse.json({ message: "Left org" });
   } catch (error) {

--- a/turbo/apps/web/app/api/org/members/route.ts
+++ b/turbo/apps/web/app/api/org/members/route.ts
@@ -29,10 +29,10 @@ export async function GET(request: Request) {
       { status: 401 },
     );
   }
-  const { userId, orgId: tokenOrgId } = authCtx;
+  const { userId } = authCtx;
 
   try {
-    const { org } = await requireOrgFromRequest(request, userId, tokenOrgId);
+    const { org } = await requireOrgFromRequest(request, userId);
     const status = await getOrgMembers(userId, org.orgId, org.slug);
     return NextResponse.json(status);
   } catch (error) {
@@ -72,7 +72,7 @@ export async function DELETE(request: Request) {
       { status: 401 },
     );
   }
-  const { userId, orgId: tokenOrgId } = authCtx;
+  const { userId } = authCtx;
 
   const parseResult = removeMemberBodySchema.safeParse(
     await request.json().catch(() => undefined),
@@ -86,11 +86,7 @@ export async function DELETE(request: Request) {
   const body = parseResult.data;
 
   try {
-    const { org, member } = await requireOrgFromRequest(
-      request,
-      userId,
-      tokenOrgId,
-    );
+    const { org, member } = await requireOrgFromRequest(request, userId);
     await removeMember(userId, org.orgId, member.role, body.email);
     return NextResponse.json({
       message: `Removed ${body.email} from org`,

--- a/turbo/apps/web/app/api/org/route.ts
+++ b/turbo/apps/web/app/api/org/route.ts
@@ -36,15 +36,10 @@ const router = tsr.router(orgContract, {
     if (!authCtx) {
       return createErrorResponse("UNAUTHORIZED", "Not authenticated");
     }
-    const { userId, orgId: tokenOrgId } = authCtx;
+    const { userId } = authCtx;
 
     try {
-      const { org: resolvedOrg } = await resolveOrg(
-        userId,
-        null,
-        null,
-        tokenOrgId,
-      );
+      const { org: resolvedOrg } = await resolveOrg(userId);
 
       return {
         status: 200 as const,
@@ -71,7 +66,7 @@ const router = tsr.router(orgContract, {
     if (!authCtx) {
       return createErrorResponse("UNAUTHORIZED", "Not authenticated");
     }
-    const { userId, orgId: tokenOrgId } = authCtx;
+    const { userId } = authCtx;
 
     const { slug, force } = body;
 
@@ -79,7 +74,7 @@ const router = tsr.router(orgContract, {
 
     let resolvedOrg;
     try {
-      ({ org: resolvedOrg } = await resolveOrg(userId, null, null, tokenOrgId));
+      ({ org: resolvedOrg } = await resolveOrg(userId));
     } catch (error) {
       if (isNotFound(error)) {
         return createErrorResponse(

--- a/turbo/apps/web/app/api/orgs/default-agent/route.ts
+++ b/turbo/apps/web/app/api/orgs/default-agent/route.ts
@@ -20,14 +20,9 @@ const router = tsr.router(orgDefaultAgentContract, {
         },
       };
     }
-    const { userId, orgId: tokenOrgId } = authCtx;
+    const { userId } = authCtx;
 
-    const { org, member } = await resolveOrg(
-      userId,
-      undefined,
-      query.org,
-      tokenOrgId,
-    );
+    const { org, member } = await resolveOrg(userId, undefined, query.org);
 
     if (member.role !== "admin") {
       return {

--- a/turbo/apps/web/app/api/platform/logs/[id]/route.ts
+++ b/turbo/apps/web/app/api/platform/logs/[id]/route.ts
@@ -112,17 +112,12 @@ const router = tsr.router(platformLogsByIdContract, {
     if (!authCtx) {
       return unauthorizedResponse();
     }
-    const { userId, orgId: tokenOrgId } = authCtx;
+    const { userId } = authCtx;
 
     // Resolve active org from JWT / CLI token / default
     let orgId: string;
     try {
-      const { org: resolvedOrg } = await resolveOrg(
-        userId,
-        undefined,
-        undefined,
-        tokenOrgId,
-      );
+      const { org: resolvedOrg } = await resolveOrg(userId);
       orgId = resolvedOrg.orgId;
     } catch (error) {
       if (isNotFound(error) || isForbidden(error)) {

--- a/turbo/apps/web/app/api/runners/jobs/[id]/claim/route.ts
+++ b/turbo/apps/web/app/api/runners/jobs/[id]/claim/route.ts
@@ -84,11 +84,7 @@ const router = tsr.router(runnersJobClaimContract, {
       }
 
       try {
-        await validateRunnerGroupOrg(
-          auth.userId,
-          jobWithRun.job.runnerGroup,
-          auth.orgId,
-        );
+        await validateRunnerGroupOrg(auth.userId, jobWithRun.job.runnerGroup);
       } catch {
         return createErrorResponse("FORBIDDEN", "Access denied");
       }

--- a/turbo/apps/web/app/api/runners/poll/route.ts
+++ b/turbo/apps/web/app/api/runners/poll/route.ts
@@ -48,7 +48,7 @@ const router = tsr.router(runnersPollContract, {
     } else {
       // User runners: validate org and filter by userId
       try {
-        await validateRunnerGroupOrg(auth.userId, group, auth.orgId);
+        await validateRunnerGroupOrg(auth.userId, group);
       } catch {
         return createErrorResponse("FORBIDDEN", "Access denied");
       }

--- a/turbo/apps/web/app/api/runners/realtime/token/route.ts
+++ b/turbo/apps/web/app/api/runners/realtime/token/route.ts
@@ -35,7 +35,7 @@ const router = tsr.router(runnerRealtimeTokenContract, {
     } else {
       // User runners: validate org
       try {
-        await validateRunnerGroupOrg(auth.userId, group, auth.orgId);
+        await validateRunnerGroupOrg(auth.userId, group);
       } catch {
         return createErrorResponse("FORBIDDEN", "Access denied");
       }

--- a/turbo/apps/web/app/api/secrets/[name]/route.ts
+++ b/turbo/apps/web/app/api/secrets/[name]/route.ts
@@ -31,10 +31,10 @@ const router = tsr.router(secretsByNameContract, {
     if (!authCtx) {
       return createErrorResponse("UNAUTHORIZED", "Not authenticated");
     }
-    const { userId, orgId: tokenOrgId } = authCtx;
+    const { userId } = authCtx;
 
     const orgSlug = new URL(request.url).searchParams.get("org");
-    const { org } = await resolveOrg(userId, orgSlug, null, tokenOrgId);
+    const { org } = await resolveOrg(userId, orgSlug);
     const secret = await getSecret(org.orgId, userId, params.name);
     if (!secret) {
       return createErrorResponse(
@@ -66,13 +66,13 @@ const router = tsr.router(secretsByNameContract, {
     if (!authCtx) {
       return createErrorResponse("UNAUTHORIZED", "Not authenticated");
     }
-    const { userId, orgId: tokenOrgId } = authCtx;
+    const { userId } = authCtx;
 
     log.debug("deleting secret", { userId, name: params.name });
 
     try {
       const orgSlug = new URL(request.url).searchParams.get("org");
-      const { org } = await resolveOrg(userId, orgSlug, null, tokenOrgId);
+      const { org } = await resolveOrg(userId, orgSlug);
       await deleteSecret(org.orgId, userId, params.name);
 
       return {

--- a/turbo/apps/web/app/api/secrets/route.ts
+++ b/turbo/apps/web/app/api/secrets/route.ts
@@ -24,10 +24,10 @@ const router = tsr.router(secretsMainContract, {
     if (!authCtx) {
       return createErrorResponse("UNAUTHORIZED", "Not authenticated");
     }
-    const { userId, orgId: tokenOrgId } = authCtx;
+    const { userId } = authCtx;
 
     const orgSlug = new URL(request.url).searchParams.get("org");
-    const { org } = await resolveOrg(userId, orgSlug, null, tokenOrgId);
+    const { org } = await resolveOrg(userId, orgSlug);
     const secrets = await listSecrets(org.orgId, userId);
 
     return {
@@ -55,7 +55,7 @@ const router = tsr.router(secretsMainContract, {
     if (!authCtx) {
       return createErrorResponse("UNAUTHORIZED", "Not authenticated");
     }
-    const { userId, orgId: tokenOrgId } = authCtx;
+    const { userId } = authCtx;
 
     const { name, value, description } = body;
 
@@ -63,7 +63,7 @@ const router = tsr.router(secretsMainContract, {
 
     try {
       const orgSlug = new URL(request.url).searchParams.get("org");
-      const { org } = await resolveOrg(userId, orgSlug, null, tokenOrgId);
+      const { org } = await resolveOrg(userId, orgSlug);
       const secret = await setSecret(
         org.orgId,
         userId,

--- a/turbo/apps/web/app/api/storages/commit/route.ts
+++ b/turbo/apps/web/app/api/storages/commit/route.ts
@@ -34,16 +34,11 @@ const router = tsr.router(storagesCommitContract, {
         },
       };
     }
-    const { userId, orgId: tokenOrgId } = authCtx;
+    const { userId } = authCtx;
 
     // Resolve user's default org
     const orgSlug = new URL(request.url).searchParams.get("org");
-    const { org: runtimeOrg } = await resolveOrg(
-      userId,
-      orgSlug,
-      null,
-      tokenOrgId,
-    );
+    const { org: runtimeOrg } = await resolveOrg(userId, orgSlug);
 
     const { storageName, storageType, versionId, files, runId, message } = body;
 

--- a/turbo/apps/web/app/api/storages/download/route.ts
+++ b/turbo/apps/web/app/api/storages/download/route.ts
@@ -30,16 +30,11 @@ const router = tsr.router(storagesDownloadContract, {
         },
       };
     }
-    const { userId, orgId: tokenOrgId } = authCtx;
+    const { userId } = authCtx;
 
     // Resolve user's default org
     const orgSlug = new URL(request.url).searchParams.get("org");
-    const { org: runtimeOrg } = await resolveOrg(
-      userId,
-      orgSlug,
-      null,
-      tokenOrgId,
-    );
+    const { org: runtimeOrg } = await resolveOrg(userId, orgSlug);
 
     const { name: storageName, type: storageType, version: versionId } = query;
 

--- a/turbo/apps/web/app/api/storages/list/route.ts
+++ b/turbo/apps/web/app/api/storages/list/route.ts
@@ -27,18 +27,13 @@ const router = tsr.router(storagesListContract, {
         },
       };
     }
-    const { userId, orgId: tokenOrgId } = authCtx;
+    const { userId } = authCtx;
 
     const { type: storageType } = query;
 
     // Resolve user's default org
     const orgSlug = new URL(request.url).searchParams.get("org");
-    const { org: runtimeOrg } = await resolveOrg(
-      userId,
-      orgSlug,
-      null,
-      tokenOrgId,
-    );
+    const { org: runtimeOrg } = await resolveOrg(userId, orgSlug);
 
     // Volumes use sentinel userId (org-shared); artifacts/memory use real userId
     const storageUserId =

--- a/turbo/apps/web/app/api/storages/prepare/route.ts
+++ b/turbo/apps/web/app/api/storages/prepare/route.ts
@@ -100,16 +100,11 @@ const router = tsr.router(storagesPrepareContract, {
         },
       };
     }
-    const { userId, orgId: tokenOrgId } = authCtx;
+    const { userId } = authCtx;
 
     // Resolve user's default org
     const orgSlug = new URL(request.url).searchParams.get("org");
-    const { org: runtimeOrg } = await resolveOrg(
-      userId,
-      orgSlug,
-      null,
-      tokenOrgId,
-    );
+    const { org: runtimeOrg } = await resolveOrg(userId, orgSlug);
 
     const {
       storageName,

--- a/turbo/apps/web/app/api/user/export/route.ts
+++ b/turbo/apps/web/app/api/user/export/route.ts
@@ -1,8 +1,8 @@
 import { NextResponse, after } from "next/server";
-import { auth } from "@clerk/nextjs/server";
 import { eq, and, gt, inArray } from "drizzle-orm";
 import { initServices } from "../../../../src/lib/init-services";
 import { getAuthContext } from "../../../../src/lib/auth/get-user-id";
+import { resolveOrg } from "../../../../src/lib/org/resolve-org";
 import { exportJobs } from "../../../../src/db/schema/export-job";
 import { executeExportJob } from "../../../../src/lib/export/export-service";
 
@@ -24,14 +24,9 @@ export async function POST(request: Request) {
 
   const { userId } = ctx;
 
-  // Resolve orgId from Clerk session
-  const { orgId: resolvedOrgId } = await auth();
-  if (!resolvedOrgId) {
-    return NextResponse.json(
-      { error: { code: "BAD_REQUEST", message: "No organization context" } },
-      { status: 400 },
-    );
-  }
+  // Resolve orgId via resolveOrg (works for both Clerk sessions and CLI tokens)
+  const { org } = await resolveOrg(userId);
+  const resolvedOrgId = org.orgId;
 
   const db = globalThis.services.db;
 

--- a/turbo/apps/web/app/api/user/export/route.ts
+++ b/turbo/apps/web/app/api/user/export/route.ts
@@ -24,9 +24,8 @@ export async function POST(request: Request) {
 
   const { userId } = ctx;
 
-  // Resolve orgId from Clerk session or CLI token
-  const { orgId: sessionOrgId } = await auth();
-  const resolvedOrgId = sessionOrgId ?? ctx.orgId;
+  // Resolve orgId from Clerk session
+  const { orgId: resolvedOrgId } = await auth();
   if (!resolvedOrgId) {
     return NextResponse.json(
       { error: { code: "BAD_REQUEST", message: "No organization context" } },

--- a/turbo/apps/web/app/api/user/preferences/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/user/preferences/__tests__/route.test.ts
@@ -184,20 +184,18 @@ describe("GET /api/user/preferences (error paths)", () => {
     context.setupMocks();
   });
 
-  it("should return BAD_REQUEST when no organization context is available", async () => {
+  it("should resolve default org when no orgId in session", async () => {
     const user = await context.setupUser();
 
-    // No orgId in session and no orgId in auth context
+    // No orgId in session — resolveOrg falls back to user's default org
     mockClerk({ userId: user.userId });
 
     const request = createTestRequest(
       "http://localhost:3000/api/user/preferences",
     );
     const response = await GET(request);
-    const data = await response.json();
 
-    expect(response.status).toBe(400);
-    expect(data.error.message).toContain("No organization context");
+    expect(response.status).toBe(200);
   });
 });
 
@@ -224,9 +222,9 @@ describe("PUT /api/user/preferences", () => {
     expect(data.error.message).toContain("Not authenticated");
   });
 
-  it("should return BAD_REQUEST when no organization context is available", async () => {
+  it("should resolve default org when no orgId in session", async () => {
     const user = await context.setupUser();
-    // No orgId in session and no orgId in auth context
+    // No orgId in session — resolveOrg falls back to user's default org
     mockClerk({ userId: user.userId });
 
     const request = createTestRequest(
@@ -238,10 +236,8 @@ describe("PUT /api/user/preferences", () => {
       },
     );
     const response = await PUT(request);
-    const data = await response.json();
 
-    expect(response.status).toBe(400);
-    expect(data.error.message).toContain("No organization context");
+    expect(response.status).toBe(200);
   });
 
   it("should update timezone successfully", async () => {

--- a/turbo/apps/web/app/api/user/preferences/route.ts
+++ b/turbo/apps/web/app/api/user/preferences/route.ts
@@ -21,13 +21,8 @@ const router = tsr.router(userPreferencesContract, {
       return createErrorResponse("UNAUTHORIZED", "Not authenticated");
     }
 
-    const { sessionClaims, orgId: authOrgId } = await auth();
+    const { sessionClaims, orgId } = await auth();
 
-    // Clerk session → orgId from JWT; CLI token → use orgId from token
-    let orgId = authOrgId;
-    if (!orgId && ctx.orgId) {
-      orgId = ctx.orgId;
-    }
     if (!orgId) {
       return createErrorResponse("BAD_REQUEST", "No organization context");
     }
@@ -60,12 +55,7 @@ const router = tsr.router(userPreferencesContract, {
       return createErrorResponse("UNAUTHORIZED", "Not authenticated");
     }
 
-    // Clerk session → orgId from JWT; CLI token → use orgId from token
-    const { orgId } = await auth();
-    let resolvedOrgId = orgId;
-    if (!resolvedOrgId && ctx.orgId) {
-      resolvedOrgId = ctx.orgId;
-    }
+    const { orgId: resolvedOrgId } = await auth();
     if (!resolvedOrgId) {
       return createErrorResponse("BAD_REQUEST", "No organization context");
     }

--- a/turbo/apps/web/app/api/user/preferences/route.ts
+++ b/turbo/apps/web/app/api/user/preferences/route.ts
@@ -3,6 +3,7 @@ import { createHandler, tsr } from "../../../../src/lib/ts-rest-handler";
 import { userPreferencesContract, createErrorResponse } from "@vm0/core";
 import { initServices } from "../../../../src/lib/init-services";
 import { getAuthContext } from "../../../../src/lib/auth/get-user-id";
+import { resolveOrg } from "../../../../src/lib/org/resolve-org";
 import {
   getUserPreferences,
   updateUserPreferences,
@@ -21,14 +22,11 @@ const router = tsr.router(userPreferencesContract, {
       return createErrorResponse("UNAUTHORIZED", "Not authenticated");
     }
 
-    const { sessionClaims, orgId } = await auth();
-
-    if (!orgId) {
-      return createErrorResponse("BAD_REQUEST", "No organization context");
-    }
+    const { sessionClaims } = await auth();
+    const { org } = await resolveOrg(ctx.userId);
 
     const prefs = await getUserPreferences(
-      orgId,
+      org.orgId,
       ctx.userId,
       sessionClaims ?? undefined,
     );
@@ -55,13 +53,10 @@ const router = tsr.router(userPreferencesContract, {
       return createErrorResponse("UNAUTHORIZED", "Not authenticated");
     }
 
-    const { orgId: resolvedOrgId } = await auth();
-    if (!resolvedOrgId) {
-      return createErrorResponse("BAD_REQUEST", "No organization context");
-    }
+    const { org } = await resolveOrg(ctx.userId);
 
     try {
-      const prefs = await updateUserPreferences(resolvedOrgId, ctx.userId, {
+      const prefs = await updateUserPreferences(org.orgId, ctx.userId, {
         timezone: body.timezone,
         notifyEmail: body.notifyEmail,
         notifySlack: body.notifySlack,

--- a/turbo/apps/web/app/api/variables/[name]/route.ts
+++ b/turbo/apps/web/app/api/variables/[name]/route.ts
@@ -31,10 +31,10 @@ const router = tsr.router(variablesByNameContract, {
     if (!authCtx) {
       return createErrorResponse("UNAUTHORIZED", "Not authenticated");
     }
-    const { userId, orgId: tokenOrgId } = authCtx;
+    const { userId } = authCtx;
 
     const orgSlug = new URL(request.url).searchParams.get("org");
-    const { org } = await resolveOrg(userId, orgSlug, null, tokenOrgId);
+    const { org } = await resolveOrg(userId, orgSlug);
     const variable = await getVariable(org.orgId, userId, params.name);
     if (!variable) {
       return createErrorResponse(
@@ -66,13 +66,13 @@ const router = tsr.router(variablesByNameContract, {
     if (!authCtx) {
       return createErrorResponse("UNAUTHORIZED", "Not authenticated");
     }
-    const { userId, orgId: tokenOrgId } = authCtx;
+    const { userId } = authCtx;
 
     log.debug("deleting variable", { userId, name: params.name });
 
     try {
       const orgSlug = new URL(request.url).searchParams.get("org");
-      const { org } = await resolveOrg(userId, orgSlug, null, tokenOrgId);
+      const { org } = await resolveOrg(userId, orgSlug);
       await deleteVariable(org.orgId, userId, params.name);
 
       return {

--- a/turbo/apps/web/app/api/variables/route.ts
+++ b/turbo/apps/web/app/api/variables/route.ts
@@ -31,10 +31,10 @@ const router = tsr.router(variablesMainContract, {
     if (!authCtx) {
       return createErrorResponse("UNAUTHORIZED", "Not authenticated");
     }
-    const { userId, orgId: tokenOrgId } = authCtx;
+    const { userId } = authCtx;
 
     const orgSlug = new URL(request.url).searchParams.get("org");
-    const { org } = await resolveOrg(userId, orgSlug, null, tokenOrgId);
+    const { org } = await resolveOrg(userId, orgSlug);
     const vars = await listVariables(org.orgId, userId);
 
     return {
@@ -62,7 +62,7 @@ const router = tsr.router(variablesMainContract, {
     if (!authCtx) {
       return createErrorResponse("UNAUTHORIZED", "Not authenticated");
     }
-    const { userId, orgId: tokenOrgId } = authCtx;
+    const { userId } = authCtx;
 
     const { name, value, description } = body;
 
@@ -70,7 +70,7 @@ const router = tsr.router(variablesMainContract, {
 
     try {
       const orgSlug = new URL(request.url).searchParams.get("org");
-      const { org } = await resolveOrg(userId, orgSlug, null, tokenOrgId);
+      const { org } = await resolveOrg(userId, orgSlug);
       const variable = await setVariable(
         org.orgId,
         userId,

--- a/turbo/apps/web/app/cli-auth/actions.ts
+++ b/turbo/apps/web/app/cli-auth/actions.ts
@@ -5,6 +5,7 @@ import { auth } from "@clerk/nextjs/server";
 import { initServices } from "../../src/lib/init-services";
 import { deviceCodes } from "../../src/db/schema/device-codes";
 import { setTimezoneIfNotSet } from "../../src/lib/user/user-preferences-service";
+import { getOrgData } from "../../src/lib/org/org-cache-service";
 
 interface VerifyResult {
   success: boolean;
@@ -46,12 +47,20 @@ export async function verifyDeviceAction(
     return { success: false, error: "Device code has expired" };
   }
 
-  // Update status to authenticated and set userId
+  // Resolve org slug from browser session for CLI activeOrg
+  let orgSlug: string | null = null;
+  if (orgId) {
+    const orgData = await getOrgData(orgId);
+    orgSlug = orgData.slug;
+  }
+
+  // Update status to authenticated and set userId + orgSlug
   await globalThis.services.db
     .update(deviceCodes)
     .set({
       status: "authenticated",
       userId,
+      orgSlug,
       updatedAt: new Date(),
     })
     .where(eq(deviceCodes.code, normalizedCode));

--- a/turbo/apps/web/src/__tests__/api-test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers.ts
@@ -259,6 +259,7 @@ export async function deleteTestCliToken(token: string): Promise<void> {
 export async function createTestDeviceCode(options?: {
   status?: "pending" | "authenticated" | "expired" | "denied";
   userId?: string;
+  orgSlug?: string;
   expiresAt?: Date;
 }): Promise<string> {
   const chars = "ABCDEFGHJKMNPQRSTUVWXYZ23456789";
@@ -276,6 +277,7 @@ export async function createTestDeviceCode(options?: {
     code,
     status,
     userId: options?.userId ?? null,
+    orgSlug: options?.orgSlug ?? null,
     expiresAt,
   });
 
@@ -2890,14 +2892,37 @@ export async function getOrgCacheEntry(orgId: string) {
 export async function insertOrgMembersCacheEntry(entry: {
   orgId: string;
   userId: string;
+  role?: string;
   cachedAt?: Date;
 }): Promise<void> {
   initServices();
-  await globalThis.services.db.insert(orgMembersCache).values({
-    orgId: entry.orgId,
-    userId: entry.userId,
-    cachedAt: entry.cachedAt ?? new Date(),
-  });
+  await globalThis.services.db
+    .insert(orgMembersCache)
+    .values({
+      orgId: entry.orgId,
+      userId: entry.userId,
+      role: entry.role ?? "member",
+      cachedAt: entry.cachedAt ?? new Date(),
+    })
+    .onConflictDoUpdate({
+      target: [orgMembersCache.orgId, orgMembersCache.userId],
+      set: {
+        role: entry.role ?? "member",
+        cachedAt: entry.cachedAt ?? new Date(),
+      },
+    });
+}
+
+export async function findOrgMembersCacheEntry(orgId: string, userId: string) {
+  initServices();
+  const [row] = await globalThis.services.db
+    .select()
+    .from(orgMembersCache)
+    .where(
+      and(eq(orgMembersCache.orgId, orgId), eq(orgMembersCache.userId, userId)),
+    )
+    .limit(1);
+  return row;
 }
 
 export async function findTestRunnerJobEntry(runId: string) {

--- a/turbo/apps/web/src/__tests__/clerk-org-mock.ts
+++ b/turbo/apps/web/src/__tests__/clerk-org-mock.ts
@@ -104,13 +104,20 @@ export function setupClerkOrgMock(options: {
                 })),
           }),
       ),
-    getOrganizationMembershipList: vi.fn().mockResolvedValue({
-      data: memberships.map((m) => ({
-        organization: { id: orgId, slug: orgSlug, name: orgSlug },
-        role: m.role,
-        publicUserData: { userId: m.userId },
-      })),
-    }),
+    getOrganizationMembershipList: vi
+      .fn()
+      .mockImplementation((params: { userId: string }) => {
+        const userMemberships = memberships.filter(
+          (m) => m.userId === params.userId,
+        );
+        return Promise.resolve({
+          data: userMemberships.map((m) => ({
+            organization: { id: orgId, slug: orgSlug, name: orgSlug },
+            role: m.role,
+            publicUserData: { userId: m.userId },
+          })),
+        });
+      }),
   };
 
   mockClerkClient.mockResolvedValue({

--- a/turbo/apps/web/src/db/migrations/0139_smooth_speed.sql
+++ b/turbo/apps/web/src/db/migrations/0139_smooth_speed.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "device_codes" ADD COLUMN "org_slug" text;--> statement-breakpoint
+ALTER TABLE "org_members_cache" ADD COLUMN "role" text DEFAULT 'member' NOT NULL;--> statement-breakpoint
+ALTER TABLE "cli_tokens" DROP COLUMN "org_id";

--- a/turbo/apps/web/src/db/migrations/meta/0137_snapshot.json
+++ b/turbo/apps/web/src/db/migrations/meta/0137_snapshot.json
@@ -1,5 +1,5 @@
 {
-  "id": "19c5ecf8-568e-431b-a214-2eaf65d6594a",
+  "id": "72436a75-5bcd-4068-b3eb-78997d03e4ec",
   "prevId": "44c365a9-6b39-4dfa-988d-7d9a0ff6062d",
   "version": "7",
   "dialect": "postgresql",
@@ -1880,6 +1880,12 @@
           "primaryKey": false,
           "notNull": false
         },
+        "org_slug": {
+          "name": "org_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
         "created_at": {
           "name": "created_at",
           "type": "timestamp",
@@ -2954,13 +2960,6 @@
           "primaryKey": false,
           "notNull": true,
           "default": "now()"
-        },
-        "pinned_agent_ids": {
-          "name": "pinned_agent_ids",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false,
-          "default": "'[]'::jsonb"
         }
       },
       "indexes": {},

--- a/turbo/apps/web/src/db/migrations/meta/0137_snapshot.json
+++ b/turbo/apps/web/src/db/migrations/meta/0137_snapshot.json
@@ -1,5 +1,5 @@
 {
-  "id": "72436a75-5bcd-4068-b3eb-78997d03e4ec",
+  "id": "19c5ecf8-568e-431b-a214-2eaf65d6594a",
   "prevId": "44c365a9-6b39-4dfa-988d-7d9a0ff6062d",
   "version": "7",
   "dialect": "postgresql",
@@ -1880,12 +1880,6 @@
           "primaryKey": false,
           "notNull": false
         },
-        "org_slug": {
-          "name": "org_slug",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
         "created_at": {
           "name": "created_at",
           "type": "timestamp",
@@ -2960,6 +2954,13 @@
           "primaryKey": false,
           "notNull": true,
           "default": "now()"
+        },
+        "pinned_agent_ids": {
+          "name": "pinned_agent_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
         }
       },
       "indexes": {},

--- a/turbo/apps/web/src/db/migrations/meta/0138_snapshot.json
+++ b/turbo/apps/web/src/db/migrations/meta/0138_snapshot.json
@@ -1,6 +1,6 @@
 {
-  "id": "ae1316ed-dabe-4560-8a2f-9c1a59fcdb14",
-  "prevId": "19c5ecf8-568e-431b-a214-2eaf65d6594a",
+  "id": "f0a71c75-5fab-47c4-8ecd-115904f51a8c",
+  "prevId": "72436a75-5bcd-4068-b3eb-78997d03e4ec",
   "version": "7",
   "dialect": "postgresql",
   "tables": {
@@ -1880,6 +1880,12 @@
           "primaryKey": false,
           "notNull": false
         },
+        "org_slug": {
+          "name": "org_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
         "created_at": {
           "name": "created_at",
           "type": "timestamp",
@@ -2139,67 +2145,6 @@
           "onUpdate": "no action"
         }
       },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.email_suppressions": {
-      "name": "email_suppressions",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "uuid",
-          "primaryKey": true,
-          "notNull": true,
-          "default": "gen_random_uuid()"
-        },
-        "email_address": {
-          "name": "email_address",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "reason": {
-          "name": "reason",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "resend_email_id": {
-          "name": "resend_email_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        }
-      },
-      "indexes": {
-        "email_suppressions_email_lower_idx": {
-          "name": "email_suppressions_email_lower_idx",
-          "columns": [
-            {
-              "expression": "lower(\"email_address\")",
-              "asc": true,
-              "isExpression": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": true,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {},
       "compositePrimaryKeys": {},
       "uniqueConstraints": {},
       "policies": {},
@@ -2989,6 +2934,13 @@
           "primaryKey": false,
           "notNull": true
         },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
         "timezone": {
           "name": "timezone",
           "type": "text",
@@ -3008,13 +2960,6 @@
           "primaryKey": false,
           "notNull": true,
           "default": true
-        },
-        "pinned_agent_ids": {
-          "name": "pinned_agent_ids",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false,
-          "default": "'[]'::jsonb"
         },
         "cached_at": {
           "name": "cached_at",

--- a/turbo/apps/web/src/db/migrations/meta/0139_snapshot.json
+++ b/turbo/apps/web/src/db/migrations/meta/0139_snapshot.json
@@ -1,6 +1,6 @@
 {
-  "id": "ae1316ed-dabe-4560-8a2f-9c1a59fcdb14",
-  "prevId": "19c5ecf8-568e-431b-a214-2eaf65d6594a",
+  "id": "a3168633-5c65-42be-bb8b-c82d7935902b",
+  "prevId": "ae1316ed-dabe-4560-8a2f-9c1a59fcdb14",
   "version": "7",
   "dialect": "postgresql",
   "tables": {
@@ -1350,12 +1350,6 @@
           "primaryKey": false,
           "notNull": true
         },
-        "org_id": {
-          "name": "org_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
         "expires_at": {
           "name": "expires_at",
           "type": "timestamp",
@@ -1876,6 +1870,12 @@
         },
         "user_id": {
           "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_slug": {
+          "name": "org_slug",
           "type": "text",
           "primaryKey": false,
           "notNull": false
@@ -2988,6 +2988,13 @@
           "type": "text",
           "primaryKey": false,
           "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
         },
         "timezone": {
           "name": "timezone",

--- a/turbo/apps/web/src/db/migrations/meta/_journal.json
+++ b/turbo/apps/web/src/db/migrations/meta/_journal.json
@@ -964,15 +964,22 @@
     {
       "idx": 137,
       "version": "7",
-      "when": 1773400000110,
-      "tag": "0137_add_pinned_agent_ids",
+      "when": 1773387824808,
+      "tag": "0137_condemned_mariko_yashida",
       "breakpoints": true
     },
     {
       "idx": 138,
       "version": "7",
-      "when": 1773400000120,
-      "tag": "0138_email_suppressions",
+      "when": 1773388066590,
+      "tag": "0138_nebulous_warlock",
+      "breakpoints": true
+    },
+    {
+      "idx": 139,
+      "version": "7",
+      "when": 1773388882358,
+      "tag": "0139_wakeful_ben_grimm",
       "breakpoints": true
     }
   ]

--- a/turbo/apps/web/src/db/migrations/meta/_journal.json
+++ b/turbo/apps/web/src/db/migrations/meta/_journal.json
@@ -964,22 +964,22 @@
     {
       "idx": 137,
       "version": "7",
-      "when": 1773400000101,
-      "tag": "0137_condemned_mariko_yashida",
+      "when": 1773400000110,
+      "tag": "0137_add_pinned_agent_ids",
       "breakpoints": true
     },
     {
       "idx": 138,
       "version": "7",
-      "when": 1773400000102,
-      "tag": "0138_nebulous_warlock",
+      "when": 1773400000120,
+      "tag": "0138_email_suppressions",
       "breakpoints": true
     },
     {
       "idx": 139,
       "version": "7",
-      "when": 1773400000103,
-      "tag": "0139_wakeful_ben_grimm",
+      "when": 1773400541600,
+      "tag": "0139_smooth_speed",
       "breakpoints": true
     }
   ]

--- a/turbo/apps/web/src/db/migrations/meta/_journal.json
+++ b/turbo/apps/web/src/db/migrations/meta/_journal.json
@@ -964,21 +964,21 @@
     {
       "idx": 137,
       "version": "7",
-      "when": 1773387824808,
+      "when": 1773400000101,
       "tag": "0137_condemned_mariko_yashida",
       "breakpoints": true
     },
     {
       "idx": 138,
       "version": "7",
-      "when": 1773388066590,
+      "when": 1773400000102,
       "tag": "0138_nebulous_warlock",
       "breakpoints": true
     },
     {
       "idx": 139,
       "version": "7",
-      "when": 1773388882358,
+      "when": 1773400000103,
       "tag": "0139_wakeful_ben_grimm",
       "breakpoints": true
     }

--- a/turbo/apps/web/src/db/schema/cli-tokens.ts
+++ b/turbo/apps/web/src/db/schema/cli-tokens.ts
@@ -5,7 +5,6 @@ export const cliTokens = pgTable("cli_tokens", {
   token: text("token").unique().notNull(), // vm0_live_xxxxx...
   userId: text("user_id").notNull(), // Clerk user ID
   name: text("name").notNull(), // User-friendly name
-  orgId: text("org_id"), // Org ID dual-write (nullable for old tokens)
   expiresAt: timestamp("expires_at").notNull(),
   lastUsedAt: timestamp("last_used_at"),
   createdAt: timestamp("created_at").defaultNow().notNull(),

--- a/turbo/apps/web/src/db/schema/device-codes.ts
+++ b/turbo/apps/web/src/db/schema/device-codes.ts
@@ -11,6 +11,7 @@ export const deviceCodes = pgTable("device_codes", {
   code: varchar("code", { length: 9 }).primaryKey(), // XXXX-XXXX format
   status: deviceCodeStatusEnum("status").default("pending").notNull(),
   userId: text("user_id"), // Clerk user ID, set after authentication
+  orgSlug: text("org_slug"), // Org slug from browser session, set on approval
   createdAt: timestamp("created_at").defaultNow().notNull(),
   expiresAt: timestamp("expires_at").notNull(),
   updatedAt: timestamp("updated_at").defaultNow().notNull(),

--- a/turbo/apps/web/src/db/schema/org-members-cache.ts
+++ b/turbo/apps/web/src/db/schema/org-members-cache.ts
@@ -17,6 +17,7 @@ export const orgMembersCache = pgTable(
   {
     orgId: text("org_id").notNull(),
     userId: text("user_id").notNull(),
+    role: text("role").notNull().default("member"),
     timezone: text("timezone"),
     notifyEmail: boolean("notify_email").notNull().default(false),
     notifySlack: boolean("notify_slack").notNull().default(true),

--- a/turbo/apps/web/src/lib/auth/get-user-id.ts
+++ b/turbo/apps/web/src/lib/auth/get-user-id.ts
@@ -8,19 +8,14 @@ const log = logger("auth:user");
 
 /**
  * Authentication context returned by getAuthContext.
- * - orgId: present when auth is via a CLI token that has a stored org
  */
 type AuthContext = {
   userId: string;
-  orgId: string | null;
 };
 
 /**
  * Get the full authentication context from CLI token or Clerk session.
  * Returns null if not authenticated.
- *
- * For Clerk sessions, orgId is null (org is resolved from Clerk JWT).
- * For CLI tokens with org_id, returns the stored orgId.
  *
  * IMPORTANT: This function rejects sandbox JWT tokens.
  * Sandbox tokens can only be used on webhook endpoints via getSandboxAuth().
@@ -31,7 +26,7 @@ export async function getAuthContext(
   // Session auth via Clerk
   const { userId } = await auth();
   if (userId) {
-    return { userId, orgId: null };
+    return { userId };
   }
 
   if (!authHeader?.startsWith("Bearer ")) {
@@ -70,15 +65,12 @@ export async function getAuthContext(
 
   return {
     userId: tokenRecord.userId,
-    orgId: tokenRecord.orgId,
   };
 }
 
 /**
  * Get the current user ID from CLI token or Clerk session.
  * Returns null if not authenticated.
- *
- * Use getAuthContext() when you also need the CLI token's orgId.
  */
 export async function getUserId(authHeader?: string): Promise<string | null> {
   const ctx = await getAuthContext(authHeader);

--- a/turbo/apps/web/src/lib/auth/runner-auth.ts
+++ b/turbo/apps/web/src/lib/auth/runner-auth.ts
@@ -28,7 +28,6 @@ type RunnerAuthContext =
   | {
       type: "user";
       userId: string;
-      orgId: string | null;
     }
   | { type: "official-runner" };
 
@@ -127,7 +126,6 @@ export async function getRunnerAuth(
       return {
         type: "user",
         userId: tokenRecord.userId,
-        orgId: tokenRecord.orgId,
       };
     }
 

--- a/turbo/apps/web/src/lib/compose/trigger-compose-job.ts
+++ b/turbo/apps/web/src/lib/compose/trigger-compose-job.ts
@@ -359,7 +359,6 @@ interface TriggerComposeJobResult {
 async function generateComposeCliToken(
   userId: string,
   jobId: string,
-  orgId?: string,
 ): Promise<string> {
   const token = `vm0_live_${crypto.randomBytes(32).toString("base64url")}`;
   const expiresAt = new Date(Date.now() + 10 * 60 * 1000); // 10 minutes
@@ -368,7 +367,6 @@ async function generateComposeCliToken(
     token,
     userId,
     name: `Compose Job ${jobId}`,
-    orgId: orgId ?? null,
     expiresAt,
   });
 
@@ -460,7 +458,7 @@ export async function triggerComposeJob(
   log.debug(`Created new job ${jobId} for user ${userId}`);
 
   // Generate tokens for sandbox
-  const cliToken = await generateComposeCliToken(userId, jobId, params.orgId);
+  const cliToken = await generateComposeCliToken(userId, jobId);
   const webhookToken = await generateComposeJobToken(userId, jobId);
 
   // Build sandbox params

--- a/turbo/apps/web/src/lib/org/__tests__/org-membership-cache.test.ts
+++ b/turbo/apps/web/src/lib/org/__tests__/org-membership-cache.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { testContext } from "../../../__tests__/test-helpers";
+import {
+  insertOrgCacheEntry,
+  insertOrgMembersCacheEntry,
+  findOrgMembersCacheEntry,
+} from "../../../__tests__/api-test-helpers";
+import { mockClerk } from "../../../__tests__/clerk-mock";
+import { verifyMembershipCached } from "../org-membership-cache";
+
+const context = testContext();
+
+describe("verifyMembershipCached", () => {
+  beforeEach(() => {
+    context.setupMocks();
+  });
+
+  it("should return null for a user not in the org", async () => {
+    const { userId } = await context.setupUser();
+
+    // Query an org the user is NOT a member of
+    const foreignOrgId = "org_foreign_no_membership";
+    await insertOrgCacheEntry({ orgId: foreignOrgId, slug: "foreign-org" });
+
+    const result = await verifyMembershipCached(foreignOrgId, userId);
+    expect(result).toBeNull();
+  });
+
+  it("should return role from Clerk API on cache miss", async () => {
+    const { userId, orgId } = await context.setupUser();
+
+    // No cache entry exists — should call Clerk API
+    const result = await verifyMembershipCached(orgId, userId);
+
+    expect(result).not.toBeNull();
+    expect(result!.role).toBe("admin");
+  });
+
+  it("should return cached role on cache hit without Clerk API call", async () => {
+    const { userId, orgId } = await context.setupUser();
+
+    // Pre-populate cache
+    await insertOrgMembersCacheEntry({ orgId, userId, role: "member" });
+
+    // Mock Clerk to return a different role — if cache is used, we should get "member"
+    mockClerk({ userId });
+
+    const result = await verifyMembershipCached(orgId, userId);
+    expect(result).not.toBeNull();
+    expect(result!.role).toBe("member"); // From cache, not Clerk
+  });
+
+  it("should refresh cache after TTL expires", async () => {
+    const { userId, orgId } = await context.setupUser();
+
+    // Insert a stale cache entry (2 minutes old)
+    const staleTime = new Date(Date.now() - 120_000);
+    await insertOrgMembersCacheEntry({
+      orgId,
+      userId,
+      role: "member",
+      cachedAt: staleTime,
+    });
+
+    // Clerk returns admin role — should override stale cache
+    const result = await verifyMembershipCached(orgId, userId);
+    expect(result).not.toBeNull();
+    expect(result!.role).toBe("admin"); // From Clerk, not stale cache
+  });
+
+  it("should delete stale cache when user is no longer a member", async () => {
+    const { userId } = await context.setupUser();
+
+    // Create a cache entry for an org the user is NOT actually a member of
+    const foreignOrgId = "org_foreign_stale";
+    await insertOrgCacheEntry({ orgId: foreignOrgId, slug: "stale-org" });
+
+    const staleTime = new Date(Date.now() - 120_000);
+    await insertOrgMembersCacheEntry({
+      orgId: foreignOrgId,
+      userId,
+      role: "admin",
+      cachedAt: staleTime,
+    });
+
+    // verifyMembershipCached should check Clerk, find no membership, return null
+    const result = await verifyMembershipCached(foreignOrgId, userId);
+    expect(result).toBeNull();
+
+    // Allow fire-and-forget cache delete to complete
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    // Verify cache entry was deleted
+    const cached = await findOrgMembersCacheEntry(foreignOrgId, userId);
+    expect(cached).toBeUndefined();
+  });
+});

--- a/turbo/apps/web/src/lib/org/__tests__/org-membership-cache.test.ts
+++ b/turbo/apps/web/src/lib/org/__tests__/org-membership-cache.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import { testContext } from "../../../__tests__/test-helpers";
 import {
   insertOrgCacheEntry,
@@ -87,11 +87,10 @@ describe("verifyMembershipCached", () => {
     const result = await verifyMembershipCached(foreignOrgId, userId);
     expect(result).toBeNull();
 
-    // Allow fire-and-forget cache delete to complete
-    await new Promise((resolve) => setTimeout(resolve, 50));
-
-    // Verify cache entry was deleted
-    const cached = await findOrgMembersCacheEntry(foreignOrgId, userId);
-    expect(cached).toBeUndefined();
+    // Wait for fire-and-forget cache delete to complete
+    await vi.waitFor(async () => {
+      const cached = await findOrgMembersCacheEntry(foreignOrgId, userId);
+      expect(cached).toBeUndefined();
+    });
   });
 });

--- a/turbo/apps/web/src/lib/org/__tests__/org-service.test.ts
+++ b/turbo/apps/web/src/lib/org/__tests__/org-service.test.ts
@@ -12,6 +12,10 @@ describe("getDefaultOrgByUserId", () => {
   });
 
   it("should return null when user has no org", async () => {
+    // setupUser initializes services (db, etc.) needed by getDefaultOrg
+    await context.setupUser();
+
+    // Re-mock Clerk with a user that has no orgs
     const userId = uniqueId("no-org-user");
     mockClerk({ userId, clerkOrgs: [] });
 
@@ -21,6 +25,10 @@ describe("getDefaultOrgByUserId", () => {
   });
 
   it("should return org from org_cache for user with Clerk org", async () => {
+    // setupUser initializes services (db, etc.) needed by getDefaultOrg
+    await context.setupUser();
+
+    // Re-mock Clerk with a specific user
     const userId = uniqueId("test-user");
     const orgId = `org_mock_${userId}`;
     const slug = uniqueId("org");

--- a/turbo/apps/web/src/lib/org/org-member-service.ts
+++ b/turbo/apps/web/src/lib/org/org-member-service.ts
@@ -100,10 +100,8 @@ export async function getDefaultOrg(
 export async function resolveOrgId(
   userId: string,
   orgId?: string | null,
-  tokenOrgId?: string | null,
 ): Promise<string> {
   if (orgId) return orgId;
-  if (tokenOrgId) return tokenOrgId;
   const { org } = await getDefaultOrg(userId);
   return org.orgId;
 }

--- a/turbo/apps/web/src/lib/org/org-member-service.ts
+++ b/turbo/apps/web/src/lib/org/org-member-service.ts
@@ -1,7 +1,9 @@
 import { auth, clerkClient } from "@clerk/nextjs/server";
+import { eq, desc } from "drizzle-orm";
 import { badRequest, forbidden, notFound } from "../errors";
 import { logger } from "../logger";
 import { getOrgData } from "./org-cache-service";
+import { orgMembersCache } from "../../db/schema/org-members-cache";
 import type { OrgRole } from "@vm0/core";
 import type { ResolvedOrg, ResolvedMember } from "./resolve-org";
 
@@ -61,6 +63,29 @@ export async function getDefaultOrg(
       };
     } catch {
       // JWT orgId not found in Clerk — fall through to slow path
+    }
+  }
+
+  // Cache fast path: check org_members_cache for a recent entry (1-min TTL)
+  const [cached] = await globalThis.services.db
+    .select()
+    .from(orgMembersCache)
+    .where(eq(orgMembersCache.userId, userId))
+    .orderBy(desc(orgMembersCache.cachedAt))
+    .limit(1);
+
+  if (cached && Date.now() - cached.cachedAt.getTime() < 60_000) {
+    try {
+      const orgData = await getOrgData(cached.orgId);
+      return {
+        org: orgData,
+        member: {
+          role: cached.role === "admin" ? "admin" : "member",
+          userId,
+        },
+      };
+    } catch {
+      // org_cache miss — fall through to Clerk API
     }
   }
 

--- a/turbo/apps/web/src/lib/org/org-membership-cache.ts
+++ b/turbo/apps/web/src/lib/org/org-membership-cache.ts
@@ -1,0 +1,76 @@
+import { eq, and } from "drizzle-orm";
+import { clerkClient } from "@clerk/nextjs/server";
+import { orgMembersCache } from "../../db/schema/org-members-cache";
+import { logger } from "../logger";
+import type { OrgRole } from "@vm0/core";
+
+const log = logger("org:membership-cache");
+
+/** Cache TTL aligned with Clerk JWT TTL */
+const CACHE_TTL_MS = 60_000; // 1 minute
+
+/**
+ * Verify a user's org membership via org_members_cache with Clerk API fallback.
+ *
+ * Returns { role } if the user is a member, null if not.
+ * Cache hit: ~1ms (DB read). Cache miss: ~50-200ms (Clerk API + cache write).
+ */
+export async function verifyMembershipCached(
+  orgId: string,
+  userId: string,
+): Promise<{ role: OrgRole } | null> {
+  // 1. Check cache
+  const [cached] = await globalThis.services.db
+    .select({ role: orgMembersCache.role, cachedAt: orgMembersCache.cachedAt })
+    .from(orgMembersCache)
+    .where(
+      and(eq(orgMembersCache.orgId, orgId), eq(orgMembersCache.userId, userId)),
+    )
+    .limit(1);
+
+  if (cached && Date.now() - cached.cachedAt.getTime() < CACHE_TTL_MS) {
+    return { role: cached.role as OrgRole };
+  }
+
+  // 2. Cache miss/stale → Clerk API
+  const client = await clerkClient();
+  const memberships = await client.users.getOrganizationMembershipList({
+    userId,
+    limit: 100,
+  });
+  const membership = memberships.data.find((m) => m.organization.id === orgId);
+
+  if (!membership) {
+    // Not a member — delete stale cache entry if exists
+    if (cached) {
+      void globalThis.services.db
+        .delete(orgMembersCache)
+        .where(
+          and(
+            eq(orgMembersCache.orgId, orgId),
+            eq(orgMembersCache.userId, userId),
+          ),
+        )
+        .catch((err: unknown) => {
+          log.warn("Failed to delete stale org_members_cache entry", { err });
+        });
+    }
+    return null;
+  }
+
+  // 3. Update cache (fire-and-forget)
+  const role = membership.role === "org:admin" ? "admin" : "member";
+  const now = new Date();
+  void globalThis.services.db
+    .insert(orgMembersCache)
+    .values({ orgId, userId, role, cachedAt: now })
+    .onConflictDoUpdate({
+      target: [orgMembersCache.orgId, orgMembersCache.userId],
+      set: { role, cachedAt: now },
+    })
+    .catch((err: unknown) => {
+      log.warn("Failed to update org_members_cache", { err });
+    });
+
+  return { role: role as OrgRole };
+}

--- a/turbo/apps/web/src/lib/org/org-membership-cache.ts
+++ b/turbo/apps/web/src/lib/org/org-membership-cache.ts
@@ -2,7 +2,7 @@ import { eq, and } from "drizzle-orm";
 import { clerkClient } from "@clerk/nextjs/server";
 import { orgMembersCache } from "../../db/schema/org-members-cache";
 import { logger } from "../logger";
-import type { OrgRole } from "@vm0/core";
+import { orgRoleSchema, type OrgRole } from "@vm0/core";
 
 const log = logger("org:membership-cache");
 
@@ -29,7 +29,7 @@ export async function verifyMembershipCached(
     .limit(1);
 
   if (cached && Date.now() - cached.cachedAt.getTime() < CACHE_TTL_MS) {
-    return { role: cached.role as OrgRole };
+    return { role: orgRoleSchema.parse(cached.role) };
   }
 
   // 2. Cache miss/stale → Clerk API
@@ -59,7 +59,7 @@ export async function verifyMembershipCached(
   }
 
   // 3. Update cache (fire-and-forget)
-  const role = membership.role === "org:admin" ? "admin" : "member";
+  const role: OrgRole = membership.role === "org:admin" ? "admin" : "member";
   const now = new Date();
   void globalThis.services.db
     .insert(orgMembersCache)
@@ -72,5 +72,5 @@ export async function verifyMembershipCached(
       log.warn("Failed to update org_members_cache", { err });
     });
 
-  return { role: role as OrgRole };
+  return { role };
 }

--- a/turbo/apps/web/src/lib/org/org-service.ts
+++ b/turbo/apps/web/src/lib/org/org-service.ts
@@ -7,6 +7,7 @@ import {
 } from "./org-cache-service";
 import { badRequest, forbidden, isNotFound } from "../errors";
 import { logger } from "../logger";
+import { verifyMembershipCached } from "./org-membership-cache";
 import type { ResolvedOrg } from "./resolve-org";
 
 const log = logger("service:org");
@@ -124,14 +125,13 @@ export function isOfficialRunnerGroup(group: string): boolean {
  * Runner groups are in format "org/name" (e.g., "e2e-stable/pr-851").
  *
  * For official runner groups (vm0/*), any authenticated user is allowed.
- * For user runner groups, the org part must match the user's personal org slug.
+ * For user runner groups, verifies membership via org_members_cache.
  *
  * @throws ForbiddenError if org doesn't match (for non-official groups)
  */
 export async function validateRunnerGroupOrg(
   userId: string,
   group: string,
-  tokenOrgId?: string | null,
 ): Promise<void> {
   const orgSlug = group.split("/")[0];
   if (!orgSlug) {
@@ -143,25 +143,16 @@ export async function validateRunnerGroupOrg(
     return;
   }
 
-  // CLI token with stored org_id — resolve slug from org_cache
-  if (tokenOrgId) {
-    const orgData = await getOrgData(tokenOrgId);
-    if (orgData.slug === orgSlug) {
-      return;
-    }
-    throw forbidden(`Runner group org "${orgSlug}" does not match your org`);
-  }
-
-  const defaultOrg = await getDefaultOrgByUserId(userId);
-  if (!defaultOrg) {
+  // Look up the org by slug, then verify membership via cache
+  const orgData = await getOrgBySlug(orgSlug);
+  if (!orgData) {
     throw forbidden(
       `Runner group org "${orgSlug}" requires you to have an org configured`,
     );
   }
 
-  if (defaultOrg.slug !== orgSlug) {
-    throw forbidden(
-      `Runner group org "${orgSlug}" does not match your org "${defaultOrg.slug}"`,
-    );
+  const membership = await verifyMembershipCached(orgData.orgId, userId);
+  if (!membership) {
+    throw forbidden(`Runner group org "${orgSlug}" does not match your org`);
   }
 }

--- a/turbo/apps/web/src/lib/org/resolve-org.ts
+++ b/turbo/apps/web/src/lib/org/resolve-org.ts
@@ -80,25 +80,11 @@ async function verifyMembership(
   }
 
   // Cache-backed path: check org_members_cache, fall back to Clerk API
-  try {
-    const result = await verifyMembershipCached(resolved.orgId, userId);
-    if (!result) {
-      throw forbidden("You are not a member of this organization");
-    }
-    return { role: result.role, userId };
-  } catch (error) {
-    // Re-throw our own forbidden errors
-    if (error instanceof Error && error.message.includes("not a member")) {
-      throw error;
-    }
-    // Clerk API failure — deny access (security-first)
-    log.error("verifyMembership failed", {
-      userId,
-      orgId: resolved.orgId,
-      error,
-    });
+  const result = await verifyMembershipCached(resolved.orgId, userId);
+  if (!result) {
     throw forbidden("You are not a member of this organization");
   }
+  return { role: result.role, userId };
 }
 
 /**

--- a/turbo/apps/web/src/lib/org/resolve-org.ts
+++ b/turbo/apps/web/src/lib/org/resolve-org.ts
@@ -1,8 +1,9 @@
-import { auth, clerkClient } from "@clerk/nextjs/server";
+import { auth } from "@clerk/nextjs/server";
 import { forbidden, badRequest, notFound } from "../errors";
 import { logger } from "../logger";
 import { getOrgBySlug, getOrgData } from "./org-cache-service";
 import { getDefaultOrg } from "./org-member-service";
+import { verifyMembershipCached } from "./org-membership-cache";
 
 import type { OrgRole } from "@vm0/core";
 
@@ -58,23 +59,14 @@ function mapOrgRole(clerkRole: string | undefined | null): OrgRole {
  * Fast path: if the org's orgId matches the JWT's active org,
  * trust the JWT claims and skip the Clerk API call entirely.
  *
- * Slow path: for cross-org access (e.g. ?org= pointing to a non-active org),
- * fall back to Clerk Backend API.
- *
- * CLI token path: if tokenOrgId is provided and matches the org,
- * trust the token (membership was verified at token creation time).
+ * Cache path: for CLI tokens or cross-org access, use org_members_cache
+ * with Clerk API fallback (1-minute TTL).
  */
 async function verifyMembership(
   resolved: ResolvedOrg,
   userId: string,
   authResult: Awaited<ReturnType<typeof auth>>,
-  tokenOrgId?: string | null,
 ): Promise<ResolvedMember> {
-  // CLI token with stored org_id — trust if it matches
-  if (tokenOrgId && resolved.orgId === tokenOrgId) {
-    return { role: "admin", userId };
-  }
-
   // JWT fast path: active org matches → trust JWT, no API call
   if (resolved.orgId === authResult.orgId) {
     return {
@@ -87,25 +79,13 @@ async function verifyMembership(
     throw forbidden("You are not a member of this organization");
   }
 
-  // Slow path: cross-org access → Clerk Backend API
+  // Cache-backed path: check org_members_cache, fall back to Clerk API
   try {
-    const client = await clerkClient();
-    const memberships =
-      await client.organizations.getOrganizationMembershipList({
-        organizationId: resolved.orgId,
-      });
-
-    const membership = memberships.data.find(
-      (m) => m.publicUserData?.userId === userId,
-    );
-    if (!membership) {
+    const result = await verifyMembershipCached(resolved.orgId, userId);
+    if (!result) {
       throw forbidden("You are not a member of this organization");
     }
-
-    return {
-      role: mapOrgRole(membership.role),
-      userId,
-    };
+    return { role: result.role, userId };
   } catch (error) {
     // Re-throw our own forbidden errors
     if (error instanceof Error && error.message.includes("not a member")) {
@@ -142,11 +122,11 @@ function applyJwtTier(
  * Resolve org from request context using org_cache.
  *
  * Uses JWT claims for membership verification when possible (zero Clerk API calls).
- * Falls back to Clerk Backend API for cross-org access or CLI tokens without org_id.
+ * Falls back to org_members_cache (with Clerk API fallback) for CLI tokens.
  *
  * Resolution order:
  * 1. orgSlug (?org=<slug> query param) -> org_cache lookup, verify membership
- * 2. orgId (from JWT session token or CLI token) -> org_cache lookup
+ * 2. orgId (from JWT session token) -> org_cache lookup
  * 3. Fallback -> user's default org via Clerk API
  *
  * When the resolved org matches the JWT's active org, `tier` is read from
@@ -156,7 +136,6 @@ export async function resolveOrg(
   userId: string,
   orgSlug?: string | null,
   orgId?: string | null,
-  tokenOrgId?: string | null,
 ): Promise<{ org: ResolvedOrg; member: ResolvedMember }> {
   const authResult = await auth();
 
@@ -165,28 +144,18 @@ export async function resolveOrg(
     const orgData = await getOrgBySlug(orgSlug);
     if (!orgData) throw notFound("Org not found");
 
-    const member = await verifyMembership(
-      orgData,
-      userId,
-      authResult,
-      tokenOrgId,
-    );
+    const member = await verifyMembership(orgData, userId, authResult);
     return { org: applyJwtTier(orgData, authResult), member };
   }
 
-  // 2. Clerk org ID — use provided value, CLI token orgId, or auto-detect from JWT.
-  // For CLI tokens without orgId, auth().orgId returns null (no Clerk session),
+  // 2. Clerk org ID — use provided value or auto-detect from JWT.
+  // For CLI tokens (no Clerk session), auth().orgId returns null,
   // so this tier is skipped and we fall through to the default org.
-  const effectiveOrgId = orgId ?? tokenOrgId ?? authResult.orgId ?? null;
+  const effectiveOrgId = orgId ?? authResult.orgId ?? null;
   if (effectiveOrgId) {
     try {
       const orgData = await getOrgData(effectiveOrgId);
-      const member = await verifyMembership(
-        orgData,
-        userId,
-        authResult,
-        tokenOrgId,
-      );
+      const member = await verifyMembership(orgData, userId, authResult);
       return { org: applyJwtTier(orgData, authResult), member };
     } catch (error) {
       // Re-throw forbidden errors (user is not a member)
@@ -214,7 +183,6 @@ export async function resolveOrg(
 export async function requireOrgFromRequest(
   request: Request,
   userId: string,
-  tokenOrgId?: string | null,
 ): Promise<{ org: ResolvedOrg; member: ResolvedMember }> {
   const url = new URL(request.url);
   const orgSlug = url.searchParams.get("org");
@@ -232,11 +200,6 @@ export async function requireOrgFromRequest(
   }
 
   const authResult = await auth();
-  const member = await verifyMembership(
-    orgData,
-    userId,
-    authResult,
-    tokenOrgId,
-  );
+  const member = await verifyMembership(orgData, userId, authResult);
   return { org: applyJwtTier(orgData, authResult), member };
 }

--- a/turbo/packages/core/src/contracts/cli-auth.ts
+++ b/turbo/packages/core/src/contracts/cli-auth.ts
@@ -58,6 +58,7 @@ export const cliAuthTokenContract = c.router({
         access_token: z.string(),
         token_type: z.literal("Bearer"),
         expires_in: z.number(),
+        org_slug: z.string().optional(),
       }),
       // Authorization pending
       202: oauthErrorSchema,


### PR DESCRIPTION
## Summary

- **Security fix**: Replace the insecure `tokenOrgId` trust shortcut in `resolve-org.ts` that blindly granted `admin` role for up to 90 days with `org_members_cache`-backed membership verification (1-minute TTL + Clerk API fallback)
- **Device flow org passthrough**: Add `org_slug` to `device_codes` so CLI receives `activeOrg` during browser-based login, eliminating the need for `getDefaultOrg` Clerk API call at token exchange
- **Schema cleanup**: Drop `org_id` column from `cli_tokens` — org context now flows via `?org=<slug>` query parameter on every CLI request, verified server-side via `org_members_cache`

### Changes across 63 files:

**New files:**
- `org-membership-cache.ts` — `verifyMembershipCached()` helper with DB cache + Clerk API fallback
- `org-membership-cache.test.ts` — 5 integration tests (cache hit/miss, TTL refresh, stale cleanup)
- 3 DB migrations (add `device_codes.org_slug`, add `org_members_cache.role`, drop `cli_tokens.org_id`)

**Core changes:**
- `resolve-org.ts` — Remove `tokenOrgId` param, use `verifyMembershipCached()` for non-JWT paths
- `get-user-id.ts` / `runner-auth.ts` — Remove `orgId` from auth context types
- `org-service.ts` — `validateRunnerGroupOrg()` uses slug lookup + cache verification
- `org-member-service.ts` — Remove `tokenOrgId` from `resolveOrgId()`
- `cli-auth.ts` contract — Add `org_slug` to token exchange response
- CLI `auth.ts` — Save `activeOrg` from token exchange response

**37 API routes updated** to remove `tokenOrgId` destructuring and parameter passing

Closes #4717

## Test plan

- [x] All 3584 existing tests pass (311 test files)
- [x] 5 new `verifyMembershipCached` tests pass (cache hit, cache miss, TTL refresh, non-member, stale cleanup)
- [x] 8 device flow token exchange tests pass (including org_slug presence/absence)
- [x] Org members lazy sync tests updated for new `verifyMembershipCached` path
- [x] TypeScript type-check passes (web, cli, core)
- [x] Lint clean (oxlint + eslint)
- [x] Knip clean (no unused exports)
- [ ] E2E tests (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)