### PR TITLE
refactor: clean up remaining scope terminology in comments, docs, and telemetry

### DIFF
--- a/docs/add-oauth-connector.md
+++ b/docs/add-oauth-connector.md
@@ -263,23 +263,16 @@ After both apps are registered and the credentials file is populated:
    # Expected: "✓ Authenticated"
    ```
 
-   **Step B: Ensure scope exists**
+   **Step B: Ensure org exists**
 
    ```bash
-   vm0 scope status
+   vm0 org status
    ```
 
-   If no scope is configured, create one:
+   If no org is configured, create one:
    ```bash
-   vm0 scope set test-user-scope
+   vm0 org set test-user-org
    ```
-
-   > If `vm0 scope set` fails with a 500 error (Clerk org creation fails in dev), create the scope directly in the database:
-   > ```bash
-   > psql "$DATABASE_URL" -c "INSERT INTO scopes (slug, clerk_org_id) VALUES ('test-user-scope', 'org_test') RETURNING id, slug;"
-   > # Then create the scope membership using the returned scope ID and user ID from `vm0 auth status`:
-   > psql "$DATABASE_URL" -c "INSERT INTO scope_members (scope_id, user_id, role) VALUES ('<scope-id>', '<clerk-user-id>', 'admin');"
-   > ```
 
    **Step C: Configure model provider**
 
@@ -302,7 +295,7 @@ After both apps are registered and the credentials file is populated:
    **Verify all prerequisites:**
    ```bash
    vm0 auth status          # ✓ Authenticated
-   vm0 scope status         # Shows scope slug
+   vm0 org status           # Shows org slug
    vm0 model-provider list  # Shows default provider for claude-code
    ```
 
@@ -329,11 +322,11 @@ Ensure the dev server is running and the CLI is authenticated:
 
 ```bash
 vm0 auth status          # ✓ Authenticated
-vm0 scope status         # Shows scope slug
+vm0 org status           # Shows org slug
 vm0 model-provider list  # Shows default provider
 ```
 
-If any of these are not set up, follow [Step C in the Add OAuth Connector Checklist](#add-oauth-connector-checklist) for CLI auth, scope, and model provider setup.
+If any of these are not set up, follow [Step C in the Add OAuth Connector Checklist](#add-oauth-connector-checklist) for CLI auth, org, and model provider setup.
 
 ### Step 1: Obtain the API token [AI + Human]
 
@@ -475,7 +468,7 @@ After fixes:
 
 - **Skill-only changes** (jq fields, example tweaks, documentation): Push to `vm0-skills` main, re-run `vm0 cook`. No human needed.
 - **Connector code changes** (response parsing, error handling): Re-run `vm0 cook`. No human needed — the dev server hot-reloads.
-- **Scope changes**: Disconnect and reconnect the connector via `agent-browser` with noVNC (see Step 3 scope fix above), then re-run `vm0 cook`.
+- **OAuth scope changes**: Disconnect and reconnect the connector via `agent-browser` with noVNC (see Step 3 scope fix above), then re-run `vm0 cook`.
 
 Repeat Steps 2–4 until all examples pass.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -104,7 +104,7 @@ The orchestration layer coordinates job execution between web API and runners.
 - **Fallback**: Polling every 30s catches missed notifications
 
 **Runner Behavior**:
-1. Subscribe to Ably channel `runner-group:{scope}/{name}`
+1. Subscribe to Ably channel `runner-group:{org}/{name}`
 2. Receive job notification: `{ runId }`
 3. Claim job atomically via `/api/runners/jobs/{id}/claim` (sets `claimed_at`)
 4. Execute in Firecracker VM
@@ -113,9 +113,9 @@ The orchestration layer coordinates job execution between web API and runners.
 
 #### Runner Groups
 
-**Format**: `{scope}/{name}`
+**Format**: `{org}/{name}`
 - Official: `vm0/*` (e.g., `vm0/production`) - VM0-managed runners
-- User: `{scope-slug}/*` (e.g., `my-team/private`) - Self-hosted runners
+- User: `{org-slug}/*` (e.g., `my-team/private`) - Self-hosted runners
 
 **Authentication**:
 - Official runners: HMAC signature using `OFFICIAL_RUNNER_SECRET`

--- a/docs/testing/patterns.md
+++ b/docs/testing/patterns.md
@@ -472,8 +472,8 @@ const context = testContext();
 describe("MyPage", () => {
   it("should render the page", async () => {
     server.use(
-      http.get("/api/scope", () => {
-        return HttpResponse.json({ id: "scope_123", slug: "user-123" });
+      http.get("/api/org", () => {
+        return HttpResponse.json({ id: "org_1", slug: "user-123" });
       }),
     );
 
@@ -521,25 +521,25 @@ import { describe, it, expect } from "vitest";
 import { http, HttpResponse } from "msw";
 import { server } from "../../mocks/server.ts";
 import { testContext } from "./test-helpers.ts";
-import { scope$, hasScope$ } from "../scope.ts";
+import { org$, hasOrg$ } from "../org.ts";
 
 const context = testContext();
 
-describe("scope signals", () => {
-  it("hasScope$ returns true when user has scope", async () => {
-    const hasScope = await context.store.get(hasScope$);
-    expect(hasScope).toBeTruthy();
+describe("org signals", () => {
+  it("hasOrg$ returns true when user has org", async () => {
+    const hasOrg = await context.store.get(hasOrg$);
+    expect(hasOrg).toBeTruthy();
   });
 
-  it("hasScope$ returns false when no scope (404)", async () => {
+  it("hasOrg$ returns false when no org (404)", async () => {
     server.use(
-      http.get("/api/scope", () => {
+      http.get("/api/org", () => {
         return new HttpResponse(null, { status: 404 });
       }),
     );
 
-    const hasScope = await context.store.get(hasScope$);
-    expect(hasScope).toBeFalsy();
+    const hasOrg = await context.store.get(hasOrg$);
+    expect(hasOrg).toBeFalsy();
   });
 });
 ```

--- a/docs/testing/platform-testing.md
+++ b/docs/testing/platform-testing.md
@@ -86,7 +86,7 @@ turbo/apps/platform/src/
 │   ├── server.ts          # MSW server setup for Node.js
 │   └── handlers/
 │       ├── index.ts       # Aggregates all handlers
-│       ├── api-scope.ts   # Scope API handlers
+│       ├── api-org.ts     # Org API handlers
 │       ├── api-model-providers.ts  # Model provider handlers
 │       └── ...            # Other API handlers
 ├── test/
@@ -106,12 +106,11 @@ For endpoints that return constant data:
 ```typescript
 import { http, HttpResponse } from "msw";
 
-export const apiScopeHandlers = [
-  http.get("/api/scope", () => {
+export const apiOrgHandlers = [
+  http.get("/api/org", () => {
     return HttpResponse.json({
-      id: "scope_1",
+      id: "org_1",
       slug: "user-12345678",
-      type: "personal",
     });
   }),
 ];
@@ -178,11 +177,11 @@ All handlers are collected in `handlers/index.ts`:
 
 ```typescript
 import { apiModelProvidersHandlers, resetMockModelProviders } from "./api-model-providers";
-import { apiScopeHandlers } from "./api-scope";
+import { apiOrgHandlers } from "./api-org";
 
 export const handlers = [
   ...apiModelProvidersHandlers,
-  ...apiScopeHandlers,
+  ...apiOrgHandlers,
 ];
 
 export function resetAllMockHandlers(): void {
@@ -224,7 +223,7 @@ import { http, HttpResponse } from "msw";
 it("should show error when API returns 404", async () => {
   // Override the default handler for this test only
   server.use(
-    http.get("/api/scope", () => {
+    http.get("/api/org", () => {
       return new HttpResponse(null, { status: 404 });
     }),
   );
@@ -280,10 +279,10 @@ Override multiple endpoints when testing complex flows:
 ```typescript
 it("should complete onboarding flow", async () => {
   server.use(
-    http.get("/api/scope", () => {
+    http.get("/api/org", () => {
       return new HttpResponse(null, { status: 404 });
     }),
-    http.post("/api/scope", () => {
+    http.post("/api/org", () => {
       return HttpResponse.json({}, { status: 201 });
     }),
     http.put("/api/settings", () => {

--- a/docs/testing/web-testing.md
+++ b/docs/testing/web-testing.md
@@ -76,7 +76,7 @@ import { RunService } from "../../../lib/run/run-service";
 import { AgentSessionService } from "../../../lib/agent-session/agent-session-service";
 import { agentRuns } from "../../../db/schema/agent-run";
 import { agentComposes } from "../../../db/schema/agent-compose";
-import { scopes } from "../../../db/schema/scope";
+import { orgCache } from "../../../db/schema/org-cache";
 import { credentials } from "../../../db/schema/credential";
 import { eq } from "drizzle-orm";
 import { encryptCredentialValue } from "../../../lib/crypto";
@@ -156,7 +156,7 @@ describe("...", () => {
 `testContext()` provides:
 
 - `setupMocks()` - Set up default mock behavior for external services
-- `setupUser()` - Create isolated user context (unique userId and scopeId)
+- `setupUser()` - Create isolated user context (unique userId and orgId)
 - `mocks` - Access mock objects for customization or assertions
 
 ---
@@ -197,18 +197,16 @@ Similar to importing internal services, direct DB operations for data setup ofte
 
 ```typescript
 // Creating data
-await globalThis.services.db.insert(scopes).values({
-  id: testScopeId,
-  slug: `test-${testScopeId.slice(0, 8)}`,
-  type: "personal",
-  ownerId: testUserId,
+await globalThis.services.db.insert(orgCache).values({
+  orgId: testOrgId,
+  slug: `test-${testOrgId.slice(0, 8)}`,
 });
 
 await globalThis.services.db.insert(agentComposes).values({
   id: testAgentId,
   name: testAgentName,
   userId: testUserId,
-  scopeId: testScopeId,
+  orgId: testOrgId,
 });
 
 // Modifying state
@@ -539,7 +537,7 @@ Create `given*` helpers that set up preconditions through real API flows:
 import { HttpResponse } from "msw";
 import { handlers, http } from "../msw";
 import { server } from "../../mocks/server";
-import { createTestCompose, createTestScope } from "../api-test-helpers";
+import { createTestCompose, createTestOrg } from "../api-test-helpers";
 import { mockClerk } from "../clerk-mock";
 
 // Import route handlers and server actions
@@ -582,9 +580,9 @@ export async function givenLinkedSlackUser(
 ): Promise<LinkedUserResult> {
   const { installation } = await givenSlackWorkspaceInstalled(options);
 
-  // Mock Clerk and create scope
+  // Mock Clerk and create org
   mockClerk({ userId: options.vm0UserId ?? "user-123" });
-  await createTestScope("test-scope");
+  await createTestOrg("test-org");
 
   // Call the actual server action
   await linkSlackAccount(options.slackUserId ?? "U123", installation.slackWorkspaceId);

--- a/e2e/tests/01-serial/ser-t02-vm0-org.bats
+++ b/e2e/tests/01-serial/ser-t02-vm0-org.bats
@@ -3,16 +3,16 @@
 # Test VM0 org commands (Happy Path Only)
 # Tests the CLI for managing user organizations/namespaces
 #
-# This test covers issue #628: scope/namespace system
+# This test covers issue #628: org/namespace system
 #
 # Note: Slug validation tests (length, reserved words, invalid characters)
 # are covered by unit tests in:
-# - turbo/apps/web/src/lib/scope/__tests__/org-service.test.ts
+# - turbo/apps/web/src/lib/org/__tests__/org-service.test.ts
 # - turbo/apps/cli/src/commands/org/__tests__/set.test.ts
 #
 # Error handling tests have been moved to CLI integration tests:
 # - turbo/apps/cli/src/commands/run/__tests__/index.test.ts
-#   - "should show error when scope does not exist" (org not found)
+#   - "should show error when org does not exist" (org not found)
 # - turbo/apps/cli/src/commands/org/__tests__/set.test.ts
 #   - "should require --force to update existing organization"
 

--- a/turbo/apps/web/src/__tests__/api-test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers.ts
@@ -316,7 +316,6 @@ export async function findTestCliToken(token: string) {
  * Create a test org by inserting into org_cache.
  *
  * Pre-populates org_cache so getOrgData() works without Clerk API calls.
- * Pre-populates org_cache so getOrgData() works without Clerk API calls.
  *
  * @param slug - The org slug
  * @returns The created org with id and slug

--- a/turbo/apps/web/src/__tests__/api-test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers.ts
@@ -316,7 +316,7 @@ export async function findTestCliToken(token: string) {
  * Create a test org by inserting into org_cache.
  *
  * Pre-populates org_cache so getOrgData() works without Clerk API calls.
- * The legacy scopes table was dropped and replaced by orgs.
+ * Pre-populates org_cache so getOrgData() works without Clerk API calls.
  *
  * @param slug - The org slug
  * @returns The created org with id and slug

--- a/turbo/apps/web/src/lib/agent/permission-service.ts
+++ b/turbo/apps/web/src/lib/agent/permission-service.ts
@@ -194,7 +194,7 @@ export async function getEmailSharedAgents(
     .where(and(...conditions))
     .orderBy(desc(agentComposes.createdAt));
 
-  // Resolve scope slugs via org cache (skip orgs that fail lookup)
+  // Resolve org slugs via org cache (skip orgs that fail lookup)
   const uniqueOrgIds = [...new Set(rows.map((r) => r.orgId))];
   const orgDataResults = await Promise.all(
     uniqueOrgIds.map(async (id) => {

--- a/turbo/apps/web/src/lib/org/org-member-service.ts
+++ b/turbo/apps/web/src/lib/org/org-member-service.ts
@@ -36,7 +36,7 @@ export async function requireOrgMember(orgId: string, userId: string) {
 }
 
 /**
- * Get user's default org using org_cache (never queries scopes table).
+ * Get user's default org using org_cache.
  *
  * Fast path: if the JWT session contains an orgId, look up via org_cache
  * — no Clerk API call needed.
@@ -64,7 +64,7 @@ export async function getDefaultOrg(
     }
   }
 
-  // Slow path: Clerk API (CLI tokens, or JWT org has no local scope yet)
+  // Slow path: Clerk API (CLI tokens, or JWT org has no local cache entry yet)
   const client = await clerkClient();
   const memberships = await client.users.getOrganizationMembershipList({
     userId,
@@ -96,7 +96,7 @@ export async function getDefaultOrg(
 
 /**
  * Resolve org ID: use the provided value or fall back to the user's default org.
- * Replaces the old resolveOrgId() which returned a scope UUID.
+ * Resolve org ID: use the provided value or fall back to the user's default org.
  */
 export async function resolveOrgId(
   userId: string,

--- a/turbo/apps/web/src/lib/org/org-member-service.ts
+++ b/turbo/apps/web/src/lib/org/org-member-service.ts
@@ -96,7 +96,6 @@ export async function getDefaultOrg(
 
 /**
  * Resolve org ID: use the provided value or fall back to the user's default org.
- * Resolve org ID: use the provided value or fall back to the user's default org.
  */
 export async function resolveOrgId(
   userId: string,

--- a/turbo/apps/web/src/lib/org/org-service.ts
+++ b/turbo/apps/web/src/lib/org/org-service.ts
@@ -39,7 +39,7 @@ function validateOrgSlug(slug: string): void {
     );
   }
 
-  // TODO: "vm0" is hardcoded as the system scope slug. This should be configurable.
+  // TODO: "vm0" is hardcoded as the system org slug. This should be configurable.
   if (RESERVED_SLUGS.includes(slug) || slug.startsWith("vm0")) {
     throw badRequest(`Org slug is reserved`);
   }

--- a/turbo/apps/web/src/lib/run/build-context.ts
+++ b/turbo/apps/web/src/lib/run/build-context.ts
@@ -797,7 +797,7 @@ async function resolveOrgs(params: BuildContextParams): Promise<{
 }
 
 interface BuildContextTimings {
-  resolveSourceAndScope: number;
+  resolveSourceAndOrg: number;
   resolveSecrets: number;
 }
 
@@ -975,7 +975,7 @@ export async function buildExecutionContext(
       apiStartTime: params.apiStartTime,
     },
     timings: {
-      resolveSourceAndScope: resolveEnd - resolveStart,
+      resolveSourceAndOrg: resolveEnd - resolveStart,
       resolveSecrets: resolveSecretsEnd - resolveSecretsStart,
     },
   };

--- a/turbo/apps/web/src/lib/run/run-service.ts
+++ b/turbo/apps/web/src/lib/run/run-service.ts
@@ -593,8 +593,8 @@ async function buildAndDispatchRun(opts: {
       { op: "api_step_dispatch", ms: dispatchTime - prepareTime },
       // Sub-step timings within buildExecutionContext
       {
-        op: "api_build_resolve_source_and_scope",
-        ms: buildContextTimings.resolveSourceAndScope,
+        op: "api_build_resolve_source_and_org",
+        ms: buildContextTimings.resolveSourceAndOrg,
       },
       {
         op: "api_build_resolve_secrets",
@@ -602,7 +602,7 @@ async function buildAndDispatchRun(opts: {
       },
       // Sub-step timings within prepareForExecution
       {
-        op: "api_prepare_resolve_scopes",
+        op: "api_prepare_resolve_orgs",
         ms: prepareResult.timings.resolveOrgs,
       },
       {

--- a/turbo/apps/web/src/lib/storage/storage-service.ts
+++ b/turbo/apps/web/src/lib/storage/storage-service.ts
@@ -34,7 +34,7 @@ function createEmptyTarGz(): Buffer {
  * @param orgId - Clerk org ID for storage access
  * @param userId - User ID for storage record ownership
  * @param storageName - Storage name
- * @param orgSlug - Scope slug for S3 prefix construction
+ * @param orgSlug - Org slug for S3 prefix construction
  * @param storageType - Storage type ("artifact" or "memory")
  */
 export async function ensureStorageExists(
@@ -272,7 +272,7 @@ async function resolveVersion(
  * @param vars - Template variables for placeholder replacement
  * @param agentClerkOrgId - Agent Clerk org ID for volume resolution (where the agent is defined)
  * @param runtimeClerkOrgId - Runtime Clerk org ID for artifact/memory resolution (where the agent is executed)
- * @param userId - User ID within the Runtime Scope (for artifact/memory ownership)
+ * @param userId - User ID within the runtime org (for artifact/memory ownership)
  * @param artifactName - Artifact storage name
  * @param artifactVersion - Artifact version (defaults to "latest")
  * @param volumeVersionOverrides - Optional volume version overrides
@@ -431,7 +431,7 @@ export async function prepareStorageManifest(
       })()
     : Promise.resolve(null);
 
-  // Resolve memory (uses Runtime Scope, same as artifact)
+  // Resolve memory (uses runtime org, same as artifact)
   // Memory storage is guaranteed to exist after ensureStorageExists() in prepareForExecution()
   const memoryPromise = memoryName
     ? (async (): Promise<ManifestArtifact | null> => {


### PR DESCRIPTION
## Summary

- Update stale "scope" comments to "org" in source code (`org-service`, `org-member-service`, `permission-service`, `storage-service`, `api-test-helpers`)
- Rename telemetry operation names: `api_build_resolve_source_and_scope` → `api_build_resolve_source_and_org`, `api_prepare_resolve_scopes` → `api_prepare_resolve_orgs`
- Rename type field `resolveSourceAndScope` → `resolveSourceAndOrg` in `build-context.ts`
- Fix wrong file path in E2E test comment (`lib/scope/` → `lib/org/`)
- Update 4 documentation files with outdated scope commands and examples (`add-oauth-connector.md`, `architecture.md`, `patterns.md`, `platform-testing.md`, `web-testing.md`)

## Test plan

- [x] TypeScript type check passes (`pnpm check-types --filter='!docs'`)
- [x] Knip passes (no unused exports)
- [x] Prettier passes (no formatting issues)
- [ ] CI passes (lint, test, deploy, cli-e2e)

🤖 Generated with [Claude Code](https://claude.com/claude-code)