### PR TITLE
feat(zero): add pinned agents, agent switching, and per-agent sessions

### DIFF
--- a/turbo/apps/platform/src/mocks/handlers/api-user-preferences.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-user-preferences.ts
@@ -11,6 +11,7 @@ let mockPreferences: UserPreferencesResponse = {
   timezone: null,
   notifyEmail: false,
   notifySlack: false,
+  pinnedAgentIds: [],
 };
 
 export function resetMockUserPreferences(): void {
@@ -18,6 +19,7 @@ export function resetMockUserPreferences(): void {
     timezone: null,
     notifyEmail: false,
     notifySlack: false,
+    pinnedAgentIds: [],
   };
 }
 
@@ -39,6 +41,9 @@ export const apiUserPreferencesHandlers = [
     }
     if (body.timezone !== undefined) {
       mockPreferences.timezone = body.timezone;
+    }
+    if (body.pinnedAgentIds !== undefined) {
+      mockPreferences.pinnedAgentIds = body.pinnedAgentIds;
     }
 
     return HttpResponse.json(mockPreferences);

--- a/turbo/apps/platform/src/signals/agent-detail/types.ts
+++ b/turbo/apps/platform/src/signals/agent-detail/types.ts
@@ -20,7 +20,7 @@ interface AgentDefinition {
   instructions?: string;
   skills?: string[];
   environment?: Record<string, string>;
-  metadata?: { displayName?: string; sound?: string };
+  metadata?: { displayName?: string; sound?: string; description?: string };
   experimental_runner?: { group: string };
   experimental_firewall?: {
     default: "allow" | "deny";

--- a/turbo/apps/platform/src/signals/theme.ts
+++ b/turbo/apps/platform/src/signals/theme.ts
@@ -75,7 +75,10 @@ export const initTheme$ = command(({ set }) => {
         "theme",
       ) as ThemePreference | null;
       if (!currentPref || currentPref === "system") {
-        const newResolved = resolveTheme("system");
+        const newResolved = window.matchMedia("(prefers-color-scheme: dark)")
+          .matches
+          ? "dark"
+          : "light";
         set(internalResolved$, newResolved);
         applyTheme(newResolved);
       }

--- a/turbo/apps/platform/src/signals/theme.ts
+++ b/turbo/apps/platform/src/signals/theme.ts
@@ -1,24 +1,58 @@
 import { command, computed, state } from "ccstate";
 
-const internalTheme$ = state<"light" | "dark">("light");
+export type ThemePreference = "light" | "dark" | "system";
+
+const internalPreference$ = state<ThemePreference>("system");
+const internalResolved$ = state<"light" | "dark">("light");
 
 /**
- * Current theme value.
+ * Current resolved theme value (always "light" or "dark").
  */
-export const theme$ = computed((get) => get(internalTheme$));
+export const theme$ = computed((get) => get(internalResolved$));
+
+/**
+ * User's theme preference ("light", "dark", or "system").
+ */
+export const themePreference$ = computed((get) => get(internalPreference$));
+
+function resolveTheme(preference: ThemePreference): "light" | "dark" {
+  if (preference === "system") {
+    return window.matchMedia("(prefers-color-scheme: dark)").matches
+      ? "dark"
+      : "light";
+  }
+  return preference;
+}
+
+function applyTheme(theme: "light" | "dark") {
+  document.documentElement.dataset.theme = theme;
+  if (theme === "dark") {
+    document.documentElement.classList.add("dark");
+  } else {
+    document.documentElement.classList.remove("dark");
+  }
+}
+
+/**
+ * Set theme preference and apply it.
+ */
+export const setTheme$ = command(({ set }, preference: ThemePreference) => {
+  set(internalPreference$, preference);
+  const resolved = resolveTheme(preference);
+  set(internalResolved$, resolved);
+  applyTheme(resolved);
+  localStorage.setItem("theme", preference);
+});
 
 /**
  * Toggle between light and dark theme.
  */
 export const toggleTheme$ = command(({ get, set }) => {
-  const currentTheme = get(internalTheme$);
-  const newTheme = currentTheme === "light" ? "dark" : "light";
-  set(internalTheme$, newTheme);
-
-  // Update the data-theme attribute on the root element
-  document.documentElement.dataset.theme = newTheme;
-
-  // Store preference in localStorage
+  const current = get(internalResolved$);
+  const newTheme = current === "light" ? "dark" : "light";
+  set(internalPreference$, newTheme);
+  set(internalResolved$, newTheme);
+  applyTheme(newTheme);
   localStorage.setItem("theme", newTheme);
 });
 
@@ -26,18 +60,24 @@ export const toggleTheme$ = command(({ get, set }) => {
  * Initialize theme from localStorage or system preference.
  */
 export const initTheme$ = command(({ set }) => {
-  // Check localStorage first
-  const stored = localStorage.getItem("theme") as "light" | "dark" | null;
+  const stored = localStorage.getItem("theme") as ThemePreference | null;
+  const preference = stored ?? "system";
+  set(internalPreference$, preference);
+  const resolved = resolveTheme(preference);
+  set(internalResolved$, resolved);
+  applyTheme(resolved);
 
-  if (stored) {
-    set(internalTheme$, stored);
-    document.documentElement.dataset.theme = stored;
-    return;
-  }
-
-  // Fall back to system preference
-  const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
-  const theme = prefersDark ? "dark" : "light";
-  set(internalTheme$, theme);
-  document.documentElement.dataset.theme = theme;
+  // Listen for system theme changes when preference is "system"
+  window
+    .matchMedia("(prefers-color-scheme: dark)")
+    .addEventListener("change", () => {
+      const currentPref = localStorage.getItem(
+        "theme",
+      ) as ThemePreference | null;
+      if (!currentPref || currentPref === "system") {
+        const newResolved = resolveTheme("system");
+        set(internalResolved$, newResolved);
+        applyTheme(newResolved);
+      }
+    });
 });

--- a/turbo/apps/platform/src/signals/zero-page/zero-agents.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-agents.ts
@@ -1,23 +1,13 @@
 import { computed } from "ccstate";
 import {
   agentsList$,
-  schedules$,
-  agentsMissingItems$,
   agentsLoading$,
   agentsError$,
   fetchAgentsList$,
-  getAgentScheduleStatus,
 } from "../agents-page/agents-list.ts";
 import { zeroOnboardingStatus$ } from "./zero-onboarding.ts";
 
-export {
-  schedules$,
-  agentsMissingItems$,
-  agentsLoading$,
-  agentsError$,
-  fetchAgentsList$,
-  getAgentScheduleStatus,
-};
+export { agentsLoading$, agentsError$, fetchAgentsList$ };
 
 /**
  * Non-default agents for display in the Zero team page.

--- a/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
@@ -5,7 +5,7 @@ import { throwIfAbort } from "../utils.ts";
 import { logger } from "../log.ts";
 import { setupPollingLoop$, type PageResult } from "../agent-detail/polling.ts";
 import { zeroOnboardingStatus$ } from "./zero-onboarding.ts";
-import { navigateToZeroSession$ } from "./zero-nav.ts";
+import { navigateToZeroSession$, zeroChatAgentId$ } from "./zero-nav.ts";
 import type { SessionListItem } from "@vm0/core";
 
 const L = logger("ZeroChat");
@@ -225,14 +225,19 @@ export const removeZeroAttachment$ = command(({ set }, id: string) => {
 // ---------------------------------------------------------------------------
 
 export const fetchZeroSessionList$ = command(async ({ get, set }) => {
-  const status = await get(zeroOnboardingStatus$);
-  const composeId = status.defaultAgentComposeId;
-  if (!composeId) {
-    return;
-  }
-
+  // Clear stale data immediately (before any await)
+  set(internalSessionList$, []);
   set(internalSessionListLoading$, true);
   set(internalSessionListError$, null);
+
+  // Read the selected agent from localStorage; fall back to default agent
+  const chatAgentId = get(zeroChatAgentId$);
+  const composeId =
+    chatAgentId ?? (await get(zeroOnboardingStatus$)).defaultAgentComposeId;
+  if (!composeId) {
+    set(internalSessionListLoading$, false);
+    return;
+  }
   try {
     const fetchFn = get(fetch$);
     const res = await fetchFn(
@@ -327,8 +332,9 @@ export const startNewZeroSession$ = command(({ set }) => {
 
 export const sendZeroChatMessage$ = command(
   async ({ get, set }, prompt: string) => {
-    const status = await get(zeroOnboardingStatus$);
-    const composeId = status.defaultAgentComposeId;
+    const chatAgentId = get(zeroChatAgentId$);
+    const composeId =
+      chatAgentId ?? (await get(zeroOnboardingStatus$)).defaultAgentComposeId;
     if (!composeId || !prompt.trim()) {
       return;
     }

--- a/turbo/apps/platform/src/signals/zero-page/zero-job-detail.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-job-detail.ts
@@ -275,6 +275,7 @@ export const zeroJobSettingsSaving$ = computed((get) => get(internalSaving$));
 
 interface ZeroJobSettingsUpdate {
   displayName?: string;
+  description?: string;
   sound?: string;
 }
 
@@ -296,12 +297,16 @@ export const zeroJobUpdateSettings$ = command(
     if (update.displayName !== undefined) {
       newMetadata.displayName = update.displayName;
     }
+    if (update.description !== undefined) {
+      newMetadata.description = update.description;
+    }
     if (update.sound !== undefined) {
       newMetadata.sound = update.sound;
     }
 
     if (
       newMetadata.displayName === currentMetadata.displayName &&
+      newMetadata.description === currentMetadata.description &&
       newMetadata.sound === currentMetadata.sound
     ) {
       return;
@@ -317,11 +322,8 @@ export const zeroJobUpdateSettings$ = command(
         },
       };
 
-      const instructions = await resolveExistingInstructions(
-        get,
-        fetchFn,
-        detail.id,
-      );
+      const instructions =
+        (await resolveExistingInstructions(get, fetchFn, detail.id)) ?? "";
 
       // Ensure instructions field in content
       const agent = newContent.agents[agentKey];
@@ -335,7 +337,7 @@ export const zeroJobUpdateSettings$ = command(
       const job = await triggerAndPollComposeJob(
         fetchFn,
         newContent,
-        instructions ?? "",
+        instructions,
       );
       if (!job.result) {
         throw new Error("Build completed without result");
@@ -343,7 +345,7 @@ export const zeroJobUpdateSettings$ = command(
 
       await set(fetchZeroJobDetail$);
       await set(fetchZeroJobInstructions$);
-      toast.success("Settings saved");
+      toast.success("Profile saved");
     } catch (error) {
       throwIfAbort(error);
       L.error("Failed to update settings:", error);

--- a/turbo/apps/platform/src/signals/zero-page/zero-meet.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-meet.ts
@@ -49,6 +49,7 @@ const zeroComposeId$ = computed(async (get) => {
 
 interface ZeroAgentMetadata {
   displayName?: string;
+  description?: string;
   sound?: string;
 }
 
@@ -339,6 +340,7 @@ export const saveZeroSkills$ = command(async ({ get, set }) => {
  * This ensures compose jobs always include the instructions file when the
  * compose content references one (e.g., instructions: "CLAUDE.md").
  */
+
 async function resolveInstructionsContent(
   fetchFn: typeof fetch,
   composeId: string | undefined,
@@ -462,6 +464,7 @@ const syncSkillsToCompose$ = command(
 
 interface ZeroSettingsUpdate {
   displayName?: string;
+  description?: string;
   sound?: string;
 }
 
@@ -484,6 +487,9 @@ export const zeroUpdateSettings$ = command(
     if (update.displayName !== undefined) {
       newMetadata.displayName = update.displayName;
     }
+    if (update.description !== undefined) {
+      newMetadata.description = update.description;
+    }
     if (update.sound !== undefined) {
       newMetadata.sound = update.sound;
     }
@@ -491,6 +497,7 @@ export const zeroUpdateSettings$ = command(
     // Skip if nothing changed
     if (
       newMetadata.displayName === currentMetadata.displayName &&
+      newMetadata.description === currentMetadata.description &&
       newMetadata.sound === currentMetadata.sound
     ) {
       return;
@@ -506,18 +513,19 @@ export const zeroUpdateSettings$ = command(
       };
 
       const fetchFn = get(fetch$);
-      const instructions = await resolveInstructionsContent(
+      let instructions = await resolveInstructionsContent(
         fetchFn,
         compose.id,
         get(instructionsState$).instructions?.content,
       );
+
       await buildAndSetDefaultAgent(fetchFn, newContent, instructions);
 
       await set(reloadOnboardingStatus$);
       set(internalComposeReload$, (x) => x + 1);
       // Refresh instructions so the profile block reflects the new settings
       await set(fetchZeroInstructions$);
-      toast.success("Settings saved");
+      toast.success("Profile saved");
     } catch (error) {
       throwIfAbort(error);
       L.error("Failed to update settings:", error);

--- a/turbo/apps/platform/src/signals/zero-page/zero-meet.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-meet.ts
@@ -513,7 +513,7 @@ export const zeroUpdateSettings$ = command(
       };
 
       const fetchFn = get(fetch$);
-      let instructions = await resolveInstructionsContent(
+      const instructions = await resolveInstructionsContent(
         fetchFn,
         compose.id,
         get(instructionsState$).instructions?.content,

--- a/turbo/apps/platform/src/signals/zero-page/zero-nav.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-nav.ts
@@ -1,6 +1,14 @@
 import { command, computed } from "ccstate";
 import { pathname$, updatePathname$ } from "../route.ts";
+import { localStorageSignals } from "../external/local-storage.ts";
 import type { ZeroNavId } from "../../views/zero-page/zero-sidebar.tsx";
+
+const CHAT_AGENT_KEY = "zero.chatAgentId";
+const {
+  get$: storedChatAgentId$,
+  set$: persistChatAgentId$,
+  clear$: clearChatAgentId$,
+} = localStorageSignals(CHAT_AGENT_KEY);
 
 function isValidTab(tab: string): tab is ZeroNavId {
   return (
@@ -47,6 +55,14 @@ export const zeroSessionId$ = computed((get): string | null => {
 });
 
 /**
+ * Currently selected chat agent ID, persisted in localStorage.
+ * Returns null when chatting with the default/main agent (Zero).
+ */
+export const zeroChatAgentId$ = computed((get): string | null => {
+  return get(storedChatAgentId$);
+});
+
+/**
  * Navigate to a zero tab — updates the URL path to `/zero/:tab`.
  * "chat" maps to `/zero` (the default, no suffix needed).
  */
@@ -54,6 +70,20 @@ export const setZeroActiveId$ = command(({ set }, id: ZeroNavId) => {
   const newPath = id === "chat" ? "/zero" : `/zero/${id}`;
   set(updatePathname$, newPath);
 });
+
+/**
+ * Set the chat agent ID, persisted in localStorage.
+ * Pass null to clear (chat with default agent).
+ */
+export const setZeroChatAgentId$ = command(
+  ({ set }, agentId: string | null) => {
+    if (agentId) {
+      set(persistChatAgentId$, agentId);
+    } else {
+      set(clearChatAgentId$);
+    }
+  },
+);
 
 /**
  * Sub-path segment under the current tab, e.g. `/zero/activity/:sub`.

--- a/turbo/apps/platform/src/signals/zero-page/zero-pinned-agents.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-pinned-agents.ts
@@ -27,7 +27,9 @@ const serverPinnedIds$ = computed(async (get) => {
  */
 export const pinnedAgentIds$ = computed((get) => {
   const optimistic = get(optimisticPinnedIds$);
-  if (optimistic !== null) return optimistic;
+  if (optimistic !== null) {
+    return optimistic;
+  }
   return get(serverPinnedIds$);
 });
 

--- a/turbo/apps/platform/src/signals/zero-page/zero-pinned-agents.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-pinned-agents.ts
@@ -1,0 +1,73 @@
+import { command, computed, state } from "ccstate";
+import { toast } from "@vm0/ui/components/ui/sonner";
+import type { UserPreferencesResponse } from "@vm0/core";
+import { fetch$ } from "../fetch.ts";
+import { clerk$ } from "../auth.ts";
+
+const reloadPinned$ = state(0);
+
+/**
+ * Optimistic override — when set, takes precedence over the server value.
+ */
+const optimisticPinnedIds$ = state<string[] | null>(null);
+
+/**
+ * Pinned agent IDs fetched from user preferences API.
+ */
+const serverPinnedIds$ = computed(async (get) => {
+  get(reloadPinned$);
+  const fetchFn = get(fetch$);
+  const resp = await fetchFn("/api/user/preferences");
+  const data = (await resp.json()) as UserPreferencesResponse;
+  return data.pinnedAgentIds;
+});
+
+/**
+ * Effective pinned agent IDs — optimistic value if set, otherwise server value.
+ */
+export const pinnedAgentIds$ = computed((get) => {
+  const optimistic = get(optimisticPinnedIds$);
+  if (optimistic !== null) return optimistic;
+  return get(serverPinnedIds$);
+});
+
+/**
+ * Whether a pinned agents update is in flight.
+ */
+const internalSavingPinned$ = state(false);
+export const savingPinnedAgents$ = computed((get) =>
+  get(internalSavingPinned$),
+);
+
+/**
+ * Update pinned agent IDs on the server with optimistic UI.
+ */
+export const updatePinnedAgentIds$ = command(
+  async ({ get, set }, ids: string[]) => {
+    // Optimistic update — UI reflects the change immediately
+    set(optimisticPinnedIds$, ids);
+    set(internalSavingPinned$, true);
+    try {
+      const fetchFn = get(fetch$);
+      const response = await fetchFn("/api/user/preferences", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ pinnedAgentIds: ids }),
+      });
+
+      if (!response.ok) {
+        toast.error("Failed to update pinned agents");
+        return;
+      }
+
+      // Force JWT refresh so updated membership metadata is available immediately
+      const clerk = await get(clerk$);
+      await clerk.session?.getToken({ skipCache: true });
+
+      set(reloadPinned$, (x) => x + 1);
+    } finally {
+      set(optimisticPinnedIds$, null);
+      set(internalSavingPinned$, false);
+    }
+  },
+);

--- a/turbo/apps/platform/src/views/css/index.css
+++ b/turbo/apps/platform/src/views/css/index.css
@@ -214,11 +214,19 @@
   border: 1px solid var(--zero-card-border);
   border-radius: var(--zero-card-radius);
   box-shadow: var(--zero-card-shadow);
+  transition: background-color 0.15s;
+}
+.zero-app .zero-card:hover {
+  background-color: hsl(220 6% 98%);
 }
 .dark .zero-app .zero-card,
 [data-theme="dark"] .zero-app .zero-card {
   background-color: hsl(220 12% 12%);
   border-color: hsl(220 8% 22%);
+}
+.dark .zero-app .zero-card:hover,
+[data-theme="dark"] .zero-app .zero-card:hover {
+  background-color: hsl(220 12% 14%);
 }
 
 /* Onboarding modal footer: frosted glass */
@@ -666,26 +674,26 @@ details[open] > summary > span:first-child {
     14px 14px;
 }
 
-@media (prefers-color-scheme: dark) {
-  .zero-workspace-bg::before {
-    background-image:
-      radial-gradient(
-        ellipse 100% 70% at 50% 0%,
-        hsl(var(--background-50) / 0.4),
-        transparent 48%
-      ),
-      radial-gradient(
-        circle at center,
-        hsl(var(--foreground) / 0.05) 1px,
-        transparent 1px
-      );
-    background-size:
-      100% 100%,
-      14px 14px;
-  }
+.dark .zero-workspace-bg::before,
+[data-theme="dark"] .zero-workspace-bg::before {
+  background-image:
+    radial-gradient(
+      ellipse 100% 70% at 50% 0%,
+      hsl(var(--background-50) / 0.4),
+      transparent 48%
+    ),
+    radial-gradient(
+      circle at center,
+      hsl(var(--foreground) / 0.05) 1px,
+      transparent 1px
+    );
+  background-size:
+    100% 100%,
+    14px 14px;
+}
 
-  .zero-nav {
-    --color-sidebar-border: hsl(220 8% 26%);
-    --color-divider: hsl(220 10% 28%);
-  }
+.dark .zero-nav,
+[data-theme="dark"] .zero-nav {
+  --color-sidebar-border: hsl(220 8% 26%);
+  --color-divider: hsl(220 10% 28%);
 }

--- a/turbo/apps/platform/src/views/zero-page/clerk-org-switcher.tsx
+++ b/turbo/apps/platform/src/views/zero-page/clerk-org-switcher.tsx
@@ -13,13 +13,15 @@ export function ClerkOrgSwitcher() {
       <OrganizationSwitcher
         appearance={{
           elements: {
-            rootBox: "w-full",
+            rootBox: "!w-full !block overflow-hidden",
             organizationSwitcherTrigger:
-              "!w-full !px-2 !py-2 !rounded-lg !gap-2.5 hover:bg-sidebar-accent/50 !text-sidebar-foreground",
-            organizationPreviewAvatarBox: "!w-7 !h-7",
+              "!w-full !px-2 !py-2 !rounded-lg !gap-2.5 hover:bg-sidebar-accent/50 !text-sidebar-foreground !overflow-hidden",
+            organizationPreviewAvatarBox: "!w-7 !h-7 !shrink-0",
             organizationPreviewMainIdentifier:
-              "!text-sm !font-semibold !leading-tight",
-            organizationSwitcherTriggerIcon: "!w-4 !h-4 !ml-auto",
+              "!text-sm !font-semibold !leading-tight !truncate",
+            organizationPreviewTextContainer: "!min-w-0 !overflow-hidden",
+            organizationSwitcherTriggerIcon: "!w-4 !h-4 !ml-auto !shrink-0",
+            organizationSwitcherPopoverCard: "!left-2",
           },
         }}
       />

--- a/turbo/apps/platform/src/views/zero-page/zero-account-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-account-page.tsx
@@ -1,11 +1,68 @@
 import { useCCState } from "ccstate-react/experimental";
-import { useGet, useSet } from "ccstate-react";
+import { useGet, useSet, useLoadable } from "ccstate-react";
+import { IconSun, IconMoon, IconDeviceDesktop } from "@tabler/icons-react";
 import { Tabs, TabsList, TabsTrigger } from "@vm0/ui/components/ui/tabs";
+import { Card, CardContent, cn } from "@vm0/ui";
 import { NotificationSettings } from "../settings-page/notification-settings.tsx";
 import { TimezoneSettings } from "../settings-page/timezone-settings.tsx";
+import {
+  themePreference$,
+  setTheme$,
+  type ThemePreference,
+} from "../../signals/theme.ts";
+
+const THEME_OPTIONS: {
+  value: ThemePreference;
+  label: string;
+  icon: typeof IconSun;
+}[] = [
+  { value: "light", label: "Light", icon: IconSun },
+  { value: "dark", label: "Dark", icon: IconMoon },
+  { value: "system", label: "System", icon: IconDeviceDesktop },
+];
+
+function AppearanceSettings() {
+  const prefLoadable = useLoadable(themePreference$);
+  const currentPref =
+    prefLoadable.state === "hasData" ? prefLoadable.data : "system";
+  const setTheme = useSet(setTheme$);
+
+  return (
+    <Card className="zero-card">
+      <CardContent className="py-5 flex flex-col gap-4">
+        <div className="flex flex-col gap-2">
+          <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            Theme
+          </span>
+          <p className="text-sm text-muted-foreground">
+            Choose how the interface looks.
+          </p>
+          <div className="flex gap-2 mt-1">
+            {THEME_OPTIONS.map(({ value, label, icon: Icon }) => (
+              <button
+                key={value}
+                type="button"
+                onClick={() => setTheme(value)}
+                className={cn(
+                  "flex items-center gap-2 rounded-lg border px-4 py-2.5 text-sm font-medium transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+                  currentPref === value
+                    ? "border-primary/40 bg-primary/10 text-primary dark:border-primary/50 dark:bg-primary/15"
+                    : "zero-chip text-muted-foreground hover:text-foreground",
+                )}
+              >
+                <Icon size={16} stroke={1.5} />
+                {label}
+              </button>
+            ))}
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
 
 export function ZeroPreferencesPage() {
-  const tab$ = useCCState("notifications");
+  const tab$ = useCCState("appearance");
   const tab = useGet(tab$);
   const setTab = useSet(tab$);
 
@@ -17,7 +74,7 @@ export function ZeroPreferencesPage() {
             Preferences
           </h1>
           <p className="text-sm text-muted-foreground mt-1">
-            Manage your notification and agent runtime preferences
+            Manage your appearance, notification and agent runtime preferences
           </p>
         </div>
       </header>
@@ -26,6 +83,12 @@ export function ZeroPreferencesPage() {
         <div className="mx-auto max-w-[900px] px-7 flex flex-col gap-8">
           <Tabs value={tab} onValueChange={(v) => setTab(v)}>
             <TabsList className="zero-tabs h-9 gap-1 px-1 py-1">
+              <TabsTrigger
+                value="appearance"
+                className="gap-1.5 text-sm data-[state=active]:bg-background px-3"
+              >
+                Appearance
+              </TabsTrigger>
               <TabsTrigger
                 value="notifications"
                 className="gap-1.5 text-sm data-[state=active]:bg-background px-3"
@@ -41,6 +104,7 @@ export function ZeroPreferencesPage() {
             </TabsList>
 
             <div className="mt-4">
+              {tab === "appearance" && <AppearanceSettings />}
               {tab === "notifications" && <NotificationSettings />}
               {tab === "timezone" && <TimezoneSettings />}
             </div>

--- a/turbo/apps/platform/src/views/zero-page/zero-account-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-account-page.tsx
@@ -11,17 +11,16 @@ import {
   type ThemePreference,
 } from "../../signals/theme.ts";
 
-const THEME_OPTIONS: {
-  value: ThemePreference;
-  label: string;
-  icon: typeof IconSun;
-}[] = [
-  { value: "light", label: "Light", icon: IconSun },
-  { value: "dark", label: "Dark", icon: IconMoon },
-  { value: "system", label: "System", icon: IconDeviceDesktop },
-];
-
 function AppearanceSettings() {
+  const THEME_OPTIONS = [
+    { value: "light" as ThemePreference, label: "Light", icon: IconSun },
+    { value: "dark" as ThemePreference, label: "Dark", icon: IconMoon },
+    {
+      value: "system" as ThemePreference,
+      label: "System",
+      icon: IconDeviceDesktop,
+    },
+  ] as const;
   const prefLoadable = useLoadable(themePreference$);
   const currentPref =
     prefLoadable.state === "hasData" ? prefLoadable.data : "system";

--- a/turbo/apps/platform/src/views/zero-page/zero-activity-detail-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-activity-detail-page.tsx
@@ -5,6 +5,7 @@ import {
   IconSearch,
   IconLoader2,
   IconDownload,
+  IconLock,
 } from "@tabler/icons-react";
 import { Button, Input } from "@vm0/ui";
 import type { LogStatus, AgentEvent } from "../../signals/logs-page/types.ts";
@@ -45,6 +46,46 @@ export function ZeroActivityDetailPage({
   const stepSearch$ = useCCState("");
   const stepSearch = useGet(stepSearch$);
   const setStepSearch = useSet(stepSearch$);
+
+  // Detail not found or no permission
+  if (detailLoadable.state === "hasError") {
+    return (
+      <div className="h-full flex flex-col min-h-0">
+        <header className="shrink-0 bg-transparent px-4 sm:px-6 pt-4 pb-3">
+          <div className="mb-3">
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8 shrink-0 -ml-2"
+              onClick={onBack}
+              aria-label="Back to activity"
+            >
+              <IconArrowLeft size={20} stroke={1.5} />
+            </Button>
+          </div>
+        </header>
+        <div className="flex-1 flex flex-col items-center justify-center gap-3 pb-20">
+          <div className="flex h-12 w-12 items-center justify-center rounded-full bg-muted">
+            <IconLock
+              size={24}
+              stroke={1.5}
+              className="text-muted-foreground"
+            />
+          </div>
+          <h2 className="text-lg font-semibold text-foreground">
+            Log not found
+          </h2>
+          <p className="text-sm text-muted-foreground text-center max-w-sm">
+            This log doesn&apos;t exist or you don&apos;t have permission to
+            view it in the current organization.
+          </p>
+          <Button variant="outline" size="sm" className="mt-2" onClick={onBack}>
+            Back to activity
+          </Button>
+        </div>
+      </div>
+    );
+  }
 
   const detail =
     detailLoadable.state === "hasData" ? detailLoadable.data : null;

--- a/turbo/apps/platform/src/views/zero-page/zero-activity-detail-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-activity-detail-page.tsx
@@ -20,6 +20,7 @@ import {
 import {
   groupEventsIntoMessages,
   groupedMessageMatchesSearch,
+  type GroupedMessage,
 } from "../logs-page/log-detail/utils.ts";
 import { GroupedMessageCard } from "../logs-page/components/grouped-message-card.tsx";
 import { StatusDot } from "../logs-page/components/status-dot.tsx";
@@ -29,8 +30,58 @@ import { Markdown } from "../components/markdown.tsx";
 // Component
 // ---------------------------------------------------------------------------
 
+/**
+ * Returns true if a grouped message should be shown (filters out text-only
+ * assistant messages immediately before a result message).
+ */
+function isVisibleMessage(
+  message: GroupedMessage,
+  nextMessage: GroupedMessage | undefined,
+): boolean {
+  if (message.type !== "assistant") {
+    return true;
+  }
+  if (!nextMessage || nextMessage.type !== "result") {
+    return true;
+  }
+  return (message.toolOperations?.length ?? 0) > 0;
+}
+
 interface ZeroActivityDetailPageProps {
   onBack: () => void;
+}
+
+function ActivityNotFound({ onBack }: { onBack: () => void }) {
+  return (
+    <div className="h-full flex flex-col min-h-0">
+      <header className="shrink-0 bg-transparent px-4 sm:px-6 pt-4 pb-3">
+        <div className="mb-3">
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-8 w-8 shrink-0 -ml-2"
+            onClick={onBack}
+            aria-label="Back to activity"
+          >
+            <IconArrowLeft size={20} stroke={1.5} />
+          </Button>
+        </div>
+      </header>
+      <div className="flex-1 flex flex-col items-center justify-center gap-3 pb-20">
+        <div className="flex h-12 w-12 items-center justify-center rounded-full bg-muted">
+          <IconLock size={24} stroke={1.5} className="text-muted-foreground" />
+        </div>
+        <h2 className="text-lg font-semibold text-foreground">Log not found</h2>
+        <p className="text-sm text-muted-foreground text-center max-w-sm">
+          This log doesn&apos;t exist or you don&apos;t have permission to view
+          it in the current organization.
+        </p>
+        <Button variant="outline" size="sm" className="mt-2" onClick={onBack}>
+          Back to activity
+        </Button>
+      </div>
+    </div>
+  );
 }
 
 export function ZeroActivityDetailPage({
@@ -49,42 +100,7 @@ export function ZeroActivityDetailPage({
 
   // Detail not found or no permission
   if (detailLoadable.state === "hasError") {
-    return (
-      <div className="h-full flex flex-col min-h-0">
-        <header className="shrink-0 bg-transparent px-4 sm:px-6 pt-4 pb-3">
-          <div className="mb-3">
-            <Button
-              variant="ghost"
-              size="icon"
-              className="h-8 w-8 shrink-0 -ml-2"
-              onClick={onBack}
-              aria-label="Back to activity"
-            >
-              <IconArrowLeft size={20} stroke={1.5} />
-            </Button>
-          </div>
-        </header>
-        <div className="flex-1 flex flex-col items-center justify-center gap-3 pb-20">
-          <div className="flex h-12 w-12 items-center justify-center rounded-full bg-muted">
-            <IconLock
-              size={24}
-              stroke={1.5}
-              className="text-muted-foreground"
-            />
-          </div>
-          <h2 className="text-lg font-semibold text-foreground">
-            Log not found
-          </h2>
-          <p className="text-sm text-muted-foreground text-center max-w-sm">
-            This log doesn&apos;t exist or you don&apos;t have permission to
-            view it in the current organization.
-          </p>
-          <Button variant="outline" size="sm" className="mt-2" onClick={onBack}>
-            Back to activity
-          </Button>
-        </div>
-      </div>
-    );
+    return <ActivityNotFound onBack={onBack} />;
   }
 
   const detail =
@@ -95,18 +111,9 @@ export function ZeroActivityDetailPage({
   const allMessages = groupEventsIntoMessages(events);
 
   // Filter out text-only assistant messages right before result (redundant)
-  const visibleMessages = allMessages.filter((message, index) => {
-    if (message.type !== "assistant") {
-      return true;
-    }
-    const nextMessage = allMessages[index + 1];
-    if (!nextMessage || nextMessage.type !== "result") {
-      return true;
-    }
-    const hasTools =
-      message.toolOperations && message.toolOperations.length > 0;
-    return hasTools;
-  });
+  const visibleMessages = allMessages.filter((message, index) =>
+    isVisibleMessage(message, allMessages[index + 1]),
+  );
 
   const messages = visibleMessages.filter((m) =>
     groupedMessageMatchesSearch(m, stepSearch.trim()),
@@ -220,40 +227,60 @@ export function ZeroActivityDetailPage({
                 </div>
               </div>
 
-              <div>
-                {prompt.trim().length > 0 && (
-                  <PromptCard
-                    prompt={prompt}
-                    showConnector={messages.length > 0}
-                  />
-                )}
-                {eventsLoadable.state === "loading" && events.length === 0 ? (
-                  <div className="flex justify-center py-8">
-                    <IconLoader2
-                      size={20}
-                      stroke={1.5}
-                      className="animate-spin text-muted-foreground"
-                    />
-                  </div>
-                ) : messages.length === 0 && prompt.trim().length === 0 ? (
-                  <div className="py-8 text-center text-muted-foreground">
-                    No events available
-                  </div>
-                ) : (
-                  messages.map((message, index) => (
-                    <GroupedMessageCard
-                      key={`${message.type}-${message.sequenceNumber}-${message.createdAt}`}
-                      message={message}
-                      searchTerm={stepSearch}
-                      showConnector={index < messages.length - 1}
-                    />
-                  ))
-                )}
-              </div>
+              <StepsList
+                prompt={prompt}
+                messages={messages}
+                stepSearch={stepSearch}
+                isLoading={
+                  eventsLoadable.state === "loading" && events.length === 0
+                }
+              />
             </div>
           </div>
         </div>
       </div>
+    </div>
+  );
+}
+
+function StepsList({
+  prompt,
+  messages,
+  stepSearch,
+  isLoading,
+}: {
+  prompt: string;
+  messages: GroupedMessage[];
+  stepSearch: string;
+  isLoading: boolean;
+}) {
+  return (
+    <div>
+      {prompt.trim().length > 0 && (
+        <PromptCard prompt={prompt} showConnector={messages.length > 0} />
+      )}
+      {isLoading ? (
+        <div className="flex justify-center py-8">
+          <IconLoader2
+            size={20}
+            stroke={1.5}
+            className="animate-spin text-muted-foreground"
+          />
+        </div>
+      ) : messages.length === 0 && prompt.trim().length === 0 ? (
+        <div className="py-8 text-center text-muted-foreground">
+          No events available
+        </div>
+      ) : (
+        messages.map((message, index) => (
+          <GroupedMessageCard
+            key={`${message.type}-${message.sequenceNumber}-${message.createdAt}`}
+            message={message}
+            searchTerm={stepSearch}
+            showConnector={index < messages.length - 1}
+          />
+        ))
+      )}
     </div>
   );
 }

--- a/turbo/apps/platform/src/views/zero-page/zero-app-shell.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-app-shell.tsx
@@ -184,6 +184,34 @@ function useSessionLifecycle(
   return { recentSessions, recentSessionsLoading, recentSessionsError };
 }
 
+/**
+ * Sync URL session ID to the chat signal, avoiding redundant switches.
+ */
+function useUrlSessionSync(
+  urlSessionId: string | null,
+  currentSessionId: string | null,
+  switchSession: (id: string) => Promise<void>,
+) {
+  const prevUrlSessionId$ = useCCState<string | null>(null);
+  const prevUrlSessionId = useGet(prevUrlSessionId$);
+  const setPrevUrlSessionId = useSet(prevUrlSessionId$);
+
+  if (
+    urlSessionId &&
+    urlSessionId !== prevUrlSessionId &&
+    urlSessionId !== currentSessionId
+  ) {
+    queueMicrotask(() => {
+      setPrevUrlSessionId(urlSessionId);
+      detach(switchSession(urlSessionId), Reason.DomCallback);
+    });
+  } else if (urlSessionId && urlSessionId !== prevUrlSessionId) {
+    queueMicrotask(() => setPrevUrlSessionId(urlSessionId));
+  } else if (!urlSessionId && prevUrlSessionId) {
+    queueMicrotask(() => setPrevUrlSessionId(null));
+  }
+}
+
 interface ZeroAppShellProps {
   initialJobAgent?: string | null;
 }
@@ -252,23 +280,7 @@ export function ZeroAppShell({ initialJobAgent }: ZeroAppShellProps) {
     useSessionLifecycle(isLoggedIn, onboardingReady, needsOnboarding);
 
   // Sync URL session ID to chat signal (skip if signal already matches)
-  const prevUrlSessionId$ = useCCState<string | null>(null);
-  const prevUrlSessionId = useGet(prevUrlSessionId$);
-  const setPrevUrlSessionId = useSet(prevUrlSessionId$);
-  if (
-    urlSessionId &&
-    urlSessionId !== prevUrlSessionId &&
-    urlSessionId !== currentSessionId
-  ) {
-    queueMicrotask(() => {
-      setPrevUrlSessionId(urlSessionId);
-      detach(switchSession(urlSessionId), Reason.DomCallback);
-    });
-  } else if (urlSessionId && urlSessionId !== prevUrlSessionId) {
-    queueMicrotask(() => setPrevUrlSessionId(urlSessionId));
-  } else if (!urlSessionId && prevUrlSessionId) {
-    queueMicrotask(() => setPrevUrlSessionId(null));
-  }
+  useUrlSessionSync(urlSessionId, currentSessionId, switchSession);
 
   const handleRecentSelect$ = useCommand(({ set }, sessionId: string) => {
     set(navigateToZeroSession$, sessionId);

--- a/turbo/apps/platform/src/views/zero-page/zero-app-shell.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-app-shell.tsx
@@ -2,8 +2,10 @@ import { useCCState, useCommand } from "ccstate-react/experimental";
 import { useGet, useSet, useLoadable, useLastLoadable } from "ccstate-react";
 import {
   ZeroSidebar,
+  getAgentAvatar,
   type ZeroNavId,
   type ZeroAccountAction,
+  type SubagentInfo,
 } from "./zero-sidebar.tsx";
 import { Button } from "@vm0/ui";
 import { ZeroAboutPage } from "./zero-about-page.tsx";
@@ -13,12 +15,15 @@ import { user$ } from "../../signals/auth.ts";
 import { zeroNeedsOnboarding$ } from "../../signals/zero-page/zero-onboarding.ts";
 import { agentDisplayName$ } from "../../signals/zero-page/zero-agent-name.ts";
 import { resetDefaultAgent$ } from "../../signals/zero-page/zero-dev-tools.ts";
+import { zeroSubagents$ } from "../../signals/zero-page/zero-agents.ts";
 import { detach, Reason } from "../../signals/utils.ts";
 import {
   zeroActiveId$,
   zeroInChat$,
   zeroSessionId$,
+  zeroChatAgentId$,
   setZeroActiveId$,
+  setZeroChatAgentId$,
   navigateToZeroSession$,
   navigateFromZeroSession$,
 } from "../../signals/zero-page/zero-nav.ts";
@@ -164,6 +169,7 @@ function useSessionLifecycle(
       const wasOnboarding = lifecycle === "onboarding";
       queueMicrotask(() => {
         setLifecycle("ready");
+        // fetchZeroSessionList$ reads zeroChatAgentId$ from localStorage
         detach(fetchSessionList(), Reason.DomCallback);
         if (wasOnboarding) {
           detach(
@@ -198,6 +204,18 @@ export function ZeroAppShell({ initialJobAgent }: ZeroAppShellProps) {
   const agentDisplayName = agentNameReady
     ? agentDisplayNameLoadable.data
     : "Zero";
+  const subagentsLoadable = useLastLoadable(zeroSubagents$);
+  const subagents: SubagentInfo[] =
+    subagentsLoadable.state === "hasData"
+      ? subagentsLoadable.data.map((a) => ({
+          id: a.id,
+          name: a.name,
+          displayName: a.displayName,
+        }))
+      : [];
+  const currentChatAgentId = useGet(zeroChatAgentId$);
+  const setChatAgentId = useSet(setZeroChatAgentId$);
+
   const activeId = useGet(zeroActiveId$);
   const setActiveId = useSet(setZeroActiveId$);
   const avatarIndex$ = useCCState(0);
@@ -206,6 +224,17 @@ export function ZeroAppShell({ initialJobAgent }: ZeroAppShellProps) {
   const showAboutPage = useGet(showAboutPage$);
   const setShowAboutPage = useSet(showAboutPage$);
   const zeroAvatarSrc = ZERO_AVATARS[avatarIndex] ?? ZERO_AVATARS[0];
+
+  // Resolve the effective agent name/avatar for the chat page
+  const selectedSubagent = currentChatAgentId
+    ? subagents.find((a) => a.id === currentChatAgentId)
+    : null;
+  const chatAgentName = selectedSubagent
+    ? (selectedSubagent.displayName ?? selectedSubagent.name)
+    : agentDisplayName;
+  const chatAvatarSrc = selectedSubagent
+    ? getAgentAvatar(selectedSubagent.name)
+    : zeroAvatarSrc;
   const cycleAvatar$ = useCommand(({ set }) => {
     set(avatarIndex$, (i: number) => (i + 1) % ZERO_AVATARS.length);
   });
@@ -246,11 +275,14 @@ export function ZeroAppShell({ initialJobAgent }: ZeroAppShellProps) {
   });
   const handleRecentSelect = useSet(handleRecentSelect$);
 
-  const handleNewChat$ = useCommand(({ set }) => {
-    set(updatePathname$, "/zero/chat");
+  const fetchSessionList = useSet(fetchZeroSessionList$);
+  const handleNewChat = (agentId: string | null) => {
+    setActiveId("chat");
+    // Persist agent selection to localStorage first, so fetchZeroSessionList$ reads it
+    setChatAgentId(agentId);
     startNewSession();
-  });
-  const handleNewChat = useSet(handleNewChat$);
+    detach(fetchSessionList(), Reason.DomCallback);
+  };
 
   const handleSendFromDemo$ = useCommand(({ set }, message: string) => {
     set(updatePathname$, "/zero/chat");
@@ -285,6 +317,10 @@ export function ZeroAppShell({ initialJobAgent }: ZeroAppShellProps) {
   const updateSearchParams = useSet(updateSearchParams$);
   const resetDefaultAgent = useSet(resetDefaultAgent$);
 
+  const sidebarCollapsed$ = useCCState(false);
+  const sidebarCollapsed = useGet(sidebarCollapsed$);
+  const setSidebarCollapsed = useSet(sidebarCollapsed$);
+
   const dataReady = isLoggedIn && onboardingReady && agentNameReady;
   const showSkeleton = useSkeletonVisibility(isLoggedIn, dataReady);
 
@@ -300,6 +336,11 @@ export function ZeroAppShell({ initialJobAgent }: ZeroAppShellProps) {
       <ZeroSidebar
         activeId={activeId}
         agentName={agentDisplayName}
+        zeroAvatarSrc={zeroAvatarSrc}
+        subagents={subagents}
+        currentChatAgentId={currentChatAgentId}
+        collapsed={sidebarCollapsed}
+        onCollapse={() => setSidebarCollapsed(!sidebarCollapsed)}
         onSelect={handleNavSelect}
         onRecentSelect={handleRecentSelect}
         selectedRecentId={urlSessionId}
@@ -365,6 +406,8 @@ export function ZeroAppShell({ initialJobAgent }: ZeroAppShellProps) {
             }}
             onBackFromSession={handleBackFromSession}
             zeroAvatarSrc={zeroAvatarSrc}
+            chatAgentName={chatAgentName}
+            chatAvatarSrc={chatAvatarSrc}
             onAvatarClick={cycleAvatar}
           />
         )}

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-page.tsx
@@ -655,6 +655,8 @@ interface ZeroChatPageProps {
   onNavigateToMeet?: (tab?: string) => void;
   onSendMessage?: (message: string) => void;
   zeroAvatarSrc?: string;
+  /** Override agent name when chatting with a sub-agent. */
+  chatAgentName?: string;
   onAvatarClick?: () => void;
 }
 
@@ -667,11 +669,13 @@ export function ZeroChatPage({
   onNavigateToMeet,
   onSendMessage,
   zeroAvatarSrc = "/zero-avatar.png",
+  chatAgentName,
   onAvatarClick,
 }: ZeroChatPageProps) {
   const agentNameLoadable = useLoadable(agentDisplayName$);
-  const agentName =
+  const defaultAgentName =
     agentNameLoadable.state === "hasData" ? agentNameLoadable.data : "Zero";
+  const agentName = chatAgentName ?? defaultAgentName;
   const input$ = useCCState("");
   const input = useGet(input$);
   const setInput = useSet(input$);

--- a/turbo/apps/platform/src/views/zero-page/zero-content.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-content.tsx
@@ -24,6 +24,10 @@ interface ZeroContentProps {
   onNavigateToMeet?: (tab?: string) => void;
   onBackFromSession?: () => void;
   zeroAvatarSrc?: string;
+  /** Override agent name for the chat page when a sub-agent is selected. */
+  chatAgentName?: string;
+  /** Override avatar for the chat page when a sub-agent is selected. */
+  chatAvatarSrc?: string;
   onAvatarClick?: () => void;
 }
 
@@ -54,6 +58,8 @@ export function ZeroContent({
   onNavigateToMeet,
   onBackFromSession,
   zeroAvatarSrc = "/zero-avatar.png",
+  chatAgentName,
+  chatAvatarSrc,
   onAvatarClick,
 }: ZeroContentProps) {
   const agentNameLoadable = useLoadable(agentDisplayName$);
@@ -78,7 +84,8 @@ export function ZeroContent({
         onNavigateToSchedule={onNavigateToSchedule}
         onNavigateToTeam={onNavigateToTeam}
         onNavigateToMeet={onNavigateToMeet}
-        zeroAvatarSrc={zeroAvatarSrc}
+        zeroAvatarSrc={chatAvatarSrc ?? zeroAvatarSrc}
+        chatAgentName={chatAgentName}
         onAvatarClick={onAvatarClick}
       />
     );
@@ -99,6 +106,7 @@ export function ZeroContent({
       <ZeroJobsPage
         onNavigateToChat={onNavigateToChat}
         selectedAgentName={selectedAgentName}
+        zeroAvatarSrc={zeroAvatarSrc}
       />
     );
   }

--- a/turbo/apps/platform/src/views/zero-page/zero-job-detail-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-job-detail-page.tsx
@@ -3,15 +3,20 @@ import { useCCState } from "ccstate-react/experimental";
 import {
   IconArrowLeft,
   IconFileText,
-  IconUser,
+  IconUserCircle,
   IconPlug,
   IconCalendar,
+  IconMessageCircle,
 } from "@tabler/icons-react";
 import {
   Button,
   Tabs,
   TabsList,
   TabsTrigger,
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
   Card,
   CardContent,
 } from "@vm0/ui";
@@ -56,6 +61,21 @@ import { detach, Reason } from "../../signals/utils.ts";
 // ---------------------------------------------------------------------------
 // Page shell: skeleton, error, header
 // ---------------------------------------------------------------------------
+
+const AGENT_AVATARS = [
+  "/avatars/avatar-1.png",
+  "/avatars/avatar-2.png",
+  "/avatars/avatar-3.png",
+  "/avatars/avatar-4.png",
+] as const;
+
+function getAgentAvatar(name: string): string {
+  let hash = 0;
+  for (let i = 0; i < name.length; i++) {
+    hash = (hash * 31 + name.charCodeAt(i)) | 0;
+  }
+  return AGENT_AVATARS[Math.abs(hash) % AGENT_AVATARS.length];
+}
 
 interface ZeroJobDetailPageProps {
   agentName: string;
@@ -145,20 +165,20 @@ const TAB_TRIGGER_CLASS =
 
 function isValidTab(tab: string): boolean {
   return (
-    tab === "skills" ||
+    tab === "connectors" ||
     tab === "schedule" ||
-    tab === "settings" ||
+    tab === "profile" ||
     tab === "instructions"
   );
 }
 
 function getInitialTab(): string {
   if (typeof window === "undefined") {
-    return "skills";
+    return "connectors";
   }
   const params = new URLSearchParams(window.location.search);
   const tab = params.get("tab") ?? "";
-  return isValidTab(tab) ? tab : "skills";
+  return isValidTab(tab) ? tab : "connectors";
 }
 
 function syncTabToUrl(tab: string) {
@@ -166,7 +186,7 @@ function syncTabToUrl(tab: string) {
     return;
   }
   const url = new URL(window.location.href);
-  if (tab === "skills") {
+  if (tab === "connectors") {
     url.searchParams.delete("tab");
   } else {
     url.searchParams.set("tab", tab);
@@ -179,7 +199,7 @@ function extractAgentFields(detail: AgentDetail | null, fallbackName: string) {
     ? Object.values(detail.content.agents)[0]
     : null;
   return {
-    description: agentDef?.description ?? null,
+    description: agentDef?.metadata?.description ?? agentDef?.description ?? "",
     framework: agentDef?.framework ?? null,
     sound: agentDef?.metadata?.sound ?? "professional",
     displayName:
@@ -287,6 +307,8 @@ function JobInstructionsTab() {
 // ---------------------------------------------------------------------------
 
 export function ZeroJobDetailPage({ agentName }: ZeroJobDetailPageProps) {
+  const navigate = useSet(navigateInReact$);
+  const navigateBack = useNavigateBack();
   const detail = useGet(zeroJobDetail$);
   const loading = useGet(zeroJobDetailLoading$);
   const error = useGet(zeroJobDetailError$);
@@ -321,38 +343,53 @@ export function ZeroJobDetailPage({ agentName }: ZeroJobDetailPageProps) {
 
   return (
     <div className="flex flex-1 flex-col min-h-0 overflow-auto [scrollbar-gutter:stable]">
-      <header className="shrink-0 bg-transparent px-4 pt-4 pb-4 sm:px-6">
+      <header className="shrink-0 bg-transparent px-4 sm:px-6 pt-4 pb-3">
+        <div className="mb-3">
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-8 w-8 shrink-0 -ml-2"
+            onClick={navigateBack}
+            aria-label="Back to agents"
+          >
+            <IconArrowLeft size={20} stroke={1.5} />
+          </Button>
+        </div>
         <div className="mx-auto max-w-[900px] px-7">
-          <BackButton />
-          <div className="min-w-0 flex-1 space-y-1.5">
-            <h1 className="text-xl font-semibold tracking-tight text-foreground leading-tight">
-              {displayName}
-            </h1>
-            {description && (
-              <p className="text-sm text-muted-foreground leading-relaxed max-w-[36rem]">
-                {description}
+          <div className="flex items-center gap-3 text-base">
+            <img
+              src={getAgentAvatar(agentName)}
+              alt={displayName}
+              className="h-10 w-10 shrink-0 rounded-full object-cover object-top"
+            />
+            <div className="min-w-0">
+              <h1 className="font-semibold tracking-tight text-foreground">
+                {displayName}
+              </h1>
+              <p className="text-sm text-muted-foreground mt-0.5 leading-tight">
+                {description || "Your AI teammate, tuned to you"}
               </p>
-            )}
+            </div>
           </div>
 
-          <div className="mt-6 flex h-9 items-center">
+          <div className="mt-4 flex h-9 items-center justify-between gap-6">
             <Tabs
               value={activeTab}
               onValueChange={setActiveTab}
               className="flex-1 min-w-0"
             >
               <TabsList className="zero-tabs h-9 w-full sm:w-auto gap-1 px-1 py-1">
-                <TabsTrigger value="skills" className={TAB_TRIGGER_CLASS}>
+                <TabsTrigger value="connectors" className={TAB_TRIGGER_CLASS}>
                   <IconPlug size={14} stroke={1.5} />
-                  Skills
+                  Connectors
                 </TabsTrigger>
                 <TabsTrigger value="schedule" className={TAB_TRIGGER_CLASS}>
                   <IconCalendar size={14} stroke={1.5} />
                   Schedule
                 </TabsTrigger>
-                <TabsTrigger value="settings" className={TAB_TRIGGER_CLASS}>
-                  <IconUser size={14} stroke={1.5} />
-                  Settings
+                <TabsTrigger value="profile" className={TAB_TRIGGER_CLASS}>
+                  <IconUserCircle size={14} stroke={1.5} />
+                  Profile
                 </TabsTrigger>
                 <TabsTrigger value="instructions" className={TAB_TRIGGER_CLASS}>
                   <IconFileText size={14} stroke={1.5} />
@@ -360,18 +397,42 @@ export function ZeroJobDetailPage({ agentName }: ZeroJobDetailPageProps) {
                 </TabsTrigger>
               </TabsList>
             </Tabs>
+            <TooltipProvider delayDuration={300}>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="zero-btn-morandi h-9 shrink-0 gap-2 rounded-lg border px-4"
+                    onClick={() =>
+                      navigate("/zero/:tab", { pathParams: { tab: "chat" } })
+                    }
+                  >
+                    <IconMessageCircle size={14} stroke={1.5} />
+                    Chat with {displayName}
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent
+                  side="bottom"
+                  className="max-w-[220px] text-center"
+                >
+                  Make updates or assign tasks
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
           </div>
         </div>
       </header>
 
       <main className="shrink-0 px-4 sm:px-6 pt-4 pb-16">
-        {activeTab === "skills" && <JobSkillsTab />}
+        {activeTab === "connectors" && <JobSkillsTab />}
 
         {activeTab === "schedule" && <JobScheduleTab agentName={displayName} />}
 
-        {activeTab === "settings" && (
+        {activeTab === "profile" && (
           <ZeroSettingsTab
             agentName={displayName}
+            description={description ?? ""}
             sound={resolvedSound}
             saving={saving}
             updateSettings$={zeroJobUpdateSettings$}

--- a/turbo/apps/platform/src/views/zero-page/zero-job-detail-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-job-detail-page.tsx
@@ -57,25 +57,11 @@ import {
 import type { AgentDetail } from "../../signals/agent-detail/types.ts";
 import { navigateInReact$ } from "../../signals/route.ts";
 import { detach, Reason } from "../../signals/utils.ts";
+import { getAgentAvatar } from "./zero-sidebar.tsx";
 
 // ---------------------------------------------------------------------------
 // Page shell: skeleton, error, header
 // ---------------------------------------------------------------------------
-
-const AGENT_AVATARS = [
-  "/avatars/avatar-1.png",
-  "/avatars/avatar-2.png",
-  "/avatars/avatar-3.png",
-  "/avatars/avatar-4.png",
-] as const;
-
-function getAgentAvatar(name: string): string {
-  let hash = 0;
-  for (let i = 0; i < name.length; i++) {
-    hash = (hash * 31 + name.charCodeAt(i)) | 0;
-  }
-  return AGENT_AVATARS[Math.abs(hash) % AGENT_AVATARS.length];
-}
 
 interface ZeroJobDetailPageProps {
   agentName: string;

--- a/turbo/apps/platform/src/views/zero-page/zero-jobs-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-jobs-page.tsx
@@ -1,50 +1,52 @@
 import { useGet, useLastResolved, useSet, useLoadable } from "ccstate-react";
 import {
-  IconCalendarCheck,
-  IconCalendarOff,
-  IconAlertTriangle,
-  IconDotsVertical,
+  IconSparkles,
   IconMessageCircle,
-  IconTrash,
+  IconUsers,
 } from "@tabler/icons-react";
 import { Button, Card, CardContent } from "@vm0/ui";
 import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "@vm0/ui/components/ui/popover";
-import {
   zeroSubagents$,
-  schedules$,
-  agentsMissingItems$,
   agentsLoading$,
   agentsError$,
-  getAgentScheduleStatus,
 } from "../../signals/zero-page/zero-agents.ts";
 import { navigateInReact$ } from "../../signals/route.ts";
 import { agentDisplayName$ } from "../../signals/zero-page/zero-agent-name.ts";
 import { ZeroJobDetailPage } from "./zero-job-detail-page.tsx";
 
+const AGENT_AVATARS = [
+  "/avatars/avatar-1.png",
+  "/avatars/avatar-2.png",
+  "/avatars/avatar-3.png",
+  "/avatars/avatar-4.png",
+] as const;
+
+function getAgentAvatar(name: string): string {
+  let hash = 0;
+  for (let i = 0; i < name.length; i++) {
+    hash = (hash * 31 + name.charCodeAt(i)) | 0;
+  }
+  return AGENT_AVATARS[Math.abs(hash) % AGENT_AVATARS.length];
+}
+
 interface ZeroJobsPageProps {
   onNavigateToChat?: () => void;
   selectedAgentName?: string | null;
+  zeroAvatarSrc?: string;
 }
 
 export function ZeroJobsPage({
   onNavigateToChat,
   selectedAgentName,
+  zeroAvatarSrc = "/zero-avatar.png",
 }: ZeroJobsPageProps) {
   const agentNameLoadable = useLoadable(agentDisplayName$);
   const agentName =
     agentNameLoadable.state === "hasData" ? agentNameLoadable.data : "Zero";
   const agents = useLastResolved(zeroSubagents$);
-  const schedulesList = useGet(schedules$);
-  const missingItems = useLastResolved(agentsMissingItems$);
   const loading = useGet(agentsLoading$);
   const error = useGet(agentsError$);
   const navigate = useSet(navigateInReact$);
-
-  const missingMap = new Map(missingItems?.map((a) => [a.agentName, a]));
 
   if (selectedAgentName) {
     return <ZeroJobDetailPage agentName={selectedAgentName} />;
@@ -53,45 +55,79 @@ export function ZeroJobsPage({
   return (
     <div className="flex flex-1 flex-col min-h-0">
       <header className="shrink-0 bg-transparent px-4 sm:px-6 pt-10 pb-3">
-        <div className="mx-auto max-w-[900px] flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4">
-          <div>
-            <h1 className="text-lg font-semibold tracking-tight text-foreground">
-              {agentName}&apos;s sub agents
-            </h1>
-            <p className="mt-0.5 text-sm text-muted-foreground">
-              Sub-agents created by {agentName} to run tailored workflows for
-              you and your team.
-            </p>
-          </div>
-          {onNavigateToChat && (
-            <Button
-              className="zero-btn-morandi h-9 shrink-0 gap-2 rounded-lg border px-4"
-              onClick={onNavigateToChat}
-            >
-              <IconMessageCircle size={14} stroke={1.5} />
-              Create sub agent
-            </Button>
-          )}
+        <div className="mx-auto max-w-[900px]">
+          <h1 className="text-lg font-semibold tracking-tight text-foreground">
+            {agentName}&apos;s team
+          </h1>
+          <p className="mt-0.5 text-sm text-muted-foreground">
+            {agentName} and sub-agents working together to run tailored
+            workflows for you and your team.
+          </p>
         </div>
       </header>
 
       <main className="flex-1 overflow-auto px-4 sm:px-6 pt-4 pb-8">
-        <div className="mx-auto max-w-[900px] flex flex-col gap-4">
+        <div className="mx-auto max-w-[900px] flex flex-col gap-6">
+          {/* Zero — full width */}
+          <Card
+            role="button"
+            tabIndex={0}
+            className="zero-card cursor-pointer"
+            onClick={() =>
+              navigate("/zero/:tab", { pathParams: { tab: "meet" } })
+            }
+            onKeyDown={(e) =>
+              e.key === "Enter" &&
+              navigate("/zero/:tab", { pathParams: { tab: "meet" } })
+            }
+          >
+            <CardContent className="p-5 flex items-center gap-4">
+              <img
+                src={zeroAvatarSrc}
+                alt={agentName}
+                className="h-12 w-12 shrink-0 rounded-full object-cover object-top"
+              />
+              <div className="min-w-0 flex-1">
+                <div className="flex items-center gap-2">
+                  <h2 className="text-base font-semibold tracking-tight text-foreground truncate">
+                    {agentName}
+                  </h2>
+                  <span className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs text-muted-foreground">
+                    <IconSparkles
+                      size={12}
+                      stroke={1.5}
+                      className="h-3 w-3 shrink-0 text-violet-600 dark:text-violet-400"
+                    />
+                    Main
+                  </span>
+                </div>
+                <p className="text-sm text-muted-foreground mt-0.5">
+                  Your primary AI assistant that manages your team and
+                  orchestrates workflows.
+                </p>
+              </div>
+            </CardContent>
+          </Card>
+
+          <div className="border-t border-border/60" />
+
+          {/* Sub-agents grid */}
           {loading && (!agents || agents.length === 0) && (
-            <>
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
               {[1, 2, 3].map((i) => (
                 <Card key={i} className="zero-card">
-                  <CardContent className="px-6 py-4">
-                    <div className="flex items-center gap-4 animate-pulse">
+                  <CardContent className="p-5">
+                    <div className="flex items-center gap-3 animate-pulse">
+                      <div className="h-10 w-10 rounded-full bg-muted" />
                       <div className="min-w-0 flex-1 space-y-2">
-                        <div className="h-4 w-40 rounded bg-muted" />
-                        <div className="h-3 w-64 rounded bg-muted" />
+                        <div className="h-4 w-24 rounded bg-muted" />
+                        <div className="h-3 w-16 rounded bg-muted" />
                       </div>
                     </div>
                   </CardContent>
                 </Card>
               ))}
-            </>
+            </div>
           )}
 
           {error && (
@@ -114,113 +150,82 @@ export function ZeroJobsPage({
             <Card className="zero-card">
               <CardContent className="px-6 py-8 text-center">
                 <p className="text-sm text-muted-foreground">
-                  No sub-agents yet. Create one by chatting with Zero.
+                  No teammates yet. Start a chat with {agentName} to create one.
                 </p>
               </CardContent>
             </Card>
           )}
 
-          {agents?.map((agent) => {
-            const hasSchedule = getAgentScheduleStatus(
-              agent.name,
-              schedulesList,
-            );
-            const missing = missingMap.get(agent.name);
-            const missingCount =
-              (missing?.missingSecrets.length ?? 0) +
-              (missing?.missingVariables.length ?? 0);
-
-            return (
-              <Card
-                key={agent.name}
-                role="button"
-                tabIndex={0}
-                className="zero-card cursor-pointer hover:border-border transition-colors"
-                onClick={() =>
-                  navigate("/zero/team/:name", {
-                    pathParams: { name: agent.name },
-                  })
-                }
-                onKeyDown={(e) =>
-                  e.key === "Enter" &&
-                  navigate("/zero/team/:name", {
-                    pathParams: { name: agent.name },
-                  })
-                }
+          {agents && agents.length > 0 && (
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+              {/* Create teammate — col-span-full */}
+              <button
+                type="button"
+                className="flex items-center gap-3 rounded-[var(--zero-card-radius)] border border-dashed border-foreground/20 px-4 py-3.5 transition-colors hover:border-foreground/30 hover:bg-muted/30 group col-span-full"
+                onClick={onNavigateToChat}
               >
-                <CardContent className="px-6 py-4">
-                  <div className="flex items-center gap-4">
-                    <div className="min-w-0 flex-1">
-                      <div className="flex flex-wrap items-center gap-2">
-                        <h2 className="text-sm font-semibold tracking-tight text-foreground">
-                          {agent.displayName ?? agent.name}
+                <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-foreground/8 group-hover:bg-foreground/12 transition-colors">
+                  <IconMessageCircle
+                    size={16}
+                    stroke={1.5}
+                    className="text-foreground/50 group-hover:text-foreground transition-colors"
+                  />
+                </span>
+                <span className="text-sm text-foreground/60 group-hover:text-foreground transition-colors">
+                  Start a chat to create a new teammate&hellip;
+                </span>
+              </button>
+
+              {agents.map((agent) => {
+                const displayName = agent.displayName ?? agent.name;
+                return (
+                  <Card
+                    key={agent.name}
+                    role="button"
+                    tabIndex={0}
+                    className="zero-card cursor-pointer flex flex-col"
+                    onClick={() =>
+                      navigate("/zero/team/:name", {
+                        pathParams: { name: agent.name },
+                      })
+                    }
+                    onKeyDown={(e) =>
+                      e.key === "Enter" &&
+                      navigate("/zero/team/:name", {
+                        pathParams: { name: agent.name },
+                      })
+                    }
+                  >
+                    <CardContent className="p-5 flex flex-col flex-1 gap-3">
+                      <span className="self-start inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs text-muted-foreground">
+                        <IconUsers
+                          size={12}
+                          stroke={1.5}
+                          className="h-3 w-3 shrink-0 text-sky-600 dark:text-sky-400"
+                        />
+                        Workspace
+                      </span>
+                      <div className="flex items-center gap-2.5">
+                        <img
+                          src={getAgentAvatar(agent.name)}
+                          alt={displayName}
+                          className="h-10 w-10 shrink-0 rounded-full object-cover object-top"
+                        />
+                        <h2 className="text-base font-semibold tracking-tight text-foreground truncate">
+                          {displayName}
                         </h2>
-                        <span className="zero-pill inline-flex items-center gap-1.5 rounded-md border px-1.5 py-0.5 text-xs font-medium">
-                          {hasSchedule ? (
-                            <IconCalendarCheck
-                              size={12}
-                              stroke={1.5}
-                              className="h-3 w-3 shrink-0 text-emerald-600 dark:text-emerald-400"
-                            />
-                          ) : (
-                            <IconCalendarOff
-                              size={12}
-                              stroke={1.5}
-                              className="h-3 w-3 shrink-0 text-muted-foreground"
-                            />
-                          )}
-                          {hasSchedule ? "Scheduled" : "No schedule"}
-                        </span>
-                        {missingCount > 0 && (
-                          <span className="zero-pill inline-flex items-center gap-1.5 rounded-md border border-amber-300 dark:border-amber-700 px-1.5 py-0.5 text-xs font-medium text-amber-700 dark:text-amber-400">
-                            <IconAlertTriangle
-                              size={12}
-                              stroke={1.5}
-                              className="h-3 w-3 shrink-0"
-                            />
-                            {missingCount} missing
-                          </span>
-                        )}
                       </div>
-                      <p className="mt-0.5 text-xs text-muted-foreground">
-                        Last edited{" "}
-                        {new Date(agent.updatedAt).toLocaleDateString("en-US", {
-                          month: "short",
-                          day: "numeric",
-                          year: "numeric",
-                        })}
-                      </p>
-                    </div>
-                    <Popover>
-                      <PopoverTrigger asChild>
-                        <button
-                          type="button"
-                          className="shrink-0 rounded p-1.5 text-muted-foreground hover:bg-muted hover:text-foreground transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-                          onClick={(e) => e.stopPropagation()}
-                          aria-label="Agent actions"
-                        >
-                          <IconDotsVertical size={16} stroke={1.5} />
-                        </button>
-                      </PopoverTrigger>
-                      <PopoverContent
-                        align="end"
-                        className="flex flex-col gap-0.5 w-40 p-2"
-                        onClick={(e) => e.stopPropagation()}
-                      >
-                        <button
-                          type="button"
-                          className="flex w-full items-center gap-2 rounded-md px-3 py-2 text-sm text-left text-destructive hover:bg-accent hover:text-accent-foreground transition-colors"
-                        >
-                          <IconTrash size={14} stroke={1.5} />
-                          Delete
-                        </button>
-                      </PopoverContent>
-                    </Popover>
-                  </div>
-                </CardContent>
-              </Card>
-            );
-          })}
+                      {agent.description && (
+                        <p className="text-sm text-muted-foreground line-clamp-2">
+                          {agent.description}
+                        </p>
+                      )}
+                    </CardContent>
+                  </Card>
+                );
+              })}
+            </div>
+          )}
         </div>
       </main>
     </div>

--- a/turbo/apps/platform/src/views/zero-page/zero-jobs-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-jobs-page.tsx
@@ -13,21 +13,7 @@ import {
 import { navigateInReact$ } from "../../signals/route.ts";
 import { agentDisplayName$ } from "../../signals/zero-page/zero-agent-name.ts";
 import { ZeroJobDetailPage } from "./zero-job-detail-page.tsx";
-
-const AGENT_AVATARS = [
-  "/avatars/avatar-1.png",
-  "/avatars/avatar-2.png",
-  "/avatars/avatar-3.png",
-  "/avatars/avatar-4.png",
-] as const;
-
-function getAgentAvatar(name: string): string {
-  let hash = 0;
-  for (let i = 0; i < name.length; i++) {
-    hash = (hash * 31 + name.charCodeAt(i)) | 0;
-  }
-  return AGENT_AVATARS[Math.abs(hash) % AGENT_AVATARS.length];
-}
+import { getAgentAvatar } from "./zero-sidebar.tsx";
 
 interface ZeroJobsPageProps {
   onNavigateToChat?: () => void;

--- a/turbo/apps/platform/src/views/zero-page/zero-meet-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-meet-page.tsx
@@ -7,8 +7,18 @@ import {
   IconPlug,
   IconCalendar,
   IconCrown,
+  IconArrowLeft,
 } from "@tabler/icons-react";
-import { Button, Tabs, TabsList, TabsTrigger } from "@vm0/ui";
+import {
+  Button,
+  Tabs,
+  TabsList,
+  TabsTrigger,
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@vm0/ui";
 import { ZeroScheduleTab } from "./zero-schedule-tab.tsx";
 import { ZeroSkillsTab } from "./zero-skills-tab.tsx";
 import { ZeroInstructionsTab } from "./zero-instructions-tab.tsx";
@@ -26,7 +36,7 @@ import {
   deleteZeroSchedule$,
   toggleZeroScheduleEnabled$,
 } from "../../signals/zero-page/zero-schedule.ts";
-import { updatePathname$ } from "../../signals/route.ts";
+import { updatePathname$, navigateInReact$ } from "../../signals/route.ts";
 import { detach, Reason } from "../../signals/utils.ts";
 import {
   zeroInstructions$,
@@ -180,6 +190,7 @@ export function ZeroMeetPage({
   onAvatarClick,
 }: ZeroMeetPageProps) {
   const navigate = useSet(updatePathname$);
+  const navigateRoute = useSet(navigateInReact$);
   const agentNameLoadable = useLoadable(agentDisplayName$);
   const resolvedAgentName =
     agentNameLoadable.state === "hasData" ? agentNameLoadable.data : "Zero";
@@ -188,6 +199,10 @@ export function ZeroMeetPage({
     metadataLoadable.state === "hasData"
       ? (metadataLoadable.data?.sound ?? "professional")
       : "professional";
+  const resolvedDescription =
+    metadataLoadable.state === "hasData"
+      ? (metadataLoadable.data?.description ?? "")
+      : "";
   const resolvedSound: Tone = (TONE_OPTIONS as readonly string[]).includes(
     rawSound,
   )
@@ -198,10 +213,10 @@ export function ZeroMeetPage({
     typeof window !== "undefined"
       ? new URLSearchParams(window.location.search)
       : new URLSearchParams();
-  const validTabs = ["skills", "schedule", "settings", "instructions"];
+  const validTabs = ["connectors", "schedule", "profile", "instructions"];
   const initialTab = validTabs.includes(params.get("tab") ?? "")
     ? params.get("tab")!
-    : "skills";
+    : "connectors";
   const activeTab$ = useCCState(initialTab);
   const activeTab = useGet(activeTab$);
   const rawSetActiveTab = useSet(activeTab$);
@@ -209,7 +224,7 @@ export function ZeroMeetPage({
     rawSetActiveTab(tab);
     if (typeof window !== "undefined") {
       const url = new URL(window.location.href);
-      if (tab === "skills") {
+      if (tab === "connectors") {
         url.searchParams.delete("tab");
       } else {
         url.searchParams.set("tab", tab);
@@ -222,6 +237,19 @@ export function ZeroMeetPage({
     <div className="flex flex-1 flex-col min-h-0 overflow-auto [scrollbar-gutter:stable]">
       <header className="shrink-0 bg-transparent px-4 pt-10 pb-4 sm:px-6">
         <div className="mx-auto max-w-[900px] px-7">
+          <div className="mb-2">
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8 shrink-0 -ml-2"
+              onClick={() =>
+                navigateRoute("/zero/:tab", { pathParams: { tab: "team" } })
+              }
+              aria-label="Back to team"
+            >
+              <IconArrowLeft size={20} stroke={1.5} />
+            </Button>
+          </div>
           <div className="flex items-center gap-4">
             <button
               type="button"
@@ -251,7 +279,7 @@ export function ZeroMeetPage({
                 </span>
               </div>
               <p className="text-sm text-muted-foreground mt-0.5 leading-tight">
-                Your AI teammate, tuned to you
+                {resolvedDescription || "Your AI teammate, tuned to you"}
               </p>
             </div>
           </div>
@@ -264,11 +292,11 @@ export function ZeroMeetPage({
             >
               <TabsList className="zero-tabs h-9 w-full sm:w-auto gap-1 px-1 py-1">
                 <TabsTrigger
-                  value="skills"
+                  value="connectors"
                   className="gap-1.5 text-sm data-[state=active]:bg-background px-3"
                 >
                   <IconPlug size={14} stroke={1.5} />
-                  Skills
+                  Connectors
                 </TabsTrigger>
                 <TabsTrigger
                   value="schedule"
@@ -278,11 +306,11 @@ export function ZeroMeetPage({
                   Schedule
                 </TabsTrigger>
                 <TabsTrigger
-                  value="settings"
+                  value="profile"
                   className="gap-1.5 text-sm data-[state=active]:bg-background px-3"
                 >
                   <IconUser size={14} stroke={1.5} />
-                  Settings
+                  Profile
                 </TabsTrigger>
                 <TabsTrigger
                   value="instructions"
@@ -293,29 +321,42 @@ export function ZeroMeetPage({
                 </TabsTrigger>
               </TabsList>
             </Tabs>
-            <Button
-              variant="outline"
-              size="sm"
-              className="zero-btn-morandi h-9 shrink-0 gap-2 rounded-lg border px-4"
-              onClick={() => navigate("/zero/chat")}
-            >
-              <IconMessageCircle size={14} stroke={1.5} />
-              Just ask
-            </Button>
+            <TooltipProvider delayDuration={300}>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="zero-btn-morandi h-9 shrink-0 gap-2 rounded-lg border px-4"
+                    onClick={() => navigate("/zero/chat")}
+                  >
+                    <IconMessageCircle size={14} stroke={1.5} />
+                    Chat with {resolvedAgentName}
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent
+                  side="bottom"
+                  className="max-w-[220px] text-center"
+                >
+                  Make updates or assign tasks
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
           </div>
         </div>
       </header>
 
       <main className="shrink-0 px-4 sm:px-6 pt-4 pb-16">
-        {activeTab === "skills" && <MeetSkillsTab />}
+        {activeTab === "connectors" && <MeetSkillsTab />}
 
         {activeTab === "schedule" && (
           <MeetScheduleTab agentName={resolvedAgentName} />
         )}
 
-        {activeTab === "settings" && (
+        {activeTab === "profile" && (
           <ZeroSettingsTab
             agentName={resolvedAgentName}
+            description={resolvedDescription}
             sound={resolvedSound}
             saving={saving}
             updateSettings$={zeroUpdateSettings$}

--- a/turbo/apps/platform/src/views/zero-page/zero-settings-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-settings-tab.tsx
@@ -14,17 +14,19 @@ import type { Command } from "ccstate";
 
 interface ZeroSettingsTabProps {
   agentName: string;
+  description: string;
   sound: Tone;
   saving: boolean;
   updateSettings$: Command<
     Promise<void>,
-    [{ displayName: string; sound: string }]
+    [{ displayName: string; sound: string; description: string }]
   >;
   inputId?: string;
 }
 
 export function ZeroSettingsTab({
   agentName: resolvedAgentName,
+  description: initialDescription,
   sound: initialSound,
   saving,
   updateSettings$,
@@ -33,11 +35,19 @@ export function ZeroSettingsTab({
   const agentName$ = useCCState(resolvedAgentName);
   const agentName = useGet(agentName$);
   const setAgentName = useSet(agentName$);
+  const desc$ = useCCState(initialDescription);
+  const desc = useGet(desc$);
+  const setDesc = useSet(desc$);
   const tone$ = useCCState<Tone>(initialSound);
   const tone = useGet(tone$);
   const setTone = useSet(tone$);
-  const savedSettings$ = useCCState<{ name: string; tone: Tone }>({
+  const savedSettings$ = useCCState<{
+    name: string;
+    description: string;
+    tone: Tone;
+  }>({
     name: resolvedAgentName,
+    description: initialDescription,
     tone: initialSound,
   });
   const savedSettings = useGet(savedSettings$);
@@ -46,35 +56,58 @@ export function ZeroSettingsTab({
   // Sync local state when props change (e.g. metadata finishes loading)
   const prevProps$ = useCCState({
     name: resolvedAgentName,
+    description: initialDescription,
     tone: initialSound,
   });
   const prevProps = useGet(prevProps$);
   const setPrevProps = useSet(prevProps$);
-  if (resolvedAgentName !== prevProps.name || initialSound !== prevProps.tone) {
+  if (
+    resolvedAgentName !== prevProps.name ||
+    initialDescription !== prevProps.description ||
+    initialSound !== prevProps.tone
+  ) {
     queueMicrotask(() => {
-      setPrevProps({ name: resolvedAgentName, tone: initialSound });
+      setPrevProps({
+        name: resolvedAgentName,
+        description: initialDescription,
+        tone: initialSound,
+      });
       setAgentName(resolvedAgentName);
+      setDesc(initialDescription);
       setTone(initialSound);
-      setSavedSettings({ name: resolvedAgentName, tone: initialSound });
+      setSavedSettings({
+        name: resolvedAgentName,
+        description: initialDescription,
+        tone: initialSound,
+      });
     });
   }
 
   const isSettingsDirty =
-    agentName !== savedSettings.name || tone !== savedSettings.tone;
+    agentName !== savedSettings.name ||
+    desc !== savedSettings.description ||
+    tone !== savedSettings.tone;
 
   const handleResetSettings = () => {
     setAgentName(savedSettings.name);
+    setDesc(savedSettings.description);
     setTone(savedSettings.tone);
   };
 
   const handleSaveSettings$ = useCommand(async ({ get, set }) => {
     const currentName = get(agentName$);
+    const currentDesc = get(desc$);
     const currentTone = get(tone$);
     await set(updateSettings$, {
       displayName: currentName,
+      description: currentDesc,
       sound: currentTone,
     });
-    set(savedSettings$, { name: currentName, tone: currentTone });
+    set(savedSettings$, {
+      name: currentName,
+      description: currentDesc,
+      tone: currentTone,
+    });
   });
   const handleSaveSettings = useSet(handleSaveSettings$);
 
@@ -97,6 +130,22 @@ export function ZeroSettingsTab({
                   onChange={(e) => setAgentName(e.target.value)}
                   placeholder="What should we call them?"
                   className="h-9"
+                />
+              </div>
+              <div className="flex flex-col gap-2">
+                <label
+                  htmlFor={`${inputId}-description`}
+                  className="text-xs font-semibold uppercase tracking-wide text-muted-foreground"
+                >
+                  Description
+                </label>
+                <textarea
+                  id={`${inputId}-description`}
+                  value={desc}
+                  onChange={(e) => setDesc(e.target.value)}
+                  placeholder="What does this agent do?"
+                  rows={3}
+                  className="w-full rounded-lg border border-border bg-input px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground outline-none transition-colors focus:border-primary focus:ring-[3px] focus:ring-primary/10 resize-y min-h-[72px]"
                 />
               </div>
               <div

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -556,14 +556,18 @@ function ManagePinnedAgentsDialog({
   const unpinned = subagents.filter((a) => !pinnedIds.includes(a.id));
 
   const moveUp = (idx: number) => {
-    if (idx <= 0) return;
+    if (idx <= 0) {
+      return;
+    }
     const next = [...pinnedIds];
     [next[idx - 1], next[idx]] = [next[idx]!, next[idx - 1]!];
     onPinnedIdsChange(next);
   };
 
   const moveDown = (idx: number) => {
-    if (idx >= pinnedIds.length - 1) return;
+    if (idx >= pinnedIds.length - 1) {
+      return;
+    }
     const next = [...pinnedIds];
     [next[idx], next[idx + 1]] = [next[idx + 1]!, next[idx]!];
     onPinnedIdsChange(next);

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -1,9 +1,7 @@
 import type { ReactNode } from "react";
-import { useLoadable, useGet, useSet } from "ccstate-react";
+import { useLoadable, useLastLoadable, useGet, useSet } from "ccstate-react";
 import { useCCState } from "ccstate-react/experimental";
 import {
-  IconMessageCircle,
-  IconRobot,
   IconChartLine,
   IconLayoutGrid,
   IconCalendar,
@@ -19,6 +17,9 @@ import {
   IconRefresh,
   IconSearch,
   IconX,
+  IconEdit,
+  IconChevronDown,
+  IconLayoutSidebarLeftCollapse,
 } from "@tabler/icons-react";
 import type { SessionListItem } from "@vm0/core";
 import {
@@ -30,12 +31,50 @@ import {
   DropdownMenuSub,
   DropdownMenuSubTrigger,
   DropdownMenuSubContent,
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  cn,
 } from "@vm0/ui";
 import slackIcon from "../settings-page/icons/slack.svg";
 import { clerk$, user$ } from "../../signals/auth.ts";
 import { detach, Reason } from "../../signals/utils.ts";
+import {
+  pinnedAgentIds$,
+  savingPinnedAgents$,
+  updatePinnedAgentIds$,
+} from "../../signals/zero-page/zero-pinned-agents.ts";
 import { VM0ClerkProvider } from "../clerk/clerk-provider.tsx";
 import { ClerkOrgSwitcher } from "./clerk-org-switcher.tsx";
+
+/** Max pinned sub-agents (default agent counts as 1, total slots = 5). */
+const MAX_PINNED = 4;
+
+const AGENT_AVATARS = [
+  "/avatars/avatar-1.png",
+  "/avatars/avatar-2.png",
+  "/avatars/avatar-3.png",
+  "/avatars/avatar-4.png",
+] as const;
+
+export function getAgentAvatar(name: string): string {
+  let hash = 0;
+  for (let i = 0; i < name.length; i++) {
+    hash = (hash * 31 + name.charCodeAt(i)) | 0;
+  }
+  return AGENT_AVATARS[Math.abs(hash) % AGENT_AVATARS.length];
+}
+
+export interface SubagentInfo {
+  id: string;
+  name: string;
+  displayName?: string | null;
+}
 
 export type ZeroNavId =
   | "chat"
@@ -48,12 +87,10 @@ export type ZeroNavId =
   | "preferences";
 
 type NavIcon = (props: { size?: number; className?: string }) => ReactNode;
-const MAIN_NAV = [
-  { id: "chat", label: "Chat with Zero", icon: IconMessageCircle as NavIcon },
-  { id: "meet", label: "Meet Zero", icon: IconRobot as NavIcon },
+const MANAGE_NAV = [
   { id: "team", label: "Zero's team", icon: IconUsers as NavIcon },
   { id: "schedule", label: "Schedule", icon: IconCalendar as NavIcon },
-  { id: "activity", label: "Activities", icon: IconChartLine as NavIcon },
+  { id: "activity", label: "Activity logs", icon: IconChartLine as NavIcon },
 ] as const;
 
 const FOOTER_NAV = [
@@ -85,6 +122,11 @@ interface SessionAccount {
 interface ZeroSidebarProps {
   activeId: ZeroNavId;
   agentName?: string | null;
+  zeroAvatarSrc?: string;
+  subagents?: SubagentInfo[];
+  currentChatAgentId?: string | null;
+  collapsed?: boolean;
+  onCollapse?: () => void;
   onSelect: (id: ZeroNavId) => void;
   onRecentSelect?: (id: string) => void;
   selectedRecentId?: string | null;
@@ -92,7 +134,7 @@ interface ZeroSidebarProps {
   recentSessions?: SessionListItem[];
   recentSessionsLoading?: boolean;
   recentSessionsError?: string | null;
-  onNewChat?: () => void;
+  onNewChat?: (agentId: string | null) => void;
   onResetAgent?: () => void;
 }
 
@@ -150,10 +192,12 @@ function AccountDropdown({
   activeId,
   onAccountAction,
   onResetAgent,
+  collapsed = false,
 }: {
   activeId: ZeroNavId;
   onAccountAction?: (action: ZeroAccountAction) => void;
   onResetAgent?: () => void;
+  collapsed?: boolean;
 }) {
   const { user, clerk, accounts } = useAccountSessions();
   const accountName = user?.fullName ?? "User";
@@ -190,10 +234,14 @@ function AccountDropdown({
       <DropdownMenuTrigger asChild>
         <button
           type="button"
-          className={`flex w-full items-center gap-2 rounded-lg p-2 text-left transition-colors duration-200 ${
-            activeId === "preferences"
-              ? "bg-sidebar-active"
-              : "hover:bg-sidebar-accent/50"
+          className={`flex items-center rounded-lg transition-colors duration-200 ${
+            collapsed
+              ? "justify-center p-2 h-10 w-10"
+              : `w-full gap-2 p-2 text-left ${
+                  activeId === "preferences"
+                    ? "bg-sidebar-active"
+                    : "hover:bg-sidebar-accent/50"
+                }`
           }`}
         >
           <AccountAvatar
@@ -201,26 +249,28 @@ function AccountDropdown({
             name={accountName}
             initial={accountInitial}
           />
-          <div className="flex-1 min-w-0">
-            <p
-              className={`text-sm font-medium leading-tight truncate ${
-                activeId === "preferences"
-                  ? "text-sidebar-primary"
-                  : "text-sidebar-foreground"
-              }`}
-            >
-              {accountName}
-            </p>
-            <p
-              className={`text-xs leading-tight truncate mt-px ${
-                activeId === "preferences"
-                  ? "text-sidebar-primary/80"
-                  : "text-sidebar-foreground opacity-70"
-              }`}
-            >
-              {accountEmail}
-            </p>
-          </div>
+          {!collapsed && (
+            <div className="flex-1 min-w-0">
+              <p
+                className={`text-sm font-medium leading-tight truncate ${
+                  activeId === "preferences"
+                    ? "text-sidebar-primary"
+                    : "text-sidebar-foreground"
+                }`}
+              >
+                {accountName}
+              </p>
+              <p
+                className={`text-xs leading-tight truncate mt-px ${
+                  activeId === "preferences"
+                    ? "text-sidebar-primary/80"
+                    : "text-sidebar-foreground opacity-70"
+                }`}
+              >
+                {accountEmail}
+              </p>
+            </div>
+          )}
         </button>
       </DropdownMenuTrigger>
 
@@ -480,9 +530,208 @@ function RecentChatSection({
   );
 }
 
+function ManagePinnedAgentsDialog({
+  open,
+  onOpenChange,
+  zeroAvatarSrc,
+  displayName,
+  subagents,
+  pinnedIds,
+  onPinnedIdsChange,
+  saving = false,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  saving?: boolean;
+  zeroAvatarSrc: string;
+  displayName: string;
+  subagents: SubagentInfo[];
+  pinnedIds: string[];
+  onPinnedIdsChange: (ids: string[]) => void;
+}) {
+  const orderedPinned = pinnedIds
+    .map((id) => subagents.find((a) => a.id === id))
+    .filter((a): a is SubagentInfo => a !== undefined);
+
+  const unpinned = subagents.filter((a) => !pinnedIds.includes(a.id));
+
+  const moveUp = (idx: number) => {
+    if (idx <= 0) return;
+    const next = [...pinnedIds];
+    [next[idx - 1], next[idx]] = [next[idx]!, next[idx - 1]!];
+    onPinnedIdsChange(next);
+  };
+
+  const moveDown = (idx: number) => {
+    if (idx >= pinnedIds.length - 1) return;
+    const next = [...pinnedIds];
+    [next[idx], next[idx + 1]] = [next[idx + 1]!, next[idx]!];
+    onPinnedIdsChange(next);
+  };
+
+  const togglePin = (agentId: string) => {
+    if (pinnedIds.includes(agentId)) {
+      onPinnedIdsChange(pinnedIds.filter((id) => id !== agentId));
+    } else if (pinnedIds.length < MAX_PINNED) {
+      onPinnedIdsChange([...pinnedIds, agentId]);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[400px] p-0 gap-0">
+        <DialogHeader className="px-5 pt-5 pb-3">
+          <div className="flex items-center gap-2">
+            <DialogTitle className="text-base font-semibold">
+              Manage pinned agents
+            </DialogTitle>
+            {saving && (
+              <IconLoader2
+                size={14}
+                className="animate-spin text-muted-foreground"
+              />
+            )}
+          </div>
+          <p className="text-sm text-muted-foreground mt-1">
+            Reorder or add agents to your sidebar (max {MAX_PINNED}).
+          </p>
+        </DialogHeader>
+
+        <div className="px-5 pb-2">
+          {/* Zero — always pinned */}
+          <div className="flex items-center gap-3 px-1 py-2.5 rounded-lg">
+            <div className="w-5 shrink-0" />
+            <img
+              src={zeroAvatarSrc}
+              alt={displayName}
+              className="h-8 w-8 shrink-0 rounded-lg object-cover object-top"
+            />
+            <span className="text-sm font-medium text-foreground flex-1 truncate">
+              {displayName}
+            </span>
+            <span className="text-xs text-muted-foreground mr-1">Main</span>
+          </div>
+        </div>
+
+        {orderedPinned.length > 0 && (
+          <div className="px-5 pb-2">
+            <div className="border-t border-border/60 mb-2" />
+            <span className="text-xs font-medium text-muted-foreground px-1">
+              Pinned
+            </span>
+            <div className="flex flex-col mt-1">
+              {orderedPinned.map((agent, idx) => (
+                <div
+                  key={agent.id}
+                  className="flex items-center gap-3 px-1 py-2 rounded-lg hover:bg-muted/50 transition-colors group"
+                >
+                  <div className="flex flex-col shrink-0 w-5 items-center gap-0.5">
+                    <button
+                      type="button"
+                      className={cn(
+                        "text-muted-foreground/40 hover:text-foreground transition-colors",
+                        idx === 0 && "invisible",
+                      )}
+                      onClick={() => moveUp(idx)}
+                      aria-label="Move up"
+                    >
+                      <IconChevronDown size={14} className="rotate-180" />
+                    </button>
+                    <button
+                      type="button"
+                      className={cn(
+                        "text-muted-foreground/40 hover:text-foreground transition-colors",
+                        idx === orderedPinned.length - 1 && "invisible",
+                      )}
+                      onClick={() => moveDown(idx)}
+                      aria-label="Move down"
+                    >
+                      <IconChevronDown size={14} />
+                    </button>
+                  </div>
+                  <img
+                    src={getAgentAvatar(agent.name)}
+                    alt={agent.displayName ?? agent.name}
+                    className="h-8 w-8 shrink-0 rounded-lg object-cover object-top"
+                  />
+                  <span className="text-sm text-foreground flex-1 truncate">
+                    {agent.displayName ?? agent.name}
+                  </span>
+                  <button
+                    type="button"
+                    className="text-muted-foreground/50 hover:text-destructive transition-colors p-1"
+                    onClick={() => togglePin(agent.id)}
+                    aria-label={`Unpin ${agent.displayName ?? agent.name}`}
+                  >
+                    <IconPlus size={14} className="rotate-45" />
+                  </button>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {unpinned.length > 0 && (
+          <div className="px-5 pb-5">
+            <div className="border-t border-border/60 mb-2" />
+            <span className="text-xs font-medium text-muted-foreground px-1">
+              Available agents
+            </span>
+            <div className="flex flex-col mt-1">
+              {unpinned.map((agent) => (
+                <div
+                  key={agent.id}
+                  className="flex items-center gap-3 px-1 py-2 rounded-lg hover:bg-muted/50 transition-colors"
+                >
+                  <div className="w-5 shrink-0" />
+                  <img
+                    src={getAgentAvatar(agent.name)}
+                    alt={agent.displayName ?? agent.name}
+                    className="h-8 w-8 shrink-0 rounded-lg object-cover object-top opacity-60"
+                  />
+                  <span className="text-sm text-muted-foreground flex-1 truncate">
+                    {agent.displayName ?? agent.name}
+                  </span>
+                  <button
+                    type="button"
+                    className={cn(
+                      "transition-colors p-1 text-xs font-medium",
+                      pinnedIds.length >= MAX_PINNED
+                        ? "text-muted-foreground/30 cursor-not-allowed"
+                        : "text-primary hover:text-primary/80",
+                    )}
+                    onClick={() => togglePin(agent.id)}
+                    disabled={pinnedIds.length >= MAX_PINNED}
+                  >
+                    Pin
+                  </button>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {subagents.length === 0 && (
+          <div className="px-5 pb-5">
+            <div className="border-t border-border/60 mb-2" />
+            <p className="text-xs text-muted-foreground px-1 py-2">
+              No sub-agents available yet.
+            </p>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
 export function ZeroSidebar({
   activeId,
   agentName,
+  zeroAvatarSrc = "/zero-avatar.png",
+  subagents = [],
+  currentChatAgentId = null,
+  collapsed = false,
+  onCollapse,
   onSelect,
   onRecentSelect,
   selectedRecentId = null,
@@ -494,7 +743,35 @@ export function ZeroSidebar({
   onResetAgent,
 }: ZeroSidebarProps) {
   const displayName = agentName || "Zero";
-  const mainNav = MAIN_NAV.map((item) => ({
+  const chatExpanded$ = useCCState(true);
+  const chatExpanded = useGet(chatExpanded$);
+  const setChatExpanded = useSet(chatExpanded$);
+  const pinnedIdsLoadable = useLastLoadable(pinnedAgentIds$);
+  const pinnedIds =
+    pinnedIdsLoadable.state === "hasData" ? pinnedIdsLoadable.data : [];
+  const savingPinned = useGet(savingPinnedAgents$);
+  const savePinnedIds = useSet(updatePinnedAgentIds$);
+  const setPinnedIds = (ids: string[]) => {
+    detach(savePinnedIds(ids), Reason.DomCallback);
+  };
+  const managePinnedOpen$ = useCCState(false);
+  const managePinnedOpen = useGet(managePinnedOpen$);
+  const setManagePinnedOpen = useSet(managePinnedOpen$);
+
+  // Resolve the selected agent label
+  const selectedAgent = currentChatAgentId
+    ? subagents.find((a) => a.id === currentChatAgentId)
+    : null;
+  const talkToLabel = selectedAgent
+    ? (selectedAgent.displayName ?? selectedAgent.name)
+    : displayName;
+
+  // Pinned agents resolved from IDs
+  const pinnedAgents = pinnedIds
+    .map((id) => subagents.find((a) => a.id === id))
+    .filter((a): a is SubagentInfo => a !== undefined);
+
+  const manageNav = MANAGE_NAV.map((item) => ({
     ...item,
     label: item.label.replace("Zero", displayName),
   }));
@@ -503,29 +780,111 @@ export function ZeroSidebar({
     label: item.label.replace("Zero", displayName),
   }));
 
+  const allNavItems = [
+    ...manageNav,
+    { id: "chat" as const, label: "New chat", icon: IconEdit as NavIcon },
+    ...footerNav.map(({ id, label, icon }) => ({ id, label, icon })),
+  ];
+
+  if (collapsed) {
+    return (
+      <VM0ClerkProvider>
+        <aside className="zero-nav flex h-full w-16 shrink-0 flex-col border-r border-sidebar-border bg-sidebar overflow-hidden transition-all duration-300">
+          {/* Expand button */}
+          <div className="shrink-0 flex items-center justify-center pt-3 pb-1">
+            <button
+              type="button"
+              className="flex h-8 w-8 items-center justify-center rounded-lg text-sidebar-foreground/70 hover:text-sidebar-foreground hover:bg-sidebar-accent transition-colors"
+              onClick={onCollapse}
+              aria-label="Expand sidebar"
+            >
+              <IconLayoutSidebarLeftCollapse size={18} className="rotate-180" />
+            </button>
+          </div>
+
+          {/* Icon-only nav */}
+          <nav className="flex-1 flex flex-col items-center gap-1 p-2">
+            <TooltipProvider delayDuration={100}>
+              {allNavItems.map(({ id, label, icon: Icon }) => (
+                <Tooltip key={id}>
+                  <TooltipTrigger asChild>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        if (id === "chat") {
+                          onSelect("chat");
+                          onNewChat?.(null);
+                        } else {
+                          onSelect(id);
+                        }
+                      }}
+                      className={`flex h-8 w-8 items-center justify-center rounded-lg transition-colors duration-200 ${
+                        activeId === id
+                          ? "bg-sidebar-active text-sidebar-primary"
+                          : "text-sidebar-foreground hover:bg-sidebar-accent"
+                      }`}
+                    >
+                      <Icon size={16} className="shrink-0" />
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent side="right">
+                    <p className="text-xs">{label}</p>
+                  </TooltipContent>
+                </Tooltip>
+              ))}
+            </TooltipProvider>
+          </nav>
+
+          {/* Account avatar */}
+          <div className="p-2 flex justify-center">
+            <AccountDropdown
+              activeId={activeId}
+              onAccountAction={onAccountAction}
+              onResetAgent={onResetAgent}
+              collapsed
+            />
+          </div>
+        </aside>
+      </VM0ClerkProvider>
+    );
+  }
+
   return (
     <VM0ClerkProvider>
-      <aside className="zero-nav flex h-full w-[255px] shrink-0 flex-col border-r border-sidebar-border bg-sidebar overflow-hidden">
+      <aside className="zero-nav flex h-full w-[255px] shrink-0 flex-col border-r border-sidebar-border bg-sidebar overflow-hidden transition-all duration-300">
         {/* Organization switcher */}
-        <div className="shrink-0 p-2 pb-1">
-          <div className="rounded-lg p-2">
-            <ClerkOrgSwitcher />
+        <div className="shrink-0 px-2 pt-1.5 pb-0">
+          <div className="flex items-center justify-between rounded-lg pr-0 py-0.5">
+            <div className="flex-1 min-w-0">
+              <ClerkOrgSwitcher />
+            </div>
+            <button
+              type="button"
+              className="flex h-7 w-7 -mr-[3px] shrink-0 items-center justify-center rounded-lg text-sidebar-foreground/70 hover:text-sidebar-foreground hover:bg-sidebar-accent transition-colors"
+              onClick={onCollapse}
+              aria-label="Collapse sidebar"
+            >
+              <IconLayoutSidebarLeftCollapse size={18} />
+            </button>
           </div>
         </div>
 
-        {/* Main nav */}
-        <nav className="flex-1 flex flex-col min-h-0 overflow-hidden p-2">
-          <div className="shrink-0 flex flex-col gap-1">
-            {mainNav.map(({ id, label, icon: Icon }) => {
-              const isActive =
-                activeId === id && !(id === "chat" && selectedRecentId);
-              return (
+        <nav className="flex-1 flex flex-col min-h-0 overflow-hidden p-2 pt-1">
+          {/* Manage section */}
+          <div className="shrink-0">
+            <div className="h-7 flex items-center pl-2">
+              <span className="text-[13px] leading-4 text-sidebar-foreground/50 font-medium">
+                Manage
+              </span>
+            </div>
+            <div className="flex flex-col gap-1">
+              {manageNav.map(({ id, label, icon: Icon }) => (
                 <button
                   key={id}
                   type="button"
                   onClick={() => onSelect(id)}
                   className={`flex w-full h-8 items-center gap-2 rounded-lg p-2 text-left text-sm leading-5 transition-colors duration-200 ${
-                    isActive
+                    activeId === id
                       ? "bg-sidebar-active text-sidebar-primary font-medium"
                       : "text-sidebar-foreground hover:bg-sidebar-accent"
                   }`}
@@ -533,8 +892,106 @@ export function ZeroSidebar({
                   <Icon size={16} className="shrink-0" />
                   <span className="truncate">{label}</span>
                 </button>
-              );
-            })}
+              ))}
+            </div>
+          </div>
+
+          {/* Chat section */}
+          <div className="shrink-0 mt-4">
+            <button
+              type="button"
+              className="flex h-7 w-full items-center gap-1 px-2 text-sidebar-foreground/50 hover:text-sidebar-foreground transition-colors"
+              onClick={() => setChatExpanded(!chatExpanded)}
+            >
+              <span className="text-[13px] font-medium truncate">
+                Talk to {talkToLabel}
+              </span>
+              <IconChevronDown
+                size={14}
+                className={`shrink-0 transition-transform ${chatExpanded ? "" : "-rotate-90"}`}
+              />
+            </button>
+            {chatExpanded && (
+              <div className="flex items-center gap-1.5 px-2 pb-1 pt-1">
+                <TooltipProvider delayDuration={300}>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <button
+                        type="button"
+                        className={`flex h-8 w-8 shrink-0 items-center justify-center rounded-lg overflow-hidden transition-all ${
+                          currentChatAgentId === null
+                            ? "bg-foreground/10"
+                            : "hover:bg-foreground/5"
+                        }`}
+                        onClick={() => onNewChat?.(null)}
+                      >
+                        <img
+                          src={zeroAvatarSrc}
+                          alt={displayName}
+                          className="h-full w-full object-cover object-top"
+                        />
+                      </button>
+                    </TooltipTrigger>
+                    <TooltipContent side="bottom" className="text-xs">
+                      {displayName}
+                    </TooltipContent>
+                  </Tooltip>
+                  {pinnedAgents.map((agent) => (
+                    <Tooltip key={agent.id}>
+                      <TooltipTrigger asChild>
+                        <button
+                          type="button"
+                          className={`flex h-8 w-8 shrink-0 items-center justify-center rounded-lg overflow-hidden transition-all ${
+                            currentChatAgentId === agent.id
+                              ? "bg-foreground/10"
+                              : "hover:bg-foreground/5"
+                          }`}
+                          onClick={() => onNewChat?.(agent.id)}
+                        >
+                          <img
+                            src={getAgentAvatar(agent.name)}
+                            alt={agent.displayName ?? agent.name}
+                            className="h-full w-full object-cover object-top"
+                          />
+                        </button>
+                      </TooltipTrigger>
+                      <TooltipContent side="bottom" className="text-xs">
+                        {agent.displayName ?? agent.name}
+                      </TooltipContent>
+                    </Tooltip>
+                  ))}
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <button
+                        type="button"
+                        className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-dashed border-sidebar-foreground/25 text-sidebar-foreground/30 hover:border-sidebar-foreground/40 hover:text-sidebar-foreground/60 transition-colors"
+                        aria-label="Manage pinned agents"
+                        onClick={() => setManagePinnedOpen(true)}
+                      >
+                        <IconPlus size={14} />
+                      </button>
+                    </TooltipTrigger>
+                    <TooltipContent side="bottom" className="text-xs">
+                      Manage pinned agents
+                    </TooltipContent>
+                  </Tooltip>
+                </TooltipProvider>
+              </div>
+            )}
+            <div className="flex flex-col gap-1 mt-1">
+              <button
+                type="button"
+                onClick={() => onSelect("chat")}
+                className={`flex w-full h-8 items-center gap-2 rounded-lg p-2 text-left text-sm leading-5 transition-colors duration-200 ${
+                  activeId === "chat" && !selectedRecentId
+                    ? "bg-sidebar-active text-sidebar-primary font-medium"
+                    : "text-sidebar-foreground hover:bg-sidebar-accent"
+                }`}
+              >
+                <IconEdit size={16} className="shrink-0" />
+                <span className="truncate">New chat</span>
+              </button>
+            </div>
           </div>
 
           {/* Recent chat sessions */}
@@ -544,7 +1001,7 @@ export function ZeroSidebar({
             recentSessionsError={recentSessionsError}
             selectedRecentId={selectedRecentId}
             onRecentSelect={onRecentSelect}
-            onNewChat={onNewChat}
+            onNewChat={() => onNewChat?.(currentChatAgentId ?? null)}
           />
         </nav>
 
@@ -585,6 +1042,18 @@ export function ZeroSidebar({
           </div>
         </div>
       </aside>
+
+      {/* Manage pinned agents dialog */}
+      <ManagePinnedAgentsDialog
+        open={managePinnedOpen}
+        onOpenChange={setManagePinnedOpen}
+        zeroAvatarSrc={zeroAvatarSrc}
+        displayName={displayName}
+        subagents={subagents}
+        pinnedIds={pinnedIds}
+        onPinnedIdsChange={setPinnedIds}
+        saving={savingPinned}
+      />
     </VM0ClerkProvider>
   );
 }

--- a/turbo/apps/platform/src/views/zero-page/zero-skill-card.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-skill-card.tsx
@@ -104,7 +104,9 @@ export function ZeroSkillCard({
                 Disconnect
               </DropdownMenuItem>
             )}
-            <DropdownMenuItem onClick={onRemove}>Remove skill</DropdownMenuItem>
+            <DropdownMenuItem onClick={onRemove}>
+              Remove connector
+            </DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>
       </div>

--- a/turbo/apps/platform/src/views/zero-page/zero-skills-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-skills-tab.tsx
@@ -75,7 +75,7 @@ export function ZeroSkillsTab({
       skillMap.get(type)?.label ??
       connectorMap.get(type as ConnectorType)?.label ??
       type;
-    toast.success(`${label} added to skills`);
+    toast.success(`${label} added to connectors`);
   };
 
   const handleRemoveSkill = (name: string) => {
@@ -84,13 +84,13 @@ export function ZeroSkillsTab({
       skillMap.get(name)?.label ??
       connectorMap.get(name as ConnectorType)?.label ??
       name;
-    toast.success(`${label} removed from skills`);
+    toast.success(`${label} removed from connectors`);
   };
 
   return (
     <div className="mx-auto max-w-[900px] px-7 flex flex-col gap-4">
       <p className="text-sm text-muted-foreground">
-        Skills manage your connections and help you get more out of these
+        Connectors manage your connections and help you get more out of these
         services.
       </p>
 
@@ -110,12 +110,12 @@ export function ZeroSkillsTab({
               />
             </span>
             <span className="text-sm font-medium text-muted-foreground group-hover:text-foreground">
-              Add skill
+              Add connector
             </span>
           </div>
           <div className="flex h-11 items-center border-t border-dashed border-border/80 px-5 group-hover:border-border">
             <span className="text-xs text-muted-foreground/70">
-              Browse 100+ popular skills
+              Browse 100+ popular connectors
             </span>
           </div>
         </button>

--- a/turbo/apps/web/app/api/agent/composes/[id]/instructions/route.ts
+++ b/turbo/apps/web/app/api/agent/composes/[id]/instructions/route.ts
@@ -167,9 +167,10 @@ export async function GET(
   // Strip any metadata the CLI may have baked in, then inject fresh metadata
   // from the compose content so it always reflects the latest agent settings.
   const rawContent = fileContent.toString("utf-8");
-  const strippedContent = stripMetadataFrontmatter(rawContent);
   const metadata = extractAgentMetadata(content);
-  const finalContent = injectMetadataFrontmatter(strippedContent, metadata);
+  const finalContent = metadata
+    ? injectMetadataFrontmatter(stripMetadataFrontmatter(rawContent), metadata)
+    : rawContent;
 
   return NextResponse.json({
     content: finalContent,

--- a/turbo/apps/web/app/api/agent/composes/[id]/instructions/route.ts
+++ b/turbo/apps/web/app/api/agent/composes/[id]/instructions/route.ts
@@ -184,11 +184,12 @@ export async function GET(
 function extractAgentMetadata(
   content: AgentComposeYaml,
 ): { displayName?: string; description?: string; sound?: string } | undefined {
-  if (!content.agents) return undefined;
+  if (!content.agents) {
+    return undefined;
+  }
   const agentKey = Object.keys(content.agents)[0];
-  if (!agentKey) return undefined;
-  const agent = content.agents[agentKey];
-  return agent?.metadata as
-    | { displayName?: string; description?: string; sound?: string }
-    | undefined;
+  if (!agentKey) {
+    return undefined;
+  }
+  return content.agents[agentKey]?.metadata;
 }

--- a/turbo/apps/web/app/api/agent/composes/[id]/instructions/route.ts
+++ b/turbo/apps/web/app/api/agent/composes/[id]/instructions/route.ts
@@ -28,7 +28,12 @@ import {
   downloadS3Buffer,
 } from "../../../../../../src/lib/s3/s3-client";
 import { env } from "../../../../../../src/env";
-import { getInstructionsStorageName, getInstructionsFilename } from "@vm0/core";
+import {
+  getInstructionsStorageName,
+  getInstructionsFilename,
+  injectMetadataFrontmatter,
+  stripMetadataFrontmatter,
+} from "@vm0/core";
 import type { AgentComposeYaml } from "../../../../../../src/types/agent-compose";
 import { extractFileFromTar } from "../../../../../../src/lib/tar";
 
@@ -159,8 +164,30 @@ export async function GET(
     });
   }
 
+  // Strip any metadata the CLI may have baked in, then inject fresh metadata
+  // from the compose content so it always reflects the latest agent settings.
+  const rawContent = fileContent.toString("utf-8");
+  const strippedContent = stripMetadataFrontmatter(rawContent);
+  const metadata = extractAgentMetadata(content);
+  const finalContent = injectMetadataFrontmatter(strippedContent, metadata);
+
   return NextResponse.json({
-    content: fileContent.toString("utf-8"),
+    content: finalContent,
     filename: instructionsFilename,
   });
+}
+
+/**
+ * Extract agent metadata from compose content for the first agent.
+ */
+function extractAgentMetadata(
+  content: AgentComposeYaml,
+): { displayName?: string; description?: string; sound?: string } | undefined {
+  if (!content.agents) return undefined;
+  const agentKey = Object.keys(content.agents)[0];
+  if (!agentKey) return undefined;
+  const agent = content.agents[agentKey];
+  return agent?.metadata as
+    | { displayName?: string; description?: string; sound?: string }
+    | undefined;
 }

--- a/turbo/apps/web/app/api/agent/composes/list/route.ts
+++ b/turbo/apps/web/app/api/agent/composes/list/route.ts
@@ -12,21 +12,25 @@ import { resolveOrg } from "../../../../../src/lib/org/resolve-org";
 import { isNotFound, isForbidden } from "../../../../../src/lib/errors";
 import { getEmailSharedAgents } from "../../../../../src/lib/agent/permission-service";
 
-function extractDisplayName(content: unknown): string | null {
+function extractMetadata(content: unknown): {
+  displayName: string | null;
+  description: string | null;
+} {
+  const empty = { displayName: null, description: null };
   if (
     content === null ||
     content === undefined ||
     typeof content !== "object"
   ) {
-    return null;
+    return empty;
   }
   const record = content as Record<string, unknown>;
   const agents = record["agents"];
   if (agents === null || agents === undefined || typeof agents !== "object") {
-    return null;
+    return empty;
   }
   const agentKeys = Object.keys(agents);
-  if (agentKeys.length === 0) return null;
+  if (agentKeys.length === 0) return empty;
   const agentsRecord = agents as Record<string, unknown>;
   const firstAgent = agentsRecord[agentKeys[0]!];
   if (
@@ -34,7 +38,7 @@ function extractDisplayName(content: unknown): string | null {
     firstAgent === undefined ||
     typeof firstAgent !== "object"
   ) {
-    return null;
+    return empty;
   }
   const agentRecord = firstAgent as Record<string, unknown>;
   const metadata = agentRecord["metadata"];
@@ -43,12 +47,18 @@ function extractDisplayName(content: unknown): string | null {
     metadata === undefined ||
     typeof metadata !== "object"
   ) {
-    return null;
+    return empty;
   }
   const metadataRecord = metadata as Record<string, unknown>;
-  const displayName = metadataRecord["displayName"];
-  if (typeof displayName !== "string") return null;
-  return displayName;
+  const displayName =
+    typeof metadataRecord["displayName"] === "string"
+      ? metadataRecord["displayName"]
+      : null;
+  const description =
+    typeof metadataRecord["description"] === "string"
+      ? metadataRecord["description"]
+      : null;
+  return { displayName, description };
 }
 
 const router = tsr.router(composesListContract, {
@@ -133,18 +143,23 @@ const router = tsr.router(composesListContract, {
 
     // Combine: own agents first, then shared agents with org/name format
     const allComposes = [
-      ...ownComposes.map((c) => ({
-        id: c.id,
-        name: c.name,
-        displayName: extractDisplayName(c.headContent),
-        headVersionId: c.headVersionId,
-        updatedAt: c.updatedAt.toISOString(),
-        isOwner: true,
-      })),
+      ...ownComposes.map((c) => {
+        const meta = extractMetadata(c.headContent);
+        return {
+          id: c.id,
+          name: c.name,
+          displayName: meta.displayName,
+          description: meta.description,
+          headVersionId: c.headVersionId,
+          updatedAt: c.updatedAt.toISOString(),
+          isOwner: true,
+        };
+      }),
       ...sharedComposes.map((c) => ({
         id: c.id,
         name: `${c.orgSlug}/${c.name}`,
         displayName: null as string | null,
+        description: null as string | null,
         headVersionId: c.headVersionId,
         updatedAt: c.updatedAt.toISOString(),
         isOwner: false,

--- a/turbo/apps/web/app/api/compose/jobs/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/compose/jobs/__tests__/route.test.ts
@@ -628,9 +628,6 @@ describe("GET /api/compose/jobs/:jobId", () => {
       const otherUser = await context.setupUser({ prefix: "other" });
       const otherCliToken = await createTestCliToken(otherUser.userId);
 
-      // Clear Clerk mock so CLI token is used for auth
-      mockClerk({ userId: null });
-
       const otherJobRequest = createTestRequest(
         "http://localhost:3000/api/compose/jobs",
         {
@@ -648,6 +645,9 @@ describe("GET /api/compose/jobs/:jobId", () => {
       const otherJobResponse = await POST(otherJobRequest);
       const otherJobData = await otherJobResponse.json();
       const otherJobId = otherJobData.jobId;
+
+      // Clear Clerk mock so CLI token is used for auth
+      mockClerk({ userId: null });
 
       // Try to access the other user's job with original user's token
       // Clerk is null, so testUserCliToken will be used for auth

--- a/turbo/apps/web/app/api/compose/jobs/route.ts
+++ b/turbo/apps/web/app/api/compose/jobs/route.ts
@@ -7,7 +7,8 @@ import { composeJobsMainContract } from "@vm0/core";
 import { initServices } from "../../../../src/lib/init-services";
 import { composeJobs } from "../../../../src/db/schema/compose-job";
 import { eq } from "drizzle-orm";
-import { getUserId } from "../../../../src/lib/auth/get-user-id";
+import { getAuthContext } from "../../../../src/lib/auth/get-user-id";
+import { resolveOrg } from "../../../../src/lib/org/resolve-org";
 import { logger } from "../../../../src/lib/logger";
 import { triggerComposeJob } from "../../../../src/lib/compose/trigger-compose-job";
 import type { ComposeJobResult } from "../../../../src/db/schema/compose-job";
@@ -45,8 +46,8 @@ const router = tsr.router(composeJobsMainContract, {
   create: async ({ body, headers }) => {
     initServices();
 
-    const userId = await getUserId(headers.authorization);
-    if (!userId) {
+    const authCtx = await getAuthContext(headers.authorization);
+    if (!authCtx) {
       return {
         status: 401 as const,
         body: {
@@ -54,6 +55,10 @@ const router = tsr.router(composeJobsMainContract, {
         },
       };
     }
+    const { userId, orgId: tokenOrgId } = authCtx;
+
+    // Resolve the caller's org so the CLI token carries the correct orgId
+    const { org } = await resolveOrg(userId, null, null, tokenOrgId);
 
     // Dispatch based on input type: GitHub URL or platform content
     const isGitHubInput = "githubUrl" in body;
@@ -61,12 +66,14 @@ const router = tsr.router(composeJobsMainContract, {
     const result = isGitHubInput
       ? await triggerComposeJob({
           userId,
+          orgId: org.orgId,
           source: "github",
           githubUrl: body.githubUrl,
           overwrite: body.overwrite,
         })
       : await triggerComposeJob({
           userId,
+          orgId: org.orgId,
           source: "platform",
           content: body.content,
           instructions: body.instructions,

--- a/turbo/apps/web/app/api/onboarding/status/route.ts
+++ b/turbo/apps/web/app/api/onboarding/status/route.ts
@@ -33,8 +33,11 @@ const router = tsr.router(onboardingStatusContract, {
     let hasDefaultAgent = false;
     let defaultAgentName: string | null = null;
     let defaultAgentComposeId: string | null = null;
-    let defaultAgentMetadata: { displayName?: string; sound?: string } | null =
-      null;
+    let defaultAgentMetadata: {
+      displayName?: string;
+      description?: string;
+      sound?: string;
+    } | null = null;
 
     try {
       const { org: resolvedOrg } = await resolveOrg(userId);

--- a/turbo/apps/web/app/api/platform/logs/[id]/route.ts
+++ b/turbo/apps/web/app/api/platform/logs/[id]/route.ts
@@ -15,8 +15,10 @@ import {
   agentComposes,
   agentComposeVersions,
 } from "../../../../../src/db/schema/agent-compose";
-import { getUserId } from "../../../../../src/lib/auth/get-user-id";
-import { eq } from "drizzle-orm";
+import { getAuthContext } from "../../../../../src/lib/auth/get-user-id";
+import { resolveOrg } from "../../../../../src/lib/org/resolve-org";
+import { isNotFound, isForbidden } from "../../../../../src/lib/errors";
+import { eq, and } from "drizzle-orm";
 
 interface RunResult {
   checkpointId?: string;
@@ -103,15 +105,33 @@ function notFoundResponse() {
 }
 
 const router = tsr.router(platformLogsByIdContract, {
-  getById: async ({ params }) => {
+  getById: async ({ params, headers }) => {
     initServices();
 
-    const userId = await getUserId();
-    if (!userId) {
+    const authCtx = await getAuthContext(headers.authorization);
+    if (!authCtx) {
       return unauthorizedResponse();
     }
+    const { userId, orgId: tokenOrgId } = authCtx;
 
-    // Query run with compose info
+    // Resolve active org from JWT / CLI token / default
+    let orgId: string;
+    try {
+      const { org: resolvedOrg } = await resolveOrg(
+        userId,
+        undefined,
+        undefined,
+        tokenOrgId,
+      );
+      orgId = resolvedOrg.orgId;
+    } catch (error) {
+      if (isNotFound(error) || isForbidden(error)) {
+        return notFoundResponse();
+      }
+      throw error;
+    }
+
+    // Query run scoped to current user + active org
     const [result] = await globalThis.services.db
       .select({
         run: agentRuns,
@@ -119,18 +139,24 @@ const router = tsr.router(platformLogsByIdContract, {
         composeVersion: agentComposeVersions,
       })
       .from(agentRuns)
-      .leftJoin(
+      .innerJoin(
         agentComposeVersions,
         eq(agentRuns.agentComposeVersionId, agentComposeVersions.id),
       )
-      .leftJoin(
+      .innerJoin(
         agentComposes,
         eq(agentComposeVersions.composeId, agentComposes.id),
       )
-      .where(eq(agentRuns.id, params.id))
+      .where(
+        and(
+          eq(agentRuns.id, params.id),
+          eq(agentRuns.userId, userId),
+          eq(agentComposes.orgId, orgId),
+        ),
+      )
       .limit(1);
 
-    if (!result || result.run.userId !== userId) {
+    if (!result) {
       return notFoundResponse();
     }
 

--- a/turbo/apps/web/app/api/user/preferences/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/user/preferences/__tests__/route.test.ts
@@ -525,4 +525,148 @@ describe("PUT /api/user/preferences", () => {
 
     expect(response.status).toBe(400);
   });
+
+  it("should update pinnedAgentIds successfully", async () => {
+    const user = await context.setupUser();
+    mockClerk({ userId: user.userId, orgId: user.orgId });
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/user/preferences",
+      {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ pinnedAgentIds: ["agent-1", "agent-2"] }),
+      },
+    );
+    const response = await PUT(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.pinnedAgentIds).toEqual(["agent-1", "agent-2"]);
+  });
+
+  it("should return empty pinnedAgentIds by default", async () => {
+    const user = await context.setupUser();
+    mockClerk({ userId: user.userId, orgId: user.orgId });
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/user/preferences",
+    );
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.pinnedAgentIds).toEqual([]);
+  });
+
+  it("should persist pinnedAgentIds across GET after PUT", async () => {
+    const user = await context.setupUser();
+    mockClerk({ userId: user.userId, orgId: user.orgId });
+
+    // Update pinnedAgentIds
+    const putRequest = createTestRequest(
+      "http://localhost:3000/api/user/preferences",
+      {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          pinnedAgentIds: ["agent-a", "agent-b", "agent-c"],
+        }),
+      },
+    );
+    await PUT(putRequest);
+
+    // Clear JWT claims so it falls back to cache
+    vi.mocked(auth).mockResolvedValue({
+      userId: user.userId,
+      orgId: user.orgId,
+      sessionClaims: {},
+    } as Awaited<ReturnType<typeof auth>>);
+
+    const getRequest = createTestRequest(
+      "http://localhost:3000/api/user/preferences",
+    );
+    const response = await GET(getRequest);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.pinnedAgentIds).toEqual(["agent-a", "agent-b", "agent-c"]);
+  });
+
+  it("should enforce max 4 pinned agents", async () => {
+    const user = await context.setupUser();
+    mockClerk({ userId: user.userId, orgId: user.orgId });
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/user/preferences",
+      {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          pinnedAgentIds: ["a1", "a2", "a3", "a4", "a5"],
+        }),
+      },
+    );
+    const response = await PUT(request);
+
+    expect(response.status).toBe(400);
+  });
+
+  it("should update pinnedAgentIds without affecting other preferences", async () => {
+    const user = await context.setupUser();
+    mockClerk({ userId: user.userId, orgId: user.orgId });
+
+    // Set timezone first
+    const setupReq = createTestRequest(
+      "http://localhost:3000/api/user/preferences",
+      {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ timezone: "America/New_York" }),
+      },
+    );
+    await PUT(setupReq);
+
+    // Update only pinnedAgentIds
+    const request = createTestRequest(
+      "http://localhost:3000/api/user/preferences",
+      {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ pinnedAgentIds: ["agent-x"] }),
+      },
+    );
+    const response = await PUT(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.pinnedAgentIds).toEqual(["agent-x"]);
+    expect(data.timezone).toBe("America/New_York");
+  });
+
+  it("should dual-write pinnedAgentIds to Clerk membership metadata", async () => {
+    const user = await context.setupUser();
+    mockClerk({ userId: user.userId, orgId: user.orgId });
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/user/preferences",
+      {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ pinnedAgentIds: ["agent-1", "agent-2"] }),
+      },
+    );
+    const response = await PUT(request);
+    expect(response.status).toBe(200);
+
+    const client = await vi.mocked(clerkClient)();
+    expect(
+      client.organizations.updateOrganizationMembershipMetadata,
+    ).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: user.userId,
+        publicMetadata: { pinned_agent_ids: ["agent-1", "agent-2"] },
+      }),
+    );
+  });
 });

--- a/turbo/apps/web/app/api/user/preferences/route.ts
+++ b/turbo/apps/web/app/api/user/preferences/route.ts
@@ -44,6 +44,7 @@ const router = tsr.router(userPreferencesContract, {
         timezone: prefs.timezone,
         notifyEmail: prefs.notifyEmail,
         notifySlack: prefs.notifySlack,
+        pinnedAgentIds: prefs.pinnedAgentIds,
       },
     };
   },
@@ -74,6 +75,7 @@ const router = tsr.router(userPreferencesContract, {
         timezone: body.timezone,
         notifyEmail: body.notifyEmail,
         notifySlack: body.notifySlack,
+        pinnedAgentIds: body.pinnedAgentIds,
       });
 
       return {
@@ -82,6 +84,7 @@ const router = tsr.router(userPreferencesContract, {
           timezone: prefs.timezone,
           notifyEmail: prefs.notifyEmail,
           notifySlack: prefs.notifySlack,
+          pinnedAgentIds: prefs.pinnedAgentIds,
         },
       };
     } catch (error) {

--- a/turbo/apps/web/app/api/webhooks/compose/complete/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/compose/complete/__tests__/route.test.ts
@@ -472,7 +472,6 @@ describe("POST /api/webhooks/compose/complete", () => {
 
       // Create a compose job for this user
       const cliToken = await createTestCliToken(userLink.vm0UserId);
-      mockClerk({ userId: null });
 
       const createRequest = createTestRequest(
         "http://localhost:3000/api/compose/jobs",
@@ -490,6 +489,8 @@ describe("POST /api/webhooks/compose/complete", () => {
       const createResponse = await createComposeJob(createRequest);
       const createData = await createResponse.json();
       const jobId = createData.jobId;
+
+      mockClerk({ userId: null });
 
       // Insert slack_compose_requests record (simulating what the Slack handler does)
       await createTestSlackComposeRequest({

--- a/turbo/apps/web/src/db/migrations/0137_add_pinned_agent_ids.sql
+++ b/turbo/apps/web/src/db/migrations/0137_add_pinned_agent_ids.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "org_members_cache" ADD COLUMN "pinned_agent_ids" jsonb DEFAULT '[]'::jsonb;

--- a/turbo/apps/web/src/db/migrations/meta/0137_snapshot.json
+++ b/turbo/apps/web/src/db/migrations/meta/0137_snapshot.json
@@ -1,0 +1,5200 @@
+{
+  "id": "19c5ecf8-568e-431b-a214-2eaf65d6594a",
+  "prevId": "44c365a9-6b39-4dfa-988d-7d9a0ff6062d",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.agent_compose_versions": {
+      "name": "agent_compose_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "compose_id": {
+          "name": "compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_compose_versions_compose_id": {
+          "name": "idx_agent_compose_versions_compose_id",
+          "columns": [
+            {
+              "expression": "compose_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_compose_versions_compose_id_agent_composes_id_fk": {
+          "name": "agent_compose_versions_compose_id_agent_composes_id_fk",
+          "tableFrom": "agent_compose_versions",
+          "tableTo": "agent_composes",
+          "columnsFrom": ["compose_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_composes": {
+      "name": "agent_composes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "head_version_id": {
+          "name": "head_version_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_composes_org": {
+          "name": "idx_agent_composes_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_composes_org_name": {
+          "name": "idx_agent_composes_org_name",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_permissions": {
+      "name": "agent_permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "agent_compose_id": {
+          "name": "agent_compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grantee_type": {
+          "name": "grantee_type",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grantee_email": {
+          "name": "grantee_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "permission": {
+          "name": "permission",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'run_view'"
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_permissions_compose": {
+          "name": "idx_agent_permissions_compose",
+          "columns": [
+            {
+              "expression": "agent_compose_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_permissions_email": {
+          "name": "idx_agent_permissions_email",
+          "columns": [
+            {
+              "expression": "grantee_email",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "grantee_email IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_permissions_agent_compose_id_agent_composes_id_fk": {
+          "name": "agent_permissions_agent_compose_id_agent_composes_id_fk",
+          "tableFrom": "agent_permissions",
+          "tableTo": "agent_composes",
+          "columnsFrom": ["agent_compose_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "agent_permissions_compose_type_email_unique": {
+          "name": "agent_permissions_compose_type_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["agent_compose_id", "grantee_type", "grantee_email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_run_callbacks": {
+      "name": "agent_run_callbacks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_secret": {
+          "name": "encrypted_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_attempt_at": {
+          "name": "last_attempt_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_run_callbacks_run_id": {
+          "name": "idx_agent_run_callbacks_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_run_callbacks_pending": {
+          "name": "idx_agent_run_callbacks_pending",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "status = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_run_callbacks_run_id_agent_runs_id_fk": {
+          "name": "agent_run_callbacks_run_id_agent_runs_id_fk",
+          "tableFrom": "agent_run_callbacks",
+          "tableTo": "agent_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_run_events": {
+      "name": "agent_run_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence_number": {
+          "name": "sequence_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_data": {
+          "name": "event_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_run_events_run_id_agent_runs_id_fk": {
+          "name": "agent_run_events_run_id_agent_runs_id_fk",
+          "tableFrom": "agent_run_events",
+          "tableTo": "agent_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_run_queue": {
+      "name": "agent_run_queue",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_params": {
+          "name": "encrypted_params",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "agent_run_queue_user_created_idx": {
+          "name": "agent_run_queue_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_run_queue_expires_at_idx": {
+          "name": "agent_run_queue_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_run_queue_run_id_agent_runs_id_fk": {
+          "name": "agent_run_queue_run_id_agent_runs_id_fk",
+          "tableFrom": "agent_run_queue",
+          "tableTo": "agent_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_runs": {
+      "name": "agent_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_compose_version_id": {
+          "name": "agent_compose_version_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resumed_from_checkpoint_id": {
+          "name": "resumed_from_checkpoint_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "continued_from_session_id": {
+          "name": "continued_from_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vars": {
+          "name": "vars",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "secret_names": {
+          "name": "secret_names",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_heartbeat_at": {
+          "name": "last_heartbeat_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_agent_runs_user_created": {
+          "name": "idx_agent_runs_user_created",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_runs_org": {
+          "name": "idx_agent_runs_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_runs_status_heartbeat": {
+          "name": "idx_agent_runs_status_heartbeat",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_heartbeat_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_runs_running_heartbeat": {
+          "name": "idx_agent_runs_running_heartbeat",
+          "columns": [
+            {
+              "expression": "last_heartbeat_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "status = 'running'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_runs_schedule_created": {
+          "name": "idx_agent_runs_schedule_created",
+          "columns": [
+            {
+              "expression": "schedule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "schedule_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_runs_agent_compose_version_id_agent_compose_versions_id_fk": {
+          "name": "agent_runs_agent_compose_version_id_agent_compose_versions_id_fk",
+          "tableFrom": "agent_runs",
+          "tableTo": "agent_compose_versions",
+          "columnsFrom": ["agent_compose_version_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "agent_runs_schedule_id_agent_schedules_id_fk": {
+          "name": "agent_runs_schedule_id_agent_schedules_id_fk",
+          "tableFrom": "agent_runs",
+          "tableTo": "agent_schedules",
+          "columnsFrom": ["schedule_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_schedules": {
+      "name": "agent_schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "compose_id": {
+          "name": "compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_type": {
+          "name": "trigger_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'cron'"
+        },
+        "cron_expression": {
+          "name": "cron_expression",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "at_time": {
+          "name": "at_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "interval_seconds": {
+          "name": "interval_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vars": {
+          "name": "vars",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_secrets": {
+          "name": "encrypted_secrets",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artifact_name": {
+          "name": "artifact_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artifact_version": {
+          "name": "artifact_version",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "volume_versions": {
+          "name": "volume_versions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_run_id": {
+          "name": "last_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retry_started_at": {
+          "name": "retry_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consecutive_failures": {
+          "name": "consecutive_failures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_schedules_compose": {
+          "name": "idx_agent_schedules_compose",
+          "columns": [
+            {
+              "expression": "compose_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_schedules_org": {
+          "name": "idx_agent_schedules_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_schedules_compose_name_org_user": {
+          "name": "idx_agent_schedules_compose_name_org_user",
+          "columns": [
+            {
+              "expression": "compose_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_schedules_next_run": {
+          "name": "idx_agent_schedules_next_run",
+          "columns": [
+            {
+              "expression": "next_run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "enabled = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_schedules_compose_id_agent_composes_id_fk": {
+          "name": "agent_schedules_compose_id_agent_composes_id_fk",
+          "tableFrom": "agent_schedules",
+          "tableTo": "agent_composes",
+          "columnsFrom": ["compose_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_schedules_last_run_id_agent_runs_id_fk": {
+          "name": "agent_schedules_last_run_id_agent_runs_id_fk",
+          "tableFrom": "agent_schedules",
+          "tableTo": "agent_runs",
+          "columnsFrom": ["last_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_sessions": {
+      "name": "agent_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_compose_id": {
+          "name": "agent_compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artifact_name": {
+          "name": "artifact_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_name": {
+          "name": "memory_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chat_messages": {
+          "name": "chat_messages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_sessions_user_compose_artifact": {
+          "name": "idx_agent_sessions_user_compose_artifact",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_compose_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "artifact_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_sessions_agent_compose_id_agent_composes_id_fk": {
+          "name": "agent_sessions_agent_compose_id_agent_composes_id_fk",
+          "tableFrom": "agent_sessions",
+          "tableTo": "agent_composes",
+          "columnsFrom": ["agent_compose_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_sessions_conversation_id_conversations_id_fk": {
+          "name": "agent_sessions_conversation_id_conversations_id_fk",
+          "tableFrom": "agent_sessions",
+          "tableTo": "conversations",
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blobs": {
+      "name": "blobs",
+      "schema": "",
+      "columns": {
+        "hash": {
+          "name": "hash",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref_count": {
+          "name": "ref_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_blobs_ref_count": {
+          "name": "idx_blobs_ref_count",
+          "columns": [
+            {
+              "expression": "ref_count",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.checkpoints": {
+      "name": "checkpoints",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_compose_snapshot": {
+          "name": "agent_compose_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_snapshot": {
+          "name": "artifact_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_snapshot": {
+          "name": "memory_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "volume_versions_snapshot": {
+          "name": "volume_versions_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "checkpoints_run_id_agent_runs_id_fk": {
+          "name": "checkpoints_run_id_agent_runs_id_fk",
+          "tableFrom": "checkpoints",
+          "tableTo": "agent_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "checkpoints_conversation_id_conversations_id_fk": {
+          "name": "checkpoints_conversation_id_conversations_id_fk",
+          "tableFrom": "checkpoints",
+          "tableTo": "conversations",
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "checkpoints_run_id_unique": {
+          "name": "checkpoints_run_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["run_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cli_tokens": {
+      "name": "cli_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cli_tokens_token_unique": {
+          "name": "cli_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.compose_jobs": {
+      "name": "compose_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_url": {
+          "name": "github_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "overwrite": {
+          "name": "overwrite",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'github'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_compose_jobs_user_status": {
+          "name": "idx_compose_jobs_user_status",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_compose_jobs_created": {
+          "name": "idx_compose_jobs_created",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_compose_jobs_user_active": {
+          "name": "idx_compose_jobs_user_active",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status IN ('pending', 'running')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.connector_sessions": {
+      "name": "connector_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(9)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "connector_session_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_connector_sessions_code": {
+          "name": "idx_connector_sessions_code",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_connector_sessions_user_status": {
+          "name": "idx_connector_sessions_user_status",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.connectors": {
+      "name": "connectors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_method": {
+          "name": "auth_method",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_username": {
+          "name": "external_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_email": {
+          "name": "external_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_scopes": {
+          "name": "oauth_scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_connectors_org": {
+          "name": "idx_connectors_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_connectors_org_user_type": {
+          "name": "idx_connectors_org_user_type",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversations": {
+      "name": "conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cli_agent_type": {
+          "name": "cli_agent_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cli_agent_session_id": {
+          "name": "cli_agent_session_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cli_agent_session_history": {
+          "name": "cli_agent_session_history",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cli_agent_session_history_hash": {
+          "name": "cli_agent_session_history_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "conversations_run_id_agent_runs_id_fk": {
+          "name": "conversations_run_id_agent_runs_id_fk",
+          "tableFrom": "conversations",
+          "tableTo": "agent_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "conversations_run_id_unique": {
+          "name": "conversations_run_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["run_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.device_codes": {
+      "name": "device_codes",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "varchar(9)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "device_code_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_outbox": {
+      "name": "email_outbox",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "from_address": {
+          "name": "from_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_addresses": {
+          "name": "to_addresses",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cc_addresses": {
+          "name": "cc_addresses",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reply_to": {
+          "name": "reply_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headers": {
+          "name": "headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "template": {
+          "name": "template",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_send_action": {
+          "name": "post_send_action",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_retry_at": {
+          "name": "next_retry_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resend_id": {
+          "name": "resend_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_outbox_drain_idx": {
+          "name": "email_outbox_drain_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_retry_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_outbox_created_at_idx": {
+          "name": "email_outbox_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_reply_requests": {
+      "name": "email_reply_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_thread_session_id": {
+          "name": "email_thread_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inbound_email_id": {
+          "name": "inbound_email_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inbound_message_id": {
+          "name": "inbound_message_id",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_email_reply_requests_run": {
+          "name": "idx_email_reply_requests_run",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_reply_requests_run_id_agent_runs_id_fk": {
+          "name": "email_reply_requests_run_id_agent_runs_id_fk",
+          "tableFrom": "email_reply_requests",
+          "tableTo": "agent_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "email_reply_requests_email_thread_session_id_email_thread_sessions_id_fk": {
+          "name": "email_reply_requests_email_thread_session_id_email_thread_sessions_id_fk",
+          "tableFrom": "email_reply_requests",
+          "tableTo": "email_thread_sessions",
+          "columnsFrom": ["email_thread_session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_thread_sessions": {
+      "name": "email_thread_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "compose_id": {
+          "name": "compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_session_id": {
+          "name": "agent_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_email_message_id": {
+          "name": "last_email_message_id",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_to_token": {
+          "name": "reply_to_token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_email_thread_sessions_reply_token": {
+          "name": "idx_email_thread_sessions_reply_token",
+          "columns": [
+            {
+              "expression": "reply_to_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_email_thread_sessions_user": {
+          "name": "idx_email_thread_sessions_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_thread_sessions_compose_id_agent_composes_id_fk": {
+          "name": "email_thread_sessions_compose_id_agent_composes_id_fk",
+          "tableFrom": "email_thread_sessions",
+          "tableTo": "agent_composes",
+          "columnsFrom": ["compose_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "email_thread_sessions_agent_session_id_agent_sessions_id_fk": {
+          "name": "email_thread_sessions_agent_session_id_agent_sessions_id_fk",
+          "tableFrom": "email_thread_sessions",
+          "tableTo": "agent_sessions",
+          "columnsFrom": ["agent_session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.export_jobs": {
+      "name": "export_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artifact_urls": {
+          "name": "artifact_urls",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_export_jobs_user_status": {
+          "name": "idx_export_jobs_user_status",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_export_jobs_created": {
+          "name": "idx_export_jobs_created",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_export_jobs_user_active": {
+          "name": "idx_export_jobs_user_active",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status IN ('pending', 'running')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_installations": {
+      "name": "github_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_access_token": {
+          "name": "encrypted_access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_name": {
+          "name": "target_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "admin_github_user_id": {
+          "name": "admin_github_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_compose_id": {
+          "name": "default_compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_configs": {
+          "name": "repo_configs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "github_installations_installation_id_unique": {
+          "name": "github_installations_installation_id_unique",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "installation_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_installations_default_compose_id_agent_composes_id_fk": {
+          "name": "github_installations_default_compose_id_agent_composes_id_fk",
+          "tableFrom": "github_installations",
+          "tableTo": "agent_composes",
+          "columnsFrom": ["default_compose_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_issue_sessions": {
+      "name": "github_issue_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo": {
+          "name": "repo",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_number": {
+          "name": "issue_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_session_id": {
+          "name": "agent_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_comment_id": {
+          "name": "last_comment_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_github_issue_sessions_installation_repo_issue": {
+          "name": "idx_github_issue_sessions_installation_repo_issue",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "repo",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "issue_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_github_issue_sessions_installation": {
+          "name": "idx_github_issue_sessions_installation",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_issue_sessions_installation_id_github_installations_id_fk": {
+          "name": "github_issue_sessions_installation_id_github_installations_id_fk",
+          "tableFrom": "github_issue_sessions",
+          "tableTo": "github_installations",
+          "columnsFrom": ["installation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_issue_sessions_agent_session_id_agent_sessions_id_fk": {
+          "name": "github_issue_sessions_agent_session_id_agent_sessions_id_fk",
+          "tableFrom": "github_issue_sessions",
+          "tableTo": "agent_sessions",
+          "columnsFrom": ["agent_session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_user_links": {
+      "name": "github_user_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "github_user_id": {
+          "name": "github_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vm0_user_id": {
+          "name": "vm0_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_github_user_links_user_installation": {
+          "name": "idx_github_user_links_user_installation",
+          "columns": [
+            {
+              "expression": "github_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_user_links_installation_id_github_installations_id_fk": {
+          "name": "github_user_links_installation_id_github_installations_id_fk",
+          "tableFrom": "github_user_links",
+          "tableTo": "github_installations",
+          "columnsFrom": ["installation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_providers": {
+      "name": "model_providers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_id": {
+          "name": "secret_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_method": {
+          "name": "auth_method",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "selected_model": {
+          "name": "selected_model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_model_providers_secret": {
+          "name": "idx_model_providers_secret",
+          "columns": [
+            {
+              "expression": "secret_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_model_providers_org": {
+          "name": "idx_model_providers_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_model_providers_org_user_type": {
+          "name": "idx_model_providers_org_user_type",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "model_providers_secret_id_secrets_id_fk": {
+          "name": "model_providers_secret_id_secrets_id_fk",
+          "tableFrom": "model_providers",
+          "tableTo": "secrets",
+          "columnsFrom": ["secret_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_cache": {
+      "name": "org_cache",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tier": {
+          "name": "tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "cached_at": {
+          "name": "cached_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_org_cache_slug": {
+          "name": "idx_org_cache_slug",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_members_cache": {
+      "name": "org_members_cache",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notify_email": {
+          "name": "notify_email",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "notify_slack": {
+          "name": "notify_slack",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "cached_at": {
+          "name": "cached_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "pinned_agent_ids": {
+          "name": "pinned_agent_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "org_members_cache_org_id_user_id_pk": {
+          "name": "org_members_cache_org_id_user_id_pk",
+          "columns": ["org_id", "user_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runner_job_queue": {
+      "name": "runner_job_queue",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "runner_group": {
+          "name": "runner_group",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_context": {
+          "name": "execution_context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "runner_job_queue_group_unclaimed_idx": {
+          "name": "runner_job_queue_group_unclaimed_idx",
+          "columns": [
+            {
+              "expression": "runner_group",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "claimed_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runner_job_queue_expires_at_idx": {
+          "name": "runner_job_queue_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "runner_job_queue_run_id_agent_runs_id_fk": {
+          "name": "runner_job_queue_run_id_agent_runs_id_fk",
+          "tableFrom": "runner_job_queue",
+          "tableTo": "agent_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sandbox_telemetry": {
+      "name": "sandbox_telemetry",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_sandbox_telemetry_run_id": {
+          "name": "idx_sandbox_telemetry_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sandbox_telemetry_run_id_agent_runs_id_fk": {
+          "name": "sandbox_telemetry_run_id_agent_runs_id_fk",
+          "tableFrom": "sandbox_telemetry",
+          "tableTo": "agent_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.secrets": {
+      "name": "secrets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_value": {
+          "name": "encrypted_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_secrets_type": {
+          "name": "idx_secrets_type",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_secrets_org": {
+          "name": "idx_secrets_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_secrets_org_user_name_type": {
+          "name": "idx_secrets_org_user_name_type",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_compose_requests": {
+      "name": "slack_compose_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "compose_job_id": {
+          "name": "compose_job_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_workspace_id": {
+          "name": "slack_workspace_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_user_id": {
+          "name": "slack_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_channel_id": {
+          "name": "slack_channel_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_slack_compose_requests_job": {
+          "name": "idx_slack_compose_requests_job",
+          "columns": [
+            {
+              "expression": "compose_job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "slack_compose_requests_compose_job_id_compose_jobs_id_fk": {
+          "name": "slack_compose_requests_compose_job_id_compose_jobs_id_fk",
+          "tableFrom": "slack_compose_requests",
+          "tableTo": "compose_jobs",
+          "columnsFrom": ["compose_job_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_installations": {
+      "name": "slack_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slack_workspace_id": {
+          "name": "slack_workspace_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_workspace_name": {
+          "name": "slack_workspace_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_bot_token": {
+          "name": "encrypted_bot_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bot_user_id": {
+          "name": "bot_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_compose_id": {
+          "name": "default_compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "admin_slack_user_id": {
+          "name": "admin_slack_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "slack_installations_default_compose_id_agent_composes_id_fk": {
+          "name": "slack_installations_default_compose_id_agent_composes_id_fk",
+          "tableFrom": "slack_installations",
+          "tableTo": "agent_composes",
+          "columnsFrom": ["default_compose_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "slack_installations_slack_workspace_id_unique": {
+          "name": "slack_installations_slack_workspace_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slack_workspace_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_org_connections": {
+      "name": "slack_org_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slack_user_id": {
+          "name": "slack_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_workspace_id": {
+          "name": "slack_workspace_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vm0_user_id": {
+          "name": "vm0_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dm_welcome_sent": {
+          "name": "dm_welcome_sent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_slack_org_connections_user_workspace": {
+          "name": "idx_slack_org_connections_user_workspace",
+          "columns": [
+            {
+              "expression": "slack_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slack_workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_slack_org_connections_workspace": {
+          "name": "idx_slack_org_connections_workspace",
+          "columns": [
+            {
+              "expression": "slack_workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_slack_org_connections_vm0_user_org": {
+          "name": "idx_slack_org_connections_vm0_user_org",
+          "columns": [
+            {
+              "expression": "vm0_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "slack_org_connections_slack_workspace_id_slack_org_installations_slack_workspace_id_fk": {
+          "name": "slack_org_connections_slack_workspace_id_slack_org_installations_slack_workspace_id_fk",
+          "tableFrom": "slack_org_connections",
+          "tableTo": "slack_org_installations",
+          "columnsFrom": ["slack_workspace_id"],
+          "columnsTo": ["slack_workspace_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_org_installations": {
+      "name": "slack_org_installations",
+      "schema": "",
+      "columns": {
+        "slack_workspace_id": {
+          "name": "slack_workspace_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slack_workspace_name": {
+          "name": "slack_workspace_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_bot_token": {
+          "name": "encrypted_bot_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bot_user_id": {
+          "name": "bot_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installed_by_user_id": {
+          "name": "installed_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_slack_org_installations_org": {
+          "name": "idx_slack_org_installations_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_slack_org_installations_org_unique": {
+          "name": "idx_slack_org_installations_org_unique",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "org_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_org_pending_questions": {
+      "name": "slack_org_pending_questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_workspace_id": {
+          "name": "slack_workspace_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_channel_id": {
+          "name": "slack_channel_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_thread_ts": {
+          "name": "slack_thread_ts",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_message_ts": {
+          "name": "slack_message_ts",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "compose_id": {
+          "name": "compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "questions": {
+          "name": "questions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "answered_at": {
+          "name": "answered_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_slack_org_pending_questions_run_id": {
+          "name": "idx_slack_org_pending_questions_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "slack_org_pending_questions_connection_id_slack_org_connections_id_fk": {
+          "name": "slack_org_pending_questions_connection_id_slack_org_connections_id_fk",
+          "tableFrom": "slack_org_pending_questions",
+          "tableTo": "slack_org_connections",
+          "columnsFrom": ["connection_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "slack_org_pending_questions_compose_id_agent_composes_id_fk": {
+          "name": "slack_org_pending_questions_compose_id_agent_composes_id_fk",
+          "tableFrom": "slack_org_pending_questions",
+          "tableTo": "agent_composes",
+          "columnsFrom": ["compose_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "slack_org_pending_questions_session_id_agent_sessions_id_fk": {
+          "name": "slack_org_pending_questions_session_id_agent_sessions_id_fk",
+          "tableFrom": "slack_org_pending_questions",
+          "tableTo": "agent_sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_org_thread_sessions": {
+      "name": "slack_org_thread_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_channel_id": {
+          "name": "slack_channel_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_thread_ts": {
+          "name": "slack_thread_ts",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_session_id": {
+          "name": "agent_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_processed_message_ts": {
+          "name": "last_processed_message_ts",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_slack_org_thread_sessions_conn_channel_thread": {
+          "name": "idx_slack_org_thread_sessions_conn_channel_thread",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slack_channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slack_thread_ts",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_slack_org_thread_sessions_connection": {
+          "name": "idx_slack_org_thread_sessions_connection",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "slack_org_thread_sessions_connection_id_slack_org_connections_id_fk": {
+          "name": "slack_org_thread_sessions_connection_id_slack_org_connections_id_fk",
+          "tableFrom": "slack_org_thread_sessions",
+          "tableTo": "slack_org_connections",
+          "columnsFrom": ["connection_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "slack_org_thread_sessions_agent_session_id_agent_sessions_id_fk": {
+          "name": "slack_org_thread_sessions_agent_session_id_agent_sessions_id_fk",
+          "tableFrom": "slack_org_thread_sessions",
+          "tableTo": "agent_sessions",
+          "columnsFrom": ["agent_session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_pending_questions": {
+      "name": "slack_pending_questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_workspace_id": {
+          "name": "slack_workspace_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_channel_id": {
+          "name": "slack_channel_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_thread_ts": {
+          "name": "slack_thread_ts",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_message_ts": {
+          "name": "slack_message_ts",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_link_id": {
+          "name": "user_link_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "compose_id": {
+          "name": "compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "questions": {
+          "name": "questions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "answered_at": {
+          "name": "answered_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_slack_pending_questions_run_id": {
+          "name": "idx_slack_pending_questions_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_thread_sessions": {
+      "name": "slack_thread_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slack_user_link_id": {
+          "name": "slack_user_link_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_channel_id": {
+          "name": "slack_channel_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_thread_ts": {
+          "name": "slack_thread_ts",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_session_id": {
+          "name": "agent_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_processed_message_ts": {
+          "name": "last_processed_message_ts",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_slack_thread_sessions_thread_user_link": {
+          "name": "idx_slack_thread_sessions_thread_user_link",
+          "columns": [
+            {
+              "expression": "slack_user_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slack_channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slack_thread_ts",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_slack_thread_sessions_user_link": {
+          "name": "idx_slack_thread_sessions_user_link",
+          "columns": [
+            {
+              "expression": "slack_user_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "slack_thread_sessions_slack_user_link_id_slack_user_links_id_fk": {
+          "name": "slack_thread_sessions_slack_user_link_id_slack_user_links_id_fk",
+          "tableFrom": "slack_thread_sessions",
+          "tableTo": "slack_user_links",
+          "columnsFrom": ["slack_user_link_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "slack_thread_sessions_agent_session_id_agent_sessions_id_fk": {
+          "name": "slack_thread_sessions_agent_session_id_agent_sessions_id_fk",
+          "tableFrom": "slack_thread_sessions",
+          "tableTo": "agent_sessions",
+          "columnsFrom": ["agent_session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_user_links": {
+      "name": "slack_user_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slack_user_id": {
+          "name": "slack_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_workspace_id": {
+          "name": "slack_workspace_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vm0_user_id": {
+          "name": "vm0_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dm_welcome_sent": {
+          "name": "dm_welcome_sent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_slack_user_links_user_workspace": {
+          "name": "idx_slack_user_links_user_workspace",
+          "columns": [
+            {
+              "expression": "slack_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slack_workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.storage_versions": {
+      "name": "storage_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "storage_id": {
+          "name": "storage_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "file_count": {
+          "name": "file_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "storage_versions_storage_id_storages_id_fk": {
+          "name": "storage_versions_storage_id_storages_id_fk",
+          "tableFrom": "storage_versions",
+          "tableTo": "storages",
+          "columnsFrom": ["storage_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.storages": {
+      "name": "storages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'volume'"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "s3_prefix": {
+          "name": "s3_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "file_count": {
+          "name": "file_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "head_version_id": {
+          "name": "head_version_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_storages_org": {
+          "name": "idx_storages_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_storages_org_user_name_type": {
+          "name": "idx_storages_org_user_name_type",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "storages_head_version_id_storage_versions_id_fk": {
+          "name": "storages_head_version_id_storage_versions_id_fk",
+          "tableFrom": "storages",
+          "tableTo": "storage_versions",
+          "columnsFrom": ["head_version_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_installations": {
+      "name": "telegram_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "telegram_bot_id": {
+          "name": "telegram_bot_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bot_username": {
+          "name": "bot_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_bot_token": {
+          "name": "encrypted_bot_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhook_secret": {
+          "name": "webhook_secret",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_compose_id": {
+          "name": "default_compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "admin_user_id": {
+          "name": "admin_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "telegram_installations_default_compose_id_agent_composes_id_fk": {
+          "name": "telegram_installations_default_compose_id_agent_composes_id_fk",
+          "tableFrom": "telegram_installations",
+          "tableTo": "agent_composes",
+          "columnsFrom": ["default_compose_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "telegram_installations_telegram_bot_id_unique": {
+          "name": "telegram_installations_telegram_bot_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["telegram_bot_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_messages": {
+      "name": "telegram_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_user_id": {
+          "name": "from_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_username": {
+          "name": "from_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_bot": {
+          "name": "is_bot",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_telegram_messages_unique": {
+          "name": "idx_telegram_messages_unique",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_telegram_messages_chat": {
+          "name": "idx_telegram_messages_chat",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_telegram_messages_created_at": {
+          "name": "idx_telegram_messages_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "telegram_messages_installation_id_telegram_installations_id_fk": {
+          "name": "telegram_messages_installation_id_telegram_installations_id_fk",
+          "tableFrom": "telegram_messages",
+          "tableTo": "telegram_installations",
+          "columnsFrom": ["installation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_thread_sessions": {
+      "name": "telegram_thread_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "telegram_user_link_id": {
+          "name": "telegram_user_link_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "root_message_id": {
+          "name": "root_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_session_id": {
+          "name": "agent_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_processed_message_id": {
+          "name": "last_processed_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_telegram_thread_sessions_chat_user_link": {
+          "name": "idx_telegram_thread_sessions_chat_user_link",
+          "columns": [
+            {
+              "expression": "telegram_user_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "root_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_telegram_thread_sessions_user_link": {
+          "name": "idx_telegram_thread_sessions_user_link",
+          "columns": [
+            {
+              "expression": "telegram_user_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "telegram_thread_sessions_telegram_user_link_id_telegram_user_links_id_fk": {
+          "name": "telegram_thread_sessions_telegram_user_link_id_telegram_user_links_id_fk",
+          "tableFrom": "telegram_thread_sessions",
+          "tableTo": "telegram_user_links",
+          "columnsFrom": ["telegram_user_link_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "telegram_thread_sessions_agent_session_id_agent_sessions_id_fk": {
+          "name": "telegram_thread_sessions_agent_session_id_agent_sessions_id_fk",
+          "tableFrom": "telegram_thread_sessions",
+          "tableTo": "agent_sessions",
+          "columnsFrom": ["agent_session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_user_links": {
+      "name": "telegram_user_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "telegram_user_id": {
+          "name": "telegram_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vm0_user_id": {
+          "name": "vm0_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dm_welcome_sent": {
+          "name": "dm_welcome_sent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_telegram_user_links_user_installation": {
+          "name": "idx_telegram_user_links_user_installation",
+          "columns": [
+            {
+              "expression": "telegram_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "telegram_user_links_installation_id_telegram_installations_id_fk": {
+          "name": "telegram_user_links_installation_id_telegram_installations_id_fk",
+          "tableFrom": "telegram_user_links",
+          "tableTo": "telegram_installations",
+          "columnsFrom": ["installation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.usage_daily": {
+      "name": "usage_daily",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_count": {
+          "name": "run_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "run_time_ms": {
+          "name": "run_time_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_usage_daily_user_date": {
+          "name": "uq_usage_daily_user_date",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_cache": {
+      "name": "user_cache",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_list_cached_at": {
+          "name": "org_list_cached_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cached_at": {
+          "name": "cached_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.variables": {
+      "name": "variables",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_variables_org": {
+          "name": "idx_variables_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_variables_org_user_name": {
+          "name": "idx_variables_org_user_name",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.connector_session_status": {
+      "name": "connector_session_status",
+      "schema": "public",
+      "values": ["pending", "complete", "expired", "error"]
+    },
+    "public.device_code_status": {
+      "name": "device_code_status",
+      "schema": "public",
+      "values": ["pending", "authenticated", "expired", "denied"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/turbo/apps/web/src/db/migrations/meta/_journal.json
+++ b/turbo/apps/web/src/db/migrations/meta/_journal.json
@@ -960,6 +960,13 @@
       "when": 1773400000100,
       "tag": "0136_volume_org_user_id",
       "breakpoints": true
+    },
+    {
+      "idx": 137,
+      "version": "7",
+      "when": 1773400000110,
+      "tag": "0137_add_pinned_agent_ids",
+      "breakpoints": true
     }
   ]
 }

--- a/turbo/apps/web/src/db/schema/org-members-cache.ts
+++ b/turbo/apps/web/src/db/schema/org-members-cache.ts
@@ -4,6 +4,7 @@ import {
   boolean,
   timestamp,
   primaryKey,
+  jsonb,
 } from "drizzle-orm/pg-core";
 
 /**
@@ -19,6 +20,7 @@ export const orgMembersCache = pgTable(
     timezone: text("timezone"),
     notifyEmail: boolean("notify_email").notNull().default(false),
     notifySlack: boolean("notify_slack").notNull().default(true),
+    pinnedAgentIds: jsonb("pinned_agent_ids").$type<string[]>().default([]),
     cachedAt: timestamp("cached_at").defaultNow().notNull(),
   },
   (table) => [primaryKey({ columns: [table.orgId, table.userId] })],

--- a/turbo/apps/web/src/lib/compose/trigger-compose-job.ts
+++ b/turbo/apps/web/src/lib/compose/trigger-compose-job.ts
@@ -9,7 +9,6 @@ import { env } from "../../env";
 import { e2bConfig } from "../e2b/config";
 import { logger } from "../logger";
 import { notifySlackComposeComplete } from "../slack/handlers/compose-notification";
-import { injectMetadataFrontmatter } from "@vm0/core";
 
 const log = logger("compose:trigger");
 
@@ -200,25 +199,6 @@ main().catch(async (error) => {
 `;
 
 /**
- * Extract agent metadata from compose content.
- * Looks for the `metadata` field in the first agent's config.
- */
-function getAgentMetadata(
-  content: Record<string, unknown>,
-): { displayName?: string; sound?: string } | undefined {
-  const agents = content.agents as
-    | Record<string, Record<string, unknown>>
-    | undefined;
-  if (!agents) return undefined;
-  const agentName = Object.keys(agents)[0];
-  if (!agentName) return undefined;
-  const metadata = agents[agentName]?.metadata as
-    | { displayName?: string; sound?: string }
-    | undefined;
-  return metadata;
-}
-
-/**
  * Extract instructions filename from compose content.
  * Looks for the `instructions` field in the first agent's config.
  */
@@ -299,18 +279,14 @@ async function spawnComposeJobSandbox(
     const yamlContent = JSON.stringify(params.content, null, 2);
     await sandbox.files.write("/tmp/compose/vm0.yaml", yamlContent);
 
-    // Write instructions file if provided, with agent profile injected
+    // Write raw instructions file — metadata injection now happens at API
+    // serve time (GET /api/agent/composes/:id/instructions), not at compose time.
     if (params.instructions !== undefined) {
       const instructionsFilename = getInstructionsFilename(params.content);
       if (instructionsFilename) {
-        const metadata = getAgentMetadata(params.content);
-        const instructionsContent = injectMetadataFrontmatter(
-          params.instructions,
-          metadata,
-        );
         await sandbox.files.write(
           `/tmp/compose/${instructionsFilename}`,
-          instructionsContent,
+          params.instructions,
         );
       }
     }
@@ -383,6 +359,7 @@ interface TriggerComposeJobResult {
 async function generateComposeCliToken(
   userId: string,
   jobId: string,
+  orgId?: string,
 ): Promise<string> {
   const token = `vm0_live_${crypto.randomBytes(32).toString("base64url")}`;
   const expiresAt = new Date(Date.now() + 10 * 60 * 1000); // 10 minutes
@@ -391,6 +368,7 @@ async function generateComposeCliToken(
     token,
     userId,
     name: `Compose Job ${jobId}`,
+    orgId: orgId ?? null,
     expiresAt,
   });
 
@@ -407,12 +385,14 @@ async function generateComposeCliToken(
 type TriggerComposeJobParams =
   | {
       userId: string;
+      orgId?: string;
       source: "github";
       githubUrl: string;
       overwrite?: boolean;
     }
   | {
       userId: string;
+      orgId?: string;
       source: "platform";
       content: Record<string, unknown>;
       instructions?: string;
@@ -480,7 +460,7 @@ export async function triggerComposeJob(
   log.debug(`Created new job ${jobId} for user ${userId}`);
 
   // Generate tokens for sandbox
-  const cliToken = await generateComposeCliToken(userId, jobId);
+  const cliToken = await generateComposeCliToken(userId, jobId, params.orgId);
   const webhookToken = await generateComposeJobToken(userId, jobId);
 
   // Build sandbox params

--- a/turbo/apps/web/src/lib/user/user-preferences-service.ts
+++ b/turbo/apps/web/src/lib/user/user-preferences-service.ts
@@ -9,6 +9,17 @@ const log = logger("service:user-preferences");
 /** Cache TTL aligned with Clerk JWT TTL */
 const CACHE_TTL_MS = 60_000; // 1 minute
 
+/**
+ * Safely extract a string array from an unknown jsonb/metadata value.
+ * Returns [] if the value is not an array of strings.
+ */
+function toStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.filter((item): item is string => typeof item === "string");
+}
+
 interface UserPreferences {
   timezone: string | null;
   notifyEmail: boolean;
@@ -51,7 +62,7 @@ async function getCachedMemberPreferences(
       timezone: cached.timezone,
       notifyEmail: cached.notifyEmail,
       notifySlack: cached.notifySlack,
-      pinnedAgentIds: (cached.pinnedAgentIds as string[] | null) ?? [],
+      pinnedAgentIds: toStringArray(cached.pinnedAgentIds),
     };
   }
 
@@ -75,9 +86,7 @@ async function getCachedMemberPreferences(
       typeof meta?.notify_email === "boolean" ? meta.notify_email : false,
     notifySlack:
       typeof meta?.notify_slack === "boolean" ? meta.notify_slack : true,
-    pinnedAgentIds: Array.isArray(meta?.pinned_agent_ids)
-      ? (meta.pinned_agent_ids as string[])
-      : [],
+    pinnedAgentIds: toStringArray(meta?.pinned_agent_ids),
   };
 
   // 3. Upsert cache
@@ -187,7 +196,7 @@ async function getCachedPinnedAgentIds(
       and(eq(orgMembersCache.orgId, orgId), eq(orgMembersCache.userId, userId)),
     )
     .limit(1);
-  return (row?.pinnedAgentIds as string[] | null) ?? [];
+  return toStringArray(row?.pinnedAgentIds);
 }
 
 /**

--- a/turbo/apps/web/src/lib/user/user-preferences-service.ts
+++ b/turbo/apps/web/src/lib/user/user-preferences-service.ts
@@ -222,9 +222,11 @@ export async function getUserPreferences(
       sessionClaims.membership_notify_slack !== undefined)
   ) {
     const pinnedFromJwt = sessionClaims.membership_pinned_agent_ids;
-    const pinnedAgentIds = Array.isArray(pinnedFromJwt)
-      ? (pinnedFromJwt as string[])
-      : await getCachedPinnedAgentIds(orgId, userId);
+    const validated = toStringArray(pinnedFromJwt);
+    const pinnedAgentIds =
+      validated.length > 0 || Array.isArray(pinnedFromJwt)
+        ? validated
+        : await getCachedPinnedAgentIds(orgId, userId);
     return {
       timezone: sessionClaims.membership_timezone ?? null,
       notifyEmail: sessionClaims.membership_notify_email ?? false,

--- a/turbo/apps/web/src/lib/user/user-preferences-service.ts
+++ b/turbo/apps/web/src/lib/user/user-preferences-service.ts
@@ -13,6 +13,7 @@ interface UserPreferences {
   timezone: string | null;
   notifyEmail: boolean;
   notifySlack: boolean;
+  pinnedAgentIds: string[];
 }
 
 /**
@@ -50,6 +51,7 @@ async function getCachedMemberPreferences(
       timezone: cached.timezone,
       notifyEmail: cached.notifyEmail,
       notifySlack: cached.notifySlack,
+      pinnedAgentIds: (cached.pinnedAgentIds as string[] | null) ?? [],
     };
   }
 
@@ -73,6 +75,9 @@ async function getCachedMemberPreferences(
       typeof meta?.notify_email === "boolean" ? meta.notify_email : false,
     notifySlack:
       typeof meta?.notify_slack === "boolean" ? meta.notify_slack : true,
+    pinnedAgentIds: Array.isArray(meta?.pinned_agent_ids)
+      ? (meta.pinned_agent_ids as string[])
+      : [],
   };
 
   // 3. Upsert cache
@@ -85,6 +90,7 @@ async function getCachedMemberPreferences(
       timezone: prefs.timezone,
       notifyEmail: prefs.notifyEmail,
       notifySlack: prefs.notifySlack,
+      pinnedAgentIds: prefs.pinnedAgentIds,
       cachedAt: now,
     })
     .onConflictDoUpdate({
@@ -93,6 +99,7 @@ async function getCachedMemberPreferences(
         timezone: prefs.timezone,
         notifyEmail: prefs.notifyEmail,
         notifySlack: prefs.notifySlack,
+        pinnedAgentIds: prefs.pinnedAgentIds,
         cachedAt: now,
       },
     });
@@ -121,6 +128,7 @@ async function upsertMemberCache(
       timezone: prefs.timezone ?? null,
       notifyEmail: prefs.notifyEmail ?? false,
       notifySlack: prefs.notifySlack ?? true,
+      pinnedAgentIds: prefs.pinnedAgentIds ?? [],
       cachedAt: now,
     })
     .onConflictDoUpdate({
@@ -132,6 +140,9 @@ async function upsertMemberCache(
         }),
         ...(prefs.notifySlack !== undefined && {
           notifySlack: prefs.notifySlack,
+        }),
+        ...(prefs.pinnedAgentIds !== undefined && {
+          pinnedAgentIds: prefs.pinnedAgentIds,
         }),
         cachedAt: now,
       },
@@ -145,6 +156,7 @@ function buildClerkMetadata(prefs: {
   timezone?: string;
   notifyEmail?: boolean;
   notifySlack?: boolean;
+  pinnedAgentIds?: string[];
 }): Record<string, unknown> {
   return {
     ...(prefs.timezone !== undefined && { timezone: prefs.timezone }),
@@ -154,7 +166,28 @@ function buildClerkMetadata(prefs: {
     ...(prefs.notifySlack !== undefined && {
       notify_slack: prefs.notifySlack,
     }),
+    ...(prefs.pinnedAgentIds !== undefined && {
+      pinned_agent_ids: prefs.pinnedAgentIds,
+    }),
   };
+}
+
+/**
+ * Read only pinnedAgentIds from org_members_cache (no Clerk API call).
+ */
+async function getCachedPinnedAgentIds(
+  orgId: string,
+  userId: string,
+): Promise<string[]> {
+  const db = globalThis.services.db;
+  const [row] = await db
+    .select({ pinnedAgentIds: orgMembersCache.pinnedAgentIds })
+    .from(orgMembersCache)
+    .where(
+      and(eq(orgMembersCache.orgId, orgId), eq(orgMembersCache.userId, userId)),
+    )
+    .limit(1);
+  return (row?.pinnedAgentIds as string[] | null) ?? [];
 }
 
 /**
@@ -171,17 +204,23 @@ export async function getUserPreferences(
   userId: string,
   sessionClaims?: CustomJwtSessionClaims,
 ): Promise<UserPreferences> {
-  // JWT fast path: use Clerk membership claims
+  // JWT fast path: use Clerk membership claims.
+  // pinnedAgentIds may not be in the JWT template yet — fallback to DB cache.
   if (
     sessionClaims &&
     (sessionClaims.membership_timezone !== undefined ||
       sessionClaims.membership_notify_email !== undefined ||
       sessionClaims.membership_notify_slack !== undefined)
   ) {
+    const pinnedFromJwt = sessionClaims.membership_pinned_agent_ids;
+    const pinnedAgentIds = Array.isArray(pinnedFromJwt)
+      ? (pinnedFromJwt as string[])
+      : await getCachedPinnedAgentIds(orgId, userId);
     return {
       timezone: sessionClaims.membership_timezone ?? null,
       notifyEmail: sessionClaims.membership_notify_email ?? false,
       notifySlack: sessionClaims.membership_notify_slack ?? true,
+      pinnedAgentIds,
     };
   }
 
@@ -195,7 +234,12 @@ export async function getUserPreferences(
 export async function updateUserPreferences(
   orgId: string,
   userId: string,
-  prefs: { timezone?: string; notifyEmail?: boolean; notifySlack?: boolean },
+  prefs: {
+    timezone?: string;
+    notifyEmail?: boolean;
+    notifySlack?: boolean;
+    pinnedAgentIds?: string[];
+  },
 ): Promise<UserPreferences> {
   if (prefs.timezone !== undefined) {
     if (!isValidTimezone(prefs.timezone)) {
@@ -216,6 +260,10 @@ export async function updateUserPreferences(
       prefs.notifySlack !== undefined
         ? prefs.notifySlack
         : existing.notifySlack,
+    pinnedAgentIds:
+      prefs.pinnedAgentIds !== undefined
+        ? prefs.pinnedAgentIds
+        : existing.pinnedAgentIds,
   };
 
   // Write to Clerk membership metadata

--- a/turbo/apps/web/src/types/agent-compose.ts
+++ b/turbo/apps/web/src/types/agent-compose.ts
@@ -90,6 +90,7 @@ interface AgentDefinition {
    */
   metadata?: {
     displayName?: string;
+    description?: string;
     sound?: string;
   };
 }

--- a/turbo/apps/web/src/types/global.d.ts
+++ b/turbo/apps/web/src/types/global.d.ts
@@ -29,5 +29,6 @@ declare global {
     membership_timezone?: string;
     membership_notify_email?: boolean;
     membership_notify_slack?: boolean;
+    membership_pinned_agent_ids?: string[];
   }
 }

--- a/turbo/packages/core/src/contracts/composes.ts
+++ b/turbo/packages/core/src/contracts/composes.ts
@@ -119,6 +119,7 @@ const agentDefinitionSchema = z.object({
   metadata: z
     .object({
       displayName: z.string().optional(),
+      description: z.string().optional(),
       sound: z.string().optional(),
     })
     .optional(),
@@ -332,6 +333,7 @@ const composeListItemSchema = z.object({
   id: z.string(),
   name: z.string(),
   displayName: z.string().nullable().optional(),
+  description: z.string().nullable().optional(),
   headVersionId: z.string().nullable(),
   updatedAt: z.string(),
   isOwner: z.boolean(),

--- a/turbo/packages/core/src/contracts/onboarding.ts
+++ b/turbo/packages/core/src/contracts/onboarding.ts
@@ -17,6 +17,7 @@ export const onboardingStatusResponseSchema = z.object({
   defaultAgentMetadata: z
     .object({
       displayName: z.string().optional(),
+      description: z.string().optional(),
       sound: z.string().optional(),
     })
     .nullable(),

--- a/turbo/packages/core/src/contracts/platform.ts
+++ b/turbo/packages/core/src/contracts/platform.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { initContract } from "./base";
+import { initContract, authHeadersSchema } from "./base";
 import { apiErrorSchema } from "./errors";
 
 /**
@@ -123,6 +123,7 @@ export const platformLogsByIdContract = c.router({
   getById: {
     method: "GET",
     path: "/api/platform/logs/:id",
+    headers: authHeadersSchema,
     pathParams: z.object({
       id: z.string().uuid("Invalid log ID"),
     }),

--- a/turbo/packages/core/src/contracts/user-preferences.ts
+++ b/turbo/packages/core/src/contracts/user-preferences.ts
@@ -11,6 +11,7 @@ export const userPreferencesResponseSchema = z.object({
   timezone: z.string().nullable(),
   notifyEmail: z.boolean(),
   notifySlack: z.boolean(),
+  pinnedAgentIds: z.array(z.string()),
 });
 
 export type UserPreferencesResponse = z.infer<
@@ -25,12 +26,14 @@ export const updateUserPreferencesRequestSchema = z
     timezone: z.string().min(1).optional(),
     notifyEmail: z.boolean().optional(),
     notifySlack: z.boolean().optional(),
+    pinnedAgentIds: z.array(z.string()).max(4).optional(),
   })
   .refine(
     (data) =>
       data.timezone !== undefined ||
       data.notifyEmail !== undefined ||
-      data.notifySlack !== undefined,
+      data.notifySlack !== undefined ||
+      data.pinnedAgentIds !== undefined,
     {
       message: "At least one preference must be provided",
     },

--- a/turbo/packages/core/src/instructions-frontmatter.ts
+++ b/turbo/packages/core/src/instructions-frontmatter.ts
@@ -1,5 +1,6 @@
 interface AgentMetadata {
   displayName?: string;
+  description?: string;
   sound?: string;
 }
 
@@ -44,6 +45,10 @@ function stripProfileBlocks(content: string): string {
   return result;
 }
 
+/** Legacy description block injected by earlier versions. */
+const LEGACY_DESCRIPTION_REGEX =
+  /<!-- AGENT_DESCRIPTION_START -->\n[\s\S]*?<!-- AGENT_DESCRIPTION_END -->\n*/g;
+
 /** Keys used by the legacy YAML frontmatter format. */
 const LEGACY_METADATA_KEYS = new Set(["name", "tone"]);
 
@@ -86,6 +91,10 @@ function buildProfileParagraph(metadata: AgentMetadata): string | null {
 
   if (metadata.displayName) {
     parts.push(`Your name is ${metadata.displayName}.`);
+  }
+
+  if (metadata.description) {
+    parts.push(metadata.description);
   }
 
   if (metadata.sound) {

--- a/turbo/packages/core/src/instructions-frontmatter.ts
+++ b/turbo/packages/core/src/instructions-frontmatter.ts
@@ -45,10 +45,6 @@ function stripProfileBlocks(content: string): string {
   return result;
 }
 
-/** Legacy description block injected by earlier versions. */
-const LEGACY_DESCRIPTION_REGEX =
-  /<!-- AGENT_DESCRIPTION_START -->\n[\s\S]*?<!-- AGENT_DESCRIPTION_END -->\n*/g;
-
 /** Keys used by the legacy YAML frontmatter format. */
 const LEGACY_METADATA_KEYS = new Set(["name", "tone"]);
 


### PR DESCRIPTION
## Summary
- Add "Talk to" section in sidebar with pinned agent avatars and manage dialog (max 4 pinned + default agent)
- Persist pinned agents to DB via user preferences API with optimistic UI updates and JWT cache refresh
- Clicking an agent avatar switches chat context (updates name, avatar, and sends messages to that agent)
- Selected agent persisted in localStorage so it survives page reloads
- Recent chat sessions filtered by currently selected agent
- Redesign team page with grid layout, random sub-agent avatars, and renamed "skills" to "connectors"
- Add activity detail page, profile rename, and various UI polish

## Test plan
- [ ] Pin/unpin agents in the manage dialog — verify persistence across page reloads
- [ ] Switch between agents in "Talk to" section — verify chat page shows correct agent name/avatar
- [ ] Send a message to a sub-agent — verify it creates a session under that agent
- [ ] Switch agents — verify recent chats update to show only that agent's sessions
- [ ] Reload the page — verify the previously selected agent is restored from localStorage
- [ ] Verify max 4 pinned agents (5 total including default) is enforced

🤖 Generated with [Claude Code](https://claude.com/claude-code)