### PR TITLE
feat(e2b): upgrade vm0 cli from 9.41.0 to 9.56.10

### DIFF
--- a/turbo/scripts/e2b/vm0-cli/template.ts
+++ b/turbo/scripts/e2b/vm0-cli/template.ts
@@ -11,4 +11,4 @@ import { Template } from "e2b";
 export const template = Template()
   .fromNodeImage("24")
   .aptInstall(["curl", "git", "jq", "tzdata"])
-  .npmInstall("@vm0/cli@9.41.0", { g: true });
+  .npmInstall("@vm0/cli@9.56.10", { g: true });


### PR DESCRIPTION
## Summary
- Upgrade `@vm0/cli` in the E2B sandbox template from `9.41.0` to `9.56.10` (latest)

## Test plan
- [ ] Verify E2B template builds successfully in CI
- [ ] Verify compose jobs work with the updated CLI version

🤖 Generated with [Claude Code](https://claude.com/claude-code)