### PR TITLE
feat: add coding-dashboard skill for pipeline and lane status overview

### DIFF
--- a/.claude/skills/coding-dashboard/SKILL.md
+++ b/.claude/skills/coding-dashboard/SKILL.md
@@ -1,0 +1,160 @@
+---
+name: coding-dashboard
+description: Dashboard view of CI pipeline, open issues/PRs by worker lane, and recently merged PRs.
+context: fork
+---
+
+# Coding Dashboard
+
+Provides a consolidated view of CI pipeline health, open issues/PRs by worker lane, and recently merged PRs.
+
+## Arguments
+
+Your args are: `$ARGUMENTS`
+
+The first argument (optional) is the **maximum worker count** (default **4**).
+
+```bash
+# Example: /coding-dashboard → vm01-vm04
+# Example: /coding-dashboard 8 → vm01-vm08
+MAX_WORKERS=${1:-4}
+```
+
+If no argument is provided, default to `MAX_WORKERS=4`.
+
+---
+
+## Steps
+
+### Step 1: Determine Parameters
+
+```bash
+MAX_WORKERS="${ARGUMENTS:-4}"
+ME=$(gh api user --jq '.login')
+```
+
+Generate lane labels: `vm01`, `vm02`, ..., `vm0N` using `printf "vm%02d" $i`.
+
+### Step 2: Check Main CI Pipeline
+
+Query the last 10 workflow runs on `main`:
+
+```bash
+gh run list --workflow turbo.yml --branch main --limit 10 \
+  --json databaseId,conclusion,url,name,headBranch,createdAt \
+  --jq '.[] | {id: .databaseId, conclusion, url, createdAt}'
+```
+
+- If **all runs** have `conclusion == "success"`, report: "All green, no failures."
+- If **any run** has `conclusion == "failure"`:
+  1. Get the failed job names for that run:
+     ```bash
+     gh run view <RUN_ID> --json jobs --jq '[.jobs[] | select(.conclusion == "failure") | .name]'
+     ```
+  2. Post to Slack `#flaky-test` channel with the failed run details (run URL, failed job names) using the Slack MCP tool (`slack_send_message` to `#flaky-test`).
+  3. Report the failure in the dashboard output.
+
+### Step 3: Check Open Issues per Lane
+
+For each lane `vm01` through `vm0N`:
+
+```bash
+gh issue list --repo vm0-ai/vm0 --label "$LANE" --assignee "$ME" --state open \
+  --json number,title,labels --limit 50 \
+  --jq '.[] | {number, title, pending: ([.labels[].name] | any(. == "pending"))}'
+```
+
+Also check issues where the current user is the author:
+
+```bash
+gh issue list --repo vm0-ai/vm0 --label "$LANE" --author "$ME" --state open \
+  --json number,title,labels --limit 50 \
+  --jq '.[] | {number, title, pending: ([.labels[].name] | any(. == "pending"))}'
+```
+
+Deduplicate by issue number. Mark items with `pending` label as `[Pending]`.
+
+### Step 4: Check Open PRs per Lane
+
+For each lane `vm01` through `vm0N`:
+
+```bash
+gh pr list --repo vm0-ai/vm0 --label "$LANE" --author "$ME" --state open \
+  --json number,title,labels --limit 50 \
+  --jq '.[] | {number, title, pending: ([.labels[].name] | any(. == "pending"))}'
+```
+
+Mark items with `pending` label as `[Pending]`.
+
+### Step 5: List Recently Merged PRs
+
+Query the last 20 merged PRs across all lanes:
+
+```bash
+# Build label filter for all lanes
+for i in $(seq 1 $MAX_WORKERS); do
+  LANE=$(printf "vm%02d" $i)
+  gh pr list --repo vm0-ai/vm0 --label "$LANE" --state merged \
+    --json number,title,mergedAt,labels --limit 20 \
+    --jq ".[] | {number, title, mergedAt, lane: \"$LANE\"}"
+done
+```
+
+Combine results, sort by `mergedAt` descending, take the top 20.
+
+---
+
+## Output Format
+
+- Titles should be translated to Chinese
+- Items with `pending` label get a `[Pending]` marker
+- Empty lanes show `-- idle`
+- Merged PRs shown in a table with columns: Time, #, Lane, Title
+
+### Output Example
+
+```
+---
+CI 流水线
+
+全部通过，无失败。
+
+通道状态
+
+vm01
+- Issue #4730 — 添加邮件退订功能 (List-Unsubscribe header + bounce/complaint webhook)
+- PR #4735 — 添加邮件退订功能
+
+vm02
+- [Pending] Issue #4740 — 重构通知服务重试逻辑
+- PR #4741 — 重构通知服务重试逻辑
+
+vm03 -- idle
+
+vm04
+- Issue #4738 — 修复 webhook 签名验证失败
+
+---
+近期完成 (最近 20 个已合并 PR，按时间倒序)
+
+┌────────────┬───────┬──────┬──────────────────────────────────────────────────────┐
+│    时间    │   #   │ 通道 │                        标题                          │
+├────────────┼───────┼──────┼──────────────────────────────────────────────────────┤
+│ 3/13 08:35 │ #4728 │ vm03 │ 升级平台 vite 从 v6 到 v7                            │
+├────────────┼───────┼──────┼──────────────────────────────────────────────────────┤
+│ 3/13 08:01 │ #4719 │ vm01 │ 通过 tsx/tsup 升级去重 esbuild 版本                  │
+└────────────┴───────┴──────┴──────────────────────────────────────────────────────┘
+---
+```
+
+---
+
+## Key Rules
+
+- Use `printf "vm%02d"` for label generation (consistent with coding-assign/coding-loop)
+- Use `gh` CLI for all GitHub queries
+- Use Slack MCP (`slack_send_message`) for `#flaky-test` notifications
+- Current user determined via `gh api user --jq '.login'`
+- No "new" markers — only `[Pending]` for items with `pending` label
+- Deduplicate issues that appear in both author and assignee queries
+- Translate titles to Chinese in the output


### PR DESCRIPTION
## Summary

- Adds new `/coding-dashboard` skill at `.claude/skills/coding-dashboard/SKILL.md`
- Provides consolidated view of CI pipeline health, open issues/PRs by worker lane, and recently merged PRs
- Supports configurable worker count (default 4), Chinese-translated output, and Slack notifications for CI failures

Closes #4731

## Test plan

- [ ] Verify `/coding-dashboard` skill is recognized by Claude Code
- [ ] Run `/coding-dashboard` and confirm CI pipeline status is displayed
- [ ] Run `/coding-dashboard 8` and confirm lanes vm01-vm08 are shown
- [ ] Verify pending items show `[Pending]` marker
- [ ] Verify idle lanes show `-- idle`

🤖 Generated with [Claude Code](https://claude.com/claude-code)