### PR TITLE
fix(web): replace check-then-insert with atomic upsert in variable and checkpoint services

### DIFF
--- a/turbo/apps/web/src/lib/checkpoint/checkpoint-service.ts
+++ b/turbo/apps/web/src/lib/checkpoint/checkpoint-service.ts
@@ -68,43 +68,27 @@ export async function createCheckpoint(
   const historyHash = await storeSessionHistory(request.cliAgentSessionHistory);
   log.debug(`Session history stored in R2, hash=${historyHash}`);
 
-  // Check if conversation already exists for this run (e.g., from a retry)
-  const [existingConversation] = await globalThis.services.db
-    .select()
-    .from(conversations)
-    .where(eq(conversations.runId, request.runId))
-    .limit(1);
-
-  let conversation;
-  if (existingConversation) {
-    // Update existing conversation with new session data
-    log.debug(`Updating existing conversation for run ${request.runId}`);
-    const [updated] = await globalThis.services.db
-      .update(conversations)
-      .set({
+  // Upsert conversation record (handles retries atomically)
+  const [conversation] = await globalThis.services.db
+    .insert(conversations)
+    .values({
+      runId: request.runId,
+      cliAgentType: request.cliAgentType,
+      cliAgentSessionId: request.cliAgentSessionId,
+      cliAgentSessionHistoryHash: historyHash,
+    })
+    .onConflictDoUpdate({
+      target: conversations.runId,
+      set: {
         cliAgentType: request.cliAgentType,
         cliAgentSessionId: request.cliAgentSessionId,
         cliAgentSessionHistoryHash: historyHash,
-      })
-      .where(eq(conversations.runId, request.runId))
-      .returning();
-    conversation = updated;
-  } else {
-    // Create new conversation record
-    const [inserted] = await globalThis.services.db
-      .insert(conversations)
-      .values({
-        runId: request.runId,
-        cliAgentType: request.cliAgentType,
-        cliAgentSessionId: request.cliAgentSessionId,
-        cliAgentSessionHistoryHash: historyHash,
-      })
-      .returning();
-    conversation = inserted;
-  }
+      },
+    })
+    .returning();
 
   if (!conversation) {
-    throw new Error("Failed to create/update conversation record");
+    throw new Error("Failed to upsert conversation record");
   }
 
   log.debug(`Conversation created: ${conversation.id}, storing checkpoint...`);
@@ -118,71 +102,38 @@ export async function createCheckpoint(
     secretNames: (run.secretNames as string[]) || undefined,
   };
 
-  // Check if checkpoint already exists for this run (e.g., from a retry)
-  const [existingCheckpoint] = await globalThis.services.db
-    .select()
-    .from(checkpoints)
-    .where(eq(checkpoints.runId, request.runId))
-    .limit(1);
+  // Upsert checkpoint record (handles retries atomically)
+  const snapshotFields = {
+    conversationId: conversation.id,
+    agentComposeSnapshot: agentComposeSnapshot as unknown as Record<
+      string,
+      unknown
+    >,
+    artifactSnapshot: request.artifactSnapshot
+      ? (request.artifactSnapshot as unknown as Record<string, unknown>)
+      : null,
+    memorySnapshot: request.memorySnapshot
+      ? (request.memorySnapshot as unknown as Record<string, unknown>)
+      : null,
+    volumeVersionsSnapshot: request.volumeVersionsSnapshot
+      ? (request.volumeVersionsSnapshot as unknown as Record<string, unknown>)
+      : null,
+  };
 
-  let checkpoint;
-  if (existingCheckpoint) {
-    // Update existing checkpoint with new data
-    log.debug(`Updating existing checkpoint for run ${request.runId}`);
-    const [updated] = await globalThis.services.db
-      .update(checkpoints)
-      .set({
-        conversationId: conversation.id,
-        agentComposeSnapshot: agentComposeSnapshot as unknown as Record<
-          string,
-          unknown
-        >,
-        artifactSnapshot: request.artifactSnapshot
-          ? (request.artifactSnapshot as unknown as Record<string, unknown>)
-          : null,
-        memorySnapshot: request.memorySnapshot
-          ? (request.memorySnapshot as unknown as Record<string, unknown>)
-          : null,
-        volumeVersionsSnapshot: request.volumeVersionsSnapshot
-          ? (request.volumeVersionsSnapshot as unknown as Record<
-              string,
-              unknown
-            >)
-          : null,
-      })
-      .where(eq(checkpoints.runId, request.runId))
-      .returning();
-    checkpoint = updated;
-  } else {
-    // Create new checkpoint record (artifactSnapshot may be undefined for runs without artifact)
-    const [inserted] = await globalThis.services.db
-      .insert(checkpoints)
-      .values({
-        runId: request.runId,
-        conversationId: conversation.id,
-        agentComposeSnapshot: agentComposeSnapshot as unknown as Record<
-          string,
-          unknown
-        >,
-        artifactSnapshot: request.artifactSnapshot
-          ? (request.artifactSnapshot as unknown as Record<string, unknown>)
-          : null,
-        memorySnapshot: request.memorySnapshot
-          ? (request.memorySnapshot as unknown as Record<string, unknown>)
-          : null,
-        volumeVersionsSnapshot: request.volumeVersionsSnapshot
-          ? (request.volumeVersionsSnapshot as unknown as Record<
-              string,
-              unknown
-            >)
-          : null,
-      })
-      .returning();
-    checkpoint = inserted;
-  }
+  const [checkpoint] = await globalThis.services.db
+    .insert(checkpoints)
+    .values({
+      runId: request.runId,
+      ...snapshotFields,
+    })
+    .onConflictDoUpdate({
+      target: checkpoints.runId,
+      set: snapshotFields,
+    })
+    .returning();
 
   if (!checkpoint) {
-    throw new Error("Failed to create/update checkpoint record");
+    throw new Error("Failed to upsert checkpoint record");
   }
 
   log.debug(`Checkpoint created successfully: ${checkpoint.id}`);

--- a/turbo/apps/web/src/lib/variable/variable-service.ts
+++ b/turbo/apps/web/src/lib/variable/variable-service.ts
@@ -133,44 +133,7 @@ export async function setVariable(
 
   log.debug("setting variable", { orgId, name });
 
-  // Check if variable exists
-  const existing = await globalThis.services.db
-    .select({ id: variables.id })
-    .from(variables)
-    .where(
-      and(
-        eq(variables.orgId, orgId),
-        eq(variables.userId, userId),
-        eq(variables.name, name),
-      ),
-    )
-    .limit(1);
-
-  if (existing[0]) {
-    // Update existing variable
-    const [updated] = await globalThis.services.db
-      .update(variables)
-      .set({
-        value,
-        description: description ?? null,
-        updatedAt: new Date(),
-      })
-      .where(eq(variables.id, existing[0].id))
-      .returning({
-        id: variables.id,
-        name: variables.name,
-        value: variables.value,
-        description: variables.description,
-        createdAt: variables.createdAt,
-        updatedAt: variables.updatedAt,
-      });
-
-    log.debug("variable updated", { variableId: updated!.id, name });
-    return updated!;
-  }
-
-  // Create new variable
-  const [created] = await globalThis.services.db
+  const [result] = await globalThis.services.db
     .insert(variables)
     .values({
       name,
@@ -178,6 +141,14 @@ export async function setVariable(
       description: description ?? null,
       userId,
       orgId,
+    })
+    .onConflictDoUpdate({
+      target: [variables.orgId, variables.userId, variables.name],
+      set: {
+        value,
+        description: description ?? null,
+        updatedAt: new Date(),
+      },
     })
     .returning({
       id: variables.id,
@@ -188,8 +159,12 @@ export async function setVariable(
       updatedAt: variables.updatedAt,
     });
 
-  log.debug("variable created", { variableId: created!.id, name });
-  return created!;
+  if (!result) {
+    throw new Error("Expected upsert to return a row");
+  }
+
+  log.debug("variable upserted", { variableId: result.id, name });
+  return result;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Replace TOCTOU (time-of-check-time-of-use) check-then-insert patterns with atomic `onConflictDoUpdate` upserts
- Same fix pattern as #4725 (secret/connector services), applied to remaining instances:
  - `variable-service.ts`: `setVariable()` — unique index on `(orgId, userId, name)`
  - `checkpoint-service.ts`: conversations upsert — unique on `runId`
  - `checkpoint-service.ts`: checkpoints upsert — unique on `runId`
- `storage-service.ts` already uses `onConflictDoNothing` + re-fetch, no change needed

## Test plan
- [x] `pnpm turbo run check-types --filter=web` passes
- [x] Variable route tests pass (21 tests)
- [x] Checkpoint route tests pass (15 tests)
- [x] Agent runs route tests pass (165 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)