### PR TITLE
chore: extract dev-logs into standalone skill

### DIFF
--- a/.claude/commands/dev-logs.md
+++ b/.claude/commands/dev-logs.md
@@ -5,7 +5,7 @@ description: View development server logs with optional filtering
 
 ```typescript
 await Skill({
-  skill: "dev-server",
-  args: "logs"
+  skill: "dev-logs",
+  args: "$ARGUMENTS"
 });
 ```

--- a/.claude/skills/dev-logs/SKILL.md
+++ b/.claude/skills/dev-logs/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: dev-logs
+description: View development server logs with optional filtering
+---
+
+View development server output logs with optional filtering. Logs are persisted to `/tmp/dev-server.log` via `tee` in the `pnpm dev` script.
+
+## Arguments Format
+
+Your args are: `$ARGUMENTS`
+
+- _(empty)_ - Show recent logs (last 50 lines)
+- `[pattern]` - Show only logs matching the regex pattern
+
+## Examples
+
+- `/dev-logs` - Show last 50 lines
+- `/dev-logs error` - Show only error messages
+- `/dev-logs "web|workspace"` - Show logs from web or workspace packages
+- `/dev-logs "compiled|ready"` - Show compilation status
+
+## Workflow
+
+### Step 1: Check Log File Exists
+
+```bash
+if [ ! -f /tmp/dev-server.log ]; then
+  echo "No dev server log found at /tmp/dev-server.log"
+  echo "Please run /dev-start first."
+  exit 1
+fi
+```
+
+### Step 2: Read Logs
+
+**If no filter pattern provided** — show last 50 lines:
+```bash
+tail -50 /tmp/dev-server.log
+```
+
+**If filter pattern provided** — grep matching lines:
+```bash
+grep -E "<pattern>" /tmp/dev-server.log | tail -50
+```
+
+### Step 3: Display Logs
+
+Show the output in readable format. If the log file is empty, mention that no logs have been recorded yet.
+
+## Notes
+
+- Logs are written to `/tmp/dev-server.log` by `pnpm dev` (via `tee`)
+- Filter parameter uses regex patterns
+- Log file persists across dev server restarts (overwritten on each start)

--- a/.claude/skills/dev-server/SKILL.md
+++ b/.claude/skills/dev-server/SKILL.md
@@ -14,7 +14,7 @@ Parse the args above to determine which operation to perform:
 
 - **start**: Start the development server in background mode (tunnel is automatic for web app). Supports `--tunnel-hostname=<fqdn>` to use a fixed tunnel domain instead of the auto-generated one.
 - **stop**: Stop the background development server
-- **logs [pattern]**: View development server logs with optional filtering
+- **logs [pattern]**: View development server logs with optional filtering (delegates to `dev-logs` skill)
 - **auth**: Authenticate with local development server and get CLI token
 - **tunnel**: Full setup with tunnel and CLI authentication
 
@@ -222,52 +222,11 @@ Use `/dev-start` to start one
 
 # Operation: logs
 
-View development server output logs with optional filtering. Logs are persisted to `/tmp/dev-server.log` via `tee` in the `pnpm dev` script.
+Delegate to the `dev-logs` skill. Extract the optional filter pattern from args (e.g. `logs error` → pattern is `error`) and invoke:
 
-## Arguments Format
-
-- `logs` - Show recent logs (last 50 lines)
-- `logs [pattern]` - Show only logs matching the regex pattern
-
-## Examples
-
-- `logs error` - Show only error messages
-- `logs "web|workspace"` - Show logs from web or workspace packages
-- `logs "compiled|ready"` - Show compilation status
-
-## Workflow
-
-### Step 1: Check Log File Exists
-
-```bash
-if [ ! -f /tmp/dev-server.log ]; then
-  echo "❌ No dev server log found at /tmp/dev-server.log"
-  echo "Please run /dev-start first."
-  exit 1
-fi
+```typescript
+await Skill({ skill: "dev-logs", args: "<pattern>" });
 ```
-
-### Step 2: Read Logs
-
-**If no filter pattern provided** — show last 50 lines:
-```bash
-tail -50 /tmp/dev-server.log
-```
-
-**If filter pattern provided** — grep matching lines:
-```bash
-grep -E "<pattern>" /tmp/dev-server.log | tail -50
-```
-
-### Step 3: Display Logs
-
-Show the output in readable format. If the log file is empty, mention that no logs have been recorded yet.
-
-## Notes
-
-- Logs are written to `/tmp/dev-server.log` by `pnpm dev` (via `tee`)
-- Filter parameter uses regex patterns
-- Log file persists across dev server restarts (overwritten on each start)
 
 ---
 


### PR DESCRIPTION
## Summary
- Extract `dev-logs` from `dev-server` skill into its own standalone skill
- Update `/dev-logs` command to delegate directly to the new `dev-logs` skill with `$ARGUMENTS` passthrough
- Keep `dev-server` logs operation as a thin delegation to `dev-logs` skill

## Test plan
- [ ] Run `/dev-logs` and verify it reads from `/tmp/dev-server.log`
- [ ] Run `/dev-logs error` and verify filtering works
- [ ] Run `/dev-server logs` and verify it delegates to `dev-logs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)