### PR TITLE
chore(e2b): upgrade vm0 cli from 9.56.10 to 9.57.0

### DIFF
--- a/turbo/scripts/e2b/vm0-cli/template.ts
+++ b/turbo/scripts/e2b/vm0-cli/template.ts
@@ -11,4 +11,4 @@ import { Template } from "e2b";
 export const template = Template()
   .fromNodeImage("24")
   .aptInstall(["curl", "git", "jq", "tzdata"])
-  .npmInstall("@vm0/cli@9.56.10", { g: true });
+  .npmInstall("@vm0/cli@9.57.0", { g: true });


### PR DESCRIPTION
## Summary
- Upgrades the e2b sandbox CLI from `@vm0/cli@9.56.10` to `@vm0/cli@9.57.0`
- CLI 9.56.10 still calls `/api/scope` (removed in the scope→org refactor), causing compose jobs to fail with "Failed to get organization"
- CLI 9.57.0 includes the updated `/api/org` endpoints

## Test plan
- [ ] Verify e2b template builds successfully with the new CLI version
- [ ] Run a compose job and confirm it no longer fails with "Failed to get organization"

🤖 Generated with [Claude Code](https://claude.com/claude-code)