### PR TITLE
fix(webhooks): use run.orgId instead of re-resolving org via Clerk API

### DIFF
--- a/turbo/apps/web/app/api/webhooks/agent/storages/commit/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/storages/commit/route.ts
@@ -12,7 +12,7 @@ import {
 } from "../../../../../../src/db/schema/storage";
 import { eq, and } from "drizzle-orm";
 import { getSandboxAuthForRun } from "../../../../../../src/lib/auth/get-sandbox-auth";
-import { getDefaultOrgByUserId } from "../../../../../../src/lib/org/org-service";
+import { getOrgData } from "../../../../../../src/lib/org/org-cache-service";
 import {
   s3ObjectExists,
   verifyS3FilesExist,
@@ -65,19 +65,8 @@ const router = tsr.router(webhookStoragesCommitContract, {
       };
     }
 
-    // Resolve Runtime Org (user's default org)
-    const runtimeOrg = await getDefaultOrgByUserId(userId);
-    if (!runtimeOrg) {
-      return {
-        status: 400 as const,
-        body: {
-          error: {
-            message: "User's default org not found",
-            code: "BAD_REQUEST",
-          },
-        },
-      };
-    }
+    // Use the org from the run record (set at run creation time)
+    const runtimeOrg = await getOrgData(run.orgId);
 
     // Volumes use sentinel userId; artifacts/memory use real userId
     const storageUserId =

--- a/turbo/apps/web/app/api/webhooks/agent/storages/prepare/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/storages/prepare/route.ts
@@ -16,7 +16,7 @@ import {
 } from "../../../../../../src/db/schema/storage";
 import { eq, and } from "drizzle-orm";
 import { getSandboxAuthForRun } from "../../../../../../src/lib/auth/get-sandbox-auth";
-import { getDefaultOrgByUserId } from "../../../../../../src/lib/org/org-service";
+import { getOrgData } from "../../../../../../src/lib/org/org-cache-service";
 import {
   generatePresignedPutUrl,
   downloadManifest,
@@ -95,19 +95,8 @@ const router = tsr.router(webhookStoragesPrepareContract, {
       };
     }
 
-    // Resolve Runtime Org (user's default org)
-    const resolvedOrg = await getDefaultOrgByUserId(userId);
-    if (!resolvedOrg) {
-      return {
-        status: 400 as const,
-        body: {
-          error: {
-            message: "User's default org not found",
-            code: "BAD_REQUEST",
-          },
-        },
-      };
-    }
+    // Use the org from the run record (set at run creation time)
+    const resolvedOrg = await getOrgData(run.orgId);
 
     // Volumes use sentinel userId (org-level shared); artifacts/memory use real userId
     const storageUserId =


### PR DESCRIPTION
## Summary

- Storage webhooks (`storages/prepare` and `storages/commit`) already query the `agent_runs` record which has `orgId` set at run creation time
- But they ignored `run.orgId` and called `getDefaultOrgByUserId(userId)`, which hits Clerk API on every webhook callback (no JWT session in sandbox context)
- Replace with `getOrgData(run.orgId)` — a simple `org_cache` DB lookup, zero Clerk API calls

## Why

The sandbox makes multiple webhook calls per run (prepare, commit, events, complete, heartbeat). With parallel E2E test shards, this generates many concurrent Clerk API requests, risking 429 rate limiting. Using `run.orgId` is also more correct — it uses the org that was resolved when the run was created, not whatever the user's "default" org happens to be at webhook time.

## Test plan

- [ ] Existing storage webhook tests pass
- [ ] E2E runner tests pass (the primary consumers of these webhooks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)