### PR TITLE
fix(e2e): make t42-service-placeholder parallel-safe

### DIFF
--- a/e2e/tests/03-experimental-runner/t42-service-placeholder.bats
+++ b/e2e/tests/03-experimental-runner/t42-service-placeholder.bats
@@ -8,6 +8,23 @@
 
 load '../../helpers/setup'
 
+# Set up connectors ONCE before parallel tests to avoid race conditions.
+# Both tests write to the same connector record (orgId + userId + type),
+# so concurrent setup_test_connector calls would overwrite each other.
+setup_file() {
+    if [[ -z "$VM0_API_URL" ]]; then
+        echo "VM0_API_URL not set" >&2
+        return 1
+    fi
+    if [[ -z "$CI_GITHUB_TOKEN" ]]; then
+        echo "CI_GITHUB_TOKEN not set" >&2
+        return 1
+    fi
+
+    setup_test_connector "github" "$CI_GITHUB_TOKEN"
+    setup_test_connector "slack" "xoxb-multi-test-token"
+}
+
 setup() {
     if [[ -z "$VM0_API_URL" ]]; then
         fail "VM0_API_URL not set"
@@ -65,9 +82,7 @@ setup_test_connector() {
 }
 
 @test "service: placeholder env vars" {
-    setup_test_connector "github" "ghp_multi_test_token"
-    setup_test_connector "slack" "xoxb-multi-test-token"
-
+    # Connectors are set up in setup_file() to avoid parallel write races.
     cat > "$TEST_DIR/vm0.yaml" <<EOF
 version: "1.0"
 
@@ -105,12 +120,7 @@ EOF
 }
 
 @test "service: permission-based request matching" {
-    if [[ -z "$CI_GITHUB_TOKEN" ]]; then
-        fail "CI_GITHUB_TOKEN not set"
-    fi
-
-    setup_test_connector "github" "$CI_GITHUB_TOKEN"
-
+    # Connectors are set up in setup_file() to avoid parallel write races.
     # Only grant repo-read — search endpoints should be blocked.
     cat > "$TEST_DIR/vm0.yaml" <<EOF
 version: "1.0"


### PR DESCRIPTION
## Summary

- Move connector setup to `setup_file()` so it runs once before parallel tests
- Both tests in `t42-service-placeholder.bats` write to the same connector record (orgId + userId + connectorType = "github"), so when they run in parallel (enabled by #4699), `setup_test_connector` calls race and one overwrites the other's token
- When the "placeholder env vars" test writes its fake token (`ghp_multi_test_token`) after the "permission-based" test writes the real `CI_GITHUB_TOKEN`, the permission test's agent run gets the fake token → GitHub returns 401

The placeholder test doesn't depend on a specific token value (placeholder substitution is independent of the actual secret), so using the real `CI_GITHUB_TOKEN` for both tests is correct.

## Test plan

- [ ] CI runner shard 6 passes consistently (no more intermittent 401 on "permission-based request matching")


🤖 Generated with [Claude Code](https://claude.com/claude-code)