### PR TITLE
feat(services): add strict validation for service configs at compose time

### DIFF
--- a/turbo/apps/cli/src/commands/compose/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/compose/__tests__/index.test.ts
@@ -7,6 +7,8 @@ import {
   composeCommand,
   getSecretsFromComposeContent,
   expandServiceConfigs,
+  validateRule,
+  validateBaseUrl,
 } from "../index";
 import * as fs from "fs/promises";
 import { mkdtempSync, rmSync, writeFileSync, mkdirSync, existsSync } from "fs";
@@ -3353,13 +3355,14 @@ describe("expandServiceConfigs", () => {
   });
 
   it("should filter api_entries when permission not selected", () => {
-    // slack has 2 api entries (slack.com/api and files.slack.com),
-    // both with full-access. Selecting full-access keeps both.
-    const config = makeConfig({ slack: { permissions: ["full-access"] } });
+    // slack has 2 api entries (slack.com/api with api-full-access and
+    // files.slack.com with files-full-access). Selecting only one keeps one.
+    const config = makeConfig({ slack: { permissions: ["api-full-access"] } });
     const expanded = getExpanded(config);
 
     expect(expanded).toHaveLength(1);
-    expect(expanded[0]!.apis).toHaveLength(2);
+    expect(expanded[0]!.apis).toHaveLength(1);
+    expect(expanded[0]!.apis[0]!.base).toBe("https://slack.com/api");
   });
 
   it("should skip services with no agents", () => {
@@ -3408,5 +3411,121 @@ describe("expandServiceConfigs", () => {
     expect(() => expandServiceConfigs(config)).toThrow(
       'Permission "does-not-exist" does not exist in service "github"',
     );
+  });
+
+  it("should validate all built-in service configs pass rule validation", () => {
+    // Every built-in service should pass validation with permissions: all
+    for (const ref of ["github", "slack", "linear", "notion"]) {
+      const config = makeConfig({ [ref]: { permissions: "all" } });
+      expect(() => expandServiceConfigs(config)).not.toThrow();
+    }
+  });
+});
+
+describe("validateRule", () => {
+  it("should accept valid rules", () => {
+    expect(() =>
+      validateRule("GET /repos/{owner}/{repo}", "p", "svc"),
+    ).not.toThrow();
+    expect(() =>
+      validateRule("POST /chat.postMessage", "p", "svc"),
+    ).not.toThrow();
+    expect(() => validateRule("ANY /{path+}", "p", "svc")).not.toThrow();
+    expect(() =>
+      validateRule("DELETE /repos/{owner}/{repo}", "p", "svc"),
+    ).not.toThrow();
+    expect(() =>
+      validateRule("PUT /repos/{owner}/{repo}/contents/{path+}", "p", "svc"),
+    ).not.toThrow();
+    expect(() =>
+      validateRule("PATCH /repos/{owner}/{repo}/pulls/{number}", "p", "svc"),
+    ).not.toThrow();
+    expect(() => validateRule("GET /", "p", "svc")).not.toThrow();
+  });
+
+  it("should reject missing path", () => {
+    expect(() => validateRule("GET", "read", "github")).toThrow(
+      'must be "METHOD /path"',
+    );
+  });
+
+  it("should reject empty string", () => {
+    expect(() => validateRule("", "read", "github")).toThrow(
+      'must be "METHOD /path"',
+    );
+  });
+
+  it("should reject unknown method", () => {
+    expect(() => validateRule("INVALID /foo", "read", "github")).toThrow(
+      'unknown method "INVALID"',
+    );
+  });
+
+  it("should reject path without leading slash", () => {
+    expect(() => validateRule("GET foo", "read", "github")).toThrow(
+      'path must start with "/"',
+    );
+  });
+
+  it("should reject {param+} not in last segment", () => {
+    expect(() =>
+      validateRule("GET /foo/{path+}/bar", "read", "github"),
+    ).toThrow("{path+} must be the last segment");
+  });
+
+  it("should accept {param+} in last segment", () => {
+    expect(() =>
+      validateRule("GET /repos/{owner}/{path+}", "p", "svc"),
+    ).not.toThrow();
+  });
+
+  it("should reject duplicate parameter names", () => {
+    expect(() =>
+      validateRule("GET /repos/{owner}/{owner}", "p", "svc"),
+    ).toThrow('duplicate parameter name "{owner}"');
+  });
+
+  it("should reject empty parameter name", () => {
+    expect(() => validateRule("GET /repos/{}", "p", "svc")).toThrow(
+      "empty parameter name",
+    );
+  });
+
+  it("should reject empty greedy parameter name", () => {
+    expect(() => validateRule("GET /repos/{+}", "p", "svc")).toThrow(
+      "empty parameter name",
+    );
+  });
+});
+
+describe("validateBaseUrl", () => {
+  it("should accept valid URLs", () => {
+    expect(() =>
+      validateBaseUrl("https://api.github.com", "github"),
+    ).not.toThrow();
+    expect(() =>
+      validateBaseUrl("https://slack.com/api", "slack"),
+    ).not.toThrow();
+    expect(() =>
+      validateBaseUrl("https://us1.api.mailchimp.com/3.0", "mailchimp"),
+    ).not.toThrow();
+  });
+
+  it("should reject invalid URLs", () => {
+    expect(() => validateBaseUrl("not-a-url", "svc")).toThrow(
+      "not a valid URL",
+    );
+  });
+
+  it("should reject URLs with query string", () => {
+    expect(() =>
+      validateBaseUrl("https://api.example.com?key=val", "svc"),
+    ).toThrow("must not contain query string");
+  });
+
+  it("should reject URLs with fragment", () => {
+    expect(() =>
+      validateBaseUrl("https://api.example.com#section", "svc"),
+    ).toThrow("must not contain fragment");
   });
 });

--- a/turbo/apps/cli/src/commands/compose/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/compose/__tests__/index.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { http, HttpResponse } from "msw";
 import { server } from "../../../mocks/server";
 import { createMockChildProcess } from "../../../mocks/spawn-helpers";
+import { connectorTypeSchema, getServiceConfig } from "@vm0/core";
 import type { ExpandedServiceConfig } from "@vm0/core";
 import {
   composeCommand,
@@ -3414,9 +3415,10 @@ describe("expandServiceConfigs", () => {
   });
 
   it("should validate all built-in service configs pass rule validation", () => {
-    // Every built-in service should pass validation with permissions: all
-    for (const ref of ["github", "slack", "linear", "notion"]) {
-      const config = makeConfig({ [ref]: { permissions: "all" } });
+    // Every built-in service with a service config should pass validation
+    for (const type of connectorTypeSchema.options) {
+      if (!getServiceConfig(type)) continue;
+      const config = makeConfig({ [type]: { permissions: "all" } });
       expect(() => expandServiceConfigs(config)).not.toThrow();
     }
   });
@@ -3458,6 +3460,24 @@ describe("validateRule", () => {
   it("should reject unknown method", () => {
     expect(() => validateRule("INVALID /foo", "read", "github")).toThrow(
       'unknown method "INVALID"',
+    );
+  });
+
+  it("should reject lowercase method", () => {
+    expect(() => validateRule("get /foo", "read", "github")).toThrow(
+      "must be uppercase",
+    );
+  });
+
+  it("should reject path with query string", () => {
+    expect(() => validateRule("GET /foo?bar=1", "read", "github")).toThrow(
+      "must not contain query string or fragment",
+    );
+  });
+
+  it("should reject path with fragment", () => {
+    expect(() => validateRule("GET /foo#section", "read", "github")).toThrow(
+      "must not contain query string or fragment",
     );
   });
 

--- a/turbo/apps/cli/src/commands/compose/index.ts
+++ b/turbo/apps/cli/src/commands/compose/index.ts
@@ -390,17 +390,127 @@ function resolveServiceConfig(ref: string): ServiceConfig {
  * Collect available permission names from a service config.
  * Validates uniqueness and that "all" is not used as a permission name.
  */
+const VALID_RULE_METHODS = new Set([
+  "GET",
+  "POST",
+  "PUT",
+  "PATCH",
+  "DELETE",
+  "HEAD",
+  "OPTIONS",
+  "ANY",
+]);
+
+export function validateRule(
+  rule: string,
+  permName: string,
+  serviceName: string,
+): void {
+  const parts = rule.split(" ", 2);
+  if (parts.length !== 2 || !parts[1]) {
+    throw new Error(
+      `Invalid rule "${rule}" in permission "${permName}" of service "${serviceName}": must be "METHOD /path"`,
+    );
+  }
+  const [method, path] = parts as [string, string];
+  if (!VALID_RULE_METHODS.has(method.toUpperCase())) {
+    throw new Error(
+      `Invalid rule "${rule}" in permission "${permName}" of service "${serviceName}": unknown method "${method}"`,
+    );
+  }
+  if (!path.startsWith("/")) {
+    throw new Error(
+      `Invalid rule "${rule}" in permission "${permName}" of service "${serviceName}": path must start with "/"`,
+    );
+  }
+  const segments = path.split("/").filter(Boolean);
+  const paramNames = new Set<string>();
+  for (let i = 0; i < segments.length; i++) {
+    const seg = segments[i]!;
+    if (seg.startsWith("{") && seg.endsWith("}")) {
+      const name = seg.slice(1, -1);
+      const baseName = name.endsWith("+") ? name.slice(0, -1) : name;
+      if (!baseName) {
+        throw new Error(
+          `Invalid rule "${rule}" in permission "${permName}" of service "${serviceName}": empty parameter name`,
+        );
+      }
+      if (paramNames.has(baseName)) {
+        throw new Error(
+          `Invalid rule "${rule}" in permission "${permName}" of service "${serviceName}": duplicate parameter name "{${baseName}}"`,
+        );
+      }
+      paramNames.add(baseName);
+      if (name.endsWith("+") && i !== segments.length - 1) {
+        throw new Error(
+          `Invalid rule "${rule}" in permission "${permName}" of service "${serviceName}": {${name}} must be the last segment`,
+        );
+      }
+    }
+  }
+}
+
+export function validateBaseUrl(base: string, serviceName: string): void {
+  let url: URL;
+  try {
+    url = new URL(base);
+  } catch {
+    throw new Error(
+      `Invalid base URL "${base}" in service "${serviceName}": not a valid URL`,
+    );
+  }
+  if (url.search) {
+    throw new Error(
+      `Invalid base URL "${base}" in service "${serviceName}": must not contain query string`,
+    );
+  }
+  if (url.hash) {
+    throw new Error(
+      `Invalid base URL "${base}" in service "${serviceName}": must not contain fragment`,
+    );
+  }
+}
+
 function collectAndValidatePermissions(
   ref: string,
   serviceConfig: ServiceConfig,
 ): Set<string> {
+  if (serviceConfig.apis.length === 0) {
+    throw new Error(
+      `Service "${serviceConfig.name}" (ref "${ref}") has no api entries`,
+    );
+  }
   const available = new Set<string>();
   for (const api of serviceConfig.apis) {
-    for (const perm of api.permissions ?? []) {
+    validateBaseUrl(api.base, serviceConfig.name);
+    if (!api.permissions || api.permissions.length === 0) {
+      throw new Error(
+        `API entry "${api.base}" in service "${serviceConfig.name}" (ref "${ref}") has no permissions`,
+      );
+    }
+    for (const perm of api.permissions) {
+      if (!perm.name) {
+        throw new Error(
+          `Service "${serviceConfig.name}" (ref "${ref}") has a permission with empty name`,
+        );
+      }
       if (perm.name === "all") {
         throw new Error(
           `Service "${serviceConfig.name}" (ref "${ref}") has a permission named "all", which is a reserved keyword`,
         );
+      }
+      if (available.has(perm.name)) {
+        throw new Error(
+          `Duplicate permission name "${perm.name}" in service "${serviceConfig.name}" (ref "${ref}")`,
+        );
+      }
+      if (perm.rules.length === 0) {
+        throw new Error(
+          `Permission "${perm.name}" in service "${serviceConfig.name}" (ref "${ref}") has no rules`,
+        );
+      }
+      for (const rule of perm.rules) {
+        validateRule(rule, perm.name, serviceConfig.name);
       }
       available.add(perm.name);
     }

--- a/turbo/apps/cli/src/commands/compose/index.ts
+++ b/turbo/apps/cli/src/commands/compose/index.ts
@@ -413,14 +413,19 @@ export function validateRule(
     );
   }
   const [method, path] = parts as [string, string];
-  if (!VALID_RULE_METHODS.has(method.toUpperCase())) {
+  if (!VALID_RULE_METHODS.has(method)) {
     throw new Error(
-      `Invalid rule "${rule}" in permission "${permName}" of service "${serviceName}": unknown method "${method}"`,
+      `Invalid rule "${rule}" in permission "${permName}" of service "${serviceName}": unknown method "${method}" (must be uppercase)`,
     );
   }
   if (!path.startsWith("/")) {
     throw new Error(
       `Invalid rule "${rule}" in permission "${permName}" of service "${serviceName}": path must start with "/"`,
+    );
+  }
+  if (path.includes("?") || path.includes("#")) {
+    throw new Error(
+      `Invalid rule "${rule}" in permission "${permName}" of service "${serviceName}": path must not contain query string or fragment`,
     );
   }
   const segments = path.split("/").filter(Boolean);

--- a/turbo/packages/core/src/contracts/services.ts
+++ b/turbo/packages/core/src/contracts/services.ts
@@ -70,15 +70,18 @@ function bearerAuth(secretName: string) {
   return { headers: { Authorization: `Bearer \${secrets.${secretName}}` } };
 }
 
-/** Default catch-all permission for services without granular permissions. */
-const FULL_ACCESS_PERMISSION: ServicePermission = {
-  name: "full-access",
-  rules: ["ANY /{path+}"],
-};
+/** Create a catch-all permission with the given name. */
+function fullAccess(name = "full-access"): ServicePermission {
+  return { name, rules: ["ANY /{path+}"] };
+}
 
-/** Shorthand: single-base API entry with bearer auth. */
-function api(base: string, auth: ServiceApi["auth"]): ServiceApi {
-  return { base, auth, permissions: [FULL_ACCESS_PERMISSION] };
+/** Shorthand: single-base API entry with bearer auth and a named catch-all permission. */
+function api(
+  base: string,
+  auth: ServiceApi["auth"],
+  permissionName = "full-access",
+): ServiceApi {
+  return { base, auth, permissions: [fullAccess(permissionName)] };
 }
 
 const SERVICE_CONFIGS: Partial<
@@ -284,8 +287,16 @@ const SERVICE_CONFIGS: Partial<
   },
   slack: {
     apis: [
-      api("https://slack.com/api", bearerAuth("SLACK_TOKEN")),
-      api("https://files.slack.com", bearerAuth("SLACK_TOKEN")),
+      api(
+        "https://slack.com/api",
+        bearerAuth("SLACK_TOKEN"),
+        "api-full-access",
+      ),
+      api(
+        "https://files.slack.com",
+        bearerAuth("SLACK_TOKEN"),
+        "files-full-access",
+      ),
     ],
     placeholders: {
       SLACK_TOKEN: "xoxb-0000-0000-vm0placeholder",
@@ -293,14 +304,30 @@ const SERVICE_CONFIGS: Partial<
   },
   docusign: {
     apis: [
-      api("https://demo.docusign.net/restapi", bearerAuth("DOCUSIGN_TOKEN")),
-      api("https://na1.docusign.net/restapi", bearerAuth("DOCUSIGN_TOKEN")),
+      api(
+        "https://demo.docusign.net/restapi",
+        bearerAuth("DOCUSIGN_TOKEN"),
+        "demo-full-access",
+      ),
+      api(
+        "https://na1.docusign.net/restapi",
+        bearerAuth("DOCUSIGN_TOKEN"),
+        "na1-full-access",
+      ),
     ],
   },
   dropbox: {
     apis: [
-      api("https://api.dropboxapi.com/2", bearerAuth("DROPBOX_TOKEN")),
-      api("https://content.dropboxapi.com/2", bearerAuth("DROPBOX_TOKEN")),
+      api(
+        "https://api.dropboxapi.com/2",
+        bearerAuth("DROPBOX_TOKEN"),
+        "api-full-access",
+      ),
+      api(
+        "https://content.dropboxapi.com/2",
+        bearerAuth("DROPBOX_TOKEN"),
+        "content-full-access",
+      ),
     ],
   },
   linear: {
@@ -308,9 +335,21 @@ const SERVICE_CONFIGS: Partial<
   },
   intercom: {
     apis: [
-      api("https://api.intercom.io", bearerAuth("INTERCOM_TOKEN")),
-      api("https://api.eu.intercom.io", bearerAuth("INTERCOM_TOKEN")),
-      api("https://api.au.intercom.io", bearerAuth("INTERCOM_TOKEN")),
+      api(
+        "https://api.intercom.io",
+        bearerAuth("INTERCOM_TOKEN"),
+        "us-full-access",
+      ),
+      api(
+        "https://api.eu.intercom.io",
+        bearerAuth("INTERCOM_TOKEN"),
+        "eu-full-access",
+      ),
+      api(
+        "https://api.au.intercom.io",
+        bearerAuth("INTERCOM_TOKEN"),
+        "au-full-access",
+      ),
     ],
   },
   jam: {
@@ -318,16 +357,24 @@ const SERVICE_CONFIGS: Partial<
   },
   jotform: {
     apis: [
-      api("https://api.jotform.com", {
-        headers: {
-          APIKEY: "${secrets.JOTFORM_TOKEN}",
+      api(
+        "https://api.jotform.com",
+        {
+          headers: {
+            APIKEY: "${secrets.JOTFORM_TOKEN}",
+          },
         },
-      }),
-      api("https://eu-api.jotform.com", {
-        headers: {
-          APIKEY: "${secrets.JOTFORM_TOKEN}",
+        "us-full-access",
+      ),
+      api(
+        "https://eu-api.jotform.com",
+        {
+          headers: {
+            APIKEY: "${secrets.JOTFORM_TOKEN}",
+          },
         },
-      }),
+        "eu-full-access",
+      ),
     ],
   },
   line: {
@@ -335,26 +382,42 @@ const SERVICE_CONFIGS: Partial<
   },
   make: {
     apis: [
-      api("https://eu1.make.com/api/v2", {
-        headers: {
-          Authorization: "Token ${secrets.MAKE_TOKEN}",
+      api(
+        "https://eu1.make.com/api/v2",
+        {
+          headers: {
+            Authorization: "Token ${secrets.MAKE_TOKEN}",
+          },
         },
-      }),
-      api("https://eu2.make.com/api/v2", {
-        headers: {
-          Authorization: "Token ${secrets.MAKE_TOKEN}",
+        "eu1-full-access",
+      ),
+      api(
+        "https://eu2.make.com/api/v2",
+        {
+          headers: {
+            Authorization: "Token ${secrets.MAKE_TOKEN}",
+          },
         },
-      }),
-      api("https://us1.make.com/api/v2", {
-        headers: {
-          Authorization: "Token ${secrets.MAKE_TOKEN}",
+        "eu2-full-access",
+      ),
+      api(
+        "https://us1.make.com/api/v2",
+        {
+          headers: {
+            Authorization: "Token ${secrets.MAKE_TOKEN}",
+          },
         },
-      }),
-      api("https://us2.make.com/api/v2", {
-        headers: {
-          Authorization: "Token ${secrets.MAKE_TOKEN}",
+        "us1-full-access",
+      ),
+      api(
+        "https://us2.make.com/api/v2",
+        {
+          headers: {
+            Authorization: "Token ${secrets.MAKE_TOKEN}",
+          },
         },
-      }),
+        "us2-full-access",
+      ),
     ],
   },
   metabase: {
@@ -439,8 +502,16 @@ const SERVICE_CONFIGS: Partial<
   },
   posthog: {
     apis: [
-      api("https://us.posthog.com/api", bearerAuth("POSTHOG_ACCESS_TOKEN")),
-      api("https://app.posthog.com/api", bearerAuth("POSTHOG_ACCESS_TOKEN")),
+      api(
+        "https://us.posthog.com/api",
+        bearerAuth("POSTHOG_ACCESS_TOKEN"),
+        "us-full-access",
+      ),
+      api(
+        "https://app.posthog.com/api",
+        bearerAuth("POSTHOG_ACCESS_TOKEN"),
+        "cloud-full-access",
+      ),
     ],
   },
   stripe: {
@@ -468,29 +539,13 @@ const SERVICE_CONFIGS: Partial<
     apis: [api("https://plausible.io/api", bearerAuth("PLAUSIBLE_TOKEN"))],
   },
   mailchimp: {
-    apis: [
-      api("https://us1.api.mailchimp.com/3.0", bearerAuth("MAILCHIMP_TOKEN")),
-      api("https://us2.api.mailchimp.com/3.0", bearerAuth("MAILCHIMP_TOKEN")),
-      api("https://us3.api.mailchimp.com/3.0", bearerAuth("MAILCHIMP_TOKEN")),
-      api("https://us4.api.mailchimp.com/3.0", bearerAuth("MAILCHIMP_TOKEN")),
-      api("https://us5.api.mailchimp.com/3.0", bearerAuth("MAILCHIMP_TOKEN")),
-      api("https://us6.api.mailchimp.com/3.0", bearerAuth("MAILCHIMP_TOKEN")),
-      api("https://us7.api.mailchimp.com/3.0", bearerAuth("MAILCHIMP_TOKEN")),
-      api("https://us8.api.mailchimp.com/3.0", bearerAuth("MAILCHIMP_TOKEN")),
-      api("https://us9.api.mailchimp.com/3.0", bearerAuth("MAILCHIMP_TOKEN")),
-      api("https://us10.api.mailchimp.com/3.0", bearerAuth("MAILCHIMP_TOKEN")),
-      api("https://us11.api.mailchimp.com/3.0", bearerAuth("MAILCHIMP_TOKEN")),
-      api("https://us12.api.mailchimp.com/3.0", bearerAuth("MAILCHIMP_TOKEN")),
-      api("https://us13.api.mailchimp.com/3.0", bearerAuth("MAILCHIMP_TOKEN")),
-      api("https://us14.api.mailchimp.com/3.0", bearerAuth("MAILCHIMP_TOKEN")),
-      api("https://us15.api.mailchimp.com/3.0", bearerAuth("MAILCHIMP_TOKEN")),
-      api("https://us16.api.mailchimp.com/3.0", bearerAuth("MAILCHIMP_TOKEN")),
-      api("https://us17.api.mailchimp.com/3.0", bearerAuth("MAILCHIMP_TOKEN")),
-      api("https://us18.api.mailchimp.com/3.0", bearerAuth("MAILCHIMP_TOKEN")),
-      api("https://us19.api.mailchimp.com/3.0", bearerAuth("MAILCHIMP_TOKEN")),
-      api("https://us20.api.mailchimp.com/3.0", bearerAuth("MAILCHIMP_TOKEN")),
-      api("https://us21.api.mailchimp.com/3.0", bearerAuth("MAILCHIMP_TOKEN")),
-    ],
+    apis: Array.from({ length: 21 }, (_, i) =>
+      api(
+        `https://us${i + 1}.api.mailchimp.com/3.0`,
+        bearerAuth("MAILCHIMP_TOKEN"),
+        `us${i + 1}-full-access`,
+      ),
+    ),
   },
   chatwoot: {
     apis: [api("https://app.chatwoot.com", bearerAuth("CHATWOOT_TOKEN"))],


### PR DESCRIPTION
## Summary

- Add comprehensive service config validation at compose time to catch errors early instead of silent runtime failures in `mitm_addon`
- Fix duplicate `full-access` permission names in 8 multi-api services by giving each api_entry a unique name
- 14 validation checks covering base URL, permission names, rule syntax, and path parameters

## Validation Checks

| # | Check | Error example |
|---|---|---|
| 1 | Service has at least one api_entry | `has no api entries` |
| 2 | Base URL is valid | `not a valid URL` |
| 3 | Base URL has no query string | `must not contain query string` |
| 4 | Base URL has no fragment | `must not contain fragment` |
| 5 | Each api_entry has permissions | `has no permissions` |
| 6 | Permission name non-empty | `has a permission with empty name` |
| 7 | Permission name != "all" | `"all" is a reserved keyword` |
| 8 | Permission name unique across api_entries | `Duplicate permission name` |
| 9 | Permission has rules | `has no rules` |
| 10 | Rule is `METHOD /path` | `must be "METHOD /path"` |
| 11 | METHOD is valid | `unknown method` |
| 12 | Path starts with `/` | `path must start with "/"` |
| 13 | Param name non-empty | `empty parameter name` |
| 14 | Param name unique in rule | `duplicate parameter name` |
| 15 | `{param+}` is last segment | `must be the last segment` |

## Multi-api permission renames

| Service | Before | After |
|---|---|---|
| slack | `full-access` x2 | `api-full-access`, `files-full-access` |
| dropbox | `full-access` x2 | `api-full-access`, `content-full-access` |
| docusign | `full-access` x2 | `demo-full-access`, `na1-full-access` |
| intercom | `full-access` x3 | `us-full-access`, `eu-full-access`, `au-full-access` |
| jotform | `full-access` x2 | `us-full-access`, `eu-full-access` |
| make | `full-access` x4 | `eu1-full-access`, `eu2-full-access`, `us1-full-access`, `us2-full-access` |
| posthog | `full-access` x2 | `us-full-access`, `cloud-full-access` |
| mailchimp | `full-access` x21 | `us1-full-access` ... `us21-full-access` |

## Test plan

- [x] 121 compose tests pass (7 new validation tests + 2 new base URL tests + updated slack filter test)
- [x] 3585 full test suite passes
- [x] 105 mitm-addon Python tests pass
- [x] Type check, lint, knip, format all pass

Closes #4744

🤖 Generated with [Claude Code](https://claude.com/claude-code)