### PR TITLE
fix(services): allow same permission name across different api_entries

### DIFF
--- a/crates/runner/mitm-addon/tests/test_connectors.py
+++ b/crates/runner/mitm-addon/tests/test_connectors.py
@@ -303,6 +303,32 @@ class TestMatchServiceRequest:
         result = mitm_addon.match_service_request("https://api.github.com/repos", "GET", services)
         assert isinstance(result, ServiceBlock)
 
+    def test_different_bases_same_permission_name(self):
+        """Same permission name across different api_entries — each matches its own base."""
+        services = _wrap_services([
+            {
+                "base": "https://slack.com/api",
+                "auth": {"headers": {"Authorization": "Bearer api-token"}},
+                "permissions": [{"name": "full-access", "rules": ["ANY /{path+}"]}],
+            },
+            {
+                "base": "https://files.slack.com",
+                "auth": {"headers": {"Authorization": "Bearer files-token"}},
+                "permissions": [{"name": "full-access", "rules": ["ANY /{path+}"]}],
+            },
+        ])
+        # Request to first base
+        result = mitm_addon.match_service_request("https://slack.com/api/conversations.history", "POST", services)
+        assert isinstance(result, ServiceAllow)
+        assert result.api_entry["auth"]["headers"]["Authorization"] == "Bearer api-token"
+        assert result.match_info["permission"] == "full-access"
+
+        # Request to second base
+        result = mitm_addon.match_service_request("https://files.slack.com/files-pri/T1/download", "GET", services)
+        assert isinstance(result, ServiceAllow)
+        assert result.api_entry["auth"]["headers"]["Authorization"] == "Bearer files-token"
+        assert result.match_info["permission"] == "full-access"
+
     def test_same_base_different_permissions(self):
         """Same base URL with different permissions/auth — second api_entry can match."""
         services = _wrap_services([

--- a/turbo/apps/cli/src/commands/compose/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/compose/__tests__/index.test.ts
@@ -3355,15 +3355,14 @@ describe("expandServiceConfigs", () => {
     expect(names).toContain("slack");
   });
 
-  it("should filter api_entries when permission not selected", () => {
-    // slack has 2 api entries (slack.com/api with api-full-access and
-    // files.slack.com with files-full-access). Selecting only one keeps one.
-    const config = makeConfig({ slack: { permissions: ["api-full-access"] } });
+  it("should keep all api_entries when shared permission is selected", () => {
+    // slack has 2 api entries (slack.com/api and files.slack.com),
+    // both with full-access. Selecting full-access keeps both.
+    const config = makeConfig({ slack: { permissions: ["full-access"] } });
     const expanded = getExpanded(config);
 
     expect(expanded).toHaveLength(1);
-    expect(expanded[0]!.apis).toHaveLength(1);
-    expect(expanded[0]!.apis[0]!.base).toBe("https://slack.com/api");
+    expect(expanded[0]!.apis).toHaveLength(2);
   });
 
   it("should skip services with no agents", () => {

--- a/turbo/apps/cli/src/commands/compose/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/compose/__tests__/index.test.ts
@@ -3363,6 +3363,10 @@ describe("expandServiceConfigs", () => {
 
     expect(expanded).toHaveLength(1);
     expect(expanded[0]!.apis).toHaveLength(2);
+    // Both api_entries share the same permission name
+    for (const api of expanded[0]!.apis) {
+      expect(api.permissions!.map((p) => p.name)).toEqual(["full-access"]);
+    }
   });
 
   it("should skip services with no agents", () => {

--- a/turbo/apps/cli/src/commands/compose/index.ts
+++ b/turbo/apps/cli/src/commands/compose/index.ts
@@ -493,6 +493,10 @@ function collectAndValidatePermissions(
         `API entry "${api.base}" in service "${serviceConfig.name}" (ref "${ref}") has no permissions`,
       );
     }
+    // Uniqueness is enforced within a single api_entry. The same permission
+    // name across different api_entries is allowed (e.g., "full-access" on
+    // both slack.com/api and files.slack.com).
+    const seen = new Set<string>();
     for (const perm of api.permissions) {
       if (!perm.name) {
         throw new Error(
@@ -504,9 +508,9 @@ function collectAndValidatePermissions(
           `Service "${serviceConfig.name}" (ref "${ref}") has a permission named "all", which is a reserved keyword`,
         );
       }
-      if (available.has(perm.name)) {
+      if (seen.has(perm.name)) {
         throw new Error(
-          `Duplicate permission name "${perm.name}" in service "${serviceConfig.name}" (ref "${ref}")`,
+          `Duplicate permission name "${perm.name}" in API entry "${api.base}" of service "${serviceConfig.name}" (ref "${ref}")`,
         );
       }
       if (perm.rules.length === 0) {
@@ -517,6 +521,7 @@ function collectAndValidatePermissions(
       for (const rule of perm.rules) {
         validateRule(rule, perm.name, serviceConfig.name);
       }
+      seen.add(perm.name);
       available.add(perm.name);
     }
   }

--- a/turbo/packages/core/src/contracts/__tests__/connectors.test.ts
+++ b/turbo/packages/core/src/contracts/__tests__/connectors.test.ts
@@ -1,12 +1,9 @@
 import { describe, it, expect } from "vitest";
 import {
   hasRequiredScopes,
-  CONNECTOR_TYPES,
   getConnectorManagedSecretNames,
   getConnectorTypeForSecretName,
 } from "../connectors";
-import type { ConnectorType } from "../connectors";
-import { getServiceConfig } from "../services";
 
 describe("hasRequiredScopes", () => {
   it("returns true for non-OAuth connector type", () => {
@@ -90,65 +87,5 @@ describe("getConnectorTypeForSecretName", () => {
 
   it("returns null for unknown secret name", () => {
     expect(getConnectorTypeForSecretName("UNKNOWN_SECRET")).toBeNull();
-  });
-});
-
-describe("getServiceConfig", () => {
-  it("returns proxy config for known connector types", () => {
-    const config = getServiceConfig("github");
-    expect(config).toBeDefined();
-    expect(config!.apis[0]!.base).toBe("https://api.github.com");
-    expect(config!.apis[0]!.auth.headers.Authorization).toBe(
-      "Bearer ${secrets.GITHUB_TOKEN}",
-    );
-    expect(config!.placeholders).toEqual({
-      GITHUB_TOKEN: "gho_vm0placeholder0000000000000000000000",
-    });
-  });
-
-  it("returns config with multiple services for slack", () => {
-    const config = getServiceConfig("slack");
-    expect(config).toBeDefined();
-    expect(config!.apis.map((s) => s.base)).toEqual([
-      "https://slack.com/api",
-      "https://files.slack.com",
-    ]);
-    expect(config!.placeholders).toEqual({
-      SLACK_TOKEN: "xoxb-0000-0000-vm0placeholder",
-    });
-  });
-
-  it("returns config with custom headers for notion", () => {
-    const config = getServiceConfig("notion");
-    expect(config).toBeDefined();
-    expect(config!.apis[0]!.auth.headers["Notion-Version"]).toBe("2022-06-28");
-  });
-
-  it("returns undefined for computer connector (no proxy support)", () => {
-    const config = getServiceConfig("computer");
-    expect(config).toBeUndefined();
-  });
-
-  it("all proxy configs have valid services and auth headers", () => {
-    const allTypes = Object.keys(CONNECTOR_TYPES) as ConnectorType[];
-
-    for (const type of allTypes) {
-      const config = getServiceConfig(type);
-      if (!config) continue;
-
-      expect(
-        config.apis.length,
-        `${type} should have at least one service`,
-      ).toBeGreaterThan(0);
-      for (const svc of config.apis) {
-        expect(svc.base, `${type} service base should be https URL`).toMatch(
-          /^https:\/\//,
-        );
-        expect(
-          Object.keys(svc.auth.headers).length,
-          `${type} service should have at least one auth header`,
-        ).toBeGreaterThan(0);
-      }
-    }
   });
 });

--- a/turbo/packages/core/src/contracts/__tests__/services.test.ts
+++ b/turbo/packages/core/src/contracts/__tests__/services.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import { CONNECTOR_TYPES } from "../connectors";
+import type { ConnectorType } from "../connectors";
+import { getServiceConfig } from "../services";
+
+describe("getServiceConfig", () => {
+  it("returns proxy config for known connector types", () => {
+    const config = getServiceConfig("github");
+    expect(config).toBeDefined();
+    expect(config!.apis[0]!.base).toBe("https://api.github.com");
+    expect(config!.apis[0]!.auth.headers.Authorization).toBe(
+      "Bearer ${secrets.GITHUB_TOKEN}",
+    );
+    expect(config!.placeholders).toEqual({
+      GITHUB_TOKEN: "gho_vm0placeholder0000000000000000000000",
+    });
+  });
+
+  it("returns config with multiple services for slack", () => {
+    const config = getServiceConfig("slack");
+    expect(config).toBeDefined();
+    expect(config!.apis.map((s) => s.base)).toEqual([
+      "https://slack.com/api",
+      "https://files.slack.com",
+    ]);
+    expect(config!.placeholders).toEqual({
+      SLACK_TOKEN: "xoxb-0000-0000-vm0placeholder",
+    });
+  });
+
+  it("returns config with custom headers for notion", () => {
+    const config = getServiceConfig("notion");
+    expect(config).toBeDefined();
+    expect(config!.apis[0]!.auth.headers["Notion-Version"]).toBe("2022-06-28");
+  });
+
+  it("returns undefined for computer connector (no proxy support)", () => {
+    const config = getServiceConfig("computer");
+    expect(config).toBeUndefined();
+  });
+
+  it("all proxy configs have valid services and auth headers", () => {
+    const allTypes = Object.keys(CONNECTOR_TYPES) as ConnectorType[];
+
+    for (const type of allTypes) {
+      const config = getServiceConfig(type);
+      if (!config) continue;
+
+      expect(
+        config.apis.length,
+        `${type} should have at least one service`,
+      ).toBeGreaterThan(0);
+      for (const svc of config.apis) {
+        expect(svc.base, `${type} service base should be https URL`).toMatch(
+          /^https:\/\//,
+        );
+        expect(
+          Object.keys(svc.auth.headers).length,
+          `${type} service should have at least one auth header`,
+        ).toBeGreaterThan(0);
+      }
+    }
+  });
+});

--- a/turbo/packages/core/src/contracts/services.ts
+++ b/turbo/packages/core/src/contracts/services.ts
@@ -70,18 +70,15 @@ function bearerAuth(secretName: string) {
   return { headers: { Authorization: `Bearer \${secrets.${secretName}}` } };
 }
 
-/** Create a catch-all permission with the given name. */
-function fullAccess(name = "full-access"): ServicePermission {
-  return { name, rules: ["ANY /{path+}"] };
-}
+/** Default catch-all permission for services without granular permissions. */
+const FULL_ACCESS_PERMISSION: ServicePermission = {
+  name: "full-access",
+  rules: ["ANY /{path+}"],
+};
 
-/** Shorthand: single-base API entry with bearer auth and a named catch-all permission. */
-function api(
-  base: string,
-  auth: ServiceApi["auth"],
-  permissionName = "full-access",
-): ServiceApi {
-  return { base, auth, permissions: [fullAccess(permissionName)] };
+/** Shorthand: single-base API entry with bearer auth. */
+function api(base: string, auth: ServiceApi["auth"]): ServiceApi {
+  return { base, auth, permissions: [FULL_ACCESS_PERMISSION] };
 }
 
 const SERVICE_CONFIGS: Partial<
@@ -287,16 +284,8 @@ const SERVICE_CONFIGS: Partial<
   },
   slack: {
     apis: [
-      api(
-        "https://slack.com/api",
-        bearerAuth("SLACK_TOKEN"),
-        "api-full-access",
-      ),
-      api(
-        "https://files.slack.com",
-        bearerAuth("SLACK_TOKEN"),
-        "files-full-access",
-      ),
+      api("https://slack.com/api", bearerAuth("SLACK_TOKEN")),
+      api("https://files.slack.com", bearerAuth("SLACK_TOKEN")),
     ],
     placeholders: {
       SLACK_TOKEN: "xoxb-0000-0000-vm0placeholder",
@@ -304,30 +293,14 @@ const SERVICE_CONFIGS: Partial<
   },
   docusign: {
     apis: [
-      api(
-        "https://demo.docusign.net/restapi",
-        bearerAuth("DOCUSIGN_TOKEN"),
-        "demo-full-access",
-      ),
-      api(
-        "https://na1.docusign.net/restapi",
-        bearerAuth("DOCUSIGN_TOKEN"),
-        "na1-full-access",
-      ),
+      api("https://demo.docusign.net/restapi", bearerAuth("DOCUSIGN_TOKEN")),
+      api("https://na1.docusign.net/restapi", bearerAuth("DOCUSIGN_TOKEN")),
     ],
   },
   dropbox: {
     apis: [
-      api(
-        "https://api.dropboxapi.com/2",
-        bearerAuth("DROPBOX_TOKEN"),
-        "api-full-access",
-      ),
-      api(
-        "https://content.dropboxapi.com/2",
-        bearerAuth("DROPBOX_TOKEN"),
-        "content-full-access",
-      ),
+      api("https://api.dropboxapi.com/2", bearerAuth("DROPBOX_TOKEN")),
+      api("https://content.dropboxapi.com/2", bearerAuth("DROPBOX_TOKEN")),
     ],
   },
   linear: {
@@ -335,21 +308,9 @@ const SERVICE_CONFIGS: Partial<
   },
   intercom: {
     apis: [
-      api(
-        "https://api.intercom.io",
-        bearerAuth("INTERCOM_TOKEN"),
-        "us-full-access",
-      ),
-      api(
-        "https://api.eu.intercom.io",
-        bearerAuth("INTERCOM_TOKEN"),
-        "eu-full-access",
-      ),
-      api(
-        "https://api.au.intercom.io",
-        bearerAuth("INTERCOM_TOKEN"),
-        "au-full-access",
-      ),
+      api("https://api.intercom.io", bearerAuth("INTERCOM_TOKEN")),
+      api("https://api.eu.intercom.io", bearerAuth("INTERCOM_TOKEN")),
+      api("https://api.au.intercom.io", bearerAuth("INTERCOM_TOKEN")),
     ],
   },
   jam: {
@@ -357,24 +318,16 @@ const SERVICE_CONFIGS: Partial<
   },
   jotform: {
     apis: [
-      api(
-        "https://api.jotform.com",
-        {
-          headers: {
-            APIKEY: "${secrets.JOTFORM_TOKEN}",
-          },
+      api("https://api.jotform.com", {
+        headers: {
+          APIKEY: "${secrets.JOTFORM_TOKEN}",
         },
-        "us-full-access",
-      ),
-      api(
-        "https://eu-api.jotform.com",
-        {
-          headers: {
-            APIKEY: "${secrets.JOTFORM_TOKEN}",
-          },
+      }),
+      api("https://eu-api.jotform.com", {
+        headers: {
+          APIKEY: "${secrets.JOTFORM_TOKEN}",
         },
-        "eu-full-access",
-      ),
+      }),
     ],
   },
   line: {
@@ -382,42 +335,26 @@ const SERVICE_CONFIGS: Partial<
   },
   make: {
     apis: [
-      api(
-        "https://eu1.make.com/api/v2",
-        {
-          headers: {
-            Authorization: "Token ${secrets.MAKE_TOKEN}",
-          },
+      api("https://eu1.make.com/api/v2", {
+        headers: {
+          Authorization: "Token ${secrets.MAKE_TOKEN}",
         },
-        "eu1-full-access",
-      ),
-      api(
-        "https://eu2.make.com/api/v2",
-        {
-          headers: {
-            Authorization: "Token ${secrets.MAKE_TOKEN}",
-          },
+      }),
+      api("https://eu2.make.com/api/v2", {
+        headers: {
+          Authorization: "Token ${secrets.MAKE_TOKEN}",
         },
-        "eu2-full-access",
-      ),
-      api(
-        "https://us1.make.com/api/v2",
-        {
-          headers: {
-            Authorization: "Token ${secrets.MAKE_TOKEN}",
-          },
+      }),
+      api("https://us1.make.com/api/v2", {
+        headers: {
+          Authorization: "Token ${secrets.MAKE_TOKEN}",
         },
-        "us1-full-access",
-      ),
-      api(
-        "https://us2.make.com/api/v2",
-        {
-          headers: {
-            Authorization: "Token ${secrets.MAKE_TOKEN}",
-          },
+      }),
+      api("https://us2.make.com/api/v2", {
+        headers: {
+          Authorization: "Token ${secrets.MAKE_TOKEN}",
         },
-        "us2-full-access",
-      ),
+      }),
     ],
   },
   metabase: {
@@ -502,16 +439,8 @@ const SERVICE_CONFIGS: Partial<
   },
   posthog: {
     apis: [
-      api(
-        "https://us.posthog.com/api",
-        bearerAuth("POSTHOG_ACCESS_TOKEN"),
-        "us-full-access",
-      ),
-      api(
-        "https://app.posthog.com/api",
-        bearerAuth("POSTHOG_ACCESS_TOKEN"),
-        "cloud-full-access",
-      ),
+      api("https://us.posthog.com/api", bearerAuth("POSTHOG_ACCESS_TOKEN")),
+      api("https://app.posthog.com/api", bearerAuth("POSTHOG_ACCESS_TOKEN")),
     ],
   },
   stripe: {
@@ -543,7 +472,6 @@ const SERVICE_CONFIGS: Partial<
       api(
         `https://us${i + 1}.api.mailchimp.com/3.0`,
         bearerAuth("MAILCHIMP_TOKEN"),
-        `us${i + 1}-full-access`,
       ),
     ),
   },


### PR DESCRIPTION
## Summary

- Allow the same permission name across different api_entries within a service (e.g., `full-access` on both `slack.com/api` and `files.slack.com`)
- Enforce uniqueness only within a single api_entry
- Revert 8 multi-api services back to shared `full-access` permission name
- Simplify `api()` helper (remove `permissionName` parameter)

## Motivation

When a user selects `permissions: ["full-access"]`, they expect it to enable **all** api_entries that have that permission. Forcing unique names per api_entry (like `api-full-access` / `files-full-access`) adds unnecessary complexity for users.

The matching in `mitm_addon` is per base URL — the permission name doesn't create ambiguity because `service_base` and `service_api_id` distinguish entries in logs.

## Test plan

- [x] 124 compose tests pass
- [x] Updated test verifies both slack api_entries kept when `full-access` selected
- [x] All built-in service configs pass validation via `connectorTypeSchema` iteration

🤖 Generated with [Claude Code](https://claude.com/claude-code)