### PR TITLE
fix(compose): pass org context to e2b compose job sandbox

### DIFF
--- a/turbo/apps/web/app/api/compose/jobs/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/compose/jobs/__tests__/route.test.ts
@@ -746,6 +746,30 @@ describe("Platform session auth (no CLI token)", () => {
     expect(sandboxEnvs.VM0_TOKEN).toMatch(/^vm0_live_/);
   });
 
+  it("should pass VM0_ACTIVE_ORG to sandbox with org slug", async () => {
+    await context.setupUser();
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/compose/jobs",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          githubUrl: "https://github.com/owner/repo",
+        }),
+      },
+    );
+
+    const response = await POST(request);
+    expect(response.status).toBe(201);
+
+    const createCall = vi.mocked(Sandbox.create).mock.calls[0];
+    expect(createCall).toBeDefined();
+    const sandboxEnvs = createCall![1]?.envs as Record<string, string>;
+    expect(sandboxEnvs.VM0_ACTIVE_ORG).toBeDefined();
+    expect(sandboxEnvs.VM0_ACTIVE_ORG).toMatch(/^org-/);
+  });
+
   it("should create a job with Clerk JWT in Authorization header", async () => {
     // Platform SaaS sends a Clerk JWT as Bearer token — this should still work
     // because getUserId() resolves auth via Clerk session cookies first

--- a/turbo/apps/web/app/api/compose/jobs/route.ts
+++ b/turbo/apps/web/app/api/compose/jobs/route.ts
@@ -66,14 +66,14 @@ const router = tsr.router(composeJobsMainContract, {
     const result = isGitHubInput
       ? await triggerComposeJob({
           userId,
-          orgId: org.orgId,
+          orgSlug: org.slug,
           source: "github",
           githubUrl: body.githubUrl,
           overwrite: body.overwrite,
         })
       : await triggerComposeJob({
           userId,
-          orgId: org.orgId,
+          orgSlug: org.slug,
           source: "platform",
           content: body.content,
           instructions: body.instructions,

--- a/turbo/apps/web/app/api/webhooks/compose/complete/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/compose/complete/__tests__/route.test.ts
@@ -597,6 +597,7 @@ describe("POST /api/webhooks/compose/complete", () => {
       // Trigger compose job (sandbox creation is pending)
       const result = await triggerComposeJob({
         userId: userLink.vm0UserId,
+        orgSlug: "test-org",
         source: "github",
         githubUrl: "https://github.com/owner/failing-repo",
       });

--- a/turbo/apps/web/src/lib/compose/trigger-compose-job.ts
+++ b/turbo/apps/web/src/lib/compose/trigger-compose-job.ts
@@ -233,6 +233,7 @@ async function spawnComposeJobSandbox(
   params: SandboxComposeParams,
   cliToken: string,
   webhookToken: string,
+  orgSlug: string,
 ): Promise<void> {
   const apiUrl = getApiUrl();
   const webhookUrl = `${apiUrl}/api/webhooks/compose/complete`;
@@ -247,6 +248,7 @@ async function spawnComposeJobSandbox(
     VM0_API_URL: apiUrl,
     VM0_WEBHOOK_URL: webhookUrl,
     VM0_WEBHOOK_TOKEN: webhookToken,
+    VM0_ACTIVE_ORG: orgSlug,
     ...(env().VERCEL_AUTOMATION_BYPASS_SECRET && {
       VERCEL_PROTECTION_BYPASS: env().VERCEL_AUTOMATION_BYPASS_SECRET,
     }),
@@ -383,14 +385,14 @@ async function generateComposeCliToken(
 type TriggerComposeJobParams =
   | {
       userId: string;
-      orgId?: string;
+      orgSlug: string;
       source: "github";
       githubUrl: string;
       overwrite?: boolean;
     }
   | {
       userId: string;
-      orgId?: string;
+      orgSlug: string;
       source: "platform";
       content: Record<string, unknown>;
       instructions?: string;
@@ -399,7 +401,7 @@ type TriggerComposeJobParams =
 export async function triggerComposeJob(
   params: TriggerComposeJobParams,
 ): Promise<TriggerComposeJobResult> {
-  const { userId, source } = params;
+  const { userId, source, orgSlug } = params;
 
   // Atomic idempotency: INSERT with ON CONFLICT DO NOTHING against the
   // partial unique index (user_id WHERE status IN ('pending','running')).
@@ -472,36 +474,40 @@ export async function triggerComposeJob(
         };
 
   // Fire-and-forget: Spawn sandbox asynchronously
-  spawnComposeJobSandbox(jobId, sandboxParams, cliToken, webhookToken).catch(
-    async (error) => {
-      log.error(`Failed to spawn sandbox for job ${jobId}:`, error);
-      const errorMessage =
-        error instanceof Error ? error.message : "Failed to create sandbox";
-      // Wrap in try/catch to prevent unhandled rejection: this is already
-      // inside a fire-and-forget .catch() handler, so a DB failure here
-      // must not propagate as a second unhandled rejection.
-      try {
-        await globalThis.services.db
-          .update(composeJobs)
-          .set({
-            status: "failed",
-            error: errorMessage,
-            completedAt: new Date(),
-          })
-          .where(eq(composeJobs.id, jobId));
-      } catch (dbError) {
-        log.error(`Failed to update job ${jobId} status to failed:`, dbError);
-      }
+  spawnComposeJobSandbox(
+    jobId,
+    sandboxParams,
+    cliToken,
+    webhookToken,
+    orgSlug,
+  ).catch(async (error) => {
+    log.error(`Failed to spawn sandbox for job ${jobId}:`, error);
+    const errorMessage =
+      error instanceof Error ? error.message : "Failed to create sandbox";
+    // Wrap in try/catch to prevent unhandled rejection: this is already
+    // inside a fire-and-forget .catch() handler, so a DB failure here
+    // must not propagate as a second unhandled rejection.
+    try {
+      await globalThis.services.db
+        .update(composeJobs)
+        .set({
+          status: "failed",
+          error: errorMessage,
+          completedAt: new Date(),
+        })
+        .where(eq(composeJobs.id, jobId));
+    } catch (dbError) {
+      log.error(`Failed to update job ${jobId} status to failed:`, dbError);
+    }
 
-      await notifySlackComposeComplete(jobId, null, errorMessage).catch(
-        (notifyError) => {
-          log.warn("Failed to send Slack failure notification", {
-            notifyError,
-          });
-        },
-      );
-    },
-  );
+    await notifySlackComposeComplete(jobId, null, errorMessage).catch(
+      (notifyError) => {
+        log.warn("Failed to send Slack failure notification", {
+          notifyError,
+        });
+      },
+    );
+  });
 
   return {
     jobId: newJob.id,

--- a/turbo/scripts/e2b/vm0-cli/template.ts
+++ b/turbo/scripts/e2b/vm0-cli/template.ts
@@ -11,4 +11,4 @@ import { Template } from "e2b";
 export const template = Template()
   .fromNodeImage("24")
   .aptInstall(["curl", "git", "jq", "tzdata"])
-  .npmInstall("@vm0/cli@9.57.0", { g: true });
+  .npmInstall("@vm0/cli@9.58.0", { g: true });


### PR DESCRIPTION
## Summary
- Replace unused `orgId?` with required `orgSlug` in `TriggerComposeJobParams`
- Thread `orgSlug` through to `spawnComposeJobSandbox()` and add `VM0_ACTIVE_ORG` env var to sandbox
- Pass `org.slug` from API route instead of `org.orgId`
- Bump E2B template CLI from 9.57.0 to 9.58.0 (includes `VM0_ACTIVE_ORG` support)
- Add test verifying `VM0_ACTIVE_ORG` is passed to sandbox with correct org slug

Closes #4752

## Test plan
- [ ] Verify `VM0_ACTIVE_ORG` env var is present in E2B sandbox creation call
- [ ] Verify org slug format matches expected pattern (`org-*`)
- [ ] CI passes (lint, type check, tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)