### PR TITLE
refactor: consolidate org resolution into single resolve-org function

### DIFF
--- a/turbo/apps/web/app/api/agent/schedules/[name]/disable/route.ts
+++ b/turbo/apps/web/app/api/agent/schedules/[name]/disable/route.ts
@@ -5,7 +5,7 @@ import { getAuthContext } from "../../../../../../src/lib/auth/get-user-id";
 import { disableSchedule } from "../../../../../../src/lib/schedule";
 import { logger } from "../../../../../../src/lib/logger";
 import { isNotFound } from "../../../../../../src/lib/errors";
-import { resolveOrgId } from "../../../../../../src/lib/org/org-member-service";
+import { resolveOrg } from "../../../../../../src/lib/org/resolve-org";
 
 const log = logger("api:schedules:disable");
 
@@ -48,7 +48,9 @@ export async function POST(
   }
   const body = parseResult.data;
 
-  const orgId = await resolveOrgId(userId);
+  const {
+    org: { orgId },
+  } = await resolveOrg(userId);
 
   log.debug(`Disabling schedule ${name} for compose ${body.composeId}`);
 

--- a/turbo/apps/web/app/api/agent/schedules/[name]/disable/route.ts
+++ b/turbo/apps/web/app/api/agent/schedules/[name]/disable/route.ts
@@ -48,9 +48,10 @@ export async function POST(
   }
   const body = parseResult.data;
 
+  const orgSlug = new URL(request.url).searchParams.get("org");
   const {
     org: { orgId },
-  } = await resolveOrg(userId);
+  } = await resolveOrg(userId, orgSlug);
 
   log.debug(`Disabling schedule ${name} for compose ${body.composeId}`);
 

--- a/turbo/apps/web/app/api/agent/schedules/[name]/enable/route.ts
+++ b/turbo/apps/web/app/api/agent/schedules/[name]/enable/route.ts
@@ -5,7 +5,7 @@ import { getAuthContext } from "../../../../../../src/lib/auth/get-user-id";
 import { enableSchedule } from "../../../../../../src/lib/schedule";
 import { logger } from "../../../../../../src/lib/logger";
 import { isNotFound, isSchedulePast } from "../../../../../../src/lib/errors";
-import { resolveOrgId } from "../../../../../../src/lib/org/org-member-service";
+import { resolveOrg } from "../../../../../../src/lib/org/resolve-org";
 
 const log = logger("api:schedules:enable");
 
@@ -48,7 +48,9 @@ export async function POST(
   }
   const body = parseResult.data;
 
-  const orgId = await resolveOrgId(userId);
+  const {
+    org: { orgId },
+  } = await resolveOrg(userId);
 
   log.debug(`Enabling schedule ${name} for compose ${body.composeId}`);
 

--- a/turbo/apps/web/app/api/agent/schedules/[name]/enable/route.ts
+++ b/turbo/apps/web/app/api/agent/schedules/[name]/enable/route.ts
@@ -48,9 +48,10 @@ export async function POST(
   }
   const body = parseResult.data;
 
+  const orgSlug = new URL(request.url).searchParams.get("org");
   const {
     org: { orgId },
-  } = await resolveOrg(userId);
+  } = await resolveOrg(userId, orgSlug);
 
   log.debug(`Enabling schedule ${name} for compose ${body.composeId}`);
 

--- a/turbo/apps/web/app/api/agent/schedules/[name]/route.ts
+++ b/turbo/apps/web/app/api/agent/schedules/[name]/route.ts
@@ -12,7 +12,7 @@ import {
 } from "../../../../../src/lib/schedule";
 import { logger } from "../../../../../src/lib/logger";
 import { isNotFound } from "../../../../../src/lib/errors";
-import { resolveOrgId } from "../../../../../src/lib/org/org-member-service";
+import { resolveOrg } from "../../../../../src/lib/org/resolve-org";
 
 const log = logger("api:schedules:name");
 
@@ -34,7 +34,9 @@ const router = tsr.router(schedulesByNameContract, {
     log.debug(`Getting schedule ${params.name} for compose ${query.composeId}`);
 
     try {
-      const orgId = await resolveOrgId(userId);
+      const {
+        org: { orgId },
+      } = await resolveOrg(userId);
 
       const schedule = await getScheduleByName(
         userId,
@@ -79,7 +81,9 @@ const router = tsr.router(schedulesByNameContract, {
     );
 
     try {
-      const orgId = await resolveOrgId(userId);
+      const {
+        org: { orgId },
+      } = await resolveOrg(userId);
 
       await deleteSchedule(userId, orgId, query.composeId, params.name);
 

--- a/turbo/apps/web/app/api/agent/schedules/[name]/route.ts
+++ b/turbo/apps/web/app/api/agent/schedules/[name]/route.ts
@@ -17,7 +17,7 @@ import { resolveOrg } from "../../../../../src/lib/org/resolve-org";
 const log = logger("api:schedules:name");
 
 const router = tsr.router(schedulesByNameContract, {
-  getByName: async ({ params, query, headers }) => {
+  getByName: async ({ params, query, headers }, { request }) => {
     initServices();
 
     const authCtx = await getAuthContext(headers.authorization);
@@ -34,9 +34,10 @@ const router = tsr.router(schedulesByNameContract, {
     log.debug(`Getting schedule ${params.name} for compose ${query.composeId}`);
 
     try {
+      const orgSlug = new URL(request.url).searchParams.get("org");
       const {
         org: { orgId },
-      } = await resolveOrg(userId);
+      } = await resolveOrg(userId, orgSlug);
 
       const schedule = await getScheduleByName(
         userId,
@@ -62,7 +63,7 @@ const router = tsr.router(schedulesByNameContract, {
     }
   },
 
-  delete: async ({ params, query, headers }) => {
+  delete: async ({ params, query, headers }, { request }) => {
     initServices();
 
     const authCtx = await getAuthContext(headers.authorization);
@@ -81,9 +82,10 @@ const router = tsr.router(schedulesByNameContract, {
     );
 
     try {
+      const orgSlug = new URL(request.url).searchParams.get("org");
       const {
         org: { orgId },
-      } = await resolveOrg(userId);
+      } = await resolveOrg(userId, orgSlug);
 
       await deleteSchedule(userId, orgId, query.composeId, params.name);
 

--- a/turbo/apps/web/app/api/agent/schedules/[name]/runs/route.ts
+++ b/turbo/apps/web/app/api/agent/schedules/[name]/runs/route.ts
@@ -14,7 +14,7 @@ import { resolveOrg } from "../../../../../../src/lib/org/resolve-org";
 const log = logger("api:schedules:runs");
 
 const router = tsr.router(scheduleRunsContract, {
-  listRuns: async ({ params, query, headers }) => {
+  listRuns: async ({ params, query, headers }, { request }) => {
     initServices();
 
     const authCtx = await getAuthContext(headers.authorization);
@@ -33,9 +33,10 @@ const router = tsr.router(scheduleRunsContract, {
     );
 
     try {
+      const orgSlug = new URL(request.url).searchParams.get("org");
       const {
         org: { orgId },
-      } = await resolveOrg(userId);
+      } = await resolveOrg(userId, orgSlug);
 
       const runs = await getScheduleRecentRuns(
         userId,

--- a/turbo/apps/web/app/api/agent/schedules/[name]/runs/route.ts
+++ b/turbo/apps/web/app/api/agent/schedules/[name]/runs/route.ts
@@ -9,7 +9,7 @@ import { getAuthContext } from "../../../../../../src/lib/auth/get-user-id";
 import { getScheduleRecentRuns } from "../../../../../../src/lib/schedule";
 import { logger } from "../../../../../../src/lib/logger";
 import { isNotFound } from "../../../../../../src/lib/errors";
-import { resolveOrgId } from "../../../../../../src/lib/org/org-member-service";
+import { resolveOrg } from "../../../../../../src/lib/org/resolve-org";
 
 const log = logger("api:schedules:runs");
 
@@ -33,7 +33,9 @@ const router = tsr.router(scheduleRunsContract, {
     );
 
     try {
-      const orgId = await resolveOrgId(userId);
+      const {
+        org: { orgId },
+      } = await resolveOrg(userId);
 
       const runs = await getScheduleRecentRuns(
         userId,

--- a/turbo/apps/web/app/api/agent/schedules/missing-secrets/route.ts
+++ b/turbo/apps/web/app/api/agent/schedules/missing-secrets/route.ts
@@ -51,7 +51,8 @@ export async function GET(request: Request) {
   }
 
   // Get user's org to query configured secrets
-  const runtimeOrg = await resolveOrgOrNull(userId);
+  const orgSlug = new URL(request.url).searchParams.get("org");
+  const runtimeOrg = await resolveOrgOrNull(userId, orgSlug);
   if (!runtimeOrg) {
     return NextResponse.json({ agents: [] });
   }

--- a/turbo/apps/web/app/api/agent/schedules/missing-secrets/route.ts
+++ b/turbo/apps/web/app/api/agent/schedules/missing-secrets/route.ts
@@ -9,7 +9,7 @@ import {
   getUserAgents,
   batchFetchVersionContents,
 } from "../../../../../src/lib/agent/get-user-agents";
-import { getDefaultOrgByUserId } from "../../../../../src/lib/org/org-service";
+import { resolveOrgOrNull } from "../../../../../src/lib/org/resolve-org";
 
 const log = logger("api:agents:missing-secrets");
 
@@ -51,7 +51,7 @@ export async function GET(request: Request) {
   }
 
   // Get user's org to query configured secrets
-  const runtimeOrg = await getDefaultOrgByUserId(userId);
+  const runtimeOrg = await resolveOrgOrNull(userId);
   if (!runtimeOrg) {
     return NextResponse.json({ agents: [] });
   }

--- a/turbo/apps/web/app/api/agent/schedules/route.ts
+++ b/turbo/apps/web/app/api/agent/schedules/route.ts
@@ -14,7 +14,7 @@ import { resolveOrg } from "../../../../src/lib/org/resolve-org";
 const log = logger("api:schedules");
 
 const router = tsr.router(schedulesMainContract, {
-  deploy: async ({ body, headers }) => {
+  deploy: async ({ body, headers }, { request }) => {
     initServices();
 
     const authCtx = await getAuthContext(headers.authorization);
@@ -33,9 +33,10 @@ const router = tsr.router(schedulesMainContract, {
     try {
       // Note: vars and secrets are no longer accepted via API
       // They must be managed via platform tables (vm0 secret set, vm0 var set)
+      const orgSlug = new URL(request.url).searchParams.get("org");
       const {
         org: { orgId },
-      } = await resolveOrg(userId);
+      } = await resolveOrg(userId, orgSlug);
 
       const result = await deploySchedule(userId, orgId, {
         name: body.name,

--- a/turbo/apps/web/app/api/agent/schedules/route.ts
+++ b/turbo/apps/web/app/api/agent/schedules/route.ts
@@ -9,7 +9,7 @@ import { getAuthContext } from "../../../../src/lib/auth/get-user-id";
 import { deploySchedule, listSchedules } from "../../../../src/lib/schedule";
 import { logger } from "../../../../src/lib/logger";
 import { isNotFound, isBadRequest } from "../../../../src/lib/errors";
-import { resolveOrgId } from "../../../../src/lib/org/org-member-service";
+import { resolveOrg } from "../../../../src/lib/org/resolve-org";
 
 const log = logger("api:schedules");
 
@@ -33,7 +33,9 @@ const router = tsr.router(schedulesMainContract, {
     try {
       // Note: vars and secrets are no longer accepted via API
       // They must be managed via platform tables (vm0 secret set, vm0 var set)
-      const orgId = await resolveOrgId(userId);
+      const {
+        org: { orgId },
+      } = await resolveOrg(userId);
 
       const result = await deploySchedule(userId, orgId, {
         name: body.name,

--- a/turbo/apps/web/app/api/cli/auth/test-connector/route.ts
+++ b/turbo/apps/web/app/api/cli/auth/test-connector/route.ts
@@ -7,7 +7,7 @@ import {
   resolveTestUserId,
   isTestVariant,
 } from "../../../../../src/lib/auth/test-user";
-import { getDefaultOrgByUserId } from "../../../../../src/lib/org/org-service";
+import { resolveOrgOrNull } from "../../../../../src/lib/org/resolve-org";
 import { env } from "../../../../../src/env";
 
 const bodySchema = z.object({
@@ -91,7 +91,7 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "Test user not found" }, { status: 500 });
   }
 
-  const org = await getDefaultOrgByUserId(userId);
+  const org = await resolveOrgOrNull(userId);
   if (!org) {
     return NextResponse.json(
       { error: "Test user has no org — run test-token first" },

--- a/turbo/apps/web/app/api/cli/auth/test-token/route.ts
+++ b/turbo/apps/web/app/api/cli/auth/test-token/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 import crypto from "crypto";
 import { initServices } from "../../../../../src/lib/init-services";
 import { cliTokens } from "../../../../../src/db/schema/cli-tokens";
-import { getDefaultOrg } from "../../../../../src/lib/org/org-member-service";
+import { resolveOrg } from "../../../../../src/lib/org/resolve-org";
 import { orgCache } from "../../../../../src/db/schema/org-cache";
 import { orgMembersCache } from "../../../../../src/db/schema/org-members-cache";
 import { isNotFound } from "../../../../../src/lib/errors";
@@ -40,7 +40,7 @@ function isTestTokenAllowed(request: Request): boolean {
 
 /**
  * Ensure the test user has an org_cache entry for org resolution.
- * Uses the same flow as production (getDefaultOrg) so that
+ * Uses the same flow as production (resolveOrg) so that
  * Clerk API membership verification works during E2E tests.
  *
  * If the user has no Clerk org yet, creates org_cache and org_members_cache
@@ -48,7 +48,7 @@ function isTestTokenAllowed(request: Request): boolean {
  */
 async function ensureTestOrg(userId: string): Promise<{ slug: string }> {
   try {
-    const { org, member } = await getDefaultOrg(userId);
+    const { org, member } = await resolveOrg(userId);
     // Pre-populate org_members_cache so verifyMembershipCached hits cache
     // instead of calling Clerk API on every request (avoids 429 rate limits)
     await globalThis.services.db

--- a/turbo/apps/web/app/api/integrations/slack/link/route.ts
+++ b/turbo/apps/web/app/api/integrations/slack/link/route.ts
@@ -17,7 +17,7 @@ import {
 } from "../../../../../src/lib/slack/handlers/shared";
 import { getUserEmail } from "../../../../../src/lib/auth/get-user-email";
 import { addPermission } from "../../../../../src/lib/agent/permission-service";
-import { getDefaultOrgByUserId } from "../../../../../src/lib/org/org-service";
+import { resolveOrgOrNull } from "../../../../../src/lib/org/resolve-org";
 import { agentComposes } from "../../../../../src/db/schema/agent-compose";
 import { logger } from "../../../../../src/lib/logger";
 import { syncWorkspaceAgentPermissions } from "../../../../../src/lib/slack/permission-sync";
@@ -130,7 +130,7 @@ async function buildAgentFields(
 
   let agents: Array<{ id: string; name: string }> = [];
   if (isAdmin) {
-    const defaultOrg = await getDefaultOrgByUserId(userId);
+    const defaultOrg = await resolveOrgOrNull(userId);
     if (defaultOrg) {
       const userAgents = await globalThis.services.db
         .select({ id: agentComposes.id, name: agentComposes.name })

--- a/turbo/apps/web/src/lib/email/handlers/inbound-trigger.ts
+++ b/turbo/apps/web/src/lib/email/handlers/inbound-trigger.ts
@@ -15,7 +15,7 @@ import { createRun } from "../../run";
 import { buildIntegrationContext } from "../../integration-context";
 import { generateCallbackSecret, getApiUrl } from "../../callback";
 import { getUserIdByEmail } from "../../auth/get-user-id-by-email";
-import { getDefaultOrgByUserId } from "../../org/org-service";
+import { resolveOrgOrNull } from "../../org/resolve-org";
 import { canAccessCompose } from "../../agent/permission-service";
 import { getUserEmail } from "../../auth/get-user-email";
 import { logger } from "../../logger";
@@ -100,7 +100,7 @@ async function resolveTrigger(
     };
   }
 
-  const runtimeOrg = await getDefaultOrgByUserId(userId);
+  const runtimeOrg = await resolveOrgOrNull(userId);
   if (!runtimeOrg) {
     log.debug("Sender has no org", { from: senderEmail, userId });
     return {

--- a/turbo/apps/web/src/lib/org/__tests__/org-service.test.ts
+++ b/turbo/apps/web/src/lib/org/__tests__/org-service.test.ts
@@ -2,30 +2,30 @@ import { describe, it, expect, beforeEach } from "vitest";
 import { testContext, uniqueId } from "../../../__tests__/test-helpers";
 import { insertOrgCacheEntry } from "../../../__tests__/api-test-helpers";
 import { mockClerk } from "../../../__tests__/clerk-mock";
-import { getDefaultOrgByUserId } from "../org-service";
+import { resolveOrgOrNull } from "../resolve-org";
 
 const context = testContext();
 
-describe("getDefaultOrgByUserId", () => {
+describe("resolveOrgOrNull", () => {
   beforeEach(() => {
     context.setupMocks();
   });
 
   it("should return null when user has no org", async () => {
-    // setupUser initializes services (db, etc.) needed by getDefaultOrg
+    // setupUser initializes services (db, etc.) needed by resolveOrg
     await context.setupUser();
 
     // Re-mock Clerk with a user that has no orgs
     const userId = uniqueId("no-org-user");
     mockClerk({ userId, clerkOrgs: [] });
 
-    const result = await getDefaultOrgByUserId(userId);
+    const result = await resolveOrgOrNull(userId);
 
     expect(result).toBeNull();
   });
 
   it("should return org from org_cache for user with Clerk org", async () => {
-    // setupUser initializes services (db, etc.) needed by getDefaultOrg
+    // setupUser initializes services (db, etc.) needed by resolveOrg
     await context.setupUser();
 
     // Re-mock Clerk with a specific user
@@ -37,7 +37,7 @@ describe("getDefaultOrgByUserId", () => {
     // Pre-populate org_cache
     await insertOrgCacheEntry({ orgId, slug, tier: "free" });
 
-    const result = await getDefaultOrgByUserId(userId);
+    const result = await resolveOrgOrNull(userId);
 
     expect(result).not.toBeNull();
     expect(result!.orgId).toBe(orgId);

--- a/turbo/apps/web/src/lib/org/__tests__/resolve-org.test.ts
+++ b/turbo/apps/web/src/lib/org/__tests__/resolve-org.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { testContext, uniqueId } from "../../../__tests__/test-helpers";
-import { createTestOrg } from "../../../__tests__/api-test-helpers";
+import {
+  createTestOrg,
+  insertOrgCacheEntry,
+  insertOrgMembersCacheEntry,
+} from "../../../__tests__/api-test-helpers";
 import { mockClerk } from "../../../__tests__/clerk-mock";
 import { resolveOrg, requireOrgFromRequest } from "../resolve-org";
 
@@ -122,6 +126,72 @@ describe("resolveOrg", () => {
     const result = await resolveOrg(userId);
 
     expect(result.org.orgId).toBe(`org_mock_${slug}`);
+  });
+
+  it("tier 3: resolves via org_members_cache when no Clerk session", async () => {
+    const userId = uniqueId("test-user");
+    const slug = uniqueId("org");
+    const orgId = `org_mock_${slug}`;
+
+    // Pre-populate org_cache so getOrgDataOrNull resolves
+    await insertOrgCacheEntry({ orgId, slug });
+
+    // Pre-populate org_members_cache with a fresh entry (< 1 min TTL)
+    await insertOrgMembersCacheEntry({ orgId, userId, role: "admin" });
+
+    // Mock as CLI token — no orgId, no Clerk orgs (tier 4 would fail)
+    mockClerk({
+      userId,
+      orgId: null,
+      clerkOrgs: [],
+    });
+
+    // Resolve without slug — tier 2 skipped (no orgId), tier 3 should hit cache
+    const result = await resolveOrg(userId);
+
+    expect(result.org.orgId).toBe(orgId);
+    expect(result.org.slug).toBe(slug);
+  });
+
+  it("tier 3: skips stale org_members_cache entries (>1 min TTL)", async () => {
+    const userId = uniqueId("test-user");
+    const slug = uniqueId("org");
+    const orgId = `org_mock_${slug}`;
+    const freshSlug = uniqueId("org");
+    const freshOrgId = `org_mock_${freshSlug}`;
+
+    // Pre-populate org_cache for the cached org
+    await insertOrgCacheEntry({ orgId, slug });
+
+    // Pre-populate org_members_cache with a STALE entry (> 1 min ago)
+    const staleTime = new Date(Date.now() - 120_000);
+    await insertOrgMembersCacheEntry({
+      orgId,
+      userId,
+      role: "admin",
+      cachedAt: staleTime,
+    });
+
+    // Set up a fresh org via Clerk API (tier 4 fallback)
+    mockClerk({
+      userId,
+      orgId: null,
+      clerkOrgs: [{ id: freshOrgId, slug: freshSlug, name: freshSlug }],
+    });
+    await createTestOrg(freshSlug);
+
+    // Re-mock without orgId for the actual resolution call
+    mockClerk({
+      userId,
+      orgId: null,
+      clerkOrgs: [{ id: freshOrgId, slug: freshSlug, name: freshSlug }],
+    });
+
+    // Stale cache should be skipped, falls through to tier 4 (Clerk API)
+    const result = await resolveOrg(userId);
+
+    expect(result.org.orgId).toBe(freshOrgId);
+    expect(result.org.slug).toBe(freshSlug);
   });
 
   it("tier 3: falls through when orgId has no matching org", async () => {

--- a/turbo/apps/web/src/lib/org/__tests__/resolve-org.test.ts
+++ b/turbo/apps/web/src/lib/org/__tests__/resolve-org.test.ts
@@ -118,7 +118,7 @@ describe("resolveOrg", () => {
       clerkOrgs: testOrgs(slug),
     });
 
-    // Resolve without slug — should fall through to getDefaultOrg (Clerk API)
+    // Resolve without slug — should fall through to default org (Clerk API)
     const result = await resolveOrg(userId);
 
     expect(result.org.orgId).toBe(`org_mock_${slug}`);

--- a/turbo/apps/web/src/lib/org/org-member-service.ts
+++ b/turbo/apps/web/src/lib/org/org-member-service.ts
@@ -1,11 +1,7 @@
-import { auth, clerkClient } from "@clerk/nextjs/server";
-import { eq, desc } from "drizzle-orm";
+import { clerkClient } from "@clerk/nextjs/server";
 import { badRequest, forbidden, notFound } from "../errors";
 import { logger } from "../logger";
-import { getOrgData } from "./org-cache-service";
-import { orgMembersCache } from "../../db/schema/org-members-cache";
 import type { OrgRole } from "@vm0/core";
-import type { ResolvedOrg, ResolvedMember } from "./resolve-org";
 
 const log = logger("service:org-member");
 
@@ -35,100 +31,6 @@ export async function requireOrgMember(orgId: string, userId: string) {
     userId,
     orgId,
   };
-}
-
-/**
- * Get user's default org using org_cache.
- *
- * Fast path: if the JWT session contains an orgId, look up via org_cache
- * — no Clerk API call needed.
- *
- * Slow path: for CLI tokens (no JWT) or when the JWT org has no cache entry,
- * fall back to Clerk Backend API to discover the user's org memberships.
- */
-export async function getDefaultOrg(
-  userId: string,
-): Promise<{ org: ResolvedOrg; member: ResolvedMember }> {
-  // JWT fast path: use active org from session token
-  const authResult = await auth();
-  if (authResult.orgId) {
-    try {
-      const orgData = await getOrgData(authResult.orgId);
-      return {
-        org: orgData,
-        member: {
-          role: mapClerkRole(authResult.orgRole ?? "org:member"),
-          userId,
-        },
-      };
-    } catch {
-      // JWT orgId not found in Clerk — fall through to slow path
-    }
-  }
-
-  // Cache fast path: check org_members_cache for a recent entry (1-min TTL)
-  const [cached] = await globalThis.services.db
-    .select()
-    .from(orgMembersCache)
-    .where(eq(orgMembersCache.userId, userId))
-    .orderBy(desc(orgMembersCache.cachedAt))
-    .limit(1);
-
-  if (cached && Date.now() - cached.cachedAt.getTime() < 60_000) {
-    try {
-      const orgData = await getOrgData(cached.orgId);
-      return {
-        org: orgData,
-        member: {
-          role: cached.role === "admin" ? "admin" : "member",
-          userId,
-        },
-      };
-    } catch {
-      // org_cache miss — fall through to Clerk API
-    }
-  }
-
-  // Slow path: Clerk API (CLI tokens, or JWT org has no local cache entry yet)
-  const client = await clerkClient();
-  const memberships = await client.users.getOrganizationMembershipList({
-    userId,
-  });
-
-  // Priority: admin orgs first, then any org
-  const adminMembership = memberships.data.find((m) => m.role === "org:admin");
-  const candidates = adminMembership
-    ? [
-        adminMembership,
-        ...memberships.data.filter((m) => m !== adminMembership),
-      ]
-    : memberships.data;
-
-  for (const membership of candidates) {
-    const orgId = membership.organization.id;
-    const orgData = await getOrgData(orgId);
-    return {
-      org: orgData,
-      member: {
-        role: mapClerkRole(membership.role),
-        userId,
-      },
-    };
-  }
-
-  throw notFound("No org found for user");
-}
-
-/**
- * Resolve org ID: use the provided value or fall back to the user's default org.
- */
-export async function resolveOrgId(
-  userId: string,
-  orgId?: string | null,
-): Promise<string> {
-  if (orgId) return orgId;
-  const { org } = await getDefaultOrg(userId);
-  return org.orgId;
 }
 
 /**

--- a/turbo/apps/web/src/lib/org/org-service.ts
+++ b/turbo/apps/web/src/lib/org/org-service.ts
@@ -1,11 +1,11 @@
 import { clerkClient } from "@clerk/nextjs/server";
-import { requireOrgMember, getDefaultOrg } from "./org-member-service";
+import { requireOrgMember } from "./org-member-service";
 import {
   getOrgData,
   getOrgBySlug,
   invalidateOrgCache,
 } from "./org-cache-service";
-import { badRequest, forbidden, isNotFound } from "../errors";
+import { badRequest, forbidden } from "../errors";
 import { logger } from "../logger";
 import { verifyMembershipCached } from "./org-membership-cache";
 import type { ResolvedOrg } from "./resolve-org";
@@ -43,23 +43,6 @@ function validateOrgSlug(slug: string): void {
   // TODO: "vm0" is hardcoded as the system org slug. This should be configurable.
   if (RESERVED_SLUGS.includes(slug) || slug.startsWith("vm0")) {
     throw badRequest(`Org slug is reserved`);
-  }
-}
-
-/**
- * Get a user's default org by their Clerk ID.
- * Finds the first org where the user is an admin member.
- * Returns the org record or null if none found.
- */
-export async function getDefaultOrgByUserId(
-  userId: string,
-): Promise<ResolvedOrg | null> {
-  try {
-    const { org } = await getDefaultOrg(userId);
-    return org;
-  } catch (error) {
-    if (isNotFound(error)) return null;
-    throw error;
   }
 }
 

--- a/turbo/apps/web/src/lib/org/resolve-org.ts
+++ b/turbo/apps/web/src/lib/org/resolve-org.ts
@@ -1,8 +1,9 @@
-import { auth } from "@clerk/nextjs/server";
-import { forbidden, badRequest, notFound } from "../errors";
+import { auth, clerkClient } from "@clerk/nextjs/server";
+import { eq, desc } from "drizzle-orm";
+import { forbidden, badRequest, notFound, isNotFound } from "../errors";
 import { logger } from "../logger";
+import { orgMembersCache } from "../../db/schema/org-members-cache";
 import { getOrgBySlug, getOrgData } from "./org-cache-service";
-import { getDefaultOrg } from "./org-member-service";
 import { verifyMembershipCached } from "./org-membership-cache";
 
 import type { OrgRole } from "@vm0/core";
@@ -43,7 +44,7 @@ export interface ResolvedOrg {
  * Minimal member object returned by org resolution.
  * Contains only the fields used downstream (primarily `role` for permission checks).
  */
-export type ResolvedMember = {
+type ResolvedMember = {
   role: OrgRole;
   userId: string;
 };
@@ -112,8 +113,9 @@ function applyJwtTier(
  *
  * Resolution order:
  * 1. orgSlug (?org=<slug> query param) -> org_cache lookup, verify membership
- * 2. orgId (from JWT session token) -> org_cache lookup
- * 3. Fallback -> user's default org via Clerk API
+ * 2. orgId (from JWT session token) -> org_cache lookup, verify membership
+ * 3. org_members_cache (1min TTL) -> org_cache lookup, verify membership
+ * 4. Clerk API slow path (last resort) -> org_cache lookup
  *
  * When the resolved org matches the JWT's active org, `tier` is read from
  * sessionClaims.org_tier (falling back to org_cache value if missing).
@@ -155,8 +157,71 @@ export async function resolveOrg(
     }
   }
 
-  // 3. Default org fallback
-  return getDefaultOrg(userId);
+  // 3. org_members_cache fallback (1min TTL)
+  const [cached] = await globalThis.services.db
+    .select()
+    .from(orgMembersCache)
+    .where(eq(orgMembersCache.userId, userId))
+    .orderBy(desc(orgMembersCache.cachedAt))
+    .limit(1);
+
+  if (cached && Date.now() - cached.cachedAt.getTime() < 60_000) {
+    const orgData = await getOrgDataOrNull(cached.orgId);
+    if (orgData) {
+      const member = await verifyMembership(orgData, userId, authResult);
+      return { org: applyJwtTier(orgData, authResult), member };
+    }
+  }
+
+  // 4. Clerk API slow path (last resort)
+  const client = await clerkClient();
+  const memberships = await client.users.getOrganizationMembershipList({
+    userId,
+  });
+
+  // Priority: admin orgs first, then any org
+  const adminMembership = memberships.data.find((m) => m.role === "org:admin");
+  const candidates = adminMembership
+    ? [
+        adminMembership,
+        ...memberships.data.filter((m) => m !== adminMembership),
+      ]
+    : memberships.data;
+
+  for (const membership of candidates) {
+    const mOrgId = membership.organization.id;
+    const orgData = await getOrgDataOrNull(mOrgId);
+    if (orgData) {
+      return {
+        org: applyJwtTier(orgData, authResult),
+        member: {
+          role: mapOrgRole(membership.role),
+          userId,
+        },
+      };
+    }
+  }
+
+  throw notFound("No org found for user");
+}
+
+/**
+ * Null-safe org resolution for contexts without request params.
+ * Returns null if no org found, instead of throwing.
+ *
+ * Used by handlers that operate outside request context
+ * (Slack, Telegram, email) where missing org is expected.
+ */
+export async function resolveOrgOrNull(
+  userId: string,
+): Promise<ResolvedOrg | null> {
+  try {
+    const { org } = await resolveOrg(userId);
+    return org;
+  } catch (error) {
+    if (isNotFound(error)) return null;
+    throw error;
+  }
 }
 
 /**

--- a/turbo/apps/web/src/lib/org/resolve-org.ts
+++ b/turbo/apps/web/src/lib/org/resolve-org.ts
@@ -1,12 +1,6 @@
 import { auth, clerkClient } from "@clerk/nextjs/server";
 import { eq, desc } from "drizzle-orm";
-import {
-  forbidden,
-  badRequest,
-  notFound,
-  isNotFound,
-  isForbidden,
-} from "../errors";
+import { forbidden, badRequest, notFound, isNotFound } from "../errors";
 import { logger } from "../logger";
 import { orgMembersCache } from "../../db/schema/org-members-cache";
 import { getOrgBySlug, getOrgData } from "./org-cache-service";
@@ -17,22 +11,44 @@ import type { OrgRole } from "@vm0/core";
 const log = logger("org:resolve");
 
 /**
+ * Returns true when the error represents a "resource not found" condition
+ * that should be treated as null rather than re-thrown.
+ *
+ * Covers:
+ * - Our own NotFoundError (from errors.ts)
+ * - Clerk API 404 responses (ClerkAPIResponseError with status 404)
+ * - Missing-slug guard in getOrgData ("has no slug")
+ */
+function isOrgNotFoundError(error: unknown): boolean {
+  if (isNotFound(error)) return true;
+  if (error instanceof Error) {
+    // Clerk API 404 responses (ClerkAPIResponseError with numeric status)
+    const statusHolder = error as { status?: unknown };
+    if (statusHolder.status === 404) return true;
+    // Clerk SDK org-not-found rejections: "Organization <id> not found"
+    // Also covers missing-slug guard: "Clerk organization <id> has no slug"
+    if (/organization\b.*\b(not found|has no slug)/i.test(error.message)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
  * Wrapper around getOrgData that returns null instead of throwing when the
  * org cannot be resolved.
  *
- * getOrgData throws when Clerk's getOrganization rejects (org not found)
- * or the fetched org has no slug.  Both are "not-found" semantics that
- * callers treat as a null result.  Database errors are unlikely to surface
- * here because getOrgBySlug (called first in the resolution chain) hits the
- * same DB — if the database were down, it would fail there first.
+ * Only swallows not-found errors (our NotFoundError, Clerk API 404,
+ * missing slug). Unexpected errors (DB failures, timeouts) propagate.
  */
 export async function getOrgDataOrNull(
   orgId: string,
 ): Promise<{ orgId: string; slug: string; tier: string } | null> {
   try {
     return await getOrgData(orgId);
-  } catch {
-    return null;
+  } catch (error) {
+    if (isOrgNotFoundError(error)) return null;
+    throw error;
   }
 }
 
@@ -152,11 +168,11 @@ export async function resolveOrg(
       const member = await verifyMembership(orgData, userId, authResult);
       return { org: applyJwtTier(orgData, authResult), member };
     } catch (error) {
-      // Re-throw forbidden errors (user is not a member)
-      if (isForbidden(error)) {
+      // Only fall through to tier 3/4 for not-found errors (org doesn't exist).
+      // Re-throw everything else (forbidden, DB errors, timeouts).
+      if (!isOrgNotFoundError(error)) {
         throw error;
       }
-      // Org not found in Clerk — fall through to default org
       log.debug("orgId lookup failed, falling through to default", {
         orgId: effectiveOrgId,
       });

--- a/turbo/apps/web/src/lib/org/resolve-org.ts
+++ b/turbo/apps/web/src/lib/org/resolve-org.ts
@@ -228,17 +228,17 @@ export async function resolveOrg(
 }
 
 /**
- * Null-safe org resolution for contexts without request params.
- * Returns null if no org found, instead of throwing.
+ * Null-safe org resolution. Returns null if no org found, instead of throwing.
  *
  * Used by handlers that operate outside request context
  * (Slack, Telegram, email) where missing org is expected.
  */
 export async function resolveOrgOrNull(
   userId: string,
+  orgSlug?: string | null,
 ): Promise<ResolvedOrg | null> {
   try {
-    const { org } = await resolveOrg(userId);
+    const { org } = await resolveOrg(userId, orgSlug);
     return org;
   } catch (error) {
     if (isNotFound(error)) return null;

--- a/turbo/apps/web/src/lib/org/resolve-org.ts
+++ b/turbo/apps/web/src/lib/org/resolve-org.ts
@@ -1,6 +1,12 @@
 import { auth, clerkClient } from "@clerk/nextjs/server";
 import { eq, desc } from "drizzle-orm";
-import { forbidden, badRequest, notFound, isNotFound } from "../errors";
+import {
+  forbidden,
+  badRequest,
+  notFound,
+  isNotFound,
+  isForbidden,
+} from "../errors";
 import { logger } from "../logger";
 import { orgMembersCache } from "../../db/schema/org-members-cache";
 import { getOrgBySlug, getOrgData } from "./org-cache-service";
@@ -147,7 +153,7 @@ export async function resolveOrg(
       return { org: applyJwtTier(orgData, authResult), member };
     } catch (error) {
       // Re-throw forbidden errors (user is not a member)
-      if (error instanceof Error && error.message.includes("not a member")) {
+      if (isForbidden(error)) {
         throw error;
       }
       // Org not found in Clerk — fall through to default org

--- a/turbo/apps/web/src/lib/run/build-context.ts
+++ b/turbo/apps/web/src/lib/run/build-context.ts
@@ -29,7 +29,7 @@ import {
   type ConversationResolution,
 } from "./resolvers";
 import { expandEnvironmentFromCompose } from "./environment";
-import { getDefaultOrg } from "../org/org-member-service";
+import { resolveOrg } from "../org/resolve-org";
 import { getUserPreferences } from "../user/user-preferences-service";
 import { getSecretValue, getSecretValues } from "../secret/secret-service";
 import { getVariableValues } from "../variable/variable-service";
@@ -574,7 +574,7 @@ interface BuildContextParams {
   apiStartTime?: number;
   // Caller-resolved org slug and orgId for secret/variable/storage resolution.
   // When provided, used for both secrets and storage (artifacts/memory).
-  // When not provided, resolved via getDefaultOrg fallback.
+  // When not provided, resolved via resolveOrg fallback.
   orgSlug?: string;
   orgId?: string;
 }
@@ -786,7 +786,7 @@ async function resolveOrgs(params: BuildContextParams): Promise<{
     };
   }
   // No explicit org — default org is used
-  const { org } = await getDefaultOrg(params.userId);
+  const { org } = await resolveOrg(params.userId);
   return {
     runtimeClerkOrgId: org.orgId,
     pendingRuntimeScope: {

--- a/turbo/apps/web/src/lib/run/run-queue-service.ts
+++ b/turbo/apps/web/src/lib/run/run-queue-service.ts
@@ -9,7 +9,7 @@ import {
   decryptSecretsMap,
 } from "../crypto/secrets-encryption";
 import { PENDING_RUN_TTL_MS } from "./run-service";
-import { getDefaultOrg } from "../org/org-member-service";
+import { resolveOrg } from "../org/resolve-org";
 import type { CreateRunParams, CreateRunResult } from "./run-service";
 
 const log = logger("service:run-queue");
@@ -43,7 +43,7 @@ export async function enqueueRun(
   if (params.orgId) {
     orgId = params.orgId;
   } else {
-    const { org } = await getDefaultOrg(userId);
+    const { org } = await resolveOrg(userId);
     orgId = org.orgId;
   }
 

--- a/turbo/apps/web/src/lib/run/run-service.ts
+++ b/turbo/apps/web/src/lib/run/run-service.ts
@@ -31,8 +31,7 @@ import { canAccessCompose } from "../agent/permission-service";
 import { getUserEmail } from "../auth/get-user-email";
 import { extractTemplateVars } from "../config-validator";
 
-import { getDefaultOrgByUserId } from "../org/org-service";
-import { getDefaultOrg } from "../org/org-member-service";
+import { resolveOrg, resolveOrgOrNull } from "../org/resolve-org";
 import { getVariableValues } from "../variable/variable-service";
 import { encryptSecretValue } from "../crypto/secrets-encryption";
 import type { OrgTier } from "@vm0/core";
@@ -306,7 +305,7 @@ export interface CreateRunParams {
   debugNoMockClaude?: boolean;
   checkEnv?: boolean;
   // Caller-resolved org slug and orgId for variable/storage resolution.
-  // When provided, used instead of getDefaultOrg fallback.
+  // When provided, used instead of resolveOrg fallback.
   orgSlug?: string;
   orgId?: string;
   // Caller-resolved org tier for concurrency limit derivation.
@@ -435,7 +434,7 @@ async function validateComposeRequirements(
     const requiredVars = extractTemplateVars(composeContent);
     if (requiredVars.length > 0) {
       const resolvedClerkOrgId =
-        orgId ?? (await getDefaultOrgByUserId(userId))?.orgId;
+        orgId ?? (await resolveOrgOrNull(userId))?.orgId;
       const storedVars = resolvedClerkOrgId
         ? await getVariableValues(resolvedClerkOrgId, userId)
         : {};
@@ -692,7 +691,7 @@ export async function createRun(
     orgId = params.orgId;
     orgSlug = params.orgSlug;
   } else {
-    const { org } = await getDefaultOrg(userId);
+    const { org } = await resolveOrg(userId);
     orgSlug = org.slug;
     orgId = org.orgId;
   }

--- a/turbo/apps/web/src/lib/slack-org/handlers/run-agent.ts
+++ b/turbo/apps/web/src/lib/slack-org/handlers/run-agent.ts
@@ -48,7 +48,7 @@ interface RunAgentResult {
  * Execute an agent run for org-aware Slack integration.
  *
  * Key difference from legacy: passes orgId, orgSlug, orgTier explicitly
- * to createRun() instead of relying on getDefaultOrg().
+ * to createRun() instead of relying on resolveOrg().
  */
 export async function runAgentForSlackOrg(
   params: RunAgentParams,

--- a/turbo/apps/web/src/lib/slack/handlers/shared.ts
+++ b/turbo/apps/web/src/lib/slack/handlers/shared.ts
@@ -11,7 +11,7 @@ import {
 import { slackThreadSessions } from "../../../db/schema/slack-thread-session";
 import { agentComposes } from "../../../db/schema/agent-compose";
 import { getPlatformUrl } from "../../url";
-import { getDefaultOrgByUserId } from "../../org/org-service";
+import { resolveOrgOrNull } from "../../org/resolve-org";
 import { validateAgentSession } from "../../run";
 import { ensureStorageExists } from "../../storage/storage-service";
 import { logger } from "../../logger";
@@ -207,7 +207,7 @@ export function buildAgentLogsUrl(agentName: string): string {
  * 2. If no HEAD version, create an empty initial version (upload manifest to S3 + commit)
  */
 export async function ensureOrgAndArtifact(vm0UserId: string): Promise<void> {
-  const org = await getDefaultOrgByUserId(vm0UserId);
+  const org = await resolveOrgOrNull(vm0UserId);
   if (!org) return;
 
   await ensureStorageExists(

--- a/turbo/apps/web/src/lib/telegram/handlers/shared.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/shared.ts
@@ -4,7 +4,7 @@ import { telegramMessages } from "../../../db/schema/telegram-message";
 import { telegramUserLinks } from "../../../db/schema/telegram-user-link";
 import { agentComposes } from "../../../db/schema/agent-compose";
 import { getPlatformUrl } from "../../url";
-import { getDefaultOrgByUserId } from "../../org/org-service";
+import { resolveOrgOrNull } from "../../org/resolve-org";
 import { validateAgentSession } from "../../run";
 import { ensureStorageExists } from "../../storage/storage-service";
 import {
@@ -242,7 +242,7 @@ async function completePendingLink(
  * Ensure org and artifact storage exist for a user.
  */
 export async function ensureOrgAndArtifact(vm0UserId: string): Promise<void> {
-  const org = await getDefaultOrgByUserId(vm0UserId);
+  const org = await resolveOrgOrNull(vm0UserId);
   if (!org) return;
 
   await ensureStorageExists(


### PR DESCRIPTION
## Summary

- Consolidate 4 org resolution functions (`resolveOrg`, `getDefaultOrg`, `resolveOrgId`, `getDefaultOrgByUserId`) into 2 (`resolveOrg` + `resolveOrgOrNull`)
- Eliminate redundant `auth()` calls (was up to 2 per resolution, now always 1)
- Ensure consistent membership verification across all 4 resolution tiers
- Extract `?org=` query param in all schedule routes for proper org context
- Migrate all 16+ call sites across schedule routes, run services, integration handlers, and test endpoints

## Changes

### Core (`resolve-org.ts`)
- Inline `getDefaultOrg` logic into `resolveOrg`, reusing the single `auth()` call
- Add `resolveOrgOrNull` as null-safe wrapper for Slack/Telegram/email handlers
- Add `isOrgNotFoundError()` helper for precise error classification
- 4-tier resolution chain: slug → orgId/JWT → org_members_cache → Clerk API

### Schedule routes (fixes #4757)
- All 7 schedule routes now extract `?org=` from request URL and pass `orgSlug` to `resolveOrg`
- Follows the same pattern as `/api/agent/runs` and other API routes
- CLI tokens now use tier 1 (explicit org) instead of falling through to tier 3/4

### Deleted
- `getDefaultOrg` from `org-member-service.ts`
- `resolveOrgId` from `org-member-service.ts`
- `getDefaultOrgByUserId` from `org-service.ts`

### Migrated call sites (21 files)
- Schedule routes (7): `resolveOrgId(userId)` → `resolveOrg(userId, orgSlug)`
- Run services (3): `getDefaultOrg(userId)` → `resolveOrg(userId)`
- Integration handlers (4): `getDefaultOrgByUserId(userId)` → `resolveOrgOrNull(userId)`
- API routes (3): mixed → unified
- Tests (2): updated imports

## Test plan

- [x] All 21 org resolution tests pass (17 resolveOrg + 2 resolveOrgOrNull + 2 requireOrgFromRequest)
- [x] Full test suite passes (163 files, 1856 tests)
- [x] Lint, type-check, format, knip all pass
- [x] Pre-commit hooks pass

Closes #4760
Closes #4757

🤖 Generated with [Claude Code](https://claude.com/claude-code)