### PR TITLE
refactor(web): remove unused runId parameter from resolveSecretsAndEnvironment

### DIFF
--- a/turbo/apps/web/src/lib/run/build-context.ts
+++ b/turbo/apps/web/src/lib/run/build-context.ts
@@ -640,7 +640,6 @@ async function resolveSecretsAndEnvironment(
   vars: Record<string, string> | undefined,
   cliSecrets: Record<string, string> | undefined,
   modelProvider: string | undefined,
-  runId: string,
   checkEnv: boolean | undefined,
   userId: string,
 ): Promise<{
@@ -930,7 +929,6 @@ export async function buildExecutionContext(
       vars,
       params.secrets,
       params.modelProvider,
-      params.runId,
       params.checkEnv,
       params.userId,
     ),


### PR DESCRIPTION
## Summary
- Remove unused `runId` parameter from `resolveSecretsAndEnvironment` function and its call site
- Leftover from #4674 refactoring that removed `autoInjectEnvVarsToEnvironment`

## Test plan
- [x] Type check passes (web workspace)
- [x] Knip finds no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)