### PR TITLE
feat(runner): plumb secret-connector map from build to proxy addon

### DIFF
--- a/crates/runner/src/cmd/benchmark.rs
+++ b/crates/runner/src/cmd/benchmark.rs
@@ -177,6 +177,7 @@ async fn run_sandbox(
         network_log_path: &network_log_path,
         services: None,
         encrypted_secrets: None,
+        secret_connector_map: None,
     };
     if let Err(e) = mitm.register_vm(&source_ip, &registration).await {
         warn!(error = %e, "failed to register VM in proxy");

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -130,6 +130,7 @@ async fn execute_inner(
             network_log_path: &network_log_path,
             services: context.experimental_services.as_deref(),
             encrypted_secrets: context.encrypted_secrets.as_deref(),
+            secret_connector_map: context.secret_connector_map.as_ref(),
         };
         if let Err(e) = config.registry.register_vm(&source_ip, &registration).await {
             warn!(run_id = %context.run_id, error = %e, "failed to register VM in proxy");
@@ -654,6 +655,7 @@ mod tests {
             resume_session: None,
             secret_values: None,
             encrypted_secrets: None,
+            secret_connector_map: None,
             cli_agent_type: String::new(),
             experimental_firewall: None,
             debug_no_mock_claude: None,

--- a/crates/runner/src/provider/local.rs
+++ b/crates/runner/src/provider/local.rs
@@ -150,6 +150,7 @@ impl JobProvider for LocalProvider {
             resume_session: None,
             secret_values: None,
             encrypted_secrets: None,
+            secret_connector_map: None,
             cli_agent_type: req.cli_agent_type,
             experimental_firewall: None,
             debug_no_mock_claude: None,

--- a/crates/runner/src/proxy.rs
+++ b/crates/runner/src/proxy.rs
@@ -28,6 +28,7 @@ struct VmEntry {
     network_log_path: String,
     services: Option<Vec<crate::types::ServiceEntry>>,
     encrypted_secrets: Option<String>,
+    secret_connector_map: Option<HashMap<String, String>>,
 }
 
 /// Firewall rule for network filtering (first-match-wins).
@@ -65,6 +66,7 @@ pub struct VmRegistration<'a> {
     pub network_log_path: &'a std::path::Path,
     pub services: Option<&'a [crate::types::ServiceEntry]>,
     pub encrypted_secrets: Option<&'a str>,
+    pub secret_connector_map: Option<&'a HashMap<String, String>>,
 }
 
 /// Embedded mitmproxy addon script (compiled into the binary).
@@ -448,6 +450,7 @@ impl ProxyRegistryHandle {
                 network_log_path: registration.network_log_path.to_string_lossy().into_owned(),
                 services,
                 encrypted_secrets: registration.encrypted_secrets.map(String::from),
+                secret_connector_map: registration.secret_connector_map.cloned(),
             },
         );
         registry.updated_at = now;
@@ -524,6 +527,7 @@ mod tests {
                 network_log_path: "/tmp/network-test-run.jsonl".to_string(),
                 services: None,
                 encrypted_secrets: None,
+                secret_connector_map: None,
             },
         );
         write_registry(&registry_path, &registry).await.unwrap();
@@ -628,6 +632,7 @@ mod tests {
             network_log_path: std::path::Path::new("/tmp/network-run-1.jsonl"),
             services: None,
             encrypted_secrets: None,
+            secret_connector_map: None,
         };
         handle
             .register_vm("10.200.0.2", &registration)
@@ -646,6 +651,7 @@ mod tests {
             network_log_path: std::path::Path::new("/tmp/network-run-2.jsonl"),
             services: None,
             encrypted_secrets: None,
+            secret_connector_map: None,
         };
         handle
             .register_vm("10.200.0.2", &registration2)
@@ -697,6 +703,7 @@ mod tests {
                     network_log_path: &log_path,
                     services: None,
                     encrypted_secrets: None,
+                    secret_connector_map: None,
                 };
                 h.register_vm(&ip, &registration).await.unwrap();
             });
@@ -743,6 +750,7 @@ mod tests {
                 network_log_path: "/tmp/network-run-1.jsonl".to_string(),
                 services: None,
                 encrypted_secrets: None,
+                secret_connector_map: None,
             },
         );
         write_registry(&registry_path, &registry).await.unwrap();
@@ -805,6 +813,7 @@ mod tests {
             network_log_path: std::path::Path::new("/tmp/network-run-svc.jsonl"),
             services: Some(&services),
             encrypted_secrets: None,
+            secret_connector_map: None,
         };
         handle
             .register_vm("10.200.0.5", &registration)
@@ -869,6 +878,7 @@ mod tests {
             network_log_path: std::path::Path::new("/tmp/network-run-enc.jsonl"),
             services: None,
             encrypted_secrets: Some("iv_b64:tag_b64:data_b64"),
+            secret_connector_map: None,
         };
         handle
             .register_vm("10.200.0.6", &registration)

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -54,6 +54,9 @@ pub struct ExecutionContext {
     // Forwarded to mitm-addon via proxy registry for auth resolution
     #[serde(default)]
     pub encrypted_secrets: Option<String>,
+    // Maps secret names to OAuth connector types for runtime token refresh
+    #[serde(default)]
+    pub secret_connector_map: Option<HashMap<String, String>>,
     pub cli_agent_type: String,
     #[serde(default)]
     pub experimental_firewall: Option<ExperimentalFirewall>,

--- a/turbo/apps/web/src/lib/run/build-context.ts
+++ b/turbo/apps/web/src/lib/run/build-context.ts
@@ -392,6 +392,8 @@ interface ConnectorSecretResult {
   connectorSecrets: Record<string, string> | undefined;
   /** Environment variables mapped from OAuth connectors via environmentMapping */
   injectedEnvVars: Record<string, string> | undefined;
+  /** Maps secret names to connector types for refresh-capable OAuth connectors */
+  secretConnectorMap: Record<string, string> | undefined;
 }
 
 /**
@@ -413,6 +415,7 @@ async function resolveConnectorSecrets(
     return {
       connectorSecrets: undefined,
       injectedEnvVars: undefined,
+      secretConnectorMap: undefined,
     };
   }
 
@@ -421,6 +424,7 @@ async function resolveConnectorSecrets(
     return {
       connectorSecrets: undefined,
       injectedEnvVars: undefined,
+      secretConnectorMap: undefined,
     };
   }
 
@@ -475,9 +479,25 @@ async function resolveConnectorSecrets(
     );
   }
 
+  // Build secretConnectorMap for refresh-capable OAuth connectors.
+  // Maps access token secret name → connector type so the auth endpoint
+  // can refresh expired tokens at runtime.
+  const secretConnectorMap: Record<string, string> = {};
+  for (const { type } of validConnectors) {
+    if (!(type in PROVIDER_HANDLERS)) continue;
+    const handler = PROVIDER_HANDLERS[type as keyof typeof PROVIDER_HANDLERS];
+    if (handler.refreshToken) {
+      secretConnectorMap[handler.getSecretName()] = type;
+    }
+  }
+
   return {
     connectorSecrets,
     injectedEnvVars: allInjectedEnvVars,
+    secretConnectorMap:
+      Object.keys(secretConnectorMap).length > 0
+        ? secretConnectorMap
+        : undefined,
   };
 }
 
@@ -646,6 +666,7 @@ async function resolveSecretsAndEnvironment(
 ): Promise<{
   secrets: Record<string, string> | undefined;
   environment: Record<string, string> | undefined;
+  secretConnectorMap: Record<string, string> | undefined;
 }> {
   // Model provider secret injection
   const hasExplicitModelProviderConfig = MODEL_PROVIDER_ENV_VARS.some(
@@ -690,6 +711,23 @@ async function resolveSecretsAndEnvironment(
       }
     : undefined;
 
+  // Filter secretConnectorMap: remove keys overridden by higher-priority sources.
+  // If a secret is provided by CLI, user DB, or model-provider, OAuth refresh should
+  // not overwrite it at runtime.
+  let secretConnectorMap = connectorResult.secretConnectorMap;
+  if (secretConnectorMap) {
+    const overrideKeys = new Set(
+      [
+        connectorResult.injectedEnvVars,
+        modelProviderResult.secrets,
+        dbSecrets,
+        cliSecrets,
+      ].flatMap((s) => (s ? Object.keys(s) : [])),
+    );
+    for (const key of overrideKeys) delete secretConnectorMap[key];
+    if (!Object.keys(secretConnectorMap).length) secretConnectorMap = undefined;
+  }
+
   // Expand environment variables from compose config.
   // Model provider env vars are passed as additionalEnvironment so they go through
   // the same servicePlaceholders logic (secret-derived values use ${{ secrets.X }} templates).
@@ -701,7 +739,7 @@ async function resolveSecretsAndEnvironment(
     modelProviderResult.injectedEnvironment,
   );
 
-  return { secrets, environment };
+  return { secrets, environment, secretConnectorMap };
 }
 
 /**
@@ -941,7 +979,7 @@ export async function buildExecutionContext(
   ]);
   const resolveSecretsEnd = Date.now();
 
-  const { secrets, environment } = secretsResult;
+  const { secrets, environment, secretConnectorMap } = secretsResult;
   const userTimezone = userPrefs?.timezone ?? undefined;
 
   // Build experimental services manifest (base + auth entries for the runner)
@@ -959,6 +997,7 @@ export async function buildExecutionContext(
       prompt: params.prompt,
       vars,
       secrets,
+      secretConnectorMap,
       sandboxToken: params.sandboxToken,
       artifactName,
       artifactVersion,

--- a/turbo/apps/web/src/lib/run/build-context.ts
+++ b/turbo/apps/web/src/lib/run/build-context.ts
@@ -714,8 +714,8 @@ async function resolveSecretsAndEnvironment(
   // Filter secretConnectorMap: remove keys overridden by higher-priority sources.
   // If a secret is provided by CLI, user DB, or model-provider, OAuth refresh should
   // not overwrite it at runtime.
-  let secretConnectorMap = connectorResult.secretConnectorMap;
-  if (secretConnectorMap) {
+  let secretConnectorMap: Record<string, string> | undefined;
+  if (connectorResult.secretConnectorMap) {
     const overrideKeys = new Set(
       [
         connectorResult.injectedEnvVars,
@@ -724,8 +724,12 @@ async function resolveSecretsAndEnvironment(
         cliSecrets,
       ].flatMap((s) => (s ? Object.keys(s) : [])),
     );
-    for (const key of overrideKeys) delete secretConnectorMap[key];
-    if (!Object.keys(secretConnectorMap).length) secretConnectorMap = undefined;
+    const filtered = Object.fromEntries(
+      Object.entries(connectorResult.secretConnectorMap).filter(
+        ([key]) => !overrideKeys.has(key),
+      ),
+    );
+    if (Object.keys(filtered).length) secretConnectorMap = filtered;
   }
 
   // Expand environment variables from compose config.

--- a/turbo/apps/web/src/lib/run/context/execution-preparer.ts
+++ b/turbo/apps/web/src/lib/run/context/execution-preparer.ts
@@ -308,6 +308,7 @@ function buildPreparedContext(
     // Environment & Secrets
     environment: context.environment || null,
     secrets: context.secrets || null,
+    secretConnectorMap: context.secretConnectorMap || null,
     // Resume support
     resumeSession: context.resumeSession || null,
     resumeArtifact: context.resumeArtifact || null,

--- a/turbo/apps/web/src/lib/run/executors/runner-executor.ts
+++ b/turbo/apps/web/src/lib/run/executors/runner-executor.ts
@@ -55,6 +55,7 @@ export async function executeRunnerJob(
     environment: context.environment,
     resumeSession: context.resumeSession,
     encryptedSecrets,
+    secretConnectorMap: context.secretConnectorMap,
     cliAgentType: context.cliAgentType,
     experimentalFirewall: context.experimentalFirewall ?? undefined,
     experimentalServices: context.experimentalServices ?? undefined,

--- a/turbo/apps/web/src/lib/run/executors/types.ts
+++ b/turbo/apps/web/src/lib/run/executors/types.ts
@@ -29,6 +29,7 @@ export interface PreparedContext {
   // Environment & Secrets
   environment: Record<string, string> | null;
   secrets: Record<string, string> | null;
+  secretConnectorMap: Record<string, string> | null;
 
   // Resume support
   resumeSession: ResumeSession | null;

--- a/turbo/apps/web/src/lib/run/types.ts
+++ b/turbo/apps/web/src/lib/run/types.ts
@@ -55,6 +55,7 @@ export interface ExecutionContext {
   prompt: string;
   vars?: Record<string, string>;
   secrets?: Record<string, string>; // Decrypted secrets for environment expansion
+  secretConnectorMap?: Record<string, string>; // Secret name → connector type for OAuth refresh
   sandboxToken: string;
 
   // Artifact settings (new runs only)

--- a/turbo/packages/core/src/contracts/runners.ts
+++ b/turbo/packages/core/src/contracts/runners.ts
@@ -154,6 +154,8 @@ export const storedExecutionContextSchema = z.object({
   environment: z.record(z.string(), z.string()).nullable(),
   resumeSession: resumeSessionSchema.nullable(),
   encryptedSecrets: z.string().nullable(), // AES-256-GCM encrypted Record<string, string> (secret name → value)
+  // Maps secret names to OAuth connector types for runtime token refresh (e.g. { "GMAIL_ACCESS_TOKEN": "gmail" })
+  secretConnectorMap: z.record(z.string(), z.string()).nullable().optional(),
   cliAgentType: z.string(),
   experimentalFirewall: experimentalFirewallSchema.optional(),
   // Debug flag to force real Claude in mock environments (internal use only)
@@ -191,6 +193,8 @@ export const executionContextSchema = z.object({
   secretValues: z.array(z.string()).nullable(),
   // AES-256-GCM encrypted Record<string, string> — passed through to mitm-addon for auth resolution
   encryptedSecrets: z.string().nullable(),
+  // Maps secret names to OAuth connector types for runtime token refresh
+  secretConnectorMap: z.record(z.string(), z.string()).nullable().optional(),
   cliAgentType: z.string(),
   // Experimental firewall configuration
   experimentalFirewall: experimentalFirewallSchema.optional(),


### PR DESCRIPTION
## Summary

- Build `secretConnectorMap` in `resolveConnectorSecrets()` mapping OAuth access-token secret names → connector types for runtime token refresh
- Filter out keys overridden by higher-priority secret sources (CLI, DB, model-provider) so OAuth refresh doesn't clobber explicit overrides
- Thread the map through the full pipeline: zod schemas → `ExecutionContext` → `PreparedContext` → `StoredExecutionContext` → Rust `types.rs` → proxy registry → VM registration

## Details

This is PR1 of 3 for #4627 (OAuth token refresh). It adds the data plumbing only — no runtime refresh logic yet.

**TypeScript (6 files):**
- `build-context.ts`: build map from refresh-capable connectors, filter overridden keys
- `runners.ts`: add `secretConnectorMap` to both stored and full execution context schemas
- `types.ts`, `executors/types.ts`: add field to interfaces
- `execution-preparer.ts`, `runner-executor.ts`: pass through

**Rust (5 files):**
- `types.rs`: add `secret_connector_map` to `ExecutionContext`
- `proxy.rs`: add to `VmEntry` and `VmRegistration`, write to proxy registry JSON
- `executor.rs`: pass from context to registration
- `benchmark.rs`, `local.rs`: add `None` defaults

## Test plan

- [x] `cargo check -p runner` passes
- [x] `pnpm check-types` passes
- [x] `pnpm turbo run lint` passes
- [x] `pnpm vitest` passes (2 unrelated email outbox timeouts)
- [x] `pnpm knip` passes
- [ ] CI pipeline green

🤖 Generated with [Claude Code](https://claude.com/claude-code)