### PR TITLE
chore: add pr-review-loop step to issue-action workflow

### DIFF
--- a/.claude/skills/issue-action/SKILL.md
+++ b/.claude/skills/issue-action/SKILL.md
@@ -86,24 +86,27 @@ Review new comments for:
 - **If blocked or need clarification**: Post comment explaining the situation, add "pending" label, and exit
 - **If intermediate checkpoint**: Post progress update comment, add "pending" label, and exit (optional)
 
-### Step 8: Create PR and Verify CI Pipeline
+### Step 8: Create PR, Review, and Verify CI Pipeline
 
 1. Push branch and create Pull Request
 
-2. Run `/pr-check` skill to monitor and fix CI pipeline
+2. Run `/pr-review-loop` skill to perform a full code review and fix cycle
+   - The pr-review-loop skill will review the PR, post comments, fix issues, and re-review until LGTM
+
+3. Run `/pr-check` skill to monitor and fix CI pipeline
    - The pr-check skill will auto-fix lint/format issues
    - If type or test errors occur, pr-check will exit with details for manual intervention
 
-3. **If pr-check completes successfully**: Post comment to issue:
+4. **If both pr-review-loop and pr-check complete successfully**: Post comment to issue:
    ```bash
    gh issue comment {issue-id} --body "Work completed. PR created: {pr-url}
 
-   All CI checks passing"
+   Code review passed and all CI checks passing."
    ```
 
-4. **If pr-check exits with manual intervention required**: Add "pending" label and exit
+5. **If pr-review-loop or pr-check exits with manual intervention required**: Add "pending" label and exit
 
-5. Keep issue open (user will close it after merging PR)
+6. Keep issue open (user will close it after merging PR)
 
 ## Label Management
 


### PR DESCRIPTION
## Summary
- Add `/pr-review-loop` step to the issue-action skill workflow before `/pr-check`
- After creating a PR, the workflow now runs a full code review and fix cycle before monitoring CI
- Updated success criteria to require both review and CI checks to pass

## Test plan
- [ ] Verify issue-action skill reads updated Step 8 correctly
- [ ] Run issue-action workflow end-to-end and confirm pr-review-loop executes before pr-check

🤖 Generated with [Claude Code](https://claude.com/claude-code)