### PR TITLE
feat: resolve skill volumes from system org with agent org fallback

### DIFF
--- a/turbo/apps/web/src/__tests__/api-test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers.ts
@@ -1192,6 +1192,55 @@ export async function createTestVolume(
 }
 
 /**
+ * Create a volume storage directly in the DB for a specific org.
+ * Unlike createTestVolume() which uses the mock user's org via API,
+ * this allows creating storages under any org (e.g., SYSTEM_ORG_ID).
+ *
+ * @param orgId - The org to create the storage under
+ * @param name - Storage name
+ * @returns The created storage with versionId
+ */
+export async function createTestVolumeForOrg(
+  orgId: string,
+  name: string,
+): Promise<{ storageId: string; versionId: string }> {
+  const { randomUUID } = await import("crypto");
+  const { eq } = await import("drizzle-orm");
+
+  const versionId = randomUUID().replace(/-/g, "").repeat(2).slice(0, 64);
+  const s3Key = `${orgId}/${name}/${versionId}`;
+
+  const [storage] = await globalThis.services.db
+    .insert(storages)
+    .values({
+      orgId,
+      userId: VOLUME_ORG_USER_ID,
+      name,
+      type: "volume",
+      s3Prefix: `${orgId}/${name}`,
+    })
+    .returning();
+
+  const storageId = storage!.id;
+
+  await globalThis.services.db.insert(storageVersions).values({
+    id: versionId,
+    storageId,
+    s3Key,
+    size: 100,
+    fileCount: 1,
+    createdBy: "test",
+  });
+
+  await globalThis.services.db
+    .update(storages)
+    .set({ headVersionId: versionId })
+    .where(eq(storages.id, storageId));
+
+  return { storageId, versionId };
+}
+
+/**
  * Create a test memory storage via API route handlers.
  * Convenience wrapper around createTestStorage with type="memory".
  *

--- a/turbo/apps/web/src/__tests__/api-test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers.ts
@@ -5,6 +5,7 @@
  * instead of direct database operations. This ensures tests validate the
  * complete API flow, catching issues that direct DB operations might miss.
  */
+import { randomUUID } from "crypto";
 import { vi } from "vitest";
 import { http as mswHttp, HttpResponse } from "msw";
 import { NextRequest } from "next/server";
@@ -1204,9 +1205,6 @@ export async function createTestVolumeForOrg(
   orgId: string,
   name: string,
 ): Promise<{ storageId: string; versionId: string }> {
-  const { randomUUID } = await import("crypto");
-  const { eq } = await import("drizzle-orm");
-
   const versionId = randomUUID().replace(/-/g, "").repeat(2).slice(0, 64);
   const s3Key = `${orgId}/${name}/${versionId}`;
 

--- a/turbo/apps/web/src/lib/storage/__tests__/system-skill-resolution.test.ts
+++ b/turbo/apps/web/src/lib/storage/__tests__/system-skill-resolution.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { prepareStorageManifest } from "../storage-service";
+import {
+  createTestVolume,
+  createTestVolumeForOrg,
+} from "../../../__tests__/api-test-helpers";
+import {
+  testContext,
+  uniqueId,
+  type UserContext,
+} from "../../../__tests__/test-helpers";
+import { SYSTEM_ORG_ID } from "@vm0/core";
+import type { AgentVolumeConfig } from "../types";
+
+const context = testContext();
+
+/** Build a skill GitHub URL with a unique suffix */
+function uniqueSkillUrl(): {
+  url: string;
+  storageName: string;
+} {
+  const suffix = uniqueId("skill");
+  const url = `https://github.com/test-org/test-repo/tree/main/${suffix}`;
+  const storageName = `agent-skills@test-org/test-repo/tree/main/${suffix}`;
+  return { url, storageName };
+}
+
+/** Agent config that produces a single skill volume */
+function skillAgentConfig(skillUrl: string): AgentVolumeConfig {
+  return {
+    agents: {
+      "test-agent": {
+        skills: [skillUrl],
+      },
+    },
+  };
+}
+
+/** Agent config that produces a regular (non-skill) volume */
+function regularVolumeConfig(
+  volumeName: string,
+  storageName: string,
+): AgentVolumeConfig {
+  return {
+    agents: {
+      "test-agent": {
+        volumes: [`${volumeName}:/data`],
+      },
+    },
+    volumes: {
+      [volumeName]: {
+        name: storageName,
+        version: "latest",
+      },
+    },
+  };
+}
+
+describe("System Skill Resolution", () => {
+  let user: UserContext;
+
+  beforeEach(async () => {
+    context.setupMocks();
+    user = await context.setupUser();
+  });
+
+  it("should resolve skill from system org when available", async () => {
+    const { url, storageName } = uniqueSkillUrl();
+
+    // Create skill storage under SYSTEM_ORG_ID
+    const { versionId } = await createTestVolumeForOrg(
+      SYSTEM_ORG_ID,
+      storageName,
+    );
+
+    const manifest = await prepareStorageManifest(
+      skillAgentConfig(url),
+      {},
+      user.orgId,
+      user.orgId,
+      user.userId,
+    );
+
+    expect(manifest.storages).toHaveLength(1);
+    expect(manifest.storages[0]!.vasStorageName).toBe(storageName);
+    expect(manifest.storages[0]!.vasVersionId).toBe(versionId);
+  });
+
+  it("should fall back to agent org when skill not in system org", async () => {
+    const { url, storageName } = uniqueSkillUrl();
+
+    // Create skill storage under agent's org (NOT system org)
+    const { versionId } = await createTestVolume(storageName);
+
+    const manifest = await prepareStorageManifest(
+      skillAgentConfig(url),
+      {},
+      user.orgId,
+      user.orgId,
+      user.userId,
+    );
+
+    expect(manifest.storages).toHaveLength(1);
+    expect(manifest.storages[0]!.vasStorageName).toBe(storageName);
+    expect(manifest.storages[0]!.vasVersionId).toBe(versionId);
+  });
+
+  it("should resolve regular volumes from agent org only", async () => {
+    const volumeName = uniqueId("vol");
+    const storageName = uniqueId("storage");
+
+    // Create regular volume under agent's org
+    await createTestVolume(storageName);
+
+    const manifest = await prepareStorageManifest(
+      regularVolumeConfig(volumeName, storageName),
+      {},
+      user.orgId,
+      user.orgId,
+      user.userId,
+    );
+
+    expect(manifest.storages).toHaveLength(1);
+    expect(manifest.storages[0]!.vasStorageName).toBe(storageName);
+  });
+
+  it("should throw when skill not found in any org", async () => {
+    const { url } = uniqueSkillUrl();
+
+    // No skill storage in system org or agent org
+    await expect(
+      prepareStorageManifest(
+        skillAgentConfig(url),
+        {},
+        user.orgId,
+        user.orgId,
+        user.userId,
+      ),
+    ).rejects.toThrow("not found");
+  });
+});

--- a/turbo/apps/web/src/lib/storage/storage-service.ts
+++ b/turbo/apps/web/src/lib/storage/storage-service.ts
@@ -15,7 +15,7 @@ import { eq, and, isNull } from "drizzle-orm";
 import { env } from "../../env";
 import { resolveVersionByPrefix, isResolutionError } from "./version-resolver";
 import { computeContentHashFromHashes } from "./content-hash";
-import { VOLUME_ORG_USER_ID } from "@vm0/core";
+import { VOLUME_ORG_USER_ID, SYSTEM_ORG_ID } from "@vm0/core";
 
 const log = logger("storage");
 
@@ -342,13 +342,36 @@ export async function prepareStorageManifest(
       }
 
       try {
-        const { versionId, s3Key } = await resolveVersion(
-          agentClerkOrgId,
-          volume.vasStorageName,
-          "volume",
-          volume.vasVersion,
-          VOLUME_ORG_USER_ID,
-        );
+        // Skill volumes: try system org first (pre-cached official skills),
+        // then fall back to agent org (old CLI uploads, third-party skills)
+        const isSkill = volume.vasStorageName.startsWith("agent-skills@");
+        let resolved: { versionId: string; s3Key: string } | undefined;
+
+        if (isSkill) {
+          try {
+            resolved = await resolveVersion(
+              SYSTEM_ORG_ID,
+              volume.vasStorageName,
+              "volume",
+              volume.vasVersion,
+              VOLUME_ORG_USER_ID,
+            );
+          } catch {
+            // System org miss — fall through to agent org
+          }
+        }
+
+        if (!resolved) {
+          resolved = await resolveVersion(
+            agentClerkOrgId,
+            volume.vasStorageName,
+            "volume",
+            volume.vasVersion,
+            VOLUME_ORG_USER_ID,
+          );
+        }
+
+        const { versionId, s3Key } = resolved;
 
         // Generate archive URL for tar.gz
         const archiveKey = `${s3Key}/archive.tar.gz`;

--- a/turbo/apps/web/src/lib/storage/storage-service.ts
+++ b/turbo/apps/web/src/lib/storage/storage-service.ts
@@ -356,7 +356,12 @@ export async function prepareStorageManifest(
               volume.vasVersion,
               VOLUME_ORG_USER_ID,
             );
-          } catch {
+          } catch (error) {
+            if (
+              !(error instanceof Error && error.message.includes("not found"))
+            ) {
+              throw error;
+            }
             // System org miss — fall through to agent org
           }
         }


### PR DESCRIPTION
## Summary

- Update `prepareStorageManifest()` to try `SYSTEM_ORG_ID` first when resolving skill volumes (`agent-skills@...`), falling back to the agent's org if not found
- Regular volumes (non-skill) continue to resolve from the agent's org only
- Add `createTestVolumeForOrg()` test helper to support creating volumes under arbitrary orgs (e.g., `SYSTEM_ORG_ID`)

Closes #4778

## Test plan

- [x] Integration test: skill resolves from system org when available
- [x] Integration test: skill falls back to agent org when not in system org
- [x] Integration test: regular volumes unchanged (always agent org)
- [x] Integration test: throws when skill not found in any org
- [x] All existing storage tests still pass
- [x] Lint, knip, format checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)