### PR TITLE
feat: add skills resolve endpoint for instant skill lookup

### DIFF
--- a/turbo/apps/web/app/api/skills/resolve/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/skills/resolve/__tests__/route.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { POST } from "../route";
+import {
+  createTestRequest,
+  createTestCliToken,
+  seedTestSkill,
+} from "../../../../../src/__tests__/api-test-helpers";
+import { testContext } from "../../../../../src/__tests__/test-helpers";
+import { mockClerk } from "../../../../../src/__tests__/clerk-mock";
+
+const context = testContext();
+let testCliToken: string;
+let testId: string;
+
+function resolveRequest(body: unknown, token?: string) {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+  if (token) headers.Authorization = `Bearer ${token}`;
+  return createTestRequest("http://localhost:3000/api/skills/resolve", {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/skills/resolve", () => {
+  beforeEach(async () => {
+    context.setupMocks();
+    const user = await context.setupUser();
+    testCliToken = await createTestCliToken(user.userId);
+    testId = Math.random().toString(36).substring(7);
+  });
+
+  describe("Authentication", () => {
+    it("should reject unauthenticated requests", async () => {
+      mockClerk({ userId: null });
+      const response = await POST(
+        resolveRequest({
+          skills: ["https://github.com/vm0-ai/vm0-skills/tree/main/slack"],
+        }),
+      );
+      expect(response.status).toBe(401);
+    });
+
+    it("should accept CLI token authentication", async () => {
+      mockClerk({ userId: null });
+      const response = await POST(
+        resolveRequest(
+          {
+            skills: ["https://github.com/vm0-ai/vm0-skills/tree/main/slack"],
+          },
+          testCliToken,
+        ),
+      );
+      expect(response.status).toBe(200);
+    });
+  });
+
+  describe("Validation", () => {
+    it("should reject empty skills array", async () => {
+      const response = await POST(resolveRequest({ skills: [] }, testCliToken));
+      expect(response.status).toBe(400);
+    });
+
+    it("should reject invalid URLs", async () => {
+      const response = await POST(
+        resolveRequest({ skills: ["not-a-url"] }, testCliToken),
+      );
+      expect(response.status).toBe(400);
+    });
+  });
+
+  describe("Resolution", () => {
+    it("should resolve seeded skills", async () => {
+      const skillUrl = `https://github.com/vm0-ai/vm0-skills/tree/main/resolve-${testId}`;
+      await seedTestSkill({
+        url: skillUrl,
+        name: `resolve-${testId}`,
+        fullPath: `vm0-ai/vm0-skills/tree/main/resolve-${testId}`,
+      });
+
+      const response = await POST(
+        resolveRequest({ skills: [skillUrl] }, testCliToken),
+      );
+      expect(response.status).toBe(200);
+      const data = await response.json();
+
+      expect(data.resolved[skillUrl]).toBeDefined();
+      expect(data.resolved[skillUrl].storageName).toBe(
+        `agent-skills@vm0-ai/vm0-skills/tree/main/resolve-${testId}`,
+      );
+      expect(data.resolved[skillUrl].versionHash).toBeDefined();
+      expect(data.resolved[skillUrl].frontmatter.name).toBe("Slack");
+      expect(data.resolved[skillUrl].frontmatter.vm0_secrets).toEqual([
+        "SLACK_BOT_TOKEN",
+      ]);
+      expect(data.unresolved).toEqual([]);
+    });
+
+    it("should return unresolved for unknown skills", async () => {
+      const unknownUrl = `https://github.com/acme/custom/tree/main/unknown-${testId}`;
+
+      const response = await POST(
+        resolveRequest({ skills: [unknownUrl] }, testCliToken),
+      );
+      const data = await response.json();
+
+      expect(data.resolved).toEqual({});
+      expect(data.unresolved).toEqual([unknownUrl]);
+    });
+
+    it("should handle mixed resolved and unresolved", async () => {
+      const skillUrl = `https://github.com/vm0-ai/vm0-skills/tree/main/mixed-${testId}`;
+      await seedTestSkill({
+        url: skillUrl,
+        name: `mixed-${testId}`,
+        fullPath: `vm0-ai/vm0-skills/tree/main/mixed-${testId}`,
+      });
+      const unknownUrl = `https://github.com/acme/custom/tree/main/unknown-${testId}`;
+
+      const response = await POST(
+        resolveRequest({ skills: [skillUrl, unknownUrl] }, testCliToken),
+      );
+      const data = await response.json();
+
+      expect(Object.keys(data.resolved)).toHaveLength(1);
+      expect(data.resolved[skillUrl]).toBeDefined();
+      expect(data.unresolved).toEqual([unknownUrl]);
+    });
+
+    it("should treat skills without versionHash as unresolved", async () => {
+      const skillUrl = `https://github.com/vm0-ai/vm0-skills/tree/main/nohash-${testId}`;
+      await seedTestSkill({
+        url: skillUrl,
+        name: `nohash-${testId}`,
+        fullPath: `vm0-ai/vm0-skills/tree/main/nohash-${testId}`,
+        versionHash: null,
+      });
+
+      const response = await POST(
+        resolveRequest({ skills: [skillUrl] }, testCliToken),
+      );
+      const data = await response.json();
+
+      expect(data.resolved).toEqual({});
+      expect(data.unresolved).toEqual([skillUrl]);
+    });
+
+    it("should handle all skills unresolved when none match", async () => {
+      const urls = [
+        `https://github.com/vm0-ai/vm0-skills/tree/main/notfound1-${testId}`,
+        `https://github.com/vm0-ai/vm0-skills/tree/main/notfound2-${testId}`,
+      ];
+      const response = await POST(
+        resolveRequest({ skills: urls }, testCliToken),
+      );
+      const data = await response.json();
+
+      expect(data.resolved).toEqual({});
+      expect(data.unresolved).toEqual(urls);
+    });
+  });
+});

--- a/turbo/apps/web/app/api/skills/resolve/route.ts
+++ b/turbo/apps/web/app/api/skills/resolve/route.ts
@@ -1,0 +1,87 @@
+import {
+  createHandler,
+  tsr,
+  createSafeErrorHandler,
+} from "../../../../src/lib/ts-rest-handler";
+import {
+  skillsResolveContract,
+  createErrorResponse,
+  getSkillStorageName,
+} from "@vm0/core";
+import { initServices } from "../../../../src/lib/init-services";
+import { getAuthContext } from "../../../../src/lib/auth/get-user-id";
+import { skills } from "../../../../src/db/schema/skill";
+import { inArray } from "drizzle-orm";
+
+interface SkillFrontmatter {
+  name?: string;
+  description?: string;
+  vm0_secrets?: string[];
+  vm0_vars?: string[];
+}
+
+const router = tsr.router(skillsResolveContract, {
+  resolve: async ({ body, headers }) => {
+    initServices();
+
+    const authCtx = await getAuthContext(headers.authorization);
+    if (!authCtx) {
+      return createErrorResponse("UNAUTHORIZED", "Not authenticated");
+    }
+
+    // Batch query skills by URL
+    const rows = await globalThis.services.db
+      .select({
+        url: skills.url,
+        fullPath: skills.fullPath,
+        versionHash: skills.versionHash,
+        frontmatter: skills.frontmatter,
+      })
+      .from(skills)
+      .where(inArray(skills.url, body.skills));
+
+    // Build resolved map
+    const resolved: Record<
+      string,
+      {
+        storageName: string;
+        versionHash: string;
+        frontmatter: SkillFrontmatter;
+      }
+    > = {};
+
+    const foundUrls = new Set<string>();
+
+    for (const row of rows) {
+      if (!row.versionHash) continue; // Skip skills not yet synced
+      foundUrls.add(row.url);
+
+      const fm = (row.frontmatter ?? {}) as SkillFrontmatter;
+
+      resolved[row.url] = {
+        storageName: getSkillStorageName(row.fullPath),
+        versionHash: row.versionHash,
+        frontmatter: {
+          name: fm.name,
+          description: fm.description,
+          vm0_secrets: fm.vm0_secrets,
+          vm0_vars: fm.vm0_vars,
+        },
+      };
+    }
+
+    // Unresolved = requested but not found (or not yet synced)
+    const unresolved = body.skills.filter((url) => !foundUrls.has(url));
+
+    return {
+      status: 200 as const,
+      body: { resolved, unresolved },
+    };
+  },
+});
+
+const handler = createHandler(skillsResolveContract, router, {
+  errorHandler: createSafeErrorHandler("skills-resolve"),
+});
+
+export { handler as POST };

--- a/turbo/apps/web/app/api/skills/resolve/route.ts
+++ b/turbo/apps/web/app/api/skills/resolve/route.ts
@@ -5,6 +5,7 @@ import {
 } from "../../../../src/lib/ts-rest-handler";
 import {
   skillsResolveContract,
+  skillFrontmatterSchema,
   createErrorResponse,
   getSkillStorageName,
 } from "@vm0/core";
@@ -12,13 +13,7 @@ import { initServices } from "../../../../src/lib/init-services";
 import { getAuthContext } from "../../../../src/lib/auth/get-user-id";
 import { skills } from "../../../../src/db/schema/skill";
 import { inArray } from "drizzle-orm";
-
-interface SkillFrontmatter {
-  name?: string;
-  description?: string;
-  vm0_secrets?: string[];
-  vm0_vars?: string[];
-}
+import { z } from "zod";
 
 const router = tsr.router(skillsResolveContract, {
   resolve: async ({ body, headers }) => {
@@ -46,7 +41,7 @@ const router = tsr.router(skillsResolveContract, {
       {
         storageName: string;
         versionHash: string;
-        frontmatter: SkillFrontmatter;
+        frontmatter: z.infer<typeof skillFrontmatterSchema>;
       }
     > = {};
 
@@ -56,7 +51,7 @@ const router = tsr.router(skillsResolveContract, {
       if (!row.versionHash) continue; // Skip skills not yet synced
       foundUrls.add(row.url);
 
-      const fm = (row.frontmatter ?? {}) as SkillFrontmatter;
+      const fm = skillFrontmatterSchema.parse(row.frontmatter ?? {});
 
       resolved[row.url] = {
         storageName: getSkillStorageName(row.fullPath),

--- a/turbo/apps/web/src/__tests__/api-test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers.ts
@@ -48,6 +48,7 @@ import { generateCallbackSecret } from "../lib/callback/hmac";
 import { initServices } from "../lib/init-services";
 import { encryptSecretsMap } from "../lib/crypto/secrets-encryption";
 import { VOLUME_ORG_USER_ID, type StoredExecutionContext } from "@vm0/core";
+import { skills } from "../db/schema/skill";
 
 // Route handlers - imported here so callers don't need to pass them
 import { POST as createComposeRoute } from "../../app/api/agent/composes/route";
@@ -3076,4 +3077,31 @@ export async function insertTestArtifactStorage(
     .where(eq(storages.id, storage!.id));
 
   return { storageId: storage!.id, versionId };
+}
+
+/**
+ * Seed a skill record in the skills table for testing.
+ */
+export async function seedTestSkill(
+  overrides: Partial<typeof skills.$inferInsert> = {},
+) {
+  initServices();
+  const [row] = await globalThis.services.db
+    .insert(skills)
+    .values({
+      url: "https://github.com/vm0-ai/vm0-skills/tree/main/slack",
+      name: "slack",
+      fullPath: "vm0-ai/vm0-skills/tree/main/slack",
+      versionHash:
+        "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2",
+      frontmatter: {
+        name: "Slack",
+        description: "Slack integration",
+        vm0_secrets: ["SLACK_BOT_TOKEN"],
+        vm0_vars: [],
+      },
+      ...overrides,
+    })
+    .returning();
+  return row;
 }

--- a/turbo/packages/core/src/contracts/index.ts
+++ b/turbo/packages/core/src/contracts/index.ts
@@ -474,4 +474,8 @@ export {
   type OnboardingStatusContract,
   type OnboardingStatusResponse,
 } from "./onboarding";
-export { skillsResolveContract, type SkillsResolveContract } from "./skills";
+export {
+  skillsResolveContract,
+  skillFrontmatterSchema,
+  type SkillsResolveContract,
+} from "./skills";

--- a/turbo/packages/core/src/contracts/index.ts
+++ b/turbo/packages/core/src/contracts/index.ts
@@ -474,3 +474,4 @@ export {
   type OnboardingStatusContract,
   type OnboardingStatusResponse,
 } from "./onboarding";
+export { skillsResolveContract, type SkillsResolveContract } from "./skills";

--- a/turbo/packages/core/src/contracts/skills.ts
+++ b/turbo/packages/core/src/contracts/skills.ts
@@ -1,0 +1,40 @@
+import { z } from "zod";
+import { initContract, authHeadersSchema } from "./base";
+import { apiErrorSchema } from "./errors";
+
+const c = initContract();
+
+const skillFrontmatterSchema = z.object({
+  name: z.string().optional(),
+  description: z.string().optional(),
+  vm0_secrets: z.array(z.string()).optional(),
+  vm0_vars: z.array(z.string()).optional(),
+});
+
+const resolvedSkillSchema = z.object({
+  storageName: z.string(),
+  versionHash: z.string(),
+  frontmatter: skillFrontmatterSchema,
+});
+
+export const skillsResolveContract = c.router({
+  resolve: {
+    method: "POST",
+    path: "/api/skills/resolve",
+    headers: authHeadersSchema,
+    body: z.object({
+      skills: z.array(z.string().url()).min(1).max(100),
+    }),
+    responses: {
+      200: z.object({
+        resolved: z.record(z.string(), resolvedSkillSchema),
+        unresolved: z.array(z.string()),
+      }),
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+    },
+    summary: "Batch resolve skill URLs to cached version info",
+  },
+});
+
+export type SkillsResolveContract = typeof skillsResolveContract;

--- a/turbo/packages/core/src/contracts/skills.ts
+++ b/turbo/packages/core/src/contracts/skills.ts
@@ -4,7 +4,7 @@ import { apiErrorSchema } from "./errors";
 
 const c = initContract();
 
-const skillFrontmatterSchema = z.object({
+export const skillFrontmatterSchema = z.object({
   name: z.string().optional(),
   description: z.string().optional(),
   vm0_secrets: z.array(z.string()).optional(),


### PR DESCRIPTION
## Summary

- Add `POST /api/skills/resolve` endpoint that batch-resolves official skill URLs to their cached version info (storageName, versionHash, frontmatter)
- Define ts-rest contract with Zod schemas in `@vm0/core` for type-safe CLI consumption
- Add `seedTestSkill()` test helper for integration tests

## Details

Part of #4768 (system skills cache). This is **Task 3** — the read-only resolve endpoint that CLI calls instead of downloading skills.

**Depends on**: #4769 (merged ✅ via PR #4770)

The endpoint:
- Authenticates via CLI token or Clerk session (standard `getAuthContext`)
- Batch queries the `skills` table with `WHERE url IN (...)`
- Partitions results into `resolved` (found with versionHash) and `unresolved` (not found or not yet synced)
- Computes `storageName` from `fullPath` using `getSkillStorageName()`

Closes #4777

## Test plan

- [x] 9 integration tests covering auth, validation, and resolution scenarios
- [x] Auth: rejects unauthenticated, accepts CLI token
- [x] Validation: rejects empty array, rejects invalid URLs
- [x] Resolution: resolves seeded skills, returns unresolved for unknown, handles mixed, treats null versionHash as unresolved, handles no matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)