### PR TITLE
feat: add cron job to sync official skills from github

### DIFF
--- a/turbo/apps/web/app/api/cron/sync-skills/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/cron/sync-skills/__tests__/route.test.ts
@@ -1,0 +1,328 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  readFileSync,
+  rmSync,
+} from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import * as tar from "tar";
+import { http, HttpResponse } from "msw";
+import { GET } from "../route";
+import {
+  createTestRequest,
+  clearSkillsData,
+  findTestSkillByUrl,
+  findAllTestSkills,
+  findTestSystemStorages,
+} from "../../../../../src/__tests__/api-test-helpers";
+import { testContext } from "../../../../../src/__tests__/test-helpers";
+import { reloadEnv } from "../../../../../src/env";
+import { server } from "../../../../../src/mocks/server";
+
+const context = testContext();
+const cronSecret = "test-cron-secret";
+const TEST_COMMIT_SHA = "a".repeat(40);
+
+function cronRequest(secret?: string) {
+  return createTestRequest(
+    "http://localhost:3000/api/cron/sync-skills",
+    secret ? { headers: { Authorization: `Bearer ${secret}` } } : undefined,
+  );
+}
+
+/**
+ * Create a mock pkt-line response for git smart HTTP info/refs.
+ * Simplified format — real responses have more lines, but the parser
+ * only looks for the refs/heads/main line.
+ */
+function createGitRefsResponse(commitSha: string): string {
+  const header = "001e# service=git-upload-pack\n0000";
+  const refLine = `003f${commitSha} refs/heads/main\n`;
+  return header + refLine;
+}
+
+/**
+ * Create a gzipped tarball buffer containing mock skills.
+ * Mimics the GitHub codeload format with a {repo}-{branch}/ prefix.
+ */
+function createMockTarball(
+  mockSkills: Array<{
+    name: string;
+    files: Array<{ path: string; content: string }>;
+  }>,
+): Buffer {
+  const tmpDir = mkdtempSync(join(tmpdir(), "vm0-test-tarball-"));
+  const prefix = "vm0-skills-main";
+
+  try {
+    // Create directory structure
+    mkdirSync(join(tmpDir, prefix), { recursive: true });
+
+    const filePaths: string[] = [];
+    for (const skill of mockSkills) {
+      const skillDir = join(tmpDir, prefix, skill.name);
+      mkdirSync(skillDir, { recursive: true });
+
+      for (const file of skill.files) {
+        const filePath = join(skillDir, file.path);
+        mkdirSync(join(filePath, ".."), { recursive: true });
+        writeFileSync(filePath, file.content);
+        filePaths.push(join(prefix, skill.name, file.path));
+      }
+    }
+
+    // Create tar.gz
+    const tarPath = join(tmpDir, "test.tar.gz");
+    tar.create(
+      { gzip: true, file: tarPath, cwd: tmpDir, sync: true },
+      filePaths,
+    );
+    return readFileSync(tarPath);
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true });
+  }
+}
+
+/** Standard mock skills for testing */
+const MOCK_SKILLS = [
+  {
+    name: "slack",
+    files: [
+      {
+        path: "SKILL.md",
+        content: [
+          "---",
+          "name: slack",
+          "description: Slack integration skill",
+          "vm0_secrets:",
+          "  - SLACK_TOKEN",
+          "---",
+          "",
+          "# Slack Skill",
+          "Send messages to Slack.",
+        ].join("\n"),
+      },
+      { path: "index.ts", content: 'console.log("slack");' },
+    ],
+  },
+  {
+    name: "github",
+    files: [
+      {
+        path: "SKILL.md",
+        content: [
+          "---",
+          "name: github",
+          "description: GitHub integration",
+          "---",
+          "",
+          "# GitHub Skill",
+        ].join("\n"),
+      },
+    ],
+  },
+];
+
+function setupMswHandlers(commitSha: string, tarball: Buffer) {
+  server.use(
+    http.get(
+      "https://github.com/vm0-ai/vm0-skills.git/info/refs",
+      () => new HttpResponse(createGitRefsResponse(commitSha)),
+    ),
+    http.get(
+      "https://codeload.github.com/vm0-ai/vm0-skills/tar.gz/refs/heads/main",
+      () => new HttpResponse(tarball),
+    ),
+  );
+}
+
+describe("GET /api/cron/sync-skills", () => {
+  beforeEach(async () => {
+    context.setupMocks();
+    vi.stubEnv("CRON_SECRET", cronSecret);
+    reloadEnv();
+    await clearSkillsData();
+  });
+
+  describe("Authentication", () => {
+    it("should reject request without cron secret", async () => {
+      const response = await GET(cronRequest());
+      expect(response.status).toBe(401);
+      const data = await response.json();
+      expect(data.error.code).toBe("UNAUTHORIZED");
+    });
+
+    it("should reject request with invalid cron secret", async () => {
+      const response = await GET(cronRequest("wrong-secret"));
+      expect(response.status).toBe(401);
+    });
+
+    it("should accept request with valid cron secret", async () => {
+      const tarball = createMockTarball(MOCK_SKILLS);
+      setupMswHandlers(TEST_COMMIT_SHA, tarball);
+
+      const response = await GET(cronRequest(cronSecret));
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.success).toBe(true);
+    });
+  });
+
+  describe("Freshness check", () => {
+    it("should skip sync when commit SHA is unchanged", async () => {
+      const tarball = createMockTarball(MOCK_SKILLS);
+      setupMswHandlers(TEST_COMMIT_SHA, tarball);
+
+      // First sync — populates DB
+      const response1 = await GET(cronRequest(cronSecret));
+      expect(response1.status).toBe(200);
+      const data1 = await response1.json();
+      expect(data1.synced).toBe(2);
+
+      // Second sync with same commit SHA — should skip
+      const response2 = await GET(cronRequest(cronSecret));
+      expect(response2.status).toBe(200);
+      const data2 = await response2.json();
+      expect(data2.synced).toBe(0);
+      expect(data2.skipped).toBe(0);
+      expect(data2.total).toBe(0);
+    });
+  });
+
+  describe("Full sync", () => {
+    it("should sync skills on first run with empty table", async () => {
+      const tarball = createMockTarball(MOCK_SKILLS);
+      setupMswHandlers(TEST_COMMIT_SHA, tarball);
+
+      const response = await GET(cronRequest(cronSecret));
+      expect(response.status).toBe(200);
+      const data = await response.json();
+
+      expect(data.success).toBe(true);
+      expect(data.commitSha).toBe(TEST_COMMIT_SHA);
+      expect(data.synced).toBe(2);
+      expect(data.total).toBe(2);
+
+      // Verify skills table records
+      const allSkills = await findAllTestSkills();
+      expect(allSkills).toHaveLength(2);
+
+      const slackSkill = await findTestSkillByUrl(
+        "https://github.com/vm0-ai/vm0-skills/tree/main/slack",
+      );
+      expect(slackSkill).not.toBeNull();
+      expect(slackSkill!.fullPath).toBe("vm0-ai/vm0-skills/tree/main/slack");
+      expect(slackSkill!.commitSha).toBe(TEST_COMMIT_SHA);
+      expect(slackSkill!.versionHash).toBeTruthy();
+      expect(slackSkill!.fileCount).toBe(2);
+      expect(slackSkill!.frontmatter).toEqual({
+        name: "slack",
+        description: "Slack integration skill",
+        vm0_secrets: ["SLACK_TOKEN"],
+      });
+
+      const githubSkill = await findTestSkillByUrl(
+        "https://github.com/vm0-ai/vm0-skills/tree/main/github",
+      );
+      expect(githubSkill).not.toBeNull();
+      expect(githubSkill!.fileCount).toBe(1);
+
+      // Verify storages records
+      const allStorages = await findTestSystemStorages();
+      expect(allStorages).toHaveLength(2);
+
+      for (const storage of allStorages) {
+        expect(storage.type).toBe("volume");
+        expect(storage.headVersionId).toBeTruthy();
+      }
+
+      // Verify S3 uploads were called (manifest + archive per skill = 4 calls)
+      expect(context.mocks.s3.putS3Object).toHaveBeenCalledTimes(4);
+    });
+
+    it("should skip directories without SKILL.md", async () => {
+      const skillsWithExtra = [
+        ...MOCK_SKILLS,
+        {
+          name: "no-skill-md",
+          files: [{ path: "README.md", content: "Not a skill" }],
+        },
+      ];
+      const tarball = createMockTarball(skillsWithExtra);
+      setupMswHandlers(TEST_COMMIT_SHA, tarball);
+
+      const response = await GET(cronRequest(cronSecret));
+      const data = await response.json();
+
+      // Only 2 skills synced (slack + github), not the dir without SKILL.md
+      expect(data.synced).toBe(2);
+      expect(data.total).toBe(2);
+    });
+  });
+
+  describe("Incremental sync", () => {
+    it("should only update changed skills", async () => {
+      const tarball1 = createMockTarball(MOCK_SKILLS);
+      setupMswHandlers(TEST_COMMIT_SHA, tarball1);
+
+      // First sync
+      await GET(cronRequest(cronSecret));
+
+      // Second sync with new commit but only slack changed
+      const newCommitSha = "b".repeat(40);
+      const modifiedSkills = [
+        {
+          name: "slack",
+          files: [
+            {
+              path: "SKILL.md",
+              content: [
+                "---",
+                "name: slack",
+                "description: Updated slack skill",
+                "vm0_secrets:",
+                "  - SLACK_TOKEN",
+                "  - SLACK_WEBHOOK",
+                "---",
+                "",
+                "# Slack Skill v2",
+              ].join("\n"),
+            },
+            { path: "index.ts", content: 'console.log("slack v2");' },
+          ],
+        },
+        // github stays the same
+        MOCK_SKILLS[1]!,
+      ];
+      const tarball2 = createMockTarball(modifiedSkills);
+      setupMswHandlers(newCommitSha, tarball2);
+
+      context.mocks.s3.putS3Object.mockClear();
+
+      const response = await GET(cronRequest(cronSecret));
+      const data = await response.json();
+
+      expect(data.commitSha).toBe(newCommitSha);
+      expect(data.synced).toBe(1); // Only slack changed
+      expect(data.skipped).toBe(1); // github unchanged
+      expect(data.total).toBe(2);
+
+      // Only 2 S3 uploads (manifest + archive for slack only)
+      expect(context.mocks.s3.putS3Object).toHaveBeenCalledTimes(2);
+
+      // Verify updated frontmatter
+      const slackSkill = await findTestSkillByUrl(
+        "https://github.com/vm0-ai/vm0-skills/tree/main/slack",
+      );
+      expect(slackSkill!.frontmatter).toEqual({
+        name: "slack",
+        description: "Updated slack skill",
+        vm0_secrets: ["SLACK_TOKEN", "SLACK_WEBHOOK"],
+      });
+      expect(slackSkill!.commitSha).toBe(newCommitSha);
+    });
+  });
+});

--- a/turbo/apps/web/app/api/cron/sync-skills/route.ts
+++ b/turbo/apps/web/app/api/cron/sync-skills/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from "next/server";
+import { initServices } from "../../../../src/lib/init-services";
+import { syncSkills } from "../../../../src/lib/skills/sync-skills";
+import { logger } from "../../../../src/lib/logger";
+import { env } from "../../../../src/env";
+
+const log = logger("cron:sync-skills");
+
+export async function GET(request: Request): Promise<Response> {
+  initServices();
+
+  const authHeader = request.headers.get("authorization");
+  const cronSecret = env().CRON_SECRET;
+
+  if (!cronSecret || authHeader !== `Bearer ${cronSecret}`) {
+    return NextResponse.json(
+      { error: { message: "Invalid cron secret", code: "UNAUTHORIZED" } },
+      { status: 401 },
+    );
+  }
+
+  const result = await syncSkills();
+
+  if (result.synced > 0) {
+    log.info("Skills sync completed", result);
+  }
+
+  return NextResponse.json({ success: true, ...result });
+}

--- a/turbo/apps/web/package.json
+++ b/turbo/apps/web/package.json
@@ -56,6 +56,7 @@
     "resend": "^6.9.2",
     "server-only": "^0.0.1",
     "svix": "^1.84.1",
+    "tar": "^7.5.11",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/turbo/apps/web/src/__tests__/api-test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers.ts
@@ -23,6 +23,7 @@ import { runnerJobQueue } from "../db/schema/runner-job-queue";
 import { composeJobs } from "../db/schema/compose-job";
 import { exportJobs } from "../db/schema/export-job";
 import { storages, storageVersions } from "../db/schema/storage";
+import { skills } from "../db/schema/skill";
 import { usageDaily } from "../db/schema/usage-daily";
 import { slackComposeRequests } from "../db/schema/slack-compose-request";
 import { slackInstallations } from "../db/schema/slack-installation";
@@ -48,7 +49,11 @@ import { and, eq, inArray, like, or, sql } from "drizzle-orm";
 import { generateCallbackSecret } from "../lib/callback/hmac";
 import { initServices } from "../lib/init-services";
 import { encryptSecretsMap } from "../lib/crypto/secrets-encryption";
-import { VOLUME_ORG_USER_ID, type StoredExecutionContext } from "@vm0/core";
+import {
+  VOLUME_ORG_USER_ID,
+  SYSTEM_ORG_ID,
+  type StoredExecutionContext,
+} from "@vm0/core";
 import { skills } from "../db/schema/skill";
 
 // Route handlers - imported here so callers don't need to pass them
@@ -3151,4 +3156,45 @@ export async function seedTestSkill(
     })
     .returning();
   return row;
+}
+
+/**
+ * Delete all skills and system storages.
+ * Used for test isolation in cron/sync-skills tests.
+ */
+export async function clearSkillsData(): Promise<void> {
+  initServices();
+  await globalThis.services.db.delete(skills);
+  await globalThis.services.db
+    .delete(storages)
+    .where(eq(storages.orgId, SYSTEM_ORG_ID));
+}
+
+/**
+ * Find a skill by its canonical URL.
+ */
+export async function findTestSkillByUrl(url: string) {
+  const [skill] = await globalThis.services.db
+    .select()
+    .from(skills)
+    .where(eq(skills.url, url))
+    .limit(1);
+  return skill ?? null;
+}
+
+/**
+ * Get all skills from the database.
+ */
+export async function findAllTestSkills() {
+  return globalThis.services.db.select().from(skills);
+}
+
+/**
+ * Get all system storages (orgId = SYSTEM_ORG_ID).
+ */
+export async function findTestSystemStorages() {
+  return globalThis.services.db
+    .select()
+    .from(storages)
+    .where(eq(storages.orgId, SYSTEM_ORG_ID));
 }

--- a/turbo/apps/web/src/__tests__/api-test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers.ts
@@ -54,7 +54,6 @@ import {
   SYSTEM_ORG_ID,
   type StoredExecutionContext,
 } from "@vm0/core";
-import { skills } from "../db/schema/skill";
 
 // Route handlers - imported here so callers don't need to pass them
 import { POST as createComposeRoute } from "../../app/api/agent/composes/route";

--- a/turbo/apps/web/src/lib/skills/git-refs.ts
+++ b/turbo/apps/web/src/lib/skills/git-refs.ts
@@ -1,0 +1,45 @@
+/**
+ * Git smart HTTP protocol utilities
+ *
+ * Fetches repository HEAD commit SHA via the git smart HTTP protocol
+ * (info/refs endpoint). This is NOT a GitHub API call — no tokens or
+ * rate limits apply.
+ */
+
+import {
+  DEFAULT_SKILLS_OWNER,
+  DEFAULT_SKILLS_REPO,
+  DEFAULT_SKILLS_BRANCH,
+} from "@vm0/core";
+
+const REPO_REFS_URL = `https://github.com/${DEFAULT_SKILLS_OWNER}/${DEFAULT_SKILLS_REPO}.git/info/refs?service=git-upload-pack`;
+
+/**
+ * Fetch the current HEAD commit SHA for refs/heads/main via git smart HTTP protocol.
+ */
+export async function fetchHeadCommitSha(): Promise<string> {
+  const res = await fetch(REPO_REFS_URL);
+  if (!res.ok) {
+    throw new Error(`Failed to fetch git refs: ${res.status}`);
+  }
+  const text = await res.text();
+  return parseMainRef(text, DEFAULT_SKILLS_BRANCH);
+}
+
+/**
+ * Parse pkt-line format response to extract a branch's commit SHA.
+ *
+ * The git smart HTTP info/refs response uses pkt-line encoding where each
+ * line is prefixed with a 4-character hex length. Lines contain:
+ *   {40-char SHA} {ref-name}
+ */
+function parseMainRef(pktLineText: string, branch: string): string {
+  const refPattern = new RegExp(`([0-9a-f]{40})\\s+refs/heads/${branch}`);
+  for (const line of pktLineText.split("\n")) {
+    const match = line.match(refPattern);
+    if (match) {
+      return match[1]!;
+    }
+  }
+  throw new Error(`refs/heads/${branch} not found in git refs`);
+}

--- a/turbo/apps/web/src/lib/skills/git-refs.ts
+++ b/turbo/apps/web/src/lib/skills/git-refs.ts
@@ -34,11 +34,21 @@ export async function fetchHeadCommitSha(): Promise<string> {
  *   {40-char SHA} {ref-name}
  */
 function parseMainRef(pktLineText: string, branch: string): string {
-  const refPattern = new RegExp(`([0-9a-f]{40})\\s+refs/heads/${branch}`);
+  const refSuffix = `refs/heads/${branch}`;
+  // In pkt-line format, each ref line contains: {sha} {ref-name}
+  // Find lines containing the target ref, then extract the 40-char SHA
+  // that immediately precedes the whitespace before the ref name.
+  const shaLength = 40;
   for (const line of pktLineText.split("\n")) {
-    const match = line.match(refPattern);
-    if (match) {
-      return match[1]!;
+    const refIndex = line.indexOf(refSuffix);
+    if (refIndex < 0) continue;
+    // SHA ends at refIndex - 1 (space separator) and starts 40 chars before that
+    const shaEnd = refIndex - 1;
+    const shaStart = shaEnd - shaLength;
+    if (shaStart < 0) continue;
+    const sha = line.substring(shaStart, shaEnd);
+    if (/^[0-9a-f]{40}$/.test(sha)) {
+      return sha;
     }
   }
   throw new Error(`refs/heads/${branch} not found in git refs`);

--- a/turbo/apps/web/src/lib/skills/sync-skills.ts
+++ b/turbo/apps/web/src/lib/skills/sync-skills.ts
@@ -1,0 +1,322 @@
+/**
+ * Skills sync orchestration
+ *
+ * Coordinates the full sync flow: freshness check via git refs,
+ * tarball download/extraction, per-skill content hashing, S3 upload,
+ * and database upserts for storages, storageVersions, and skills tables.
+ */
+
+import {
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  readFileSync,
+  rmSync,
+} from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import * as tar from "tar";
+import { eq } from "drizzle-orm";
+import {
+  SYSTEM_ORG_ID,
+  VOLUME_ORG_USER_ID,
+  getSkillStorageName,
+  DEFAULT_SKILLS_OWNER,
+  DEFAULT_SKILLS_REPO,
+  DEFAULT_SKILLS_BRANCH,
+  parseSkillFrontmatter,
+  type SkillFrontmatter,
+} from "@vm0/core";
+import { fetchHeadCommitSha } from "./git-refs";
+import { downloadAndExtractSkills, type ExtractedSkill } from "./tarball";
+import {
+  computeSystemSkillHash,
+  type FileEntryWithHash,
+} from "../storage/content-hash";
+import { putS3Object } from "../s3/s3-client";
+import { skills } from "../../db/schema/skill";
+import { storages, storageVersions } from "../../db/schema/storage";
+import { env } from "../../env";
+import { logger } from "../logger";
+
+const log = logger("skills:sync");
+
+interface SyncResult {
+  commitSha: string;
+  /** Skills that were created or updated */
+  synced: number;
+  /** Skills unchanged (same version hash) */
+  skipped: number;
+  /** Total skills found in tarball */
+  total: number;
+}
+
+/**
+ * Sync all official skills from the vm0-skills repository.
+ *
+ * 1. Fetch HEAD commit SHA via git smart HTTP protocol
+ * 2. Compare with stored commit SHA — skip if unchanged
+ * 3. Download and extract tarball
+ * 4. For each skill: compute hash, compare, upload to S3, upsert DB
+ */
+export async function syncSkills(): Promise<SyncResult> {
+  const db = globalThis.services.db;
+
+  // 1. Fetch current HEAD
+  const headSha = await fetchHeadCommitSha();
+
+  // 2. Check stored commit SHA from any existing skill row
+  const [existing] = await db
+    .select({ commitSha: skills.commitSha })
+    .from(skills)
+    .limit(1);
+
+  if (existing?.commitSha === headSha) {
+    return { commitSha: headSha, synced: 0, skipped: 0, total: 0 };
+  }
+
+  // 3. Download and extract tarball
+  const extractedSkills = await downloadAndExtractSkills();
+
+  // 4. Sync each skill
+  let synced = 0;
+  let skipped = 0;
+
+  for (const extracted of extractedSkills) {
+    const wasUpdated = await syncSingleSkill(db, extracted, headSha);
+    if (wasUpdated) {
+      synced++;
+    } else {
+      skipped++;
+    }
+  }
+
+  log.info("Sync completed", {
+    commitSha: headSha,
+    synced,
+    skipped,
+    total: extractedSkills.length,
+  });
+
+  return {
+    commitSha: headSha,
+    synced,
+    skipped,
+    total: extractedSkills.length,
+  };
+}
+
+/**
+ * Sync a single skill: compute hash, compare with DB, upload to S3 if changed,
+ * and upsert all DB records.
+ *
+ * @returns true if the skill was created or updated, false if skipped
+ */
+async function syncSingleSkill(
+  db: typeof globalThis.services.db,
+  extracted: ExtractedSkill,
+  commitSha: string,
+): Promise<boolean> {
+  const { skillName, files } = extracted;
+  const skillUrl = `https://github.com/${DEFAULT_SKILLS_OWNER}/${DEFAULT_SKILLS_REPO}/tree/${DEFAULT_SKILLS_BRANCH}/${skillName}`;
+  const fullPath = `${DEFAULT_SKILLS_OWNER}/${DEFAULT_SKILLS_REPO}/tree/${DEFAULT_SKILLS_BRANCH}/${skillName}`;
+  const storageName = getSkillStorageName(fullPath);
+
+  // Parse SKILL.md frontmatter
+  const skillMd = files.find((f) => f.path === "SKILL.md");
+  const frontmatter: SkillFrontmatter = skillMd
+    ? parseSkillFrontmatter(skillMd.content.toString("utf-8"))
+    : {};
+
+  // Compute file hashes for version hash
+  const fileEntries: FileEntryWithHash[] = files.map((f) => ({
+    path: f.path,
+    hash: f.hash,
+    size: f.size,
+  }));
+  const versionHash = computeSystemSkillHash(skillUrl, fileEntries);
+
+  // Check if skill already exists with same version hash
+  const [existingSkill] = await db
+    .select({ versionHash: skills.versionHash })
+    .from(skills)
+    .where(eq(skills.url, skillUrl))
+    .limit(1);
+
+  if (existingSkill?.versionHash === versionHash) {
+    // Content unchanged — just update commitSha
+    await db
+      .update(skills)
+      .set({ commitSha, updatedAt: new Date() })
+      .where(eq(skills.url, skillUrl));
+    return false;
+  }
+
+  // Create archive.tar.gz and manifest.json
+  const { archiveBuffer, manifestBuffer } = createSkillArchive(files);
+
+  // Upload to S3
+  const bucketName = env().R2_USER_STORAGES_BUCKET_NAME;
+  const s3Prefix = `${SYSTEM_ORG_ID}/volume/${storageName}`;
+  const s3Key = `${s3Prefix}/${versionHash}`;
+
+  await Promise.all([
+    putS3Object(
+      bucketName,
+      `${s3Key}/archive.tar.gz`,
+      archiveBuffer,
+      "application/gzip",
+    ),
+    putS3Object(
+      bucketName,
+      `${s3Key}/manifest.json`,
+      manifestBuffer,
+      "application/json",
+    ),
+  ]);
+
+  // Upsert storages record
+  const [storage] = await db
+    .insert(storages)
+    .values({
+      orgId: SYSTEM_ORG_ID,
+      userId: VOLUME_ORG_USER_ID,
+      name: storageName,
+      type: "volume",
+      s3Prefix,
+      size: archiveBuffer.length,
+      fileCount: files.length,
+    })
+    .onConflictDoUpdate({
+      target: [storages.orgId, storages.userId, storages.name, storages.type],
+      set: {
+        size: archiveBuffer.length,
+        fileCount: files.length,
+        updatedAt: new Date(),
+      },
+    })
+    .returning({ id: storages.id });
+
+  const storageId = storage!.id;
+
+  // Upsert storageVersions record (content-addressed by versionHash)
+  await db
+    .insert(storageVersions)
+    .values({
+      id: versionHash,
+      storageId,
+      s3Key,
+      size: archiveBuffer.length,
+      fileCount: files.length,
+      message: `Synced from ${DEFAULT_SKILLS_OWNER}/${DEFAULT_SKILLS_REPO}@${commitSha.slice(0, 7)}`,
+      createdBy: "system",
+    })
+    .onConflictDoNothing();
+
+  // Update storage HEAD pointer
+  await db
+    .update(storages)
+    .set({
+      headVersionId: versionHash,
+      size: archiveBuffer.length,
+      fileCount: files.length,
+      updatedAt: new Date(),
+    })
+    .where(eq(storages.id, storageId));
+
+  // Upsert skills record
+  const displayName = frontmatter.name || skillName;
+  const totalSize = files.reduce((sum, f) => sum + f.size, 0);
+
+  await db
+    .insert(skills)
+    .values({
+      url: skillUrl,
+      name: displayName,
+      fullPath,
+      storageId,
+      versionHash,
+      commitSha,
+      frontmatter,
+      s3Key,
+      size: totalSize,
+      fileCount: files.length,
+      syncedAt: new Date(),
+    })
+    .onConflictDoUpdate({
+      target: skills.url,
+      set: {
+        name: displayName,
+        fullPath,
+        storageId,
+        versionHash,
+        commitSha,
+        frontmatter,
+        s3Key,
+        size: totalSize,
+        fileCount: files.length,
+        syncedAt: new Date(),
+        updatedAt: new Date(),
+      },
+    });
+
+  log.debug("Synced skill", {
+    skillName,
+    versionHash: versionHash.slice(0, 8),
+  });
+  return true;
+}
+
+/**
+ * Create archive.tar.gz and manifest.json from in-memory files.
+ *
+ * Writes files to a temp directory, creates the tar with `tar.create()`,
+ * then reads the result back as Buffers.
+ */
+function createSkillArchive(
+  files: Array<{ path: string; content: Buffer; hash: string; size: number }>,
+): { archiveBuffer: Buffer; manifestBuffer: Buffer } {
+  const tmpDir = mkdtempSync(join(tmpdir(), "vm0-skill-"));
+
+  try {
+    // Write files to temp directory
+    for (const file of files) {
+      const filePath = join(tmpDir, file.path);
+      const dir = join(filePath, "..");
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(filePath, file.content);
+    }
+
+    // Create tar.gz synchronously
+    const tarPath = join(tmpDir, "__archive.tar.gz");
+    const filePaths = files.map((f) => f.path);
+
+    tar.create(
+      {
+        gzip: true,
+        file: tarPath,
+        cwd: tmpDir,
+        sync: true,
+      },
+      filePaths,
+    );
+
+    const archiveBuffer = readFileSync(tarPath);
+
+    // Create manifest
+    const manifest = {
+      version: 1,
+      files: files.map((f) => ({
+        path: f.path,
+        hash: f.hash,
+        size: f.size,
+      })),
+      createdAt: new Date().toISOString(),
+    };
+    const manifestBuffer = Buffer.from(JSON.stringify(manifest, null, 2));
+
+    return { archiveBuffer, manifestBuffer };
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true });
+  }
+}

--- a/turbo/apps/web/src/lib/skills/tarball.ts
+++ b/turbo/apps/web/src/lib/skills/tarball.ts
@@ -1,0 +1,115 @@
+/**
+ * GitHub codeload tarball download and extraction
+ *
+ * Downloads the vm0-skills repository tarball and extracts skill
+ * directories in memory using the tar streaming parser.
+ */
+
+import { createHash } from "crypto";
+import { gunzipSync } from "node:zlib";
+import { Parser } from "tar";
+import {
+  DEFAULT_SKILLS_OWNER,
+  DEFAULT_SKILLS_REPO,
+  DEFAULT_SKILLS_BRANCH,
+} from "@vm0/core";
+
+const TARBALL_URL = `https://codeload.github.com/${DEFAULT_SKILLS_OWNER}/${DEFAULT_SKILLS_REPO}/tar.gz/refs/heads/${DEFAULT_SKILLS_BRANCH}`;
+
+interface ExtractedFile {
+  /** Relative path within skill directory (e.g., "SKILL.md") */
+  path: string;
+  content: Buffer;
+  /** SHA-256 hash of file content */
+  hash: string;
+  size: number;
+}
+
+export interface ExtractedSkill {
+  /** Directory name (e.g., "slack") */
+  skillName: string;
+  files: ExtractedFile[];
+}
+
+/**
+ * Download the vm0-skills tarball and extract all skill directories.
+ * Returns only directories that contain a SKILL.md file.
+ */
+export async function downloadAndExtractSkills(): Promise<ExtractedSkill[]> {
+  const res = await fetch(TARBALL_URL);
+  if (!res.ok) {
+    throw new Error(`Failed to download tarball: ${res.status}`);
+  }
+
+  const compressed = Buffer.from(await res.arrayBuffer());
+  return extractSkillsFromTarball(compressed);
+}
+
+/**
+ * Extract skill directories from a gzipped tarball buffer.
+ *
+ * GitHub wraps tarball contents in a `{repo}-{branch}/` prefix directory.
+ * Each subdirectory containing a SKILL.md is treated as a skill.
+ */
+function extractSkillsFromTarball(gzipped: Buffer): Promise<ExtractedSkill[]> {
+  const decompressed = gunzipSync(gzipped);
+
+  // Collect all files grouped by top-level skill directory
+  const filesBySkill = new Map<string, ExtractedFile[]>();
+
+  return new Promise((resolve, reject) => {
+    const parser = new Parser({
+      onReadEntry: (entry) => {
+        if (entry.type !== "File") {
+          entry.resume();
+          return;
+        }
+
+        // Parse path: "{repo}-{branch}/{skillName}/..." → strip prefix
+        const parts = entry.path.split("/");
+        // parts[0] = "vm0-skills-main", parts[1] = skill dir, parts[2+] = file
+        if (parts.length < 3) {
+          entry.resume();
+          return;
+        }
+
+        const skillName = parts[1]!;
+        const relativePath = parts.slice(2).join("/");
+
+        const chunks: Buffer[] = [];
+        entry.on("data", (chunk: Buffer) => chunks.push(chunk));
+        entry.on("end", () => {
+          const content = Buffer.concat(chunks);
+          const hash = createHash("sha256").update(content).digest("hex");
+
+          if (!filesBySkill.has(skillName)) {
+            filesBySkill.set(skillName, []);
+          }
+          filesBySkill.get(skillName)!.push({
+            path: relativePath,
+            content,
+            hash,
+            size: content.length,
+          });
+        });
+      },
+    });
+
+    parser.on("end", () => {
+      // Only include directories that contain a SKILL.md file
+      const skills: ExtractedSkill[] = [];
+      for (const [skillName, files] of filesBySkill) {
+        if (files.some((f) => f.path === "SKILL.md")) {
+          skills.push({ skillName, files });
+        }
+      }
+      resolve(skills);
+    });
+
+    parser.on("error", reject);
+
+    // Feed decompressed tar data to parser
+    parser.write(decompressed);
+    parser.end();
+  });
+}

--- a/turbo/apps/web/src/lib/storage/content-hash.ts
+++ b/turbo/apps/web/src/lib/storage/content-hash.ts
@@ -40,7 +40,7 @@ export function isValidVersionPrefix(prefix: string): boolean {
  * File entry with pre-computed hash (no content needed)
  * Used for direct upload flow where client computes hashes
  */
-interface FileEntryWithHash {
+export interface FileEntryWithHash {
   /** Relative path within the storage */
   path: string;
   /** SHA-256 hash of file content (computed by client) */
@@ -87,5 +87,30 @@ export function computeContentHashFromHashes(
 
   // Include storageId prefix and combine with file entries
   const combined = `storage:${storageId}\n${entries.join("\n")}`;
+  return createHash("sha256").update(combined).digest("hex");
+}
+
+/**
+ * Compute content-addressable hash for a system skill.
+ *
+ * Uses a fixed prefix (skill URL) instead of storageId so the same
+ * skill content always produces the same hash across environments.
+ *
+ * @param skillUrl Canonical GitHub tree URL for the skill
+ * @param files Array of file entries with path and pre-computed hash
+ * @returns 64-character lowercase hexadecimal SHA-256 hash
+ */
+export function computeSystemSkillHash(
+  skillUrl: string,
+  files: FileEntryWithHash[],
+): string {
+  if (files.length === 0) {
+    return createHash("sha256")
+      .update(`system-skill:${skillUrl}\n`)
+      .digest("hex");
+  }
+
+  const entries = files.map((file) => `${file.path}:${file.hash}`).sort();
+  const combined = `system-skill:${skillUrl}\n${entries.join("\n")}`;
   return createHash("sha256").update(combined).digest("hex");
 }

--- a/turbo/apps/web/vercel.json
+++ b/turbo/apps/web/vercel.json
@@ -22,6 +22,10 @@
     {
       "path": "/api/cron/drain-email-outbox",
       "schedule": "* * * * *"
+    },
+    {
+      "path": "/api/cron/sync-skills",
+      "schedule": "* * * * *"
     }
   ]
 }

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -432,7 +432,7 @@ importers:
         specifier: ^1.84.1
         version: 1.84.1
       tar:
-        specifier: ^7.5.11
+        specifier: '>=7.5.7'
         version: 7.5.11
       zod:
         specifier: ^4.3.6

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -431,6 +431,9 @@ importers:
       svix:
         specifier: ^1.84.1
         version: 1.84.1
+      tar:
+        specifier: ^7.5.11
+        version: 7.5.11
       zod:
         specifier: ^4.3.6
         version: 4.3.6


### PR DESCRIPTION
## Summary

- Add `/api/cron/sync-skills` Vercel cron endpoint that syncs all official skills from `vm0-ai/vm0-skills` into system VAS storage and `skills` table
- Uses git smart HTTP protocol for zero GitHub API calls, zero tokens, zero rate limits
- Freshness check via commit SHA comparison — only downloads tarball when HEAD changes
- Per-skill content hashing for incremental sync — skips unchanged skills
- Self-bootstrapping: works on first run with empty skills table

## Changes

| File | Purpose |
|------|---------|
| `src/lib/skills/git-refs.ts` | Parse pkt-line format to fetch HEAD commit SHA |
| `src/lib/skills/tarball.ts` | Download and extract GitHub codeload tarball in memory |
| `src/lib/skills/sync-skills.ts` | Orchestrate freshness check, per-skill sync, DB/S3 upserts |
| `src/lib/storage/content-hash.ts` | Add `computeSystemSkillHash()` for deterministic hashing |
| `app/api/cron/sync-skills/route.ts` | Cron endpoint with CRON_SECRET auth |
| `vercel.json` | Add `* * * * *` cron schedule |
| `__tests__/api-test-helpers.ts` | Add skills cleanup/query test helpers |
| `__tests__/route.test.ts` | Integration test (7 tests) with MSW mocking |

## Test plan

- [x] Auth tests: reject without secret, reject invalid, accept valid
- [x] Skip sync when commit SHA unchanged
- [x] Full sync on first run with empty table (verify skills, storages, storageVersions, S3 uploads)
- [x] Skip directories without SKILL.md
- [x] Incremental sync: only update changed skills
- [x] `pnpm check-types` passes
- [x] `pnpm turbo run lint` passes
- [x] `pnpm knip` passes

Closes #4776

🤖 Generated with [Claude Code](https://claude.com/claude-code)