### PR TITLE
refactor(connector): extract token refresh to connector-service

### DIFF
--- a/turbo/apps/web/src/lib/connector/connector-service.ts
+++ b/turbo/apps/web/src/lib/connector/connector-service.ts
@@ -427,9 +427,87 @@ export async function deleteConnector(
 }
 
 /**
+ * Generic connector access token refresh.
+ * Looks up the connector's handler from PROVIDER_HANDLERS, calls its refreshToken
+ * method, persists new tokens, and updates the in-memory secrets map.
+ *
+ * Returns null if refresh token is unavailable, OAuth credentials are missing,
+ * or the refresh fails (caller should fall back to the existing access token).
+ */
+export async function refreshConnectorAccessToken(
+  connectorType: string,
+  orgId: string,
+  userId: string,
+  connectorSecrets: Record<string, string>,
+): Promise<string | null> {
+  const handler =
+    PROVIDER_HANDLERS[connectorType as keyof typeof PROVIDER_HANDLERS];
+  if (!handler?.refreshToken || !handler.getRefreshSecretName) {
+    return null;
+  }
+
+  const refreshTokenSecret = handler.getRefreshSecretName();
+  const currentRefreshToken = connectorSecrets[refreshTokenSecret];
+  if (!currentRefreshToken) {
+    log.debug(`No ${connectorType} refresh token available, skipping`);
+    return null;
+  }
+
+  const env = globalThis.services.env;
+  const clientId = handler.getClientId(env);
+  const clientSecret = handler.getClientSecret(env);
+
+  if (!clientId || !clientSecret) {
+    log.debug(
+      `${connectorType} OAuth credentials not configured, skipping token refresh`,
+    );
+    return null;
+  }
+
+  const accessTokenSecret = handler.getSecretName();
+
+  try {
+    const result = await handler.refreshToken(
+      clientId,
+      clientSecret,
+      currentRefreshToken,
+    );
+
+    // Persist new tokens to database
+    await upsertConnectorSecret(
+      orgId,
+      userId,
+      accessTokenSecret,
+      result.accessToken,
+    );
+    if (result.refreshToken) {
+      await upsertConnectorSecret(
+        orgId,
+        userId,
+        refreshTokenSecret,
+        result.refreshToken,
+      );
+    }
+
+    // Update in-memory secrets map so subsequent mapping uses fresh token
+    connectorSecrets[accessTokenSecret] = result.accessToken;
+    if (result.refreshToken) {
+      connectorSecrets[refreshTokenSecret] = result.refreshToken;
+    }
+
+    log.debug(`${connectorType} access token refreshed successfully`);
+    return result.accessToken;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+    log.warn(`${connectorType} token refresh failed: ${message}`);
+    return null;
+  }
+}
+
+/**
  * Create or update a connector secret (e.g., refresh token)
  */
-export async function upsertConnectorSecret(
+async function upsertConnectorSecret(
   orgId: string,
   userId: string,
   secretName: string,

--- a/turbo/apps/web/src/lib/run/build-context.ts
+++ b/turbo/apps/web/src/lib/run/build-context.ts
@@ -36,7 +36,7 @@ import { getVariableValues } from "../variable/variable-service";
 import { getDefaultModelProvider } from "../model-provider/model-provider-service";
 import { connectors } from "../../db/schema/connector";
 import { PROVIDER_HANDLERS } from "../connector/provider-registry";
-import { upsertConnectorSecret } from "../connector/connector-service";
+import { refreshConnectorAccessToken } from "../connector/connector-service";
 
 const log = logger("run:build-context");
 
@@ -304,84 +304,6 @@ async function resolveModelProviderSecrets(
   );
 
   return { secrets, injectedEnvironment };
-}
-
-/**
- * Generic connector access token refresh.
- * Looks up the connector's handler from PROVIDER_HANDLERS, calls its refreshToken
- * method, persists new tokens, and updates the in-memory secrets map.
- *
- * Returns null if refresh token is unavailable, OAuth credentials are missing,
- * or the refresh fails (caller should fall back to the existing access token).
- */
-async function refreshConnectorAccessToken(
-  connectorType: string,
-  orgId: string,
-  userId: string,
-  connectorSecrets: Record<string, string>,
-): Promise<string | null> {
-  const handler =
-    PROVIDER_HANDLERS[connectorType as keyof typeof PROVIDER_HANDLERS];
-  if (!handler?.refreshToken || !handler.getRefreshSecretName) {
-    return null;
-  }
-
-  const refreshTokenSecret = handler.getRefreshSecretName();
-  const currentRefreshToken = connectorSecrets[refreshTokenSecret];
-  if (!currentRefreshToken) {
-    log.debug(`No ${connectorType} refresh token available, skipping`);
-    return null;
-  }
-
-  const env = globalThis.services.env;
-  const clientId = handler.getClientId(env);
-  const clientSecret = handler.getClientSecret(env);
-
-  if (!clientId || !clientSecret) {
-    log.debug(
-      `${connectorType} OAuth credentials not configured, skipping token refresh`,
-    );
-    return null;
-  }
-
-  const accessTokenSecret = handler.getSecretName();
-
-  try {
-    const result = await handler.refreshToken(
-      clientId,
-      clientSecret,
-      currentRefreshToken,
-    );
-
-    // Persist new tokens to database
-    await upsertConnectorSecret(
-      orgId,
-      userId,
-      accessTokenSecret,
-      result.accessToken,
-    );
-    if (result.refreshToken) {
-      await upsertConnectorSecret(
-        orgId,
-        userId,
-        refreshTokenSecret,
-        result.refreshToken,
-      );
-    }
-
-    // Update in-memory secrets map so subsequent mapping uses fresh token
-    connectorSecrets[accessTokenSecret] = result.accessToken;
-    if (result.refreshToken) {
-      connectorSecrets[refreshTokenSecret] = result.refreshToken;
-    }
-
-    log.debug(`${connectorType} access token refreshed successfully`);
-    return result.accessToken;
-  } catch (err) {
-    const message = err instanceof Error ? err.message : "Unknown error";
-    log.warn(`${connectorType} token refresh failed: ${message}`);
-    return null;
-  }
 }
 
 /**


### PR DESCRIPTION
## Summary

- Move `refreshConnectorAccessToken` from `build-context.ts` (private) to `connector-service.ts` (exported) for reuse by the auth endpoint
- Make `upsertConnectorSecret` module-internal since its only callers are now within `connector-service.ts`

Pure code move — no logic changes. 80 lines removed, 80 lines added.

## Context

Preparation for #4627 PR2 (auth endpoint OAuth token refresh). The auth endpoint needs to call `refreshConnectorAccessToken` at runtime when tokens expire, so it must be exported from a shared module.

## Test plan

- [x] `pnpm check-types` passes
- [x] `pnpm knip` passes (no unused exports)
- [ ] CI pipeline green

🤖 Generated with [Claude Code](https://claude.com/claude-code)