### PR TITLE
fix(connector): update token expiry after oauth refresh with accurate expires_in

### DIFF
--- a/turbo/apps/web/src/lib/connector/connector-service.ts
+++ b/turbo/apps/web/src/lib/connector/connector-service.ts
@@ -489,6 +489,20 @@ export async function refreshConnectorAccessToken(
       );
     }
 
+    // Update tokenExpiresAt so subsequent expiry checks are accurate
+    const expiresInSec = result.expiresIn ?? 3600; // default 1 hour
+    const expiresAt = new Date(Date.now() + expiresInSec * 1000);
+    await globalThis.services.db
+      .update(connectors)
+      .set({ tokenExpiresAt: expiresAt, updatedAt: new Date() })
+      .where(
+        and(
+          eq(connectors.orgId, orgId),
+          eq(connectors.userId, userId),
+          eq(connectors.type, connectorType),
+        ),
+      );
+
     // Update in-memory secrets map so subsequent mapping uses fresh token
     connectorSecrets[accessTokenSecret] = result.accessToken;
     if (result.refreshToken) {

--- a/turbo/apps/web/src/lib/connector/connector-service.ts
+++ b/turbo/apps/web/src/lib/connector/connector-service.ts
@@ -489,9 +489,9 @@ export async function refreshConnectorAccessToken(
       );
     }
 
-    // Update tokenExpiresAt so subsequent expiry checks are accurate
-    const expiresInSec = result.expiresIn ?? 3600; // default 1 hour
-    const expiresAt = new Date(Date.now() + expiresInSec * 1000);
+    // Update tokenExpiresAt so subsequent expiry checks are accurate.
+    // Fallback to 1 hour — all providers without expires_in (e.g. Notion) have ~1h tokens.
+    const expiresAt = new Date(Date.now() + (result.expiresIn ?? 3600) * 1000);
     await globalThis.services.db
       .update(connectors)
       .set({ tokenExpiresAt: expiresAt, updatedAt: new Date() })

--- a/turbo/apps/web/src/lib/connector/provider-types.ts
+++ b/turbo/apps/web/src/lib/connector/provider-types.ts
@@ -39,5 +39,9 @@ export interface ProviderHandler {
     clientId: string,
     clientSecret: string,
     refreshToken: string,
-  ): Promise<{ accessToken: string; refreshToken: string | null }>;
+  ): Promise<{
+    accessToken: string;
+    refreshToken: string | null;
+    expiresIn?: number;
+  }>;
 }

--- a/turbo/apps/web/src/lib/connector/providers/ahrefs.ts
+++ b/turbo/apps/web/src/lib/connector/providers/ahrefs.ts
@@ -21,6 +21,7 @@ interface AhrefsTokenResult {
 interface AhrefsRefreshResult {
   accessToken: string;
   refreshToken: string | null;
+  expiresIn?: number;
 }
 
 /**
@@ -112,6 +113,7 @@ export async function exchangeAhrefsCode(
 
 /**
  * Refresh an Ahrefs access token using the refresh token.
+ * Access token expires_in: returned but value undocumented. Ref: https://docs.ahrefs.com/docs/ahrefs-connect/developers/oauth-guide
  */
 export async function refreshAhrefsToken(
   clientId: string,
@@ -144,6 +146,7 @@ export async function refreshAhrefsToken(
     .object({
       access_token: z.string().optional(),
       refresh_token: z.string().nullable().optional(),
+      expires_in: z.number().optional(),
       error: z.string().optional(),
       error_description: z.string().optional(),
     })
@@ -160,6 +163,7 @@ export async function refreshAhrefsToken(
   return {
     accessToken: data.access_token,
     refreshToken: data.refresh_token ?? null,
+    expiresIn: data.expires_in,
   };
 }
 

--- a/turbo/apps/web/src/lib/connector/providers/airtable.ts
+++ b/turbo/apps/web/src/lib/connector/providers/airtable.ts
@@ -20,6 +20,7 @@ interface AirtableTokenResult {
 interface AirtableRefreshResult {
   accessToken: string;
   refreshToken: string | null;
+  expiresIn?: number;
 }
 
 /**
@@ -153,6 +154,7 @@ export async function exchangeAirtableCode(
 /**
  * Refresh an Airtable access token using the refresh token.
  * Airtable uses Basic auth for refresh as well.
+ * Access token expires_in: 3600s (1 hour). Ref: https://airtable.com/developers/web/api/oauth-reference
  */
 export async function refreshAirtableToken(
   clientId: string,
@@ -186,6 +188,7 @@ export async function refreshAirtableToken(
     .object({
       access_token: z.string().optional(),
       refresh_token: z.string().nullable().optional(),
+      expires_in: z.number().optional(),
       error: z.string().optional(),
       error_description: z.string().optional(),
     })
@@ -202,6 +205,7 @@ export async function refreshAirtableToken(
   return {
     accessToken: data.access_token,
     refreshToken: data.refresh_token ?? null,
+    expiresIn: data.expires_in,
   };
 }
 

--- a/turbo/apps/web/src/lib/connector/providers/asana.ts
+++ b/turbo/apps/web/src/lib/connector/providers/asana.ts
@@ -18,6 +18,7 @@ interface AsanaTokenResult {
 interface AsanaRefreshResult {
   accessToken: string;
   refreshToken: string | null;
+  expiresIn?: number;
 }
 
 /**
@@ -157,6 +158,7 @@ async function fetchAsanaUserInfo(accessToken: string): Promise<{
 
 /**
  * Refresh an Asana access token using the refresh token.
+ * Access token expires_in: 3600s (1 hour). Ref: https://developers.asana.com/docs/oauth
  */
 export async function refreshAsanaToken(
   clientId: string,
@@ -189,6 +191,7 @@ export async function refreshAsanaToken(
     .object({
       access_token: z.string().optional(),
       refresh_token: z.string().nullable().optional(),
+      expires_in: z.number().optional(),
       error: z.string().optional(),
     })
     .parse(await response.json());
@@ -204,6 +207,7 @@ export async function refreshAsanaToken(
   return {
     accessToken: data.access_token,
     refreshToken: data.refresh_token ?? null,
+    expiresIn: data.expires_in,
   };
 }
 

--- a/turbo/apps/web/src/lib/connector/providers/canva.ts
+++ b/turbo/apps/web/src/lib/connector/providers/canva.ts
@@ -21,6 +21,7 @@ interface CanvaTokenResult {
 interface CanvaRefreshResult {
   accessToken: string;
   refreshToken: string | null;
+  expiresIn?: number;
 }
 
 /**
@@ -86,6 +87,7 @@ export async function buildCanvaAuthorizationUrl(
 /**
  * Refresh a Canva access token using the refresh token.
  * Canva uses Basic Auth for token requests. PKCE is not required for refresh.
+ * Access token expires_in: 14400s (4 hours). Ref: https://www.canva.dev/docs/connect/authentication/
  */
 export async function refreshCanvaToken(
   clientId: string,
@@ -121,6 +123,7 @@ export async function refreshCanvaToken(
     .object({
       access_token: z.string().optional(),
       refresh_token: z.string().nullable().optional(),
+      expires_in: z.number().optional(),
       error: z.string().optional(),
       error_description: z.string().optional(),
     })
@@ -137,6 +140,7 @@ export async function refreshCanvaToken(
   return {
     accessToken: data.access_token,
     refreshToken: data.refresh_token ?? null,
+    expiresIn: data.expires_in,
   };
 }
 

--- a/turbo/apps/web/src/lib/connector/providers/close.ts
+++ b/turbo/apps/web/src/lib/connector/providers/close.ts
@@ -18,6 +18,7 @@ interface CloseTokenResult {
 interface CloseRefreshResult {
   accessToken: string;
   refreshToken: string | null;
+  expiresIn?: number;
 }
 
 /**
@@ -113,6 +114,7 @@ export async function exchangeCloseCode(
 
 /**
  * Refresh a Close access token using the refresh token.
+ * Access token expires_in: 3600s (1 hour). Ref: https://developer.close.com/topics/authentication-oauth2/
  */
 export async function refreshCloseToken(
   clientId: string,
@@ -145,6 +147,7 @@ export async function refreshCloseToken(
     .object({
       access_token: z.string().optional(),
       refresh_token: z.string().nullable().optional(),
+      expires_in: z.number().optional(),
       error: z.string().optional(),
       error_description: z.string().optional(),
     })
@@ -161,6 +164,7 @@ export async function refreshCloseToken(
   return {
     accessToken: data.access_token,
     refreshToken: data.refresh_token ?? null,
+    expiresIn: data.expires_in,
   };
 }
 

--- a/turbo/apps/web/src/lib/connector/providers/deel.ts
+++ b/turbo/apps/web/src/lib/connector/providers/deel.ts
@@ -20,6 +20,7 @@ interface DeelTokenResult {
 interface DeelRefreshResult {
   accessToken: string;
   refreshToken: string | null;
+  expiresIn?: number;
 }
 
 /**
@@ -86,6 +87,7 @@ export async function buildDeelAuthorizationUrl(
  * Refresh a Deel access token using the refresh token.
  * Deel uses Basic Auth for token requests. PKCE is not required for refresh.
  * Returns new access token and new refresh token (both must be stored).
+ * Access token expires_in: 2592000s (30 days). Ref: https://developer.deel.com/docs/oauth2
  */
 export async function refreshDeelToken(
   clientId: string,
@@ -121,6 +123,7 @@ export async function refreshDeelToken(
     .object({
       access_token: z.string().optional(),
       refresh_token: z.string().nullable().optional(),
+      expires_in: z.number().optional(),
       error: z.string().optional(),
       error_description: z.string().optional(),
     })
@@ -137,6 +140,7 @@ export async function refreshDeelToken(
   return {
     accessToken: data.access_token,
     refreshToken: data.refresh_token ?? null,
+    expiresIn: data.expires_in,
   };
 }
 

--- a/turbo/apps/web/src/lib/connector/providers/docusign.ts
+++ b/turbo/apps/web/src/lib/connector/providers/docusign.ts
@@ -20,6 +20,7 @@ interface DocuSignTokenResult {
 interface DocuSignRefreshResult {
   accessToken: string;
   refreshToken: string | null;
+  expiresIn?: number;
 }
 
 /**
@@ -158,6 +159,7 @@ export async function exchangeDocuSignCode(
  * Refresh a DocuSign access token using the refresh token.
  * DocuSign uses Basic Auth for token requests. PKCE is not required for refresh.
  * Returns new access token and new refresh token (both must be stored).
+ * Access token expires_in: 28800s (8 hours) for auth code grant. Ref: https://developers.docusign.com/platform/auth/reference/obtain-access-token/
  */
 export async function refreshDocuSignToken(
   clientId: string,
@@ -193,6 +195,7 @@ export async function refreshDocuSignToken(
     .object({
       access_token: z.string().optional(),
       refresh_token: z.string().nullable().optional(),
+      expires_in: z.number().optional(),
       error: z.string().optional(),
       error_description: z.string().optional(),
     })
@@ -209,6 +212,7 @@ export async function refreshDocuSignToken(
   return {
     accessToken: data.access_token,
     refreshToken: data.refresh_token ?? null,
+    expiresIn: data.expires_in,
   };
 }
 

--- a/turbo/apps/web/src/lib/connector/providers/dropbox.ts
+++ b/turbo/apps/web/src/lib/connector/providers/dropbox.ts
@@ -21,6 +21,7 @@ interface DropboxTokenResult {
 interface DropboxRefreshResult {
   accessToken: string;
   refreshToken: string | null;
+  expiresIn?: number;
 }
 
 /**
@@ -114,6 +115,7 @@ export async function exchangeDropboxCode(
 /**
  * Refresh a Dropbox access token using the refresh token.
  * Returns new access token (Dropbox does not rotate refresh tokens).
+ * Access token expires_in: 14400s (4 hours). Ref: https://developers.dropbox.com/oauth-guide
  */
 export async function refreshDropboxToken(
   clientId: string,
@@ -146,6 +148,7 @@ export async function refreshDropboxToken(
     .object({
       access_token: z.string().optional(),
       refresh_token: z.string().nullable().optional(),
+      expires_in: z.number().optional(),
       error: z.string().optional(),
       error_description: z.string().optional(),
     })
@@ -162,6 +165,7 @@ export async function refreshDropboxToken(
   return {
     accessToken: data.access_token,
     refreshToken: data.refresh_token ?? null,
+    expiresIn: data.expires_in,
   };
 }
 

--- a/turbo/apps/web/src/lib/connector/providers/figma.ts
+++ b/turbo/apps/web/src/lib/connector/providers/figma.ts
@@ -20,6 +20,7 @@ interface FigmaTokenResult {
 interface FigmaRefreshResult {
   accessToken: string;
   refreshToken: string | null;
+  expiresIn?: number;
 }
 
 /**
@@ -115,6 +116,7 @@ export async function exchangeFigmaCode(
  * Refresh a Figma access token using the refresh token.
  * Figma uses Basic Auth for token requests.
  * Returns new access token and new refresh token (both must be stored).
+ * Access token expires_in: ~7776000s (90 days). Ref: https://developers.figma.com/docs/rest-api/authentication/
  */
 export async function refreshFigmaToken(
   clientId: string,
@@ -150,6 +152,7 @@ export async function refreshFigmaToken(
     .object({
       access_token: z.string().optional(),
       refresh_token: z.string().nullable().optional(),
+      expires_in: z.number().optional(),
       error: z.string().optional(),
       error_description: z.string().optional(),
     })
@@ -166,6 +169,7 @@ export async function refreshFigmaToken(
   return {
     accessToken: data.access_token,
     refreshToken: data.refresh_token ?? null,
+    expiresIn: data.expires_in,
   };
 }
 

--- a/turbo/apps/web/src/lib/connector/providers/garmin-connect.ts
+++ b/turbo/apps/web/src/lib/connector/providers/garmin-connect.ts
@@ -20,6 +20,7 @@ interface GarminConnectTokenResult {
 interface GarminConnectRefreshResult {
   accessToken: string;
   refreshToken: string | null;
+  expiresIn?: number;
 }
 
 /**
@@ -151,6 +152,7 @@ export async function exchangeGarminConnectCode(
  * Refresh a Garmin Connect access token using the refresh token.
  * PKCE is not required for refresh — only client credentials and refresh token.
  * Garmin rotates refresh tokens — both must be stored.
+ * Access token expires_in: 86400s (1 day). Ref: https://developerportal.garmin.com
  */
 export async function refreshGarminConnectToken(
   clientId: string,
@@ -183,6 +185,7 @@ export async function refreshGarminConnectToken(
     .object({
       access_token: z.string().optional(),
       refresh_token: z.string().nullable().optional(),
+      expires_in: z.number().optional(),
       error: z.string().optional(),
       error_description: z.string().optional(),
     })
@@ -199,6 +202,7 @@ export async function refreshGarminConnectToken(
   return {
     accessToken: data.access_token,
     refreshToken: data.refresh_token ?? null,
+    expiresIn: data.expires_in,
   };
 }
 

--- a/turbo/apps/web/src/lib/connector/providers/google-oauth.ts
+++ b/turbo/apps/web/src/lib/connector/providers/google-oauth.ts
@@ -20,6 +20,7 @@ interface GoogleTokenResult {
 interface GoogleRefreshResult {
   accessToken: string;
   refreshToken: string | null;
+  expiresIn?: number;
 }
 
 /**
@@ -120,6 +121,7 @@ export async function exchangeGoogleOAuthCode(
  * Refresh a Google access token using the refresh token.
  * Works for any Google connector (Gmail, Sheets, Docs, Drive).
  * Returns new access token (Google does not rotate refresh tokens).
+ * Access token expires_in: 3600s (1 hour). Ref: https://developers.google.com/identity/protocols/oauth2/web-server
  */
 export async function refreshGoogleToken(
   connectorType: ConnectorType,
@@ -155,6 +157,7 @@ export async function refreshGoogleToken(
     .object({
       access_token: z.string().optional(),
       refresh_token: z.string().nullable().optional(),
+      expires_in: z.number().optional(),
       error: z.string().optional(),
       error_description: z.string().optional(),
     })
@@ -171,6 +174,7 @@ export async function refreshGoogleToken(
   return {
     accessToken: data.access_token,
     refreshToken: data.refresh_token ?? null,
+    expiresIn: data.expires_in,
   };
 }
 

--- a/turbo/apps/web/src/lib/connector/providers/hubspot.ts
+++ b/turbo/apps/web/src/lib/connector/providers/hubspot.ts
@@ -20,6 +20,7 @@ interface HubSpotTokenResult {
 interface HubSpotRefreshResult {
   accessToken: string;
   refreshToken: string | null;
+  expiresIn?: number;
 }
 
 /**
@@ -108,6 +109,7 @@ export async function exchangeHubSpotCode(
 
 /**
  * Refresh a HubSpot access token using the refresh token.
+ * Access token expires_in: 1800s (30 min). Ref: https://developers.hubspot.com/docs/api-reference/auth-oauth-v1/guide
  */
 export async function refreshHubSpotToken(
   clientId: string,
@@ -140,6 +142,7 @@ export async function refreshHubSpotToken(
     .object({
       access_token: z.string().optional(),
       refresh_token: z.string().nullable().optional(),
+      expires_in: z.number().optional(),
       error: z.string().optional(),
       error_description: z.string().optional(),
     })
@@ -156,6 +159,7 @@ export async function refreshHubSpotToken(
   return {
     accessToken: data.access_token,
     refreshToken: data.refresh_token ?? null,
+    expiresIn: data.expires_in,
   };
 }
 

--- a/turbo/apps/web/src/lib/connector/providers/linear.ts
+++ b/turbo/apps/web/src/lib/connector/providers/linear.ts
@@ -22,6 +22,7 @@ interface LinearTokenResult {
 interface LinearRefreshResult {
   accessToken: string;
   refreshToken: string | null;
+  expiresIn?: number;
 }
 
 /**
@@ -115,6 +116,7 @@ export async function exchangeLinearCode(
 /**
  * Refresh a Linear access token using the refresh token.
  * Returns new access token and new refresh token (both must be stored).
+ * Access token expires_in: 86399s (24 hours). Ref: https://developers.linear.app/docs/oauth/authentication
  */
 export async function refreshLinearToken(
   clientId: string,
@@ -147,6 +149,7 @@ export async function refreshLinearToken(
     .object({
       access_token: z.string().optional(),
       refresh_token: z.string().nullable().optional(),
+      expires_in: z.number().optional(),
       error: z.string().optional(),
       error_description: z.string().optional(),
     })
@@ -163,6 +166,7 @@ export async function refreshLinearToken(
   return {
     accessToken: data.access_token,
     refreshToken: data.refresh_token ?? null,
+    expiresIn: data.expires_in,
   };
 }
 

--- a/turbo/apps/web/src/lib/connector/providers/mercury.ts
+++ b/turbo/apps/web/src/lib/connector/providers/mercury.ts
@@ -20,6 +20,7 @@ interface MercuryTokenResult {
 interface MercuryRefreshResult {
   accessToken: string;
   refreshToken: string | null;
+  expiresIn?: number;
 }
 
 /**
@@ -112,6 +113,7 @@ export async function exchangeMercuryCode(
 /**
  * Refresh a Mercury access token using the refresh token.
  * Returns new access token and new refresh token (both must be stored).
+ * Access token expires_in: 3600s (1 hour). Ref: https://docs.mercury.com/reference/obtain-the-tokens
  */
 export async function refreshMercuryToken(
   clientId: string,
@@ -144,6 +146,7 @@ export async function refreshMercuryToken(
     .object({
       access_token: z.string().optional(),
       refresh_token: z.string().nullable().optional(),
+      expires_in: z.number().optional(),
       error: z.string().optional(),
       error_description: z.string().optional(),
     })
@@ -160,6 +163,7 @@ export async function refreshMercuryToken(
   return {
     accessToken: data.access_token,
     refreshToken: data.refresh_token ?? null,
+    expiresIn: data.expires_in,
   };
 }
 

--- a/turbo/apps/web/src/lib/connector/providers/microsoft-oauth.ts
+++ b/turbo/apps/web/src/lib/connector/providers/microsoft-oauth.ts
@@ -20,6 +20,7 @@ interface MicrosoftTokenResult {
 interface MicrosoftRefreshResult {
   accessToken: string;
   refreshToken: string | null;
+  expiresIn?: number;
 }
 
 /**
@@ -119,6 +120,7 @@ export async function exchangeMicrosoftOAuthCode(
  * Refresh a Microsoft access token using the refresh token.
  * Works for any Microsoft connector (Outlook Calendar, etc.).
  * Microsoft rotates refresh tokens on each refresh.
+ * Access token expires_in: 3600-5400s (~75 min). Ref: https://learn.microsoft.com/en-us/entra/identity-platform/v2-oauth2-auth-code-flow
  */
 export async function refreshMicrosoftToken(
   connectorType: ConnectorType,
@@ -154,6 +156,7 @@ export async function refreshMicrosoftToken(
     .object({
       access_token: z.string().optional(),
       refresh_token: z.string().nullable().optional(),
+      expires_in: z.number().optional(),
       error: z.string().optional(),
       error_description: z.string().optional(),
     })
@@ -170,6 +173,7 @@ export async function refreshMicrosoftToken(
   return {
     accessToken: data.access_token,
     refreshToken: data.refresh_token ?? null,
+    expiresIn: data.expires_in,
   };
 }
 

--- a/turbo/apps/web/src/lib/connector/providers/monday.ts
+++ b/turbo/apps/web/src/lib/connector/providers/monday.ts
@@ -18,6 +18,7 @@ interface MondayTokenResult {
 interface MondayRefreshResult {
   accessToken: string;
   refreshToken: string | null;
+  expiresIn?: number;
 }
 
 const MONDAY_GRAPHQL_URL = "https://api.monday.com/v2";
@@ -111,6 +112,7 @@ export async function exchangeMondayCode(
 
 /**
  * Refresh a Monday.com access token.
+ * Note: Monday.com tokens reportedly do not expire. expires_in may not be returned. Ref: https://developer.monday.com/apps/docs/oauth
  */
 export async function refreshMondayToken(
   clientId: string,
@@ -143,6 +145,7 @@ export async function refreshMondayToken(
     .object({
       access_token: z.string().optional(),
       refresh_token: z.string().nullable().optional(),
+      expires_in: z.number().optional(),
       error: z.string().optional(),
       error_description: z.string().optional(),
     })
@@ -159,6 +162,7 @@ export async function refreshMondayToken(
   return {
     accessToken: data.access_token,
     refreshToken: data.refresh_token ?? null,
+    expiresIn: data.expires_in,
   };
 }
 

--- a/turbo/apps/web/src/lib/connector/providers/neon.ts
+++ b/turbo/apps/web/src/lib/connector/providers/neon.ts
@@ -20,6 +20,7 @@ interface NeonTokenResult {
 interface NeonRefreshResult {
   accessToken: string;
   refreshToken: string | null;
+  expiresIn?: number;
 }
 
 /**
@@ -113,6 +114,7 @@ export async function exchangeNeonCode(
 
 /**
  * Refresh an expired Neon access token using the refresh token.
+ * Access token expires_in: expected (OIDC-compliant) but not explicitly documented. Ref: https://neon.com/docs/guides/oauth-integration
  */
 export async function refreshNeonToken(
   clientId: string,
@@ -145,6 +147,7 @@ export async function refreshNeonToken(
     .object({
       access_token: z.string().optional(),
       refresh_token: z.string().nullable().optional(),
+      expires_in: z.number().optional(),
       error: z.string().optional(),
       error_description: z.string().optional(),
     })
@@ -161,6 +164,7 @@ export async function refreshNeonToken(
   return {
     accessToken: data.access_token,
     refreshToken: data.refresh_token ?? null,
+    expiresIn: data.expires_in,
   };
 }
 

--- a/turbo/apps/web/src/lib/connector/providers/notion.ts
+++ b/turbo/apps/web/src/lib/connector/providers/notion.ts
@@ -18,6 +18,7 @@ interface NotionTokenResult {
 interface NotionRefreshResult {
   accessToken: string;
   refreshToken: string | null;
+  expiresIn?: number;
 }
 
 /**
@@ -129,6 +130,7 @@ export async function exchangeNotionCode(
 /**
  * Refresh a Notion access token using the refresh token.
  * Returns new access token and new refresh token (both must be stored).
+ * Note: Notion does not return expires_in. Token lifetime ~1 hour (undocumented). Ref: https://developers.notion.com/reference/refresh-a-token
  */
 export async function refreshNotionToken(
   clientId: string,
@@ -160,6 +162,7 @@ export async function refreshNotionToken(
     .object({
       access_token: z.string().optional(),
       refresh_token: z.string().nullable().optional(),
+      expires_in: z.number().optional(),
       error: z.string().optional(),
       error_description: z.string().optional(),
     })
@@ -176,6 +179,7 @@ export async function refreshNotionToken(
   return {
     accessToken: data.access_token,
     refreshToken: data.refresh_token ?? null,
+    expiresIn: data.expires_in,
   };
 }
 

--- a/turbo/apps/web/src/lib/connector/providers/posthog.ts
+++ b/turbo/apps/web/src/lib/connector/providers/posthog.ts
@@ -20,6 +20,7 @@ interface PosthogTokenResult {
 interface PosthogRefreshResult {
   accessToken: string;
   refreshToken: string | null;
+  expiresIn?: number;
 }
 
 /**
@@ -110,6 +111,7 @@ export async function exchangePosthogCode(
 
 /**
  * Refresh a PostHog access token using the refresh token.
+ * Access token expires_in: 36000s (10 hours). Ref: https://posthog.com/handbook/engineering/oauth-development-guide
  */
 export async function refreshPosthogToken(
   clientId: string,
@@ -142,6 +144,7 @@ export async function refreshPosthogToken(
     .object({
       access_token: z.string().optional(),
       refresh_token: z.string().nullable().optional(),
+      expires_in: z.number().optional(),
       error: z.string().optional(),
       error_description: z.string().optional(),
     })
@@ -158,6 +161,7 @@ export async function refreshPosthogToken(
   return {
     accessToken: data.access_token,
     refreshToken: data.refresh_token ?? null,
+    expiresIn: data.expires_in,
   };
 }
 

--- a/turbo/apps/web/src/lib/connector/providers/reddit.ts
+++ b/turbo/apps/web/src/lib/connector/providers/reddit.ts
@@ -152,11 +152,13 @@ async function fetchRedditUserInfo(
 interface RedditRefreshResult {
   accessToken: string;
   refreshToken: string | null;
+  expiresIn?: number;
 }
 
 /**
  * Refresh a Reddit access token using the refresh token.
  * Reddit uses Basic Auth (same as token exchange) and may rotate refresh tokens.
+ * Access token expires_in: 3600s (1 hour). Ref: https://github.com/reddit-archive/reddit/wiki/oauth2
  */
 export async function refreshRedditToken(
   clientId: string,
@@ -189,6 +191,7 @@ export async function refreshRedditToken(
     .object({
       access_token: z.string().optional(),
       refresh_token: z.string().nullable().optional(),
+      expires_in: z.number().optional(),
       error: z.string().optional(),
       error_description: z.string().optional(),
     })
@@ -205,6 +208,7 @@ export async function refreshRedditToken(
   return {
     accessToken: data.access_token,
     refreshToken: data.refresh_token ?? null,
+    expiresIn: data.expires_in,
   };
 }
 

--- a/turbo/apps/web/src/lib/connector/providers/sentry.ts
+++ b/turbo/apps/web/src/lib/connector/providers/sentry.ts
@@ -18,6 +18,7 @@ interface SentryTokenResult {
 interface SentryRefreshResult {
   accessToken: string;
   refreshToken: string | null;
+  expiresIn?: number;
 }
 
 /**
@@ -123,6 +124,7 @@ export async function exchangeSentryCode(
 
 /**
  * Refresh a Sentry access token using the refresh token.
+ * Access token expires_in: ~2592000s (30 days). Ref: https://docs.sentry.io/api/auth/
  */
 export async function refreshSentryToken(
   clientId: string,
@@ -155,6 +157,7 @@ export async function refreshSentryToken(
     .object({
       access_token: z.string().optional(),
       refresh_token: z.string().nullable().optional(),
+      expires_in: z.number().optional(),
       error: z.string().optional(),
       error_description: z.string().optional(),
     })
@@ -171,6 +174,7 @@ export async function refreshSentryToken(
   return {
     accessToken: data.access_token,
     refreshToken: data.refresh_token ?? null,
+    expiresIn: data.expires_in,
   };
 }
 

--- a/turbo/apps/web/src/lib/connector/providers/strava.ts
+++ b/turbo/apps/web/src/lib/connector/providers/strava.ts
@@ -20,6 +20,7 @@ interface StravaTokenResult {
 interface StravaRefreshResult {
   accessToken: string;
   refreshToken: string | null;
+  expiresIn?: number;
 }
 
 /**
@@ -130,6 +131,7 @@ export async function exchangeStravaCode(
 /**
  * Refresh a Strava access token using the refresh token.
  * Strava rotates refresh tokens — both must be stored.
+ * Access token expires_in: 21600s (6 hours). Ref: https://developers.strava.com/docs/authentication/
  */
 export async function refreshStravaToken(
   clientId: string,
@@ -162,6 +164,7 @@ export async function refreshStravaToken(
     .object({
       access_token: z.string().optional(),
       refresh_token: z.string().nullable().optional(),
+      expires_in: z.number().optional(),
       error: z.string().optional(),
       error_description: z.string().optional(),
     })
@@ -178,6 +181,7 @@ export async function refreshStravaToken(
   return {
     accessToken: data.access_token,
     refreshToken: data.refresh_token ?? null,
+    expiresIn: data.expires_in,
   };
 }
 

--- a/turbo/apps/web/src/lib/connector/providers/stripe.ts
+++ b/turbo/apps/web/src/lib/connector/providers/stripe.ts
@@ -19,6 +19,7 @@ interface StripeTokenResult {
 interface StripeRefreshResult {
   accessToken: string;
   refreshToken: string | null;
+  expiresIn?: number;
 }
 
 /**
@@ -113,6 +114,7 @@ export async function exchangeStripeCode(
 
 /**
  * Refresh a Stripe access token using the refresh token.
+ * Access token expires_in: 3600s (1 hour). Ref: https://docs.stripe.com/stripe-apps/api-authentication/oauth
  */
 export async function refreshStripeToken(
   _clientId: string,
@@ -144,6 +146,7 @@ export async function refreshStripeToken(
     .object({
       access_token: z.string().optional(),
       refresh_token: z.string().nullable().optional(),
+      expires_in: z.number().optional(),
       error: z.string().optional(),
       error_description: z.string().optional(),
     })
@@ -160,6 +163,7 @@ export async function refreshStripeToken(
   return {
     accessToken: data.access_token,
     refreshToken: data.refresh_token ?? null,
+    expiresIn: data.expires_in,
   };
 }
 

--- a/turbo/apps/web/src/lib/connector/providers/supabase.ts
+++ b/turbo/apps/web/src/lib/connector/providers/supabase.ts
@@ -20,6 +20,7 @@ interface SupabaseTokenResult {
 interface SupabaseRefreshResult {
   accessToken: string;
   refreshToken: string | null;
+  expiresIn?: number;
 }
 
 /**
@@ -85,6 +86,7 @@ export async function buildSupabaseAuthorizationUrl(
 /**
  * Refresh a Supabase access token using the refresh token.
  * Supabase uses Basic Auth for token requests. PKCE is not required for refresh.
+ * Access token expires_in: 3600s (1 hour, configurable). Ref: https://supabase.com/docs/guides/auth/oauth-server/oauth-flows
  */
 export async function refreshSupabaseToken(
   clientId: string,
@@ -120,6 +122,7 @@ export async function refreshSupabaseToken(
     .object({
       access_token: z.string().optional(),
       refresh_token: z.string().nullable().optional(),
+      expires_in: z.number().optional(),
       error: z.string().optional(),
       error_description: z.string().optional(),
     })
@@ -136,6 +139,7 @@ export async function refreshSupabaseToken(
   return {
     accessToken: data.access_token,
     refreshToken: data.refresh_token ?? null,
+    expiresIn: data.expires_in,
   };
 }
 

--- a/turbo/apps/web/src/lib/connector/providers/x.ts
+++ b/turbo/apps/web/src/lib/connector/providers/x.ts
@@ -21,6 +21,7 @@ interface XTokenResult {
 interface XRefreshResult {
   accessToken: string;
   refreshToken: string | null;
+  expiresIn?: number;
 }
 
 /**
@@ -86,6 +87,7 @@ export async function buildXAuthorizationUrl(
 /**
  * Refresh an X access token using the refresh token.
  * PKCE is not required for refresh — only client credentials and refresh token.
+ * Access token expires_in: 7200s (2 hours). Ref: https://developer.twitter.com/en/docs/authentication/oauth-2-0/authorization-code
  */
 export async function refreshXToken(
   clientId: string,
@@ -121,6 +123,7 @@ export async function refreshXToken(
     .object({
       access_token: z.string().optional(),
       refresh_token: z.string().nullable().optional(),
+      expires_in: z.number().optional(),
       error: z.string().optional(),
       error_description: z.string().optional(),
     })
@@ -137,6 +140,7 @@ export async function refreshXToken(
   return {
     accessToken: data.access_token,
     refreshToken: data.refresh_token ?? null,
+    expiresIn: data.expires_in,
   };
 }
 

--- a/turbo/apps/web/src/lib/connector/providers/xero.ts
+++ b/turbo/apps/web/src/lib/connector/providers/xero.ts
@@ -20,6 +20,7 @@ interface XeroTokenResult {
 interface XeroRefreshResult {
   accessToken: string;
   refreshToken: string | null;
+  expiresIn?: number;
 }
 
 /**
@@ -113,6 +114,7 @@ export async function exchangeXeroCode(
 /**
  * Refresh a Xero access token using the refresh token.
  * Xero rotates both access and refresh tokens on each refresh.
+ * Access token expires_in: 1800s (30 min). Ref: https://developer.xero.com/documentation/guides/oauth2/auth-flow/
  */
 export async function refreshXeroToken(
   clientId: string,
@@ -145,6 +147,7 @@ export async function refreshXeroToken(
     .object({
       access_token: z.string().optional(),
       refresh_token: z.string().nullable().optional(),
+      expires_in: z.number().optional(),
       error: z.string().optional(),
       error_description: z.string().optional(),
     })
@@ -161,6 +164,7 @@ export async function refreshXeroToken(
   return {
     accessToken: data.access_token,
     refreshToken: data.refresh_token ?? null,
+    expiresIn: data.expires_in,
   };
 }
 


### PR DESCRIPTION
## Summary

- After refreshing an OAuth access token, update `connectors.tokenExpiresAt` in the database using the provider's actual `expires_in` value (fallback: 1 hour)
- Previously `tokenExpiresAt` was only set during initial OAuth exchange and never updated after refresh, causing stale expiry values and unnecessary re-refreshes
- Add `expiresIn?: number` to `ProviderHandler.refreshToken` return type and update all 26 provider refresh functions to parse and return `expires_in`
- Document each provider's expected token lifetime and reference URL

## Test plan

- [ ] Verify `tokenExpiresAt` is updated in DB after `refreshConnectorAccessToken` call
- [ ] Verify providers that return `expires_in` use the actual value
- [ ] Verify providers that don't return `expires_in` (Notion) fallback to 1 hour
- [ ] Verify existing OAuth exchange flow still sets `tokenExpiresAt` correctly

Closes #4798

🤖 Generated with [Claude Code](https://claude.com/claude-code)