### PR TITLE
chore: upgrade e2b template cli to v9.59.0 for skills resolve

### DIFF
--- a/turbo/scripts/e2b/vm0-cli/template.ts
+++ b/turbo/scripts/e2b/vm0-cli/template.ts
@@ -11,4 +11,4 @@ import { Template } from "e2b";
 export const template = Template()
   .fromNodeImage("24")
   .aptInstall(["curl", "git", "jq", "tzdata"])
-  .npmInstall("@vm0/cli@9.58.0", { g: true });
+  .npmInstall("@vm0/cli@9.59.0", { g: true });


### PR DESCRIPTION
## Summary

- Bump `@vm0/cli` from 9.58.0 to 9.59.0 in the E2B sandbox template
- CLI v9.59.0 includes #4784 which adds `/api/skills/resolve` support
- This enables platform compose (web UI) to resolve official skills from server cache instead of downloading from GitHub

## Context

This is the final step of the system skills cache initiative (#4768). Without this upgrade, platform compose still runs old CLI in E2B sandbox and downloads every skill from GitHub. After this upgrade, both local CLI users and platform compose benefit from fast skill resolution.

## Test plan

- [ ] E2B template rebuild succeeds with new CLI version
- [ ] Platform compose correctly resolves official skills from cache

Closes #4788

🤖 Generated with [Claude Code](https://claude.com/claude-code)