### PR TITLE
feat(services): add oauth token refresh and ttl caching to auth endpoint

### DIFF
--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -240,11 +240,19 @@ def match_service_request(url: str, method: str, vm_services: list | None) -> Se
     return None
 
 
-def fetch_service_headers(encrypted_secrets: str, auth_headers: dict, sandbox_token: str) -> dict:
-    """Resolve auth headers via server-side decryption."""
+def fetch_service_headers(encrypted_secrets: str, auth_headers: dict, sandbox_token: str,
+                          secret_connector_map: dict | None = None) -> dict:
+    """Resolve auth headers via server-side decryption.
+
+    When secret_connector_map is provided, the auth endpoint can refresh
+    expired OAuth tokens and returns an expiresAt timestamp for TTL caching.
+    """
     api_url = get_api_url()
     url = f"{api_url}/api/webhooks/agent/services/auth"
-    data = json.dumps({"encryptedSecrets": encrypted_secrets, "authHeaders": auth_headers}).encode()
+    body: dict = {"encryptedSecrets": encrypted_secrets, "authHeaders": auth_headers}
+    if secret_connector_map:
+        body["secretConnectorMap"] = secret_connector_map
+    data = json.dumps(body).encode()
     req = urllib.request.Request(url, data=data, headers={
         "Authorization": f"Bearer {sandbox_token}",
         "Content-Type": "application/json",
@@ -255,20 +263,26 @@ def fetch_service_headers(encrypted_secrets: str, auth_headers: dict, sandbox_to
     return json.loads(resp.read())
 
 
-def get_service_headers(run_id: str, api_id: str, encrypted_secrets: str, auth_headers: dict, sandbox_token: str) -> dict:
-    """Get service auth headers with caching.
+def get_service_headers(run_id: str, api_id: str, encrypted_secrets: str, auth_headers: dict,
+                        sandbox_token: str, secret_connector_map: dict | None = None) -> dict:
+    """Get service auth headers with TTL-based caching.
 
-    Cache is evicted when the run is removed from the registry (see
-    load_registry) or on 401 response (see response handler).
+    Cache is evicted when:
+    - The run is removed from the registry (see load_registry)
+    - A 401 response is received (see response handler)
+    - The expiresAt timestamp from the auth endpoint has passed
     """
     cache_key = (run_id, api_id)
     cached = _service_header_cache.get(cache_key)
     if cached:
-        return cached["headers"]
+        expires_at = cached.get("expiresAt")
+        if expires_at is None or time.time() < expires_at:
+            return cached["headers"]
+        # Token expired — evict and re-fetch
 
-    result = fetch_service_headers(encrypted_secrets, auth_headers, sandbox_token)
+    result = fetch_service_headers(encrypted_secrets, auth_headers, sandbox_token, secret_connector_map)
     headers = result["headers"]
-    _service_header_cache[cache_key] = {"headers": headers}
+    _service_header_cache[cache_key] = {"headers": headers, "expiresAt": result.get("expiresAt")}
     return headers
 
 
@@ -281,6 +295,7 @@ def handle_service_request(flow: http.HTTPFlow, api_entry: dict, vm_info: dict, 
     sandbox_token = vm_info.get("sandboxToken", "")
     encrypted_secrets = vm_info.get("encryptedSecrets")
     auth_headers = api_entry.get("auth", {}).get("headers", {})
+    secret_connector_map = vm_info.get("secretConnectorMap")
 
     if not encrypted_secrets:
         ctx.log.error(f"[{run_id}] No encryptedSecrets for service {service_base}")
@@ -295,7 +310,7 @@ def handle_service_request(flow: http.HTTPFlow, api_entry: dict, vm_info: dict, 
         return
 
     try:
-        headers = get_service_headers(run_id, api_id, encrypted_secrets, auth_headers, sandbox_token)
+        headers = get_service_headers(run_id, api_id, encrypted_secrets, auth_headers, sandbox_token, secret_connector_map)
     except Exception as e:
         ctx.log.error(f"[{run_id}] Service {service_base} header fetch failed: {e}")
         flow.metadata["firewall_action"] = "DENY"

--- a/crates/runner/mitm-addon/tests/test_connectors.py
+++ b/crates/runner/mitm-addon/tests/test_connectors.py
@@ -388,6 +388,55 @@ class TestGetServiceHeaders:
         assert headers == cached_headers
         mock_fetch.assert_not_called()
 
+    def test_cache_hit_with_valid_ttl_returns_cached(self):
+        """Cached entry with expiresAt in the future should be returned without fetching."""
+        cache_key = ("run-1", "api-1")
+        cached_headers = {"Authorization": "Bearer valid-token"}
+        mitm_addon._service_header_cache[cache_key] = {
+            "headers": cached_headers,
+            "expiresAt": time.time() + 3600,  # 1 hour from now
+        }
+
+        with patch.object(mitm_addon, "fetch_service_headers") as mock_fetch:
+            headers = mitm_addon.get_service_headers("run-1", "api-1", "iv:tag:data", {}, "tok-xyz")
+
+        assert headers == cached_headers
+        mock_fetch.assert_not_called()
+
+    def test_cache_evicted_when_ttl_expired(self):
+        """Cached entry with expiresAt in the past should trigger a re-fetch."""
+        cache_key = ("run-1", "api-1")
+        mitm_addon._service_header_cache[cache_key] = {
+            "headers": {"Authorization": "Bearer stale-token"},
+            "expiresAt": time.time() - 10,  # expired 10 seconds ago
+        }
+
+        fresh_headers = {"Authorization": "Bearer fresh-token"}
+        mock_result = {"headers": fresh_headers, "expiresAt": time.time() + 3600}
+
+        with patch.object(mitm_addon, "fetch_service_headers", return_value=mock_result) as mock_fetch:
+            headers = mitm_addon.get_service_headers("run-1", "api-1", "iv:tag:data", {}, "tok-xyz")
+
+        assert headers == fresh_headers
+        mock_fetch.assert_called_once()
+        # Verify cache was updated with new entry
+        assert mitm_addon._service_header_cache[cache_key]["headers"] == fresh_headers
+
+    def test_cache_with_null_expires_at_never_evicts(self):
+        """Cached entry with expiresAt=None (non-expiring) should never be evicted by TTL."""
+        cache_key = ("run-1", "api-1")
+        cached_headers = {"Authorization": "Bearer permanent-token"}
+        mitm_addon._service_header_cache[cache_key] = {
+            "headers": cached_headers,
+            "expiresAt": None,
+        }
+
+        with patch.object(mitm_addon, "fetch_service_headers") as mock_fetch:
+            headers = mitm_addon.get_service_headers("run-1", "api-1", "iv:tag:data", {}, "tok-xyz")
+
+        assert headers == cached_headers
+        mock_fetch.assert_not_called()
+
 
 # =========================================================================
 # handle_service_request

--- a/crates/runner/mitm-addon/tests/test_connectors.py
+++ b/crates/runner/mitm-addon/tests/test_connectors.py
@@ -368,7 +368,7 @@ class TestGetServiceHeaders:
             headers = mitm_addon.get_service_headers("run-1", "https://api.github.com", encrypted, auth_templates, "tok-xyz")
 
         assert headers == mock_headers
-        mock_fetch.assert_called_once_with(encrypted, auth_templates, "tok-xyz")
+        mock_fetch.assert_called_once_with(encrypted, auth_templates, "tok-xyz", None)
 
         # Verify the cache was populated
         cache_key = ("run-1", "https://api.github.com")

--- a/turbo/apps/web/app/api/webhooks/agent/services/auth/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/services/auth/__tests__/route.test.ts
@@ -1,12 +1,13 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { http as mswHttp, HttpResponse } from "msw";
-import { eq, and } from "drizzle-orm";
 import { POST } from "../route";
 import {
   createTestRequest,
   createTestCompose,
   createTestRun,
   createTestSandboxToken,
+  insertTestConnectorSecret,
+  findTestConnectorTokenExpiresAt,
 } from "../../../../../../../src/__tests__/api-test-helpers";
 import {
   testContext,
@@ -14,12 +15,7 @@ import {
 } from "../../../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../../../src/__tests__/clerk-mock";
 import { server } from "../../../../../../../src/mocks/server";
-import {
-  encryptSecretsMap,
-  encryptSecretValue,
-} from "../../../../../../../src/lib/crypto/secrets-encryption";
-import { connectors } from "../../../../../../../src/db/schema/connector";
-import { secrets as secretsTable } from "../../../../../../../src/db/schema/secret";
+import { encryptSecretsMap } from "../../../../../../../src/lib/crypto/secrets-encryption";
 
 const context = testContext();
 
@@ -219,7 +215,6 @@ describe("POST /api/webhooks/agent/services/auth", () => {
     }) {
       const accessToken = opts.accessToken ?? "old-notion-token";
       const refreshToken = opts.refreshToken ?? "notion-refresh-token";
-      const encryptionKey = globalThis.services.env.SECRETS_ENCRYPTION_KEY;
 
       // Stub Notion OAuth credentials
       vi.stubEnv("NOTION_OAUTH_CLIENT_ID", "test-notion-client-id");
@@ -228,32 +223,27 @@ describe("POST /api/webhooks/agent/services/auth", () => {
       const { reloadEnv } = await import("../../../../../../../src/env");
       reloadEnv();
 
-      // Insert connector record with tokenExpiresAt
-      await globalThis.services.db.insert(connectors).values({
+      // Create connector record with tokenExpiresAt
+      await context.createConnector(user.orgId, {
         userId: user.userId,
-        orgId: user.orgId,
         type: "notion",
         authMethod: "oauth",
         tokenExpiresAt: opts.tokenExpiresAt,
       });
 
       // Insert access token and refresh token secrets
-      await globalThis.services.db.insert(secretsTable).values([
-        {
-          name: "NOTION_ACCESS_TOKEN",
-          encryptedValue: encryptSecretValue(accessToken, encryptionKey),
-          type: "connector",
-          userId: user.userId,
-          orgId: user.orgId,
-        },
-        {
-          name: "NOTION_REFRESH_TOKEN",
-          encryptedValue: encryptSecretValue(refreshToken, encryptionKey),
-          type: "connector",
-          userId: user.userId,
-          orgId: user.orgId,
-        },
-      ]);
+      await insertTestConnectorSecret(
+        user.orgId,
+        user.userId,
+        "NOTION_ACCESS_TOKEN",
+        accessToken,
+      );
+      await insertTestConnectorSecret(
+        user.orgId,
+        user.userId,
+        "NOTION_REFRESH_TOKEN",
+        refreshToken,
+      );
 
       return { accessToken, refreshToken };
     }
@@ -457,20 +447,14 @@ describe("POST /api/webhooks/agent/services/auth", () => {
       );
 
       // Verify tokenExpiresAt was updated in the database
-      const [connector] = await globalThis.services.db
-        .select({ tokenExpiresAt: connectors.tokenExpiresAt })
-        .from(connectors)
-        .where(
-          and(
-            eq(connectors.orgId, user.orgId),
-            eq(connectors.userId, user.userId),
-            eq(connectors.type, "notion"),
-          ),
-        )
-        .limit(1);
+      const tokenExpiresAt = await findTestConnectorTokenExpiresAt(
+        user.orgId,
+        "notion",
+      );
 
-      expect(connector).toBeDefined();
-      const newExpiry = connector!.tokenExpiresAt!.getTime();
+      expect(tokenExpiresAt).toBeDefined();
+      expect(tokenExpiresAt).not.toBeNull();
+      const newExpiry = tokenExpiresAt!.getTime();
       const expectedMin = Date.now() + 1700 * 1000; // ~1800s minus small margin
       expect(newExpiry).toBeGreaterThan(expectedMin);
     });

--- a/turbo/apps/web/app/api/webhooks/agent/services/auth/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/services/auth/__tests__/route.test.ts
@@ -1,4 +1,6 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { http as mswHttp, HttpResponse } from "msw";
+import { eq, and } from "drizzle-orm";
 import { POST } from "../route";
 import {
   createTestRequest,
@@ -11,7 +13,13 @@ import {
   type UserContext,
 } from "../../../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../../../src/__tests__/clerk-mock";
-import { encryptSecretsMap } from "../../../../../../../src/lib/crypto/secrets-encryption";
+import { server } from "../../../../../../../src/mocks/server";
+import {
+  encryptSecretsMap,
+  encryptSecretValue,
+} from "../../../../../../../src/lib/crypto/secrets-encryption";
+import { connectors } from "../../../../../../../src/db/schema/connector";
+import { secrets as secretsTable } from "../../../../../../../src/db/schema/secret";
 
 const context = testContext();
 
@@ -198,6 +206,273 @@ describe("POST /api/webhooks/agent/services/auth", () => {
       expect(response.status).toBe(200);
       const data = await response.json();
       expect(data.headers["X-Static"]).toBe("plain-value");
+    });
+  });
+
+  describe("Token refresh with secretConnectorMap", () => {
+    const NOTION_TOKEN_URL = "https://api.notion.com/v1/oauth/token";
+
+    async function setupNotionConnector(opts: {
+      tokenExpiresAt: Date | null;
+      accessToken?: string;
+      refreshToken?: string;
+    }) {
+      const accessToken = opts.accessToken ?? "old-notion-token";
+      const refreshToken = opts.refreshToken ?? "notion-refresh-token";
+      const encryptionKey = globalThis.services.env.SECRETS_ENCRYPTION_KEY;
+
+      // Stub Notion OAuth credentials
+      vi.stubEnv("NOTION_OAUTH_CLIENT_ID", "test-notion-client-id");
+      vi.stubEnv("NOTION_OAUTH_CLIENT_SECRET", "test-notion-client-secret");
+      // Re-initialize env after stubbing
+      const { reloadEnv } = await import("../../../../../../../src/env");
+      reloadEnv();
+
+      // Insert connector record with tokenExpiresAt
+      await globalThis.services.db.insert(connectors).values({
+        userId: user.userId,
+        orgId: user.orgId,
+        type: "notion",
+        authMethod: "oauth",
+        tokenExpiresAt: opts.tokenExpiresAt,
+      });
+
+      // Insert access token and refresh token secrets
+      await globalThis.services.db.insert(secretsTable).values([
+        {
+          name: "NOTION_ACCESS_TOKEN",
+          encryptedValue: encryptSecretValue(accessToken, encryptionKey),
+          type: "connector",
+          userId: user.userId,
+          orgId: user.orgId,
+        },
+        {
+          name: "NOTION_REFRESH_TOKEN",
+          encryptedValue: encryptSecretValue(refreshToken, encryptionKey),
+          type: "connector",
+          userId: user.userId,
+          orgId: user.orgId,
+        },
+      ]);
+
+      return { accessToken, refreshToken };
+    }
+
+    it("should refresh expired token and return accurate expiresAt", async () => {
+      const expiredAt = new Date(Date.now() - 60 * 1000); // 1 min ago
+      await setupNotionConnector({ tokenExpiresAt: expiredAt });
+
+      // MSW handler for Notion token refresh
+      server.use(
+        mswHttp.post(NOTION_TOKEN_URL, () =>
+          HttpResponse.json({
+            access_token: "fresh-notion-token",
+            refresh_token: "new-refresh-token",
+            expires_in: 3600,
+          }),
+        ),
+      );
+
+      const encrypted = encryptTestSecrets({
+        NOTION_ACCESS_TOKEN: "old-notion-token",
+        NOTION_REFRESH_TOKEN: "notion-refresh-token",
+      });
+
+      const response = await POST(
+        makeRequest(
+          {
+            encryptedSecrets: encrypted,
+            authHeaders: {
+              Authorization: "Bearer ${secrets.NOTION_ACCESS_TOKEN}",
+            },
+            secretConnectorMap: { NOTION_ACCESS_TOKEN: "notion" },
+          },
+          testToken,
+        ),
+      );
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      // Should use refreshed token in resolved header
+      expect(data.headers.Authorization).toBe("Bearer fresh-notion-token");
+      // expiresAt should be close to now + 3600 (from provider's expires_in)
+      expect(data.expiresAt).toBeTypeOf("number");
+      const nowEpoch = Math.floor(Date.now() / 1000);
+      expect(data.expiresAt).toBeGreaterThan(nowEpoch + 3500);
+      expect(data.expiresAt).toBeLessThanOrEqual(nowEpoch + 3600);
+    });
+
+    it("should proactively refresh token expiring within 60s buffer", async () => {
+      // Token expires in 30 seconds — within the 60s buffer
+      const expiresIn30s = new Date(Date.now() + 30 * 1000);
+      await setupNotionConnector({ tokenExpiresAt: expiresIn30s });
+
+      server.use(
+        mswHttp.post(NOTION_TOKEN_URL, () =>
+          HttpResponse.json({
+            access_token: "proactive-fresh-token",
+            expires_in: 3600,
+          }),
+        ),
+      );
+
+      const encrypted = encryptTestSecrets({
+        NOTION_ACCESS_TOKEN: "old-notion-token",
+        NOTION_REFRESH_TOKEN: "notion-refresh-token",
+      });
+
+      const response = await POST(
+        makeRequest(
+          {
+            encryptedSecrets: encrypted,
+            authHeaders: {
+              Authorization: "Bearer ${secrets.NOTION_ACCESS_TOKEN}",
+            },
+            secretConnectorMap: { NOTION_ACCESS_TOKEN: "notion" },
+          },
+          testToken,
+        ),
+      );
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      // Should have proactively refreshed
+      expect(data.headers.Authorization).toBe("Bearer proactive-fresh-token");
+      expect(data.expiresAt).toBeTypeOf("number");
+    });
+
+    it("should skip refresh for valid token and return its expiresAt", async () => {
+      // Token valid for another 30 minutes — well outside the 60s buffer
+      const validExpiry = new Date(Date.now() + 30 * 60 * 1000);
+      await setupNotionConnector({ tokenExpiresAt: validExpiry });
+
+      const encrypted = encryptTestSecrets({
+        NOTION_ACCESS_TOKEN: "valid-notion-token",
+        NOTION_REFRESH_TOKEN: "notion-refresh-token",
+      });
+
+      const response = await POST(
+        makeRequest(
+          {
+            encryptedSecrets: encrypted,
+            authHeaders: {
+              Authorization: "Bearer ${secrets.NOTION_ACCESS_TOKEN}",
+            },
+            secretConnectorMap: { NOTION_ACCESS_TOKEN: "notion" },
+          },
+          testToken,
+        ),
+      );
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      // Should use the existing token (no refresh)
+      expect(data.headers.Authorization).toBe("Bearer valid-notion-token");
+      // expiresAt should match the stored value
+      const expectedExpiry = Math.floor(validExpiry.getTime() / 1000);
+      expect(data.expiresAt).toBe(expectedExpiry);
+    });
+
+    it("should return null expiresAt for non-expiring token", async () => {
+      // tokenExpiresAt = null means non-expiring
+      await setupNotionConnector({ tokenExpiresAt: null });
+
+      const encrypted = encryptTestSecrets({
+        NOTION_ACCESS_TOKEN: "permanent-notion-token",
+        NOTION_REFRESH_TOKEN: "notion-refresh-token",
+      });
+
+      const response = await POST(
+        makeRequest(
+          {
+            encryptedSecrets: encrypted,
+            authHeaders: {
+              Authorization: "Bearer ${secrets.NOTION_ACCESS_TOKEN}",
+            },
+            secretConnectorMap: { NOTION_ACCESS_TOKEN: "notion" },
+          },
+          testToken,
+        ),
+      );
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.headers.Authorization).toBe("Bearer permanent-notion-token");
+      expect(data.expiresAt).toBeNull();
+    });
+
+    it("should return null expiresAt without secretConnectorMap", async () => {
+      const encrypted = encryptTestSecrets({
+        GITHUB_TOKEN: "ghp_test_token_123",
+      });
+
+      const response = await POST(
+        makeRequest(
+          {
+            encryptedSecrets: encrypted,
+            authHeaders: {
+              Authorization: "Bearer ${secrets.GITHUB_TOKEN}",
+            },
+          },
+          testToken,
+        ),
+      );
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.headers.Authorization).toBe("Bearer ghp_test_token_123");
+      expect(data.expiresAt).toBeNull();
+    });
+
+    it("should update tokenExpiresAt in DB after refresh", async () => {
+      const expiredAt = new Date(Date.now() - 60 * 1000);
+      await setupNotionConnector({ tokenExpiresAt: expiredAt });
+
+      server.use(
+        mswHttp.post(NOTION_TOKEN_URL, () =>
+          HttpResponse.json({
+            access_token: "refreshed-token",
+            refresh_token: "new-refresh",
+            expires_in: 1800,
+          }),
+        ),
+      );
+
+      const encrypted = encryptTestSecrets({
+        NOTION_ACCESS_TOKEN: "old-notion-token",
+        NOTION_REFRESH_TOKEN: "notion-refresh-token",
+      });
+
+      await POST(
+        makeRequest(
+          {
+            encryptedSecrets: encrypted,
+            authHeaders: {
+              Authorization: "Bearer ${secrets.NOTION_ACCESS_TOKEN}",
+            },
+            secretConnectorMap: { NOTION_ACCESS_TOKEN: "notion" },
+          },
+          testToken,
+        ),
+      );
+
+      // Verify tokenExpiresAt was updated in the database
+      const [connector] = await globalThis.services.db
+        .select({ tokenExpiresAt: connectors.tokenExpiresAt })
+        .from(connectors)
+        .where(
+          and(
+            eq(connectors.orgId, user.orgId),
+            eq(connectors.userId, user.userId),
+            eq(connectors.type, "notion"),
+          ),
+        )
+        .limit(1);
+
+      expect(connector).toBeDefined();
+      const newExpiry = connector!.tokenExpiresAt!.getTime();
+      const expectedMin = Date.now() + 1700 * 1000; // ~1800s minus small margin
+      expect(newExpiry).toBeGreaterThan(expectedMin);
     });
   });
 });

--- a/turbo/apps/web/app/api/webhooks/agent/services/auth/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/services/auth/__tests__/route.test.ts
@@ -458,5 +458,43 @@ describe("POST /api/webhooks/agent/services/auth", () => {
       const expectedMin = Date.now() + 1700 * 1000; // ~1800s minus small margin
       expect(newExpiry).toBeGreaterThan(expectedMin);
     });
+
+    it("should use existing token when refresh fails", async () => {
+      const expiredAt = new Date(Date.now() - 60 * 1000);
+      await setupNotionConnector({ tokenExpiresAt: expiredAt });
+
+      // Provider returns error
+      server.use(
+        mswHttp.post(NOTION_TOKEN_URL, () =>
+          HttpResponse.json({ error: "invalid_grant" }, { status: 400 }),
+        ),
+      );
+
+      const encrypted = encryptTestSecrets({
+        NOTION_ACCESS_TOKEN: "old-notion-token",
+        NOTION_REFRESH_TOKEN: "notion-refresh-token",
+      });
+
+      const response = await POST(
+        makeRequest(
+          {
+            encryptedSecrets: encrypted,
+            authHeaders: {
+              Authorization: "Bearer ${secrets.NOTION_ACCESS_TOKEN}",
+            },
+            secretConnectorMap: { NOTION_ACCESS_TOKEN: "notion" },
+          },
+          testToken,
+        ),
+      );
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      // Falls back to old token
+      expect(data.headers.Authorization).toBe("Bearer old-notion-token");
+      // expiresAt is the original expired value (not cached for long by addon)
+      const expiredEpoch = Math.floor(expiredAt.getTime() / 1000);
+      expect(data.expiresAt).toBe(expiredEpoch);
+    });
   });
 });

--- a/turbo/apps/web/app/api/webhooks/agent/services/auth/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/services/auth/route.ts
@@ -1,26 +1,137 @@
 import { NextResponse } from "next/server";
+import { eq, and } from "drizzle-orm";
 import { z } from "zod";
 import { initServices } from "../../../../../../src/lib/init-services";
 import { verifySandboxToken } from "../../../../../../src/lib/auth/sandbox-token";
+import type { SandboxAuth } from "../../../../../../src/lib/auth/sandbox-token";
 import { decryptSecretsMap } from "../../../../../../src/lib/crypto/secrets-encryption";
 import { logger } from "../../../../../../src/lib/logger";
+import { agentRuns } from "../../../../../../src/db/schema/agent-run";
+import {
+  refreshConnectorAccessToken,
+  getConnectorExpiry,
+} from "../../../../../../src/lib/connector/connector-service";
 
 const bodySchema = z.object({
   encryptedSecrets: z.string().min(1),
   authHeaders: z.record(z.string(), z.string()),
+  secretConnectorMap: z.record(z.string(), z.string()).optional(),
 });
 
 const log = logger("webhook:service-auth");
 
 /**
+ * Refresh expired OAuth tokens referenced by auth templates.
+ * Mutates `secrets` in place with fresh token values.
+ * Returns the earliest expiry timestamp (epoch seconds) or null if all are non-expiring.
+ */
+async function refreshExpiredTokens(
+  auth: SandboxAuth,
+  secrets: Record<string, string>,
+  secretConnectorMap: Record<string, string>,
+  referencedKeys: Set<string>,
+): Promise<number | null> {
+  // Find which referenced secrets are refreshable OAuth tokens
+  const refreshable = new Map<string, string>();
+  for (const key of referencedKeys) {
+    const connectorType = secretConnectorMap[key];
+    if (connectorType) refreshable.set(key, connectorType);
+  }
+  if (refreshable.size === 0) return null;
+
+  // Look up orgId from runId
+  const [run] = await globalThis.services.db
+    .select({ orgId: agentRuns.orgId })
+    .from(agentRuns)
+    .where(and(eq(agentRuns.id, auth.runId), eq(agentRuns.userId, auth.userId)))
+    .limit(1);
+
+  if (!run) {
+    log.warn(`[${auth.runId}] Run not found for token refresh`);
+    return null;
+  }
+
+  const connectorTypes = [...new Set(refreshable.values())];
+  const expiryMap = await getConnectorExpiry(
+    run.orgId,
+    auth.userId,
+    connectorTypes,
+  );
+
+  const now = Math.floor(Date.now() / 1000);
+  let earliestExpiry: number | null = null;
+
+  for (const connectorType of connectorTypes) {
+    const tokenExpiry = expiryMap.get(connectorType);
+
+    if (
+      tokenExpiry !== undefined &&
+      tokenExpiry !== null &&
+      tokenExpiry <= now
+    ) {
+      // Token expired — refresh
+      log.debug(`[${auth.runId}] Refreshing expired ${connectorType} token`);
+      await refreshConnectorAccessToken(
+        connectorType,
+        run.orgId,
+        auth.userId,
+        secrets,
+      );
+      // After refresh, tokenExpiresAt is ~55 min from now
+      const newExpiry = now + 55 * 60;
+      earliestExpiry =
+        earliestExpiry === null
+          ? newExpiry
+          : Math.min(earliestExpiry, newExpiry);
+    } else if (tokenExpiry !== undefined && tokenExpiry !== null) {
+      // Token still valid — track expiry for cache TTL
+      earliestExpiry =
+        earliestExpiry === null
+          ? tokenExpiry
+          : Math.min(earliestExpiry, tokenExpiry);
+    }
+    // tokenExpiry null/undefined = non-expiring or not found, no TTL needed
+  }
+
+  return earliestExpiry;
+}
+
+/**
+ * Resolve ${secrets.XXX} templates with decrypted secret values.
+ */
+function resolveTemplates(
+  authHeaders: Record<string, string>,
+  secrets: Record<string, string>,
+  runId: string,
+): Record<string, string> {
+  const resolved: Record<string, string> = {};
+  for (const [name, template] of Object.entries(authHeaders)) {
+    resolved[name] = template.replace(
+      /\$\{secrets\.([^}]+)\}/g,
+      (_match, key: string) => {
+        if (!(key in secrets)) {
+          log.warn(`[${runId}] No secret value for "${key}" in template`);
+          return "";
+        }
+        return secrets[key] ?? "";
+      },
+    );
+  }
+  return resolved;
+}
+
+/**
  * POST /api/webhooks/agent/services/auth
  *
- * Pure decrypter/template resolver for service auth headers.
+ * Decrypter/template resolver for service auth headers.
  * Called by the mitmproxy addon when it intercepts a service-matched request.
  *
+ * When secretConnectorMap is provided, expired OAuth tokens are refreshed
+ * on demand and an expiresAt timestamp is returned for addon-side TTL caching.
+ *
  * Auth: Sandbox JWT
- * Body: { encryptedSecrets: string, authHeaders: Record<string, string> }
- * Response: { headers: Record<string, string> }
+ * Body: { encryptedSecrets, authHeaders, secretConnectorMap? }
+ * Response: { headers, expiresAt? }
  */
 export async function POST(request: Request) {
   initServices();
@@ -65,7 +176,7 @@ export async function POST(request: Request) {
       { status: 400 },
     );
   }
-  const { encryptedSecrets, authHeaders } = parsed.data;
+  const { encryptedSecrets, authHeaders, secretConnectorMap } = parsed.data;
 
   // Decrypt secrets
   let secrets: Record<string, string> | null;
@@ -84,20 +195,27 @@ export async function POST(request: Request) {
     );
   }
 
-  // Resolve ${secrets.XXX} templates with decrypted values
-  const resolved: Record<string, string> = {};
-  for (const [name, template] of Object.entries(authHeaders)) {
-    resolved[name] = template.replace(
-      /\$\{secrets\.([^}]+)\}/g,
-      (_match, key: string) => {
-        if (!(key in secrets)) {
-          log.warn(`[${auth.runId}] No secret value for "${key}" in template`);
-          return "";
-        }
-        return secrets[key] ?? "";
-      },
+  // Collect which secret keys are referenced in auth templates
+  const referencedKeys = new Set<string>();
+  for (const template of Object.values(authHeaders)) {
+    for (const match of template.matchAll(/\$\{secrets\.([^}]+)\}/g)) {
+      if (match[1]) referencedKeys.add(match[1]);
+    }
+  }
+
+  // Refresh expired OAuth tokens (mutates secrets map with fresh values)
+  let expiresAt: number | null = null;
+  if (secretConnectorMap) {
+    expiresAt = await refreshExpiredTokens(
+      auth,
+      secrets,
+      secretConnectorMap,
+      referencedKeys,
     );
   }
 
-  return NextResponse.json({ headers: resolved });
+  // Resolve templates with (possibly refreshed) secret values
+  const headers = resolveTemplates(authHeaders, secrets, auth.runId);
+
+  return NextResponse.json({ headers, expiresAt });
 }

--- a/turbo/apps/web/app/api/webhooks/agent/services/auth/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/services/auth/route.ts
@@ -20,6 +20,9 @@ const bodySchema = z.object({
 
 const log = logger("webhook:service-auth");
 
+/** Matches ${secrets.KEY_NAME} template placeholders in auth header values. */
+const SECRET_TEMPLATE_RE = /\$\{secrets\.([^}]+)\}/g;
+
 /**
  * Refresh expired OAuth tokens referenced by auth templates.
  * Mutates `secrets` in place with fresh token values.
@@ -109,7 +112,7 @@ function resolveTemplates(
   const resolved: Record<string, string> = {};
   for (const [name, template] of Object.entries(authHeaders)) {
     resolved[name] = template.replace(
-      /\$\{secrets\.([^}]+)\}/g,
+      SECRET_TEMPLATE_RE,
       (_match, key: string) => {
         if (!(key in secrets)) {
           log.warn(`[${runId}] No secret value for "${key}" in template`);
@@ -200,7 +203,7 @@ export async function POST(request: Request) {
   // Collect which secret keys are referenced in auth templates
   const referencedKeys = new Set<string>();
   for (const template of Object.values(authHeaders)) {
-    for (const match of template.matchAll(/\$\{secrets\.([^}]+)\}/g)) {
+    for (const match of template.matchAll(SECRET_TEMPLATE_RE)) {
       if (match[1]) referencedKeys.add(match[1]);
     }
   }

--- a/turbo/apps/web/app/api/webhooks/agent/services/auth/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/services/auth/route.ts
@@ -64,15 +64,18 @@ async function refreshExpiredTokens(
   const now = Math.floor(Date.now() / 1000);
   const REFRESH_BUFFER_SECS = 60;
 
-  // Refresh tokens that are expired or expiring within the buffer window
-  let refreshed = false;
-  for (const connectorType of connectorTypes) {
-    const tokenExpiry = expiryMap.get(connectorType);
-    if (
+  // Refresh tokens that are expired or expiring within the buffer window (parallel)
+  const toRefresh = connectorTypes.filter((ct) => {
+    const tokenExpiry = expiryMap.get(ct);
+    return (
       tokenExpiry !== undefined &&
       tokenExpiry !== null &&
       tokenExpiry <= now + REFRESH_BUFFER_SECS
-    ) {
+    );
+  });
+
+  const results = await Promise.all(
+    toRefresh.map(async (connectorType) => {
       log.debug(`[${auth.runId}] Refreshing expired ${connectorType} token`);
       const freshToken = await refreshConnectorAccessToken(
         connectorType,
@@ -80,15 +83,15 @@ async function refreshExpiredTokens(
         auth.userId,
         secrets,
       );
-      if (freshToken) {
-        refreshed = true;
-      } else {
+      if (!freshToken) {
         log.warn(
           `[${auth.runId}] Failed to refresh ${connectorType} token, using existing`,
         );
       }
-    }
-  }
+      return !!freshToken;
+    }),
+  );
+  const refreshed = results.some(Boolean);
 
   // Use accurate DB values after refresh; skip extra query if nothing changed
   const finalExpiryMap = refreshed

--- a/turbo/apps/web/app/api/webhooks/agent/services/auth/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/services/auth/route.ts
@@ -59,17 +59,17 @@ async function refreshExpiredTokens(
   );
 
   const now = Math.floor(Date.now() / 1000);
-  let earliestExpiry: number | null = null;
+  const REFRESH_BUFFER_SECS = 60;
 
+  // Refresh tokens that are expired or expiring within the buffer window
+  let refreshed = false;
   for (const connectorType of connectorTypes) {
     const tokenExpiry = expiryMap.get(connectorType);
-
     if (
       tokenExpiry !== undefined &&
       tokenExpiry !== null &&
-      tokenExpiry <= now
+      tokenExpiry <= now + REFRESH_BUFFER_SECS
     ) {
-      // Token expired — refresh
       log.debug(`[${auth.runId}] Refreshing expired ${connectorType} token`);
       await refreshConnectorAccessToken(
         connectorType,
@@ -77,20 +77,22 @@ async function refreshExpiredTokens(
         auth.userId,
         secrets,
       );
-      // After refresh, tokenExpiresAt is ~55 min from now
-      const newExpiry = now + 55 * 60;
-      earliestExpiry =
-        earliestExpiry === null
-          ? newExpiry
-          : Math.min(earliestExpiry, newExpiry);
-    } else if (tokenExpiry !== undefined && tokenExpiry !== null) {
-      // Token still valid — track expiry for cache TTL
-      earliestExpiry =
-        earliestExpiry === null
-          ? tokenExpiry
-          : Math.min(earliestExpiry, tokenExpiry);
+      refreshed = true;
     }
-    // tokenExpiry null/undefined = non-expiring or not found, no TTL needed
+  }
+
+  // Use accurate DB values after refresh; skip extra query if nothing changed
+  const finalExpiryMap = refreshed
+    ? await getConnectorExpiry(run.orgId, auth.userId, connectorTypes)
+    : expiryMap;
+
+  let earliestExpiry: number | null = null;
+  for (const connectorType of connectorTypes) {
+    const expiry = finalExpiryMap.get(connectorType);
+    if (expiry !== undefined && expiry !== null) {
+      earliestExpiry =
+        earliestExpiry === null ? expiry : Math.min(earliestExpiry, expiry);
+    }
   }
 
   return earliestExpiry;

--- a/turbo/apps/web/app/api/webhooks/agent/services/auth/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/services/auth/route.ts
@@ -74,13 +74,19 @@ async function refreshExpiredTokens(
       tokenExpiry <= now + REFRESH_BUFFER_SECS
     ) {
       log.debug(`[${auth.runId}] Refreshing expired ${connectorType} token`);
-      await refreshConnectorAccessToken(
+      const freshToken = await refreshConnectorAccessToken(
         connectorType,
         run.orgId,
         auth.userId,
         secrets,
       );
-      refreshed = true;
+      if (freshToken) {
+        refreshed = true;
+      } else {
+        log.warn(
+          `[${auth.runId}] Failed to refresh ${connectorType} token, using existing`,
+        );
+      }
     }
   }
 

--- a/turbo/apps/web/src/__tests__/api-test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers.ts
@@ -1809,6 +1809,26 @@ export async function findTestConnectorTokenExpiresAt(
 }
 
 /**
+ * Insert an encrypted connector secret into the database.
+ * Used for setting up test state (e.g., access tokens, refresh tokens) without going through the OAuth flow.
+ */
+export async function insertTestConnectorSecret(
+  orgId: string,
+  userId: string,
+  name: string,
+  value: string,
+): Promise<void> {
+  const encryptionKey = globalThis.services.env.SECRETS_ENCRYPTION_KEY;
+  await globalThis.services.db.insert(secrets).values({
+    name,
+    encryptedValue: encryptSecretValue(value, encryptionKey),
+    type: "connector",
+    userId,
+    orgId,
+  });
+}
+
+/**
  * Generate a unique session code for testing (format: XXXX-XXXX, max 9 chars)
  */
 function generateTestSessionCode(): string {

--- a/turbo/apps/web/src/__tests__/test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/test-helpers.ts
@@ -205,7 +205,12 @@ interface TestContext {
   ): Promise<{ id: string; name: string; orgId: string }>;
   createConnector(
     orgId: string,
-    options: { userId: string; type?: string; authMethod?: string },
+    options: {
+      userId: string;
+      type?: string;
+      authMethod?: string;
+      tokenExpiresAt?: Date | null;
+    },
   ): Promise<{ id: string; type: string }>;
 }
 
@@ -630,7 +635,12 @@ export function testContext(): TestContext {
    */
   async function createConnector(
     orgId: string,
-    options: { userId: string; type?: string; authMethod?: string },
+    options: {
+      userId: string;
+      type?: string;
+      authMethod?: string;
+      tokenExpiresAt?: Date | null;
+    },
   ): Promise<{ id: string; type: string }> {
     const { userId, type = "github", authMethod = "oauth" } = options;
 
@@ -643,6 +653,7 @@ export function testContext(): TestContext {
         orgId,
         type,
         authMethod,
+        tokenExpiresAt: options.tokenExpiresAt ?? undefined,
       })
       .returning();
 

--- a/turbo/apps/web/src/lib/connector/connector-service.ts
+++ b/turbo/apps/web/src/lib/connector/connector-service.ts
@@ -519,6 +519,39 @@ export async function refreshConnectorAccessToken(
 }
 
 /**
+ * Get tokenExpiresAt for connectors matching the given types.
+ * Returns a map of connector type → expiry timestamp (epoch seconds), or null if non-expiring.
+ */
+export async function getConnectorExpiry(
+  orgId: string,
+  userId: string,
+  connectorTypes: string[],
+): Promise<Map<string, number | null>> {
+  const result = new Map<string, number | null>();
+  if (connectorTypes.length === 0) return result;
+
+  const rows = await globalThis.services.db
+    .select({
+      type: connectors.type,
+      tokenExpiresAt: connectors.tokenExpiresAt,
+    })
+    .from(connectors)
+    .where(and(eq(connectors.orgId, orgId), eq(connectors.userId, userId)));
+
+  for (const row of rows) {
+    if (connectorTypes.includes(row.type)) {
+      result.set(
+        row.type,
+        row.tokenExpiresAt
+          ? Math.floor(row.tokenExpiresAt.getTime() / 1000)
+          : null,
+      );
+    }
+  }
+  return result;
+}
+
+/**
  * Create or update a connector secret (e.g., refresh token)
  */
 async function upsertConnectorSecret(

--- a/turbo/apps/web/src/lib/connector/connector-service.ts
+++ b/turbo/apps/web/src/lib/connector/connector-service.ts
@@ -1,4 +1,4 @@
-import { eq, and } from "drizzle-orm";
+import { eq, and, inArray } from "drizzle-orm";
 import {
   CONNECTOR_TYPES,
   type ConnectorType,
@@ -536,17 +536,21 @@ export async function getConnectorExpiry(
       tokenExpiresAt: connectors.tokenExpiresAt,
     })
     .from(connectors)
-    .where(and(eq(connectors.orgId, orgId), eq(connectors.userId, userId)));
+    .where(
+      and(
+        eq(connectors.orgId, orgId),
+        eq(connectors.userId, userId),
+        inArray(connectors.type, connectorTypes),
+      ),
+    );
 
   for (const row of rows) {
-    if (connectorTypes.includes(row.type)) {
-      result.set(
-        row.type,
-        row.tokenExpiresAt
-          ? Math.floor(row.tokenExpiresAt.getTime() / 1000)
-          : null,
-      );
-    }
+    result.set(
+      row.type,
+      row.tokenExpiresAt
+        ? Math.floor(row.tokenExpiresAt.getTime() / 1000)
+        : null,
+    );
   }
   return result;
 }


### PR DESCRIPTION
## Summary

Closes #4627

- Add on-demand OAuth token refresh to the service auth endpoint (`POST /api/webhooks/agent/services/auth`). When `secretConnectorMap` is provided in the request body, expired tokens are refreshed via `refreshConnectorAccessToken` before resolving auth header templates.
- Add `getConnectorExpiry` to look up `tokenExpiresAt` for connector types, enabling expiry-based refresh decisions.
- Add TTL-based caching in the mitmproxy addon (`get_service_headers`). The auth endpoint returns `expiresAt` for cache TTL management. Cache is also evicted on 401 responses and when runs are removed from the registry.

## Test plan

- [ ] Verify auth endpoint returns `expiresAt` when `secretConnectorMap` is provided
- [ ] Verify expired tokens are refreshed before template resolution
- [ ] Verify addon caches headers and respects TTL
- [ ] Verify 401 response evicts addon cache entry
- [ ] Verify non-expiring tokens (null `tokenExpiresAt`) skip refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)