### PR TITLE
fix: skip malformed frontmatter in sync-skills instead of crashing

### DIFF
--- a/turbo/apps/web/app/api/cron/sync-skills/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/cron/sync-skills/__tests__/route.test.ts
@@ -263,6 +263,49 @@ describe("GET /api/cron/sync-skills", () => {
     });
   });
 
+  describe("Malformed frontmatter resilience", () => {
+    it("should skip skill with malformed frontmatter and sync others", async () => {
+      const skillsWithBadFrontmatter = [
+        MOCK_SKILLS[0]!, // slack — valid
+        {
+          name: "bad-yaml",
+          files: [
+            {
+              path: "SKILL.md",
+              content: [
+                "---",
+                "name: bad-yaml",
+                "vm0_vars:",
+                "  - GOOD_VAR",
+                "- BAD_VAR",
+                "---",
+                "",
+                "# Bad YAML Skill",
+              ].join("\n"),
+            },
+            { path: "index.ts", content: 'console.log("bad");' },
+          ],
+        },
+        MOCK_SKILLS[1]!, // github — valid
+      ];
+      const tarball = createMockTarball(skillsWithBadFrontmatter);
+      setupMswHandlers(TEST_COMMIT_SHA, tarball);
+
+      const response = await GET(cronRequest(cronSecret));
+      expect(response.status).toBe(200);
+      const data = await response.json();
+
+      expect(data.success).toBe(true);
+      expect(data.synced).toBe(2); // slack + github
+      expect(data.failed).toBe(1); // bad-yaml
+      expect(data.total).toBe(3);
+
+      // Verify only the valid skills were synced
+      const allSkills = await findAllTestSkills();
+      expect(allSkills).toHaveLength(2);
+    });
+  });
+
   describe("Incremental sync", () => {
     it("should only update changed skills", async () => {
       const tarball1 = createMockTarball(MOCK_SKILLS);

--- a/turbo/apps/web/src/lib/skills/sync-skills.ts
+++ b/turbo/apps/web/src/lib/skills/sync-skills.ts
@@ -47,6 +47,8 @@ interface SyncResult {
   synced: number;
   /** Skills unchanged (same version hash) */
   skipped: number;
+  /** Skills that failed to sync (e.g. bad frontmatter) */
+  failed: number;
   /** Total skills found in tarball */
   total: number;
 }
@@ -72,7 +74,7 @@ export async function syncSkills(): Promise<SyncResult> {
     .limit(1);
 
   if (existing?.commitSha === headSha) {
-    return { commitSha: headSha, synced: 0, skipped: 0, total: 0 };
+    return { commitSha: headSha, synced: 0, skipped: 0, failed: 0, total: 0 };
   }
 
   // 3. Download and extract tarball
@@ -81,13 +83,22 @@ export async function syncSkills(): Promise<SyncResult> {
   // 4. Sync each skill
   let synced = 0;
   let skipped = 0;
+  let failed = 0;
 
   for (const extracted of extractedSkills) {
-    const wasUpdated = await syncSingleSkill(db, extracted, headSha);
-    if (wasUpdated) {
-      synced++;
-    } else {
-      skipped++;
+    try {
+      const wasUpdated = await syncSingleSkill(db, extracted, headSha);
+      if (wasUpdated) {
+        synced++;
+      } else {
+        skipped++;
+      }
+    } catch (error) {
+      failed++;
+      log.warn("Skipping skill due to sync error", {
+        skillName: extracted.skillName,
+        error: error instanceof Error ? error.message : String(error),
+      });
     }
   }
 
@@ -95,6 +106,7 @@ export async function syncSkills(): Promise<SyncResult> {
     commitSha: headSha,
     synced,
     skipped,
+    failed,
     total: extractedSkills.length,
   });
 
@@ -102,6 +114,7 @@ export async function syncSkills(): Promise<SyncResult> {
     commitSha: headSha,
     synced,
     skipped,
+    failed,
     total: extractedSkills.length,
   };
 }


### PR DESCRIPTION
## Summary

- Wrap `syncSingleSkill()` in try-catch so a single skill with bad YAML frontmatter is skipped with a warning instead of crashing the entire sync
- Add `failed` counter to `SyncResult` for observability
- Add test case: skill with malformed frontmatter is skipped, other skills sync successfully

Closes #4803

## Test plan

- [x] Existing sync-skills tests pass (8 tests)
- [x] New test: skill with malformed YAML frontmatter is skipped gracefully while other skills sync
- [x] Lint, type-check, and knip pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)