### PR TITLE
ci: make perf commits visible in changelog and trigger releases

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,7 +8,7 @@
         {"type": "docs", "section": "Documentation"},
         {"type": "style", "hidden": true},
         {"type": "refactor", "section": "Refactoring"},
-        {"type": "perf", "hidden": true},
+        {"type": "perf", "section": "Performance Improvements"},
         {"type": "test", "hidden": true},
         {"type": "build", "hidden": true},
         {"type": "revert", "hidden": true}


### PR DESCRIPTION
## Summary

- Change `perf` type from `hidden: true` to `section: "Performance Improvements"` in release-please config
- This ensures `perf` commits trigger patch version bumps and appear in CHANGELOG

## Why

PR #4807 (`perf: skip unnecessary api calls in compose --json mode`) didn't trigger a CLI release because `perf` was marked as `hidden` in `release-please-config.json`. Hidden commit types are filtered out by release-please's `filterCommits()`, so the CLI package had zero releasable commits → no release PR created.

## Test plan

- [x] Verify release-please-config.json is valid JSON
- [ ] After merge, release-please should pick up #4807's `perf` commit and include CLI in the next release PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)