### PR TITLE
chore: upgrade e2b template cli to v9.59.1 for compose --json perf

### DIFF
--- a/turbo/scripts/e2b/vm0-cli/template.ts
+++ b/turbo/scripts/e2b/vm0-cli/template.ts
@@ -11,4 +11,4 @@ import { Template } from "e2b";
 export const template = Template()
   .fromNodeImage("24")
   .aptInstall(["curl", "git", "jq", "tzdata"])
-  .npmInstall("@vm0/cli@9.59.0", { g: true });
+  .npmInstall("@vm0/cli@9.59.1", { g: true });


### PR DESCRIPTION
## Summary

- Upgrade E2B template CLI from v9.59.0 to v9.59.1
- v9.59.1 includes #4807 (`perf: skip unnecessary api calls in compose --json mode`)

## Impact

Platform compose in E2B sandbox will skip 5 unnecessary API calls in `--json` mode:
- `getComposeByName()` — was computing trulyNewSecrets for unused confirmation prompt
- `getOrg()` — was constructing displayName that E2B doesn't read
- `listSecrets()` + `listVariables()` + `listConnectors()` — were checking missing items that E2B doesn't read

Expected speedup: **~6-7s → ~2-3s** for cached skills compose.

## Test plan

- [x] Template file has correct version
- [ ] CI passes
- [ ] After merge + E2B template rebuild, platform compose should be faster

🤖 Generated with [Claude Code](https://claude.com/claude-code)