### PR TITLE
fix: add heartbeat update during build-and-dispatch-run pipeline

### DIFF
--- a/turbo/apps/web/src/lib/run/__tests__/create-run.test.ts
+++ b/turbo/apps/web/src/lib/run/__tests__/create-run.test.ts
@@ -82,15 +82,15 @@ describe("createRun()", () => {
     });
 
     it("should refresh lastHeartbeatAt during pipeline", async () => {
-      const beforeCreate = new Date();
       const result = await createRun(baseParams());
 
       const run = await findTestRunRecord(result.runId);
 
-      // lastHeartbeatAt should be at or after creation time,
-      // confirming the mid-pipeline heartbeat refresh executed
-      expect(run!.lastHeartbeatAt!.getTime()).toBeGreaterThanOrEqual(
-        beforeCreate.getTime(),
+      // The mid-pipeline heartbeat UPDATE runs after generateSandboxToken +
+      // buildContext, so lastHeartbeatAt must be strictly later than
+      // createdAt (which is set by the initial INSERT's defaultNow()).
+      expect(run!.lastHeartbeatAt!.getTime()).toBeGreaterThan(
+        run!.createdAt.getTime(),
       );
     });
 

--- a/turbo/apps/web/src/lib/run/__tests__/create-run.test.ts
+++ b/turbo/apps/web/src/lib/run/__tests__/create-run.test.ts
@@ -81,6 +81,19 @@ describe("createRun()", () => {
       expect(run!.lastHeartbeatAt).not.toBeNull();
     });
 
+    it("should refresh lastHeartbeatAt during pipeline", async () => {
+      const beforeCreate = new Date();
+      const result = await createRun(baseParams());
+
+      const run = await findTestRunRecord(result.runId);
+
+      // lastHeartbeatAt should be at or after creation time,
+      // confirming the mid-pipeline heartbeat refresh executed
+      expect(run!.lastHeartbeatAt!.getTime()).toBeGreaterThanOrEqual(
+        beforeCreate.getTime(),
+      );
+    });
+
     it("should store vars when provided", async () => {
       const vars = { MY_VAR: "value1", OTHER_VAR: "value2" };
       const result = await createRun(baseParams({ vars }));

--- a/turbo/apps/web/src/lib/run/run-service.ts
+++ b/turbo/apps/web/src/lib/run/run-service.ts
@@ -571,6 +571,19 @@ async function buildAndDispatchRun(opts: {
     });
     const buildContextTime = Date.now();
 
+    // Refresh heartbeat after the heaviest pipeline step to prevent the
+    // cleanup cron from timing out runs whose dispatch takes > 5 minutes.
+    // Status guard avoids touching runs cancelled/failed while in-flight.
+    await globalThis.services.db
+      .update(agentRuns)
+      .set({ lastHeartbeatAt: new Date() })
+      .where(
+        and(
+          eq(agentRuns.id, runId),
+          or(eq(agentRuns.status, "pending"), eq(agentRuns.status, "running")),
+        ),
+      );
+
     // Prepare execution context (storage manifest, working dir, etc.)
     const prepareResult = await prepareForExecution(context, runtimeOrg);
     const prepareTime = Date.now();


### PR DESCRIPTION
## Summary

- Add `lastHeartbeatAt` refresh after `buildContext()` in `buildAndDispatchRun` to prevent the cleanup cron from prematurely marking runs as timed out when the dispatch pipeline exceeds 5 minutes
- Use status guard (`pending`/`running`) to avoid updating cancelled/failed runs
- Add integration test verifying heartbeat is refreshed during the pipeline

## Test plan

- [x] New integration test: "should refresh lastHeartbeatAt during pipeline" passes
- [x] All 40 existing `create-run.test.ts` tests pass
- [x] Full test suite passes (3634/3636 — 2 pre-existing failures unrelated to this change)
- [x] Lint and knip checks pass

Fixes #4825
Fixes #4775

🤖 Generated with [Claude Code](https://claude.com/claude-code)