### PR TITLE
fix: align stale queue drain with per-org concurrency and preserve ttl on re-enqueue

### DIFF
--- a/turbo/apps/web/src/lib/run/__tests__/run-queue-service.test.ts
+++ b/turbo/apps/web/src/lib/run/__tests__/run-queue-service.test.ts
@@ -20,6 +20,7 @@ import {
 import {
   enqueueRun,
   drainUserQueue,
+  drainStaleQueues,
   cleanupExpiredQueueEntries,
 } from "../run-queue-service";
 
@@ -163,6 +164,102 @@ describe("run-queue-service", () => {
 
       const cleaned = await cleanupExpiredQueueEntries();
       expect(cleaned).toBe(0);
+    });
+  });
+
+  describe("drainStaleQueues", () => {
+    it("should not drain when another user in the same org has an active run", async () => {
+      vi.stubEnv("CONCURRENT_RUN_LIMIT", "1");
+      reloadEnv();
+
+      // user1 creates a run first (before changing Clerk mock)
+      const run1 = await createRun(
+        baseParams({ prompt: "User1 running", orgId: user.orgId }),
+      );
+      expect(run1.status).toBe("pending");
+
+      // Create second user sharing user1's org
+      const user2 = await context.setupUser({ prefix: "test-user-2" });
+
+      // user2's run gets queued in the same org
+      const run2 = await enqueueRun(
+        baseParams({
+          userId: user2.userId,
+          orgId: user.orgId,
+          prompt: "User2 queued",
+        }),
+      );
+      expect(run2.status).toBe("queued");
+
+      // drainStaleQueues should NOT drain user2's queue (org has an active run)
+      await drainStaleQueues(executeQueuedRun);
+
+      // Queue entry should still exist — org-level concurrency prevented drain
+      const queueEntry = await findTestQueueEntry(run2.runId);
+      expect(queueEntry).toBeDefined();
+
+      // Run should still be queued
+      const run = await findTestRunRecord(run2.runId);
+      expect(run!.status).toBe("queued");
+    });
+
+    it("should drain when org has no active runs", async () => {
+      vi.stubEnv("CONCURRENT_RUN_LIMIT", "1");
+      reloadEnv();
+
+      // user1 creates a run first (before changing Clerk mock)
+      await createRun(
+        baseParams({ prompt: "User1 running", orgId: user.orgId }),
+      );
+
+      // Create second user sharing user1's org
+      const user2 = await context.setupUser({ prefix: "test-user-2" });
+
+      // user2's run gets queued in the same org
+      const run2 = await enqueueRun(
+        baseParams({
+          userId: user2.userId,
+          orgId: user.orgId,
+          prompt: "User2 queued",
+        }),
+      );
+
+      // Complete user1's run → org now has no active runs
+      await markRunningRunsAsCompleted(user.userId);
+
+      // drainStaleQueues should drain user2's queue
+      const drained = await drainStaleQueues(executeQueuedRun);
+      expect(drained).toBeGreaterThanOrEqual(1);
+
+      // Queue entry should be consumed
+      const queueEntry = await findTestQueueEntry(run2.runId);
+      expect(queueEntry).toBeUndefined();
+    });
+  });
+
+  describe("reEnqueueRun TTL preservation", () => {
+    it("should preserve original expiresAt on re-enqueue", async () => {
+      vi.stubEnv("CONCURRENT_RUN_LIMIT", "1");
+      reloadEnv();
+
+      // Create a running run and a queued run
+      await createRun(baseParams({ prompt: "Running" }));
+      const queued = await createRun(baseParams({ prompt: "Queued" }));
+      expect(queued.status).toBe("queued");
+
+      // Record original expiresAt
+      const originalEntry = await findTestQueueEntry(queued.runId);
+      const originalExpiresAt = originalEntry!.expiresAt;
+
+      // Drain — concurrency limit still hit → re-enqueue
+      await drainUserQueue(user.userId, executeQueuedRun);
+
+      // Verify re-enqueued entry preserves original expiresAt
+      const reEnqueuedEntry = await findTestQueueEntry(queued.runId);
+      expect(reEnqueuedEntry).toBeDefined();
+      expect(reEnqueuedEntry!.expiresAt.getTime()).toBe(
+        originalExpiresAt.getTime(),
+      );
     });
   });
 });

--- a/turbo/apps/web/src/lib/run/__tests__/run-queue-service.test.ts
+++ b/turbo/apps/web/src/lib/run/__tests__/run-queue-service.test.ts
@@ -261,5 +261,35 @@ describe("run-queue-service", () => {
         originalExpiresAt.getTime(),
       );
     });
+
+    it("should expire re-enqueued run via cleanup", async () => {
+      vi.stubEnv("CONCURRENT_RUN_LIMIT", "1");
+      reloadEnv();
+
+      // Drain any pre-existing expired entries from other test suites
+      await cleanupExpiredQueueEntries();
+
+      // Create a running run and a queued run
+      await createRun(baseParams({ prompt: "Running" }));
+      const queued = await createRun(baseParams({ prompt: "Queued" }));
+      expect(queued.status).toBe("queued");
+
+      // Drain — concurrency limit still hit → re-enqueue with preserved TTL
+      await drainUserQueue(user.userId, executeQueuedRun);
+
+      // Simulate TTL expiry on the re-enqueued entry
+      await expireQueueEntry(queued.runId);
+
+      // Cleanup should remove the expired entry and mark run as timeout
+      const cleaned = await cleanupExpiredQueueEntries();
+      expect(cleaned).toBe(1);
+
+      const run = await findTestRunRecord(queued.runId);
+      expect(run!.status).toBe("timeout");
+      expect(run!.error).toContain("expired");
+
+      const queueEntry = await findTestQueueEntry(queued.runId);
+      expect(queueEntry).toBeUndefined();
+    });
   });
 });

--- a/turbo/apps/web/src/lib/run/run-queue-service.ts
+++ b/turbo/apps/web/src/lib/run/run-queue-service.ts
@@ -154,6 +154,7 @@ export async function drainUserQueue(
           userId,
           entry.encryptedParams,
           entry.createdAt,
+          entry.expiresAt,
         );
         return;
       }
@@ -171,6 +172,7 @@ interface QueueEntry {
   runId: string;
   encryptedParams: string | null;
   createdAt: Date;
+  expiresAt: Date;
 }
 
 /**
@@ -186,8 +188,9 @@ async function dequeueNext(userId: string): Promise<QueueEntry | undefined> {
       run_id: string;
       encrypted_params: string | null;
       created_at: string;
+      expires_at: string;
     }>(
-      sql`SELECT run_id, encrypted_params, created_at
+      sql`SELECT run_id, encrypted_params, created_at, expires_at
        FROM agent_run_queue
        WHERE user_id = ${userId}
        ORDER BY created_at ASC
@@ -208,6 +211,7 @@ async function dequeueNext(userId: string): Promise<QueueEntry | undefined> {
       runId: row.run_id,
       encryptedParams: row.encrypted_params,
       createdAt: new Date(row.created_at),
+      expiresAt: new Date(row.expires_at),
     };
   });
 }
@@ -256,21 +260,22 @@ export async function drainStaleQueues(
 ): Promise<number> {
   const staleThreshold = new Date(Date.now() - PENDING_RUN_TTL_MS);
 
-  // Find distinct users with queued runs
-  const usersWithQueued = await globalThis.services.db
-    .selectDistinct({ userId: agentRunQueue.userId })
-    .from(agentRunQueue);
+  // Find distinct orgs with queued runs (JOIN queue with runs to get orgId)
+  const orgsWithQueued = await globalThis.services.db
+    .selectDistinct({ orgId: agentRuns.orgId })
+    .from(agentRunQueue)
+    .innerJoin(agentRuns, eq(agentRunQueue.runId, agentRuns.id));
 
   let drained = 0;
 
-  for (const { userId } of usersWithQueued) {
-    // Check if user has any active runs
+  for (const { orgId } of orgsWithQueued) {
+    // Check if org has any active runs (same logic as checkRunConcurrencyLimit)
     const [result] = await globalThis.services.db
       .select({ count: count() })
       .from(agentRuns)
       .where(
         and(
-          eq(agentRuns.userId, userId),
+          eq(agentRuns.orgId, orgId),
           or(
             eq(agentRuns.status, "running"),
             and(
@@ -283,9 +288,21 @@ export async function drainStaleQueues(
 
     const activeCount = Number(result?.count ?? 0);
     if (activeCount === 0) {
-      log.debug(`Draining stale queue for user ${userId}`);
-      await drainUserQueue(userId, execute);
-      drained++;
+      // Find a userId with queued runs in this org to drain
+      const [userRow] = await globalThis.services.db
+        .select({ userId: agentRunQueue.userId })
+        .from(agentRunQueue)
+        .innerJoin(agentRuns, eq(agentRunQueue.runId, agentRuns.id))
+        .where(eq(agentRuns.orgId, orgId))
+        .limit(1);
+
+      if (userRow) {
+        log.debug(
+          `Draining stale queue for org ${orgId}, user ${userRow.userId}`,
+        );
+        await drainUserQueue(userRow.userId, execute);
+        drained++;
+      }
     }
   }
 
@@ -301,14 +318,14 @@ async function reEnqueueRun(
   userId: string,
   encryptedParams: string | null,
   originalCreatedAt: Date,
+  originalExpiresAt: Date,
 ): Promise<void> {
-  const expiresAt = new Date(Date.now() + QUEUE_TTL_MS);
   await globalThis.services.db.insert(agentRunQueue).values({
     runId,
     userId,
     encryptedParams,
     createdAt: originalCreatedAt,
-    expiresAt,
+    expiresAt: originalExpiresAt,
   });
   log.debug(`Re-enqueued run ${runId} (concurrency conflict)`);
 }

--- a/turbo/apps/web/src/lib/run/run-queue-service.ts
+++ b/turbo/apps/web/src/lib/run/run-queue-service.ts
@@ -1,4 +1,4 @@
-import { eq, lt, and, or, count, gt, sql, inArray } from "drizzle-orm";
+import { eq, lt, and, or, count, gt, sql, inArray, asc } from "drizzle-orm";
 import { agentRuns } from "../../db/schema/agent-run";
 import { agentRunQueue } from "../../db/schema/agent-run-queue";
 import { env } from "../../env";
@@ -294,6 +294,7 @@ export async function drainStaleQueues(
         .from(agentRunQueue)
         .innerJoin(agentRuns, eq(agentRunQueue.runId, agentRuns.id))
         .where(eq(agentRuns.orgId, orgId))
+        .orderBy(asc(agentRunQueue.createdAt))
         .limit(1);
 
       if (userRow) {


### PR DESCRIPTION
## Summary

- **Fix dimension mismatch**: `drainStaleQueues` now checks active runs per-orgId (via JOIN with `agent_runs`) instead of per-userId, matching `checkRunConcurrencyLimit` behavior
- **Fix TTL refresh**: `reEnqueueRun` preserves the original `expiresAt` instead of generating a fresh 2-hour TTL on every re-enqueue, allowing `cleanupExpiredQueueEntries` to eventually expire stuck runs
- **Add integration tests**: Multi-user org drain scenarios and TTL preservation verification

Fixes #4824
Fixes #4774

## Test plan

- [x] Existing `run-queue-service` tests pass (enqueueRun, drainUserQueue, cleanupExpiredQueueEntries)
- [x] New test: `drainStaleQueues` does NOT drain when another user in the same org has an active run
- [x] New test: `drainStaleQueues` drains when org has no active runs
- [x] New test: re-enqueued run preserves original `expiresAt`
- [x] Lint passes
- [x] Knip passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)