### PR TITLE
fix(web): add atomic run status transition guards to prevent race conditions

### DIFF
--- a/turbo/apps/cli/src/commands/run/__tests__/list.test.ts
+++ b/turbo/apps/cli/src/commands/run/__tests__/list.test.ts
@@ -153,7 +153,7 @@ describe("run list command", () => {
       await listCommand.parseAsync(["node", "cli", "--all"]);
 
       expect(capturedUrl?.searchParams.get("status")).toBe(
-        "queued,pending,running,completed,failed,timeout",
+        "queued,pending,running,completed,failed,timeout,cancelled",
       );
     });
 
@@ -214,7 +214,7 @@ describe("run list command", () => {
       await listCommand.parseAsync(["node", "cli", "--since", "7d"]);
 
       expect(capturedUrl?.searchParams.get("status")).toBe(
-        "queued,pending,running,completed,failed,timeout",
+        "queued,pending,running,completed,failed,timeout,cancelled",
       );
     });
 

--- a/turbo/apps/cli/src/lib/api/core/types.ts
+++ b/turbo/apps/cli/src/lib/api/core/types.ts
@@ -54,7 +54,8 @@ type RunStatus =
   | "running"
   | "completed"
   | "failed"
-  | "timeout";
+  | "timeout"
+  | "cancelled";
 
 export interface CreateRunResponse {
   runId: string;

--- a/turbo/apps/web/app/api/agent/runs/[id]/cancel/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/cancel/__tests__/route.test.ts
@@ -7,6 +7,7 @@ import {
   createTestRun,
   findTestQueueEntry,
   findTestRunRecord,
+  setTestRunStatus,
 } from "../../../../../../../src/__tests__/api-test-helpers";
 import {
   testContext,
@@ -190,6 +191,27 @@ describe("POST /api/agent/runs/:id/cancel - Cancel Run", () => {
 
       expect(response.status).toBe(400);
       expect(data.error.message).toContain("cannot be cancelled");
+    });
+
+    it("should not overwrite a concurrently completed run", async () => {
+      const run = await createTestRun(testComposeId, "Run to cancel");
+
+      // Simulate a concurrent completion between the SELECT and the transaction
+      await setTestRunStatus(run.runId, "completed");
+
+      // Cancel should fail — either fast-path or transaction guard catches it
+      const request = createTestRequest(
+        `http://localhost:3000/api/agent/runs/${run.runId}/cancel`,
+        { method: "POST" },
+      );
+
+      const response = await POST(request);
+
+      expect(response.status).toBe(400);
+
+      // Run should still be completed (not overwritten to cancelled)
+      const record = await findTestRunRecord(run.runId);
+      expect(record!.status).toBe("completed");
     });
   });
 });

--- a/turbo/apps/web/app/api/agent/runs/[id]/cancel/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/cancel/route.ts
@@ -6,6 +6,7 @@ import { agentRunQueue } from "../../../../../../src/db/schema/agent-run-queue";
 import { eq, and } from "drizzle-orm";
 import { getUserId } from "../../../../../../src/lib/auth/get-user-id";
 import { logger } from "../../../../../../src/lib/logger";
+import { transitionRunStatus } from "../../../../../../src/lib/run/run-status";
 import { drainUserQueue } from "../../../../../../src/lib/run/run-queue-service";
 import { executeQueuedRun } from "../../../../../../src/lib/run/run-service";
 import { after } from "next/server";
@@ -61,21 +62,31 @@ const router = tsr.router(runsCancelContract, {
       };
     }
 
-    // If queued, remove from queue table (encrypted secrets deleted)
-    if (run.status === "queued") {
-      await globalThis.services.db
-        .delete(agentRunQueue)
-        .where(eq(agentRunQueue.runId, runId));
-    }
+    // Atomically delete queue entry (if present) and transition status.
+    // The transaction prevents a concurrent drainUserQueue from dequeuing
+    // the run between the queue delete and the status update.
+    const cancelled = await globalThis.services.db.transaction(async (tx) => {
+      await tx.delete(agentRunQueue).where(eq(agentRunQueue.runId, runId));
 
-    // Update run status to cancelled
-    await globalThis.services.db
-      .update(agentRuns)
-      .set({
-        status: "cancelled",
-        completedAt: new Date(),
-      })
-      .where(eq(agentRuns.id, runId));
+      return transitionRunStatus(
+        runId,
+        { status: "cancelled", completedAt: new Date() },
+        ["queued", "pending", "running"],
+        tx,
+      );
+    });
+
+    if (!cancelled) {
+      return {
+        status: 400 as const,
+        body: {
+          error: {
+            message: `Run cannot be cancelled: status has already changed`,
+            code: "BAD_REQUEST",
+          },
+        },
+      };
+    }
 
     // Drain queue if cancelling a running/pending run freed a concurrency slot
     if (run.status === "running" || run.status === "pending") {

--- a/turbo/apps/web/app/api/cron/cleanup-sandboxes/route.ts
+++ b/turbo/apps/web/app/api/cron/cleanup-sandboxes/route.ts
@@ -2,6 +2,7 @@ import { createHandler, tsr } from "../../../../src/lib/ts-rest-handler";
 import { cronCleanupSandboxesContract, createErrorResponse } from "@vm0/core";
 import { initServices } from "../../../../src/lib/init-services";
 import { agentRuns } from "../../../../src/db/schema/agent-run";
+import { transitionRunStatus } from "../../../../src/lib/run/run-status";
 import {
   agentComposeVersions,
   agentComposes,
@@ -209,15 +210,21 @@ const router = tsr.router(cronCleanupSandboxesContract, {
               ? "Run timed out while pending (never started)"
               : "Run timed out (no heartbeat)";
 
-          // Update run status to timeout
-          await globalThis.services.db
-            .update(agentRuns)
-            .set({
+          // Update run status to timeout (only if still pending/running)
+          const transitioned = await transitionRunStatus(
+            run.id,
+            {
               status: "timeout",
               completedAt: new Date(),
               error: timeoutReason,
-            })
-            .where(eq(agentRuns.id, run.id));
+            },
+            ["pending", "running"],
+          );
+
+          if (!transitioned) {
+            log.debug(`Run ${run.id} already transitioned, skipping timeout`);
+            continue;
+          }
 
           const isDebug =
             run.composeName?.startsWith(DEBUG_COMPOSE_PREFIX) ?? false;

--- a/turbo/apps/web/app/api/runners/jobs/[id]/claim/route.ts
+++ b/turbo/apps/web/app/api/runners/jobs/[id]/claim/route.ts
@@ -110,7 +110,7 @@ const router = tsr.router(runnersJobClaimContract, {
       );
     }
 
-    // Update agent_runs status to running
+    // Update agent_runs status to running (only if still pending)
     const [run] = await globalThis.services.db
       .update(agentRuns)
       .set({
@@ -118,7 +118,7 @@ const router = tsr.router(runnersJobClaimContract, {
         startedAt: now,
         lastHeartbeatAt: now,
       })
-      .where(eq(agentRuns.id, runId))
+      .where(and(eq(agentRuns.id, runId), eq(agentRuns.status, "pending")))
       .returning();
 
     if (!run) {

--- a/turbo/apps/web/app/api/webhooks/agent/complete/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/complete/route.ts
@@ -8,7 +8,8 @@ import { initServices } from "../../../../../src/lib/init-services";
 import { agentRuns } from "../../../../../src/db/schema/agent-run";
 import { checkpoints } from "../../../../../src/db/schema/checkpoint";
 import { agentSessions } from "../../../../../src/db/schema/agent-session";
-import { eq, and, inArray } from "drizzle-orm";
+import { eq, and } from "drizzle-orm";
+import { transitionRunStatus } from "../../../../../src/lib/run/run-status";
 import { getSandboxAuthForRun } from "../../../../../src/lib/auth/get-sandbox-auth";
 import type {
   ArtifactSnapshot,
@@ -28,33 +29,6 @@ import {
 import { after } from "next/server";
 
 const log = logger("webhook:complete");
-
-/**
- * Atomically transition a run to a terminal status.
- * Uses WHERE status IN ('pending', 'running') to prevent double transitions.
- * Returns true if the transition was applied (this caller "won" the race).
- */
-async function atomicTransition(
-  runId: string,
-  update: {
-    status: "completed" | "failed";
-    completedAt: Date;
-    result?: RunResult;
-    error?: string;
-  },
-): Promise<boolean> {
-  const [updated] = await globalThis.services.db
-    .update(agentRuns)
-    .set(update)
-    .where(
-      and(
-        eq(agentRuns.id, runId),
-        inArray(agentRuns.status, ["pending", "running"]),
-      ),
-    )
-    .returning({ id: agentRuns.id });
-  return !!updated;
-}
 
 /**
  * Query Axiom for the last "result" event of a run.
@@ -224,11 +198,15 @@ const router = tsr.router(webhookCompleteContract, {
         .limit(1);
 
       if (!checkpoint) {
-        const transitioned = await atomicTransition(body.runId, {
-          status: "failed",
-          completedAt: new Date(),
-          error: "Checkpoint for run not found",
-        });
+        const transitioned = await transitionRunStatus(
+          body.runId,
+          {
+            status: "failed",
+            completedAt: new Date(),
+            error: "Checkpoint for run not found",
+          },
+          ["pending", "running"],
+        );
 
         // Dispatch callbacks so the user gets notified about the failure
         // (previously this path returned without dispatching)
@@ -262,11 +240,15 @@ const router = tsr.router(webhookCompleteContract, {
       const result = buildRunResult(checkpoint, session?.id);
 
       // Atomically transition to "completed" only if still pending/running
-      const transitioned = await atomicTransition(body.runId, {
-        status: "completed",
-        completedAt: new Date(),
-        result,
-      });
+      const transitioned = await transitionRunStatus(
+        body.runId,
+        {
+          status: "completed",
+          completedAt: new Date(),
+          result,
+        },
+        ["pending", "running"],
+      );
 
       if (!transitioned) {
         log.debug(
@@ -299,11 +281,15 @@ const router = tsr.router(webhookCompleteContract, {
       const errorMessage =
         body.error || `Agent exited with code ${body.exitCode}`;
 
-      const transitioned = await atomicTransition(body.runId, {
-        status: "failed",
-        completedAt: new Date(),
-        error: errorMessage,
-      });
+      const transitioned = await transitionRunStatus(
+        body.runId,
+        {
+          status: "failed",
+          completedAt: new Date(),
+          error: errorMessage,
+        },
+        ["pending", "running"],
+      );
 
       if (!transitioned) {
         log.debug(

--- a/turbo/apps/web/src/__tests__/api-test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers.ts
@@ -2814,6 +2814,21 @@ export async function markRunningRunsAsCompleted(userId: string) {
     );
 }
 
+export async function setTestRunStatus(
+  runId: string,
+  status: string,
+): Promise<void> {
+  await globalThis.services.db
+    .update(agentRuns)
+    .set({
+      status,
+      ...(["completed", "failed", "timeout", "cancelled"].includes(status)
+        ? { completedAt: new Date() }
+        : {}),
+    })
+    .where(eq(agentRuns.id, runId));
+}
+
 export async function expireQueueEntry(runId: string) {
   // Set expiresAt far enough in the past to avoid any timing issues in CI
   await globalThis.services.db

--- a/turbo/apps/web/src/lib/run/__tests__/run-queue-service.test.ts
+++ b/turbo/apps/web/src/lib/run/__tests__/run-queue-service.test.ts
@@ -10,6 +10,7 @@ import {
   findTestQueueEntry,
   markRunningRunsAsCompleted,
   expireQueueEntry,
+  setTestRunStatus,
 } from "../../../__tests__/api-test-helpers";
 import { reloadEnv } from "../../../env";
 import {
@@ -163,6 +164,27 @@ describe("run-queue-service", () => {
 
       const cleaned = await cleanupExpiredQueueEntries();
       expect(cleaned).toBe(0);
+    });
+
+    it("should skip runs that are no longer queued", async () => {
+      // Drain any pre-existing expired entries from other test suites
+      await cleanupExpiredQueueEntries();
+
+      const result = await enqueueRun(baseParams({ prompt: "Will expire" }));
+
+      // Simulate a concurrent completion: mark the run as completed
+      await setTestRunStatus(result.runId, "completed");
+
+      // Expire the queue entry
+      await expireQueueEntry(result.runId);
+
+      // Cleanup should delete the queue entry but NOT overwrite completed status
+      const cleaned = await cleanupExpiredQueueEntries();
+      expect(cleaned).toBe(1); // queue entry was deleted
+
+      // Run should still be completed (not timeout)
+      const run = await findTestRunRecord(result.runId);
+      expect(run!.status).toBe("completed");
     });
   });
 });

--- a/turbo/apps/web/src/lib/run/__tests__/run-status.test.ts
+++ b/turbo/apps/web/src/lib/run/__tests__/run-status.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  testContext,
+  uniqueId,
+  type UserContext,
+} from "../../../__tests__/test-helpers";
+import {
+  createTestCompose,
+  createTestRunInDb,
+  findTestRunRecord,
+} from "../../../__tests__/api-test-helpers";
+import { transitionRunStatus } from "../run-status";
+
+const context = testContext();
+
+describe("transitionRunStatus", () => {
+  let user: UserContext;
+  let composeId: string;
+
+  beforeEach(async () => {
+    context.setupMocks();
+    user = await context.setupUser();
+    const compose = await createTestCompose(uniqueId("agent"));
+    composeId = compose.composeId;
+  });
+
+  it("should transition from valid status", async () => {
+    const { runId } = await createTestRunInDb(user.userId, composeId, {
+      status: "pending",
+    });
+
+    const result = await transitionRunStatus(
+      runId,
+      { status: "completed", completedAt: new Date() },
+      ["pending", "running"],
+    );
+
+    expect(result).toBe(true);
+    const run = await findTestRunRecord(runId);
+    expect(run!.status).toBe("completed");
+  });
+
+  it("should reject transition from terminal status", async () => {
+    const { runId } = await createTestRunInDb(user.userId, composeId, {
+      status: "completed",
+    });
+
+    const result = await transitionRunStatus(
+      runId,
+      { status: "failed", error: "test", completedAt: new Date() },
+      ["pending", "running"],
+    );
+
+    expect(result).toBe(false);
+    const run = await findTestRunRecord(runId);
+    expect(run!.status).toBe("completed");
+  });
+
+  it("should reject transition when status not in allowed list", async () => {
+    const { runId } = await createTestRunInDb(user.userId, composeId, {
+      status: "running",
+    });
+
+    const result = await transitionRunStatus(
+      runId,
+      { status: "failed", error: "test", completedAt: new Date() },
+      ["queued"], // running not in allowed list
+    );
+
+    expect(result).toBe(false);
+    const run = await findTestRunRecord(runId);
+    expect(run!.status).toBe("running");
+  });
+
+  it("should ensure only one concurrent transition wins", async () => {
+    const { runId } = await createTestRunInDb(user.userId, composeId, {
+      status: "running",
+    });
+
+    const [result1, result2] = await Promise.all([
+      transitionRunStatus(
+        runId,
+        { status: "completed", completedAt: new Date() },
+        ["pending", "running"],
+      ),
+      transitionRunStatus(
+        runId,
+        { status: "failed", error: "test", completedAt: new Date() },
+        ["pending", "running"],
+      ),
+    ]);
+
+    // Exactly one should succeed
+    expect([result1, result2].filter(Boolean)).toHaveLength(1);
+
+    const run = await findTestRunRecord(runId);
+    expect(["completed", "failed"]).toContain(run!.status);
+  });
+});

--- a/turbo/apps/web/src/lib/run/run-queue-service.ts
+++ b/turbo/apps/web/src/lib/run/run-queue-service.ts
@@ -1,5 +1,6 @@
 import { eq, lt, and, or, count, gt, sql, inArray } from "drizzle-orm";
 import { agentRuns } from "../../db/schema/agent-run";
+import { transitionRunStatus } from "./run-status";
 import { agentRunQueue } from "../../db/schema/agent-run-queue";
 import { env } from "../../env";
 import { logger } from "../logger";
@@ -231,7 +232,7 @@ export async function cleanupExpiredQueueEntries(): Promise<number> {
 
   const runIds = deleted.map((e) => e.runId);
 
-  // Mark associated runs as timeout
+  // Mark associated runs as timeout (only if still queued)
   await globalThis.services.db
     .update(agentRuns)
     .set({
@@ -239,7 +240,7 @@ export async function cleanupExpiredQueueEntries(): Promise<number> {
       completedAt: now,
       error: "Queued run expired (exceeded queue TTL)",
     })
-    .where(inArray(agentRuns.id, runIds));
+    .where(and(inArray(agentRuns.id, runIds), eq(agentRuns.status, "queued")));
 
   log.debug(`Cleaned up ${deleted.length} expired queue entries`);
   return deleted.length;
@@ -317,12 +318,13 @@ async function markQueuedRunFailed(
   runId: string,
   errorMessage: string,
 ): Promise<void> {
-  await globalThis.services.db
-    .update(agentRuns)
-    .set({
+  await transitionRunStatus(
+    runId,
+    {
       status: "failed",
       error: errorMessage,
       completedAt: new Date(),
-    })
-    .where(eq(agentRuns.id, runId));
+    },
+    ["queued", "pending"],
+  );
 }

--- a/turbo/apps/web/src/lib/run/run-service.ts
+++ b/turbo/apps/web/src/lib/run/run-service.ts
@@ -2,6 +2,7 @@ import { eq, and, count, gt, or, sql } from "drizzle-orm";
 import { env } from "../../env";
 import { checkpoints } from "../../db/schema/checkpoint";
 import { agentRuns } from "../../db/schema/agent-run";
+import { transitionRunStatus } from "./run-status";
 import {
   agentComposeVersions,
   agentComposes,
@@ -484,14 +485,15 @@ async function markRunFailed(
   const errorMessage = error instanceof Error ? error.message : "Unknown error";
   log.error(`Run ${runId} failed: ${errorMessage}`);
 
-  await globalThis.services.db
-    .update(agentRuns)
-    .set({
+  await transitionRunStatus(
+    runId,
+    {
       status: "failed",
       error: errorMessage,
       completedAt: new Date(),
-    })
-    .where(eq(agentRuns.id, runId));
+    },
+    ["queued", "pending", "running"],
+  );
 
   // Attach run metadata so callers can return partial results
   if (error instanceof Error) {

--- a/turbo/apps/web/src/lib/run/run-status.ts
+++ b/turbo/apps/web/src/lib/run/run-status.ts
@@ -1,0 +1,37 @@
+import { and, eq, inArray } from "drizzle-orm";
+import { agentRuns } from "../../db/schema/agent-run";
+import type { RunResult } from "./types";
+import type { Database } from "../../types/global";
+
+/**
+ * Atomically transition a run to a new status.
+ * Only succeeds if the current status is in allowedFromStatuses.
+ * Returns true if the transition was applied, false if the run was
+ * already in a different status (lost the race).
+ */
+export async function transitionRunStatus(
+  runId: string,
+  update: {
+    status: string;
+    completedAt?: Date;
+    startedAt?: Date;
+    lastHeartbeatAt?: Date;
+    error?: string;
+    result?: RunResult;
+  },
+  allowedFromStatuses: string[],
+  db?: Database,
+): Promise<boolean> {
+  const queryDb = db ?? globalThis.services.db;
+  const [updated] = await queryDb
+    .update(agentRuns)
+    .set(update)
+    .where(
+      and(
+        eq(agentRuns.id, runId),
+        inArray(agentRuns.status, allowedFromStatuses),
+      ),
+    )
+    .returning({ id: agentRuns.id });
+  return !!updated;
+}

--- a/turbo/apps/web/src/lib/run/types.ts
+++ b/turbo/apps/web/src/lib/run/types.ts
@@ -10,7 +10,8 @@ export type RunStatus =
   | "running"
   | "completed"
   | "failed"
-  | "timeout";
+  | "timeout"
+  | "cancelled";
 
 /**
  * Run result stored in agent_runs.result when status = 'completed'

--- a/turbo/packages/core/src/contracts/runs.ts
+++ b/turbo/packages/core/src/contracts/runs.ts
@@ -14,6 +14,7 @@ export const ALL_RUN_STATUSES = [
   "completed",
   "failed",
   "timeout",
+  "cancelled",
 ] as const;
 
 /**


### PR DESCRIPTION
## Summary

- Extract `atomicTransition()` from completion webhook into shared `transitionRunStatus()` utility (`src/lib/run/run-status.ts`)
- Apply status guards (`WHERE status IN (...)`) to all 6 previously unguarded run status update sites
- Make cancel handler's queue delete + status update atomic via `db.transaction()`
- Add `cancelled` to `RunStatus` type union (was used but missing from type definition)

## Changes

| File | Change |
|------|--------|
| `src/lib/run/run-status.ts` | **New**: shared `transitionRunStatus()` utility |
| `src/lib/run/types.ts` | Add "cancelled" to RunStatus |
| `app/api/webhooks/agent/complete/route.ts` | Use shared utility (no behavior change) |
| `src/lib/run/run-service.ts` | Guard `markRunFailed()` with `["queued", "pending", "running"]` |
| `src/lib/run/run-queue-service.ts` | Guard `markQueuedRunFailed()` and `cleanupExpiredQueueEntries()` |
| `app/api/cron/cleanup-sandboxes/route.ts` | Guard timeout update with `["pending", "running"]` |
| `app/api/agent/runs/[id]/cancel/route.ts` | Wrap in transaction + guard with `["queued", "pending", "running"]` |
| `app/api/runners/jobs/[id]/claim/route.ts` | Guard claim with `status = 'pending'` |

## Test plan

- [x] All 21 existing completion webhook tests pass unchanged
- [x] All 39 existing create-run tests pass unchanged
- [x] All 7 existing queue service tests pass unchanged
- [x] All 7 existing cancel handler tests pass unchanged
- [x] New: `transitionRunStatus` utility tests (4 tests) — valid transition, terminal rejection, wrong status rejection, concurrent race
- [x] New: `cleanupExpiredQueueEntries` skips non-queued runs (status guard test)
- [x] New: cancel handler rejects when run status changed concurrently
- [x] Lint: 0 errors, 0 warnings
- [x] Knip: no unused exports

Fixes #4823
Fixes #4772
Fixes #4773

🤖 Generated with [Claude Code](https://claude.com/claude-code)