### PR TITLE
fix(guest-agent): add watchdog to kill cli when stuck on network tools

### DIFF
--- a/crates/guest-agent/src/cli.rs
+++ b/crates/guest-agent/src/cli.rs
@@ -7,7 +7,9 @@ use crate::masker::SecretMasker;
 use crate::paths;
 use guest_common::telemetry::record_sandbox_op;
 use guest_common::{log_error, log_info, log_warn};
+use std::collections::HashMap;
 use std::process::Stdio;
+use std::time::{Duration, Instant};
 use tokio::io::AsyncBufReadExt;
 use tokio::io::AsyncWriteExt;
 
@@ -225,6 +227,21 @@ pub async fn execute_cli(
 
     let mut cli_status: Option<std::process::ExitStatus> = None;
 
+    // Stuck-tool watchdog: workaround for Claude Code bug where
+    // WebSearch/WebFetch hang indefinitely. Track all in-flight tool calls;
+    // if a network tool exceeds STUCK_TOOL_TIMEOUT_SECS without producing
+    // a tool_result, kill the process. Keyed by tool_use_id to handle
+    // parallel tool calls correctly.
+    // See: https://github.com/anthropics/claude-code/issues/11650
+    let mut stuck_tool_tracker: HashMap<String, (String, Instant)> = HashMap::new();
+    let stuck_tool_interval = Duration::from_secs(crate::constants::STUCK_TOOL_CHECK_INTERVAL_SECS);
+    let mut stuck_tool_check = tokio::time::interval_at(
+        tokio::time::Instant::now() + stuck_tool_interval,
+        stuck_tool_interval,
+    );
+    // MAINTENANCE: update if Claude Code adds new network tools that can hang.
+    const STUCK_TOOL_NAMES: &[&str] = &["WebSearch", "WebFetch"];
+
     // Background event sender: HTTP POSTs happen here, never in the
     // stdout reading loop.  Unbounded channel because events are small
     // and CLI lifetime is bounded by JOB_TIMEOUT.
@@ -262,6 +279,17 @@ pub async fn execute_cli(
                             {
                                 println!("{result}");
                             }
+                            // Extract tool info BEFORE masking (masker may replace tool names)
+                            for tool_event in events::extract_claude_tool_info(&event) {
+                                match tool_event {
+                                    events::ClaudeToolEvent::Use { id, name } => {
+                                        stuck_tool_tracker.insert(id.to_string(), (name.to_string(), Instant::now()));
+                                    }
+                                    events::ClaudeToolEvent::Result { tool_use_id } => {
+                                        stuck_tool_tracker.remove(tool_use_id);
+                                    }
+                                }
+                            }
                             // Prepare event (fast: mask secrets, add seq) and enqueue
                             // for background sending.  Never blocks the reading loop.
                             if let Some(payload) = events::prepare_event(&mut event, seq, masker)
@@ -283,6 +311,30 @@ pub async fn execute_cli(
                         cli_status = Some(s);
                     }
                     Err(e) => break Err(AgentError::Io(e)),
+                }
+            }
+            _ = stuck_tool_check.tick() => {
+                let timeout_secs = env::stuck_tool_timeout_secs();
+                // Find the oldest network tool that has exceeded the timeout.
+                let stuck = stuck_tool_tracker
+                    .values()
+                    .filter(|(name, started)| {
+                        started.elapsed().as_secs() >= timeout_secs
+                            && STUCK_TOOL_NAMES.contains(&name.as_str())
+                    })
+                    .min_by_key(|(_, started)| *started)
+                    .map(|(name, started)| (name.clone(), started.elapsed().as_secs()));
+                if let Some((name, elapsed)) = stuck {
+                    log_warn!(
+                        LOG_TAG,
+                        "Tool timeout: {name} stuck for {elapsed}s, killing process"
+                    );
+                    if let Some(pid) = pgid {
+                        unsafe { libc::kill(-pid, libc::SIGTERM); }
+                    }
+                    break Err(AgentError::Execution(format!(
+                        "Tool timeout: {name} exceeded {timeout_secs}s without returning a result"
+                    )));
                 }
             }
             hb_result = &mut heartbeat_handle => {

--- a/crates/guest-agent/src/constants.rs
+++ b/crates/guest-agent/src/constants.rs
@@ -24,3 +24,12 @@ pub const HTTP_TIMEOUT_SECS: u64 = 30;
 
 /// HTTP request timeout for uploads in seconds.
 pub const HTTP_UPLOAD_TIMEOUT_SECS: u64 = 60;
+
+/// Workaround for Claude Code bug where WebSearch/WebFetch hang indefinitely.
+/// Kill the CLI process if a network tool hasn't returned a result within
+/// this duration.  Override with `VM0_STUCK_TOOL_TIMEOUT_SECS` env var.
+/// See: https://github.com/anthropics/claude-code/issues/11650
+pub const STUCK_TOOL_TIMEOUT_SECS: u64 = 60;
+
+/// How often (in seconds) to check for stuck tools in the select loop.
+pub const STUCK_TOOL_CHECK_INTERVAL_SECS: u64 = 5;

--- a/crates/guest-agent/src/env.rs
+++ b/crates/guest-agent/src/env.rs
@@ -34,6 +34,23 @@ static USE_MOCK_CLAUDE: LazyLock<bool> = LazyLock::new(|| {
         .map(|v| v == "true")
         .unwrap_or(false)
 });
+/// Workaround for Claude Code bug: WebSearch/WebFetch can hang indefinitely.
+/// See: https://github.com/anthropics/claude-code/issues/11650
+static STUCK_TOOL_TIMEOUT: LazyLock<u64> = LazyLock::new(|| {
+    match std::env::var("VM0_STUCK_TOOL_TIMEOUT_SECS") {
+        Ok(v) => match v.parse() {
+            Ok(secs) => secs,
+            Err(_) => {
+                eprintln!(
+                    "[WARN] VM0_STUCK_TOOL_TIMEOUT_SECS={v:?} is not a valid u64, using default {}s",
+                    crate::constants::STUCK_TOOL_TIMEOUT_SECS
+                );
+                crate::constants::STUCK_TOOL_TIMEOUT_SECS
+            }
+        },
+        Err(_) => crate::constants::STUCK_TOOL_TIMEOUT_SECS,
+    }
+});
 
 // ---------------------------------------------------------------------------
 // Artifact
@@ -111,6 +128,9 @@ pub fn memory_mount_path() -> &'static str {
 }
 pub fn memory_name() -> &'static str {
     &MEMORY_NAME
+}
+pub fn stuck_tool_timeout_secs() -> u64 {
+    *STUCK_TOOL_TIMEOUT
 }
 /// Whether a backend API is available (token set).
 ///

--- a/crates/guest-agent/src/events.rs
+++ b/crates/guest-agent/src/events.rs
@@ -77,6 +77,54 @@ pub async fn post_event(payload: &Value) -> Result<(), AgentError> {
     }
 }
 
+/// Tool event extracted from a Claude Code JSONL line.
+#[derive(Debug, PartialEq)]
+pub(crate) enum ClaudeToolEvent<'a> {
+    /// Tool invocation: `(tool_use_id, tool_name)`.
+    Use { id: &'a str, name: &'a str },
+    /// Tool result: `(tool_use_id)`.
+    Result { tool_use_id: &'a str },
+}
+
+/// Extract tool call info from a Claude Code JSONL event.
+///
+/// Iterates all content blocks (handles `[text, tool_use]` and parallel
+/// `[tool_use, tool_use]` patterns).  Returns an empty vec for non-tool
+/// events or non-Claude-Code formats (e.g. Codex).
+pub(crate) fn extract_claude_tool_info(event: &Value) -> Vec<ClaudeToolEvent<'_>> {
+    let Some(contents) = event
+        .get("message")
+        .and_then(|m| m.get("content"))
+        .and_then(|c| c.as_array())
+    else {
+        return Vec::new();
+    };
+
+    let mut results = Vec::new();
+    for content in contents {
+        let Some(content_type) = content.get("type").and_then(|v| v.as_str()) else {
+            continue;
+        };
+        match content_type {
+            "tool_use" => {
+                if let (Some(id), Some(name)) = (
+                    content.get("id").and_then(|v| v.as_str()),
+                    content.get("name").and_then(|v| v.as_str()),
+                ) {
+                    results.push(ClaudeToolEvent::Use { id, name });
+                }
+            }
+            "tool_result" => {
+                if let Some(tool_use_id) = content.get("tool_use_id").and_then(|v| v.as_str()) {
+                    results.push(ClaudeToolEvent::Result { tool_use_id });
+                }
+            }
+            _ => {}
+        }
+    }
+    results
+}
+
 /// If this is an init event, extract session ID and write temp files.
 fn extract_session_id(event: &Value) {
     let event_type = event.get("type").and_then(|v| v.as_str()).unwrap_or("");
@@ -126,4 +174,153 @@ fn extract_session_id(event: &Value) {
 
     let _ = std::fs::write(paths::session_history_path_file(), &history_path);
     log_info!(LOG_TAG, "Session history will be at: {history_path}");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extract_tool_use() {
+        let event = serde_json::json!({
+            "type": "assistant",
+            "message": {
+                "content": [{"type": "tool_use", "id": "t1", "name": "WebFetch", "input": {}}]
+            }
+        });
+        assert_eq!(
+            extract_claude_tool_info(&event),
+            vec![ClaudeToolEvent::Use {
+                id: "t1",
+                name: "WebFetch"
+            }]
+        );
+    }
+
+    #[test]
+    fn extract_tool_result() {
+        let event = serde_json::json!({
+            "type": "user",
+            "message": {
+                "content": [{"type": "tool_result", "tool_use_id": "t1", "content": "ok"}]
+            }
+        });
+        assert_eq!(
+            extract_claude_tool_info(&event),
+            vec![ClaudeToolEvent::Result { tool_use_id: "t1" }]
+        );
+    }
+
+    #[test]
+    fn extract_text_then_tool_use() {
+        let event = serde_json::json!({
+            "type": "assistant",
+            "message": {
+                "content": [
+                    {"type": "text", "text": "Let me search..."},
+                    {"type": "tool_use", "id": "t2", "name": "WebSearch", "input": {}}
+                ]
+            }
+        });
+        assert_eq!(
+            extract_claude_tool_info(&event),
+            vec![ClaudeToolEvent::Use {
+                id: "t2",
+                name: "WebSearch"
+            }]
+        );
+    }
+
+    #[test]
+    fn extract_parallel_tool_uses() {
+        let event = serde_json::json!({
+            "type": "assistant",
+            "message": {
+                "content": [
+                    {"type": "tool_use", "id": "t1", "name": "WebFetch", "input": {}},
+                    {"type": "tool_use", "id": "t2", "name": "WebSearch", "input": {}}
+                ]
+            }
+        });
+        assert_eq!(
+            extract_claude_tool_info(&event),
+            vec![
+                ClaudeToolEvent::Use {
+                    id: "t1",
+                    name: "WebFetch"
+                },
+                ClaudeToolEvent::Use {
+                    id: "t2",
+                    name: "WebSearch"
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn extract_tool_use_missing_id_skipped() {
+        let event = serde_json::json!({
+            "type": "assistant",
+            "message": {
+                "content": [{"type": "tool_use", "name": "WebFetch", "input": {}}]
+            }
+        });
+        assert!(extract_claude_tool_info(&event).is_empty());
+    }
+
+    #[test]
+    fn extract_tool_result_missing_id_skipped() {
+        let event = serde_json::json!({
+            "type": "user",
+            "message": {
+                "content": [{"type": "tool_result", "content": "ok"}]
+            }
+        });
+        assert!(extract_claude_tool_info(&event).is_empty());
+    }
+
+    #[test]
+    fn extract_text_event_returns_empty() {
+        let event = serde_json::json!({
+            "type": "assistant",
+            "message": {
+                "content": [{"type": "text", "text": "hello"}]
+            }
+        });
+        assert!(extract_claude_tool_info(&event).is_empty());
+    }
+
+    #[test]
+    fn extract_non_network_tool_still_parsed() {
+        // Non-network tools (Bash, Read, etc.) ARE parsed by extract_claude_tool_info.
+        // Filtering by STUCK_TOOL_NAMES happens in the caller (cli.rs watchdog).
+        let event = serde_json::json!({
+            "type": "assistant",
+            "message": {
+                "content": [{"type": "tool_use", "id": "t1", "name": "Bash", "input": {"command": "sleep 999"}}]
+            }
+        });
+        assert_eq!(
+            extract_claude_tool_info(&event),
+            vec![ClaudeToolEvent::Use {
+                id: "t1",
+                name: "Bash"
+            }]
+        );
+    }
+
+    #[test]
+    fn extract_init_event_returns_empty() {
+        let event = serde_json::json!({"type": "system", "subtype": "init"});
+        assert!(extract_claude_tool_info(&event).is_empty());
+    }
+
+    #[test]
+    fn extract_empty_content_returns_empty() {
+        let event = serde_json::json!({
+            "type": "assistant",
+            "message": {"content": []}
+        });
+        assert!(extract_claude_tool_info(&event).is_empty());
+    }
 }

--- a/crates/guest-mock-claude/src/main.rs
+++ b/crates/guest-mock-claude/src/main.rs
@@ -233,6 +233,55 @@ fn main() -> ExitCode {
         return ExitCode::from(1);
     }
 
+    // Special test prefix: @stuck-tool — emit tool_use for WebFetch then hang
+    if parsed.prompt.starts_with("@stuck-tool") {
+        if parsed.output_format == "stream-json" {
+            let session_id = generate_session_id();
+            let cwd = std::env::current_dir()
+                .map(|p| p.to_string_lossy().into_owned())
+                .unwrap_or_else(|_| "/".to_string());
+
+            // Init event
+            println!(
+                "{}",
+                json!({
+                    "type": "system",
+                    "subtype": "init",
+                    "cwd": cwd,
+                    "session_id": session_id,
+                    "tools": ["WebFetch"],
+                    "model": "mock-claude"
+                })
+            );
+
+            // Tool use event — WebFetch that never completes
+            println!(
+                "{}",
+                json!({
+                    "type": "assistant",
+                    "session_id": session_id,
+                    "message": {
+                        "role": "assistant",
+                        "content": [{
+                            "type": "tool_use",
+                            "id": "toolu_stuck_001",
+                            "name": "WebFetch",
+                            "input": {"url": "https://example.com/hang"}
+                        }]
+                    }
+                })
+            );
+
+            // Flush stdout so guest-agent receives the events before we hang.
+            // When piped, stdout is fully buffered and println! may not flush.
+            let _ = std::io::stdout().flush();
+
+            // Hang forever — simulates a stuck WebFetch
+            std::thread::sleep(std::time::Duration::from_secs(3600));
+        }
+        return ExitCode::from(1);
+    }
+
     let session_id = generate_session_id();
 
     if parsed.output_format == "stream-json" {

--- a/e2e/tests/03-experimental-runner/t43-stuck-tool-watchdog.bats
+++ b/e2e/tests/03-experimental-runner/t43-stuck-tool-watchdog.bats
@@ -1,0 +1,68 @@
+#!/usr/bin/env bats
+
+# Test stuck-tool watchdog: guest-agent kills CLI when WebFetch hangs.
+# Uses @stuck-tool mock-claude mode + short timeout (3s) for fast testing.
+#
+# Workaround for Claude Code bug:
+# https://github.com/anthropics/claude-code/issues/11650
+
+load '../../helpers/setup'
+
+setup() {
+    export TEST_DIR="$(mktemp -d)"
+    export UNIQUE_ID="$(date +%s%3N)-$RANDOM"
+    export AGENT_NAME="e2e-stuck-tool-${UNIQUE_ID}"
+}
+
+teardown() {
+    if [ -n "$TEST_DIR" ] && [ -d "$TEST_DIR" ]; then
+        rm -rf "$TEST_DIR"
+    fi
+}
+
+@test "stuck-tool watchdog kills agent when WebFetch hangs" {
+    if $CLI_COMMAND auth status 2>&1 | grep -q "Not authenticated"; then
+        skip "Not authenticated"
+    fi
+
+    cd "$TEST_DIR"
+
+    cat > vm0.yaml <<EOF
+version: "1.0"
+
+agents:
+  $AGENT_NAME:
+    description: "Stuck tool watchdog test"
+    framework: claude-code
+    working_dir: /home/user/workspace
+    environment:
+      VM0_STUCK_TOOL_TIMEOUT_SECS: "3"
+EOF
+
+    echo "# Step 1: Compose agent..."
+    run $CLI_COMMAND compose vm0.yaml
+    assert_success
+
+    echo "# Step 2: Run with @stuck-tool prompt and 3s timeout..."
+    # VM0_STUCK_TOOL_TIMEOUT_SECS=3 makes the watchdog trigger in ~3-8s
+    # instead of 60s, keeping the test fast.
+    run timeout 60 $CLI_COMMAND run "$AGENT_NAME" --no-auto-update "@stuck-tool"
+
+    echo "# Step 3: Verify run failed..."
+    assert_failure
+    assert_output --partial "Run failed"
+
+    # Extract Run ID to check system logs for the tool timeout message
+    RUN_ID=$(echo "$output" | grep -oP 'Run ID:\s+\K[a-f0-9-]{36}' | head -1)
+    [ -n "$RUN_ID" ] || {
+        echo "# Failed to extract Run ID from output"
+        echo "$output"
+        return 1
+    }
+
+    echo "# Step 4: Verify system logs contain tool timeout error..."
+    run $CLI_COMMAND logs "$RUN_ID" --system
+    assert_success
+    assert_output --partial "Tool timeout"
+    assert_output --partial "WebFetch"
+}


### PR DESCRIPTION
## Summary

- Add tool-call timeout detection to guest-agent's `tokio::select!` loop
- When Claude Code is stuck on `WebSearch`/`WebFetch` for >= 60s without a `tool_result`, SIGTERM the process group
- Track all in-flight tools via `HashMap<tool_use_id, (name, started_at)>` to handle parallel tool calls correctly

## Changes

| File | Change |
|------|--------|
| `guest-agent/src/constants.rs` | `TOOL_TIMEOUT_SECS` (60s), `TOOL_CHECK_INTERVAL_SECS` (5s) |
| `guest-agent/src/events.rs` | `ClaudeToolEvent` enum + `extract_claude_tool_info()` + 7 unit tests |
| `guest-agent/src/cli.rs` | Tool state tracking + watchdog timer branch in `select!` |
| `guest-mock-claude/src/main.rs` | `@stuck-tool` test mode (emit tool_use then hang) |

## Test plan

- [x] 7 unit tests for `extract_claude_tool_info` (tool_use, tool_result, missing ids, text, init, empty)
- [x] All 49 existing tests pass (28 unit + 21 integration)
- [x] `cargo clippy --all-targets` clean
- [ ] Manual test with `@stuck-tool` mock in staging sandbox

Closes #4785

🤖 Generated with [Claude Code](https://claude.com/claude-code)