### PR TITLE
feat: server-side instruction upload utility for direct S3 write

### DIFF
--- a/turbo/apps/web/src/lib/storage/__tests__/instruction-upload.test.ts
+++ b/turbo/apps/web/src/lib/storage/__tests__/instruction-upload.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { gunzipSync } from "node:zlib";
+import { testContext } from "../../../__tests__/test-helpers";
+import { uploadInstructionsServerSide } from "../instruction-upload";
+import { extractFileFromTar } from "../../tar";
+
+vi.hoisted(() => {
+  vi.stubEnv("R2_USER_STORAGES_BUCKET_NAME", "test-storages-bucket");
+});
+
+const context = testContext();
+
+describe("uploadInstructionsServerSide", () => {
+  let orgId: string;
+
+  beforeEach(async () => {
+    context.setupMocks();
+    const user = await context.setupUser();
+    orgId = user.orgId;
+  });
+
+  it("should upload new instructions and return correct result", async () => {
+    const result = await uploadInstructionsServerSide({
+      orgId,
+      agentName: "my-agent",
+      content: "# Instructions\nDo the thing.",
+    });
+
+    expect(result.storageName).toBe("agent-instructions@my-agent");
+    expect(result.versionId).toMatch(/^[a-f0-9]{64}$/);
+
+    // Verify putS3Object called twice (archive + manifest)
+    expect(context.mocks.s3.putS3Object).toHaveBeenCalledTimes(2);
+
+    // Verify archive upload
+    const archiveCall = context.mocks.s3.putS3Object.mock.calls.find(
+      (c) => typeof c[1] === "string" && c[1].endsWith("/archive.tar.gz"),
+    );
+    expect(archiveCall).toBeDefined();
+    expect(archiveCall![2]).toBeInstanceOf(Buffer);
+    expect(archiveCall![3]).toBe("application/gzip");
+
+    // Verify manifest upload
+    const manifestCall = context.mocks.s3.putS3Object.mock.calls.find(
+      (c) => typeof c[1] === "string" && c[1].endsWith("/manifest.json"),
+    );
+    expect(manifestCall).toBeDefined();
+    expect(manifestCall![3]).toBe("application/json");
+
+    // Verify manifest content
+    const manifestBody = JSON.parse(manifestCall![2] as string);
+    expect(manifestBody.version).toBe(result.versionId);
+    expect(manifestBody.fileCount).toBe(1);
+    expect(manifestBody.files).toHaveLength(1);
+    expect(manifestBody.files[0].path).toBe("CLAUDE.md");
+    expect(manifestBody.files[0].hash).toMatch(/^[a-f0-9]{64}$/);
+    expect(manifestBody.files[0].size).toBeGreaterThan(0);
+  });
+
+  it("should inject metadata frontmatter into archive", async () => {
+    const result = await uploadInstructionsServerSide({
+      orgId,
+      agentName: "meta-agent",
+      content: "# Instructions",
+      metadata: { displayName: "Test Agent" },
+    });
+
+    expect(result.storageName).toBe("agent-instructions@meta-agent");
+
+    // Extract the archive content and verify metadata
+    const archiveCall = context.mocks.s3.putS3Object.mock.calls.find(
+      (c) => typeof c[1] === "string" && c[1].endsWith("/archive.tar.gz"),
+    );
+    expect(archiveCall).toBeDefined();
+
+    const archiveBuffer = archiveCall![2] as Buffer;
+    const tarBuffer = gunzipSync(archiveBuffer);
+    const fileContent = extractFileFromTar(tarBuffer, "CLAUDE.md");
+    expect(fileContent).not.toBeNull();
+
+    const text = fileContent!.toString("utf-8");
+    expect(text).toContain("ZERO_PROFILE");
+    expect(text).toContain("Test Agent");
+  });
+
+  it("should use AGENTS.md for codex framework", async () => {
+    await uploadInstructionsServerSide({
+      orgId,
+      agentName: "codex-agent",
+      content: "# Codex Instructions",
+      framework: "codex",
+    });
+
+    // Verify manifest has AGENTS.md
+    const manifestCall = context.mocks.s3.putS3Object.mock.calls.find(
+      (c) => typeof c[1] === "string" && c[1].endsWith("/manifest.json"),
+    );
+    const manifestBody = JSON.parse(manifestCall![2] as string);
+    expect(manifestBody.files[0].path).toBe("AGENTS.md");
+
+    // Verify archive contains AGENTS.md
+    const archiveCall = context.mocks.s3.putS3Object.mock.calls.find(
+      (c) => typeof c[1] === "string" && c[1].endsWith("/archive.tar.gz"),
+    );
+    const tarBuffer = gunzipSync(archiveCall![2] as Buffer);
+    const fileContent = extractFileFromTar(tarBuffer, "AGENTS.md");
+    expect(fileContent).not.toBeNull();
+    expect(fileContent!.toString("utf-8")).toBe("# Codex Instructions");
+  });
+
+  it("should deduplicate when same content is uploaded twice", async () => {
+    const params = {
+      orgId,
+      agentName: "dedup-agent",
+      content: "# Same content",
+    };
+
+    // First upload — creates new version
+    const result1 = await uploadInstructionsServerSide(params);
+    expect(context.mocks.s3.putS3Object).toHaveBeenCalledTimes(2);
+
+    // Mock verifyS3FilesExist to return true (S3 files exist from first upload)
+    context.mocks.s3.verifyS3FilesExist.mockResolvedValue(true);
+
+    // Second upload with same content — should skip S3 upload
+    const result2 = await uploadInstructionsServerSide(params);
+
+    expect(result2.versionId).toBe(result1.versionId);
+    expect(result2.storageName).toBe(result1.storageName);
+
+    // putS3Object should NOT have been called again (still 2 from first upload)
+    expect(context.mocks.s3.putS3Object).toHaveBeenCalledTimes(2);
+  });
+
+  it("should return different versionId for different content", async () => {
+    const resultA = await uploadInstructionsServerSide({
+      orgId,
+      agentName: "version-agent",
+      content: "# Content A",
+    });
+
+    const resultB = await uploadInstructionsServerSide({
+      orgId,
+      agentName: "version-agent",
+      content: "# Content B",
+    });
+
+    // Different content produces different version IDs
+    expect(resultB.versionId).not.toBe(resultA.versionId);
+    // Same storage name since same agent
+    expect(resultB.storageName).toBe(resultA.storageName);
+    // putS3Object called 4 times total (2 per upload)
+    expect(context.mocks.s3.putS3Object).toHaveBeenCalledTimes(4);
+  });
+});

--- a/turbo/apps/web/src/lib/storage/__tests__/instruction-upload.test.ts
+++ b/turbo/apps/web/src/lib/storage/__tests__/instruction-upload.test.ts
@@ -115,14 +115,15 @@ describe("uploadInstructionsServerSide", () => {
       content: "# Same content",
     };
 
-    // First upload — creates new version
+    // First upload — no existing version in DB, so verifyS3FilesExist is never
+    // reached. Set it to false to make the mock state explicit.
+    context.mocks.s3.verifyS3FilesExist.mockResolvedValue(false);
     const result1 = await uploadInstructionsServerSide(params);
     expect(context.mocks.s3.putS3Object).toHaveBeenCalledTimes(2);
 
-    // Mock verifyS3FilesExist to return true (S3 files exist from first upload)
+    // Second upload — existing version found in DB, verifyS3FilesExist is
+    // called and returns true so the S3 upload is skipped (dedup).
     context.mocks.s3.verifyS3FilesExist.mockResolvedValue(true);
-
-    // Second upload with same content — should skip S3 upload
     const result2 = await uploadInstructionsServerSide(params);
 
     expect(result2.versionId).toBe(result1.versionId);

--- a/turbo/apps/web/src/lib/storage/instruction-upload.ts
+++ b/turbo/apps/web/src/lib/storage/instruction-upload.ts
@@ -1,0 +1,180 @@
+import { gzipSync } from "node:zlib";
+import { eq, and } from "drizzle-orm";
+import {
+  getInstructionsFilename,
+  getInstructionsStorageName,
+  injectMetadataFrontmatter,
+  VOLUME_ORG_USER_ID,
+} from "@vm0/core";
+import { storages, storageVersions } from "../../db/schema/storage";
+import { putS3Object, verifyS3FilesExist } from "../s3/s3-client";
+import type { S3StorageManifest } from "../s3/types";
+import { computeContentHashFromHashes, hashFileContent } from "./content-hash";
+import { createSingleFileTar } from "../tar";
+import { env } from "../../env";
+import { getOrgData } from "../org/org-cache-service";
+import { logger } from "../logger";
+
+const log = logger("storage:instruction-upload");
+
+/**
+ * Upload instructions directly to S3 from the server side.
+ *
+ * Bypasses the CLI's prepare → presigned URL → commit flow by writing
+ * archive.tar.gz and manifest.json directly via putS3Object().
+ * Used by server-side compose to upload instructions without a sandbox.
+ */
+export async function uploadInstructionsServerSide(params: {
+  orgId: string;
+  agentName: string;
+  content: string;
+  framework?: string;
+  metadata?: { displayName?: string; sound?: string };
+}): Promise<{ storageName: string; versionId: string }> {
+  const { orgId, agentName, content, framework, metadata } = params;
+
+  // 1. Resolve org slug for S3 prefix
+  const orgData = await getOrgData(orgId);
+  const orgSlug = orgData.slug;
+
+  // 2. Determine filename and storage name
+  const filename = getInstructionsFilename(framework);
+  const storageName = getInstructionsStorageName(agentName.toLowerCase());
+
+  // 3. Inject metadata frontmatter
+  const processedContent = injectMetadataFrontmatter(content, metadata);
+
+  // 4. Create tar.gz archive
+  const contentBuffer = Buffer.from(processedContent, "utf-8");
+  const tarBuffer = createSingleFileTar(filename, contentBuffer);
+  const archiveBuffer = gzipSync(tarBuffer);
+
+  // 5. Compute file hash and content hash
+  const fileHash = hashFileContent(contentBuffer);
+  const fileSize = contentBuffer.length;
+  const fileEntry = { path: filename, hash: fileHash, size: fileSize };
+
+  // 6. Upsert storage record
+  const db = globalThis.services.db;
+  const storageType = "volume";
+  const s3Prefix = `${orgSlug}/${storageType}/${storageName}`;
+
+  const [storage] = await db
+    .insert(storages)
+    .values({
+      userId: VOLUME_ORG_USER_ID,
+      orgId,
+      name: storageName,
+      type: storageType,
+      s3Prefix,
+      size: 0,
+      fileCount: 0,
+    })
+    .onConflictDoUpdate({
+      target: [storages.orgId, storages.userId, storages.name, storages.type],
+      set: { updatedAt: new Date() },
+    })
+    .returning();
+
+  if (!storage) {
+    throw new Error(`Failed to create storage for ${storageName}`);
+  }
+
+  // 7. Compute version ID
+  const versionId = computeContentHashFromHashes(storage.id, [fileEntry]);
+  const s3Key = `${s3Prefix}/${versionId}`;
+  const bucketName = env().R2_USER_STORAGES_BUCKET_NAME;
+
+  // 8. Check for existing version (dedup)
+  const [existingVersion] = await db
+    .select()
+    .from(storageVersions)
+    .where(
+      and(
+        eq(storageVersions.storageId, storage.id),
+        eq(storageVersions.id, versionId),
+      ),
+    )
+    .limit(1);
+
+  if (existingVersion) {
+    const s3Exists = await verifyS3FilesExist(
+      bucketName,
+      existingVersion.s3Key,
+      existingVersion.fileCount,
+    );
+
+    if (s3Exists) {
+      log.debug(`Version ${versionId} already exists, updating HEAD`);
+      if (storage.headVersionId !== versionId) {
+        await db
+          .update(storages)
+          .set({ headVersionId: versionId, updatedAt: new Date() })
+          .where(eq(storages.id, storage.id));
+      }
+      return { storageName, versionId };
+    }
+    log.warn(`Version ${versionId} in DB but S3 files missing, re-uploading`);
+  }
+
+  // 9. Upload to S3
+  const manifestKey = `${s3Key}/manifest.json`;
+  const archiveKey = `${s3Key}/archive.tar.gz`;
+
+  const manifest: S3StorageManifest = {
+    version: versionId,
+    createdAt: new Date().toISOString(),
+    totalSize: fileSize,
+    fileCount: 1,
+    files: [fileEntry],
+  };
+
+  await Promise.all([
+    putS3Object(bucketName, archiveKey, archiveBuffer, "application/gzip"),
+    putS3Object(
+      bucketName,
+      manifestKey,
+      JSON.stringify(manifest),
+      "application/json",
+    ),
+  ]);
+
+  // 10. Create version + update HEAD in transaction
+  await db.transaction(async (tx) => {
+    await tx
+      .insert(storageVersions)
+      .values({
+        id: versionId,
+        storageId: storage.id,
+        s3Key,
+        size: fileSize,
+        fileCount: 1,
+        message: null,
+        createdBy: "user",
+      })
+      .onConflictDoNothing();
+
+    const [version] = await tx
+      .select({ id: storageVersions.id })
+      .from(storageVersions)
+      .where(eq(storageVersions.id, versionId))
+      .limit(1);
+
+    if (!version) {
+      throw new Error(`Version ${versionId} not found after insert`);
+    }
+
+    await tx
+      .update(storages)
+      .set({
+        headVersionId: versionId,
+        size: fileSize,
+        fileCount: 1,
+        updatedAt: new Date(),
+      })
+      .where(eq(storages.id, storage.id));
+  });
+
+  log.debug(`Uploaded instructions for ${agentName}: ${versionId}`);
+  return { storageName, versionId };
+}


### PR DESCRIPTION
## Summary

- Add `uploadInstructionsServerSide()` function that uploads instructions directly to S3 from the web server, bypassing the CLI's prepare → presigned URL → commit flow
- Enables server-side compose to handle instruction upload without needing an E2B sandbox
- Uses existing `createSingleFileTar()` for in-memory tar.gz creation and `putS3Object()` for direct S3 upload
- Implements content-addressed deduplication (same content → skip S3 upload)

## Test plan

- [x] Happy path: upload new instructions, verify S3 calls and return value
- [x] Metadata injection: verify `<!-- ZERO_PROFILE -->` block is injected into archive
- [x] Framework selection: verify CLAUDE.md (default) vs AGENTS.md (codex)
- [x] Content-addressed dedup: same content uploaded twice skips S3 on second call
- [x] Different content: produces different versionId for same agent

Closes #4835

🤖 Generated with [Claude Code](https://claude.com/claude-code)