### PR TITLE
feat: server-side compose for platform mode — bypass E2B sandbox

### DIFF
--- a/turbo/apps/web/app/api/compose/jobs/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/compose/jobs/__tests__/route.test.ts
@@ -718,7 +718,8 @@ describe("Platform session auth (no CLI token)", () => {
     expect(response.status).toBe(201);
     const data = await response.json();
     expect(data.jobId).toBeDefined();
-    expect(data.status).toBe("pending");
+    // Server-side compose completes synchronously when no skills need caching
+    expect(data.status).toBe("completed");
     expect(data.source).toBe("platform");
   });
 
@@ -798,13 +799,27 @@ describe("Platform session auth (no CLI token)", () => {
   it("should complete full lifecycle: session auth → webhook → poll", async () => {
     const user = await context.setupUser();
 
+    // Use content with an uncached skill to force sandbox path
+    const sandboxContent = {
+      version: "1",
+      agents: {
+        "my-agent": {
+          framework: "claude-code",
+          description: "A test agent",
+          skills: [
+            "https://github.com/vm0-ai/vm0-skills/tree/main/uncached-for-test",
+          ],
+        },
+      },
+    };
+
     // 1. Create job via session auth (no CLI token)
     const createRequest = createTestRequest(
       "http://localhost:3000/api/compose/jobs",
       {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ content: testContent }),
+        body: JSON.stringify({ content: sandboxContent }),
       },
     );
 

--- a/turbo/apps/web/app/api/compose/jobs/__tests__/server-side-compose.test.ts
+++ b/turbo/apps/web/app/api/compose/jobs/__tests__/server-side-compose.test.ts
@@ -1,0 +1,325 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { POST } from "../route";
+import { GET as getCompose } from "../../../../api/agent/composes/route";
+import {
+  createTestRequest,
+  createTestCliToken,
+  seedTestSkill,
+  clearSkillsData,
+} from "../../../../../src/__tests__/api-test-helpers";
+import { testContext } from "../../../../../src/__tests__/test-helpers";
+import { Sandbox } from "@e2b/code-interpreter";
+
+vi.mock("@e2b/code-interpreter", () => ({
+  Sandbox: {
+    create: vi.fn().mockResolvedValue({
+      sandboxId: "mock-sandbox-id",
+      files: { write: vi.fn().mockResolvedValue(undefined) },
+      commands: { run: vi.fn().mockResolvedValue({ exitCode: 0 }) },
+    }),
+    connect: vi.fn(),
+  },
+}));
+
+const context = testContext();
+
+let testCliToken: string;
+
+function makeContent(overrides: Record<string, unknown> = {}) {
+  return {
+    version: "1",
+    agents: {
+      "test-agent": {
+        framework: "claude-code",
+        description: "A test agent",
+        ...overrides,
+      },
+    },
+  };
+}
+
+function postComposeJob(body: Record<string, unknown>, token: string) {
+  return POST(
+    createTestRequest("http://localhost:3000/api/compose/jobs", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify(body),
+    }),
+  );
+}
+
+function getComposeByName(name: string, token: string) {
+  return getCompose(
+    createTestRequest(`http://localhost:3000/api/agent/composes?name=${name}`, {
+      method: "GET",
+      headers: { Authorization: `Bearer ${token}` },
+    }),
+  );
+}
+
+describe("Server-side compose", () => {
+  beforeEach(async () => {
+    context.setupMocks();
+    await clearSkillsData();
+    const user = await context.setupUser();
+    testCliToken = await createTestCliToken(user.userId);
+    vi.mocked(Sandbox.create).mockClear();
+  });
+
+  describe("happy path", () => {
+    it("should complete synchronously when all skills are cached", async () => {
+      await seedTestSkill({
+        url: "https://github.com/vm0-ai/vm0-skills/tree/main/slack",
+        name: "slack",
+        fullPath: "vm0-ai/vm0-skills/tree/main/slack",
+        frontmatter: {
+          name: "Slack",
+          description: "Slack integration",
+          vm0_secrets: ["SLACK_BOT_TOKEN"],
+          vm0_vars: ["LOG_LEVEL"],
+        },
+      });
+
+      const content = makeContent({ skills: ["slack"] });
+      const response = await postComposeJob(
+        { content, instructions: "# My Instructions" },
+        testCliToken,
+      );
+
+      expect(response.status).toBe(201);
+      const data = await response.json();
+      expect(data.status).toBe("completed");
+      expect(data.source).toBe("platform");
+      expect(data.result).toBeDefined();
+      expect(data.result.composeId).toBeDefined();
+      expect(data.result.composeName).toBe("test-agent");
+      expect(data.result.versionId).toMatch(/^[a-f0-9]{64}$/);
+      expect(data.completedAt).toBeDefined();
+
+      // Verify no sandbox was spawned
+      expect(Sandbox.create).not.toHaveBeenCalled();
+
+      // Verify compose record via API
+      const composeResponse = await getComposeByName(
+        "test-agent",
+        testCliToken,
+      );
+      expect(composeResponse.status).toBe(200);
+      const compose = await composeResponse.json();
+      expect(compose.name).toBe("test-agent");
+      expect(compose.headVersionId).toBe(data.result.versionId);
+    });
+
+    it("should complete synchronously when agent has no skills", async () => {
+      const content = makeContent();
+      const response = await postComposeJob({ content }, testCliToken);
+
+      expect(response.status).toBe(201);
+      const data = await response.json();
+      expect(data.status).toBe("completed");
+      expect(data.result.composeName).toBe("test-agent");
+
+      expect(Sandbox.create).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("fallback to sandbox", () => {
+    it("should fall back when skill is not cached", async () => {
+      const content = makeContent({
+        skills: ["https://github.com/vm0-ai/vm0-skills/tree/main/uncached"],
+      });
+      const response = await postComposeJob({ content }, testCliToken);
+
+      expect(response.status).toBe(201);
+      const data = await response.json();
+      expect(data.status).toBe("pending");
+      expect(data.source).toBe("platform");
+
+      expect(Sandbox.create).toHaveBeenCalled();
+    });
+
+    it("should always use sandbox for GitHub URL mode", async () => {
+      const response = await postComposeJob(
+        { githubUrl: "https://github.com/owner/repo" },
+        testCliToken,
+      );
+
+      expect(response.status).toBe(201);
+      const data = await response.json();
+      expect(data.status).toBe("pending");
+      expect(data.source).toBe("github");
+    });
+  });
+
+  describe("idempotency", () => {
+    it("should return existing active job instead of creating server-side compose", async () => {
+      // Create a sandbox job first (uncached skill triggers sandbox)
+      const content = makeContent({
+        skills: ["https://github.com/vm0-ai/vm0-skills/tree/main/uncached"],
+      });
+      const response1 = await postComposeJob({ content }, testCliToken);
+      expect(response1.status).toBe(201);
+      const data1 = await response1.json();
+      expect(data1.status).toBe("pending");
+
+      // Second request should return existing job, even though we could do server-side
+      const content2 = makeContent();
+      const response2 = await postComposeJob(
+        { content: content2 },
+        testCliToken,
+      );
+      expect(response2.status).toBe(200);
+      const data2 = await response2.json();
+      expect(data2.jobId).toBe(data1.jobId);
+    });
+  });
+
+  describe("skill variable merging", () => {
+    it("should merge skill variables from cached frontmatter", async () => {
+      await seedTestSkill({
+        url: "https://github.com/vm0-ai/vm0-skills/tree/main/slack",
+        name: "slack",
+        fullPath: "vm0-ai/vm0-skills/tree/main/slack",
+        frontmatter: {
+          name: "Slack",
+          vm0_secrets: ["SLACK_BOT_TOKEN"],
+          vm0_vars: ["LOG_LEVEL"],
+        },
+      });
+
+      const content = makeContent({
+        skills: ["slack"],
+        environment: { EXISTING_VAR: "keep-me" },
+      });
+      const response = await postComposeJob({ content }, testCliToken);
+
+      expect(response.status).toBe(201);
+      const data = await response.json();
+      expect(data.status).toBe("completed");
+
+      // Verify the compose version has merged environment via compose API
+      const composeResponse = await getComposeByName(
+        "test-agent",
+        testCliToken,
+      );
+      const compose = await composeResponse.json();
+      const agentEnv =
+        compose.content?.agents?.["test-agent"]?.environment ?? {};
+      expect(agentEnv["EXISTING_VAR"]).toBe("keep-me");
+      expect(agentEnv["SLACK_BOT_TOKEN"]).toBe(
+        "${{ secrets.SLACK_BOT_TOKEN }}",
+      );
+      expect(agentEnv["LOG_LEVEL"]).toBe("${{ vars.LOG_LEVEL }}");
+    });
+
+    it("should not overwrite existing environment variables", async () => {
+      await seedTestSkill({
+        url: "https://github.com/vm0-ai/vm0-skills/tree/main/slack",
+        name: "slack",
+        fullPath: "vm0-ai/vm0-skills/tree/main/slack",
+        frontmatter: {
+          name: "Slack",
+          vm0_secrets: ["SLACK_BOT_TOKEN"],
+          vm0_vars: [],
+        },
+      });
+
+      const content = makeContent({
+        skills: ["slack"],
+        environment: { SLACK_BOT_TOKEN: "my-custom-value" },
+      });
+      const response = await postComposeJob({ content }, testCliToken);
+
+      expect(response.status).toBe(201);
+      const data = await response.json();
+      expect(data.status).toBe("completed");
+
+      const composeResponse = await getComposeByName(
+        "test-agent",
+        testCliToken,
+      );
+      const compose = await composeResponse.json();
+      expect(
+        compose.content?.agents?.["test-agent"]?.environment?.[
+          "SLACK_BOT_TOKEN"
+        ],
+      ).toBe("my-custom-value");
+    });
+  });
+
+  describe("instructions upload", () => {
+    it("should upload instructions via server-side path", async () => {
+      const content = makeContent();
+      const response = await postComposeJob(
+        { content, instructions: "# Be helpful" },
+        testCliToken,
+      );
+
+      expect(response.status).toBe(201);
+      const data = await response.json();
+      expect(data.status).toBe("completed");
+
+      // Verify S3 upload was called for instructions
+      expect(context.mocks.s3.putS3Object).toHaveBeenCalled();
+    });
+
+    it("should succeed without instructions", async () => {
+      const content = makeContent();
+      const response = await postComposeJob({ content }, testCliToken);
+
+      expect(response.status).toBe(201);
+      const data = await response.json();
+      expect(data.status).toBe("completed");
+    });
+  });
+
+  describe("compose record", () => {
+    it("should create compose record accessible via API", async () => {
+      const content = makeContent({
+        environment: { UNIQUE_KEY: `test-${Date.now()}` },
+      });
+      const response = await postComposeJob({ content }, testCliToken);
+
+      expect(response.status).toBe(201);
+      const data = await response.json();
+      expect(data.status).toBe("completed");
+
+      // Verify compose record via GET /api/agent/composes?name=
+      const composeResponse = await getComposeByName(
+        "test-agent",
+        testCliToken,
+      );
+      expect(composeResponse.status).toBe(200);
+      const compose = await composeResponse.json();
+      expect(compose.id).toBe(data.result.composeId);
+      expect(compose.name).toBe("test-agent");
+      expect(compose.headVersionId).toBe(data.result.versionId);
+      expect(compose.content).toBeDefined();
+    });
+
+    it("should reuse existing compose record for same agent name", async () => {
+      const content = makeContent();
+
+      // First compose
+      const response1 = await postComposeJob({ content }, testCliToken);
+      expect(response1.status).toBe(201);
+      const data1 = await response1.json();
+
+      // Second compose with different environment (creates new version)
+      const content2 = makeContent({ environment: { NEW: "value" } });
+      const response2 = await postComposeJob(
+        { content: content2 },
+        testCliToken,
+      );
+      expect(response2.status).toBe(201);
+      const data2 = await response2.json();
+
+      // Same composeId, different versionId
+      expect(data2.result.composeId).toBe(data1.result.composeId);
+      expect(data2.result.versionId).not.toBe(data1.result.versionId);
+    });
+  });
+});

--- a/turbo/apps/web/app/api/compose/jobs/route.ts
+++ b/turbo/apps/web/app/api/compose/jobs/route.ts
@@ -1,3 +1,4 @@
+import crypto from "crypto";
 import {
   createHandler,
   tsr,
@@ -6,11 +7,12 @@ import {
 import { composeJobsMainContract } from "@vm0/core";
 import { initServices } from "../../../../src/lib/init-services";
 import { composeJobs } from "../../../../src/db/schema/compose-job";
-import { eq } from "drizzle-orm";
+import { eq, and, inArray } from "drizzle-orm";
 import { getAuthContext } from "../../../../src/lib/auth/get-user-id";
 import { resolveOrg } from "../../../../src/lib/org/resolve-org";
 import { logger } from "../../../../src/lib/logger";
 import { triggerComposeJob } from "../../../../src/lib/compose/trigger-compose-job";
+import { serverSideCompose } from "../../../../src/lib/compose/server-side-compose";
 import type { ComposeJobResult } from "../../../../src/db/schema/compose-job";
 
 const log = logger("api:compose-jobs");
@@ -63,6 +65,87 @@ const router = tsr.router(composeJobsMainContract, {
     // Dispatch based on input type: GitHub URL or platform content
     const isGitHubInput = "githubUrl" in body;
 
+    // Try server-side compose for platform mode (bypasses E2B sandbox)
+    if (!isGitHubInput) {
+      // Check for existing active job first (preserve idempotency)
+      const [existingActiveJob] = await globalThis.services.db
+        .select()
+        .from(composeJobs)
+        .where(
+          and(
+            eq(composeJobs.userId, userId),
+            inArray(composeJobs.status, ["pending", "running"]),
+          ),
+        )
+        .limit(1);
+
+      if (existingActiveJob) {
+        log.debug(
+          `Returning existing active job ${existingActiveJob.id} for user ${userId}`,
+        );
+        return {
+          status: 200 as const,
+          body: formatJobResponse(existingActiveJob),
+        };
+      }
+
+      // Attempt server-side compose — returns null if fallback needed
+      const serverResult = await serverSideCompose({
+        userId,
+        orgId: org.orgId,
+        orgSlug: org.slug,
+        content: body.content,
+        instructions: body.instructions,
+      });
+
+      if (serverResult) {
+        // Server-side compose succeeded — create completed job record
+        const jobId = crypto.randomUUID();
+        const now = new Date();
+        const jobResult: ComposeJobResult = {
+          composeId: serverResult.composeId,
+          composeName: serverResult.composeName,
+          versionId: serverResult.versionId,
+          warnings: [],
+        };
+
+        await globalThis.services.db.insert(composeJobs).values({
+          id: jobId,
+          userId,
+          source: "platform",
+          status: "completed",
+          content: body.content,
+          instructions: body.instructions,
+          result: jobResult,
+          createdAt: now,
+          completedAt: now,
+        });
+
+        log.info(
+          `Server-side compose completed for user ${userId}: ${serverResult.composeName}`,
+        );
+
+        return {
+          status: 201 as const,
+          body: formatJobResponse({
+            id: jobId,
+            status: "completed",
+            githubUrl: null,
+            source: "platform",
+            result: jobResult,
+            createdAt: now,
+            completedAt: now,
+          }),
+        };
+      }
+
+      // Server-side compose not possible — fall back to sandbox
+      log.info(
+        `Server-side compose not possible for user ${userId}, falling back to sandbox`,
+      );
+    }
+
+    // GitHub mode or server-side fallback: use sandbox
     const result = isGitHubInput
       ? await triggerComposeJob({
           userId,

--- a/turbo/apps/web/src/lib/compose/server-side-compose.ts
+++ b/turbo/apps/web/src/lib/compose/server-side-compose.ts
@@ -1,0 +1,269 @@
+import { eq, and, inArray } from "drizzle-orm";
+import {
+  resolveSkillRef,
+  AGENT_NAME_REGEX,
+  isSupportedFramework,
+  expandServiceConfigs,
+  type SkillFrontmatter,
+  type SupportedFramework,
+} from "@vm0/core";
+import type { AgentComposeYaml } from "../../types/agent-compose";
+import {
+  resolveFrameworkImage,
+  resolveFrameworkWorkingDir,
+} from "../framework/framework-config";
+import { uploadInstructionsServerSide } from "../storage/instruction-upload";
+import { computeComposeVersionId } from "../agent-compose/content-hash";
+import {
+  agentComposes,
+  agentComposeVersions,
+} from "../../db/schema/agent-compose";
+import { skills } from "../../db/schema/skill";
+import { logger } from "../logger";
+
+const log = logger("compose:server-side");
+
+interface AgentConfig {
+  agentName: string;
+  normalizedName: string;
+  framework: SupportedFramework;
+  agent: Record<string, unknown>;
+}
+
+/**
+ * Validate content and extract agent configuration.
+ * Throws on invalid content (these are content errors, not fallback scenarios).
+ */
+function extractAgentConfig(content: Record<string, unknown>): AgentConfig {
+  const agents = content.agents;
+  if (!agents || typeof agents !== "object" || Array.isArray(agents)) {
+    throw new Error(
+      "agents must be an object, not an array. Use format: agents: { agent-name: { ... } }",
+    );
+  }
+
+  const agentKeys = Object.keys(agents as Record<string, unknown>);
+  if (agentKeys.length !== 1) {
+    throw new Error(
+      agentKeys.length === 0
+        ? "agents must have at least one agent defined"
+        : "Multiple agents not supported yet. Only one agent allowed.",
+    );
+  }
+
+  const agentName = agentKeys[0]!;
+  if (!AGENT_NAME_REGEX.test(agentName)) {
+    throw new Error(
+      "Invalid agent name format. Must be 3-64 characters, letters, numbers, and hyphens only.",
+    );
+  }
+
+  const agent = (agents as Record<string, Record<string, unknown>>)[agentName]!;
+  const framework = agent.framework as string | undefined;
+  if (!framework || !isSupportedFramework(framework)) {
+    throw new Error(`Unsupported framework: "${framework}"`);
+  }
+
+  return {
+    agentName,
+    normalizedName: agentName.toLowerCase(),
+    framework,
+    agent,
+  };
+}
+
+/**
+ * Merge skill variables from cached frontmatter into the environment.
+ * Does not overwrite existing entries.
+ */
+function mergeSkillVariables(
+  environment: Record<string, string>,
+  cachedSkills: { frontmatter: unknown }[],
+): void {
+  for (const skill of cachedSkills) {
+    const fm = skill.frontmatter as SkillFrontmatter | null;
+    for (const name of fm?.vm0_secrets ?? []) {
+      if (!(name in environment)) {
+        environment[name] = `\${{ secrets.${name} }}`;
+      }
+    }
+    for (const name of fm?.vm0_vars ?? []) {
+      if (!(name in environment)) {
+        environment[name] = `\${{ vars.${name} }}`;
+      }
+    }
+  }
+}
+
+/**
+ * Upsert compose and version records.
+ * Returns the composeId.
+ */
+async function upsertComposeRecord(params: {
+  userId: string;
+  orgId: string;
+  normalizedName: string;
+  resolvedContent: AgentComposeYaml;
+  versionId: string;
+}): Promise<string> {
+  const { userId, orgId, normalizedName, resolvedContent, versionId } = params;
+  const db = globalThis.services.db;
+
+  const [existingComposes, existingVersions] = await Promise.all([
+    db
+      .select()
+      .from(agentComposes)
+      .where(
+        and(
+          eq(agentComposes.orgId, orgId),
+          eq(agentComposes.name, normalizedName),
+        ),
+      )
+      .limit(1),
+    db
+      .select()
+      .from(agentComposeVersions)
+      .where(eq(agentComposeVersions.id, versionId))
+      .limit(1),
+  ]);
+
+  let composeId: string;
+  const existing = existingComposes[0];
+
+  if (existing) {
+    composeId = existing.id;
+  } else {
+    const [created] = await db
+      .insert(agentComposes)
+      .values({ userId, name: normalizedName, orgId })
+      .returning({ id: agentComposes.id });
+
+    if (!created) {
+      throw new Error("Failed to create agent compose");
+    }
+    composeId = created.id;
+  }
+
+  if (existingVersions.length === 0) {
+    await db.insert(agentComposeVersions).values({
+      id: versionId,
+      composeId,
+      content: resolvedContent,
+      createdBy: userId,
+    });
+  }
+
+  await db
+    .update(agentComposes)
+    .set({ headVersionId: versionId, updatedAt: new Date() })
+    .where(eq(agentComposes.id, composeId));
+
+  return composeId;
+}
+
+/**
+ * Attempt server-side compose for platform mode.
+ *
+ * Bypasses the E2B sandbox by resolving skills from the database cache,
+ * merging skill variables, expanding service configs, uploading instructions,
+ * and creating the compose record — all server-side.
+ *
+ * @returns Compose result if successful, or `null` if the server-side path
+ *          is not possible (e.g., uncached skills) and the caller should
+ *          fall back to the sandbox.
+ */
+export async function serverSideCompose(params: {
+  userId: string;
+  orgId: string;
+  orgSlug: string;
+  content: Record<string, unknown>;
+  instructions?: string;
+}): Promise<{
+  composeId: string;
+  composeName: string;
+  versionId: string;
+} | null> {
+  const { userId, orgId, content, instructions } = params;
+  const db = globalThis.services.db;
+
+  // 1. Validate and extract agent config
+  const { agentName, normalizedName, framework, agent } =
+    extractAgentConfig(content);
+
+  // 2. Resolve skill references and check cache
+  const agentSkills = (agent.skills ?? []) as string[];
+  const resolvedSkillUrls = agentSkills.map(resolveSkillRef);
+
+  let cachedSkills: { frontmatter: unknown }[] = [];
+  if (resolvedSkillUrls.length > 0) {
+    cachedSkills = await db
+      .select({ frontmatter: skills.frontmatter })
+      .from(skills)
+      .where(inArray(skills.url, resolvedSkillUrls));
+
+    if (cachedSkills.length !== resolvedSkillUrls.length) {
+      log.info(
+        `Missing ${resolvedSkillUrls.length - cachedSkills.length} cached skills, falling back to sandbox`,
+      );
+      return null;
+    }
+  }
+
+  // 3. Merge skill variables from cached frontmatter
+  const environment: Record<string, string> = {
+    ...((agent.environment ?? {}) as Record<string, string>),
+  };
+  mergeSkillVariables(environment, cachedSkills);
+
+  // 4. Expand service configs (mutates in-place, so deep-clone first)
+  const contentCopy = structuredClone(content);
+  expandServiceConfigs(contentCopy);
+
+  // 5. Build resolved content with server-determined image and working_dir
+  const agentsCopy = contentCopy.agents as Record<
+    string,
+    Record<string, unknown>
+  >;
+  const resolvedContent = {
+    ...contentCopy,
+    version: contentCopy.version as string,
+    agents: {
+      [normalizedName]: {
+        ...agentsCopy[agentName],
+        environment,
+        image: resolveFrameworkImage(framework),
+        working_dir: resolveFrameworkWorkingDir(framework),
+      },
+    },
+  } as AgentComposeYaml;
+
+  // 6. Upload instructions if provided
+  if (instructions) {
+    const metadata = agent.metadata as
+      | { displayName?: string; sound?: string }
+      | undefined;
+    await uploadInstructionsServerSide({
+      orgId,
+      agentName: normalizedName,
+      content: instructions,
+      framework,
+      metadata,
+    });
+  }
+
+  // 7. Create compose record
+  const versionId = computeComposeVersionId(resolvedContent);
+  const composeId = await upsertComposeRecord({
+    userId,
+    orgId,
+    normalizedName,
+    resolvedContent,
+    versionId,
+  });
+
+  log.info(
+    `Server-side compose completed: ${normalizedName} (${versionId.slice(0, 8)})`,
+  );
+
+  return { composeId, composeName: normalizedName, versionId };
+}


### PR DESCRIPTION
## Summary

- Add `serverSideCompose()` function that resolves skills from DB cache, merges skill variables, expands service configs, uploads instructions, and creates compose records — all server-side
- Add smart router in `POST /api/compose/jobs` that tries server-side compose first, falls back to E2B sandbox when skills are uncached
- Platform compose with all cached skills now completes synchronously (<1s) instead of async with polling (~5-7s)

## Changes

| File | Action | Description |
|------|--------|-------------|
| `web/src/lib/compose/server-side-compose.ts` | **New** | Core `serverSideCompose()` function |
| `web/app/api/compose/jobs/route.ts` | **Modified** | Smart router: try server-side, fall back to sandbox |
| `web/app/api/compose/jobs/__tests__/server-side-compose.test.ts` | **New** | 11 integration tests for server-side compose |
| `web/app/api/compose/jobs/__tests__/route.test.ts` | **Modified** | Updated 2 tests to reflect new server-side behavior |

## How it works

```
POST /api/compose/jobs { content, instructions }
  → if platform mode (no githubUrl):
      → check for existing active job (idempotency)
      → try serverSideCompose()
        → resolve skill refs → batch query skills cache
        → all cached? → merge vars, expand services, upload instructions, create compose
        → return { status: "completed", result: {...} } immediately
      → if null (uncached skills) → fall back to sandbox
  → if GitHub mode → sandbox (unchanged)
```

## Test plan

- [x] Server-side compose with all cached skills → synchronous completion
- [x] Server-side compose with no skills → synchronous completion
- [x] Fallback to sandbox when skill not cached
- [x] GitHub URL mode always uses sandbox
- [x] Idempotency: existing active job returned
- [x] Skill variable merging from cached frontmatter
- [x] Existing environment variables not overwritten
- [x] Instructions upload via server-side path
- [x] Compose and version records created correctly
- [x] Compose record reused for same agent name
- [x] All 48 compose tests pass
- [x] All 97 agent/composes tests pass
- [x] lint, check-types, knip all pass

Closes #4830

🤖 Generated with [Claude Code](https://claude.com/claude-code)