### PR TITLE
ci: use filtered pnpm install for cli-e2e-03-runner chunks

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1388,7 +1388,12 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: recursive
-      - uses: ./.github/actions/toolchain-init
+
+      - name: Configure git safe directory
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+      - name: Install CLI dependencies
+        run: cd turbo && pnpm install --frozen-lockfile --filter @vm0/cli
 
       - name: Setup pnpm global directory
         run: |


### PR DESCRIPTION
## Summary
- Replace `toolchain-init` (full monorepo `pnpm install`) with `pnpm install --filter @vm0/cli` in cli-e2e-03-runner chunks
- Each of the 8 parallel chunks only needs the CLI package, not web/platform/docs dependencies
- Expected to reduce install time from ~16s to a few seconds per chunk

## Test plan
- [x] CI will validate that CLI builds and e2e tests still pass with filtered install

🤖 Generated with [Claude Code](https://claude.com/claude-code)