### PR TITLE
ci: replace ansible with ssh for cleanup-runner

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1607,9 +1607,6 @@ jobs:
 
       - uses: actions/checkout@v6
 
-      - name: Install Ansible
-        run: pip3 install ansible
-
       - name: Setup SSH via Cloudflare Tunnel
         uses: ./.github/actions/setup-ssh-tunnel
         with:
@@ -1623,13 +1620,19 @@ jobs:
           METAL_HOSTS: ${{ secrets.AWS_METAL_RUNNER_HOSTS }}
           JOB_REF: ${{ needs.prepare.outputs.job-ref }}
         run: |
-          cd ansible
-          ansible-playbook \
-            -i "${METAL_HOSTS}," \
-            playbooks/cleanup-turbo-runner.yml \
-            -e "ansible_user=${METAL_USER}" \
-            -e "job_ref=${JOB_REF}" \
-            -v || true
+          BASE_DIR="\$HOME/.vm0-runner"
+          BIN_DIR="${BASE_DIR}/bin/${JOB_REF}"
+          RUNNER_DIR="${BASE_DIR}/runners/${JOB_REF}"
+          for HOST in $(echo "$METAL_HOSTS" | tr ',' ' '); do
+            REMOTE="${METAL_USER}@${HOST}"
+            echo "Cleaning up ${HOST}..."
+            ssh "$REMOTE" "
+              for svc in \$(systemctl list-units 'vm0-runner-${JOB_REF}-*' --no-legend --plain 2>/dev/null | awk '{print \$1}'); do
+                sudo systemctl stop \$svc || true
+              done
+              rm -rf ${BIN_DIR} ${RUNNER_DIR}
+            " || true
+          done
 
   # Build E2B templates (development account)
   # Uses repository-level E2B_API_KEY secret

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1620,18 +1620,16 @@ jobs:
           METAL_HOSTS: ${{ secrets.AWS_METAL_RUNNER_HOSTS }}
           JOB_REF: ${{ needs.prepare.outputs.job-ref }}
         run: |
-          BASE_DIR="\$HOME/.vm0-runner"
-          BIN_DIR="${BASE_DIR}/bin/${JOB_REF}"
-          RUNNER_DIR="${BASE_DIR}/runners/${JOB_REF}"
           for HOST in $(echo "$METAL_HOSTS" | tr ',' ' '); do
-            REMOTE="${METAL_USER}@${HOST}"
             echo "Cleaning up ${HOST}..."
-            ssh "$REMOTE" "
-              for svc in \$(systemctl list-units 'vm0-runner-${JOB_REF}-*' --no-legend --plain 2>/dev/null | awk '{print \$1}'); do
-                sudo systemctl stop \$svc || true
+            ssh "${METAL_USER}@${HOST}" bash -s "$JOB_REF" <<'SCRIPT' || true
+              JOB_REF="$1"
+              BASE_DIR="$HOME/.vm0-runner"
+              for svc in $(systemctl list-units "vm0-runner-${JOB_REF}-*" --no-legend --plain 2>/dev/null | awk '{print $1}'); do
+                sudo systemctl stop "$svc" || true
               done
-              rm -rf ${BIN_DIR} ${RUNNER_DIR}
-            " || true
+              rm -rf "${BASE_DIR}/bin/${JOB_REF}" "${BASE_DIR}/runners/${JOB_REF}"
+            SCRIPT
           done
 
   # Build E2B templates (development account)


### PR DESCRIPTION
## Summary
- Replace `pip3 install ansible` + `ansible-playbook` with direct SSH commands
- The cleanup playbook only does 3 things: stop systemd services, rm bin dir, rm runner dir
- Ansible is overkill for this — saves ~30s of pip install time

## Test plan
- [x] CI will validate cleanup still works after e2e tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)