### PR TITLE
ci: use ansible-core instead of full ansible package

### DIFF
--- a/.github/actions/provision/action.yml
+++ b/.github/actions/provision/action.yml
@@ -60,7 +60,7 @@ runs:
           if ! command -v pip3 &>/dev/null; then
             rm -rf /var/lib/apt/lists/* && apt-get update && apt-get install -y python3 python3-pip
           fi
-          pip3 install ansible
+          pip3 install ansible-core
         fi
 
         ansible-playbook -i "${STALE_HOSTS}," ansible/playbooks/provision-runner.yml \

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Install Ansible
         if: steps.check.outputs.should-cleanup == 'true'
-        run: pip3 install ansible
+        run: pip3 install ansible-core
 
       - name: Setup SSH via Cloudflare Tunnel
         if: steps.check.outputs.should-cleanup == 'true'

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -695,7 +695,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install Ansible
-        run: pip3 install ansible
+        run: pip3 install ansible-core
 
       - name: Setup SSH via Cloudflare Tunnel
         uses: ./.github/actions/setup-ssh-tunnel

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -639,7 +639,7 @@ jobs:
       - name: Install Python3 and Ansible
         run: |
           rm -rf /var/lib/apt/lists/* && apt-get update && apt-get install -y python3 python3-pip
-          pip3 install ansible
+          pip3 install ansible-core
 
       - name: Notify Slack - Starting
         id: slack-start

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1608,7 +1608,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install Ansible
-        run: pip3 install ansible
+        run: pip3 install ansible-core
 
       - name: Setup SSH via Cloudflare Tunnel
         uses: ./.github/actions/setup-ssh-tunnel


### PR DESCRIPTION
## Summary
- Replace `pip3 install ansible` with `pip3 install ansible-core` across all 5 CI locations
- All playbooks only use built-in modules (shell, command, file, assert) — no community collections needed
- `ansible-core` is much smaller and faster to install

**Changed files:**
- `.github/workflows/turbo.yml` (cleanup-runner)
- `.github/workflows/cleanup.yml` (stale cleanup)
- `.github/workflows/crates.yml` (runner cleanup)
- `.github/workflows/release-please.yml` (runner deploy)
- `.github/actions/provision/action.yml` (provisioning)

## Test plan
- [x] CI will validate ansible-core works for all playbook executions

🤖 Generated with [Claude Code](https://claude.com/claude-code)