### PR TITLE
feat(core): add github user-read and user-write service permissions

### DIFF
--- a/turbo/packages/core/src/contracts/services.ts
+++ b/turbo/packages/core/src/contracts/services.ts
@@ -196,6 +196,33 @@ const SERVICE_CONFIGS: Partial<
             ],
           },
           {
+            name: "user-read",
+            description: "Read authenticated user profile and related data",
+            rules: [
+              "GET /user",
+              "GET /user/emails",
+              "GET /user/repos",
+              "GET /user/orgs",
+              "GET /user/teams",
+              "GET /user/starred",
+              "GET /user/subscriptions",
+              "GET /users/{username}",
+              "GET /users/{username}/repos",
+              "GET /users/{username}/orgs",
+            ],
+          },
+          {
+            name: "user-write",
+            description: "Update user profile, manage starred repos and email",
+            rules: [
+              "PATCH /user",
+              "POST /user/emails",
+              "DELETE /user/emails",
+              "PUT /user/starred/{owner}/{repo}",
+              "DELETE /user/starred/{owner}/{repo}",
+            ],
+          },
+          {
             name: "search",
             description: "Search code, issues, and repositories",
             rules: [


### PR DESCRIPTION
## Summary

- Add `user-read` permission group: `GET /user`, `/user/emails`, `/user/repos`, `/user/orgs`, `/user/teams`, `/user/starred`, `/user/subscriptions`, `/users/{username}`, etc.
- Add `user-write` permission group: `PATCH /user`, `POST/DELETE /user/emails`, `PUT/DELETE /user/starred/{owner}/{repo}`

## Test plan

- [x] Knip clean
- [x] Prettier clean
- [ ] Verify service auth proxy correctly routes user API requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)