### PR TITLE
fix: dispatch callbacks on timeout and cancel to prevent loop schedule stall

### DIFF
--- a/turbo/apps/web/app/api/agent/runs/[id]/cancel/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/cancel/__tests__/route.test.ts
@@ -5,8 +5,10 @@ import {
   createTestRequest,
   createTestCompose,
   createTestRun,
+  createTestCallback,
   findTestQueueEntry,
   findTestRunRecord,
+  findTestRunCallbacks,
   setTestRunStatus,
 } from "../../../../../../../src/__tests__/api-test-helpers";
 import {
@@ -112,6 +114,38 @@ describe("POST /api/agent/runs/:id/cancel - Cancel Run", () => {
       // Queue entry should be deleted
       const queueEntry = await findTestQueueEntry(queued.runId);
       expect(queueEntry).toBeUndefined();
+    });
+  });
+
+  describe("Callback Dispatch on Cancel", () => {
+    it("should dispatch registered callbacks after cancel", async () => {
+      // Create a running run with a registered callback
+      const run = await createTestRun(testComposeId, "Loop iteration");
+      await createTestCallback({
+        runId: run.runId,
+        url: "http://localhost:3000/api/internal/callbacks/schedule/loop",
+        payload: { scheduleId: "test-schedule", intervalSeconds: 60 },
+      });
+
+      // Verify callback is pending before cancel
+      const beforeCallbacks = await findTestRunCallbacks(run.runId);
+      expect(beforeCallbacks).toHaveLength(1);
+      expect(beforeCallbacks[0]!.status).toBe("pending");
+
+      // Cancel the run
+      const request = createTestRequest(
+        `http://localhost:3000/api/agent/runs/${run.runId}/cancel`,
+        { method: "POST" },
+      );
+      const response = await POST(request);
+      expect(response.status).toBe(200);
+
+      // Flush the after() callback which triggers dispatchTerminalSideEffects
+      await context.mocks.flushAfter();
+
+      // Verify callback was dispatched (status changed from "pending")
+      const afterCallbacks = await findTestRunCallbacks(run.runId);
+      expect(afterCallbacks[0]!.status).not.toBe("pending");
     });
   });
 

--- a/turbo/apps/web/app/api/agent/runs/[id]/cancel/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/cancel/route.ts
@@ -6,10 +6,12 @@ import { agentRunQueue } from "../../../../../../src/db/schema/agent-run-queue";
 import { eq, and } from "drizzle-orm";
 import { getUserId } from "../../../../../../src/lib/auth/get-user-id";
 import { logger } from "../../../../../../src/lib/logger";
-import { transitionRunStatus } from "../../../../../../src/lib/run/run-status";
+import {
+  transitionRunStatus,
+  dispatchTerminalSideEffects,
+} from "../../../../../../src/lib/run/run-status";
 import { drainOrgQueue } from "../../../../../../src/lib/run/run-queue-service";
 import { executeQueuedRun } from "../../../../../../src/lib/run/run-service";
-import { dispatchCallbacks } from "../../../../../../src/lib/callback";
 import { after } from "next/server";
 
 const log = logger("api:runs:cancel");
@@ -89,20 +91,17 @@ const router = tsr.router(runsCancelContract, {
       };
     }
 
-    // Dispatch callbacks (so loop schedules can advance) and drain queue
-    // if cancelling a running/pending run freed a concurrency slot.
+    // Dispatch callbacks (e.g., loop schedule advancement) and drain queue
     after(async () => {
-      await Promise.all([
-        dispatchCallbacks(runId, "failed", undefined, "Run cancelled").catch(
-          (err) =>
-            log.error("Failed to dispatch callbacks after cancel", { err }),
-        ),
-        run.status === "running" || run.status === "pending"
-          ? drainOrgQueue(run.orgId, executeQueuedRun).catch((err) =>
-              log.error("Failed to drain org queue after cancel", { err }),
-            )
-          : null,
-      ]);
+      const shouldDrain = run.status === "running" || run.status === "pending";
+      await dispatchTerminalSideEffects(
+        runId,
+        "cancelled",
+        "Run cancelled",
+        shouldDrain
+          ? () => drainOrgQueue(run.orgId, executeQueuedRun)
+          : undefined,
+      );
     });
 
     log.debug(

--- a/turbo/apps/web/app/api/agent/runs/[id]/cancel/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/cancel/route.ts
@@ -9,6 +9,7 @@ import { logger } from "../../../../../../src/lib/logger";
 import { transitionRunStatus } from "../../../../../../src/lib/run/run-status";
 import { drainOrgQueue } from "../../../../../../src/lib/run/run-queue-service";
 import { executeQueuedRun } from "../../../../../../src/lib/run/run-service";
+import { dispatchCallbacks } from "../../../../../../src/lib/callback";
 import { after } from "next/server";
 
 const log = logger("api:runs:cancel");
@@ -88,14 +89,21 @@ const router = tsr.router(runsCancelContract, {
       };
     }
 
-    // Drain queue if cancelling a running/pending run freed a concurrency slot
-    if (run.status === "running" || run.status === "pending") {
-      after(async () => {
-        await drainOrgQueue(run.orgId, executeQueuedRun).catch((err) =>
-          log.error("Failed to drain org queue after cancel", { err }),
-        );
-      });
-    }
+    // Dispatch callbacks (so loop schedules can advance) and drain queue
+    // if cancelling a running/pending run freed a concurrency slot.
+    after(async () => {
+      await Promise.all([
+        dispatchCallbacks(runId, "failed", undefined, "Run cancelled").catch(
+          (err) =>
+            log.error("Failed to dispatch callbacks after cancel", { err }),
+        ),
+        run.status === "running" || run.status === "pending"
+          ? drainOrgQueue(run.orgId, executeQueuedRun).catch((err) =>
+              log.error("Failed to drain org queue after cancel", { err }),
+            )
+          : null,
+      ]);
+    });
 
     log.debug(
       `Run ${runId} cancelled by user ${userId}, sandbox: ${run.sandboxId ?? "none"}`,

--- a/turbo/apps/web/app/api/cron/cleanup-sandboxes/route.ts
+++ b/turbo/apps/web/app/api/cron/cleanup-sandboxes/route.ts
@@ -2,7 +2,10 @@ import { createHandler, tsr } from "../../../../src/lib/ts-rest-handler";
 import { cronCleanupSandboxesContract, createErrorResponse } from "@vm0/core";
 import { initServices } from "../../../../src/lib/init-services";
 import { agentRuns } from "../../../../src/db/schema/agent-run";
-import { transitionRunStatus } from "../../../../src/lib/run/run-status";
+import {
+  transitionRunStatus,
+  dispatchTerminalSideEffects,
+} from "../../../../src/lib/run/run-status";
 import {
   agentComposeVersions,
   agentComposes,
@@ -17,7 +20,6 @@ import {
   drainOrgQueue,
 } from "../../../../src/lib/run/run-queue-service";
 import { executeQueuedRun } from "../../../../src/lib/run/run-service";
-import { dispatchCallbacks } from "../../../../src/lib/callback";
 import { logger } from "../../../../src/lib/logger";
 import { env } from "../../../../src/env";
 
@@ -229,19 +231,12 @@ const router = tsr.router(cronCleanupSandboxesContract, {
             continue;
           }
 
-          // Dispatch callbacks so loop schedules can advance, and drain queue
-          // to release concurrency slots. Uses "failed" status since timeout
-          // is a non-successful terminal state.
-          await dispatchCallbacks(
+          // Dispatch callbacks (e.g., loop schedule advancement) and drain queue
+          await dispatchTerminalSideEffects(
             run.id,
-            "failed",
-            undefined,
+            "timeout",
             timeoutReason,
-          ).catch((err) =>
-            log.error("Failed to dispatch callbacks after timeout", { err }),
-          );
-          await drainOrgQueue(run.orgId, executeQueuedRun).catch((err) =>
-            log.error("Failed to drain org queue after timeout", { err }),
+            () => drainOrgQueue(run.orgId, executeQueuedRun),
           );
 
           const isDebug =

--- a/turbo/apps/web/app/api/cron/cleanup-sandboxes/route.ts
+++ b/turbo/apps/web/app/api/cron/cleanup-sandboxes/route.ts
@@ -14,8 +14,10 @@ import { deleteS3Objects } from "../../../../src/lib/s3/s3-client";
 import {
   cleanupExpiredQueueEntries,
   drainStaleQueues,
+  drainOrgQueue,
 } from "../../../../src/lib/run/run-queue-service";
 import { executeQueuedRun } from "../../../../src/lib/run/run-service";
+import { dispatchCallbacks } from "../../../../src/lib/callback";
 import { logger } from "../../../../src/lib/logger";
 import { env } from "../../../../src/env";
 
@@ -143,6 +145,7 @@ const router = tsr.router(cronCleanupSandboxesContract, {
     const staleRuns = await globalThis.services.db
       .select({
         id: agentRuns.id,
+        orgId: agentRuns.orgId,
         status: agentRuns.status,
         sandboxId: agentRuns.sandboxId,
         lastHeartbeatAt: agentRuns.lastHeartbeatAt,
@@ -225,6 +228,21 @@ const router = tsr.router(cronCleanupSandboxesContract, {
             log.debug(`Run ${run.id} already transitioned, skipping timeout`);
             continue;
           }
+
+          // Dispatch callbacks so loop schedules can advance, and drain queue
+          // to release concurrency slots. Uses "failed" status since timeout
+          // is a non-successful terminal state.
+          await dispatchCallbacks(
+            run.id,
+            "failed",
+            undefined,
+            timeoutReason,
+          ).catch((err) =>
+            log.error("Failed to dispatch callbacks after timeout", { err }),
+          );
+          await drainOrgQueue(run.orgId, executeQueuedRun).catch((err) =>
+            log.error("Failed to drain org queue after timeout", { err }),
+          );
 
           const isDebug =
             run.composeName?.startsWith(DEBUG_COMPOSE_PREFIX) ?? false;

--- a/turbo/apps/web/app/api/webhooks/agent/complete/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/complete/route.ts
@@ -9,7 +9,10 @@ import { agentRuns } from "../../../../../src/db/schema/agent-run";
 import { checkpoints } from "../../../../../src/db/schema/checkpoint";
 import { agentSessions } from "../../../../../src/db/schema/agent-session";
 import { eq, and } from "drizzle-orm";
-import { transitionRunStatus } from "../../../../../src/lib/run/run-status";
+import {
+  transitionRunStatus,
+  dispatchTerminalSideEffects,
+} from "../../../../../src/lib/run/run-status";
 import { getSandboxAuthForRun } from "../../../../../src/lib/auth/get-sandbox-auth";
 import type {
   ArtifactSnapshot,
@@ -17,7 +20,6 @@ import type {
 } from "../../../../../src/lib/checkpoint";
 import type { RunResult } from "../../../../../src/lib/run/types";
 import { logger } from "../../../../../src/lib/logger";
-import { dispatchCallbacks } from "../../../../../src/lib/callback";
 import { drainOrgQueue } from "../../../../../src/lib/run/run-queue-service";
 import { executeQueuedRun } from "../../../../../src/lib/run/run-service";
 import { appendChatMessages } from "../../../../../src/lib/agent-session/agent-session-service";
@@ -77,23 +79,18 @@ async function persistChatMessages(
 }
 
 /**
- * Schedule callback dispatch and queue drain in a non-blocking after() block.
+ * Schedule terminal side effects in a non-blocking after() block.
  */
-function scheduleCallbackDispatch(
+function scheduleTerminalSideEffects(
   runId: string,
   status: "completed" | "failed",
   orgId: string,
   errorMsg?: string,
 ): void {
   after(async () => {
-    await Promise.all([
-      dispatchCallbacks(runId, status, undefined, errorMsg).catch((err) =>
-        log.error("Failed to dispatch callbacks", { err }),
-      ),
-      drainOrgQueue(orgId, executeQueuedRun).catch((err) =>
-        log.error("Failed to drain org queue", { err }),
-      ),
-    ]);
+    await dispatchTerminalSideEffects(runId, status, errorMsg, () =>
+      drainOrgQueue(orgId, executeQueuedRun),
+    );
   });
 }
 
@@ -211,7 +208,7 @@ const router = tsr.router(webhookCompleteContract, {
         // Dispatch callbacks so the user gets notified about the failure
         // (previously this path returned without dispatching)
         if (transitioned) {
-          scheduleCallbackDispatch(
+          scheduleTerminalSideEffects(
             body.runId,
             "failed",
             run.orgId,
@@ -310,7 +307,7 @@ const router = tsr.router(webhookCompleteContract, {
       finalStatus === "failed"
         ? (body.error ?? `Agent exited with code ${body.exitCode}`)
         : undefined;
-    scheduleCallbackDispatch(body.runId, finalStatus, run.orgId, errorMsg);
+    scheduleTerminalSideEffects(body.runId, finalStatus, run.orgId, errorMsg);
 
     return {
       status: 200 as const,

--- a/turbo/apps/web/src/lib/run/run-service.ts
+++ b/turbo/apps/web/src/lib/run/run-service.ts
@@ -2,7 +2,7 @@ import { eq, and, count, gt, or, sql } from "drizzle-orm";
 import { env } from "../../env";
 import { checkpoints } from "../../db/schema/checkpoint";
 import { agentRuns } from "../../db/schema/agent-run";
-import { transitionRunStatus } from "./run-status";
+import { transitionRunStatus, dispatchTerminalSideEffects } from "./run-status";
 import {
   agentComposeVersions,
   agentComposes,
@@ -475,17 +475,19 @@ async function registerCallbacks(
 }
 
 /**
- * Mark a run as failed and attach run metadata to the error for callers.
+ * Mark a run as failed, dispatch terminal side effects, and attach run
+ * metadata to the error for callers.
  */
 async function markRunFailed(
   runId: string,
   createdAt: Date,
   error: unknown,
+  orgId?: string,
 ): Promise<void> {
   const errorMessage = error instanceof Error ? error.message : "Unknown error";
   log.error(`Run ${runId} failed: ${errorMessage}`);
 
-  await transitionRunStatus(
+  const transitioned = await transitionRunStatus(
     runId,
     {
       status: "failed",
@@ -494,6 +496,11 @@ async function markRunFailed(
     },
     ["queued", "pending", "running"],
   );
+
+  // Dispatch callbacks (e.g., loop schedule advancement) if transition succeeded
+  if (transitioned) {
+    await dispatchTerminalSideEffects(runId, "failed", errorMessage);
+  }
 
   // Attach run metadata so callers can return partial results
   if (error instanceof Error) {

--- a/turbo/apps/web/src/lib/run/run-service.ts
+++ b/turbo/apps/web/src/lib/run/run-service.ts
@@ -16,7 +16,7 @@ import {
   concurrentRunLimit,
   isConcurrentRunLimit,
 } from "../errors";
-import { enqueueRun } from "./run-queue-service";
+import { enqueueRun, drainOrgQueue } from "./run-queue-service";
 import { logger } from "../logger";
 import type { Database } from "../../types/global";
 import type { AgentComposeSnapshot } from "../checkpoint/types";
@@ -477,12 +477,15 @@ async function registerCallbacks(
 /**
  * Mark a run as failed, dispatch terminal side effects, and attach run
  * metadata to the error for callers.
+ *
+ * @param drain - Optional queue drain function. Injected by callers to release
+ *   concurrency slots when a run that occupied one fails during dispatch.
  */
 async function markRunFailed(
   runId: string,
   createdAt: Date,
   error: unknown,
-  orgId?: string,
+  drain?: () => Promise<void>,
 ): Promise<void> {
   const errorMessage = error instanceof Error ? error.message : "Unknown error";
   log.error(`Run ${runId} failed: ${errorMessage}`);
@@ -497,9 +500,9 @@ async function markRunFailed(
     ["queued", "pending", "running"],
   );
 
-  // Dispatch callbacks (e.g., loop schedule advancement) if transition succeeded
+  // Dispatch callbacks (e.g., loop schedule advancement) and drain queue if transition succeeded
   if (transitioned) {
-    await dispatchTerminalSideEffects(runId, "failed", errorMessage);
+    await dispatchTerminalSideEffects(runId, "failed", errorMessage, drain);
   }
 
   // Attach run metadata so callers can return partial results
@@ -647,7 +650,12 @@ async function buildAndDispatchRun(opts: {
     log.debug(`Run ${runId} dispatched with status: ${result.status}`);
     return result;
   } catch (error) {
-    await markRunFailed(runId, createdAt, error);
+    await markRunFailed(
+      runId,
+      createdAt,
+      error,
+      orgId ? () => drainOrgQueue(orgId, executeQueuedRun) : undefined,
+    );
     throw error;
   }
 }

--- a/turbo/apps/web/src/lib/run/run-status.ts
+++ b/turbo/apps/web/src/lib/run/run-status.ts
@@ -1,7 +1,11 @@
 import { and, eq, inArray } from "drizzle-orm";
 import { agentRuns } from "../../db/schema/agent-run";
+import { dispatchCallbacks } from "../callback";
+import { logger } from "../logger";
 import type { RunResult, RunStatus } from "./types";
 import type { Database } from "../../types/global";
+
+const log = logger("service:run-status");
 
 /**
  * Atomically transition a run to a new status.
@@ -34,4 +38,33 @@ export async function transitionRunStatus(
     )
     .returning({ id: agentRuns.id });
   return !!updated;
+}
+
+/**
+ * Dispatch side effects after a successful terminal status transition.
+ *
+ * Every terminal transition (completed, failed, timeout, cancelled) must call
+ * this to ensure:
+ * 1. Registered callbacks fire (e.g., loop schedule advancement)
+ * 2. Concurrency slots are released via queue drain
+ *
+ * @param drain - Optional queue drain function. Injected by callers to avoid
+ *   circular dependency with run-queue-service. Omit when callbacks are not
+ *   yet registered (e.g., markQueuedRunFailed for runs that never dispatched).
+ */
+export async function dispatchTerminalSideEffects(
+  runId: string,
+  status: RunStatus,
+  error?: string,
+  drain?: () => Promise<void>,
+): Promise<void> {
+  const callbackStatus = status === "completed" ? "completed" : "failed";
+  await dispatchCallbacks(runId, callbackStatus, undefined, error).catch(
+    (err) => log.error("Failed to dispatch callbacks", { err }),
+  );
+  if (drain) {
+    await drain().catch((err) =>
+      log.error("Failed to drain org queue", { err }),
+    );
+  }
 }


### PR DESCRIPTION
## Summary
- Dispatch `dispatchCallbacks` from cron timeout and cancel paths so loop schedules can advance
- Add `drainOrgQueue` to cron timeout path to release concurrency slots

## Problem
When a loop schedule's run is timed out or cancelled, the loop callback (which sets `nextRunAt`) was never fired. This left `nextRunAt = null` permanently, silently stalling the loop schedule with `enabled = true` in the UI.

## Changes

### Cron timeout path (`cleanup-sandboxes/route.ts`)
- Added `orgId` to staleRuns query
- After successful timeout transition: call `dispatchCallbacks(runId, "failed")` + `drainOrgQueue(orgId)`

### Cancel handler (`cancel/route.ts`)
- After successful cancel: call `dispatchCallbacks(runId, "failed", "Run cancelled")` in `after()` block
- Callbacks dispatched for all cancelled runs (queued, pending, running)
- Queue drain only for running/pending (when concurrency slot is freed)

## How it works
The loop callback handler treats non-"completed" status as a failure → increments `consecutiveFailures` → sets `nextRunAt = now + interval`. After 3 consecutive failures, `MAX_CONSECUTIVE_FAILURES` auto-disables the loop.

## Test plan
- [x] All 8 cancel route tests pass
- [x] All 13 queue service tests pass
- [x] Type check passes (web)

Fixes #4468

🤖 Generated with [Claude Code](https://claude.com/claude-code)