### PR TITLE
ci: set concurrency-factor to 2.0 for e2e runner

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1298,6 +1298,7 @@ jobs:
               --runner-dirname ${JOB_REF} \
               --vcpu ${RUNNER_VCPU} \
               --memory-mb ${RUNNER_MEMORY_MB} \
+              --concurrency-factor 2.0 \
               --api-url ${PREVIEW_URL} \
               --token vm0_official_${OFFICIAL_RUNNER_SECRET}"
 


### PR DESCRIPTION
## Summary
- Add `--concurrency-factor 2.0` to `runner config` in deploy-runner-start
- E2E tests use mock Claude and finish quickly, so 2x overcommit is safe
- Doubles runner capacity → doubles test parallelism per chunk → faster test execution

## Test plan
- [x] CI will validate e2e tests pass with increased concurrency

🤖 Generated with [Claude Code](https://claude.com/claude-code)