### PR TITLE
fix: point email unsubscribe link to web app instead of platform

### DIFF
--- a/turbo/apps/web/src/lib/email/handlers/shared.ts
+++ b/turbo/apps/web/src/lib/email/handlers/shared.ts
@@ -5,6 +5,7 @@ import { agentComposes } from "../../../db/schema/agent-compose";
 import { getOrgBySlug } from "../../org/org-cache-service";
 import { env } from "../../../env";
 import { getPlatformUrl } from "../../url";
+import { getApiUrl } from "../../callback/dispatcher";
 import { enqueueEmail } from "../outbox-service";
 
 // ============================================================================
@@ -427,7 +428,7 @@ export function verifyUnsubscribeToken(token: string): string | null {
  */
 export function buildUnsubscribeUrl(userId: string): string {
   const token = generateUnsubscribeToken(userId);
-  return `${getPlatformUrl()}/api/email/unsubscribe?token=${token}`;
+  return `${getApiUrl()}/api/email/unsubscribe?token=${token}`;
 }
 
 /**


### PR DESCRIPTION
## Summary

- **Fix 404 on email unsubscribe links**: `buildUnsubscribeUrl()` was using `getPlatformUrl()` (NEXT_PUBLIC_PLATFORM_URL) to build the unsubscribe URL, but the `/api/email/unsubscribe` route only exists in the web app. Users clicking unsubscribe got a 404.
- Changed to use `getApiUrl()` which resolves to the web app's public URL (VM0_API_URL > VERCEL_URL > localhost:3000)
- All 5 email templates and their List-Unsubscribe headers are automatically fixed since they all call `buildUnsubscribeUrl()`

Closes #4858

## Test plan

- [x] Existing tests pass (38 tests in shared.test.ts)
- [ ] Verify unsubscribe link in sent emails points to web app domain
- [ ] Verify one-click unsubscribe (RFC 8058) works with corrected URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)