### PR TITLE
refactor(services): unify secret template syntax to ${{ }}

### DIFF
--- a/.claude/skills/agent-api-connector/SKILL.md
+++ b/.claude/skills/agent-api-connector/SKILL.md
@@ -176,7 +176,7 @@ Edit these files (use existing connectors like `twenty`, `qiita`, `zeptomail` as
 
 - **SERVICE_CONFIGS** — Add service configuration if the API uses header-based auth:
   - Bearer auth: `api("https://api.example.com", bearerAuth("XXX_TOKEN"))`
-  - Custom header: `api("https://api.example.com", { headers: { "x-api-key": "${secrets.XXX_TOKEN}" } })`
+  - Custom header: `api("https://api.example.com", { headers: { "x-api-key": "${{ secrets.XXX_TOKEN }}" } })`
   - **Skip** if auth is query-param-based or requires base64 encoding (Basic auth)
 
 #### 4b. `turbo/apps/web/src/lib/connector/providers/<name>-handler.ts` (new file)

--- a/crates/runner/mitm-addon/tests/test_connectors.py
+++ b/crates/runner/mitm-addon/tests/test_connectors.py
@@ -362,7 +362,7 @@ class TestGetServiceHeaders:
         mock_headers = {"Authorization": "Bearer fresh-token"}
         mock_result = {"headers": mock_headers}
         encrypted = "iv:tag:data"
-        auth_templates = {"Authorization": "Bearer ${secrets.TOKEN}"}
+        auth_templates = {"Authorization": "Bearer ${{ secrets.TOKEN }}"}
 
         with patch.object(mitm_addon, "fetch_service_headers", return_value=mock_result) as mock_fetch:
             headers = mitm_addon.get_service_headers("run-1", "https://api.github.com", encrypted, auth_templates, "tok-xyz")
@@ -449,7 +449,7 @@ class TestHandleServiceRequest:
 
     def test_success_injects_headers_and_audit_metadata(self):
         flow = _make_http_flow()
-        api_entry = {"id": "run-1:0", "base": "https://api.github.com", "auth": {"headers": {"Authorization": "Bearer ${secrets.GITHUB_TOKEN}"}}}
+        api_entry = {"id": "run-1:0", "base": "https://api.github.com", "auth": {"headers": {"Authorization": "Bearer ${{ secrets.GITHUB_TOKEN }}"}}}
         vm_info = {
             "runId": "run-1",
             "sandboxToken": "tok-xyz",
@@ -555,7 +555,7 @@ class TestFetchServiceHeaders:
             patch("mitm_addon.urllib.request.urlopen", return_value=mock_resp),
             patch.object(mitm_addon, "VERCEL_BYPASS", ""),
         ):
-            result = mitm_addon.fetch_service_headers("iv:tag:data", {"Authorization": "Bearer ${secrets.TOKEN}"}, "tok-xyz")
+            result = mitm_addon.fetch_service_headers("iv:tag:data", {"Authorization": "Bearer ${{ secrets.TOKEN }}"}, "tok-xyz")
 
         assert result == {"headers": {"Authorization": "Bearer tok"}}
 
@@ -565,7 +565,7 @@ class TestFetchServiceHeaders:
         assert call_args[0][0] == "https://api.vm0.ai/api/webhooks/agent/services/auth"
         body = json.loads(call_args[1]["data"])
         assert body["encryptedSecrets"] == "iv:tag:data"
-        assert body["authHeaders"] == {"Authorization": "Bearer ${secrets.TOKEN}"}
+        assert body["authHeaders"] == {"Authorization": "Bearer ${{ secrets.TOKEN }}"}
         assert "runId" not in body
         assert "base" not in body
         assert call_args[1]["headers"]["Authorization"] == "Bearer tok-xyz"

--- a/crates/runner/mitm-addon/tests/test_handlers.py
+++ b/crates/runner/mitm-addon/tests/test_handlers.py
@@ -140,7 +140,7 @@ class TestRequestHandler:
                         {"name": "github", "ref": "github", "apis": [
                             {
                                 "base": "https://api.github.com",
-                                "auth": {"headers": {"Authorization": "Bearer ${secrets.GITHUB_TOKEN}"}},
+                                "auth": {"headers": {"Authorization": "Bearer ${{ secrets.GITHUB_TOKEN }}"}},
                                 "permissions": [{"name": "full-access", "rules": ["ANY /{path+}"]}],
                             },
                         ]},
@@ -189,7 +189,7 @@ class TestRequestHandler:
                         {"name": "github", "ref": "github", "apis": [
                             {
                                 "base": "https://api.github.com",
-                                "auth": {"headers": {"Authorization": "Bearer ${secrets.GITHUB_TOKEN}"}},
+                                "auth": {"headers": {"Authorization": "Bearer ${{ secrets.GITHUB_TOKEN }}"}},
                                 "permissions": [
                                     {"name": "read-repos", "rules": ["GET /repos/{owner}/{repo}"]},
                                 ],
@@ -237,7 +237,7 @@ class TestRequestHandler:
                         {"name": "github", "ref": "github", "apis": [
                             {
                                 "base": "https://api.github.com",
-                                "auth": {"headers": {"Authorization": "Bearer ${secrets.GITHUB_TOKEN}"}},
+                                "auth": {"headers": {"Authorization": "Bearer ${{ secrets.GITHUB_TOKEN }}"}},
                                 "permissions": [
                                     {"name": "read-repos", "rules": ["GET /repos/{owner}/{repo}"]},
                                 ],
@@ -333,7 +333,7 @@ class TestRequestHandler:
                         {"name": "github", "ref": "github", "apis": [
                             {
                                 "base": "https://api.github.com",
-                                "auth": {"headers": {"Authorization": "Bearer ${secrets.GITHUB_TOKEN}"}},
+                                "auth": {"headers": {"Authorization": "Bearer ${{ secrets.GITHUB_TOKEN }}"}},
                                 "permissions": [{"name": "full-access", "rules": ["ANY /{path+}"]}],
                             },
                         ]},

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -968,7 +968,7 @@ mod tests {
                 auth: crate::types::ServiceApiAuth {
                     headers: std::collections::HashMap::from([(
                         "Authorization".into(),
-                        "Bearer ${secrets.GMAIL_TOKEN}".into(),
+                        "Bearer ${{ secrets.GMAIL_TOKEN }}".into(),
                     )]),
                 },
                 permissions: None,
@@ -1001,7 +1001,7 @@ mod tests {
                     "base": "https://api.github.com",
                     "auth": {
                         "headers": {
-                            "Authorization": "Bearer ${secrets.GITHUB_TOKEN}"
+                            "Authorization": "Bearer ${{ secrets.GITHUB_TOKEN }}"
                         }
                     },
                     "permissions": [

--- a/crates/runner/src/proxy.rs
+++ b/crates/runner/src/proxy.rs
@@ -791,7 +791,7 @@ mod tests {
                 auth: crate::types::ServiceApiAuth {
                     headers: std::collections::HashMap::from([(
                         "Authorization".to_string(),
-                        "Bearer ${secrets.GMAIL_TOKEN}".to_string(),
+                        "Bearer ${{ secrets.GMAIL_TOKEN }}".to_string(),
                     )]),
                 },
                 permissions: Some(vec![crate::types::ServiceApiPermission {

--- a/turbo/apps/web/app/api/webhooks/agent/services/auth/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/services/auth/__tests__/route.test.ts
@@ -104,7 +104,7 @@ describe("POST /api/webhooks/agent/services/auth", () => {
         makeRequest(
           {
             encryptedSecrets: "not-valid-encrypted-data",
-            authHeaders: { Authorization: "Bearer ${secrets.TOKEN}" },
+            authHeaders: { Authorization: "Bearer ${{ secrets.TOKEN }}" },
           },
           testToken,
         ),
@@ -124,7 +124,7 @@ describe("POST /api/webhooks/agent/services/auth", () => {
           {
             encryptedSecrets: encrypted,
             authHeaders: {
-              Authorization: "Bearer ${secrets.GITHUB_TOKEN}",
+              Authorization: "Bearer ${{ secrets.GITHUB_TOKEN }}",
             },
           },
           testToken,
@@ -150,8 +150,8 @@ describe("POST /api/webhooks/agent/services/auth", () => {
           {
             encryptedSecrets: encrypted,
             authHeaders: {
-              "X-Api-Key": "${secrets.API_KEY}",
-              "X-Api-Secret": "${secrets.API_SECRET}",
+              "X-Api-Key": "${{ secrets.API_KEY }}",
+              "X-Api-Secret": "${{ secrets.API_SECRET }}",
             },
           },
           testToken,
@@ -174,7 +174,7 @@ describe("POST /api/webhooks/agent/services/auth", () => {
           {
             encryptedSecrets: encrypted,
             authHeaders: {
-              Authorization: "Bearer ${secrets.UNKNOWN_KEY}",
+              Authorization: "Bearer ${{ secrets.UNKNOWN_KEY }}",
             },
           },
           testToken,
@@ -273,7 +273,7 @@ describe("POST /api/webhooks/agent/services/auth", () => {
           {
             encryptedSecrets: encrypted,
             authHeaders: {
-              Authorization: "Bearer ${secrets.NOTION_ACCESS_TOKEN}",
+              Authorization: "Bearer ${{ secrets.NOTION_ACCESS_TOKEN }}",
             },
             secretConnectorMap: { NOTION_ACCESS_TOKEN: "notion" },
           },
@@ -316,7 +316,7 @@ describe("POST /api/webhooks/agent/services/auth", () => {
           {
             encryptedSecrets: encrypted,
             authHeaders: {
-              Authorization: "Bearer ${secrets.NOTION_ACCESS_TOKEN}",
+              Authorization: "Bearer ${{ secrets.NOTION_ACCESS_TOKEN }}",
             },
             secretConnectorMap: { NOTION_ACCESS_TOKEN: "notion" },
           },
@@ -346,7 +346,7 @@ describe("POST /api/webhooks/agent/services/auth", () => {
           {
             encryptedSecrets: encrypted,
             authHeaders: {
-              Authorization: "Bearer ${secrets.NOTION_ACCESS_TOKEN}",
+              Authorization: "Bearer ${{ secrets.NOTION_ACCESS_TOKEN }}",
             },
             secretConnectorMap: { NOTION_ACCESS_TOKEN: "notion" },
           },
@@ -377,7 +377,7 @@ describe("POST /api/webhooks/agent/services/auth", () => {
           {
             encryptedSecrets: encrypted,
             authHeaders: {
-              Authorization: "Bearer ${secrets.NOTION_ACCESS_TOKEN}",
+              Authorization: "Bearer ${{ secrets.NOTION_ACCESS_TOKEN }}",
             },
             secretConnectorMap: { NOTION_ACCESS_TOKEN: "notion" },
           },
@@ -401,7 +401,7 @@ describe("POST /api/webhooks/agent/services/auth", () => {
           {
             encryptedSecrets: encrypted,
             authHeaders: {
-              Authorization: "Bearer ${secrets.GITHUB_TOKEN}",
+              Authorization: "Bearer ${{ secrets.GITHUB_TOKEN }}",
             },
           },
           testToken,
@@ -438,7 +438,7 @@ describe("POST /api/webhooks/agent/services/auth", () => {
           {
             encryptedSecrets: encrypted,
             authHeaders: {
-              Authorization: "Bearer ${secrets.NOTION_ACCESS_TOKEN}",
+              Authorization: "Bearer ${{ secrets.NOTION_ACCESS_TOKEN }}",
             },
             secretConnectorMap: { NOTION_ACCESS_TOKEN: "notion" },
           },
@@ -480,7 +480,7 @@ describe("POST /api/webhooks/agent/services/auth", () => {
           {
             encryptedSecrets: encrypted,
             authHeaders: {
-              Authorization: "Bearer ${secrets.NOTION_ACCESS_TOKEN}",
+              Authorization: "Bearer ${{ secrets.NOTION_ACCESS_TOKEN }}",
             },
             secretConnectorMap: { NOTION_ACCESS_TOKEN: "notion" },
           },

--- a/turbo/apps/web/app/api/webhooks/agent/services/auth/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/services/auth/route.ts
@@ -20,8 +20,8 @@ const bodySchema = z.object({
 
 const log = logger("webhook:service-auth");
 
-/** Matches ${secrets.KEY_NAME} template placeholders in auth header values. */
-const SECRET_TEMPLATE_RE = /\$\{secrets\.([^}]+)\}/g;
+/** Matches ${{ secrets.KEY_NAME }} template placeholders in auth header values. */
+const SECRET_TEMPLATE_RE = /\$\{\{\s*secrets\.([a-zA-Z_][a-zA-Z0-9_]*)\s*\}\}/g;
 
 /**
  * Refresh expired OAuth tokens referenced by auth templates.
@@ -111,7 +111,7 @@ async function refreshExpiredTokens(
 }
 
 /**
- * Resolve ${secrets.XXX} templates with decrypted secret values.
+ * Resolve ${{ secrets.XXX }} templates with decrypted secret values.
  */
 function resolveTemplates(
   authHeaders: Record<string, string>,

--- a/turbo/apps/web/src/lib/run/environment/__tests__/expand-environment.test.ts
+++ b/turbo/apps/web/src/lib/run/environment/__tests__/expand-environment.test.ts
@@ -26,7 +26,9 @@ const githubService: ExpandedServiceConfig = {
   apis: [
     {
       base: "https://api.github.com",
-      auth: { headers: { Authorization: "Bearer ${secrets.GITHUB_TOKEN}" } },
+      auth: {
+        headers: { Authorization: "Bearer ${{ secrets.GITHUB_TOKEN }}" },
+      },
     },
   ],
   placeholders: { GITHUB_TOKEN: "gho_vm0placeholder0000000000000000000000" },
@@ -38,7 +40,7 @@ const slackService: ExpandedServiceConfig = {
   apis: [
     {
       base: "https://slack.com/api",
-      auth: { headers: { Authorization: "Bearer ${secrets.SLACK_TOKEN}" } },
+      auth: { headers: { Authorization: "Bearer ${{ secrets.SLACK_TOKEN }}" } },
     },
   ],
   placeholders: { SLACK_TOKEN: "xoxb-0000-0000-vm0placeholder" },
@@ -50,7 +52,9 @@ const airtableService: ExpandedServiceConfig = {
   apis: [
     {
       base: "https://api.airtable.com",
-      auth: { headers: { Authorization: "Bearer ${secrets.AIRTABLE_TOKEN}" } },
+      auth: {
+        headers: { Authorization: "Bearer ${{ secrets.AIRTABLE_TOKEN }}" },
+      },
     },
   ],
 };

--- a/turbo/apps/web/src/lib/run/environment/expand-environment.ts
+++ b/turbo/apps/web/src/lib/run/environment/expand-environment.ts
@@ -53,7 +53,7 @@ function processSecretValues(
 /**
  * Build service placeholder map keyed by canonical secret name.
  * Reads pre-expanded service configs and extracts secret names from auth templates
- * (`${secrets.XXX}`), then maps each to a placeholder value (custom or auto-generated).
+ * (`${{ secrets.XXX }}`), then maps each to a placeholder value (custom or auto-generated).
  */
 function buildServicePlaceholders(
   expandedServices: ExpandedServiceConfig[],

--- a/turbo/packages/core/src/contracts/__tests__/services.test.ts
+++ b/turbo/packages/core/src/contracts/__tests__/services.test.ts
@@ -9,7 +9,7 @@ describe("getServiceConfig", () => {
     expect(config).toBeDefined();
     expect(config!.apis[0]!.base).toBe("https://api.github.com");
     expect(config!.apis[0]!.auth.headers.Authorization).toBe(
-      "Bearer ${secrets.GITHUB_TOKEN}",
+      "Bearer ${{ secrets.GITHUB_TOKEN }}",
     );
     expect(config!.placeholders).toEqual({
       GITHUB_TOKEN: "gho_vm0placeholder0000000000000000000000",

--- a/turbo/packages/core/src/contracts/services.ts
+++ b/turbo/packages/core/src/contracts/services.ts
@@ -7,7 +7,7 @@ import type { ConnectorType } from "./connectors";
  * are constructed. Used by the proxy to intercept requests matching a
  * connector's base URLs and replace placeholder tokens with real credentials.
  *
- * `${secrets.XXX}` in header values is replaced by the proxy with the real secret value.
+ * `${{ secrets.XXX }}` in header values is replaced by the proxy with the real secret value.
  *
  * NOTE: Currently hardcoded in SERVICE_CONFIGS below.
  * Will be migrated to GitHub-hosted connector.yaml definitions in Phase 2.
@@ -35,7 +35,7 @@ export interface ServiceConfig {
   description?: string;
   apis: ServiceApi[];
   /**
-   * Custom placeholder values keyed by secret name (matching `${secrets.XXX}` in auth templates).
+   * Custom placeholder values keyed by secret name (matching `${{ secrets.XXX }}` in auth templates).
    * Falls back to auto-generated `VM0_PLACEHOLDER_{secretName}`.
    * Only needed when the service requires a specific credential format (e.g., GitHub's `gho_` prefix).
    */
@@ -43,13 +43,15 @@ export interface ServiceConfig {
 }
 
 /**
- * Regex pattern matching `${secrets.XXX}` references in auth header templates.
+ * Regex pattern matching `${{ secrets.XXX }}` references in auth header templates.
+ * Tolerates optional whitespace inside braces: `${{ secrets.X }}` and `${{secrets.X}}`.
  */
-const AUTH_SECRET_PATTERN = /\$\{secrets\.([^}]+)\}/g;
+const AUTH_SECRET_PATTERN =
+  /\$\{\{\s*secrets\.([a-zA-Z_][a-zA-Z0-9_]*)\s*\}\}/g;
 
 /**
  * Extract all secret names referenced in service API auth header templates.
- * E.g., `Bearer ${secrets.GITHUB_TOKEN}` → `["GITHUB_TOKEN"]`
+ * E.g., `Bearer ${{ secrets.GITHUB_TOKEN }}` → `["GITHUB_TOKEN"]`
  */
 export function extractSecretNamesFromApis(
   apis: ServiceConfig["apis"],
@@ -67,7 +69,7 @@ export function extractSecretNamesFromApis(
 
 /** Helper to build standard Bearer auth header with a secret reference. */
 function bearerAuth(secretName: string) {
-  return { headers: { Authorization: `Bearer \${secrets.${secretName}}` } };
+  return { headers: { Authorization: `Bearer \${{ secrets.${secretName} }}` } };
 }
 
 /** Default catch-all permission for services without granular permissions. */
@@ -243,7 +245,7 @@ const SERVICE_CONFIGS: Partial<
     apis: [
       api("https://api.notion.com/v1", {
         headers: {
-          Authorization: "Bearer ${secrets.NOTION_TOKEN}",
+          Authorization: "Bearer ${{ secrets.NOTION_TOKEN }}",
           "Notion-Version": "2022-06-28",
         },
       }),
@@ -295,14 +297,14 @@ const SERVICE_CONFIGS: Partial<
   hume: {
     apis: [
       api("https://api.hume.ai", {
-        headers: { "X-Hume-Api-Key": "${secrets.HUME_TOKEN}" },
+        headers: { "X-Hume-Api-Key": "${{ secrets.HUME_TOKEN }}" },
       }),
     ],
   },
   heygen: {
     apis: [
       api("https://api.heygen.com", {
-        headers: { "x-api-key": "${secrets.HEYGEN_TOKEN}" },
+        headers: { "x-api-key": "${{ secrets.HEYGEN_TOKEN }}" },
       }),
     ],
   },
@@ -347,12 +349,12 @@ const SERVICE_CONFIGS: Partial<
     apis: [
       api("https://api.jotform.com", {
         headers: {
-          APIKEY: "${secrets.JOTFORM_TOKEN}",
+          APIKEY: "${{ secrets.JOTFORM_TOKEN }}",
         },
       }),
       api("https://eu-api.jotform.com", {
         headers: {
-          APIKEY: "${secrets.JOTFORM_TOKEN}",
+          APIKEY: "${{ secrets.JOTFORM_TOKEN }}",
         },
       }),
     ],
@@ -364,22 +366,22 @@ const SERVICE_CONFIGS: Partial<
     apis: [
       api("https://eu1.make.com/api/v2", {
         headers: {
-          Authorization: "Token ${secrets.MAKE_TOKEN}",
+          Authorization: "Token ${{ secrets.MAKE_TOKEN }}",
         },
       }),
       api("https://eu2.make.com/api/v2", {
         headers: {
-          Authorization: "Token ${secrets.MAKE_TOKEN}",
+          Authorization: "Token ${{ secrets.MAKE_TOKEN }}",
         },
       }),
       api("https://us1.make.com/api/v2", {
         headers: {
-          Authorization: "Token ${secrets.MAKE_TOKEN}",
+          Authorization: "Token ${{ secrets.MAKE_TOKEN }}",
         },
       }),
       api("https://us2.make.com/api/v2", {
         headers: {
-          Authorization: "Token ${secrets.MAKE_TOKEN}",
+          Authorization: "Token ${{ secrets.MAKE_TOKEN }}",
         },
       }),
     ],
@@ -388,7 +390,7 @@ const SERVICE_CONFIGS: Partial<
     apis: [
       api("https://api.metabase.com", {
         headers: {
-          "x-api-key": "${secrets.METABASE_TOKEN}",
+          "x-api-key": "${{ secrets.METABASE_TOKEN }}",
         },
       }),
     ],
@@ -484,7 +486,7 @@ const SERVICE_CONFIGS: Partial<
   similarweb: {
     apis: [
       api("https://api.similarweb.com", {
-        headers: { "api-key": "${secrets.SIMILARWEB_API_KEY}" },
+        headers: { "api-key": "${{ secrets.SIMILARWEB_API_KEY }}" },
       }),
     ],
   },
@@ -514,14 +516,14 @@ const SERVICE_CONFIGS: Partial<
   pdf4me: {
     apis: [
       api("https://api.pdf4me.com", {
-        headers: { Authorization: "${secrets.PDF4ME_TOKEN}" },
+        headers: { Authorization: "${{ secrets.PDF4ME_TOKEN }}" },
       }),
     ],
   },
   pdfco: {
     apis: [
       api("https://api.pdf.co/v1", {
-        headers: { "x-api-key": "${secrets.PDFCO_TOKEN}" },
+        headers: { "x-api-key": "${{ secrets.PDFCO_TOKEN }}" },
       }),
     ],
   },
@@ -534,7 +536,7 @@ const SERVICE_CONFIGS: Partial<
   browserbase: {
     apis: [
       api("https://api.browserbase.com/v1", {
-        headers: { "X-BB-API-Key": "${secrets.BROWSERBASE_TOKEN}" },
+        headers: { "X-BB-API-Key": "${{ secrets.BROWSERBASE_TOKEN }}" },
       }),
     ],
   },
@@ -546,7 +548,7 @@ const SERVICE_CONFIGS: Partial<
   explorium: {
     apis: [
       api("https://api.explorium.ai", {
-        headers: { api_key: "${secrets.EXPLORIUM_TOKEN}" },
+        headers: { api_key: "${{ secrets.EXPLORIUM_TOKEN }}" },
       }),
     ],
   },
@@ -556,21 +558,21 @@ const SERVICE_CONFIGS: Partial<
   scrapeninja: {
     apis: [
       api("https://scrapeninja.p.rapidapi.com", {
-        headers: { "X-RapidAPI-Key": "${secrets.SCRAPENINJA_TOKEN}" },
+        headers: { "X-RapidAPI-Key": "${{ secrets.SCRAPENINJA_TOKEN }}" },
       }),
     ],
   },
   elevenlabs: {
     apis: [
       api("https://api.elevenlabs.io", {
-        headers: { "xi-api-key": "${secrets.ELEVENLABS_TOKEN}" },
+        headers: { "xi-api-key": "${{ secrets.ELEVENLABS_TOKEN }}" },
       }),
     ],
   },
   devto: {
     apis: [
       api("https://dev.to/api", {
-        headers: { "api-key": "${secrets.DEVTO_TOKEN}" },
+        headers: { "api-key": "${{ secrets.DEVTO_TOKEN }}" },
       }),
     ],
   },
@@ -586,7 +588,7 @@ const SERVICE_CONFIGS: Partial<
   qdrant: {
     apis: [
       api("https://cloud.qdrant.io", {
-        headers: { "api-key": "${secrets.QDRANT_TOKEN}" },
+        headers: { "api-key": "${{ secrets.QDRANT_TOKEN }}" },
       }),
     ],
   },
@@ -602,7 +604,7 @@ const SERVICE_CONFIGS: Partial<
     apis: [
       api("https://api.zeptomail.com/v1.1", {
         headers: {
-          Authorization: "Zoho-enczapikey ${secrets.ZEPTOMAIL_TOKEN}",
+          Authorization: "Zoho-enczapikey ${{ secrets.ZEPTOMAIL_TOKEN }}",
         },
       }),
     ],
@@ -613,14 +615,14 @@ const SERVICE_CONFIGS: Partial<
   shortio: {
     apis: [
       api("https://api.short.io", {
-        headers: { Authorization: "${secrets.SHORTIO_TOKEN}" },
+        headers: { Authorization: "${{ secrets.SHORTIO_TOKEN }}" },
       }),
     ],
   },
   supadata: {
     apis: [
       api("https://api.supadata.ai/v1", {
-        headers: { "x-api-key": "${secrets.SUPADATA_TOKEN}" },
+        headers: { "x-api-key": "${{ secrets.SUPADATA_TOKEN }}" },
       }),
     ],
   },
@@ -630,7 +632,7 @@ const SERVICE_CONFIGS: Partial<
   tldv: {
     apis: [
       api("https://pasta.tldv.io", {
-        headers: { "x-api-key": "${secrets.TLDV_TOKEN}" },
+        headers: { "x-api-key": "${{ secrets.TLDV_TOKEN }}" },
       }),
     ],
   },


### PR DESCRIPTION
## Summary

- Unify all secret template references from `${secrets.XXX}` to `${{ secrets.XXX }}`, consistent with the environment variable expansion syntax (`${{ vars.XXX }}`, `${{ secrets.XXX }}`)
- Update regex capture groups from `[^}]+?` to `[a-zA-Z_][a-zA-Z0-9_]*` for strict identifier matching, consistent with `variable-expander.ts`

## Changed files

| File | Change |
|------|--------|
| `packages/core/src/contracts/services.ts` | Regex + `bearerAuth` helper + ~20 inline auth templates + comments |
| `apps/web/.../services/auth/route.ts` | Regex + comments |
| `apps/web/.../services/auth/__tests__/route.test.ts` | All template strings in 16 tests |
| `packages/core/.../services.test.ts` | Test expectation |
| `apps/web/.../expand-environment.test.ts` | Test fixture templates |
| `apps/web/.../expand-environment.ts` | Comment only |
| `crates/runner/mitm-addon/tests/test_connectors.py` | Mock data |
| `crates/runner/mitm-addon/tests/test_handlers.py` | Mock data |
| `crates/runner/src/proxy.rs` | Test data |
| `crates/runner/src/executor.rs` | Test data |
| `.claude/skills/agent-api-connector/SKILL.md` | Doc reference |

## Test plan

- [x] 60 TS tests pass (services, service-expander, expand-environment, auth route)
- [x] 71 Python tests pass (test_connectors, test_handlers)
- [x] Lint clean
- [x] No remaining `${secrets.` references in codebase

Closes #4806

🤖 Generated with [Claude Code](https://claude.com/claude-code)