### PR TITLE
fix: use array-form child process api to prevent command injection in git-client

### DIFF
--- a/turbo/apps/cli/src/commands/compose/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/compose/__tests__/index.test.ts
@@ -10,20 +10,21 @@ import * as os from "os";
 import * as yaml from "yaml";
 import chalk from "chalk";
 
-// Configurable handler called when exec encounters a "git checkout" command.
+// Configurable handler called when execFile encounters a "git checkout" command.
 // Tests set this to populate the working directory with expected files.
 let onGitCheckout: ((cwd: string) => void) | undefined;
 
-// Mock child_process — the true external boundary for both spawn and exec.
-// spawn is used by silentUpgradeAfterCommand; exec is used by git-client for git operations.
+// Mock child_process — the true external boundary for both spawn and execFile.
+// spawn is used by silentUpgradeAfterCommand; execFile is used by git-client for git operations.
 vi.mock("child_process", async (importOriginal) => {
   const original = await importOriginal<typeof import("child_process")>();
   return {
     ...original,
     spawn: vi.fn(),
-    exec: vi.fn(
+    execFile: vi.fn(
       (
-        cmd: string,
+        file: string,
+        args: string[],
         optionsOrCallback: unknown,
         maybeCallback?: unknown,
       ): { pid: number } => {
@@ -42,6 +43,7 @@ vi.mock("child_process", async (importOriginal) => {
             ? (optionsOrCallback as { cwd?: string })
             : undefined;
         const cwd = options?.cwd;
+        const cmd = [file, ...args].join(" ");
 
         // git init: create .git/info/ so sparse-checkout file writes succeed
         if (cmd.startsWith("git init") && cwd) {
@@ -69,9 +71,9 @@ vi.mock("child_process", async (importOriginal) => {
   };
 });
 
-import { spawn, exec } from "child_process";
+import { spawn, execFile } from "child_process";
 const mockSpawn = vi.mocked(spawn);
-const mockExec = vi.mocked(exec);
+const mockExecFile = vi.mocked(execFile);
 
 /**
  * Helper to create a mock skill directory with SKILL.md frontmatter.
@@ -2221,8 +2223,9 @@ agents:
       ]);
 
       // Verify git operations targeted the correct repository
-      expect(mockExec).toHaveBeenCalledWith(
-        expect.stringContaining("owner/repo.git"),
+      expect(mockExecFile).toHaveBeenCalledWith(
+        "git",
+        expect.arrayContaining([expect.stringContaining("owner/repo.git")]),
         expect.anything(),
         expect.anything(),
       );
@@ -2270,8 +2273,9 @@ agents:
       ]);
 
       // Verify git operations targeted the correct repository
-      expect(mockExec).toHaveBeenCalledWith(
-        expect.stringContaining("owner/repo.git"),
+      expect(mockExecFile).toHaveBeenCalledWith(
+        "git",
+        expect.arrayContaining([expect.stringContaining("owner/repo.git")]),
         expect.anything(),
         expect.anything(),
       );
@@ -2316,8 +2320,9 @@ agents:
       ]);
 
       // Verify git operations targeted the correct repository
-      expect(mockExec).toHaveBeenCalledWith(
-        expect.stringContaining("owner/repo.git"),
+      expect(mockExecFile).toHaveBeenCalledWith(
+        "git",
+        expect.arrayContaining([expect.stringContaining("owner/repo.git")]),
         expect.anything(),
         expect.anything(),
       );
@@ -2366,8 +2371,9 @@ agents:
       ]);
 
       // Verify git operations targeted the correct repository
-      expect(mockExec).toHaveBeenCalledWith(
-        expect.stringContaining("owner/repo.git"),
+      expect(mockExecFile).toHaveBeenCalledWith(
+        "git",
+        expect.arrayContaining([expect.stringContaining("owner/repo.git")]),
         expect.anything(),
         expect.anything(),
       );

--- a/turbo/apps/cli/src/commands/compose/__tests__/skill-resolve.test.ts
+++ b/turbo/apps/cli/src/commands/compose/__tests__/skill-resolve.test.ts
@@ -9,17 +9,20 @@ import * as path from "path";
 import * as os from "os";
 import chalk from "chalk";
 
-// Configurable handler called when exec encounters a "git checkout" command.
+// Configurable handler called when execFile encounters a "git checkout" command.
 let onGitCheckout: ((cwd: string) => void) | undefined;
 
+// Mock child_process — the true external boundary for both spawn and execFile.
+// spawn is used by silentUpgradeAfterCommand; execFile is used by git-client for git operations.
 vi.mock("child_process", async (importOriginal) => {
   const original = await importOriginal<typeof import("child_process")>();
   return {
     ...original,
     spawn: vi.fn(),
-    exec: vi.fn(
+    execFile: vi.fn(
       (
-        cmd: string,
+        file: string,
+        args: string[],
         optionsOrCallback: unknown,
         maybeCallback?: unknown,
       ): { pid: number } => {
@@ -38,15 +41,19 @@ vi.mock("child_process", async (importOriginal) => {
             ? (optionsOrCallback as { cwd?: string })
             : undefined;
         const cwd = options?.cwd;
+        const cmd = [file, ...args].join(" ");
 
+        // git init: create .git/info/ so sparse-checkout file writes succeed
         if (cmd.startsWith("git init") && cwd) {
           mkdirSync(path.join(cwd, ".git", "info"), { recursive: true });
         }
 
+        // git checkout: populate the working directory via test-provided handler
         if (cmd.startsWith("git checkout") && cwd && onGitCheckout) {
           onGitCheckout(cwd);
         }
 
+        // git ls-remote: return a fake default branch reference
         if (cmd.includes("git ls-remote")) {
           callback(null, {
             stdout: "ref: refs/heads/main\tHEAD\n",

--- a/turbo/apps/cli/src/lib/external/git-client.ts
+++ b/turbo/apps/cli/src/lib/external/git-client.ts
@@ -11,6 +11,17 @@ import {
 const execFileAsync = promisify(execFile);
 
 /**
+ * Validate that a value intended as a git positional argument does not
+ * look like a command-line option. This prevents second-order command
+ * injection via flags such as `--upload-pack`.
+ */
+function assertNotOption(value: string, label: string): void {
+  if (value.startsWith("-")) {
+    throw new Error(`Invalid ${label}: must not start with a dash`);
+  }
+}
+
+/**
  * Result of downloading a GitHub directory
  */
 interface GitHubDownloadResult {
@@ -31,6 +42,8 @@ export async function downloadGitHubSkill(
   parsed: ParsedGitHubTreeUrl,
   destDir: string,
 ): Promise<string> {
+  assertNotOption(parsed.owner, "repository owner");
+  assertNotOption(parsed.repo, "repository name");
   const repoUrl = `https://github.com/${parsed.owner}/${parsed.repo}.git`;
   const skillDir = path.join(destDir, parsed.skillName);
 
@@ -55,6 +68,7 @@ export async function downloadGitHubSkill(
     await fs.writeFile(sparseFile, sparsePattern + "\n");
 
     // Fetch only the required branch
+    assertNotOption(parsed.branch, "branch name");
     await execFileAsync(
       "git",
       ["fetch", "--depth", "1", "origin", parsed.branch],
@@ -96,6 +110,8 @@ export async function downloadGitHubSkill(
  * @returns Default branch name
  */
 async function getDefaultBranch(owner: string, repo: string): Promise<string> {
+  assertNotOption(owner, "repository owner");
+  assertNotOption(repo, "repository name");
   const repoUrl = `https://github.com/${owner}/${repo}.git`;
   try {
     // git ls-remote --symref outputs:
@@ -158,6 +174,8 @@ export async function downloadGitHubDirectory(
     );
   }
 
+  assertNotOption(parsed.owner, "repository owner");
+  assertNotOption(parsed.repo, "repository name");
   const repoUrl = `https://github.com/${parsed.owner}/${parsed.repo}.git`;
   const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "vm0-github-"));
 
@@ -192,6 +210,7 @@ export async function downloadGitHubDirectory(
     await fs.writeFile(sparseFile, sparsePattern + "\n");
 
     // Fetch only the required branch with better error handling
+    assertNotOption(branch, "branch name");
     try {
       await execFileAsync("git", ["fetch", "--depth", "1", "origin", branch], {
         cwd: tempDir,

--- a/turbo/apps/cli/src/lib/external/git-client.ts
+++ b/turbo/apps/cli/src/lib/external/git-client.ts
@@ -1,14 +1,14 @@
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import * as os from "node:os";
-import { exec } from "node:child_process";
+import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import {
   parseGitHubUrl as parseGitHubUrlCore,
   type ParsedGitHubTreeUrl,
 } from "@vm0/core";
 
-const execAsync = promisify(exec);
+const execFileAsync = promisify(execFile);
 
 /**
  * Result of downloading a GitHub directory
@@ -39,9 +39,13 @@ export async function downloadGitHubSkill(
 
   try {
     // Initialize sparse checkout
-    await execAsync(`git init`, { cwd: tempDir });
-    await execAsync(`git remote add origin "${repoUrl}"`, { cwd: tempDir });
-    await execAsync(`git config core.sparseCheckout true`, { cwd: tempDir });
+    await execFileAsync("git", ["init"], { cwd: tempDir });
+    await execFileAsync("git", ["remote", "add", "origin", repoUrl], {
+      cwd: tempDir,
+    });
+    await execFileAsync("git", ["config", "core.sparseCheckout", "true"], {
+      cwd: tempDir,
+    });
 
     // Configure sparse checkout to only fetch the skill path
     // For root: use "/*" to get all root-level files
@@ -51,10 +55,14 @@ export async function downloadGitHubSkill(
     await fs.writeFile(sparseFile, sparsePattern + "\n");
 
     // Fetch only the required branch
-    await execAsync(`git fetch --depth 1 origin "${parsed.branch}"`, {
-      cwd: tempDir,
-    });
-    await execAsync(`git checkout "${parsed.branch}"`, { cwd: tempDir });
+    await execFileAsync(
+      "git",
+      ["fetch", "--depth", "1", "origin", parsed.branch],
+      {
+        cwd: tempDir,
+      },
+    );
+    await execFileAsync("git", ["checkout", parsed.branch], { cwd: tempDir });
 
     // Move the skill directory to destination
     await fs.mkdir(path.dirname(skillDir), { recursive: true });
@@ -93,9 +101,12 @@ async function getDefaultBranch(owner: string, repo: string): Promise<string> {
     // git ls-remote --symref outputs:
     // ref: refs/heads/main    HEAD
     // a1b2c3d...              HEAD
-    const { stdout } = await execAsync(
-      `git ls-remote --symref "${repoUrl}" HEAD`,
-    );
+    const { stdout } = await execFileAsync("git", [
+      "ls-remote",
+      "--symref",
+      repoUrl,
+      "HEAD",
+    ]);
 
     // Extract branch name from "ref: refs/heads/main" line
     const match = stdout.match(/ref: refs\/heads\/([^\s]+)/);
@@ -153,7 +164,7 @@ export async function downloadGitHubDirectory(
   try {
     // Check git is available
     try {
-      await execAsync("git --version");
+      await execFileAsync("git", ["--version"]);
     } catch {
       throw new Error(
         "git command not found. Please install git to use GitHub URLs.",
@@ -165,9 +176,13 @@ export async function downloadGitHubDirectory(
       parsed.branch ?? (await getDefaultBranch(parsed.owner, parsed.repo));
 
     // Initialize sparse checkout
-    await execAsync(`git init`, { cwd: tempDir });
-    await execAsync(`git remote add origin "${repoUrl}"`, { cwd: tempDir });
-    await execAsync(`git config core.sparseCheckout true`, { cwd: tempDir });
+    await execFileAsync("git", ["init"], { cwd: tempDir });
+    await execFileAsync("git", ["remote", "add", "origin", repoUrl], {
+      cwd: tempDir,
+    });
+    await execFileAsync("git", ["config", "core.sparseCheckout", "true"], {
+      cwd: tempDir,
+    });
 
     // Configure sparse checkout pattern
     // For root: use "/*" to get all root-level files
@@ -178,7 +193,7 @@ export async function downloadGitHubDirectory(
 
     // Fetch only the required branch with better error handling
     try {
-      await execAsync(`git fetch --depth 1 origin "${branch}"`, {
+      await execFileAsync("git", ["fetch", "--depth", "1", "origin", branch], {
         cwd: tempDir,
       });
     } catch (error) {
@@ -195,7 +210,7 @@ export async function downloadGitHubDirectory(
       throw error;
     }
 
-    await execAsync(`git checkout "${branch}"`, { cwd: tempDir });
+    await execFileAsync("git", ["checkout", branch], { cwd: tempDir });
 
     // Return directory path
     // For root: return tempDir directly

--- a/turbo/apps/cli/src/lib/external/git-client.ts
+++ b/turbo/apps/cli/src/lib/external/git-client.ts
@@ -11,14 +11,21 @@ import {
 const execFileAsync = promisify(execFile);
 
 /**
- * Validate that a value intended as a git positional argument does not
- * look like a command-line option. This prevents second-order command
- * injection via flags such as `--upload-pack`.
+ * Sanitize a value intended as a git positional argument to prevent
+ * second-order command injection via flags like `--upload-pack`.
+ * Only allows safe characters (alphanumeric, dash, underscore, dot, slash).
+ * Returns the value if safe; throws otherwise.
  */
-function assertNotOption(value: string, label: string): void {
+function sanitizeGitArg(value: string, label: string): string {
+  if (!/^[a-zA-Z0-9._/\-@]+$/.test(value)) {
+    throw new Error(
+      `Invalid ${label}: contains disallowed characters. Only alphanumeric, dash, underscore, dot, slash, and @ are permitted.`,
+    );
+  }
   if (value.startsWith("-")) {
     throw new Error(`Invalid ${label}: must not start with a dash`);
   }
+  return value;
 }
 
 /**
@@ -42,9 +49,10 @@ export async function downloadGitHubSkill(
   parsed: ParsedGitHubTreeUrl,
   destDir: string,
 ): Promise<string> {
-  assertNotOption(parsed.owner, "repository owner");
-  assertNotOption(parsed.repo, "repository name");
-  const repoUrl = `https://github.com/${parsed.owner}/${parsed.repo}.git`;
+  const owner = sanitizeGitArg(parsed.owner, "repository owner");
+  const repo = sanitizeGitArg(parsed.repo, "repository name");
+  const branch = sanitizeGitArg(parsed.branch, "branch name");
+  const repoUrl = `https://github.com/${owner}/${repo}.git`;
   const skillDir = path.join(destDir, parsed.skillName);
 
   // Create a temporary directory for sparse checkout
@@ -68,15 +76,10 @@ export async function downloadGitHubSkill(
     await fs.writeFile(sparseFile, sparsePattern + "\n");
 
     // Fetch only the required branch
-    assertNotOption(parsed.branch, "branch name");
-    await execFileAsync(
-      "git",
-      ["fetch", "--depth", "1", "origin", parsed.branch],
-      {
-        cwd: tempDir,
-      },
-    );
-    await execFileAsync("git", ["checkout", parsed.branch], { cwd: tempDir });
+    await execFileAsync("git", ["fetch", "--depth", "1", "origin", branch], {
+      cwd: tempDir,
+    });
+    await execFileAsync("git", ["checkout", branch], { cwd: tempDir });
 
     // Move the skill directory to destination
     await fs.mkdir(path.dirname(skillDir), { recursive: true });
@@ -110,9 +113,9 @@ export async function downloadGitHubSkill(
  * @returns Default branch name
  */
 async function getDefaultBranch(owner: string, repo: string): Promise<string> {
-  assertNotOption(owner, "repository owner");
-  assertNotOption(repo, "repository name");
-  const repoUrl = `https://github.com/${owner}/${repo}.git`;
+  const safeOwner = sanitizeGitArg(owner, "repository owner");
+  const safeRepo = sanitizeGitArg(repo, "repository name");
+  const repoUrl = `https://github.com/${safeOwner}/${safeRepo}.git`;
   try {
     // git ls-remote --symref outputs:
     // ref: refs/heads/main    HEAD
@@ -174,9 +177,9 @@ export async function downloadGitHubDirectory(
     );
   }
 
-  assertNotOption(parsed.owner, "repository owner");
-  assertNotOption(parsed.repo, "repository name");
-  const repoUrl = `https://github.com/${parsed.owner}/${parsed.repo}.git`;
+  const safeOwner = sanitizeGitArg(parsed.owner, "repository owner");
+  const safeRepo = sanitizeGitArg(parsed.repo, "repository name");
+  const repoUrl = `https://github.com/${safeOwner}/${safeRepo}.git`;
   const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "vm0-github-"));
 
   try {
@@ -190,8 +193,10 @@ export async function downloadGitHubDirectory(
     }
 
     // Resolve branch if not specified
-    const branch =
-      parsed.branch ?? (await getDefaultBranch(parsed.owner, parsed.repo));
+    const branch = sanitizeGitArg(
+      parsed.branch ?? (await getDefaultBranch(safeOwner, safeRepo)),
+      "branch name",
+    );
 
     // Initialize sparse checkout
     await execFileAsync("git", ["init"], { cwd: tempDir });
@@ -210,7 +215,6 @@ export async function downloadGitHubDirectory(
     await fs.writeFile(sparseFile, sparsePattern + "\n");
 
     // Fetch only the required branch with better error handling
-    assertNotOption(branch, "branch name");
     try {
       await execFileAsync("git", ["fetch", "--depth", "1", "origin", branch], {
         cwd: tempDir,


### PR DESCRIPTION
## Summary

- Replace `child_process.exec()` with `child_process.execFile()` in all git operations in `git-client.ts` to eliminate command-line injection vulnerabilities
- Convert all 7 shell-interpolated command strings to array-form arguments, bypassing the shell entirely
- Update compose integration test mock from `exec` to `execFile`

Closes #4855 (CodeQL alerts #123, #124, #125)

## Test plan

- [x] All 94 compose integration tests pass
- [x] TypeScript type check passes for `@vm0/cli`
- [x] Lint passes
- [x] Knip finds no unused exports
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)