### PR TITLE
ci: extract build-cli job and remove custom container from e2e jobs

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -932,14 +932,45 @@ jobs:
           CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
 
-  # Run CLI E2E tests - Phase 1: Serial tests (org/provider CRUD)
-  cli-e2e-01-serial:
+  # Build CLI once and share via artifact — e2e jobs download instead of rebuilding
+  build-cli:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/vm0-ai/vm0-toolchain:20260310
+    needs: [prepare]
+    if: |
+      (github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore: release')) &&
+      needs.prepare.outputs.job-ref != '' && (
+        needs.prepare.outputs.web-changed == 'true' ||
+        needs.prepare.outputs.cli-changed == 'true' ||
+        needs.prepare.outputs.crates-changed == 'true' ||
+        needs.prepare.outputs.ci-changed == 'true' ||
+        needs.prepare.outputs.e2e-changed == 'true'
+      )
+    steps:
+      - uses: actions/checkout@v6
+      - name: Configure git safe directory
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+      - name: Install CLI dependencies
+        run: cd turbo && pnpm install --frozen-lockfile --filter @vm0/cli
+      - name: Build CLI
+        run: cd turbo && pnpm --filter @vm0/cli build
+      - name: Install CLI production dependencies
+        run: cd turbo/apps/cli/dist && npm install --production
+      - name: Upload CLI artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: cli-dist
+          path: turbo/apps/cli/dist
+          retention-days: 1
+
+  # Run CLI E2E tests - Phase 1: Serial tests (org/provider CRUD)
+  cli-e2e-01-serial:
+    runs-on: ubuntu-latest
     needs:
       [
         prepare,
+        build-cli,
         deploy-web,
         lint-eslint,
         lint-types,
@@ -966,19 +997,16 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: recursive
-      - uses: ./.github/actions/toolchain-init
-
-      - name: Setup pnpm global directory
-        run: |
-          mkdir -p $HOME/.local/share/pnpm
-          pnpm config set global-bin-dir $HOME/.local/share/pnpm
-          echo "$HOME/.local/share/pnpm" >> $GITHUB_PATH
-
-      - name: Build CLI
-        run: cd turbo && pnpm --filter @vm0/cli build
-
-      - name: Setup CLI globally
-        run: cd turbo/apps/cli && pnpm link --global
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - name: Download CLI artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: cli-dist
+          path: turbo/apps/cli/dist
+      - name: Link CLI globally
+        run: cd turbo/apps/cli/dist && sudo npm link
 
       - name: Restore test token from cache
         uses: actions/cache/restore@v5
@@ -1362,11 +1390,10 @@ jobs:
   # Skip on push to main - runner tests are only needed for PRs
   cli-e2e-03-runner:
     runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260310
     needs:
       [
         prepare,
+        build-cli,
         deploy-web,
         deploy-runner-prepare,
         deploy-runner-start,
@@ -1389,27 +1416,19 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: recursive
-
-      - name: Configure git safe directory
-        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
-
-      - name: Install CLI dependencies
-        run: cd turbo && pnpm install --frozen-lockfile --filter @vm0/cli
-
-      - name: Setup pnpm global directory
-        run: |
-          mkdir -p $HOME/.local/share/pnpm
-          pnpm config set global-bin-dir $HOME/.local/share/pnpm
-          echo "$HOME/.local/share/pnpm" >> $GITHUB_PATH
-
-      - name: Build CLI
-        run: cd turbo && pnpm --filter @vm0/cli build
-
-      - name: Setup CLI globally
-        run: cd turbo/apps/cli && pnpm link --global
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - name: Download CLI artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: cli-dist
+          path: turbo/apps/cli/dist
+      - name: Link CLI globally
+        run: cd turbo/apps/cli/dist && sudo npm link
 
       - name: Install GNU parallel for bats
-        run: curl -sL https://raw.githubusercontent.com/martinda/gnu-parallel/master/src/parallel > /usr/local/bin/parallel && chmod +x /usr/local/bin/parallel
+        run: sudo curl -sL https://raw.githubusercontent.com/martinda/gnu-parallel/master/src/parallel -o /usr/local/bin/parallel && sudo chmod +x /usr/local/bin/parallel
 
       - name: Restore test token from cache
         uses: actions/cache/restore@v5
@@ -1472,11 +1491,10 @@ jobs:
   # Only runs on PRs with the 'stress-test' label (opt-in)
   runner-stress-test:
     runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260310
     needs:
       [
         prepare,
+        build-cli,
         deploy-web,
         deploy-runner-prepare,
         deploy-runner-start,
@@ -1490,19 +1508,16 @@ jobs:
       STRESS_PROMPT: "sleep 10 && echo done"
     steps:
       - uses: actions/checkout@v6
-      - uses: ./.github/actions/toolchain-init
-
-      - name: Setup pnpm global directory
-        run: |
-          mkdir -p $HOME/.local/share/pnpm
-          pnpm config set global-bin-dir $HOME/.local/share/pnpm
-          echo "$HOME/.local/share/pnpm" >> $GITHUB_PATH
-
-      - name: Build CLI
-        run: cd turbo && pnpm --filter @vm0/cli build
-
-      - name: Setup CLI globally
-        run: cd turbo/apps/cli && pnpm link --global
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - name: Download CLI artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: cli-dist
+          path: turbo/apps/cli/dist
+      - name: Link CLI globally
+        run: cd turbo/apps/cli/dist && sudo npm link
 
       - name: Restore test token from cache
         uses: actions/cache/restore@v5

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -999,7 +999,6 @@ jobs:
           path: turbo/apps/cli/dist
       - name: Link CLI globally
         run: cd turbo/apps/cli/dist && sudo npm link
-
       - name: Download E2E test tokens
         uses: actions/download-artifact@v4
         with:
@@ -1417,10 +1416,8 @@ jobs:
           path: turbo/apps/cli/dist
       - name: Link CLI globally
         run: cd turbo/apps/cli/dist && sudo npm link
-
       - name: Install GNU parallel for bats
         run: sudo curl -sL https://raw.githubusercontent.com/martinda/gnu-parallel/master/src/parallel -o /usr/local/bin/parallel && sudo chmod +x /usr/local/bin/parallel
-
       - name: Download E2E test tokens
         uses: actions/download-artifact@v4
         with:
@@ -1508,7 +1505,6 @@ jobs:
           path: turbo/apps/cli/dist
       - name: Link CLI globally
         run: cd turbo/apps/cli/dist && sudo npm link
-
       - name: Download E2E test tokens
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -767,20 +767,14 @@ jobs:
           VM0_API_URL: ${{ steps.alias.outputs.url || steps.deploy.outputs.url }}
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
 
-      - run: cp /tmp/e2e-token-serial.json ~/.vm0/config.json
-      - name: Save serial token to cache
-        uses: actions/cache/save@v5
+      - name: Upload E2E test tokens
+        uses: actions/upload-artifact@v4
         with:
-          path: ~/.vm0
-          key: e2e-token-serial-${{ github.run_id }}-${{ github.run_attempt }}
-
-
-      - run: cp /tmp/e2e-token-runner.json ~/.vm0/config.json
-      - name: Save runner token to cache
-        uses: actions/cache/save@v5
-        with:
-          path: ~/.vm0
-          key: e2e-token-runner-${{ github.run_id }}-${{ github.run_attempt }}
+          name: e2e-tokens
+          path: |
+            /tmp/e2e-token-serial.json
+            /tmp/e2e-token-runner.json
+          retention-days: 1
 
   # Deploy docs application
   deploy-docs:
@@ -991,8 +985,6 @@ jobs:
         needs.prepare.outputs.e2e-changed == 'true'
       )
     timeout-minutes: 5
-    permissions:
-      actions: read # Required to query cache API
     steps:
       - uses: actions/checkout@v6
         with:
@@ -1008,14 +1000,13 @@ jobs:
       - name: Link CLI globally
         run: cd turbo/apps/cli/dist && sudo npm link
 
-      - name: Restore test token from cache
-        uses: actions/cache/restore@v5
+      - name: Download E2E test tokens
+        uses: actions/download-artifact@v4
         with:
-          path: ~/.vm0
-          key: e2e-token-serial-${{ github.run_id }}-${{ github.run_attempt }}
-          restore-keys: |
-            e2e-token-serial-${{ github.run_id }}-
-          fail-on-cache-miss: true
+          name: e2e-tokens
+          path: /tmp
+      - name: Setup test token
+        run: mkdir -p ~/.vm0 && cp /tmp/e2e-token-serial.json ~/.vm0/config.json
 
       - name: Start Cron Simulator
         run: |
@@ -1430,14 +1421,13 @@ jobs:
       - name: Install GNU parallel for bats
         run: sudo curl -sL https://raw.githubusercontent.com/martinda/gnu-parallel/master/src/parallel -o /usr/local/bin/parallel && sudo chmod +x /usr/local/bin/parallel
 
-      - name: Restore test token from cache
-        uses: actions/cache/restore@v5
+      - name: Download E2E test tokens
+        uses: actions/download-artifact@v4
         with:
-          path: ~/.vm0
-          key: e2e-token-runner-${{ github.run_id }}-${{ github.run_attempt }}
-          restore-keys: |
-            e2e-token-runner-${{ github.run_id }}-
-          fail-on-cache-miss: true
+          name: e2e-tokens
+          path: /tmp
+      - name: Setup test token
+        run: mkdir -p ~/.vm0 && cp /tmp/e2e-token-runner.json ~/.vm0/config.json
 
       - name: Bootstrap test account
         run: |
@@ -1519,14 +1509,13 @@ jobs:
       - name: Link CLI globally
         run: cd turbo/apps/cli/dist && sudo npm link
 
-      - name: Restore test token from cache
-        uses: actions/cache/restore@v5
+      - name: Download E2E test tokens
+        uses: actions/download-artifact@v4
         with:
-          path: ~/.vm0
-          key: e2e-token-runner-${{ github.run_id }}-${{ github.run_attempt }}
-          restore-keys: |
-            e2e-token-runner-${{ github.run_id }}-
-          fail-on-cache-miss: true
+          name: e2e-tokens
+          path: /tmp
+      - name: Setup test token
+        run: mkdir -p ~/.vm0 && cp /tmp/e2e-token-runner.json ~/.vm0/config.json
 
       - name: Bootstrap test account
         run: |


### PR DESCRIPTION
## Summary

- Extract CLI build into a dedicated `build-cli` job (runs in toolchain container)
- CLI artifact (dist + node_modules) shared via `upload-artifact` / `download-artifact`
- `cli-e2e-01-serial`, `cli-e2e-03-runner`, `runner-stress-test` now run on bare `ubuntu-latest` with `actions/setup-node` — no custom container
- E2e jobs just download artifact and `sudo npm link` — no build, no pnpm

## Test plan

- [ ] `build-cli` job builds and uploads artifact successfully
- [ ] `cli-e2e-01-serial` downloads artifact, links CLI, passes serial tests
- [ ] `cli-e2e-03-runner` downloads artifact, links CLI, passes runner tests
- [ ] `runner-stress-test` (with stress-test label) downloads artifact and runs

Closes #4869

🤖 Generated with [Claude Code](https://claude.com/claude-code)