### PR TITLE
feat: add experimental_capabilities to compose schema and types

### DIFF
--- a/turbo/apps/web/src/types/agent-compose.ts
+++ b/turbo/apps/web/src/types/agent-compose.ts
@@ -2,7 +2,7 @@
  * Agent compose types matching agent.yaml format
  */
 
-import type { ExpandedServiceConfig } from "@vm0/core";
+import type { ExpandedServiceConfig, VALID_CAPABILITIES } from "@vm0/core";
 
 /**
  * Volume configuration for static dependencies
@@ -54,7 +54,7 @@ interface AgentDefinition {
    * Capabilities that the agent is allowed to use.
    * Validated at compose time against VALID_CAPABILITIES.
    */
-  experimental_capabilities?: string[];
+  experimental_capabilities?: (typeof VALID_CAPABILITIES)[number][];
   /**
    * Agent metadata for display and personalization.
    */

--- a/turbo/apps/web/src/types/agent-compose.ts
+++ b/turbo/apps/web/src/types/agent-compose.ts
@@ -51,6 +51,11 @@ interface AgentDefinition {
    */
   experimental_services?: ExpandedServiceConfig[];
   /**
+   * Capabilities that the agent is allowed to use.
+   * Validated at compose time against VALID_CAPABILITIES.
+   */
+  experimental_capabilities?: string[];
+  /**
    * Agent metadata for display and personalization.
    */
   metadata?: {

--- a/turbo/packages/core/src/contracts/__tests__/composes.test.ts
+++ b/turbo/packages/core/src/contracts/__tests__/composes.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from "vitest";
+import {
+  agentDefinitionSchema,
+  agentComposeApiContentSchema,
+  VALID_CAPABILITIES,
+} from "../composes";
+
+const baseAgent = {
+  framework: "claude-code",
+};
+
+function wrapInCompose(agentOverrides: Record<string, unknown>) {
+  return {
+    version: "1.0",
+    agents: {
+      "test-agent": { ...baseAgent, ...agentOverrides },
+    },
+  };
+}
+
+describe("VALID_CAPABILITIES", () => {
+  it("contains 12 capabilities", () => {
+    expect(VALID_CAPABILITIES).toHaveLength(12);
+  });
+
+  it("all follow resource:action format", () => {
+    for (const cap of VALID_CAPABILITIES) {
+      expect(cap).toMatch(/^[a-z-]+:(read|write)$/);
+    }
+  });
+});
+
+describe("experimental_capabilities in agentDefinitionSchema", () => {
+  it("accepts valid capabilities array", () => {
+    const result = agentDefinitionSchema.safeParse({
+      ...baseAgent,
+      experimental_capabilities: ["volume:read", "artifact:write"],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts a single valid capability", () => {
+    const result = agentDefinitionSchema.safeParse({
+      ...baseAgent,
+      experimental_capabilities: ["memory:read"],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts empty array", () => {
+    const result = agentDefinitionSchema.safeParse({
+      ...baseAgent,
+      experimental_capabilities: [],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts missing field (backward compatibility)", () => {
+    const result = agentDefinitionSchema.safeParse(baseAgent);
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects invalid capability name", () => {
+    const result = agentDefinitionSchema.safeParse({
+      ...baseAgent,
+      experimental_capabilities: ["invalid:capability"],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects duplicate capabilities", () => {
+    const result = agentDefinitionSchema.safeParse({
+      ...baseAgent,
+      experimental_capabilities: ["volume:read", "volume:read"],
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0]?.message).toBe(
+        "Duplicate capabilities are not allowed",
+      );
+    }
+  });
+});
+
+describe("experimental_capabilities in agentComposeApiContentSchema", () => {
+  it("accepts compose with valid capabilities", () => {
+    const result = agentComposeApiContentSchema.safeParse(
+      wrapInCompose({
+        experimental_capabilities: [
+          "volume:read",
+          "volume:write",
+          "agent-run:read",
+        ],
+      }),
+    );
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts compose without capabilities", () => {
+    const result = agentComposeApiContentSchema.safeParse(wrapInCompose({}));
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects compose with invalid capability", () => {
+    const result = agentComposeApiContentSchema.safeParse(
+      wrapInCompose({
+        experimental_capabilities: ["not-a-capability"],
+      }),
+    );
+    expect(result.success).toBe(false);
+  });
+});

--- a/turbo/packages/core/src/contracts/composes.ts
+++ b/turbo/packages/core/src/contracts/composes.ts
@@ -24,6 +24,25 @@ const composeVersionQuerySchema = z
 export const AGENT_NAME_REGEX = /^[a-zA-Z0-9][a-zA-Z0-9-]{1,62}[a-zA-Z0-9]$/;
 
 /**
+ * Valid capability strings for experimental_capabilities.
+ * Format: {resource}:{action}
+ */
+export const VALID_CAPABILITIES = [
+  "volume:read",
+  "volume:write",
+  "artifact:read",
+  "artifact:write",
+  "memory:read",
+  "memory:write",
+  "agent:read",
+  "agent:write",
+  "agent-run:read",
+  "agent-run:write",
+  "schedule:read",
+  "schedule:write",
+] as const;
+
+/**
  * Agent name validation schema
  * - Must be 3-64 characters
  * - Letters, numbers, and hyphens only
@@ -104,6 +123,16 @@ const agentDefinitionSchema = z.object({
         permissions: z.union([z.literal("all"), z.array(z.string()).min(1)]),
       }),
     )
+    .optional(),
+  /**
+   * Capabilities that the agent is allowed to use.
+   * Validated against VALID_CAPABILITIES at compose time.
+   */
+  experimental_capabilities: z
+    .array(z.enum(VALID_CAPABILITIES))
+    .refine((arr) => new Set(arr).size === arr.length, {
+      message: "Duplicate capabilities are not allowed",
+    })
     .optional(),
   /**
    * Agent metadata for display and personalization.

--- a/turbo/packages/core/src/contracts/index.ts
+++ b/turbo/packages/core/src/contracts/index.ts
@@ -36,6 +36,7 @@ export {
   agentComposeApiContentSchema,
   composeResponseSchema,
   composeListItemSchema,
+  VALID_CAPABILITIES,
   // Inferred types
   type ComposeResponse,
   type ComposeListItem,


### PR DESCRIPTION
## Summary

- Add `VALID_CAPABILITIES` constant with 12 resource:action capability strings to `@vm0/core`
- Add `experimental_capabilities` field to `agentDefinitionSchema` with `z.enum()` validation and duplicate detection
- Add `experimental_capabilities?: string[]` to `AgentDefinition` TypeScript interface
- Schema-only change — field is accepted, validated, and stored in JSONB, no behavior change

## Test plan

- [x] Schema validation tests: valid capabilities accepted, invalid rejected, duplicates rejected, empty array accepted, backward compatibility
- [x] Integration test: `agentComposeApiContentSchema` validates capabilities through full compose structure
- [x] All existing tests pass (257 tests, 12 test files)
- [x] Lint, format, knip all pass

Closes #4870

🤖 Generated with [Claude Code](https://claude.com/claude-code)