### PR TITLE
feat: flow experimental_capabilities through execution context pipeline

### DIFF
--- a/turbo/apps/web/app/api/runners/jobs/[id]/claim/route.ts
+++ b/turbo/apps/web/app/api/runners/jobs/[id]/claim/route.ts
@@ -198,6 +198,7 @@ const router = tsr.router(runnersJobClaimContract, {
         encryptedSecrets: storedContext.encryptedSecrets, // Encrypted blob for auth resolution
         cliAgentType: storedContext.cliAgentType,
         experimentalServices: storedContext.experimentalServices,
+        experimentalCapabilities: storedContext.experimentalCapabilities,
         debugNoMockClaude: storedContext.debugNoMockClaude,
         apiStartTime: storedContext.apiStartTime,
         userTimezone: storedContext.userTimezone,

--- a/turbo/apps/web/src/lib/run/build-context.ts
+++ b/turbo/apps/web/src/lib/run/build-context.ts
@@ -801,6 +801,23 @@ function buildExperimentalServices(
 }
 
 /**
+ * Extract experimental_capabilities from the first agent in compose.
+ * Returns undefined if not present or empty.
+ */
+function buildExperimentalCapabilities(
+  agentCompose: unknown,
+): string[] | undefined {
+  const compose = agentCompose as AgentComposeYaml | undefined;
+  if (!compose?.agents) return undefined;
+
+  const firstAgent = Object.values(compose.agents)[0];
+  const capabilities = firstAgent?.experimental_capabilities;
+  if (!capabilities || capabilities.length === 0) return undefined;
+
+  return [...capabilities];
+}
+
+/**
  * Build unified execution context from various parameter sources.
  * Supports: new run, checkpoint resume, session continue.
  *
@@ -910,6 +927,9 @@ export async function buildExecutionContext(
   const experimentalServices =
     buildExperimentalServices(agentCompose) ?? undefined;
 
+  // Build experimental capabilities list from compose
+  const experimentalCapabilities = buildExperimentalCapabilities(agentCompose);
+
   // Build final execution context
   return {
     runtimeOrg,
@@ -930,6 +950,7 @@ export async function buildExecutionContext(
       environment,
       userTimezone,
       experimentalServices,
+      experimentalCapabilities,
       resumeSession,
       resumeArtifact,
       // Metadata for vm0_start event

--- a/turbo/apps/web/src/lib/run/build-context.ts
+++ b/turbo/apps/web/src/lib/run/build-context.ts
@@ -10,6 +10,7 @@ import {
   getConnectorEnvironmentMapping,
   connectorTypeSchema,
   MODEL_PROVIDER_TYPES,
+  VALID_CAPABILITIES,
   type ExperimentalServices,
   type ConnectorType,
   type ModelProviderType,
@@ -806,7 +807,7 @@ function buildExperimentalServices(
  */
 function buildExperimentalCapabilities(
   agentCompose: unknown,
-): string[] | undefined {
+): (typeof VALID_CAPABILITIES)[number][] | undefined {
   const compose = agentCompose as AgentComposeYaml | undefined;
   if (!compose?.agents) return undefined;
 

--- a/turbo/apps/web/src/lib/run/context/execution-preparer.ts
+++ b/turbo/apps/web/src/lib/run/context/execution-preparer.ts
@@ -227,6 +227,9 @@ function buildPreparedContext(
     // Experimental services for proxy-side token replacement
     experimentalServices: context.experimentalServices ?? null,
 
+    // Experimental capabilities
+    experimentalCapabilities: context.experimentalCapabilities ?? null,
+
     // Routing
     runnerGroup,
 

--- a/turbo/apps/web/src/lib/run/executors/runner-executor.ts
+++ b/turbo/apps/web/src/lib/run/executors/runner-executor.ts
@@ -58,6 +58,7 @@ export async function executeRunnerJob(
     secretConnectorMap: context.secretConnectorMap,
     cliAgentType: context.cliAgentType,
     experimentalServices: context.experimentalServices ?? undefined,
+    experimentalCapabilities: context.experimentalCapabilities ?? undefined,
     debugNoMockClaude: context.debugNoMockClaude || undefined,
     apiStartTime: context.apiStartTime ?? undefined,
     userTimezone: context.userTimezone ?? undefined,

--- a/turbo/apps/web/src/lib/run/executors/types.ts
+++ b/turbo/apps/web/src/lib/run/executors/types.ts
@@ -1,7 +1,7 @@
 import type { StorageManifest } from "../../storage/types";
 import type { ResumeSession } from "../types";
 import type { ArtifactSnapshot } from "../../checkpoint/types";
-import type { ExperimentalServices } from "@vm0/core";
+import type { ExperimentalServices, VALID_CAPABILITIES } from "@vm0/core";
 
 /**
  * Prepared execution context for executors
@@ -46,7 +46,7 @@ export interface PreparedContext {
   experimentalServices: ExperimentalServices | null;
 
   // Experimental capabilities for agent permission enforcement
-  experimentalCapabilities: string[] | null;
+  experimentalCapabilities: (typeof VALID_CAPABILITIES)[number][] | null;
 
   // Routing hint (runner group name)
   runnerGroup: string | null;

--- a/turbo/apps/web/src/lib/run/executors/types.ts
+++ b/turbo/apps/web/src/lib/run/executors/types.ts
@@ -45,6 +45,9 @@ export interface PreparedContext {
   // Experimental services for proxy-side token replacement
   experimentalServices: ExperimentalServices | null;
 
+  // Experimental capabilities for agent permission enforcement
+  experimentalCapabilities: string[] | null;
+
   // Routing hint (runner group name)
   runnerGroup: string | null;
 

--- a/turbo/apps/web/src/lib/run/types.ts
+++ b/turbo/apps/web/src/lib/run/types.ts
@@ -80,6 +80,9 @@ export interface ExecutionContext {
   // Experimental services for proxy-side token replacement
   experimentalServices?: ExperimentalServices;
 
+  // Experimental capabilities for agent permission enforcement
+  experimentalCapabilities?: string[];
+
   // Resume-specific (optional)
   resumeSession?: ResumeSession;
   resumeArtifact?: ArtifactSnapshot;

--- a/turbo/apps/web/src/lib/run/types.ts
+++ b/turbo/apps/web/src/lib/run/types.ts
@@ -1,5 +1,5 @@
 import type { ArtifactSnapshot } from "../checkpoint/types";
-import type { ExperimentalServices } from "@vm0/core";
+import type { ExperimentalServices, VALID_CAPABILITIES } from "@vm0/core";
 
 /**
  * Run status values
@@ -81,7 +81,7 @@ export interface ExecutionContext {
   experimentalServices?: ExperimentalServices;
 
   // Experimental capabilities for agent permission enforcement
-  experimentalCapabilities?: string[];
+  experimentalCapabilities?: (typeof VALID_CAPABILITIES)[number][];
 
   // Resume-specific (optional)
   resumeSession?: ResumeSession;

--- a/turbo/packages/core/src/contracts/composes.ts
+++ b/turbo/packages/core/src/contracts/composes.ts
@@ -1,7 +1,6 @@
 import { z } from "zod";
 import { authHeadersSchema, initContract } from "./base";
 import { apiErrorSchema } from "./errors";
-import { servicePermissionSchema } from "./runners";
 
 const c = initContract();
 
@@ -41,6 +40,17 @@ export const VALID_CAPABILITIES = [
   "schedule:read",
   "schedule:write",
 ] as const;
+
+/**
+ * Service permission schema for proxy-side token replacement.
+ * Defined here (not in runners.ts) to avoid circular dependency:
+ * composes.ts exports VALID_CAPABILITIES used by runners.ts.
+ */
+export const servicePermissionSchema = z.object({
+  name: z.string(),
+  description: z.string().optional(),
+  rules: z.array(z.string()),
+});
 
 /**
  * Agent name validation schema

--- a/turbo/packages/core/src/contracts/runners.ts
+++ b/turbo/packages/core/src/contracts/runners.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { authHeadersSchema, initContract } from "./base";
+import { VALID_CAPABILITIES } from "./composes";
 import { apiErrorSchema } from "./errors";
 
 const c = initContract();
@@ -147,7 +148,7 @@ export const storedExecutionContextSchema = z.object({
   // Experimental services for proxy-side token replacement
   experimentalServices: experimentalServicesSchema.optional(),
   // Experimental capabilities for agent permission enforcement
-  experimentalCapabilities: z.array(z.string()).optional(),
+  experimentalCapabilities: z.array(z.enum(VALID_CAPABILITIES)).optional(),
 });
 
 /**
@@ -187,7 +188,7 @@ export const executionContextSchema = z.object({
   // Experimental services for proxy-side token replacement
   experimentalServices: experimentalServicesSchema.optional(),
   // Experimental capabilities for agent permission enforcement
-  experimentalCapabilities: z.array(z.string()).optional(),
+  experimentalCapabilities: z.array(z.enum(VALID_CAPABILITIES)).optional(),
 });
 
 /**

--- a/turbo/packages/core/src/contracts/runners.ts
+++ b/turbo/packages/core/src/contracts/runners.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { authHeadersSchema, initContract } from "./base";
-import { VALID_CAPABILITIES } from "./composes";
+import { servicePermissionSchema, VALID_CAPABILITIES } from "./composes";
 import { apiErrorSchema } from "./errors";
 
 const c = initContract();
@@ -56,12 +56,6 @@ export const runnersPollContract = c.router({
 /**
  * Service API entry for proxy-side token replacement
  */
-export const servicePermissionSchema = z.object({
-  name: z.string(),
-  description: z.string().optional(),
-  rules: z.array(z.string()),
-});
-
 export const serviceApiEntrySchema = z.object({
   base: z.string(),
   auth: z.object({

--- a/turbo/packages/core/src/contracts/runners.ts
+++ b/turbo/packages/core/src/contracts/runners.ts
@@ -146,6 +146,8 @@ export const storedExecutionContextSchema = z.object({
   memoryName: z.string().optional(),
   // Experimental services for proxy-side token replacement
   experimentalServices: experimentalServicesSchema.optional(),
+  // Experimental capabilities for agent permission enforcement
+  experimentalCapabilities: z.array(z.string()).optional(),
 });
 
 /**
@@ -184,6 +186,8 @@ export const executionContextSchema = z.object({
   memoryName: z.string().optional(),
   // Experimental services for proxy-side token replacement
   experimentalServices: experimentalServicesSchema.optional(),
+  // Experimental capabilities for agent permission enforcement
+  experimentalCapabilities: z.array(z.string()).optional(),
 });
 
 /**


### PR DESCRIPTION
## Summary

- Flow `experimental_capabilities` from compose content through the entire execution context chain
- Follow the exact same pattern as `experimentalServices` across all 7 pipeline stages
- Data-flow-only change with no behavior change — capabilities are extracted and passed through but not consumed yet

Closes #4879
Tracking: #4867 (Task 2 / Layer 2)
Depends on: #4870 (merged)

## Changes

| File | Change |
|------|--------|
| `packages/core/src/contracts/runners.ts` | Add `experimentalCapabilities` to `storedExecutionContextSchema` and `executionContextSchema` |
| `apps/web/src/lib/run/types.ts` | Add `experimentalCapabilities` to `ExecutionContext` interface |
| `apps/web/src/lib/run/executors/types.ts` | Add `experimentalCapabilities` to `PreparedContext` interface |
| `apps/web/src/lib/run/build-context.ts` | Add `buildExperimentalCapabilities()` extraction function |
| `apps/web/src/lib/run/context/execution-preparer.ts` | Pass through to `PreparedContext` |
| `apps/web/src/lib/run/executors/runner-executor.ts` | Pass through to `StoredExecutionContext` |
| `apps/web/app/api/runners/jobs/[id]/claim/route.ts` | Include in claim response |

## Test plan

- [x] `pnpm check-types` passes (core package; web has pre-existing unrelated errors)
- [x] `pnpm turbo run lint` passes
- [x] `pnpm vitest` — all related tests pass (pre-existing failures unrelated to this PR)
- [x] `pnpm knip` — no unused exports
- [x] Schema validation tests for `experimental_capabilities` pass (from #4870)
- [x] Backward compatibility: existing runs without capabilities unaffected (all fields optional)

🤖 Generated with [Claude Code](https://claude.com/claude-code)