### PR TITLE
feat(auth): encode capabilities in sandbox jwt token payload

### DIFF
--- a/turbo/apps/web/src/lib/auth/__tests__/sandbox-token.test.ts
+++ b/turbo/apps/web/src/lib/auth/__tests__/sandbox-token.test.ts
@@ -123,6 +123,59 @@ describe("sandbox-token", () => {
     });
   });
 
+  describe("capabilities", () => {
+    it("should include capabilities in verified token", async () => {
+      const capabilities = ["volume:read", "artifact:write"];
+      const token = await generateSandboxToken(
+        "user-123",
+        "run-456",
+        capabilities,
+      );
+      const auth = verifySandboxToken(token);
+
+      expect(auth).not.toBeNull();
+      expect(auth?.userId).toBe("user-123");
+      expect(auth?.runId).toBe("run-456");
+      expect(auth?.capabilities).toEqual(["volume:read", "artifact:write"]);
+    });
+
+    it("should work without capabilities (backward compat)", async () => {
+      const token = await generateSandboxToken("user-123", "run-456");
+      const auth = verifySandboxToken(token);
+
+      expect(auth).not.toBeNull();
+      expect(auth?.userId).toBe("user-123");
+      expect(auth?.capabilities).toBeUndefined();
+    });
+
+    it("should treat empty capabilities array as undefined", async () => {
+      const token = await generateSandboxToken("user-123", "run-456", []);
+      const auth = verifySandboxToken(token);
+
+      expect(auth).not.toBeNull();
+      expect(auth?.capabilities).toBeUndefined();
+    });
+
+    it("should roundtrip all valid capabilities", async () => {
+      const capabilities = [
+        "volume:read",
+        "volume:write",
+        "artifact:read",
+        "artifact:write",
+        "memory:read",
+        "memory:write",
+      ];
+      const token = await generateSandboxToken(
+        "user-123",
+        "run-456",
+        capabilities,
+      );
+      const auth = verifySandboxToken(token);
+
+      expect(auth?.capabilities).toEqual(capabilities);
+    });
+  });
+
   describe("roundtrip", () => {
     it("should correctly roundtrip userId and runId", async () => {
       const testCases = [

--- a/turbo/apps/web/src/lib/auth/__tests__/sandbox-token.test.ts
+++ b/turbo/apps/web/src/lib/auth/__tests__/sandbox-token.test.ts
@@ -125,7 +125,7 @@ describe("sandbox-token", () => {
 
   describe("capabilities", () => {
     it("should include capabilities in verified token", async () => {
-      const capabilities = ["volume:read", "artifact:write"];
+      const capabilities = ["volume:read", "artifact:write"] as const;
       const token = await generateSandboxToken(
         "user-123",
         "run-456",
@@ -164,7 +164,7 @@ describe("sandbox-token", () => {
         "artifact:write",
         "memory:read",
         "memory:write",
-      ];
+      ] as const;
       const token = await generateSandboxToken(
         "user-123",
         "run-456",

--- a/turbo/apps/web/src/lib/auth/sandbox-token.ts
+++ b/turbo/apps/web/src/lib/auth/sandbox-token.ts
@@ -11,6 +11,7 @@ interface SandboxTokenPayload {
   userId: string;
   runId: string;
   scope: "sandbox";
+  capabilities?: string[];
   iat: number;
   exp: number;
 }
@@ -32,6 +33,7 @@ interface ComposeJobTokenPayload {
 export interface SandboxAuth {
   userId: string;
   runId: string;
+  capabilities?: string[];
 }
 
 /**
@@ -150,6 +152,7 @@ function verifyJwt(token: string): SandboxTokenPayload | null {
 export async function generateSandboxToken(
   userId: string,
   runId: string,
+  capabilities?: string[],
 ): Promise<string> {
   const now = Math.floor(Date.now() / 1000);
   const expiresIn = 2 * 60 * 60; // 2 hours in seconds
@@ -158,6 +161,7 @@ export async function generateSandboxToken(
     userId,
     runId,
     scope: "sandbox",
+    ...(capabilities && capabilities.length > 0 ? { capabilities } : {}),
     iat: now,
     exp: now + expiresIn,
   };
@@ -182,6 +186,7 @@ export function verifySandboxToken(token: string): SandboxAuth | null {
   return {
     userId: payload.userId,
     runId: payload.runId,
+    ...(payload.capabilities ? { capabilities: payload.capabilities } : {}),
   };
 }
 

--- a/turbo/apps/web/src/lib/auth/sandbox-token.ts
+++ b/turbo/apps/web/src/lib/auth/sandbox-token.ts
@@ -1,6 +1,9 @@
 import { createHmac, hkdfSync } from "crypto";
+import type { VALID_CAPABILITIES } from "@vm0/core";
 import { env } from "../../env";
 import { logger } from "../logger";
+
+type Capability = (typeof VALID_CAPABILITIES)[number];
 
 const log = logger("auth:sandbox");
 
@@ -11,7 +14,7 @@ interface SandboxTokenPayload {
   userId: string;
   runId: string;
   scope: "sandbox";
-  capabilities?: string[];
+  capabilities?: readonly Capability[];
   iat: number;
   exp: number;
 }
@@ -33,7 +36,7 @@ interface ComposeJobTokenPayload {
 export interface SandboxAuth {
   userId: string;
   runId: string;
-  capabilities?: string[];
+  capabilities?: readonly Capability[];
 }
 
 /**
@@ -152,7 +155,7 @@ function verifyJwt(token: string): SandboxTokenPayload | null {
 export async function generateSandboxToken(
   userId: string,
   runId: string,
-  capabilities?: string[],
+  capabilities?: readonly Capability[],
 ): Promise<string> {
   const now = Math.floor(Date.now() / 1000);
   const expiresIn = 2 * 60 * 60; // 2 hours in seconds

--- a/turbo/apps/web/src/lib/run/run-service.ts
+++ b/turbo/apps/web/src/lib/run/run-service.ts
@@ -541,12 +541,16 @@ async function buildAndDispatchRun(opts: {
   const { userId, agentComposeVersionId, prompt } = params;
 
   try {
+    // Extract capabilities from compose content for sandbox token
+    const capabilities = Object.values(composeContent.agents)[0]
+      ?.experimental_capabilities;
+
     // Register callbacks and generate sandbox token in parallel (independent operations)
     const [, sandboxToken] = await Promise.all([
       params.callbacks && params.callbacks.length > 0
         ? registerCallbacks(runId, params.callbacks)
         : null,
-      generateSandboxToken(userId, runId),
+      generateSandboxToken(userId, runId, capabilities),
     ]);
     const tokenTime = Date.now();
 

--- a/turbo/apps/web/src/lib/run/run-service.ts
+++ b/turbo/apps/web/src/lib/run/run-service.ts
@@ -542,8 +542,10 @@ async function buildAndDispatchRun(opts: {
 
   try {
     // Extract capabilities from compose content for sandbox token
-    const capabilities = Object.values(composeContent.agents)[0]
-      ?.experimental_capabilities;
+    const agents = composeContent.agents;
+    const capabilities = agents
+      ? Object.values(agents)[0]?.experimental_capabilities
+      : undefined;
 
     // Register callbacks and generate sandbox token in parallel (independent operations)
     const [, sandboxToken] = await Promise.all([


### PR DESCRIPTION
## Summary

Extend the sandbox JWT token to carry an optional `capabilities` array in its payload. This is a token-format-only change with no behavior change — tokens carry capabilities but the auth layer doesn't check them yet (Task 4 in #4867).

- Add `capabilities?: string[]` to `SandboxTokenPayload` and `SandboxAuth` interfaces
- `generateSandboxToken()` accepts optional `capabilities` parameter; omits field when empty/undefined for backward compatibility
- `verifySandboxToken()` extracts and returns capabilities from verified payload
- `run-service.ts` extracts capabilities from compose content and passes to token generation
- `claim/route.ts` unchanged — Task 2 dependency not merged yet, optional param defaults to `undefined`

## Test plan

- [x] Token with capabilities can be verified and capabilities are returned
- [x] Token without capabilities (backward compat) still works
- [x] Empty capabilities array behaves same as undefined
- [x] Capabilities round-trip correctly through generate → verify
- [x] All 17 tests pass (13 existing + 4 new)
- [x] Lint, knip pass

Closes #4880

🤖 Generated with [Claude Code](https://claude.com/claude-code)