### PR TITLE
feat: sync skills cache on web server startup

### DIFF
--- a/turbo/apps/web/instrumentation.ts
+++ b/turbo/apps/web/instrumentation.ts
@@ -1,6 +1,12 @@
 export async function register() {
   if (process.env.NEXT_RUNTIME === "nodejs") {
     await import("./sentry.server.config");
+
+    // Sync skills cache on startup (needed for dev environments without Vercel cron)
+    const { initServices } = await import("./src/lib/init-services");
+    initServices();
+    const { syncSkills } = await import("./src/lib/skills/sync-skills");
+    syncSkills().catch(() => {}); // fire-and-forget, don't block startup
   }
 
   if (process.env.NEXT_RUNTIME === "edge") {

--- a/turbo/apps/web/instrumentation.ts
+++ b/turbo/apps/web/instrumentation.ts
@@ -5,8 +5,14 @@ export async function register() {
     // Sync skills cache on startup (needed for dev environments without Vercel cron)
     const { initServices } = await import("./src/lib/init-services");
     initServices();
+    const { logger } = await import("./src/lib/logger");
+    const log = logger("instrumentation");
     const { syncSkills } = await import("./src/lib/skills/sync-skills");
-    syncSkills().catch(() => {}); // fire-and-forget, don't block startup
+    syncSkills().catch((error: unknown) => {
+      log.error("Failed to sync skills on startup", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    });
   }
 
   if (process.env.NEXT_RUNTIME === "edge") {


### PR DESCRIPTION
## Summary

- Add fire-and-forget `syncSkills()` call in `instrumentation.ts` `register()` function (Node.js runtime)
- Ensures skills DB cache is populated at server startup, enabling server-side compose in dev environments without Vercel cron
- In production, this is effectively a no-op when cron has already populated skills (commitSha match → instant return)

## Details

The compose system has a two-tier design: fast server-side compose (preferred) and slow E2B sandbox compose (fallback). The server-side path requires skills to be cached in the `skills` DB table, which is populated by a Vercel cron job. In dev environments without cron, the table stays empty, forcing every compose through the slow E2B sandbox path.

This change calls `syncSkills()` at server startup as fire-and-forget:
- `initServices()` is called first (required for DB access)
- `syncSkills()` checks commitSha freshness — skips entirely if already synced
- `.catch(() => {})` prevents unhandled rejection; internal logging handles success/error visibility
- No `await` — does not block server startup

Closes #4893

## Test plan

- [x] Existing `sync-skills` cron route tests validate `syncSkills()` behavior (freshness check, full sync, incremental, malformed frontmatter)
- [ ] Manual: start dev server → verify skills table populated → onboarding compose uses server-side path
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)