### PR TITLE
feat: conditionally inject cli env vars in sandbox when capabilities present

### DIFF
--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -570,6 +570,19 @@ fn build_env_json(context: &ExecutionContext, api_url: &str) -> HashMap<String, 
         env.insert("NODE_EXTRA_CA_CERTS".into(), VM_PROXY_CA_PATH.into());
     }
 
+    // When capabilities are declared, inject CLI-compatible env vars
+    // so vm0 CLI can authenticate inside the sandbox.
+    if context
+        .experimental_capabilities
+        .as_ref()
+        .is_some_and(|caps| !caps.is_empty())
+    {
+        env.insert("VM0_TOKEN".into(), context.sandbox_token.clone());
+        if let Some(slug) = &context.agent_org_slug {
+            env.insert("VM0_ACTIVE_ORG".into(), slug.clone());
+        }
+    }
+
     // Artifact config
     if let Some(manifest) = &context.storage_manifest
         && let Some(artifact) = &manifest.artifact
@@ -654,6 +667,7 @@ mod tests {
             agent_org_slug: None,
             memory_name: None,
             experimental_firewall: None,
+            experimental_capabilities: None,
         }
     }
 
@@ -898,6 +912,62 @@ mod tests {
         ctx.experimental_firewall = Some(vec![]);
         let env = build_env_json(&ctx, "http://localhost");
         assert!(!env.contains_key("NODE_EXTRA_CA_CERTS"));
+    }
+
+    #[test]
+    fn build_env_json_capabilities_inject_cli_vars() {
+        let mut ctx = minimal_context();
+        ctx.experimental_capabilities = Some(vec!["volume:read".into()]);
+        ctx.agent_org_slug = Some("my-org".into());
+        let env = build_env_json(&ctx, "http://localhost");
+        assert_eq!(env.get("VM0_TOKEN").unwrap(), "tok");
+        assert_eq!(env.get("VM0_ACTIVE_ORG").unwrap(), "my-org");
+    }
+
+    #[test]
+    fn build_env_json_no_capabilities_no_cli_vars() {
+        let ctx = minimal_context();
+        let env = build_env_json(&ctx, "http://localhost");
+        assert!(!env.contains_key("VM0_TOKEN"));
+        assert!(!env.contains_key("VM0_ACTIVE_ORG"));
+    }
+
+    #[test]
+    fn build_env_json_empty_capabilities_no_cli_vars() {
+        let mut ctx = minimal_context();
+        ctx.experimental_capabilities = Some(vec![]);
+        let env = build_env_json(&ctx, "http://localhost");
+        assert!(!env.contains_key("VM0_TOKEN"));
+        assert!(!env.contains_key("VM0_ACTIVE_ORG"));
+    }
+
+    #[test]
+    fn build_env_json_capabilities_cli_vars_override_user_env() {
+        let mut ctx = minimal_context();
+        ctx.experimental_capabilities = Some(vec!["volume:read".into()]);
+        ctx.agent_org_slug = Some("my-org".into());
+        ctx.environment = Some(HashMap::from([
+            ("VM0_TOKEN".into(), "tampered".into()),
+            ("VM0_ACTIVE_ORG".into(), "evil-org".into()),
+        ]));
+        let env = build_env_json(&ctx, "http://localhost");
+        assert_eq!(env.get("VM0_TOKEN").unwrap(), "tok");
+        assert_eq!(env.get("VM0_ACTIVE_ORG").unwrap(), "my-org");
+    }
+
+    #[test]
+    fn execution_context_deserializes_with_capabilities() {
+        let json = serde_json::json!({
+            "runId": "00000000-0000-0000-0000-000000000001",
+            "prompt": "test",
+            "sandboxToken": "tok",
+            "workingDir": "/workspace",
+            "cliAgentType": "claude-code",
+            "experimentalCapabilities": ["volume:read", "artifact:write"]
+        });
+        let ctx: ExecutionContext = serde_json::from_value(json).unwrap();
+        let caps = ctx.experimental_capabilities.unwrap();
+        assert_eq!(caps, vec!["volume:read", "artifact:write"]);
     }
 
     #[test]

--- a/crates/runner/src/provider/local.rs
+++ b/crates/runner/src/provider/local.rs
@@ -159,6 +159,7 @@ impl JobProvider for LocalProvider {
             agent_org_slug: None,
             memory_name: None,
             experimental_firewall: None,
+            experimental_capabilities: None,
         })
     }
 

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -68,8 +68,7 @@ pub struct ExecutionContext {
     #[allow(dead_code)]
     #[serde(default)]
     pub agent_name: Option<String>,
-    // Not yet used by runner — org slug for agent
-    #[allow(dead_code)]
+    // Org slug for agent — used for VM0_ACTIVE_ORG when capabilities are present
     #[serde(default)]
     pub agent_org_slug: Option<String>,
     // Not yet used by runner — memory storage name for first-run init
@@ -78,6 +77,8 @@ pub struct ExecutionContext {
     pub memory_name: Option<String>,
     #[serde(default)]
     pub experimental_firewall: Option<Vec<Firewall>>,
+    #[serde(default)]
+    pub experimental_capabilities: Option<Vec<String>>,
 }
 
 /// A single firewall config with its name, ref key, and API entries.


### PR DESCRIPTION
## Summary

- Add `experimental_capabilities` field to Rust `ExecutionContext` struct
- Conditionally inject `VM0_TOKEN` and `VM0_ACTIVE_ORG` into sandbox environment when capabilities are present and non-empty
- Remove `#[allow(dead_code)]` from `agent_org_slug` since it's now actively used

## Test plan

- [x] `cargo test` — all 186 tests pass (5 new tests added)
- [x] `cargo clippy` — no warnings
- [ ] CI pipeline passes

Closes #4899

🤖 Generated with [Claude Code](https://claude.com/claude-code)