### PR TITLE
feat(auth): add opt-in capability parameter to auth context

### DIFF
--- a/turbo/apps/web/src/lib/auth/__tests__/capability-check.test.ts
+++ b/turbo/apps/web/src/lib/auth/__tests__/capability-check.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from "vitest";
+import {
+  hasCapability,
+  isSandboxAuth,
+  storageCapability,
+  missingCapabilityError,
+} from "../capability-check";
+
+describe("capability-check", () => {
+  describe("hasCapability", () => {
+    it("should return true for CLI auth (no capabilities)", () => {
+      expect(hasCapability({ userId: "user-1" }, "volume:read")).toBe(true);
+    });
+
+    it("should return true for sandbox auth with matching capability", () => {
+      expect(
+        hasCapability(
+          { userId: "user-1", runId: "run-1", capabilities: ["volume:read"] },
+          "volume:read",
+        ),
+      ).toBe(true);
+    });
+
+    it("should return false for sandbox auth without matching capability", () => {
+      expect(
+        hasCapability(
+          { userId: "user-1", runId: "run-1", capabilities: ["volume:read"] },
+          "artifact:write",
+        ),
+      ).toBe(false);
+    });
+
+    it("should return false for sandbox auth with empty capabilities", () => {
+      expect(
+        hasCapability(
+          { userId: "user-1", runId: "run-1", capabilities: [] },
+          "volume:read",
+        ),
+      ).toBe(false);
+    });
+  });
+
+  describe("isSandboxAuth", () => {
+    it("should return false for CLI auth", () => {
+      expect(isSandboxAuth({ userId: "user-1" })).toBe(false);
+    });
+
+    it("should return true for sandbox auth", () => {
+      expect(isSandboxAuth({ userId: "user-1", runId: "run-1" })).toBe(true);
+    });
+  });
+
+  describe("storageCapability", () => {
+    it("should map storage type and action to capability string", () => {
+      expect(storageCapability("volume", "read")).toBe("volume:read");
+      expect(storageCapability("volume", "write")).toBe("volume:write");
+      expect(storageCapability("artifact", "read")).toBe("artifact:read");
+      expect(storageCapability("artifact", "write")).toBe("artifact:write");
+      expect(storageCapability("memory", "read")).toBe("memory:read");
+      expect(storageCapability("memory", "write")).toBe("memory:write");
+    });
+  });
+
+  describe("missingCapabilityError", () => {
+    it("should return 403 error body with capability name", () => {
+      const error = missingCapabilityError("volume:read");
+
+      expect(error.error.message).toBe(
+        "Missing required capability: volume:read",
+      );
+      expect(error.error.code).toBe("FORBIDDEN");
+    });
+  });
+});

--- a/turbo/apps/web/src/lib/auth/__tests__/get-user-id.spec.ts
+++ b/turbo/apps/web/src/lib/auth/__tests__/get-user-id.spec.ts
@@ -1,6 +1,7 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { auth } from "@clerk/nextjs/server";
-import { getUserId } from "../get-user-id";
+import { getAuthContext, getUserId } from "../get-user-id";
+import { generateSandboxToken } from "../sandbox-token";
 
 describe("getUserId", () => {
   const mockAuth = vi.mocked(auth);
@@ -45,5 +46,72 @@ describe("getUserId", () => {
     const result = await getUserId("Basic sometoken");
 
     expect(result).toBeNull();
+  });
+});
+
+describe("getAuthContext with requiredCapability", () => {
+  const mockAuth = vi.mocked(auth);
+
+  beforeEach(() => {
+    mockAuth.mockResolvedValue({
+      userId: null,
+    } as Awaited<ReturnType<typeof auth>>);
+  });
+
+  it("should reject sandbox token without requiredCapability (backward compat)", async () => {
+    const token = await generateSandboxToken("user-123", "run-456", [
+      "volume:read",
+    ]);
+    const result = await getAuthContext(`Bearer ${token}`);
+
+    expect(result).toBeNull();
+  });
+
+  it("should accept sandbox token with matching capability", async () => {
+    const token = await generateSandboxToken("user-123", "run-456", [
+      "volume:read",
+    ]);
+    const result = await getAuthContext(`Bearer ${token}`, {
+      requiredCapability: "volume:read",
+    });
+
+    expect(result).not.toBeNull();
+    expect(result?.userId).toBe("user-123");
+    expect(result?.runId).toBe("run-456");
+    expect(result?.capabilities).toContain("volume:read");
+  });
+
+  it("should reject sandbox token without matching capability", async () => {
+    const token = await generateSandboxToken("user-123", "run-456", [
+      "volume:read",
+    ]);
+    const result = await getAuthContext(`Bearer ${token}`, {
+      requiredCapability: "artifact:write",
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it("should reject sandbox token with no capabilities", async () => {
+    const token = await generateSandboxToken("user-123", "run-456");
+    const result = await getAuthContext(`Bearer ${token}`, {
+      requiredCapability: "volume:read",
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it("should return Clerk session auth regardless of requiredCapability", async () => {
+    mockAuth.mockResolvedValue({
+      userId: "clerk-user",
+    } as Awaited<ReturnType<typeof auth>>);
+
+    const result = await getAuthContext(undefined, {
+      requiredCapability: "volume:read",
+    });
+
+    expect(result).not.toBeNull();
+    expect(result?.userId).toBe("clerk-user");
+    expect(result?.capabilities).toBeUndefined();
   });
 });

--- a/turbo/apps/web/src/lib/auth/capability-check.ts
+++ b/turbo/apps/web/src/lib/auth/capability-check.ts
@@ -1,4 +1,7 @@
+import type { VALID_CAPABILITIES } from "@vm0/core";
 import type { AuthContext } from "./get-user-id";
+
+type Capability = (typeof VALID_CAPABILITIES)[number];
 
 /**
  * Check if an auth context has a specific capability.
@@ -7,7 +10,7 @@ import type { AuthContext } from "./get-user-id";
  */
 export function hasCapability(
   authCtx: AuthContext,
-  capability: string,
+  capability: Capability,
 ): boolean {
   if (!authCtx.capabilities) {
     return true;
@@ -16,7 +19,7 @@ export function hasCapability(
 }
 
 /**
- * Type guard: check if auth context is from a sandbox token.
+ * Check if auth context is from a sandbox token.
  * Sandbox auth contexts have a runId field.
  */
 export function isSandboxAuth(authCtx: AuthContext): boolean {
@@ -30,15 +33,15 @@ export function isSandboxAuth(authCtx: AuthContext): boolean {
 export function storageCapability(
   storageType: "volume" | "artifact" | "memory",
   action: "read" | "write",
-): string {
-  return `${storageType}:${action}`;
+): Capability {
+  return `${storageType}:${action}` as Capability;
 }
 
 /**
  * Build 403 response body for missing capability.
  * Response body tells which capability is missing (aids debugging).
  */
-export function missingCapabilityError(capability: string): {
+export function missingCapabilityError(capability: Capability): {
   error: { message: string; code: string };
 } {
   return {

--- a/turbo/apps/web/src/lib/auth/capability-check.ts
+++ b/turbo/apps/web/src/lib/auth/capability-check.ts
@@ -1,0 +1,50 @@
+import type { AuthContext } from "./get-user-id";
+
+/**
+ * Check if an auth context has a specific capability.
+ * Returns true for non-sandbox auth (CLI/session tokens have full access).
+ * Returns false if sandbox token lacks the capability.
+ */
+export function hasCapability(
+  authCtx: AuthContext,
+  capability: string,
+): boolean {
+  if (!authCtx.capabilities) {
+    return true;
+  }
+  return authCtx.capabilities.includes(capability);
+}
+
+/**
+ * Type guard: check if auth context is from a sandbox token.
+ * Sandbox auth contexts have a runId field.
+ */
+export function isSandboxAuth(authCtx: AuthContext): boolean {
+  return authCtx.runId !== undefined;
+}
+
+/**
+ * Map storage type + action to capability string.
+ * e.g., ("volume", "read") → "volume:read"
+ */
+export function storageCapability(
+  storageType: "volume" | "artifact" | "memory",
+  action: "read" | "write",
+): string {
+  return `${storageType}:${action}`;
+}
+
+/**
+ * Build 403 response body for missing capability.
+ * Response body tells which capability is missing (aids debugging).
+ */
+export function missingCapabilityError(capability: string): {
+  error: { message: string; code: string };
+} {
+  return {
+    error: {
+      message: `Missing required capability: ${capability}`,
+      code: "FORBIDDEN",
+    },
+  };
+}

--- a/turbo/apps/web/src/lib/auth/get-user-id.ts
+++ b/turbo/apps/web/src/lib/auth/get-user-id.ts
@@ -1,8 +1,11 @@
 import { eq, and, gt } from "drizzle-orm";
 import { auth } from "@clerk/nextjs/server";
+import type { VALID_CAPABILITIES } from "@vm0/core";
 import { cliTokens } from "../../db/schema/cli-tokens";
 import { isSandboxToken, verifySandboxToken } from "./sandbox-token";
 import { logger } from "../logger";
+
+type Capability = (typeof VALID_CAPABILITIES)[number];
 
 const log = logger("auth:user");
 
@@ -11,7 +14,7 @@ const log = logger("auth:user");
  */
 export type AuthContext = {
   userId: string;
-  capabilities?: readonly string[];
+  capabilities?: readonly Capability[];
   runId?: string;
 };
 
@@ -24,7 +27,7 @@ export type AuthContext = {
  */
 export async function getAuthContext(
   authHeader?: string,
-  options?: { requiredCapability?: string },
+  options?: { requiredCapability?: Capability },
 ): Promise<AuthContext | null> {
   // Session auth via Clerk
   const { userId } = await auth();
@@ -104,7 +107,7 @@ export async function getAuthContext(
  */
 export async function getUserId(
   authHeader?: string,
-  options?: { requiredCapability?: string },
+  options?: { requiredCapability?: Capability },
 ): Promise<string | null> {
   const ctx = await getAuthContext(authHeader, options);
   return ctx?.userId ?? null;

--- a/turbo/apps/web/src/lib/auth/get-user-id.ts
+++ b/turbo/apps/web/src/lib/auth/get-user-id.ts
@@ -1,7 +1,7 @@
 import { eq, and, gt } from "drizzle-orm";
 import { auth } from "@clerk/nextjs/server";
 import { cliTokens } from "../../db/schema/cli-tokens";
-import { isSandboxToken } from "./sandbox-token";
+import { isSandboxToken, verifySandboxToken } from "./sandbox-token";
 import { logger } from "../logger";
 
 const log = logger("auth:user");
@@ -9,19 +9,22 @@ const log = logger("auth:user");
 /**
  * Authentication context returned by getAuthContext.
  */
-type AuthContext = {
+export type AuthContext = {
   userId: string;
+  capabilities?: readonly string[];
+  runId?: string;
 };
 
 /**
  * Get the full authentication context from CLI token or Clerk session.
  * Returns null if not authenticated.
  *
- * IMPORTANT: This function rejects sandbox JWT tokens.
- * Sandbox tokens can only be used on webhook endpoints via getSandboxAuth().
+ * By default, sandbox JWT tokens are rejected. Pass `options.requiredCapability`
+ * to accept sandbox tokens that include the specified capability.
  */
 export async function getAuthContext(
   authHeader?: string,
+  options?: { requiredCapability?: string },
 ): Promise<AuthContext | null> {
   // Session auth via Clerk
   const { userId } = await auth();
@@ -35,10 +38,37 @@ export async function getAuthContext(
 
   const token = authHeader.substring(7); // Remove "Bearer "
 
-  // Reject sandbox JWT tokens on normal APIs
   if (isSandboxToken(token)) {
-    log.debug("Rejected sandbox JWT token on normal API endpoint");
-    return null;
+    // Without requiredCapability, reject sandbox tokens (existing behavior)
+    if (!options?.requiredCapability) {
+      log.debug("Rejected sandbox JWT token on normal API endpoint");
+      return null;
+    }
+
+    // With requiredCapability, verify sandbox token and check capability
+    const sandboxAuth = verifySandboxToken(token);
+    if (!sandboxAuth) {
+      log.debug("Invalid or expired sandbox token");
+      return null;
+    }
+
+    const hasCap = sandboxAuth.capabilities?.some(
+      (cap) => cap === options.requiredCapability,
+    );
+    if (!hasCap) {
+      log.debug(
+        `Sandbox token missing required capability: ${options.requiredCapability}`,
+      );
+      return null;
+    }
+
+    return {
+      userId: sandboxAuth.userId,
+      runId: sandboxAuth.runId,
+      capabilities: sandboxAuth.capabilities
+        ? [...sandboxAuth.capabilities]
+        : undefined,
+    };
   }
 
   // Check for CLI token format (vm0_live_)
@@ -72,8 +102,11 @@ export async function getAuthContext(
  * Get the current user ID from CLI token or Clerk session.
  * Returns null if not authenticated.
  */
-export async function getUserId(authHeader?: string): Promise<string | null> {
-  const ctx = await getAuthContext(authHeader);
+export async function getUserId(
+  authHeader?: string,
+  options?: { requiredCapability?: string },
+): Promise<string | null> {
+  const ctx = await getAuthContext(authHeader, options);
   return ctx?.userId ?? null;
 }
 


### PR DESCRIPTION
## Summary

- Extend `getAuthContext()` to accept optional `requiredCapability` parameter that enables sandbox tokens to be accepted on normal API routes
- Export `AuthContext` type with optional `capabilities` and `runId` fields
- Create `capability-check.ts` helper module with `hasCapability`, `isSandboxAuth`, `storageCapability`, and `missingCapabilityError`
- Without `requiredCapability` parameter, sandbox tokens are still rejected (backward compatible, zero behavior change)

Closes #4898
Tracking issue: #4867 (Task 4 / Layer 3)

## Test plan

- [x] `getAuthContext()` without options rejects sandbox tokens (backward compat)
- [x] `getAuthContext()` with matching capability accepts sandbox token
- [x] `getAuthContext()` with non-matching capability rejects sandbox token
- [x] `getAuthContext()` with no capabilities rejects sandbox token
- [x] Clerk session auth works regardless of `requiredCapability`
- [x] `hasCapability()` returns true for CLI auth (no capabilities)
- [x] `hasCapability()` returns false for sandbox auth missing capability
- [x] `isSandboxAuth()` correctly identifies sandbox vs CLI auth
- [x] `storageCapability()` maps type+action to capability string
- [x] `missingCapabilityError()` returns proper 403 error body
- [x] All 17 tests passing, lint clean, knip clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)