### PR TITLE
chore: update claude skills to use invoke syntax and improve dev tooling

### DIFF
--- a/.claude/commands/defensive-code-cleanup.md
+++ b/.claude/commands/defensive-code-cleanup.md
@@ -3,9 +3,4 @@ command: defensive-code-cleanup
 description: Clean Defensive Try-Catch Blocks
 ---
 
-```typescript
-await Skill({
-  skill: "code-quality",
-  args: "cleanup"
-});
-```
+invoke skill /code-quality cleanup

--- a/.claude/commands/dev-auth.md
+++ b/.claude/commands/dev-auth.md
@@ -3,9 +3,4 @@ command: dev-auth
 description: Authenticate with local development server and get CLI token
 ---
 
-```typescript
-await Skill({
-  skill: "dev-server",
-  args: "auth"
-});
-```
+invoke skill /dev-server auth

--- a/.claude/commands/dev-logs.md
+++ b/.claude/commands/dev-logs.md
@@ -3,9 +3,4 @@ command: dev-logs
 description: View development server logs with optional filtering
 ---
 
-```typescript
-await Skill({
-  skill: "dev-logs",
-  args: "$ARGUMENTS"
-});
-```
+invoke skill /dev-logs $ARGUMENTS

--- a/.claude/commands/dev-start-github.md
+++ b/.claude/commands/dev-start-github.md
@@ -3,9 +3,4 @@ command: dev-start-github
 description: Start the development server with a fixed GitHub tunnel URL
 ---
 
-```typescript
-await Skill({
-  skill: "dev-server",
-  args: "start --tunnel-hostname=tunnel-github-dev.vm7.ai"
-});
-```
+invoke skill /dev-server start --tunnel-hostname=tunnel-github-dev.vm7.ai

--- a/.claude/commands/dev-start.md
+++ b/.claude/commands/dev-start.md
@@ -3,9 +3,4 @@ command: dev-start
 description: Start the development server in background mode
 ---
 
-```typescript
-await Skill({
-  skill: "dev-server",
-  args: "start"
-});
-```
+invoke skill /dev-server start

--- a/.claude/commands/dev-stop.md
+++ b/.claude/commands/dev-stop.md
@@ -3,9 +3,4 @@ command: dev-stop
 description: Stop the background development server
 ---
 
-```typescript
-await Skill({
-  skill: "dev-server",
-  args: "stop"
-});
-```
+invoke skill /dev-server stop

--- a/.claude/commands/dev-tunnel.md
+++ b/.claude/commands/dev-tunnel.md
@@ -3,9 +3,4 @@ command: dev-tunnel
 description: Full dev setup with tunnel (automatic) and CLI authentication
 ---
 
-```typescript
-await Skill({
-  skill: "dev-server",
-  args: "tunnel"
-});
-```
+invoke skill /dev-server tunnel

--- a/.claude/commands/pr-create.md
+++ b/.claude/commands/pr-create.md
@@ -3,9 +3,4 @@ command: pr-create
 description: Alias for pull-request create
 ---
 
-```typescript
-await Skill({
-  skill: "pull-request",
-  args: "create"
-});
-```
+invoke skill /pull-request create

--- a/.claude/commands/preview-envs-cleanup.md
+++ b/.claude/commands/preview-envs-cleanup.md
@@ -3,9 +3,4 @@ command: preview-envs-cleanup
 description: Clean up old GitHub preview deployment environments
 ---
 
-```typescript
-await Skill({
-  skill: "ops-utils",
-  args: "cleanup-previews"
-});
-```
+invoke skill /ops-utils cleanup-previews

--- a/.claude/commands/tech-debt-issue.md
+++ b/.claude/commands/tech-debt-issue.md
@@ -3,9 +3,4 @@ command: tech-debt-issue
 description: Alias for tech-debt issue
 ---
 
-```typescript
-await Skill({
-  skill: "tech-debt",
-  args: "issue"
-});
-```
+invoke skill /tech-debt issue

--- a/.claude/commands/tech-debt-research.md
+++ b/.claude/commands/tech-debt-research.md
@@ -3,9 +3,4 @@ command: tech-debt-research
 description: Alias for tech-debt research
 ---
 
-```typescript
-await Skill({
-  skill: "tech-debt",
-  args: "research"
-});
-```
+invoke skill /tech-debt research

--- a/.claude/skills/agent-browser/SKILL.md
+++ b/.claude/skills/agent-browser/SKILL.md
@@ -258,7 +258,7 @@ In this project, headed mode is the default (see noVNC Setup above). Additional 
 
 ```bash
 agent-browser highlight @e1          # Highlight element
-agent-browser record start demo.webm # Record session
+agent-browser record restart demo.webm # Record session (restart avoids "stop first" error)
 agent-browser profiler start         # Start Chrome DevTools profiling
 agent-browser profiler stop trace.json # Stop and save profile (path optional)
 ```

--- a/.claude/skills/dev-browser/SKILL.md
+++ b/.claude/skills/dev-browser/SKILL.md
@@ -28,6 +28,20 @@ PROJECT_ROOT=$(git rev-parse --show-toplevel)
 cd "$PROJECT_ROOT" && VNC_URL=$(scripts/start-vnc.sh) && echo "$VNC_URL"
 ```
 
+After VNC starts, verify Chrome is reachable via CDP:
+
+```bash
+curl -sf http://localhost:9222/json/version > /dev/null || { echo "❌ CDP not ready"; exit 1; }
+```
+
+If CDP is not ready, Playwright Chromium may not be installed. Install it and re-run the VNC script:
+
+```bash
+PROJECT_ROOT=$(git rev-parse --show-toplevel)
+cd "$PROJECT_ROOT/e2e" && pnpm exec playwright install chromium
+cd "$PROJECT_ROOT" && scripts/start-vnc.sh
+```
+
 Tell the user the noVNC URL so they can watch:
 
 > The browser is running in headed mode with noVNC. Open this URL to view and interact:
@@ -43,7 +57,7 @@ TASK_NAME="connect-atlassian"  # example - derive from the user's request
 TIMESTAMP=$(date +%Y%m%d-%H%M%S)
 PROJECT_ROOT=$(git rev-parse --show-toplevel)
 mkdir -p "$PROJECT_ROOT/tmp"
-agent-browser record start "$PROJECT_ROOT/tmp/${TASK_NAME}-${TIMESTAMP}.webm"
+agent-browser record restart "$PROJECT_ROOT/tmp/${TASK_NAME}-${TIMESTAMP}.webm"
 ```
 
 ## URL Rules
@@ -66,8 +80,10 @@ agent-browser record start "$PROJECT_ROOT/tmp/${TASK_NAME}-${TIMESTAMP}.webm"
 
 ```bash
 agent-browser open "https://www.vm7.ai:8443"
-agent-browser wait --load networkidle
+agent-browser snapshot -i
 ```
+
+**Do NOT use `agent-browser wait --load networkidle`** — it frequently times out on local HTTPS pages even when the page is fully usable. Instead, go straight to `snapshot -i` after `open` to verify the page state.
 
 ### Taking Snapshots and Interacting
 
@@ -140,6 +156,6 @@ Video:
 
 - **Do NOT use `agent-browser close`** — that kills the shared Chrome and breaks the user's noVNC view
 - **Always re-snapshot** after clicking links/buttons that cause navigation or DOM changes
-- **Wait for pages to load** — use `agent-browser wait --load networkidle` after navigation
+- **Verify page state with snapshot** — use `agent-browser snapshot -i` after navigation instead of `wait --load networkidle` (which frequently times out)
 - **Scroll within modals** — use `agent-browser scroll down 500 --selector "<modal-selector>"` for content inside modals, not plain `scroll down`
 - **Handle modals/dialogs** — check snapshot output for unexpected modals and close them before proceeding

--- a/.claude/skills/dev-logs/SKILL.md
+++ b/.claude/skills/dev-logs/SKILL.md
@@ -3,52 +3,40 @@ name: dev-logs
 description: View development server logs with optional filtering
 ---
 
-View development server output logs with optional filtering. Logs are persisted to `/tmp/dev-server.log` via `tee` in the `pnpm dev` script.
+View development server output by reading the background task output via TaskOutput.
 
 ## Arguments Format
 
 Your args are: `$ARGUMENTS`
 
-- _(empty)_ - Show recent logs (last 50 lines)
-- `[pattern]` - Show only logs matching the regex pattern
+- _(empty)_ - Show recent output from the dev server
+- `[pattern]` - Show only lines matching the regex pattern
 
 ## Examples
 
-- `/dev-logs` - Show last 50 lines
+- `/dev-logs` - Show recent dev server output
 - `/dev-logs error` - Show only error messages
-- `/dev-logs "web|workspace"` - Show logs from web or workspace packages
 - `/dev-logs "compiled|ready"` - Show compilation status
 
 ## Workflow
 
-### Step 1: Check Log File Exists
+### Step 1: Check Dev Server is Running
 
 ```bash
-if [ ! -f /tmp/dev-server.log ]; then
-  echo "No dev server log found at /tmp/dev-server.log"
-  echo "Please run /dev-start first."
-  exit 1
-fi
+curl -k -s --connect-timeout 3 https://www.vm7.ai:8443/ > /dev/null 2>&1 && echo "✅ Dev server is running" || echo "❌ Dev server is not running. Please run /dev-start first."
 ```
 
-### Step 2: Read Logs
+### Step 2: Read Background Task Output
 
-**If no filter pattern provided** — show last 50 lines:
-```bash
-tail -50 /tmp/dev-server.log
-```
+Use TaskOutput to read the dev server's background task output. The task_id comes from the `run_in_background` Bash call that started the server.
 
-**If filter pattern provided** — grep matching lines:
-```bash
-grep -E "<pattern>" /tmp/dev-server.log | tail -50
-```
+If no task_id is available (e.g., server was started in a previous conversation), inform the user that logs are only available within the same session that started the server.
 
-### Step 3: Display Logs
+### Step 3: Display Output
 
-Show the output in readable format. If the log file is empty, mention that no logs have been recorded yet.
+Show the output in readable format. If a filter pattern was provided, grep the output for matching lines.
 
 ## Notes
 
-- Logs are written to `/tmp/dev-server.log` by `pnpm dev` (via `tee`)
-- Filter parameter uses regex patterns
-- Log file persists across dev server restarts (overwritten on each start)
+- Dev server logs are only accessible via TaskOutput within the same session
+- For persistent logs, check individual service outputs or use the Turbo TUI

--- a/.claude/skills/dev-server/SKILL.md
+++ b/.claude/skills/dev-server/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: dev-server
 description: Development server lifecycle management for the vm0 project
-context: fork
+context: main
 ---
 
 You are a development server specialist for the vm0 project. Your role is to manage the development server lifecycle, ensuring smooth operation in background mode.
@@ -24,108 +24,49 @@ Parse the args above to determine which operation to perform:
 
 # Operation: start
 
-Start the Turbo development server in background with stream UI mode.
+Start the Turbo development server in background mode.
 
 **Note**: The web app now automatically starts a Cloudflare tunnel during dev startup. This means `VM0_API_URL` is set automatically and webhooks will work out of the box. The web app takes ~15 seconds longer to start than other packages due to tunnel setup.
 
 ## Workflow
 
-### Step 1: Check if Dev Server is Already Running
+### Step 1: Pre-flight Check
 
-First, check if dev server is already accessible by testing the port:
-
-```bash
-# Test if dev server port is open
-if nc -z -w 3 localhost 3000 2>/dev/null || curl -k -s --connect-timeout 3 https://www.vm7.ai:8443/ > /dev/null 2>&1; then
-  echo "✅ Dev server is already running at https://www.vm7.ai:8443"
-  echo ""
-  echo "To use with CLI, run /dev-auth to authenticate"
-  exit 0
-fi
-```
-
-If not accessible, proceed to stop any orphaned processes:
+Run the dev server status check. This verifies SSL certificates (regenerating if missing) and checks port accessibility:
 
 ```bash
-# Check and stop existing dev server processes
-if pgrep -f "turbo.*dev" > /dev/null; then
-  echo "⚠️ Found existing dev server process, stopping it..."
-  pkill -9 -f "turbo.*dev"
-  sleep 2
-  echo "✅ Stopped existing dev server"
-else
-  echo "✅ No existing dev server process found"
-fi
-```
-
-### Step 2: Generate SSL Certificates if Needed
-
-Ensure SSL certificates exist before starting the server:
-
-```bash
-# Get project root dynamically
 PROJECT_ROOT=$(git rev-parse --show-toplevel)
-CERT_DIR="$PROJECT_ROOT/.certs"
-
-# Check if all required certificates exist
-if [ ! -f "$CERT_DIR/www.vm7.ai.pem" ] || \
-   [ ! -f "$CERT_DIR/docs.vm7.ai.pem" ] || \
-   [ ! -f "$CERT_DIR/vm7.ai.pem" ]; then
-  echo "📜 Generating SSL certificates..."
-  bash "$PROJECT_ROOT/scripts/generate-certs.sh"
-else
-  echo "✅ SSL certificates already exist"
-fi
+cd "$PROJECT_ROOT/turbo" && pnpm dev:status
 ```
 
-### Step 3: Start Dev Server in Background
+If all three services show `running`, the dev server is already up — display the output and stop. Otherwise, proceed to start the server.
 
-Start the server with non-interactive output using Bash tool with `run_in_background: true` parameter.
+### Step 2: Start Dev Server in Background
+
+Start the server using Bash tool with `run_in_background: true` parameter.
 
 **If `--tunnel-hostname=<fqdn>` was provided in args**, pass it as `TUNNEL_HOSTNAME` env var:
 
 ```bash
 PROJECT_ROOT=$(git rev-parse --show-toplevel)
-cd "$PROJECT_ROOT/turbo" && TUNNEL_HOSTNAME=<fqdn> pnpm dev --ui=stream
+cd "$PROJECT_ROOT/turbo" && TUNNEL_HOSTNAME=<fqdn> pnpm dev
 ```
 
 **Otherwise** (default):
 
 ```bash
 PROJECT_ROOT=$(git rev-parse --show-toplevel)
-cd "$PROJECT_ROOT/turbo" && pnpm dev --ui=stream
+cd "$PROJECT_ROOT/turbo" && pnpm dev
 ```
 
-This will return a shell_id (task_id) for monitoring.
+This will return a task_id for monitoring.
 
-### Step 4: Persist Shell ID
+### Step 3: Display Results
 
-Save the shell_id to a file for later use:
-
-```bash
-echo "<shell_id>" > /tmp/dev-server-shell-id
-```
-
-Also save the output file path:
-
-```bash
-echo "/tmp/claude/-workspaces-vm01/tasks/<shell_id>.output" > /tmp/dev-server-output-file
-```
-
-### Step 5: Wait for Startup and Confirm
-
-Wait a few seconds, then read the dev server logs. Look for the **Caddy proxy** output lines to determine the correct URLs. Ignore any tunnel URLs (e.g., `tunnel-*.vm7.ai`). The correct URLs are the ones reported by the Caddy proxy:
-
-- **Web**: `https://www.vm7.ai:8443`
-- **Docs**: `https://docs.vm7.ai:8443`
-- **Platform**: `https://platform.vm7.ai:8443`
-
-These `vm7.ai` domains are mapped to `127.0.0.1` locally.
-
-Display the shell ID and URLs:
+Once the server is confirmed running, display the URLs:
 
 ```
-✅ Dev server started in background (shell_id: <id>)
+✅ Dev server started in background
 
 - Web:      https://www.vm7.ai:8443
 - Platform: https://platform.vm7.ai:8443
@@ -139,9 +80,9 @@ Next steps:
 
 ## Notes
 
-- The `--ui=stream` flag ensures non-interactive output suitable for background monitoring
-- This operation uses context fork for isolation - the main conversation won't be polluted by server startup logs
-- Tool access is restricted to: Bash, KillShell, TaskOutput only
+- Use TaskOutput with the task_id from `run_in_background` to check server output
+- This operation runs in main context so the background task persists throughout the conversation
+- **NEVER use `nohup` to start the server** (e.g., `nohup pnpm dev > /tmp/dev-server.log 2>&1 &`). Always use the Bash tool's `run_in_background: true` parameter instead.
 
 ---
 
@@ -151,51 +92,25 @@ Stop the background development server gracefully.
 
 ## Workflow
 
-### Step 1: Find the Dev Server Shell ID
+### Step 1: Stop the Server
 
-Read the saved shell_id from persistent storage:
-
-```bash
-if [ -f /tmp/dev-server-shell-id ]; then
-  SHELL_ID=$(cat /tmp/dev-server-shell-id)
-  echo "Found shell_id: $SHELL_ID"
-else
-  echo "No shell_id file found"
-fi
-```
-
-### Step 2: Stop the Server
-
-**If shell_id was found**, use KillShell tool:
-
-```javascript
-KillShell({ shell_id: "<shell-id>" })
-```
-
-**If shell_id not found**, try force kill:
+Kill the dev server processes:
 
 ```bash
-pkill -9 -f "turbo.*dev"
+pkill -f "turbo.*dev" 2>/dev/null
+pkill -f "pnpm.*dev" 2>/dev/null
 ```
 
-### Step 3: Clean Up Persistent Files
+### Step 2: Verify Stopped
 
-Remove the shell_id files:
+Check if processes are gone and Caddy is no longer responding:
 
 ```bash
-rm -f /tmp/dev-server-shell-id
-rm -f /tmp/dev-server-output-file
+pgrep -f "turbo.*dev" || echo "✅ No turbo dev processes found"
+curl -k -s --connect-timeout 3 https://www.vm7.ai:8443/ > /dev/null 2>&1 && echo "⚠️ Server still responding" || echo "✅ Server is down"
 ```
 
-### Step 4: Verify Stopped
-
-Check if process still exists:
-
-```bash
-pgrep -f "turbo.*dev"
-```
-
-### Step 5: Show Results
+### Step 3: Show Results
 
 **If stopped successfully**:
 ```
@@ -224,9 +139,7 @@ Use `/dev-start` to start one
 
 Delegate to the `dev-logs` skill. Extract the optional filter pattern from args (e.g. `logs error` → pattern is `error`) and invoke:
 
-```typescript
-await Skill({ skill: "dev-logs", args: "<pattern>" });
-```
+invoke skill /dev-logs <pattern>
 
 ---
 
@@ -243,11 +156,10 @@ Authenticate with local development server and get CLI token.
 
 ### Step 1: Check Dev Server Running
 
-First, check if dev server is accessible by testing the port:
+Check if dev server is accessible via the Caddy reverse proxy:
 
 ```bash
-# Test if dev server port is open
-if nc -z -w 3 localhost 3000 2>/dev/null || curl -k -s --connect-timeout 3 https://www.vm7.ai:8443/ > /dev/null 2>&1; then
+if curl -k -s --connect-timeout 3 https://www.vm7.ai:8443/ > /dev/null 2>&1; then
   echo "✅ Dev server is accessible at https://www.vm7.ai:8443"
 else
   echo "❌ Dev server is not accessible"
@@ -255,27 +167,6 @@ else
   exit 1
 fi
 ```
-
-Optionally, if you want to check logs from background server, read shell_id:
-
-```bash
-if [ -f /tmp/dev-server-shell-id ]; then
-  SHELL_ID=$(cat /tmp/dev-server-shell-id)
-  echo "Found background server with shell_id: $SHELL_ID"
-fi
-```
-
-If shell_id exists, you can use TaskOutput to check logs:
-
-```javascript
-TaskOutput({
-  task_id: "<shell-id>",
-  block: false,
-  timeout: 5000
-})
-```
-
-But the key indicator is **HTTP endpoint accessibility**, not just the shell_id.
 
 ### Step 2: Check Required Environment Variables
 
@@ -312,34 +203,8 @@ echo "✅ All required environment variables are present"
 
 ### Step 3: Build and Install CLI Globally
 
-Check dev server logs to see if CLI build was successful.
+Build and install the CLI globally:
 
-First, get the shell_id:
-```bash
-SHELL_ID=$(cat /tmp/dev-server-shell-id)
-```
-
-Then use TaskOutput to check CLI build status:
-```javascript
-TaskOutput({
-  task_id: "<shell-id>",
-  block: false,
-  timeout: 5000
-})
-```
-
-Look for these indicators:
-- "@vm0/cli:dev:" messages
-- "Build success" or "ESM Build success" in CLI logs
-- No build errors or failures
-
-**If CLI build succeeded in dev mode**:
-```bash
-PROJECT_ROOT=$(git rev-parse --show-toplevel)
-cd "$PROJECT_ROOT/turbo/apps/cli" && pnpm link --global
-```
-
-**If CLI build failed or not found in logs**:
 ```bash
 PROJECT_ROOT=$(git rev-parse --show-toplevel)
 cd "$PROJECT_ROOT/turbo/apps/cli" && pnpm build && pnpm link --global
@@ -349,13 +214,13 @@ cd "$PROJECT_ROOT/turbo/apps/cli" && pnpm build && pnpm link --global
 
 ```bash
 PROJECT_ROOT=$(git rev-parse --show-toplevel)
-cd "$PROJECT_ROOT" && npx tsx e2e/cli-auth-automation.ts http://localhost:3000
+cd "$PROJECT_ROOT" && npx tsx e2e/cli-auth-automation.ts $(printenv VM0_API_URL)
 ```
 
 This script:
-- Spawns `vm0 auth login` with `VM0_API_URL=http://localhost:3000`
+- Spawns `vm0 auth login` with the current `VM0_API_URL`
 - Launches Playwright browser in headless mode
-- Logs in via Clerk using `e2e+clerk_test@vm0.ai`
+- Logs in via Clerk using `$(hostname)+clerk_test@vm0.ai`
 - Automatically enters the CLI device code
 - Clicks "Authorize Device" button
 - Saves token to `~/.vm0/config.json`
@@ -422,34 +287,20 @@ Use Bash tool with `run_in_background: true`:
 
 ```bash
 PROJECT_ROOT=$(git rev-parse --show-toplevel)
-cd "$PROJECT_ROOT/turbo" && pnpm dev --ui=stream
+cd "$PROJECT_ROOT/turbo" && pnpm dev
 ```
 
-This will return a shell_id for monitoring. The web app will automatically start a Cloudflare tunnel.
+This will return a task_id for monitoring. The web app will automatically start a Cloudflare tunnel.
 
-### Step 4: Persist Shell ID
+### Step 4: Wait for Tunnel URL
 
-Save the shell_id to a file for later use:
-
-```bash
-echo "<shell_id>" > /tmp/dev-server-shell-id
-```
-
-### Step 5: Wait for Tunnel URL
-
-Monitor background shell output using TaskOutput until you see:
+Use TaskOutput with the task_id from Step 3 to monitor the background task output. Look for:
 - `[tunnel] Tunnel URL:` followed by the URL
 - `Ready in` (Next.js ready message)
 
-```javascript
-TaskOutput({
-  task_id: "<shell-id>",
-  block: false,
-  timeout: 60000
-})
-```
+Poll TaskOutput every few seconds until the tunnel URL appears (up to ~60 seconds). Extract the tunnel URL (format: `https://*.trycloudflare.com`).
 
-Extract the tunnel URL from output (format: `https://*.trycloudflare.com`).
+If the tunnel URL does not appear within ~60 seconds, report the failure and let the user investigate.
 
 ### Step 6: Export VM0_API_URL
 
@@ -490,7 +341,7 @@ PROJECT_ROOT=$(git rev-parse --show-toplevel)
 cd "$PROJECT_ROOT/e2e" && \
 CLERK_PUBLISHABLE_KEY=<publishable-key> \
 CLERK_SECRET_KEY=<secret-key> \
-npx tsx cli-auth-automation.ts http://localhost:3000
+npx tsx cli-auth-automation.ts $(printenv VM0_API_URL)
 ```
 
 ### Step 11: Verify Authentication

--- a/.claude/skills/pr-review-loop/SKILL.md
+++ b/.claude/skills/pr-review-loop/SKILL.md
@@ -118,12 +118,7 @@ Read the ACTION output from the driver script and execute the corresponding acti
 
 1. Run the `code-quality` skill (analysis only, do NOT post a comment):
 
-```typescript
-await Skill({
-  skill: "code-quality",
-  args: `review ${PR_NUMBER}`
-});
-```
+invoke skill /code-quality review ${PR_NUMBER}
 
 2. Perform testing coverage and convention review (same checks as `/pr-review`):
    - Identify changed source files from PR diff

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -33,12 +33,7 @@ Display PR metadata (title, author, URL).
 
 Invoke the `code-quality` skill to perform comprehensive code review:
 
-```typescript
-await Skill({
-  skill: "code-quality",
-  args: `review ${PR_NUMBER}`
-});
-```
+invoke skill /code-quality review ${PR_NUMBER}
 
 This will:
 - Analyze all PR commits against bad smell criteria

--- a/.claude/skills/skill-alias/SKILL.md
+++ b/.claude/skills/skill-alias/SKILL.md
@@ -66,13 +66,7 @@ command: {ALIAS}
 description: Alias for {SKILL_NAME} {ARGUMENTS}
 ---
 
-```typescript
-await Skill({
-  skill: "{SKILL_NAME}",
-  args: "{ARGUMENTS}"
-});
-```
-
+invoke skill /{SKILL_NAME} {ARGUMENTS}
 ```
 
 ### Step 3: Verify Creation
@@ -147,23 +141,18 @@ description: Alias for skill-name operation
 ---
 ```
 
-### TypeScript Block
+### Invoke Directive
 
-Must be a valid TypeScript code block with:
-- Three backticks with `typescript` language tag
-- Proper await Skill() call syntax
-- Both skill and args parameters as strings
-- Proper closing backticks
+The body must contain a single `invoke skill` directive:
+
+```
+invoke skill /{SKILL_NAME} {ARGUMENTS}
+```
 
 Example:
-````markdown
-```typescript
-await Skill({
-  skill: "tech-debt",
-  args: "research"
-});
+```markdown
+invoke skill /tech-debt research
 ```
-````
 
 ### Error Handling
 
@@ -191,12 +180,7 @@ command: tech-debt-research
 description: Alias for tech-debt research
 ---
 
-```typescript
-await Skill({
-  skill: "tech-debt",
-  args: "research"
-});
-```
+invoke skill /tech-debt research
 ```
 
 ### Example 2: Tech Debt Issue
@@ -211,12 +195,7 @@ command: tech-debt-issue
 description: Alias for tech-debt issue
 ---
 
-```typescript
-await Skill({
-  skill: "tech-debt",
-  args: "issue"
-});
-```
+invoke skill /tech-debt issue
 ```
 
 ### Example 3: PR Check Fix
@@ -231,12 +210,7 @@ command: pr-check-fix
 description: Alias for pr-check fix
 ---
 
-```typescript
-await Skill({
-  skill: "pr-check",
-  args: "fix"
-});
-```
+invoke skill /pr-check fix
 ```
 
 ## Guidelines

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -20,6 +20,15 @@ sudo locale-gen en_US.UTF-8 2>/dev/null || true
 sudo update-locale LANG=en_US.UTF-8 2>/dev/null || true
 echo "✓ Locale configured"
 
+# Add vm7.ai domains to /etc/hosts (Caddy reverse proxy listens on 127.0.0.1)
+echo "🌐 Configuring vm7.ai hosts..."
+if ! grep -q "vm7.ai" /etc/hosts 2>/dev/null; then
+  echo "127.0.0.1 vm7.ai www.vm7.ai docs.vm7.ai platform.vm7.ai" | sudo tee -a /etc/hosts > /dev/null
+  echo "✓ vm7.ai domains added to /etc/hosts"
+else
+  echo "✓ vm7.ai domains already in /etc/hosts"
+fi
+
 # Setup directories - fix ownership for all mounted volumes
 sudo mkdir -p /home/vscode/.local/bin /home/vscode/.pki
 sudo chown -R vscode:vscode /home/vscode/.config /home/vscode/.cache /home/vscode/.local /home/vscode/.pki /home/vscode/.cloudflared

--- a/e2e/cli-auth-automation.ts
+++ b/e2e/cli-auth-automation.ts
@@ -148,7 +148,10 @@ export async function automateCliAuth(apiHost?: string) {
     // Enter email address
     const emailInput = page.locator('input[name="identifier"]');
     await emailInput.waitFor({ state: "visible", timeout: 10000 });
-    await emailInput.fill("e2e+clerk_test@vm0.ai");
+    const os = require("os");
+    const testEmail = `${os.hostname()}+clerk_test@vm0.ai`;
+    await emailInput.fill(testEmail);
+    console.log(`📧 Using test email: ${testEmail}`);
     console.log("📧 Entered email address");
 
     // Click Continue button

--- a/e2e/cli-auth-automation.ts
+++ b/e2e/cli-auth-automation.ts
@@ -1,6 +1,9 @@
 import { chromium } from "playwright";
 import { spawn, ChildProcess } from "child_process";
 import * as dotenv from "dotenv";
+import * as os from "os";
+import * as fs from "fs";
+import * as path from "path";
 
 // Load environment variables
 dotenv.config({ path: ".env.local" });
@@ -148,7 +151,6 @@ export async function automateCliAuth(apiHost?: string) {
     // Enter email address
     const emailInput = page.locator('input[name="identifier"]');
     await emailInput.waitFor({ state: "visible", timeout: 10000 });
-    const os = require("os");
     const testEmail = `${os.hostname()}+clerk_test@vm0.ai`;
     await emailInput.fill(testEmail);
     console.log(`📧 Using test email: ${testEmail}`);
@@ -279,9 +281,6 @@ export async function automateCliAuth(apiHost?: string) {
     console.log("🎉 CLI authentication flow complete!");
 
     // Verify auth file was created
-    const fs = require("fs");
-    const os = require("os");
-    const path = require("path");
     const configPath = path.join(os.homedir(), ".vm0", "config.json");
 
     if (fs.existsSync(configPath)) {

--- a/e2e/cli-auth-automation.ts
+++ b/e2e/cli-auth-automation.ts
@@ -151,7 +151,7 @@ export async function automateCliAuth(apiHost?: string) {
     // Enter email address
     const emailInput = page.locator('input[name="identifier"]');
     await emailInput.waitFor({ state: "visible", timeout: 10000 });
-    const testEmail = `${os.hostname()}+clerk_test@vm0.ai`;
+    const testEmail = "e2e+clerk_test@vm0.ai";
     await emailInput.fill(testEmail);
     console.log(`📧 Using test email: ${testEmail}`);
     console.log("📧 Entered email address");

--- a/turbo/apps/docs/next-env.d.ts
+++ b/turbo/apps/docs/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/turbo/apps/web/next-env.d.ts
+++ b/turbo/apps/web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/turbo/apps/web/tsconfig.json
+++ b/turbo/apps/web/tsconfig.json
@@ -6,7 +6,8 @@
       {
         "name": "next"
       }
-    ]
+    ],
+    "jsx": "preserve"
   },
   "include": [
     "**/*.ts",

--- a/turbo/package.json
+++ b/turbo/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "scripts": {
     "build": "turbo run build",
-    "dev": "turbo run dev --ui=stream 2>&1 | tee /tmp/dev-server.log",
+    "dev": "turbo run dev",
     "dev:auth": "bash ../scripts/dev-auth.sh",
     "lint": "turbo run lint --concurrency=2",
     "format": "prettier --write --ignore-unknown .",
@@ -17,6 +17,7 @@
     "generate-certs": "bash ../scripts/generate-certs.sh",
     "check-certs": "node packages/proxy/scripts/check-certs.js",
     "e2b:cli:build": "dotenv -e apps/web/.env.local -- npx tsx scripts/e2b/vm0-cli/build.ts",
+    "dev:status": "bash scripts/dev-server-check.sh",
     "runner": "bash ../scripts/dev-runner.sh deploy",
     "runner:remove": "bash ../scripts/dev-runner.sh remove"
   },

--- a/turbo/scripts/dev-server-check.sh
+++ b/turbo/scripts/dev-server-check.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Dev server health check: verify SSL certs and port accessibility
+
+PROJECT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
+if [ -z "$PROJECT_ROOT" ]; then
+  echo "Error: Not in a git repository" >&2
+  exit 1
+fi
+
+CERT_DIR="$PROJECT_ROOT/.certs"
+
+# --- Certificate check (silent, auto-regenerate if missing) ---
+if [ ! -f "$CERT_DIR/www.vm7.ai.pem" ] || \
+   [ ! -f "$CERT_DIR/platform.vm7.ai.pem" ] || \
+   [ ! -f "$CERT_DIR/docs.vm7.ai.pem" ] || \
+   [ ! -f "$CERT_DIR/vm7.ai.pem" ]; then
+  bash "$PROJECT_ROOT/scripts/generate-certs.sh" >&2
+fi
+
+# --- Port check ---
+check_port() {
+  local label="$1"
+  local url="$2"
+  if curl -k -s --connect-timeout 3 --resolve "$(echo "$url" | sed 's|https://||;s|/.*||'):127.0.0.1" "$url" > /dev/null 2>&1; then
+    echo "$label | running"
+  else
+    echo "$label | not started"
+  fi
+}
+
+check_port "Web:      https://www.vm7.ai:8443"      "https://www.vm7.ai:8443/"
+check_port "Platform: https://platform.vm7.ai:8443"  "https://platform.vm7.ai:8443/"
+check_port "Docs:     https://docs.vm7.ai:8443"      "https://docs.vm7.ai:8443/"


### PR DESCRIPTION
## Summary
- Migrate all command aliases from `await Skill({...})` to `invoke skill /...` syntax
- Simplify dev-server, dev-logs, and skill-alias SKILL.md files
- Add dev-server-check script and update devcontainer setup
- Minor tsconfig and next-env updates

## Test plan
- [ ] Verify `/dev-start` skill works correctly
- [ ] Verify `/dev-auth` skill works correctly
- [ ] Verify command aliases (e.g., `/pr-create`, `/dev-logs`) invoke correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)