### PR TITLE
ci: deduplicate base-ref calculation in prepare job

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -60,6 +60,8 @@ jobs:
             echo "Main push mode: comparing against HEAD^"
           fi
 
+          echo "base-ref=$BASE_REF" >> $GITHUB_OUTPUT
+
           # Run changed.sh to get all package changes in one go
           CHANGES_JSON=$(./scripts/changed.sh $BASE_REF)
 
@@ -86,16 +88,7 @@ jobs:
       - name: Detect E2B template changes
         id: detect-e2b
         run: |
-          # Determine base ref based on event type
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            BASE_REF=$(git merge-base ${{ github.event.pull_request.base.sha }} HEAD)
-          elif [ "${{ github.event_name }}" = "merge_group" ]; then
-            BASE_REF="${{ github.event.merge_group.base_sha }}"
-          else
-            BASE_REF="HEAD^"
-          fi
-
-          # Check if E2B template files changed
+          BASE_REF="${{ steps.detect.outputs.base-ref }}"
           if git diff --name-only "$BASE_REF" HEAD | grep -q "^turbo/scripts/e2b/"; then
             echo "E2B template changes detected"
             echo "e2b-changed=true" >> $GITHUB_OUTPUT
@@ -107,16 +100,7 @@ jobs:
       - name: Detect migration/schema changes
         id: detect-migration
         run: |
-          # Determine base ref based on event type
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            BASE_REF=$(git merge-base ${{ github.event.pull_request.base.sha }} HEAD)
-          elif [ "${{ github.event_name }}" = "merge_group" ]; then
-            BASE_REF="${{ github.event.merge_group.base_sha }}"
-          else
-            BASE_REF="HEAD^"
-          fi
-
-          # Check if migration or schema files changed
+          BASE_REF="${{ steps.detect.outputs.base-ref }}"
           if git diff --name-only "$BASE_REF" HEAD | grep -qE "^turbo/apps/web/src/db/(migrations|schema)/"; then
             echo "Migration or schema changes detected"
             echo "migration-changed=true" >> $GITHUB_OUTPUT
@@ -128,15 +112,7 @@ jobs:
       - name: Detect crates changes
         id: detect-crates
         run: |
-          # Determine base ref based on event type
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            BASE_REF=$(git merge-base ${{ github.event.pull_request.base.sha }} HEAD)
-          elif [ "${{ github.event_name }}" = "merge_group" ]; then
-            BASE_REF="${{ github.event.merge_group.base_sha }}"
-          else
-            BASE_REF="HEAD^"
-          fi
-
+          BASE_REF="${{ steps.detect.outputs.base-ref }}"
           if git diff --name-only "$BASE_REF" HEAD | grep -q "^crates/"; then
             echo "Crates changes detected"
             echo "crates-changed=true" >> $GITHUB_OUTPUT
@@ -148,14 +124,7 @@ jobs:
       - name: Detect CI workflow changes
         id: detect-ci
         run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            BASE_REF=$(git merge-base ${{ github.event.pull_request.base.sha }} HEAD)
-          elif [ "${{ github.event_name }}" = "merge_group" ]; then
-            BASE_REF="${{ github.event.merge_group.base_sha }}"
-          else
-            BASE_REF="HEAD^"
-          fi
-
+          BASE_REF="${{ steps.detect.outputs.base-ref }}"
           if git diff --name-only "$BASE_REF" HEAD | grep -qE "^\.github/workflows/turbo\.yml$|^ansible/"; then
             echo "CI workflow changes detected"
             echo "ci-changed=true" >> $GITHUB_OUTPUT
@@ -167,14 +136,7 @@ jobs:
       - name: Detect E2E test changes
         id: detect-e2e
         run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            BASE_REF=$(git merge-base ${{ github.event.pull_request.base.sha }} HEAD)
-          elif [ "${{ github.event_name }}" = "merge_group" ]; then
-            BASE_REF="${{ github.event.merge_group.base_sha }}"
-          else
-            BASE_REF="HEAD^"
-          fi
-
+          BASE_REF="${{ steps.detect.outputs.base-ref }}"
           if git diff --name-only "$BASE_REF" HEAD | grep -q "^e2e/"; then
             echo "E2E test changes detected"
             echo "e2e-changed=true" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary

- Extract `BASE_REF` calculation to a step output in the first `detect` step
- Replace 5 identical if/elif/else blocks with `${{ steps.detect.outputs.base-ref }}`
- Net: -45 lines, +7 lines

## Test plan

- [ ] `prepare` job detects changes correctly (all outputs match expected)
- [ ] Downstream jobs trigger based on correct change detection

Closes #4889

🤖 Generated with [Claude Code](https://claude.com/claude-code)