### PR TITLE
feat: revoke oauth token on disconnect and force re-consent

### DIFF
--- a/turbo/apps/web/app/api/connectors/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/connectors/__tests__/route.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach } from "vitest";
+import { HttpResponse } from "msw";
 import { GET } from "../route";
 import {
   GET as getConnector,
@@ -10,6 +11,8 @@ import {
 } from "../../../../src/__tests__/api-test-helpers";
 import { testContext } from "../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../src/__tests__/clerk-mock";
+import { handlers, http } from "../../../../src/__tests__/msw";
+import { server } from "../../../../src/mocks/server";
 
 const context = testContext();
 
@@ -179,9 +182,18 @@ describe("DELETE /api/connectors/:type - Delete Connector", () => {
     expect(data.error.message).toContain("not found");
   });
 
-  it("should delete connector successfully", async () => {
+  it("should delete connector and revoke remote token", async () => {
     await context.setupUser();
     await createTestConnector({ type: "github" });
+
+    // Mock the revocation endpoint AFTER connector setup (so it doesn't interfere with OAuth callback)
+    const { mocked, handlers: mswHandlers } = handlers({
+      revokeGrant: http.delete(
+        "https://api.github.com/applications/test-client-id/grant",
+        () => new HttpResponse(null, { status: 204 }),
+      ),
+    });
+    server.use(...mswHandlers);
 
     // Delete connector
     const deleteRequest = createTestRequest(
@@ -199,5 +211,54 @@ describe("DELETE /api/connectors/:type - Delete Connector", () => {
     const getResponse = await getConnector(getRequest);
 
     expect(getResponse.status).toBe(404);
+
+    // Verify revocation was called
+    expect(mocked.revokeGrant).toHaveBeenCalledTimes(1);
+  });
+
+  it("should delete connector even when revocation fails", async () => {
+    await context.setupUser();
+    await createTestConnector({ type: "github" });
+
+    // Mock the revocation endpoint to return 500 AFTER connector setup
+    const { handlers: mswHandlers } = handlers({
+      revokeGrant: http.delete(
+        "https://api.github.com/applications/test-client-id/grant",
+        () => new HttpResponse(null, { status: 500 }),
+      ),
+    });
+    server.use(...mswHandlers);
+
+    // Delete connector should still succeed
+    const deleteRequest = createTestRequest(
+      "http://localhost:3000/api/connectors/github",
+      { method: "DELETE" },
+    );
+    const deleteResponse = await deleteConnector(deleteRequest);
+
+    expect(deleteResponse.status).toBe(204);
+
+    // Verify connector is gone
+    const getRequest = createTestRequest(
+      "http://localhost:3000/api/connectors/github",
+    );
+    const getResponse = await getConnector(getRequest);
+
+    expect(getResponse.status).toBe(404);
+  });
+});
+
+describe("Dropbox auth URL - force_reapprove", () => {
+  it("should include force_reapprove=true in authorization URL", async () => {
+    const { buildDropboxAuthorizationUrl } = await import(
+      "../../../../src/lib/connector/providers/dropbox"
+    );
+    const url = buildDropboxAuthorizationUrl(
+      "test-client-id",
+      "http://localhost:3000/callback",
+      "test-state",
+    );
+    const parsed = new URL(url);
+    expect(parsed.searchParams.get("force_reapprove")).toBe("true");
   });
 });

--- a/turbo/apps/web/src/lib/connector/connector-service.ts
+++ b/turbo/apps/web/src/lib/connector/connector-service.ts
@@ -12,7 +12,7 @@ import { secrets } from "../../db/schema/secret";
 import { variables } from "../../db/schema/variable";
 import { notFound, badRequest } from "../errors";
 import { logger } from "../logger";
-import { upsertSecretByOrg } from "../secret/secret-service";
+import { getSecretValue, upsertSecretByOrg } from "../secret/secret-service";
 import { PROVIDER_HANDLERS } from "./provider-registry";
 
 const log = logger("service:connector");
@@ -322,6 +322,53 @@ export async function upsertOAuthConnector(
 }
 
 /**
+ * Best-effort revocation of an OAuth provider's remote token/grant.
+ * Looks up the connector's handler, reads the access token from DB,
+ * and calls the handler's revokeToken method if available.
+ * Errors are logged and swallowed — revocation must never block disconnect.
+ */
+async function revokeConnectorToken(
+  orgId: string,
+  userId: string,
+  type: ConnectorType,
+): Promise<void> {
+  if (type === "computer") return;
+
+  const handler = PROVIDER_HANDLERS[type as Exclude<ConnectorType, "computer">];
+  if (!handler.revokeToken) return;
+
+  const env = globalThis.services.env;
+  const clientId = handler.getClientId(env);
+  const clientSecret = handler.getClientSecret(env);
+  if (!clientId || !clientSecret) {
+    log.debug(
+      `${type} OAuth credentials not configured, skipping token revocation`,
+    );
+    return;
+  }
+
+  const accessTokenName = handler.getSecretName();
+  const accessToken = await getSecretValue(
+    orgId,
+    userId,
+    accessTokenName,
+    "connector",
+  );
+  if (!accessToken) {
+    log.debug(`${type} access token not found, skipping revocation`);
+    return;
+  }
+
+  try {
+    await handler.revokeToken(clientId, clientSecret, accessToken);
+    log.debug(`${type} token revoked successfully`);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+    log.warn(`${type} token revocation failed: ${message}`);
+  }
+}
+
+/**
  * Delete a connector and its associated secrets.
  * For OAuth connectors: deletes DB record + connector-type secrets.
  * For api-token connectors (no DB record): deletes user secrets matching required api-token secret names.
@@ -347,6 +394,11 @@ export async function deleteConnector(
     .limit(1);
 
   if (existing) {
+    // Revoke remote token before deleting local state (best-effort)
+    if (existing.authMethod === "oauth") {
+      await revokeConnectorToken(orgId, userId, type);
+    }
+
     // OAuth connector: delete DB record + connector-type secrets
     await db.delete(connectors).where(eq(connectors.id, existing.id));
 

--- a/turbo/apps/web/src/lib/connector/provider-types.ts
+++ b/turbo/apps/web/src/lib/connector/provider-types.ts
@@ -44,4 +44,9 @@ export interface ProviderHandler {
     refreshToken: string | null;
     expiresIn?: number;
   }>;
+  revokeToken?(
+    clientId: string,
+    clientSecret: string,
+    accessToken: string,
+  ): Promise<void>;
 }

--- a/turbo/apps/web/src/lib/connector/providers/dropbox.ts
+++ b/turbo/apps/web/src/lib/connector/providers/dropbox.ts
@@ -45,6 +45,7 @@ export function buildDropboxAuthorizationUrl(
     scope: oauthConfig.scopes.join(" "),
     state,
     token_access_type: "offline",
+    force_reapprove: "true",
   });
 
   return `${oauthConfig.authorizationUrl}?${params.toString()}`;

--- a/turbo/apps/web/src/lib/connector/providers/github-handler.ts
+++ b/turbo/apps/web/src/lib/connector/providers/github-handler.ts
@@ -4,6 +4,7 @@ import {
   exchangeGitHubCode,
   fetchGitHubUserInfo,
   getGitHubSecretName,
+  revokeGitHubGrant,
 } from "./github";
 
 export const githubHandler: ProviderHandler = {
@@ -21,4 +22,5 @@ export const githubHandler: ProviderHandler = {
   getClientId: (e) => e.GH_OAUTH_CLIENT_ID,
   getClientSecret: (e) => e.GH_OAUTH_CLIENT_SECRET,
   getSecretName: getGitHubSecretName,
+  revokeToken: revokeGitHubGrant,
 };

--- a/turbo/apps/web/src/lib/connector/providers/github.ts
+++ b/turbo/apps/web/src/lib/connector/providers/github.ts
@@ -121,6 +121,35 @@ export async function fetchGitHubUserInfo(
 }
 
 /**
+ * Revoke GitHub OAuth app authorization grant.
+ * Uses the grant revocation endpoint (not token) to force re-consent on next connect.
+ * Ref: https://docs.github.com/en/rest/apps/oauth-applications#delete-an-app-authorization
+ */
+export async function revokeGitHubGrant(
+  clientId: string,
+  clientSecret: string,
+  accessToken: string,
+): Promise<void> {
+  const response = await fetch(
+    `${GITHUB_API_BASE}/applications/${clientId}/grant`,
+    {
+      method: "DELETE",
+      headers: {
+        Authorization: `Basic ${btoa(`${clientId}:${clientSecret}`)}`,
+        Accept: "application/vnd.github+json",
+        "Content-Type": "application/json",
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+      body: JSON.stringify({ access_token: accessToken }),
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error(`GitHub grant revocation failed: ${response.status}`);
+  }
+}
+
+/**
  * Get the primary secret name for GitHub connector (the access token).
  * Uses an explicit key rather than Object.keys() ordering to avoid
  * fragile dependency on property insertion order.

--- a/turbo/apps/web/src/lib/connector/providers/linear-handler.ts
+++ b/turbo/apps/web/src/lib/connector/providers/linear-handler.ts
@@ -4,6 +4,7 @@ import {
   exchangeLinearCode,
   getLinearSecretName,
   refreshLinearToken,
+  revokeLinearToken,
 } from "./linear";
 
 export const linearHandler: ProviderHandler = {
@@ -32,4 +33,5 @@ export const linearHandler: ProviderHandler = {
   getSecretName: getLinearSecretName,
   getRefreshSecretName: () => "LINEAR_REFRESH_TOKEN",
   refreshToken: refreshLinearToken,
+  revokeToken: revokeLinearToken,
 };

--- a/turbo/apps/web/src/lib/connector/providers/linear.ts
+++ b/turbo/apps/web/src/lib/connector/providers/linear.ts
@@ -225,6 +225,33 @@ async function fetchLinearUserInfo(
 }
 
 /**
+ * Revoke a Linear OAuth token.
+ * Uses RFC 7009 token revocation endpoint with Basic Auth.
+ * Ref: https://linear.app/developers/oauth-2-0-authentication
+ */
+export async function revokeLinearToken(
+  clientId: string,
+  clientSecret: string,
+  accessToken: string,
+): Promise<void> {
+  const response = await fetch("https://api.linear.app/oauth/revoke", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+      Authorization: `Basic ${btoa(`${clientId}:${clientSecret}`)}`,
+    },
+    body: new URLSearchParams({
+      token: accessToken,
+      token_type_hint: "access_token",
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Linear token revocation failed: ${response.status}`);
+  }
+}
+
+/**
  * Get the primary secret name for Linear connector (the access token).
  */
 export function getLinearSecretName(): string {

--- a/turbo/apps/web/src/lib/connector/providers/slack-handler.ts
+++ b/turbo/apps/web/src/lib/connector/providers/slack-handler.ts
@@ -4,6 +4,7 @@ import {
   exchangeSlackCode,
   fetchSlackUserInfo,
   getSlackSecretName,
+  revokeSlackToken,
 } from "./slack";
 
 export const slackHandler: ProviderHandler = {
@@ -32,4 +33,5 @@ export const slackHandler: ProviderHandler = {
   getClientId: (e) => e.SLACK_CLIENT_ID,
   getClientSecret: (e) => e.SLACK_CLIENT_SECRET,
   getSecretName: getSlackSecretName,
+  revokeToken: revokeSlackToken,
 };

--- a/turbo/apps/web/src/lib/connector/providers/slack.ts
+++ b/turbo/apps/web/src/lib/connector/providers/slack.ts
@@ -145,6 +145,32 @@ export async function fetchSlackUserInfo(
 }
 
 /**
+ * Revoke a Slack user token.
+ * Ref: https://api.slack.com/methods/auth.revoke
+ */
+export async function revokeSlackToken(
+  _clientId: string,
+  _clientSecret: string,
+  accessToken: string,
+): Promise<void> {
+  const response = await fetch("https://slack.com/api/auth.revoke", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Slack token revocation failed: ${response.status}`);
+  }
+
+  const data = (await response.json()) as { ok: boolean; error?: string };
+  if (!data.ok) {
+    throw new Error(data.error ?? "Slack token revocation returned ok=false");
+  }
+}
+
+/**
  * Get the primary secret name for Slack connector (the user access token).
  */
 export function getSlackSecretName(): string {


### PR DESCRIPTION
## Summary

- Add `revokeToken` optional method to `ProviderHandler` interface, following the existing `refreshToken` pattern
- Implement grant/token revocation for **GitHub** (DELETE grant), **Linear** (RFC 7009 revoke), and **Slack** (auth.revoke)
- Add `force_reapprove=true` to **Dropbox** authorization URL to force consent screen on reconnect
- Orchestrate revocation in `deleteConnector()` as best-effort (errors logged, never block disconnect)

## Test plan

- [ ] Dropbox auth URL test verifies `force_reapprove=true` parameter is present
- [ ] GitHub revocation integration test verifies revocation endpoint is called on delete
- [ ] Revocation failure test verifies connector deletion succeeds even when revocation returns 500
- [ ] Lint, type check, knip all pass cleanly
- [ ] No regressions in existing tests

Closes #4891

🤖 Generated with [Claude Code](https://claude.com/claude-code)