### PR TITLE
fix: rename missed service comment to firewall in composes.ts

### DIFF
--- a/turbo/packages/core/src/contracts/composes.ts
+++ b/turbo/packages/core/src/contracts/composes.ts
@@ -42,7 +42,7 @@ export const VALID_CAPABILITIES = [
 ] as const;
 
 /**
- * Service permission schema for proxy-side token replacement.
+ * Firewall permission schema for proxy-side token replacement.
  * Defined here (not in runners.ts) to avoid circular dependency:
  * composes.ts exports VALID_CAPABILITIES used by runners.ts.
  */


### PR DESCRIPTION
## Summary

- Fix one missed comment rename from `Service permission schema` to `Firewall permission schema` in `composes.ts`
- This was missed because the merge queue merged #4895 before the rebase that included this fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)