### PR TITLE
ci: skip lint-types, lint-format, lint-knip on release commits

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -229,6 +229,8 @@ jobs:
 
   lint-types:
     runs-on: ubuntu-latest
+    # Skip for release-please commits (only version bumps and changelogs)
+    if: "${{ github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore: release') }}"
     container:
       image: ghcr.io/vm0-ai/vm0-toolchain:20260310
     steps:
@@ -240,6 +242,8 @@ jobs:
 
   lint-format:
     runs-on: ubuntu-latest
+    # Skip for release-please commits (only version bumps and changelogs)
+    if: "${{ github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore: release') }}"
     container:
       image: ghcr.io/vm0-ai/vm0-toolchain:20260310
     steps:
@@ -251,6 +255,8 @@ jobs:
 
   lint-knip:
     runs-on: ubuntu-latest
+    # Skip for release-please commits (only version bumps and changelogs)
+    if: "${{ github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore: release') }}"
     container:
       image: ghcr.io/vm0-ai/vm0-toolchain:20260310
     steps:


### PR DESCRIPTION
## Summary

- Add missing `if` condition to `lint-types`, `lint-format`, and `lint-knip` jobs
- All lint jobs now consistently skip `chore: release` commits (matching `lint-eslint` and test jobs)

## Test plan

- [ ] All lint jobs still run on normal PRs
- [ ] Release commits on main skip all lint jobs

Closes #4890

🤖 Generated with [Claude Code](https://claude.com/claude-code)