### PR TITLE
feat(auth): enforce capabilities on agent run routes

### DIFF
--- a/turbo/apps/web/app/api/agent/runs/[id]/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/__tests__/route.test.ts
@@ -7,6 +7,7 @@ import {
   createTestRun,
   completeTestRun,
 } from "../../../../../../src/__tests__/api-test-helpers";
+import { generateSandboxToken } from "../../../../../../src/lib/auth/sandbox-token";
 import {
   testContext,
   uniqueId,
@@ -120,6 +121,39 @@ describe("GET /api/agent/runs/:id - Get Run By ID", () => {
       // Should return 404 to avoid leaking existence of other user's run
       expect(response.status).toBe(404);
       expect(data.error.message).toContain("not found");
+    });
+  });
+
+  describe("Sandbox Token Capability Enforcement", () => {
+    it("should accept sandbox token with agent-run:read", async () => {
+      const run = await createTestRun(testComposeId, "Test prompt");
+      mockClerk({ userId: null });
+      const token = await generateSandboxToken(user.userId, run.runId, [
+        "agent-run:read",
+      ]);
+
+      const request = createTestRequest(
+        `http://localhost:3000/api/agent/runs/${run.runId}`,
+        { headers: { authorization: `Bearer ${token}` } },
+      );
+      const response = await GET(request);
+
+      expect(response.status).toBe(200);
+    });
+
+    it("should reject sandbox token without agent-run:read", async () => {
+      mockClerk({ userId: null });
+      const token = await generateSandboxToken(user.userId, "run-1", [
+        "volume:read",
+      ]);
+
+      const request = createTestRequest(
+        `http://localhost:3000/api/agent/runs/${randomUUID()}`,
+        { headers: { authorization: `Bearer ${token}` } },
+      );
+      const response = await GET(request);
+
+      expect(response.status).toBe(401);
     });
   });
 });

--- a/turbo/apps/web/app/api/agent/runs/[id]/cancel/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/cancel/__tests__/route.test.ts
@@ -11,6 +11,7 @@ import {
   findTestRunCallbacks,
   setTestRunStatus,
 } from "../../../../../../../src/__tests__/api-test-helpers";
+import { generateSandboxToken } from "../../../../../../../src/lib/auth/sandbox-token";
 import {
   testContext,
   uniqueId,
@@ -246,6 +247,45 @@ describe("POST /api/agent/runs/:id/cancel - Cancel Run", () => {
       // Run should still be completed (not overwritten to cancelled)
       const record = await findTestRunRecord(run.runId);
       expect(record!.status).toBe("completed");
+    });
+  });
+
+  describe("Sandbox Token Capability Enforcement", () => {
+    it("should accept sandbox token with agent-run:write", async () => {
+      const run = await createTestRun(testComposeId, "Run to cancel");
+      mockClerk({ userId: null });
+      const token = await generateSandboxToken(user.userId, run.runId, [
+        "agent-run:write",
+      ]);
+
+      const request = createTestRequest(
+        `http://localhost:3000/api/agent/runs/${run.runId}/cancel`,
+        {
+          method: "POST",
+          headers: { authorization: `Bearer ${token}` },
+        },
+      );
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+    });
+
+    it("should reject sandbox token without agent-run:write", async () => {
+      mockClerk({ userId: null });
+      const token = await generateSandboxToken(user.userId, "run-1", [
+        "agent-run:read",
+      ]);
+
+      const request = createTestRequest(
+        `http://localhost:3000/api/agent/runs/${randomUUID()}/cancel`,
+        {
+          method: "POST",
+          headers: { authorization: `Bearer ${token}` },
+        },
+      );
+      const response = await POST(request);
+
+      expect(response.status).toBe(401);
     });
   });
 });

--- a/turbo/apps/web/app/api/agent/runs/[id]/cancel/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/cancel/route.ts
@@ -20,7 +20,9 @@ const router = tsr.router(runsCancelContract, {
   cancel: async ({ params, headers }) => {
     initServices();
 
-    const userId = await getUserId(headers.authorization);
+    const userId = await getUserId(headers.authorization, {
+      requiredCapability: "agent-run:write",
+    });
     if (!userId) {
       return {
         status: 401 as const,

--- a/turbo/apps/web/app/api/agent/runs/[id]/events/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/events/route.ts
@@ -25,7 +25,9 @@ const router = tsr.router(runEventsContract, {
   getEvents: async ({ params, query, headers }) => {
     initServices();
 
-    const userId = await getUserId(headers.authorization);
+    const userId = await getUserId(headers.authorization, {
+      requiredCapability: "agent-run:read",
+    });
     if (!userId) {
       return {
         status: 401 as const,

--- a/turbo/apps/web/app/api/agent/runs/[id]/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/route.ts
@@ -9,7 +9,9 @@ const router = tsr.router(runsByIdContract, {
   getById: async ({ params, headers }) => {
     initServices();
 
-    const userId = await getUserId(headers.authorization);
+    const userId = await getUserId(headers.authorization, {
+      requiredCapability: "agent-run:read",
+    });
     if (!userId) {
       return {
         status: 401 as const,

--- a/turbo/apps/web/app/api/agent/runs/[id]/telemetry/agent/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/telemetry/agent/route.ts
@@ -27,7 +27,9 @@ const router = tsr.router(runAgentEventsContract, {
   getAgentEvents: async ({ params, query, headers }) => {
     initServices();
 
-    const userId = await getUserId(headers.authorization);
+    const userId = await getUserId(headers.authorization, {
+      requiredCapability: "agent-run:read",
+    });
     if (!userId) {
       return {
         status: 401 as const,

--- a/turbo/apps/web/app/api/agent/runs/[id]/telemetry/metrics/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/telemetry/metrics/route.ts
@@ -28,7 +28,9 @@ const router = tsr.router(runMetricsContract, {
   getMetrics: async ({ params, query, headers }) => {
     initServices();
 
-    const userId = await getUserId(headers.authorization);
+    const userId = await getUserId(headers.authorization, {
+      requiredCapability: "agent-run:read",
+    });
     if (!userId) {
       return {
         status: 401 as const,

--- a/turbo/apps/web/app/api/agent/runs/[id]/telemetry/network/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/telemetry/network/route.ts
@@ -37,7 +37,9 @@ const router = tsr.router(runNetworkLogsContract, {
   getNetworkLogs: async ({ params, query, headers }) => {
     initServices();
 
-    const userId = await getUserId(headers.authorization);
+    const userId = await getUserId(headers.authorization, {
+      requiredCapability: "agent-run:read",
+    });
     if (!userId) {
       return {
         status: 401 as const,

--- a/turbo/apps/web/app/api/agent/runs/[id]/telemetry/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/telemetry/route.ts
@@ -29,7 +29,9 @@ const router = tsr.router(runTelemetryContract, {
   getTelemetry: async ({ params, headers }) => {
     initServices();
 
-    const userId = await getUserId(headers.authorization);
+    const userId = await getUserId(headers.authorization, {
+      requiredCapability: "agent-run:read",
+    });
     if (!userId) {
       return {
         status: 401 as const,

--- a/turbo/apps/web/app/api/agent/runs/[id]/telemetry/system-log/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/telemetry/system-log/route.ts
@@ -24,7 +24,9 @@ const router = tsr.router(runSystemLogContract, {
   getSystemLog: async ({ params, query, headers }) => {
     initServices();
 
-    const userId = await getUserId(headers.authorization);
+    const userId = await getUserId(headers.authorization, {
+      requiredCapability: "agent-run:read",
+    });
     if (!userId) {
       return {
         status: 401 as const,

--- a/turbo/apps/web/app/api/agent/runs/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/__tests__/route.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { POST } from "../route";
+import { GET, POST } from "../route";
 import { POST as createComposeRoute } from "../../composes/route";
 import { PUT as putSecret } from "../../../secrets/route";
 import { PUT as setVariableRoute } from "../../../variables/route";
@@ -13,6 +13,7 @@ import {
   createTestMultiAuthModelProvider,
   createTestConnector,
   createTestRun,
+  createTestRunInDb,
   getTestRun,
   completeTestRun,
   createTestPermission,
@@ -20,6 +21,7 @@ import {
   insertOrgCacheEntry,
   getOrgCacheEntry,
 } from "../../../../../src/__tests__/api-test-helpers";
+import { generateSandboxToken } from "../../../../../src/lib/auth/sandbox-token";
 import {
   testContext,
   uniqueId,
@@ -1463,6 +1465,92 @@ describe("POST /api/agent/runs - Internal Runs API", () => {
       );
 
       expect(data.status).toBe("pending");
+    });
+  });
+
+  describe("Sandbox Token Capability Enforcement", () => {
+    it("should accept sandbox token with agent-run:read for list", async () => {
+      mockClerk({ userId: null });
+
+      // Create a run via DB so it exists for listing
+      const { runId } = await createTestRunInDb(user.userId, testComposeId);
+      const token = await generateSandboxToken(user.userId, runId, [
+        "agent-run:read",
+      ]);
+
+      const request = createTestRequest(
+        "http://localhost:3000/api/agent/runs?limit=10",
+        { headers: { authorization: `Bearer ${token}` } },
+      );
+      const response = await GET(request);
+
+      expect(response.status).toBe(200);
+    });
+
+    it("should reject sandbox token without agent-run:read for list", async () => {
+      mockClerk({ userId: null });
+      const token = await generateSandboxToken(user.userId, "run-1", [
+        "volume:read",
+      ]);
+
+      const request = createTestRequest(
+        "http://localhost:3000/api/agent/runs?limit=10",
+        { headers: { authorization: `Bearer ${token}` } },
+      );
+      const response = await GET(request);
+
+      expect(response.status).toBe(401);
+    });
+
+    it("should accept sandbox token with agent-run:write for create", async () => {
+      mockClerk({ userId: null });
+      const token = await generateSandboxToken(user.userId, "run-1", [
+        "agent-run:write",
+      ]);
+
+      const request = createTestRequest(
+        "http://localhost:3000/api/agent/runs",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({
+            agentComposeId: testComposeId,
+            prompt: "sandbox test",
+          }),
+        },
+      );
+      const response = await POST(request);
+
+      // Should pass auth (not 401) — downstream may fail for other reasons
+      expect(response.status).not.toBe(401);
+    });
+
+    it("should reject sandbox token without agent-run:write for create", async () => {
+      mockClerk({ userId: null });
+      const token = await generateSandboxToken(user.userId, "run-1", [
+        "agent-run:read",
+      ]);
+
+      const request = createTestRequest(
+        "http://localhost:3000/api/agent/runs",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({
+            agentComposeId: testComposeId,
+            prompt: "sandbox test",
+          }),
+        },
+      );
+      const response = await POST(request);
+
+      expect(response.status).toBe(401);
     });
   });
 });

--- a/turbo/apps/web/app/api/agent/runs/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/route.ts
@@ -274,7 +274,9 @@ const router = tsr.router(runsMainContract, {
   list: async ({ query, headers }) => {
     initServices();
 
-    const authCtx = await getAuthContext(headers.authorization);
+    const authCtx = await getAuthContext(headers.authorization, {
+      requiredCapability: "agent-run:read",
+    });
     if (!authCtx) {
       return {
         status: 401 as const,
@@ -389,7 +391,9 @@ const router = tsr.router(runsMainContract, {
   create: async ({ body, headers }, { request }) => {
     initServices();
 
-    const authCtx = await getAuthContext(headers.authorization);
+    const authCtx = await getAuthContext(headers.authorization, {
+      requiredCapability: "agent-run:write",
+    });
     if (!authCtx) {
       return {
         status: 401 as const,


### PR DESCRIPTION
## Summary

- Add `requiredCapability` parameter to all 10 agent run route handlers across 8 files
- GET endpoints enforce `agent-run:read`, POST endpoints enforce `agent-run:write`
- Add integration tests for sandbox token capability enforcement (8 test cases across 3 test files)

Closes #4915

## Changes

**Route migrations (8 files):**
- `runs/route.ts` — GET (list) + POST (create)
- `runs/[id]/route.ts` — GET (get by ID)
- `runs/[id]/events/route.ts` — GET (events)
- `runs/[id]/cancel/route.ts` — POST (cancel)
- `runs/[id]/telemetry/route.ts` — GET (telemetry)
- `runs/[id]/telemetry/agent/route.ts` — GET (agent events)
- `runs/[id]/telemetry/metrics/route.ts` — GET (metrics)
- `runs/[id]/telemetry/network/route.ts` — GET (network logs)
- `runs/[id]/telemetry/system-log/route.ts` — GET (system logs)

**Integration tests (3 files):**
- `runs/__tests__/route.test.ts` — sandbox token tests for list (read) and create (write)
- `runs/[id]/__tests__/route.test.ts` — sandbox token tests for get by ID (read)
- `runs/[id]/cancel/__tests__/route.test.ts` — sandbox token tests for cancel (write)

## Test plan

- [x] Sandbox token with `agent-run:read` can list runs
- [x] Sandbox token with `agent-run:read` can get run by ID
- [x] Sandbox token with `agent-run:write` can create run (auth passes)
- [x] Sandbox token with `agent-run:write` can cancel run
- [x] Sandbox token without required capability gets 401
- [x] CLI/session tokens continue to work unchanged (existing tests)
- [x] All pre-commit hooks pass (prettier, knip, commitlint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)