### PR TITLE
feat: enforce capabilities on storage routes (volume/artifact/memory)

### DIFF
--- a/turbo/apps/web/app/api/storages/__tests__/capability-enforcement.test.ts
+++ b/turbo/apps/web/app/api/storages/__tests__/capability-enforcement.test.ts
@@ -1,0 +1,260 @@
+import { randomUUID } from "crypto";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { GET as listRoute } from "../list/route";
+import { POST as prepareRoute } from "../prepare/route";
+import {
+  createTestRequest,
+  createTestVolume,
+  createTestArtifact,
+  createTestMemory,
+  createTestCompose,
+  createTestRunInDb,
+  createTestCliToken,
+} from "../../../../src/__tests__/api-test-helpers";
+import { testContext } from "../../../../src/__tests__/test-helpers";
+import { mockClerk } from "../../../../src/__tests__/clerk-mock";
+import { generateSandboxToken } from "../../../../src/lib/auth/sandbox-token";
+
+vi.hoisted(() => {
+  vi.stubEnv("R2_USER_STORAGES_BUCKET_NAME", "test-storages-bucket");
+});
+
+const context = testContext();
+
+// Valid SHA-256 hash for test file entries
+const TEST_HASH = "a".repeat(64);
+
+describe("Storage capability enforcement", () => {
+  let userId: string;
+  let runId: string;
+
+  beforeEach(async () => {
+    context.setupMocks();
+    await context.setupUser();
+    const user = await context.user;
+    userId = user.userId;
+
+    // Create a compose and run so sandbox tokens can resolve org
+    const { composeId } = await createTestCompose("test-agent");
+    const result = await createTestRunInDb(userId, composeId);
+    runId = result.runId;
+  });
+
+  describe("sandbox token access for list", () => {
+    it("should accept sandbox token with volume:read for list", async () => {
+      await createTestVolume("test-vol");
+      const token = await generateSandboxToken(userId, runId, ["volume:read"]);
+      mockClerk({ userId: null });
+
+      const response = await listRoute(
+        createTestRequest(
+          "http://localhost:3000/api/storages/list?type=volume",
+          { headers: { authorization: `Bearer ${token}` } },
+        ),
+      );
+
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(body).toHaveLength(1);
+      expect(body[0].name).toBe("test-vol");
+    });
+
+    it("should accept sandbox token with artifact:read for list", async () => {
+      await createTestArtifact("test-art");
+      const token = await generateSandboxToken(userId, runId, [
+        "artifact:read",
+      ]);
+      mockClerk({ userId: null });
+
+      const response = await listRoute(
+        createTestRequest(
+          "http://localhost:3000/api/storages/list?type=artifact",
+          { headers: { authorization: `Bearer ${token}` } },
+        ),
+      );
+
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(body).toHaveLength(1);
+      expect(body[0].name).toBe("test-art");
+    });
+
+    it("should accept sandbox token with memory:read for list", async () => {
+      await createTestMemory("test-mem");
+      const token = await generateSandboxToken(userId, runId, ["memory:read"]);
+      mockClerk({ userId: null });
+
+      const response = await listRoute(
+        createTestRequest(
+          "http://localhost:3000/api/storages/list?type=memory",
+          { headers: { authorization: `Bearer ${token}` } },
+        ),
+      );
+
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(body).toHaveLength(1);
+      expect(body[0].name).toBe("test-mem");
+    });
+
+    it("should reject sandbox token without matching read capability", async () => {
+      const token = await generateSandboxToken(userId, runId, [
+        "artifact:read",
+      ]);
+      mockClerk({ userId: null });
+
+      const response = await listRoute(
+        createTestRequest(
+          "http://localhost:3000/api/storages/list?type=volume",
+          { headers: { authorization: `Bearer ${token}` } },
+        ),
+      );
+
+      expect(response.status).toBe(401);
+    });
+
+    it("should reject sandbox token with write capability on read route", async () => {
+      const token = await generateSandboxToken(userId, runId, ["volume:write"]);
+      mockClerk({ userId: null });
+
+      const response = await listRoute(
+        createTestRequest(
+          "http://localhost:3000/api/storages/list?type=volume",
+          { headers: { authorization: `Bearer ${token}` } },
+        ),
+      );
+
+      expect(response.status).toBe(401);
+    });
+
+    it("should reject sandbox token with no capabilities", async () => {
+      const token = await generateSandboxToken(userId, runId);
+      mockClerk({ userId: null });
+
+      const response = await listRoute(
+        createTestRequest(
+          "http://localhost:3000/api/storages/list?type=volume",
+          { headers: { authorization: `Bearer ${token}` } },
+        ),
+      );
+
+      expect(response.status).toBe(401);
+    });
+  });
+
+  describe("sandbox token access for prepare", () => {
+    it("should accept sandbox token with volume:write for prepare", async () => {
+      const token = await generateSandboxToken(userId, runId, ["volume:write"]);
+      mockClerk({ userId: null });
+
+      const response = await prepareRoute(
+        createTestRequest("http://localhost:3000/api/storages/prepare", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({
+            storageName: "test-vol",
+            storageType: "volume",
+            files: [{ path: "a.txt", hash: TEST_HASH, size: 10 }],
+          }),
+        }),
+      );
+
+      expect(response.status).toBe(200);
+    });
+
+    it("should reject sandbox token without matching write capability for prepare", async () => {
+      const token = await generateSandboxToken(userId, runId, ["volume:read"]);
+      mockClerk({ userId: null });
+
+      const response = await prepareRoute(
+        createTestRequest("http://localhost:3000/api/storages/prepare", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({
+            storageName: "test-vol",
+            storageType: "volume",
+            files: [{ path: "a.txt", hash: TEST_HASH, size: 10 }],
+          }),
+        }),
+      );
+
+      expect(response.status).toBe(401);
+    });
+  });
+
+  describe("backward compatibility", () => {
+    it("should accept CLI token without capabilities for list", async () => {
+      // CLI token user is authenticated via Clerk session (getAuthContext checks Clerk first).
+      // The key is that adding requiredCapability to getAuthContext doesn't break CLI/session flows.
+      const cliToken = await createTestCliToken(userId);
+
+      const response = await listRoute(
+        createTestRequest(
+          "http://localhost:3000/api/storages/list?type=artifact",
+          { headers: { authorization: `Bearer ${cliToken}` } },
+        ),
+      );
+
+      expect(response.status).toBe(200);
+    });
+
+    it("should accept session token without capabilities for list", async () => {
+      // Session is already set up by context.setupUser() + setupMocks()
+      const response = await listRoute(
+        createTestRequest(
+          "http://localhost:3000/api/storages/list?type=artifact",
+        ),
+      );
+
+      expect(response.status).toBe(200);
+    });
+  });
+
+  describe("org resolution for sandbox tokens", () => {
+    it("should use run orgId for sandbox token", async () => {
+      // Create a volume in the user's org
+      await createTestVolume("org-vol");
+
+      // Sandbox token should resolve to the same org via run record
+      const token = await generateSandboxToken(userId, runId, ["volume:read"]);
+      mockClerk({ userId: null });
+
+      const response = await listRoute(
+        createTestRequest(
+          "http://localhost:3000/api/storages/list?type=volume",
+          { headers: { authorization: `Bearer ${token}` } },
+        ),
+      );
+
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(body).toHaveLength(1);
+      expect(body[0].name).toBe("org-vol");
+    });
+
+    it("should return 404 when sandbox token run not found", async () => {
+      const fakeRunId = randomUUID();
+      const token = await generateSandboxToken(userId, fakeRunId, [
+        "volume:read",
+      ]);
+      mockClerk({ userId: null });
+
+      const response = await listRoute(
+        createTestRequest(
+          "http://localhost:3000/api/storages/list?type=volume",
+          { headers: { authorization: `Bearer ${token}` } },
+        ),
+      );
+
+      expect(response.status).toBe(404);
+      const body = await response.json();
+      expect(body.error.code).toBe("NOT_FOUND");
+    });
+  });
+});

--- a/turbo/apps/web/app/api/storages/commit/route.ts
+++ b/turbo/apps/web/app/api/storages/commit/route.ts
@@ -9,7 +9,12 @@ import { agentRuns } from "../../../../src/db/schema/agent-run";
 import { storages, storageVersions } from "../../../../src/db/schema/storage";
 import { eq, and } from "drizzle-orm";
 import { getAuthContext } from "../../../../src/lib/auth/get-user-id";
+import {
+  storageCapability,
+  isSandboxAuth,
+} from "../../../../src/lib/auth/capability-check";
 import { resolveOrg } from "../../../../src/lib/org/resolve-org";
+import { getOrgData } from "../../../../src/lib/org/org-cache-service";
 import {
   s3ObjectExists,
   verifyS3FilesExist,
@@ -24,8 +29,14 @@ const router = tsr.router(storagesCommitContract, {
   commit: async ({ body, headers }, { request }) => {
     initServices();
 
-    // Authenticate user
-    const authCtx = await getAuthContext(headers.authorization);
+    const { storageName, storageType, versionId, files, runId, message } = body;
+
+    const capability = storageCapability(storageType, "write");
+
+    // Authenticate user (sandbox tokens accepted if they have the required capability)
+    const authCtx = await getAuthContext(headers.authorization, {
+      requiredCapability: capability,
+    });
     if (!authCtx) {
       return {
         status: 401 as const,
@@ -36,24 +47,21 @@ const router = tsr.router(storagesCommitContract, {
     }
     const { userId } = authCtx;
 
-    // Resolve user's default org
-    const orgSlug = new URL(request.url).searchParams.get("org");
-    const { org: runtimeOrg } = await resolveOrg(userId, orgSlug);
-
-    const { storageName, storageType, versionId, files, runId, message } = body;
-
     log.debug(
       `Committing version ${versionId} for "${storageName}" (type: ${storageType}), ${files.length} files`,
     );
 
-    // If runId provided, verify it belongs to the user (sandbox auth)
-    if (runId) {
+    // Resolve org: sandbox tokens use the run's org; CLI/session use resolveOrg
+    let runtimeOrg: { orgId: string; slug: string };
+    if (isSandboxAuth(authCtx)) {
+      // Sandbox: run lookup also verifies ownership (runId + userId from signed JWT)
       const [run] = await globalThis.services.db
-        .select()
+        .select({ orgId: agentRuns.orgId })
         .from(agentRuns)
-        .where(and(eq(agentRuns.id, runId), eq(agentRuns.userId, userId)))
+        .where(
+          and(eq(agentRuns.id, authCtx.runId!), eq(agentRuns.userId, userId)),
+        )
         .limit(1);
-
       if (!run) {
         return {
           status: 404 as const,
@@ -61,6 +69,28 @@ const router = tsr.router(storagesCommitContract, {
             error: { message: "Agent run not found", code: "NOT_FOUND" },
           },
         };
+      }
+      runtimeOrg = await getOrgData(run.orgId);
+    } else {
+      const orgSlug = new URL(request.url).searchParams.get("org");
+      const { org } = await resolveOrg(userId, orgSlug);
+      runtimeOrg = org;
+
+      // For CLI tokens, verify body.runId belongs to the user if provided
+      if (runId) {
+        const [run] = await globalThis.services.db
+          .select({ id: agentRuns.id })
+          .from(agentRuns)
+          .where(and(eq(agentRuns.id, runId), eq(agentRuns.userId, userId)))
+          .limit(1);
+        if (!run) {
+          return {
+            status: 404 as const,
+            body: {
+              error: { message: "Agent run not found", code: "NOT_FOUND" },
+            },
+          };
+        }
       }
     }
 

--- a/turbo/apps/web/app/api/storages/commit/route.ts
+++ b/turbo/apps/web/app/api/storages/commit/route.ts
@@ -59,7 +59,7 @@ const router = tsr.router(storagesCommitContract, {
         .select({ orgId: agentRuns.orgId })
         .from(agentRuns)
         .where(
-          and(eq(agentRuns.id, authCtx.runId!), eq(agentRuns.userId, userId)),
+          and(eq(agentRuns.id, authCtx.runId), eq(agentRuns.userId, userId)),
         )
         .limit(1);
       if (!run) {

--- a/turbo/apps/web/app/api/storages/download/route.ts
+++ b/turbo/apps/web/app/api/storages/download/route.ts
@@ -50,7 +50,7 @@ const router = tsr.router(storagesDownloadContract, {
         .select({ orgId: agentRuns.orgId })
         .from(agentRuns)
         .where(
-          and(eq(agentRuns.id, authCtx.runId!), eq(agentRuns.userId, userId)),
+          and(eq(agentRuns.id, authCtx.runId), eq(agentRuns.userId, userId)),
         )
         .limit(1);
       if (!run) {

--- a/turbo/apps/web/app/api/storages/download/route.ts
+++ b/turbo/apps/web/app/api/storages/download/route.ts
@@ -6,9 +6,15 @@ import {
 import { storagesDownloadContract, VOLUME_ORG_USER_ID } from "@vm0/core";
 import { initServices } from "../../../../src/lib/init-services";
 import { storages, storageVersions } from "../../../../src/db/schema/storage";
+import { agentRuns } from "../../../../src/db/schema/agent-run";
 import { eq, and } from "drizzle-orm";
 import { getAuthContext } from "../../../../src/lib/auth/get-user-id";
+import {
+  storageCapability,
+  isSandboxAuth,
+} from "../../../../src/lib/auth/capability-check";
 import { resolveOrg } from "../../../../src/lib/org/resolve-org";
+import { getOrgData } from "../../../../src/lib/org/org-cache-service";
 import { generatePresignedUrl } from "../../../../src/lib/s3/s3-client";
 import { env } from "../../../../src/env";
 import { resolveVersionByPrefix } from "../../../../src/lib/storage/version-resolver";
@@ -20,8 +26,13 @@ const router = tsr.router(storagesDownloadContract, {
   download: async ({ query, headers }, { request }) => {
     initServices();
 
-    // Authenticate user
-    const authCtx = await getAuthContext(headers.authorization);
+    const { name: storageName, type: storageType, version: versionId } = query;
+    const capability = storageCapability(storageType, "read");
+
+    // Authenticate user (sandbox tokens accepted if they have the required capability)
+    const authCtx = await getAuthContext(headers.authorization, {
+      requiredCapability: capability,
+    });
     if (!authCtx) {
       return {
         status: 401 as const,
@@ -32,11 +43,30 @@ const router = tsr.router(storagesDownloadContract, {
     }
     const { userId } = authCtx;
 
-    // Resolve user's default org
-    const orgSlug = new URL(request.url).searchParams.get("org");
-    const { org: runtimeOrg } = await resolveOrg(userId, orgSlug);
-
-    const { name: storageName, type: storageType, version: versionId } = query;
+    // Resolve org: sandbox tokens use the run's org; CLI/session use resolveOrg
+    let runtimeOrg: { orgId: string; slug: string };
+    if (isSandboxAuth(authCtx)) {
+      const [run] = await globalThis.services.db
+        .select({ orgId: agentRuns.orgId })
+        .from(agentRuns)
+        .where(
+          and(eq(agentRuns.id, authCtx.runId!), eq(agentRuns.userId, userId)),
+        )
+        .limit(1);
+      if (!run) {
+        return {
+          status: 404 as const,
+          body: {
+            error: { message: "Agent run not found", code: "NOT_FOUND" },
+          },
+        };
+      }
+      runtimeOrg = await getOrgData(run.orgId);
+    } else {
+      const orgSlug = new URL(request.url).searchParams.get("org");
+      const { org } = await resolveOrg(userId, orgSlug);
+      runtimeOrg = org;
+    }
 
     log.debug(
       `Getting download URL for "${storageName}" (type: ${storageType})${versionId ? ` version ${versionId}` : ""} for org ${runtimeOrg.slug}`,

--- a/turbo/apps/web/app/api/storages/list/route.ts
+++ b/turbo/apps/web/app/api/storages/list/route.ts
@@ -47,7 +47,7 @@ const router = tsr.router(storagesListContract, {
         .select({ orgId: agentRuns.orgId })
         .from(agentRuns)
         .where(
-          and(eq(agentRuns.id, authCtx.runId!), eq(agentRuns.userId, userId)),
+          and(eq(agentRuns.id, authCtx.runId), eq(agentRuns.userId, userId)),
         )
         .limit(1);
       if (!run) {

--- a/turbo/apps/web/app/api/storages/list/route.ts
+++ b/turbo/apps/web/app/api/storages/list/route.ts
@@ -6,9 +6,15 @@ import {
 import { storagesListContract, VOLUME_ORG_USER_ID } from "@vm0/core";
 import { initServices } from "../../../../src/lib/init-services";
 import { storages } from "../../../../src/db/schema/storage";
+import { agentRuns } from "../../../../src/db/schema/agent-run";
 import { eq, and, desc } from "drizzle-orm";
 import { getAuthContext } from "../../../../src/lib/auth/get-user-id";
+import {
+  storageCapability,
+  isSandboxAuth,
+} from "../../../../src/lib/auth/capability-check";
 import { resolveOrg } from "../../../../src/lib/org/resolve-org";
+import { getOrgData } from "../../../../src/lib/org/org-cache-service";
 import { logger } from "../../../../src/lib/logger";
 
 const log = logger("api:storages:list");
@@ -17,8 +23,13 @@ const router = tsr.router(storagesListContract, {
   list: async ({ query, headers }, { request }) => {
     initServices();
 
-    // Authenticate user
-    const authCtx = await getAuthContext(headers.authorization);
+    const { type: storageType } = query;
+    const capability = storageCapability(storageType, "read");
+
+    // Authenticate user (sandbox tokens accepted if they have the required capability)
+    const authCtx = await getAuthContext(headers.authorization, {
+      requiredCapability: capability,
+    });
     if (!authCtx) {
       return {
         status: 401 as const,
@@ -29,11 +40,30 @@ const router = tsr.router(storagesListContract, {
     }
     const { userId } = authCtx;
 
-    const { type: storageType } = query;
-
-    // Resolve user's default org
-    const orgSlug = new URL(request.url).searchParams.get("org");
-    const { org: runtimeOrg } = await resolveOrg(userId, orgSlug);
+    // Resolve org: sandbox tokens use the run's org; CLI/session use resolveOrg
+    let runtimeOrg: { orgId: string; slug: string };
+    if (isSandboxAuth(authCtx)) {
+      const [run] = await globalThis.services.db
+        .select({ orgId: agentRuns.orgId })
+        .from(agentRuns)
+        .where(
+          and(eq(agentRuns.id, authCtx.runId!), eq(agentRuns.userId, userId)),
+        )
+        .limit(1);
+      if (!run) {
+        return {
+          status: 404 as const,
+          body: {
+            error: { message: "Agent run not found", code: "NOT_FOUND" },
+          },
+        };
+      }
+      runtimeOrg = await getOrgData(run.orgId);
+    } else {
+      const orgSlug = new URL(request.url).searchParams.get("org");
+      const { org } = await resolveOrg(userId, orgSlug);
+      runtimeOrg = org;
+    }
 
     // Volumes use sentinel userId (org-shared); artifacts/memory use real userId
     const storageUserId =

--- a/turbo/apps/web/app/api/storages/prepare/route.ts
+++ b/turbo/apps/web/app/api/storages/prepare/route.ts
@@ -13,7 +13,12 @@ import { agentRuns } from "../../../../src/db/schema/agent-run";
 import { storages, storageVersions } from "../../../../src/db/schema/storage";
 import { eq, and } from "drizzle-orm";
 import { getAuthContext } from "../../../../src/lib/auth/get-user-id";
+import {
+  storageCapability,
+  isSandboxAuth,
+} from "../../../../src/lib/auth/capability-check";
 import { resolveOrg } from "../../../../src/lib/org/resolve-org";
+import { getOrgData } from "../../../../src/lib/org/org-cache-service";
 import {
   generatePresignedPutUrl,
   downloadManifest,
@@ -90,22 +95,6 @@ const router = tsr.router(storagesPrepareContract, {
   prepare: async ({ body, headers }, { request }) => {
     initServices();
 
-    // Authenticate user
-    const authCtx = await getAuthContext(headers.authorization);
-    if (!authCtx) {
-      return {
-        status: 401 as const,
-        body: {
-          error: { message: "Not authenticated", code: "UNAUTHORIZED" },
-        },
-      };
-    }
-    const { userId } = authCtx;
-
-    // Resolve user's default org
-    const orgSlug = new URL(request.url).searchParams.get("org");
-    const { org: runtimeOrg } = await resolveOrg(userId, orgSlug);
-
     const {
       storageName,
       storageType,
@@ -115,6 +104,22 @@ const router = tsr.router(storagesPrepareContract, {
       baseVersion,
       changes,
     } = body;
+
+    const capability = storageCapability(storageType, "write");
+
+    // Authenticate user (sandbox tokens accepted if they have the required capability)
+    const authCtx = await getAuthContext(headers.authorization, {
+      requiredCapability: capability,
+    });
+    if (!authCtx) {
+      return {
+        status: 401 as const,
+        body: {
+          error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+        },
+      };
+    }
+    const { userId } = authCtx;
 
     // Validate total declared file size (100MB per-file limit is enforced by schema)
     const totalDeclaredSize = files.reduce(
@@ -137,14 +142,17 @@ const router = tsr.router(storagesPrepareContract, {
       `Preparing upload for "${storageName}" (type: ${storageType}), ${files.length} files`,
     );
 
-    // If runId provided, verify it belongs to the user (sandbox auth)
-    if (runId) {
+    // Resolve org: sandbox tokens use the run's org; CLI/session use resolveOrg
+    let runtimeOrg: { orgId: string; slug: string };
+    if (isSandboxAuth(authCtx)) {
+      // Sandbox: run lookup also verifies ownership (runId + userId from signed JWT)
       const [run] = await globalThis.services.db
-        .select()
+        .select({ orgId: agentRuns.orgId })
         .from(agentRuns)
-        .where(and(eq(agentRuns.id, runId), eq(agentRuns.userId, userId)))
+        .where(
+          and(eq(agentRuns.id, authCtx.runId!), eq(agentRuns.userId, userId)),
+        )
         .limit(1);
-
       if (!run) {
         return {
           status: 404 as const,
@@ -152,6 +160,28 @@ const router = tsr.router(storagesPrepareContract, {
             error: { message: "Agent run not found", code: "NOT_FOUND" },
           },
         };
+      }
+      runtimeOrg = await getOrgData(run.orgId);
+    } else {
+      const orgSlug = new URL(request.url).searchParams.get("org");
+      const { org } = await resolveOrg(userId, orgSlug);
+      runtimeOrg = org;
+
+      // For CLI tokens, verify body.runId belongs to the user if provided
+      if (runId) {
+        const [run] = await globalThis.services.db
+          .select({ id: agentRuns.id })
+          .from(agentRuns)
+          .where(and(eq(agentRuns.id, runId), eq(agentRuns.userId, userId)))
+          .limit(1);
+        if (!run) {
+          return {
+            status: 404 as const,
+            body: {
+              error: { message: "Agent run not found", code: "NOT_FOUND" },
+            },
+          };
+        }
       }
     }
 

--- a/turbo/apps/web/app/api/storages/prepare/route.ts
+++ b/turbo/apps/web/app/api/storages/prepare/route.ts
@@ -150,7 +150,7 @@ const router = tsr.router(storagesPrepareContract, {
         .select({ orgId: agentRuns.orgId })
         .from(agentRuns)
         .where(
-          and(eq(agentRuns.id, authCtx.runId!), eq(agentRuns.userId, userId)),
+          and(eq(agentRuns.id, authCtx.runId), eq(agentRuns.userId, userId)),
         )
         .limit(1);
       if (!run) {

--- a/turbo/apps/web/src/lib/auth/capability-check.ts
+++ b/turbo/apps/web/src/lib/auth/capability-check.ts
@@ -21,8 +21,11 @@ export function hasCapability(
 /**
  * Check if auth context is from a sandbox token.
  * Sandbox auth contexts have a runId field.
+ * Type guard narrows authCtx so callers can access runId without non-null assertion.
  */
-export function isSandboxAuth(authCtx: AuthContext): boolean {
+export function isSandboxAuth(
+  authCtx: AuthContext,
+): authCtx is AuthContext & { runId: string } {
   return authCtx.runId !== undefined;
 }
 


### PR DESCRIPTION
## Summary

- Migrate 4 storage API routes to accept sandbox tokens via `requiredCapability` on `getAuthContext()`
- Add org resolution branching: sandbox tokens resolve org from `agent_runs` table; CLI/session tokens use existing `resolveOrg()`
- Add 12 integration tests for capability enforcement, backward compatibility, and sandbox org resolution

Closes #4913

## Routes Migrated

| Route | Capabilities |
|-------|-------------|
| `GET /api/storages/list` | `volume:read`, `artifact:read`, `memory:read` |
| `GET /api/storages/download` | `volume:read`, `artifact:read`, `memory:read` |
| `POST /api/storages/prepare` | `volume:write`, `artifact:write`, `memory:write` |
| `POST /api/storages/commit` | `volume:write`, `artifact:write`, `memory:write` |

## Test plan

- [x] Sandbox token with correct capability accepted (all 3 storage types)
- [x] Sandbox token with wrong/missing capability rejected (401)
- [x] CLI token backward compatibility preserved
- [x] Session token backward compatibility preserved
- [x] Sandbox org resolution via agent_runs table works
- [x] Nonexistent run returns 404
- [x] All 61 storage tests pass (49 existing + 12 new)
- [x] lint, check-types, format, knip all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)