### PR TITLE
feat: enforce capabilities on schedule routes

### DIFF
--- a/turbo/apps/web/app/api/agent/schedules/[name]/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/schedules/[name]/__tests__/route.test.ts
@@ -6,12 +6,14 @@ import {
   createTestSchedule,
   getTestSchedule,
   deleteTestSchedule,
+  insertOrgMembersCacheEntry,
 } from "../../../../../../src/__tests__/api-test-helpers";
 import {
   testContext,
   type UserContext,
 } from "../../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
+import { generateSandboxToken } from "../../../../../../src/lib/auth/sandbox-token";
 
 const context = testContext();
 
@@ -231,5 +233,127 @@ describe("DELETE /api/agent/schedules/:name - Delete Schedule", () => {
     );
     const response = await GET(request);
     expect(response.status).toBe(404);
+  });
+});
+
+describe("GET /api/agent/schedules/:name - Sandbox Token Auth", () => {
+  let user: UserContext;
+  let testComposeId: string;
+
+  beforeEach(async () => {
+    context.setupMocks();
+    user = await context.setupUser();
+
+    const { composeId } = await createTestCompose(
+      `sandbox-get-agent-${Date.now()}`,
+    );
+    testComposeId = composeId;
+  });
+
+  it("should accept sandbox token with schedule:read capability", async () => {
+    await createTestSchedule(testComposeId, "sandbox-get-test", {
+      cronExpression: "0 9 * * *",
+      prompt: "Test",
+    });
+
+    await insertOrgMembersCacheEntry({
+      orgId: user.orgId,
+      userId: user.userId,
+    });
+    mockClerk({ userId: null });
+    const token = await generateSandboxToken(user.userId, "run-123", [
+      "schedule:read",
+    ]);
+
+    const request = createTestRequest(
+      `http://localhost:3000/api/agent/schedules/sandbox-get-test?composeId=${testComposeId}`,
+      {
+        headers: { Authorization: `Bearer ${token}` },
+      },
+    );
+
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+  });
+
+  it("should reject sandbox token without schedule:read capability", async () => {
+    mockClerk({ userId: null });
+    const token = await generateSandboxToken(user.userId, "run-123", [
+      "volume:read",
+    ]);
+
+    const request = createTestRequest(
+      `http://localhost:3000/api/agent/schedules/any-schedule?composeId=${testComposeId}`,
+      {
+        headers: { Authorization: `Bearer ${token}` },
+      },
+    );
+
+    const response = await GET(request);
+
+    expect(response.status).toBe(401);
+  });
+});
+
+describe("DELETE /api/agent/schedules/:name - Sandbox Token Auth", () => {
+  let user: UserContext;
+  let testComposeId: string;
+
+  beforeEach(async () => {
+    context.setupMocks();
+    user = await context.setupUser();
+
+    const { composeId } = await createTestCompose(
+      `sandbox-del-agent-${Date.now()}`,
+    );
+    testComposeId = composeId;
+  });
+
+  it("should accept sandbox token with schedule:write capability", async () => {
+    await createTestSchedule(testComposeId, "sandbox-delete-test", {
+      cronExpression: "0 9 * * *",
+      prompt: "Test",
+    });
+
+    await insertOrgMembersCacheEntry({
+      orgId: user.orgId,
+      userId: user.userId,
+    });
+    mockClerk({ userId: null });
+    const token = await generateSandboxToken(user.userId, "run-123", [
+      "schedule:write",
+    ]);
+
+    const request = createTestRequest(
+      `http://localhost:3000/api/agent/schedules/sandbox-delete-test?composeId=${testComposeId}`,
+      {
+        method: "DELETE",
+        headers: { Authorization: `Bearer ${token}` },
+      },
+    );
+
+    const response = await DELETE(request);
+
+    expect(response.status).toBe(204);
+  });
+
+  it("should reject sandbox token without schedule:write capability", async () => {
+    mockClerk({ userId: null });
+    const token = await generateSandboxToken(user.userId, "run-123", [
+      "volume:read",
+    ]);
+
+    const request = createTestRequest(
+      `http://localhost:3000/api/agent/schedules/any-schedule?composeId=${testComposeId}`,
+      {
+        method: "DELETE",
+        headers: { Authorization: `Bearer ${token}` },
+      },
+    );
+
+    const response = await DELETE(request);
+
+    expect(response.status).toBe(401);
   });
 });

--- a/turbo/apps/web/app/api/agent/schedules/[name]/disable/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/schedules/[name]/disable/__tests__/route.test.ts
@@ -7,9 +7,14 @@ import {
   enableTestSchedule,
   disableTestSchedule,
   getTestSchedule,
+  insertOrgMembersCacheEntry,
 } from "../../../../../../../src/__tests__/api-test-helpers";
-import { testContext } from "../../../../../../../src/__tests__/test-helpers";
+import {
+  testContext,
+  type UserContext,
+} from "../../../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../../../src/__tests__/clerk-mock";
+import { generateSandboxToken } from "../../../../../../../src/lib/auth/sandbox-token";
 
 const context = testContext();
 
@@ -164,5 +169,80 @@ describe("POST /api/agent/schedules/:name/disable", () => {
 
     expect(response.status).toBe(401);
     expect(data.error.message).toContain("Not authenticated");
+  });
+});
+
+describe("POST /api/agent/schedules/:name/disable - Sandbox Token Auth", () => {
+  let user: UserContext;
+  let testComposeId: string;
+
+  beforeEach(async () => {
+    context.setupMocks();
+    user = await context.setupUser();
+
+    const { composeId } = await createTestCompose(
+      `sandbox-disable-agent-${Date.now()}`,
+    );
+    testComposeId = composeId;
+  });
+
+  it("should accept sandbox token with schedule:write capability", async () => {
+    await createTestSchedule(testComposeId, "sandbox-disable-test", {
+      cronExpression: "0 9 * * *",
+      prompt: "Test",
+    });
+    await enableTestSchedule(testComposeId, "sandbox-disable-test");
+
+    await insertOrgMembersCacheEntry({
+      orgId: user.orgId,
+      userId: user.userId,
+    });
+    mockClerk({ userId: null });
+    const token = await generateSandboxToken(user.userId, "run-123", [
+      "schedule:write",
+    ]);
+
+    const request = createTestRequest(
+      `http://localhost:3000/api/agent/schedules/sandbox-disable-test/disable`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ composeId: testComposeId }),
+      },
+    );
+
+    const response = await POST(request, {
+      params: Promise.resolve({ name: "sandbox-disable-test" }),
+    });
+
+    expect(response.status).toBe(200);
+  });
+
+  it("should reject sandbox token without schedule:write capability", async () => {
+    mockClerk({ userId: null });
+    const token = await generateSandboxToken(user.userId, "run-123", [
+      "volume:read",
+    ]);
+
+    const request = createTestRequest(
+      `http://localhost:3000/api/agent/schedules/any-schedule/disable`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ composeId: testComposeId }),
+      },
+    );
+
+    const response = await POST(request, {
+      params: Promise.resolve({ name: "any-schedule" }),
+    });
+
+    expect(response.status).toBe(401);
   });
 });

--- a/turbo/apps/web/app/api/agent/schedules/[name]/disable/route.ts
+++ b/turbo/apps/web/app/api/agent/schedules/[name]/disable/route.ts
@@ -21,6 +21,7 @@ export async function POST(
 
   const authCtx = await getAuthContext(
     request.headers.get("Authorization") ?? undefined,
+    { requiredCapability: "schedule:write" },
   );
   if (!authCtx) {
     return NextResponse.json(

--- a/turbo/apps/web/app/api/agent/schedules/[name]/enable/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/schedules/[name]/enable/__tests__/route.test.ts
@@ -8,9 +8,14 @@ import {
   enableTestSchedule,
   getTestSchedule,
   updateTestScheduleState,
+  insertOrgMembersCacheEntry,
 } from "../../../../../../../src/__tests__/api-test-helpers";
-import { testContext } from "../../../../../../../src/__tests__/test-helpers";
+import {
+  testContext,
+  type UserContext,
+} from "../../../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../../../src/__tests__/clerk-mock";
+import { generateSandboxToken } from "../../../../../../../src/lib/auth/sandbox-token";
 
 const context = testContext();
 
@@ -228,5 +233,79 @@ describe("POST /api/agent/schedules/:name/enable", () => {
 
     expect(response.status).toBe(401);
     expect(data.error.message).toContain("Not authenticated");
+  });
+});
+
+describe("POST /api/agent/schedules/:name/enable - Sandbox Token Auth", () => {
+  let user: UserContext;
+  let testComposeId: string;
+
+  beforeEach(async () => {
+    context.setupMocks();
+    user = await context.setupUser();
+
+    const { composeId } = await createTestCompose(
+      `sandbox-enable-agent-${Date.now()}`,
+    );
+    testComposeId = composeId;
+  });
+
+  it("should accept sandbox token with schedule:write capability", async () => {
+    await createTestSchedule(testComposeId, "sandbox-enable-test", {
+      cronExpression: "0 9 * * *",
+      prompt: "Test",
+    });
+
+    await insertOrgMembersCacheEntry({
+      orgId: user.orgId,
+      userId: user.userId,
+    });
+    mockClerk({ userId: null });
+    const token = await generateSandboxToken(user.userId, "run-123", [
+      "schedule:write",
+    ]);
+
+    const request = createTestRequest(
+      `http://localhost:3000/api/agent/schedules/sandbox-enable-test/enable`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ composeId: testComposeId }),
+      },
+    );
+
+    const response = await POST(request, {
+      params: Promise.resolve({ name: "sandbox-enable-test" }),
+    });
+
+    expect(response.status).toBe(200);
+  });
+
+  it("should reject sandbox token without schedule:write capability", async () => {
+    mockClerk({ userId: null });
+    const token = await generateSandboxToken(user.userId, "run-123", [
+      "volume:read",
+    ]);
+
+    const request = createTestRequest(
+      `http://localhost:3000/api/agent/schedules/any-schedule/enable`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ composeId: testComposeId }),
+      },
+    );
+
+    const response = await POST(request, {
+      params: Promise.resolve({ name: "any-schedule" }),
+    });
+
+    expect(response.status).toBe(401);
   });
 });

--- a/turbo/apps/web/app/api/agent/schedules/[name]/enable/route.ts
+++ b/turbo/apps/web/app/api/agent/schedules/[name]/enable/route.ts
@@ -21,6 +21,7 @@ export async function POST(
 
   const authCtx = await getAuthContext(
     request.headers.get("Authorization") ?? undefined,
+    { requiredCapability: "schedule:write" },
   );
   if (!authCtx) {
     return NextResponse.json(

--- a/turbo/apps/web/app/api/agent/schedules/[name]/route.ts
+++ b/turbo/apps/web/app/api/agent/schedules/[name]/route.ts
@@ -20,7 +20,9 @@ const router = tsr.router(schedulesByNameContract, {
   getByName: async ({ params, query, headers }, { request }) => {
     initServices();
 
-    const authCtx = await getAuthContext(headers.authorization);
+    const authCtx = await getAuthContext(headers.authorization, {
+      requiredCapability: "schedule:read",
+    });
     if (!authCtx) {
       return {
         status: 401 as const,
@@ -66,7 +68,9 @@ const router = tsr.router(schedulesByNameContract, {
   delete: async ({ params, query, headers }, { request }) => {
     initServices();
 
-    const authCtx = await getAuthContext(headers.authorization);
+    const authCtx = await getAuthContext(headers.authorization, {
+      requiredCapability: "schedule:write",
+    });
     if (!authCtx) {
       return {
         status: 401 as const,

--- a/turbo/apps/web/app/api/agent/schedules/[name]/runs/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/schedules/[name]/runs/__tests__/route.test.ts
@@ -5,9 +5,14 @@ import {
   createTestCompose,
   createTestSchedule,
   getTestScheduleRuns,
+  insertOrgMembersCacheEntry,
 } from "../../../../../../../src/__tests__/api-test-helpers";
-import { testContext } from "../../../../../../../src/__tests__/test-helpers";
+import {
+  testContext,
+  type UserContext,
+} from "../../../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../../../src/__tests__/clerk-mock";
+import { generateSandboxToken } from "../../../../../../../src/lib/auth/sandbox-token";
 
 const context = testContext();
 
@@ -120,5 +125,65 @@ describe("GET /api/agent/schedules/:name/runs", () => {
 
     expect(response.status).toBe(400);
     expect(data.error.message).toContain("composeId");
+  });
+});
+
+describe("GET /api/agent/schedules/:name/runs - Sandbox Token Auth", () => {
+  let user: UserContext;
+  let testComposeId: string;
+
+  beforeEach(async () => {
+    context.setupMocks();
+    user = await context.setupUser();
+
+    const { composeId } = await createTestCompose(
+      `sandbox-runs-agent-${Date.now()}`,
+    );
+    testComposeId = composeId;
+  });
+
+  it("should accept sandbox token with schedule:read capability", async () => {
+    await createTestSchedule(testComposeId, "sandbox-runs-test", {
+      cronExpression: "0 9 * * *",
+      prompt: "Test",
+    });
+
+    await insertOrgMembersCacheEntry({
+      orgId: user.orgId,
+      userId: user.userId,
+    });
+    mockClerk({ userId: null });
+    const token = await generateSandboxToken(user.userId, "run-123", [
+      "schedule:read",
+    ]);
+
+    const request = createTestRequest(
+      `http://localhost:3000/api/agent/schedules/sandbox-runs-test/runs?composeId=${testComposeId}`,
+      {
+        headers: { Authorization: `Bearer ${token}` },
+      },
+    );
+
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+  });
+
+  it("should reject sandbox token without schedule:read capability", async () => {
+    mockClerk({ userId: null });
+    const token = await generateSandboxToken(user.userId, "run-123", [
+      "volume:read",
+    ]);
+
+    const request = createTestRequest(
+      `http://localhost:3000/api/agent/schedules/any-schedule/runs?composeId=${testComposeId}`,
+      {
+        headers: { Authorization: `Bearer ${token}` },
+      },
+    );
+
+    const response = await GET(request);
+
+    expect(response.status).toBe(401);
   });
 });

--- a/turbo/apps/web/app/api/agent/schedules/[name]/runs/route.ts
+++ b/turbo/apps/web/app/api/agent/schedules/[name]/runs/route.ts
@@ -17,7 +17,9 @@ const router = tsr.router(scheduleRunsContract, {
   listRuns: async ({ params, query, headers }, { request }) => {
     initServices();
 
-    const authCtx = await getAuthContext(headers.authorization);
+    const authCtx = await getAuthContext(headers.authorization, {
+      requiredCapability: "schedule:read",
+    });
     if (!authCtx) {
       return {
         status: 401 as const,

--- a/turbo/apps/web/app/api/agent/schedules/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/schedules/__tests__/route.test.ts
@@ -8,6 +8,7 @@ import {
   listTestSchedules,
   createTestSecret,
   createTestVariable,
+  insertOrgMembersCacheEntry,
 } from "../../../../../src/__tests__/api-test-helpers";
 import {
   testContext,
@@ -15,6 +16,7 @@ import {
   type UserContext,
 } from "../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../src/__tests__/clerk-mock";
+import { generateSandboxToken } from "../../../../../src/lib/auth/sandbox-token";
 
 const context = testContext();
 
@@ -971,5 +973,137 @@ describe("POST /api/agent/schedules - Platform Configuration Validation", () => 
 
     expect(response.status).toBe(400);
     expect(data.error.code).toBe("BAD_REQUEST");
+  });
+});
+
+describe("POST /api/agent/schedules - Sandbox Token Auth", () => {
+  let user: UserContext;
+  let testComposeId: string;
+
+  beforeEach(async () => {
+    context.setupMocks();
+    user = await context.setupUser();
+
+    const { composeId } = await createTestCompose(
+      `sandbox-deploy-agent-${Date.now()}`,
+    );
+    testComposeId = composeId;
+
+    // Populate membership cache so resolveOrg works without Clerk session
+    await insertOrgMembersCacheEntry({
+      orgId: user.orgId,
+      userId: user.userId,
+    });
+
+    // Clear Clerk session so sandbox token path is exercised
+    mockClerk({ userId: null });
+  });
+
+  it("should accept sandbox token with schedule:write capability", async () => {
+    const token = await generateSandboxToken(user.userId, "run-123", [
+      "schedule:write",
+    ]);
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/agent/schedules",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({
+          composeId: testComposeId,
+          name: "sandbox-schedule",
+          cronExpression: "0 9 * * *",
+          timezone: "UTC",
+          prompt: "Sandbox deploy test",
+        }),
+      },
+    );
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(201);
+  });
+
+  it("should reject sandbox token without schedule:write capability", async () => {
+    const token = await generateSandboxToken(user.userId, "run-123", [
+      "volume:read",
+    ]);
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/agent/schedules",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({
+          composeId: testComposeId,
+          name: "sandbox-schedule",
+          cronExpression: "0 9 * * *",
+          timezone: "UTC",
+          prompt: "Should be rejected",
+        }),
+      },
+    );
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(401);
+  });
+});
+
+describe("GET /api/agent/schedules - Sandbox Token Auth", () => {
+  let user: UserContext;
+
+  beforeEach(async () => {
+    context.setupMocks();
+    user = await context.setupUser();
+
+    // Populate membership cache so resolveOrg works without Clerk session
+    await insertOrgMembersCacheEntry({
+      orgId: user.orgId,
+      userId: user.userId,
+    });
+
+    // Clear Clerk session so sandbox token path is exercised
+    mockClerk({ userId: null });
+  });
+
+  it("should accept sandbox token with schedule:read capability", async () => {
+    const token = await generateSandboxToken(user.userId, "run-123", [
+      "schedule:read",
+    ]);
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/agent/schedules",
+      {
+        headers: { Authorization: `Bearer ${token}` },
+      },
+    );
+
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+  });
+
+  it("should reject sandbox token without schedule:read capability", async () => {
+    const token = await generateSandboxToken(user.userId, "run-123", [
+      "volume:read",
+    ]);
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/agent/schedules",
+      {
+        headers: { Authorization: `Bearer ${token}` },
+      },
+    );
+
+    const response = await GET(request);
+
+    expect(response.status).toBe(401);
   });
 });

--- a/turbo/apps/web/app/api/agent/schedules/missing-secrets/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/schedules/missing-secrets/__tests__/route.test.ts
@@ -5,6 +5,7 @@ import {
   createTestCompose,
   createTestPermission,
   createTestSecret,
+  insertOrgMembersCacheEntry,
 } from "../../../../../../src/__tests__/api-test-helpers";
 import {
   testContext,
@@ -15,6 +16,7 @@ import {
   mockClerk,
   MOCK_USER_EMAIL,
 } from "../../../../../../src/__tests__/clerk-mock";
+import { generateSandboxToken } from "../../../../../../src/lib/auth/sandbox-token";
 
 const context = testContext();
 
@@ -151,5 +153,54 @@ describe("GET /api/agent/schedules/missing-secrets", () => {
     );
     expect(agent).toBeDefined();
     expect(agent.missingSecrets).toContain("SHARED_KEY");
+  });
+});
+
+describe("GET /api/agent/schedules/missing-secrets - Sandbox Token Auth", () => {
+  let user: UserContext;
+
+  beforeEach(async () => {
+    context.setupMocks();
+    user = await context.setupUser();
+  });
+
+  it("should accept sandbox token with schedule:read capability", async () => {
+    await insertOrgMembersCacheEntry({
+      orgId: user.orgId,
+      userId: user.userId,
+    });
+    mockClerk({ userId: null });
+    const token = await generateSandboxToken(user.userId, "run-123", [
+      "schedule:read",
+    ]);
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/agent/schedules/missing-secrets",
+      {
+        headers: { Authorization: `Bearer ${token}` },
+      },
+    );
+
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+  });
+
+  it("should reject sandbox token without schedule:read capability", async () => {
+    mockClerk({ userId: null });
+    const token = await generateSandboxToken(user.userId, "run-123", [
+      "volume:read",
+    ]);
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/agent/schedules/missing-secrets",
+      {
+        headers: { Authorization: `Bearer ${token}` },
+      },
+    );
+
+    const response = await GET(request);
+
+    expect(response.status).toBe(401);
   });
 });

--- a/turbo/apps/web/app/api/agent/schedules/missing-secrets/route.ts
+++ b/turbo/apps/web/app/api/agent/schedules/missing-secrets/route.ts
@@ -31,7 +31,9 @@ export async function GET(request: Request) {
   initServices();
 
   const authHeader = request.headers.get("authorization");
-  const userId = await getUserId(authHeader ?? undefined);
+  const userId = await getUserId(authHeader ?? undefined, {
+    requiredCapability: "schedule:read",
+  });
 
   if (!userId) {
     return NextResponse.json(

--- a/turbo/apps/web/app/api/agent/schedules/route.ts
+++ b/turbo/apps/web/app/api/agent/schedules/route.ts
@@ -21,7 +21,9 @@ const router = tsr.router(schedulesMainContract, {
   deploy: async ({ body, headers }, { request }) => {
     initServices();
 
-    const authCtx = await getAuthContext(headers.authorization);
+    const authCtx = await getAuthContext(headers.authorization, {
+      requiredCapability: "schedule:write",
+    });
     if (!authCtx) {
       return {
         status: 401 as const,
@@ -86,7 +88,9 @@ const router = tsr.router(schedulesMainContract, {
   list: async ({ headers }) => {
     initServices();
 
-    const authCtx = await getAuthContext(headers.authorization);
+    const authCtx = await getAuthContext(headers.authorization, {
+      requiredCapability: "schedule:read",
+    });
     if (!authCtx) {
       return {
         status: 401 as const,


### PR DESCRIPTION
## Summary

- Add `requiredCapability` parameter to all 6 schedule route auth calls so sandbox tokens with correct capability are accepted
- `schedule:read` for GET endpoints (list, getByName, runs, missing-secrets)
- `schedule:write` for POST/DELETE endpoints (deploy, delete, enable, disable)
- Add sandbox token integration tests to all 6 route test files (14 new tests)

Closes #4916

## Test plan

- [x] Sandbox token with `schedule:write` can deploy, delete, enable, disable schedules
- [x] Sandbox token with `schedule:read` can list, get, view runs, check missing secrets
- [x] Sandbox token without correct capability gets rejected (401)
- [x] CLI/session tokens continue to work unchanged (all existing 67 tests pass)
- [x] `pnpm turbo run lint` passes
- [x] `pnpm format` passes
- [x] `pnpm knip` passes
- [ ] `pnpm check-types` — pre-existing failure in `tarball.ts` (unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)