### PR TITLE
feat: enforce capabilities on agent compose routes and /api/auth/me

### DIFF
--- a/turbo/apps/web/app/api/agent/composes/[id]/route.ts
+++ b/turbo/apps/web/app/api/agent/composes/[id]/route.ts
@@ -25,7 +25,9 @@ const router = tsr.router(composesByIdContract, {
   getById: async ({ params, headers }) => {
     initServices();
 
-    const userId = await getUserId(headers.authorization);
+    const userId = await getUserId(headers.authorization, {
+      requiredCapability: "agent:read",
+    });
     if (!userId) {
       return {
         status: 401 as const,
@@ -93,7 +95,9 @@ const router = tsr.router(composesByIdContract, {
     initServices();
 
     // 1. Authenticate
-    const userId = await getUserId(headers.authorization);
+    const userId = await getUserId(headers.authorization, {
+      requiredCapability: "agent:write",
+    });
     if (!userId) {
       return {
         status: 401 as const,

--- a/turbo/apps/web/app/api/agent/composes/__tests__/sandbox-capability.test.ts
+++ b/turbo/apps/web/app/api/agent/composes/__tests__/sandbox-capability.test.ts
@@ -1,0 +1,292 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { GET, POST } from "../route";
+import { GET as listGET } from "../list/route";
+import { GET as getByIdGET, DELETE as deleteDELETE } from "../[id]/route";
+import {
+  createTestRequest,
+  createTestCompose,
+  insertOrgMembersCacheEntry,
+} from "../../../../../src/__tests__/api-test-helpers";
+import {
+  testContext,
+  type UserContext,
+} from "../../../../../src/__tests__/test-helpers";
+import { mockClerk } from "../../../../../src/__tests__/clerk-mock";
+import { generateSandboxToken } from "../../../../../src/lib/auth/sandbox-token";
+
+const context = testContext();
+
+describe("Sandbox capability enforcement on compose routes", () => {
+  let user: UserContext;
+
+  beforeEach(async () => {
+    context.setupMocks();
+    user = await context.setupUser();
+  });
+
+  describe("GET /api/agent/composes (getByName)", () => {
+    it("sandbox token with agent:read can get compose by name", async () => {
+      const agentName = `test-sandbox-get-${Date.now()}`;
+      await createTestCompose(agentName);
+
+      // Seed org cache so resolveOrg works without Clerk session
+      await insertOrgMembersCacheEntry({
+        userId: user.userId,
+        orgId: user.orgId,
+        role: "admin",
+      });
+
+      // Switch to sandbox auth
+      mockClerk({ userId: null });
+      const token = await generateSandboxToken(user.userId, "run-123", [
+        "agent:read",
+      ]);
+
+      const request = createTestRequest(
+        `http://localhost:3000/api/agent/composes?name=${agentName}`,
+        {
+          headers: { Authorization: `Bearer ${token}` },
+        },
+      );
+
+      const response = await GET(request);
+      expect(response.status).toBe(200);
+
+      const data = await response.json();
+      expect(data.name).toBe(agentName);
+    });
+
+    it("sandbox token without agent:read gets 401", async () => {
+      const agentName = `test-sandbox-noread-${Date.now()}`;
+      await createTestCompose(agentName);
+
+      mockClerk({ userId: null });
+      const token = await generateSandboxToken(user.userId, "run-123", [
+        "volume:read",
+      ]);
+
+      const request = createTestRequest(
+        `http://localhost:3000/api/agent/composes?name=${agentName}`,
+        {
+          headers: { Authorization: `Bearer ${token}` },
+        },
+      );
+
+      const response = await GET(request);
+      expect(response.status).toBe(401);
+    });
+  });
+
+  describe("POST /api/agent/composes (create)", () => {
+    it("sandbox token with agent:write can create compose", async () => {
+      const agentName = `test-sandbox-create-${Date.now()}`;
+
+      // Seed org cache so resolveOrg works without Clerk session
+      await insertOrgMembersCacheEntry({
+        userId: user.userId,
+        orgId: user.orgId,
+        role: "admin",
+      });
+
+      mockClerk({ userId: null });
+      const token = await generateSandboxToken(user.userId, "run-123", [
+        "agent:write",
+      ]);
+
+      const request = createTestRequest(
+        "http://localhost:3000/api/agent/composes",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({
+            content: {
+              version: "1.0",
+              agents: {
+                [agentName]: { framework: "claude-code" },
+              },
+            },
+          }),
+        },
+      );
+
+      const response = await POST(request);
+      expect(response.status).toBe(201);
+
+      const data = await response.json();
+      expect(data.name).toBe(agentName);
+    });
+
+    it("sandbox token with agent:read but not agent:write gets 401", async () => {
+      const agentName = `test-sandbox-nocreate-${Date.now()}`;
+
+      mockClerk({ userId: null });
+      const token = await generateSandboxToken(user.userId, "run-123", [
+        "agent:read",
+      ]);
+
+      const request = createTestRequest(
+        "http://localhost:3000/api/agent/composes",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({
+            content: {
+              version: "1.0",
+              agents: {
+                [agentName]: { framework: "claude-code" },
+              },
+            },
+          }),
+        },
+      );
+
+      const response = await POST(request);
+      expect(response.status).toBe(401);
+    });
+  });
+
+  describe("GET /api/agent/composes/list", () => {
+    it("sandbox token with agent:read can list composes", async () => {
+      const agentName = `test-sandbox-list-${Date.now()}`;
+      await createTestCompose(agentName);
+
+      // Seed org cache so resolveOrg works without Clerk session
+      await insertOrgMembersCacheEntry({
+        userId: user.userId,
+        orgId: user.orgId,
+        role: "admin",
+      });
+
+      mockClerk({ userId: null });
+      const token = await generateSandboxToken(user.userId, "run-123", [
+        "agent:read",
+      ]);
+
+      const request = createTestRequest(
+        "http://localhost:3000/api/agent/composes/list",
+        {
+          headers: { Authorization: `Bearer ${token}` },
+        },
+      );
+
+      const response = await listGET(request);
+      expect(response.status).toBe(200);
+
+      const data = await response.json();
+      expect(data.composes).toBeDefined();
+      expect(Array.isArray(data.composes)).toBe(true);
+    });
+
+    it("sandbox token without agent:read gets 401", async () => {
+      mockClerk({ userId: null });
+      const token = await generateSandboxToken(user.userId, "run-123", [
+        "volume:write",
+      ]);
+
+      const request = createTestRequest(
+        "http://localhost:3000/api/agent/composes/list",
+        {
+          headers: { Authorization: `Bearer ${token}` },
+        },
+      );
+
+      const response = await listGET(request);
+      expect(response.status).toBe(401);
+    });
+  });
+
+  describe("GET /api/agent/composes/:id", () => {
+    it("sandbox token with agent:read can get compose by id", async () => {
+      const agentName = `test-sandbox-getid-${Date.now()}`;
+      const { composeId } = await createTestCompose(agentName);
+
+      mockClerk({ userId: null });
+      const token = await generateSandboxToken(user.userId, "run-123", [
+        "agent:read",
+      ]);
+
+      const request = createTestRequest(
+        `http://localhost:3000/api/agent/composes/${composeId}`,
+        {
+          headers: { Authorization: `Bearer ${token}` },
+        },
+      );
+
+      const response = await getByIdGET(request);
+      expect(response.status).toBe(200);
+
+      const data = await response.json();
+      expect(data.name).toBe(agentName);
+    });
+
+    it("sandbox token without agent:read gets 401", async () => {
+      const agentName = `test-sandbox-nogetid-${Date.now()}`;
+      const { composeId } = await createTestCompose(agentName);
+
+      mockClerk({ userId: null });
+      const token = await generateSandboxToken(user.userId, "run-123", [
+        "volume:read",
+      ]);
+
+      const request = createTestRequest(
+        `http://localhost:3000/api/agent/composes/${composeId}`,
+        {
+          headers: { Authorization: `Bearer ${token}` },
+        },
+      );
+
+      const response = await getByIdGET(request);
+      expect(response.status).toBe(401);
+    });
+  });
+
+  describe("DELETE /api/agent/composes/:id", () => {
+    it("sandbox token with agent:write can delete compose", async () => {
+      const agentName = `test-sandbox-delete-${Date.now()}`;
+      const { composeId } = await createTestCompose(agentName);
+
+      mockClerk({ userId: null });
+      const token = await generateSandboxToken(user.userId, "run-123", [
+        "agent:write",
+      ]);
+
+      const request = createTestRequest(
+        `http://localhost:3000/api/agent/composes/${composeId}`,
+        {
+          method: "DELETE",
+          headers: { Authorization: `Bearer ${token}` },
+        },
+      );
+
+      const response = await deleteDELETE(request);
+      expect(response.status).toBe(204);
+    });
+
+    it("sandbox token without agent:write gets 401", async () => {
+      const agentName = `test-sandbox-nodelete-${Date.now()}`;
+      const { composeId } = await createTestCompose(agentName);
+
+      mockClerk({ userId: null });
+      const token = await generateSandboxToken(user.userId, "run-123", [
+        "agent:read",
+      ]);
+
+      const request = createTestRequest(
+        `http://localhost:3000/api/agent/composes/${composeId}`,
+        {
+          method: "DELETE",
+          headers: { Authorization: `Bearer ${token}` },
+        },
+      );
+
+      const response = await deleteDELETE(request);
+      expect(response.status).toBe(401);
+    });
+  });
+});

--- a/turbo/apps/web/app/api/agent/composes/list/route.ts
+++ b/turbo/apps/web/app/api/agent/composes/list/route.ts
@@ -65,7 +65,9 @@ const router = tsr.router(composesListContract, {
   list: async ({ query, headers }) => {
     initServices();
 
-    const authCtx = await getAuthContext(headers.authorization);
+    const authCtx = await getAuthContext(headers.authorization, {
+      requiredCapability: "agent:read",
+    });
     if (!authCtx) {
       return {
         status: 401 as const,

--- a/turbo/apps/web/app/api/agent/composes/route.ts
+++ b/turbo/apps/web/app/api/agent/composes/route.ts
@@ -34,7 +34,9 @@ const router = tsr.router(composesMainContract, {
   getByName: async ({ query, headers }) => {
     initServices();
 
-    const authCtx = await getAuthContext(headers.authorization);
+    const authCtx = await getAuthContext(headers.authorization, {
+      requiredCapability: "agent:read",
+    });
     if (!authCtx) {
       return {
         status: 401 as const,
@@ -139,7 +141,9 @@ const router = tsr.router(composesMainContract, {
   create: async ({ body, headers }) => {
     initServices();
 
-    const authCtx = await getAuthContext(headers.authorization);
+    const authCtx = await getAuthContext(headers.authorization, {
+      requiredCapability: "agent:write",
+    });
     if (!authCtx) {
       return {
         status: 401 as const,

--- a/turbo/apps/web/app/api/auth/me/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/auth/me/__tests__/route.test.ts
@@ -1,15 +1,21 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { GET } from "../route";
 import { createTestRequest } from "../../../../../src/__tests__/api-test-helpers";
-import { testContext } from "../../../../../src/__tests__/test-helpers";
+import {
+  testContext,
+  type UserContext,
+} from "../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../src/__tests__/clerk-mock";
+import { generateSandboxToken } from "../../../../../src/lib/auth/sandbox-token";
 
 const context = testContext();
 
 describe("GET /api/auth/me", () => {
+  let user: UserContext;
+
   beforeEach(async () => {
     context.setupMocks();
-    await context.setupUser();
+    user = await context.setupUser();
   });
 
   it("should return 401 when not authenticated", async () => {
@@ -33,5 +39,56 @@ describe("GET /api/auth/me", () => {
     expect(response.status).toBe(200);
     expect(body).not.toHaveProperty("error");
     expect(body.email).toBe("test@example.com");
+  });
+
+  describe("sandbox token support", () => {
+    it("sandbox token with any capability returns user info", async () => {
+      mockClerk({ userId: null });
+      const token = await generateSandboxToken(user.userId, "run-123", [
+        "agent:read",
+      ]);
+
+      const response = await GET(
+        createTestRequest("http://localhost:3000/api/auth/me", {
+          headers: { Authorization: `Bearer ${token}` },
+        }),
+      );
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.userId).toBe(user.userId);
+    });
+
+    it("sandbox token with volume:write returns user info", async () => {
+      mockClerk({ userId: null });
+      const token = await generateSandboxToken(user.userId, "run-456", [
+        "volume:write",
+      ]);
+
+      const response = await GET(
+        createTestRequest("http://localhost:3000/api/auth/me", {
+          headers: { Authorization: `Bearer ${token}` },
+        }),
+      );
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.userId).toBe(user.userId);
+    });
+
+    it("sandbox token with no capabilities gets 401", async () => {
+      mockClerk({ userId: null });
+      const token = await generateSandboxToken(user.userId, "run-789");
+
+      const response = await GET(
+        createTestRequest("http://localhost:3000/api/auth/me", {
+          headers: { Authorization: `Bearer ${token}` },
+        }),
+      );
+      const body = await response.json();
+
+      expect(response.status).toBe(401);
+      expect(body.error.code).toBe("UNAUTHORIZED");
+    });
   });
 });

--- a/turbo/apps/web/app/api/auth/me/route.ts
+++ b/turbo/apps/web/app/api/auth/me/route.ts
@@ -1,13 +1,15 @@
 import { createHandler, tsr } from "../../../../src/lib/ts-rest-handler";
 import { authContract } from "@vm0/core";
-import { getUserId } from "../../../../src/lib/auth/get-user-id";
+import { getAuthContext } from "../../../../src/lib/auth/get-user-id";
 import { getUserEmail } from "../../../../src/lib/auth/get-user-email";
 
 const router = tsr.router(authContract, {
   me: async ({ headers }) => {
-    const userId = await getUserId(headers.authorization);
+    const authCtx = await getAuthContext(headers.authorization, {
+      acceptAnySandboxCapability: true,
+    });
 
-    if (!userId) {
+    if (!authCtx) {
       return {
         status: 401 as const,
         body: {
@@ -16,12 +18,12 @@ const router = tsr.router(authContract, {
       };
     }
 
-    const email = await getUserEmail(userId);
+    const email = await getUserEmail(authCtx.userId);
 
     return {
       status: 200 as const,
       body: {
-        userId,
+        userId: authCtx.userId,
         email,
       },
     };

--- a/turbo/apps/web/src/lib/auth/__tests__/get-user-id.spec.ts
+++ b/turbo/apps/web/src/lib/auth/__tests__/get-user-id.spec.ts
@@ -115,3 +115,65 @@ describe("getAuthContext with requiredCapability", () => {
     expect(result?.capabilities).toBeUndefined();
   });
 });
+
+describe("getAuthContext with acceptAnySandboxCapability", () => {
+  const mockAuth = vi.mocked(auth);
+
+  beforeEach(() => {
+    mockAuth.mockResolvedValue({
+      userId: null,
+    } as Awaited<ReturnType<typeof auth>>);
+  });
+
+  it("should accept sandbox token with any capability", async () => {
+    const token = await generateSandboxToken("user-123", "run-456", [
+      "agent:read",
+    ]);
+    const result = await getAuthContext(`Bearer ${token}`, {
+      acceptAnySandboxCapability: true,
+    });
+
+    expect(result).not.toBeNull();
+    expect(result?.userId).toBe("user-123");
+    expect(result?.runId).toBe("run-456");
+    expect(result?.capabilities).toContain("agent:read");
+  });
+
+  it("should accept sandbox token with multiple capabilities", async () => {
+    const token = await generateSandboxToken("user-123", "run-456", [
+      "volume:read",
+      "agent:write",
+    ]);
+    const result = await getAuthContext(`Bearer ${token}`, {
+      acceptAnySandboxCapability: true,
+    });
+
+    expect(result).not.toBeNull();
+    expect(result?.userId).toBe("user-123");
+    expect(result?.capabilities).toContain("volume:read");
+    expect(result?.capabilities).toContain("agent:write");
+  });
+
+  it("should reject sandbox token with no capabilities", async () => {
+    const token = await generateSandboxToken("user-123", "run-456");
+    const result = await getAuthContext(`Bearer ${token}`, {
+      acceptAnySandboxCapability: true,
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it("should return Clerk session auth regardless of acceptAnySandboxCapability", async () => {
+    mockAuth.mockResolvedValue({
+      userId: "clerk-user",
+    } as Awaited<ReturnType<typeof auth>>);
+
+    const result = await getAuthContext(undefined, {
+      acceptAnySandboxCapability: true,
+    });
+
+    expect(result).not.toBeNull();
+    expect(result?.userId).toBe("clerk-user");
+    expect(result?.capabilities).toBeUndefined();
+  });
+});

--- a/turbo/apps/web/src/lib/auth/get-user-id.ts
+++ b/turbo/apps/web/src/lib/auth/get-user-id.ts
@@ -23,11 +23,15 @@ export type AuthContext = {
  * Returns null if not authenticated.
  *
  * By default, sandbox JWT tokens are rejected. Pass `options.requiredCapability`
- * to accept sandbox tokens that include the specified capability.
+ * to accept sandbox tokens that include the specified capability, or
+ * `options.acceptAnySandboxCapability` to accept tokens with any capability.
  */
 export async function getAuthContext(
   authHeader?: string,
-  options?: { requiredCapability?: Capability },
+  options?: {
+    requiredCapability?: Capability;
+    acceptAnySandboxCapability?: boolean;
+  },
 ): Promise<AuthContext | null> {
   // Session auth via Clerk
   const { userId } = await auth();
@@ -42,19 +46,33 @@ export async function getAuthContext(
   const token = authHeader.substring(7); // Remove "Bearer "
 
   if (isSandboxToken(token)) {
-    // Without requiredCapability, reject sandbox tokens (existing behavior)
-    if (!options?.requiredCapability) {
+    // Without any sandbox opt-in, reject sandbox tokens (existing behavior)
+    if (!options?.requiredCapability && !options?.acceptAnySandboxCapability) {
       log.debug("Rejected sandbox JWT token on normal API endpoint");
       return null;
     }
 
-    // With requiredCapability, verify sandbox token and check capability
+    // Verify sandbox token signature and expiry
     const sandboxAuth = verifySandboxToken(token);
     if (!sandboxAuth) {
       log.debug("Invalid or expired sandbox token");
       return null;
     }
 
+    // acceptAnySandboxCapability: accept if token has any capability
+    if (options?.acceptAnySandboxCapability) {
+      if (!sandboxAuth.capabilities || sandboxAuth.capabilities.length === 0) {
+        log.debug("Sandbox token has no capabilities");
+        return null;
+      }
+      return {
+        userId: sandboxAuth.userId,
+        runId: sandboxAuth.runId,
+        capabilities: [...sandboxAuth.capabilities],
+      };
+    }
+
+    // requiredCapability: check specific capability
     const hasCap = sandboxAuth.capabilities?.some(
       (cap) => cap === options.requiredCapability,
     );
@@ -107,7 +125,10 @@ export async function getAuthContext(
  */
 export async function getUserId(
   authHeader?: string,
-  options?: { requiredCapability?: Capability },
+  options?: {
+    requiredCapability?: Capability;
+    acceptAnySandboxCapability?: boolean;
+  },
 ): Promise<string | null> {
   const ctx = await getAuthContext(authHeader, options);
   return ctx?.userId ?? null;


### PR DESCRIPTION
## Summary

- Add `acceptAnySandboxCapability` option to `getAuthContext()` for endpoints that accept sandbox tokens with any capability
- Migrate all agent compose routes to enforce `agent:read` / `agent:write` capabilities for sandbox tokens
- Migrate `/api/auth/me` to accept sandbox tokens with any capability (for `vm0 auth status` inside sandbox)
- CLI/session tokens continue to work unchanged (backward compatible)

## Changes

| Route | Method | Capability |
|-------|--------|-----------|
| `/api/agent/composes` | GET | `agent:read` |
| `/api/agent/composes` | POST | `agent:write` |
| `/api/agent/composes/list` | GET | `agent:read` |
| `/api/agent/composes/:id` | GET | `agent:read` |
| `/api/agent/composes/:id` | DELETE | `agent:write` |
| `/api/auth/me` | GET | any capability |

## Test plan

- [x] Unit tests for `acceptAnySandboxCapability` option in `getAuthContext`
- [x] Integration tests: sandbox token with correct capability can access each route
- [x] Integration tests: sandbox token without required capability gets 401
- [x] Integration tests: `/api/auth/me` works with any sandbox capability
- [x] Integration tests: `/api/auth/me` rejects sandbox token with no capabilities
- [x] Backward compatibility: all existing tests pass (CLI/session tokens unchanged)
- [x] Lint, type checks, knip all pass

Closes #4914

🤖 Generated with [Claude Code](https://claude.com/claude-code)