### PR TITLE
feat(skills): add release status annotation to coding-dashboard

### DIFF
--- a/.claude/skills/coding-dashboard/SKILL.md
+++ b/.claude/skills/coding-dashboard/SKILL.md
@@ -96,21 +96,51 @@ gh pr list --repo vm0-ai/vm0 --label "$LANE" --author "$ME" --state open \
 
 Mark items with `pending` label as `[Pending]`.
 
-### Step 5: List Recently Merged PRs
+### Step 5: List Recently Merged PRs with Release Status
 
-Query the last 20 merged PRs across all lanes:
+#### Step 5a: Get Release Reference Points
+
+Fetch the latest GitHub Release tag and its commit SHA, and check for in-progress release-please runs:
 
 ```bash
-# Build label filter for all lanes
+# Latest release tag and commit
+LATEST_TAG=$(gh release list --repo vm0-ai/vm0 --limit 1 --json tagName --jq '.[0].tagName')
+RELEASE_SHA=$(gh api repos/vm0-ai/vm0/releases/tags/$LATEST_TAG --jq '.target_commitish')
+
+# In-progress release-please workflow
+RUNNING_SHA=$(gh run list --repo vm0-ai/vm0 --workflow release-please.yml --status in_progress --limit 1 --json headSha --jq '.[0].headSha // empty')
+```
+
+#### Step 5b: Query Merged PRs
+
+Query the last 20 merged PRs across all lanes, including merge commit SHA:
+
+```bash
 for i in $(seq 1 $MAX_WORKERS); do
   LANE=$(printf "vm%02d" $i)
   gh pr list --repo vm0-ai/vm0 --label "$LANE" --state merged \
-    --json number,title,mergedAt,labels --limit 20 \
-    --jq ".[] | {number, title, mergedAt, lane: \"$LANE\"}"
+    --json number,title,mergedAt,labels,mergeCommit --limit 20 \
+    --jq ".[] | {number, title, mergedAt, lane: \"$LANE\", mergeCommitSha: .mergeCommit.oid}"
 done
 ```
 
 Combine results, sort by `mergedAt` descending, take the top 20.
+
+#### Step 5c: Annotate Each PR with Release Status
+
+For each merged PR, classify its release status using the merge commit SHA:
+
+```bash
+git merge-base --is-ancestor <mergeCommitSha> $RELEASE_SHA && echo "✅" || ([ -n "$RUNNING_SHA" ] && echo "🚀" || echo "⏳")
+```
+
+| Marker | Meaning | Condition |
+|--------|---------|-----------|
+| ✅ | Released | PR merge commit is an ancestor of the latest release commit |
+| 🚀 | Releasing | Not yet released, but release-please workflow is in progress |
+| ⏳ | Pending release | Not yet released, no release-please run in progress |
+
+Prepend the marker to each PR line in the output.
 
 ---
 
@@ -119,7 +149,8 @@ Combine results, sort by `mergedAt` descending, take the top 20.
 - Titles should be translated to Chinese
 - Items with `pending` label get a `[Pending]` marker
 - Empty lanes show `-- idle`
-- Merged PRs shown as a list, each line: `Time #ID Lane — Title`
+- Merged PRs shown as a list, each line: `Marker Time #ID Lane — Title`
+- Release status markers: ✅ (released), 🚀 (releasing), ⏳ (pending release)
 
 ### Output Example
 
@@ -147,8 +178,8 @@ vm04
 ---
 近期完成 (最近 20 个已合并 PR，按时间倒序)
 
-- 3/13 08:35 #4728 vm03 — 升级平台 vite 从 v6 到 v7
-- 3/13 08:01 #4719 vm01 — 通过 tsx/tsup 升级去重 esbuild 版本
+- ✅ 3/13 08:35 #4728 vm03 — 升级平台 vite 从 v6 到 v7
+- 🚀 3/13 08:01 #4719 vm01 — 通过 tsx/tsup 升级去重 esbuild 版本
 ---
 ```
 


### PR DESCRIPTION
## Summary
- Add release status markers (✅ released, 🚀 releasing, ⏳ pending release) to merged PRs in the coding-dashboard "近期完成" section
- Classify each PR by checking if its merge commit is an ancestor of the latest GitHub release tag
- Detect in-progress release-please workflows to distinguish "releasing" from "pending release"

Closes #4923

## Test plan
- [ ] Run `/coding-dashboard` and verify merged PRs show release status markers
- [ ] Verify ✅ appears for PRs included in the latest release
- [ ] Verify ⏳ or 🚀 appears for PRs after the latest release

🤖 Generated with [Claude Code](https://claude.com/claude-code)