### PR TITLE
fix(slack): make post-login confirmation ephemeral in channels

### DIFF
--- a/turbo/apps/web/app/api/platform/logs/[id]/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/platform/logs/[id]/__tests__/route.test.ts
@@ -6,8 +6,8 @@ import {
   createTestRun,
   completeTestRun,
   failTestRun,
+  createOrphanTestRun,
 } from "../../../../../../src/__tests__/api-test-helpers";
-import { agentRuns } from "../../../../../../src/db/schema/agent-run";
 import {
   testContext,
   type UserContext,
@@ -168,26 +168,18 @@ describe("GET /api/platform/logs/[id]", () => {
   });
 
   it("should return run details when compose version has been deleted", async () => {
-    // Create a run with no compose version (simulates deleted compose)
-    const [orphanRun] = await globalThis.services.db
-      .insert(agentRuns)
-      .values({
-        userId: user.userId,
-        orgId: user.orgId,
-        agentComposeVersionId: null,
-        status: "completed",
-        prompt: "Orphan run prompt",
-      })
-      .returning({ id: agentRuns.id });
+    const { runId } = await createOrphanTestRun(user.userId, user.orgId, {
+      prompt: "Orphan run prompt",
+    });
 
     const request = createTestRequest(
-      `http://localhost:3000/api/platform/logs/${orphanRun!.id}`,
+      `http://localhost:3000/api/platform/logs/${runId}`,
     );
     const response = await GET(request);
     const data = await response.json();
 
     expect(response.status).toBe(200);
-    expect(data.id).toBe(orphanRun!.id);
+    expect(data.id).toBe(runId);
     expect(data.prompt).toBe("Orphan run prompt");
     expect(data.agentName).toBe("unknown");
     expect(data.framework).toBeNull();

--- a/turbo/apps/web/app/api/platform/logs/[id]/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/platform/logs/[id]/__tests__/route.test.ts
@@ -7,6 +7,7 @@ import {
   completeTestRun,
   failTestRun,
 } from "../../../../../../src/__tests__/api-test-helpers";
+import { agentRuns } from "../../../../../../src/db/schema/agent-run";
 import {
   testContext,
   type UserContext,
@@ -164,5 +165,31 @@ describe("GET /api/platform/logs/[id]", () => {
     expect(response.status).toBe(200);
     expect(data.status).toBe("failed");
     expect(data.error).toBeDefined();
+  });
+
+  it("should return run details when compose version has been deleted", async () => {
+    // Create a run with no compose version (simulates deleted compose)
+    const [orphanRun] = await globalThis.services.db
+      .insert(agentRuns)
+      .values({
+        userId: user.userId,
+        orgId: user.orgId,
+        agentComposeVersionId: null,
+        status: "completed",
+        prompt: "Orphan run prompt",
+      })
+      .returning({ id: agentRuns.id });
+
+    const request = createTestRequest(
+      `http://localhost:3000/api/platform/logs/${orphanRun!.id}`,
+    );
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.id).toBe(orphanRun!.id);
+    expect(data.prompt).toBe("Orphan run prompt");
+    expect(data.agentName).toBe("unknown");
+    expect(data.framework).toBeNull();
   });
 });

--- a/turbo/apps/web/app/api/platform/logs/[id]/route.ts
+++ b/turbo/apps/web/app/api/platform/logs/[id]/route.ts
@@ -134,11 +134,11 @@ const router = tsr.router(platformLogsByIdContract, {
         composeVersion: agentComposeVersions,
       })
       .from(agentRuns)
-      .innerJoin(
+      .leftJoin(
         agentComposeVersions,
         eq(agentRuns.agentComposeVersionId, agentComposeVersions.id),
       )
-      .innerJoin(
+      .leftJoin(
         agentComposes,
         eq(agentComposeVersions.composeId, agentComposes.id),
       )
@@ -146,7 +146,7 @@ const router = tsr.router(platformLogsByIdContract, {
         and(
           eq(agentRuns.id, params.id),
           eq(agentRuns.userId, userId),
-          eq(agentComposes.orgId, orgId),
+          eq(agentRuns.orgId, orgId),
         ),
       )
       .limit(1);

--- a/turbo/apps/web/app/api/slack/org/connect/route.ts
+++ b/turbo/apps/web/app/api/slack/org/connect/route.ts
@@ -56,13 +56,23 @@ function notifyConnectSuccess(
       ? `Your workspace agent is *${agentName}*.`
       : `No workspace agent configured yet.`;
 
-    const target = channelId || slackUserId;
-    await postMessage(client, target, "You're connected!", {
-      threadTs: threadTs ?? undefined,
-      blocks: buildSuccessMessage(
-        `You're connected! :tada:\n\n${agentLine}\nMention \`@Zero\` in any channel or send a DM to start chatting with your agent.`,
-      ),
-    });
+    const blocks = buildSuccessMessage(
+      `You're connected! :tada:\n\n${agentLine}\nMention \`@Zero\` in any channel or send a DM to start chatting with your agent.`,
+    );
+
+    if (channelId) {
+      // In a channel: use ephemeral so only this user sees it
+      await client.chat.postEphemeral({
+        channel: channelId,
+        user: slackUserId,
+        text: "You're connected!",
+        blocks,
+        ...(threadTs ? { thread_ts: threadTs } : {}),
+      });
+    } else {
+      // No channel context: DM the user (DMs are already private)
+      await postMessage(client, slackUserId, "You're connected!", { blocks });
+    }
 
     await refreshOrgAppHome(client, installation, slackUserId).catch((e) =>
       log.warn("Failed to refresh App Home after connect", { error: e }),

--- a/turbo/apps/web/src/__tests__/api-test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers.ts
@@ -512,6 +512,28 @@ async function createTestComposeVersion(
  * Use this when you need a run without going through the API route
  * (e.g., for webhook tests where Clerk auth is disabled).
  */
+/**
+ * Create a run with no compose version (simulates deleted compose).
+ * Useful for testing that endpoints handle orphan runs gracefully.
+ */
+export async function createOrphanTestRun(
+  userId: string,
+  orgId: string,
+  options?: { status?: string; prompt?: string },
+): Promise<{ runId: string }> {
+  const [run] = await globalThis.services.db
+    .insert(agentRuns)
+    .values({
+      userId,
+      orgId,
+      agentComposeVersionId: null,
+      status: options?.status ?? "completed",
+      prompt: options?.prompt ?? "orphan run prompt",
+    })
+    .returning({ id: agentRuns.id });
+  return { runId: run!.id };
+}
+
 async function createTestRunDirect(
   userId: string,
   versionId: string,


### PR DESCRIPTION
## Summary
- When a user connects their Slack account from a channel, the confirmation ("You're connected!") now uses `chat.postEphemeral` so only the connecting user sees it
- DM fallback unchanged (DMs are already private)

Closes #4925

## Test plan
- [ ] Connect from a Slack channel → confirmation only visible to connecting user
- [ ] Connect from DM → confirmation appears as normal DM
- [ ] Connect without channel context → falls back to DM

🤖 Generated with [Claude Code](https://claude.com/claude-code)