### PR TITLE
feat(runner): replace semaphore with resource-budget concurrency control

### DIFF
--- a/crates/runner/src/cmd/start.rs
+++ b/crates/runner/src/cmd/start.rs
@@ -5,7 +5,6 @@ use std::time::Duration;
 use clap::Args;
 use sandbox::SandboxFactory;
 use sandbox_fc::FirecrackerFactory;
-use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info, warn};
@@ -18,6 +17,7 @@ use crate::lock;
 use crate::paths::{HomePaths, RunnerPaths};
 use crate::provider::{ApiProvider, JobProvider, LocalProvider};
 use crate::proxy;
+use crate::resource_budget::ResourceBudget;
 use crate::retry::{RetryState, recv_retry, sleep_until_retry};
 use crate::status::{RunnerMode, StatusTracker};
 
@@ -164,31 +164,37 @@ pub async fn run_start(args: StartArgs) -> RunnerResult<()> {
         memory_mb,
         concurrency_factor,
     } = sandbox;
-    let max_concurrent = if max_concurrent == 0 {
-        let host_cpus = crate::host::cpu_count()?;
-        let host_memory_mb = crate::host::memory_mb()?;
-        let computed = crate::host::compute_max_concurrent(
-            host_cpus,
-            host_memory_mb,
-            vcpu,
-            memory_mb,
-            concurrency_factor,
-        );
-        info!(
-            host_cpus,
-            host_memory_mb,
-            vcpu,
-            memory_mb,
-            concurrency_factor,
-            computed,
-            "auto-detected max_concurrent"
-        );
-        computed
+    let host_cpus = crate::host::cpu_count()?;
+    let host_memory_mb = crate::host::memory_mb()?;
+    let budget = Arc::new(ResourceBudget::new(
+        host_cpus as u32,
+        host_memory_mb as u32,
+        concurrency_factor,
+        max_concurrent,
+    ));
+    info!(
+        host_cpus,
+        host_memory_mb,
+        vcpu,
+        memory_mb,
+        concurrency_factor,
+        max_concurrent,
+        effective_vcpu = budget.effective_vcpu(),
+        effective_memory_mb = budget.effective_memory_mb(),
+        "resource budget initialized"
+    );
+    // Factory concurrency hint for pool sizing (overlay + netns pre-warming).
+    let resource_limit = std::cmp::min(
+        budget.effective_vcpu() as usize / vcpu as usize,
+        budget.effective_memory_mb() as usize / memory_mb as usize,
+    )
+    .max(1);
+    fc_config.concurrency = if max_concurrent > 0 {
+        std::cmp::min(resource_limit, max_concurrent)
     } else {
-        max_concurrent
+        resource_limit
     };
-    fc_config.concurrency = max_concurrent;
-    let mut status = StatusTracker::new(paths.status(), max_concurrent);
+    let mut status = StatusTracker::new(paths.status(), fc_config.concurrency);
     status.set_proxy_port(mitm.port()).await;
     let status = Arc::new(status);
 
@@ -223,7 +229,7 @@ pub async fn run_start(args: StartArgs) -> RunnerResult<()> {
         name,
         group: group_name,
         fc_config,
-        max_concurrent,
+        budget,
         status,
         mitm,
         mitm_crash_rx,
@@ -239,7 +245,7 @@ struct RunConfig {
     name: String,
     group: String,
     fc_config: sandbox_fc::FirecrackerConfig,
-    max_concurrent: usize,
+    budget: Arc<ResourceBudget>,
     status: Arc<StatusTracker>,
     mitm: proxy::MitmProxy,
     mitm_crash_rx: tokio::sync::mpsc::Receiver<()>,
@@ -255,7 +261,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
         name,
         group,
         fc_config,
-        max_concurrent,
+        budget,
         status,
         mut mitm,
         mut mitm_crash_rx,
@@ -264,18 +270,22 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
         exec_config,
     } = config;
 
+    let vcpu = exec_config.vcpu;
+    let memory_mb = exec_config.memory_mb;
+
     let mut factory = FirecrackerFactory::new(fc_config).await?;
     factory.startup().await?;
     let factory = Arc::new(factory);
 
-    let semaphore = Arc::new(Semaphore::new(max_concurrent));
     let mut jobs = JoinSet::new();
 
     status.write_initial().await;
     info!(
         name = %name,
         group = %group,
-        max_concurrent,
+        effective_vcpu = budget.effective_vcpu(),
+        effective_memory_mb = budget.effective_memory_mb(),
+        max_concurrent = budget.max_concurrent(),
         "runner started"
     );
 
@@ -334,8 +344,8 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
         // Spawn background restart task when timer fires
         maybe_spawn_mitm_restart(&mut mitm, &mut mitm_crash_rx, &mut mitm_retry).await;
 
-        // If all permits are taken, wait for a job to finish or mode change
-        if semaphore.available_permits() == 0 {
+        // If budget is exhausted, wait for a job to finish or mode change
+        if !budget.can_afford(vcpu, memory_mb) {
             tokio::select! {
                 _ = mode_rx.changed() => {}
                 result = jobs.join_next() => {
@@ -360,29 +370,22 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
             // discover() has no server-side side effects — safe to cancel.
             discovered = provider.discover() => {
                 let Some(run_id) = discovered else { break }; // provider shutdown
+                // Reserve resources before claiming so we don't waste a job
+                // that another runner could handle.
+                if !budget.try_reserve(vcpu, memory_mb) {
+                    continue;
+                }
                 // claim() runs in the branch handler — non-interruptible,
                 // so a successful claim is always paired with complete().
                 let Some(context) = provider.claim(run_id).await else {
-                    continue; // already claimed by another runner
+                    budget.release(vcpu, memory_mb); // rollback on 409
+                    continue;
                 };
-                info!(run_id = %run_id, "job claimed, acquiring permit");
-                // Acquire permit in the main loop *before* spawning. Permits are
-                // only acquired here and released by completing tasks, so since
-                // we checked available_permits() > 0 above, this succeeds
-                // immediately.
-                let permit = match Arc::clone(&semaphore).acquire_owned().await {
-                    Ok(p) => p,
-                    Err(_) => {
-                        error!(run_id = %run_id, "semaphore closed unexpectedly");
-                        provider.complete(run_id, 1, Some("runner internal error: semaphore closed")).await;
-                        break;
-                    }
-                };
-                info!(run_id = %run_id, "spawning executor");
+                info!(run_id = %run_id, "job claimed, spawning executor");
                 status.add_run(run_id).await;
                 spawn_job(
                     context, &provider, &factory, &exec_config,
-                    permit, &mut jobs, &status,
+                    &budget, &mut jobs, &status,
                 );
             }
             // Mitmproxy crash detection
@@ -451,28 +454,31 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
 
 /// Spawn a job executor task.
 ///
-/// The provider has already claimed the job and the caller has acquired
-/// a semaphore permit — this function spawns the executor and reports
-/// completion via the provider when done.
+/// The provider has already claimed the job and the caller has reserved
+/// resources in the budget — this function spawns the executor, reports
+/// completion via the provider, and releases the budget when done.
 fn spawn_job(
     context: crate::types::ExecutionContext,
     provider: &Arc<dyn JobProvider>,
     factory: &Arc<FirecrackerFactory>,
     exec_config: &Arc<ExecutorConfig>,
-    permit: OwnedSemaphorePermit,
+    budget: &Arc<ResourceBudget>,
     jobs: &mut JoinSet<()>,
     status: &Arc<StatusTracker>,
 ) {
     let run_id = context.run_id;
+    let vcpu = exec_config.vcpu;
+    let memory_mb = exec_config.memory_mb;
 
     let provider = Arc::clone(provider);
     let factory = Arc::clone(factory);
     let exec_config = Arc::clone(exec_config);
+    let budget = Arc::clone(budget);
     let status = Arc::clone(status);
 
     jobs.spawn(async move {
         // Inner spawn isolates panics: if execute_job panics, the outer task
-        // still reports completion and cleans up status/permit.
+        // still reports completion and releases budget.
         let inner = tokio::spawn(async move {
             executor::execute_job(factory.as_ref(), context, &exec_config).await
         });
@@ -488,7 +494,7 @@ fn spawn_job(
         // Structural guarantee: claim (in provider) is always paired with complete.
         provider.complete(run_id, exit_code, err.as_deref()).await;
         status.remove_run(run_id).await;
-        drop(permit);
+        budget.release(vcpu, memory_mb);
     });
 }
 

--- a/crates/runner/src/cmd/start.rs
+++ b/crates/runner/src/cmd/start.rs
@@ -184,6 +184,8 @@ pub async fn run_start(args: StartArgs) -> RunnerResult<()> {
         "resource budget initialized"
     );
     // Factory concurrency hint for pool sizing (overlay + netns pre-warming).
+    assert!(vcpu > 0, "sandbox.vcpu must be > 0");
+    assert!(memory_mb > 0, "sandbox.memory_mb must be > 0");
     let resource_limit = std::cmp::min(
         budget.effective_vcpu() as usize / vcpu as usize,
         budget.effective_memory_mb() as usize / memory_mb as usize,

--- a/crates/runner/src/host.rs
+++ b/crates/runner/src/host.rs
@@ -27,35 +27,6 @@ pub fn memory_mb() -> RunnerResult<usize> {
     ))
 }
 
-/// Compute how many sandboxes can run concurrently given host resources and
-/// per-sandbox requirements.
-///
-/// Uses integer division because we need whole sandboxes — a host with 5 CPUs
-/// and vcpu=2 can run 2 sandboxes, not 2.5.
-///
-/// `cpu_factor` is a multiplier applied to host CPU count before division,
-/// enabling CPU overcommit for I/O-bound workloads (e.g. 2.0 = 2x overcommit).
-/// Memory side is always 1:1 since Firecracker pre-allocates `mem_size_mib`.
-pub fn compute_max_concurrent(
-    host_cpus: usize,
-    host_memory_mb: usize,
-    vcpu: u32,
-    memory_mb: u32,
-    cpu_factor: f64,
-) -> usize {
-    assert!(
-        cpu_factor.is_finite() && cpu_factor > 0.0,
-        "cpu_factor must be a positive finite number, got {cpu_factor}"
-    );
-    let effective = (host_cpus as f64 * cpu_factor).floor();
-    let effective_cpus = (effective.clamp(0.0, usize::MAX as f64)) as usize;
-    std::cmp::min(
-        effective_cpus / vcpu as usize,
-        host_memory_mb / memory_mb as usize,
-    )
-    .max(1)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -71,50 +42,5 @@ mod tests {
         if std::path::Path::new("/proc/meminfo").exists() {
             assert!(memory_mb().unwrap() > 0);
         }
-    }
-
-    #[test]
-    fn compute_max_concurrent_cpu_limited() {
-        // 8 CPUs, 32 GB, 2 vcpu, 4 GB per VM → min(4, 8) = 4
-        assert_eq!(compute_max_concurrent(8, 32768, 2, 4096, 1.0), 4);
-    }
-
-    #[test]
-    fn compute_max_concurrent_memory_limited() {
-        // 16 CPUs, 8 GB, 2 vcpu, 4 GB per VM → min(8, 2) = 2
-        assert_eq!(compute_max_concurrent(16, 8192, 2, 4096, 1.0), 2);
-    }
-
-    #[test]
-    fn compute_max_concurrent_minimum_one() {
-        // 1 CPU, 1 GB, 2 vcpu, 4 GB → min(0, 0) → max(1) = 1
-        assert_eq!(compute_max_concurrent(1, 1024, 2, 4096, 1.0), 1);
-    }
-
-    #[test]
-    fn compute_max_concurrent_exact_fit() {
-        // 4 CPUs, 8 GB, 2 vcpu, 2 GB → min(2, 4) = 2
-        assert_eq!(compute_max_concurrent(4, 8192, 2, 2048, 1.0), 2);
-    }
-
-    #[test]
-    fn compute_max_concurrent_factor_doubles_cpu() {
-        // 8 CPUs * 2.0 = 16 effective, 32 GB, vcpu=2, mem=4096
-        // min(16/2, 32768/4096) = min(8, 8) = 8
-        assert_eq!(compute_max_concurrent(8, 32768, 2, 4096, 2.0), 8);
-    }
-
-    #[test]
-    fn compute_max_concurrent_factor_hits_memory_limit() {
-        // 8 CPUs * 4.0 = 32 effective, 32 GB, vcpu=2, mem=4096
-        // min(32/2, 32768/4096) = min(16, 8) = 8 (memory-limited)
-        assert_eq!(compute_max_concurrent(8, 32768, 2, 4096, 4.0), 8);
-    }
-
-    #[test]
-    fn compute_max_concurrent_factor_fractional() {
-        // 8 CPUs * 1.5 = 12.0 effective, 32 GB, vcpu=2, mem=4096
-        // min(12/2, 32768/4096) = min(6, 8) = 6
-        assert_eq!(compute_max_concurrent(8, 32768, 2, 4096, 1.5), 6);
     }
 }

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -12,6 +12,7 @@ mod prefetch;
 mod process;
 mod provider;
 mod proxy;
+mod resource_budget;
 mod retry;
 mod status;
 mod telemetry;

--- a/crates/runner/src/resource_budget.rs
+++ b/crates/runner/src/resource_budget.rs
@@ -87,17 +87,17 @@ impl ResourceBudget {
     /// Release resources after a job completes.
     pub fn release(&self, vcpu: u32, memory_mb: u32) {
         let mut state = self.lock();
-        debug_assert!(
+        assert!(
             state.running_vcpu >= vcpu,
             "release underflow: running_vcpu ({}) < vcpu ({vcpu})",
             state.running_vcpu,
         );
-        debug_assert!(
+        assert!(
             state.running_memory_mb >= memory_mb,
             "release underflow: running_memory_mb ({}) < memory_mb ({memory_mb})",
             state.running_memory_mb,
         );
-        debug_assert!(
+        assert!(
             state.running_count > 0,
             "release underflow: running_count is 0"
         );

--- a/crates/runner/src/resource_budget.rs
+++ b/crates/runner/src/resource_budget.rs
@@ -1,0 +1,296 @@
+use std::sync::{Mutex, MutexGuard};
+
+/// Resource-budget concurrency control.
+///
+/// Tracks running vcpu, memory, and job count against effective limits.
+/// Uses a mutex for correctness — hold times are negligible (no I/O),
+/// and `try_reserve` is called from a single async task (main loop).
+///
+/// Three conditions must hold for admission:
+/// 1. `running_vcpu + vcpu <= effective_vcpu`
+/// 2. `running_memory_mb + memory_mb <= effective_memory_mb`
+/// 3. `max_concurrent == 0 || running_count < max_concurrent`
+///
+/// Exception: if `running_count == 0`, the first job is always admitted
+/// regardless of resource limits (ensures at least 1 job can run on
+/// under-provisioned hosts — matches old `.max(1)` behaviour).
+pub struct ResourceBudget {
+    effective_vcpu: u32,
+    effective_memory_mb: u32,
+    max_concurrent: usize,
+    state: Mutex<BudgetState>,
+}
+
+struct BudgetState {
+    running_vcpu: u32,
+    running_memory_mb: u32,
+    running_count: usize,
+}
+
+impl ResourceBudget {
+    /// Create a new resource budget from physical resources and config.
+    ///
+    /// `concurrency_factor` is applied to both CPU and memory budgets.
+    /// The balloon controller reclaims unused guest memory at runtime,
+    /// so memory overcommit is safe for typical workloads.
+    pub fn new(
+        host_cpus: u32,
+        host_memory_mb: u32,
+        concurrency_factor: f64,
+        max_concurrent: usize,
+    ) -> Self {
+        let effective_vcpu = (host_cpus as f64 * concurrency_factor).floor() as u32;
+        let effective_memory_mb = (host_memory_mb as f64 * concurrency_factor).floor() as u32;
+        Self {
+            effective_vcpu,
+            effective_memory_mb,
+            max_concurrent,
+            state: Mutex::new(BudgetState {
+                running_vcpu: 0,
+                running_memory_mb: 0,
+                running_count: 0,
+            }),
+        }
+    }
+
+    /// Try to reserve resources for a job. Returns `true` if reserved.
+    ///
+    /// If nothing is currently running, the first job is always admitted
+    /// regardless of resource limits.
+    pub fn try_reserve(&self, vcpu: u32, memory_mb: u32) -> bool {
+        let mut state = self.lock();
+
+        // First-job guarantee: always admit when idle.
+        if state.running_count == 0 {
+            state.running_vcpu += vcpu;
+            state.running_memory_mb += memory_mb;
+            state.running_count += 1;
+            return true;
+        }
+
+        if state.running_vcpu + vcpu > self.effective_vcpu {
+            return false;
+        }
+        if state.running_memory_mb + memory_mb > self.effective_memory_mb {
+            return false;
+        }
+        if self.max_concurrent > 0 && state.running_count >= self.max_concurrent {
+            return false;
+        }
+
+        state.running_vcpu += vcpu;
+        state.running_memory_mb += memory_mb;
+        state.running_count += 1;
+        true
+    }
+
+    /// Release resources after a job completes.
+    pub fn release(&self, vcpu: u32, memory_mb: u32) {
+        let mut state = self.lock();
+        debug_assert!(
+            state.running_vcpu >= vcpu,
+            "release underflow: running_vcpu ({}) < vcpu ({vcpu})",
+            state.running_vcpu,
+        );
+        debug_assert!(
+            state.running_memory_mb >= memory_mb,
+            "release underflow: running_memory_mb ({}) < memory_mb ({memory_mb})",
+            state.running_memory_mb,
+        );
+        debug_assert!(
+            state.running_count > 0,
+            "release underflow: running_count is 0"
+        );
+        state.running_vcpu -= vcpu;
+        state.running_memory_mb -= memory_mb;
+        state.running_count -= 1;
+    }
+
+    /// Check if there is potentially enough budget for a job with the given
+    /// resources. Used as a gate in the main loop to avoid blocking on
+    /// discovery when resources are exhausted.
+    pub fn can_afford(&self, vcpu: u32, memory_mb: u32) -> bool {
+        let state = self.lock();
+        if state.running_count == 0 {
+            return true;
+        }
+        let vcpu_ok = state.running_vcpu + vcpu <= self.effective_vcpu;
+        let mem_ok = state.running_memory_mb + memory_mb <= self.effective_memory_mb;
+        let count_ok = self.max_concurrent == 0 || state.running_count < self.max_concurrent;
+        vcpu_ok && mem_ok && count_ok
+    }
+
+    pub fn effective_vcpu(&self) -> u32 {
+        self.effective_vcpu
+    }
+
+    pub fn effective_memory_mb(&self) -> u32 {
+        self.effective_memory_mb
+    }
+
+    pub fn max_concurrent(&self) -> usize {
+        self.max_concurrent
+    }
+
+    /// Lock the budget state, recovering from poison if a thread panicked.
+    fn lock(&self) -> MutexGuard<'_, BudgetState> {
+        match self.state.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reserve_within_budget() {
+        let budget = ResourceBudget::new(8, 16384, 1.0, 0);
+        assert!(budget.try_reserve(2, 2048));
+        let state = budget.lock();
+        assert_eq!(state.running_vcpu, 2);
+        assert_eq!(state.running_memory_mb, 2048);
+        assert_eq!(state.running_count, 1);
+    }
+
+    #[test]
+    fn reserve_fails_on_vcpu_exhaustion() {
+        let budget = ResourceBudget::new(4, 16384, 1.0, 0);
+        assert!(budget.try_reserve(2, 2048));
+        assert!(budget.try_reserve(2, 2048));
+        assert!(!budget.try_reserve(2, 2048)); // 6 > 4
+        assert_eq!(budget.lock().running_count, 2);
+    }
+
+    #[test]
+    fn reserve_fails_on_memory_exhaustion() {
+        let budget = ResourceBudget::new(16, 4096, 1.0, 0);
+        assert!(budget.try_reserve(2, 2048));
+        assert!(budget.try_reserve(2, 2048));
+        assert!(!budget.try_reserve(2, 2048)); // 6144 > 4096
+        // vcpu should not be consumed on memory failure
+        assert_eq!(budget.lock().running_vcpu, 4);
+    }
+
+    #[test]
+    fn reserve_fails_on_max_concurrent() {
+        let budget = ResourceBudget::new(16, 32768, 1.0, 2);
+        assert!(budget.try_reserve(2, 2048));
+        assert!(budget.try_reserve(2, 2048));
+        assert!(!budget.try_reserve(2, 2048)); // count 2 >= max 2
+        let state = budget.lock();
+        assert_eq!(state.running_vcpu, 4);
+        assert_eq!(state.running_memory_mb, 4096);
+    }
+
+    #[test]
+    fn release_frees_resources() {
+        let budget = ResourceBudget::new(4, 4096, 1.0, 0);
+        assert!(budget.try_reserve(2, 2048));
+        assert!(budget.try_reserve(2, 2048));
+        assert!(!budget.try_reserve(2, 2048));
+        budget.release(2, 2048);
+        assert!(budget.try_reserve(2, 2048)); // works after release
+    }
+
+    #[test]
+    fn can_afford_matches_reserve() {
+        let budget = ResourceBudget::new(4, 4096, 1.0, 0);
+        assert!(budget.can_afford(2, 2048));
+        assert!(budget.try_reserve(2, 2048));
+        assert!(budget.can_afford(2, 2048));
+        assert!(budget.try_reserve(2, 2048));
+        assert!(!budget.can_afford(2, 2048));
+    }
+
+    #[test]
+    fn concurrency_factor_increases_budget() {
+        // 4 CPUs * 2.0 = 8 effective vcpu, 8 GB * 2.0 = 16 GB effective mem
+        let budget = ResourceBudget::new(4, 8192, 2.0, 0);
+        assert_eq!(budget.effective_vcpu(), 8);
+        assert_eq!(budget.effective_memory_mb(), 16384);
+        for _ in 0..4 {
+            assert!(budget.try_reserve(2, 2048));
+        }
+        assert!(!budget.try_reserve(2, 2048)); // vcpu: 10 > 8
+    }
+
+    #[test]
+    fn max_concurrent_zero_means_no_cap() {
+        let budget = ResourceBudget::new(16, 65536, 1.0, 0);
+        for _ in 0..8 {
+            assert!(budget.try_reserve(2, 2048));
+        }
+        assert_eq!(budget.lock().running_count, 8);
+    }
+
+    #[test]
+    fn mixed_resource_jobs() {
+        // 8 vcpu, 8GB — can fit 1 browser (4vcpu/4GB) + 2 default (2vcpu/2GB)
+        let budget = ResourceBudget::new(8, 8192, 1.0, 0);
+        assert!(budget.try_reserve(4, 4096)); // browser
+        assert!(budget.try_reserve(2, 2048)); // default
+        assert!(budget.try_reserve(2, 2048)); // default — exactly 8/8
+        assert!(!budget.try_reserve(2, 2048)); // no room
+    }
+
+    #[test]
+    fn first_job_admitted_even_if_exceeds_budget() {
+        // 1 CPU, 1GB — job needs 2 vcpu / 2GB, exceeds both limits
+        let budget = ResourceBudget::new(1, 1024, 1.0, 0);
+        assert!(budget.try_reserve(2, 2048)); // first job always admitted
+        assert!(!budget.try_reserve(2, 2048)); // second blocked
+        budget.release(2, 2048);
+        assert!(budget.try_reserve(2, 2048)); // first again after release
+    }
+
+    #[test]
+    fn first_job_bypass_respects_max_concurrent() {
+        // max_concurrent=1 still limits to 1 job, but first job can exceed resource budget
+        let budget = ResourceBudget::new(1, 512, 1.0, 1);
+        assert!(budget.try_reserve(2, 2048)); // first job: exceeds budget but admitted
+        assert!(!budget.try_reserve(2, 2048)); // blocked by max_concurrent
+    }
+
+    #[test]
+    fn release_returns_to_zero() {
+        let budget = ResourceBudget::new(8, 16384, 1.0, 0);
+        assert!(budget.try_reserve(2, 2048));
+        assert!(budget.try_reserve(4, 4096));
+        budget.release(2, 2048);
+        budget.release(4, 4096);
+        let state = budget.lock();
+        assert_eq!(state.running_vcpu, 0);
+        assert_eq!(state.running_memory_mb, 0);
+        assert_eq!(state.running_count, 0);
+    }
+
+    #[test]
+    fn concurrent_reserves_no_overcommit() {
+        use std::sync::Arc;
+
+        let budget = Arc::new(ResourceBudget::new(4, 8192, 1.0, 0));
+        let mut handles = vec![];
+
+        // Spawn 10 threads each trying to reserve 2 vcpu / 2048 MB
+        // Only 2 should succeed (4 vcpu total — first-job bypass doesn't
+        // help the second thread because count > 0 after the first).
+        for _ in 0..10 {
+            let b = Arc::clone(&budget);
+            handles.push(std::thread::spawn(move || b.try_reserve(2, 2048)));
+        }
+
+        let successes: usize = handles
+            .into_iter()
+            .map(|h| if h.join().unwrap() { 1 } else { 0 })
+            .sum();
+
+        assert_eq!(successes, 2);
+        let state = budget.lock();
+        assert_eq!(state.running_vcpu, 4);
+        assert_eq!(state.running_memory_mb, 4096);
+        assert_eq!(state.running_count, 2);
+    }
+}


### PR DESCRIPTION
## Summary

- Replace count-based `tokio::sync::Semaphore` with `ResourceBudget` that tracks vcpu, memory, and job count
- Three-condition admission: vcpu budget + memory budget + `max_concurrent` hard cap
- `concurrency_factor` applies to both CPU and memory (balloon controller reclaims unused guest memory)
- Reserve resources before claiming jobs — don't waste jobs on budget-exhausted runners
- First-job guarantee: always admit when idle (matches old `.max(1)` behaviour)
- Remove `compute_max_concurrent()`, derive pool size from budget directly

Closes #4882
Part of #4500

## Test plan

- [x] `reserve_within_budget` — basic reserve updates counters
- [x] `reserve_fails_on_vcpu_exhaustion` — rejects when vcpu budget exceeded
- [x] `reserve_fails_on_memory_exhaustion` — rejects when memory exceeded, no vcpu leak
- [x] `reserve_fails_on_max_concurrent` — hard cap enforced, no resource leak
- [x] `release_frees_resources` — release enables subsequent reserve
- [x] `can_afford_matches_reserve` — gate consistent with admission
- [x] `concurrency_factor_increases_budget` — factor applies to both vcpu and memory
- [x] `max_concurrent_zero_means_no_cap` — 0 = unlimited count
- [x] `mixed_resource_jobs` — different job sizes coexist correctly
- [x] `first_job_admitted_even_if_exceeds_budget` — under-provisioned host still runs 1 job
- [x] `first_job_bypass_respects_max_concurrent` — first-job bypass + max_concurrent interaction
- [x] `release_returns_to_zero` — all counters zero after full release
- [x] `concurrent_reserves_no_overcommit` — 10 threads, mutex prevents overcommit

🤖 Generated with [Claude Code](https://claude.com/claude-code)