### PR TITLE
fix: activity detail auth alignment and platform team endpoint

### DIFF
--- a/turbo/apps/platform/src/mocks/handlers/api-agents.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-agents.ts
@@ -8,6 +8,22 @@
 import { http, HttpResponse } from "msw";
 
 export const apiAgentsHandlers = [
+  // GET /api/platform/team
+  http.get("/api/platform/team", () => {
+    return HttpResponse.json({
+      composes: [
+        {
+          id: "mock-compose-id",
+          name: "zero",
+          displayName: null,
+          headVersionId: "version_1",
+          updatedAt: "2024-01-01T00:00:00Z",
+          isOwner: true,
+        },
+      ],
+    });
+  }),
+
   // GET /api/agent/composes/list
   http.get("/api/agent/composes/list", () => {
     return HttpResponse.json({

--- a/turbo/apps/platform/src/signals/agents-page/__tests__/agents-list.test.ts
+++ b/turbo/apps/platform/src/signals/agents-page/__tests__/agents-list.test.ts
@@ -33,7 +33,7 @@ describe("agents-list signals", () => {
       ];
 
       server.use(
-        http.get("http://localhost:3000/api/agent/composes/list", () => {
+        http.get("http://localhost:3000/api/platform/team", () => {
           return HttpResponse.json({ composes: mockAgents });
         }),
         http.get("http://localhost:3000/api/agent/schedules", () => {
@@ -58,7 +58,7 @@ describe("agents-list signals", () => {
 
     it("should set error state when agents API fails", async () => {
       server.use(
-        http.get("http://localhost:3000/api/agent/composes/list", () => {
+        http.get("http://localhost:3000/api/platform/team", () => {
           return HttpResponse.json(
             { error: "Unauthorized" },
             { status: 401, statusText: "Unauthorized" },
@@ -83,7 +83,7 @@ describe("agents-list signals", () => {
       ];
 
       server.use(
-        http.get("http://localhost:3000/api/agent/composes/list", () => {
+        http.get("http://localhost:3000/api/platform/team", () => {
           return HttpResponse.json({ composes: mockAgents });
         }),
         http.get("http://localhost:3000/api/agent/schedules", () => {

--- a/turbo/apps/platform/src/signals/agents-page/agents-list.ts
+++ b/turbo/apps/platform/src/signals/agents-page/agents-list.ts
@@ -142,8 +142,8 @@ export const fetchAgentsList$ = command(async ({ get, set }) => {
   try {
     const fetchFn = get(fetch$);
 
-    // Fetch agents (required)
-    const agentsResponse = await fetchFn("/api/agent/composes/list");
+    // Fetch agents from platform team endpoint (uses Clerk active org)
+    const agentsResponse = await fetchFn("/api/platform/team");
 
     if (!agentsResponse.ok) {
       throw new Error(`Failed to fetch agents: ${agentsResponse.statusText}`);

--- a/turbo/apps/platform/src/views/agents-page/__tests__/agents-page.test.tsx
+++ b/turbo/apps/platform/src/views/agents-page/__tests__/agents-page.test.tsx
@@ -10,7 +10,7 @@ const context = testContext();
 describe("agents page", () => {
   it("shows agents table with agent names", async () => {
     server.use(
-      http.get("/api/agent/composes/list", () => {
+      http.get("/api/platform/team", () => {
         return HttpResponse.json({
           composes: [
             {
@@ -35,7 +35,7 @@ describe("agents page", () => {
 
   it("shows empty state when no agents exist", async () => {
     server.use(
-      http.get("/api/agent/composes/list", () => {
+      http.get("/api/platform/team", () => {
         return HttpResponse.json({ composes: [] });
       }),
     );
@@ -51,7 +51,7 @@ describe("agents page", () => {
 
   it("shows error state when agents API fails", async () => {
     server.use(
-      http.get("/api/agent/composes/list", () => {
+      http.get("/api/platform/team", () => {
         return HttpResponse.json(
           { error: "Unauthorized" },
           { status: 401, statusText: "Unauthorized" },
@@ -68,7 +68,7 @@ describe("agents page", () => {
 
   it("shows missing environment variables count for agent with missing items", async () => {
     server.use(
-      http.get("/api/agent/composes/list", () => {
+      http.get("/api/platform/team", () => {
         return HttpResponse.json({
           composes: [
             {
@@ -118,7 +118,7 @@ describe("agents page", () => {
 
   it("shows singular label for one missing environment variable", async () => {
     server.use(
-      http.get("/api/agent/composes/list", () => {
+      http.get("/api/platform/team", () => {
         return HttpResponse.json({
           composes: [
             {
@@ -163,7 +163,7 @@ describe("agents page", () => {
 
   it("does not show missing env count when all items are provided", async () => {
     server.use(
-      http.get("/api/agent/composes/list", () => {
+      http.get("/api/platform/team", () => {
         return HttpResponse.json({
           composes: [
             {

--- a/turbo/apps/web/app/api/platform/team/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/platform/team/__tests__/route.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { randomUUID } from "crypto";
+import { GET } from "../route";
+import { createTestCompose } from "../../../../../src/__tests__/api-test-helpers";
+import {
+  testContext,
+  type UserContext,
+} from "../../../../../src/__tests__/test-helpers";
+import { mockClerk } from "../../../../../src/__tests__/clerk-mock";
+
+const context = testContext();
+
+describe("GET /api/platform/team", () => {
+  let user: UserContext;
+
+  beforeEach(async () => {
+    context.setupMocks();
+    user = await context.setupUser();
+    // Team endpoint reads orgId from Clerk session, so configure it
+    mockClerk({ userId: user.userId, orgId: user.orgId });
+  });
+
+  it("should return 401 when not authenticated", async () => {
+    mockClerk({ userId: null });
+
+    const response = await GET();
+    const data = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(data.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("should return 403 when no active org", async () => {
+    mockClerk({ userId: user.userId, orgId: null });
+
+    const response = await GET();
+    const data = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(data.error.code).toBe("FORBIDDEN");
+  });
+
+  it("should return empty list when org has no composes", async () => {
+    const response = await GET();
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.composes).toEqual([]);
+  });
+
+  it("should return composes for the active org", async () => {
+    const composeName = `team-test-${randomUUID().slice(0, 8)}`;
+    await createTestCompose(composeName);
+
+    const response = await GET();
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.composes).toHaveLength(1);
+    expect(data.composes[0].name).toBe(composeName);
+    expect(data.composes[0].id).toBeDefined();
+    expect(data.composes[0].updatedAt).toBeDefined();
+  });
+
+  it("should not return composes from other orgs", async () => {
+    // Create compose for current user's org
+    const myComposeName = `my-agent-${randomUUID().slice(0, 8)}`;
+    await createTestCompose(myComposeName);
+
+    // Create another user with a different org
+    const otherUser = await context.setupUser({ prefix: "other-user" });
+    mockClerk({ userId: otherUser.userId, orgId: otherUser.orgId });
+    const otherComposeName = `other-agent-${randomUUID().slice(0, 8)}`;
+    await createTestCompose(otherComposeName);
+
+    // Switch back to original user
+    mockClerk({ userId: user.userId, orgId: user.orgId });
+
+    const response = await GET();
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    const names = data.composes.map((c: { name: string }) => c.name);
+    expect(names).toContain(myComposeName);
+    expect(names).not.toContain(otherComposeName);
+  });
+});

--- a/turbo/apps/web/app/api/platform/team/route.ts
+++ b/turbo/apps/web/app/api/platform/team/route.ts
@@ -1,0 +1,133 @@
+/**
+ * Platform API - Team Endpoint
+ *
+ * GET /api/platform/team - List all agents in the user's active Clerk org.
+ * Unlike /api/agent/composes/list, this endpoint strictly uses the Clerk
+ * session orgId and does not fall through to heuristic org resolution.
+ */
+import { NextResponse } from "next/server";
+import { auth } from "@clerk/nextjs/server";
+import { eq, desc } from "drizzle-orm";
+import { initServices } from "../../../../src/lib/init-services";
+import {
+  agentComposes,
+  agentComposeVersions,
+} from "../../../../src/db/schema/agent-compose";
+import { getOrgData } from "../../../../src/lib/org/org-cache-service";
+
+function extractMetadata(content: unknown): {
+  displayName: string | null;
+  description: string | null;
+} {
+  const empty = { displayName: null, description: null };
+  if (
+    content === null ||
+    content === undefined ||
+    typeof content !== "object"
+  ) {
+    return empty;
+  }
+  const record = content as Record<string, unknown>;
+  const agents = record["agents"];
+  if (agents === null || agents === undefined || typeof agents !== "object") {
+    return empty;
+  }
+  const agentKeys = Object.keys(agents);
+  if (agentKeys.length === 0) return empty;
+  const agentsRecord = agents as Record<string, unknown>;
+  const firstAgent = agentsRecord[agentKeys[0]!];
+  if (
+    firstAgent === null ||
+    firstAgent === undefined ||
+    typeof firstAgent !== "object"
+  ) {
+    return empty;
+  }
+  const agentRecord = firstAgent as Record<string, unknown>;
+  const metadata = agentRecord["metadata"];
+  if (
+    metadata === null ||
+    metadata === undefined ||
+    typeof metadata !== "object"
+  ) {
+    return empty;
+  }
+  const metadataRecord = metadata as Record<string, unknown>;
+  const displayName =
+    typeof metadataRecord["displayName"] === "string"
+      ? metadataRecord["displayName"]
+      : null;
+  const description =
+    typeof metadataRecord["description"] === "string"
+      ? metadataRecord["description"]
+      : null;
+  return { displayName, description };
+}
+
+export async function GET() {
+  initServices();
+
+  const { userId, orgId } = await auth();
+
+  if (!userId) {
+    return NextResponse.json(
+      { error: { message: "Not authenticated", code: "UNAUTHORIZED" } },
+      { status: 401 },
+    );
+  }
+
+  if (!orgId) {
+    return NextResponse.json(
+      {
+        error: {
+          message: "No active organization. Please select an org.",
+          code: "FORBIDDEN",
+        },
+      },
+      { status: 403 },
+    );
+  }
+
+  // Verify org exists in our DB
+  let resolvedOrgId: string;
+  try {
+    const orgData = await getOrgData(orgId);
+    resolvedOrgId = orgData.orgId;
+  } catch {
+    return NextResponse.json(
+      { error: { message: "Organization not found", code: "NOT_FOUND" } },
+      { status: 404 },
+    );
+  }
+
+  const composes = await globalThis.services.db
+    .select({
+      id: agentComposes.id,
+      name: agentComposes.name,
+      headVersionId: agentComposes.headVersionId,
+      updatedAt: agentComposes.updatedAt,
+      headContent: agentComposeVersions.content,
+    })
+    .from(agentComposes)
+    .leftJoin(
+      agentComposeVersions,
+      eq(agentComposes.headVersionId, agentComposeVersions.id),
+    )
+    .where(eq(agentComposes.orgId, resolvedOrgId))
+    .orderBy(desc(agentComposes.updatedAt));
+
+  return NextResponse.json({
+    composes: composes.map((c) => {
+      const meta = extractMetadata(c.headContent);
+      return {
+        id: c.id,
+        name: c.name,
+        displayName: meta.displayName,
+        description: meta.description,
+        headVersionId: c.headVersionId,
+        updatedAt: c.updatedAt.toISOString(),
+        isOwner: true,
+      };
+    }),
+  });
+}

--- a/turbo/apps/web/app/api/platform/team/route.ts
+++ b/turbo/apps/web/app/api/platform/team/route.ts
@@ -14,6 +14,7 @@ import {
   agentComposeVersions,
 } from "../../../../src/db/schema/agent-compose";
 import { getOrgData } from "../../../../src/lib/org/org-cache-service";
+import { isNotFound, isForbidden } from "../../../../src/lib/errors";
 
 function extractMetadata(content: unknown): {
   displayName: string | null;
@@ -93,11 +94,14 @@ export async function GET() {
   try {
     const orgData = await getOrgData(orgId);
     resolvedOrgId = orgData.orgId;
-  } catch {
-    return NextResponse.json(
-      { error: { message: "Organization not found", code: "NOT_FOUND" } },
-      { status: 404 },
-    );
+  } catch (error) {
+    if (isNotFound(error) || isForbidden(error)) {
+      return NextResponse.json(
+        { error: { message: "Organization not found", code: "NOT_FOUND" } },
+        { status: 404 },
+      );
+    }
+    throw error;
   }
 
   const composes = await globalThis.services.db

--- a/turbo/apps/web/src/__tests__/api-test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers.ts
@@ -507,11 +507,6 @@ async function createTestComposeVersion(
 }
 
 /**
- * Create a run record directly in the database.
- * Use this when you need a run without going through the API route
- * (e.g., for webhook tests where Clerk auth is disabled).
- */
-/**
  * Create a run with no compose version (simulates deleted compose).
  * Useful for testing that endpoints handle orphan runs gracefully.
  */
@@ -533,6 +528,11 @@ export async function createOrphanTestRun(
   return { runId: run!.id };
 }
 
+/**
+ * Create a run record directly in the database.
+ * Use this when you need a run without going through the API route
+ * (e.g., for webhook tests where Clerk auth is disabled).
+ */
 async function createTestRunDirect(
   userId: string,
   versionId: string,


### PR DESCRIPTION
## Summary
- **Activity detail auth**: Changed `innerJoin` to `leftJoin` for compose tables and filter by `agentRuns.orgId` instead of `agentComposes.orgId`, aligning with the list endpoint. Fixes 404 on detail page when compose was deleted.
- **Platform team endpoint**: New `GET /api/platform/team` that strictly uses Clerk session `orgId` (no fallback heuristics), ensuring all users in the same org see the same team list. Frontend `fetchAgentsList$` now calls this instead of `/api/agent/composes/list`.

## Test plan
- [ ] Activity list shows a run → detail page also accessible (no 404)
- [ ] Run with deleted compose → detail page returns 200 with `agentName: "unknown"`
- [ ] Two users in same org → both see identical team list on `/zero/team`
- [ ] User with no active org → gets 403 from `/api/platform/team`

🤖 Generated with [Claude Code](https://claude.com/claude-code)