### PR TITLE
fix: enforce sandbox capabilities on compose sub-routes

### DIFF
--- a/turbo/apps/web/app/api/agent/composes/[id]/instructions/route.ts
+++ b/turbo/apps/web/app/api/agent/composes/[id]/instructions/route.ts
@@ -44,7 +44,9 @@ export async function GET(
   initServices();
 
   const authorization = request.headers.get("authorization") ?? undefined;
-  const userId = await getUserId(authorization);
+  const userId = await getUserId(authorization, {
+    requiredCapability: "agent:read",
+  });
   if (!userId) {
     return NextResponse.json(
       { error: { message: "Not authenticated", code: "UNAUTHORIZED" } },

--- a/turbo/apps/web/app/api/agent/composes/__tests__/sandbox-capability.test.ts
+++ b/turbo/apps/web/app/api/agent/composes/__tests__/sandbox-capability.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach } from "vitest";
 import { GET, POST } from "../route";
 import { GET as listGET } from "../list/route";
 import { GET as getByIdGET, DELETE as deleteDELETE } from "../[id]/route";
+import { GET as versionsGET } from "../versions/route";
 import {
   createTestRequest,
   createTestCompose,
@@ -289,4 +290,50 @@ describe("Sandbox capability enforcement on compose routes", () => {
       expect(response.status).toBe(401);
     });
   });
+
+  describe("GET /api/agent/composes/versions", () => {
+    it("sandbox token with agent:read can resolve version", async () => {
+      const agentName = `test-sandbox-versions-${Date.now()}`;
+      const { composeId, versionId } = await createTestCompose(agentName);
+
+      mockClerk({ userId: null });
+      const token = await generateSandboxToken(user.userId, "run-123", [
+        "agent:read",
+      ]);
+
+      const request = createTestRequest(
+        `http://localhost:3000/api/agent/composes/versions?composeId=${composeId}&version=latest`,
+        {
+          headers: { Authorization: `Bearer ${token}` },
+        },
+      );
+
+      const response = await versionsGET(request);
+      expect(response.status).toBe(200);
+
+      const data = await response.json();
+      expect(data.versionId).toBe(versionId);
+    });
+
+    it("sandbox token without agent:read gets 401", async () => {
+      const agentName = `test-sandbox-noversions-${Date.now()}`;
+      const { composeId } = await createTestCompose(agentName);
+
+      mockClerk({ userId: null });
+      const token = await generateSandboxToken(user.userId, "run-123", [
+        "volume:read",
+      ]);
+
+      const request = createTestRequest(
+        `http://localhost:3000/api/agent/composes/versions?composeId=${composeId}&version=latest`,
+        {
+          headers: { Authorization: `Bearer ${token}` },
+        },
+      );
+
+      const response = await versionsGET(request);
+      expect(response.status).toBe(401);
+    });
+  });
+
 });

--- a/turbo/apps/web/app/api/agent/composes/__tests__/sandbox-capability.test.ts
+++ b/turbo/apps/web/app/api/agent/composes/__tests__/sandbox-capability.test.ts
@@ -3,6 +3,7 @@ import { GET, POST } from "../route";
 import { GET as listGET } from "../list/route";
 import { GET as getByIdGET, DELETE as deleteDELETE } from "../[id]/route";
 import { GET as versionsGET } from "../versions/route";
+import { GET as instructionsGET } from "../[id]/instructions/route";
 import {
   createTestRequest,
   createTestCompose,
@@ -336,4 +337,51 @@ describe("Sandbox capability enforcement on compose routes", () => {
     });
   });
 
+  describe("GET /api/agent/composes/:id/instructions", () => {
+    it("sandbox token with agent:read can access instructions endpoint", async () => {
+      const agentName = `test-sandbox-instructions-${Date.now()}`;
+      const { composeId } = await createTestCompose(agentName);
+
+      mockClerk({ userId: null });
+      const token = await generateSandboxToken(user.userId, "run-123", [
+        "agent:read",
+      ]);
+
+      const request = createTestRequest(
+        `http://localhost:3000/api/agent/composes/${composeId}/instructions`,
+        {
+          headers: { Authorization: `Bearer ${token}` },
+        },
+      );
+
+      const response = await instructionsGET(request, {
+        params: Promise.resolve({ id: composeId }),
+      });
+      // Should pass auth and reach compose lookup - returns 200 with null content
+      // (no storage volume exists for test compose)
+      expect(response.status).toBe(200);
+    });
+
+    it("sandbox token without agent:read gets 401", async () => {
+      const agentName = `test-sandbox-noinstructions-${Date.now()}`;
+      const { composeId } = await createTestCompose(agentName);
+
+      mockClerk({ userId: null });
+      const token = await generateSandboxToken(user.userId, "run-123", [
+        "volume:read",
+      ]);
+
+      const request = createTestRequest(
+        `http://localhost:3000/api/agent/composes/${composeId}/instructions`,
+        {
+          headers: { Authorization: `Bearer ${token}` },
+        },
+      );
+
+      const response = await instructionsGET(request, {
+        params: Promise.resolve({ id: composeId }),
+      });
+      expect(response.status).toBe(401);
+    });
+  });
 });

--- a/turbo/apps/web/app/api/agent/composes/versions/route.ts
+++ b/turbo/apps/web/app/api/agent/composes/versions/route.ts
@@ -16,7 +16,9 @@ const router = tsr.router(composesVersionsContract, {
   resolveVersion: async ({ query, headers }) => {
     initServices();
 
-    const userId = await getUserId(headers.authorization);
+    const userId = await getUserId(headers.authorization, {
+      requiredCapability: "agent:read",
+    });
     if (!userId) {
       return {
         status: 401 as const,


### PR DESCRIPTION
## Summary

- Add missing `requiredCapability` parameter to `getUserId()` calls in 5 compose sub-routes, enabling sandbox agents with `agent:read`/`agent:write` capabilities to access these endpoints
- Routes fixed: `versions` (GET), `permissions` (GET/POST/DELETE), `instructions` (GET)
- Add 10 integration tests covering sandbox token acceptance and rejection for each route

Closes #4931
Tracking: #4867

## Test plan

- [x] All 18 sandbox capability tests pass (including 10 new tests)
- [x] Lint, type-check, format, and knip all pass
- [x] Existing compose route tests unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)