### PR TITLE
feat: add org run queue visibility api and cli command

### DIFF
--- a/turbo/apps/cli/src/commands/run/__tests__/queue.test.ts
+++ b/turbo/apps/cli/src/commands/run/__tests__/queue.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Tests for run queue command
+ *
+ * Tests command-level behavior via parseAsync() following CLI testing principles:
+ * - Entry point: command.parseAsync()
+ * - Mock (external): Web API via MSW
+ * - Real (internal): All CLI code, formatters, validators
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../mocks/server";
+import { queueCommand } from "../queue";
+import chalk from "chalk";
+
+describe("run queue command", () => {
+  vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  beforeEach(() => {
+    chalk.level = 0;
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("VM0_TOKEN", "test-token");
+  });
+
+  it("displays concurrency header and queue table", async () => {
+    server.use(
+      http.get("http://localhost:3000/api/agent/runs/queue", () => {
+        return HttpResponse.json({
+          concurrency: { tier: "max", limit: 10, active: 8, available: 2 },
+          queue: [
+            {
+              position: 1,
+              agentName: "data-processor",
+              userEmail: "alice@example.com",
+              createdAt: new Date(Date.now() - 120000).toISOString(),
+              isOwner: true,
+              runId: "run-uuid-1",
+            },
+            {
+              position: 2,
+              agentName: "my-agent",
+              userEmail: "bob@example.com",
+              createdAt: new Date(Date.now() - 60000).toISOString(),
+              isOwner: false,
+              runId: null,
+            },
+          ],
+        });
+      }),
+    );
+
+    await queueCommand.parseAsync(["node", "cli"]);
+
+    const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+    expect(logCalls).toContain("8/10 slots used");
+    expect(logCalls).toContain("max tier");
+    expect(logCalls).toContain("2 runs waiting");
+    expect(logCalls).toContain("AGENT");
+    expect(logCalls).toContain("USER");
+    expect(logCalls).toContain("data-processor");
+    expect(logCalls).toContain("alice@example.com");
+    expect(logCalls).toContain("my-agent");
+    expect(logCalls).toContain("bob@example.com");
+  });
+
+  it("marks own entries with you indicator", async () => {
+    server.use(
+      http.get("http://localhost:3000/api/agent/runs/queue", () => {
+        return HttpResponse.json({
+          concurrency: { tier: "max", limit: 10, active: 8, available: 2 },
+          queue: [
+            {
+              position: 1,
+              agentName: "my-agent",
+              userEmail: "alice@example.com",
+              createdAt: new Date().toISOString(),
+              isOwner: true,
+              runId: "run-uuid-1",
+            },
+            {
+              position: 2,
+              agentName: "other-agent",
+              userEmail: "bob@example.com",
+              createdAt: new Date().toISOString(),
+              isOwner: false,
+              runId: null,
+            },
+          ],
+        });
+      }),
+    );
+
+    await queueCommand.parseAsync(["node", "cli"]);
+
+    const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+    // The "you" marker should appear for own entries
+    expect(logCalls).toContain("you");
+  });
+
+  it("displays empty queue state", async () => {
+    server.use(
+      http.get("http://localhost:3000/api/agent/runs/queue", () => {
+        return HttpResponse.json({
+          concurrency: { tier: "free", limit: 1, active: 0, available: 1 },
+          queue: [],
+        });
+      }),
+    );
+
+    await queueCommand.parseAsync(["node", "cli"]);
+
+    const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+    expect(logCalls).toContain("0/1 slots used");
+    expect(logCalls).toContain("free tier");
+    expect(logCalls).toContain("empty");
+  });
+
+  it("handles API error gracefully", async () => {
+    server.use(
+      http.get("http://localhost:3000/api/agent/runs/queue", () => {
+        return HttpResponse.json(
+          {
+            error: {
+              message: "Not authenticated",
+              code: "UNAUTHORIZED",
+            },
+          },
+          { status: 401 },
+        );
+      }),
+    );
+
+    await expect(async () => {
+      await queueCommand.parseAsync(["node", "cli"]);
+    }).rejects.toThrow("process.exit called");
+
+    expect(mockConsoleError).toHaveBeenCalledWith(
+      expect.stringContaining("Not authenticated"),
+    );
+  });
+
+  it("handles single queued run", async () => {
+    server.use(
+      http.get("http://localhost:3000/api/agent/runs/queue", () => {
+        return HttpResponse.json({
+          concurrency: { tier: "pro", limit: 2, active: 2, available: 0 },
+          queue: [
+            {
+              position: 1,
+              agentName: "test-agent",
+              userEmail: "user@example.com",
+              createdAt: new Date().toISOString(),
+              isOwner: true,
+              runId: "run-1",
+            },
+          ],
+        });
+      }),
+    );
+
+    await queueCommand.parseAsync(["node", "cli"]);
+
+    const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+    expect(logCalls).toContain("2/2 slots used");
+    expect(logCalls).toContain("1 run waiting");
+    expect(logCalls).toContain("test-agent");
+  });
+});

--- a/turbo/apps/cli/src/commands/run/index.ts
+++ b/turbo/apps/cli/src/commands/run/index.ts
@@ -3,11 +3,13 @@ import { resumeCommand } from "./resume";
 import { continueCommand } from "./continue";
 import { listCommand } from "./list";
 import { killCommand } from "./kill";
+import { queueCommand } from "./queue";
 
 // Add subcommands to the main run command
 mainRunCommand.addCommand(resumeCommand);
 mainRunCommand.addCommand(continueCommand);
 mainRunCommand.addCommand(listCommand);
 mainRunCommand.addCommand(killCommand);
+mainRunCommand.addCommand(queueCommand);
 
 export const runCommand = mainRunCommand;

--- a/turbo/apps/cli/src/commands/run/queue.ts
+++ b/turbo/apps/cli/src/commands/run/queue.ts
@@ -1,0 +1,59 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import { getRunQueue } from "../../lib/api";
+import { formatRelativeTime } from "../../lib/utils/file-utils";
+import { withErrorHandler } from "../../lib/command";
+
+export const queueCommand = new Command()
+  .name("queue")
+  .description("Show org run queue status")
+  .action(
+    withErrorHandler(async () => {
+      const data = await getRunQueue();
+      const { concurrency, queue } = data;
+
+      // Concurrency header
+      const limitDisplay =
+        concurrency.limit === 0
+          ? "unlimited"
+          : `${concurrency.active}/${concurrency.limit} slots used`;
+      console.log(`Concurrency: ${limitDisplay} (${concurrency.tier} tier)`);
+
+      // Queue status
+      if (queue.length === 0) {
+        console.log(chalk.dim("Queue: empty — all slots available"));
+        return;
+      }
+
+      console.log(
+        `Queue: ${queue.length} run${queue.length > 1 ? "s" : ""} waiting`,
+      );
+      console.log();
+
+      // Dynamic column widths
+      const posWidth = Math.max(1, String(queue.length).length);
+      const agentWidth = Math.max(5, ...queue.map((e) => e.agentName.length));
+      const emailWidth = Math.max(4, ...queue.map((e) => e.userEmail.length));
+
+      // Header
+      const header = [
+        "#".padEnd(posWidth),
+        "AGENT".padEnd(agentWidth),
+        "USER".padEnd(emailWidth),
+        "CREATED",
+      ].join("  ");
+      console.log(chalk.dim(header));
+
+      // Rows
+      for (const entry of queue) {
+        const marker = entry.isOwner ? chalk.cyan("  ← you") : "";
+        const row = [
+          String(entry.position).padEnd(posWidth),
+          entry.agentName.padEnd(agentWidth),
+          entry.userEmail.padEnd(emailWidth),
+          formatRelativeTime(entry.createdAt),
+        ].join("  ");
+        console.log(row + marker);
+      }
+    }),
+  );

--- a/turbo/apps/cli/src/lib/api/domains/runs.ts
+++ b/turbo/apps/cli/src/lib/api/domains/runs.ts
@@ -3,8 +3,10 @@ import {
   runsMainContract,
   runEventsContract,
   runsCancelContract,
+  runsQueueContract,
   type RunsListResponse,
   type CancelRunResponse,
+  type QueueResponse,
 } from "@vm0/core";
 import { getClientConfig, handleError } from "../core/client-factory";
 import type { CreateRunResponse, GetEventsResponse } from "../core/types";
@@ -99,6 +101,22 @@ export async function listRuns(params?: {
   }
 
   handleError(result, "Failed to list runs");
+}
+
+/**
+ * Get org run queue status
+ */
+export async function getRunQueue(): Promise<QueueResponse> {
+  const config = await getClientConfig();
+  const client = initClient(runsQueueContract, config);
+
+  const result = await client.getQueue({});
+
+  if (result.status === 200) {
+    return result.body;
+  }
+
+  handleError(result, "Failed to get run queue");
 }
 
 /**

--- a/turbo/apps/cli/src/lib/api/index.ts
+++ b/turbo/apps/cli/src/lib/api/index.ts
@@ -17,7 +17,13 @@ export {
 } from "./domains/composes";
 
 // Domain modules - Runs
-export { createRun, getEvents, listRuns, cancelRun } from "./domains/runs";
+export {
+  createRun,
+  getEvents,
+  listRuns,
+  cancelRun,
+  getRunQueue,
+} from "./domains/runs";
 
 // Domain modules - Sessions
 export { getSession, getCheckpoint } from "./domains/sessions";

--- a/turbo/apps/web/app/api/agent/runs/queue/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/queue/__tests__/route.test.ts
@@ -1,0 +1,250 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { GET } from "../route";
+import {
+  createTestRequest,
+  createTestCompose,
+  createTestRunInDb,
+  insertUserCacheEntry,
+} from "../../../../../../src/__tests__/api-test-helpers";
+import {
+  testContext,
+  uniqueId,
+  type UserContext,
+} from "../../../../../../src/__tests__/test-helpers";
+import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
+
+const context = testContext();
+
+describe("GET /api/agent/runs/queue", () => {
+  let user: UserContext;
+  let testComposeId: string;
+
+  beforeEach(async () => {
+    context.setupMocks();
+    user = await context.setupUser();
+
+    const { composeId } = await createTestCompose(uniqueId("agent"));
+    testComposeId = composeId;
+  });
+
+  it("returns 401 for unauthenticated requests", async () => {
+    mockClerk({ userId: null });
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/agent/runs/queue",
+    );
+    const response = await GET(request);
+
+    expect(response.status).toBe(401);
+  });
+
+  it("returns concurrency context with empty queue", async () => {
+    const request = createTestRequest(
+      "http://localhost:3000/api/agent/runs/queue",
+    );
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.concurrency).toEqual(
+      expect.objectContaining({
+        limit: expect.any(Number),
+        active: 0,
+        available: expect.any(Number),
+      }),
+    );
+    expect(data.queue).toEqual([]);
+  });
+
+  it("counts active runs (running + fresh pending)", async () => {
+    // Create running and pending runs
+    await createTestRunInDb(user.userId, testComposeId, {
+      status: "running",
+    });
+    await createTestRunInDb(user.userId, testComposeId, {
+      status: "pending",
+    });
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/agent/runs/queue",
+    );
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.concurrency.active).toBe(2);
+  });
+
+  it("returns queued runs in FIFO order with correct positions", async () => {
+    // Create queued runs with specific order
+    await createTestRunInDb(user.userId, testComposeId, {
+      status: "queued",
+      prompt: "first queued",
+    });
+    // Small delay to ensure ordering
+    await new Promise((r) => setTimeout(r, 10));
+    await createTestRunInDb(user.userId, testComposeId, {
+      status: "queued",
+      prompt: "second queued",
+    });
+
+    // Insert user cache so email resolution works without Clerk API
+    await insertUserCacheEntry({
+      userId: user.userId,
+      email: "test@example.com",
+    });
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/agent/runs/queue",
+    );
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.queue).toHaveLength(2);
+    expect(data.queue[0].position).toBe(1);
+    expect(data.queue[1].position).toBe(2);
+    // FIFO: first created should be position 1
+    expect(new Date(data.queue[0].createdAt).getTime()).toBeLessThanOrEqual(
+      new Date(data.queue[1].createdAt).getTime(),
+    );
+  });
+
+  it("includes runId only for requesting user's own runs", async () => {
+    const otherUserId = uniqueId("other-user");
+
+    // Both users' runs use the same compose (same org)
+    await createTestRunInDb(user.userId, testComposeId, {
+      status: "queued",
+    });
+    // Insert run for other user using same compose (orgId comes from compose)
+    await createTestRunInDb(otherUserId, testComposeId, {
+      status: "queued",
+    });
+
+    // Insert user cache entries
+    await insertUserCacheEntry({
+      userId: user.userId,
+      email: "alice@example.com",
+    });
+    await insertUserCacheEntry({
+      userId: otherUserId,
+      email: "bob@example.com",
+    });
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/agent/runs/queue",
+    );
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.queue).toHaveLength(2);
+
+    const ownEntry = data.queue.find(
+      (e: { isOwner: boolean }) => e.isOwner === true,
+    );
+    const otherEntry = data.queue.find(
+      (e: { isOwner: boolean }) => e.isOwner === false,
+    );
+
+    // Own run should include runId
+    expect(ownEntry).toBeDefined();
+    expect(ownEntry.runId).toBeTruthy();
+    expect(ownEntry.isOwner).toBe(true);
+
+    // Other user's run should NOT include runId
+    expect(otherEntry).toBeDefined();
+    expect(otherEntry.runId).toBeNull();
+    expect(otherEntry.isOwner).toBe(false);
+  });
+
+  it("never exposes prompt in response", async () => {
+    await createTestRunInDb(user.userId, testComposeId, {
+      status: "queued",
+      prompt: "secret-prompt-content",
+    });
+
+    await insertUserCacheEntry({
+      userId: user.userId,
+      email: "test@example.com",
+    });
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/agent/runs/queue",
+    );
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    const responseStr = JSON.stringify(data);
+    expect(responseStr).not.toContain("secret-prompt-content");
+    // Verify no prompt field exists on queue entries
+    for (const entry of data.queue) {
+      expect(entry).not.toHaveProperty("prompt");
+    }
+  });
+
+  it("only shows runs from the requested org", async () => {
+    // Create runs in the default org
+    await createTestRunInDb(user.userId, testComposeId, {
+      status: "queued",
+    });
+
+    await insertUserCacheEntry({
+      userId: user.userId,
+      email: "test@example.com",
+    });
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/agent/runs/queue",
+    );
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    // Should only see runs from user's org
+    expect(data.queue.length).toBeGreaterThanOrEqual(1);
+    for (const entry of data.queue) {
+      expect(entry.isOwner).toBe(true);
+    }
+  });
+
+  it("resolves user emails correctly", async () => {
+    await createTestRunInDb(user.userId, testComposeId, {
+      status: "queued",
+    });
+
+    await insertUserCacheEntry({
+      userId: user.userId,
+      email: "resolved@example.com",
+    });
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/agent/runs/queue",
+    );
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.queue[0].userEmail).toBe("resolved@example.com");
+  });
+
+  it("does not count completed or failed runs as active", async () => {
+    await createTestRunInDb(user.userId, testComposeId, {
+      status: "completed",
+    });
+    await createTestRunInDb(user.userId, testComposeId, {
+      status: "failed",
+    });
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/agent/runs/queue",
+    );
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.concurrency.active).toBe(0);
+  });
+});

--- a/turbo/apps/web/app/api/agent/runs/queue/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/queue/__tests__/route.test.ts
@@ -76,16 +76,17 @@ describe("GET /api/agent/runs/queue", () => {
   });
 
   it("returns queued runs in FIFO order with correct positions", async () => {
-    // Create queued runs with specific order
+    // Create queued runs with explicit timestamps to ensure deterministic ordering
+    const now = Date.now();
     await createTestRunInDb(user.userId, testComposeId, {
       status: "queued",
       prompt: "first queued",
+      createdAt: new Date(now - 1000),
     });
-    // Small delay to ensure ordering
-    await new Promise((r) => setTimeout(r, 10));
     await createTestRunInDb(user.userId, testComposeId, {
       status: "queued",
       prompt: "second queued",
+      createdAt: new Date(now),
     });
 
     // Insert user cache so email resolution works without Clerk API

--- a/turbo/apps/web/app/api/agent/runs/queue/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/queue/route.ts
@@ -1,0 +1,119 @@
+import { createHandler, tsr } from "../../../../../src/lib/ts-rest-handler";
+import { runsQueueContract, orgTierSchema } from "@vm0/core";
+import { initServices } from "../../../../../src/lib/init-services";
+import { getAuthContext } from "../../../../../src/lib/auth/get-user-id";
+import { resolveOrg } from "../../../../../src/lib/org/resolve-org";
+import {
+  getEffectiveConcurrencyLimit,
+  PENDING_RUN_TTL_MS,
+} from "../../../../../src/lib/run/run-service";
+import { getCachedUser } from "../../../../../src/lib/auth/user-cache-service";
+import { agentRuns } from "../../../../../src/db/schema/agent-run";
+import {
+  agentComposeVersions,
+  agentComposes,
+} from "../../../../../src/db/schema/agent-compose";
+import { eq, and, or, gt, count, asc } from "drizzle-orm";
+
+const router = tsr.router(runsQueueContract, {
+  getQueue: async ({ headers }, { request }) => {
+    initServices();
+
+    const authCtx = await getAuthContext(headers.authorization, {
+      requiredCapability: "agent-run:read",
+    });
+    if (!authCtx) {
+      return {
+        status: 401 as const,
+        body: {
+          error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+        },
+      };
+    }
+    const { userId } = authCtx;
+
+    const orgSlug = new URL(request.url).searchParams.get("org");
+    const { org } = await resolveOrg(userId, orgSlug);
+    const orgTier = orgTierSchema.parse(org.tier);
+
+    const limit = getEffectiveConcurrencyLimit(orgTier);
+
+    // Count active runs (same logic as checkRunConcurrencyLimit)
+    const staleThreshold = new Date(Date.now() - PENDING_RUN_TTL_MS);
+    const [activeResult] = await globalThis.services.db
+      .select({ count: count() })
+      .from(agentRuns)
+      .where(
+        and(
+          eq(agentRuns.orgId, org.orgId),
+          or(
+            eq(agentRuns.status, "running"),
+            and(
+              eq(agentRuns.status, "pending"),
+              gt(agentRuns.createdAt, staleThreshold),
+            ),
+          ),
+        ),
+      );
+    const active = Number(activeResult?.count ?? 0);
+
+    // Fetch queued runs in FIFO order
+    const queuedRuns = await globalThis.services.db
+      .select({
+        id: agentRuns.id,
+        runUserId: agentRuns.userId,
+        createdAt: agentRuns.createdAt,
+        agentName: agentComposes.name,
+      })
+      .from(agentRuns)
+      .leftJoin(
+        agentComposeVersions,
+        eq(agentRuns.agentComposeVersionId, agentComposeVersions.id),
+      )
+      .leftJoin(
+        agentComposes,
+        eq(agentComposeVersions.composeId, agentComposes.id),
+      )
+      .where(
+        and(eq(agentRuns.orgId, org.orgId), eq(agentRuns.status, "queued")),
+      )
+      .orderBy(asc(agentRuns.createdAt));
+
+    // Resolve user emails in parallel
+    const uniqueUserIds = [...new Set(queuedRuns.map((r) => r.runUserId))];
+    const userMap = new Map<string, string>();
+    await Promise.all(
+      uniqueUserIds.map(async (uid) => {
+        const user = await getCachedUser(uid);
+        userMap.set(uid, user.email);
+      }),
+    );
+
+    // Build response with privacy filtering
+    const queue = queuedRuns.map((run, index) => ({
+      position: index + 1,
+      agentName: run.agentName ?? "unknown",
+      userEmail: userMap.get(run.runUserId) ?? "unknown",
+      createdAt: run.createdAt.toISOString(),
+      isOwner: run.runUserId === userId,
+      runId: run.runUserId === userId ? run.id : null,
+    }));
+
+    return {
+      status: 200 as const,
+      body: {
+        concurrency: {
+          tier: orgTier,
+          limit,
+          active,
+          available: limit === 0 ? 0 : Math.max(0, limit - active),
+        },
+        queue,
+      },
+    };
+  },
+});
+
+const handler = createHandler(runsQueueContract, router);
+
+export { handler as GET };

--- a/turbo/apps/web/app/api/agent/runs/queue/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/queue/route.ts
@@ -106,7 +106,7 @@ const router = tsr.router(runsQueueContract, {
           tier: orgTier,
           limit,
           active,
-          available: limit === 0 ? 0 : Math.max(0, limit - active),
+          available: limit === 0 ? -1 : Math.max(0, limit - active),
         },
         queue,
       },

--- a/turbo/apps/web/src/__tests__/api-test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers.ts
@@ -541,6 +541,7 @@ async function createTestRunDirect(
     status?: string;
     prompt?: string;
     continuedFromSessionId?: string;
+    createdAt?: Date;
   },
 ): Promise<{ id: string }> {
   const [run] = await globalThis.services.db
@@ -552,6 +553,7 @@ async function createTestRunDirect(
       status: options?.status ?? "running",
       prompt: options?.prompt ?? "test prompt",
       continuedFromSessionId: options?.continuedFromSessionId,
+      ...(options?.createdAt ? { createdAt: options.createdAt } : {}),
     })
     .returning({ id: agentRuns.id });
   return run!;
@@ -623,6 +625,7 @@ export async function createTestRunInDb(
   options?: {
     status?: string;
     prompt?: string;
+    createdAt?: Date;
   },
 ): Promise<{ runId: string }> {
   // Look up orgId from compose
@@ -640,6 +643,7 @@ export async function createTestRunInDb(
   const run = await createTestRunDirect(userId, versionId, compose.orgId, {
     status: options?.status ?? "pending",
     prompt: options?.prompt ?? "test prompt",
+    createdAt: options?.createdAt,
   });
   return { runId: run.id };
 }

--- a/turbo/apps/web/src/lib/run/run-service.ts
+++ b/turbo/apps/web/src/lib/run/run-service.ts
@@ -63,7 +63,8 @@ export function getEffectiveConcurrencyLimit(orgTier: OrgTier): number {
   const tierLimit = getConcurrencyLimitForTier(orgTier);
   const envCap = env().CONCURRENT_RUN_LIMIT_CAP;
   if (envCap === 0) return 0;
-  if (envCap !== undefined && !isNaN(envCap)) return Math.min(tierLimit, envCap);
+  if (envCap !== undefined && !isNaN(envCap))
+    return Math.min(tierLimit, envCap);
   return tierLimit;
 }
 

--- a/turbo/apps/web/src/lib/run/run-service.ts
+++ b/turbo/apps/web/src/lib/run/run-service.ts
@@ -55,6 +55,19 @@ function getConcurrencyLimitForTier(tier: OrgTier): number {
 }
 
 /**
+ * Get the effective concurrency limit for an org tier.
+ * Tier-based limit is the baseline; env var acts as a global cap.
+ * Returns 0 for unlimited.
+ */
+export function getEffectiveConcurrencyLimit(orgTier: OrgTier): number {
+  const tierLimit = getConcurrencyLimitForTier(orgTier);
+  const envCap = env().CONCURRENT_RUN_LIMIT_CAP;
+  if (envCap === 0) return 0;
+  if (envCap !== undefined && !isNaN(envCap)) return Math.min(tierLimit, envCap);
+  return tierLimit;
+}
+
+/**
  * Check if org has reached concurrent run limit
  *
  * @param orgId Clerk org ID to check
@@ -67,16 +80,7 @@ async function checkRunConcurrencyLimit(
   orgTier: OrgTier = "free",
   db?: Database,
 ): Promise<void> {
-  // Tier-based limit is the baseline; env var acts as a global cap.
-  // 0 means no limit (unlimited).
-  const tierLimit = getConcurrencyLimitForTier(orgTier);
-  const envCap = env().CONCURRENT_RUN_LIMIT_CAP;
-  const effectiveLimit =
-    envCap === 0
-      ? 0
-      : envCap !== undefined && !isNaN(envCap)
-        ? Math.min(tierLimit, envCap)
-        : tierLimit;
+  const effectiveLimit = getEffectiveConcurrencyLimit(orgTier);
 
   // Skip check if limit is 0 (no limit)
   if (effectiveLimit === 0) {

--- a/turbo/packages/core/src/contracts/index.ts
+++ b/turbo/packages/core/src/contracts/index.ts
@@ -103,6 +103,14 @@ export {
   type NetworkLogsResponse,
   type SearchResult,
   type LogsSearchResponse,
+  runsQueueContract,
+  queueEntrySchema,
+  concurrencyInfoSchema,
+  queueResponseSchema,
+  type RunsQueueContract,
+  type QueueEntry,
+  type ConcurrencyInfo,
+  type QueueResponse,
 } from "./runs";
 export {
   storagesContract,

--- a/turbo/packages/core/src/contracts/runs.ts
+++ b/turbo/packages/core/src/contracts/runs.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { authHeadersSchema, initContract } from "./base";
 import { apiErrorSchema } from "./errors";
+import { orgTierSchema } from "./orgs";
 
 const c = initContract();
 
@@ -557,6 +558,60 @@ export const logsSearchContract = c.router({
 
 export type LogsSearchContract = typeof logsSearchContract;
 
+/**
+ * Queue entry schema — runId only present for own runs
+ */
+const queueEntrySchema = z.object({
+  position: z.number(),
+  agentName: z.string(),
+  userEmail: z.string(),
+  createdAt: z.string(),
+  isOwner: z.boolean(),
+  runId: z.string().nullable(),
+});
+
+/**
+ * Concurrency info schema
+ */
+const concurrencyInfoSchema = z.object({
+  tier: orgTierSchema,
+  limit: z.number(),
+  active: z.number(),
+  available: z.number(),
+});
+
+/**
+ * Queue response schema
+ */
+const queueResponseSchema = z.object({
+  concurrency: concurrencyInfoSchema,
+  queue: z.array(queueEntrySchema),
+});
+
+/**
+ * Runs queue route contract (/api/agent/runs/queue)
+ * Returns org-wide queue status with concurrency context
+ */
+export const runsQueueContract = c.router({
+  /**
+   * GET /api/agent/runs/queue
+   * Get org run queue status including concurrency context and queued entries
+   */
+  getQueue: {
+    method: "GET",
+    path: "/api/agent/runs/queue",
+    headers: authHeadersSchema,
+    responses: {
+      200: queueResponseSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+    },
+    summary: "Get org run queue status",
+  },
+});
+
+export type RunsQueueContract = typeof runsQueueContract;
+
 // Export schemas for reuse
 export {
   runStatusSchema,
@@ -579,6 +634,9 @@ export {
   networkLogsResponseSchema,
   searchResultSchema,
   logsSearchResponseSchema,
+  queueEntrySchema,
+  concurrencyInfoSchema,
+  queueResponseSchema,
 };
 
 // Export inferred types for consumers
@@ -601,3 +659,6 @@ export type NetworkLogEntry = z.infer<typeof networkLogEntrySchema>;
 export type NetworkLogsResponse = z.infer<typeof networkLogsResponseSchema>;
 export type SearchResult = z.infer<typeof searchResultSchema>;
 export type LogsSearchResponse = z.infer<typeof logsSearchResponseSchema>;
+export type QueueEntry = z.infer<typeof queueEntrySchema>;
+export type ConcurrencyInfo = z.infer<typeof concurrencyInfoSchema>;
+export type QueueResponse = z.infer<typeof queueResponseSchema>;


### PR DESCRIPTION
## Summary

- Add `GET /api/agent/runs/queue` endpoint returning org-wide queue status with concurrency context (tier, limit, active/available slots) and queued run entries in FIFO order
- Privacy: other users' `runId` is never exposed; `prompt` is never included in response; own runs marked with `isOwner` flag
- Add `vm0 run queue` CLI command displaying concurrency header and queue table with `← you` markers
- Define ts-rest contract (`runsQueueContract`) in `@vm0/core` following existing patterns
- Extract `getEffectiveConcurrencyLimit()` from `run-service.ts` for reuse

## Test plan

- [x] Backend: 9 integration tests (auth, concurrency context, FIFO order, privacy filtering, org scoping, email resolution)
- [x] CLI: 5 integration tests (table display, own-run markers, empty state, error handling, single run)
- [x] All 14 tests passing
- [x] Lint, format, knip checks clean

Closes #4938

🤖 Generated with [Claude Code](https://claude.com/claude-code)