### PR TITLE
refactor: remove leftover shared agent terminology

### DIFF
--- a/turbo/apps/platform/src/views/integrations-page/__tests__/slack-settings-page.test.tsx
+++ b/turbo/apps/platform/src/views/integrations-page/__tests__/slack-settings-page.test.tsx
@@ -134,7 +134,7 @@ describe("slack settings page", () => {
       http.get("/api/integrations/slack", () => {
         return HttpResponse.json({
           workspace: { id: "T123", name: "Test Workspace" },
-          agent: { id: "other_compose", name: "shared-agent" },
+          agent: { id: "other_compose", name: "workspace-agent" },
           isAdmin: true,
           environment: {
             requiredSecrets: [],
@@ -160,7 +160,7 @@ describe("slack settings page", () => {
     await setupPage({ context, path: "/settings/slack" });
 
     // The workspace default agent should be visible in the select
-    expect(screen.getByText("shared-agent")).toBeInTheDocument();
+    expect(screen.getByText("workspace-agent")).toBeInTheDocument();
   });
 
   it("closes uninstall dialog on cancel", async () => {

--- a/turbo/apps/web/app/api/agent/composes/__tests__/get-by-name.test.ts
+++ b/turbo/apps/web/app/api/agent/composes/__tests__/get-by-name.test.ts
@@ -143,7 +143,7 @@ describe("GET /api/agent/composes?name=<name>", () => {
   });
 
   it("should return org member agent via cross-org lookup with ?org=", async () => {
-    const agentName = `test-shared-agent-${Date.now()}`;
+    const agentName = `test-org-member-agent-${Date.now()}`;
 
     // Create compose as owner
     const { composeId } = await createTestCompose(agentName);

--- a/turbo/apps/web/app/api/integrations/github/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/integrations/github/__tests__/route.test.ts
@@ -440,7 +440,7 @@ describe("/api/integrations/github", () => {
       mockClerk({ userId: otherUserId });
       await createTestOrg(uniqueId("other-org"));
       const { composeId: otherComposeId } =
-        await createTestCompose("shared-agent");
+        await createTestCompose("other-org-agent");
 
       // Switch back to original user
       mockClerk({ userId });

--- a/turbo/apps/web/app/api/integrations/slack/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/integrations/slack/__tests__/route.test.ts
@@ -266,7 +266,7 @@ describe("/api/integrations/slack", () => {
       mockClerk({ userId: otherUserId });
       await createTestOrg(uniqueId("other-org"));
       const { composeId: otherComposeId } =
-        await createTestCompose("shared-agent");
+        await createTestCompose("other-org-agent");
 
       // Switch back to admin user
       mockClerk({ userId: userLink.vm0UserId });

--- a/turbo/apps/web/src/lib/telegram/handlers/commands.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/commands.ts
@@ -90,7 +90,7 @@ export async function handleConnectCommand(
 /**
  * Handle /disconnect command
  *
- * Removes the user link and revokes agent permission.
+ * Removes the user link and disconnects the Telegram integration.
  */
 export async function handleDisconnectCommand(
   update: TelegramHandlerUpdate,


### PR DESCRIPTION
## Summary
- Replace ACL-era "shared agent" naming with accurate terminology in tests and comments
- Rename test fixture names: `shared-agent` → `workspace-agent` / `other-org-agent` / `org-member-agent`
- Fix stale comment in telegram disconnect handler ("revokes agent permission" → "disconnects the Telegram integration")

Agent access is now strictly owner or org member — no cross-org sharing exists.

Part of #4871

## Test plan
- [x] All changes are test fixtures and comments only — no behavioral changes
- [x] Prettier validation passed (all files unchanged after format)

🤖 Generated with [Claude Code](https://claude.com/claude-code)