### PR TITLE
feat(runner): add profile definitions and multi-profile build pipeline

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -241,7 +241,7 @@ jobs:
           # Use tee to stream output in real-time while capturing for hash extraction
           echo "=== Running build ==="
           BUILD_LOG=$(mktemp)
-          ssh $REMOTE "${BIN_DIR}/runner build" | tee "$BUILD_LOG"
+          ssh $REMOTE "${BIN_DIR}/runner build --profile vm0/default" | tee "$BUILD_LOG"
           ROOTFS_HASH=$(grep '^rootfs_hash=' "$BUILD_LOG" | cut -d= -f2)
           SNAPSHOT_HASH=$(grep '^snapshot_hash=' "$BUILD_LOG" | cut -d= -f2)
           rm -f "$BUILD_LOG"
@@ -282,6 +282,7 @@ jobs:
 
           echo "=== Generating config ==="
           ssh $REMOTE "${BIN_DIR}/runner config \
+            --profile vm0/default \
             --rootfs-hash ${ROOTFS_HASH} \
             --snapshot-hash ${SNAPSHOT_HASH} \
             --name ${JOB_REF}-bench \
@@ -293,6 +294,7 @@ jobs:
           echo "=== Running benchmark ==="
           ssh $REMOTE "${BIN_DIR}/runner benchmark \
             --config ${RUNNER_DIR}/runner.yaml \
+            --profile vm0/default \
             'curl -sf --max-time 10 https://httpbin.org/get'"
 
   runner-exec:
@@ -323,6 +325,7 @@ jobs:
 
           echo "=== Generating config ==="
           ssh $REMOTE "${BIN_DIR}/runner config \
+            --profile vm0/default \
             --rootfs-hash ${ROOTFS_HASH} \
             --snapshot-hash ${SNAPSHOT_HASH} \
             --name ${JOB_REF}-exec \
@@ -423,6 +426,7 @@ jobs:
 
           echo "=== Generating config ==="
           ssh $REMOTE "${BIN_DIR}/runner config \
+            --profile vm0/default \
             --rootfs-hash ${ROOTFS_HASH} \
             --snapshot-hash ${SNAPSHOT_HASH} \
             --name ${JOB_REF}-balloon \
@@ -602,6 +606,7 @@ jobs:
           echo "=== Generating configs for runner A and B ==="
           for SUFFIX in upgrade-a upgrade-b; do
             ssh $REMOTE "${BIN_DIR}/runner config \
+              --profile vm0/default \
               --rootfs-hash ${ROOTFS_HASH} \
               --snapshot-hash ${SNAPSHOT_HASH} \
               --name ${JOB_REF}-${SUFFIX} \

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1168,9 +1168,7 @@ jobs:
             ssh $REMOTE "${BIN_DIR}/runner setup"
 
             # Run build to create rootfs + snapshot (outputs hashes to stdout)
-            ssh $REMOTE "${BIN_DIR}/runner build \
-              --vcpu ${RUNNER_VCPU} \
-              --memory-mb ${RUNNER_MEMORY_MB}"
+            ssh $REMOTE "${BIN_DIR}/runner build --profile vm0/default"
             echo "=== Done deploying to ${HOST} ==="
           }
 
@@ -1268,13 +1266,12 @@ jobs:
 
             # Generate runner.yaml with real preview URL (no build needed, uses cached hashes)
             ssh $REMOTE "${BIN_DIR}/runner config \
+              --profile vm0/default \
               --rootfs-hash ${ROOTFS_HASH} \
               --snapshot-hash ${SNAPSHOT_HASH} \
               --name ${RUNNER_NAME} \
               --group vm0/development-${JOB_REF} \
               --runner-dirname ${JOB_REF} \
-              --vcpu ${RUNNER_VCPU} \
-              --memory-mb ${RUNNER_MEMORY_MB} \
               --concurrency-factor 2.0 \
               --api-url ${PREVIEW_URL} \
               --token vm0_official_${OFFICIAL_RUNNER_SECRET}"

--- a/ansible/playbooks/deploy-runner.yml
+++ b/ansible/playbooks/deploy-runner.yml
@@ -54,8 +54,7 @@
     - name: Build rootfs and snapshot
       command: >
         {{ bin_dir }}/runner build
-        --vcpu {{ vcpu }}
-        --memory-mb {{ memory_mb }}
+        --profile vm0/default
       register: build_output
 
     - name: Parse build hashes
@@ -69,13 +68,12 @@
     - name: Generate runner config
       command: >
         {{ bin_dir }}/runner config
+        --profile vm0/default
         --rootfs-hash {{ rootfs_hash }}
         --snapshot-hash {{ snapshot_hash }}
         --name {{ runner_name }}
         --group {{ runner_group }}
         --runner-dirname {{ runner_name }}
-        --vcpu {{ vcpu }}
-        --memory-mb {{ memory_mb }}
         --api-url {{ api_url }}
         --token vm0_official_{{ official_runner_secret }}
 

--- a/crates/runner/src/cmd/benchmark.rs
+++ b/crates/runner/src/cmd/benchmark.rs
@@ -37,6 +37,9 @@ pub struct BenchmarkArgs {
     /// Run the command as root (sudo)
     #[arg(long)]
     sudo: bool,
+    /// Profile to benchmark
+    #[arg(long)]
+    profile: String,
 }
 
 pub async fn run_benchmark(args: BenchmarkArgs) -> RunnerResult<ExitCode> {
@@ -45,17 +48,30 @@ pub async fn run_benchmark(args: BenchmarkArgs) -> RunnerResult<ExitCode> {
     // 1. Load config, force concurrency=1
     let mut runner_config = config::load(&args.config).await?;
     runner_config.sandbox.max_concurrent = 1;
-    let is_snapshot = runner_config.firecracker.snapshot.is_some();
+
+    let home = HomePaths::new()?;
+
+    // Use the default profile for benchmark.
+    let default_profile = runner_config
+        .profiles
+        .get(&args.profile)
+        .ok_or_else(|| {
+            crate::error::RunnerError::Config(format!(
+                "profile '{}' not found in config",
+                args.profile
+            ))
+        })?
+        .clone();
+    let is_snapshot = default_profile.snapshot_hash.is_some();
 
     // Block until memory.bin is in page cache so benchmark numbers are stable.
-    if let Some(snapshot) = &runner_config.firecracker.snapshot {
-        let path = snapshot.memory_path.clone();
+    if let Some(hash) = &default_profile.snapshot_hash {
+        let path = home.snapshots_dir().join(hash).join("memory.bin");
         let _ = tokio::task::spawn_blocking(move || crate::prefetch::prefetch_memory(&path)).await;
     }
 
     // 2. Start proxy (unconditional — benchmark always uses proxy)
     let t = Instant::now();
-    let home = HomePaths::new()?;
     let runner_paths = RunnerPaths::new(runner_config.base_dir.clone());
     // Benchmark runs a single short-lived sandbox; crash recovery is not needed.
     let (mut mitm, _crash_rx) = proxy::MitmProxy::new(proxy::ProxyConfig {
@@ -72,8 +88,7 @@ pub async fn run_benchmark(args: BenchmarkArgs) -> RunnerResult<ExitCode> {
     info!(proxy_ms, port = mitm.port(), "proxy ready");
 
     // 3. Factory init (with proxy port)
-    let mut fc_config = runner_config.firecracker_config();
-    fc_config.proxy_port = Some(mitm.port());
+    let fc_config = runner_config.firecracker_config(&default_profile, &home, 1, Some(mitm.port()));
 
     let t = Instant::now();
     let mut factory = FirecrackerFactory::new(fc_config).await?;
@@ -85,8 +100,8 @@ pub async fn run_benchmark(args: BenchmarkArgs) -> RunnerResult<ExitCode> {
     let sandbox_config = SandboxConfig {
         id: Uuid::new_v4(),
         resources: sandbox::ResourceLimits {
-            cpu_count: runner_config.sandbox.vcpu,
-            memory_mb: runner_config.sandbox.memory_mb,
+            cpu_count: default_profile.vcpu,
+            memory_mb: default_profile.memory_mb,
         },
         use_proxy: true,
     };

--- a/crates/runner/src/cmd/build.rs
+++ b/crates/runner/src/cmd/build.rs
@@ -2,28 +2,23 @@ use clap::Args;
 
 use super::rootfs::RootfsArgs;
 use super::snapshot::SnapshotArgs;
-use crate::config::{DEFAULT_MEMORY_MB, DEFAULT_VCPU};
 use crate::error::RunnerResult;
+use crate::profile;
 
 #[derive(Args)]
 pub struct BuildArgs {
     #[command(flatten)]
     rootfs: RootfsArgs,
-    /// Number of vCPUs for the snapshot VM
-    #[arg(long, default_value_t = DEFAULT_VCPU)]
-    vcpu: u32,
-    /// Memory size in MiB for the snapshot VM
-    #[arg(long, default_value_t = DEFAULT_MEMORY_MB)]
-    memory_mb: u32,
 }
 
 pub async fn run_build(args: BuildArgs) -> RunnerResult<()> {
+    let def = profile::get(&args.rootfs.profile)?;
     let dry_run = args.rootfs.dry_run;
     let rootfs_hash = super::rootfs::run_rootfs(args.rootfs).await?;
     super::snapshot::run_snapshot(SnapshotArgs {
         rootfs_hash,
-        vcpu: args.vcpu,
-        memory_mb: args.memory_mb,
+        vcpu: def.vcpu,
+        memory_mb: def.memory_mb,
         dry_run,
     })
     .await?;

--- a/crates/runner/src/cmd/config.rs
+++ b/crates/runner/src/cmd/config.rs
@@ -1,23 +1,28 @@
+use std::collections::BTreeMap;
+
 use clap::Args;
 
-use sandbox_fc::SnapshotOutputPaths;
-
 use crate::config::{
-    self, DEFAULT_CONCURRENCY_FACTOR, DEFAULT_MAX_CONCURRENT, DEFAULT_MEMORY_MB, DEFAULT_VCPU,
-    FirecrackerConfig, RunnerConfig, SandboxConfig, ServerConfig,
+    self, DEFAULT_CONCURRENCY_FACTOR, DEFAULT_MAX_CONCURRENT, FirecrackerConfig, ProfileConfig,
+    RunnerConfig, SandboxConfig, ServerConfig,
 };
 use crate::deps::{FIRECRACKER_VERSION, KERNEL_VERSION};
 use crate::error::{RunnerError, RunnerResult};
-use crate::paths::{HomePaths, RootfsPaths};
+use crate::paths::HomePaths;
+use crate::profile;
 
 #[derive(Args)]
 pub struct ConfigArgs {
-    /// SHA-256 hash of the rootfs inputs (output of `runner build` or `runner rootfs`).
-    #[arg(long)]
-    rootfs_hash: String,
-    /// SHA-256 hash of the snapshot inputs (output of `runner build` or `runner snapshot`).
-    #[arg(long)]
-    snapshot_hash: String,
+    /// Profile entries: --profile vm0/default --rootfs-hash abc --snapshot-hash def
+    /// Can be repeated for multiple profiles. Each --profile starts a new entry.
+    #[arg(long, required = true)]
+    profile: Vec<String>,
+    /// Rootfs hash for the preceding --profile (one per profile, in order)
+    #[arg(long, required = true)]
+    rootfs_hash: Vec<String>,
+    /// Snapshot hash for the preceding --profile (one per profile, in order)
+    #[arg(long, required = true)]
+    snapshot_hash: Vec<String>,
 
     /// Runner logical name
     #[arg(long)]
@@ -29,16 +34,10 @@ pub struct ConfigArgs {
     #[arg(long)]
     runner_dirname: String,
 
-    /// Number of vCPUs for sandbox VMs
-    #[arg(long, default_value_t = DEFAULT_VCPU)]
-    vcpu: u32,
-    /// Memory size in MiB for sandbox VMs
-    #[arg(long, default_value_t = DEFAULT_MEMORY_MB)]
-    memory_mb: u32,
     /// Maximum concurrent VMs (0 = auto-detect from host CPU/memory)
     #[arg(long, default_value_t = DEFAULT_MAX_CONCURRENT)]
     max_concurrent: usize,
-    /// CPU overcommit factor for auto-detected concurrency (must be > 0)
+    /// Overcommit factor for auto-detected concurrency (must be > 0)
     #[arg(long, default_value_t = DEFAULT_CONCURRENCY_FACTOR)]
     concurrency_factor: f64,
 
@@ -51,33 +50,67 @@ pub struct ConfigArgs {
 }
 
 pub async fn run_config(args: ConfigArgs) -> RunnerResult<()> {
+    // Validate parallel arrays have same length.
+    if args.profile.len() != args.rootfs_hash.len()
+        || args.profile.len() != args.snapshot_hash.len()
+    {
+        return Err(RunnerError::Config(
+            "--profile, --rootfs-hash, and --snapshot-hash must be specified the same number of times".into(),
+        ));
+    }
+
     let paths = HomePaths::new()?;
-    let rootfs_paths = RootfsPaths::new(&paths, &args.rootfs_hash);
 
-    // Fail fast if referenced artifacts don't exist.
-    let rootfs_dir = rootfs_paths.dir();
-    if !tokio::fs::try_exists(rootfs_dir)
-        .await
-        .map_err(|e| RunnerError::Internal(format!("check rootfs dir: {e}")))?
-    {
-        return Err(RunnerError::Config(format!(
-            "rootfs not found for hash {}; run `build` or `rootfs` first",
-            args.rootfs_hash
-        )));
-    }
-    let snapshot_dir = paths.snapshots_dir().join(&args.snapshot_hash);
-    if !tokio::fs::try_exists(&snapshot_dir)
-        .await
-        .map_err(|e| RunnerError::Internal(format!("check snapshot dir: {e}")))?
-    {
-        return Err(RunnerError::Config(format!(
-            "snapshot not found for hash {}; run `build` or `snapshot` first",
-            args.snapshot_hash
-        )));
-    }
+    // Build profiles map, validating each entry.
+    let mut profiles = BTreeMap::new();
+    for (i, profile_name) in args.profile.iter().enumerate() {
+        if !profile::validate_name(profile_name) {
+            return Err(RunnerError::Config(format!(
+                "invalid profile name: {profile_name}"
+            )));
+        }
 
-    let snapshot_output = SnapshotOutputPaths::new(snapshot_dir);
-    let snapshot_config = snapshot_output.snapshot_config(&args.snapshot_hash).into();
+        let def = profile::get(profile_name)?;
+        // Length equality is validated above, so these indices are safe.
+        let rootfs_hash = args
+            .rootfs_hash
+            .get(i)
+            .ok_or_else(|| RunnerError::Internal(format!("missing rootfs_hash at index {i}")))?;
+        let snapshot_hash = args
+            .snapshot_hash
+            .get(i)
+            .ok_or_else(|| RunnerError::Internal(format!("missing snapshot_hash at index {i}")))?;
+
+        // Verify artifacts exist on disk.
+        let rootfs_dir = paths.rootfs_dir().join(rootfs_hash);
+        if !tokio::fs::try_exists(&rootfs_dir)
+            .await
+            .map_err(|e| RunnerError::Internal(format!("check rootfs dir: {e}")))?
+        {
+            return Err(RunnerError::Config(format!(
+                "rootfs not found for hash {rootfs_hash}; run `build --profile {profile_name}` first"
+            )));
+        }
+        let snapshot_dir = paths.snapshots_dir().join(snapshot_hash);
+        if !tokio::fs::try_exists(&snapshot_dir)
+            .await
+            .map_err(|e| RunnerError::Internal(format!("check snapshot dir: {e}")))?
+        {
+            return Err(RunnerError::Config(format!(
+                "snapshot not found for hash {snapshot_hash}; run `build --profile {profile_name}` first"
+            )));
+        }
+
+        profiles.insert(
+            profile_name.clone(),
+            ProfileConfig {
+                rootfs_hash: rootfs_hash.clone(),
+                snapshot_hash: Some(snapshot_hash.clone()),
+                vcpu: def.vcpu,
+                memory_mb: def.memory_mb,
+            },
+        );
+    }
 
     let runner_dir = paths.runners_dir().join(&args.runner_dirname);
 
@@ -89,12 +122,9 @@ pub async fn run_config(args: ConfigArgs) -> RunnerResult<()> {
         firecracker: FirecrackerConfig {
             binary: paths.firecracker_bin(FIRECRACKER_VERSION),
             kernel: paths.kernel_bin(FIRECRACKER_VERSION, KERNEL_VERSION),
-            rootfs: rootfs_paths.rootfs(),
-            snapshot: Some(snapshot_config),
         },
+        profiles,
         sandbox: SandboxConfig {
-            vcpu: args.vcpu,
-            memory_mb: args.memory_mb,
             max_concurrent: args.max_concurrent,
             concurrency_factor: args.concurrency_factor,
         },

--- a/crates/runner/src/cmd/rootfs.rs
+++ b/crates/runner/src/cmd/rootfs.rs
@@ -8,7 +8,6 @@ use crate::paths::{HomePaths, RootfsPaths};
 
 const BUILD_SCRIPT: &str = include_str!("../../scripts/build-rootfs.sh");
 const VERIFY_SCRIPT: &str = include_str!("../../scripts/verify-rootfs.sh");
-const EMBEDDED_DOCKERFILE: &str = include_str!("../../scripts/rootfs.Dockerfile");
 
 #[cfg(bundled_guests)]
 mod embedded {
@@ -72,6 +71,9 @@ pub struct RootfsArgs {
         arg(long, help = "Path to guest-mock-claude binary (required)")
     )]
     guest_mock_claude: Option<PathBuf>,
+    /// Profile to build (determines Dockerfile)
+    #[arg(long)]
+    pub profile: String,
     /// Compute and print the input hash without building
     #[arg(long)]
     pub dry_run: bool,
@@ -109,6 +111,8 @@ async fn resolve_guest(
 
 /// Build rootfs and return the content hash of the inputs.
 pub async fn run_rootfs(args: RootfsArgs) -> RunnerResult<String> {
+    let def = crate::profile::get(&args.profile)?;
+    let dockerfile = def.dockerfile;
     let dry_run = args.dry_run;
 
     // Create temp dir for any bundled guest binaries that need extracting.
@@ -137,7 +141,7 @@ pub async fn run_rootfs(args: RootfsArgs) -> RunnerResult<String> {
 
     // Compute input hash: script + dockerfile + guest binaries.
     // The build script content is included so any logic change invalidates cache.
-    let hash = compute_input_hash(&bins).await?;
+    let hash = compute_input_hash(dockerfile, &bins).await?;
     tracing::info!("rootfs input hash: {hash}");
     // Machine-readable output — do not change format without updating consumers
     println!("rootfs_hash={hash}");
@@ -186,7 +190,7 @@ pub async fn run_rootfs(args: RootfsArgs) -> RunnerResult<String> {
     tokio::fs::write(work_dir.path().join("verify-rootfs.sh"), VERIFY_SCRIPT)
         .await
         .map_err(|e| RunnerError::Internal(format!("write verify script: {e}")))?;
-    tokio::fs::write(work_dir.path().join("Dockerfile"), EMBEDDED_DOCKERFILE)
+    tokio::fs::write(work_dir.path().join("Dockerfile"), dockerfile)
         .await
         .map_err(|e| RunnerError::Internal(format!("write Dockerfile: {e}")))?;
 
@@ -267,7 +271,10 @@ async fn is_build_complete(rootfs: &RootfsPaths) -> RunnerResult<bool> {
 }
 
 /// Hash all deterministic inputs: build script, Dockerfile, and guest binaries.
-async fn compute_input_hash(guest_bins: &[(&Path, &str)]) -> RunnerResult<String> {
+async fn compute_input_hash(
+    dockerfile: &str,
+    guest_bins: &[(&Path, &str)],
+) -> RunnerResult<String> {
     let mut hasher = Sha256::new();
 
     // Hash build script content (includes resolv.conf, constants, all logic)
@@ -276,7 +283,7 @@ async fn compute_input_hash(guest_bins: &[(&Path, &str)]) -> RunnerResult<String
 
     // Hash Dockerfile content
     hasher.update(b"dockerfile:");
-    hasher.update(EMBEDDED_DOCKERFILE.as_bytes());
+    hasher.update(dockerfile.as_bytes());
 
     // Hash guest binaries (already sorted by name via guest_bins())
     for (src, dest) in guest_bins {

--- a/crates/runner/src/cmd/snapshot.rs
+++ b/crates/runner/src/cmd/snapshot.rs
@@ -3,7 +3,7 @@ use sha2::{Digest, Sha256};
 
 use sandbox_fc::SnapshotOutputPaths;
 
-use crate::config::{DEFAULT_MEMORY_MB, DEFAULT_VCPU, SnapshotConfig};
+use crate::config::SnapshotConfig;
 use crate::deps::{FIRECRACKER_VERSION, KERNEL_VERSION};
 use crate::error::{RunnerError, RunnerResult};
 use crate::paths::{HomePaths, RootfsPaths};
@@ -14,10 +14,10 @@ pub struct SnapshotArgs {
     #[arg(long)]
     pub rootfs_hash: String,
     /// Number of vCPUs for the snapshot VM.
-    #[arg(long, default_value_t = DEFAULT_VCPU)]
+    #[arg(long)]
     pub vcpu: u32,
     /// Memory size in MiB for the snapshot VM.
-    #[arg(long, default_value_t = DEFAULT_MEMORY_MB)]
+    #[arg(long)]
     pub memory_mb: u32,
     /// Compute and print the snapshot hash without building
     #[arg(long)]

--- a/crates/runner/src/cmd/start.rs
+++ b/crates/runner/src/cmd/start.rs
@@ -98,24 +98,18 @@ pub async fn run_start(args: StartArgs) -> RunnerResult<()> {
                 runner_config.base_dir.display()
             ))
         })?;
-    // Shared locks on rootfs/snapshot — allows `runner gc` to detect in-use resources.
-    let _rootfs_lock =
-        if let Some(hash) = home.extract_rootfs_hash(&runner_config.firecracker.rootfs) {
-            let lock = lock::acquire_shared(home.rootfs_lock(&hash)).await?;
-            crate::paths::touch_mtime(&home.rootfs_dir().join(&hash));
-            Some(lock)
-        } else {
-            None
-        };
-    let _snapshot_lock = if let Some(ref snap) = runner_config.firecracker.snapshot
-        && let Some(hash) = home.extract_snapshot_hash(&snap.snapshot_path)
-    {
-        let lock = lock::acquire_shared(home.snapshot_lock(&hash)).await?;
-        crate::paths::touch_mtime(&home.snapshots_dir().join(&hash));
-        Some(lock)
-    } else {
-        None
-    };
+    // Shared locks on rootfs/snapshot per profile — allows `runner gc` to detect in-use resources.
+    let mut _resource_locks = Vec::new();
+    for profile in runner_config.profiles.values() {
+        let lock = lock::acquire_shared(home.rootfs_lock(&profile.rootfs_hash)).await?;
+        crate::paths::touch_mtime(&home.rootfs_dir().join(&profile.rootfs_hash));
+        _resource_locks.push(lock);
+        if let Some(hash) = &profile.snapshot_hash {
+            let lock = lock::acquire_shared(home.snapshot_lock(hash)).await?;
+            crate::paths::touch_mtime(&home.snapshots_dir().join(hash));
+            _resource_locks.push(lock);
+        }
+    }
 
     let log_paths = crate::paths::LogPaths::new(home.logs_dir());
     tokio::fs::create_dir_all(log_paths.dir())
@@ -127,11 +121,26 @@ pub async fn run_start(args: StartArgs) -> RunnerResult<()> {
             ))
         })?;
 
-    // Start background prefetch so memory.bin is in page cache before the first VM.
-    if let Some(snapshot) = &runner_config.firecracker.snapshot {
-        let path = snapshot.memory_path.clone();
-        tokio::task::spawn_blocking(move || crate::prefetch::prefetch_memory(&path));
+    // Start background prefetch of snapshot memory for all profiles.
+    for profile in runner_config.profiles.values() {
+        if let Some(hash) = &profile.snapshot_hash {
+            let path = home.snapshots_dir().join(hash).join("memory.bin");
+            tokio::task::spawn_blocking(move || crate::prefetch::prefetch_memory(&path));
+        }
     }
+
+    // Use the default profile for vcpu/memory (used for budget and pool sizing).
+    let default_profile = runner_config
+        .profiles
+        .get(crate::profile::DEFAULT_PROFILE)
+        .ok_or_else(|| {
+            RunnerError::Config(format!(
+                "profile '{}' not found in config",
+                crate::profile::DEFAULT_PROFILE
+            ))
+        })?;
+    let vcpu = default_profile.vcpu;
+    let memory_mb = default_profile.memory_mb;
 
     // Start proxy before factory so proxy_port is available for netns pool.
     let paths = RunnerPaths::new(runner_config.base_dir.clone());
@@ -147,23 +156,13 @@ pub async fn run_start(args: StartArgs) -> RunnerResult<()> {
     mitm.start().await?;
     info!(port = mitm.port(), "proxy ready");
 
-    let mut fc_config = runner_config.firecracker_config();
-    fc_config.proxy_port = Some(mitm.port());
     let registry_handle = mitm.registry_handle();
 
-    // Destructure — no clones needed
-    let config::RunnerConfig {
-        name,
-        group,
-        sandbox,
-        ..
-    } = runner_config;
+    // Resource budget from host resources + config.
     let config::SandboxConfig {
         max_concurrent,
-        vcpu,
-        memory_mb,
         concurrency_factor,
-    } = sandbox;
+    } = runner_config.sandbox;
     let host_cpus = crate::host::cpu_count()?;
     let host_memory_mb = crate::host::memory_mb()?;
     let budget = Arc::new(ResourceBudget::new(
@@ -183,26 +182,35 @@ pub async fn run_start(args: StartArgs) -> RunnerResult<()> {
         effective_memory_mb = budget.effective_memory_mb(),
         "resource budget initialized"
     );
+
     // Factory concurrency hint for pool sizing (overlay + netns pre-warming).
-    assert!(vcpu > 0, "sandbox.vcpu must be > 0");
-    assert!(memory_mb > 0, "sandbox.memory_mb must be > 0");
+    assert!(vcpu > 0, "profile vcpu must be > 0");
+    assert!(memory_mb > 0, "profile memory_mb must be > 0");
     let resource_limit = std::cmp::min(
         budget.effective_vcpu() as usize / vcpu as usize,
         budget.effective_memory_mb() as usize / memory_mb as usize,
     )
     .max(1);
-    fc_config.concurrency = if max_concurrent > 0 {
+    let concurrency = if max_concurrent > 0 {
         std::cmp::min(resource_limit, max_concurrent)
     } else {
         resource_limit
     };
-    let mut status = StatusTracker::new(paths.status(), fc_config.concurrency);
+
+    // Build firecracker config with all parameters resolved.
+    let fc_config =
+        runner_config.firecracker_config(default_profile, &home, concurrency, Some(mitm.port()));
+    let is_snapshot = fc_config.snapshot.is_some();
+
+    let mut status = StatusTracker::new(paths.status(), concurrency);
     status.set_proxy_port(mitm.port()).await;
     let status = Arc::new(status);
 
     // Create provider — handles discovery + claim + complete
     let cancel = CancellationToken::new();
     let http = crate::http::HttpClient::new(server.url.clone())?;
+    let name = runner_config.name;
+    let group = runner_config.group;
     let (provider, group_name): (Arc<dyn JobProvider>, String) = if args.local {
         let group_dir = home.groups_dir().join(&group);
         std::fs::create_dir_all(&group_dir).map_err(|e| {
@@ -216,7 +224,6 @@ pub async fn run_start(args: StartArgs) -> RunnerResult<()> {
         (provider, group_name)
     };
 
-    let is_snapshot = fc_config.snapshot.is_some();
     let exec_config = Arc::new(ExecutorConfig {
         api_url: server.url,
         vcpu,

--- a/crates/runner/src/config.rs
+++ b/crates/runner/src/config.rs
@@ -1,11 +1,10 @@
+use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 
 use crate::error::{RunnerError, RunnerResult};
 
-pub(crate) const DEFAULT_VCPU: u32 = 2;
-pub(crate) const DEFAULT_MEMORY_MB: u32 = 2048;
 /// 0 means auto-detect from host CPU and memory at startup.
 pub(crate) const DEFAULT_MAX_CONCURRENT: usize = 0;
 pub(crate) const DEFAULT_CONCURRENCY_FACTOR: f64 = 1.0;
@@ -19,6 +18,7 @@ pub struct RunnerConfig {
     pub firecracker: FirecrackerConfig,
     #[serde(default)]
     pub sandbox: SandboxConfig,
+    pub profiles: BTreeMap<String, ProfileConfig>,
     pub server: Option<ServerConfig>,
 }
 
@@ -26,8 +26,15 @@ pub struct RunnerConfig {
 pub struct FirecrackerConfig {
     pub binary: PathBuf,
     pub kernel: PathBuf,
-    pub rootfs: PathBuf,
-    pub snapshot: Option<SnapshotConfig>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ProfileConfig {
+    pub rootfs_hash: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub snapshot_hash: Option<String>,
+    pub vcpu: u32,
+    pub memory_mb: u32,
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
@@ -54,19 +61,14 @@ impl From<sandbox_fc::SnapshotConfig> for SnapshotConfig {
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[serde(default)]
 pub struct SandboxConfig {
-    pub vcpu: u32,
-    pub memory_mb: u32,
     pub max_concurrent: usize,
-    /// CPU overcommit factor for auto-detected concurrency (default: 1.0).
-    /// Only used when max_concurrent is 0 (auto mode).
+    /// Overcommit factor applied to both CPU and memory budgets (default: 1.0).
     pub concurrency_factor: f64,
 }
 
 impl Default for SandboxConfig {
     fn default() -> Self {
         Self {
-            vcpu: DEFAULT_VCPU,
-            memory_mb: DEFAULT_MEMORY_MB,
             max_concurrent: DEFAULT_MAX_CONCURRENT,
             concurrency_factor: DEFAULT_CONCURRENCY_FACTOR,
         }
@@ -83,6 +85,11 @@ pub struct ServerConfig {
 ///
 /// Relative paths in the config are resolved against the config file's parent directory.
 pub async fn load(path: &Path) -> RunnerResult<RunnerConfig> {
+    let home = crate::paths::HomePaths::new()?;
+    load_with_home(path, &home).await
+}
+
+async fn load_with_home(path: &Path, home: &crate::paths::HomePaths) -> RunnerResult<RunnerConfig> {
     let content = tokio::fs::read_to_string(path)
         .await
         .map_err(|e| RunnerError::Config(format!("read {}: {e}", path.display())))?;
@@ -91,17 +98,7 @@ pub async fn load(path: &Path) -> RunnerResult<RunnerConfig> {
     if let Some(config_dir) = path.parent() {
         config.resolve_relative_paths(config_dir);
     }
-    validate_paths(&config).await?;
-    if config.sandbox.vcpu == 0 || config.sandbox.memory_mb == 0 {
-        return Err(RunnerError::Config(
-            "sandbox.vcpu and sandbox.memory_mb must be non-zero".into(),
-        ));
-    }
-    if !config.sandbox.concurrency_factor.is_finite() || config.sandbox.concurrency_factor <= 0.0 {
-        return Err(RunnerError::Config(
-            "sandbox.concurrency_factor must be a positive finite number".into(),
-        ));
-    }
+    validate(&config, home).await?;
     Ok(config)
 }
 
@@ -135,19 +132,54 @@ async fn check_path_exists(path: &Path, label: &str) -> RunnerResult<()> {
     Ok(())
 }
 
-async fn validate_paths(config: &RunnerConfig) -> RunnerResult<()> {
+async fn validate(config: &RunnerConfig, home: &crate::paths::HomePaths) -> RunnerResult<()> {
     check_path_exists(&config.ca_dir, "ca_dir").await?;
     check_path_exists(&config.firecracker.binary, "firecracker binary").await?;
     check_path_exists(&config.firecracker.kernel, "kernel").await?;
-    check_path_exists(&config.firecracker.rootfs, "rootfs").await?;
 
-    if let Some(snap) = &config.firecracker.snapshot {
-        check_path_exists(&snap.snapshot_path, "snapshot state").await?;
-        check_path_exists(&snap.memory_path, "snapshot memory").await?;
-        check_path_exists(&snap.overlay_path, "snapshot overlay").await?;
-        // overlay_bind_path and vsock_bind_dir are created at sandbox runtime
+    if config.profiles.is_empty() {
+        return Err(RunnerError::Config("profiles must not be empty".into()));
+    }
+    for (name, profile) in &config.profiles {
+        if !crate::profile::validate_name(name) {
+            return Err(RunnerError::Config(format!(
+                "invalid profile name: {name} (must be org/name format, lowercase alphanumeric + hyphens)"
+            )));
+        }
+        if profile.vcpu == 0 || profile.memory_mb == 0 {
+            return Err(RunnerError::Config(format!(
+                "profile {name}: vcpu and memory_mb must be non-zero"
+            )));
+        }
+        // Validate rootfs exists on disk.
+        let rootfs_path = crate::paths::RootfsPaths::new(home, &profile.rootfs_hash).rootfs();
+        check_path_exists(&rootfs_path, &format!("profile {name} rootfs")).await?;
+        // Validate snapshot files exist if snapshot_hash is set.
+        if let Some(hash) = &profile.snapshot_hash {
+            let snap_dir = home.snapshots_dir().join(hash);
+            check_path_exists(
+                &snap_dir.join("snapshot.bin"),
+                &format!("profile {name} snapshot"),
+            )
+            .await?;
+            check_path_exists(
+                &snap_dir.join("memory.bin"),
+                &format!("profile {name} snapshot memory"),
+            )
+            .await?;
+            check_path_exists(
+                &snap_dir.join("overlay.ext4"),
+                &format!("profile {name} snapshot overlay"),
+            )
+            .await?;
+        }
     }
 
+    if !config.sandbox.concurrency_factor.is_finite() || config.sandbox.concurrency_factor <= 0.0 {
+        return Err(RunnerError::Config(
+            "sandbox.concurrency_factor must be a positive finite number".into(),
+        ));
+    }
     Ok(())
 }
 
@@ -163,40 +195,33 @@ impl RunnerConfig {
         resolve(&mut self.ca_dir);
         resolve(&mut self.firecracker.binary);
         resolve(&mut self.firecracker.kernel);
-        resolve(&mut self.firecracker.rootfs);
-        if let Some(snap) = &mut self.firecracker.snapshot {
-            resolve(&mut snap.snapshot_path);
-            resolve(&mut snap.memory_path);
-            resolve(&mut snap.overlay_path);
-            resolve(&mut snap.overlay_bind_path);
-            resolve(&mut snap.vsock_bind_dir);
-        }
     }
 
-    /// Build a `sandbox_fc::SnapshotConfig` from the config's snapshot paths.
-    pub fn snapshot_config(&self) -> Option<sandbox_fc::SnapshotConfig> {
-        self.firecracker
-            .snapshot
-            .as_ref()
-            .map(|s| sandbox_fc::SnapshotConfig {
-                snapshot_path: s.snapshot_path.clone(),
-                memory_path: s.memory_path.clone(),
-                overlay_path: s.overlay_path.clone(),
-                overlay_bind_path: s.overlay_bind_path.clone(),
-                vsock_bind_dir: s.vsock_bind_dir.clone(),
-            })
-    }
-
-    /// Build a `sandbox_fc::FirecrackerConfig` from this runner config.
-    pub fn firecracker_config(&self) -> sandbox_fc::FirecrackerConfig {
+    /// Build a `sandbox_fc::FirecrackerConfig` for a given profile.
+    ///
+    /// Resolves rootfs and snapshot paths from the profile's hashes
+    /// using the standard content-addressed storage layout.
+    pub fn firecracker_config(
+        &self,
+        profile: &ProfileConfig,
+        home: &crate::paths::HomePaths,
+        concurrency: usize,
+        proxy_port: Option<u16>,
+    ) -> sandbox_fc::FirecrackerConfig {
+        let rootfs_paths = crate::paths::RootfsPaths::new(home, &profile.rootfs_hash);
+        let snapshot = profile.snapshot_hash.as_ref().map(|hash| {
+            let snapshot_output =
+                sandbox_fc::SnapshotOutputPaths::new(home.snapshots_dir().join(hash));
+            snapshot_output.snapshot_config(hash)
+        });
         sandbox_fc::FirecrackerConfig {
             binary_path: self.firecracker.binary.clone(),
             kernel_path: self.firecracker.kernel.clone(),
-            rootfs_path: self.firecracker.rootfs.clone(),
+            rootfs_path: rootfs_paths.rootfs(),
             base_dir: self.base_dir.clone(),
-            concurrency: self.sandbox.max_concurrent,
-            proxy_port: None,
-            snapshot: self.snapshot_config(),
+            concurrency,
+            proxy_port,
+            snapshot,
         }
     }
 }
@@ -205,13 +230,50 @@ impl RunnerConfig {
 mod tests {
     use super::*;
 
+    /// Create a HomePaths rooted in a temp dir and populate fake rootfs/snapshot
+    /// files for the given profile hashes so config validation passes.
+    async fn test_home_with_artifacts(
+        dir: &std::path::Path,
+        profiles: &[(&str, Option<&str>)], // (rootfs_hash, snapshot_hash)
+    ) -> crate::paths::HomePaths {
+        let home = crate::paths::HomePaths::with_root(dir.join(".vm0-runner"));
+        for &(rootfs_hash, snapshot_hash) in profiles {
+            let rootfs = crate::paths::RootfsPaths::new(&home, rootfs_hash).rootfs();
+            tokio::fs::create_dir_all(rootfs.parent().unwrap())
+                .await
+                .unwrap();
+            tokio::fs::write(&rootfs, b"").await.unwrap();
+            if let Some(hash) = snapshot_hash {
+                let snap_dir = home.snapshots_dir().join(hash);
+                tokio::fs::create_dir_all(&snap_dir).await.unwrap();
+                for name in ["snapshot.bin", "memory.bin", "overlay.ext4"] {
+                    tokio::fs::write(snap_dir.join(name), b"").await.unwrap();
+                }
+            }
+        }
+        home
+    }
+
+    fn make_profiles() -> BTreeMap<String, ProfileConfig> {
+        let mut profiles = BTreeMap::new();
+        profiles.insert(
+            "vm0/default".into(),
+            ProfileConfig {
+                rootfs_hash: "abc123".into(),
+                snapshot_hash: Some("def456".into()),
+                vcpu: 2,
+                memory_mb: 2048,
+            },
+        );
+        profiles
+    }
+
     #[tokio::test]
-    async fn load_full_config() {
+    async fn load_config_with_profiles() {
         let dir = tempfile::tempdir().unwrap();
         let fc = dir.path().join("firecracker");
         let kernel = dir.path().join("vmlinux");
-        let rootfs = dir.path().join("rootfs.squashfs");
-        for f in [&fc, &kernel, &rootfs] {
+        for f in [&fc, &kernel] {
             tokio::fs::write(f, b"").await.unwrap();
         }
 
@@ -224,10 +286,18 @@ ca_dir: {ca_dir}
 firecracker:
   binary: {fc}
   kernel: {kernel}
-  rootfs: {rootfs}
+profiles:
+  vm0/default:
+    rootfs_hash: abc123
+    snapshot_hash: def456
+    vcpu: 2
+    memory_mb: 2048
+  vm0/browser:
+    rootfs_hash: fed987
+    snapshot_hash: cba654
+    vcpu: 4
+    memory_mb: 4096
 sandbox:
-  vcpu: 4
-  memory_mb: 4096
   max_concurrent: 8
   concurrency_factor: 2.0
 server:
@@ -238,17 +308,26 @@ server:
             ca_dir = dir.path().display(),
             fc = fc.display(),
             kernel = kernel.display(),
-            rootfs = rootfs.display(),
         );
+
+        let home = test_home_with_artifacts(
+            dir.path(),
+            &[("abc123", Some("def456")), ("fed987", Some("cba654"))],
+        )
+        .await;
 
         let config_path = dir.path().join("runner.yaml");
         tokio::fs::write(&config_path, &yaml).await.unwrap();
 
-        let config = load(&config_path).await.unwrap();
+        let config = load_with_home(&config_path, &home).await.unwrap();
         assert_eq!(config.name, "test-runner");
-        assert_eq!(config.group, "acme/prod");
-        assert_eq!(config.sandbox.vcpu, 4);
-        assert_eq!(config.sandbox.memory_mb, 4096);
+        assert_eq!(config.profiles.len(), 2);
+        let default = &config.profiles["vm0/default"];
+        assert_eq!(default.vcpu, 2);
+        assert_eq!(default.rootfs_hash, "abc123");
+        let browser = &config.profiles["vm0/browser"];
+        assert_eq!(browser.vcpu, 4);
+        assert_eq!(browser.memory_mb, 4096);
         assert_eq!(config.sandbox.max_concurrent, 8);
         assert!((config.sandbox.concurrency_factor - 2.0).abs() < f64::EPSILON);
         let server = config.server.unwrap();
@@ -261,10 +340,10 @@ server:
         let dir = tempfile::tempdir().unwrap();
         let fc = dir.path().join("firecracker");
         let kernel = dir.path().join("vmlinux");
-        let rootfs = dir.path().join("rootfs.squashfs");
-        for f in [&fc, &kernel, &rootfs] {
+        for f in [&fc, &kernel] {
             tokio::fs::write(f, b"").await.unwrap();
         }
+        let home = test_home_with_artifacts(dir.path(), &[("abc", None)]).await;
 
         let yaml = format!(
             r#"
@@ -275,21 +354,22 @@ ca_dir: {ca_dir}
 firecracker:
   binary: {fc}
   kernel: {kernel}
-  rootfs: {rootfs}
+profiles:
+  vm0/default:
+    rootfs_hash: abc
+    vcpu: 2
+    memory_mb: 2048
 "#,
             base_dir = dir.path().display(),
             ca_dir = dir.path().display(),
             fc = fc.display(),
             kernel = kernel.display(),
-            rootfs = rootfs.display(),
         );
 
         let config_path = dir.path().join("runner.yaml");
         tokio::fs::write(&config_path, &yaml).await.unwrap();
 
-        let config = load(&config_path).await.unwrap();
-        assert_eq!(config.sandbox.vcpu, DEFAULT_VCPU);
-        assert_eq!(config.sandbox.memory_mb, DEFAULT_MEMORY_MB);
+        let config = load_with_home(&config_path, &home).await.unwrap();
         assert_eq!(config.sandbox.max_concurrent, DEFAULT_MAX_CONCURRENT);
         assert!(
             (config.sandbox.concurrency_factor - DEFAULT_CONCURRENCY_FACTOR).abs() < f64::EPSILON
@@ -298,38 +378,14 @@ firecracker:
     }
 
     #[tokio::test]
-    async fn load_fails_on_missing_paths() {
-        let dir = tempfile::tempdir().unwrap();
-        let yaml = format!(
-            r#"
-name: test
-group: test/group
-base_dir: {base_dir}
-ca_dir: /nonexistent/ca
-firecracker:
-  binary: /nonexistent/firecracker
-  kernel: /nonexistent/kernel
-  rootfs: /nonexistent/rootfs
-"#,
-            base_dir = dir.path().display(),
-        );
-
-        let config_path = dir.path().join("runner.yaml");
-        tokio::fs::write(&config_path, &yaml).await.unwrap();
-
-        let err = load(&config_path).await.unwrap_err();
-        assert!(err.to_string().contains("not found"), "got: {err}");
-    }
-
-    #[tokio::test]
-    async fn load_rejects_zero_vcpu() {
+    async fn load_rejects_empty_profiles() {
         let dir = tempfile::tempdir().unwrap();
         let fc = dir.path().join("firecracker");
         let kernel = dir.path().join("vmlinux");
-        let rootfs = dir.path().join("rootfs.squashfs");
-        for f in [&fc, &kernel, &rootfs] {
+        for f in [&fc, &kernel] {
             tokio::fs::write(f, b"").await.unwrap();
         }
+        let home = test_home_with_artifacts(dir.path(), &[]).await;
 
         let yaml = format!(
             r#"
@@ -340,37 +396,33 @@ ca_dir: {ca_dir}
 firecracker:
   binary: {fc}
   kernel: {kernel}
-  rootfs: {rootfs}
-sandbox:
-  vcpu: 0
-  memory_mb: 2048
+profiles: {{}}
 "#,
             base_dir = dir.path().display(),
             ca_dir = dir.path().display(),
             fc = fc.display(),
             kernel = kernel.display(),
-            rootfs = rootfs.display(),
         );
 
         let config_path = dir.path().join("runner.yaml");
         tokio::fs::write(&config_path, &yaml).await.unwrap();
 
-        let err = load(&config_path).await.unwrap_err();
+        let err = load_with_home(&config_path, &home).await.unwrap_err();
         assert!(
-            err.to_string().contains("non-zero"),
-            "expected non-zero error, got: {err}"
+            err.to_string().contains("profiles must not be empty"),
+            "got: {err}"
         );
     }
 
     #[tokio::test]
-    async fn load_rejects_zero_memory_mb() {
+    async fn load_rejects_invalid_profile_name() {
         let dir = tempfile::tempdir().unwrap();
         let fc = dir.path().join("firecracker");
         let kernel = dir.path().join("vmlinux");
-        let rootfs = dir.path().join("rootfs.squashfs");
-        for f in [&fc, &kernel, &rootfs] {
+        for f in [&fc, &kernel] {
             tokio::fs::write(f, b"").await.unwrap();
         }
+        let home = test_home_with_artifacts(dir.path(), &[]).await;
 
         let yaml = format!(
             r#"
@@ -381,26 +433,64 @@ ca_dir: {ca_dir}
 firecracker:
   binary: {fc}
   kernel: {kernel}
-  rootfs: {rootfs}
-sandbox:
-  vcpu: 2
-  memory_mb: 0
+profiles:
+  bad-name:
+    rootfs_hash: abc
+    vcpu: 2
+    memory_mb: 2048
 "#,
             base_dir = dir.path().display(),
             ca_dir = dir.path().display(),
             fc = fc.display(),
             kernel = kernel.display(),
-            rootfs = rootfs.display(),
         );
 
         let config_path = dir.path().join("runner.yaml");
         tokio::fs::write(&config_path, &yaml).await.unwrap();
 
-        let err = load(&config_path).await.unwrap_err();
+        let err = load_with_home(&config_path, &home).await.unwrap_err();
         assert!(
-            err.to_string().contains("non-zero"),
-            "expected non-zero error, got: {err}"
+            err.to_string().contains("invalid profile name"),
+            "got: {err}"
         );
+    }
+
+    #[tokio::test]
+    async fn load_rejects_zero_vcpu_in_profile() {
+        let dir = tempfile::tempdir().unwrap();
+        let fc = dir.path().join("firecracker");
+        let kernel = dir.path().join("vmlinux");
+        for f in [&fc, &kernel] {
+            tokio::fs::write(f, b"").await.unwrap();
+        }
+        let home = test_home_with_artifacts(dir.path(), &[]).await;
+
+        let yaml = format!(
+            r#"
+name: test
+group: test/group
+base_dir: {base_dir}
+ca_dir: {ca_dir}
+firecracker:
+  binary: {fc}
+  kernel: {kernel}
+profiles:
+  vm0/default:
+    rootfs_hash: abc
+    vcpu: 0
+    memory_mb: 2048
+"#,
+            base_dir = dir.path().display(),
+            ca_dir = dir.path().display(),
+            fc = fc.display(),
+            kernel = kernel.display(),
+        );
+
+        let config_path = dir.path().join("runner.yaml");
+        tokio::fs::write(&config_path, &yaml).await.unwrap();
+
+        let err = load_with_home(&config_path, &home).await.unwrap_err();
+        assert!(err.to_string().contains("non-zero"), "got: {err}");
     }
 
     #[tokio::test]
@@ -408,10 +498,11 @@ sandbox:
         let dir = tempfile::tempdir().unwrap();
         let fc = dir.path().join("firecracker");
         let kernel = dir.path().join("vmlinux");
-        let rootfs = dir.path().join("rootfs.squashfs");
-        for f in [&fc, &kernel, &rootfs] {
+        for f in [&fc, &kernel] {
             tokio::fs::write(f, b"").await.unwrap();
         }
+
+        let home = test_home_with_artifacts(dir.path(), &[("abc", None)]).await;
 
         for bad_value in ["0.0", "-1.0", ".nan", ".inf", "-.inf"] {
             let yaml = format!(
@@ -423,7 +514,11 @@ ca_dir: {ca_dir}
 firecracker:
   binary: {fc}
   kernel: {kernel}
-  rootfs: {rootfs}
+profiles:
+  vm0/default:
+    rootfs_hash: abc
+    vcpu: 2
+    memory_mb: 2048
 sandbox:
   concurrency_factor: {bad_value}
 "#,
@@ -431,13 +526,12 @@ sandbox:
                 ca_dir = dir.path().display(),
                 fc = fc.display(),
                 kernel = kernel.display(),
-                rootfs = rootfs.display(),
             );
 
             let config_path = dir.path().join("runner.yaml");
             tokio::fs::write(&config_path, &yaml).await.unwrap();
 
-            let err = load(&config_path).await.unwrap_err();
+            let err = load_with_home(&config_path, &home).await.unwrap_err();
             assert!(
                 err.to_string().contains("concurrency_factor"),
                 "expected concurrency_factor error for {bad_value}, got: {err}"
@@ -446,70 +540,14 @@ sandbox:
     }
 
     #[tokio::test]
-    async fn load_with_snapshot() {
-        let dir = tempfile::tempdir().unwrap();
-        let fc = dir.path().join("firecracker");
-        let kernel = dir.path().join("vmlinux");
-        let rootfs = dir.path().join("rootfs.squashfs");
-        let snap = dir.path().join("snapshot.bin");
-        let mem = dir.path().join("memory.bin");
-        let overlay = dir.path().join("overlay.ext4");
-        let overlay_bind = dir.path().join("overlay_bind.ext4");
-        let vsock_dir = dir.path().join("vsock");
-        for f in [&fc, &kernel, &rootfs, &snap, &mem, &overlay] {
-            tokio::fs::write(f, b"").await.unwrap();
-        }
-
-        let yaml = format!(
-            r#"
-name: test
-group: test/group
-base_dir: {base_dir}
-ca_dir: {ca_dir}
-firecracker:
-  binary: {fc}
-  kernel: {kernel}
-  rootfs: {rootfs}
-  snapshot:
-    snapshot_path: {snap}
-    memory_path: {mem}
-    overlay_path: {overlay}
-    overlay_bind_path: {overlay_bind}
-    vsock_bind_dir: {vsock_dir}
-"#,
-            base_dir = dir.path().display(),
-            ca_dir = dir.path().display(),
-            fc = fc.display(),
-            kernel = kernel.display(),
-            rootfs = rootfs.display(),
-            snap = snap.display(),
-            mem = mem.display(),
-            overlay = overlay.display(),
-            overlay_bind = overlay_bind.display(),
-            vsock_dir = vsock_dir.display(),
-        );
-
-        let config_path = dir.path().join("runner.yaml");
-        tokio::fs::write(&config_path, &yaml).await.unwrap();
-
-        let config = load(&config_path).await.unwrap();
-        let snap_config = config.snapshot_config().unwrap();
-        assert_eq!(snap_config.snapshot_path, snap);
-        assert_eq!(snap_config.memory_path, mem);
-        assert_eq!(snap_config.overlay_path, overlay);
-        assert_eq!(snap_config.overlay_bind_path, overlay_bind);
-        assert_eq!(snap_config.vsock_bind_dir, vsock_dir);
-    }
-
-    #[tokio::test]
     async fn generate_then_load_round_trip() {
         let dir = tempfile::tempdir().unwrap();
         let fc = dir.path().join("firecracker");
         let kernel = dir.path().join("vmlinux");
-        let rootfs = dir.path().join("rootfs.squashfs");
-        for f in [&fc, &kernel, &rootfs] {
+        for f in [&fc, &kernel] {
             tokio::fs::write(f, b"").await.unwrap();
         }
+        let home = test_home_with_artifacts(dir.path(), &[("abc123", Some("def456"))]).await;
 
         let runner_dir = dir.path().join("my-runner");
         let config = RunnerConfig {
@@ -517,15 +555,9 @@ firecracker:
             group: "acme/prod".into(),
             base_dir: runner_dir.clone(),
             ca_dir: dir.path().to_path_buf(),
-            firecracker: FirecrackerConfig {
-                binary: fc.clone(),
-                kernel: kernel.clone(),
-                rootfs: rootfs.clone(),
-                snapshot: None,
-            },
+            firecracker: FirecrackerConfig { binary: fc, kernel },
+            profiles: make_profiles(),
             sandbox: SandboxConfig {
-                vcpu: 4,
-                memory_mb: 4096,
                 max_concurrent: 8,
                 concurrency_factor: 2.0,
             },
@@ -537,48 +569,9 @@ firecracker:
 
         generate(&config).await.unwrap();
 
-        let loaded = load(&runner_dir.join("runner.yaml")).await.unwrap();
-        assert_eq!(loaded, config);
-    }
-
-    #[tokio::test]
-    async fn generate_then_load_round_trip_with_snapshot() {
-        let dir = tempfile::tempdir().unwrap();
-        let fc = dir.path().join("firecracker");
-        let kernel = dir.path().join("vmlinux");
-        let rootfs = dir.path().join("rootfs.squashfs");
-        let snap = dir.path().join("snapshot.bin");
-        let mem = dir.path().join("memory.bin");
-        let overlay = dir.path().join("overlay.ext4");
-        for f in [&fc, &kernel, &rootfs, &snap, &mem, &overlay] {
-            tokio::fs::write(f, b"").await.unwrap();
-        }
-
-        let runner_dir = dir.path().join("my-runner");
-        let config = RunnerConfig {
-            name: "snap-runner".into(),
-            group: "acme/staging".into(),
-            base_dir: runner_dir.clone(),
-            ca_dir: dir.path().to_path_buf(),
-            firecracker: FirecrackerConfig {
-                binary: fc,
-                kernel,
-                rootfs,
-                snapshot: Some(SnapshotConfig {
-                    snapshot_path: snap,
-                    memory_path: mem,
-                    overlay_path: overlay,
-                    overlay_bind_path: dir.path().join("work/overlay.ext4"),
-                    vsock_bind_dir: dir.path().join("work/vsock"),
-                }),
-            },
-            sandbox: SandboxConfig::default(),
-            server: None,
-        };
-
-        generate(&config).await.unwrap();
-
-        let loaded = load(&runner_dir.join("runner.yaml")).await.unwrap();
+        let loaded = load_with_home(&runner_dir.join("runner.yaml"), &home)
+            .await
+            .unwrap();
         assert_eq!(loaded, config);
     }
 
@@ -586,14 +579,13 @@ firecracker:
     async fn load_resolves_relative_paths() {
         let dir = tempfile::tempdir().unwrap();
 
-        // Create files in a subdirectory
         let sub = dir.path().join("artifacts");
         tokio::fs::create_dir_all(&sub).await.unwrap();
-        for name in ["firecracker", "vmlinux", "rootfs.squashfs"] {
+        for name in ["firecracker", "vmlinux"] {
             tokio::fs::write(sub.join(name), b"").await.unwrap();
         }
+        let home = test_home_with_artifacts(dir.path(), &[("abc", None)]).await;
 
-        // YAML uses relative paths (relative to config file location)
         let yaml = r#"
 name: test
 group: test/group
@@ -602,20 +594,55 @@ ca_dir: artifacts
 firecracker:
   binary: artifacts/firecracker
   kernel: artifacts/vmlinux
-  rootfs: artifacts/rootfs.squashfs
+profiles:
+  vm0/default:
+    rootfs_hash: abc
+    vcpu: 2
+    memory_mb: 2048
 "#;
 
         let config_path = dir.path().join("runner.yaml");
         tokio::fs::write(&config_path, yaml).await.unwrap();
 
-        let config = load(&config_path).await.unwrap();
+        let config = load_with_home(&config_path, &home).await.unwrap();
 
-        // All paths should be resolved to absolute paths under dir
         assert!(config.base_dir.is_absolute());
         assert_eq!(config.base_dir, dir.path().join("my-runner"));
         assert_eq!(config.ca_dir, sub);
         assert_eq!(config.firecracker.binary, sub.join("firecracker"));
         assert_eq!(config.firecracker.kernel, sub.join("vmlinux"));
-        assert_eq!(config.firecracker.rootfs, sub.join("rootfs.squashfs"));
+    }
+
+    #[test]
+    fn firecracker_config_resolves_paths() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = crate::paths::HomePaths::with_root(dir.path().to_path_buf());
+
+        let config = RunnerConfig {
+            name: "test".into(),
+            group: "test/group".into(),
+            base_dir: dir.path().join("runner"),
+            ca_dir: dir.path().join("ca"),
+            firecracker: FirecrackerConfig {
+                binary: dir.path().join("firecracker"),
+                kernel: dir.path().join("vmlinux"),
+            },
+            profiles: make_profiles(),
+            sandbox: SandboxConfig::default(),
+            server: None,
+        };
+
+        let profile = &config.profiles["vm0/default"];
+        let fc = config.firecracker_config(profile, &home, 4, Some(8080));
+
+        assert_eq!(fc.binary_path, dir.path().join("firecracker"));
+        assert_eq!(fc.kernel_path, dir.path().join("vmlinux"));
+        assert_eq!(
+            fc.rootfs_path,
+            home.rootfs_dir().join("abc123").join("rootfs.squashfs")
+        );
+        assert_eq!(fc.concurrency, 4);
+        assert_eq!(fc.proxy_port, Some(8080));
+        assert!(fc.snapshot.is_some());
     }
 }

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -11,6 +11,7 @@ mod network_logs;
 mod paths;
 mod prefetch;
 mod process;
+mod profile;
 mod provider;
 mod proxy;
 mod resource_budget;

--- a/crates/runner/src/paths.rs
+++ b/crates/runner/src/paths.rs
@@ -135,30 +135,6 @@ impl HomePaths {
     pub fn snapshot_lock(&self, hash: &str) -> PathBuf {
         self.locks_dir().join(format!("snapshot-{hash}.lock"))
     }
-
-    /// Extract the rootfs hash from a managed rootfs file path.
-    ///
-    /// Returns `Some(hash)` if the path is `<rootfs_dir>/{hash}/<file>`, `None` otherwise.
-    pub fn extract_rootfs_hash(&self, rootfs_path: &Path) -> Option<String> {
-        let parent = rootfs_path.parent()?;
-        if parent.parent()? == self.rootfs_dir() {
-            parent.file_name()?.to_str().map(String::from)
-        } else {
-            None
-        }
-    }
-
-    /// Extract the snapshot hash from a managed snapshot file path.
-    ///
-    /// Returns `Some(hash)` if the path is `<snapshots_dir>/{hash}/<file>`, `None` otherwise.
-    pub fn extract_snapshot_hash(&self, snapshot_path: &Path) -> Option<String> {
-        let parent = snapshot_path.parent()?;
-        if parent.parent()? == self.snapshots_dir() {
-            parent.file_name()?.to_str().map(String::from)
-        } else {
-            None
-        }
-    }
 }
 
 /// Paths for a rootfs build output directory (keyed by input hash).
@@ -219,50 +195,5 @@ impl LogPaths {
         (name.starts_with("network-") && name.ends_with(".jsonl"))
             || (name.starts_with("system-") && name.ends_with(".log"))
             || (name.starts_with("metrics-") && name.ends_with(".jsonl"))
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn home(root: &Path) -> HomePaths {
-        HomePaths::with_root(root.to_path_buf())
-    }
-
-    #[test]
-    fn extract_rootfs_hash_from_managed_path() {
-        let h = home(Path::new("/home/user/.vm0-runner"));
-        let path = Path::new("/home/user/.vm0-runner/rootfs/abc123/rootfs.squashfs");
-        assert_eq!(h.extract_rootfs_hash(path).as_deref(), Some("abc123"));
-    }
-
-    #[test]
-    fn extract_rootfs_hash_returns_none_for_unmanaged_path() {
-        let h = home(Path::new("/home/user/.vm0-runner"));
-        let path = Path::new("/other/rootfs/abc123/rootfs.squashfs");
-        assert_eq!(h.extract_rootfs_hash(path), None);
-    }
-
-    #[test]
-    fn extract_rootfs_hash_returns_none_for_bare_file() {
-        let h = home(Path::new("/home/user/.vm0-runner"));
-        let path = Path::new("/home/user/.vm0-runner/rootfs/rootfs.squashfs");
-        // parent = rootfs/, parent.parent = .vm0-runner/ — doesn't match rootfs_dir
-        assert_eq!(h.extract_rootfs_hash(path), None);
-    }
-
-    #[test]
-    fn extract_snapshot_hash_from_managed_path() {
-        let h = home(Path::new("/home/user/.vm0-runner"));
-        let path = Path::new("/home/user/.vm0-runner/snapshots/def456/snapshot.bin");
-        assert_eq!(h.extract_snapshot_hash(path).as_deref(), Some("def456"));
-    }
-
-    #[test]
-    fn extract_snapshot_hash_returns_none_for_unmanaged_path() {
-        let h = home(Path::new("/home/user/.vm0-runner"));
-        let path = Path::new("/tmp/snapshots/def456/snapshot.bin");
-        assert_eq!(h.extract_snapshot_hash(path), None);
     }
 }

--- a/crates/runner/src/profile.rs
+++ b/crates/runner/src/profile.rs
@@ -1,0 +1,95 @@
+use crate::error::{RunnerError, RunnerResult};
+
+const EMBEDDED_DOCKERFILE_DEFAULT: &str = include_str!("../scripts/rootfs.Dockerfile");
+
+/// A platform-defined profile specifying rootfs image and VM resources.
+pub struct ProfileDef {
+    /// Embedded Dockerfile content for building the rootfs.
+    pub dockerfile: &'static str,
+    /// Number of vCPUs for VMs using this profile.
+    pub vcpu: u32,
+    /// Memory in MiB for VMs using this profile.
+    pub memory_mb: u32,
+}
+
+pub const DEFAULT_PROFILE: &str = "vm0/default";
+
+/// Return the profile definition for a given profile name.
+pub fn get(name: &str) -> RunnerResult<&'static ProfileDef> {
+    static DEFAULT: ProfileDef = ProfileDef {
+        dockerfile: EMBEDDED_DOCKERFILE_DEFAULT,
+        vcpu: 2,
+        memory_mb: 2048,
+    };
+
+    // Phase 1: only vm0/default is buildable. vm0/browser will be added
+    // in PR 5 when rootfs-browser.Dockerfile is created.
+    match name {
+        "vm0/default" => Ok(&DEFAULT),
+        _ => Err(RunnerError::Config(format!(
+            "unknown profile: {name}. available profiles: vm0/default"
+        ))),
+    }
+}
+
+/// Validate that a profile name follows the `org/name` format.
+/// Each part must be lowercase alphanumeric + hyphens.
+pub fn validate_name(name: &str) -> bool {
+    let Some((org, profile_name)) = name.split_once('/') else {
+        return false;
+    };
+    if org.is_empty() || profile_name.is_empty() {
+        return false;
+    }
+    // No additional slashes
+    if profile_name.contains('/') {
+        return false;
+    }
+    let valid_part = |s: &str| {
+        s.chars()
+            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
+            && !s.starts_with('-')
+            && !s.ends_with('-')
+    };
+    valid_part(org) && valid_part(profile_name)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn get_default_profile() {
+        let def = get("vm0/default").unwrap();
+        assert_eq!(def.vcpu, 2);
+        assert_eq!(def.memory_mb, 2048);
+        assert!(!def.dockerfile.is_empty());
+    }
+
+    #[test]
+    fn get_unknown_profile_fails() {
+        assert!(get("vm0/browser").is_err());
+        assert!(get("unknown").is_err());
+    }
+
+    #[test]
+    fn validate_name_valid() {
+        assert!(validate_name("vm0/default"));
+        assert!(validate_name("vm0/browser"));
+        assert!(validate_name("my-org/data-science"));
+        assert!(validate_name("acme/my-profile-123"));
+    }
+
+    #[test]
+    fn validate_name_invalid() {
+        assert!(!validate_name("default")); // no org
+        assert!(!validate_name("/default")); // empty org
+        assert!(!validate_name("vm0/")); // empty name
+        assert!(!validate_name("vm0/my/nested")); // extra slash
+        assert!(!validate_name("VM0/default")); // uppercase
+        assert!(!validate_name("vm0/Default")); // uppercase
+        assert!(!validate_name("-vm0/default")); // leading hyphen
+        assert!(!validate_name("vm0/default-")); // trailing hyphen
+        assert!(!validate_name("vm0/def ault")); // space
+    }
+}


### PR DESCRIPTION
## Summary

- New `profile.rs`: `ProfileDef` struct, `get()` lookup, `validate_name()` for `org/name` format
- `config.rs`: replace `firecracker.rootfs`/`snapshot` + `sandbox.vcpu`/`memory_mb` with `profiles: HashMap<String, ProfileConfig>`
- `build.rs`: `--profile` flag selects Dockerfile and vcpu/memory from profile definition
- `rootfs.rs`: parameterized Dockerfile content (no longer hardcoded single Dockerfile)
- `config` cmd: repeated `--profile`/`--rootfs-hash`/`--snapshot-hash` groups for multi-profile config generation
- `start.rs`: resolve rootfs/snapshot paths from profile hashes, per-profile resource locks and memory prefetch
- Remove `extract_rootfs_hash`/`extract_snapshot_hash` from paths.rs (hashes now stored directly in config)

No backward compatibility — old runner.yaml must be regenerated via `runner config`.

Closes #4941
Part of #4500

## Test plan

- [x] `get_default_profile` — returns correct vcpu/memory/dockerfile
- [x] `get_unknown_profile_fails` — rejects unknown profiles
- [x] `validate_name_valid` — accepts org/name format
- [x] `validate_name_invalid` — rejects bad formats (no org, uppercase, spaces, etc.)
- [x] `load_config_with_profiles` — parses multi-profile YAML
- [x] `load_defaults_for_sandbox` — sandbox defaults when omitted
- [x] `load_rejects_empty_profiles` — empty profiles map rejected
- [x] `load_rejects_invalid_profile_name` — bad name format rejected
- [x] `load_rejects_zero_vcpu_in_profile` — zero vcpu rejected
- [x] `load_rejects_invalid_concurrency_factor` — bad factor values rejected
- [x] `generate_then_load_round_trip` — serialize → deserialize preserves config
- [x] `load_resolves_relative_paths` — relative paths resolved against config dir

🤖 Generated with [Claude Code](https://claude.com/claude-code)