### PR TITLE
fix: hide credit and invite buttons from chat page

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/zero-app-shell.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-app-shell.tsx
@@ -8,7 +8,6 @@ import {
   type SubagentInfo,
 } from "./zero-sidebar.tsx";
 import { Button } from "@vm0/ui";
-import { IconUserPlus, IconCoins } from "@tabler/icons-react";
 import { ZeroAboutPage } from "./zero-about-page.tsx";
 import { ZeroContent } from "./zero-content.tsx";
 import { ZeroOnboarding } from "./zero-onboarding.tsx";
@@ -239,27 +238,6 @@ function GuestNavBar({ onAbout }: { onAbout: () => void }) {
   );
 }
 
-function TopBarActions() {
-  return (
-    <div className="absolute right-4 top-4 z-10 flex items-center gap-2">
-      <button
-        type="button"
-        className="zero-btn-morandi flex h-9 items-center gap-2 rounded-lg px-4 text-sm font-medium transition-colors"
-      >
-        <IconCoins size={14} stroke={1.5} />
-        <span>500</span>
-      </button>
-      <button
-        type="button"
-        className="zero-btn-morandi flex h-9 items-center gap-2 rounded-lg px-4 text-sm font-medium transition-colors"
-      >
-        <IconUserPlus size={14} stroke={1.5} />
-        <span>Invite</span>
-      </button>
-    </div>
-  );
-}
-
 interface ZeroAppShellProps {
   initialJobAgent?: string | null;
 }
@@ -416,7 +394,7 @@ export function ZeroAppShell({ initialJobAgent }: ZeroAppShellProps) {
         onResetAgent={() => detach(resetDefaultAgent(), Reason.DomCallback)}
       />
       <div className="flex flex-1 flex-col min-w-0 zero-workspace-bg">
-        {isLoggedIn && activeId === "chat" && !inSession && <TopBarActions />}
+        {/* TopBarActions (credit & invite) hidden until feature is ready */}
         {!isLoggedIn && <GuestNavBar onAbout={() => setShowAboutPage(true)} />}
         {showAboutPage ? (
           <ZeroAboutPage onBack={() => setShowAboutPage(false)} />


### PR DESCRIPTION
## Summary
- Remove the credit counter (500) and Invite button from the chat page header
- These are placeholder UI elements — will be re-added when the feature is implemented

## Test plan
- [ ] Chat page no longer shows credit/invite buttons in top-right corner

🤖 Generated with [Claude Code](https://claude.com/claude-code)