### PR TITLE
fix(slack): remove documentation links from app home and help message

### DIFF
--- a/turbo/apps/web/src/lib/slack/blocks.ts
+++ b/turbo/apps/web/src/lib/slack/blocks.ts
@@ -11,8 +11,6 @@ import type {
 import { getPlatformUrl } from "../url";
 import type { DeepLink } from "../deep-links";
 
-const SLACK_DOCS_URL = "https://docs.vm0.ai/docs/integrations/slack";
-
 /**
  * Build the App Home tab view
  *
@@ -190,16 +188,6 @@ export function buildAppHomeView(options: {
     },
   });
 
-  blocks.push({
-    type: "context",
-    elements: [
-      {
-        type: "mrkdwn",
-        text: `:book: <${SLACK_DOCS_URL}|View full documentation>`,
-      },
-    ],
-  });
-
   blocks.push({ type: "divider" });
 
   blocks.push({
@@ -372,15 +360,6 @@ export function buildHelpMessage(options?: {
         type: "mrkdwn",
         text: "*Usage*\n\u2022 `@Zero <message>` - Send a message to your agent",
       },
-    },
-    {
-      type: "context",
-      elements: [
-        {
-          type: "mrkdwn",
-          text: `:book: <${SLACK_DOCS_URL}|View full documentation>`,
-        },
-      ],
     },
   ];
 }


### PR DESCRIPTION
## Summary
- Remove the `SLACK_DOCS_URL` constant and documentation link blocks from the Slack App Home view and help message
- The "View full documentation" context blocks are no longer needed

## Test plan
- [ ] Verify Slack App Home tab renders correctly without the docs link
- [ ] Verify `/help` or help message renders correctly without the docs link
- [ ] Confirm no remaining references to `SLACK_DOCS_URL`

🤖 Generated with [Claude Code](https://claude.com/claude-code)