### PR TITLE
refactor: merge volume/artifact/memory capabilities into storage:read and storage:write

### DIFF
--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -917,7 +917,7 @@ mod tests {
     #[test]
     fn build_env_json_capabilities_inject_cli_vars() {
         let mut ctx = minimal_context();
-        ctx.experimental_capabilities = Some(vec!["volume:read".into()]);
+        ctx.experimental_capabilities = Some(vec!["storage:read".into()]);
         ctx.agent_org_slug = Some("my-org".into());
         let env = build_env_json(&ctx, "http://localhost");
         assert_eq!(env.get("VM0_TOKEN").unwrap(), "tok");
@@ -944,7 +944,7 @@ mod tests {
     #[test]
     fn build_env_json_capabilities_cli_vars_override_user_env() {
         let mut ctx = minimal_context();
-        ctx.experimental_capabilities = Some(vec!["volume:read".into()]);
+        ctx.experimental_capabilities = Some(vec!["storage:read".into()]);
         ctx.agent_org_slug = Some("my-org".into());
         ctx.environment = Some(HashMap::from([
             ("VM0_TOKEN".into(), "tampered".into()),
@@ -963,11 +963,11 @@ mod tests {
             "sandboxToken": "tok",
             "workingDir": "/workspace",
             "cliAgentType": "claude-code",
-            "experimentalCapabilities": ["volume:read", "artifact:write"]
+            "experimentalCapabilities": ["storage:read", "storage:write"]
         });
         let ctx: ExecutionContext = serde_json::from_value(json).unwrap();
         let caps = ctx.experimental_capabilities.unwrap();
-        assert_eq!(caps, vec!["volume:read", "artifact:write"]);
+        assert_eq!(caps, vec!["storage:read", "storage:write"]);
     }
 
     #[test]

--- a/turbo/apps/web/app/api/agent/composes/__tests__/sandbox-capability.test.ts
+++ b/turbo/apps/web/app/api/agent/composes/__tests__/sandbox-capability.test.ts
@@ -64,7 +64,7 @@ describe("Sandbox capability enforcement on compose routes", () => {
 
       mockClerk({ userId: null });
       const token = await generateSandboxToken(user.userId, "run-123", [
-        "volume:read",
+        "storage:read",
       ]);
 
       const request = createTestRequest(
@@ -188,7 +188,7 @@ describe("Sandbox capability enforcement on compose routes", () => {
     it("sandbox token without agent:read gets 401", async () => {
       mockClerk({ userId: null });
       const token = await generateSandboxToken(user.userId, "run-123", [
-        "volume:write",
+        "storage:write",
       ]);
 
       const request = createTestRequest(
@@ -233,7 +233,7 @@ describe("Sandbox capability enforcement on compose routes", () => {
 
       mockClerk({ userId: null });
       const token = await generateSandboxToken(user.userId, "run-123", [
-        "volume:read",
+        "storage:read",
       ]);
 
       const request = createTestRequest(
@@ -322,7 +322,7 @@ describe("Sandbox capability enforcement on compose routes", () => {
 
       mockClerk({ userId: null });
       const token = await generateSandboxToken(user.userId, "run-123", [
-        "volume:read",
+        "storage:read",
       ]);
 
       const request = createTestRequest(
@@ -368,7 +368,7 @@ describe("Sandbox capability enforcement on compose routes", () => {
 
       mockClerk({ userId: null });
       const token = await generateSandboxToken(user.userId, "run-123", [
-        "volume:read",
+        "storage:read",
       ]);
 
       const request = createTestRequest(

--- a/turbo/apps/web/app/api/agent/runs/[id]/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/__tests__/route.test.ts
@@ -144,7 +144,7 @@ describe("GET /api/agent/runs/:id - Get Run By ID", () => {
     it("should reject sandbox token without agent-run:read", async () => {
       mockClerk({ userId: null });
       const token = await generateSandboxToken(user.userId, "run-1", [
-        "volume:read",
+        "storage:read",
       ]);
 
       const request = createTestRequest(

--- a/turbo/apps/web/app/api/agent/runs/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/__tests__/route.test.ts
@@ -1447,7 +1447,7 @@ describe("POST /api/agent/runs - Internal Runs API", () => {
     it("should reject sandbox token without agent-run:read for list", async () => {
       mockClerk({ userId: null });
       const token = await generateSandboxToken(user.userId, "run-1", [
-        "volume:read",
+        "storage:read",
       ]);
 
       const request = createTestRequest(

--- a/turbo/apps/web/app/api/agent/schedules/[name]/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/schedules/[name]/__tests__/route.test.ts
@@ -280,7 +280,7 @@ describe("GET /api/agent/schedules/:name - Sandbox Token Auth", () => {
   it("should reject sandbox token without schedule:read capability", async () => {
     mockClerk({ userId: null });
     const token = await generateSandboxToken(user.userId, "run-123", [
-      "volume:read",
+      "storage:read",
     ]);
 
     const request = createTestRequest(
@@ -341,7 +341,7 @@ describe("DELETE /api/agent/schedules/:name - Sandbox Token Auth", () => {
   it("should reject sandbox token without schedule:write capability", async () => {
     mockClerk({ userId: null });
     const token = await generateSandboxToken(user.userId, "run-123", [
-      "volume:read",
+      "storage:read",
     ]);
 
     const request = createTestRequest(

--- a/turbo/apps/web/app/api/agent/schedules/[name]/disable/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/schedules/[name]/disable/__tests__/route.test.ts
@@ -224,7 +224,7 @@ describe("POST /api/agent/schedules/:name/disable - Sandbox Token Auth", () => {
   it("should reject sandbox token without schedule:write capability", async () => {
     mockClerk({ userId: null });
     const token = await generateSandboxToken(user.userId, "run-123", [
-      "volume:read",
+      "storage:read",
     ]);
 
     const request = createTestRequest(

--- a/turbo/apps/web/app/api/agent/schedules/[name]/enable/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/schedules/[name]/enable/__tests__/route.test.ts
@@ -287,7 +287,7 @@ describe("POST /api/agent/schedules/:name/enable - Sandbox Token Auth", () => {
   it("should reject sandbox token without schedule:write capability", async () => {
     mockClerk({ userId: null });
     const token = await generateSandboxToken(user.userId, "run-123", [
-      "volume:read",
+      "storage:read",
     ]);
 
     const request = createTestRequest(

--- a/turbo/apps/web/app/api/agent/schedules/[name]/runs/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/schedules/[name]/runs/__tests__/route.test.ts
@@ -172,7 +172,7 @@ describe("GET /api/agent/schedules/:name/runs - Sandbox Token Auth", () => {
   it("should reject sandbox token without schedule:read capability", async () => {
     mockClerk({ userId: null });
     const token = await generateSandboxToken(user.userId, "run-123", [
-      "volume:read",
+      "storage:read",
     ]);
 
     const request = createTestRequest(

--- a/turbo/apps/web/app/api/agent/schedules/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/schedules/__tests__/route.test.ts
@@ -1029,7 +1029,7 @@ describe("POST /api/agent/schedules - Sandbox Token Auth", () => {
 
   it("should reject sandbox token without schedule:write capability", async () => {
     const token = await generateSandboxToken(user.userId, "run-123", [
-      "volume:read",
+      "storage:read",
     ]);
 
     const request = createTestRequest(
@@ -1092,7 +1092,7 @@ describe("GET /api/agent/schedules - Sandbox Token Auth", () => {
 
   it("should reject sandbox token without schedule:read capability", async () => {
     const token = await generateSandboxToken(user.userId, "run-123", [
-      "volume:read",
+      "storage:read",
     ]);
 
     const request = createTestRequest(

--- a/turbo/apps/web/app/api/agent/schedules/missing-secrets/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/schedules/missing-secrets/__tests__/route.test.ts
@@ -150,7 +150,7 @@ describe("GET /api/agent/schedules/missing-secrets - Sandbox Token Auth", () => 
   it("should reject sandbox token without schedule:read capability", async () => {
     mockClerk({ userId: null });
     const token = await generateSandboxToken(user.userId, "run-123", [
-      "volume:read",
+      "storage:read",
     ]);
 
     const request = createTestRequest(

--- a/turbo/apps/web/app/api/auth/me/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/auth/me/__tests__/route.test.ts
@@ -59,10 +59,10 @@ describe("GET /api/auth/me", () => {
       expect(body.userId).toBe(user.userId);
     });
 
-    it("sandbox token with volume:write returns user info", async () => {
+    it("sandbox token with storage:write returns user info", async () => {
       mockClerk({ userId: null });
       const token = await generateSandboxToken(user.userId, "run-456", [
-        "volume:write",
+        "storage:write",
       ]);
 
       const response = await GET(

--- a/turbo/apps/web/app/api/storages/__tests__/capability-enforcement.test.ts
+++ b/turbo/apps/web/app/api/storages/__tests__/capability-enforcement.test.ts
@@ -41,9 +41,9 @@ describe("Storage capability enforcement", () => {
   });
 
   describe("sandbox token access for list", () => {
-    it("should accept sandbox token with volume:read for list", async () => {
+    it("should accept sandbox token with storage:read for volume list", async () => {
       await createTestVolume("test-vol");
-      const token = await generateSandboxToken(userId, runId, ["volume:read"]);
+      const token = await generateSandboxToken(userId, runId, ["storage:read"]);
       mockClerk({ userId: null });
 
       const response = await listRoute(
@@ -59,11 +59,9 @@ describe("Storage capability enforcement", () => {
       expect(body[0].name).toBe("test-vol");
     });
 
-    it("should accept sandbox token with artifact:read for list", async () => {
+    it("should accept sandbox token with storage:read for artifact list", async () => {
       await createTestArtifact("test-art");
-      const token = await generateSandboxToken(userId, runId, [
-        "artifact:read",
-      ]);
+      const token = await generateSandboxToken(userId, runId, ["storage:read"]);
       mockClerk({ userId: null });
 
       const response = await listRoute(
@@ -79,9 +77,9 @@ describe("Storage capability enforcement", () => {
       expect(body[0].name).toBe("test-art");
     });
 
-    it("should accept sandbox token with memory:read for list", async () => {
+    it("should accept sandbox token with storage:read for memory list", async () => {
       await createTestMemory("test-mem");
-      const token = await generateSandboxToken(userId, runId, ["memory:read"]);
+      const token = await generateSandboxToken(userId, runId, ["storage:read"]);
       mockClerk({ userId: null });
 
       const response = await listRoute(
@@ -97,24 +95,10 @@ describe("Storage capability enforcement", () => {
       expect(body[0].name).toBe("test-mem");
     });
 
-    it("should reject sandbox token without matching read capability", async () => {
-      const token = await generateSandboxToken(userId, runId, [
-        "artifact:read",
-      ]);
-      mockClerk({ userId: null });
-
-      const response = await listRoute(
-        createTestRequest(
-          "http://localhost:3000/api/storages/list?type=volume",
-          { headers: { authorization: `Bearer ${token}` } },
-        ),
-      );
-
-      expect(response.status).toBe(401);
-    });
-
     it("should reject sandbox token with write capability on read route", async () => {
-      const token = await generateSandboxToken(userId, runId, ["volume:write"]);
+      const token = await generateSandboxToken(userId, runId, [
+        "storage:write",
+      ]);
       mockClerk({ userId: null });
 
       const response = await listRoute(
@@ -143,8 +127,10 @@ describe("Storage capability enforcement", () => {
   });
 
   describe("sandbox token access for prepare", () => {
-    it("should accept sandbox token with volume:write for prepare", async () => {
-      const token = await generateSandboxToken(userId, runId, ["volume:write"]);
+    it("should accept sandbox token with storage:write for prepare", async () => {
+      const token = await generateSandboxToken(userId, runId, [
+        "storage:write",
+      ]);
       mockClerk({ userId: null });
 
       const response = await prepareRoute(
@@ -166,7 +152,7 @@ describe("Storage capability enforcement", () => {
     });
 
     it("should reject sandbox token without matching write capability for prepare", async () => {
-      const token = await generateSandboxToken(userId, runId, ["volume:read"]);
+      const token = await generateSandboxToken(userId, runId, ["storage:read"]);
       mockClerk({ userId: null });
 
       const response = await prepareRoute(
@@ -222,7 +208,7 @@ describe("Storage capability enforcement", () => {
       await createTestVolume("org-vol");
 
       // Sandbox token should resolve to the same org via run record
-      const token = await generateSandboxToken(userId, runId, ["volume:read"]);
+      const token = await generateSandboxToken(userId, runId, ["storage:read"]);
       mockClerk({ userId: null });
 
       const response = await listRoute(
@@ -241,7 +227,7 @@ describe("Storage capability enforcement", () => {
     it("should return 404 when sandbox token run not found", async () => {
       const fakeRunId = randomUUID();
       const token = await generateSandboxToken(userId, fakeRunId, [
-        "volume:read",
+        "storage:read",
       ]);
       mockClerk({ userId: null });
 

--- a/turbo/apps/web/src/lib/auth/__tests__/capability-check.test.ts
+++ b/turbo/apps/web/src/lib/auth/__tests__/capability-check.test.ts
@@ -9,14 +9,14 @@ import {
 describe("capability-check", () => {
   describe("hasCapability", () => {
     it("should return true for CLI auth (no capabilities)", () => {
-      expect(hasCapability({ userId: "user-1" }, "volume:read")).toBe(true);
+      expect(hasCapability({ userId: "user-1" }, "storage:read")).toBe(true);
     });
 
     it("should return true for sandbox auth with matching capability", () => {
       expect(
         hasCapability(
-          { userId: "user-1", runId: "run-1", capabilities: ["volume:read"] },
-          "volume:read",
+          { userId: "user-1", runId: "run-1", capabilities: ["storage:read"] },
+          "storage:read",
         ),
       ).toBe(true);
     });
@@ -24,8 +24,8 @@ describe("capability-check", () => {
     it("should return false for sandbox auth without matching capability", () => {
       expect(
         hasCapability(
-          { userId: "user-1", runId: "run-1", capabilities: ["volume:read"] },
-          "artifact:write",
+          { userId: "user-1", runId: "run-1", capabilities: ["storage:read"] },
+          "storage:write",
         ),
       ).toBe(false);
     });
@@ -34,7 +34,7 @@ describe("capability-check", () => {
       expect(
         hasCapability(
           { userId: "user-1", runId: "run-1", capabilities: [] },
-          "volume:read",
+          "storage:read",
         ),
       ).toBe(false);
     });
@@ -51,22 +51,22 @@ describe("capability-check", () => {
   });
 
   describe("storageCapability", () => {
-    it("should map storage type and action to capability string", () => {
-      expect(storageCapability("volume", "read")).toBe("volume:read");
-      expect(storageCapability("volume", "write")).toBe("volume:write");
-      expect(storageCapability("artifact", "read")).toBe("artifact:read");
-      expect(storageCapability("artifact", "write")).toBe("artifact:write");
-      expect(storageCapability("memory", "read")).toBe("memory:read");
-      expect(storageCapability("memory", "write")).toBe("memory:write");
+    it("should map all storage types to unified storage capability", () => {
+      expect(storageCapability("volume", "read")).toBe("storage:read");
+      expect(storageCapability("volume", "write")).toBe("storage:write");
+      expect(storageCapability("artifact", "read")).toBe("storage:read");
+      expect(storageCapability("artifact", "write")).toBe("storage:write");
+      expect(storageCapability("memory", "read")).toBe("storage:read");
+      expect(storageCapability("memory", "write")).toBe("storage:write");
     });
   });
 
   describe("missingCapabilityError", () => {
     it("should return 403 error body with capability name", () => {
-      const error = missingCapabilityError("volume:read");
+      const error = missingCapabilityError("storage:read");
 
       expect(error.error.message).toBe(
-        "Missing required capability: volume:read",
+        "Missing required capability: storage:read",
       );
       expect(error.error.code).toBe("FORBIDDEN");
     });

--- a/turbo/apps/web/src/lib/auth/__tests__/get-user-id.spec.ts
+++ b/turbo/apps/web/src/lib/auth/__tests__/get-user-id.spec.ts
@@ -60,7 +60,7 @@ describe("getAuthContext with requiredCapability", () => {
 
   it("should reject sandbox token without requiredCapability (backward compat)", async () => {
     const token = await generateSandboxToken("user-123", "run-456", [
-      "volume:read",
+      "storage:read",
     ]);
     const result = await getAuthContext(`Bearer ${token}`);
 
@@ -69,24 +69,24 @@ describe("getAuthContext with requiredCapability", () => {
 
   it("should accept sandbox token with matching capability", async () => {
     const token = await generateSandboxToken("user-123", "run-456", [
-      "volume:read",
+      "storage:read",
     ]);
     const result = await getAuthContext(`Bearer ${token}`, {
-      requiredCapability: "volume:read",
+      requiredCapability: "storage:read",
     });
 
     expect(result).not.toBeNull();
     expect(result?.userId).toBe("user-123");
     expect(result?.runId).toBe("run-456");
-    expect(result?.capabilities).toContain("volume:read");
+    expect(result?.capabilities).toContain("storage:read");
   });
 
   it("should reject sandbox token without matching capability", async () => {
     const token = await generateSandboxToken("user-123", "run-456", [
-      "volume:read",
+      "storage:read",
     ]);
     const result = await getAuthContext(`Bearer ${token}`, {
-      requiredCapability: "artifact:write",
+      requiredCapability: "storage:write",
     });
 
     expect(result).toBeNull();
@@ -95,7 +95,7 @@ describe("getAuthContext with requiredCapability", () => {
   it("should reject sandbox token with no capabilities", async () => {
     const token = await generateSandboxToken("user-123", "run-456");
     const result = await getAuthContext(`Bearer ${token}`, {
-      requiredCapability: "volume:read",
+      requiredCapability: "storage:read",
     });
 
     expect(result).toBeNull();
@@ -107,7 +107,7 @@ describe("getAuthContext with requiredCapability", () => {
     } as Awaited<ReturnType<typeof auth>>);
 
     const result = await getAuthContext(undefined, {
-      requiredCapability: "volume:read",
+      requiredCapability: "storage:read",
     });
 
     expect(result).not.toBeNull();
@@ -141,7 +141,7 @@ describe("getAuthContext with acceptAnySandboxCapability", () => {
 
   it("should accept sandbox token with multiple capabilities", async () => {
     const token = await generateSandboxToken("user-123", "run-456", [
-      "volume:read",
+      "storage:read",
       "agent:write",
     ]);
     const result = await getAuthContext(`Bearer ${token}`, {
@@ -150,7 +150,7 @@ describe("getAuthContext with acceptAnySandboxCapability", () => {
 
     expect(result).not.toBeNull();
     expect(result?.userId).toBe("user-123");
-    expect(result?.capabilities).toContain("volume:read");
+    expect(result?.capabilities).toContain("storage:read");
     expect(result?.capabilities).toContain("agent:write");
   });
 

--- a/turbo/apps/web/src/lib/auth/__tests__/sandbox-token.test.ts
+++ b/turbo/apps/web/src/lib/auth/__tests__/sandbox-token.test.ts
@@ -125,7 +125,7 @@ describe("sandbox-token", () => {
 
   describe("capabilities", () => {
     it("should include capabilities in verified token", async () => {
-      const capabilities = ["volume:read", "artifact:write"] as const;
+      const capabilities = ["storage:read", "storage:write"] as const;
       const token = await generateSandboxToken(
         "user-123",
         "run-456",
@@ -136,7 +136,7 @@ describe("sandbox-token", () => {
       expect(auth).not.toBeNull();
       expect(auth?.userId).toBe("user-123");
       expect(auth?.runId).toBe("run-456");
-      expect(auth?.capabilities).toEqual(["volume:read", "artifact:write"]);
+      expect(auth?.capabilities).toEqual(["storage:read", "storage:write"]);
     });
 
     it("should work without capabilities (backward compat)", async () => {
@@ -158,12 +158,12 @@ describe("sandbox-token", () => {
 
     it("should roundtrip all valid capabilities", async () => {
       const capabilities = [
-        "volume:read",
-        "volume:write",
-        "artifact:read",
-        "artifact:write",
-        "memory:read",
-        "memory:write",
+        "storage:read",
+        "storage:write",
+        "agent:read",
+        "agent:write",
+        "agent-run:read",
+        "agent-run:write",
       ] as const;
       const token = await generateSandboxToken(
         "user-123",

--- a/turbo/apps/web/src/lib/auth/capability-check.ts
+++ b/turbo/apps/web/src/lib/auth/capability-check.ts
@@ -30,14 +30,14 @@ export function isSandboxAuth(
 }
 
 /**
- * Map storage type + action to capability string.
- * e.g., ("volume", "read") → "volume:read"
+ * Map storage action to unified capability string.
+ * All storage types (volume, artifact, memory) use "storage:read" / "storage:write".
  */
 export function storageCapability(
-  storageType: "volume" | "artifact" | "memory",
+  _storageType: "volume" | "artifact" | "memory",
   action: "read" | "write",
 ): Capability {
-  return `${storageType}:${action}` as Capability;
+  return `storage:${action}` as Capability;
 }
 
 /**

--- a/turbo/packages/core/src/contracts/__tests__/composes.test.ts
+++ b/turbo/packages/core/src/contracts/__tests__/composes.test.ts
@@ -19,8 +19,8 @@ function wrapInCompose(agentOverrides: Record<string, unknown>) {
 }
 
 describe("VALID_CAPABILITIES", () => {
-  it("contains 12 capabilities", () => {
-    expect(VALID_CAPABILITIES).toHaveLength(12);
+  it("contains 8 capabilities", () => {
+    expect(VALID_CAPABILITIES).toHaveLength(8);
   });
 
   it("all follow resource:action format", () => {
@@ -34,7 +34,7 @@ describe("experimental_capabilities in agentDefinitionSchema", () => {
   it("accepts valid capabilities array", () => {
     const result = agentDefinitionSchema.safeParse({
       ...baseAgent,
-      experimental_capabilities: ["volume:read", "artifact:write"],
+      experimental_capabilities: ["storage:read", "storage:write"],
     });
     expect(result.success).toBe(true);
   });
@@ -42,7 +42,7 @@ describe("experimental_capabilities in agentDefinitionSchema", () => {
   it("accepts a single valid capability", () => {
     const result = agentDefinitionSchema.safeParse({
       ...baseAgent,
-      experimental_capabilities: ["memory:read"],
+      experimental_capabilities: ["storage:read"],
     });
     expect(result.success).toBe(true);
   });
@@ -71,7 +71,7 @@ describe("experimental_capabilities in agentDefinitionSchema", () => {
   it("rejects duplicate capabilities", () => {
     const result = agentDefinitionSchema.safeParse({
       ...baseAgent,
-      experimental_capabilities: ["volume:read", "volume:read"],
+      experimental_capabilities: ["storage:read", "storage:read"],
     });
     expect(result.success).toBe(false);
     if (!result.success) {
@@ -87,8 +87,8 @@ describe("experimental_capabilities in agentComposeApiContentSchema", () => {
     const result = agentComposeApiContentSchema.safeParse(
       wrapInCompose({
         experimental_capabilities: [
-          "volume:read",
-          "volume:write",
+          "storage:read",
+          "storage:write",
           "agent-run:read",
         ],
       }),

--- a/turbo/packages/core/src/contracts/composes.ts
+++ b/turbo/packages/core/src/contracts/composes.ts
@@ -27,12 +27,8 @@ export const AGENT_NAME_REGEX = /^[a-zA-Z0-9][a-zA-Z0-9-]{1,62}[a-zA-Z0-9]$/;
  * Format: {resource}:{action}
  */
 export const VALID_CAPABILITIES = [
-  "volume:read",
-  "volume:write",
-  "artifact:read",
-  "artifact:write",
-  "memory:read",
-  "memory:write",
+  "storage:read",
+  "storage:write",
   "agent:read",
   "agent:write",
   "agent-run:read",


### PR DESCRIPTION
## Summary

- Consolidate 6 storage-related capabilities (`volume:read`, `volume:write`, `artifact:read`, `artifact:write`, `memory:read`, `memory:write`) into 2 unified capabilities (`storage:read`, `storage:write`)
- All three storage types share the same route handlers and there is no real-world need to grant access to one but not another
- Reduces total capabilities from 12 to 8

## Changes

| File | Change |
|------|--------|
| `packages/core/src/contracts/composes.ts` | Updated `VALID_CAPABILITIES` — removed 6, added 2 |
| `apps/web/src/lib/auth/capability-check.ts` | `storageCapability()` now returns `storage:read`/`storage:write` for all storage types |
| `crates/runner/src/executor.rs` | Updated test capability strings |
| ~15 test files | Updated capability strings from `volume:*`/`artifact:*`/`memory:*` to `storage:*` |

## Test plan

- [x] All 3765 TypeScript tests pass
- [x] All 30 Rust executor tests pass
- [x] TypeScript type check passes
- [x] Lint passes
- [x] Knip passes (no unused exports)
- [x] Pre-commit hooks pass (prettier, cargo-fmt, cargo-clippy, commitlint)

Closes #4956

🤖 Generated with [Claude Code](https://claude.com/claude-code)