### PR TITLE
chore: remove codex web api behavior and tests

### DIFF
--- a/turbo/apps/web/app/api/agent/composes/[id]/instructions/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/composes/[id]/instructions/__tests__/route.test.ts
@@ -261,49 +261,6 @@ describe("GET /api/agent/composes/:id/instructions", () => {
     expect(data.filename).toBe("AGENTS.md");
   });
 
-  it("should use AGENTS.md canonical filename for codex framework", async () => {
-    const agentName = "codex-agent";
-    const instructionsContent = "# Codex Instructions\n";
-
-    const { composeId } = await createTestCompose(agentName, {
-      overrides: { instructions: "AGENTS.md", framework: "codex" },
-    });
-
-    const storageName = getInstructionsStorageName(agentName);
-    await createTestVolume(storageName);
-
-    // Manifest contains AGENTS.md — the canonical filename for codex framework
-    context.mocks.s3.downloadManifest.mockResolvedValueOnce({
-      version: "a".repeat(64),
-      createdAt: new Date().toISOString(),
-      totalSize: instructionsContent.length,
-      fileCount: 1,
-      files: [
-        {
-          path: "AGENTS.md",
-          hash: "f".repeat(64),
-          size: instructionsContent.length,
-        },
-      ],
-    });
-
-    context.mocks.s3.downloadS3Buffer.mockResolvedValueOnce(
-      buildTarGz("AGENTS.md", instructionsContent),
-    );
-
-    const request = createTestRequest(
-      `http://localhost:3000/api/agent/composes/${composeId}/instructions`,
-    );
-    const response = await GET(request, {
-      params: Promise.resolve({ id: composeId }),
-    });
-    const data = await response.json();
-
-    expect(response.status).toBe(200);
-    expect(data.content).toBe(instructionsContent);
-    expect(data.filename).toBe("AGENTS.md");
-  });
-
   it("should normalize ./ prefix when matching instructions file in manifest", async () => {
     const agentName = "normalize-prefix-agent";
     const instructionsContent = "# Normalized content\n";

--- a/turbo/apps/web/app/api/agent/composes/__tests__/upsert.test.ts
+++ b/turbo/apps/web/app/api/agent/composes/__tests__/upsert.test.ts
@@ -432,43 +432,6 @@ describe("Agent Compose Upsert Behavior", () => {
       const response = await POST(request);
       expect(response.status).toBe(201);
     });
-
-    it("should accept codex framework", async () => {
-      const agentName = `test-codex-framework-${Date.now()}`;
-      const config = {
-        version: "1.0",
-        agents: {
-          [agentName]: {
-            framework: "codex",
-          },
-        },
-      };
-
-      const request = createTestRequest(
-        "http://localhost:3000/api/agent/composes",
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ content: config }),
-        },
-      );
-
-      const response = await POST(request);
-      expect(response.status).toBe(201);
-
-      // Get the created compose to verify codex image
-      const data = await response.json();
-      const getRequest = createTestRequest(
-        `http://localhost:3000/api/agent/composes/${data.composeId}`,
-        { method: "GET" },
-      );
-
-      const getResponse = await GET(getRequest);
-      const composeData = await getResponse.json();
-
-      const agent = composeData.content.agents[agentName];
-      expect(agent.image).toMatch(/^vm0\/codex:/);
-    });
   });
 
   describe("GET /api/agent/composes/:id", () => {

--- a/turbo/apps/web/app/api/agent/runs/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/__tests__/route.test.ts
@@ -750,20 +750,6 @@ describe("POST /api/agent/runs - Internal Runs API", () => {
       expect(data.status).toBe("pending");
     });
 
-    it("should skip injection when compose has explicit OPENAI_API_KEY (codex)", async () => {
-      // Create compose with OPENAI_API_KEY for codex framework
-      const { composeId } = await createTestCompose(uniqueId("codex"), {
-        overrides: {
-          framework: "codex",
-          environment: { OPENAI_API_KEY: "explicit-openai-key" },
-        },
-      });
-
-      const data = await createTestRun(composeId, "Test codex with key");
-
-      expect(data.status).toBe("pending");
-    });
-
     it("should skip injection when compose has CLAUDE_CODE_USE_FOUNDRY", async () => {
       // Create compose with alternative auth method
       const { composeId } = await createTestCompose(uniqueId("foundry"), {

--- a/turbo/apps/web/app/api/compose/jobs/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/compose/jobs/__tests__/route.test.ts
@@ -245,7 +245,7 @@ describe("POST /api/compose/jobs", () => {
           body: JSON.stringify({
             content: {
               version: "1",
-              agents: { other: { framework: "codex" } },
+              agents: { other: { framework: "claude-code" } },
             },
           }),
         },

--- a/turbo/apps/web/src/lib/run/build-context.ts
+++ b/turbo/apps/web/src/lib/run/build-context.ts
@@ -191,10 +191,7 @@ async function resolveModelProviderSecrets(
   let secrets: Record<string, string> | undefined;
 
   // Skip if explicit model provider config exists or framework doesn't use model providers
-  if (
-    hasExplicitModelProviderConfig ||
-    (framework !== "claude-code" && framework !== "codex")
-  ) {
+  if (hasExplicitModelProviderConfig || framework !== "claude-code") {
     return { secrets, injectedEnvironment: undefined };
   }
 

--- a/turbo/apps/web/src/lib/storage/__tests__/instruction-upload.test.ts
+++ b/turbo/apps/web/src/lib/storage/__tests__/instruction-upload.test.ts
@@ -83,31 +83,6 @@ describe("uploadInstructionsServerSide", () => {
     expect(text).toContain("Test Agent");
   });
 
-  it("should use AGENTS.md for codex framework", async () => {
-    await uploadInstructionsServerSide({
-      orgId,
-      agentName: "codex-agent",
-      content: "# Codex Instructions",
-      framework: "codex",
-    });
-
-    // Verify manifest has AGENTS.md
-    const manifestCall = context.mocks.s3.putS3Object.mock.calls.find(
-      (c) => typeof c[1] === "string" && c[1].endsWith("/manifest.json"),
-    );
-    const manifestBody = JSON.parse(manifestCall![2] as string);
-    expect(manifestBody.files[0].path).toBe("AGENTS.md");
-
-    // Verify archive contains AGENTS.md
-    const archiveCall = context.mocks.s3.putS3Object.mock.calls.find(
-      (c) => typeof c[1] === "string" && c[1].endsWith("/archive.tar.gz"),
-    );
-    const tarBuffer = gunzipSync(archiveCall![2] as Buffer);
-    const fileContent = extractFileFromTar(tarBuffer, "AGENTS.md");
-    expect(fileContent).not.toBeNull();
-    expect(fileContent!.toString("utf-8")).toBe("# Codex Instructions");
-  });
-
   it("should deduplicate when same content is uploaded twice", async () => {
     const params = {
       orgId,


### PR DESCRIPTION
## Summary

- Remove codex-specific model provider injection logic from `build-context.ts` — only `claude-code` framework now gets auto-injection
- Remove codex-specific test cases from runs, composes, instructions, and instruction-upload tests
- Change codex fixture in compose jobs idempotency test to use `claude-code` instead

Closes #4966

## Test plan

- [x] All quality checks pass (lint, types, format, knip)
- [x] Existing tests pass — only codex-specific tests removed
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>