### PR TITLE
chore: remove codex from rust crates

### DIFF
--- a/crates/guest-agent/src/checkpoint.rs
+++ b/crates/guest-agent/src/checkpoint.rs
@@ -202,7 +202,7 @@ async fn create_checkpoint_impl(start: std::time::Instant) -> Result<(), AgentEr
     // Build and send checkpoint payload
     let mut payload = json!({
         "runId": env::run_id(),
-        "cliAgentType": env::cli_agent_type(),
+        "cliAgentType": "claude-code",
         "cliAgentSessionId": session_id,
         "cliAgentSessionHistory": session_history,
     });

--- a/crates/guest-agent/src/checkpoint.rs
+++ b/crates/guest-agent/src/checkpoint.rs
@@ -1,6 +1,4 @@
 //! Checkpoint creation — reads session history and calls checkpoint API.
-//!
-//! For Codex, searches for the session file in date-organized directories.
 
 use crate::artifact;
 use crate::constants;
@@ -64,37 +62,7 @@ async fn create_checkpoint_impl(start: std::time::Instant) -> Result<(), AgentEr
         .trim()
         .to_string();
 
-    // Handle Codex session search marker: CODEX_SEARCH:{dir}:{id}
-    let session_history_path = if let Some(rest) = raw_path.strip_prefix("CODEX_SEARCH:") {
-        let Some((sessions_dir, codex_session_id)) = rest.split_once(':') else {
-            record_sandbox_op(
-                "session_history_read",
-                start.elapsed(),
-                false,
-                Some("Invalid Codex search marker"),
-            );
-            return Err(AgentError::Checkpoint(format!(
-                "Invalid Codex search marker: {raw_path}"
-            )));
-        };
-        log_info!(LOG_TAG, "Searching for Codex session in {sessions_dir}");
-        match find_codex_session_file(sessions_dir, codex_session_id) {
-            Some(path) => path,
-            None => {
-                record_sandbox_op(
-                    "session_history_read",
-                    start.elapsed(),
-                    false,
-                    Some("Codex session file not found"),
-                );
-                return Err(AgentError::Checkpoint(format!(
-                    "Could not find Codex session file for {codex_session_id}"
-                )));
-            }
-        }
-    } else {
-        raw_path
-    };
+    let session_history_path = raw_path;
 
     // Read session history
     if !Path::new(&session_history_path).exists() {
@@ -288,128 +256,5 @@ async fn create_checkpoint_impl(start: std::time::Instant) -> Result<(), AgentEr
         Err(AgentError::Checkpoint(
             "Invalid checkpoint API response".into(),
         ))
-    }
-}
-
-/// Find Codex session file by searching recursively for JSONL files.
-fn find_codex_session_file(sessions_dir: &str, session_id: &str) -> Option<String> {
-    let files = find_jsonl_files(sessions_dir);
-    log_info!(
-        LOG_TAG,
-        "Searching for Codex session {session_id} in {} files",
-        files.len()
-    );
-
-    // Try matching session ID in filename
-    let normalized_id = session_id.replace('-', "");
-    for f in &files {
-        let filename = Path::new(f)
-            .file_name()
-            .and_then(|n| n.to_str())
-            .unwrap_or("");
-        if filename.contains(session_id) || filename.replace('-', "").contains(&normalized_id) {
-            log_info!(LOG_TAG, "Found Codex session file: {f}");
-            return Some(f.clone());
-        }
-    }
-
-    // Fallback: most recent file
-    if let Some(most_recent) = files.into_iter().max_by_key(|f| {
-        std::fs::metadata(f)
-            .and_then(|m| m.modified())
-            .unwrap_or(std::time::SystemTime::UNIX_EPOCH)
-    }) {
-        log_info!(
-            LOG_TAG,
-            "Session ID not found in filenames, using most recent: {most_recent}"
-        );
-        return Some(most_recent);
-    }
-
-    None
-}
-
-/// Recursively find all `.jsonl` files in a directory.
-fn find_jsonl_files(dir: &str) -> Vec<String> {
-    let mut files = Vec::new();
-    walk_jsonl(dir, &mut files);
-    files
-}
-
-fn walk_jsonl(dir: &str, out: &mut Vec<String>) {
-    let entries = match std::fs::read_dir(dir) {
-        Ok(e) => e,
-        Err(_) => return,
-    };
-    for entry in entries.flatten() {
-        let path = entry.path();
-        if path.is_dir()
-            && let Some(s) = path.to_str()
-        {
-            walk_jsonl(s, out);
-        } else if path
-            .extension()
-            .and_then(|e| e.to_str())
-            .is_some_and(|ext| ext == "jsonl")
-            && let Some(s) = path.to_str()
-        {
-            out.push(s.to_string());
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use std::fs;
-
-    #[test]
-    fn find_codex_session_by_id_in_filename() {
-        let dir = tempfile::tempdir().unwrap();
-        let sub = dir.path().join("2026-02-10");
-        fs::create_dir_all(&sub).unwrap();
-        fs::write(sub.join("abc123.jsonl"), "{}").unwrap();
-        fs::write(sub.join("other.jsonl"), "{}").unwrap();
-
-        let result = find_codex_session_file(dir.path().to_str().unwrap(), "abc123");
-        assert_eq!(
-            result.as_deref(),
-            Some(sub.join("abc123.jsonl").to_str().unwrap())
-        );
-    }
-
-    #[test]
-    fn find_codex_session_falls_back_to_most_recent() {
-        let dir = tempfile::tempdir().unwrap();
-        fs::write(dir.path().join("old.jsonl"), "{}").unwrap();
-        // Ensure different mtime
-        std::thread::sleep(std::time::Duration::from_millis(50));
-        fs::write(dir.path().join("new.jsonl"), "{}").unwrap();
-
-        let result = find_codex_session_file(dir.path().to_str().unwrap(), "nonexistent");
-        assert!(result.is_some());
-        assert!(result.unwrap().contains("new.jsonl"));
-    }
-
-    #[test]
-    fn find_codex_session_empty_dir() {
-        let dir = tempfile::tempdir().unwrap();
-        let result = find_codex_session_file(dir.path().to_str().unwrap(), "any");
-        assert!(result.is_none());
-    }
-
-    #[test]
-    fn find_jsonl_files_recursive() {
-        let dir = tempfile::tempdir().unwrap();
-        let sub = dir.path().join("a").join("b");
-        fs::create_dir_all(&sub).unwrap();
-        fs::write(dir.path().join("root.jsonl"), "{}").unwrap();
-        fs::write(sub.join("nested.jsonl"), "{}").unwrap();
-        fs::write(dir.path().join("skip.txt"), "").unwrap();
-
-        let files = find_jsonl_files(dir.path().to_str().unwrap());
-        assert_eq!(files.len(), 2);
-        assert!(files.iter().any(|f| f.contains("root.jsonl")));
-        assert!(files.iter().any(|f| f.contains("nested.jsonl")));
     }
 }

--- a/crates/guest-agent/src/cli.rs
+++ b/crates/guest-agent/src/cli.rs
@@ -1,12 +1,11 @@
-//! CLI command building and execution for Claude Code / Codex.
+//! CLI command building and execution for Claude Code.
 
 use crate::env;
 use crate::error::AgentError;
 use crate::events;
 use crate::masker::SecretMasker;
 use crate::paths;
-use guest_common::telemetry::record_sandbox_op;
-use guest_common::{log_error, log_info, log_warn};
+use guest_common::{log_info, log_warn};
 use std::collections::HashMap;
 use std::process::Stdio;
 use std::time::{Duration, Instant};
@@ -15,20 +14,9 @@ use tokio::io::AsyncWriteExt;
 
 const LOG_TAG: &str = "sandbox:guest-agent";
 
-/// Build the CLI command + args based on `CLI_AGENT_TYPE`.
+/// Build the CLI command + args.
 pub fn build_cli_command() -> Result<Vec<String>, AgentError> {
-    let use_mock = env::use_mock_claude();
-
-    if env::cli_agent_type() == "codex" {
-        if use_mock {
-            return Err(AgentError::Execution(
-                "Mock mode not supported for Codex".into(),
-            ));
-        }
-        Ok(build_codex_command())
-    } else {
-        Ok(build_claude_command(use_mock))
-    }
+    Ok(build_claude_command(env::use_mock_claude()))
 }
 
 fn build_claude_command(use_mock: bool) -> Vec<String> {
@@ -63,91 +51,6 @@ fn build_claude_command(use_mock: bool) -> Vec<String> {
     cmd
 }
 
-fn build_codex_command() -> Vec<String> {
-    let mut args = vec![
-        "exec".to_string(),
-        "--json".to_string(),
-        "--dangerously-bypass-approvals-and-sandbox".to_string(),
-        "--skip-git-repo-check".to_string(),
-        "-C".to_string(),
-        env::working_dir().to_string(),
-    ];
-
-    let model = env::openai_model();
-    if !model.is_empty() {
-        args.push("-m".to_string());
-        args.push(model.to_string());
-    }
-
-    let resume = env::resume_session_id();
-    if !resume.is_empty() {
-        log_info!(LOG_TAG, "Resuming session: {resume}");
-        args.push("resume".to_string());
-        args.push(resume.to_string());
-        args.push(env::prompt().to_string());
-    } else {
-        log_info!(LOG_TAG, "Starting new session");
-        args.push(env::prompt().to_string());
-    }
-
-    let mut cmd = vec!["codex".to_string()];
-    cmd.append(&mut args);
-    cmd
-}
-
-/// Set up Codex: create home dir, login with API key.
-pub fn setup_codex() -> Result<(), AgentError> {
-    let home = std::env::var("HOME").unwrap_or_else(|_| "/home/user".to_string());
-    let codex_home = format!("{home}/.codex");
-    std::fs::create_dir_all(&codex_home)?;
-    log_info!(LOG_TAG, "Codex home directory: {codex_home}");
-
-    let login_start = std::time::Instant::now();
-    let api_key = std::env::var("OPENAI_API_KEY").unwrap_or_default();
-    if api_key.is_empty() {
-        let msg = "OPENAI_API_KEY not set";
-        log_error!(LOG_TAG, "{msg}");
-        record_sandbox_op("codex_login", login_start.elapsed(), false, Some(msg));
-        return Err(AgentError::Execution(msg.into()));
-    }
-    let output = std::process::Command::new("codex")
-        .args(["login", "--with-api-key"])
-        .env("CODEX_HOME", &codex_home)
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .and_then(|mut child| {
-            if let Some(mut stdin) = child.stdin.take() {
-                use std::io::Write;
-                let _ = stdin.write_all(api_key.as_bytes());
-            }
-            child.wait_with_output()
-        });
-
-    // Login failure is non-fatal: OPENAI_API_KEY is already in the environment
-    // and `codex exec` will use it directly. Some Codex versions may not support
-    // the `login` subcommand. We log + record the failure but continue.
-    let success = match &output {
-        Ok(o) if o.status.success() => {
-            log_info!(LOG_TAG, "Codex authenticated with API key");
-            true
-        }
-        Ok(o) => {
-            let stderr = String::from_utf8_lossy(&o.stderr);
-            log_error!(LOG_TAG, "Codex login failed: {stderr}");
-            false
-        }
-        Err(e) => {
-            log_error!(LOG_TAG, "Codex login failed: {e}");
-            false
-        }
-    };
-    record_sandbox_op("codex_login", login_start.elapsed(), success, None);
-
-    Ok(())
-}
-
 /// Execute the CLI process, streaming JSONL events and racing against heartbeat.
 ///
 /// Returns `(exit_code, stderr_lines)`.
@@ -169,23 +72,17 @@ pub async fn execute_cli(
         .stderr(Stdio::piped())
         .process_group(0);
 
-    if env::cli_agent_type() == "codex" {
-        // Pass CODEX_HOME via Command::env instead of global set_var
-        let home = std::env::var("HOME").unwrap_or_else(|_| "/home/user".to_string());
-        cmd.env("CODEX_HOME", format!("{home}/.codex"));
-    } else {
-        // Suppress Claude CLI features that are unnecessary or harmful in a
-        // sandbox: startup network calls (statsig, Datadog, Segment, GCS
-        // update check, GitHub) add ~2s latency, telemetry has no receiver,
-        // and the CLI version is baked into the rootfs image.
-        cmd.env("CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC", "1");
-        cmd.env("CLAUDE_CODE_DISABLE_FEEDBACK_SURVEY", "1");
-        cmd.env("CLAUDE_CODE_DISABLE_TERMINAL_TITLE", "1");
-        cmd.env("DISABLE_AUTOUPDATER", "1");
-        cmd.env("DISABLE_ERROR_REPORTING", "1");
-        cmd.env("DISABLE_INSTALLATION_CHECKS", "1");
-        cmd.env("DISABLE_TELEMETRY", "1");
-    }
+    // Suppress Claude CLI features that are unnecessary or harmful in a
+    // sandbox: startup network calls (statsig, Datadog, Segment, GCS
+    // update check, GitHub) add ~2s latency, telemetry has no receiver,
+    // and the CLI version is baked into the rootfs image.
+    cmd.env("CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC", "1");
+    cmd.env("CLAUDE_CODE_DISABLE_FEEDBACK_SURVEY", "1");
+    cmd.env("CLAUDE_CODE_DISABLE_TERMINAL_TITLE", "1");
+    cmd.env("DISABLE_AUTOUPDATER", "1");
+    cmd.env("DISABLE_ERROR_REPORTING", "1");
+    cmd.env("DISABLE_INSTALLATION_CHECKS", "1");
+    cmd.env("DISABLE_TELEMETRY", "1");
 
     let mut child = cmd.spawn()?;
 

--- a/crates/guest-agent/src/cli.rs
+++ b/crates/guest-agent/src/cli.rs
@@ -58,7 +58,7 @@ pub async fn execute_cli(
     masker: &SecretMasker,
     mut heartbeat_handle: tokio::task::JoinHandle<Result<(), AgentError>>,
 ) -> Result<(i32, Vec<String>), AgentError> {
-    log_info!(LOG_TAG, "Starting {} execution...", env::cli_agent_type());
+    log_info!(LOG_TAG, "Starting claude-code execution...");
 
     let cmd = build_cli_command()?;
     let (bin, args) = cmd

--- a/crates/guest-agent/src/env.rs
+++ b/crates/guest-agent/src/env.rs
@@ -26,7 +26,6 @@ static CLI_AGENT_TYPE: LazyLock<String> = LazyLock::new(|| {
     }
 });
 static API_START_TIME: LazyLock<String> = LazyLock::new(|| env_or_empty("VM0_API_START_TIME"));
-static OPENAI_MODEL: LazyLock<String> = LazyLock::new(|| env_or_empty("OPENAI_MODEL"));
 static WORKING_DIR: LazyLock<String> = LazyLock::new(|| env_or_empty("VM0_WORKING_DIR"));
 static SECRET_VALUES: LazyLock<String> = LazyLock::new(|| env_or_empty("VM0_SECRET_VALUES"));
 static USE_MOCK_CLAUDE: LazyLock<bool> = LazyLock::new(|| {
@@ -98,9 +97,6 @@ pub fn cli_agent_type() -> &'static str {
 }
 pub fn api_start_time() -> &'static str {
     &API_START_TIME
-}
-pub fn openai_model() -> &'static str {
-    &OPENAI_MODEL
 }
 pub fn working_dir() -> &'static str {
     &WORKING_DIR

--- a/crates/guest-agent/src/events.rs
+++ b/crates/guest-agent/src/events.rs
@@ -1,7 +1,7 @@
 //! Event sending — forwards masked JSONL events to the webhook endpoint.
 //!
-//! Extracts session ID from the init event (Claude: `system/init`,
-//! Codex: `thread.started`) and persists it for checkpoint use.
+//! Extracts session ID from the `system/init` event and persists it for
+//! checkpoint use.
 
 use crate::env;
 use crate::error::AgentError;
@@ -90,7 +90,7 @@ pub(crate) enum ClaudeToolEvent<'a> {
 ///
 /// Iterates all content blocks (handles `[text, tool_use]` and parallel
 /// `[tool_use, tool_use]` patterns).  Returns an empty vec for non-tool
-/// events or non-Claude-Code formats (e.g. Codex).
+/// events.
 pub(crate) fn extract_claude_tool_info(event: &Value) -> Vec<ClaudeToolEvent<'_>> {
     let Some(contents) = event
         .get("message")
@@ -128,21 +128,12 @@ pub(crate) fn extract_claude_tool_info(event: &Value) -> Vec<ClaudeToolEvent<'_>
 /// If this is an init event, extract session ID and write temp files.
 fn extract_session_id(event: &Value) {
     let event_type = event.get("type").and_then(|v| v.as_str()).unwrap_or("");
-    let agent_type = env::cli_agent_type();
+    let subtype = event.get("subtype").and_then(|v| v.as_str()).unwrap_or("");
 
-    let session_id = if agent_type == "codex" {
-        if event_type == "thread.started" {
-            event.get("thread_id").and_then(|v| v.as_str())
-        } else {
-            None
-        }
+    let session_id = if event_type == "system" && subtype == "init" {
+        event.get("session_id").and_then(|v| v.as_str())
     } else {
-        let subtype = event.get("subtype").and_then(|v| v.as_str()).unwrap_or("");
-        if event_type == "system" && subtype == "init" {
-            event.get("session_id").and_then(|v| v.as_str())
-        } else {
-            None
-        }
+        None
     };
 
     let Some(session_id) = session_id.filter(|s| !s.is_empty()) else {
@@ -159,18 +150,12 @@ fn extract_session_id(event: &Value) {
 
     // Build session history path
     let home = std::env::var("HOME").unwrap_or_else(|_| "/home/user".to_string());
-
-    let history_path = if agent_type == "codex" {
-        let codex_home = std::env::var("CODEX_HOME").unwrap_or_else(|_| format!("{home}/.codex"));
-        format!("CODEX_SEARCH:{codex_home}/sessions:{session_id}")
-    } else {
-        let working_dir = env::working_dir();
-        let project_name = working_dir
-            .strip_prefix('/')
-            .unwrap_or(working_dir)
-            .replace('/', "-");
-        format!("{home}/.claude/projects/-{project_name}/{session_id}.jsonl")
-    };
+    let working_dir = env::working_dir();
+    let project_name = working_dir
+        .strip_prefix('/')
+        .unwrap_or(working_dir)
+        .replace('/', "-");
+    let history_path = format!("{home}/.claude/projects/-{project_name}/{session_id}.jsonl");
 
     let _ = std::fs::write(paths::session_history_path_file(), &history_path);
     log_info!(LOG_TAG, "Session history will be at: {history_path}");

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -101,7 +101,7 @@ async fn run() -> i32 {
     exit_code
 }
 
-/// Main execution logic: working dir, codex setup, CLI, checkpoint.
+/// Main execution logic: working dir, CLI, checkpoint.
 async fn execute(
     masker: &masker::SecretMasker,
     start: Instant,
@@ -110,13 +110,8 @@ async fn execute(
     // Pre-warm kernel DNS cache for the CLI's API endpoint.
     // Fire-and-forget: runs in background so the cache is populated by the
     // time the CLI spawns and makes its first HTTPS request.
-    let dns_target = if env::cli_agent_type() == "codex" {
-        "api.openai.com:443"
-    } else {
-        "api.anthropic.com:443"
-    };
     tokio::spawn(async move {
-        let _ = tokio::net::lookup_host(dns_target).await;
+        let _ = tokio::net::lookup_host("api.anthropic.com:443").await;
     });
 
     // Working directory setup
@@ -137,13 +132,6 @@ async fn execute(
     record_sandbox_op("memory_symlink_setup", mem_start.elapsed(), true, None);
     if mem_linked {
         log_info!(LOG_TAG, "Auto-memory symlink created");
-    }
-
-    // Codex setup (sandbox op recorded inside setup_codex)
-    if env::cli_agent_type() == "codex"
-        && let Err(e) = cli::setup_codex()
-    {
-        log_error!(LOG_TAG, "Codex setup failed: {e}");
     }
 
     let init_elapsed = start.elapsed();

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -192,7 +192,7 @@ async fn execute(
 
     // Checkpoint on success (skip when no API — local/test mode)
     if cli_exit_code == 0 && exit_code == 0 && env::has_api() {
-        log_info!(LOG_TAG, "{} completed successfully", env::cli_agent_type());
+        log_info!(LOG_TAG, "claude-code completed successfully");
 
         log_info!(LOG_TAG, "▷ Checkpoint");
         let cp_start = Instant::now();
@@ -217,13 +217,9 @@ async fn execute(
             }
         }
     } else if cli_exit_code == 0 && exit_code == 0 {
-        log_info!(LOG_TAG, "{} completed successfully", env::cli_agent_type());
+        log_info!(LOG_TAG, "claude-code completed successfully");
     } else if cli_exit_code != 0 {
-        log_info!(
-            LOG_TAG,
-            "{} failed with exit code {cli_exit_code}",
-            env::cli_agent_type()
-        );
+        log_info!(LOG_TAG, "claude-code failed with exit code {cli_exit_code}");
     }
 
     exit_code

--- a/crates/guest-agent/src/paths.rs
+++ b/crates/guest-agent/src/paths.rs
@@ -2,7 +2,7 @@
 //!
 //! Naming conventions:
 //! - "system log" = guest-agent's own stderr (matches TS `SYSTEM_LOG_FILE` and API `systemLog`)
-//! - "agent log" = AI agent (Claude Code / Codex) stdout output
+//! - "agent log" = AI agent (Claude Code) stdout output
 //! - "metrics" = periodic CPU/memory/disk snapshots
 //! - "sandbox ops" = operation timing records (defined in guest-common, re-exported here)
 

--- a/crates/runner/scripts/rootfs.Dockerfile
+++ b/crates/runner/scripts/rootfs.Dockerfile
@@ -1,9 +1,8 @@
-# Firecracker VM rootfs image (Universal)
+# Firecracker VM rootfs image
 # Based on Node.js 24 with Python 3.11+, guest-init, and agent CLIs
 #
-# This is a universal image that supports all frameworks and apps:
-# - Claude Code CLI (@anthropic-ai/claude-code) for framework: claude-code
-# - Codex CLI (@openai/codex) for framework: codex
+# Included CLIs:
+# - Claude Code CLI (@anthropic-ai/claude-code)
 # - GitHub CLI (gh) for apps: [github]
 #
 # This mirrors the e2b template configurations for consistency.
@@ -58,10 +57,6 @@ RUN ARCH=$(dpkg --print-architecture) \
        | jq -r ".platforms[\"$PLATFORM\"].checksum") \
     && echo "${CHECKSUM}  /usr/local/bin/claude" | sha256sum -c - \
     && chmod +x /usr/local/bin/claude
-
-# Install Codex CLI globally (matching e2b template)
-# See: turbo/scripts/e2b/vm0-codex/template.ts
-RUN npm install -g @openai/codex@latest
 
 # Install GitHub CLI (included in base image)
 # See: turbo/scripts/e2b/vm0-claude-code/template.ts

--- a/crates/runner/scripts/verify-rootfs.sh
+++ b/crates/runner/scripts/verify-rootfs.sh
@@ -107,12 +107,6 @@ for dest in "${dests[@]}"; do
 done
 
 # Check CLIs
-if [[ -f "${MOUNT_DIR}/usr/local/bin/codex" ]]; then
-  echo "  codex CLI: found"
-else
-  errors+=("codex CLI not found at /usr/local/bin/codex")
-fi
-
 if [[ -f "${MOUNT_DIR}/usr/bin/gh" ]]; then
   echo "  gh CLI: found"
 else

--- a/crates/runner/src/cmd/snapshot.rs
+++ b/crates/runner/src/cmd/snapshot.rs
@@ -200,7 +200,7 @@ mod tests {
         // Changing this assertion means ALL existing cached snapshots are
         // invalidated.  Only update deliberately.
         assert_eq!(
-            hash, "91c42866b486a8a2a0edb81ee0c74f503c1eab47b34e8e91aa838c2f05431b70",
+            hash, "293b14570b00874e4cf5adf3c8c099e18a59c2eadcce8c26f267a41ace35b5f8",
             "snapshot hash changed — this invalidates all cached snapshots"
         );
     }

--- a/crates/sandbox-fc/src/factory.rs
+++ b/crates/sandbox-fc/src/factory.rs
@@ -27,11 +27,8 @@ use crate::sandbox::FirecrackerSandbox;
 ///   "Invalid API key" but still loads the complete module graph. The claude
 ///   binary is a Bun-compiled executable (not Node.js), so
 ///   `NODE_COMPILE_CACHE` has no effect.
-/// - `codex --help`: lightweight pre-warm for Codex (no `--print` equivalent).
-///   Also tolerated because codex may not be installed.
 pub const PREWARM_SCRIPT: &str = "\
-    (claude --print --verbose --output-format stream-json hi 2>/dev/null || true) && \
-    (codex --help >/dev/null 2>&1 || true)";
+    (claude --print --verbose --output-format stream-json hi 2>/dev/null || true)";
 
 /// Balloon device configuration (invariant across all sandboxes).
 #[derive(serde::Serialize)]


### PR DESCRIPTION
## Summary

- Remove all Codex-specific logic from Rust crates (guest-agent, sandbox-fc, runner)
- Remove ~300 lines of codex-specific code including CLI command building, OpenAI authentication, session handling, Docker image setup, and prewarm scripts
- Simplify remaining code paths to always use Claude Code

## Changes

- **guest-agent/cli.rs**: Remove `build_codex_command()`, `setup_codex()`, and codex branches in `build_cli_command()` and `execute_cli()`
- **guest-agent/events.rs**: Remove codex session ID extraction (`thread.started`/`thread_id`) and `CODEX_SEARCH` history path format
- **guest-agent/checkpoint.rs**: Remove `CODEX_SEARCH` prefix handling, `find_codex_session_file()`, `find_jsonl_files()`, `walk_jsonl()`, and 3 codex test cases
- **guest-agent/main.rs**: Remove codex DNS pre-warming (`api.openai.com`) and codex setup call
- **guest-agent/env.rs**: Remove unused `openai_model()` accessor
- **sandbox-fc/factory.rs**: Remove `codex --help` from `PREWARM_SCRIPT`
- **runner/scripts/rootfs.Dockerfile**: Remove `npm install -g @openai/codex@latest`
- **runner/scripts/verify-rootfs.sh**: Remove codex CLI check

## Test plan

- [x] `cargo build` passes
- [x] `cargo test` passes (192 tests, snapshot hash updated)
- [ ] CI pipeline passes

Closes #4964

🤖 Generated with [Claude Code](https://claude.com/claude-code)