### PR TITLE
feat(chat): add streaming state indicators to chat panel

### DIFF
--- a/turbo/apps/platform/src/signals/agent-detail/__tests__/chat.test.ts
+++ b/turbo/apps/platform/src/signals/agent-detail/__tests__/chat.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect } from "vitest";
+import type { AgentEvent } from "../../logs-page/types.ts";
+import { extractKeyParam, extractStreamingState } from "../chat.ts";
+
+describe("extractKeyParam", () => {
+  it("should extract truncated command for bash tool", () => {
+    const cmd = "a".repeat(80);
+    expect(extractKeyParam("Bash", { command: cmd })).toBe(
+      `${"a".repeat(57)}...`,
+    );
+  });
+
+  it("should return full command when under 60 chars", () => {
+    expect(extractKeyParam("bash", { command: "ls -la" })).toBe("ls -la");
+  });
+
+  it("should extract url for webfetch", () => {
+    expect(extractKeyParam("WebFetch", { url: "https://example.com" })).toBe(
+      "https://example.com",
+    );
+  });
+
+  it("should extract query for websearch", () => {
+    expect(extractKeyParam("WebSearch", { query: "test query" })).toBe(
+      "test query",
+    );
+  });
+
+  it("should prefer url over query for webfetch", () => {
+    expect(
+      extractKeyParam("WebFetch", {
+        url: "https://example.com",
+        query: "fallback",
+      }),
+    ).toBe("https://example.com");
+  });
+
+  it("should extract file_path for read tool", () => {
+    expect(extractKeyParam("Read", { file_path: "/tmp/test.ts" })).toBe(
+      "/tmp/test.ts",
+    );
+  });
+
+  it("should extract path for write tool", () => {
+    expect(extractKeyParam("Write", { path: "/tmp/out.ts" })).toBe(
+      "/tmp/out.ts",
+    );
+  });
+
+  it("should extract pattern for grep tool", () => {
+    expect(extractKeyParam("Grep", { pattern: "*.ts" })).toBe("*.ts");
+  });
+
+  it("should extract skill name for skill tool", () => {
+    expect(extractKeyParam("Skill", { skill: "code-quality" })).toBe(
+      "code-quality",
+    );
+  });
+
+  it("should return empty string for unknown tool", () => {
+    expect(extractKeyParam("UnknownTool", { foo: "bar" })).toBe("");
+  });
+
+  it("should return empty string when expected param is missing", () => {
+    expect(extractKeyParam("bash", {})).toBe("");
+  });
+});
+
+describe("extractStreamingState", () => {
+  function makeEvent(
+    seq: number,
+    eventType: string,
+    eventData: unknown,
+  ): AgentEvent {
+    return {
+      sequenceNumber: seq,
+      eventType,
+      eventData,
+      createdAt: new Date().toISOString(),
+    };
+  }
+
+  it("should return empty state for no events", () => {
+    expect(extractStreamingState([])).toStrictEqual({
+      latestText: "",
+      toolUses: [],
+    });
+  });
+
+  it("should detect system init as tool indicator", () => {
+    const events = [makeEvent(1, "system", { subtype: "init" })];
+    expect(extractStreamingState(events)).toStrictEqual({
+      latestText: "",
+      toolUses: [{ name: "Initialize", keyParam: "" }],
+    });
+  });
+
+  it("should extract text from assistant message", () => {
+    const events = [
+      makeEvent(1, "assistant", {
+        message: {
+          content: [{ type: "text", text: "Hello world" }],
+        },
+      }),
+    ];
+    expect(extractStreamingState(events)).toStrictEqual({
+      latestText: "Hello world",
+      toolUses: [],
+    });
+  });
+
+  it("should extract tool use from assistant message", () => {
+    const events = [
+      makeEvent(1, "assistant", {
+        message: {
+          content: [
+            { type: "tool_use", name: "Bash", input: { command: "ls" } },
+          ],
+        },
+      }),
+    ];
+    expect(extractStreamingState(events)).toStrictEqual({
+      latestText: "",
+      toolUses: [{ name: "Bash", keyParam: "ls" }],
+    });
+  });
+
+  it("should clear tool uses when new text arrives", () => {
+    const events = [
+      makeEvent(1, "assistant", {
+        message: {
+          content: [
+            { type: "tool_use", name: "Bash", input: { command: "ls" } },
+          ],
+        },
+      }),
+      makeEvent(2, "assistant", {
+        message: {
+          content: [{ type: "text", text: "Result text" }],
+        },
+      }),
+    ];
+    expect(extractStreamingState(events)).toStrictEqual({
+      latestText: "Result text",
+      toolUses: [],
+    });
+  });
+
+  it("should accumulate tool uses after text", () => {
+    const events = [
+      makeEvent(1, "assistant", {
+        message: {
+          content: [{ type: "text", text: "Let me check" }],
+        },
+      }),
+      makeEvent(2, "assistant", {
+        message: {
+          content: [
+            { type: "tool_use", name: "Read", input: { file_path: "/a.ts" } },
+          ],
+        },
+      }),
+      makeEvent(3, "assistant", {
+        message: {
+          content: [
+            { type: "tool_use", name: "Grep", input: { pattern: "foo" } },
+          ],
+        },
+      }),
+    ];
+    const result = extractStreamingState(events);
+    expect(result.latestText).toBe("Let me check");
+    expect(result.toolUses).toHaveLength(2);
+    expect(result.toolUses[0]).toStrictEqual({
+      name: "Read",
+      keyParam: "/a.ts",
+    });
+    expect(result.toolUses[1]).toStrictEqual({ name: "Grep", keyParam: "foo" });
+  });
+
+  it("should skip non-system non-assistant events", () => {
+    const events = [
+      makeEvent(1, "user", { message: "hello" }),
+      makeEvent(2, "result", { result: "done" }),
+    ];
+    expect(extractStreamingState(events)).toStrictEqual({
+      latestText: "",
+      toolUses: [],
+    });
+  });
+
+  it("should handle null content gracefully", () => {
+    const events = [makeEvent(1, "assistant", { message: { content: null } })];
+    expect(extractStreamingState(events)).toStrictEqual({
+      latestText: "",
+      toolUses: [],
+    });
+  });
+
+  it("should skip events with non-object eventData", () => {
+    const events = [
+      makeEvent(1, "assistant", "not-an-object"),
+      makeEvent(2, "assistant", null),
+      makeEvent(3, "assistant", 42),
+    ];
+    expect(extractStreamingState(events)).toStrictEqual({
+      latestText: "",
+      toolUses: [],
+    });
+  });
+});

--- a/turbo/apps/platform/src/signals/agent-detail/chat.ts
+++ b/turbo/apps/platform/src/signals/agent-detail/chat.ts
@@ -31,7 +31,7 @@ export interface ChatStreamingState {
 // ---------------------------------------------------------------------------
 
 /** Extract key parameter from tool input for display. */
-function extractKeyParam(
+export function extractKeyParam(
   toolName: string,
   input: Record<string, unknown>,
 ): string {
@@ -77,15 +77,31 @@ interface StreamingEventData {
   };
 }
 
+function isStreamingEventData(data: unknown): data is StreamingEventData {
+  if (typeof data !== "object" || data === null) {
+    return false;
+  }
+  const obj = data as Record<string, unknown>;
+  if ("subtype" in obj && typeof obj.subtype !== "string") {
+    return false;
+  }
+  return true;
+}
+
 /** Extract streaming display state from flat events following the UX spec rules. */
-function extractStreamingState(events: AgentEvent[]): ChatStreamingState {
+export function extractStreamingState(
+  events: AgentEvent[],
+): ChatStreamingState {
   let latestText = "";
   let toolUses: ToolUseInfo[] = [];
 
   for (const event of events) {
+    if (!isStreamingEventData(event.eventData)) {
+      continue;
+    }
+
     if (event.eventType === "system") {
-      const data = event.eventData as StreamingEventData;
-      if (data.subtype === "init") {
+      if (event.eventData.subtype === "init") {
         // System init shows as a tool-like indicator
         toolUses = [{ name: "Initialize", keyParam: "" }];
       }
@@ -96,7 +112,7 @@ function extractStreamingState(events: AgentEvent[]): ChatStreamingState {
       continue;
     }
 
-    const data = event.eventData as StreamingEventData;
+    const data = event.eventData;
     const contents = data.message?.content ?? [];
 
     for (const content of contents) {

--- a/turbo/apps/platform/src/signals/agent-detail/chat.ts
+++ b/turbo/apps/platform/src/signals/agent-detail/chat.ts
@@ -1,5 +1,5 @@
 import { command, computed, state, type Computed } from "ccstate";
-import type { LogStatus } from "../logs-page/types.ts";
+import type { AgentEvent, LogStatus } from "../logs-page/types.ts";
 import { fetch$ } from "../fetch.ts";
 import { throwIfAbort } from "../utils.ts";
 import { logger } from "../log.ts";
@@ -13,8 +13,109 @@ export type { SessionListItem };
 const L = logger("Chat");
 
 // ---------------------------------------------------------------------------
+// Streaming state types
+// ---------------------------------------------------------------------------
+
+interface ToolUseInfo {
+  name: string;
+  keyParam: string;
+}
+
+export interface ChatStreamingState {
+  latestText: string;
+  toolUses: ToolUseInfo[];
+}
+
+// ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+/** Extract key parameter from tool input for display. */
+function extractKeyParam(
+  toolName: string,
+  input: Record<string, unknown>,
+): string {
+  const name = toolName.toLowerCase();
+
+  if (name === "bash" && typeof input.command === "string") {
+    const cmd = input.command;
+    return cmd.length > 60 ? `${cmd.slice(0, 57)}...` : cmd;
+  }
+  if (
+    (name === "webfetch" || name === "websearch") &&
+    typeof input.url === "string"
+  ) {
+    return input.url;
+  }
+  if (
+    (name === "webfetch" || name === "websearch") &&
+    typeof input.query === "string"
+  ) {
+    return input.query;
+  }
+  if (["read", "write", "edit", "glob", "grep"].includes(name)) {
+    const filePath = input.file_path ?? input.path ?? input.pattern;
+    if (typeof filePath === "string") {
+      return filePath;
+    }
+  }
+  if (name === "skill" && typeof input.skill === "string") {
+    return input.skill;
+  }
+  return "";
+}
+
+interface StreamingEventData {
+  subtype?: string;
+  message?: {
+    content: Array<{
+      type: string;
+      text?: string;
+      name?: string;
+      input?: Record<string, unknown>;
+    }> | null;
+  };
+}
+
+/** Extract streaming display state from flat events following the UX spec rules. */
+function extractStreamingState(events: AgentEvent[]): ChatStreamingState {
+  let latestText = "";
+  let toolUses: ToolUseInfo[] = [];
+
+  for (const event of events) {
+    if (event.eventType === "system") {
+      const data = event.eventData as StreamingEventData;
+      if (data.subtype === "init") {
+        // System init shows as a tool-like indicator
+        toolUses = [{ name: "Initialize", keyParam: "" }];
+      }
+      continue;
+    }
+
+    if (event.eventType !== "assistant") {
+      continue;
+    }
+
+    const data = event.eventData as StreamingEventData;
+    const contents = data.message?.content ?? [];
+
+    for (const content of contents) {
+      if (content.type === "text" && content.text) {
+        // New text appears → replace latestText, clear tool uses (UX rule 3/5)
+        latestText = content.text;
+        toolUses = [];
+      } else if (content.type === "tool_use" && content.name) {
+        // Tool use after text → append to tool uses (UX rule 4)
+        toolUses.push({
+          name: content.name,
+          keyParam: extractKeyParam(content.name, content.input ?? {}),
+        });
+      }
+    }
+  }
+
+  return { latestText, toolUses };
+}
 
 /** Scan telemetry event pages for the last "result" event content. */
 async function extractResultFromEvents(
@@ -81,6 +182,22 @@ const internalRunEvents$ = state<Computed<Promise<PageResult>>[]>([]);
 
 const internalSending$ = state(false);
 export const chatSending$ = computed((get) => get(internalSending$));
+
+/** Derived streaming state from run events — used by chat panel during loading. */
+export const chatStreamingState$ = computed(async (get) => {
+  const pages = get(internalRunEvents$);
+  if (pages.length === 0) {
+    return { latestText: "", toolUses: [] };
+  }
+
+  const allEvents: AgentEvent[] = [];
+  for (const page$ of pages) {
+    const page = await get(page$);
+    allEvents.push(...page.events);
+  }
+  allEvents.sort((a, b) => a.sequenceNumber - b.sequenceNumber);
+  return extractStreamingState(allEvents);
+});
 
 const pollingAbortController$ = state<AbortController | null>(null);
 

--- a/turbo/apps/platform/src/views/agent-detail-page/chat-panel.tsx
+++ b/turbo/apps/platform/src/views/agent-detail-page/chat-panel.tsx
@@ -1,4 +1,4 @@
-import { useGet, useSet } from "ccstate-react";
+import { useGet, useLastResolved, useSet } from "ccstate-react";
 import {
   IconX,
   IconLoader2,
@@ -19,6 +19,7 @@ import { detach, Reason } from "../../signals/utils.ts";
 import {
   chatMessages$,
   chatSending$,
+  chatStreamingState$,
   closeChatPanel$,
   sendChatMessage$,
   chatInput$,
@@ -30,6 +31,7 @@ import {
   startNewSession$,
   currentSessionId$,
   type ChatMessage,
+  type ChatStreamingState,
   type SessionListItem,
 } from "../../signals/agent-detail/chat.ts";
 import { agentName$ } from "../../signals/agent-detail/agent-detail.ts";
@@ -206,7 +208,102 @@ function UserMessage({ content }: { content: string }) {
   );
 }
 
+function BouncingDots() {
+  return (
+    <span className="inline-flex items-center gap-0.5" aria-label="Loading">
+      {[0, 1, 2].map((i) => (
+        <span
+          key={i}
+          className="inline-block h-1.5 w-1.5 rounded-full bg-muted-foreground animate-bounce"
+          style={{ animationDelay: `${i * 150}ms` }}
+        />
+      ))}
+    </span>
+  );
+}
+
+function StreamingToolIndicator({
+  name,
+  keyParam,
+}: {
+  name: string;
+  keyParam: string;
+}) {
+  return (
+    <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+      <StatusDot variant="pending" className="animate-pulse" />
+      <span className="font-medium">{name}</span>
+      {keyParam ? (
+        <span className="truncate max-w-[200px] opacity-70">{keyParam}</span>
+      ) : null}
+    </div>
+  );
+}
+
+function StreamingAssistantContent({
+  streaming,
+}: {
+  streaming: ChatStreamingState;
+}) {
+  const { latestText, toolUses } = streaming;
+
+  // State 1: No content yet — bouncing dots
+  if (!latestText && toolUses.length === 0) {
+    return (
+      <div className="py-2">
+        <div className="rounded-lg border border-border bg-background px-3 py-2">
+          <BouncingDots />
+        </div>
+      </div>
+    );
+  }
+
+  // State 2: Tool uses only, no text yet
+  if (!latestText && toolUses.length > 0) {
+    return (
+      <div className="py-2 space-y-1">
+        {toolUses.map((tool) => (
+          <StreamingToolIndicator
+            key={`${tool.name}-${tool.keyParam}`}
+            name={tool.name}
+            keyParam={tool.keyParam}
+          />
+        ))}
+      </div>
+    );
+  }
+
+  // State 3/4: Has text (possibly with tool uses after)
+  return (
+    <div className="py-2 space-y-2">
+      <div className="rounded-lg border border-border bg-background px-3 py-2">
+        <div className="text-sm">
+          <Markdown source={latestText} />
+        </div>
+        {toolUses.length === 0 ? (
+          <div className="mt-1">
+            <BouncingDots />
+          </div>
+        ) : null}
+      </div>
+      {toolUses.length > 0 ? (
+        <div className="space-y-1 pl-1">
+          {toolUses.map((tool) => (
+            <StreamingToolIndicator
+              key={`${tool.name}-${tool.keyParam}`}
+              name={tool.name}
+              keyParam={tool.keyParam}
+            />
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
 function AssistantMessage({ message }: { message: ChatMessage }) {
+  const streaming = useLastResolved(chatStreamingState$);
+
   if (message.error) {
     return (
       <div className="py-2">
@@ -236,15 +333,9 @@ function AssistantMessage({ message }: { message: ChatMessage }) {
     );
   }
 
-  // Waiting: run in progress or output still loading
-  return (
-    <div className="py-2">
-      <div className="flex gap-2 items-center">
-        <StatusDot variant="pending" className="animate-pulse" />
-        <span className="text-sm text-muted-foreground">Thinking...</span>
-      </div>
-    </div>
-  );
+  // Streaming: show live text + tool use indicators
+  const state = streaming ?? { latestText: "", toolUses: [] };
+  return <StreamingAssistantContent streaming={state} />;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Replace the static "Thinking..." message with live streaming indicators during agent runs
- Extract streaming display state (latest text + active tool uses) from telemetry events via new `chatStreamingState$` computed signal
- Show bouncing dots while waiting, tool use indicators with key parameters (command, file path, URL, etc.), and the latest assistant text with markdown rendering

## Test plan
- [ ] Verify chat panel shows bouncing dots immediately after sending a message
- [ ] Verify tool use indicators appear with correct names and key parameters during agent execution
- [ ] Verify latest assistant text renders with markdown formatting
- [ ] Verify the display transitions correctly between states (dots -> tools -> text -> tools)

🤖 Generated with [Claude Code](https://claude.com/claude-code)