### PR TITLE
chore: remove unused slack_default_agent from workflow files

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -219,7 +219,6 @@ jobs:
             SLACK_CLIENT_SECRET=${{ secrets.SLACK_CLIENT_SECRET }}
             SLACK_SIGNING_SECRET=${{ secrets.SLACK_SIGNING_SECRET }}
             SLACK_REDIRECT_BASE_URL=${{ vars.SLACK_REDIRECT_BASE_URL }}
-            SLACK_DEFAULT_AGENT=${{ vars.SLACK_DEFAULT_AGENT }}
             SENTRY_DSN_WEB=${{ secrets.SENTRY_DSN_WEB }}
             SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
             SENTRY_ORG=${{ vars.SENTRY_ORG }}

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -426,7 +426,6 @@ jobs:
           SLACK_CLIENT_SECRET: ${{ secrets.SLACK_CLIENT_SECRET }}
           SLACK_SIGNING_SECRET: ${{ secrets.SLACK_SIGNING_SECRET }}
           SLACK_REDIRECT_BASE_URL: ${{ needs.prepare.outputs.web-preview-url }}
-          SLACK_DEFAULT_AGENT: ${{ vars.SLACK_DEFAULT_AGENT }}
           SENTRY_DSN_WEB: ${{ secrets.SENTRY_DSN_WEB }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: ${{ vars.SENTRY_ORG }}
@@ -620,7 +619,6 @@ jobs:
             SLACK_CLIENT_SECRET=${{ secrets.SLACK_CLIENT_SECRET }}
             SLACK_SIGNING_SECRET=${{ secrets.SLACK_SIGNING_SECRET }}
             SLACK_REDIRECT_BASE_URL=${{ needs.prepare.outputs.web-preview-url }}
-            SLACK_DEFAULT_AGENT=${{ vars.SLACK_DEFAULT_AGENT }}
             SENTRY_DSN_WEB=${{ secrets.SENTRY_DSN_WEB }}
             SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
             SENTRY_ORG=${{ vars.SENTRY_ORG }}


### PR DESCRIPTION
## Summary
- Remove `SLACK_DEFAULT_AGENT` variable references from `turbo.yml` and `release-please.yml` workflow files
- Remove `SLACK_DEFAULT_AGENT` and commented `VM0_ADMIN_USERS` from `.env.local` (untracked)
- Neither variable is referenced in any TypeScript code and their GitHub Variables have been deleted

Closes #4973

## Test plan
- [ ] CI passes (no functionality change, only removing unused env var references)
- [ ] Verify no remaining references to `SLACK_DEFAULT_AGENT` or `VM0_ADMIN_USERS` in tracked files

🤖 Generated with [Claude Code](https://claude.com/claude-code)