### PR TITLE
fix: ensure slack links are clickable in coding-dashboard flaky-test messages

### DIFF
--- a/.claude/skills/coding-dashboard/SKILL.md
+++ b/.claude/skills/coding-dashboard/SKILL.md
@@ -61,7 +61,12 @@ gh run list --workflow turbo.yml --branch main --limit 10 \
      ```bash
      gh run view <RUN_ID> --json jobs --jq '[.jobs[] | select(.conclusion == "failure") | .name]'
      ```
-  2. Post to Slack `#flaky-test` channel with the failed run details (run URL, failed job names) using the Slack MCP tool (`slack_send_message` to `#flaky-test`).
+  2. Post to Slack `#flaky-test` channel using the Slack MCP tool (`slack_send_message` to `#flaky-test`). Use Slack mrkdwn link syntax `<url|display text>` for all URLs so they render as clickable links. Example message format:
+     ```
+     🔴 main CI failure
+     Failed jobs: lint, test
+     Run: <https://github.com/vm0-ai/vm0/actions/runs/12345|#12345>
+     ```
   3. Report the failure in the dashboard output.
 
 ### Step 3: Check Open Issues per Lane


### PR DESCRIPTION
## Summary

- Add explicit Slack mrkdwn link formatting guidance (`<url|display text>`) to Step 2 of the coding-dashboard skill
- Include an example message format showing clickable run URLs posted to `#flaky-test`

Closes #4977

## Test plan

- [ ] Verify the SKILL.md renders correctly in GitHub
- [ ] Next time coding-dashboard posts a flaky-test message, confirm URLs are clickable in Slack

🤖 Generated with [Claude Code](https://claude.com/claude-code)