### PR TITLE
fix(test): restore e2b mock in compose webhook complete test

### DIFF
--- a/turbo/apps/web/app/api/webhooks/compose/complete/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/compose/complete/__tests__/route.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import { POST } from "../route";
 import { POST as createComposeJob } from "../../../../compose/jobs/route";
 import { GET as getComposeJob } from "../../../../compose/jobs/[jobId]/route";
@@ -13,6 +13,17 @@ import {
 } from "../../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
 import { randomUUID } from "crypto";
+
+vi.mock("@e2b/code-interpreter", () => ({
+  Sandbox: {
+    create: vi.fn().mockResolvedValue({
+      sandboxId: "mock-sandbox-id",
+      files: { write: vi.fn().mockResolvedValue(undefined) },
+      commands: { run: vi.fn().mockResolvedValue({ exitCode: 0 }) },
+    }),
+    connect: vi.fn(),
+  },
+}));
 
 const context = testContext();
 


### PR DESCRIPTION
## Summary

- Restore `vi.mock("@e2b/code-interpreter")` that was accidentally removed in #4944
- Without this mock, `triggerComposeJob()` spawns a real E2B sandbox during test setup which fails (no API key), asynchronously setting the job status to `"failed"` before the webhook completion test runs
- Fixes the `test-web` CI failure on main: `expected 'failed' to be 'completed'`

## Test plan

- [x] `pnpm vitest run apps/web/app/api/webhooks/compose/complete/__tests__/route.test.ts` — all 11 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)