### PR TITLE
chore: remove codex from core types and remaining configs

### DIFF
--- a/turbo/apps/cli/src/commands/compose/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/compose/__tests__/index.test.ts
@@ -754,7 +754,7 @@ agents:
             {
               error: {
                 message:
-                  'Unsupported framework: "unsupported-framework". Supported frameworks: claude-code, codex',
+                  'Unsupported framework: "unsupported-framework". Supported frameworks: claude-code',
                 code: "BAD_REQUEST",
               },
             },

--- a/turbo/apps/cli/src/lib/storage/system-storage.ts
+++ b/turbo/apps/cli/src/lib/storage/system-storage.ts
@@ -65,7 +65,7 @@ export async function uploadInstructions(
   const instructionsDir = path.join(tmpDir, "instructions");
   await fs.mkdir(instructionsDir);
 
-  // Write file with framework-specific name (CLAUDE.md for claude-code, AGENTS.md for codex)
+  // Write file with framework-specific name (e.g., CLAUDE.md for claude-code)
   const filename = getInstructionsFilename(framework);
   await fs.writeFile(path.join(instructionsDir, filename), content);
 

--- a/turbo/apps/docs/content/docs/experimental/meta.json
+++ b/turbo/apps/docs/content/docs/experimental/meta.json
@@ -1,4 +1,0 @@
-{
-  "title": "Experimental",
-  "pages": []
-}

--- a/turbo/apps/docs/content/docs/meta.json
+++ b/turbo/apps/docs/content/docs/meta.json
@@ -10,7 +10,6 @@
     "model-selection",
     "agent-skills",
     "reference",
-    "integrations",
-    "experimental"
+    "integrations"
   ]
 }

--- a/turbo/apps/web/app/api/agent/composes/[id]/instructions/route.ts
+++ b/turbo/apps/web/app/api/agent/composes/[id]/instructions/route.ts
@@ -140,8 +140,8 @@ export async function GET(
 
   // Derive the canonical filename from the agent's framework.
   // CLI uploads instructions with a framework-canonical name (e.g., CLAUDE.md
-  // for claude-code, AGENTS.md for codex). Use the same mapping to look up
-  // the file in the manifest, ensuring the read path matches the write path.
+  // for claude-code). Use the same mapping to look up the file in the manifest,
+  // ensuring the read path matches the write path.
   const canonicalFilename = getInstructionsFilename(agentDef?.framework);
   const normalize = (p: string) => (p.startsWith("./") ? p.slice(2) : p);
   const instructionFile = manifest.files.find(

--- a/turbo/apps/web/src/lib/framework/framework-config.ts
+++ b/turbo/apps/web/src/lib/framework/framework-config.ts
@@ -24,10 +24,6 @@ const FRAMEWORK_DEFAULTS: Record<SupportedFramework, FrameworkDefaults> = {
     workingDir: "/home/user/workspace",
     image: "vm0/claude-code:latest",
   },
-  codex: {
-    workingDir: "/home/user/workspace",
-    image: "vm0/codex:latest",
-  },
 };
 
 /**

--- a/turbo/apps/web/src/lib/storage/storage-resolver.ts
+++ b/turbo/apps/web/src/lib/storage/storage-resolver.ts
@@ -20,17 +20,13 @@ import {
  *
  * Each framework expects instructions at a specific location:
  * - claude-code: ~/.claude/
- * - codex: ~/.codex/
  *
- * @param framework - The framework name (e.g., "claude-code", "codex")
+ * @param framework - The framework name (e.g., "claude-code")
  * @returns The mount path for instructions
  * @throws Error if framework is defined but not supported
  */
 function getInstructionsMountPath(framework?: string): string {
-  const validatedFramework = getValidatedFramework(framework);
-  if (validatedFramework === "codex") {
-    return "/home/user/.codex";
-  }
+  getValidatedFramework(framework);
   return "/home/user/.claude";
 }
 
@@ -39,17 +35,13 @@ function getInstructionsMountPath(framework?: string): string {
  *
  * Each framework expects skills at a specific location:
  * - claude-code: ~/.claude/skills/
- * - codex: ~/.codex/skills/
  *
- * @param framework - The framework name (e.g., "claude-code", "codex")
+ * @param framework - The framework name (e.g., "claude-code")
  * @returns The base path for skills
  * @throws Error if framework is defined but not supported
  */
 function getSkillsBasePath(framework?: string): string {
-  const validatedFramework = getValidatedFramework(framework);
-  if (validatedFramework === "codex") {
-    return "/home/user/.codex/skills";
-  }
+  getValidatedFramework(framework);
   return "/home/user/.claude/skills";
 }
 

--- a/turbo/apps/web/src/lib/storage/types.ts
+++ b/turbo/apps/web/src/lib/storage/types.ts
@@ -68,7 +68,7 @@ export interface AgentVolumeConfig {
   agents?: Record<
     string,
     {
-      framework?: string; // Framework name (e.g., "claude-code", "codex") for mount path resolution
+      framework?: string; // Framework name (e.g., "claude-code") for mount path resolution
       volumes?: string[];
       working_dir?: string; // Optional when framework supports auto-config
       instructions?: string; // Path to instructions file (stored as agent-instructions@{name} volume)

--- a/turbo/packages/core/src/__tests__/frameworks.spec.ts
+++ b/turbo/packages/core/src/__tests__/frameworks.spec.ts
@@ -10,23 +10,18 @@ import {
 
 describe("frameworks", () => {
   describe("SUPPORTED_FRAMEWORKS", () => {
-    it("includes claude-code and codex", () => {
+    it("includes claude-code", () => {
       expect(SUPPORTED_FRAMEWORKS).toContain("claude-code");
-      expect(SUPPORTED_FRAMEWORKS).toContain("codex");
     });
 
-    it("has exactly 2 frameworks", () => {
-      expect(SUPPORTED_FRAMEWORKS).toHaveLength(2);
+    it("has exactly 1 framework", () => {
+      expect(SUPPORTED_FRAMEWORKS).toHaveLength(1);
     });
   });
 
   describe("isSupportedFramework", () => {
     it("returns true for claude-code", () => {
       expect(isSupportedFramework("claude-code")).toBe(true);
-    });
-
-    it("returns true for codex", () => {
-      expect(isSupportedFramework("codex")).toBe(true);
     });
 
     it("returns false for undefined", () => {
@@ -45,10 +40,6 @@ describe("frameworks", () => {
   describe("assertSupportedFramework", () => {
     it("does not throw for claude-code", () => {
       expect(() => assertSupportedFramework("claude-code")).not.toThrow();
-    });
-
-    it("does not throw for codex", () => {
-      expect(() => assertSupportedFramework("codex")).not.toThrow();
     });
 
     it("throws for undefined", () => {
@@ -71,7 +62,7 @@ describe("frameworks", () => {
 
     it("lists supported frameworks in error message", () => {
       expect(() => assertSupportedFramework("unknown")).toThrow(
-        "Supported frameworks: claude-code, codex",
+        "Supported frameworks: claude-code",
       );
     });
   });
@@ -83,10 +74,6 @@ describe("frameworks", () => {
 
     it("returns claude-code for claude-code", () => {
       expect(getValidatedFramework("claude-code")).toBe("claude-code");
-    });
-
-    it("returns codex for codex", () => {
-      expect(getValidatedFramework("codex")).toBe("codex");
     });
 
     it("throws for unknown framework", () => {
@@ -101,10 +88,6 @@ describe("frameworks", () => {
       expect(getFrameworkDisplayName("claude-code")).toBe("Claude Code");
     });
 
-    it('returns "Codex" for codex', () => {
-      expect(getFrameworkDisplayName("codex")).toBe("Codex");
-    });
-
     it("throws for unknown framework", () => {
       expect(() => getFrameworkDisplayName("unknown")).toThrow(
         'Unsupported framework "unknown"',
@@ -115,10 +98,6 @@ describe("frameworks", () => {
   describe("getInstructionsFilename", () => {
     it('returns "CLAUDE.md" for claude-code', () => {
       expect(getInstructionsFilename("claude-code")).toBe("CLAUDE.md");
-    });
-
-    it('returns "AGENTS.md" for codex', () => {
-      expect(getInstructionsFilename("codex")).toBe("AGENTS.md");
     });
 
     it('returns "CLAUDE.md" for undefined (defaults to claude-code)', () => {

--- a/turbo/packages/core/src/__tests__/org-reference.spec.ts
+++ b/turbo/packages/core/src/__tests__/org-reference.spec.ts
@@ -5,7 +5,6 @@ import {
   resolveSystemImageToE2b,
   getLegacySystemTemplateWarning,
   SYSTEM_IMAGE_CLAUDE_CODE,
-  SYSTEM_IMAGE_CODEX,
   SYSTEM_IMAGES,
   SYSTEM_VALID_TAGS,
 } from "../org-reference";
@@ -26,11 +25,10 @@ describe("isLegacySystemTemplate", () => {
 describe("system image constants", () => {
   it("has correct system image names", () => {
     expect(SYSTEM_IMAGE_CLAUDE_CODE).toBe("claude-code");
-    expect(SYSTEM_IMAGE_CODEX).toBe("codex");
   });
 
   it("has correct system images array", () => {
-    expect(SYSTEM_IMAGES).toEqual(["claude-code", "codex"]);
+    expect(SYSTEM_IMAGES).toEqual(["claude-code"]);
   });
 
   it("has correct valid tags", () => {
@@ -75,27 +73,10 @@ describe("resolveSystemImageToE2b", () => {
     });
   });
 
-  describe("codex conversions", () => {
-    it("converts vm0/codex to vm0-codex", () => {
-      const result = resolveSystemImageToE2b("codex");
-      expect(result.e2bTemplate).toBe("vm0-codex");
-    });
-
-    it("converts vm0/codex:latest to vm0-codex", () => {
-      const result = resolveSystemImageToE2b("codex", "latest");
-      expect(result.e2bTemplate).toBe("vm0-codex");
-    });
-  });
-
   describe("legacy github aliases", () => {
     it("resolves claude-code-github to vm0-claude-code", () => {
       const result = resolveSystemImageToE2b("claude-code-github");
       expect(result.e2bTemplate).toBe("vm0-claude-code");
-    });
-
-    it("resolves codex-github to vm0-codex", () => {
-      const result = resolveSystemImageToE2b("codex-github");
-      expect(result.e2bTemplate).toBe("vm0-codex");
     });
 
     it("resolves claude-code-github:latest to vm0-claude-code", () => {
@@ -113,7 +94,7 @@ describe("resolveSystemImageToE2b", () => {
 
     it("error message lists available images", () => {
       expect(() => resolveSystemImageToE2b("unknown-image")).toThrow(
-        "vm0/claude-code, vm0/codex",
+        "vm0/claude-code",
       );
     });
 
@@ -146,14 +127,6 @@ describe("getLegacySystemTemplateWarning", () => {
     });
   });
 
-  describe("codex legacy formats", () => {
-    it("returns warning for vm0-codex", () => {
-      const warning = getLegacySystemTemplateWarning("vm0-codex");
-      expect(warning).toContain("deprecated");
-      expect(warning).toContain("vm0/codex");
-    });
-  });
-
   describe("other legacy formats", () => {
     it("returns warning for vm0-github-cli", () => {
       const warning = getLegacySystemTemplateWarning("vm0-github-cli");
@@ -169,7 +142,6 @@ describe("getLegacySystemTemplateWarning", () => {
 
   it("returns undefined for non-legacy formats", () => {
     expect(getLegacySystemTemplateWarning("vm0/claude-code")).toBeUndefined();
-    expect(getLegacySystemTemplateWarning("vm0/codex")).toBeUndefined();
     expect(getLegacySystemTemplateWarning("my-image")).toBeUndefined();
     expect(getLegacySystemTemplateWarning("myorg/image")).toBeUndefined();
   });

--- a/turbo/packages/core/src/contracts/model-providers.ts
+++ b/turbo/packages/core/src/contracts/model-providers.ts
@@ -265,7 +265,7 @@ export const MODEL_PROVIDER_TYPES = {
 } as const;
 
 export type ModelProviderType = keyof typeof MODEL_PROVIDER_TYPES;
-export type ModelProviderFramework = "claude-code" | "codex";
+export type ModelProviderFramework = "claude-code";
 
 export const modelProviderTypeSchema = z.enum([
   "claude-code-oauth-token",
@@ -279,7 +279,7 @@ export const modelProviderTypeSchema = z.enum([
   "aws-bedrock",
 ]);
 
-export const modelProviderFrameworkSchema = z.enum(["claude-code", "codex"]);
+export const modelProviderFrameworkSchema = z.enum(["claude-code"]);
 
 /**
  * Get framework for a model provider type

--- a/turbo/packages/core/src/frameworks.ts
+++ b/turbo/packages/core/src/frameworks.ts
@@ -7,7 +7,7 @@
 /**
  * Supported framework identifiers
  */
-export const SUPPORTED_FRAMEWORKS = ["claude-code", "codex"] as const;
+export const SUPPORTED_FRAMEWORKS = ["claude-code"] as const;
 
 export type SupportedFramework = (typeof SUPPORTED_FRAMEWORKS)[number];
 
@@ -65,7 +65,6 @@ export function getValidatedFramework(
  */
 const FRAMEWORK_DISPLAY_NAMES: Record<SupportedFramework, string> = {
   "claude-code": "Claude Code",
-  codex: "Codex",
 };
 
 /**
@@ -85,7 +84,6 @@ export function getFrameworkDisplayName(framework: string): string {
  */
 const FRAMEWORK_INSTRUCTIONS_FILENAMES: Record<SupportedFramework, string> = {
   "claude-code": "CLAUDE.md",
-  codex: "AGENTS.md",
 };
 
 /**
@@ -93,7 +91,6 @@ const FRAMEWORK_INSTRUCTIONS_FILENAMES: Record<SupportedFramework, string> = {
  *
  * Each framework expects instructions at a specific filename:
  * - claude-code: CLAUDE.md (read from ~/.claude/)
- * - codex: AGENTS.md (read from ~/.codex/)
  *
  * Used by CLI (upload) and web API (read) to ensure a symmetric contract.
  *

--- a/turbo/packages/core/src/org-reference.ts
+++ b/turbo/packages/core/src/org-reference.ts
@@ -10,11 +10,7 @@
  * System image constants
  */
 export const SYSTEM_IMAGE_CLAUDE_CODE = "claude-code";
-export const SYSTEM_IMAGE_CODEX = "codex";
-export const SYSTEM_IMAGES = [
-  SYSTEM_IMAGE_CLAUDE_CODE,
-  SYSTEM_IMAGE_CODEX,
-] as const;
+export const SYSTEM_IMAGES = [SYSTEM_IMAGE_CLAUDE_CODE] as const;
 export const SYSTEM_VALID_TAGS = ["latest"] as const;
 
 export type SystemValidTag = (typeof SYSTEM_VALID_TAGS)[number];
@@ -29,7 +25,6 @@ type SystemImage = (typeof SYSTEM_IMAGES)[number];
 
 const IMAGE_ALIASES: Record<string, SystemImage> = {
   "claude-code-github": "claude-code",
-  "codex-github": "codex",
 };
 
 /**
@@ -47,10 +42,7 @@ export function isValidSystemTag(
  * Conversion rules:
  * - vm0/claude-code → vm0-claude-code
  * - vm0/claude-code:latest → vm0-claude-code
- * - vm0/codex → vm0-codex
- * - vm0/codex:latest → vm0-codex
  * - vm0/claude-code-github → vm0-claude-code (legacy alias)
- * - vm0/codex-github → vm0-codex (legacy alias)
  *
  * Note: :dev tag is no longer supported. Development and production use the
  * same template names but different E2B accounts (controlled by E2B_API_KEY).
@@ -105,9 +97,6 @@ export function getLegacySystemTemplateWarning(
   // Map legacy format to new format
   if (legacyFormat === "vm0-claude-code") {
     return `Warning: "${legacyFormat}" format is deprecated. Use "vm0/claude-code" instead.`;
-  }
-  if (legacyFormat === "vm0-codex") {
-    return `Warning: "${legacyFormat}" format is deprecated. Use "vm0/codex" instead.`;
   }
   if (legacyFormat.startsWith("vm0-github-cli")) {
     return `Warning: "${legacyFormat}" is deprecated. GitHub CLI is now included in the base image.`;


### PR DESCRIPTION
## Summary

- Remove all codex references from core type definitions (`SUPPORTED_FRAMEWORKS`, `SYSTEM_IMAGES`, `ModelProviderFramework`, Zod schemas)
- Remove codex entries from `Record<SupportedFramework, X>` configs (`FRAMEWORK_DEFAULTS`, `FRAMEWORK_DISPLAY_NAMES`, `FRAMEWORK_INSTRUCTIONS_FILENAMES`, `IMAGE_ALIASES`)
- Remove dead codex branches in `storage-resolver.ts` (`getInstructionsMountPath`, `getSkillsBasePath`)
- Remove empty `experimental/` docs directory (only contained codex.mdx, removed in Phase 1)
- Update all affected tests and comments across core, web, CLI, and docs packages

## Test plan

- [x] `pnpm turbo run lint` — all packages pass
- [x] `pnpm check-types` — core package passes (pre-existing unrelated errors in @vm0/ui, docs, web)
- [x] `pnpm vitest run` — frameworks.spec.ts (19 tests), org-reference.spec.ts (23 tests), compose/index.test.ts (94 tests) all pass
- [x] `pnpm knip` — no issues found
- [x] Pre-commit hooks pass (prettier, knip, commitlint)

Closes #4983

🤖 Generated with [Claude Code](https://claude.com/claude-code)