### PR TITLE
refactor: drop per-pr release status markers from coding-dashboard

### DIFF
--- a/.claude/skills/coding-dashboard/SKILL.md
+++ b/.claude/skills/coding-dashboard/SKILL.md
@@ -147,51 +147,20 @@ gh pr list --repo vm0-ai/vm0 --label "$LANE" --author "$ME" --state open \
 
 Mark items with `pending` label as `[Pending]`.
 
-### Step 6: List Recently Merged PRs with Release Status
+### Step 6: List Recently Merged PRs
 
-#### Step 6a: Get Release Reference Points
-
-Fetch the latest GitHub Release tag and its commit SHA, and check for in-progress release-please runs:
-
-```bash
-# Latest release tag and commit
-LATEST_TAG=$(gh release list --repo vm0-ai/vm0 --limit 1 --json tagName --jq '.[0].tagName')
-RELEASE_SHA=$(gh api repos/vm0-ai/vm0/releases/tags/$LATEST_TAG --jq '.target_commitish')
-
-# In-progress release-please workflow
-RUNNING_SHA=$(gh run list --repo vm0-ai/vm0 --workflow release-please.yml --status in_progress --limit 1 --json headSha --jq '.[0].headSha // empty')
-```
-
-#### Step 6b: Query Merged PRs
-
-Query the last 20 merged PRs across all lanes, including merge commit SHA:
+Query the last 20 merged PRs across all lanes:
 
 ```bash
 for i in $(seq 1 $MAX_WORKERS); do
   LANE=$(printf "vm%02d" $i)
   gh pr list --repo vm0-ai/vm0 --label "$LANE" --state merged \
-    --json number,title,mergedAt,labels,mergeCommit --limit 20 \
-    --jq ".[] | {number, title, mergedAt, lane: \"$LANE\", mergeCommitSha: .mergeCommit.oid}"
+    --json number,title,mergedAt,labels --limit 20 \
+    --jq ".[] | {number, title, mergedAt, lane: \"$LANE\"}"
 done
 ```
 
 Combine results, sort by `mergedAt` descending, take the top 20.
-
-#### Step 6c: Annotate Each PR with Release Status
-
-For each merged PR, classify its release status using the merge commit SHA:
-
-```bash
-git merge-base --is-ancestor <mergeCommitSha> $RELEASE_SHA && echo "✅" || ([ -n "$RUNNING_SHA" ] && echo "🚀" || echo "⏳")
-```
-
-| Marker | Meaning | Condition |
-|--------|---------|-----------|
-| ✅ | Released | PR merge commit is an ancestor of the latest release commit |
-| 🚀 | Releasing | Not yet released, but release-please workflow is in progress |
-| ⏳ | Pending release | Not yet released, no release-please run in progress |
-
-Prepend the marker to each PR line in the output.
 
 ---
 
@@ -200,8 +169,7 @@ Prepend the marker to each PR line in the output.
 - Titles should be translated to Chinese
 - Items with `pending` label get a `[Pending]` marker
 - Empty lanes show `-- idle`
-- Merged PRs shown as a list, each line: `Marker Time #ID Lane — Title`
-- Release status markers: ✅ (released), 🚀 (releasing), ⏳ (pending release)
+- Merged PRs shown as a list, each line: `Time #ID Lane — Title`
 
 ### Output Example
 
@@ -240,8 +208,8 @@ vm04
 ---
 近期完成 (最近 20 个已合并 PR，按时间倒序)
 
-- ✅ 3/13 08:35 #4728 vm03 — 升级平台 vite 从 v6 到 v7
-- 🚀 3/13 08:01 #4719 vm01 — 通过 tsx/tsup 升级去重 esbuild 版本
+- 3/13 08:35 #4728 vm03 — 升级平台 vite 从 v6 到 v7
+- 3/13 08:01 #4719 vm01 — 通过 tsx/tsup 升级去重 esbuild 版本
 ---
 ```
 


### PR DESCRIPTION
## Summary
- Remove Step 6a (release reference points query) and Step 6c (per-PR release status annotation logic) from coding-dashboard skill
- Simplify recently merged PR lines to show only time, PR number, lane, and title — no release status emoji markers
- Clean up output format description and example to match

Closes #4989

## Test plan
- [ ] Run `/coding-dashboard` and verify recently merged PRs display without release status emoji markers
- [ ] Verify no references to release status classification remain in the skill

🤖 Generated with [Claude Code](https://claude.com/claude-code)