### PR TITLE
refactor(queue): mask other users' agent and email in run queue response

### DIFF
--- a/turbo/apps/cli/src/commands/run/__tests__/queue.test.ts
+++ b/turbo/apps/cli/src/commands/run/__tests__/queue.test.ts
@@ -43,13 +43,12 @@ describe("run queue command", () => {
             },
             {
               position: 2,
-              agentName: "-",
-              userEmail: "-",
+              agentName: null,
+              userEmail: null,
               createdAt: new Date(Date.now() - 60000).toISOString(),
               runId: null,
             },
           ],
-          total: 2,
         });
       }),
     );
@@ -84,13 +83,12 @@ describe("run queue command", () => {
             },
             {
               position: 2,
-              agentName: "-",
-              userEmail: "-",
+              agentName: null,
+              userEmail: null,
               createdAt: new Date().toISOString(),
               runId: null,
             },
           ],
-          total: 2,
         });
       }),
     );
@@ -108,7 +106,6 @@ describe("run queue command", () => {
         return HttpResponse.json({
           concurrency: { tier: "free", limit: 1, active: 0, available: 1 },
           queue: [],
-          total: 0,
         });
       }),
     );
@@ -159,7 +156,6 @@ describe("run queue command", () => {
               runId: "run-1",
             },
           ],
-          total: 1,
         });
       }),
     );

--- a/turbo/apps/cli/src/commands/run/__tests__/queue.test.ts
+++ b/turbo/apps/cli/src/commands/run/__tests__/queue.test.ts
@@ -39,18 +39,17 @@ describe("run queue command", () => {
               agentName: "data-processor",
               userEmail: "alice@example.com",
               createdAt: new Date(Date.now() - 120000).toISOString(),
-              isOwner: true,
               runId: "run-uuid-1",
             },
             {
               position: 2,
-              agentName: "my-agent",
-              userEmail: "bob@example.com",
+              agentName: "-",
+              userEmail: "-",
               createdAt: new Date(Date.now() - 60000).toISOString(),
-              isOwner: false,
               runId: null,
             },
           ],
+          total: 2,
         });
       }),
     );
@@ -65,8 +64,9 @@ describe("run queue command", () => {
     expect(logCalls).toContain("USER");
     expect(logCalls).toContain("data-processor");
     expect(logCalls).toContain("alice@example.com");
-    expect(logCalls).toContain("my-agent");
-    expect(logCalls).toContain("bob@example.com");
+    // Other user's entries are masked
+    expect(logCalls).toContain("-");
+    expect(logCalls).not.toContain("bob@example.com");
   });
 
   it("marks own entries with you indicator", async () => {
@@ -80,18 +80,17 @@ describe("run queue command", () => {
               agentName: "my-agent",
               userEmail: "alice@example.com",
               createdAt: new Date().toISOString(),
-              isOwner: true,
               runId: "run-uuid-1",
             },
             {
               position: 2,
-              agentName: "other-agent",
-              userEmail: "bob@example.com",
+              agentName: "-",
+              userEmail: "-",
               createdAt: new Date().toISOString(),
-              isOwner: false,
               runId: null,
             },
           ],
+          total: 2,
         });
       }),
     );
@@ -109,6 +108,7 @@ describe("run queue command", () => {
         return HttpResponse.json({
           concurrency: { tier: "free", limit: 1, active: 0, available: 1 },
           queue: [],
+          total: 0,
         });
       }),
     );
@@ -156,10 +156,10 @@ describe("run queue command", () => {
               agentName: "test-agent",
               userEmail: "user@example.com",
               createdAt: new Date().toISOString(),
-              isOwner: true,
               runId: "run-1",
             },
           ],
+          total: 1,
         });
       }),
     );

--- a/turbo/apps/cli/src/commands/run/queue.ts
+++ b/turbo/apps/cli/src/commands/run/queue.ts
@@ -32,8 +32,14 @@ export const queueCommand = new Command()
 
       // Dynamic column widths
       const posWidth = Math.max(1, String(queue.length).length);
-      const agentWidth = Math.max(5, ...queue.map((e) => e.agentName.length));
-      const emailWidth = Math.max(4, ...queue.map((e) => e.userEmail.length));
+      const agentWidth = Math.max(
+        5,
+        ...queue.map((e) => (e.agentName ?? "-").length),
+      );
+      const emailWidth = Math.max(
+        4,
+        ...queue.map((e) => (e.userEmail ?? "-").length),
+      );
 
       // Header
       const header = [
@@ -49,8 +55,8 @@ export const queueCommand = new Command()
         const marker = entry.runId !== null ? chalk.cyan("  ← you") : "";
         const row = [
           String(entry.position).padEnd(posWidth),
-          entry.agentName.padEnd(agentWidth),
-          entry.userEmail.padEnd(emailWidth),
+          (entry.agentName ?? "-").padEnd(agentWidth),
+          (entry.userEmail ?? "-").padEnd(emailWidth),
           formatRelativeTime(entry.createdAt),
         ].join("  ");
         console.log(row + marker);

--- a/turbo/apps/cli/src/commands/run/queue.ts
+++ b/turbo/apps/cli/src/commands/run/queue.ts
@@ -46,7 +46,7 @@ export const queueCommand = new Command()
 
       // Rows
       for (const entry of queue) {
-        const marker = entry.isOwner ? chalk.cyan("  ← you") : "";
+        const marker = entry.runId !== null ? chalk.cyan("  ← you") : "";
         const row = [
           String(entry.position).padEnd(posWidth),
           entry.agentName.padEnd(agentWidth),

--- a/turbo/apps/web/app/api/agent/runs/queue/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/queue/__tests__/route.test.ts
@@ -54,7 +54,6 @@ describe("GET /api/agent/runs/queue", () => {
       }),
     );
     expect(data.queue).toEqual([]);
-    expect(data.total).toBe(0);
   });
 
   it("counts active runs (running + fresh pending)", async () => {
@@ -138,7 +137,6 @@ describe("GET /api/agent/runs/queue", () => {
 
     expect(response.status).toBe(200);
     expect(data.queue).toHaveLength(2);
-    expect(data.total).toBe(2);
 
     const ownEntry = data.queue.find(
       (e: { runId: string | null }) => e.runId !== null,
@@ -152,13 +150,12 @@ describe("GET /api/agent/runs/queue", () => {
     expect(ownEntry.runId).toBeTruthy();
     expect(ownEntry.userEmail).toBe("alice@example.com");
     expect(ownEntry.agentName).toBeTruthy();
-    expect(ownEntry.agentName).not.toBe("-");
 
-    // Other user's run should have masked fields
+    // Other user's run should have null for private fields
     expect(otherEntry).toBeDefined();
     expect(otherEntry.runId).toBeNull();
-    expect(otherEntry.agentName).toBe("-");
-    expect(otherEntry.userEmail).toBe("-");
+    expect(otherEntry.agentName).toBeNull();
+    expect(otherEntry.userEmail).toBeNull();
   });
 
   it("never exposes prompt in response", async () => {

--- a/turbo/apps/web/app/api/agent/runs/queue/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/queue/__tests__/route.test.ts
@@ -54,6 +54,7 @@ describe("GET /api/agent/runs/queue", () => {
       }),
     );
     expect(data.queue).toEqual([]);
+    expect(data.total).toBe(0);
   });
 
   it("counts active runs (running + fresh pending)", async () => {
@@ -111,7 +112,7 @@ describe("GET /api/agent/runs/queue", () => {
     );
   });
 
-  it("includes runId only for requesting user's own runs", async () => {
+  it("masks agentName and userEmail for other users' runs", async () => {
     const otherUserId = uniqueId("other-user");
 
     // Both users' runs use the same compose (same org)
@@ -123,14 +124,10 @@ describe("GET /api/agent/runs/queue", () => {
       status: "queued",
     });
 
-    // Insert user cache entries
+    // Insert user cache entry only for requesting user
     await insertUserCacheEntry({
       userId: user.userId,
       email: "alice@example.com",
-    });
-    await insertUserCacheEntry({
-      userId: otherUserId,
-      email: "bob@example.com",
     });
 
     const request = createTestRequest(
@@ -141,23 +138,27 @@ describe("GET /api/agent/runs/queue", () => {
 
     expect(response.status).toBe(200);
     expect(data.queue).toHaveLength(2);
+    expect(data.total).toBe(2);
 
     const ownEntry = data.queue.find(
-      (e: { isOwner: boolean }) => e.isOwner === true,
+      (e: { runId: string | null }) => e.runId !== null,
     );
     const otherEntry = data.queue.find(
-      (e: { isOwner: boolean }) => e.isOwner === false,
+      (e: { runId: string | null }) => e.runId === null,
     );
 
-    // Own run should include runId
+    // Own run should include real data and runId
     expect(ownEntry).toBeDefined();
     expect(ownEntry.runId).toBeTruthy();
-    expect(ownEntry.isOwner).toBe(true);
+    expect(ownEntry.userEmail).toBe("alice@example.com");
+    expect(ownEntry.agentName).toBeTruthy();
+    expect(ownEntry.agentName).not.toBe("-");
 
-    // Other user's run should NOT include runId
+    // Other user's run should have masked fields
     expect(otherEntry).toBeDefined();
     expect(otherEntry.runId).toBeNull();
-    expect(otherEntry.isOwner).toBe(false);
+    expect(otherEntry.agentName).toBe("-");
+    expect(otherEntry.userEmail).toBe("-");
   });
 
   it("never exposes prompt in response", async () => {
@@ -204,10 +205,10 @@ describe("GET /api/agent/runs/queue", () => {
     const data = await response.json();
 
     expect(response.status).toBe(200);
-    // Should only see runs from user's org
+    // Should only see runs from user's org (all own entries have runId)
     expect(data.queue.length).toBeGreaterThanOrEqual(1);
     for (const entry of data.queue) {
-      expect(entry.isOwner).toBe(true);
+      expect(entry.runId).toBeTruthy();
     }
   });
 

--- a/turbo/apps/web/app/api/agent/runs/queue/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/queue/route.ts
@@ -79,25 +79,21 @@ const router = tsr.router(runsQueueContract, {
       )
       .orderBy(asc(agentRuns.createdAt));
 
-    // Resolve user emails in parallel
-    const uniqueUserIds = [...new Set(queuedRuns.map((r) => r.runUserId))];
-    const userMap = new Map<string, string>();
-    await Promise.all(
-      uniqueUserIds.map(async (uid) => {
-        const user = await getCachedUser(uid);
-        userMap.set(uid, user.email);
-      }),
-    );
+    // Only resolve email for the requesting user (skip others for privacy + perf)
+    const hasOwnRuns = queuedRuns.some((r) => r.runUserId === userId);
+    const ownEmail = hasOwnRuns ? (await getCachedUser(userId)).email : null;
 
-    // Build response with privacy filtering
-    const queue = queuedRuns.map((run, index) => ({
-      position: index + 1,
-      agentName: run.agentName ?? "unknown",
-      userEmail: userMap.get(run.runUserId) ?? "unknown",
-      createdAt: run.createdAt.toISOString(),
-      isOwner: run.runUserId === userId,
-      runId: run.runUserId === userId ? run.id : null,
-    }));
+    // Build response with privacy masking
+    const queue = queuedRuns.map((run, index) => {
+      const isOwner = run.runUserId === userId;
+      return {
+        position: index + 1,
+        agentName: isOwner ? (run.agentName ?? "unknown") : "-",
+        userEmail: isOwner ? (ownEmail ?? "unknown") : "-",
+        createdAt: run.createdAt.toISOString(),
+        runId: isOwner ? run.id : null,
+      };
+    });
 
     return {
       status: 200 as const,
@@ -109,6 +105,7 @@ const router = tsr.router(runsQueueContract, {
           available: limit === 0 ? -1 : Math.max(0, limit - active),
         },
         queue,
+        total: queue.length,
       },
     };
   },

--- a/turbo/apps/web/app/api/agent/runs/queue/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/queue/route.ts
@@ -88,8 +88,8 @@ const router = tsr.router(runsQueueContract, {
       const isOwner = run.runUserId === userId;
       return {
         position: index + 1,
-        agentName: isOwner ? (run.agentName ?? "unknown") : "-",
-        userEmail: isOwner ? (ownEmail ?? "unknown") : "-",
+        agentName: isOwner ? (run.agentName ?? "unknown") : null,
+        userEmail: isOwner ? (ownEmail ?? "unknown") : null,
         createdAt: run.createdAt.toISOString(),
         runId: isOwner ? run.id : null,
       };
@@ -105,7 +105,6 @@ const router = tsr.router(runsQueueContract, {
           available: limit === 0 ? -1 : Math.max(0, limit - active),
         },
         queue,
-        total: queue.length,
       },
     };
   },

--- a/turbo/packages/core/src/contracts/runs.ts
+++ b/turbo/packages/core/src/contracts/runs.ts
@@ -566,13 +566,13 @@ export const logsSearchContract = c.router({
 export type LogsSearchContract = typeof logsSearchContract;
 
 /**
- * Queue entry schema — own entries have real data, others are masked with "-"
+ * Queue entry schema — own entries have real data, others have null for private fields
  * Ownership is detected via runId: non-null = own entry, null = other user's entry
  */
 const queueEntrySchema = z.object({
   position: z.number(),
-  agentName: z.string(),
-  userEmail: z.string(),
+  agentName: z.string().nullable(),
+  userEmail: z.string().nullable(),
   createdAt: z.string(),
   runId: z.string().nullable(),
 });
@@ -593,7 +593,6 @@ const concurrencyInfoSchema = z.object({
 const queueResponseSchema = z.object({
   concurrency: concurrencyInfoSchema,
   queue: z.array(queueEntrySchema),
-  total: z.number(),
 });
 
 /**

--- a/turbo/packages/core/src/contracts/runs.ts
+++ b/turbo/packages/core/src/contracts/runs.ts
@@ -566,14 +566,14 @@ export const logsSearchContract = c.router({
 export type LogsSearchContract = typeof logsSearchContract;
 
 /**
- * Queue entry schema — runId only present for own runs
+ * Queue entry schema — own entries have real data, others are masked with "-"
+ * Ownership is detected via runId: non-null = own entry, null = other user's entry
  */
 const queueEntrySchema = z.object({
   position: z.number(),
   agentName: z.string(),
   userEmail: z.string(),
   createdAt: z.string(),
-  isOwner: z.boolean(),
   runId: z.string().nullable(),
 });
 
@@ -593,6 +593,7 @@ const concurrencyInfoSchema = z.object({
 const queueResponseSchema = z.object({
   concurrency: concurrencyInfoSchema,
   queue: z.array(queueEntrySchema),
+  total: z.number(),
 });
 
 /**


### PR DESCRIPTION
## Summary

- Mask `agentName` and `userEmail` with `"-"` for non-owner queue entries to protect user privacy
- Remove `isOwner` field from contract schema (ownership detected via `runId !== null`)
- Add `total` field to queue response schema
- Skip email resolution for non-owner entries (performance optimization)
- Update CLI to detect own entries via `runId` instead of `isOwner`

## Data Exposure After Change

| Field | Own runs | Other users' runs |
|-------|----------|-------------------|
| position | real | real |
| agentName | real | `"-"` |
| userEmail | real | `"-"` |
| createdAt | real | real |
| runId | real | null |

## Test plan

- [x] API integration tests: verify masking of agentName/userEmail for non-owner entries
- [x] API tests: verify `total` field in response
- [x] CLI tests: verify masked display and `← you` marker via `runId`
- [x] Type check passes across all packages
- [x] Lint passes with zero warnings
- [x] Knip finds no unused exports

Closes #4986

🤖 Generated with [Claude Code](https://claude.com/claude-code)