### PR TITLE
fix(auth): pass capabilities to sandbox token in runner claim route

### DIFF
--- a/turbo/apps/web/app/api/runners/jobs/[id]/claim/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/runners/jobs/[id]/claim/__tests__/route.test.ts
@@ -13,6 +13,7 @@ import {
   type UserContext,
 } from "../../../../../../../src/__tests__/test-helpers";
 import { encryptSecretsMap } from "../../../../../../../src/lib/crypto/secrets-encryption";
+import { verifySandboxToken } from "../../../../../../../src/lib/auth/sandbox-token";
 
 const context = testContext();
 
@@ -307,6 +308,80 @@ describe("POST /api/runners/jobs/:id/claim", () => {
       const data = await response.json();
       expect(data.agentName).toBeUndefined();
       expect(data.agentOrgSlug).toBeUndefined();
+    });
+  });
+
+  describe("Claim flow - capabilities in sandbox token", () => {
+    it("should include capabilities in returned sandbox token", async () => {
+      const { composeId, versionId } = await createTestCompose("test-caps");
+      const composeInfo = await findTestComposeWithOrg(composeId);
+      const orgSlug = composeInfo!.orgSlug;
+
+      const { runId } = await createTestRunnerJob(
+        user.userId,
+        versionId,
+        `${orgSlug}/default`,
+        {
+          experimentalCapabilities: ["storage:read", "storage:write"],
+        },
+      );
+
+      const token = await createTestCliToken(user.userId);
+      const request = createTestRequest(
+        `http://localhost:3000/api/runners/jobs/${runId}/claim`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({}),
+        },
+      );
+
+      const response = await POST(request);
+      expect(response.status).toBe(200);
+
+      const data = await response.json();
+      const sandboxAuth = verifySandboxToken(data.sandboxToken);
+      expect(sandboxAuth).not.toBeNull();
+      expect(sandboxAuth!.capabilities).toEqual([
+        "storage:read",
+        "storage:write",
+      ]);
+    });
+
+    it("should generate token without capabilities when not in stored context", async () => {
+      const { composeId, versionId } = await createTestCompose("test-no-caps");
+      const composeInfo = await findTestComposeWithOrg(composeId);
+      const orgSlug = composeInfo!.orgSlug;
+
+      const { runId } = await createTestRunnerJob(
+        user.userId,
+        versionId,
+        `${orgSlug}/default`,
+      );
+
+      const token = await createTestCliToken(user.userId);
+      const request = createTestRequest(
+        `http://localhost:3000/api/runners/jobs/${runId}/claim`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({}),
+        },
+      );
+
+      const response = await POST(request);
+      expect(response.status).toBe(200);
+
+      const data = await response.json();
+      const sandboxAuth = verifySandboxToken(data.sandboxToken);
+      expect(sandboxAuth).not.toBeNull();
+      expect(sandboxAuth!.capabilities).toBeUndefined();
     });
   });
 

--- a/turbo/apps/web/app/api/runners/jobs/[id]/claim/route.ts
+++ b/turbo/apps/web/app/api/runners/jobs/[id]/claim/route.ts
@@ -127,9 +127,6 @@ const router = tsr.router(runnersJobClaimContract, {
 
     log.debug(`Job ${runId} claimed`);
 
-    // Generate sandbox token for the runner to use when calling webhooks
-    const sandboxToken = await generateSandboxToken(run.userId, run.id);
-
     // Load stored execution context from the job queue
     const storedContext =
       claimedJob.executionContext as StoredExecutionContext | null;
@@ -141,6 +138,13 @@ const router = tsr.router(runnersJobClaimContract, {
         "Job missing execution context",
       );
     }
+
+    // Generate sandbox token with capabilities from stored context
+    const sandboxToken = await generateSandboxToken(
+      run.userId,
+      run.id,
+      storedContext.experimentalCapabilities,
+    );
 
     // Record api_to_claim metric
     if (storedContext.apiStartTime) {


### PR DESCRIPTION
## Summary

- Fix runner job claim route to pass `experimentalCapabilities` from stored execution context to `generateSandboxToken`
- Move `storedContext` loading before token generation so capabilities are available
- Add 2 integration tests verifying capabilities are correctly included in the returned sandbox token JWT

Closes #4981

## Test plan

- [x] New test: claim job with capabilities → verify sandbox token JWT contains capabilities
- [x] New test: claim job without capabilities → verify sandbox token JWT has no capabilities
- [x] All 16 existing claim route tests pass
- [x] Lint passes
- [x] Pre-commit hooks pass (prettier, knip, commitlint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)