### PR TITLE
fix: normalize deprecated capability names to unified storage prefix

### DIFF
--- a/turbo/apps/web/app/api/runners/jobs/[id]/claim/route.ts
+++ b/turbo/apps/web/app/api/runners/jobs/[id]/claim/route.ts
@@ -6,6 +6,7 @@ import {
 import {
   runnersJobClaimContract,
   createErrorResponse,
+  normalizeCapabilities,
   type StoredExecutionContext,
 } from "@vm0/core";
 import { initServices } from "../../../../../../src/lib/init-services";
@@ -198,7 +199,9 @@ const router = tsr.router(runnersJobClaimContract, {
         encryptedSecrets: storedContext.encryptedSecrets, // Encrypted blob for auth resolution
         cliAgentType: storedContext.cliAgentType,
         experimentalFirewall: storedContext.experimentalFirewall,
-        experimentalCapabilities: storedContext.experimentalCapabilities,
+        experimentalCapabilities: storedContext.experimentalCapabilities
+          ? normalizeCapabilities(storedContext.experimentalCapabilities)
+          : undefined,
         debugNoMockClaude: storedContext.debugNoMockClaude,
         apiStartTime: storedContext.apiStartTime,
         userTimezone: storedContext.userTimezone,

--- a/turbo/apps/web/src/lib/run/build-context.ts
+++ b/turbo/apps/web/src/lib/run/build-context.ts
@@ -11,6 +11,7 @@ import {
   connectorTypeSchema,
   MODEL_PROVIDER_TYPES,
   VALID_CAPABILITIES,
+  normalizeCapabilities,
   type ExperimentalFirewall,
   type ConnectorType,
   type ModelProviderType,
@@ -812,7 +813,7 @@ function buildExperimentalCapabilities(
   const capabilities = firstAgent?.experimental_capabilities;
   if (!capabilities || capabilities.length === 0) return undefined;
 
-  return [...capabilities];
+  return normalizeCapabilities(capabilities);
 }
 
 /**

--- a/turbo/apps/web/src/lib/run/run-service.ts
+++ b/turbo/apps/web/src/lib/run/run-service.ts
@@ -34,7 +34,7 @@ import { canAccessCompose } from "../agent/compose-access";
 import { resolveOrg, resolveOrgOrNull } from "../org/resolve-org";
 import { getVariableValues } from "../variable/variable-service";
 import { encryptSecretValue } from "../crypto/secrets-encryption";
-import type { OrgTier } from "@vm0/core";
+import { normalizeCapabilities, type OrgTier } from "@vm0/core";
 
 const log = logger("service:run");
 
@@ -546,9 +546,13 @@ async function buildAndDispatchRun(opts: {
 
   try {
     // Extract capabilities from compose content for sandbox token
+    // Normalize deprecated capability names (e.g., volume:read → storage:read)
     const agents = composeContent.agents;
-    const capabilities = agents
+    const rawCapabilities = agents
       ? Object.values(agents)[0]?.experimental_capabilities
+      : undefined;
+    const capabilities = rawCapabilities
+      ? normalizeCapabilities(rawCapabilities)
       : undefined;
 
     // Register callbacks and generate sandbox token in parallel (independent operations)

--- a/turbo/packages/core/src/contracts/__tests__/composes.test.ts
+++ b/turbo/packages/core/src/contracts/__tests__/composes.test.ts
@@ -3,6 +3,7 @@ import {
   agentDefinitionSchema,
   agentComposeApiContentSchema,
   VALID_CAPABILITIES,
+  normalizeCapabilities,
 } from "../composes";
 
 const baseAgent = {
@@ -108,5 +109,58 @@ describe("experimental_capabilities in agentComposeApiContentSchema", () => {
       }),
     );
     expect(result.success).toBe(false);
+  });
+});
+
+describe("normalizeCapabilities", () => {
+  it("passes through current capabilities unchanged", () => {
+    expect(normalizeCapabilities(["storage:read", "agent:write"])).toEqual(
+      expect.arrayContaining(["storage:read", "agent:write"]),
+    );
+  });
+
+  it("normalizes volume:read to storage:read", () => {
+    expect(normalizeCapabilities(["volume:read"])).toEqual(["storage:read"]);
+  });
+
+  it("normalizes volume:write to storage:write", () => {
+    expect(normalizeCapabilities(["volume:write"])).toEqual(["storage:write"]);
+  });
+
+  it("normalizes artifact:read to storage:read", () => {
+    expect(normalizeCapabilities(["artifact:read"])).toEqual(["storage:read"]);
+  });
+
+  it("normalizes memory:write to storage:write", () => {
+    expect(normalizeCapabilities(["memory:write"])).toEqual(["storage:write"]);
+  });
+
+  it("deduplicates when multiple old caps map to same new cap", () => {
+    const result = normalizeCapabilities([
+      "volume:read",
+      "artifact:read",
+      "memory:read",
+    ]);
+    expect(result).toEqual(["storage:read"]);
+  });
+
+  it("handles mixed old and new capabilities", () => {
+    const result = normalizeCapabilities([
+      "volume:read",
+      "agent:write",
+      "storage:write",
+    ]);
+    expect(result).toHaveLength(3);
+    expect(result).toContain("storage:read");
+    expect(result).toContain("agent:write");
+    expect(result).toContain("storage:write");
+  });
+
+  it("drops unknown capabilities", () => {
+    expect(normalizeCapabilities(["unknown:cap"])).toEqual([]);
+  });
+
+  it("returns empty array for empty input", () => {
+    expect(normalizeCapabilities([])).toEqual([]);
   });
 });

--- a/turbo/packages/core/src/contracts/composes.ts
+++ b/turbo/packages/core/src/contracts/composes.ts
@@ -39,6 +39,41 @@ export const VALID_CAPABILITIES = [
 ] as const;
 
 /**
+ * Alias map for deprecated capability names.
+ * PR #4959 merged volume/artifact/memory into unified storage capabilities.
+ * Old compose versions in the database may still contain these values.
+ */
+const CAPABILITY_ALIASES: Record<string, (typeof VALID_CAPABILITIES)[number]> =
+  {
+    "volume:read": "storage:read",
+    "volume:write": "storage:write",
+    "artifact:read": "storage:read",
+    "artifact:write": "storage:write",
+    "memory:read": "storage:read",
+    "memory:write": "storage:write",
+  };
+
+/**
+ * Normalize capability strings by resolving deprecated aliases.
+ * Unknown capabilities are silently dropped.
+ * Deduplicates results (multiple old caps may map to the same new cap).
+ */
+export function normalizeCapabilities(
+  capabilities: readonly string[],
+): (typeof VALID_CAPABILITIES)[number][] {
+  const result = new Set<(typeof VALID_CAPABILITIES)[number]>();
+  for (const cap of capabilities) {
+    const alias = CAPABILITY_ALIASES[cap];
+    if (alias) {
+      result.add(alias);
+    } else if ((VALID_CAPABILITIES as readonly string[]).includes(cap)) {
+      result.add(cap as (typeof VALID_CAPABILITIES)[number]);
+    }
+  }
+  return [...result];
+}
+
+/**
  * Agent name validation schema
  * - Must be 3-64 characters
  * - Letters, numbers, and hyphens only

--- a/turbo/packages/core/src/contracts/index.ts
+++ b/turbo/packages/core/src/contracts/index.ts
@@ -37,6 +37,7 @@ export {
   composeResponseSchema,
   composeListItemSchema,
   VALID_CAPABILITIES,
+  normalizeCapabilities,
   // Inferred types
   type ComposeResponse,
   type ComposeListItem,


### PR DESCRIPTION
## Summary

- Add `normalizeCapabilities()` function in `@vm0/core` that maps deprecated capability names (`volume:read/write`, `artifact:read/write`, `memory:read/write`) to their unified `storage:read/write` equivalents
- Apply normalization at three independent capability flow points: JWT token generation, execution context building, and runner claim response
- Add 8 test cases covering alias resolution, deduplication, mixed capabilities, and edge cases

## Context

PR #4959 merged storage capabilities but left existing compose versions in the database with old capability names. This caused silent 403 failures when sandbox tokens encoded stale values like `volume:read` while routes checked for `storage:read`.

Closes #4982

## Test plan

- [x] Unit tests for `normalizeCapabilities()` — all 8 cases pass
- [x] Type checking passes across all packages
- [x] Lint and knip pass cleanly
- [x] Existing test suite unaffected (284 core tests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)