### PR TITLE
refactor(auth): clean up capability check helpers and add JWT validation

### DIFF
--- a/turbo/apps/web/app/api/storages/commit/route.ts
+++ b/turbo/apps/web/app/api/storages/commit/route.ts
@@ -34,7 +34,7 @@ const router = tsr.router(storagesCommitContract, {
 
     const { storageName, storageType, versionId, files, runId, message } = body;
 
-    const capability = storageCapability(storageType, "write");
+    const capability = storageCapability("write");
 
     // Authenticate user (sandbox tokens accepted if they have the required capability)
     const authCtx = await requireAuth(headers.authorization, {

--- a/turbo/apps/web/app/api/storages/download/route.ts
+++ b/turbo/apps/web/app/api/storages/download/route.ts
@@ -30,7 +30,7 @@ const router = tsr.router(storagesDownloadContract, {
     initServices();
 
     const { name: storageName, type: storageType, version: versionId } = query;
-    const capability = storageCapability(storageType, "read");
+    const capability = storageCapability("read");
 
     // Authenticate user (sandbox tokens accepted if they have the required capability)
     const authCtx = await requireAuth(headers.authorization, {

--- a/turbo/apps/web/app/api/storages/list/route.ts
+++ b/turbo/apps/web/app/api/storages/list/route.ts
@@ -27,7 +27,7 @@ const router = tsr.router(storagesListContract, {
     initServices();
 
     const { type: storageType } = query;
-    const capability = storageCapability(storageType, "read");
+    const capability = storageCapability("read");
 
     // Authenticate user (sandbox tokens accepted if they have the required capability)
     const authCtx = await requireAuth(headers.authorization, {

--- a/turbo/apps/web/app/api/storages/prepare/route.ts
+++ b/turbo/apps/web/app/api/storages/prepare/route.ts
@@ -108,7 +108,7 @@ const router = tsr.router(storagesPrepareContract, {
       changes,
     } = body;
 
-    const capability = storageCapability(storageType, "write");
+    const capability = storageCapability("write");
 
     // Authenticate user (sandbox tokens accepted if they have the required capability)
     const authCtx = await requireAuth(headers.authorization, {

--- a/turbo/apps/web/src/lib/auth/__tests__/capability-check.test.ts
+++ b/turbo/apps/web/src/lib/auth/__tests__/capability-check.test.ts
@@ -1,45 +1,11 @@
 import { describe, it, expect } from "vitest";
 import {
-  hasCapability,
   isSandboxAuth,
   storageCapability,
   missingCapabilityError,
 } from "../capability-check";
 
 describe("capability-check", () => {
-  describe("hasCapability", () => {
-    it("should return true for CLI auth (no capabilities)", () => {
-      expect(hasCapability({ userId: "user-1" }, "storage:read")).toBe(true);
-    });
-
-    it("should return true for sandbox auth with matching capability", () => {
-      expect(
-        hasCapability(
-          { userId: "user-1", runId: "run-1", capabilities: ["storage:read"] },
-          "storage:read",
-        ),
-      ).toBe(true);
-    });
-
-    it("should return false for sandbox auth without matching capability", () => {
-      expect(
-        hasCapability(
-          { userId: "user-1", runId: "run-1", capabilities: ["storage:read"] },
-          "storage:write",
-        ),
-      ).toBe(false);
-    });
-
-    it("should return false for sandbox auth with empty capabilities", () => {
-      expect(
-        hasCapability(
-          { userId: "user-1", runId: "run-1", capabilities: [] },
-          "storage:read",
-        ),
-      ).toBe(false);
-    });
-  });
-
   describe("isSandboxAuth", () => {
     it("should return false for CLI auth", () => {
       expect(isSandboxAuth({ userId: "user-1" })).toBe(false);
@@ -51,13 +17,9 @@ describe("capability-check", () => {
   });
 
   describe("storageCapability", () => {
-    it("should map all storage types to unified storage capability", () => {
-      expect(storageCapability("volume", "read")).toBe("storage:read");
-      expect(storageCapability("volume", "write")).toBe("storage:write");
-      expect(storageCapability("artifact", "read")).toBe("storage:read");
-      expect(storageCapability("artifact", "write")).toBe("storage:write");
-      expect(storageCapability("memory", "read")).toBe("storage:read");
-      expect(storageCapability("memory", "write")).toBe("storage:write");
+    it("should map action to unified storage capability", () => {
+      expect(storageCapability("read")).toBe("storage:read");
+      expect(storageCapability("write")).toBe("storage:write");
     });
   });
 

--- a/turbo/apps/web/src/lib/auth/__tests__/sandbox-token.test.ts
+++ b/turbo/apps/web/src/lib/auth/__tests__/sandbox-token.test.ts
@@ -156,6 +156,22 @@ describe("sandbox-token", () => {
       expect(auth?.capabilities).toBeUndefined();
     });
 
+    it("should reject token with invalid capability value", async () => {
+      // Cast invalid capability through type system to simulate a malformed token
+      const invalidCaps = [
+        "storage:read",
+        "volume:read",
+      ] as unknown as readonly ("storage:read" | "storage:write")[];
+      const token = await generateSandboxToken(
+        "user-123",
+        "run-456",
+        invalidCaps,
+      );
+      const auth = verifySandboxToken(token);
+
+      expect(auth).toBeNull();
+    });
+
     it("should roundtrip all valid capabilities", async () => {
       const capabilities = [
         "storage:read",

--- a/turbo/apps/web/src/lib/auth/capability-check.ts
+++ b/turbo/apps/web/src/lib/auth/capability-check.ts
@@ -4,21 +4,6 @@ import type { AuthContext } from "./get-user-id";
 type Capability = (typeof VALID_CAPABILITIES)[number];
 
 /**
- * Check if an auth context has a specific capability.
- * Returns true for non-sandbox auth (CLI/session tokens have full access).
- * Returns false if sandbox token lacks the capability.
- */
-export function hasCapability(
-  authCtx: AuthContext,
-  capability: Capability,
-): boolean {
-  if (!authCtx.capabilities) {
-    return true;
-  }
-  return authCtx.capabilities.includes(capability);
-}
-
-/**
  * Check if auth context is from a sandbox token.
  * Sandbox auth contexts have a runId field.
  * Type guard narrows authCtx so callers can access runId without non-null assertion.
@@ -31,12 +16,8 @@ export function isSandboxAuth(
 
 /**
  * Map storage action to unified capability string.
- * All storage types (volume, artifact, memory) use "storage:read" / "storage:write".
  */
-export function storageCapability(
-  _storageType: "volume" | "artifact" | "memory",
-  action: "read" | "write",
-): Capability {
+export function storageCapability(action: "read" | "write"): Capability {
   return `storage:${action}` as Capability;
 }
 

--- a/turbo/apps/web/src/lib/auth/sandbox-token.ts
+++ b/turbo/apps/web/src/lib/auth/sandbox-token.ts
@@ -1,5 +1,5 @@
 import { createHmac, hkdfSync } from "crypto";
-import type { VALID_CAPABILITIES } from "@vm0/core";
+import { VALID_CAPABILITIES } from "@vm0/core";
 import { env } from "../../env";
 import { logger } from "../logger";
 
@@ -135,6 +135,20 @@ function verifyJwt(token: string): SandboxTokenPayload | null {
     // Validate required fields
     if (payload.scope !== "sandbox" || !payload.userId || !payload.runId) {
       return null;
+    }
+
+    // Validate capability values if present
+    if (payload.capabilities) {
+      if (!Array.isArray(payload.capabilities)) {
+        return null;
+      }
+      const validSet = new Set<string>(VALID_CAPABILITIES);
+      for (const cap of payload.capabilities) {
+        if (typeof cap !== "string" || !validSet.has(cap)) {
+          log.debug(`Invalid capability in token: ${String(cap)}`);
+          return null;
+        }
+      }
     }
 
     return payload;


### PR DESCRIPTION
## Summary

Closes #4984

- Add runtime validation of JWT capability values against `VALID_CAPABILITIES` in `verifyJwt()` — tokens with invalid capabilities (e.g. old `"volume:read"`) are now rejected early with a debug log instead of surfacing as a generic 401
- Remove dead `_storageType` parameter from `storageCapability()` — after the storage capability merge (#4959), all storage types map to unified `storage:read` / `storage:write`
- Remove unused `hasCapability()` function — only referenced in tests, never used in production code

## Test plan

- [x] New test: token with invalid capability value is rejected
- [x] Updated `storageCapability` tests for simplified signature
- [x] Removed `hasCapability` tests (dead code)
- [x] All 53 auth tests passing
- [x] Type check, lint, format, knip all passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)