### PR TITLE
feat: redirect to login page on 401 response

### DIFF
--- a/turbo/apps/platform/src/signals/__tests__/fetch.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/fetch.test.ts
@@ -253,6 +253,8 @@ describe("401 redirect", () => {
       }),
     );
 
+    mockedClerk.redirectToSignIn.mockClear();
+
     const fch = context.store.get(fetch$);
     const response = await fch("/test");
 

--- a/turbo/apps/platform/src/signals/__tests__/fetch.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/fetch.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { http } from "msw";
+import { http, HttpResponse } from "msw";
 import { server } from "../../mocks/server.ts";
 import { fetch$ } from "../fetch.ts";
 import { testContext } from "./test-helpers.ts";
 import { setupPage } from "../../__tests__/page-helper.ts";
+import { mockedClerk } from "../../__tests__/mock-auth.ts";
 
 const context = testContext();
 
@@ -232,6 +233,55 @@ describe("url handling", () => {
     expect(captured.request?.url).toBe(
       "http://localhost:3000/api/users?page=1&size=10",
     );
+  });
+});
+
+describe("401 redirect", () => {
+  it("should redirect to sign-in when API returns 401", async () => {
+    await setupPage({
+      context,
+      path: "/",
+      withoutRender: true,
+    });
+
+    server.use(
+      http.get("http://localhost:3000/test", () => {
+        return HttpResponse.json(
+          { error: { message: "Unauthorized", code: "UNAUTHORIZED" } },
+          { status: 401 },
+        );
+      }),
+    );
+
+    const fch = context.store.get(fetch$);
+    const response = await fch("/test");
+
+    expect(response.status).toBe(401);
+    expect(mockedClerk.redirectToSignIn).toHaveBeenCalledWith();
+  });
+
+  it("should not redirect on non-401 errors", async () => {
+    await setupPage({
+      context,
+      path: "/",
+      withoutRender: true,
+    });
+
+    server.use(
+      http.get("http://localhost:3000/test", () => {
+        return HttpResponse.json(
+          { error: { message: "Forbidden", code: "FORBIDDEN" } },
+          { status: 403 },
+        );
+      }),
+    );
+
+    mockedClerk.redirectToSignIn.mockClear();
+
+    const fch = context.store.get(fetch$);
+    await fch("/test");
+
+    expect(mockedClerk.redirectToSignIn).not.toHaveBeenCalled();
   });
 });
 

--- a/turbo/apps/platform/src/signals/fetch.ts
+++ b/turbo/apps/platform/src/signals/fetch.ts
@@ -198,6 +198,13 @@ export const fetch$ = computed((get) => {
       }
     }
 
-    return await fetch(finalUrl, finalInit);
+    const response = await fetch(finalUrl, finalInit);
+
+    if (response.status === 401) {
+      const clerk = await get(clerk$);
+      await clerk.redirectToSignIn();
+    }
+
+    return response;
   };
 });

--- a/turbo/apps/platform/src/signals/fetch.ts
+++ b/turbo/apps/platform/src/signals/fetch.ts
@@ -1,5 +1,6 @@
 import { computed } from "ccstate";
 import { clerk$ } from "./auth.ts";
+import { detach, Reason } from "./utils.ts";
 
 function getConfiguredApiUrl(): string {
   const url = import.meta.env.VITE_API_URL as string | undefined;
@@ -201,8 +202,7 @@ export const fetch$ = computed((get) => {
     const response = await fetch(finalUrl, finalInit);
 
     if (response.status === 401) {
-      const clerk = await get(clerk$);
-      await clerk.redirectToSignIn();
+      detach(clerk.redirectToSignIn(), Reason.DomCallback);
     }
 
     return response;


### PR DESCRIPTION
## Summary
- Intercept 401 Unauthorized responses in the platform app's global fetch wrapper (`fetch$` signal)
- Automatically redirect users to the Clerk sign-in page when a 401 is received
- Prevents users from getting stuck on broken pages after session expiry or org changes

## Changes
- **`apps/platform/src/signals/fetch.ts`** — After each fetch call, check for 401 status and call `clerk.redirectToSignIn()`
- **`apps/platform/src/signals/__tests__/fetch.test.ts`** — Added integration tests for 401 redirect behavior and non-401 error passthrough

## Test plan
- [x] Verify 401 response triggers `redirectToSignIn()`
- [x] Verify 403 and other errors do NOT trigger redirect
- [x] All existing fetch tests continue to pass
- [x] Lint, type-check, and knip all pass

Closes #4796

🤖 Generated with [Claude Code](https://claude.com/claude-code)