### PR TITLE
fix(ci): extract ts from slack action v3 response output

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -107,14 +107,14 @@ jobs:
           echo "text=$text" >> $GITHUB_OUTPUT
 
       - name: Notify Slack - Success
-        if: ${{ success() && steps.slack-start.outputs.ts }}
+        if: ${{ success() && fromJSON(steps.slack-start.outputs.response).ts }}
         uses: slackapi/slack-github-action@v3.0.1
         with:
           method: chat.update
           token: ${{ secrets.CI_SLACK_BOT_TOKEN }}
           payload: |
             channel: ${{ vars.SLACK_RELEASE_CHANNEL_ID }}
-            ts: "${{ steps.slack-start.outputs.ts }}"
+            ts: "${{ fromJSON(steps.slack-start.outputs.response).ts }}"
             text: "*Database Migration* ✅ Migration completed"
             blocks:
               - type: section
@@ -123,14 +123,14 @@ jobs:
                   text: "*Database Migration* ✅ Migration completed\n📦 Version: `${{ needs.release-please.outputs.web_version }}`\n⏱️ `${{ steps.duration.outputs.text }}`\n🔗 <${{ github.server_url }}/${{ github.repository }}/releases/tag/web-v${{ needs.release-please.outputs.web_version }}|View Release>"
 
       - name: Notify Slack - Failure
-        if: ${{ failure() && steps.slack-start.outputs.ts }}
+        if: ${{ failure() && fromJSON(steps.slack-start.outputs.response).ts }}
         uses: slackapi/slack-github-action@v3.0.1
         with:
           method: chat.update
           token: ${{ secrets.CI_SLACK_BOT_TOKEN }}
           payload: |
             channel: ${{ vars.SLACK_RELEASE_CHANNEL_ID }}
-            ts: "${{ steps.slack-start.outputs.ts }}"
+            ts: "${{ fromJSON(steps.slack-start.outputs.response).ts }}"
             text: "*Database Migration* ❌ Migration failed"
             blocks:
               - type: section
@@ -311,14 +311,14 @@ jobs:
           echo "text=$text" >> $GITHUB_OUTPUT
 
       - name: Notify Slack - Success
-        if: ${{ success() && steps.slack-start.outputs.ts }}
+        if: ${{ success() && fromJSON(steps.slack-start.outputs.response).ts }}
         uses: slackapi/slack-github-action@v3.0.1
         with:
           method: chat.update
           token: ${{ secrets.CI_SLACK_BOT_TOKEN }}
           payload: |
             channel: ${{ vars.SLACK_RELEASE_CHANNEL_ID }}
-            ts: "${{ steps.slack-start.outputs.ts }}"
+            ts: "${{ fromJSON(steps.slack-start.outputs.response).ts }}"
             text: "*Web App* ✅ Deployed successfully"
             blocks:
               - type: section
@@ -327,14 +327,14 @@ jobs:
                   text: "*Web App* ✅ Deployed successfully\n📦 Version: `${{ needs.release-please.outputs.web_version }}`\n⏱️ `${{ steps.duration.outputs.text }}`\n🔗 <${{ github.server_url }}/${{ github.repository }}/releases/tag/web-v${{ needs.release-please.outputs.web_version }}|View Release>"
 
       - name: Notify Slack - Failure
-        if: ${{ failure() && steps.slack-start.outputs.ts }}
+        if: ${{ failure() && fromJSON(steps.slack-start.outputs.response).ts }}
         uses: slackapi/slack-github-action@v3.0.1
         with:
           method: chat.update
           token: ${{ secrets.CI_SLACK_BOT_TOKEN }}
           payload: |
             channel: ${{ vars.SLACK_RELEASE_CHANNEL_ID }}
-            ts: "${{ steps.slack-start.outputs.ts }}"
+            ts: "${{ fromJSON(steps.slack-start.outputs.response).ts }}"
             text: "*Web App* ❌ Deploy failed"
             blocks:
               - type: section
@@ -399,14 +399,14 @@ jobs:
           echo "text=$text" >> $GITHUB_OUTPUT
 
       - name: Notify Slack - Success
-        if: ${{ success() && steps.slack-start.outputs.ts }}
+        if: ${{ success() && fromJSON(steps.slack-start.outputs.response).ts }}
         uses: slackapi/slack-github-action@v3.0.1
         with:
           method: chat.update
           token: ${{ secrets.CI_SLACK_BOT_TOKEN }}
           payload: |
             channel: ${{ vars.SLACK_RELEASE_CHANNEL_ID }}
-            ts: "${{ steps.slack-start.outputs.ts }}"
+            ts: "${{ fromJSON(steps.slack-start.outputs.response).ts }}"
             text: "*Docs* ✅ Deployed successfully"
             blocks:
               - type: section
@@ -415,14 +415,14 @@ jobs:
                   text: "*Docs* ✅ Deployed successfully\n📦 Version: `${{ needs.release-please.outputs.docs_version }}`\n⏱️ `${{ steps.duration.outputs.text }}`\n🔗 <${{ github.server_url }}/${{ github.repository }}/releases/tag/docs-v${{ needs.release-please.outputs.docs_version }}|View Release>"
 
       - name: Notify Slack - Failure
-        if: ${{ failure() && steps.slack-start.outputs.ts }}
+        if: ${{ failure() && fromJSON(steps.slack-start.outputs.response).ts }}
         uses: slackapi/slack-github-action@v3.0.1
         with:
           method: chat.update
           token: ${{ secrets.CI_SLACK_BOT_TOKEN }}
           payload: |
             channel: ${{ vars.SLACK_RELEASE_CHANNEL_ID }}
-            ts: "${{ steps.slack-start.outputs.ts }}"
+            ts: "${{ fromJSON(steps.slack-start.outputs.response).ts }}"
             text: "*Docs* ❌ Deploy failed"
             blocks:
               - type: section
@@ -494,14 +494,14 @@ jobs:
           echo "text=$text" >> $GITHUB_OUTPUT
 
       - name: Notify Slack - Success
-        if: ${{ success() && steps.slack-start.outputs.ts }}
+        if: ${{ success() && fromJSON(steps.slack-start.outputs.response).ts }}
         uses: slackapi/slack-github-action@v3.0.1
         with:
           method: chat.update
           token: ${{ secrets.CI_SLACK_BOT_TOKEN }}
           payload: |
             channel: ${{ vars.SLACK_RELEASE_CHANNEL_ID }}
-            ts: "${{ steps.slack-start.outputs.ts }}"
+            ts: "${{ fromJSON(steps.slack-start.outputs.response).ts }}"
             text: "*Platform* ✅ Deployed successfully"
             blocks:
               - type: section
@@ -510,14 +510,14 @@ jobs:
                   text: "*Platform* ✅ Deployed successfully\n📦 Version: `${{ needs.release-please.outputs.platform_version }}`\n⏱️ `${{ steps.duration.outputs.text }}`\n🔗 <${{ github.server_url }}/${{ github.repository }}/releases/tag/platform-v${{ needs.release-please.outputs.platform_version }}|View Release>"
 
       - name: Notify Slack - Failure
-        if: ${{ failure() && steps.slack-start.outputs.ts }}
+        if: ${{ failure() && fromJSON(steps.slack-start.outputs.response).ts }}
         uses: slackapi/slack-github-action@v3.0.1
         with:
           method: chat.update
           token: ${{ secrets.CI_SLACK_BOT_TOKEN }}
           payload: |
             channel: ${{ vars.SLACK_RELEASE_CHANNEL_ID }}
-            ts: "${{ steps.slack-start.outputs.ts }}"
+            ts: "${{ fromJSON(steps.slack-start.outputs.response).ts }}"
             text: "*Platform* ❌ Deploy failed"
             blocks:
               - type: section
@@ -590,14 +590,14 @@ jobs:
           echo "text=$text" >> $GITHUB_OUTPUT
 
       - name: Notify Slack - Success
-        if: ${{ success() && steps.slack-start.outputs.ts }}
+        if: ${{ success() && fromJSON(steps.slack-start.outputs.response).ts }}
         uses: slackapi/slack-github-action@v3.0.1
         with:
           method: chat.update
           token: ${{ secrets.CI_SLACK_BOT_TOKEN }}
           payload: |
             channel: ${{ vars.SLACK_RELEASE_CHANNEL_ID }}
-            ts: "${{ steps.slack-start.outputs.ts }}"
+            ts: "${{ fromJSON(steps.slack-start.outputs.response).ts }}"
             text: "*CLI* ✅ Published successfully"
             blocks:
               - type: section
@@ -606,14 +606,14 @@ jobs:
                   text: "*CLI* ✅ Published successfully\n📦 Version: `${{ needs.release-please.outputs.cli_version }}`\n⏱️ `${{ steps.duration.outputs.text }}`\n🔗 <${{ github.server_url }}/${{ github.repository }}/releases/tag/cli-v${{ needs.release-please.outputs.cli_version }}|View Release>\n📦 <https://www.npmjs.com/package/@vm0/cli/v/${{ needs.release-please.outputs.cli_version }}|View on npm>"
 
       - name: Notify Slack - Failure
-        if: ${{ failure() && steps.slack-start.outputs.ts }}
+        if: ${{ failure() && fromJSON(steps.slack-start.outputs.response).ts }}
         uses: slackapi/slack-github-action@v3.0.1
         with:
           method: chat.update
           token: ${{ secrets.CI_SLACK_BOT_TOKEN }}
           payload: |
             channel: ${{ vars.SLACK_RELEASE_CHANNEL_ID }}
-            ts: "${{ steps.slack-start.outputs.ts }}"
+            ts: "${{ fromJSON(steps.slack-start.outputs.response).ts }}"
             text: "*CLI* ❌ Publish failed"
             blocks:
               - type: section
@@ -766,14 +766,14 @@ jobs:
           echo "text=$text" >> $GITHUB_OUTPUT
 
       - name: Notify Slack - Success
-        if: ${{ success() && steps.slack-start.outputs.ts }}
+        if: ${{ success() && fromJSON(steps.slack-start.outputs.response).ts }}
         uses: slackapi/slack-github-action@v3.0.1
         with:
           method: chat.update
           token: ${{ secrets.CI_SLACK_BOT_TOKEN }}
           payload: |
             channel: ${{ vars.SLACK_RELEASE_CHANNEL_ID }}
-            ts: "${{ steps.slack-start.outputs.ts }}"
+            ts: "${{ fromJSON(steps.slack-start.outputs.response).ts }}"
             text: "*Runner RS* ✅ Deployed successfully"
             blocks:
               - type: section
@@ -782,14 +782,14 @@ jobs:
                   text: "*Runner RS* ✅ Deployed successfully\n📦 Version: `${{ needs.release-please.outputs.runner_rs_version }}`\n⏱️ `${{ steps.duration.outputs.text }}`\n🔗 <${{ github.server_url }}/${{ github.repository }}/releases/tag/runner-rs-v${{ needs.release-please.outputs.runner_rs_version }}|View Release>"
 
       - name: Notify Slack - Failure
-        if: ${{ failure() && steps.slack-start.outputs.ts }}
+        if: ${{ failure() && fromJSON(steps.slack-start.outputs.response).ts }}
         uses: slackapi/slack-github-action@v3.0.1
         with:
           method: chat.update
           token: ${{ secrets.CI_SLACK_BOT_TOKEN }}
           payload: |
             channel: ${{ vars.SLACK_RELEASE_CHANNEL_ID }}
-            ts: "${{ steps.slack-start.outputs.ts }}"
+            ts: "${{ fromJSON(steps.slack-start.outputs.response).ts }}"
             text: "*Runner RS* ❌ Deploy failed"
             blocks:
               - type: section

--- a/.github/workflows/test-slack-notification.yml
+++ b/.github/workflows/test-slack-notification.yml
@@ -1,0 +1,49 @@
+name: Test Slack Notification
+
+on:
+  push:
+    branches:
+      - fix/release-slack-notifications
+
+jobs:
+  test-slack:
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - name: Send test message
+        id: slack-start
+        if: ${{ vars.SLACK_RELEASE_CHANNEL_ID != '' }}
+        uses: slackapi/slack-github-action@v3.0.1
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.CI_SLACK_BOT_TOKEN }}
+          payload: |
+            channel: ${{ vars.SLACK_RELEASE_CHANNEL_ID }}
+            text: "Test: Slack notification from release pipeline fix PR"
+            blocks:
+              - type: section
+                text:
+                  type: mrkdwn
+                  text: "*Test Notification* deploying...\n\nThis is a test to verify Slack notifications are working with `slackapi/slack-github-action@v3.0.1`."
+
+      - name: Debug output
+        if: ${{ always() }}
+        run: |
+          echo "response output: ${{ steps.slack-start.outputs.response }}"
+          echo "ts from response: ${{ fromJSON(steps.slack-start.outputs.response).ts }}"
+
+      - name: Update message with success
+        if: ${{ success() && fromJSON(steps.slack-start.outputs.response).ts }}
+        uses: slackapi/slack-github-action@v3.0.1
+        with:
+          method: chat.update
+          token: ${{ secrets.CI_SLACK_BOT_TOKEN }}
+          payload: |
+            channel: ${{ vars.SLACK_RELEASE_CHANNEL_ID }}
+            ts: "${{ fromJSON(steps.slack-start.outputs.response).ts }}"
+            text: "Test: Slack notification working correctly"
+            blocks:
+              - type: section
+                text:
+                  type: mrkdwn
+                  text: "*Test Notification* updated successfully\n\nThe `chat.postMessage` -> `chat.update` flow works correctly with `fromJSON(steps.slack-start.outputs.response).ts`."


### PR DESCRIPTION
## Summary
- `slackapi/slack-github-action@v3` changed output format: `ts` is no longer a direct output, it's nested inside `outputs.response` JSON
- All `steps.slack-start.outputs.ts` references updated to `fromJSON(steps.slack-start.outputs.response).ts`
- Added temporary test workflow (`test-slack-notification.yml`) to verify the fix — will remove after verification

## Test plan
- [ ] Verify test-slack-notification workflow sends a message to Slack channel
- [ ] Verify the message gets updated (chat.update) successfully
- [ ] Remove test-slack-notification.yml after verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)