### PR TITLE
chore: remove unused cli_agent_type() from guest-agent

### DIFF
--- a/crates/guest-agent/src/env.rs
+++ b/crates/guest-agent/src/env.rs
@@ -17,14 +17,6 @@ static PROMPT: LazyLock<String> = LazyLock::new(|| env_or_empty("VM0_PROMPT"));
 static VERCEL_BYPASS: LazyLock<String> = LazyLock::new(|| env_or_empty("VERCEL_PROTECTION_BYPASS"));
 static RESUME_SESSION_ID: LazyLock<String> =
     LazyLock::new(|| env_or_empty("VM0_RESUME_SESSION_ID"));
-static CLI_AGENT_TYPE: LazyLock<String> = LazyLock::new(|| {
-    let v = env_or_empty("CLI_AGENT_TYPE");
-    if v.is_empty() {
-        "claude-code".to_string()
-    } else {
-        v
-    }
-});
 static API_START_TIME: LazyLock<String> = LazyLock::new(|| env_or_empty("VM0_API_START_TIME"));
 static WORKING_DIR: LazyLock<String> = LazyLock::new(|| env_or_empty("VM0_WORKING_DIR"));
 static SECRET_VALUES: LazyLock<String> = LazyLock::new(|| env_or_empty("VM0_SECRET_VALUES"));
@@ -91,9 +83,6 @@ pub fn vercel_bypass() -> &'static str {
 }
 pub fn resume_session_id() -> &'static str {
     &RESUME_SESSION_ID
-}
-pub fn cli_agent_type() -> &'static str {
-    &CLI_AGENT_TYPE
 }
 pub fn api_start_time() -> &'static str {
     &API_START_TIME

--- a/crates/guest-agent/src/memory.rs
+++ b/crates/guest-agent/src/memory.rs
@@ -3,7 +3,6 @@
 //! Creates a symlink from Claude Code's expected auto-memory directory to the
 //! vm0 memory volume mount path, enabling native auto-memory read/write.
 
-use crate::env;
 use guest_common::log_info;
 use std::path::Path;
 
@@ -24,16 +23,11 @@ fn encode_project_name(working_dir: &str) -> String {
 /// Returns `true` if the symlink was created, `false` if skipped.
 ///
 /// No-op when:
-/// - Agent type is not claude-code
 /// - No memory volume configured (mount path empty)
 /// - Memory mount path doesn't exist on disk
 /// - Symlink target already exists
 pub fn setup_auto_memory_symlink() -> bool {
-    if env::cli_agent_type() != "claude-code" {
-        return false;
-    }
-
-    let memory_mount = env::memory_mount_path();
+    let memory_mount = crate::env::memory_mount_path();
     if memory_mount.is_empty() {
         return false;
     }
@@ -44,7 +38,7 @@ pub fn setup_auto_memory_symlink() -> bool {
     }
 
     let home = std::env::var("HOME").unwrap_or_else(|_| "/home/user".to_string());
-    let project_name = encode_project_name(env::working_dir());
+    let project_name = encode_project_name(crate::env::working_dir());
     let auto_memory_dir = Path::new(&home)
         .join(".claude")
         .join("projects")


### PR DESCRIPTION
## Summary

- Remove `CLI_AGENT_TYPE` static and `cli_agent_type()` accessor from `crates/guest-agent/src/env.rs`
- Remove dead agent-type guard in `setup_auto_memory_symlink()` in `crates/guest-agent/src/memory.rs`

Since the Codex framework was removed (PR #4972), the only agent type is `claude-code`, making this function and its sole call-site (`cli_agent_type() != "claude-code"` — always false) redundant.

Closes #5028

## Test plan

- [x] `cargo build --package guest-agent` passes
- [x] `cargo test --package guest-agent` — all 48 tests pass
- [x] Pre-commit hooks (cargo-fmt, cargo-clippy, commitlint) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)