### PR TITLE
refactor: rename firewall array fields to plural form

### DIFF
--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -176,7 +176,7 @@ class FirewallBlock(NamedTuple):
     path: str
 
 
-def match_firewall_request(url: str, method: str, vm_firewall: list | None) -> FirewallAllow | FirewallBlock | None:
+def match_firewall_request(url: str, method: str, vm_firewalls: list | None) -> FirewallAllow | FirewallBlock | None:
     """Match request against firewall permissions.
 
     Returns:
@@ -184,7 +184,7 @@ def match_firewall_request(url: str, method: str, vm_firewall: list | None) -> F
       FirewallBlock — base URL matched but no permission granted
       None — no base URL match (not a firewall request)
     """
-    if not vm_firewall:
+    if not vm_firewalls:
         return None
 
     # Track the first base URL that matched. If we find a base match but no
@@ -195,7 +195,7 @@ def match_firewall_request(url: str, method: str, vm_firewall: list | None) -> F
 
     upper_method = method.upper()
 
-    for fw_entry in vm_firewall:
+    for fw_entry in vm_firewalls:
         fw_name = fw_entry.get("name", "")
         fw_ref = fw_entry.get("ref", "")
         for api_entry in fw_entry.get("apis", []):
@@ -442,10 +442,10 @@ def request(flow: http.HTTPFlow) -> None:
 
     # --- Step 2: Firewall match with permission check ---
     # Match base URL, then check permission rules before injecting auth headers.
-    vm_firewall = vm_info.get("firewall")
-    if vm_firewall:
+    vm_firewalls = vm_info.get("firewalls")
+    if vm_firewalls:
         original_url = get_original_url(flow)
-        result = match_firewall_request(original_url, flow.request.method, vm_firewall)
+        result = match_firewall_request(original_url, flow.request.method, vm_firewalls)
         if isinstance(result, FirewallBlock):
             ctx.log.warn(f"[{run_id}] Firewall {result.firewall_ref}: no matching permission for {result.method} {result.path}")
             flow.metadata["firewall_action"] = "DENY"

--- a/crates/runner/mitm-addon/tests/test_connectors.py
+++ b/crates/runner/mitm-addon/tests/test_connectors.py
@@ -24,7 +24,7 @@ def _make_http_flow(client_ip="10.200.0.1", host="api.github.com", port=443, pat
     return flow
 
 
-def _wrap_firewall(apis, name="test", ref="test"):
+def _wrap_firewalls(apis, name="test", ref="test"):
     """Wrap a list of API entries into a firewall entry list."""
     return [{"name": name, "ref": ref, "apis": apis}]
 
@@ -95,7 +95,7 @@ class TestMatchFirewallRequest:
 
     def test_no_permissions_blocks(self):
         """Missing permissions field → block (fail-closed)."""
-        fw_configs = _wrap_firewall([
+        fw_configs = _wrap_firewalls([
             {"base": "https://api.github.com", "auth": {"headers": {}}},
         ], name="github", ref="github")
         result = mitm_addon.match_firewall_request("https://api.github.com/repos", "GET", fw_configs)
@@ -106,7 +106,7 @@ class TestMatchFirewallRequest:
         assert result.path == "/repos"
 
     def test_permission_match_allows(self):
-        fw_configs = _wrap_firewall([{
+        fw_configs = _wrap_firewalls([{
             "base": "https://api.github.com",
             "auth": {"headers": {}},
             "permissions": [{"name": "repo-read", "rules": ["GET /repos/{owner}/{repo}"]}],
@@ -119,7 +119,7 @@ class TestMatchFirewallRequest:
         assert result.match_info["rule"] == "GET /repos/{owner}/{repo}"
 
     def test_any_method_matches(self):
-        fw_configs = _wrap_firewall([{
+        fw_configs = _wrap_firewalls([{
             "base": "https://api.github.com",
             "auth": {"headers": {}},
             "permissions": [{"name": "full-access", "rules": ["ANY /{path+}"]}],
@@ -129,7 +129,7 @@ class TestMatchFirewallRequest:
         assert result.match_info["permission"] == "full-access"
 
     def test_method_case_insensitive(self):
-        fw_configs = _wrap_firewall([{
+        fw_configs = _wrap_firewalls([{
             "base": "https://api.github.com",
             "auth": {"headers": {}},
             "permissions": [{"name": "p", "rules": ["post /repos"]}],
@@ -138,7 +138,7 @@ class TestMatchFirewallRequest:
         assert isinstance(result, FirewallAllow)
 
     def test_wrong_method_blocks(self):
-        fw_configs = _wrap_firewall([{
+        fw_configs = _wrap_firewalls([{
             "base": "https://api.github.com",
             "auth": {"headers": {}},
             "permissions": [{"name": "read-only", "rules": ["GET /repos/{owner}/{repo}"]}],
@@ -147,7 +147,7 @@ class TestMatchFirewallRequest:
         assert isinstance(result, FirewallBlock)
 
     def test_wrong_path_blocks(self):
-        fw_configs = _wrap_firewall([{
+        fw_configs = _wrap_firewalls([{
             "base": "https://api.github.com",
             "auth": {"headers": {}},
             "permissions": [{"name": "repo-read", "rules": ["GET /repos/{owner}/{repo}"]}],
@@ -156,7 +156,7 @@ class TestMatchFirewallRequest:
         assert isinstance(result, FirewallBlock)
 
     def test_no_base_match_returns_none(self):
-        fw_configs = _wrap_firewall([{
+        fw_configs = _wrap_firewalls([{
             "base": "https://api.github.com",
             "auth": {"headers": {}},
             "permissions": [{"name": "p", "rules": ["GET /{path+}"]}],
@@ -172,7 +172,7 @@ class TestMatchFirewallRequest:
 
     def test_exact_base_no_path(self):
         """URL equals base exactly (rest='') → rel_path='/' → matches root rule."""
-        fw_configs = _wrap_firewall([{
+        fw_configs = _wrap_firewalls([{
             "base": "https://api.github.com",
             "auth": {"headers": {}},
             "permissions": [{"name": "root", "rules": ["GET /"]}],
@@ -183,7 +183,7 @@ class TestMatchFirewallRequest:
 
     def test_trailing_slash_on_url(self):
         """URL trailing slash doesn't affect matching (split filters empty segments)."""
-        fw_configs = _wrap_firewall([{
+        fw_configs = _wrap_firewalls([{
             "base": "https://api.github.com",
             "auth": {"headers": {}},
             "permissions": [{"name": "p", "rules": ["GET /repos"]}],
@@ -193,7 +193,7 @@ class TestMatchFirewallRequest:
 
     def test_trailing_slash_on_base_config(self):
         """Base URL with trailing slash still matches (rstrip strips it)."""
-        fw_configs = _wrap_firewall([{
+        fw_configs = _wrap_firewalls([{
             "base": "https://api.github.com/",
             "auth": {"headers": {}},
             "permissions": [{"name": "p", "rules": ["GET /repos"]}],
@@ -203,7 +203,7 @@ class TestMatchFirewallRequest:
 
     def test_port_boundary_rejected(self):
         """Port in URL (rest starts with ':') is not a valid path boundary."""
-        fw_configs = _wrap_firewall([{
+        fw_configs = _wrap_firewalls([{
             "base": "https://api.github.com",
             "auth": {"headers": {}},
             "permissions": [{"name": "p", "rules": ["ANY /{path+}"]}],
@@ -212,7 +212,7 @@ class TestMatchFirewallRequest:
         assert result is None
 
     def test_evil_domain_not_matched(self):
-        fw_configs = _wrap_firewall([{
+        fw_configs = _wrap_firewalls([{
             "base": "https://api.github.com",
             "auth": {"headers": {}},
             "permissions": [{"name": "p", "rules": ["ANY /{path+}"]}],
@@ -221,7 +221,7 @@ class TestMatchFirewallRequest:
         assert result is None
 
     def test_multiple_permissions_first_match_wins(self):
-        fw_configs = _wrap_firewall([{
+        fw_configs = _wrap_firewalls([{
             "base": "https://slack.com/api",
             "auth": {"headers": {}},
             "permissions": [
@@ -235,7 +235,7 @@ class TestMatchFirewallRequest:
 
     def test_malformed_rules_skipped(self):
         """Rules without 'METHOD /path' format are silently skipped, not crash or false-allow."""
-        fw_configs = _wrap_firewall([{
+        fw_configs = _wrap_firewalls([{
             "base": "https://api.github.com",
             "auth": {"headers": {}},
             "permissions": [{"name": "bad", "rules": ["GET", "", "INVALID", "  ", "GET /repos"]}],
@@ -249,7 +249,7 @@ class TestMatchFirewallRequest:
 
     def test_path_case_sensitive(self):
         """URL paths are case-sensitive — /REPOS must not match /repos."""
-        fw_configs = _wrap_firewall([{
+        fw_configs = _wrap_firewalls([{
             "base": "https://api.github.com",
             "auth": {"headers": {}},
             "permissions": [{"name": "p", "rules": ["GET /repos/{owner}"]}],
@@ -279,7 +279,7 @@ class TestMatchFirewallRequest:
         assert sl.match_info["name"] == "slack"
 
     def test_query_string_stripped_for_matching(self):
-        fw_configs = _wrap_firewall([{
+        fw_configs = _wrap_firewalls([{
             "base": "https://api.github.com",
             "auth": {"headers": {}},
             "permissions": [{"name": "p", "rules": ["GET /repos"]}],
@@ -288,7 +288,7 @@ class TestMatchFirewallRequest:
         assert isinstance(result, FirewallAllow)
 
     def test_fragment_stripped_for_matching(self):
-        fw_configs = _wrap_firewall([{
+        fw_configs = _wrap_firewalls([{
             "base": "https://api.github.com",
             "auth": {"headers": {}},
             "permissions": [{"name": "p", "rules": ["GET /repos"]}],
@@ -298,7 +298,7 @@ class TestMatchFirewallRequest:
 
     def test_empty_permissions_list_blocks(self):
         """If permissions is present but empty, no rules can match → block."""
-        fw_configs = _wrap_firewall([{
+        fw_configs = _wrap_firewalls([{
             "base": "https://api.github.com",
             "auth": {"headers": {}},
             "permissions": [],
@@ -308,7 +308,7 @@ class TestMatchFirewallRequest:
 
     def test_different_bases_same_permission_name(self):
         """Same permission name across different api_entries — each matches its own base."""
-        fw_configs = _wrap_firewall([
+        fw_configs = _wrap_firewalls([
             {
                 "base": "https://slack.com/api",
                 "auth": {"headers": {"Authorization": "Bearer api-token"}},
@@ -334,7 +334,7 @@ class TestMatchFirewallRequest:
 
     def test_same_base_different_permissions(self):
         """Same base URL with different permissions/auth — second api_entry can match."""
-        fw_configs = _wrap_firewall([
+        fw_configs = _wrap_firewalls([
             {
                 "base": "https://slack.com/api",
                 "auth": {"headers": {"Authorization": "Bearer bot"}},

--- a/crates/runner/mitm-addon/tests/test_handlers.py
+++ b/crates/runner/mitm-addon/tests/test_handlers.py
@@ -119,7 +119,7 @@ class TestRequestHandler:
                     "runId": "run-conn-1",
                     "sandboxToken": "tok-conn",
                     "networkLogPath": str(tmp_path / "net.jsonl"),
-                    "firewall": [
+                    "firewalls": [
                         {"name": "github", "ref": "github", "apis": [
                             {
                                 "base": "https://api.github.com",
@@ -164,7 +164,7 @@ class TestRequestHandler:
                     "runId": "run-conn-1",
                     "sandboxToken": "tok-conn",
                     "networkLogPath": str(tmp_path / "net.jsonl"),
-                    "firewall": [
+                    "firewalls": [
                         {"name": "github", "ref": "github", "apis": [
                             {
                                 "base": "https://api.github.com",
@@ -215,7 +215,7 @@ class TestRequestHandler:
                     "runId": "run-conn-1",
                     "sandboxToken": "tok-conn",
                     "networkLogPath": str(tmp_path / "net.jsonl"),
-                    "firewall": [
+                    "firewalls": [
                         {"name": "github", "ref": "github", "apis": [
                             {
                                 "base": "https://api.github.com",
@@ -264,7 +264,7 @@ class TestRequestHandler:
                     "runId": "run-conn-1",
                     "sandboxToken": "tok-conn",
                     "networkLogPath": str(tmp_path / "net.jsonl"),
-                    "firewall": [
+                    "firewalls": [
                         {"name": "github", "ref": "github", "apis": [
                             {
                                 "base": "https://api.github.com",

--- a/crates/runner/src/cmd/benchmark.rs
+++ b/crates/runner/src/cmd/benchmark.rs
@@ -189,7 +189,7 @@ async fn run_sandbox(
         run_id: &run_id,
         sandbox_token: "",
         network_log_path: &network_log_path,
-        firewall: None,
+        firewalls: None,
         encrypted_secrets: None,
         secret_connector_map: None,
     };

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -109,11 +109,11 @@ async fn execute_inner(
 
     // Register VM in proxy registry when firewall rules are present
     let source_ip = sandbox.source_ip().to_string();
-    let has_firewall = context
-        .experimental_firewall
+    let has_firewalls = context
+        .experimental_firewalls
         .as_ref()
         .is_some_and(|s| s.iter().any(|entry| !entry.apis.is_empty()));
-    let proxy_registered = has_firewall;
+    let proxy_registered = has_firewalls;
     let network_log_path = config.log_paths.network_log(context.run_id);
 
     if proxy_registered {
@@ -122,7 +122,7 @@ async fn execute_inner(
             run_id: &run_id_str,
             sandbox_token: &context.sandbox_token,
             network_log_path: &network_log_path,
-            firewall: context.experimental_firewall.as_deref(),
+            firewalls: context.experimental_firewalls.as_deref(),
             encrypted_secrets: context.encrypted_secrets.as_deref(),
             secret_connector_map: context.secret_connector_map.as_ref(),
         };
@@ -563,7 +563,7 @@ fn build_env_json(context: &ExecutionContext, api_url: &str) -> HashMap<String, 
     // MITM is always enabled when firewall rules are configured.
     // The certificate is pre-baked into the rootfs at build time.
     let proxy_active = context
-        .experimental_firewall
+        .experimental_firewalls
         .as_ref()
         .is_some_and(|s| s.iter().any(|entry| !entry.apis.is_empty()));
     if proxy_active {
@@ -666,7 +666,7 @@ mod tests {
             agent_name: None,
             agent_org_slug: None,
             memory_name: None,
-            experimental_firewall: None,
+            experimental_firewalls: None,
             experimental_capabilities: None,
         }
     }
@@ -887,7 +887,7 @@ mod tests {
     #[test]
     fn build_env_json_firewall_enable_ca_certs() {
         let mut ctx = minimal_context();
-        ctx.experimental_firewall = Some(vec![crate::types::Firewall {
+        ctx.experimental_firewalls = Some(vec![crate::types::Firewall {
             name: "gmail".into(),
             ref_key: "gmail".into(),
             apis: vec![crate::types::FirewallApi {
@@ -909,7 +909,7 @@ mod tests {
     #[test]
     fn build_env_json_empty_firewall_no_ca_certs() {
         let mut ctx = minimal_context();
-        ctx.experimental_firewall = Some(vec![]);
+        ctx.experimental_firewalls = Some(vec![]);
         let env = build_env_json(&ctx, "http://localhost");
         assert!(!env.contains_key("NODE_EXTRA_CA_CERTS"));
     }
@@ -971,14 +971,14 @@ mod tests {
     }
 
     #[test]
-    fn execution_context_deserializes_with_firewall() {
+    fn execution_context_deserializes_with_firewalls() {
         let json = serde_json::json!({
             "runId": "00000000-0000-0000-0000-000000000001",
             "prompt": "test",
             "sandboxToken": "tok",
             "workingDir": "/workspace",
             "cliAgentType": "claude-code",
-            "experimentalFirewall": [{
+            "experimentalFirewalls": [{
                 "name": "github",
                 "ref": "github",
                 "apis": [{
@@ -1001,7 +1001,7 @@ mod tests {
             }]
         });
         let ctx: ExecutionContext = serde_json::from_value(json).unwrap();
-        let svcs = ctx.experimental_firewall.unwrap();
+        let svcs = ctx.experimental_firewalls.unwrap();
         assert_eq!(svcs.len(), 1);
         assert_eq!(svcs[0].name, "github");
         assert_eq!(svcs[0].ref_key, "github");
@@ -1015,7 +1015,7 @@ mod tests {
     }
 
     #[test]
-    fn execution_context_deserializes_without_firewall() {
+    fn execution_context_deserializes_without_firewalls() {
         let json = serde_json::json!({
             "runId": "00000000-0000-0000-0000-000000000001",
             "prompt": "test",
@@ -1024,7 +1024,7 @@ mod tests {
             "cliAgentType": "claude-code"
         });
         let ctx: ExecutionContext = serde_json::from_value(json).unwrap();
-        assert!(ctx.experimental_firewall.is_none());
+        assert!(ctx.experimental_firewalls.is_none());
     }
 
     #[test]

--- a/crates/runner/src/provider/local.rs
+++ b/crates/runner/src/provider/local.rs
@@ -158,7 +158,7 @@ impl JobProvider for LocalProvider {
             agent_name: None,
             agent_org_slug: None,
             memory_name: None,
-            experimental_firewall: None,
+            experimental_firewalls: None,
             experimental_capabilities: None,
         })
     }

--- a/crates/runner/src/proxy.rs
+++ b/crates/runner/src/proxy.rs
@@ -25,7 +25,7 @@ struct VmEntry {
     sandbox_token: String,
     registered_at: i64,
     network_log_path: String,
-    firewall: Option<Vec<crate::types::Firewall>>,
+    firewalls: Option<Vec<crate::types::Firewall>>,
     encrypted_secrets: Option<String>,
     secret_connector_map: Option<HashMap<String, String>>,
 }
@@ -36,7 +36,7 @@ pub struct VmRegistration<'a> {
     pub run_id: &'a str,
     pub sandbox_token: &'a str,
     pub network_log_path: &'a std::path::Path,
-    pub firewall: Option<&'a [crate::types::Firewall]>,
+    pub firewalls: Option<&'a [crate::types::Firewall]>,
     pub encrypted_secrets: Option<&'a str>,
     pub secret_connector_map: Option<&'a HashMap<String, String>>,
 }
@@ -399,7 +399,7 @@ impl ProxyRegistryHandle {
 
         let mut registry = read_registry(&self.registry_path).await?;
         let now = chrono::Utc::now().timestamp_millis();
-        let firewall = registration.firewall.map(|s| {
+        let firewalls = registration.firewalls.map(|s| {
             let mut s = s.to_vec();
             let mut idx = 0usize;
             for entry in &mut s {
@@ -419,7 +419,7 @@ impl ProxyRegistryHandle {
                 sandbox_token: registration.sandbox_token.to_string(),
                 registered_at: now,
                 network_log_path: registration.network_log_path.to_string_lossy().into_owned(),
-                firewall,
+                firewalls,
                 encrypted_secrets: registration.encrypted_secrets.map(String::from),
                 secret_connector_map: registration.secret_connector_map.cloned(),
             },
@@ -494,7 +494,7 @@ mod tests {
                 sandbox_token: String::new(),
                 registered_at: 1000,
                 network_log_path: "/tmp/network-test-run.jsonl".to_string(),
-                firewall: None,
+                firewalls: None,
                 encrypted_secrets: None,
                 secret_connector_map: None,
             },
@@ -540,7 +540,7 @@ mod tests {
             run_id: "run-1",
             sandbox_token: "tok-1",
             network_log_path: std::path::Path::new("/tmp/network-run-1.jsonl"),
-            firewall: None,
+            firewalls: None,
             encrypted_secrets: None,
             secret_connector_map: None,
         };
@@ -559,7 +559,7 @@ mod tests {
             sandbox_token: "tok-2",
 
             network_log_path: std::path::Path::new("/tmp/network-run-2.jsonl"),
-            firewall: None,
+            firewalls: None,
             encrypted_secrets: None,
             secret_connector_map: None,
         };
@@ -611,7 +611,7 @@ mod tests {
                     sandbox_token: "",
 
                     network_log_path: &log_path,
-                    firewall: None,
+                    firewalls: None,
                     encrypted_secrets: None,
                     secret_connector_map: None,
                 };
@@ -628,7 +628,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn registry_with_firewall() {
+    async fn registry_with_firewalls() {
         let dir = tempfile::tempdir().unwrap();
         let registry_path = dir.path().join("proxy-registry.json");
         let lock_path = dir.path().join("proxy-registry.json.lock");
@@ -670,7 +670,7 @@ mod tests {
             run_id: "run-fw",
             sandbox_token: "tok",
             network_log_path: std::path::Path::new("/tmp/network-run-fw.jsonl"),
-            firewall: Some(&firewall_entries),
+            firewalls: Some(&firewall_entries),
             encrypted_secrets: None,
             secret_connector_map: None,
         };
@@ -682,7 +682,7 @@ mod tests {
         // Verify firewall entries are stored in registry.
         let loaded = read_registry(&registry_path).await.unwrap();
         let vm = loaded.vms.get("10.200.0.5").unwrap();
-        let stored = vm.firewall.as_ref().unwrap();
+        let stored = vm.firewalls.as_ref().unwrap();
         assert_eq!(stored.len(), 1);
         assert_eq!(stored[0].apis.len(), 1);
         assert_eq!(
@@ -697,7 +697,7 @@ mod tests {
         let raw = tokio::fs::read_to_string(&registry_path).await.unwrap();
         let value: serde_json::Value = serde_json::from_str(&raw).unwrap();
         let vm_json = &value["vms"]["10.200.0.5"];
-        let fw = &vm_json["firewall"][0];
+        let fw = &vm_json["firewalls"][0];
         assert_eq!(fw["name"], "gmail");
         assert_eq!(fw["ref"], "gmail");
         assert_eq!(
@@ -735,7 +735,7 @@ mod tests {
             sandbox_token: "tok",
 
             network_log_path: std::path::Path::new("/tmp/network-run-enc.jsonl"),
-            firewall: None,
+            firewalls: None,
             encrypted_secrets: Some("iv_b64:tag_b64:data_b64"),
             secret_connector_map: None,
         };

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -76,7 +76,7 @@ pub struct ExecutionContext {
     #[serde(default)]
     pub memory_name: Option<String>,
     #[serde(default)]
-    pub experimental_firewall: Option<Vec<Firewall>>,
+    pub experimental_firewalls: Option<Vec<Firewall>>,
     #[serde(default)]
     pub experimental_capabilities: Option<Vec<String>>,
 }

--- a/e2e/tests/03-experimental-runner/t42-firewall-placeholder.bats
+++ b/e2e/tests/03-experimental-runner/t42-firewall-placeholder.bats
@@ -1,8 +1,8 @@
 #!/usr/bin/env bats
 
-# Test experimental_firewall placeholder env var injection and permission-based matching
+# Test experimental_firewalls placeholder env var injection and permission-based matching
 #
-# Verifies that when experimental_firewall is declared:
+# Verifies that when experimental_firewalls is declared:
 # 1. Placeholder env vars replace secret values in the sandbox (with custom formats)
 # 2. Proxy replaces placeholder tokens and enforces permission-based access control
 
@@ -91,7 +91,7 @@ agents:
     description: "Multi-firewall placeholder test"
     framework: claude-code
     working_dir: /home/user/workspace
-    experimental_firewall:
+    experimental_firewalls:
       github:
         permissions: all
       slack:
@@ -130,7 +130,7 @@ agents:
     description: "Permission-based request matching test"
     framework: claude-code
     working_dir: /home/user/workspace
-    experimental_firewall:
+    experimental_firewalls:
       github:
         permissions:
           - repo-read

--- a/turbo/apps/cli/src/commands/compose/index.ts
+++ b/turbo/apps/cli/src/commands/compose/index.ts
@@ -74,7 +74,7 @@ interface AgentConfig {
   skills?: string[];
   environment?: Record<string, string>;
   metadata?: { displayName?: string; sound?: string };
-  experimental_firewall?: Record<string, FirewallSelection>;
+  experimental_firewalls?: Record<string, FirewallSelection>;
 }
 
 interface LoadedConfig {
@@ -512,7 +512,7 @@ async function finalizeCompose(
   // Merge skill variables into environment
   mergeSkillVariables(agent, variables);
 
-  // Expand experimental_firewall from names to full configs before sending to API
+  // Expand experimental_firewalls from names to full configs before sending to API
   await expandFirewallConfigs(config);
 
   // Call API

--- a/turbo/apps/web/app/api/runners/jobs/[id]/claim/route.ts
+++ b/turbo/apps/web/app/api/runners/jobs/[id]/claim/route.ts
@@ -202,7 +202,7 @@ const router = tsr.router(runnersJobClaimContract, {
         secretValues, // Decrypted secret values for log masking
         encryptedSecrets: storedContext.encryptedSecrets, // Encrypted blob for auth resolution
         cliAgentType: storedContext.cliAgentType,
-        experimentalFirewall: storedContext.experimentalFirewall,
+        experimentalFirewalls: storedContext.experimentalFirewalls,
         experimentalCapabilities: storedContext.experimentalCapabilities
           ? normalizeCapabilities(storedContext.experimentalCapabilities)
           : undefined,

--- a/turbo/apps/web/src/lib/run/build-context.ts
+++ b/turbo/apps/web/src/lib/run/build-context.ts
@@ -12,7 +12,7 @@ import {
   MODEL_PROVIDER_TYPES,
   VALID_CAPABILITIES,
   normalizeCapabilities,
-  type ExperimentalFirewall,
+  type ExperimentalFirewalls,
   type ConnectorType,
   type ModelProviderType,
   type ModelProviderFramework,
@@ -770,7 +770,7 @@ interface BuildContextResult {
 }
 
 /**
- * Build ExperimentalFirewall manifest from agent compose's expanded experimental_firewall.
+ * Build ExperimentalFirewalls manifest from agent compose's expanded experimental_firewalls.
  * Returns null if no firewall configs are declared.
  *
  * Reads pre-expanded ExpandedFirewallConfig objects (resolved at compose time)
@@ -778,14 +778,14 @@ interface BuildContextResult {
  *
  * Placeholder env var injection is handled by expandEnvironmentFromCompose.
  */
-function buildExperimentalFirewall(
+function buildExperimentalFirewalls(
   agentCompose: unknown,
-): ExperimentalFirewall | null {
+): ExperimentalFirewalls | null {
   const compose = agentCompose as AgentComposeYaml | undefined;
   if (!compose?.agents) return null;
 
   const firstAgent = Object.values(compose.agents)[0];
-  const firewallConfigs = firstAgent?.experimental_firewall;
+  const firewallConfigs = firstAgent?.experimental_firewalls;
   if (!firewallConfigs || firewallConfigs.length === 0) return null;
 
   return firewallConfigs.map((fw) => ({
@@ -923,8 +923,8 @@ export async function buildExecutionContext(
   const userTimezone = userPrefs?.timezone ?? undefined;
 
   // Build experimental firewall manifest (base + auth entries for the runner)
-  const experimentalFirewall =
-    buildExperimentalFirewall(agentCompose) ?? undefined;
+  const experimentalFirewalls =
+    buildExperimentalFirewalls(agentCompose) ?? undefined;
 
   // Build experimental capabilities list from compose
   const experimentalCapabilities = buildExperimentalCapabilities(agentCompose);
@@ -948,7 +948,7 @@ export async function buildExecutionContext(
       volumeVersions,
       environment,
       userTimezone,
-      experimentalFirewall,
+      experimentalFirewalls,
       experimentalCapabilities,
       resumeSession,
       resumeArtifact,

--- a/turbo/apps/web/src/lib/run/context/execution-preparer.ts
+++ b/turbo/apps/web/src/lib/run/context/execution-preparer.ts
@@ -225,7 +225,7 @@ function buildPreparedContext(
     memoryName: context.memoryName || null,
 
     // Experimental firewall for proxy-side token replacement
-    experimentalFirewall: context.experimentalFirewall ?? null,
+    experimentalFirewalls: context.experimentalFirewalls ?? null,
 
     // Experimental capabilities
     experimentalCapabilities: context.experimentalCapabilities ?? null,

--- a/turbo/apps/web/src/lib/run/environment/__tests__/expand-environment.test.ts
+++ b/turbo/apps/web/src/lib/run/environment/__tests__/expand-environment.test.ts
@@ -14,7 +14,7 @@ function makeCompose(
         framework: "claude-code" as const,
         working_dir: "/home/user",
         environment,
-        ...(firewallConfigs ? { experimental_firewall: firewallConfigs } : {}),
+        ...(firewallConfigs ? { experimental_firewalls: firewallConfigs } : {}),
       },
     },
   };

--- a/turbo/apps/web/src/lib/run/environment/expand-environment.ts
+++ b/turbo/apps/web/src/lib/run/environment/expand-environment.ts
@@ -76,7 +76,7 @@ function buildFirewallPlaceholders(
  * Extract and expand environment variables from agent compose config
  * Expands ${{ vars.xxx }} and ${{ secrets.xxx }} references
  *
- * When experimental_firewall is declared:
+ * When experimental_firewalls is declared:
  * - Firewall secret values are replaced with placeholders (proxy resolves real secrets at runtime)
  *
  * @param agentCompose Agent compose configuration
@@ -125,7 +125,7 @@ export function expandEnvironmentFromCompose(
   }
 
   const firewallPlaceholders = buildFirewallPlaceholders(
-    firstAgent?.experimental_firewall ?? [],
+    firstAgent?.experimental_firewalls ?? [],
   );
 
   // Process secrets if needed

--- a/turbo/apps/web/src/lib/run/executors/runner-executor.ts
+++ b/turbo/apps/web/src/lib/run/executors/runner-executor.ts
@@ -57,7 +57,7 @@ export async function executeRunnerJob(
     encryptedSecrets,
     secretConnectorMap: context.secretConnectorMap,
     cliAgentType: context.cliAgentType,
-    experimentalFirewall: context.experimentalFirewall ?? undefined,
+    experimentalFirewalls: context.experimentalFirewalls ?? undefined,
     experimentalCapabilities: context.experimentalCapabilities ?? undefined,
     debugNoMockClaude: context.debugNoMockClaude || undefined,
     apiStartTime: context.apiStartTime ?? undefined,

--- a/turbo/apps/web/src/lib/run/executors/types.ts
+++ b/turbo/apps/web/src/lib/run/executors/types.ts
@@ -1,7 +1,7 @@
 import type { StorageManifest } from "../../storage/types";
 import type { ResumeSession } from "../types";
 import type { ArtifactSnapshot } from "../../checkpoint/types";
-import type { ExperimentalFirewall, VALID_CAPABILITIES } from "@vm0/core";
+import type { ExperimentalFirewalls, VALID_CAPABILITIES } from "@vm0/core";
 
 /**
  * Prepared execution context for executors
@@ -43,7 +43,7 @@ export interface PreparedContext {
   memoryName: string | null;
 
   // Experimental firewall for proxy-side token replacement
-  experimentalFirewall: ExperimentalFirewall | null;
+  experimentalFirewalls: ExperimentalFirewalls | null;
 
   // Experimental capabilities for agent permission enforcement
   experimentalCapabilities: (typeof VALID_CAPABILITIES)[number][] | null;

--- a/turbo/apps/web/src/lib/run/types.ts
+++ b/turbo/apps/web/src/lib/run/types.ts
@@ -1,5 +1,5 @@
 import type { ArtifactSnapshot } from "../checkpoint/types";
-import type { ExperimentalFirewall, VALID_CAPABILITIES } from "@vm0/core";
+import type { ExperimentalFirewalls, VALID_CAPABILITIES } from "@vm0/core";
 
 /**
  * Run status values
@@ -78,7 +78,7 @@ export interface ExecutionContext {
   userTimezone?: string;
 
   // Experimental firewall for proxy-side token replacement
-  experimentalFirewall?: ExperimentalFirewall;
+  experimentalFirewalls?: ExperimentalFirewalls;
 
   // Experimental capabilities for agent permission enforcement
   experimentalCapabilities?: (typeof VALID_CAPABILITIES)[number][];

--- a/turbo/apps/web/src/types/agent-compose.ts
+++ b/turbo/apps/web/src/types/agent-compose.ts
@@ -49,7 +49,7 @@ interface AgentDefinition {
    * Resolved from firewall names at compose time, stored as full objects.
    * Input format (CLI): string[] — expanded server-side before storage.
    */
-  experimental_firewall?: ExpandedFirewallConfig[];
+  experimental_firewalls?: ExpandedFirewallConfig[];
   /**
    * Capabilities that the agent is allowed to use.
    * Validated at compose time against VALID_CAPABILITIES.

--- a/turbo/packages/core/src/contracts/__tests__/firewall-expander.test.ts
+++ b/turbo/packages/core/src/contracts/__tests__/firewall-expander.test.ts
@@ -76,7 +76,7 @@ describe("expandFirewallConfigs", () => {
       agents: {
         myagent: {
           framework: "claude-code",
-          experimental_firewall: configs,
+          experimental_firewalls: configs,
         },
       },
     };
@@ -88,7 +88,7 @@ describe("expandFirewallConfigs", () => {
   ) {
     await expandFirewallConfigs(config, fetchFn);
     return config.agents.myagent
-      .experimental_firewall as unknown as ExpandedFirewallConfig[];
+      .experimental_firewalls as unknown as ExpandedFirewallConfig[];
   }
 
   /** Mock fetch that returns the right YAML based on URL */
@@ -178,14 +178,14 @@ describe("expandFirewallConfigs", () => {
       agents: {
         myagent: {
           framework: "claude-code",
-          experimental_firewall: [
+          experimental_firewalls: [
             { name: "github", ref: "github", apis: [], placeholders: {} },
           ],
         },
       },
     };
     await expandFirewallConfigs(config);
-    expect(Array.isArray(config.agents.myagent.experimental_firewall)).toBe(
+    expect(Array.isArray(config.agents.myagent.experimental_firewalls)).toBe(
       true,
     );
   });

--- a/turbo/packages/core/src/contracts/composes.ts
+++ b/turbo/packages/core/src/contracts/composes.ts
@@ -147,7 +147,7 @@ const agentDefinitionSchema = z.object({
    * CLI input: map format { slack: { permissions: [...] | "all" } }
    * — expanded by CLI to full ExpandedFirewallConfig[] before API call.
    */
-  experimental_firewall: z
+  experimental_firewalls: z
     .record(
       z.string(),
       z.object({
@@ -190,7 +190,7 @@ const agentDefinitionSchema = z.object({
 });
 
 /**
- * Agent compose YAML content schema (CLI input — experimental_firewall is map format)
+ * Agent compose YAML content schema (CLI input — experimental_firewalls is map format)
  */
 const agentComposeContentSchema = z.object({
   version: z.string().min(1, "Version is required"),
@@ -219,14 +219,14 @@ const expandedFirewallConfigSchema = z.object({
 
 /**
  * Agent compose content schema for API requests.
- * Same as agentComposeContentSchema but experimental_firewall is pre-expanded by CLI.
+ * Same as agentComposeContentSchema but experimental_firewalls is pre-expanded by CLI.
  */
 const agentComposeApiContentSchema = z.object({
   version: z.string().min(1, "Version is required"),
   agents: z.record(
     z.string(),
     agentDefinitionSchema.extend({
-      experimental_firewall: z.array(expandedFirewallConfigSchema).optional(),
+      experimental_firewalls: z.array(expandedFirewallConfigSchema).optional(),
     }),
   ),
   volumes: z.record(z.string(), volumeConfigSchema).optional(),

--- a/turbo/packages/core/src/contracts/firewall-expander.ts
+++ b/turbo/packages/core/src/contracts/firewall-expander.ts
@@ -148,7 +148,7 @@ export function collectAndValidatePermissions(
 }
 
 /**
- * Expand experimental_firewall from map format to ExpandedFirewallConfig[] in-place.
+ * Expand experimental_firewalls from map format to ExpandedFirewallConfig[] in-place.
  * Validates permission names and filters api_entries to only include selected permissions.
  * Mutates the config object so the API receives pre-expanded firewall objects.
  *
@@ -172,7 +172,7 @@ export async function expandFirewallConfigs(
     agents?: Record<
       string,
       {
-        experimental_firewall?:
+        experimental_firewalls?:
           | Record<string, FirewallSelection>
           | ExpandedFirewallConfig[];
       }
@@ -181,7 +181,7 @@ export async function expandFirewallConfigs(
   if (!compose?.agents) return;
 
   for (const agent of Object.values(compose.agents)) {
-    const configs = agent.experimental_firewall;
+    const configs = agent.experimental_firewalls;
     if (!configs) continue;
     // Skip if already expanded (array, not map)
     if (Array.isArray(configs)) continue;
@@ -242,6 +242,6 @@ export async function expandFirewallConfigs(
       expanded.push(entry);
     }
 
-    agent.experimental_firewall = expanded;
+    agent.experimental_firewalls = expanded;
   }
 }

--- a/turbo/packages/core/src/contracts/firewalls.ts
+++ b/turbo/packages/core/src/contracts/firewalls.ts
@@ -45,7 +45,7 @@ export const firewallSchema = z.object({
  * Experimental firewall configuration for proxy-side token replacement.
  * Flat array of firewall entries: [{ name, ref, apis }]
  */
-export const experimentalFirewallSchema = z.array(firewallSchema);
+export const experimentalFirewallsSchema = z.array(firewallSchema);
 
 /**
  * Zod schema for validating firewall config (GitHub-hosted YAML).
@@ -63,7 +63,7 @@ export const firewallConfigSchema = z.object({
 export type FirewallApi = z.infer<typeof firewallApiSchema>;
 export type FirewallConfig = z.infer<typeof firewallConfigSchema>;
 export type Firewall = z.infer<typeof firewallSchema>;
-export type ExperimentalFirewall = z.infer<typeof experimentalFirewallSchema>;
+export type ExperimentalFirewalls = z.infer<typeof experimentalFirewallsSchema>;
 
 /**
  * Regex pattern matching `${{ secrets.XXX }}` references in auth header templates.

--- a/turbo/packages/core/src/contracts/index.ts
+++ b/turbo/packages/core/src/contracts/index.ts
@@ -437,13 +437,13 @@ export {
   firewallPermissionSchema,
   firewallApiSchema,
   firewallSchema,
-  experimentalFirewallSchema,
+  experimentalFirewallsSchema,
   firewallConfigSchema,
   type FirewallConfig,
   type ExpandedFirewallConfig,
   type FirewallApi,
   type Firewall,
-  type ExperimentalFirewall,
+  type ExperimentalFirewalls,
 } from "./firewalls";
 
 export {

--- a/turbo/packages/core/src/contracts/runners.ts
+++ b/turbo/packages/core/src/contracts/runners.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { authHeadersSchema, initContract } from "./base";
 import { VALID_CAPABILITIES } from "./composes";
-import { experimentalFirewallSchema } from "./firewalls";
+import { experimentalFirewallsSchema } from "./firewalls";
 import { apiErrorSchema } from "./errors";
 
 const c = initContract();
@@ -115,7 +115,7 @@ export const storedExecutionContextSchema = z.object({
   // Memory storage name (for first-run when manifest.memory is null)
   memoryName: z.string().optional(),
   // Experimental firewall for proxy-side token replacement
-  experimentalFirewall: experimentalFirewallSchema.optional(),
+  experimentalFirewalls: experimentalFirewallsSchema.optional(),
   // Experimental capabilities for agent permission enforcement
   experimentalCapabilities: z.array(z.enum(VALID_CAPABILITIES)).optional(),
 });
@@ -155,7 +155,7 @@ export const executionContextSchema = z.object({
   // Memory storage name (for first-run when manifest.memory is null)
   memoryName: z.string().optional(),
   // Experimental firewall for proxy-side token replacement
-  experimentalFirewall: experimentalFirewallSchema.optional(),
+  experimentalFirewalls: experimentalFirewallsSchema.optional(),
   // Experimental capabilities for agent permission enforcement
   experimentalCapabilities: z.array(z.enum(VALID_CAPABILITIES)).optional(),
 });


### PR DESCRIPTION
## Summary
- Rename all array-typed firewall fields and related identifiers to use plural form
- `experimental_firewall` → `experimental_firewalls` (YAML/JSON key, Rust field)
- `experimentalFirewall` → `experimentalFirewalls` (TS field/variable, JSON key)
- `ExperimentalFirewall` → `ExperimentalFirewalls` (type name)
- `experimentalFirewallSchema` → `experimentalFirewallsSchema` (schema)
- `buildExperimentalFirewall` → `buildExperimentalFirewalls` (function)
- `VmEntry.firewall` / `VmRegistration.firewall` → `firewalls` (proxy registry struct + JSON)
- `vm_firewall` → `vm_firewalls` (Python addon)

Closes #5036

## Test plan
- [ ] CI passes (lint, types, tests, clippy, e2e)
- [ ] Firewall E2E test (`t42-firewall-placeholder.bats`) passes with new field names

🤖 Generated with [Claude Code](https://claude.com/claude-code)