### PR TITLE
refactor: merge run queue dequeue and execute into single advisory lock transaction

### DIFF
--- a/turbo/apps/web/app/api/agent/runs/[id]/cancel/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/cancel/route.ts
@@ -14,7 +14,7 @@ import {
   dispatchTerminalSideEffects,
 } from "../../../../../../src/lib/run/run-status";
 import { drainOrgQueue } from "../../../../../../src/lib/run/run-queue-service";
-import { executeQueuedRun } from "../../../../../../src/lib/run/run-service";
+import { dispatchQueuedRun } from "../../../../../../src/lib/run/run-service";
 import { after } from "next/server";
 
 const log = logger("api:runs:cancel");
@@ -98,7 +98,7 @@ const router = tsr.router(runsCancelContract, {
         "cancelled",
         "Run cancelled",
         shouldDrain
-          ? () => drainOrgQueue(run.orgId, executeQueuedRun)
+          ? () => drainOrgQueue(run.orgId, dispatchQueuedRun)
           : undefined,
       );
     });

--- a/turbo/apps/web/app/api/cron/cleanup-sandboxes/route.ts
+++ b/turbo/apps/web/app/api/cron/cleanup-sandboxes/route.ts
@@ -19,7 +19,7 @@ import {
   drainStaleQueues,
   drainOrgQueue,
 } from "../../../../src/lib/run/run-queue-service";
-import { executeQueuedRun } from "../../../../src/lib/run/run-service";
+import { dispatchQueuedRun } from "../../../../src/lib/run/run-service";
 import { logger } from "../../../../src/lib/logger";
 import { env } from "../../../../src/env";
 
@@ -191,7 +191,7 @@ const router = tsr.router(cronCleanupSandboxesContract, {
     // as it serves as the fallback for missed webhook-triggered drains.
     const [expiredQueueCount, drainedCount] = await Promise.all([
       cleanupExpiredQueueEntries(),
-      drainStaleQueues(executeQueuedRun),
+      drainStaleQueues(dispatchQueuedRun),
     ]);
 
     if (expiredQueueCount > 0 || drainedCount > 0) {
@@ -236,7 +236,7 @@ const router = tsr.router(cronCleanupSandboxesContract, {
             run.id,
             "timeout",
             timeoutReason,
-            () => drainOrgQueue(run.orgId, executeQueuedRun),
+            () => drainOrgQueue(run.orgId, dispatchQueuedRun),
           );
 
           const isDebug =

--- a/turbo/apps/web/app/api/webhooks/agent/complete/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/complete/route.ts
@@ -21,7 +21,7 @@ import type {
 import type { RunResult } from "../../../../../src/lib/run/types";
 import { logger } from "../../../../../src/lib/logger";
 import { drainOrgQueue } from "../../../../../src/lib/run/run-queue-service";
-import { executeQueuedRun } from "../../../../../src/lib/run/run-service";
+import { dispatchQueuedRun } from "../../../../../src/lib/run/run-service";
 import { appendChatMessages } from "../../../../../src/lib/agent-session/agent-session-service";
 import {
   queryAxiom,
@@ -89,7 +89,7 @@ function scheduleTerminalSideEffects(
 ): void {
   after(async () => {
     await dispatchTerminalSideEffects(runId, status, errorMsg, () =>
-      drainOrgQueue(orgId, executeQueuedRun),
+      drainOrgQueue(orgId, dispatchQueuedRun),
     );
   });
 }

--- a/turbo/apps/web/src/lib/run/__tests__/run-queue-service.test.ts
+++ b/turbo/apps/web/src/lib/run/__tests__/run-queue-service.test.ts
@@ -15,7 +15,7 @@ import {
 import { reloadEnv } from "../../../env";
 import {
   createRun,
-  executeQueuedRun,
+  dispatchQueuedRun,
   type CreateRunParams,
 } from "../run-service";
 import {
@@ -107,7 +107,7 @@ describe("run-queue-service", () => {
   describe("drainOrgQueue", () => {
     it("should be a no-op when queue is empty", async () => {
       // Should not throw
-      await drainOrgQueue(user.orgId, executeQueuedRun);
+      await drainOrgQueue(user.orgId, dispatchQueuedRun);
     });
 
     it("should dequeue and execute the oldest entry", async () => {
@@ -123,7 +123,7 @@ describe("run-queue-service", () => {
       await markRunningRunsAsCompleted(user.userId);
 
       // Drain queue by orgId
-      await drainOrgQueue(user.orgId, executeQueuedRun);
+      await drainOrgQueue(user.orgId, dispatchQueuedRun);
 
       // Queued run should now be dispatched (pending)
       const run = await findTestRunRecord(queued.runId);
@@ -157,21 +157,66 @@ describe("run-queue-service", () => {
       // Alice's run completes
       await markRunningRunsAsCompleted(user.userId);
 
-      // Track which runs the executor was called with
-      const executedRunIds: string[] = [];
-      const mockExecutor = async (runId: string) => {
-        executedRunIds.push(runId);
+      // Track which runs the dispatcher was called with
+      const dispatchedRunIds: string[] = [];
+      const mockDispatcher = async (runId: string) => {
+        dispatchedRunIds.push(runId);
       };
 
       // Drain org queue — should dequeue Bob's run from Alice's org
-      await drainOrgQueue(user.orgId, mockExecutor);
+      await drainOrgQueue(user.orgId, mockDispatcher);
 
-      // Executor should have been called with Bob's run
-      expect(executedRunIds).toContain(bobRun.runId);
+      // Dispatcher should have been called with Bob's run
+      expect(dispatchedRunIds).toContain(bobRun.runId);
 
       // Queue entry should be deleted
       const queueEntry = await findTestQueueEntry(bobRun.runId);
       expect(queueEntry).toBeUndefined();
+    });
+
+    it("should not dequeue when concurrency limit is reached", async () => {
+      vi.stubEnv("CONCURRENT_RUN_LIMIT_CAP", "1");
+      reloadEnv();
+
+      // Create a running run and a queued run
+      await createRun(baseParams({ prompt: "Running" }));
+      const queued = await createRun(baseParams({ prompt: "Queued" }));
+      expect(queued.status).toBe("queued");
+
+      // Drain without completing the running run — concurrency limit blocks dequeue
+      await drainOrgQueue(user.orgId, dispatchQueuedRun);
+
+      // Queue entry should still exist (nothing was dequeued)
+      const queueEntry = await findTestQueueEntry(queued.runId);
+      expect(queueEntry).toBeDefined();
+
+      // Run should still be queued
+      const run = await findTestRunRecord(queued.runId);
+      expect(run!.status).toBe("queued");
+    });
+
+    it("should skip cancelled runs and try next entry", async () => {
+      vi.stubEnv("CONCURRENT_RUN_LIMIT_CAP", "2");
+      reloadEnv();
+
+      // Enqueue two runs
+      const run1 = await enqueueRun(baseParams({ prompt: "Run 1" }));
+      const run2 = await enqueueRun(baseParams({ prompt: "Run 2" }));
+
+      // Cancel the first run (simulates cancel handler race)
+      await setTestRunStatus(run1.runId, "cancelled");
+
+      // Track dispatched runs
+      const dispatchedRunIds: string[] = [];
+      const mockDispatcher = async (runId: string) => {
+        dispatchedRunIds.push(runId);
+      };
+
+      // Drain should skip run1 (cancelled) and dispatch run2
+      await drainOrgQueue(user.orgId, mockDispatcher);
+
+      expect(dispatchedRunIds).toContain(run2.runId);
+      expect(dispatchedRunIds).not.toContain(run1.runId);
     });
   });
 
@@ -255,7 +300,7 @@ describe("run-queue-service", () => {
       expect(run2.status).toBe("queued");
 
       // drainStaleQueues should NOT drain user2's queue (org has an active run)
-      await drainStaleQueues(executeQueuedRun);
+      await drainStaleQueues(dispatchQueuedRun);
 
       // Queue entry should still exist — org-level concurrency prevented drain
       const queueEntry = await findTestQueueEntry(run2.runId);
@@ -291,67 +336,11 @@ describe("run-queue-service", () => {
       await markRunningRunsAsCompleted(user.userId);
 
       // drainStaleQueues should drain user2's queue
-      const drained = await drainStaleQueues(executeQueuedRun);
+      const drained = await drainStaleQueues(dispatchQueuedRun);
       expect(drained).toBeGreaterThanOrEqual(1);
 
       // Queue entry should be consumed
       const queueEntry = await findTestQueueEntry(run2.runId);
-      expect(queueEntry).toBeUndefined();
-    });
-  });
-
-  describe("reEnqueueRun TTL preservation", () => {
-    it("should preserve original expiresAt on re-enqueue", async () => {
-      vi.stubEnv("CONCURRENT_RUN_LIMIT_CAP", "1");
-      reloadEnv();
-
-      // Create a running run and a queued run
-      await createRun(baseParams({ prompt: "Running" }));
-      const queued = await createRun(baseParams({ prompt: "Queued" }));
-      expect(queued.status).toBe("queued");
-
-      // Record original expiresAt
-      const originalEntry = await findTestQueueEntry(queued.runId);
-      const originalExpiresAt = originalEntry!.expiresAt;
-
-      // Drain — concurrency limit still hit → re-enqueue
-      await drainOrgQueue(user.orgId, executeQueuedRun);
-
-      // Verify re-enqueued entry preserves original expiresAt
-      const reEnqueuedEntry = await findTestQueueEntry(queued.runId);
-      expect(reEnqueuedEntry).toBeDefined();
-      expect(reEnqueuedEntry!.expiresAt.getTime()).toBe(
-        originalExpiresAt.getTime(),
-      );
-    });
-
-    it("should expire re-enqueued run via cleanup", async () => {
-      vi.stubEnv("CONCURRENT_RUN_LIMIT_CAP", "1");
-      reloadEnv();
-
-      // Drain any pre-existing expired entries from other test suites
-      await cleanupExpiredQueueEntries();
-
-      // Create a running run and a queued run
-      await createRun(baseParams({ prompt: "Running" }));
-      const queued = await createRun(baseParams({ prompt: "Queued" }));
-      expect(queued.status).toBe("queued");
-
-      // Drain — concurrency limit still hit → re-enqueue with preserved TTL
-      await drainOrgQueue(user.orgId, executeQueuedRun);
-
-      // Simulate TTL expiry on the re-enqueued entry
-      await expireQueueEntry(queued.runId);
-
-      // Cleanup should remove the expired entry and mark run as timeout
-      const cleaned = await cleanupExpiredQueueEntries();
-      expect(cleaned).toBe(1);
-
-      const run = await findTestRunRecord(queued.runId);
-      expect(run!.status).toBe("timeout");
-      expect(run!.error).toContain("expired");
-
-      const queueEntry = await findTestQueueEntry(queued.runId);
       expect(queueEntry).toBeUndefined();
     });
   });

--- a/turbo/apps/web/src/lib/run/run-queue-service.ts
+++ b/turbo/apps/web/src/lib/run/run-queue-service.ts
@@ -2,6 +2,7 @@ import { eq, lt, and, or, count, gt, sql, inArray } from "drizzle-orm";
 import { agentRuns } from "../../db/schema/agent-run";
 import { transitionRunStatus } from "./run-status";
 import { agentRunQueue } from "../../db/schema/agent-run-queue";
+import { orgCache } from "../../db/schema/org-cache";
 import { env } from "../../env";
 import { logger } from "../logger";
 import { isConcurrentRunLimit } from "../errors";
@@ -12,6 +13,7 @@ import {
 import { PENDING_RUN_TTL_MS, checkRunConcurrencyLimit } from "./run-service";
 import { resolveOrg } from "../org/resolve-org";
 import type { CreateRunParams, CreateRunResult } from "./run-service";
+import type { OrgTier } from "@vm0/core";
 
 const log = logger("service:run-queue");
 
@@ -198,8 +200,17 @@ async function dequeueNextAtomic(
       // Serialize all queue operations for this org
       await tx.execute(sql`SELECT pg_advisory_xact_lock(hashtext(${orgId}))`);
 
+      // Look up org tier from cache (simple DB read, no external API call).
+      // Falls back to "free" (most conservative limit) if cache is empty.
+      const [cached] = await tx
+        .select({ tier: orgCache.tier })
+        .from(orgCache)
+        .where(eq(orgCache.orgId, orgId))
+        .limit(1);
+      const orgTier = parseOrgTier(cached?.tier);
+
       // Check concurrency FIRST — don't dequeue if no slot available
-      await checkRunConcurrencyLimit(orgId, "free", tx);
+      await checkRunConcurrencyLimit(orgId, orgTier, tx);
 
       // Fetch all queue entries for this org (ordered FIFO).
       // Typically 0-2 entries; iterating in-transaction to skip
@@ -332,6 +343,14 @@ export async function drainStaleQueues(
   }
 
   return drained;
+}
+
+const VALID_ORG_TIERS = new Set<string>(["free", "pro", "max"]);
+
+/** Parse a raw tier string into OrgTier, defaulting to "free". */
+function parseOrgTier(raw: string | undefined): OrgTier {
+  if (raw && VALID_ORG_TIERS.has(raw)) return raw as OrgTier;
+  return "free";
 }
 
 async function markQueuedRunFailed(

--- a/turbo/apps/web/src/lib/run/run-queue-service.ts
+++ b/turbo/apps/web/src/lib/run/run-queue-service.ts
@@ -9,7 +9,7 @@ import {
   encryptSecretsMap,
   decryptSecretsMap,
 } from "../crypto/secrets-encryption";
-import { PENDING_RUN_TTL_MS } from "./run-service";
+import { PENDING_RUN_TTL_MS, checkRunConcurrencyLimit } from "./run-service";
 import { resolveOrg } from "../org/resolve-org";
 import type { CreateRunParams, CreateRunResult } from "./run-service";
 
@@ -19,11 +19,13 @@ const log = logger("service:run-queue");
 const QUEUE_TTL_MS = 2 * 60 * 60 * 1000;
 
 /**
- * Executor function type for dispatching queued runs.
+ * Dispatcher function type for queued runs.
+ * Receives a run that has already been dequeued and transitioned to "pending".
  * Injected by callers to avoid circular dependency with run-service.
  */
-type QueuedRunExecutor = (
+type QueuedRunDispatcher = (
   runId: string,
+  createdAt: Date,
   params: CreateRunParams,
 ) => Promise<void>;
 
@@ -105,13 +107,14 @@ export async function enqueueRun(
 /**
  * Drain the run queue for an org.
  *
- * Dequeues the oldest entry using SELECT FOR UPDATE SKIP LOCKED,
- * deletes the queue record (encrypted secrets removed), and dispatches
- * the run through the provided executor.
+ * Atomically dequeues the oldest entry, checks concurrency, deletes the
+ * queue record, and transitions the run to "pending" — all within a single
+ * advisory-locked transaction. This eliminates the orphaned run risk that
+ * existed when dequeue and execute were separate transactions.
  *
  * Uses an iterative approach: on dispatch failure, marks the run as failed
  * and tries the next entry. Stops when a run is successfully dispatched,
- * the queue is empty, or a concurrency conflict occurs.
+ * the queue is empty, or the concurrency limit is reached.
  *
  * Called from:
  * - Completion webhook (event-driven, primary path)
@@ -119,112 +122,136 @@ export async function enqueueRun(
  * - Cleanup cron (fallback for missed dequeues)
  *
  * @param orgId - Org whose queue to drain
- * @param execute - Executor function (injected to avoid circular dependency)
+ * @param dispatch - Dispatcher function (injected to avoid circular dependency)
  */
 export async function drainOrgQueue(
   orgId: string,
-  execute: QueuedRunExecutor,
+  dispatch: QueuedRunDispatcher,
 ): Promise<void> {
+  const db = globalThis.services.db;
   const encryptionKey = env().SECRETS_ENCRYPTION_KEY;
-  let entry = await dequeueNext(orgId);
 
-  while (entry) {
-    const runId = entry.runId;
+  for (;;) {
+    // Single transaction: advisory lock → concurrency check → dequeue → status update
+    const dequeued = await dequeueNextAtomic(db, orgId);
+    if (!dequeued) return; // Queue empty, entry skipped, or concurrency full
 
-    // Decrypt CreateRunParams
+    // Decrypt CreateRunParams (outside transaction — no lock held)
     const decryptedMap = decryptSecretsMap(
-      entry.encryptedParams,
+      dequeued.encryptedParams,
       encryptionKey,
     );
     if (!decryptedMap?.__params) {
-      log.error(`Failed to decrypt params for queued run ${runId}`);
-      await markQueuedRunFailed(runId, "Failed to decrypt queued run params");
-      entry = await dequeueNext(orgId);
-      continue;
+      log.error(`Failed to decrypt params for queued run ${dequeued.runId}`);
+      await markQueuedRunFailed(
+        dequeued.runId,
+        "Failed to decrypt queued run params",
+      );
+      continue; // Try next entry
     }
 
     const params: CreateRunParams = JSON.parse(decryptedMap.__params);
 
-    // Execute the queued run (re-checks concurrency before dispatching)
+    // Dispatch the run (compose loading, authorization, execution)
     try {
-      await execute(runId, params);
-      log.debug(`Queued run ${runId} dispatched successfully`);
+      await dispatch(dequeued.runId, dequeued.createdAt, params);
+      log.debug(`Queued run ${dequeued.runId} dispatched successfully`);
       return; // Successfully dispatched — done
     } catch (error) {
-      if (isConcurrentRunLimit(error)) {
-        // Slot was claimed by another request — re-enqueue and stop
-        await reEnqueueRun(
-          runId,
-          entry.userId,
-          entry.orgId,
-          entry.encryptedParams,
-          entry.createdAt,
-          entry.expiresAt,
-        );
-        return;
-      }
       const errorMessage =
         error instanceof Error ? error.message : "Unknown error";
-      log.error(`Failed to dispatch queued run ${runId}: ${errorMessage}`);
-      await markQueuedRunFailed(runId, errorMessage);
-      entry = await dequeueNext(orgId);
-      continue;
+      log.error(
+        `Failed to dispatch queued run ${dequeued.runId}: ${errorMessage}`,
+      );
+      await markQueuedRunFailed(dequeued.runId, errorMessage);
+      continue; // Try next entry
     }
   }
 }
 
-interface QueueEntry {
+interface DequeuedEntry {
   runId: string;
-  userId: string;
-  orgId: string;
-  encryptedParams: string | null;
   createdAt: Date;
-  expiresAt: Date;
+  encryptedParams: string | null;
 }
 
 /**
  * Atomically dequeue the oldest queue entry for an org.
  *
- * SELECT FOR UPDATE SKIP LOCKED + DELETE run inside a single transaction
- * so the row-level lock is held until the delete commits, preventing
- * concurrent dequeue of the same entry.
+ * Within a single advisory-locked transaction:
+ * 1. Check concurrency limit (don't dequeue if no slot)
+ * 2. Select oldest queue entry
+ * 3. Delete queue entry
+ * 4. Transition run from "queued" to "pending"
+ *
+ * If a run was already processed (e.g. cancelled), its queue entry is
+ * removed and the next entry is tried within the same transaction.
+ *
+ * Returns undefined if queue is empty or concurrency limit reached.
  */
-async function dequeueNext(orgId: string): Promise<QueueEntry | undefined> {
-  return globalThis.services.db.transaction(async (tx) => {
-    const rows = await tx.execute<{
-      run_id: string;
-      user_id: string;
-      org_id: string;
-      encrypted_params: string | null;
-      created_at: string;
-      expires_at: string;
-    }>(
-      sql`SELECT run_id, user_id, org_id, encrypted_params, created_at, expires_at
-       FROM agent_run_queue
-       WHERE org_id = ${orgId}
-       ORDER BY created_at ASC
-       LIMIT 1
-       FOR UPDATE SKIP LOCKED`,
-    );
+async function dequeueNextAtomic(
+  db: typeof globalThis.services.db,
+  orgId: string,
+): Promise<DequeuedEntry | undefined> {
+  try {
+    return await db.transaction(async (tx) => {
+      // Serialize all queue operations for this org
+      await tx.execute(sql`SELECT pg_advisory_xact_lock(hashtext(${orgId}))`);
 
-    const row = rows.rows[0];
-    if (!row) {
+      // Check concurrency FIRST — don't dequeue if no slot available
+      await checkRunConcurrencyLimit(orgId, "free", tx);
+
+      // Fetch all queue entries for this org (ordered FIFO).
+      // Typically 0-2 entries; iterating in-transaction to skip
+      // already-processed runs without releasing the advisory lock.
+      const rows = await tx.execute<{
+        run_id: string;
+        encrypted_params: string | null;
+      }>(
+        sql`SELECT run_id, encrypted_params
+         FROM agent_run_queue
+         WHERE org_id = ${orgId}
+         ORDER BY created_at ASC`,
+      );
+
+      for (const row of rows.rows) {
+        // Delete queue entry
+        await tx
+          .delete(agentRunQueue)
+          .where(eq(agentRunQueue.runId, row.run_id));
+
+        // Update run status — fails silently if run was already cancelled/failed
+        const [updated] = await tx
+          .update(agentRuns)
+          .set({ status: "pending", lastHeartbeatAt: new Date() })
+          .where(
+            and(eq(agentRuns.id, row.run_id), eq(agentRuns.status, "queued")),
+          )
+          .returning({ createdAt: agentRuns.createdAt });
+
+        if (!updated) {
+          // Run was cancelled/failed between enqueue and drain — skip it
+          log.debug(`Run ${row.run_id} already processed, skipping`);
+          continue;
+        }
+
+        log.debug(`Dequeued run ${row.run_id} for org ${orgId}`);
+        return {
+          runId: row.run_id,
+          createdAt: updated.createdAt,
+          encryptedParams: row.encrypted_params,
+        };
+      }
+
+      return undefined; // Queue empty (all entries were already processed)
+    });
+  } catch (error) {
+    if (isConcurrentRunLimit(error)) {
+      // No slot available — nothing was dequeued
       return undefined;
     }
-
-    // Delete queue entry within the same transaction
-    await tx.delete(agentRunQueue).where(eq(agentRunQueue.runId, row.run_id));
-
-    log.debug(`Dequeued run ${row.run_id} for org ${orgId}`);
-    return {
-      runId: row.run_id,
-      userId: row.user_id,
-      orgId: row.org_id,
-      encryptedParams: row.encrypted_params,
-      createdAt: new Date(row.created_at),
-      expiresAt: new Date(row.expires_at),
-    };
-  });
+    throw error;
+  }
 }
 
 /**
@@ -264,10 +291,10 @@ export async function cleanupExpiredQueueEntries(): Promise<number> {
  * Drain queues for orgs that have queued runs but no active runs.
  * Used as a cron fallback in case completion webhooks miss the drain.
  *
- * @param execute - Executor function (injected to avoid circular dependency)
+ * @param dispatch - Dispatcher function (injected to avoid circular dependency)
  */
 export async function drainStaleQueues(
-  execute: QueuedRunExecutor,
+  dispatch: QueuedRunDispatcher,
 ): Promise<number> {
   const staleThreshold = new Date(Date.now() - PENDING_RUN_TTL_MS);
 
@@ -299,35 +326,12 @@ export async function drainStaleQueues(
     const activeCount = Number(result?.count ?? 0);
     if (activeCount === 0) {
       log.debug(`Draining stale queue for org ${orgId}`);
-      await drainOrgQueue(orgId, execute);
+      await drainOrgQueue(orgId, dispatch);
       drained++;
     }
   }
 
   return drained;
-}
-
-/**
- * Re-enqueue a run that was dequeued but couldn't execute due to concurrency.
- * Preserves the original createdAt to maintain FIFO ordering.
- */
-async function reEnqueueRun(
-  runId: string,
-  userId: string,
-  orgId: string,
-  encryptedParams: string | null,
-  originalCreatedAt: Date,
-  originalExpiresAt: Date,
-): Promise<void> {
-  await globalThis.services.db.insert(agentRunQueue).values({
-    runId,
-    userId,
-    orgId,
-    encryptedParams,
-    createdAt: originalCreatedAt,
-    expiresAt: originalExpiresAt,
-  });
-  log.debug(`Re-enqueued run ${runId} (concurrency conflict)`);
 }
 
 async function markQueuedRunFailed(

--- a/turbo/apps/web/src/lib/run/run-service.ts
+++ b/turbo/apps/web/src/lib/run/run-service.ts
@@ -76,7 +76,7 @@ export function getEffectiveConcurrencyLimit(orgTier: OrgTier): number {
  * @param db Optional database instance (for use within transactions)
  * @throws ConcurrentRunLimitError if limit exceeded
  */
-async function checkRunConcurrencyLimit(
+export async function checkRunConcurrencyLimit(
   orgId: string,
   orgTier: OrgTier = "free",
   db?: Database,
@@ -518,7 +518,7 @@ async function markRunFailed(
 
 /**
  * Shared dispatch pipeline for steps 6-10 of the run creation flow.
- * Used by both createRun (new runs) and executeQueuedRun (dequeued runs).
+ * Used by both createRun (new runs) and dispatchQueuedRun (dequeued runs).
  */
 async function buildAndDispatchRun(opts: {
   runId: string;
@@ -664,7 +664,7 @@ async function buildAndDispatchRun(opts: {
       runId,
       createdAt,
       error,
-      orgId ? () => drainOrgQueue(orgId, executeQueuedRun) : undefined,
+      orgId ? () => drainOrgQueue(orgId, dispatchQueuedRun) : undefined,
     );
     throw error;
   }
@@ -805,48 +805,27 @@ export async function createRun(
 }
 
 /**
- * Execute a previously queued run.
+ * Dispatch a previously queued run that has already been dequeued and
+ * transitioned to "pending" by drainOrgQueue().
  *
- * Runs the createRun pipeline steps 1-10 for an existing agent_runs record.
- * Re-checks concurrency (another request may have claimed the slot),
- * then skips INSERT (record already exists) and dispatches.
+ * Loads compose content, authorizes, and dispatches. Does NOT acquire
+ * advisory lock or check concurrency — that is handled atomically in
+ * the drain transaction.
  *
- * Called from drainOrgQueue() after dequeuing an entry.
- *
- * @throws ConcurrentRunLimitError if the slot was claimed by another request
+ * Called from drainOrgQueue() after the atomic dequeue + status update.
  */
-export async function executeQueuedRun(
+export async function dispatchQueuedRun(
   runId: string,
+  createdAt: Date,
   params: CreateRunParams,
 ): Promise<void> {
   const apiStartTime = Date.now();
   const { userId, agentComposeVersionId } = params;
+  const transactionTime = apiStartTime; // No separate transaction step
 
-  // Step 1: Re-check concurrency + update status atomically with advisory lock
-  // to prevent TOCTOU race where a concurrent createRun claims the slot.
-  const orgId = params.orgId ?? "";
-  const [run] = await globalThis.services.db.transaction(async (tx) => {
-    await tx.execute(sql`SELECT pg_advisory_xact_lock(hashtext(${orgId}))`);
-    await checkRunConcurrencyLimit(orgId, params.orgTier ?? "free", tx);
+  log.debug(`Dispatching queued run ${runId} for user ${userId}`);
 
-    return tx
-      .update(agentRuns)
-      .set({
-        status: "pending",
-        lastHeartbeatAt: new Date(),
-      })
-      .where(and(eq(agentRuns.id, runId), eq(agentRuns.status, "queued")))
-      .returning();
-  });
-  const transactionTime = Date.now();
-
-  if (!run) {
-    throw new Error(`Queued run ${runId} not found or already processed`);
-  }
-
-  log.debug(`Executing queued run ${runId} for user ${userId}`);
-
-  // Steps 2-3: Load compose and authorize
+  // Load compose and authorize
   const { composeContent, compose: queuedCompose } = await loadCompose(
     agentComposeVersionId,
     params.composeId,
@@ -854,7 +833,7 @@ export async function executeQueuedRun(
   await authorizeCompose(userId, queuedCompose);
   const authorizeTime = Date.now();
 
-  // Step 4: Validate template vars and image access (for new runs only)
+  // Validate template vars and image access (for new runs only)
   if (!params.checkpointId && !params.sessionId) {
     await validateComposeRequirements(
       userId,
@@ -865,11 +844,9 @@ export async function executeQueuedRun(
     );
   }
 
-  // Steps 5 already validated at enqueue time, skip
-
   await buildAndDispatchRun({
     runId,
-    createdAt: run.createdAt,
+    createdAt,
     params,
     composeContent,
     apiStartTime,


### PR DESCRIPTION
## Summary

- Merge two-transaction dequeue/execute pattern in `drainOrgQueue()` into a single advisory-locked transaction, eliminating orphaned run risk and unnecessary dequeue churn
- Remove `FOR UPDATE SKIP LOCKED` (advisory lock provides serialization), `reEnqueueRun()` (concurrency checked before dequeue), and simplify `executeQueuedRun` → `dispatchQueuedRun`
- Add tests for concurrency-blocked drain and cancelled run skipping

## Test plan

- [x] All 13 run-queue-service tests pass (including 2 new tests)
- [x] All 65 run-related tests pass (create-run, cancel, queue)
- [x] Lint, format, knip, type-check pass
- [ ] CI pipeline passes

Closes #5024

🤖 Generated with [Claude Code](https://claude.com/claude-code)