### PR TITLE
feat: constrain vercel ai gateway to moonshot provider with kimi-k2.5 model

### DIFF
--- a/turbo/apps/web/src/lib/run/__tests__/create-run.test.ts
+++ b/turbo/apps/web/src/lib/run/__tests__/create-run.test.ts
@@ -739,6 +739,8 @@ describe("createRun()", () => {
         ANTHROPIC_AUTH_TOKEN: "test-gateway-key",
         ANTHROPIC_BASE_URL: "https://ai-gateway.vercel.sh",
         ANTHROPIC_API_KEY: "",
+        ANTHROPIC_MODEL: "moonshotai/kimi-k2.5",
+        ANTHROPIC_CUSTOM_HEADERS: "x-ai-gateway-providers-only: moonshot",
       });
     });
   });

--- a/turbo/packages/core/src/contracts/model-providers.ts
+++ b/turbo/packages/core/src/contracts/model-providers.ts
@@ -172,6 +172,8 @@ export const MODEL_PROVIDER_TYPES = {
       ANTHROPIC_AUTH_TOKEN: "$secret",
       ANTHROPIC_BASE_URL: "https://ai-gateway.vercel.sh",
       ANTHROPIC_API_KEY: "",
+      ANTHROPIC_MODEL: "moonshotai/kimi-k2.5",
+      ANTHROPIC_CUSTOM_HEADERS: "x-ai-gateway-providers-only: moonshot",
     } as Record<string, string>,
   },
   "azure-foundry": {


### PR DESCRIPTION
## Summary

- Add `ANTHROPIC_MODEL` (`moonshotai/kimi-k2.5`) and `ANTHROPIC_CUSTOM_HEADERS` (`x-ai-gateway-providers-only: moonshot`) to the `vercel-ai-gateway` environment mapping
- Update integration test to assert all 5 injected env vars

Closes #5048

## Test plan

- [x] Integration test `create-run.test.ts` passes with updated assertions (38/38 tests pass)
- [x] Type check passes
- [x] Lint passes
- [x] Knip passes
- [x] Format passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)