### PR TITLE
feat(docs): remove non-existent vm0 org create from cli reference

### DIFF
--- a/turbo/apps/docs/content/docs/reference/cli/index.mdx
+++ b/turbo/apps/docs/content/docs/reference/cli/index.mdx
@@ -124,7 +124,6 @@ Organizations are namespaces for organizing agents.
 | `vm0 org set <slug>` | Set the active organization | `--force` |
 | `vm0 org list` | List all accessible organizations | - |
 | `vm0 org use [slug]` | Switch to a different organization | `--personal` |
-| `vm0 org create <slug>` | Create a new team organization | - |
 | `vm0 org members` | View organization members | - |
 | `vm0 org invite` | Invite a member to the current organization | `--email <email>` (required) |
 | `vm0 org remove <email>` | Remove a member from the current organization | - |


### PR DESCRIPTION
## Summary
- Remove the `vm0 org create <slug>` row from the CLI reference documentation
- This command does not exist in the codebase (`apps/cli/src/commands/org/` has no `create.ts`)
- Prevents user confusion when referencing CLI docs

Closes #5039

## Test plan
- [ ] Verify the CLI reference table no longer lists `vm0 org create`
- [ ] Confirm remaining org commands are intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)