### PR TITLE
fix: return detailed json error on firewall 403 responses

### DIFF
--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -171,6 +171,9 @@ class FirewallAllow(NamedTuple):
 class FirewallBlock(NamedTuple):
     """Base URL matched but no permission granted — return 403."""
     base: str
+    firewall_ref: str
+    method: str
+    path: str
 
 
 def match_firewall_request(url: str, method: str, vm_firewall: list | None) -> FirewallAllow | FirewallBlock | None:
@@ -188,6 +191,9 @@ def match_firewall_request(url: str, method: str, vm_firewall: list | None) -> F
     # permission rule allows the request, we block it (fail-closed). Only the
     # first matched base is recorded — subsequent base matches don't overwrite.
     blocked_base = None
+    blocked_ref = ""
+
+    upper_method = method.upper()
 
     for fw_entry in vm_firewall:
         fw_name = fw_entry.get("name", "")
@@ -203,6 +209,7 @@ def match_firewall_request(url: str, method: str, vm_firewall: list | None) -> F
             # Base URL matched
             if blocked_base is None:
                 blocked_base = base
+                blocked_ref = fw_ref
 
             permissions = api_entry.get("permissions")
             if not permissions:
@@ -212,7 +219,6 @@ def match_firewall_request(url: str, method: str, vm_firewall: list | None) -> F
             # Extract relative path, strip query/fragment
             rel_path = rest.split("?")[0].split("#")[0] or "/"
 
-            upper_method = method.upper()
             for perm in permissions:
                 perm_name = perm.get("name", "")
                 for rule_str in perm.get("rules", []):
@@ -233,7 +239,10 @@ def match_firewall_request(url: str, method: str, vm_firewall: list | None) -> F
                         })
 
     if blocked_base is not None:
-        return FirewallBlock(blocked_base)
+        # Extract relative path for the error message
+        rest = url[len(blocked_base):]
+        rel_path = rest.split("?")[0].split("#")[0] or "/"
+        return FirewallBlock(blocked_base, blocked_ref, upper_method, rel_path)
     return None
 
 
@@ -426,14 +435,23 @@ def request(flow: http.HTTPFlow) -> None:
         original_url = get_original_url(flow)
         result = match_firewall_request(original_url, flow.request.method, vm_firewall)
         if isinstance(result, FirewallBlock):
-            ctx.log.warn(f"[{run_id}] Firewall {result.base}: no matching permission for {flow.request.method} {flow.request.path}")
+            ctx.log.warn(f"[{run_id}] Firewall {result.firewall_ref}: no matching permission for {result.method} {result.path}")
             flow.metadata["firewall_action"] = "DENY"
             flow.metadata["firewall_rule"] = f"firewall:{result.base}"
             flow.metadata["original_url"] = original_url
+            error_body = json.dumps({
+                "error": "firewall_permission_denied",
+                "message": "Request blocked: no matching permission rule",
+                "method": result.method,
+                "path": result.path,
+                "firewall": result.firewall_ref,
+                "base": result.base,
+                "hint": f"Add a permission rule for '{result.method} {result.path}' to the {result.firewall_ref} firewall in vm0.yaml",
+            })
             flow.response = http.Response.make(
                 403,
-                b"No matching firewall permission",
-                {"Content-Type": "text/plain"},
+                error_body.encode(),
+                {"Content-Type": "application/json"},
             )
             return
         if isinstance(result, FirewallAllow):

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -308,10 +308,16 @@ def handle_firewall_request(flow: http.HTTPFlow, api_entry: dict, vm_info: dict,
         flow.metadata["firewall_action"] = "DENY"
         flow.metadata["firewall_rule"] = f"firewall:{firewall_base}"
         flow.metadata["original_url"] = get_original_url(flow)
+        error_body = json.dumps({
+            "error": "firewall_auth_unavailable",
+            "message": "Firewall auth secrets not configured",
+            "firewall": match_info.get("ref", ""),
+            "base": firewall_base,
+        })
         flow.response = http.Response.make(
             502,
-            b"Firewall auth unavailable",
-            {"Content-Type": "text/plain"},
+            error_body.encode(),
+            {"Content-Type": "application/json"},
         )
         return
 
@@ -322,10 +328,16 @@ def handle_firewall_request(flow: http.HTTPFlow, api_entry: dict, vm_info: dict,
         flow.metadata["firewall_action"] = "DENY"
         flow.metadata["firewall_rule"] = f"firewall:{firewall_base}"
         flow.metadata["original_url"] = get_original_url(flow)
+        error_body = json.dumps({
+            "error": "firewall_auth_failed",
+            "message": f"Failed to resolve firewall auth headers: {e}",
+            "firewall": match_info.get("ref", ""),
+            "base": firewall_base,
+        })
         flow.response = http.Response.make(
             502,
-            b"Firewall header fetch failed",
-            {"Content-Type": "text/plain"},
+            error_body.encode(),
+            {"Content-Type": "application/json"},
         )
         return
 

--- a/crates/runner/mitm-addon/tests/test_connectors.py
+++ b/crates/runner/mitm-addon/tests/test_connectors.py
@@ -101,6 +101,9 @@ class TestMatchFirewallRequest:
         result = mitm_addon.match_firewall_request("https://api.github.com/repos", "GET", fw_configs)
         assert isinstance(result, FirewallBlock)
         assert result.base == "https://api.github.com"
+        assert result.firewall_ref == "github"
+        assert result.method == "GET"
+        assert result.path == "/repos"
 
     def test_permission_match_allows(self):
         fw_configs = _wrap_firewall([{

--- a/crates/runner/mitm-addon/tests/test_connectors.py
+++ b/crates/runner/mitm-addon/tests/test_connectors.py
@@ -511,6 +511,10 @@ class TestHandleFirewallRequest:
         assert flow.response.status_code == 502
         assert flow.metadata["firewall_action"] == "DENY"
         assert flow.metadata["firewall_rule"] == "firewall:https://api.github.com"
+        body = json.loads(flow.response.content)
+        assert body["error"] == "firewall_auth_failed"
+        assert "API unreachable" in body["message"]
+        assert body["firewall"] == "github"
 
     def test_no_response_set_on_success(self):
         """On success, flow.response should remain None (request continues to origin)."""
@@ -540,6 +544,9 @@ class TestHandleFirewallRequest:
         assert flow.response is not None
         assert flow.response.status_code == 502
         assert flow.metadata["firewall_action"] == "DENY"
+        body = json.loads(flow.response.content)
+        assert body["error"] == "firewall_auth_unavailable"
+        assert body["firewall"] == "github"
 
 
 # =========================================================================

--- a/crates/runner/mitm-addon/tests/test_handlers.py
+++ b/crates/runner/mitm-addon/tests/test_handlers.py
@@ -199,6 +199,13 @@ class TestRequestHandler:
         assert flow.response.status_code == 403
         assert flow.metadata["firewall_action"] == "DENY"
         assert flow.metadata["firewall_rule"] == "firewall:https://api.github.com"
+        body = json.loads(flow.response.content)
+        assert body["error"] == "firewall_permission_denied"
+        assert body["method"] == "GET"
+        assert body["path"] == "/orgs"
+        assert body["firewall"] == "github"
+        assert body["base"] == "https://api.github.com"
+        assert "hint" in body
 
     def test_firewall_permission_allows_matched(self, tmp_path):
         """Firewall with permissions and matching rule calls handler with match_info."""


### PR DESCRIPTION
## Summary

- Firewall 403 responses now return structured JSON instead of plain text
- Includes method, path, firewall name, base URL, and a hint for how to fix
- AI agents can parse the error and understand what permission rule to add

### Before
```
403 No matching firewall permission
```

### After
```json
{
  "error": "firewall_permission_denied",
  "message": "Request blocked: no matching permission rule",
  "method": "POST",
  "path": "/chat.postMessage",
  "firewall": "slack",
  "base": "https://slack.com/api",
  "hint": "Add a permission rule for 'POST /chat.postMessage' to the slack firewall in vm0.yaml"
}
```

## Test plan

- [x] `mitm-addon` unit tests pass (82/82)
- [ ] E2E firewall placeholder test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)