### PR TITLE
feat(docs): add vm0 run queue to cli reference

### DIFF
--- a/turbo/apps/docs/content/docs/reference/cli/index.mdx
+++ b/turbo/apps/docs/content/docs/reference/cli/index.mdx
@@ -139,6 +139,7 @@ Organizations are namespaces for organizing agents.
 | `vm0 run continue <session-id> <prompt>` | Continue from session (uses latest artifact) | `--env-file <path>`, `--vars`, `--secrets`, `--model-provider <type>`, `--verbose`, `--check-env` |
 | `vm0 run resume <checkpoint-id> <prompt>` | Resume from checkpoint (uses snapshot data) | `--env-file <path>`, `--vars`, `--secrets`, `--volume-version <name=version>`, `--model-provider <type>`, `--verbose`, `--check-env` |
 | `vm0 run list` | List runs | Alias: `ls`. Options: `--status <status,...>`, `--all`, `--agent <name>`, `--since <date>`, `--until <date>`, `--limit <n>` |
+| `vm0 run queue` | Show org run queue status (concurrency slots and waiting runs) | - |
 | `vm0 run kill <run-id>` | Kill (cancel) a pending or running run | - |
 | `vm0 cook [prompt]` | Prepare and execute agent from `vm0.yaml` | `--env-file <path>`, `-y, --yes`, `-v, --verbose` |
 | `vm0 cook logs` | View logs from the last cook run | Same as `vm0 logs` options |


### PR DESCRIPTION
## Summary
- Add `vm0 run queue` command to the Agent Management table in CLI reference docs
- The command shows org run queue status including concurrency slots and waiting runs

Closes #5045

## Test plan
- [ ] Verify the new row appears correctly in the CLI reference page
- [ ] Confirm the description matches the actual command behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)