### PR TITLE
feat(docs): update claude model version examples to current models

### DIFF
--- a/turbo/apps/docs/content/docs/model-selection/claude.mdx
+++ b/turbo/apps/docs/content/docs/model-selection/claude.mdx
@@ -53,10 +53,10 @@ agents:
   my-agent:
     framework: claude-code
     environment:
-      ANTHROPIC_DEFAULT_OPUS_MODEL: "claude-opus-4-5-20251101"
-      ANTHROPIC_DEFAULT_SONNET_MODEL: "claude-sonnet-4-5-20250929"
+      ANTHROPIC_DEFAULT_OPUS_MODEL: "claude-opus-4-6"
+      ANTHROPIC_DEFAULT_SONNET_MODEL: "claude-sonnet-4-6"
       ANTHROPIC_DEFAULT_HAIKU_MODEL: "claude-haiku-4-5-20251001"
-      CLAUDE_CODE_SUBAGENT_MODEL: "claude-sonnet-4-5-20250929"
+      CLAUDE_CODE_SUBAGENT_MODEL: "claude-sonnet-4-6"
 ```
 
 | Variable | Purpose | Default |
@@ -71,7 +71,7 @@ If you don't specify these variables, Claude Code automatically uses the latest 
 </Callout>
 
 <Callout type="warning">
-You must use the **full model name** (e.g., `claude-sonnet-4-5-20250929`) in environment variables, not aliases like `opus`, `sonnet`, or `haiku`.
+You must use the **full model name** (e.g., `claude-sonnet-4-6`) in environment variables, not aliases like `opus`, `sonnet`, or `haiku`.
 </Callout>
 
 ## Resources

--- a/turbo/apps/docs/content/docs/tutorial/my-first-agent.mdx
+++ b/turbo/apps/docs/content/docs/tutorial/my-first-agent.mdx
@@ -99,7 +99,7 @@ Running agent:
 
 [init] Starting Claude Code agent
   Session: 4b5d44f8-2d5f-494d-b8ce-698eb355096d
-  Model: claude-sonnet-4-5-20250929
+  Model: claude-sonnet-4-6
 
 [text] I'll help you curate AI content from HackerNews! Let me create a todo list...
 [tool_use] TodoWrite


### PR DESCRIPTION
## Summary
- Update outdated Claude 4.5 model IDs to current Claude 4.6 versions in docs
- `claude-opus-4-5-20251101` → `claude-opus-4-6`, `claude-sonnet-4-5-20250929` → `claude-sonnet-4-6`
- Haiku 4.5 (`claude-haiku-4-5-20251001`) unchanged as it's still the latest Haiku model

## Test plan
- [ ] Verify model IDs in `model-selection/claude.mdx` are correct
- [ ] Verify model ID in `tutorial/my-first-agent.mdx` example output is correct
- [ ] Docs build passes

Closes #5040

🤖 Generated with [Claude Code](https://claude.com/claude-code)