### PR TITLE
feat(docs): add claude 4.6 series models to openrouter available models

### DIFF
--- a/turbo/apps/docs/content/docs/model-selection/index.mdx
+++ b/turbo/apps/docs/content/docs/model-selection/index.mdx
@@ -57,7 +57,7 @@ Some providers support choosing specific models. During setup, you'll be prompte
 
 | Provider | Available Models | Default |
 |----------|-----------------|---------|
-| OpenRouter | `anthropic/claude-sonnet-4.5`, `anthropic/claude-opus-4.5`, `anthropic/claude-haiku-4.5` | auto |
+| OpenRouter | `anthropic/claude-sonnet-4.6`, `anthropic/claude-opus-4.6`, `anthropic/claude-sonnet-4.5`, `anthropic/claude-opus-4.5`, `anthropic/claude-haiku-4.5` | auto |
 | Moonshot | `kimi-k2.5`, `kimi-k2-thinking-turbo`, `kimi-k2-thinking` | `kimi-k2.5` |
 | Z.AI | `glm-5`, `glm-4.7`, `glm-4.5-air` | `glm-4.7` |
 | MiniMax | `MiniMax-M2.1` | `MiniMax-M2.1` |

--- a/turbo/apps/docs/content/docs/model-selection/openrouter.mdx
+++ b/turbo/apps/docs/content/docs/model-selection/openrouter.mdx
@@ -21,6 +21,8 @@ Visit [OpenRouter Settings](https://openrouter.ai/settings/keys) to create and o
 
 | Model | Description |
 |-------|-------------|
+| `anthropic/claude-sonnet-4.6` | Latest balanced performance |
+| `anthropic/claude-opus-4.6` | Latest highest capability |
 | `anthropic/claude-sonnet-4.5` | Balanced performance |
 | `anthropic/claude-opus-4.5` | Highest capability |
 | `anthropic/claude-haiku-4.5` | Fastest response |

--- a/turbo/packages/core/src/contracts/model-providers.ts
+++ b/turbo/packages/core/src/contracts/model-providers.ts
@@ -72,6 +72,8 @@ export const MODEL_PROVIDER_TYPES = {
       CLAUDE_CODE_SUBAGENT_MODEL: "$model",
     } as Record<string, string>,
     models: [
+      "anthropic/claude-sonnet-4.6",
+      "anthropic/claude-opus-4.6",
       "anthropic/claude-sonnet-4.5",
       "anthropic/claude-opus-4.5",
       "anthropic/claude-haiku-4.5",


### PR DESCRIPTION
## Summary
- Add `anthropic/claude-sonnet-4.6` and `anthropic/claude-opus-4.6` to the OpenRouter model list
- Updated in code (`model-providers.ts`), OpenRouter docs page, and model selection overview page
- New 4.6 models listed before existing 4.5 models

## Test plan
- [ ] Verify `pnpm turbo run lint` passes
- [ ] Verify `pnpm check-types` passes
- [ ] Verify OpenRouter model dropdown shows new 4.6 models

Closes #5041

🤖 Generated with [Claude Code](https://claude.com/claude-code)