### PR TITLE
feat(docs): clarify openrouter default model behavior

### DIFF
--- a/turbo/apps/docs/content/docs/model-selection/index.mdx
+++ b/turbo/apps/docs/content/docs/model-selection/index.mdx
@@ -57,7 +57,7 @@ Some providers support choosing specific models. During setup, you'll be prompte
 
 | Provider | Available Models | Default |
 |----------|-----------------|---------|
-| OpenRouter | `anthropic/claude-sonnet-4.6`, `anthropic/claude-opus-4.6`, `anthropic/claude-sonnet-4.5`, `anthropic/claude-opus-4.5`, `anthropic/claude-haiku-4.5` | auto |
+| OpenRouter | `anthropic/claude-sonnet-4.6`, `anthropic/claude-opus-4.6`, `anthropic/claude-sonnet-4.5`, `anthropic/claude-opus-4.5`, `anthropic/claude-haiku-4.5` | `anthropic/claude-sonnet-4.5` |
 | Moonshot | `kimi-k2.5`, `kimi-k2-thinking-turbo`, `kimi-k2-thinking` | `kimi-k2.5` |
 | Z.AI | `glm-5`, `glm-4.7`, `glm-4.5-air` | `glm-4.7` |
 | MiniMax | `MiniMax-M2.1` | `MiniMax-M2.1` |

--- a/turbo/apps/docs/content/docs/model-selection/index.mdx
+++ b/turbo/apps/docs/content/docs/model-selection/index.mdx
@@ -57,7 +57,7 @@ Some providers support choosing specific models. During setup, you'll be prompte
 
 | Provider | Available Models | Default |
 |----------|-----------------|---------|
-| OpenRouter | `anthropic/claude-sonnet-4.6`, `anthropic/claude-opus-4.6`, `anthropic/claude-sonnet-4.5`, `anthropic/claude-opus-4.5`, `anthropic/claude-haiku-4.5` | `anthropic/claude-sonnet-4.5` |
+| OpenRouter | `anthropic/claude-sonnet-4.6`, `anthropic/claude-opus-4.6`, `anthropic/claude-sonnet-4.5`, `anthropic/claude-opus-4.5`, `anthropic/claude-haiku-4.5` | Claude Code default |
 | Moonshot | `kimi-k2.5`, `kimi-k2-thinking-turbo`, `kimi-k2-thinking` | `kimi-k2.5` |
 | Z.AI | `glm-5`, `glm-4.7`, `glm-4.5-air` | `glm-4.7` |
 | MiniMax | `MiniMax-M2.1` | `MiniMax-M2.1` |

--- a/turbo/apps/docs/content/docs/model-selection/openrouter.mdx
+++ b/turbo/apps/docs/content/docs/model-selection/openrouter.mdx
@@ -23,19 +23,22 @@ Visit [OpenRouter Settings](https://openrouter.ai/settings/keys) to create and o
 |-------|-------------|
 | `anthropic/claude-sonnet-4.6` | Latest balanced performance |
 | `anthropic/claude-opus-4.6` | Latest highest capability |
-| `anthropic/claude-sonnet-4.5` | Balanced performance |
+| `anthropic/claude-sonnet-4.5` | Balanced performance (recommended) |
 | `anthropic/claude-opus-4.5` | Highest capability |
 | `anthropic/claude-haiku-4.5` | Fastest response |
-| auto | Automatic model selection (default) |
+
+<Callout type="info">
+If no model is specified during setup, Claude Code uses its built-in default model. This is shown as the "auto" option in the CLI setup wizard.
+</Callout>
 
 ## Non-Interactive Setup
 
 ```bash
-# With default model (auto)
-vm0 model-provider setup --type openrouter-api-key --secret "sk-or-xxx"
-
-# With specific model
+# With recommended model
 vm0 model-provider setup --type openrouter-api-key --secret "sk-or-xxx" --model "anthropic/claude-sonnet-4.5"
+
+# Without model (Claude Code uses its built-in default)
+vm0 model-provider setup --type openrouter-api-key --secret "sk-or-xxx"
 ```
 
 ## Run


### PR DESCRIPTION
## Summary
- Remove misleading `auto` model from OpenRouter docs — it's not OpenRouter's auto-routing feature
- Clarify that when no model is specified, Claude Code uses its built-in default model
- Update the Model Selection overview table to show `anthropic/claude-sonnet-4.5` as the recommended default instead of `auto`

## Context
The documentation was inconsistent with the actual implementation:
- Core config (`model-providers.ts`): `defaultModel: ""` (empty string)
- UI config (`provider-ui-config.ts`): display override to `anthropic/claude-sonnet-4.5`
- Docs: listed `auto` as default

When no model is selected, the empty string causes `ANTHROPIC_MODEL` to not be set in the environment, so Claude Code uses its built-in default model — not OpenRouter's auto-routing.

Closes #5046

## Test plan
- [ ] Verify OpenRouter docs page renders correctly with the new callout
- [ ] Verify Model Selection overview table shows correct default

🤖 Generated with [Claude Code](https://claude.com/claude-code)