### PR TITLE
feat(docs): remove connector references from strava and intervals.icu skill pages

### DIFF
--- a/turbo/apps/docs/content/docs/agent-skills/intervals-icu.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/intervals-icu.mdx
@@ -9,9 +9,7 @@ description: Access training data and wellness metrics with the Intervals.icu AP
 
 | Name                  | Type   | Description                     |
 | --------------------- | ------ | ------------------------------- |
-| `INTERVALS_ICU_TOKEN` | secret | Intervals.icu API bearer token  |
-
-Connect your Intervals.icu account in **Settings > Connectors** on the vm0 platform. The token is automatically injected at runtime.
+| `INTERVALS_ICU_TOKEN` | secret | API key from [Intervals.icu Settings](https://intervals.icu/settings) |
 
 ## Configuration
 

--- a/turbo/apps/docs/content/docs/agent-skills/strava.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/strava.mdx
@@ -9,9 +9,7 @@ description: Access fitness activities and athlete data with the Strava API
 
 | Name            | Type   | Description              |
 | --------------- | ------ | ------------------------ |
-| `STRAVA_TOKEN`  | secret | Strava API bearer token  |
-
-Connect your Strava account in **Settings > Connectors** on the vm0 platform. The token is automatically injected at runtime.
+| `STRAVA_TOKEN`  | secret | Strava API access token from [Strava API Settings](https://www.strava.com/settings/api) |
 
 ## Configuration
 


### PR DESCRIPTION
## Summary

- Remove "Connect your account in Settings > Connectors" references from Strava and Intervals.icu skill pages since OAuth env vars were removed in a38f6207
- Both skills still work via `vm0 secret set` with API tokens — pages and index entries are kept
- Update token descriptions with direct links to token sources (Strava API Settings, Intervals.icu Settings)

Closes #5044

## Test plan

- [ ] Verify strava.mdx renders correctly with updated token description
- [ ] Verify intervals-icu.mdx renders correctly with updated token description
- [ ] Confirm no broken links in the docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)