### PR TITLE
refactor(rust): replace inline crate:: paths with top-level use imports

### DIFF
--- a/crates/ably-subscriber/src/connection.rs
+++ b/crates/ably-subscriber/src/connection.rs
@@ -10,9 +10,10 @@ use tokio::time::Instant;
 use tokio_tungstenite::tungstenite;
 
 use crate::Error;
+use crate::TokenRequest;
 use crate::protocol::{
-    AuthDetails, ProtocolMessage, action, build_attach_msg, decode_msg, encode_msg, error_code,
-    flags,
+    AuthDetails, ErrorInfo, ProtocolMessage, action, build_attach_msg, decode_msg, encode_msg,
+    error_code, flags,
 };
 use crate::types::{Event, Message, TimingConfig, TokenDetails, TokenFuture};
 
@@ -28,8 +29,8 @@ fn is_localhost(host: &str) -> bool {
     host.starts_with("127.0.0.1") || host.starts_with("localhost")
 }
 
-fn error_or_unknown(error: Option<crate::protocol::ErrorInfo>) -> crate::protocol::ErrorInfo {
-    error.unwrap_or_else(|| crate::protocol::ErrorInfo {
+fn error_or_unknown(error: Option<ErrorInfo>) -> ErrorInfo {
+    error.unwrap_or_else(|| ErrorInfo {
         code: error_code::FAILED,
         status_code: None,
         message: "no error details from server".to_string(),
@@ -62,7 +63,7 @@ pub(crate) fn rest_host(realtime_host: &str) -> String {
 /// Exchange a TokenRequest for a TokenDetails via Ably's REST API.
 pub(crate) async fn exchange_token(
     client: &reqeast::Client,
-    token_request: &crate::TokenRequest,
+    token_request: &TokenRequest,
     host: &str,
 ) -> Result<TokenDetails, Error> {
     let scheme = if is_localhost(host) { "http" } else { "https" };
@@ -469,7 +470,7 @@ enum LoopAction {
 /// An error is retriable when it has no status code, no error code, is a
 /// server error (5xx), or carries a well-known connection error code even
 /// at 4xx.
-fn is_retriable(err: &crate::protocol::ErrorInfo) -> bool {
+fn is_retriable(err: &ErrorInfo) -> bool {
     const CONNECTION_ERROR_CODES: &[i32] = &[
         80003, // DISCONNECTED
         80002, // SUSPENDED
@@ -858,6 +859,7 @@ async fn attempt_reconnect(p: &mut EventLoopState) -> Result<(), Error> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::protocol::ConnectionDetails;
 
     #[test]
     fn build_ws_url_basic() {
@@ -906,7 +908,7 @@ mod tests {
             connection_id: Some("conn-1".to_string()),
             connection_key: Some("conn-1!key".to_string()),
             connection_serial: Some(-1),
-            connection_details: Some(crate::protocol::ConnectionDetails {
+            connection_details: Some(ConnectionDetails {
                 connection_state_ttl: Some(60000),
                 max_idle_interval: Some(10000),
                 ..Default::default()
@@ -1012,7 +1014,7 @@ mod tests {
 
     #[test]
     fn is_retriable_no_status_code() {
-        let err = crate::protocol::ErrorInfo {
+        let err = ErrorInfo {
             code: 12345,
             status_code: None,
             message: String::new(),
@@ -1022,7 +1024,7 @@ mod tests {
 
     #[test]
     fn is_retriable_server_error() {
-        let err = crate::protocol::ErrorInfo {
+        let err = ErrorInfo {
             code: 50000,
             status_code: Some(500),
             message: String::new(),
@@ -1032,7 +1034,7 @@ mod tests {
 
     #[test]
     fn is_retriable_connection_error_code_with_4xx() {
-        let err = crate::protocol::ErrorInfo {
+        let err = ErrorInfo {
             code: 80003, // DISCONNECTED connection error
             status_code: Some(400),
             message: String::new(),
@@ -1042,7 +1044,7 @@ mod tests {
 
     #[test]
     fn is_retriable_auth_error_not_retriable() {
-        let err = crate::protocol::ErrorInfo {
+        let err = ErrorInfo {
             code: 40142, // token expired
             status_code: Some(401),
             message: String::new(),
@@ -1052,7 +1054,7 @@ mod tests {
 
     #[test]
     fn is_retriable_rate_limit_not_retriable() {
-        let err = crate::protocol::ErrorInfo {
+        let err = ErrorInfo {
             code: 42910,
             status_code: Some(429),
             message: String::new(),
@@ -1062,7 +1064,7 @@ mod tests {
 
     #[test]
     fn is_retriable_zero_code() {
-        let err = crate::protocol::ErrorInfo {
+        let err = ErrorInfo {
             code: 0,
             status_code: Some(400),
             message: String::new(),

--- a/crates/guest-agent/src/cli.rs
+++ b/crates/guest-agent/src/cli.rs
@@ -1,10 +1,12 @@
 //! CLI command building and execution for Claude Code.
 
+use crate::constants;
 use crate::env;
 use crate::error::AgentError;
 use crate::events;
 use crate::masker::SecretMasker;
 use crate::paths;
+use crate::timing;
 use guest_common::{log_info, log_warn};
 use std::collections::HashMap;
 use std::process::Stdio;
@@ -131,7 +133,7 @@ pub async fn execute_cli(
     // parallel tool calls correctly.
     // See: https://github.com/anthropics/claude-code/issues/11650
     let mut stuck_tool_tracker: HashMap<String, (String, Instant)> = HashMap::new();
-    let stuck_tool_interval = Duration::from_secs(crate::constants::STUCK_TOOL_CHECK_INTERVAL_SECS);
+    let stuck_tool_interval = Duration::from_secs(constants::STUCK_TOOL_CHECK_INTERVAL_SECS);
     let mut stuck_tool_check = tokio::time::interval_at(
         tokio::time::Instant::now() + stuck_tool_interval,
         stuck_tool_interval,
@@ -168,7 +170,7 @@ pub async fn execute_cli(
                         if let Ok(mut event) = serde_json::from_str::<serde_json::Value>(stripped) {
                             // First event is the CLI init (system/init or thread.started)
                             if seq == 0 {
-                                crate::timing::record_e2e_from_api("api_to_cli_init");
+                                timing::record_e2e_from_api("api_to_cli_init");
                             }
                             // Print result to stdout if applicable
                             if event.get("type").and_then(|v| v.as_str()) == Some("result")

--- a/crates/guest-agent/src/env.rs
+++ b/crates/guest-agent/src/env.rs
@@ -2,6 +2,8 @@
 
 use std::sync::LazyLock;
 
+use crate::constants;
+
 fn env_or_empty(name: &str) -> String {
     std::env::var(name).unwrap_or_default()
 }
@@ -34,12 +36,12 @@ static STUCK_TOOL_TIMEOUT: LazyLock<u64> = LazyLock::new(|| {
             Err(_) => {
                 eprintln!(
                     "[WARN] VM0_STUCK_TOOL_TIMEOUT_SECS={v:?} is not a valid u64, using default {}s",
-                    crate::constants::STUCK_TOOL_TIMEOUT_SECS
+                    constants::STUCK_TOOL_TIMEOUT_SECS
                 );
-                crate::constants::STUCK_TOOL_TIMEOUT_SECS
+                constants::STUCK_TOOL_TIMEOUT_SECS
             }
         },
-        Err(_) => crate::constants::STUCK_TOOL_TIMEOUT_SECS,
+        Err(_) => constants::STUCK_TOOL_TIMEOUT_SECS,
     }
 });
 

--- a/crates/guest-agent/src/events.rs
+++ b/crates/guest-agent/src/events.rs
@@ -3,6 +3,7 @@
 //! Extracts session ID from the `system/init` event and persists it for
 //! checkpoint use.
 
+use crate::constants;
 use crate::env;
 use crate::error::AgentError;
 use crate::http;
@@ -61,13 +62,7 @@ pub fn prepare_event(event: &mut Value, seq: u32, masker: &SecretMasker) -> Opti
 
 /// POST a prepared event payload to the webhook endpoint.
 pub async fn post_event(payload: &Value) -> Result<(), AgentError> {
-    match http::post_json(
-        urls::events_url(),
-        payload,
-        crate::constants::HTTP_MAX_RETRIES,
-    )
-    .await
-    {
+    match http::post_json(urls::events_url(), payload, constants::HTTP_MAX_RETRIES).await {
         Ok(_) => Ok(()),
         Err(e) => {
             log_error!(LOG_TAG, "Failed to send event after retries");

--- a/crates/guest-agent/src/memory.rs
+++ b/crates/guest-agent/src/memory.rs
@@ -6,6 +6,8 @@
 use guest_common::log_info;
 use std::path::Path;
 
+use crate::env;
+
 const LOG_TAG: &str = "sandbox:guest-agent";
 
 /// Compute Claude Code's project directory name from a working directory path.
@@ -27,7 +29,7 @@ fn encode_project_name(working_dir: &str) -> String {
 /// - Memory mount path doesn't exist on disk
 /// - Symlink target already exists
 pub fn setup_auto_memory_symlink() -> bool {
-    let memory_mount = crate::env::memory_mount_path();
+    let memory_mount = env::memory_mount_path();
     if memory_mount.is_empty() {
         return false;
     }
@@ -38,7 +40,7 @@ pub fn setup_auto_memory_symlink() -> bool {
     }
 
     let home = std::env::var("HOME").unwrap_or_else(|_| "/home/user".to_string());
-    let project_name = encode_project_name(crate::env::working_dir());
+    let project_name = encode_project_name(env::working_dir());
     let auto_memory_dir = Path::new(&home)
         .join(".claude")
         .join("projects")

--- a/crates/runner/src/cmd/benchmark.rs
+++ b/crates/runner/src/cmd/benchmark.rs
@@ -10,9 +10,10 @@ use uuid::Uuid;
 
 use crate::config;
 use crate::deps::MITMPROXY_VERSION;
-use crate::error::RunnerResult;
+use crate::error::{RunnerError, RunnerResult};
 use crate::executor;
 use crate::paths::{HomePaths, RunnerPaths};
+use crate::prefetch;
 use crate::proxy;
 
 struct Timing {
@@ -56,10 +57,7 @@ pub async fn run_benchmark(args: BenchmarkArgs) -> RunnerResult<ExitCode> {
         .profiles
         .get(&args.profile)
         .ok_or_else(|| {
-            crate::error::RunnerError::Config(format!(
-                "profile '{}' not found in config",
-                args.profile
-            ))
+            RunnerError::Config(format!("profile '{}' not found in config", args.profile))
         })?
         .clone();
     let is_snapshot = default_profile.snapshot_hash.is_some();
@@ -67,7 +65,7 @@ pub async fn run_benchmark(args: BenchmarkArgs) -> RunnerResult<ExitCode> {
     // Block until memory.bin is in page cache so benchmark numbers are stable.
     if let Some(hash) = &default_profile.snapshot_hash {
         let path = home.snapshots_dir().join(hash).join("memory.bin");
-        let _ = tokio::task::spawn_blocking(move || crate::prefetch::prefetch_memory(&path)).await;
+        let _ = tokio::task::spawn_blocking(move || prefetch::prefetch_memory(&path)).await;
     }
 
     // 2. Start proxy (unconditional — benchmark always uses proxy)

--- a/crates/runner/src/cmd/gc.rs
+++ b/crates/runner/src/cmd/gc.rs
@@ -8,7 +8,8 @@ use tracing::info;
 
 use crate::cmd::service;
 use crate::error::{RunnerError, RunnerResult};
-use crate::paths::HomePaths;
+use crate::lock;
+use crate::paths::{HomePaths, LogPaths};
 
 /// Per-job log files older than this are eligible for GC.
 const JOB_LOG_MAX_AGE: Duration = Duration::from_secs(7 * 24 * 3600);
@@ -181,7 +182,7 @@ enum LockProbe {
 
 /// Try a nonblocking exclusive flock to check if a resource is in use.
 fn probe_lock(path: &Path) -> LockProbe {
-    let file = match crate::lock::open_lock_file(path) {
+    let file = match lock::open_lock_file(path) {
         Ok(f) => f,
         Err(e) => return LockProbe::Error(e.to_string()),
     };
@@ -266,7 +267,7 @@ async fn gc_job_logs(home: &HomePaths, dry_run: bool) -> RunnerResult<(u64, u64)
         let Some(name) = name.to_str() else { continue };
 
         // Only target per-job log files, not runner logs.
-        if !crate::paths::LogPaths::is_job_log(name) {
+        if !LogPaths::is_job_log(name) {
             continue;
         }
 

--- a/crates/runner/src/cmd/rootfs.rs
+++ b/crates/runner/src/cmd/rootfs.rs
@@ -3,8 +3,11 @@ use std::path::{Path, PathBuf};
 use clap::Args;
 use sha2::{Digest, Sha256};
 
+use crate::ca;
 use crate::error::{RunnerError, RunnerResult};
-use crate::paths::{HomePaths, RootfsPaths};
+use crate::lock;
+use crate::paths::{HomePaths, RootfsPaths, touch_mtime};
+use crate::profile;
 
 const BUILD_SCRIPT: &str = include_str!("../../scripts/build-rootfs.sh");
 const VERIFY_SCRIPT: &str = include_str!("../../scripts/verify-rootfs.sh");
@@ -111,7 +114,7 @@ async fn resolve_guest(
 
 /// Build rootfs and return the content hash of the inputs.
 pub async fn run_rootfs(args: RootfsArgs) -> RunnerResult<String> {
-    let def = crate::profile::get(&args.profile)?;
+    let def = profile::get(&args.profile)?;
     let dockerfile = def.dockerfile;
     let dry_run = args.dry_run;
 
@@ -153,7 +156,7 @@ pub async fn run_rootfs(args: RootfsArgs) -> RunnerResult<String> {
     let paths = HomePaths::new()?;
 
     // Ensure CA exists — rootfs build embeds the CA cert into the image.
-    crate::ca::ensure(&paths).await?;
+    ca::ensure(&paths).await?;
 
     let rootfs_paths = RootfsPaths::new(&paths, &hash);
     let output_dir = rootfs_paths.dir();
@@ -161,18 +164,18 @@ pub async fn run_rootfs(args: RootfsArgs) -> RunnerResult<String> {
     if is_build_complete(&rootfs_paths).await? {
         tracing::info!("[OK] rootfs already built: {}", output_dir.display());
         tracing::info!("rootfs hash: {hash}");
-        crate::paths::touch_mtime(output_dir);
+        touch_mtime(output_dir);
         return Ok(hash);
     }
 
     // Acquire exclusive lock to prevent concurrent builds with the same hash.
-    let _lock = crate::lock::acquire(paths.rootfs_lock(&hash)).await?;
+    let _lock = lock::acquire(paths.rootfs_lock(&hash)).await?;
 
     // Re-check after acquiring lock — another process may have completed the build.
     if is_build_complete(&rootfs_paths).await? {
         tracing::info!("[OK] rootfs already built: {}", output_dir.display());
         tracing::info!("rootfs hash: {hash}");
-        crate::paths::touch_mtime(output_dir);
+        touch_mtime(output_dir);
         return Ok(hash);
     }
 

--- a/crates/runner/src/cmd/snapshot.rs
+++ b/crates/runner/src/cmd/snapshot.rs
@@ -6,7 +6,8 @@ use sandbox_fc::SnapshotOutputPaths;
 use crate::config::SnapshotConfig;
 use crate::deps::{FIRECRACKER_VERSION, KERNEL_VERSION};
 use crate::error::{RunnerError, RunnerResult};
-use crate::paths::{HomePaths, RootfsPaths};
+use crate::lock;
+use crate::paths::{HomePaths, RootfsPaths, touch_mtime};
 
 #[derive(Args, Clone)]
 pub struct SnapshotArgs {
@@ -41,18 +42,18 @@ pub async fn run_snapshot(args: SnapshotArgs) -> RunnerResult<(String, Option<Sn
 
     if is_snapshot_complete(&output).await? {
         tracing::info!("[OK] snapshot already exists: {}", output_dir.display());
-        crate::paths::touch_mtime(&output_dir);
+        touch_mtime(&output_dir);
         let config = output.snapshot_config(&snapshot_hash).into();
         return Ok((snapshot_hash, Some(config)));
     }
 
     // Acquire exclusive lock to prevent concurrent builds with the same hash.
-    let _lock = crate::lock::acquire(paths.snapshot_lock(&snapshot_hash)).await?;
+    let _lock = lock::acquire(paths.snapshot_lock(&snapshot_hash)).await?;
 
     // Re-check after acquiring lock — another process may have completed the build.
     if is_snapshot_complete(&output).await? {
         tracing::info!("[OK] snapshot already exists: {}", output_dir.display());
-        crate::paths::touch_mtime(&output_dir);
+        touch_mtime(&output_dir);
         let config = output.snapshot_config(&snapshot_hash).into();
         return Ok((snapshot_hash, Some(config)));
     }

--- a/crates/runner/src/cmd/start.rs
+++ b/crates/runner/src/cmd/start.rs
@@ -13,13 +13,18 @@ use crate::config;
 use crate::deps;
 use crate::error::{RunnerError, RunnerResult};
 use crate::executor::{self, ExecutorConfig};
+use crate::host;
+use crate::http::HttpClient;
 use crate::lock;
-use crate::paths::{HomePaths, RunnerPaths};
+use crate::paths::{HomePaths, LogPaths, RunnerPaths, touch_mtime};
+use crate::prefetch;
+use crate::profile;
 use crate::provider::{ApiProvider, JobProvider, LocalProvider};
 use crate::proxy;
 use crate::resource_budget::ResourceBudget;
 use crate::retry::{RetryState, recv_retry, sleep_until_retry};
 use crate::status::{RunnerMode, StatusTracker};
+use crate::types::ExecutionContext;
 
 /// Initial backoff before retrying mitmproxy after a crash.
 const MITM_BACKOFF_INITIAL: Duration = Duration::from_secs(1);
@@ -102,16 +107,16 @@ pub async fn run_start(args: StartArgs) -> RunnerResult<()> {
     let mut _resource_locks = Vec::new();
     for profile in runner_config.profiles.values() {
         let lock = lock::acquire_shared(home.rootfs_lock(&profile.rootfs_hash)).await?;
-        crate::paths::touch_mtime(&home.rootfs_dir().join(&profile.rootfs_hash));
+        touch_mtime(&home.rootfs_dir().join(&profile.rootfs_hash));
         _resource_locks.push(lock);
         if let Some(hash) = &profile.snapshot_hash {
             let lock = lock::acquire_shared(home.snapshot_lock(hash)).await?;
-            crate::paths::touch_mtime(&home.snapshots_dir().join(hash));
+            touch_mtime(&home.snapshots_dir().join(hash));
             _resource_locks.push(lock);
         }
     }
 
-    let log_paths = crate::paths::LogPaths::new(home.logs_dir());
+    let log_paths = LogPaths::new(home.logs_dir());
     tokio::fs::create_dir_all(log_paths.dir())
         .await
         .map_err(|e| {
@@ -125,18 +130,18 @@ pub async fn run_start(args: StartArgs) -> RunnerResult<()> {
     for profile in runner_config.profiles.values() {
         if let Some(hash) = &profile.snapshot_hash {
             let path = home.snapshots_dir().join(hash).join("memory.bin");
-            tokio::task::spawn_blocking(move || crate::prefetch::prefetch_memory(&path));
+            tokio::task::spawn_blocking(move || prefetch::prefetch_memory(&path));
         }
     }
 
     // Use the default profile for vcpu/memory (used for budget and pool sizing).
     let default_profile = runner_config
         .profiles
-        .get(crate::profile::DEFAULT_PROFILE)
+        .get(profile::DEFAULT_PROFILE)
         .ok_or_else(|| {
             RunnerError::Config(format!(
                 "profile '{}' not found in config",
-                crate::profile::DEFAULT_PROFILE
+                profile::DEFAULT_PROFILE
             ))
         })?;
     let vcpu = default_profile.vcpu;
@@ -163,8 +168,8 @@ pub async fn run_start(args: StartArgs) -> RunnerResult<()> {
         max_concurrent,
         concurrency_factor,
     } = runner_config.sandbox;
-    let host_cpus = crate::host::cpu_count()?;
-    let host_memory_mb = crate::host::memory_mb()?;
+    let host_cpus = host::cpu_count()?;
+    let host_memory_mb = host::memory_mb()?;
     let budget = Arc::new(ResourceBudget::new(
         host_cpus as u32,
         host_memory_mb as u32,
@@ -208,7 +213,7 @@ pub async fn run_start(args: StartArgs) -> RunnerResult<()> {
 
     // Create provider — handles discovery + claim + complete
     let cancel = CancellationToken::new();
-    let http = crate::http::HttpClient::new(server.url.clone())?;
+    let http = HttpClient::new(server.url.clone())?;
     let name = runner_config.name;
     let group = runner_config.group;
     let (provider, group_name): (Arc<dyn JobProvider>, String) = if args.local {
@@ -467,7 +472,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
 /// resources in the budget — this function spawns the executor, reports
 /// completion via the provider, and releases the budget when done.
 fn spawn_job(
-    context: crate::types::ExecutionContext,
+    context: ExecutionContext,
     provider: &Arc<dyn JobProvider>,
     factory: &Arc<FirecrackerFactory>,
     exec_config: &Arc<ExecutorConfig>,

--- a/crates/runner/src/config.rs
+++ b/crates/runner/src/config.rs
@@ -4,6 +4,8 @@ use std::path::{Path, PathBuf};
 use serde::{Deserialize, Serialize};
 
 use crate::error::{RunnerError, RunnerResult};
+use crate::paths::{HomePaths, RootfsPaths};
+use crate::profile;
 
 /// 0 means auto-detect from host CPU and memory at startup.
 pub(crate) const DEFAULT_MAX_CONCURRENT: usize = 0;
@@ -85,11 +87,11 @@ pub struct ServerConfig {
 ///
 /// Relative paths in the config are resolved against the config file's parent directory.
 pub async fn load(path: &Path) -> RunnerResult<RunnerConfig> {
-    let home = crate::paths::HomePaths::new()?;
+    let home = HomePaths::new()?;
     load_with_home(path, &home).await
 }
 
-async fn load_with_home(path: &Path, home: &crate::paths::HomePaths) -> RunnerResult<RunnerConfig> {
+async fn load_with_home(path: &Path, home: &HomePaths) -> RunnerResult<RunnerConfig> {
     let content = tokio::fs::read_to_string(path)
         .await
         .map_err(|e| RunnerError::Config(format!("read {}: {e}", path.display())))?;
@@ -132,7 +134,7 @@ async fn check_path_exists(path: &Path, label: &str) -> RunnerResult<()> {
     Ok(())
 }
 
-async fn validate(config: &RunnerConfig, home: &crate::paths::HomePaths) -> RunnerResult<()> {
+async fn validate(config: &RunnerConfig, home: &HomePaths) -> RunnerResult<()> {
     check_path_exists(&config.ca_dir, "ca_dir").await?;
     check_path_exists(&config.firecracker.binary, "firecracker binary").await?;
     check_path_exists(&config.firecracker.kernel, "kernel").await?;
@@ -141,7 +143,7 @@ async fn validate(config: &RunnerConfig, home: &crate::paths::HomePaths) -> Runn
         return Err(RunnerError::Config("profiles must not be empty".into()));
     }
     for (name, profile) in &config.profiles {
-        if !crate::profile::validate_name(name) {
+        if !profile::validate_name(name) {
             return Err(RunnerError::Config(format!(
                 "invalid profile name: {name} (must be org/name format, lowercase alphanumeric + hyphens)"
             )));
@@ -152,7 +154,7 @@ async fn validate(config: &RunnerConfig, home: &crate::paths::HomePaths) -> Runn
             )));
         }
         // Validate rootfs exists on disk.
-        let rootfs_path = crate::paths::RootfsPaths::new(home, &profile.rootfs_hash).rootfs();
+        let rootfs_path = RootfsPaths::new(home, &profile.rootfs_hash).rootfs();
         check_path_exists(&rootfs_path, &format!("profile {name} rootfs")).await?;
         // Validate snapshot files exist if snapshot_hash is set.
         if let Some(hash) = &profile.snapshot_hash {
@@ -204,11 +206,11 @@ impl RunnerConfig {
     pub fn firecracker_config(
         &self,
         profile: &ProfileConfig,
-        home: &crate::paths::HomePaths,
+        home: &HomePaths,
         concurrency: usize,
         proxy_port: Option<u16>,
     ) -> sandbox_fc::FirecrackerConfig {
-        let rootfs_paths = crate::paths::RootfsPaths::new(home, &profile.rootfs_hash);
+        let rootfs_paths = RootfsPaths::new(home, &profile.rootfs_hash);
         let snapshot = profile.snapshot_hash.as_ref().map(|hash| {
             let snapshot_output =
                 sandbox_fc::SnapshotOutputPaths::new(home.snapshots_dir().join(hash));
@@ -235,10 +237,10 @@ mod tests {
     async fn test_home_with_artifacts(
         dir: &std::path::Path,
         profiles: &[(&str, Option<&str>)], // (rootfs_hash, snapshot_hash)
-    ) -> crate::paths::HomePaths {
-        let home = crate::paths::HomePaths::with_root(dir.join(".vm0-runner"));
+    ) -> HomePaths {
+        let home = HomePaths::with_root(dir.join(".vm0-runner"));
         for &(rootfs_hash, snapshot_hash) in profiles {
-            let rootfs = crate::paths::RootfsPaths::new(&home, rootfs_hash).rootfs();
+            let rootfs = RootfsPaths::new(&home, rootfs_hash).rootfs();
             tokio::fs::create_dir_all(rootfs.parent().unwrap())
                 .await
                 .unwrap();
@@ -616,7 +618,7 @@ profiles:
     #[test]
     fn firecracker_config_resolves_paths() {
         let dir = tempfile::tempdir().unwrap();
-        let home = crate::paths::HomePaths::with_root(dir.path().to_path_buf());
+        let home = HomePaths::with_root(dir.path().to_path_buf());
 
         let config = RunnerConfig {
             name: "test".into(),

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -14,12 +14,13 @@ const EXIT_SIGNAL_KILL: i32 = 9;
 /// Default timeout for guest commands (5 minutes).
 const DEFAULT_EXEC_TIMEOUT: Duration = Duration::from_secs(300);
 
-use crate::error::RunnerResult;
+use crate::error::{RunnerError, RunnerResult};
 use crate::http::HttpClient;
+use crate::network_logs;
 use crate::paths::{LogPaths, guest};
 use crate::proxy::{self, ProxyRegistryHandle};
 use crate::telemetry::JobTelemetry;
-use crate::types::ExecutionContext;
+use crate::types::{ExecutionContext, ResumeSession, StorageManifest};
 
 /// Configuration for a single execution.
 pub struct ExecutorConfig {
@@ -143,7 +144,7 @@ async fn execute_inner(
         if let Err(e) = config.registry.unregister_vm(&source_ip).await {
             warn!(run_id = %context.run_id, error = %e, "failed to unregister VM from proxy");
         }
-        crate::network_logs::upload_network_logs(
+        network_logs::upload_network_logs(
             &config.http,
             context.run_id,
             &context.sandbox_token,
@@ -407,11 +408,11 @@ pub(crate) async fn fix_guest_clock(sandbox: &dyn Sandbox) -> RunnerResult<()> {
 async fn download_storages(
     sandbox: &dyn Sandbox,
     context: &ExecutionContext,
-    manifest: &crate::types::StorageManifest,
+    manifest: &StorageManifest,
     log_file: &str,
 ) -> RunnerResult<()> {
     let manifest_json = serde_json::to_vec(manifest)
-        .map_err(|e| crate::error::RunnerError::Internal(format!("manifest json: {e}")))?;
+        .map_err(|e| RunnerError::Internal(format!("manifest json: {e}")))?;
     sandbox
         .write_file(guest::STORAGE_MANIFEST, &manifest_json)
         .await?;
@@ -432,7 +433,7 @@ async fn download_storages(
         .await?;
 
     if result.exit_code != 0 {
-        return Err(crate::error::RunnerError::Internal(format!(
+        return Err(RunnerError::Internal(format!(
             "storage download failed (exit code {})",
             result.exit_code
         )));
@@ -446,7 +447,7 @@ async fn download_storages(
 async fn restore_session(
     sandbox: &dyn Sandbox,
     context: &ExecutionContext,
-    session: &crate::types::ResumeSession,
+    session: &ResumeSession,
 ) -> RunnerResult<()> {
     if !(context.cli_agent_type.is_empty() || context.cli_agent_type == "claude-code") {
         return Ok(());
@@ -460,7 +461,7 @@ async fn restore_session(
 
     // Validate session_id to prevent path traversal (only allow alnum, dash, underscore)
     if !is_valid_session_id(&session.session_id) {
-        return Err(crate::error::RunnerError::Internal(format!(
+        return Err(RunnerError::Internal(format!(
             "invalid session_id: {}",
             session.session_id
         )));
@@ -641,7 +642,10 @@ fn build_env_json(context: &ExecutionContext, api_url: &str) -> HashMap<String, 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::types::{ArtifactEntry, ResumeSession, StorageEntry, StorageManifest};
+    use crate::types::{
+        ArtifactEntry, Firewall, FirewallApi, FirewallAuth, ResumeSession, StorageEntry,
+        StorageManifest,
+    };
     use uuid::Uuid;
 
     fn minimal_context() -> ExecutionContext {
@@ -887,13 +891,13 @@ mod tests {
     #[test]
     fn build_env_json_firewall_enable_ca_certs() {
         let mut ctx = minimal_context();
-        ctx.experimental_firewalls = Some(vec![crate::types::Firewall {
+        ctx.experimental_firewalls = Some(vec![Firewall {
             name: "gmail".into(),
             ref_key: "gmail".into(),
-            apis: vec![crate::types::FirewallApi {
+            apis: vec![FirewallApi {
                 id: String::new(),
                 base: "https://gmail.googleapis.com/gmail/v1/users/me".into(),
-                auth: crate::types::FirewallAuth {
+                auth: FirewallAuth {
                     headers: std::collections::HashMap::from([(
                         "Authorization".into(),
                         "Bearer ${{ secrets.GMAIL_TOKEN }}".into(),

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -13,7 +13,7 @@ use reqeast::StatusCode;
 use super::JobProvider;
 use crate::error::{RunnerError, RunnerResult};
 use crate::http::HttpClient;
-use crate::retry::RetryState;
+use crate::retry::{RetryState, recv_retry, sleep_until_retry};
 use crate::types::{CompleteRequest, ExecutionContext, Job, PollResponse};
 
 // ---------------------------------------------------------------------------
@@ -188,11 +188,11 @@ impl JobProvider for ApiProvider {
                     }
                 }
                 // Ably reconnection result
-                result = crate::retry::recv_retry(&mut ably_retry.handle) => {
+                result = recv_retry(&mut ably_retry.handle) => {
                     handle_ably_reconnect_result(result, ably, ably_connected, ably_retry);
                 }
                 // Ably retry timer
-                () = crate::retry::sleep_until_retry(&ably_retry.restart_at) => {}
+                () = sleep_until_retry(&ably_retry.restart_at) => {}
             }
         }
     }

--- a/crates/runner/src/proxy.rs
+++ b/crates/runner/src/proxy.rs
@@ -10,6 +10,8 @@ use tokio::sync::mpsc;
 use tracing::{info, warn};
 
 use crate::error::{RunnerError, RunnerResult};
+use crate::lock;
+use crate::types::Firewall;
 
 #[derive(Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -25,7 +27,7 @@ struct VmEntry {
     sandbox_token: String,
     registered_at: i64,
     network_log_path: String,
-    firewalls: Option<Vec<crate::types::Firewall>>,
+    firewalls: Option<Vec<Firewall>>,
     encrypted_secrets: Option<String>,
     secret_connector_map: Option<HashMap<String, String>>,
 }
@@ -36,7 +38,7 @@ pub struct VmRegistration<'a> {
     pub run_id: &'a str,
     pub sandbox_token: &'a str,
     pub network_log_path: &'a std::path::Path,
-    pub firewalls: Option<&'a [crate::types::Firewall]>,
+    pub firewalls: Option<&'a [Firewall]>,
     pub encrypted_secrets: Option<&'a str>,
     pub secret_connector_map: Option<&'a HashMap<String, String>>,
 }
@@ -395,7 +397,7 @@ impl ProxyRegistryHandle {
         source_ip: &str,
         registration: &VmRegistration<'_>,
     ) -> RunnerResult<()> {
-        let _guard = crate::lock::acquire(self.lock_path.clone()).await?;
+        let _guard = lock::acquire(self.lock_path.clone()).await?;
 
         let mut registry = read_registry(&self.registry_path).await?;
         let now = chrono::Utc::now().timestamp_millis();
@@ -436,7 +438,7 @@ impl ProxyRegistryHandle {
 
     /// Unregister a VM from the proxy registry.
     pub async fn unregister_vm(&self, source_ip: &str) -> RunnerResult<()> {
-        let _guard = crate::lock::acquire(self.lock_path.clone()).await?;
+        let _guard = lock::acquire(self.lock_path.clone()).await?;
 
         let mut registry = read_registry(&self.registry_path).await?;
         registry.vms.remove(source_ip);
@@ -460,6 +462,7 @@ fn send_sigterm(child: &tokio::process::Child) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::types::{FirewallApi, FirewallAuth, FirewallPermission};
 
     #[test]
     fn find_port_returns_nonzero() {
@@ -643,19 +646,19 @@ mod tests {
             lock_path,
         };
 
-        let firewall_entries = vec![crate::types::Firewall {
+        let firewall_entries = vec![Firewall {
             name: "gmail".to_string(),
             ref_key: "gmail".to_string(),
-            apis: vec![crate::types::FirewallApi {
+            apis: vec![FirewallApi {
                 id: String::new(),
                 base: "https://gmail.googleapis.com/gmail/v1/users/me".to_string(),
-                auth: crate::types::FirewallAuth {
+                auth: FirewallAuth {
                     headers: std::collections::HashMap::from([(
                         "Authorization".to_string(),
                         "Bearer ${{ secrets.GMAIL_TOKEN }}".to_string(),
                     )]),
                 },
-                permissions: Some(vec![crate::types::FirewallPermission {
+                permissions: Some(vec![FirewallPermission {
                     name: "mail-read".to_string(),
                     description: None,
                     rules: vec![

--- a/crates/sandbox-fc/src/factory.rs
+++ b/crates/sandbox-fc/src/factory.rs
@@ -9,6 +9,7 @@ use crate::overlay::{
     Ext4Creator, OverlayCreator, OverlayPool, OverlayPoolConfig, SnapshotCopyCreator,
 };
 use crate::paths::{FactoryPaths, RuntimePaths, SandboxPaths, SockPaths};
+use crate::prerequisites;
 use crate::sandbox::FirecrackerSandbox;
 
 /// Shell command executed during snapshot creation to pre-warm guest state.
@@ -114,7 +115,7 @@ impl FirecrackerFactory {
     /// Call `startup()` to initialize pools before use.
     pub async fn new(config: FirecrackerConfig) -> Result<Self, SandboxError> {
         let t = std::time::Instant::now();
-        crate::prerequisites::check_prerequisites(&crate::prerequisites::PrerequisiteConfig {
+        prerequisites::check_prerequisites(&prerequisites::PrerequisiteConfig {
             binary_path: &config.binary_path,
             kernel_path: &config.kernel_path,
             rootfs_path: &config.rootfs_path,

--- a/crates/sandbox-fc/src/paths.rs
+++ b/crates/sandbox-fc/src/paths.rs
@@ -1,5 +1,7 @@
 use std::path::{Path, PathBuf};
 
+use crate::SnapshotConfig;
+
 /// Base directory for runtime sockets under `/run`.
 /// Created with mode 1777 (world-writable + sticky bit) by `prerequisites.rs`.
 pub const RUNTIME_DIR: &str = "/run/vm0";
@@ -174,11 +176,11 @@ impl SnapshotOutputPaths {
     ///
     /// `sock_id` identifies the socket directory under `/run/vm0/sock/` —
     /// typically the config hash so each snapshot gets a unique path.
-    pub fn snapshot_config(&self, sock_id: &str) -> crate::SnapshotConfig {
+    pub fn snapshot_config(&self, sock_id: &str) -> SnapshotConfig {
         let work = SandboxPaths::new(self.work_dir());
         let runtime = RuntimePaths::new();
         let sock = SockPaths::new(runtime.sock_dir(sock_id));
-        crate::SnapshotConfig {
+        SnapshotConfig {
             snapshot_path: self.snapshot(),
             memory_path: self.memory(),
             overlay_path: self.overlay(),

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -12,9 +12,14 @@ use tokio::sync::Notify;
 use tracing::{info, warn};
 use vsock_host::VsockHost;
 
+use crate::api::ApiClient;
+use crate::balloon;
 use crate::config::FirecrackerConfig;
+use crate::control;
+use crate::factory::InvariantConfig;
 use crate::network::PooledNetns;
 use crate::paths::{SandboxPaths, SockPaths};
+use crate::process::kill_process_group;
 
 /// Timeout for waiting for the guest to connect via vsock after start.
 const VSOCK_CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
@@ -128,7 +133,7 @@ impl FirecrackerSandbox {
 
     /// Build the Firecracker JSON configuration for fresh boot.
     fn build_config(&self) -> serde_json::Value {
-        let inv = crate::factory::InvariantConfig::new();
+        let inv = InvariantConfig::new();
         let kernel_path = self.factory_config.kernel_path.display().to_string();
         let rootfs_path = self.factory_config.rootfs_path.display().to_string();
         let overlay_path = self.overlay.display().to_string();
@@ -312,7 +317,7 @@ impl FirecrackerSandbox {
 
         // Wait for Firecracker API to be ready, but bail early if the
         // process crashes before the socket appears.
-        let client = crate::api::ApiClient::new(&api_sock);
+        let client = ApiClient::new(&api_sock);
         let crash = Arc::clone(&self.crash_notify);
         tokio::select! {
             result = client.wait_for_ready(API_READY_TIMEOUT) => {
@@ -353,7 +358,7 @@ impl FirecrackerSandbox {
             return;
         };
 
-        crate::process::kill_process_group(child);
+        kill_process_group(child);
 
         // Reap the zombie process.
         let _ = child.wait().await;
@@ -374,7 +379,7 @@ impl Drop for FirecrackerSandbox {
         // `kill_on_drop(true)` only sends SIGKILL to the direct child (`sudo`);
         // `killpg` ensures the entire tree (including firecracker) is cleaned up.
         if let Some(ref child) = self.process {
-            crate::process::kill_process_group(child);
+            kill_process_group(child);
         }
         // Dropping `self.process` (Option<Child>) will trigger kill_on_drop as
         // a secondary safety net.
@@ -500,7 +505,7 @@ impl Sandbox for FirecrackerSandbox {
         }
 
         // Start control socket server for `runner exec`.
-        self.control_server = Some(crate::control::spawn_server(
+        self.control_server = Some(control::spawn_server(
             self.sock_paths.control_sock(),
             Arc::clone(&self.guest),
         ));
@@ -508,7 +513,7 @@ impl Sandbox for FirecrackerSandbox {
         // Spawn balloon controller to reclaim unused guest memory.
         // Only in snapshot mode — fresh boot uses --no-api so no API socket exists.
         if self.factory_config.snapshot.is_some() {
-            self.balloon_controller = Some(crate::balloon::spawn(
+            self.balloon_controller = Some(balloon::spawn(
                 self.sock_paths.api_sock().to_owned(),
                 self.config.resources.memory_mb,
                 Arc::clone(&self.crash_notify),

--- a/crates/sandbox-fc/src/snapshot.rs
+++ b/crates/sandbox-fc/src/snapshot.rs
@@ -4,12 +4,16 @@ use std::time::Duration;
 use tokio::io::AsyncBufReadExt;
 use tracing::info;
 
-use crate::api::ApiClient;
+use crate::api::{ApiClient, ApiError};
+use crate::command;
 use crate::config::SnapshotConfig;
+use crate::factory::InvariantConfig;
 use crate::network::{NetnsPool, NetnsPoolConfig};
 use crate::overlay::{Ext4Creator, OverlayCreator as _};
 use crate::paths::{RuntimePaths, SandboxPaths, SnapshotOutputPaths, SockPaths};
+use crate::prerequisites;
 use crate::process;
+use crate::process::kill_process_group;
 
 /// Timeout for waiting for the Firecracker API socket after process spawn.
 const API_READY_TIMEOUT: Duration = Duration::from_secs(5);
@@ -44,7 +48,7 @@ pub enum SnapshotError {
     #[error("firecracker process failed: {0}")]
     Process(String),
     #[error("api error: {0}")]
-    Api(#[from] crate::api::ApiError),
+    Api(#[from] ApiError),
     #[error("vsock connection failed: {0}")]
     Vsock(String),
     #[error("io error: {0}")]
@@ -71,7 +75,7 @@ pub async fn create_snapshot(
     config: SnapshotCreateConfig,
 ) -> Result<SnapshotConfig, SnapshotError> {
     // Check prerequisites (binary, kernel, rootfs, kvm, sudo, runtime dir, etc.).
-    crate::prerequisites::check_prerequisites(&crate::prerequisites::PrerequisiteConfig {
+    prerequisites::check_prerequisites(&prerequisites::PrerequisiteConfig {
         binary_path: &config.binary_path,
         kernel_path: &config.kernel_path,
         rootfs_path: &config.rootfs_path,
@@ -90,7 +94,7 @@ pub async fn create_snapshot(
     let work = output.work_dir();
     if work.exists() {
         let work_str = work.display().to_string();
-        crate::command::exec("rm", &["-rf", &work_str], crate::command::Privilege::Sudo)
+        command::exec("rm", &["-rf", &work_str], command::Privilege::Sudo)
             .await
             .map_err(|e| SnapshotError::Setup(format!("clean stale work dir: {e}")))?;
     }
@@ -218,7 +222,7 @@ async fn run_snapshot_workflow(
     // Guard: ensure process cleanup on any exit path.
     let result = run_with_firecracker(config, paths, sock_paths, output).await;
 
-    crate::process::kill_process_group(&child);
+    kill_process_group(&child);
     let _ = child.wait().await;
 
     result
@@ -239,7 +243,7 @@ async fn run_with_firecracker(
     info!("firecracker API ready");
 
     // 6. Configure VM via API (7 parallel PUT calls).
-    let inv = crate::factory::InvariantConfig::new();
+    let inv = InvariantConfig::new();
     let kernel_path = config.kernel_path.display().to_string();
     let rootfs_path = config.rootfs_path.display().to_string();
     let overlay_path = paths.overlay().display().to_string();


### PR DESCRIPTION
## Summary

- Replace inline `crate::xxx::Yyy` paths in function bodies/signatures with top-level `use` imports across all 4 crates (18 files)
- Move test-only types (`Firewall*`, `ConnectionDetails`) to `#[cfg(test)]` module imports
- One intentional exception: `sandbox.rs::current_username()` keeps `crate::process::current_username()` to avoid recursion with the same-name local wrapper

## Test plan

- [x] `cargo build --all-targets` passes
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets` clean
- [x] No remaining inline `crate::` paths (except the one intentional exception)

Closes #5038

🤖 Generated with [Claude Code](https://claude.com/claude-code)