### PR TITLE
refactor: align experimental_capabilities with resource model

### DIFF
--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -917,7 +917,7 @@ mod tests {
     #[test]
     fn build_env_json_capabilities_inject_cli_vars() {
         let mut ctx = minimal_context();
-        ctx.experimental_capabilities = Some(vec!["storage:read".into()]);
+        ctx.experimental_capabilities = Some(vec!["artifact:read".into()]);
         ctx.agent_org_slug = Some("my-org".into());
         let env = build_env_json(&ctx, "http://localhost");
         assert_eq!(env.get("VM0_TOKEN").unwrap(), "tok");
@@ -944,7 +944,7 @@ mod tests {
     #[test]
     fn build_env_json_capabilities_cli_vars_override_user_env() {
         let mut ctx = minimal_context();
-        ctx.experimental_capabilities = Some(vec!["storage:read".into()]);
+        ctx.experimental_capabilities = Some(vec!["artifact:read".into()]);
         ctx.agent_org_slug = Some("my-org".into());
         ctx.environment = Some(HashMap::from([
             ("VM0_TOKEN".into(), "tampered".into()),
@@ -963,11 +963,11 @@ mod tests {
             "sandboxToken": "tok",
             "workingDir": "/workspace",
             "cliAgentType": "claude-code",
-            "experimentalCapabilities": ["storage:read", "storage:write"]
+            "experimentalCapabilities": ["artifact:read", "artifact:write"]
         });
         let ctx: ExecutionContext = serde_json::from_value(json).unwrap();
         let caps = ctx.experimental_capabilities.unwrap();
-        assert_eq!(caps, vec!["storage:read", "storage:write"]);
+        assert_eq!(caps, vec!["artifact:read", "artifact:write"]);
     }
 
     #[test]

--- a/turbo/apps/web/app/api/agent/composes/__tests__/sandbox-capability.test.ts
+++ b/turbo/apps/web/app/api/agent/composes/__tests__/sandbox-capability.test.ts
@@ -64,7 +64,7 @@ describe("Sandbox capability enforcement on compose routes", () => {
 
       mockClerk({ userId: null });
       const token = await generateSandboxToken(user.userId, "run-123", [
-        "storage:read",
+        "artifact:read",
       ]);
 
       const request = createTestRequest(
@@ -188,7 +188,7 @@ describe("Sandbox capability enforcement on compose routes", () => {
     it("sandbox token without agent:read gets 403", async () => {
       mockClerk({ userId: null });
       const token = await generateSandboxToken(user.userId, "run-123", [
-        "storage:write",
+        "artifact:write",
       ]);
 
       const request = createTestRequest(
@@ -233,7 +233,7 @@ describe("Sandbox capability enforcement on compose routes", () => {
 
       mockClerk({ userId: null });
       const token = await generateSandboxToken(user.userId, "run-123", [
-        "storage:read",
+        "artifact:read",
       ]);
 
       const request = createTestRequest(
@@ -322,7 +322,7 @@ describe("Sandbox capability enforcement on compose routes", () => {
 
       mockClerk({ userId: null });
       const token = await generateSandboxToken(user.userId, "run-123", [
-        "storage:read",
+        "artifact:read",
       ]);
 
       const request = createTestRequest(
@@ -368,7 +368,7 @@ describe("Sandbox capability enforcement on compose routes", () => {
 
       mockClerk({ userId: null });
       const token = await generateSandboxToken(user.userId, "run-123", [
-        "storage:read",
+        "artifact:read",
       ]);
 
       const request = createTestRequest(

--- a/turbo/apps/web/app/api/agent/runs/[id]/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/__tests__/route.test.ts
@@ -144,7 +144,7 @@ describe("GET /api/agent/runs/:id - Get Run By ID", () => {
     it("should reject sandbox token without agent-run:read", async () => {
       mockClerk({ userId: null });
       const token = await generateSandboxToken(user.userId, "run-1", [
-        "storage:read",
+        "artifact:read",
       ]);
 
       const request = createTestRequest(

--- a/turbo/apps/web/app/api/agent/runs/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/__tests__/route.test.ts
@@ -1433,7 +1433,7 @@ describe("POST /api/agent/runs - Internal Runs API", () => {
     it("should reject sandbox token without agent-run:read for list", async () => {
       mockClerk({ userId: null });
       const token = await generateSandboxToken(user.userId, "run-1", [
-        "storage:read",
+        "artifact:read",
       ]);
 
       const request = createTestRequest(

--- a/turbo/apps/web/app/api/agent/schedules/[name]/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/schedules/[name]/__tests__/route.test.ts
@@ -280,7 +280,7 @@ describe("GET /api/agent/schedules/:name - Sandbox Token Auth", () => {
   it("should reject sandbox token without schedule:read capability", async () => {
     mockClerk({ userId: null });
     const token = await generateSandboxToken(user.userId, "run-123", [
-      "storage:read",
+      "artifact:read",
     ]);
 
     const request = createTestRequest(
@@ -341,7 +341,7 @@ describe("DELETE /api/agent/schedules/:name - Sandbox Token Auth", () => {
   it("should reject sandbox token without schedule:write capability", async () => {
     mockClerk({ userId: null });
     const token = await generateSandboxToken(user.userId, "run-123", [
-      "storage:read",
+      "artifact:read",
     ]);
 
     const request = createTestRequest(

--- a/turbo/apps/web/app/api/agent/schedules/[name]/disable/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/schedules/[name]/disable/__tests__/route.test.ts
@@ -224,7 +224,7 @@ describe("POST /api/agent/schedules/:name/disable - Sandbox Token Auth", () => {
   it("should reject sandbox token without schedule:write capability", async () => {
     mockClerk({ userId: null });
     const token = await generateSandboxToken(user.userId, "run-123", [
-      "storage:read",
+      "artifact:read",
     ]);
 
     const request = createTestRequest(

--- a/turbo/apps/web/app/api/agent/schedules/[name]/enable/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/schedules/[name]/enable/__tests__/route.test.ts
@@ -287,7 +287,7 @@ describe("POST /api/agent/schedules/:name/enable - Sandbox Token Auth", () => {
   it("should reject sandbox token without schedule:write capability", async () => {
     mockClerk({ userId: null });
     const token = await generateSandboxToken(user.userId, "run-123", [
-      "storage:read",
+      "artifact:read",
     ]);
 
     const request = createTestRequest(

--- a/turbo/apps/web/app/api/agent/schedules/[name]/runs/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/schedules/[name]/runs/__tests__/route.test.ts
@@ -172,7 +172,7 @@ describe("GET /api/agent/schedules/:name/runs - Sandbox Token Auth", () => {
   it("should reject sandbox token without schedule:read capability", async () => {
     mockClerk({ userId: null });
     const token = await generateSandboxToken(user.userId, "run-123", [
-      "storage:read",
+      "artifact:read",
     ]);
 
     const request = createTestRequest(

--- a/turbo/apps/web/app/api/agent/schedules/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/schedules/__tests__/route.test.ts
@@ -1029,7 +1029,7 @@ describe("POST /api/agent/schedules - Sandbox Token Auth", () => {
 
   it("should reject sandbox token without schedule:write capability", async () => {
     const token = await generateSandboxToken(user.userId, "run-123", [
-      "storage:read",
+      "artifact:read",
     ]);
 
     const request = createTestRequest(
@@ -1092,7 +1092,7 @@ describe("GET /api/agent/schedules - Sandbox Token Auth", () => {
 
   it("should reject sandbox token without schedule:read capability", async () => {
     const token = await generateSandboxToken(user.userId, "run-123", [
-      "storage:read",
+      "artifact:read",
     ]);
 
     const request = createTestRequest(

--- a/turbo/apps/web/app/api/agent/schedules/missing-secrets/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/schedules/missing-secrets/__tests__/route.test.ts
@@ -150,7 +150,7 @@ describe("GET /api/agent/schedules/missing-secrets - Sandbox Token Auth", () => 
   it("should reject sandbox token without schedule:read capability", async () => {
     mockClerk({ userId: null });
     const token = await generateSandboxToken(user.userId, "run-123", [
-      "storage:read",
+      "artifact:read",
     ]);
 
     const request = createTestRequest(

--- a/turbo/apps/web/app/api/auth/me/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/auth/me/__tests__/route.test.ts
@@ -62,7 +62,7 @@ describe("GET /api/auth/me", () => {
     it("sandbox token with storage:write returns user info", async () => {
       mockClerk({ userId: null });
       const token = await generateSandboxToken(user.userId, "run-456", [
-        "storage:write",
+        "artifact:write",
       ]);
 
       const response = await GET(

--- a/turbo/apps/web/app/api/runners/jobs/[id]/claim/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/runners/jobs/[id]/claim/__tests__/route.test.ts
@@ -322,7 +322,7 @@ describe("POST /api/runners/jobs/:id/claim", () => {
         versionId,
         `${orgSlug}/default`,
         {
-          experimentalCapabilities: ["storage:read", "storage:write"],
+          experimentalCapabilities: ["artifact:read", "artifact:write"],
         },
       );
 
@@ -346,8 +346,8 @@ describe("POST /api/runners/jobs/:id/claim", () => {
       const sandboxAuth = verifySandboxToken(data.sandboxToken);
       expect(sandboxAuth).not.toBeNull();
       expect(sandboxAuth!.capabilities).toEqual([
-        "storage:read",
-        "storage:write",
+        "artifact:read",
+        "artifact:write",
       ]);
     });
 

--- a/turbo/apps/web/app/api/storages/__tests__/capability-enforcement.test.ts
+++ b/turbo/apps/web/app/api/storages/__tests__/capability-enforcement.test.ts
@@ -41,9 +41,9 @@ describe("Storage capability enforcement", () => {
   });
 
   describe("sandbox token access for list", () => {
-    it("should accept sandbox token with storage:read for volume list", async () => {
+    it("should accept sandbox token with agent:read for volume list", async () => {
       await createTestVolume("test-vol");
-      const token = await generateSandboxToken(userId, runId, ["storage:read"]);
+      const token = await generateSandboxToken(userId, runId, ["agent:read"]);
       mockClerk({ userId: null });
 
       const response = await listRoute(
@@ -59,9 +59,11 @@ describe("Storage capability enforcement", () => {
       expect(body[0].name).toBe("test-vol");
     });
 
-    it("should accept sandbox token with storage:read for artifact list", async () => {
+    it("should accept sandbox token with artifact:read for artifact list", async () => {
       await createTestArtifact("test-art");
-      const token = await generateSandboxToken(userId, runId, ["storage:read"]);
+      const token = await generateSandboxToken(userId, runId, [
+        "artifact:read",
+      ]);
       mockClerk({ userId: null });
 
       const response = await listRoute(
@@ -77,9 +79,11 @@ describe("Storage capability enforcement", () => {
       expect(body[0].name).toBe("test-art");
     });
 
-    it("should accept sandbox token with storage:read for memory list", async () => {
+    it("should accept sandbox token with artifact:read for memory list", async () => {
       await createTestMemory("test-mem");
-      const token = await generateSandboxToken(userId, runId, ["storage:read"]);
+      const token = await generateSandboxToken(userId, runId, [
+        "artifact:read",
+      ]);
       mockClerk({ userId: null });
 
       const response = await listRoute(
@@ -97,7 +101,7 @@ describe("Storage capability enforcement", () => {
 
     it("should reject sandbox token with write capability on read route", async () => {
       const token = await generateSandboxToken(userId, runId, [
-        "storage:write",
+        "artifact:write",
       ]);
       mockClerk({ userId: null });
 
@@ -128,13 +132,41 @@ describe("Storage capability enforcement", () => {
       const body = await response.json();
       expect(body.error.code).toBe("FORBIDDEN");
     });
+
+    it("should reject artifact:read token for volume list", async () => {
+      const token = await generateSandboxToken(userId, runId, [
+        "artifact:read",
+      ]);
+      mockClerk({ userId: null });
+
+      const response = await listRoute(
+        createTestRequest(
+          "http://localhost:3000/api/storages/list?type=volume",
+          { headers: { authorization: `Bearer ${token}` } },
+        ),
+      );
+
+      expect(response.status).toBe(403);
+    });
+
+    it("should reject agent:read token for artifact list", async () => {
+      const token = await generateSandboxToken(userId, runId, ["agent:read"]);
+      mockClerk({ userId: null });
+
+      const response = await listRoute(
+        createTestRequest(
+          "http://localhost:3000/api/storages/list?type=artifact",
+          { headers: { authorization: `Bearer ${token}` } },
+        ),
+      );
+
+      expect(response.status).toBe(403);
+    });
   });
 
   describe("sandbox token access for prepare", () => {
-    it("should accept sandbox token with storage:write for prepare", async () => {
-      const token = await generateSandboxToken(userId, runId, [
-        "storage:write",
-      ]);
+    it("should accept sandbox token with agent:write for volume prepare", async () => {
+      const token = await generateSandboxToken(userId, runId, ["agent:write"]);
       mockClerk({ userId: null });
 
       const response = await prepareRoute(
@@ -155,8 +187,34 @@ describe("Storage capability enforcement", () => {
       expect(response.status).toBe(200);
     });
 
+    it("should accept sandbox token with artifact:write for artifact prepare", async () => {
+      const token = await generateSandboxToken(userId, runId, [
+        "artifact:write",
+      ]);
+      mockClerk({ userId: null });
+
+      const response = await prepareRoute(
+        createTestRequest("http://localhost:3000/api/storages/prepare", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({
+            storageName: "test-art",
+            storageType: "artifact",
+            files: [{ path: "a.txt", hash: TEST_HASH, size: 10 }],
+          }),
+        }),
+      );
+
+      expect(response.status).toBe(200);
+    });
+
     it("should reject sandbox token without matching write capability for prepare", async () => {
-      const token = await generateSandboxToken(userId, runId, ["storage:read"]);
+      const token = await generateSandboxToken(userId, runId, [
+        "artifact:read",
+      ]);
       mockClerk({ userId: null });
 
       const response = await prepareRoute(
@@ -177,6 +235,30 @@ describe("Storage capability enforcement", () => {
       expect(response.status).toBe(403);
       const body = await response.json();
       expect(body.error.code).toBe("FORBIDDEN");
+    });
+
+    it("should reject artifact:write token for volume prepare", async () => {
+      const token = await generateSandboxToken(userId, runId, [
+        "artifact:write",
+      ]);
+      mockClerk({ userId: null });
+
+      const response = await prepareRoute(
+        createTestRequest("http://localhost:3000/api/storages/prepare", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({
+            storageName: "test-vol",
+            storageType: "volume",
+            files: [{ path: "a.txt", hash: TEST_HASH, size: 10 }],
+          }),
+        }),
+      );
+
+      expect(response.status).toBe(403);
     });
   });
 
@@ -214,7 +296,7 @@ describe("Storage capability enforcement", () => {
       await createTestVolume("org-vol");
 
       // Sandbox token should resolve to the same org via run record
-      const token = await generateSandboxToken(userId, runId, ["storage:read"]);
+      const token = await generateSandboxToken(userId, runId, ["agent:read"]);
       mockClerk({ userId: null });
 
       const response = await listRoute(
@@ -233,7 +315,7 @@ describe("Storage capability enforcement", () => {
     it("should return 404 when sandbox token run not found", async () => {
       const fakeRunId = randomUUID();
       const token = await generateSandboxToken(userId, fakeRunId, [
-        "storage:read",
+        "agent:read",
       ]);
       mockClerk({ userId: null });
 

--- a/turbo/apps/web/app/api/storages/__tests__/capability-enforcement.test.ts
+++ b/turbo/apps/web/app/api/storages/__tests__/capability-enforcement.test.ts
@@ -2,6 +2,8 @@ import { randomUUID } from "crypto";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { GET as listRoute } from "../list/route";
 import { POST as prepareRoute } from "../prepare/route";
+import { POST as commitRoute } from "../commit/route";
+import { GET as downloadRoute } from "../download/route";
 import {
   createTestRequest,
   createTestVolume,
@@ -256,6 +258,168 @@ describe("Storage capability enforcement", () => {
             files: [{ path: "a.txt", hash: TEST_HASH, size: 10 }],
           }),
         }),
+      );
+
+      expect(response.status).toBe(403);
+    });
+
+    it("should accept artifact:write token for memory prepare", async () => {
+      const token = await generateSandboxToken(userId, runId, [
+        "artifact:write",
+      ]);
+      mockClerk({ userId: null });
+
+      const response = await prepareRoute(
+        createTestRequest("http://localhost:3000/api/storages/prepare", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({
+            storageName: "test-mem",
+            storageType: "memory",
+            files: [{ path: "a.txt", hash: TEST_HASH, size: 10 }],
+          }),
+        }),
+      );
+
+      expect(response.status).toBe(200);
+    });
+
+    it("should reject agent:write token for artifact prepare", async () => {
+      const token = await generateSandboxToken(userId, runId, ["agent:write"]);
+      mockClerk({ userId: null });
+
+      const response = await prepareRoute(
+        createTestRequest("http://localhost:3000/api/storages/prepare", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({
+            storageName: "test-art",
+            storageType: "artifact",
+            files: [{ path: "a.txt", hash: TEST_HASH, size: 10 }],
+          }),
+        }),
+      );
+
+      expect(response.status).toBe(403);
+    });
+  });
+
+  describe("sandbox token access for commit", () => {
+    it("should reject artifact:write token for volume commit", async () => {
+      const token = await generateSandboxToken(userId, runId, [
+        "artifact:write",
+      ]);
+      mockClerk({ userId: null });
+
+      const response = await commitRoute(
+        createTestRequest("http://localhost:3000/api/storages/commit", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({
+            storageName: "test-vol",
+            storageType: "volume",
+            versionId: TEST_HASH,
+            files: [{ path: "a.txt", hash: TEST_HASH, size: 10 }],
+          }),
+        }),
+      );
+
+      expect(response.status).toBe(403);
+    });
+
+    it("should reject agent:write token for artifact commit", async () => {
+      const token = await generateSandboxToken(userId, runId, ["agent:write"]);
+      mockClerk({ userId: null });
+
+      const response = await commitRoute(
+        createTestRequest("http://localhost:3000/api/storages/commit", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({
+            storageName: "test-art",
+            storageType: "artifact",
+            versionId: TEST_HASH,
+            files: [{ path: "a.txt", hash: TEST_HASH, size: 10 }],
+          }),
+        }),
+      );
+
+      expect(response.status).toBe(403);
+    });
+  });
+
+  describe("sandbox token access for download", () => {
+    it("should accept agent:read token for volume download", async () => {
+      await createTestVolume("test-vol");
+      const token = await generateSandboxToken(userId, runId, ["agent:read"]);
+      mockClerk({ userId: null });
+
+      const response = await downloadRoute(
+        createTestRequest(
+          "http://localhost:3000/api/storages/download?name=test-vol&type=volume",
+          { headers: { authorization: `Bearer ${token}` } },
+        ),
+      );
+
+      // Auth passed (not 403) — may be 200 or 404 depending on storage state
+      expect(response.status).not.toBe(403);
+    });
+
+    it("should accept artifact:read token for artifact download", async () => {
+      await createTestArtifact("test-art");
+      const token = await generateSandboxToken(userId, runId, [
+        "artifact:read",
+      ]);
+      mockClerk({ userId: null });
+
+      const response = await downloadRoute(
+        createTestRequest(
+          "http://localhost:3000/api/storages/download?name=test-art&type=artifact",
+          { headers: { authorization: `Bearer ${token}` } },
+        ),
+      );
+
+      // Auth passed (not 403) — may be 200 or 404 depending on storage state
+      expect(response.status).not.toBe(403);
+    });
+
+    it("should reject artifact:read token for volume download", async () => {
+      const token = await generateSandboxToken(userId, runId, [
+        "artifact:read",
+      ]);
+      mockClerk({ userId: null });
+
+      const response = await downloadRoute(
+        createTestRequest(
+          "http://localhost:3000/api/storages/download?name=test-vol&type=volume",
+          { headers: { authorization: `Bearer ${token}` } },
+        ),
+      );
+
+      expect(response.status).toBe(403);
+    });
+
+    it("should reject agent:read token for artifact download", async () => {
+      const token = await generateSandboxToken(userId, runId, ["agent:read"]);
+      mockClerk({ userId: null });
+
+      const response = await downloadRoute(
+        createTestRequest(
+          "http://localhost:3000/api/storages/download?name=test-art&type=artifact",
+          { headers: { authorization: `Bearer ${token}` } },
+        ),
       );
 
       expect(response.status).toBe(403);

--- a/turbo/apps/web/app/api/storages/commit/route.ts
+++ b/turbo/apps/web/app/api/storages/commit/route.ts
@@ -34,7 +34,7 @@ const router = tsr.router(storagesCommitContract, {
 
     const { storageName, storageType, versionId, files, runId, message } = body;
 
-    const capability = storageCapability("write");
+    const capability = storageCapability("write", storageType);
 
     // Authenticate user (sandbox tokens accepted if they have the required capability)
     const authCtx = await requireAuth(headers.authorization, {

--- a/turbo/apps/web/app/api/storages/download/route.ts
+++ b/turbo/apps/web/app/api/storages/download/route.ts
@@ -30,7 +30,7 @@ const router = tsr.router(storagesDownloadContract, {
     initServices();
 
     const { name: storageName, type: storageType, version: versionId } = query;
-    const capability = storageCapability("read");
+    const capability = storageCapability("read", storageType);
 
     // Authenticate user (sandbox tokens accepted if they have the required capability)
     const authCtx = await requireAuth(headers.authorization, {

--- a/turbo/apps/web/app/api/storages/list/route.ts
+++ b/turbo/apps/web/app/api/storages/list/route.ts
@@ -27,7 +27,7 @@ const router = tsr.router(storagesListContract, {
     initServices();
 
     const { type: storageType } = query;
-    const capability = storageCapability("read");
+    const capability = storageCapability("read", storageType);
 
     // Authenticate user (sandbox tokens accepted if they have the required capability)
     const authCtx = await requireAuth(headers.authorization, {

--- a/turbo/apps/web/app/api/storages/prepare/route.ts
+++ b/turbo/apps/web/app/api/storages/prepare/route.ts
@@ -108,7 +108,7 @@ const router = tsr.router(storagesPrepareContract, {
       changes,
     } = body;
 
-    const capability = storageCapability("write");
+    const capability = storageCapability("write", storageType);
 
     // Authenticate user (sandbox tokens accepted if they have the required capability)
     const authCtx = await requireAuth(headers.authorization, {

--- a/turbo/apps/web/src/lib/auth/__tests__/capability-check.test.ts
+++ b/turbo/apps/web/src/lib/auth/__tests__/capability-check.test.ts
@@ -17,18 +17,33 @@ describe("capability-check", () => {
   });
 
   describe("storageCapability", () => {
-    it("should map action to unified storage capability", () => {
-      expect(storageCapability("read")).toBe("storage:read");
-      expect(storageCapability("write")).toBe("storage:write");
+    it("should map volume to agent capability", () => {
+      expect(storageCapability("read", "volume")).toBe("agent:read");
+      expect(storageCapability("write", "volume")).toBe("agent:write");
+    });
+
+    it("should map artifact to artifact capability", () => {
+      expect(storageCapability("read", "artifact")).toBe("artifact:read");
+      expect(storageCapability("write", "artifact")).toBe("artifact:write");
+    });
+
+    it("should map memory to artifact capability", () => {
+      expect(storageCapability("read", "memory")).toBe("artifact:read");
+      expect(storageCapability("write", "memory")).toBe("artifact:write");
+    });
+
+    it("should default to artifact capability when no type provided", () => {
+      expect(storageCapability("read")).toBe("artifact:read");
+      expect(storageCapability("write")).toBe("artifact:write");
     });
   });
 
   describe("missingCapabilityError", () => {
     it("should return 403 error body with capability name", () => {
-      const error = missingCapabilityError("storage:read");
+      const error = missingCapabilityError("artifact:read");
 
       expect(error.error.message).toBe(
-        "Missing required capability: storage:read",
+        "Missing required capability: artifact:read",
       );
       expect(error.error.code).toBe("FORBIDDEN");
     });

--- a/turbo/apps/web/src/lib/auth/__tests__/get-user-id.spec.ts
+++ b/turbo/apps/web/src/lib/auth/__tests__/get-user-id.spec.ts
@@ -60,7 +60,7 @@ describe("getAuthContext with requiredCapability", () => {
 
   it("should reject sandbox token without requiredCapability (backward compat)", async () => {
     const token = await generateSandboxToken("user-123", "run-456", [
-      "storage:read",
+      "artifact:read",
     ]);
     const result = await getAuthContext(`Bearer ${token}`);
 
@@ -69,24 +69,24 @@ describe("getAuthContext with requiredCapability", () => {
 
   it("should accept sandbox token with matching capability", async () => {
     const token = await generateSandboxToken("user-123", "run-456", [
-      "storage:read",
+      "artifact:read",
     ]);
     const result = await getAuthContext(`Bearer ${token}`, {
-      requiredCapability: "storage:read",
+      requiredCapability: "artifact:read",
     });
 
     expect(result).not.toBeNull();
     expect(result?.userId).toBe("user-123");
     expect(result?.runId).toBe("run-456");
-    expect(result?.capabilities).toContain("storage:read");
+    expect(result?.capabilities).toContain("artifact:read");
   });
 
   it("should reject sandbox token without matching capability", async () => {
     const token = await generateSandboxToken("user-123", "run-456", [
-      "storage:read",
+      "artifact:read",
     ]);
     const result = await getAuthContext(`Bearer ${token}`, {
-      requiredCapability: "storage:write",
+      requiredCapability: "artifact:write",
     });
 
     expect(result).toBeNull();
@@ -95,7 +95,7 @@ describe("getAuthContext with requiredCapability", () => {
   it("should reject sandbox token with no capabilities", async () => {
     const token = await generateSandboxToken("user-123", "run-456");
     const result = await getAuthContext(`Bearer ${token}`, {
-      requiredCapability: "storage:read",
+      requiredCapability: "artifact:read",
     });
 
     expect(result).toBeNull();
@@ -107,7 +107,7 @@ describe("getAuthContext with requiredCapability", () => {
     } as Awaited<ReturnType<typeof auth>>);
 
     const result = await getAuthContext(undefined, {
-      requiredCapability: "storage:read",
+      requiredCapability: "artifact:read",
     });
 
     expect(result).not.toBeNull();
@@ -141,7 +141,7 @@ describe("getAuthContext with acceptAnySandboxCapability", () => {
 
   it("should accept sandbox token with multiple capabilities", async () => {
     const token = await generateSandboxToken("user-123", "run-456", [
-      "storage:read",
+      "artifact:read",
       "agent:write",
     ]);
     const result = await getAuthContext(`Bearer ${token}`, {
@@ -150,7 +150,7 @@ describe("getAuthContext with acceptAnySandboxCapability", () => {
 
     expect(result).not.toBeNull();
     expect(result?.userId).toBe("user-123");
-    expect(result?.capabilities).toContain("storage:read");
+    expect(result?.capabilities).toContain("artifact:read");
     expect(result?.capabilities).toContain("agent:write");
   });
 

--- a/turbo/apps/web/src/lib/auth/__tests__/require-auth.test.ts
+++ b/turbo/apps/web/src/lib/auth/__tests__/require-auth.test.ts
@@ -18,7 +18,7 @@ describe("requireAuth", () => {
     } as Awaited<ReturnType<typeof auth>>);
 
     const result = await requireAuth(undefined, {
-      requiredCapability: "storage:read",
+      requiredCapability: "artifact:read",
     });
 
     expect(isAuthError(result)).toBe(false);
@@ -29,28 +29,28 @@ describe("requireAuth", () => {
 
   it("should return AuthContext for sandbox token with matching capability", async () => {
     const token = await generateSandboxToken("user-1", "run-1", [
-      "storage:read",
+      "artifact:read",
     ]);
 
     const result = await requireAuth(`Bearer ${token}`, {
-      requiredCapability: "storage:read",
+      requiredCapability: "artifact:read",
     });
 
     expect(isAuthError(result)).toBe(false);
     if (!isAuthError(result)) {
       expect(result.userId).toBe("user-1");
       expect(result.runId).toBe("run-1");
-      expect(result.capabilities).toContain("storage:read");
+      expect(result.capabilities).toContain("artifact:read");
     }
   });
 
   it("should return 403 for sandbox token missing required capability", async () => {
     const token = await generateSandboxToken("user-1", "run-1", [
-      "storage:read",
+      "artifact:read",
     ]);
 
     const result = await requireAuth(`Bearer ${token}`, {
-      requiredCapability: "storage:write",
+      requiredCapability: "artifact:write",
     });
 
     expect(isAuthError(result)).toBe(true);
@@ -58,7 +58,7 @@ describe("requireAuth", () => {
       expect(result.status).toBe(403);
       expect(result.body.error.code).toBe("FORBIDDEN");
       expect(result.body.error.message).toBe(
-        "Missing required capability: storage:write",
+        "Missing required capability: artifact:write",
       );
     }
   });
@@ -67,7 +67,7 @@ describe("requireAuth", () => {
     const token = await generateSandboxToken("user-1", "run-1");
 
     const result = await requireAuth(`Bearer ${token}`, {
-      requiredCapability: "storage:read",
+      requiredCapability: "artifact:read",
     });
 
     expect(isAuthError(result)).toBe(true);
@@ -75,14 +75,14 @@ describe("requireAuth", () => {
       expect(result.status).toBe(403);
       expect(result.body.error.code).toBe("FORBIDDEN");
       expect(result.body.error.message).toBe(
-        "Missing required capability: storage:read",
+        "Missing required capability: artifact:read",
       );
     }
   });
 
   it("should return 403 for sandbox token on uncovered endpoint", async () => {
     const token = await generateSandboxToken("user-1", "run-1", [
-      "storage:read",
+      "artifact:read",
     ]);
 
     // No requiredCapability = uncovered endpoint

--- a/turbo/apps/web/src/lib/auth/__tests__/sandbox-token.test.ts
+++ b/turbo/apps/web/src/lib/auth/__tests__/sandbox-token.test.ts
@@ -125,7 +125,7 @@ describe("sandbox-token", () => {
 
   describe("capabilities", () => {
     it("should include capabilities in verified token", async () => {
-      const capabilities = ["storage:read", "storage:write"] as const;
+      const capabilities = ["artifact:read", "artifact:write"] as const;
       const token = await generateSandboxToken(
         "user-123",
         "run-456",
@@ -136,7 +136,7 @@ describe("sandbox-token", () => {
       expect(auth).not.toBeNull();
       expect(auth?.userId).toBe("user-123");
       expect(auth?.runId).toBe("run-456");
-      expect(auth?.capabilities).toEqual(["storage:read", "storage:write"]);
+      expect(auth?.capabilities).toEqual(["artifact:read", "artifact:write"]);
     });
 
     it("should work without capabilities (backward compat)", async () => {
@@ -159,9 +159,9 @@ describe("sandbox-token", () => {
     it("should reject token with invalid capability value", async () => {
       // Cast invalid capability through type system to simulate a malformed token
       const invalidCaps = [
-        "storage:read",
+        "artifact:read",
         "volume:read",
-      ] as unknown as readonly ("storage:read" | "storage:write")[];
+      ] as unknown as readonly ("artifact:read" | "artifact:write")[];
       const token = await generateSandboxToken(
         "user-123",
         "run-456",
@@ -174,8 +174,8 @@ describe("sandbox-token", () => {
 
     it("should roundtrip all valid capabilities", async () => {
       const capabilities = [
-        "storage:read",
-        "storage:write",
+        "artifact:read",
+        "artifact:write",
         "agent:read",
         "agent:write",
         "agent-run:read",

--- a/turbo/apps/web/src/lib/auth/capability-check.ts
+++ b/turbo/apps/web/src/lib/auth/capability-check.ts
@@ -15,10 +15,20 @@ export function isSandboxAuth(
 }
 
 /**
- * Map storage action to unified capability string.
+ * Map storage type + action to the correct capability.
+ *
+ * Aligned with the resource model:
+ * - volume → agent:* (Agent Org static resource)
+ * - artifact, memory → artifact:* (Runtime Org dynamic resource)
  */
-export function storageCapability(action: "read" | "write"): Capability {
-  return `storage:${action}` as Capability;
+export function storageCapability(
+  action: "read" | "write",
+  storageType?: "volume" | "artifact" | "memory",
+): Capability {
+  if (storageType === "volume") {
+    return `agent:${action}` as Capability;
+  }
+  return `artifact:${action}` as Capability;
 }
 
 /**

--- a/turbo/packages/core/src/contracts/__tests__/composes.test.ts
+++ b/turbo/packages/core/src/contracts/__tests__/composes.test.ts
@@ -35,7 +35,7 @@ describe("experimental_capabilities in agentDefinitionSchema", () => {
   it("accepts valid capabilities array", () => {
     const result = agentDefinitionSchema.safeParse({
       ...baseAgent,
-      experimental_capabilities: ["storage:read", "storage:write"],
+      experimental_capabilities: ["artifact:read", "artifact:write"],
     });
     expect(result.success).toBe(true);
   });
@@ -43,7 +43,7 @@ describe("experimental_capabilities in agentDefinitionSchema", () => {
   it("accepts a single valid capability", () => {
     const result = agentDefinitionSchema.safeParse({
       ...baseAgent,
-      experimental_capabilities: ["storage:read"],
+      experimental_capabilities: ["agent:read"],
     });
     expect(result.success).toBe(true);
   });
@@ -69,10 +69,18 @@ describe("experimental_capabilities in agentDefinitionSchema", () => {
     expect(result.success).toBe(false);
   });
 
+  it("rejects deprecated storage:read as direct value", () => {
+    const result = agentDefinitionSchema.safeParse({
+      ...baseAgent,
+      experimental_capabilities: ["storage:read"],
+    });
+    expect(result.success).toBe(false);
+  });
+
   it("rejects duplicate capabilities", () => {
     const result = agentDefinitionSchema.safeParse({
       ...baseAgent,
-      experimental_capabilities: ["storage:read", "storage:read"],
+      experimental_capabilities: ["artifact:read", "artifact:read"],
     });
     expect(result.success).toBe(false);
     if (!result.success) {
@@ -88,8 +96,8 @@ describe("experimental_capabilities in agentComposeApiContentSchema", () => {
     const result = agentComposeApiContentSchema.safeParse(
       wrapInCompose({
         experimental_capabilities: [
-          "storage:read",
-          "storage:write",
+          "agent:read",
+          "artifact:write",
           "agent-run:read",
         ],
       }),
@@ -114,34 +122,36 @@ describe("experimental_capabilities in agentComposeApiContentSchema", () => {
 
 describe("normalizeCapabilities", () => {
   it("passes through current capabilities unchanged", () => {
-    expect(normalizeCapabilities(["storage:read", "agent:write"])).toEqual(
-      expect.arrayContaining(["storage:read", "agent:write"]),
+    expect(normalizeCapabilities(["artifact:read", "agent:write"])).toEqual(
+      expect.arrayContaining(["artifact:read", "agent:write"]),
     );
   });
 
-  it("normalizes volume:read to storage:read", () => {
-    expect(normalizeCapabilities(["volume:read"])).toEqual(["storage:read"]);
+  it("normalizes volume:read to agent:read", () => {
+    expect(normalizeCapabilities(["volume:read"])).toEqual(["agent:read"]);
   });
 
-  it("normalizes volume:write to storage:write", () => {
-    expect(normalizeCapabilities(["volume:write"])).toEqual(["storage:write"]);
+  it("normalizes volume:write to agent:write", () => {
+    expect(normalizeCapabilities(["volume:write"])).toEqual(["agent:write"]);
   });
 
-  it("normalizes artifact:read to storage:read", () => {
-    expect(normalizeCapabilities(["artifact:read"])).toEqual(["storage:read"]);
+  it("normalizes storage:read to artifact:read", () => {
+    expect(normalizeCapabilities(["storage:read"])).toEqual(["artifact:read"]);
   });
 
-  it("normalizes memory:write to storage:write", () => {
-    expect(normalizeCapabilities(["memory:write"])).toEqual(["storage:write"]);
+  it("normalizes storage:write to artifact:write", () => {
+    expect(normalizeCapabilities(["storage:write"])).toEqual([
+      "artifact:write",
+    ]);
+  });
+
+  it("normalizes memory:write to artifact:write", () => {
+    expect(normalizeCapabilities(["memory:write"])).toEqual(["artifact:write"]);
   });
 
   it("deduplicates when multiple old caps map to same new cap", () => {
-    const result = normalizeCapabilities([
-      "volume:read",
-      "artifact:read",
-      "memory:read",
-    ]);
-    expect(result).toEqual(["storage:read"]);
+    const result = normalizeCapabilities(["storage:read", "memory:read"]);
+    expect(result).toEqual(["artifact:read"]);
   });
 
   it("handles mixed old and new capabilities", () => {
@@ -151,9 +161,9 @@ describe("normalizeCapabilities", () => {
       "storage:write",
     ]);
     expect(result).toHaveLength(3);
-    expect(result).toContain("storage:read");
+    expect(result).toContain("agent:read");
     expect(result).toContain("agent:write");
-    expect(result).toContain("storage:write");
+    expect(result).toContain("artifact:write");
   });
 
   it("drops unknown capabilities", () => {

--- a/turbo/packages/core/src/contracts/composes.ts
+++ b/turbo/packages/core/src/contracts/composes.ts
@@ -26,12 +26,17 @@ export const AGENT_NAME_REGEX = /^[a-zA-Z0-9][a-zA-Z0-9-]{1,62}[a-zA-Z0-9]$/;
 /**
  * Valid capability strings for experimental_capabilities.
  * Format: {resource}:{action}
+ *
+ * Aligned with the resource model (docs/resource-model.md):
+ * - agent:*    → Agent Org static resources (compose + volumes)
+ * - artifact:* → Runtime Org dynamic resources (artifacts + memories)
+ * - agent-run:*, schedule:* → operational capabilities
  */
 export const VALID_CAPABILITIES = [
-  "storage:read",
-  "storage:write",
   "agent:read",
   "agent:write",
+  "artifact:read",
+  "artifact:write",
   "agent-run:read",
   "agent-run:write",
   "schedule:read",
@@ -40,17 +45,16 @@ export const VALID_CAPABILITIES = [
 
 /**
  * Alias map for deprecated capability names.
- * PR #4959 merged volume/artifact/memory into unified storage capabilities.
- * Old compose versions in the database may still contain these values.
+ * Maps old storage:* and granular volume:/memory: names to the new model.
  */
 const CAPABILITY_ALIASES: Record<string, (typeof VALID_CAPABILITIES)[number]> =
   {
-    "volume:read": "storage:read",
-    "volume:write": "storage:write",
-    "artifact:read": "storage:read",
-    "artifact:write": "storage:write",
-    "memory:read": "storage:read",
-    "memory:write": "storage:write",
+    "storage:read": "artifact:read",
+    "storage:write": "artifact:write",
+    "volume:read": "agent:read",
+    "volume:write": "agent:write",
+    "memory:read": "artifact:read",
+    "memory:write": "artifact:write",
   };
 
 /**


### PR DESCRIPTION
## Summary

Closes #5051

- Replace `storage:read`/`storage:write` capabilities with resource-model-aligned names
- `agent:*` now covers Agent Org static resources (compose + volumes)
- `artifact:*` now covers Runtime Org dynamic resources (artifacts + memories)
- Storage endpoints resolve capability based on `storageType` parameter
- Backward-compatible aliases map old capability names in existing compose data

Fixes the issue where an agent with `agent:write` could not compose because instructions upload (a volume operation) required the separate `storage:write` capability.

## Test plan

- [x] All 1905 existing tests pass (167 test files)
- [x] Updated capability-check unit tests verify type-based resolution
- [x] Updated storage capability-enforcement tests verify volume→agent:*, artifact/memory→artifact:*
- [x] Updated compose sandbox-capability tests use new capability names
- [x] Normalization tests verify backward-compatible alias mapping
- [x] Type check, lint, format, knip all pass
- [x] Pre-commit hooks (prettier, knip, cargo-clippy, commitlint) all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)