### PR TITLE
test: add missing run queue tests for dispatch failure and org tier lookup

### DIFF
--- a/turbo/apps/web/src/lib/run/__tests__/run-queue-service.test.ts
+++ b/turbo/apps/web/src/lib/run/__tests__/run-queue-service.test.ts
@@ -11,6 +11,7 @@ import {
   markRunningRunsAsCompleted,
   expireQueueEntry,
   setTestRunStatus,
+  insertOrgCacheEntry,
 } from "../../../__tests__/api-test-helpers";
 import { reloadEnv } from "../../../env";
 import {
@@ -217,6 +218,63 @@ describe("run-queue-service", () => {
 
       expect(dispatchedRunIds).toContain(run2.runId);
       expect(dispatchedRunIds).not.toContain(run1.runId);
+    });
+
+    it("should try next entry when dispatch fails", async () => {
+      vi.stubEnv("CONCURRENT_RUN_LIMIT_CAP", "2");
+      reloadEnv();
+
+      // Enqueue two runs
+      const run1 = await enqueueRun(baseParams({ prompt: "Will fail" }));
+      await enqueueRun(baseParams({ prompt: "Will succeed" }));
+
+      // Dispatcher fails on first call, succeeds on second
+      let callCount = 0;
+      const mockDispatcher = async () => {
+        callCount++;
+        if (callCount === 1) throw new Error("Sandbox creation failed");
+      };
+
+      await drainOrgQueue(user.orgId, mockDispatcher);
+
+      // First run should be marked failed
+      const r1 = await findTestRunRecord(run1.runId);
+      expect(r1!.status).toBe("failed");
+      expect(r1!.error).toContain("Sandbox creation failed");
+
+      // Second run should have been dispatched (status set to pending by dequeue)
+      expect(callCount).toBe(2);
+    });
+
+    it("should use org tier from cache for concurrency limit", async () => {
+      // Set env cap high so tier limit is the binding constraint
+      vi.stubEnv("CONCURRENT_RUN_LIMIT_CAP", "10");
+      reloadEnv();
+
+      // Update org_cache to "pro" tier (limit=2 vs free limit=1)
+      await insertOrgCacheEntry({
+        orgId: user.orgId,
+        slug: `org-${user.orgId}`,
+        tier: "pro",
+      });
+
+      // Create 1 running run — fills free limit but not pro limit
+      await createRun(baseParams({ prompt: "Running" }));
+      const queued = await enqueueRun(baseParams({ prompt: "Queued" }));
+
+      // With pro tier (limit=2), drain should succeed despite 1 active run
+      const dispatchedRunIds: string[] = [];
+      const mockDispatcher = async (runId: string) => {
+        dispatchedRunIds.push(runId);
+      };
+
+      await drainOrgQueue(user.orgId, mockDispatcher);
+
+      expect(dispatchedRunIds).toContain(queued.runId);
+
+      // Queue entry should be consumed
+      const queueEntry = await findTestQueueEntry(queued.runId);
+      expect(queueEntry).toBeUndefined();
     });
   });
 


### PR DESCRIPTION
## Summary

- Add test for dispatch failure recovery: verifies `drainOrgQueue` marks the failing run as failed and continues to the next queue entry
- Add test for org tier cache lookup: verifies `dequeueNextAtomic` reads the org tier from `org_cache` and applies the correct concurrency limit (pro=2 vs free=1)

These cover two untested behaviors introduced in the queue concurrency refactor (#5024, PR #5035).

## Test plan

- [x] All 15 run-queue-service tests pass
- [x] Lint, format, knip pass
- [ ] CI pipeline passes

Relates to #5024

🤖 Generated with [Claude Code](https://claude.com/claude-code)