### PR TITLE
ci: increase runner e2e test chunks from 8 to 12

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1095,7 +1095,7 @@ jobs:
           # Weight = number of @test cases per file.
           # Greedy assignment: heaviest file goes to the lightest chunk,
           # ensuring heavy tests are spread across chunks instead of clustering.
-          NUM_CHUNKS=8
+          NUM_CHUNKS=12
 
           # Compute weight per file: count @test declarations
           declare -A WEIGHTS


### PR DESCRIPTION
## Summary
- Increase `NUM_CHUNKS` from 8 to 12 for runner E2E test parallelization
- More chunks = smaller per-chunk workload = faster overall CI time

## Test plan
- [ ] CI passes with 12 chunks

🤖 Generated with [Claude Code](https://claude.com/claude-code)