### PR TITLE
fix: prevent cross-org session access via org validation

### DIFF
--- a/turbo/apps/web/app/api/agent/runs/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/__tests__/route.test.ts
@@ -1044,6 +1044,38 @@ describe("POST /api/agent/runs - Internal Runs API", () => {
       expect(data.error.code).toBe("NOT_FOUND");
     });
 
+    it("should return 404 when creating new run against compose from a different org", async () => {
+      // testComposeId belongs to user's default org (org A)
+      // Switch to org B
+      const otherOrgId = uniqueId("org-other");
+      const otherOrgSlug = uniqueId("org-other");
+      await insertOrgCacheEntry({ orgId: otherOrgId, slug: otherOrgSlug });
+      mockClerk({
+        userId: user.userId,
+        orgId: otherOrgId,
+        orgSlug: otherOrgSlug,
+        clerkOrgs: [{ id: otherOrgId, slug: otherOrgSlug, name: otherOrgSlug }],
+      });
+
+      const request = createTestRequest(
+        "http://localhost:3000/api/agent/runs",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            agentComposeId: testComposeId,
+            prompt: "Cross-org new run",
+          }),
+        },
+      );
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(404);
+      expect(data.error.code).toBe("NOT_FOUND");
+    });
+
     // Note: "Missing required secrets" validation is tested in the Validation
     // describe block above (lines 138-197).
   });
@@ -1103,6 +1135,41 @@ describe("POST /api/agent/runs - Internal Runs API", () => {
       const data = await response.json();
 
       // Returns 404 for security (don't leak checkpoint existence)
+      expect(response.status).toBe(404);
+      expect(data.error.code).toBe("NOT_FOUND");
+    });
+
+    it("should return 404 when resuming checkpoint from a different org", async () => {
+      // Create compose and run under org A, then complete it (creates checkpoint)
+      const { runId } = await createTestRun(testComposeId, "Checkpoint run");
+      const { checkpointId } = await completeTestRun(user.userId, runId);
+
+      // Switch to org B
+      const otherOrgId = uniqueId("org-other");
+      const otherOrgSlug = uniqueId("org-other");
+      await insertOrgCacheEntry({ orgId: otherOrgId, slug: otherOrgSlug });
+      mockClerk({
+        userId: user.userId,
+        orgId: otherOrgId,
+        orgSlug: otherOrgSlug,
+        clerkOrgs: [{ id: otherOrgId, slug: otherOrgSlug, name: otherOrgSlug }],
+      });
+
+      const request = createTestRequest(
+        "http://localhost:3000/api/agent/runs",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            checkpointId,
+            prompt: "Cross-org checkpoint resume",
+          }),
+        },
+      );
+
+      const response = await POST(request);
+      const data = await response.json();
+
       expect(response.status).toBe(404);
       expect(data.error.code).toBe("NOT_FOUND");
     });

--- a/turbo/apps/web/app/api/agent/runs/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/__tests__/route.test.ts
@@ -373,11 +373,9 @@ describe("POST /api/agent/runs - Internal Runs API", () => {
       const response = await POST(request);
       const data = await response.json();
 
-      // Returns 403 Forbidden for unauthorized access
-      expect(response.status).toBe(403);
-      expect(data.error.message).toMatch(
-        /access denied|not authorized|permission/i,
-      );
+      // Returns 404 to avoid leaking resource existence (cross-org check)
+      expect(response.status).toBe(404);
+      expect(data.error.code).toBe("NOT_FOUND");
 
       // Switch back to owner for cleanup
       mockClerk({ userId: ownerUser.userId });
@@ -436,11 +434,9 @@ describe("POST /api/agent/runs - Internal Runs API", () => {
       const response = await POST(request);
       const data = await response.json();
 
-      // Returns 403 Forbidden for unauthorized access
-      expect(response.status).toBe(403);
-      expect(data.error.message).toMatch(
-        /access denied|not authorized|permission/i,
-      );
+      // Returns 404 to avoid leaking resource existence (cross-org check)
+      expect(response.status).toBe(404);
+      expect(data.error.code).toBe("NOT_FOUND");
 
       // Switch back to owner for cleanup
       mockClerk({ userId: ownerUser.userId });

--- a/turbo/apps/web/app/api/agent/runs/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/__tests__/route.test.ts
@@ -1013,6 +1013,41 @@ describe("POST /api/agent/runs - Internal Runs API", () => {
       expect(data.error.code).toBe("NOT_FOUND");
     });
 
+    it("should return 404 when continuing session from a different org", async () => {
+      // Create compose and run under user's default org (org A)
+      const { runId } = await createTestRun(testComposeId, "Session run");
+      const { agentSessionId } = await completeTestRun(user.userId, runId);
+
+      // Switch to org B — different org for the same user
+      const otherOrgId = uniqueId("org-other");
+      const otherOrgSlug = uniqueId("org-other");
+      await insertOrgCacheEntry({ orgId: otherOrgId, slug: otherOrgSlug });
+      mockClerk({
+        userId: user.userId,
+        orgId: otherOrgId,
+        orgSlug: otherOrgSlug,
+        clerkOrgs: [{ id: otherOrgId, slug: otherOrgSlug, name: otherOrgSlug }],
+      });
+
+      const request = createTestRequest(
+        "http://localhost:3000/api/agent/runs",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            sessionId: agentSessionId,
+            prompt: "Cross-org continue",
+          }),
+        },
+      );
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(404);
+      expect(data.error.code).toBe("NOT_FOUND");
+    });
+
     // Note: "Missing required secrets" validation is tested in the Validation
     // describe block above (lines 138-197).
   });

--- a/turbo/apps/web/app/api/agent/runs/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/route.ts
@@ -40,6 +40,7 @@ interface ResolvedCompose {
   agentComposeVersionId: string;
   agentComposeName?: string;
   composeId?: string;
+  composeOrgId?: string;
 }
 
 type ErrorResponse = {
@@ -192,6 +193,7 @@ async function resolveSessionContinue(
     .select({
       name: agentComposes.name,
       headVersionId: agentComposes.headVersionId,
+      orgId: agentComposes.orgId,
     })
     .from(agentComposes)
     .where(eq(agentComposes.id, sessionData.agentComposeId))
@@ -225,6 +227,7 @@ async function resolveSessionContinue(
     agentComposeVersionId: compose.headVersionId,
     agentComposeName: compose.name || undefined,
     composeId: sessionData.agentComposeId,
+    composeOrgId: compose.orgId,
   };
 }
 
@@ -441,6 +444,16 @@ const router = tsr.router(runsMainContract, {
     // The actual variable fetching happens in build-context.ts.
     const orgSlug = new URL(request.url).searchParams.get("org");
     const { org } = await resolveOrg(userId, orgSlug);
+
+    // Cross-org session access check: session's compose must belong to the resolved org
+    if (resolved.composeOrgId && resolved.composeOrgId !== org.orgId) {
+      return {
+        status: 404 as const,
+        body: {
+          error: { message: "Resource not found", code: "NOT_FOUND" },
+        },
+      };
+    }
 
     // Delegate run creation, validation, and dispatch to createRun()
     try {

--- a/turbo/apps/web/app/api/agent/runs/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/route.ts
@@ -81,7 +81,11 @@ async function resolveNewRun(body: {
 }): Promise<ResolvedCompose | ErrorResponse> {
   if (body.agentComposeVersionId) {
     const [versionRow] = await globalThis.services.db
-      .select({ composeName: agentComposes.name })
+      .select({
+        composeName: agentComposes.name,
+        composeOrgId: agentComposes.orgId,
+        composeId: agentComposes.id,
+      })
       .from(agentComposeVersions)
       .leftJoin(
         agentComposes,
@@ -93,6 +97,8 @@ async function resolveNewRun(body: {
     return {
       agentComposeVersionId: body.agentComposeVersionId,
       agentComposeName: versionRow?.composeName || undefined,
+      composeId: versionRow?.composeId || undefined,
+      composeOrgId: versionRow?.composeOrgId || undefined,
     };
   }
 
@@ -101,6 +107,7 @@ async function resolveNewRun(body: {
     .select({
       name: agentComposes.name,
       headVersionId: agentComposes.headVersionId,
+      orgId: agentComposes.orgId,
     })
     .from(agentComposes)
     .where(eq(agentComposes.id, composeId))
@@ -131,6 +138,7 @@ async function resolveNewRun(body: {
     agentComposeVersionId: compose.headVersionId,
     agentComposeName: compose.name || undefined,
     composeId,
+    composeOrgId: compose.orgId,
   };
 }
 

--- a/turbo/apps/web/app/api/agent/runs/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/route.ts
@@ -163,7 +163,11 @@ async function resolveCheckpointResume(
   }
 
   const [versionWithCompose] = await globalThis.services.db
-    .select({ composeName: agentComposes.name })
+    .select({
+      composeName: agentComposes.name,
+      composeOrgId: agentComposes.orgId,
+      composeId: agentComposes.id,
+    })
     .from(agentComposeVersions)
     .leftJoin(
       agentComposes,
@@ -175,6 +179,8 @@ async function resolveCheckpointResume(
   return {
     agentComposeVersionId,
     agentComposeName: versionWithCompose?.composeName || undefined,
+    composeId: versionWithCompose?.composeId || undefined,
+    composeOrgId: versionWithCompose?.composeOrgId || undefined,
   };
 }
 

--- a/turbo/apps/web/app/api/agent/sessions/[id]/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/sessions/[id]/__tests__/route.test.ts
@@ -5,6 +5,7 @@ import {
   createTestCompose,
   createTestRun,
   completeTestRun,
+  insertOrgCacheEntry,
 } from "../../../../../../src/__tests__/api-test-helpers";
 import {
   testContext,
@@ -89,6 +90,33 @@ describe("GET /api/agent/sessions/:id", () => {
 
     expect(response.status).toBe(403);
     expect(data.error.code).toBe("FORBIDDEN");
+  });
+
+  it("should return 404 when accessing session from a different org", async () => {
+    // Create run and complete it under org A (user's default org)
+    const { runId } = await createTestRun(testComposeId, "Test session");
+    const { agentSessionId } = await completeTestRun(user.userId, runId);
+
+    // Switch to org B — different org for the same user
+    const otherOrgId = uniqueId("org-other");
+    const otherOrgSlug = uniqueId("org-other");
+    await insertOrgCacheEntry({ orgId: otherOrgId, slug: otherOrgSlug });
+    mockClerk({
+      userId: user.userId,
+      orgId: otherOrgId,
+      orgSlug: otherOrgSlug,
+      clerkOrgs: [{ id: otherOrgId, slug: otherOrgSlug, name: otherOrgSlug }],
+    });
+
+    const request = createTestRequest(
+      `http://localhost:3000/api/agent/sessions/${agentSessionId}`,
+    );
+
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(data.error.code).toBe("NOT_FOUND");
   });
 
   it("should return 401 when not authenticated", async () => {

--- a/turbo/apps/web/app/api/agent/sessions/[id]/messages/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/sessions/[id]/messages/__tests__/route.test.ts
@@ -6,6 +6,7 @@ import {
   createTestCompose,
   createTestRun,
   completeTestRun,
+  insertOrgCacheEntry,
 } from "../../../../../../../src/__tests__/api-test-helpers";
 import {
   testContext,
@@ -170,6 +171,39 @@ describe("POST /api/agent/sessions/:id/messages", () => {
     const data = await response.json();
 
     // appendChatMessages uses WHERE userId = ... so it's a 404 (not found or not owned)
+    expect(response.status).toBe(404);
+    expect(data.error.code).toBe("NOT_FOUND");
+  });
+
+  it("should return 404 when appending messages to session from a different org", async () => {
+    const { runId } = await createTestRun(testComposeId, "Test prompt");
+    const { agentSessionId } = await completeTestRun(user.userId, runId);
+
+    // Switch to org B — different org for the same user
+    const otherOrgId = uniqueId("org-other");
+    const otherOrgSlug = uniqueId("org-other");
+    await insertOrgCacheEntry({ orgId: otherOrgId, slug: otherOrgSlug });
+    mockClerk({
+      userId: user.userId,
+      orgId: otherOrgId,
+      orgSlug: otherOrgSlug,
+      clerkOrgs: [{ id: otherOrgId, slug: otherOrgSlug, name: otherOrgSlug }],
+    });
+
+    const request = createTestRequest(
+      `http://localhost:3000/api/agent/sessions/${agentSessionId}/messages`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          messages: [{ role: "user", content: "Cross-org message" }],
+        }),
+      },
+    );
+
+    const response = await POST(request);
+    const data = await response.json();
+
     expect(response.status).toBe(404);
     expect(data.error.code).toBe("NOT_FOUND");
   });

--- a/turbo/apps/web/app/api/agent/sessions/[id]/messages/route.ts
+++ b/turbo/apps/web/app/api/agent/sessions/[id]/messages/route.ts
@@ -8,10 +8,9 @@ import { eq } from "drizzle-orm";
 import { initServices } from "../../../../../../src/lib/init-services";
 import { getUserId } from "../../../../../../src/lib/auth/get-user-id";
 import { appendChatMessages } from "../../../../../../src/lib/agent-session";
-import { isNotFound, isForbidden } from "../../../../../../src/lib/errors";
+import { isNotFound } from "../../../../../../src/lib/errors";
 import { agentSessions } from "../../../../../../src/db/schema/agent-session";
-import { agentComposes } from "../../../../../../src/db/schema/agent-compose";
-import { resolveOrg } from "../../../../../../src/lib/org/resolve-org";
+import { verifyComposeOrgAccess } from "../../../../../../src/lib/org/verify-compose-org-access";
 
 const router = tsr.router(sessionMessagesContract, {
   append: async ({ params, body, headers }, { request }) => {
@@ -46,35 +45,18 @@ const router = tsr.router(sessionMessagesContract, {
       };
     }
 
-    const [compose] = await globalThis.services.db
-      .select({ orgId: agentComposes.orgId })
-      .from(agentComposes)
-      .where(eq(agentComposes.id, session.agentComposeId))
-      .limit(1);
-
-    if (compose) {
-      const orgSlug = new URL(request.url).searchParams.get("org");
-      try {
-        const { org } = await resolveOrg(userId, orgSlug);
-        if (compose.orgId !== org.orgId) {
-          return {
-            status: 404 as const,
-            body: {
-              error: { message: "Session not found", code: "NOT_FOUND" },
-            },
-          };
-        }
-      } catch (error) {
-        if (isNotFound(error) || isForbidden(error)) {
-          return {
-            status: 404 as const,
-            body: {
-              error: { message: "Session not found", code: "NOT_FOUND" },
-            },
-          };
-        }
-        throw error;
-      }
+    const hasOrgAccess = await verifyComposeOrgAccess(
+      session.agentComposeId,
+      userId,
+      request.url,
+    );
+    if (!hasOrgAccess) {
+      return {
+        status: 404 as const,
+        body: {
+          error: { message: "Session not found", code: "NOT_FOUND" },
+        },
+      };
     }
 
     await appendChatMessages(params.id, userId, body.messages);

--- a/turbo/apps/web/app/api/agent/sessions/[id]/messages/route.ts
+++ b/turbo/apps/web/app/api/agent/sessions/[id]/messages/route.ts
@@ -4,13 +4,17 @@ import {
   TsRestResponse,
 } from "../../../../../../src/lib/ts-rest-handler";
 import { sessionMessagesContract } from "@vm0/core";
+import { eq } from "drizzle-orm";
 import { initServices } from "../../../../../../src/lib/init-services";
 import { getUserId } from "../../../../../../src/lib/auth/get-user-id";
 import { appendChatMessages } from "../../../../../../src/lib/agent-session";
-import { isNotFound } from "../../../../../../src/lib/errors";
+import { isNotFound, isForbidden } from "../../../../../../src/lib/errors";
+import { agentSessions } from "../../../../../../src/db/schema/agent-session";
+import { agentComposes } from "../../../../../../src/db/schema/agent-compose";
+import { resolveOrg } from "../../../../../../src/lib/org/resolve-org";
 
 const router = tsr.router(sessionMessagesContract, {
-  append: async ({ params, body, headers }) => {
+  append: async ({ params, body, headers }, { request }) => {
     initServices();
 
     const userId = await getUserId(headers.authorization);
@@ -21,6 +25,56 @@ const router = tsr.router(sessionMessagesContract, {
           error: { message: "Not authenticated", code: "UNAUTHORIZED" },
         },
       };
+    }
+
+    // Verify session belongs to the caller's active organization
+    const [session] = await globalThis.services.db
+      .select({
+        agentComposeId: agentSessions.agentComposeId,
+        userId: agentSessions.userId,
+      })
+      .from(agentSessions)
+      .where(eq(agentSessions.id, params.id))
+      .limit(1);
+
+    if (!session || session.userId !== userId) {
+      return {
+        status: 404 as const,
+        body: {
+          error: { message: "Session not found", code: "NOT_FOUND" },
+        },
+      };
+    }
+
+    const [compose] = await globalThis.services.db
+      .select({ orgId: agentComposes.orgId })
+      .from(agentComposes)
+      .where(eq(agentComposes.id, session.agentComposeId))
+      .limit(1);
+
+    if (compose) {
+      const orgSlug = new URL(request.url).searchParams.get("org");
+      try {
+        const { org } = await resolveOrg(userId, orgSlug);
+        if (compose.orgId !== org.orgId) {
+          return {
+            status: 404 as const,
+            body: {
+              error: { message: "Session not found", code: "NOT_FOUND" },
+            },
+          };
+        }
+      } catch (error) {
+        if (isNotFound(error) || isForbidden(error)) {
+          return {
+            status: 404 as const,
+            body: {
+              error: { message: "Session not found", code: "NOT_FOUND" },
+            },
+          };
+        }
+        throw error;
+      }
     }
 
     await appendChatMessages(params.id, userId, body.messages);

--- a/turbo/apps/web/app/api/agent/sessions/[id]/route.ts
+++ b/turbo/apps/web/app/api/agent/sessions/[id]/route.ts
@@ -56,14 +56,6 @@ const router = tsr.router(sessionsByIdContract, {
       };
     }
 
-    // Extract secret names from HEAD compose content
-    let secretNames: string[] | null = null;
-    const [compose] = await globalThis.services.db
-      .select()
-      .from(agentComposes)
-      .where(eq(agentComposes.id, session.agentComposeId))
-      .limit(1);
-
     // Verify session belongs to the caller's active organization
     const hasOrgAccess = await verifyComposeOrgAccess(
       session.agentComposeId,
@@ -78,6 +70,14 @@ const router = tsr.router(sessionsByIdContract, {
         },
       };
     }
+
+    // Extract secret names from HEAD compose content
+    let secretNames: string[] | null = null;
+    const [compose] = await globalThis.services.db
+      .select()
+      .from(agentComposes)
+      .where(eq(agentComposes.id, session.agentComposeId))
+      .limit(1);
 
     if (compose?.headVersionId) {
       const [version] = await globalThis.services.db

--- a/turbo/apps/web/app/api/agent/sessions/[id]/route.ts
+++ b/turbo/apps/web/app/api/agent/sessions/[id]/route.ts
@@ -12,9 +12,11 @@ import {
   agentComposeVersions,
 } from "../../../../../src/db/schema/agent-compose";
 import { getUserId } from "../../../../../src/lib/auth/get-user-id";
+import { resolveOrg } from "../../../../../src/lib/org/resolve-org";
+import { isNotFound, isForbidden } from "../../../../../src/lib/errors";
 
 const router = tsr.router(sessionsByIdContract, {
-  getById: async ({ params, headers }) => {
+  getById: async ({ params, headers }, { request }) => {
     initServices();
 
     const userId = await getUserId(headers.authorization);
@@ -62,6 +64,32 @@ const router = tsr.router(sessionsByIdContract, {
       .from(agentComposes)
       .where(eq(agentComposes.id, session.agentComposeId))
       .limit(1);
+
+    // Verify session belongs to the caller's active organization
+    if (compose) {
+      const orgSlug = new URL(request.url).searchParams.get("org");
+      try {
+        const { org } = await resolveOrg(userId, orgSlug);
+        if (compose.orgId !== org.orgId) {
+          return {
+            status: 404 as const,
+            body: {
+              error: { message: "Session not found", code: "NOT_FOUND" },
+            },
+          };
+        }
+      } catch (error) {
+        if (isNotFound(error) || isForbidden(error)) {
+          return {
+            status: 404 as const,
+            body: {
+              error: { message: "Session not found", code: "NOT_FOUND" },
+            },
+          };
+        }
+        throw error;
+      }
+    }
 
     if (compose?.headVersionId) {
       const [version] = await globalThis.services.db

--- a/turbo/apps/web/app/api/agent/sessions/[id]/route.ts
+++ b/turbo/apps/web/app/api/agent/sessions/[id]/route.ts
@@ -12,8 +12,7 @@ import {
   agentComposeVersions,
 } from "../../../../../src/db/schema/agent-compose";
 import { getUserId } from "../../../../../src/lib/auth/get-user-id";
-import { resolveOrg } from "../../../../../src/lib/org/resolve-org";
-import { isNotFound, isForbidden } from "../../../../../src/lib/errors";
+import { verifyComposeOrgAccess } from "../../../../../src/lib/org/verify-compose-org-access";
 
 const router = tsr.router(sessionsByIdContract, {
   getById: async ({ params, headers }, { request }) => {
@@ -66,29 +65,18 @@ const router = tsr.router(sessionsByIdContract, {
       .limit(1);
 
     // Verify session belongs to the caller's active organization
-    if (compose) {
-      const orgSlug = new URL(request.url).searchParams.get("org");
-      try {
-        const { org } = await resolveOrg(userId, orgSlug);
-        if (compose.orgId !== org.orgId) {
-          return {
-            status: 404 as const,
-            body: {
-              error: { message: "Session not found", code: "NOT_FOUND" },
-            },
-          };
-        }
-      } catch (error) {
-        if (isNotFound(error) || isForbidden(error)) {
-          return {
-            status: 404 as const,
-            body: {
-              error: { message: "Session not found", code: "NOT_FOUND" },
-            },
-          };
-        }
-        throw error;
-      }
+    const hasOrgAccess = await verifyComposeOrgAccess(
+      session.agentComposeId,
+      userId,
+      request.url,
+    );
+    if (!hasOrgAccess) {
+      return {
+        status: 404 as const,
+        body: {
+          error: { message: "Session not found", code: "NOT_FOUND" },
+        },
+      };
     }
 
     if (compose?.headVersionId) {

--- a/turbo/apps/web/app/api/agent/sessions/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/sessions/__tests__/route.test.ts
@@ -5,6 +5,7 @@ import {
   createTestCompose,
   createTestRun,
   completeTestRun,
+  insertOrgCacheEntry,
 } from "../../../../../src/__tests__/api-test-helpers";
 import {
   testContext,
@@ -78,6 +79,29 @@ describe("GET /api/agent/sessions", () => {
     expect(session.id).toBe(agentSessionId);
     expect(session.messageCount).toBe(0);
     expect(session.preview).toBeNull();
+  });
+
+  it("should return 404 when accessing compose from a different org", async () => {
+    // Switch to org B — different org for the same user
+    const otherOrgId = uniqueId("org-other");
+    const otherOrgSlug = uniqueId("org-other");
+    await insertOrgCacheEntry({ orgId: otherOrgId, slug: otherOrgSlug });
+    mockClerk({
+      userId: user.userId,
+      orgId: otherOrgId,
+      orgSlug: otherOrgSlug,
+      clerkOrgs: [{ id: otherOrgId, slug: otherOrgSlug, name: otherOrgSlug }],
+    });
+
+    const request = createTestRequest(
+      `http://localhost:3000/api/agent/sessions?agentComposeId=${testComposeId}`,
+    );
+
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(data.error.code).toBe("NOT_FOUND");
   });
 
   it("should return 401 when not authenticated", async () => {

--- a/turbo/apps/web/app/api/agent/sessions/route.ts
+++ b/turbo/apps/web/app/api/agent/sessions/route.ts
@@ -1,12 +1,9 @@
 import { createHandler, tsr } from "../../../../src/lib/ts-rest-handler";
 import { sessionsContract } from "@vm0/core";
-import { eq } from "drizzle-orm";
 import { initServices } from "../../../../src/lib/init-services";
 import { getUserId } from "../../../../src/lib/auth/get-user-id";
 import { listAgentSessions } from "../../../../src/lib/agent-session";
-import { agentComposes } from "../../../../src/db/schema/agent-compose";
-import { resolveOrg } from "../../../../src/lib/org/resolve-org";
-import { isNotFound, isForbidden } from "../../../../src/lib/errors";
+import { verifyComposeOrgAccess } from "../../../../src/lib/org/verify-compose-org-access";
 
 const router = tsr.router(sessionsContract, {
   list: async ({ query, headers }, { request }) => {
@@ -23,34 +20,18 @@ const router = tsr.router(sessionsContract, {
     }
 
     // Verify the requested compose belongs to the caller's active org
-    const orgSlug = new URL(request.url).searchParams.get("org");
-    try {
-      const { org } = await resolveOrg(userId, orgSlug);
-
-      const [compose] = await globalThis.services.db
-        .select({ orgId: agentComposes.orgId })
-        .from(agentComposes)
-        .where(eq(agentComposes.id, query.agentComposeId))
-        .limit(1);
-
-      if (!compose || compose.orgId !== org.orgId) {
-        return {
-          status: 404 as const,
-          body: {
-            error: { message: "Agent not found", code: "NOT_FOUND" },
-          },
-        };
-      }
-    } catch (error) {
-      if (isNotFound(error) || isForbidden(error)) {
-        return {
-          status: 404 as const,
-          body: {
-            error: { message: "Agent not found", code: "NOT_FOUND" },
-          },
-        };
-      }
-      throw error;
+    const hasOrgAccess = await verifyComposeOrgAccess(
+      query.agentComposeId,
+      userId,
+      request.url,
+    );
+    if (!hasOrgAccess) {
+      return {
+        status: 404 as const,
+        body: {
+          error: { message: "Agent not found", code: "NOT_FOUND" },
+        },
+      };
     }
 
     const sessions = await listAgentSessions(userId, query.agentComposeId);

--- a/turbo/apps/web/app/api/agent/sessions/route.ts
+++ b/turbo/apps/web/app/api/agent/sessions/route.ts
@@ -1,11 +1,15 @@
 import { createHandler, tsr } from "../../../../src/lib/ts-rest-handler";
 import { sessionsContract } from "@vm0/core";
+import { eq } from "drizzle-orm";
 import { initServices } from "../../../../src/lib/init-services";
 import { getUserId } from "../../../../src/lib/auth/get-user-id";
 import { listAgentSessions } from "../../../../src/lib/agent-session";
+import { agentComposes } from "../../../../src/db/schema/agent-compose";
+import { resolveOrg } from "../../../../src/lib/org/resolve-org";
+import { isNotFound, isForbidden } from "../../../../src/lib/errors";
 
 const router = tsr.router(sessionsContract, {
-  list: async ({ query, headers }) => {
+  list: async ({ query, headers }, { request }) => {
     initServices();
 
     const userId = await getUserId(headers.authorization);
@@ -16,6 +20,37 @@ const router = tsr.router(sessionsContract, {
           error: { message: "Not authenticated", code: "UNAUTHORIZED" },
         },
       };
+    }
+
+    // Verify the requested compose belongs to the caller's active org
+    const orgSlug = new URL(request.url).searchParams.get("org");
+    try {
+      const { org } = await resolveOrg(userId, orgSlug);
+
+      const [compose] = await globalThis.services.db
+        .select({ orgId: agentComposes.orgId })
+        .from(agentComposes)
+        .where(eq(agentComposes.id, query.agentComposeId))
+        .limit(1);
+
+      if (!compose || compose.orgId !== org.orgId) {
+        return {
+          status: 404 as const,
+          body: {
+            error: { message: "Agent not found", code: "NOT_FOUND" },
+          },
+        };
+      }
+    } catch (error) {
+      if (isNotFound(error) || isForbidden(error)) {
+        return {
+          status: 404 as const,
+          body: {
+            error: { message: "Agent not found", code: "NOT_FOUND" },
+          },
+        };
+      }
+      throw error;
     }
 
     const sessions = await listAgentSessions(userId, query.agentComposeId);

--- a/turbo/apps/web/src/lib/org/verify-compose-org-access.ts
+++ b/turbo/apps/web/src/lib/org/verify-compose-org-access.ts
@@ -1,0 +1,38 @@
+import { eq } from "drizzle-orm";
+import { agentComposes } from "../../db/schema/agent-compose";
+import { resolveOrg } from "./resolve-org";
+import { isNotFound, isForbidden } from "../errors";
+
+/**
+ * Verify that a compose belongs to the caller's active organization.
+ *
+ * Returns true if the compose exists and belongs to the resolved org.
+ * Returns false if the compose does not exist or belongs to a different org.
+ * Throws on unexpected errors (DB failures, timeouts).
+ */
+export async function verifyComposeOrgAccess(
+  composeId: string,
+  userId: string,
+  requestUrl: string,
+): Promise<boolean> {
+  const [compose] = await globalThis.services.db
+    .select({ orgId: agentComposes.orgId })
+    .from(agentComposes)
+    .where(eq(agentComposes.id, composeId))
+    .limit(1);
+
+  if (!compose) {
+    return false;
+  }
+
+  const orgSlug = new URL(requestUrl).searchParams.get("org");
+  try {
+    const { org } = await resolveOrg(userId, orgSlug);
+    return compose.orgId === org.orgId;
+  } catch (error) {
+    if (isNotFound(error) || isForbidden(error)) {
+      return false;
+    }
+    throw error;
+  }
+}


### PR DESCRIPTION
## Summary
- Add org-level authorization checks to all session-related API endpoints (`/api/agent/runs`, `/api/agent/sessions`, `/api/agent/sessions/:id`, `/api/agent/sessions/:id/messages`)
- Each endpoint now verifies that the session's compose `orgId` matches the caller's resolved org, returning 404 if mismatched
- Add integration tests for cross-org access scenarios across all affected endpoints

## Test plan
- [ ] Verify existing session tests still pass
- [ ] Verify new cross-org access tests pass for all four endpoints
- [ ] Confirm that legitimate same-org session access is unaffected

Closes #4997

🤖 Generated with [Claude Code](https://claude.com/claude-code)