### PR TITLE
refactor: replace deprecated z.string().uuid() with z.uuid()

### DIFF
--- a/turbo/apps/web/app/api/agent/schedules/[name]/disable/route.ts
+++ b/turbo/apps/web/app/api/agent/schedules/[name]/disable/route.ts
@@ -13,7 +13,7 @@ import { resolveOrg } from "../../../../../../src/lib/org/resolve-org";
 const log = logger("api:schedules:disable");
 
 const disableScheduleBodySchema = z.object({
-  composeId: z.string().uuid(),
+  composeId: z.uuid(),
 });
 
 export async function POST(

--- a/turbo/apps/web/app/api/agent/schedules/[name]/enable/route.ts
+++ b/turbo/apps/web/app/api/agent/schedules/[name]/enable/route.ts
@@ -13,7 +13,7 @@ import { resolveOrg } from "../../../../../../src/lib/org/resolve-org";
 const log = logger("api:schedules:enable");
 
 const enableScheduleBodySchema = z.object({
-  composeId: z.string().uuid(),
+  composeId: z.uuid(),
 });
 
 export async function POST(

--- a/turbo/packages/core/src/contracts/compose-jobs.ts
+++ b/turbo/packages/core/src/contracts/compose-jobs.ts
@@ -96,7 +96,7 @@ export const composeJobsByIdContract = c.router({
     path: "/api/compose/jobs/:jobId",
     headers: authHeadersSchema,
     pathParams: z.object({
-      jobId: z.string().uuid(),
+      jobId: z.uuid(),
     }),
     responses: {
       200: composeJobResponseSchema,
@@ -120,7 +120,7 @@ export const webhookComposeCompleteContract = c.router({
     path: "/api/webhooks/compose/complete",
     headers: authHeadersSchema,
     body: z.object({
-      jobId: z.string().uuid(),
+      jobId: z.uuid(),
       success: z.boolean(),
       // Result from CLI compose command
       result: composeJobResultSchema.optional(),

--- a/turbo/packages/core/src/contracts/connectors.ts
+++ b/turbo/packages/core/src/contracts/connectors.ts
@@ -3045,7 +3045,7 @@ export function deriveApiTokenConnectedTypes(
  * Connector response schema
  */
 export const connectorResponseSchema = z.object({
-  id: z.string().uuid().nullable(),
+  id: z.uuid().nullable(),
   type: connectorTypeSchema,
   authMethod: z.string(),
   externalId: z.string().nullable(),
@@ -3144,7 +3144,7 @@ export type ConnectorSessionStatus = z.infer<
  * Connector session response schema
  */
 export const connectorSessionResponseSchema = z.object({
-  id: z.string().uuid(),
+  id: z.uuid(),
   code: z.string(),
   type: connectorTypeSchema,
   status: connectorSessionStatusSchema,
@@ -3214,7 +3214,7 @@ export const connectorSessionByIdContract = c.router({
     headers: authHeadersSchema,
     pathParams: z.object({
       type: connectorTypeSchema,
-      sessionId: z.string().uuid(),
+      sessionId: z.uuid(),
     }),
     responses: {
       200: connectorSessionStatusResponseSchema,
@@ -3233,7 +3233,7 @@ export type ConnectorSessionByIdContract = typeof connectorSessionByIdContract;
  * Computer connector create response
  */
 export const computerConnectorCreateResponseSchema = z.object({
-  id: z.string().uuid(),
+  id: z.uuid(),
   ngrokToken: z.string(),
   bridgeToken: z.string(),
   endpointPrefix: z.string(),

--- a/turbo/packages/core/src/contracts/model-providers.ts
+++ b/turbo/packages/core/src/contracts/model-providers.ts
@@ -470,7 +470,7 @@ export function getCustomModelPlaceholder(
  * Model provider response
  */
 export const modelProviderResponseSchema = z.object({
-  id: z.string().uuid(),
+  id: z.uuid(),
   type: modelProviderTypeSchema,
   framework: modelProviderFrameworkSchema,
   secretName: z.string().nullable(), // Legacy single-secret (deprecated for multi-auth)

--- a/turbo/packages/core/src/contracts/orgs.ts
+++ b/turbo/packages/core/src/contracts/orgs.ts
@@ -110,11 +110,11 @@ export const orgDefaultAgentContract = c.router({
       org: z.string().optional(),
     }),
     body: z.object({
-      agentComposeId: z.string().uuid().nullable(),
+      agentComposeId: z.uuid().nullable(),
     }),
     responses: {
       200: z.object({
-        agentComposeId: z.string().uuid().nullable(),
+        agentComposeId: z.uuid().nullable(),
       }),
       400: apiErrorSchema,
       401: apiErrorSchema,

--- a/turbo/packages/core/src/contracts/platform.ts
+++ b/turbo/packages/core/src/contracts/platform.ts
@@ -48,7 +48,7 @@ const platformLogStatusSchema = z.enum([
  * Log entry in list response - includes basic fields for list display
  */
 const platformLogEntrySchema = z.object({
-  id: z.string().uuid(),
+  id: z.uuid(),
   sessionId: z.string().nullable(),
   agentName: z.string(),
   orgSlug: z.string().nullable(),
@@ -79,7 +79,7 @@ const artifactSchema = z.object({
  * Log detail response schema
  */
 const platformLogDetailSchema = z.object({
-  id: z.string().uuid(),
+  id: z.uuid(),
   sessionId: z.string().nullable(),
   agentName: z.string(),
   framework: z.string().nullable(),

--- a/turbo/packages/core/src/contracts/runners.ts
+++ b/turbo/packages/core/src/contracts/runners.ts
@@ -20,11 +20,11 @@ export const runnerGroupSchema = z
  * Job schema for polling response
  */
 export const jobSchema = z.object({
-  runId: z.string().uuid(),
+  runId: z.uuid(),
   prompt: z.string(),
   agentComposeVersionId: z.string().nullable(),
   vars: z.record(z.string(), z.string()).nullable(),
-  checkpointId: z.string().uuid().nullable(),
+  checkpointId: z.uuid().nullable(),
 });
 
 /**
@@ -126,11 +126,11 @@ export const storedExecutionContextSchema = z.object({
  * Keep in sync with Rust: crates/runner/src/types.rs → ExecutionContext
  */
 export const executionContextSchema = z.object({
-  runId: z.string().uuid(),
+  runId: z.uuid(),
   prompt: z.string(),
   agentComposeVersionId: z.string().nullable(),
   vars: z.record(z.string(), z.string()).nullable(),
-  checkpointId: z.string().uuid().nullable(),
+  checkpointId: z.uuid().nullable(),
   sandboxToken: z.string(),
   // New fields for E2B parity:
   workingDir: z.string(),
@@ -171,7 +171,7 @@ export const runnersJobClaimContract = c.router({
     path: "/api/runners/jobs/:id/claim",
     headers: authHeadersSchema,
     pathParams: z.object({
-      id: z.string().uuid(),
+      id: z.uuid(),
     }),
     body: z.object({}),
     responses: {

--- a/turbo/packages/core/src/contracts/schedules.ts
+++ b/turbo/packages/core/src/contracts/schedules.ts
@@ -97,8 +97,8 @@ const deployScheduleRequestSchema = z
  * Schedule response - returned from API
  */
 const scheduleResponseSchema = z.object({
-  id: z.string().uuid(),
-  composeId: z.string().uuid(),
+  id: z.uuid(),
+  composeId: z.uuid(),
   composeName: z.string(),
   orgSlug: z.string(),
   userId: z.string(),
@@ -130,7 +130,7 @@ const scheduleResponseSchema = z.object({
  * Run summary for schedule runs list
  */
 const runSummarySchema = z.object({
-  id: z.string().uuid(),
+  id: z.uuid(),
   status: z.enum([
     "queued",
     "pending",

--- a/turbo/packages/core/src/contracts/secrets.ts
+++ b/turbo/packages/core/src/contracts/secrets.ts
@@ -32,7 +32,7 @@ export type SecretType = z.infer<typeof secretTypeSchema>;
  * Secret metadata response (value is never returned)
  */
 export const secretResponseSchema = z.object({
-  id: z.string().uuid(),
+  id: z.uuid(),
   name: z.string(),
   description: z.string().nullable(),
   type: secretTypeSchema,

--- a/turbo/packages/core/src/contracts/variables.ts
+++ b/turbo/packages/core/src/contracts/variables.ts
@@ -25,7 +25,7 @@ export const variableNameSchema = z
  * Variable response (includes value - key difference from secrets)
  */
 export const variableResponseSchema = z.object({
-  id: z.string().uuid(),
+  id: z.uuid(),
   name: z.string(),
   value: z.string(),
   description: z.string().nullable(),


### PR DESCRIPTION
## Summary

- Replace all `z.string().uuid()` with `z.uuid()` across 11 files (23 occurrences)
- `z.string().uuid()` is deprecated in Zod 4 in favor of `z.uuid()`

## Test plan

- [x] Type check passes (no new errors)
- [x] Knip passes (no unused exports)
- [ ] CI lint and test pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)