### PR TITLE
feat(platform): zero ui polish and sidebar improvements

### DIFF
--- a/turbo/apps/platform/src/views/settings-page/add-provider-dialog.tsx
+++ b/turbo/apps/platform/src/views/settings-page/add-provider-dialog.tsx
@@ -55,7 +55,7 @@ function ProviderCardInDialog({
         </div>
       )}
       <div className="mt-auto">
-        <span className="w-full rounded-md border border-border bg-background px-2 py-1.5 text-xs font-medium text-foreground text-center block">
+        <span className="w-full h-8 rounded-lg border-[0.7px] border-[hsl(var(--gray-400))] bg-[hsl(var(--gray-50))] px-3 text-sm font-medium text-foreground hover:bg-[hsl(var(--gray-100))] transition-colors text-center flex items-center justify-center">
           Add
         </span>
       </div>

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-page.tsx
@@ -792,7 +792,7 @@ function ConnectorsPopoverButton({
             <TooltipTrigger asChild>
               <button
                 type="button"
-                className="inline-flex shrink-0 items-center rounded-lg h-9 px-1.5 hover:bg-accent transition-colors"
+                className="inline-flex shrink-0 items-center justify-center rounded-lg h-9 min-w-9 px-1.5 hover:bg-accent transition-colors"
               >
                 <ConnectorTriggerIcons connectors={connectors} />
               </button>
@@ -804,56 +804,58 @@ function ConnectorsPopoverButton({
         </Tooltip>
       </TooltipProvider>
       <PopoverContent side="top" align="start" className="w-64 p-0 rounded-xl">
-        <div className="p-2">
-          <div className="flex flex-col">
-            {connectors.map((item) => (
-              <div
-                key={item.type}
-                className="flex items-center gap-2.5 px-3 py-2.5 rounded-lg hover:bg-muted/50 transition-colors"
-              >
-                <span
-                  className={cn(
-                    "flex h-5 w-5 shrink-0 items-center justify-center",
-                    !item.connected && "opacity-40",
-                  )}
+        {connectors.length > 0 && (
+          <div className="p-2">
+            <div className="flex flex-col">
+              {connectors.map((item) => (
+                <div
+                  key={item.type}
+                  className="flex items-center gap-2.5 px-3 py-2.5 rounded-lg hover:bg-muted/50 transition-colors"
                 >
-                  {item.iconUrl ? (
-                    <img src={item.iconUrl} alt="" className="h-5 w-5" />
-                  ) : (
-                    <ConnectorIcon
-                      type={item.type as ConnectorType}
-                      size={20}
-                    />
-                  )}
-                </span>
-                <span
-                  className={cn(
-                    "text-sm flex-1",
-                    item.connected
-                      ? "text-foreground"
-                      : "text-muted-foreground",
-                  )}
-                >
-                  {item.label}
-                </span>
-                {item.connected ? (
-                  <span className="h-1.5 w-1.5 rounded-full bg-emerald-500 shrink-0" />
-                ) : (
-                  <button
-                    type="button"
-                    className="text-sm font-medium text-muted-foreground hover:text-foreground transition-colors"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      onConnect(item.type);
-                    }}
+                  <span
+                    className={cn(
+                      "flex h-5 w-5 shrink-0 items-center justify-center",
+                      !item.connected && "opacity-40",
+                    )}
                   >
-                    Connect
-                  </button>
-                )}
-              </div>
-            ))}
+                    {item.iconUrl ? (
+                      <img src={item.iconUrl} alt="" className="h-5 w-5" />
+                    ) : (
+                      <ConnectorIcon
+                        type={item.type as ConnectorType}
+                        size={20}
+                      />
+                    )}
+                  </span>
+                  <span
+                    className={cn(
+                      "text-sm flex-1",
+                      item.connected
+                        ? "text-foreground"
+                        : "text-muted-foreground",
+                    )}
+                  >
+                    {item.label}
+                  </span>
+                  {item.connected ? (
+                    <span className="h-1.5 w-1.5 rounded-full bg-emerald-500 shrink-0" />
+                  ) : (
+                    <button
+                      type="button"
+                      className="text-sm font-medium text-muted-foreground hover:text-foreground transition-colors"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onConnect(item.type);
+                      }}
+                    >
+                      Connect
+                    </button>
+                  )}
+                </div>
+              ))}
+            </div>
           </div>
-        </div>
+        )}
         <div
           className={cn(
             "p-2 flex flex-col",
@@ -1389,7 +1391,7 @@ export function ZeroChatPage({
                     <div className="flex items-center gap-1 text-muted-foreground">
                       <button
                         type="button"
-                        className="p-2 rounded-lg hover:bg-accent hover:text-foreground transition-colors duration-200"
+                        className="p-[9px] rounded-lg hover:bg-accent hover:text-foreground transition-colors duration-200"
                         aria-label="Attach"
                         onClick={handleFileSelect}
                       >
@@ -1494,7 +1496,7 @@ export function ZeroChatPage({
                   <div className="flex items-center gap-1 text-muted-foreground">
                     <button
                       type="button"
-                      className="p-2 rounded-lg hover:bg-accent hover:text-foreground transition-colors duration-200"
+                      className="p-[9px] rounded-lg hover:bg-accent hover:text-foreground transition-colors duration-200"
                       aria-label="Attach"
                       onClick={handleFileSelect}
                     >
@@ -1552,7 +1554,7 @@ export function ZeroChatPage({
                 <button
                   key={title}
                   type="button"
-                  className="zero-card cursor-pointer p-4 text-left flex gap-3 items-center relative group"
+                  className="zero-card cursor-pointer p-4 text-left flex flex-col sm:flex-row gap-3 items-start sm:items-center relative group"
                   onClick={() => setInput(prompt)}
                 >
                   <IconArrowUpRight

--- a/turbo/apps/platform/src/views/zero-page/zero-jobs-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-jobs-page.tsx
@@ -147,7 +147,7 @@ export function ZeroJobsPage({
                 className="flex items-center gap-3 rounded-[var(--zero-card-radius)] border border-dashed border-[hsl(var(--gray-400))] px-4 py-3.5 transition-colors hover:border-[hsl(var(--gray-400))] hover:bg-muted/30 group col-span-full"
                 onClick={onNavigateToChat}
               >
-                <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-foreground/8 group-hover:bg-foreground/12 transition-colors">
+                <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg transition-colors">
                   <IconMessageCircle
                     size={16}
                     stroke={1.5}

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -19,7 +19,6 @@ import {
   IconX,
   IconEdit,
   IconGripVertical,
-  IconChevronDown,
   IconLayoutSidebarLeftCollapse,
 } from "@tabler/icons-react";
 import {
@@ -802,9 +801,6 @@ export function ZeroSidebar({
   onResetAgent,
 }: ZeroSidebarProps) {
   const displayName = agentName || "Zero";
-  const chatExpanded$ = useCCState(true);
-  const chatExpanded = useGet(chatExpanded$);
-  const setChatExpanded = useSet(chatExpanded$);
   const pinnedIdsLoadable = useLastLoadable(pinnedAgentIds$);
   const pinnedIds =
     pinnedIdsLoadable.state === "hasData" ? pinnedIdsLoadable.data : [];
@@ -970,105 +966,60 @@ export function ZeroSidebar({
 
           {/* Chat section */}
           <div className="shrink-0 mt-4">
-            <button
-              type="button"
-              className="flex h-7 w-full items-center gap-1 px-2 text-sidebar-foreground/50 hover:text-sidebar-foreground transition-colors"
-              onClick={() => setChatExpanded(!chatExpanded)}
-            >
-              <span className="text-[13px] font-medium truncate">
+            <div className="h-7 flex items-center pl-2">
+              <span className="text-[13px] leading-4 text-sidebar-foreground/50 font-medium">
                 Talk to {talkToLabel}
               </span>
-              <IconChevronDown
-                size={14}
-                className={`shrink-0 transition-transform ${chatExpanded ? "" : "-rotate-90"}`}
-              />
-            </button>
-            {chatExpanded && (
-              <div className="flex items-center gap-1.5 px-2 pb-1 pt-1">
-                <TooltipProvider delayDuration={300}>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <button
-                        type="button"
-                        className={`flex h-8 w-8 shrink-0 items-center justify-center rounded-lg overflow-hidden transition-all ${
-                          currentChatAgentId === null
-                            ? "bg-foreground/10"
-                            : "hover:bg-foreground/5"
-                        }`}
-                        onClick={() => onNewChat?.(null)}
-                      >
-                        <img
-                          src={zeroAvatarSrc}
-                          alt={displayName}
-                          className="h-full w-full object-cover object-top"
-                        />
-                      </button>
-                    </TooltipTrigger>
-                    <TooltipContent side="bottom" className="text-xs">
-                      {displayName}
-                    </TooltipContent>
-                  </Tooltip>
-                  {pinnedAgents.map((agent) => (
-                    <Tooltip key={agent.id}>
-                      <TooltipTrigger asChild>
-                        <button
-                          type="button"
-                          className={`flex h-8 w-8 shrink-0 items-center justify-center rounded-lg overflow-hidden transition-all ${
-                            currentChatAgentId === agent.id
-                              ? "bg-foreground/10"
-                              : "hover:bg-foreground/5"
-                          }`}
-                          onClick={() => onNewChat?.(agent.id)}
-                        >
-                          <AgentAvatarImg
-                            name={agent.name}
-                            alt={agent.displayName ?? agent.name}
-                            className="h-full w-full object-cover object-top"
-                          />
-                        </button>
-                      </TooltipTrigger>
-                      <TooltipContent side="bottom" className="text-xs">
-                        {agent.displayName ?? agent.name}
-                      </TooltipContent>
-                    </Tooltip>
-                  ))}
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <button
-                        type="button"
-                        className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-dashed border-sidebar-foreground/25 text-sidebar-foreground/30 hover:border-sidebar-foreground/40 hover:text-sidebar-foreground/60 transition-colors"
-                        aria-label="Manage pinned agents"
-                        onClick={() => setManagePinnedOpen(true)}
-                      >
-                        <IconPlus size={14} />
-                      </button>
-                    </TooltipTrigger>
-                    <TooltipContent side="bottom" className="text-xs">
-                      Manage pinned agents
-                    </TooltipContent>
-                  </Tooltip>
-                </TooltipProvider>
-              </div>
-            )}
-            <div className="flex flex-col gap-1 mt-1">
-              <Link
-                pathname="/zero"
-                onClick={(e) => {
-                  if (e.metaKey || e.ctrlKey || e.shiftKey) {
-                    return;
-                  }
-                  e.preventDefault();
-                  onSelect("chat");
-                }}
-                className={`flex w-full h-8 items-center gap-2 rounded-lg p-2 text-left text-sm leading-5 transition-colors duration-200 ${
-                  activeId === "chat" && !selectedRecentId
+            </div>
+            <div className="flex flex-col gap-0.5">
+              <button
+                type="button"
+                className={`flex w-full h-8 items-center gap-2 rounded-lg px-2 text-left text-sm leading-5 transition-colors duration-200 ${
+                  activeId === "chat" && currentChatAgentId === null
                     ? "bg-sidebar-active text-sidebar-primary font-medium"
                     : "text-sidebar-foreground hover:bg-sidebar-accent"
                 }`}
+                onClick={() => onNewChat?.(null)}
               >
-                <IconEdit size={16} className="shrink-0" />
-                <span className="truncate">New chat</span>
-              </Link>
+                <img
+                  src={zeroAvatarSrc}
+                  alt={displayName}
+                  className="h-5 w-5 shrink-0 rounded-md object-cover object-top"
+                />
+                <span className="truncate">{displayName}</span>
+              </button>
+              {pinnedAgents.map((agent) => (
+                <button
+                  key={agent.id}
+                  type="button"
+                  className={`flex w-full h-8 items-center gap-2 rounded-lg px-2 text-left text-sm leading-5 transition-colors duration-200 ${
+                    activeId === "chat" && currentChatAgentId === agent.id
+                      ? "bg-sidebar-active text-sidebar-primary font-medium"
+                      : "text-sidebar-foreground hover:bg-sidebar-accent"
+                  }`}
+                  onClick={() => onNewChat?.(agent.id)}
+                >
+                  <AgentAvatarImg
+                    name={agent.name}
+                    alt={agent.displayName ?? agent.name}
+                    className="h-5 w-5 shrink-0 rounded-md object-cover object-top"
+                  />
+                  <span className="truncate">
+                    {agent.displayName ?? agent.name}
+                  </span>
+                </button>
+              ))}
+              <button
+                type="button"
+                className="flex w-full h-8 items-center gap-2 rounded-lg px-2 text-left text-sm leading-5 text-sidebar-foreground/50 hover:text-sidebar-foreground hover:bg-sidebar-accent transition-colors duration-200"
+                aria-label="Manage pinned agents"
+                onClick={() => setManagePinnedOpen(true)}
+              >
+                <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-md bg-sidebar-accent">
+                  <IconPlus size={12} />
+                </span>
+                <span className="truncate">Pin agent</span>
+              </button>
             </div>
           </div>
 


### PR DESCRIPTION
## Summary
- Align provider dialog "Add" button style (size, color) with connector dialog buttons
- Make attach button sizing consistent (36px)
- Responsive suggested prompts: stack icon above text on small screens
- Refactor sidebar chat section: show agents as vertical list with avatars and names, remove collapsible toggle, remove redundant "New chat" button, highlight agent only on chat page

## Test plan
- [ ] Open "Add model provider" dialog — verify "Add" buttons match connector dialog button style
- [ ] Check attach button size is 36x36
- [ ] Resize to small screen — suggested prompts icons should stack above text
- [ ] Sidebar "Talk to" section shows agents vertically with names visible
- [ ] Selecting an agent highlights it only when on chat page
- [ ] Navigating to other pages (Activity logs, Settings) does not highlight any agent

Made with [Cursor](https://cursor.com)