### PR TITLE
fix(platform): navigate to /zero on org switch instead of reloading

### DIFF
--- a/turbo/apps/platform/src/signals/auth.ts
+++ b/turbo/apps/platform/src/signals/auth.ts
@@ -112,11 +112,11 @@ export const watchOrgSwitch$ = command(
       if (newOrgId !== prevOrgId) {
         prevOrgId = newOrgId;
         persistOrgId(newOrgId);
-        // Full page reload is required because server-side data (agents, jobs,
-        // secrets, etc.) is scoped to the active organization. A lighter state
-        // refresh is not feasible since multiple signal trees depend on the
-        // org context established at bootstrap time.
-        location.reload();
+        // Navigate to the Zero homepage on org switch. A full page load is
+        // required because server-side data (agents, jobs, secrets, etc.) is
+        // scoped to the active organization, and multiple signal trees depend
+        // on the org context established at bootstrap time.
+        location.href = "/zero";
       }
     });
     signal.addEventListener("abort", unsubscribe);


### PR DESCRIPTION
## Summary
- Changes org switch behavior to navigate to `/zero` instead of calling `location.reload()`, ensuring users land on the Zero homepage after switching organizations

## Test plan
- [ ] Switch organizations in the platform UI and verify navigation goes to `/zero`
- [ ] Confirm server-side data is properly refreshed after the full page navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)