### PR TITLE
fix: add org-scoped filtering to run list and detail endpoints

### DIFF
--- a/turbo/apps/web/app/api/agent/runs/[id]/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/__tests__/route.test.ts
@@ -5,7 +5,11 @@ import {
   createTestRequest,
   createTestCompose,
   createTestRun,
+  createTestRunInDb,
   completeTestRun,
+  insertOrgCacheEntry,
+  insertOrgMembersCacheEntry,
+  getOrgCacheEntry,
 } from "../../../../../../src/__tests__/api-test-helpers";
 import { generateSandboxToken } from "../../../../../../src/lib/auth/sandbox-token";
 import {
@@ -124,16 +128,81 @@ describe("GET /api/agent/runs/:id - Get Run By ID", () => {
     });
   });
 
+  describe("Org-Scoped Filtering", () => {
+    it("should return 404 for run from a different org", async () => {
+      // Create a compose + run in a different org
+      const otherOrg = await context.createAgentCompose(user.userId);
+      const { runId } = await createTestRunInDb(user.userId, otherOrg.id, {
+        status: "running",
+        prompt: "Other org run",
+      });
+
+      // Default user is in the default org — the run belongs to otherOrg
+      const request = createTestRequest(
+        `http://localhost:3000/api/agent/runs/${runId}`,
+      );
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(404);
+      expect(data.error.code).toBe("NOT_FOUND");
+    });
+
+    it("should return run when switching to the correct org", async () => {
+      // Create a compose + run in a different org
+      const otherOrg = await context.createAgentCompose(user.userId);
+      const { runId } = await createTestRunInDb(user.userId, otherOrg.id, {
+        status: "running",
+        prompt: "Other org run",
+      });
+
+      // Switch Clerk mock to the other org
+      const orgEntry = await getOrgCacheEntry(otherOrg.orgId);
+      mockClerk({
+        userId: user.userId,
+        orgId: otherOrg.orgId,
+        orgSlug: orgEntry!.slug,
+        clerkOrgs: [
+          { id: otherOrg.orgId, slug: orgEntry!.slug, name: orgEntry!.slug },
+        ],
+      });
+
+      const request = createTestRequest(
+        `http://localhost:3000/api/agent/runs/${runId}?org=${orgEntry!.slug}`,
+      );
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.runId).toBe(runId);
+    });
+  });
+
   describe("Sandbox Token Capability Enforcement", () => {
     it("should accept sandbox token with agent-run:read", async () => {
       const run = await createTestRun(testComposeId, "Test prompt");
+
+      // Refresh caches with current Date.now() timestamp
+      // (a previous test may have advanced Date.now via dateNow mock)
+      await insertOrgCacheEntry({
+        orgId: user.orgId,
+        slug: (await getOrgCacheEntry(user.orgId))!.slug,
+        cachedAt: new Date(Date.now()),
+      });
+      await insertOrgMembersCacheEntry({
+        orgId: user.orgId,
+        userId: user.userId,
+        cachedAt: new Date(Date.now()),
+      });
+
       mockClerk({ userId: null });
       const token = await generateSandboxToken(user.userId, run.runId, [
         "agent-run:read",
       ]);
 
+      const orgEntry = await getOrgCacheEntry(user.orgId);
       const request = createTestRequest(
-        `http://localhost:3000/api/agent/runs/${run.runId}`,
+        `http://localhost:3000/api/agent/runs/${run.runId}?org=${orgEntry!.slug}`,
         { headers: { authorization: `Bearer ${token}` } },
       );
       const response = await GET(request);
@@ -153,7 +222,8 @@ describe("GET /api/agent/runs/:id - Get Run By ID", () => {
       );
       const response = await GET(request);
 
-      expect(response.status).toBe(401);
+      // requireAuth returns 403 for valid sandbox tokens missing the required capability
+      expect(response.status).toBe(403);
     });
   });
 });

--- a/turbo/apps/web/app/api/agent/runs/[id]/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/route.ts
@@ -3,29 +3,36 @@ import { runsByIdContract } from "@vm0/core";
 import { initServices } from "../../../../../src/lib/init-services";
 import { agentRuns } from "../../../../../src/db/schema/agent-run";
 import { eq, and } from "drizzle-orm";
-import { getUserId } from "../../../../../src/lib/auth/get-user-id";
+import {
+  requireAuth,
+  isAuthError,
+} from "../../../../../src/lib/auth/require-auth";
+import { resolveOrg } from "../../../../../src/lib/org/resolve-org";
 
 const router = tsr.router(runsByIdContract, {
-  getById: async ({ params, headers }) => {
+  getById: async ({ params, headers }, { request }) => {
     initServices();
 
-    const userId = await getUserId(headers.authorization, {
+    const authCtx = await requireAuth(headers.authorization, {
       requiredCapability: "agent-run:read",
     });
-    if (!userId) {
-      return {
-        status: 401 as const,
-        body: {
-          error: { message: "Not authenticated", code: "UNAUTHORIZED" },
-        },
-      };
-    }
+    if (isAuthError(authCtx)) return authCtx;
+    const { userId } = authCtx;
 
-    // Query run from database - filter by userId for security
+    const orgSlug = new URL(request.url).searchParams.get("org");
+    const { org } = await resolveOrg(userId, orgSlug);
+
+    // Query run from database - filter by userId and orgId for security
     const [run] = await globalThis.services.db
       .select()
       .from(agentRuns)
-      .where(and(eq(agentRuns.id, params.id), eq(agentRuns.userId, userId)))
+      .where(
+        and(
+          eq(agentRuns.id, params.id),
+          eq(agentRuns.userId, userId),
+          eq(agentRuns.orgId, org.orgId),
+        ),
+      )
       .limit(1);
 
     if (!run) {

--- a/turbo/apps/web/app/api/agent/runs/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/__tests__/route.test.ts
@@ -1511,16 +1511,33 @@ describe("POST /api/agent/runs - Internal Runs API", () => {
 
   describe("Sandbox Token Capability Enforcement", () => {
     it("should accept sandbox token with agent-run:read for list", async () => {
+      // Refresh org and member caches with current Date.now() timestamp
+      // (a previous test may have advanced Date.now via dateNow mock,
+      // making older cache entries appear stale)
+      await insertOrgCacheEntry({
+        orgId: user.orgId,
+        slug: (await getOrgCacheEntry(user.orgId))!.slug,
+        cachedAt: new Date(Date.now()),
+      });
+      await insertOrgMembersCacheEntry({
+        orgId: user.orgId,
+        userId: user.userId,
+        cachedAt: new Date(Date.now()),
+      });
+
+      // Create a run via DB (needs Clerk mock for compose lookup)
+      const { runId } = await createTestRunInDb(user.userId, testComposeId);
+
+      // Now switch to sandbox auth (no Clerk session)
       mockClerk({ userId: null });
 
-      // Create a run via DB so it exists for listing
-      const { runId } = await createTestRunInDb(user.userId, testComposeId);
       const token = await generateSandboxToken(user.userId, runId, [
         "agent-run:read",
       ]);
 
+      const orgEntry = await getOrgCacheEntry(user.orgId);
       const request = createTestRequest(
-        "http://localhost:3000/api/agent/runs?limit=10",
+        `http://localhost:3000/api/agent/runs?limit=10&org=${orgEntry!.slug}`,
         { headers: { authorization: `Bearer ${token}` } },
       );
       const response = await GET(request);
@@ -1593,5 +1610,97 @@ describe("POST /api/agent/runs - Internal Runs API", () => {
 
       expect(response.status).toBe(403);
     });
+  });
+});
+
+describe("GET /api/agent/runs - List Runs", () => {
+  const context = testContext();
+  let user: UserContext;
+  let testComposeId: string;
+
+  beforeEach(async () => {
+    context.setupMocks();
+    user = await context.setupUser();
+
+    const { composeId } = await createTestCompose(uniqueId("list-agent"));
+    testComposeId = composeId;
+  });
+
+  it("should return runs belonging to the user's org", async () => {
+    await createTestRunInDb(user.userId, testComposeId, {
+      status: "running",
+      prompt: "Org A run",
+    });
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/agent/runs?status=running&limit=50",
+    );
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.runs.length).toBeGreaterThanOrEqual(1);
+    expect(
+      data.runs.some((r: { prompt: string }) => r.prompt === "Org A run"),
+    ).toBe(true);
+  });
+
+  it("should not return runs from a different org", async () => {
+    // Create a run in the user's default org
+    await createTestRunInDb(user.userId, testComposeId, {
+      status: "running",
+      prompt: "Default org run",
+    });
+
+    // Create a compose + run in a different org
+    const otherOrg = await context.createAgentCompose(user.userId);
+    await createTestRunInDb(user.userId, otherOrg.id, {
+      status: "running",
+      prompt: "Other org run",
+    });
+
+    // List runs — should only see runs from the default org
+    const request = createTestRequest(
+      "http://localhost:3000/api/agent/runs?status=running&limit=50",
+    );
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    const prompts = data.runs.map((r: { prompt: string }) => r.prompt);
+    expect(prompts).toContain("Default org run");
+    expect(prompts).not.toContain("Other org run");
+  });
+
+  it("should filter by org when ?org= query param is provided", async () => {
+    // Create a compose + run in a different org
+    const otherOrg = await context.createAgentCompose(user.userId);
+    await createTestRunInDb(user.userId, otherOrg.id, {
+      status: "running",
+      prompt: "Target org run",
+    });
+
+    // Look up the other org's slug
+    const orgEntry = await getOrgCacheEntry(otherOrg.orgId);
+
+    // Switch Clerk mock to be a member of the other org
+    mockClerk({
+      userId: user.userId,
+      orgId: otherOrg.orgId,
+      orgSlug: orgEntry!.slug,
+      clerkOrgs: [
+        { id: otherOrg.orgId, slug: orgEntry!.slug, name: orgEntry!.slug },
+      ],
+    });
+
+    const request = createTestRequest(
+      `http://localhost:3000/api/agent/runs?status=running&limit=50&org=${orgEntry!.slug}`,
+    );
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    const prompts = data.runs.map((r: { prompt: string }) => r.prompt);
+    expect(prompts).toContain("Target org run");
   });
 });

--- a/turbo/apps/web/app/api/agent/runs/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/route.ts
@@ -291,7 +291,7 @@ function handleCreateRunError(error: unknown) {
 }
 
 const router = tsr.router(runsMainContract, {
-  list: async ({ query, headers }) => {
+  list: async ({ query, headers }, { request }) => {
     initServices();
 
     const authCtx = await requireAuth(headers.authorization, {
@@ -299,6 +299,9 @@ const router = tsr.router(runsMainContract, {
     });
     if (isAuthError(authCtx)) return authCtx;
     const { userId } = authCtx;
+
+    const orgSlug = new URL(request.url).searchParams.get("org");
+    const { org } = await resolveOrg(userId, orgSlug);
 
     // Parse and validate status values
     const statusValues: string[] = query.status
@@ -321,7 +324,10 @@ const router = tsr.router(runsMainContract, {
     }
 
     // Build query conditions
-    const conditions = [eq(agentRuns.userId, userId)];
+    const conditions = [
+      eq(agentRuns.userId, userId),
+      eq(agentRuns.orgId, org.orgId),
+    ];
 
     // Filter by status
     conditions.push(inArray(agentRuns.status, statusValues));


### PR DESCRIPTION
## Summary

- Add `resolveOrg()` call and `eq(agentRuns.orgId, org.orgId)` filter to `GET /api/agent/runs` (list) and `GET /api/agent/runs/[id]` (detail) endpoints
- Upgrade detail endpoint auth from `getUserId()` to `requireAuth()` for consistent 401/403 sandbox token semantics
- Return 404 for cross-org access (consistent with project security pattern)
- Add integration tests for org-scoped filtering on both endpoints

## Test plan

- [x] Existing 61 POST /api/agent/runs tests pass
- [x] New list endpoint tests: runs from default org returned, other org filtered out, `?org=` param works
- [x] New detail endpoint tests: cross-org run returns 404, switching to correct org returns 200
- [x] Sandbox token tests updated with org context
- [x] Pre-commit hooks pass (lint, format, knip, commitlint)
- [x] TypeScript type check passes for web package

Closes #5091

🤖 Generated with [Claude Code](https://claude.com/claude-code)