### PR TITLE
feat(platform): add talk route for url-driven agent chat selection

### DIFF
--- a/turbo/apps/platform/src/signals/bootstrap.ts
+++ b/turbo/apps/platform/src/signals/bootstrap.ts
@@ -34,6 +34,10 @@ const ROUTE_CONFIG = [
     setup: setupAuthPageWrapper(setupZeroPage$),
   },
   {
+    path: "/zero/talk/:name",
+    setup: setupAuthPageWrapper(setupZeroPage$),
+  },
+  {
     path: "/zero/team/:name",
     setup: setupAuthPageWrapper(setupZeroJobDetailRoute$),
   },

--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-chat.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-chat.test.ts
@@ -186,6 +186,12 @@ describe("zero-chat signals", () => {
             statusText: "Not Found",
           });
         }),
+        http.get("*/api/agent/sessions/:id", () => {
+          return new HttpResponse(null, {
+            status: 404,
+            statusText: "Not Found",
+          });
+        }),
       );
 
       await setup();

--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-nav.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-nav.test.ts
@@ -2,7 +2,14 @@ import { describe, expect, it } from "vitest";
 import { mockLocation } from "../../location.ts";
 import { testContext } from "../../__tests__/test-helpers.ts";
 import { createPushStateMock } from "../../../__tests__/page-helper.ts";
-import { zeroActiveId$, setZeroActiveId$ } from "../zero-nav.ts";
+import {
+  zeroActiveId$,
+  setZeroActiveId$,
+  zeroChatAgentName$,
+  zeroChatAgentId$,
+  setZeroChatAgent$,
+  navigateFromZeroSession$,
+} from "../zero-nav.ts";
 
 const context = testContext();
 
@@ -86,6 +93,114 @@ describe("zero-nav", () => {
 
       expect(pushStateMock).toHaveBeenCalledWith({}, "", "/zero/schedule");
       expect(context.store.get(zeroActiveId$)).toBe("schedule");
+    });
+  });
+
+  describe("zeroActiveId$ with /zero/talk/:name", () => {
+    it("should resolve /zero/talk/agent-name to 'chat'", () => {
+      mockLocation(
+        { pathname: "/zero/talk/agent-name", search: "" },
+        context.signal,
+      );
+      expect(context.store.get(zeroActiveId$)).toBe("chat");
+    });
+  });
+
+  describe("zeroChatAgentName$", () => {
+    it("should return null for /zero", () => {
+      mockLocation({ pathname: "/zero", search: "" }, context.signal);
+      expect(context.store.get(zeroChatAgentName$)).toBeNull();
+    });
+
+    it("should return null for /zero/chat", () => {
+      mockLocation({ pathname: "/zero/chat", search: "" }, context.signal);
+      expect(context.store.get(zeroChatAgentName$)).toBeNull();
+    });
+
+    it("should extract agent name from /zero/talk/:name", () => {
+      mockLocation(
+        { pathname: "/zero/talk/my-agent", search: "" },
+        context.signal,
+      );
+      expect(context.store.get(zeroChatAgentName$)).toBe("my-agent");
+    });
+
+    it("should decode URI-encoded agent names", () => {
+      mockLocation(
+        { pathname: "/zero/talk/agent%20with%20spaces", search: "" },
+        context.signal,
+      );
+      expect(context.store.get(zeroChatAgentName$)).toBe("agent with spaces");
+    });
+  });
+
+  describe("setZeroChatAgent$ and zeroChatAgentId$", () => {
+    it("should set and read agent ID", () => {
+      context.store.set(setZeroChatAgent$, {
+        id: "agent-123",
+        name: "test-agent",
+      });
+      expect(context.store.get(zeroChatAgentId$)).toBe("agent-123");
+    });
+
+    it("should clear agent ID when set to null", () => {
+      context.store.set(setZeroChatAgent$, {
+        id: "agent-123",
+        name: "test-agent",
+      });
+      context.store.set(setZeroChatAgent$, null);
+      expect(context.store.get(zeroChatAgentId$)).toBeNull();
+    });
+  });
+
+  describe("navigateFromZeroSession$", () => {
+    it("should navigate to /zero when no agent was selected", () => {
+      const pushStateMock = createPushStateMock(context.signal);
+      mockLocation(
+        { pathname: "/zero/chat/session-1", search: "" },
+        context.signal,
+      );
+
+      context.store.set(setZeroChatAgent$, null);
+      context.store.set(navigateFromZeroSession$);
+
+      expect(pushStateMock).toHaveBeenCalledWith({}, "", "/zero");
+    });
+
+    it("should navigate to /zero/talk/:name when agent was selected", () => {
+      const pushStateMock = createPushStateMock(context.signal);
+      mockLocation(
+        { pathname: "/zero/chat/session-1", search: "" },
+        context.signal,
+      );
+
+      context.store.set(setZeroChatAgent$, {
+        id: "agent-123",
+        name: "my-agent",
+      });
+      context.store.set(navigateFromZeroSession$);
+
+      expect(pushStateMock).toHaveBeenCalledWith({}, "", "/zero/talk/my-agent");
+    });
+
+    it("should encode agent names with special characters", () => {
+      const pushStateMock = createPushStateMock(context.signal);
+      mockLocation(
+        { pathname: "/zero/chat/session-1", search: "" },
+        context.signal,
+      );
+
+      context.store.set(setZeroChatAgent$, {
+        id: "agent-456",
+        name: "agent with spaces",
+      });
+      context.store.set(navigateFromZeroSession$);
+
+      expect(pushStateMock).toHaveBeenCalledWith(
+        {},
+        "",
+        "/zero/talk/agent%20with%20spaces",
+      );
     });
   });
 });

--- a/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
@@ -473,8 +473,7 @@ export const removeZeroAttachment$ = command(({ set }, id: string) => {
 // ---------------------------------------------------------------------------
 
 export const fetchZeroSessionList$ = command(async ({ get, set }) => {
-  // Clear stale data immediately (before any await)
-  set(internalSessionList$, []);
+  // Keep previous list visible while loading (no flash to empty).
   set(internalSessionListLoading$, true);
   set(internalSessionListError$, null);
 

--- a/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
@@ -1,7 +1,7 @@
 import { command, computed, state, type Computed } from "ccstate";
 import type { AgentEvent, LogStatus } from "./log-types.ts";
 import { fetch$ } from "../fetch.ts";
-import { throwIfAbort } from "../utils.ts";
+import { throwIfAbort, detach, Reason } from "../utils.ts";
 import { logger } from "../log.ts";
 import { setupPollingLoop$, type PageResult } from "./polling.ts";
 import { zeroOnboardingStatus$ } from "./zero-onboarding.ts";
@@ -516,19 +516,28 @@ export const switchZeroSession$ = command(
         set(internalSessionId$, data.latestSessionId);
       }
 
-      // Resolve the correct agent from the thread's compose ID
+      // Resolve the correct agent from the thread's compose ID.
+      // If it differs from the current selection, update and re-fetch sessions.
       if (data.agentComposeId) {
+        const currentAgentId = get(zeroChatAgentId$);
         const status = await get(zeroOnboardingStatus$);
         const isDefault = data.agentComposeId === status.defaultAgentComposeId;
-        if (isDefault) {
-          set(setZeroChatAgent$, null);
-        } else {
-          // Sub-agent: set compose ID so sidebar highlights correctly
-          const subagents = await get(zeroSubagents$);
-          const agent = subagents.find((a) => a.id === data.agentComposeId);
-          if (agent) {
-            set(setZeroChatAgent$, { id: agent.id, name: agent.name });
+        const needsSwitch = isDefault
+          ? currentAgentId !== null
+          : currentAgentId !== data.agentComposeId;
+
+        if (needsSwitch) {
+          if (isDefault) {
+            set(setZeroChatAgent$, null);
+          } else {
+            const subagents = await get(zeroSubagents$);
+            const agent = subagents.find((a) => a.id === data.agentComposeId);
+            if (agent) {
+              set(setZeroChatAgent$, { id: agent.id, name: agent.name });
+            }
           }
+          // Re-fetch session list for the correct agent
+          detach(set(fetchZeroSessionList$), Reason.DomCallback);
         }
       }
 

--- a/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
@@ -631,7 +631,8 @@ export const switchZeroSession$ = command(
           runId: data.activeRunId,
         });
       } else if (data.failedRunId && data.failedRunPrompt) {
-        // If the latest run failed, show the user's message and the error
+        // If the latest run failed, show the user's message and a generic error.
+        // Don't expose internal error details — guide user to activity logs.
         messages.push({
           id: crypto.randomUUID(),
           role: "user",
@@ -643,7 +644,7 @@ export const switchZeroSession$ = command(
           content: "",
           runId: data.failedRunId,
           status: "failed",
-          error: data.failedRunError ?? "Run failed",
+          error: "Something went wrong. Check the activity logs for details.",
         });
       }
 

--- a/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
@@ -511,21 +511,30 @@ export const switchZeroSession$ = command(
         set(internalSessionId$, data.latestSessionId);
       }
 
-      // Resolve the correct agent from the thread's compose ID.
       // Set the correct agent from the thread's compose ID and fetch sessions
       if (data.agentComposeId) {
         const status = await get(zeroOnboardingStatus$);
         const isDefault = data.agentComposeId === status.defaultAgentComposeId;
+        L.debug(
+          `switchSession: agentComposeId=${data.agentComposeId}, defaultComposeId=${status.defaultAgentComposeId}, isDefault=${isDefault}`,
+        );
         if (isDefault) {
+          L.debug("switchSession: setting agent to default (null)");
           set(setZeroChatAgent$, null);
         } else {
           const subagents = await get(zeroSubagents$);
           const agent = subagents.find((a) => a.id === data.agentComposeId);
+          L.debug(
+            `switchSession: found subagent=${agent?.name ?? "NOT FOUND"} for composeId=${data.agentComposeId}`,
+          );
           if (agent) {
             set(setZeroChatAgent$, { id: agent.id, name: agent.name });
           }
         }
+        L.debug("switchSession: fetching session list");
         detach(set(fetchZeroSessionList$), Reason.DomCallback);
+      } else {
+        L.debug("switchSession: no agentComposeId in thread response");
       }
 
       const messages: ZeroChatMessage[] = (data.chatMessages ?? []).map(

--- a/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
@@ -430,11 +430,6 @@ export const removeZeroAttachment$ = command(({ set }, id: string) => {
 // ---------------------------------------------------------------------------
 
 export const fetchZeroSessionList$ = command(async ({ get, set }) => {
-  // Skip if already loading (prevents duplicate calls from rapid re-renders)
-  if (get(internalSessionListLoading$)) {
-    return;
-  }
-
   // Clear stale data immediately (before any await)
   set(internalSessionList$, []);
   set(internalSessionListLoading$, true);

--- a/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
@@ -589,11 +589,12 @@ export const switchZeroSession$ = command(
           createdAt: string;
         }[];
         latestSessionId?: string | null;
-        activeRunId?: string | null;
-        activeRunPrompt?: string | null;
-        failedRunId?: string | null;
-        failedRunPrompt?: string | null;
-        failedRunError?: string | null;
+        unsavedRuns?: Array<{
+          runId: string;
+          status: string;
+          prompt: string;
+          error: string | null;
+        }>;
       };
 
       L.info("loaded:", {
@@ -622,43 +623,46 @@ export const switchZeroSession$ = command(
         }),
       );
 
-      // If there's an active run, add the user prompt + assistant placeholder
-      // and resume polling so the user sees the conversation continuing.
-      if (data.activeRunId && data.activeRunPrompt) {
+      // Append unsaved runs (active, failed, pending) not yet in chatMessages.
+      // These are in chronological order from the server.
+      let activeRunToResume: string | null = null;
+      for (const run of data.unsavedRuns ?? []) {
         messages.push({
           id: crypto.randomUUID(),
           role: "user",
-          content: data.activeRunPrompt,
+          content: run.prompt,
         });
-        messages.push({
-          id: crypto.randomUUID(),
-          role: "assistant",
-          content: "",
-          runId: data.activeRunId,
-        });
-      } else if (data.failedRunId && data.failedRunPrompt) {
-        // If the latest run failed, show the user's message and a generic error.
-        // Don't expose internal error details — guide user to activity logs.
-        messages.push({
-          id: crypto.randomUUID(),
-          role: "user",
-          content: data.failedRunPrompt,
-        });
-        messages.push({
-          id: crypto.randomUUID(),
-          role: "assistant",
-          content: "",
-          runId: data.failedRunId,
-          status: "failed",
-          error: "Something went wrong. Check the activity logs for details.",
-        });
+
+        const isFailed =
+          run.status === "failed" ||
+          run.status === "timeout" ||
+          run.status === "cancelled";
+        if (isFailed) {
+          messages.push({
+            id: crypto.randomUUID(),
+            role: "assistant",
+            content: "",
+            runId: run.runId,
+            status: "failed",
+            error: "Something went wrong. Check the activity logs for details.",
+          });
+        } else {
+          // Active/pending/running — show placeholder for polling
+          messages.push({
+            id: crypto.randomUUID(),
+            role: "assistant",
+            content: "",
+            runId: run.runId,
+          });
+          activeRunToResume = run.runId;
+        }
       }
 
       set(internalMessages$, messages);
 
-      // Resume polling for the active run
-      if (data.activeRunId) {
-        resumeRunPolling(get, set, fetchFn, data.activeRunId);
+      // Resume polling for the latest active run
+      if (activeRunToResume) {
+        resumeRunPolling(get, set, fetchFn, activeRunToResume);
       }
     } catch (error) {
       throwIfAbort(error);

--- a/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
@@ -500,7 +500,14 @@ export const switchZeroSession$ = command(
 
     try {
       const fetchFn = get(fetch$);
-      const res = await fetchFn(`/api/chat-threads/${threadId}`);
+
+      // Try chat-threads API first; fall back to legacy sessions API
+      let res = await fetchFn(`/api/chat-threads/${threadId}`);
+      let isLegacySession = false;
+      if (!res.ok) {
+        res = await fetchFn(`/api/agent/sessions/${threadId}`);
+        isLegacySession = true;
+      }
       if (!res.ok) {
         set(internalSessionError$, `Failed to load chat: ${res.statusText}`);
         return;
@@ -519,7 +526,10 @@ export const switchZeroSession$ = command(
         activeRunPrompt?: string | null;
       };
 
-      if (data.latestSessionId) {
+      if (isLegacySession) {
+        // Legacy session: the ID itself is the sessionId
+        set(internalSessionId$, threadId);
+      } else if (data.latestSessionId) {
         set(internalSessionId$, data.latestSessionId);
       }
 
@@ -536,6 +546,9 @@ export const switchZeroSession$ = command(
             set(switchActiveAgent$, { id: agent.id, name: agent.name });
           }
         }
+      } else {
+        // Legacy session or no agentComposeId: fetch default agent sessions
+        set(switchActiveAgent$, null);
       }
 
       const messages: ZeroChatMessage[] = (data.chatMessages ?? []).map(

--- a/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
@@ -5,9 +5,11 @@ import { throwIfAbort } from "../utils.ts";
 import { logger } from "../log.ts";
 import { setupPollingLoop$, type PageResult } from "./polling.ts";
 import { zeroOnboardingStatus$ } from "./zero-onboarding.ts";
+import { zeroSubagents$ } from "./zero-agents.ts";
 import {
   navigateToZeroSession$,
   zeroChatAgentId$,
+  setZeroChatAgent$,
   zeroInChat$,
 } from "./zero-nav.ts";
 import type { ChatThreadListItem } from "@vm0/core";
@@ -498,6 +500,7 @@ export const switchZeroSession$ = command(
       }
 
       const data = (await res.json()) as {
+        agentComposeId?: string;
         chatMessages?: {
           role: "user" | "assistant";
           content: string;
@@ -511,6 +514,22 @@ export const switchZeroSession$ = command(
 
       if (data.latestSessionId) {
         set(internalSessionId$, data.latestSessionId);
+      }
+
+      // Resolve the correct agent from the thread's compose ID
+      if (data.agentComposeId) {
+        const status = await get(zeroOnboardingStatus$);
+        const isDefault = data.agentComposeId === status.defaultAgentComposeId;
+        if (isDefault) {
+          set(setZeroChatAgent$, null);
+        } else {
+          // Sub-agent: set compose ID so sidebar highlights correctly
+          const subagents = await get(zeroSubagents$);
+          const agent = subagents.find((a) => a.id === data.agentComposeId);
+          if (agent) {
+            set(setZeroChatAgent$, { id: agent.id, name: agent.name });
+          }
+        }
       }
 
       const messages: ZeroChatMessage[] = (data.chatMessages ?? []).map(

--- a/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
@@ -311,6 +311,50 @@ function summarizeEvent(event: AgentEvent, skipText: boolean): string | null {
 
 const pollingAbortController$ = state<AbortController | null>(null);
 
+/** Resume polling for an active run (used when switching to a session with an in-progress run). */
+function resumeRunPolling(
+  get: Parameters<Parameters<typeof command>[0]>[0]["get"],
+  set: Parameters<Parameters<typeof command>[0]>[0]["set"],
+  fetchFn: typeof fetch,
+  runId: string,
+) {
+  set(internalActiveRunId$, runId);
+  set(internalSending$, true);
+
+  const controller = new AbortController();
+  set(pollingAbortController$, controller);
+
+  set(setupPollingLoop$, {
+    runId,
+    signal: controller.signal,
+    state: {
+      get events$() {
+        return get(internalRunEvents$);
+      },
+      setEvents: (updater) => {
+        set(internalRunEvents$, updater);
+      },
+      setStatus: (s) => {
+        set(internalRunStatus$, s);
+        updateQueuePosition(s, fetchFn, runId, (pos) =>
+          set(internalQueuePosition$, pos),
+        );
+      },
+      setError: (e) => {
+        set(internalRunError$, e);
+      },
+    },
+    onTerminal: (completedRunId) => {
+      set(onZeroRunComplete$, completedRunId).catch((error: unknown) => {
+        throwIfAbort(error);
+        L.error("onRunComplete error:", error);
+      });
+    },
+  }).catch((error: unknown) => {
+    throwIfAbort(error);
+  });
+}
+
 // Chat thread ID (for URL routing — set before run starts)
 const internalChatThreadId$ = state<string | null>(null);
 export const zeroChatThreadId$ = computed((get) => get(internalChatThreadId$));
@@ -501,7 +545,7 @@ export const switchZeroSession$ = command(
       const fetchFn = get(fetch$);
 
       // Try chat-threads API first; fall back to legacy sessions API
-      console.warn("[switchSession] loading thread:", threadId);
+      L.info("loading thread:", threadId);
       let res = await fetchFn(`/api/chat-threads/${threadId}`);
       let isLegacySession = false;
       if (!res.ok) {
@@ -509,7 +553,7 @@ export const switchZeroSession$ = command(
         isLegacySession = true;
       }
       if (!res.ok) {
-        console.warn("[switchSession] both APIs failed, status:", res.status);
+        L.warn("both APIs failed, status:", res.status);
         set(internalSessionError$, `Failed to load chat: ${res.statusText}`);
         return;
       }
@@ -524,9 +568,12 @@ export const switchZeroSession$ = command(
         latestSessionId?: string | null;
         activeRunId?: string | null;
         activeRunPrompt?: string | null;
+        failedRunId?: string | null;
+        failedRunPrompt?: string | null;
+        failedRunError?: string | null;
       };
 
-      console.warn("[switchSession] loaded:", {
+      L.info("loaded:", {
         isLegacySession,
         agentComposeId: data.agentComposeId,
         latestSessionId: data.latestSessionId,
@@ -583,48 +630,28 @@ export const switchZeroSession$ = command(
           content: "",
           runId: data.activeRunId,
         });
+      } else if (data.failedRunId && data.failedRunPrompt) {
+        // If the latest run failed, show the user's message and the error
+        messages.push({
+          id: crypto.randomUUID(),
+          role: "user",
+          content: data.failedRunPrompt,
+        });
+        messages.push({
+          id: crypto.randomUUID(),
+          role: "assistant",
+          content: "",
+          runId: data.failedRunId,
+          status: "failed",
+          error: data.failedRunError ?? "Run failed",
+        });
       }
 
       set(internalMessages$, messages);
 
       // Resume polling for the active run
       if (data.activeRunId) {
-        set(internalActiveRunId$, data.activeRunId);
-        set(internalSending$, true);
-
-        const controller = new AbortController();
-        set(pollingAbortController$, controller);
-
-        // Fire-and-forget: polling loop runs in background
-        set(setupPollingLoop$, {
-          runId: data.activeRunId,
-          signal: controller.signal,
-          state: {
-            get events$() {
-              return get(internalRunEvents$);
-            },
-            setEvents: (updater) => {
-              set(internalRunEvents$, updater);
-            },
-            setStatus: (s) => {
-              set(internalRunStatus$, s);
-              updateQueuePosition(s, fetchFn, data.activeRunId!, (pos) =>
-                set(internalQueuePosition$, pos),
-              );
-            },
-            setError: (e) => {
-              set(internalRunError$, e);
-            },
-          },
-          onTerminal: (completedRunId) => {
-            set(onZeroRunComplete$, completedRunId).catch((error: unknown) => {
-              throwIfAbort(error);
-              L.error("onRunComplete error:", error);
-            });
-          },
-        }).catch((error: unknown) => {
-          throwIfAbort(error);
-        });
+        resumeRunPolling(get, set, fetchFn, data.activeRunId);
       }
     } catch (error) {
       throwIfAbort(error);

--- a/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
@@ -512,28 +512,20 @@ export const switchZeroSession$ = command(
       }
 
       // Resolve the correct agent from the thread's compose ID.
-      // If it differs from the current selection, update and re-fetch sessions.
+      // Set the correct agent from the thread's compose ID and fetch sessions
       if (data.agentComposeId) {
-        const currentAgentId = get(zeroChatAgentId$);
         const status = await get(zeroOnboardingStatus$);
         const isDefault = data.agentComposeId === status.defaultAgentComposeId;
-        const needsSwitch = isDefault
-          ? currentAgentId !== null
-          : currentAgentId !== data.agentComposeId;
-
-        if (needsSwitch) {
-          if (isDefault) {
-            set(setZeroChatAgent$, null);
-          } else {
-            const subagents = await get(zeroSubagents$);
-            const agent = subagents.find((a) => a.id === data.agentComposeId);
-            if (agent) {
-              set(setZeroChatAgent$, { id: agent.id, name: agent.name });
-            }
+        if (isDefault) {
+          set(setZeroChatAgent$, null);
+        } else {
+          const subagents = await get(zeroSubagents$);
+          const agent = subagents.find((a) => a.id === data.agentComposeId);
+          if (agent) {
+            set(setZeroChatAgent$, { id: agent.id, name: agent.name });
           }
-          // Re-fetch session list for the correct agent
-          detach(set(fetchZeroSessionList$), Reason.DomCallback);
         }
+        detach(set(fetchZeroSessionList$), Reason.DomCallback);
       }
 
       const messages: ZeroChatMessage[] = (data.chatMessages ?? []).map(

--- a/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
@@ -589,12 +589,12 @@ export const switchZeroSession$ = command(
           createdAt: string;
         }[];
         latestSessionId?: string | null;
-        unsavedRuns?: Array<{
+        unsavedRuns?: {
           runId: string;
           status: string;
           prompt: string;
           error: string | null;
-        }>;
+        }[];
       };
 
       L.info("loaded:", {

--- a/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
@@ -11,6 +11,7 @@ import {
   setZeroChatAgent$,
   zeroInChat$,
 } from "./zero-nav.ts";
+import { agentsList$ } from "./agents-list.ts";
 import type { ChatThreadListItem } from "@vm0/core";
 
 const L = logger("ZeroChat");
@@ -530,7 +531,12 @@ async function syncAgentForThread(
     const isDefault = agentComposeId === status.defaultAgentComposeId;
     const newAgentId = isDefault ? null : agentComposeId;
     if (newAgentId !== currentAgentId) {
-      set(switchActiveAgent$, newAgentId ? { id: newAgentId, name: "" } : null);
+      const agentName =
+        newAgentId && get(agentsList$).find((a) => a.id === newAgentId)?.name;
+      set(
+        switchActiveAgent$,
+        newAgentId ? { id: newAgentId, name: agentName ?? "" } : null,
+      );
     } else if (get(internalSessionList$).length === 0) {
       detach(set(fetchZeroSessionList$), Reason.DomCallback);
     }

--- a/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
@@ -5,7 +5,6 @@ import { throwIfAbort, detach, Reason } from "../utils.ts";
 import { logger } from "../log.ts";
 import { setupPollingLoop$, type PageResult } from "./polling.ts";
 import { zeroOnboardingStatus$ } from "./zero-onboarding.ts";
-import { zeroSubagents$ } from "./zero-agents.ts";
 import {
   navigateToZeroSession$,
   zeroChatAgentId$,
@@ -502,6 +501,7 @@ export const switchZeroSession$ = command(
       const fetchFn = get(fetch$);
 
       // Try chat-threads API first; fall back to legacy sessions API
+      console.warn("[switchSession] loading thread:", threadId);
       let res = await fetchFn(`/api/chat-threads/${threadId}`);
       let isLegacySession = false;
       if (!res.ok) {
@@ -509,10 +509,10 @@ export const switchZeroSession$ = command(
         isLegacySession = true;
       }
       if (!res.ok) {
+        console.warn("[switchSession] both APIs failed, status:", res.status);
         set(internalSessionError$, `Failed to load chat: ${res.statusText}`);
         return;
       }
-
       const data = (await res.json()) as {
         agentComposeId?: string;
         chatMessages?: {
@@ -526,6 +526,13 @@ export const switchZeroSession$ = command(
         activeRunPrompt?: string | null;
       };
 
+      console.warn("[switchSession] loaded:", {
+        isLegacySession,
+        agentComposeId: data.agentComposeId,
+        latestSessionId: data.latestSessionId,
+        msgCount: data.chatMessages?.length,
+      });
+
       if (isLegacySession) {
         // Legacy session: the ID itself is the sessionId
         set(internalSessionId$, threadId);
@@ -533,22 +540,24 @@ export const switchZeroSession$ = command(
         set(internalSessionId$, data.latestSessionId);
       }
 
-      // Resolve agent from thread's compose ID and switch active agent
+      // Switch agent if it changed, or fetch session list if empty (fresh load).
       if (data.agentComposeId) {
+        const currentAgentId = get(zeroChatAgentId$);
         const status = await get(zeroOnboardingStatus$);
         const isDefault = data.agentComposeId === status.defaultAgentComposeId;
-        if (isDefault) {
-          set(switchActiveAgent$, null);
-        } else {
-          const subagents = await get(zeroSubagents$);
-          const agent = subagents.find((a) => a.id === data.agentComposeId);
-          if (agent) {
-            set(switchActiveAgent$, { id: agent.id, name: agent.name });
-          }
+        const newAgentId = isDefault ? null : data.agentComposeId;
+        if (newAgentId !== currentAgentId) {
+          set(
+            switchActiveAgent$,
+            newAgentId ? { id: newAgentId, name: "" } : null,
+          );
+        } else if (get(internalSessionList$).length === 0) {
+          detach(set(fetchZeroSessionList$), Reason.DomCallback);
         }
-      } else {
-        // Legacy session or no agentComposeId: fetch default agent sessions
+      } else if (get(zeroChatAgentId$) !== null) {
         set(switchActiveAgent$, null);
+      } else if (get(internalSessionList$).length === 0) {
+        detach(set(fetchZeroSessionList$), Reason.DomCallback);
       }
 
       const messages: ZeroChatMessage[] = (data.chatMessages ?? []).map(

--- a/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
@@ -519,6 +519,29 @@ export const switchActiveAgent$ = command(
   },
 );
 
+/** Resolve which agent to activate based on the thread's agentComposeId. */
+async function syncAgentForThread(
+  get: Parameters<Parameters<typeof command>[0]>[0]["get"],
+  set: Parameters<Parameters<typeof command>[0]>[0]["set"],
+  agentComposeId: string | undefined,
+) {
+  if (agentComposeId) {
+    const currentAgentId = get(zeroChatAgentId$);
+    const status = await get(zeroOnboardingStatus$);
+    const isDefault = agentComposeId === status.defaultAgentComposeId;
+    const newAgentId = isDefault ? null : agentComposeId;
+    if (newAgentId !== currentAgentId) {
+      set(switchActiveAgent$, newAgentId ? { id: newAgentId, name: "" } : null);
+    } else if (get(internalSessionList$).length === 0) {
+      detach(set(fetchZeroSessionList$), Reason.DomCallback);
+    }
+  } else if (get(zeroChatAgentId$) !== null) {
+    set(switchActiveAgent$, null);
+  } else if (get(internalSessionList$).length === 0) {
+    detach(set(fetchZeroSessionList$), Reason.DomCallback);
+  }
+}
+
 export const switchZeroSession$ = command(
   async ({ get, set }, threadId: string) => {
     // Abort any in-flight polling from the previous session
@@ -588,24 +611,7 @@ export const switchZeroSession$ = command(
       }
 
       // Switch agent if it changed, or fetch session list if empty (fresh load).
-      if (data.agentComposeId) {
-        const currentAgentId = get(zeroChatAgentId$);
-        const status = await get(zeroOnboardingStatus$);
-        const isDefault = data.agentComposeId === status.defaultAgentComposeId;
-        const newAgentId = isDefault ? null : data.agentComposeId;
-        if (newAgentId !== currentAgentId) {
-          set(
-            switchActiveAgent$,
-            newAgentId ? { id: newAgentId, name: "" } : null,
-          );
-        } else if (get(internalSessionList$).length === 0) {
-          detach(set(fetchZeroSessionList$), Reason.DomCallback);
-        }
-      } else if (get(zeroChatAgentId$) !== null) {
-        set(switchActiveAgent$, null);
-      } else if (get(internalSessionList$).length === 0) {
-        detach(set(fetchZeroSessionList$), Reason.DomCallback);
-      }
+      await syncAgentForThread(get, set, data.agentComposeId);
 
       const messages: ZeroChatMessage[] = (data.chatMessages ?? []).map(
         (m) => ({

--- a/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
@@ -464,6 +464,18 @@ export const fetchZeroSessionList$ = command(async ({ get, set }) => {
   }
 });
 
+/**
+ * Single entry point for changing the active agent.
+ * Sets the agent identity AND refreshes the session list atomically.
+ * All callers that need to change the active agent should use this.
+ */
+export const switchActiveAgent$ = command(
+  ({ set }, agent: { id: string; name: string } | null) => {
+    set(setZeroChatAgent$, agent);
+    detach(set(fetchZeroSessionList$), Reason.DomCallback);
+  },
+);
+
 export const switchZeroSession$ = command(
   async ({ get, set }, threadId: string) => {
     // Abort any in-flight polling from the previous session
@@ -511,30 +523,19 @@ export const switchZeroSession$ = command(
         set(internalSessionId$, data.latestSessionId);
       }
 
-      // Set the correct agent from the thread's compose ID and fetch sessions
+      // Resolve agent from thread's compose ID and switch active agent
       if (data.agentComposeId) {
         const status = await get(zeroOnboardingStatus$);
         const isDefault = data.agentComposeId === status.defaultAgentComposeId;
-        L.debug(
-          `switchSession: agentComposeId=${data.agentComposeId}, defaultComposeId=${status.defaultAgentComposeId}, isDefault=${isDefault}`,
-        );
         if (isDefault) {
-          L.debug("switchSession: setting agent to default (null)");
-          set(setZeroChatAgent$, null);
+          set(switchActiveAgent$, null);
         } else {
           const subagents = await get(zeroSubagents$);
           const agent = subagents.find((a) => a.id === data.agentComposeId);
-          L.debug(
-            `switchSession: found subagent=${agent?.name ?? "NOT FOUND"} for composeId=${data.agentComposeId}`,
-          );
           if (agent) {
-            set(setZeroChatAgent$, { id: agent.id, name: agent.name });
+            set(switchActiveAgent$, { id: agent.id, name: agent.name });
           }
         }
-        L.debug("switchSession: fetching session list");
-        detach(set(fetchZeroSessionList$), Reason.DomCallback);
-      } else {
-        L.debug("switchSession: no agentComposeId in thread response");
       }
 
       const messages: ZeroChatMessage[] = (data.chatMessages ?? []).map(

--- a/turbo/apps/platform/src/signals/zero-page/zero-nav.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-nav.ts
@@ -87,6 +87,15 @@ export const setZeroActiveId$ = command(({ set }, id: ZeroNavId) => {
 });
 
 /**
+ * Whether the talk agent has been resolved from the URL.
+ * Set to true after setupZeroPage$ processes the /zero/talk/:name route.
+ */
+const internalTalkAgentResolved$ = state(false);
+export const zeroTalkAgentResolved$ = computed((get) =>
+  get(internalTalkAgentResolved$),
+);
+
+/**
  * Set the chat agent ID and name (in-memory).
  * Pass null to clear (chat with default agent).
  */
@@ -94,6 +103,7 @@ export const setZeroChatAgent$ = command(
   ({ set }, agent: { id: string; name: string } | null) => {
     set(internalChatAgentId$, agent?.id ?? null);
     set(internalLastChatAgentName$, agent?.name ?? null);
+    set(internalTalkAgentResolved$, true);
   },
 );
 

--- a/turbo/apps/platform/src/signals/zero-page/zero-nav.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-nav.ts
@@ -1,14 +1,6 @@
-import { command, computed } from "ccstate";
+import { command, computed, state } from "ccstate";
 import { pathname$, updatePathname$ } from "../route.ts";
-import { localStorageSignals } from "../external/local-storage.ts";
 import type { ZeroNavId } from "../../views/zero-page/zero-sidebar.tsx";
-
-const CHAT_AGENT_KEY = "zero.chatAgentId";
-const {
-  get$: storedChatAgentId$,
-  set$: persistChatAgentId$,
-  clear$: clearChatAgentId$,
-} = localStorageSignals(CHAT_AGENT_KEY);
 
 function isValidTab(tab: string): tab is ZeroNavId {
   return (
@@ -24,7 +16,8 @@ function isValidTab(tab: string): tab is ZeroNavId {
 
 /**
  * Active zero nav id, derived from the URL path `/zero/:tab`.
- * `/zero`, `/zero/chat`, and `/zero/chat/:sessionId` all resolve to "chat".
+ * `/zero`, `/zero/chat`, `/zero/chat/:sessionId`, and `/zero/talk/:name`
+ * all resolve to "chat".
  */
 export const zeroActiveId$ = computed((get): ZeroNavId => {
   const path = get(pathname$);
@@ -36,7 +29,7 @@ export const zeroActiveId$ = computed((get): ZeroNavId => {
 });
 
 /**
- * Whether the user is on a chat page — `/zero/chat` or `/zero/chat/:sessionId`.
+ * Whether the user is on a chat session page — `/zero/chat` or `/zero/chat/:sessionId`.
  */
 export const zeroInChat$ = computed((get): boolean => {
   const path = get(pathname$);
@@ -45,7 +38,7 @@ export const zeroInChat$ = computed((get): boolean => {
 
 /**
  * Session ID extracted from `/zero/chat/:sessionId`.
- * Returns null when on `/zero` or `/zero/chat` (no active session).
+ * Returns null when on `/zero`, `/zero/chat`, or `/zero/talk/:name`.
  */
 export const zeroSessionId$ = computed((get): string | null => {
   const path = get(pathname$);
@@ -54,12 +47,35 @@ export const zeroSessionId$ = computed((get): string | null => {
 });
 
 /**
- * Currently selected chat agent ID, persisted in localStorage.
- * Returns null when chatting with the default/main agent (Zero).
+ * Agent name extracted from `/zero/talk/:name`.
+ * Returns null when chatting with the default agent.
+ */
+export const zeroChatAgentName$ = computed((get): string | null => {
+  const path = get(pathname$);
+  const match = /^\/zero\/talk\/([^/]+)/.exec(path);
+  return match ? decodeURIComponent(match[1]) : null;
+});
+
+/**
+ * In-memory state tracking the current chat agent ID.
+ * Null means default agent. Set when navigating to a chat route.
+ */
+const internalChatAgentId$ = state<string | null>(null);
+
+/**
+ * Currently selected chat agent ID (in-memory).
+ * Returns null when chatting with the default/main agent.
  */
 export const zeroChatAgentId$ = computed((get): string | null => {
-  return get(storedChatAgentId$);
+  return get(internalChatAgentId$);
 });
+
+/**
+ * Last chat agent name, preserved across non-chat navigation.
+ * Used to maintain recent chat context when visiting schedule/team pages,
+ * and to navigate back from sessions to the correct talk route.
+ */
+const internalLastChatAgentName$ = state<string | null>(null);
 
 /**
  * Navigate to a zero tab — updates the URL path to `/zero/:tab`.
@@ -71,16 +87,13 @@ export const setZeroActiveId$ = command(({ set }, id: ZeroNavId) => {
 });
 
 /**
- * Set the chat agent ID, persisted in localStorage.
+ * Set the chat agent ID and name (in-memory).
  * Pass null to clear (chat with default agent).
  */
-export const setZeroChatAgentId$ = command(
-  ({ set }, agentId: string | null) => {
-    if (agentId) {
-      set(persistChatAgentId$, agentId);
-    } else {
-      set(clearChatAgentId$);
-    }
+export const setZeroChatAgent$ = command(
+  ({ set }, agent: { id: string; name: string } | null) => {
+    set(internalChatAgentId$, agent?.id ?? null);
+    set(internalLastChatAgentName$, agent?.name ?? null);
   },
 );
 
@@ -102,8 +115,14 @@ export const navigateToZeroSession$ = command(({ set }, sessionId: string) => {
 });
 
 /**
- * Navigate back from a chat session to the chat home — `/zero`.
+ * Navigate back from a chat session to the chat home.
+ * Returns to `/zero/talk/:name` if a team agent was selected, otherwise `/zero`.
  */
-export const navigateFromZeroSession$ = command(({ set }) => {
-  set(updatePathname$, "/zero");
+export const navigateFromZeroSession$ = command(({ get, set }) => {
+  const agentName = get(internalLastChatAgentName$);
+  if (agentName) {
+    set(updatePathname$, `/zero/talk/${encodeURIComponent(agentName)}`);
+  } else {
+    set(updatePathname$, "/zero");
+  }
 });

--- a/turbo/apps/platform/src/signals/zero-page/zero-page.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-page.ts
@@ -1,4 +1,4 @@
-import { command } from "ccstate";
+import { command, state } from "ccstate";
 import { createElement } from "react";
 import { ZeroPage } from "../../views/zero-page/zero-page.tsx";
 import { updatePage$ } from "../react-router.ts";
@@ -12,64 +12,82 @@ import { fetchZeroSessionList$ } from "./zero-chat.ts";
 import { pathname$ } from "../route.ts";
 import { Reason, detach } from "../utils.ts";
 
+/** Tracks whether the initial heavy data (agents, onboarding, slack) has loaded. */
+const initialDataLoaded$ = state(false);
+
+/**
+ * Resolve the talk agent from the URL and fetch the session list.
+ * This is the fast path — it only awaits data that's already cached
+ * after the initial page load (zeroSubagents$, defaultAgentName$).
+ */
+async function resolveTalkAgent(
+  get: Parameters<Parameters<typeof command>[0]>[0]["get"],
+  set: Parameters<Parameters<typeof command>[0]>[0]["set"],
+  signal: AbortSignal,
+) {
+  // If on bare /zero, redirect to /zero/talk/:defaultAgent
+  const currentPath = get(pathname$);
+  const isBareZero = /^\/zero\/?$/.test(currentPath);
+  if (isBareZero) {
+    const rawName = await get(defaultAgentName$);
+    signal.throwIfAborted();
+    if (rawName) {
+      window.history.replaceState(
+        {},
+        "",
+        `/zero/talk/${encodeURIComponent(rawName)}`,
+      );
+    }
+  }
+
+  // Initialize chat agent from URL /zero/talk/:name
+  const agentName = get(zeroChatAgentName$);
+  if (agentName) {
+    const subagents = await get(zeroSubagents$);
+    const rawDefaultName = await get(defaultAgentName$);
+    signal.throwIfAborted();
+
+    if (agentName === rawDefaultName) {
+      set(setZeroChatAgent$, null);
+    } else {
+      const agent = subagents.find((a) => a.name === agentName);
+      if (agent) {
+        set(setZeroChatAgent$, { id: agent.id, name: agent.name });
+      } else {
+        set(setZeroChatAgent$, null);
+        if (rawDefaultName) {
+          window.history.replaceState(
+            {},
+            "",
+            `/zero/talk/${encodeURIComponent(rawDefaultName)}`,
+          );
+        }
+      }
+    }
+  } else {
+    set(setZeroChatAgent$, null);
+  }
+
+  detach(set(fetchZeroSessionList$), Reason.DomCallback);
+}
+
 export const setupZeroPage$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     set(updatePage$, createElement(ZeroPage));
 
-    await Promise.all([
-      set(fetchAgentsList$),
-      set(initZeroOnboarding$, signal),
-      set(initSlackOrg$),
-    ]);
-    signal.throwIfAborted();
-
-    // If on bare /zero, redirect to /zero/talk/:defaultAgent
-    const currentPath = get(pathname$);
-    const isBareZero = /^\/zero\/?$/.test(currentPath);
-    if (isBareZero) {
-      const rawName = await get(defaultAgentName$);
+    // Only fetch heavy initial data once — skip on subsequent route changes
+    // (e.g. switching between talk agents).
+    if (!get(initialDataLoaded$)) {
+      await Promise.all([
+        set(fetchAgentsList$),
+        set(initZeroOnboarding$, signal),
+        set(initSlackOrg$),
+      ]);
       signal.throwIfAborted();
-      if (rawName) {
-        window.history.replaceState(
-          {},
-          "",
-          `/zero/talk/${encodeURIComponent(rawName)}`,
-        );
-      }
+      set(initialDataLoaded$, true);
+      detach(set(initZeroActivity$), Reason.Daemon);
     }
 
-    // Initialize chat agent from URL /zero/talk/:name
-    const agentName = get(zeroChatAgentName$);
-    if (agentName) {
-      const subagents = await get(zeroSubagents$);
-      const rawDefaultName = await get(defaultAgentName$);
-      signal.throwIfAborted();
-
-      if (agentName === rawDefaultName) {
-        // Default agent — null ID means default
-        set(setZeroChatAgent$, null);
-      } else {
-        const agent = subagents.find((a) => a.name === agentName);
-        if (agent) {
-          set(setZeroChatAgent$, { id: agent.id, name: agent.name });
-        } else {
-          // Unknown agent name — redirect to default
-          set(setZeroChatAgent$, null);
-          if (rawDefaultName) {
-            window.history.replaceState(
-              {},
-              "",
-              `/zero/talk/${encodeURIComponent(rawDefaultName)}`,
-            );
-          }
-        }
-      }
-    } else {
-      set(setZeroChatAgent$, null);
-    }
-
-    // Fetch session list after agent is resolved
-    detach(set(fetchZeroSessionList$), Reason.DomCallback);
-    detach(set(initZeroActivity$), Reason.Daemon);
+    await resolveTalkAgent(get, set, signal);
   },
 );

--- a/turbo/apps/platform/src/signals/zero-page/zero-page.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-page.ts
@@ -2,20 +2,37 @@ import { command } from "ccstate";
 import { createElement } from "react";
 import { ZeroPage } from "../../views/zero-page/zero-page.tsx";
 import { updatePage$ } from "../react-router.ts";
-import { fetchAgentsList$ } from "./zero-agents.ts";
+import { fetchAgentsList$, zeroSubagents$ } from "./zero-agents.ts";
 import { initZeroOnboarding$ } from "./zero-onboarding.ts";
 import { initZeroActivity$ } from "./zero-activity.ts";
 import { initSlackOrg$ } from "./zero-slack.ts";
+import { zeroChatAgentName$, setZeroChatAgent$ } from "./zero-nav.ts";
 import { Reason, detach } from "../utils.ts";
 
-export const setupZeroPage$ = command(async ({ set }, signal: AbortSignal) => {
-  set(updatePage$, createElement(ZeroPage));
+export const setupZeroPage$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    set(updatePage$, createElement(ZeroPage));
 
-  await Promise.all([
-    set(fetchAgentsList$),
-    set(initZeroOnboarding$, signal),
-    set(initSlackOrg$),
-  ]);
-  signal.throwIfAborted();
-  detach(set(initZeroActivity$), Reason.Daemon);
-});
+    await Promise.all([
+      set(fetchAgentsList$),
+      set(initZeroOnboarding$, signal),
+      set(initSlackOrg$),
+    ]);
+    signal.throwIfAborted();
+
+    // Initialize chat agent from URL /zero/talk/:name
+    const agentName = get(zeroChatAgentName$);
+    if (agentName) {
+      const subagents = await get(zeroSubagents$);
+      signal.throwIfAborted();
+      const agent = subagents.find((a) => a.name === agentName);
+      if (agent) {
+        set(setZeroChatAgent$, { id: agent.id, name: agent.name });
+      }
+    } else {
+      set(setZeroChatAgent$, null);
+    }
+
+    detach(set(initZeroActivity$), Reason.Daemon);
+  },
+);

--- a/turbo/apps/platform/src/signals/zero-page/zero-page.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-page.ts
@@ -3,11 +3,12 @@ import { createElement } from "react";
 import { ZeroPage } from "../../views/zero-page/zero-page.tsx";
 import { updatePage$ } from "../react-router.ts";
 import { fetchAgentsList$, zeroSubagents$ } from "./zero-agents.ts";
+import { defaultAgentName$ } from "./zero-agent-name.ts";
 import { initZeroOnboarding$ } from "./zero-onboarding.ts";
 import { initZeroActivity$ } from "./zero-activity.ts";
 import { initSlackOrg$ } from "./zero-slack.ts";
 import { zeroChatAgentName$, setZeroChatAgent$ } from "./zero-nav.ts";
-import { updatePathname$ } from "../route.ts";
+import { pathname$ } from "../route.ts";
 import { Reason, detach } from "../utils.ts";
 
 export const setupZeroPage$ = command(
@@ -21,18 +22,46 @@ export const setupZeroPage$ = command(
     ]);
     signal.throwIfAborted();
 
+    // If on bare /zero, redirect to /zero/talk/:defaultAgent
+    const currentPath = get(pathname$);
+    const isBareZero = /^\/zero\/?$/.test(currentPath);
+    if (isBareZero) {
+      const rawName = await get(defaultAgentName$);
+      signal.throwIfAborted();
+      if (rawName) {
+        window.history.replaceState(
+          {},
+          "",
+          `/zero/talk/${encodeURIComponent(rawName)}`,
+        );
+      }
+    }
+
     // Initialize chat agent from URL /zero/talk/:name
     const agentName = get(zeroChatAgentName$);
     if (agentName) {
       const subagents = await get(zeroSubagents$);
+      const rawDefaultName = await get(defaultAgentName$);
       signal.throwIfAborted();
-      const agent = subagents.find((a) => a.name === agentName);
-      if (agent) {
-        set(setZeroChatAgent$, { id: agent.id, name: agent.name });
-      } else {
-        // Unknown agent name — clear agent and redirect to /zero
+
+      if (agentName === rawDefaultName) {
+        // Default agent — null ID means default
         set(setZeroChatAgent$, null);
-        set(updatePathname$, "/zero");
+      } else {
+        const agent = subagents.find((a) => a.name === agentName);
+        if (agent) {
+          set(setZeroChatAgent$, { id: agent.id, name: agent.name });
+        } else {
+          // Unknown agent name — redirect to default
+          set(setZeroChatAgent$, null);
+          if (rawDefaultName) {
+            window.history.replaceState(
+              {},
+              "",
+              `/zero/talk/${encodeURIComponent(rawDefaultName)}`,
+            );
+          }
+        }
       }
     } else {
       set(setZeroChatAgent$, null);

--- a/turbo/apps/platform/src/signals/zero-page/zero-page.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-page.ts
@@ -35,8 +35,10 @@ async function resolveAndSwitchAgent(
   // On /zero/chat/:threadId, switchZeroSession$ resolves the agent from
   // the thread's agentComposeId. Don't interfere here.
   if (get(zeroInChat$)) {
+    console.warn("[resolveAgent] on chat URL, deferring to switchZeroSession$");
     return;
   }
+  console.warn("[resolveAgent] path:", currentPath);
 
   // If on bare /zero, redirect to /zero/talk/:defaultAgent
   if (/^\/zero\/?$/.test(currentPath)) {

--- a/turbo/apps/platform/src/signals/zero-page/zero-page.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-page.ts
@@ -7,38 +7,39 @@ import { defaultAgentName$ } from "./zero-agent-name.ts";
 import { initZeroOnboarding$ } from "./zero-onboarding.ts";
 import { initZeroActivity$ } from "./zero-activity.ts";
 import { initSlackOrg$ } from "./zero-slack.ts";
-import {
-  zeroChatAgentName$,
-  setZeroChatAgent$,
-  zeroInChat$,
-} from "./zero-nav.ts";
-import { fetchZeroSessionList$ } from "./zero-chat.ts";
+import { zeroChatAgentName$, zeroInChat$ } from "./zero-nav.ts";
+import { switchActiveAgent$ } from "./zero-chat.ts";
 import { pathname$ } from "../route.ts";
 import { Reason, detach } from "../utils.ts";
-import { logger } from "../log.ts";
-
-const L = logger("ZeroPage");
 
 /** Tracks whether the initial heavy data (agents, onboarding, slack) has loaded. */
 const initialDataLoaded$ = state(false);
 
 /**
- * Resolve the talk agent from the URL and fetch the session list.
- * This is the fast path — it only awaits data that's already cached
- * after the initial page load (zeroSubagents$, defaultAgentName$).
+ * Resolve the active agent from the URL and switch to it.
+ *
+ * - `/zero/talk/:name` → find agent by name, switch to it
+ * - `/zero/chat/:threadId` → skip (switchZeroSession$ handles it)
+ * - `/zero` → redirect to `/zero/talk/:defaultAgent`
+ * - other `/zero/*` → switch to default agent
+ *
+ * switchActiveAgent$ sets the agent AND fetches the session list atomically.
  */
-async function resolveTalkAgent(
+async function resolveAndSwitchAgent(
   get: Parameters<Parameters<typeof command>[0]>[0]["get"],
   set: Parameters<Parameters<typeof command>[0]>[0]["set"],
   signal: AbortSignal,
 ) {
   const currentPath = get(pathname$);
-  const inChat = get(zeroInChat$);
-  L.debug(`resolveTalkAgent: path=${currentPath}, inChat=${inChat}`);
+
+  // On /zero/chat/:threadId, switchZeroSession$ resolves the agent from
+  // the thread's agentComposeId. Don't interfere here.
+  if (get(zeroInChat$)) {
+    return;
+  }
 
   // If on bare /zero, redirect to /zero/talk/:defaultAgent
-  const isBareZero = /^\/zero\/?$/.test(currentPath);
-  if (isBareZero) {
+  if (/^\/zero\/?$/.test(currentPath)) {
     const rawName = await get(defaultAgentName$);
     signal.throwIfAborted();
     if (rawName) {
@@ -50,29 +51,22 @@ async function resolveTalkAgent(
     }
   }
 
-  // Initialize chat agent from URL /zero/talk/:name
+  // Resolve agent from /zero/talk/:name
   const agentName = get(zeroChatAgentName$);
-  L.debug(`resolveTalkAgent: agentName=${agentName}`);
   if (agentName) {
     const subagents = await get(zeroSubagents$);
     const rawDefaultName = await get(defaultAgentName$);
     signal.throwIfAborted();
 
     if (agentName === rawDefaultName) {
-      L.debug("resolveTalkAgent: is default agent, setting null");
-      set(setZeroChatAgent$, null);
+      set(switchActiveAgent$, null);
     } else {
       const agent = subagents.find((a) => a.name === agentName);
       if (agent) {
-        L.debug(
-          `resolveTalkAgent: found subagent id=${agent.id} name=${agent.name}`,
-        );
-        set(setZeroChatAgent$, { id: agent.id, name: agent.name });
+        set(switchActiveAgent$, { id: agent.id, name: agent.name });
       } else {
-        L.debug(
-          `resolveTalkAgent: agent "${agentName}" not found, redirecting to default`,
-        );
-        set(setZeroChatAgent$, null);
+        // Unknown agent → redirect to default
+        set(switchActiveAgent$, null);
         if (rawDefaultName) {
           window.history.replaceState(
             {},
@@ -82,18 +76,9 @@ async function resolveTalkAgent(
         }
       }
     }
-    detach(set(fetchZeroSessionList$), Reason.DomCallback);
-  } else if (!inChat) {
-    // Only reset agent on non-chat URLs (e.g. /zero/schedule, /zero/team).
-    // On /zero/chat/:threadId, switchZeroSession$ will resolve the correct
-    // agent from the thread's agentComposeId.
-    L.debug("resolveTalkAgent: non-talk, non-chat URL → reset to default");
-    set(setZeroChatAgent$, null);
-    detach(set(fetchZeroSessionList$), Reason.DomCallback);
   } else {
-    L.debug(
-      "resolveTalkAgent: on chat URL, skipping agent reset (switchZeroSession$ handles it)",
-    );
+    // Non-talk, non-chat URL (e.g. /zero/schedule)
+    set(switchActiveAgent$, null);
   }
 }
 
@@ -114,9 +99,6 @@ export const setupZeroPage$ = command(
       detach(set(initZeroActivity$), Reason.Daemon);
     }
 
-    L.debug(
-      `setupZeroPage: initialDataLoaded=${get(initialDataLoaded$)}, resolving talk agent`,
-    );
-    await resolveTalkAgent(get, set, signal);
+    await resolveAndSwitchAgent(get, set, signal);
   },
 );

--- a/turbo/apps/platform/src/signals/zero-page/zero-page.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-page.ts
@@ -7,6 +7,7 @@ import { initZeroOnboarding$ } from "./zero-onboarding.ts";
 import { initZeroActivity$ } from "./zero-activity.ts";
 import { initSlackOrg$ } from "./zero-slack.ts";
 import { zeroChatAgentName$, setZeroChatAgent$ } from "./zero-nav.ts";
+import { updatePathname$ } from "../route.ts";
 import { Reason, detach } from "../utils.ts";
 
 export const setupZeroPage$ = command(
@@ -28,6 +29,10 @@ export const setupZeroPage$ = command(
       const agent = subagents.find((a) => a.name === agentName);
       if (agent) {
         set(setZeroChatAgent$, { id: agent.id, name: agent.name });
+      } else {
+        // Unknown agent name — clear agent and redirect to /zero
+        set(setZeroChatAgent$, null);
+        set(updatePathname$, "/zero");
       }
     } else {
       set(setZeroChatAgent$, null);

--- a/turbo/apps/platform/src/signals/zero-page/zero-page.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-page.ts
@@ -82,6 +82,7 @@ async function resolveTalkAgent(
         }
       }
     }
+    detach(set(fetchZeroSessionList$), Reason.DomCallback);
   } else if (!inChat) {
     // Only reset agent on non-chat URLs (e.g. /zero/schedule, /zero/team).
     // On /zero/chat/:threadId, switchZeroSession$ will resolve the correct

--- a/turbo/apps/platform/src/signals/zero-page/zero-page.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-page.ts
@@ -9,8 +9,11 @@ import { initZeroActivity$ } from "./zero-activity.ts";
 import { initSlackOrg$ } from "./zero-slack.ts";
 import { zeroChatAgentName$, zeroInChat$ } from "./zero-nav.ts";
 import { switchActiveAgent$ } from "./zero-chat.ts";
+import { logger } from "../log.ts";
 import { pathname$ } from "../route.ts";
 import { Reason, detach } from "../utils.ts";
+
+const L = logger("ZeroPage");
 
 /** Tracks whether the initial heavy data (agents, onboarding, slack) has loaded. */
 const initialDataLoaded$ = state(false);
@@ -35,10 +38,10 @@ async function resolveAndSwitchAgent(
   // On /zero/chat/:threadId, switchZeroSession$ resolves the agent from
   // the thread's agentComposeId. Don't interfere here.
   if (get(zeroInChat$)) {
-    console.warn("[resolveAgent] on chat URL, deferring to switchZeroSession$");
+    L.info("on chat URL, deferring to switchZeroSession$");
     return;
   }
-  console.warn("[resolveAgent] path:", currentPath);
+  L.info("resolveAgent path:", currentPath);
 
   // If on bare /zero, redirect to /zero/talk/:defaultAgent
   if (/^\/zero\/?$/.test(currentPath)) {

--- a/turbo/apps/platform/src/signals/zero-page/zero-page.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-page.ts
@@ -15,6 +15,9 @@ import {
 import { fetchZeroSessionList$ } from "./zero-chat.ts";
 import { pathname$ } from "../route.ts";
 import { Reason, detach } from "../utils.ts";
+import { logger } from "../log.ts";
+
+const L = logger("ZeroPage");
 
 /** Tracks whether the initial heavy data (agents, onboarding, slack) has loaded. */
 const initialDataLoaded$ = state(false);
@@ -29,8 +32,11 @@ async function resolveTalkAgent(
   set: Parameters<Parameters<typeof command>[0]>[0]["set"],
   signal: AbortSignal,
 ) {
-  // If on bare /zero, redirect to /zero/talk/:defaultAgent
   const currentPath = get(pathname$);
+  const inChat = get(zeroInChat$);
+  L.debug(`resolveTalkAgent: path=${currentPath}, inChat=${inChat}`);
+
+  // If on bare /zero, redirect to /zero/talk/:defaultAgent
   const isBareZero = /^\/zero\/?$/.test(currentPath);
   if (isBareZero) {
     const rawName = await get(defaultAgentName$);
@@ -46,18 +52,26 @@ async function resolveTalkAgent(
 
   // Initialize chat agent from URL /zero/talk/:name
   const agentName = get(zeroChatAgentName$);
+  L.debug(`resolveTalkAgent: agentName=${agentName}`);
   if (agentName) {
     const subagents = await get(zeroSubagents$);
     const rawDefaultName = await get(defaultAgentName$);
     signal.throwIfAborted();
 
     if (agentName === rawDefaultName) {
+      L.debug("resolveTalkAgent: is default agent, setting null");
       set(setZeroChatAgent$, null);
     } else {
       const agent = subagents.find((a) => a.name === agentName);
       if (agent) {
+        L.debug(
+          `resolveTalkAgent: found subagent id=${agent.id} name=${agent.name}`,
+        );
         set(setZeroChatAgent$, { id: agent.id, name: agent.name });
       } else {
+        L.debug(
+          `resolveTalkAgent: agent "${agentName}" not found, redirecting to default`,
+        );
         set(setZeroChatAgent$, null);
         if (rawDefaultName) {
           window.history.replaceState(
@@ -68,15 +82,17 @@ async function resolveTalkAgent(
         }
       }
     }
-  } else {
+  } else if (!inChat) {
+    // Only reset agent on non-chat URLs (e.g. /zero/schedule, /zero/team).
+    // On /zero/chat/:threadId, switchZeroSession$ will resolve the correct
+    // agent from the thread's agentComposeId.
+    L.debug("resolveTalkAgent: non-talk, non-chat URL → reset to default");
     set(setZeroChatAgent$, null);
-  }
-
-  // On chat session URLs (/zero/chat/:threadId), switchZeroSession$ will
-  // resolve the correct agent and fetch sessions. Skip here to avoid a
-  // race where this fetch (for the wrong agent) overwrites the correct one.
-  if (!get(zeroInChat$)) {
     detach(set(fetchZeroSessionList$), Reason.DomCallback);
+  } else {
+    L.debug(
+      "resolveTalkAgent: on chat URL, skipping agent reset (switchZeroSession$ handles it)",
+    );
   }
 }
 
@@ -97,6 +113,9 @@ export const setupZeroPage$ = command(
       detach(set(initZeroActivity$), Reason.Daemon);
     }
 
+    L.debug(
+      `setupZeroPage: initialDataLoaded=${get(initialDataLoaded$)}, resolving talk agent`,
+    );
     await resolveTalkAgent(get, set, signal);
   },
 );

--- a/turbo/apps/platform/src/signals/zero-page/zero-page.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-page.ts
@@ -8,6 +8,7 @@ import { initZeroOnboarding$ } from "./zero-onboarding.ts";
 import { initZeroActivity$ } from "./zero-activity.ts";
 import { initSlackOrg$ } from "./zero-slack.ts";
 import { zeroChatAgentName$, setZeroChatAgent$ } from "./zero-nav.ts";
+import { fetchZeroSessionList$ } from "./zero-chat.ts";
 import { pathname$ } from "../route.ts";
 import { Reason, detach } from "../utils.ts";
 
@@ -67,6 +68,8 @@ export const setupZeroPage$ = command(
       set(setZeroChatAgent$, null);
     }
 
+    // Fetch session list after agent is resolved
+    detach(set(fetchZeroSessionList$), Reason.DomCallback);
     detach(set(initZeroActivity$), Reason.Daemon);
   },
 );

--- a/turbo/apps/platform/src/signals/zero-page/zero-page.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-page.ts
@@ -7,7 +7,11 @@ import { defaultAgentName$ } from "./zero-agent-name.ts";
 import { initZeroOnboarding$ } from "./zero-onboarding.ts";
 import { initZeroActivity$ } from "./zero-activity.ts";
 import { initSlackOrg$ } from "./zero-slack.ts";
-import { zeroChatAgentName$, setZeroChatAgent$ } from "./zero-nav.ts";
+import {
+  zeroChatAgentName$,
+  setZeroChatAgent$,
+  zeroInChat$,
+} from "./zero-nav.ts";
 import { fetchZeroSessionList$ } from "./zero-chat.ts";
 import { pathname$ } from "../route.ts";
 import { Reason, detach } from "../utils.ts";
@@ -68,7 +72,12 @@ async function resolveTalkAgent(
     set(setZeroChatAgent$, null);
   }
 
-  detach(set(fetchZeroSessionList$), Reason.DomCallback);
+  // On chat session URLs (/zero/chat/:threadId), switchZeroSession$ will
+  // resolve the correct agent and fetch sessions. Skip here to avoid a
+  // race where this fetch (for the wrong agent) overwrites the correct one.
+  if (!get(zeroInChat$)) {
+    detach(set(fetchZeroSessionList$), Reason.DomCallback);
+  }
 }
 
 export const setupZeroPage$ = command(

--- a/turbo/apps/platform/src/types/route.ts
+++ b/turbo/apps/platform/src/types/route.ts
@@ -5,4 +5,5 @@ export type RoutePath =
   | "/zero/:tab"
   | "/zero/chat/:sessionId"
   | "/zero/team/:name"
+  | "/zero/talk/:name"
   | `/projects/${string}`;

--- a/turbo/apps/platform/src/views/zero-page/zero-activity-detail-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-activity-detail-page.tsx
@@ -220,7 +220,7 @@ export function ZeroActivityDetailPage() {
               </Button>
             </div>
             {detail.error && status === "failed" && (
-              <div className="mt-2 rounded-lg bg-destructive/10 px-3 py-2 text-sm text-destructive">
+              <div className="mt-2 rounded-lg bg-destructive/10 px-3 py-2 text-sm text-destructive break-words whitespace-pre-wrap">
                 {detail.error}
               </div>
             )}

--- a/turbo/apps/platform/src/views/zero-page/zero-app-shell.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-app-shell.tsx
@@ -26,6 +26,7 @@ import {
   zeroSessionId$,
   zeroChatAgentId$,
   zeroChatAgentName$,
+  zeroTalkAgentResolved$,
   setZeroActiveId$,
   setZeroChatAgent$,
   navigateToZeroSession$,
@@ -312,7 +313,8 @@ export function ZeroAppShell({ initialJobAgent }: ZeroAppShellProps) {
 
   // When visiting /zero/talk/:name, wait for the agent to be resolved
   const talkAgentName = useGet(zeroChatAgentName$);
-  const talkAgentReady = !talkAgentName || currentChatAgentId !== null;
+  const talkAgentResolved = useGet(zeroTalkAgentResolved$);
+  const talkAgentReady = !talkAgentName || talkAgentResolved;
 
   const { recentSessions, recentSessionsLoading, recentSessionsError } =
     useSessionLifecycle(
@@ -394,6 +396,7 @@ export function ZeroAppShell({ initialJobAgent }: ZeroAppShellProps) {
       <ZeroSidebar
         activeId={activeId}
         agentName={agentDisplayName}
+        defaultAgentRawName={defaultRawName}
         zeroAvatarSrc={zeroAvatarSrc}
         subagents={subagents}
         currentChatAgentId={currentChatAgentId}

--- a/turbo/apps/platform/src/views/zero-page/zero-app-shell.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-app-shell.tsx
@@ -38,7 +38,6 @@ import {
   zeroSessionListLoading$,
   zeroSessionListError$,
   zeroChatThreadId$,
-  fetchZeroSessionList$,
   switchZeroSession$,
   startNewZeroSession$,
   sendZeroChatMessage$,
@@ -150,38 +149,10 @@ function useSkeletonVisibility(isLoggedIn: boolean, dataReady: boolean) {
  * Manages session lifecycle: fetches session list when onboarding completes,
  * and auto-sends an introductory message for new users.
  */
-function useSessionLifecycle(
-  isLoggedIn: boolean,
-  onboardingReady: boolean,
-  needsOnboarding: boolean,
-  talkAgentReady: boolean,
-) {
+function useSessionLifecycle() {
   const recentSessions = useGet(zeroSessionList$);
   const recentSessionsLoading = useGet(zeroSessionListLoading$);
   const recentSessionsError = useGet(zeroSessionListError$);
-  const fetchSessionList = useSet(fetchZeroSessionList$);
-  // "init" → "onboarding" → "ready" lifecycle
-  const lifecycleRef$ = useCCState<"init" | "onboarding" | "ready">("init");
-  const lifecycle = useGet(lifecycleRef$);
-  const setLifecycle = useSet(lifecycleRef$);
-
-  if (isLoggedIn && onboardingReady && talkAgentReady) {
-    if (needsOnboarding && lifecycle === "init") {
-      queueMicrotask(() => setLifecycle("onboarding"));
-    } else if (!needsOnboarding && lifecycle !== "ready") {
-      const wasOnboarding = lifecycle === "onboarding";
-      queueMicrotask(() => {
-        setLifecycle("ready");
-        // Skip fetching sessions right after onboarding — the onboarding
-        // handler already navigates to chat and sends the intro message,
-        // which will create the first session.
-        if (!wasOnboarding) {
-          detach(fetchSessionList(), Reason.DomCallback);
-        }
-      });
-    }
-  }
-
   return { recentSessions, recentSessionsLoading, recentSessionsError };
 }
 
@@ -317,12 +288,7 @@ export function ZeroAppShell({ initialJobAgent }: ZeroAppShellProps) {
   const talkAgentReady = !talkAgentName || talkAgentResolved;
 
   const { recentSessions, recentSessionsLoading, recentSessionsError } =
-    useSessionLifecycle(
-      isLoggedIn,
-      onboardingReady,
-      needsOnboarding,
-      talkAgentReady,
-    );
+    useSessionLifecycle();
 
   // Sync URL thread ID to chat signal (skip if signal already matches)
   useUrlSessionSync(urlSessionId, currentThreadId, switchSession);
@@ -331,19 +297,16 @@ export function ZeroAppShell({ initialJobAgent }: ZeroAppShellProps) {
     set(navigateToZeroSession$, sessionId);
   });
   const handleRecentSelect = useSet(handleRecentSelect$);
+  const navigate = useSet(updatePathname$);
 
-  const fetchSessionList = useSet(fetchZeroSessionList$);
   const handleNewChat = (agent: { id: string; name: string } | null) => {
-    // Set agent in-memory first, so fetchZeroSessionList$ reads it
     setChatAgent(agent);
-    // Navigate to the correct URL
+    startNewSession();
     if (agent) {
       navigate(`/zero/talk/${encodeURIComponent(agent.name)}`);
     } else {
       setActiveId("chat");
     }
-    startNewSession();
-    detach(fetchSessionList(), Reason.DomCallback);
   };
 
   const handleSendFromDemo$ = useCommand(

--- a/turbo/apps/platform/src/views/zero-page/zero-app-shell.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-app-shell.tsx
@@ -25,6 +25,7 @@ import {
   zeroInChat$,
   zeroSessionId$,
   zeroChatAgentId$,
+  zeroChatAgentName$,
   setZeroActiveId$,
   setZeroChatAgent$,
   navigateToZeroSession$,
@@ -372,7 +373,11 @@ export function ZeroAppShell({ initialJobAgent }: ZeroAppShellProps) {
   const sidebarCollapsed = useGet(sidebarCollapsed$);
   const setSidebarCollapsed = useSet(sidebarCollapsed$);
 
-  const dataReady = isLoggedIn && onboardingReady && agentNameReady;
+  // When visiting /zero/talk/:name, wait for the agent to be resolved
+  const talkAgentName = useGet(zeroChatAgentName$);
+  const talkAgentReady = !talkAgentName || currentChatAgentId !== null;
+  const dataReady =
+    isLoggedIn && onboardingReady && agentNameReady && talkAgentReady;
   const showSkeleton = useSkeletonVisibility(isLoggedIn, dataReady);
 
   return (

--- a/turbo/apps/platform/src/views/zero-page/zero-app-shell.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-app-shell.tsx
@@ -158,28 +158,25 @@ function useSessionLifecycle() {
 /**
  * Sync URL session ID to the chat signal, avoiding redundant switches.
  */
+/** Track the last URL session ID we dispatched a switch for. */
+const lastDispatchedId: { current: string | null } = { current: null };
+
 function useUrlSessionSync(
   urlSessionId: string | null,
   currentSessionId: string | null,
   switchSession: (id: string) => Promise<void>,
 ) {
-  const prevUrlSessionId$ = useCCState<string | null>(null);
-  const prevUrlSessionId = useGet(prevUrlSessionId$);
-  const setPrevUrlSessionId = useSet(prevUrlSessionId$);
-
   if (
     urlSessionId &&
-    urlSessionId !== prevUrlSessionId &&
+    urlSessionId !== lastDispatchedId.current &&
     urlSessionId !== currentSessionId
   ) {
+    lastDispatchedId.current = urlSessionId;
     queueMicrotask(() => {
-      setPrevUrlSessionId(urlSessionId);
       detach(switchSession(urlSessionId), Reason.DomCallback);
     });
-  } else if (urlSessionId && urlSessionId !== prevUrlSessionId) {
-    queueMicrotask(() => setPrevUrlSessionId(urlSessionId));
-  } else if (!urlSessionId && prevUrlSessionId) {
-    queueMicrotask(() => setPrevUrlSessionId(null));
+  } else if (!urlSessionId) {
+    lastDispatchedId.current = null;
   }
 }
 

--- a/turbo/apps/platform/src/views/zero-page/zero-app-shell.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-app-shell.tsx
@@ -158,25 +158,25 @@ function useSessionLifecycle() {
 /**
  * Sync URL session ID to the chat signal, avoiding redundant switches.
  */
-/** Track the last URL session ID we dispatched a switch for. */
-const lastDispatchedId: { current: string | null } = { current: null };
-
 function useUrlSessionSync(
   urlSessionId: string | null,
   currentSessionId: string | null,
   switchSession: (id: string) => Promise<void>,
 ) {
+  const lastDispatched$ = useCCState<string | null>(null);
+  const lastDispatched = useGet(lastDispatched$);
+  const setLastDispatched = useSet(lastDispatched$);
   if (
     urlSessionId &&
-    urlSessionId !== lastDispatchedId.current &&
+    urlSessionId !== lastDispatched &&
     urlSessionId !== currentSessionId
   ) {
-    lastDispatchedId.current = urlSessionId;
+    setLastDispatched(urlSessionId);
     queueMicrotask(() => {
       detach(switchSession(urlSessionId), Reason.DomCallback);
     });
   } else if (!urlSessionId) {
-    lastDispatchedId.current = null;
+    setLastDispatched(null);
   }
 }
 

--- a/turbo/apps/platform/src/views/zero-page/zero-app-shell.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-app-shell.tsx
@@ -26,7 +26,7 @@ import {
   zeroSessionId$,
   zeroChatAgentId$,
   setZeroActiveId$,
-  setZeroChatAgentId$,
+  setZeroChatAgent$,
   navigateToZeroSession$,
   navigateFromZeroSession$,
 } from "../../signals/zero-page/zero-nav.ts";
@@ -277,7 +277,7 @@ export function ZeroAppShell({ initialJobAgent }: ZeroAppShellProps) {
         }))
       : [];
   const currentChatAgentId = useGet(zeroChatAgentId$);
-  const setChatAgentId = useSet(setZeroChatAgentId$);
+  const setChatAgent = useSet(setZeroChatAgent$);
 
   const activeId = useGet(zeroActiveId$);
   const setActiveId = useSet(setZeroActiveId$);
@@ -320,10 +320,15 @@ export function ZeroAppShell({ initialJobAgent }: ZeroAppShellProps) {
   const handleRecentSelect = useSet(handleRecentSelect$);
 
   const fetchSessionList = useSet(fetchZeroSessionList$);
-  const handleNewChat = (agentId: string | null) => {
-    setActiveId("chat");
-    // Persist agent selection to localStorage first, so fetchZeroSessionList$ reads it
-    setChatAgentId(agentId);
+  const handleNewChat = (agent: { id: string; name: string } | null) => {
+    // Set agent in-memory first, so fetchZeroSessionList$ reads it
+    setChatAgent(agent);
+    // Navigate to the correct URL
+    if (agent) {
+      navigate(`/zero/talk/${encodeURIComponent(agent.name)}`);
+    } else {
+      setActiveId("chat");
+    }
     startNewSession();
     detach(fetchSessionList(), Reason.DomCallback);
   };

--- a/turbo/apps/platform/src/views/zero-page/zero-app-shell.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-app-shell.tsx
@@ -28,7 +28,6 @@ import {
   zeroChatAgentName$,
   zeroTalkAgentResolved$,
   setZeroActiveId$,
-  setZeroChatAgent$,
   navigateToZeroSession$,
   navigateFromZeroSession$,
 } from "../../signals/zero-page/zero-nav.ts";
@@ -249,6 +248,7 @@ function useContentNavigation(resolvedAgentName: string | null) {
 
   return {
     navigate,
+    navigateInReact,
     handleNavigateToSchedule,
     handleNavigateToMeet,
     handleChatAvatarClick,
@@ -309,7 +309,6 @@ export function ZeroAppShell({ initialJobAgent }: ZeroAppShellProps) {
     subagents,
   } = useZeroLoadables();
   const currentChatAgentId = useGet(zeroChatAgentId$);
-  const setChatAgent = useSet(setZeroChatAgent$);
 
   const activeId = useGet(zeroActiveId$);
   const avatarIndex$ = useCCState(0);
@@ -352,7 +351,7 @@ export function ZeroAppShell({ initialJobAgent }: ZeroAppShellProps) {
 
   const resolvedAgentName = selectedSubagent?.name ?? defaultRawName;
   const {
-    navigate,
+    navigateInReact,
     handleNavigateToSchedule,
     handleNavigateToMeet,
     handleChatAvatarClick,
@@ -364,12 +363,16 @@ export function ZeroAppShell({ initialJobAgent }: ZeroAppShellProps) {
   const handleRecentSelect = useSet(handleRecentSelect$);
 
   const handleNewChat = (agent: { id: string; name: string } | null) => {
-    setChatAgent(agent);
     startNewSession();
-    const target = agent
-      ? `/zero/talk/${encodeURIComponent(agent.name)}`
-      : "/zero";
-    navigate(target);
+    // navigateInReact triggers loadRoute$ → setupZeroPage$ → resolveAndSwitchAgent
+    // which sets the agent and fetches the session list.
+    if (agent) {
+      navigateInReact("/zero/talk/:name", {
+        pathParams: { name: agent.name },
+      });
+    } else {
+      navigateInReact("/zero");
+    }
   };
 
   const handleSendFromDemo$ = useCommand(

--- a/turbo/apps/platform/src/views/zero-page/zero-app-shell.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-app-shell.tsx
@@ -216,21 +216,53 @@ function GuestNavBar({ onAbout }: { onAbout: () => void }) {
   );
 }
 
-interface ZeroAppShellProps {
-  initialJobAgent?: string | null;
+function useContentNavigation(resolvedAgentName: string | null) {
+  const navigate = useSet(updatePathname$);
+  const navigateInReact = useSet(navigateInReact$);
+
+  const handleNavigateToSchedule = () => {
+    if (resolvedAgentName) {
+      navigateInReact("/zero/team/:name", {
+        pathParams: { name: resolvedAgentName },
+        searchParams: new URLSearchParams({ tab: "schedule" }),
+      });
+    }
+  };
+
+  const handleNavigateToMeet = (tab?: string) => {
+    if (resolvedAgentName) {
+      const searchParams = tab ? new URLSearchParams({ tab }) : undefined;
+      navigateInReact("/zero/team/:name", {
+        pathParams: { name: resolvedAgentName },
+        searchParams,
+      });
+    }
+  };
+
+  const handleChatAvatarClick = () => {
+    if (resolvedAgentName) {
+      navigateInReact("/zero/team/:name", {
+        pathParams: { name: resolvedAgentName },
+      });
+    }
+  };
+
+  return {
+    navigate,
+    handleNavigateToSchedule,
+    handleNavigateToMeet,
+    handleChatAvatarClick,
+  };
 }
 
-export function ZeroAppShell({ initialJobAgent }: ZeroAppShellProps) {
+function useZeroLoadables() {
   const userLoadable = useLoadable(user$);
   const isLoggedIn =
     userLoadable.state === "hasData" && userLoadable.data !== undefined;
-  // useLastLoadable keeps the previous value during re-fetches (e.g. Clerk
-  // session touch), preventing the onboarding dialog from unmounting.
   const onboardingLoadable = useLastLoadable(zeroNeedsOnboarding$);
   const onboardingReady = onboardingLoadable.state === "hasData";
   const needsOnboarding =
     onboardingLoadable.state === "hasData" && onboardingLoadable.data === true;
-  const showOnboarding = isLoggedIn && needsOnboarding;
   const agentDisplayNameLoadable = useLastLoadable(agentDisplayName$);
   const agentNameReady = agentDisplayNameLoadable.state === "hasData";
   const agentDisplayName = agentNameReady
@@ -250,11 +282,36 @@ export function ZeroAppShell({ initialJobAgent }: ZeroAppShellProps) {
           displayName: a.displayName,
         }))
       : [];
+  return {
+    isLoggedIn,
+    onboardingReady,
+    needsOnboarding,
+    showOnboarding: isLoggedIn && needsOnboarding,
+    agentNameReady,
+    agentDisplayName,
+    defaultRawName,
+    subagents,
+  };
+}
+
+interface ZeroAppShellProps {
+  initialJobAgent?: string | null;
+}
+
+export function ZeroAppShell({ initialJobAgent }: ZeroAppShellProps) {
+  const {
+    isLoggedIn,
+    onboardingReady,
+    showOnboarding,
+    agentNameReady,
+    agentDisplayName,
+    defaultRawName,
+    subagents,
+  } = useZeroLoadables();
   const currentChatAgentId = useGet(zeroChatAgentId$);
   const setChatAgent = useSet(setZeroChatAgent$);
 
   const activeId = useGet(zeroActiveId$);
-  const setActiveId = useSet(setZeroActiveId$);
   const avatarIndex$ = useCCState(0);
   const avatarIndex = useGet(avatarIndex$);
   const setAvatarIndex = useSet(avatarIndex$);
@@ -293,20 +350,26 @@ export function ZeroAppShell({ initialJobAgent }: ZeroAppShellProps) {
   // Sync URL thread ID to chat signal (skip if signal already matches)
   useUrlSessionSync(urlSessionId, currentThreadId, switchSession);
 
+  const resolvedAgentName = selectedSubagent?.name ?? defaultRawName;
+  const {
+    navigate,
+    handleNavigateToSchedule,
+    handleNavigateToMeet,
+    handleChatAvatarClick,
+  } = useContentNavigation(resolvedAgentName);
+
   const handleRecentSelect$ = useCommand(({ set }, sessionId: string) => {
     set(navigateToZeroSession$, sessionId);
   });
   const handleRecentSelect = useSet(handleRecentSelect$);
-  const navigate = useSet(updatePathname$);
 
   const handleNewChat = (agent: { id: string; name: string } | null) => {
     setChatAgent(agent);
     startNewSession();
-    if (agent) {
-      navigate(`/zero/talk/${encodeURIComponent(agent.name)}`);
-    } else {
-      setActiveId("chat");
-    }
+    const target = agent
+      ? `/zero/talk/${encodeURIComponent(agent.name)}`
+      : "/zero";
+    navigate(target);
   };
 
   const handleSendFromDemo$ = useCommand(
@@ -341,7 +404,6 @@ export function ZeroAppShell({ initialJobAgent }: ZeroAppShellProps) {
   );
   const handleAccountAction = useSet(handleAccountAction$);
 
-  const navigateInReact = useSet(navigateInReact$);
   const resetDefaultAgent = useSet(resetDefaultAgent$);
 
   const sidebarCollapsed$ = useCCState(false);
@@ -386,39 +448,13 @@ export function ZeroAppShell({ initialJobAgent }: ZeroAppShellProps) {
             inSession={inSession}
             onSendMessage={handleSendFromDemo}
             selectedAgentName={initialJobAgent}
-            onNavigateToSchedule={() => {
-              const agentName = selectedSubagent?.name ?? defaultRawName;
-              if (agentName) {
-                navigateInReact("/zero/team/:name", {
-                  pathParams: { name: agentName },
-                  searchParams: new URLSearchParams({ tab: "schedule" }),
-                });
-              }
-            }}
-            onNavigateToMeet={(tab) => {
-              const agentName = selectedSubagent?.name ?? defaultRawName;
-              if (agentName) {
-                const searchParams = tab
-                  ? new URLSearchParams({ tab })
-                  : undefined;
-                navigateInReact("/zero/team/:name", {
-                  pathParams: { name: agentName },
-                  searchParams,
-                });
-              }
-            }}
+            onNavigateToSchedule={handleNavigateToSchedule}
+            onNavigateToMeet={handleNavigateToMeet}
             onBackFromSession={handleBackFromSession}
             zeroAvatarSrc={zeroAvatarSrc}
             chatAgentName={chatAgentName}
             chatAvatarSrc={chatAvatarSrc}
-            onChatAvatarClick={() => {
-              const agentName = selectedSubagent?.name ?? defaultRawName;
-              if (agentName) {
-                navigateInReact("/zero/team/:name", {
-                  pathParams: { name: agentName },
-                });
-              }
-            }}
+            onChatAvatarClick={handleChatAvatarClick}
             onCycleZeroAvatar={cycleZeroAvatar}
           />
         )}

--- a/turbo/apps/platform/src/views/zero-page/zero-app-shell.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-app-shell.tsx
@@ -153,6 +153,7 @@ function useSessionLifecycle(
   isLoggedIn: boolean,
   onboardingReady: boolean,
   needsOnboarding: boolean,
+  talkAgentReady: boolean,
 ) {
   const recentSessions = useGet(zeroSessionList$);
   const recentSessionsLoading = useGet(zeroSessionListLoading$);
@@ -163,7 +164,7 @@ function useSessionLifecycle(
   const lifecycle = useGet(lifecycleRef$);
   const setLifecycle = useSet(lifecycleRef$);
 
-  if (isLoggedIn && onboardingReady) {
+  if (isLoggedIn && onboardingReady && talkAgentReady) {
     if (needsOnboarding && lifecycle === "init") {
       queueMicrotask(() => setLifecycle("onboarding"));
     } else if (!needsOnboarding && lifecycle !== "ready") {
@@ -309,8 +310,17 @@ export function ZeroAppShell({ initialJobAgent }: ZeroAppShellProps) {
   const startNewSession = useSet(startNewZeroSession$);
   const sendMessage = useSet(sendZeroChatMessage$);
 
+  // When visiting /zero/talk/:name, wait for the agent to be resolved
+  const talkAgentName = useGet(zeroChatAgentName$);
+  const talkAgentReady = !talkAgentName || currentChatAgentId !== null;
+
   const { recentSessions, recentSessionsLoading, recentSessionsError } =
-    useSessionLifecycle(isLoggedIn, onboardingReady, needsOnboarding);
+    useSessionLifecycle(
+      isLoggedIn,
+      onboardingReady,
+      needsOnboarding,
+      talkAgentReady,
+    );
 
   // Sync URL thread ID to chat signal (skip if signal already matches)
   useUrlSessionSync(urlSessionId, currentThreadId, switchSession);
@@ -373,9 +383,6 @@ export function ZeroAppShell({ initialJobAgent }: ZeroAppShellProps) {
   const sidebarCollapsed = useGet(sidebarCollapsed$);
   const setSidebarCollapsed = useSet(sidebarCollapsed$);
 
-  // When visiting /zero/talk/:name, wait for the agent to be resolved
-  const talkAgentName = useGet(zeroChatAgentName$);
-  const talkAgentReady = !talkAgentName || currentChatAgentId !== null;
   const dataReady =
     isLoggedIn && onboardingReady && agentNameReady && talkAgentReady;
   const showSkeleton = useSkeletonVisibility(isLoggedIn, dataReady);

--- a/turbo/apps/platform/src/views/zero-page/zero-session-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-session-chat-page.tsx
@@ -619,6 +619,7 @@ function AssistantMessage({ message, zeroAvatarSrc }: AssistantMessageProps) {
           <RunActivityLine />
         </div>
       </div>
+      {logButton}
     </div>
   );
 }

--- a/turbo/apps/platform/src/views/zero-page/zero-session-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-session-chat-page.tsx
@@ -585,8 +585,8 @@ function AssistantMessage({ message, zeroAvatarSrc }: AssistantMessageProps) {
         <div className="grid grid-cols-[48px_1fr] gap-3 items-start">
           {avatar}
           <div className="zero-chat-bubble-assistant rounded-xl border backdrop-blur-sm px-4 py-4 text-sm leading-relaxed min-w-0 break-words overflow-hidden">
-            <div className="flex items-center gap-2 text-destructive">
-              <IconAlertCircle size={16} className="shrink-0" />
+            <div className="flex items-start gap-2 text-destructive">
+              <IconAlertCircle size={16} className="shrink-0 mt-[3px]" />
               <span>{message.error}</span>
             </div>
           </div>

--- a/turbo/apps/platform/src/views/zero-page/zero-session-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-session-chat-page.tsx
@@ -585,8 +585,8 @@ function AssistantMessage({ message, zeroAvatarSrc }: AssistantMessageProps) {
         <div className="grid grid-cols-[48px_1fr] gap-3 items-start">
           {avatar}
           <div className="zero-chat-bubble-assistant rounded-xl border backdrop-blur-sm px-4 py-4 text-sm leading-relaxed min-w-0 break-words overflow-hidden">
-            <div className="flex items-start gap-1.5 text-destructive">
-              <IconAlertCircle size={14} className="shrink-0 mt-0.5" />
+            <div className="flex items-center gap-2 text-destructive">
+              <IconAlertCircle size={16} className="shrink-0" />
               <span>{message.error}</span>
             </div>
           </div>

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -981,7 +981,9 @@ export function ZeroSidebar({
                     : undefined
                 }
                 className={`flex w-full h-8 items-center gap-2 rounded-lg px-2 text-left text-sm leading-5 no-underline transition-colors duration-200 ${
-                  activeId === "chat" && currentChatAgentId === null
+                  activeId === "chat" &&
+                  !selectedRecentId &&
+                  currentChatAgentId === null
                     ? "bg-sidebar-active text-sidebar-primary font-medium"
                     : "text-sidebar-foreground hover:bg-sidebar-accent"
                 }`}
@@ -999,7 +1001,9 @@ export function ZeroSidebar({
                   pathname="/zero/talk/:name"
                   options={{ pathParams: { name: agent.name } }}
                   className={`flex w-full h-8 items-center gap-2 rounded-lg px-2 text-left text-sm leading-5 no-underline transition-colors duration-200 ${
-                    activeId === "chat" && currentChatAgentId === agent.id
+                    activeId === "chat" &&
+                    !selectedRecentId &&
+                    currentChatAgentId === agent.id
                       ? "bg-sidebar-active text-sidebar-primary font-medium"
                       : "text-sidebar-foreground hover:bg-sidebar-accent"
                   }`}

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -971,14 +971,20 @@ export function ZeroSidebar({
               </span>
             </div>
             <div className="flex flex-col gap-0.5">
-              <button
-                type="button"
-                className={`flex w-full h-8 items-center gap-2 rounded-lg px-2 text-left text-sm leading-5 transition-colors duration-200 ${
+              <Link
+                pathname="/zero"
+                onClick={(e) => {
+                  if (e.metaKey || e.ctrlKey || e.shiftKey) {
+                    return;
+                  }
+                  e.preventDefault();
+                  onNewChat?.(null);
+                }}
+                className={`flex w-full h-8 items-center gap-2 rounded-lg px-2 text-left text-sm leading-5 no-underline transition-colors duration-200 ${
                   activeId === "chat" && currentChatAgentId === null
                     ? "bg-sidebar-active text-sidebar-primary font-medium"
                     : "text-sidebar-foreground hover:bg-sidebar-accent"
                 }`}
-                onClick={() => onNewChat?.(null)}
               >
                 <img
                   src={zeroAvatarSrc}
@@ -986,19 +992,24 @@ export function ZeroSidebar({
                   className="h-5 w-5 shrink-0 rounded-md object-cover object-top"
                 />
                 <span className="truncate">{displayName}</span>
-              </button>
+              </Link>
               {pinnedAgents.map((agent) => (
-                <button
+                <Link
                   key={agent.id}
-                  type="button"
-                  className={`flex w-full h-8 items-center gap-2 rounded-lg px-2 text-left text-sm leading-5 transition-colors duration-200 ${
+                  pathname="/zero/talk/:name"
+                  options={{ pathParams: { name: agent.name } }}
+                  onClick={(e) => {
+                    if (e.metaKey || e.ctrlKey || e.shiftKey) {
+                      return;
+                    }
+                    e.preventDefault();
+                    onNewChat?.({ id: agent.id, name: agent.name });
+                  }}
+                  className={`flex w-full h-8 items-center gap-2 rounded-lg px-2 text-left text-sm leading-5 no-underline transition-colors duration-200 ${
                     activeId === "chat" && currentChatAgentId === agent.id
                       ? "bg-sidebar-active text-sidebar-primary font-medium"
                       : "text-sidebar-foreground hover:bg-sidebar-accent"
                   }`}
-                  onClick={() =>
-                    onNewChat?.({ id: agent.id, name: agent.name })
-                  }
                 >
                   <AgentAvatarImg
                     name={agent.name}
@@ -1008,7 +1019,7 @@ export function ZeroSidebar({
                   <span className="truncate">
                     {agent.displayName ?? agent.name}
                   </span>
-                </button>
+                </Link>
               ))}
               <button
                 type="button"

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -162,6 +162,7 @@ interface SessionAccount {
 interface ZeroSidebarProps {
   activeId: ZeroNavId;
   agentName?: string | null;
+  defaultAgentRawName?: string | null;
   zeroAvatarSrc?: string;
   subagents?: SubagentInfo[];
   currentChatAgentId?: string | null;
@@ -784,6 +785,7 @@ function ManagePinnedAgentsDialog({
 export function ZeroSidebar({
   activeId,
   agentName,
+  defaultAgentRawName,
   zeroAvatarSrc = "/zero-avatar.png",
   subagents = [],
   currentChatAgentId = null,
@@ -972,7 +974,12 @@ export function ZeroSidebar({
             </div>
             <div className="flex flex-col gap-0.5">
               <Link
-                pathname="/zero"
+                pathname={defaultAgentRawName ? "/zero/talk/:name" : "/zero"}
+                options={
+                  defaultAgentRawName
+                    ? { pathParams: { name: defaultAgentRawName } }
+                    : undefined
+                }
                 className={`flex w-full h-8 items-center gap-2 rounded-lg px-2 text-left text-sm leading-5 no-underline transition-colors duration-200 ${
                   activeId === "chat" && currentChatAgentId === null
                     ? "bg-sidebar-active text-sidebar-primary font-medium"

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -507,7 +507,7 @@ function RecentChatSection({
       )}
       <div className="flex-1 min-h-0 overflow-y-auto overflow-x-hidden">
         <div className="flex flex-col gap-1">
-          {recentSessionsLoading ? (
+          {recentSessionsLoading && recentSessions.length === 0 ? (
             <div className="flex items-center justify-center py-3">
               <IconLoader2
                 size={14}

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -174,7 +174,7 @@ interface ZeroSidebarProps {
   recentSessions?: ChatThreadListItem[];
   recentSessionsLoading?: boolean;
   recentSessionsError?: string | null;
-  onNewChat?: (agentId: string | null) => void;
+  onNewChat?: (agent: { id: string; name: string } | null) => void;
   onResetAgent?: () => void;
 }
 
@@ -996,7 +996,9 @@ export function ZeroSidebar({
                       ? "bg-sidebar-active text-sidebar-primary font-medium"
                       : "text-sidebar-foreground hover:bg-sidebar-accent"
                   }`}
-                  onClick={() => onNewChat?.(agent.id)}
+                  onClick={() =>
+                    onNewChat?.({ id: agent.id, name: agent.name })
+                  }
                 >
                   <AgentAvatarImg
                     name={agent.name}

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -973,13 +973,6 @@ export function ZeroSidebar({
             <div className="flex flex-col gap-0.5">
               <Link
                 pathname="/zero"
-                onClick={(e) => {
-                  if (e.metaKey || e.ctrlKey || e.shiftKey) {
-                    return;
-                  }
-                  e.preventDefault();
-                  onNewChat?.(null);
-                }}
                 className={`flex w-full h-8 items-center gap-2 rounded-lg px-2 text-left text-sm leading-5 no-underline transition-colors duration-200 ${
                   activeId === "chat" && currentChatAgentId === null
                     ? "bg-sidebar-active text-sidebar-primary font-medium"
@@ -998,13 +991,6 @@ export function ZeroSidebar({
                   key={agent.id}
                   pathname="/zero/talk/:name"
                   options={{ pathParams: { name: agent.name } }}
-                  onClick={(e) => {
-                    if (e.metaKey || e.ctrlKey || e.shiftKey) {
-                      return;
-                    }
-                    e.preventDefault();
-                    onNewChat?.({ id: agent.id, name: agent.name });
-                  }}
                   className={`flex w-full h-8 items-center gap-2 rounded-lg px-2 text-left text-sm leading-5 no-underline transition-colors duration-200 ${
                     activeId === "chat" && currentChatAgentId === agent.id
                       ? "bg-sidebar-active text-sidebar-primary font-medium"

--- a/turbo/apps/web/app/api/chat-threads/[id]/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/chat-threads/[id]/__tests__/route.test.ts
@@ -75,8 +75,7 @@ describe("GET /api/chat-threads/:id - Get Thread Detail", () => {
     expect(data.agentComposeId).toBe(testComposeId);
     expect(data.chatMessages).toEqual([]);
     expect(data.latestSessionId).toBeNull();
-    expect(data.activeRunId).toBeNull();
-    expect(data.activeRunPrompt).toBeNull();
+    expect(data.unsavedRuns).toEqual([]);
     expect(data.createdAt).toBeDefined();
     expect(data.updatedAt).toBeDefined();
   });

--- a/turbo/apps/web/app/api/chat-threads/[id]/route.ts
+++ b/turbo/apps/web/app/api/chat-threads/[id]/route.ts
@@ -24,8 +24,15 @@ const router = tsr.router(chatThreadByIdContract, {
 
     try {
       const thread = await getChatThread(params.id, userId);
-      const { chatMessages, latestSessionId, activeRunId, activeRunPrompt } =
-        await getChatThreadMessages(params.id, userId);
+      const {
+        chatMessages,
+        latestSessionId,
+        activeRunId,
+        activeRunPrompt,
+        failedRunId,
+        failedRunPrompt,
+        failedRunError,
+      } = await getChatThreadMessages(params.id, userId);
 
       return {
         status: 200 as const,
@@ -37,6 +44,9 @@ const router = tsr.router(chatThreadByIdContract, {
           latestSessionId,
           activeRunId,
           activeRunPrompt,
+          failedRunId,
+          failedRunPrompt,
+          failedRunError,
           createdAt: thread.createdAt.toISOString(),
           updatedAt: thread.updatedAt.toISOString(),
         },

--- a/turbo/apps/web/app/api/chat-threads/[id]/route.ts
+++ b/turbo/apps/web/app/api/chat-threads/[id]/route.ts
@@ -24,15 +24,8 @@ const router = tsr.router(chatThreadByIdContract, {
 
     try {
       const thread = await getChatThread(params.id, userId);
-      const {
-        chatMessages,
-        latestSessionId,
-        activeRunId,
-        activeRunPrompt,
-        failedRunId,
-        failedRunPrompt,
-        failedRunError,
-      } = await getChatThreadMessages(params.id, userId);
+      const { chatMessages, latestSessionId, unsavedRuns } =
+        await getChatThreadMessages(params.id, userId);
 
       return {
         status: 200 as const,
@@ -42,11 +35,7 @@ const router = tsr.router(chatThreadByIdContract, {
           agentComposeId: thread.agentComposeId,
           chatMessages,
           latestSessionId,
-          activeRunId,
-          activeRunPrompt,
-          failedRunId,
-          failedRunPrompt,
-          failedRunError,
+          unsavedRuns,
           createdAt: thread.createdAt.toISOString(),
           updatedAt: thread.updatedAt.toISOString(),
         },

--- a/turbo/apps/web/src/lib/chat-thread/chat-thread-service.ts
+++ b/turbo/apps/web/src/lib/chat-thread/chat-thread-service.ts
@@ -152,6 +152,17 @@ const TERMINAL_STATUSES = new Set([
   "cancelled",
 ]);
 
+/**
+ * Represents a run whose messages are not persisted in the session yet.
+ * The frontend uses these to reconstruct the full conversation on refresh.
+ */
+interface UnsavedRun {
+  runId: string;
+  status: string;
+  prompt: string;
+  error: string | null;
+}
+
 export async function getChatThreadMessages(
   threadId: string,
   userId: string,
@@ -163,13 +174,10 @@ export async function getChatThreadMessages(
     createdAt: string;
   }>;
   latestSessionId: string | null;
-  activeRunId: string | null;
-  activeRunPrompt: string | null;
-  failedRunId: string | null;
-  failedRunPrompt: string | null;
-  failedRunError: string | null;
+  /** Runs not yet reflected in chatMessages (active, failed, etc.) */
+  unsavedRuns: UnsavedRun[];
 }> {
-  // Get all runs for this thread, ordered by creation time desc
+  // Get all runs for this thread, ordered by creation time ASC (chronological)
   const runs = await globalThis.services.db
     .select({
       runId: agentRuns.id,
@@ -178,76 +186,66 @@ export async function getChatThreadMessages(
       error: agentRuns.error,
       result: agentRuns.result,
       continuedFromSessionId: agentRuns.continuedFromSessionId,
+      createdAt: agentRuns.createdAt,
     })
     .from(chatThreadRuns)
     .innerJoin(agentRuns, eq(chatThreadRuns.runId, agentRuns.id))
     .where(eq(chatThreadRuns.chatThreadId, threadId))
-    .orderBy(desc(chatThreadRuns.createdAt));
+    .orderBy(chatThreadRuns.createdAt);
 
-  // Find active run, failed run (latest), and session ID
   let sessionId: string | null = null;
-  let activeRunId: string | null = null;
-  let activeRunPrompt: string | null = null;
-  let failedRunId: string | null = null;
-  let failedRunPrompt: string | null = null;
-  let failedRunError: string | null = null;
+  const savedRunIds = new Set<string>();
 
   for (const run of runs) {
-    if (!TERMINAL_STATUSES.has(run.status) && !activeRunId) {
-      activeRunId = run.runId;
-      activeRunPrompt = run.prompt;
-    }
-    // Capture the most recent failed run
-    if (run.status === "failed" && !failedRunId) {
-      failedRunId = run.runId;
-      failedRunPrompt = run.prompt;
-      failedRunError = run.error;
-    }
-    if (!sessionId && hasAgentSessionId(run.result)) {
+    if (hasAgentSessionId(run.result)) {
       sessionId = run.result.agentSessionId;
+      savedRunIds.add(run.runId);
     }
     if (!sessionId && run.continuedFromSessionId) {
       sessionId = run.continuedFromSessionId;
     }
   }
 
-  if (!sessionId) {
-    return {
-      chatMessages: [],
-      latestSessionId: null,
-      activeRunId,
-      activeRunPrompt,
-      failedRunId,
-      failedRunPrompt,
-      failedRunError,
-    };
-  }
-
   // Load messages from the session
-  const [session] = await globalThis.services.db
-    .select({ chatMessages: agentSessions.chatMessages })
-    .from(agentSessions)
-    .where(
-      and(eq(agentSessions.id, sessionId), eq(agentSessions.userId, userId)),
-    )
-    .limit(1);
-
   type StoredMessage = {
     role: "user" | "assistant";
     content: string;
     runId?: string;
     createdAt: string;
   };
+  let messages: StoredMessage[] = [];
 
-  const messages = (session?.chatMessages ?? []) as StoredMessage[];
+  if (sessionId) {
+    const [session] = await globalThis.services.db
+      .select({ chatMessages: agentSessions.chatMessages })
+      .from(agentSessions)
+      .where(
+        and(eq(agentSessions.id, sessionId), eq(agentSessions.userId, userId)),
+      )
+      .limit(1);
+    messages = (session?.chatMessages ?? []) as StoredMessage[];
+
+    // Mark runs that have messages in the session
+    for (const msg of messages) {
+      if (msg.runId) {
+        savedRunIds.add(msg.runId);
+      }
+    }
+  }
+
+  // Collect runs not reflected in chatMessages (active, failed, pending, etc.)
+  const unsavedRuns: UnsavedRun[] = runs
+    .filter((r) => !savedRunIds.has(r.runId))
+    .map((r) => ({
+      runId: r.runId,
+      status: r.status,
+      prompt: r.prompt,
+      error: r.error,
+    }));
 
   return {
     chatMessages: messages,
     latestSessionId: sessionId,
-    activeRunId,
-    activeRunPrompt,
-    failedRunId,
-    failedRunPrompt,
-    failedRunError,
+    unsavedRuns,
   };
 }

--- a/turbo/apps/web/src/lib/chat-thread/chat-thread-service.ts
+++ b/turbo/apps/web/src/lib/chat-thread/chat-thread-service.ts
@@ -165,6 +165,9 @@ export async function getChatThreadMessages(
   latestSessionId: string | null;
   activeRunId: string | null;
   activeRunPrompt: string | null;
+  failedRunId: string | null;
+  failedRunPrompt: string | null;
+  failedRunError: string | null;
 }> {
   // Get all runs for this thread, ordered by creation time desc
   const runs = await globalThis.services.db
@@ -172,6 +175,7 @@ export async function getChatThreadMessages(
       runId: agentRuns.id,
       status: agentRuns.status,
       prompt: agentRuns.prompt,
+      error: agentRuns.error,
       result: agentRuns.result,
       continuedFromSessionId: agentRuns.continuedFromSessionId,
     })
@@ -180,15 +184,24 @@ export async function getChatThreadMessages(
     .where(eq(chatThreadRuns.chatThreadId, threadId))
     .orderBy(desc(chatThreadRuns.createdAt));
 
-  // Find the active (non-terminal) run and the latest sessionId
+  // Find active run, failed run (latest), and session ID
   let sessionId: string | null = null;
   let activeRunId: string | null = null;
   let activeRunPrompt: string | null = null;
+  let failedRunId: string | null = null;
+  let failedRunPrompt: string | null = null;
+  let failedRunError: string | null = null;
 
   for (const run of runs) {
     if (!TERMINAL_STATUSES.has(run.status) && !activeRunId) {
       activeRunId = run.runId;
       activeRunPrompt = run.prompt;
+    }
+    // Capture the most recent failed run
+    if (run.status === "failed" && !failedRunId) {
+      failedRunId = run.runId;
+      failedRunPrompt = run.prompt;
+      failedRunError = run.error;
     }
     if (!sessionId && hasAgentSessionId(run.result)) {
       sessionId = run.result.agentSessionId;
@@ -204,6 +217,9 @@ export async function getChatThreadMessages(
       latestSessionId: null,
       activeRunId,
       activeRunPrompt,
+      failedRunId,
+      failedRunPrompt,
+      failedRunError,
     };
   }
 
@@ -230,5 +246,8 @@ export async function getChatThreadMessages(
     latestSessionId: sessionId,
     activeRunId,
     activeRunPrompt,
+    failedRunId,
+    failedRunPrompt,
+    failedRunError,
   };
 }

--- a/turbo/apps/web/src/lib/chat-thread/chat-thread-service.ts
+++ b/turbo/apps/web/src/lib/chat-thread/chat-thread-service.ts
@@ -142,17 +142,6 @@ function hasAgentSessionId(
 }
 
 /**
- * Get chat messages for a thread by finding the associated session.
- * Resolves: thread → runs → latest completed run → agentSessionId → chatMessages
- */
-const TERMINAL_STATUSES = new Set([
-  "completed",
-  "failed",
-  "timeout",
-  "cancelled",
-]);
-
-/**
  * Represents a run whose messages are not persisted in the session yet.
  * The frontend uses these to reconstruct the full conversation on refresh.
  */

--- a/turbo/packages/core/src/contracts/chat-threads.ts
+++ b/turbo/packages/core/src/contracts/chat-threads.ts
@@ -19,17 +19,20 @@ const storedChatMessageSchema = z.object({
   createdAt: z.string(),
 });
 
+const unsavedRunSchema = z.object({
+  runId: z.string(),
+  status: z.string(),
+  prompt: z.string(),
+  error: z.string().nullable(),
+});
+
 const chatThreadDetailSchema = z.object({
   id: z.string(),
   title: z.string().nullable(),
   agentComposeId: z.string(),
   chatMessages: z.array(storedChatMessageSchema),
   latestSessionId: z.string().nullable(),
-  activeRunId: z.string().nullable(),
-  activeRunPrompt: z.string().nullable(),
-  failedRunId: z.string().nullable(),
-  failedRunPrompt: z.string().nullable(),
-  failedRunError: z.string().nullable(),
+  unsavedRuns: z.array(unsavedRunSchema),
   createdAt: z.string(),
   updatedAt: z.string(),
 });

--- a/turbo/packages/core/src/contracts/chat-threads.ts
+++ b/turbo/packages/core/src/contracts/chat-threads.ts
@@ -27,6 +27,9 @@ const chatThreadDetailSchema = z.object({
   latestSessionId: z.string().nullable(),
   activeRunId: z.string().nullable(),
   activeRunPrompt: z.string().nullable(),
+  failedRunId: z.string().nullable(),
+  failedRunPrompt: z.string().nullable(),
+  failedRunError: z.string().nullable(),
   createdAt: z.string(),
   updatedAt: z.string(),
 });


### PR DESCRIPTION
## Summary

- Add `/zero/talk/:name` route for deep-linking to agent-specific chats
- Replace localStorage-based chat agent tracking with in-memory state for cleaner lifecycle management
- Update back-navigation from sessions to return to `/zero/talk/:name` when a team agent was selected

## Test plan

- [ ] Navigate to `/zero/talk/<agent-name>` and verify the correct agent is selected
- [ ] Start a new chat with an agent from the sidebar and verify URL updates to `/zero/talk/<name>`
- [ ] Navigate back from a session and verify it returns to the correct talk route
- [ ] Chat with the default agent and verify navigation stays at `/zero`
- [ ] Verify agent selection resets when navigating to `/zero` directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)