### PR TITLE
fix: {param+} path matching should require one or more segments

### DIFF
--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -143,7 +143,9 @@ def match_path(path: str, pattern: str) -> dict | None:
         if seg.startswith("{") and seg.endswith("}"):
             name = seg[1:-1]
             if name.endswith("+"):
-                # Greedy: consume rest of path (zero or more segments)
+                # Greedy: consume rest of path (one or more segments)
+                if pi >= len(path_segs):
+                    return None
                 params[name[:-1]] = "/".join(path_segs[pi:])
                 return params
             # Single segment

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -131,7 +131,7 @@ def match_path(path: str, pattern: str) -> dict | None:
 
     - Literal segments must match exactly.
     - {name} matches a single non-empty path segment.
-    - {name+} matches the rest of the path (zero or more segments). Must be last.
+    - {name+} matches the rest of the path (one or more segments). Must be last.
     """
     path_segs = [s for s in path.split("/") if s]
     pattern_segs = [s for s in pattern.split("/") if s]

--- a/crates/runner/mitm-addon/tests/test_connectors.py
+++ b/crates/runner/mitm-addon/tests/test_connectors.py
@@ -61,9 +61,9 @@ class TestMatchPath:
         result = mitm_addon.match_path("/foo", "/{path+}")
         assert result == {"path": "foo"}
 
-    def test_greedy_param_matches_empty(self):
+    def test_greedy_param_rejects_empty(self):
         result = mitm_addon.match_path("/", "/{path+}")
-        assert result == {"path": ""}
+        assert result is None
 
     def test_greedy_after_literal(self):
         result = mitm_addon.match_path("/api/v1/anything/here", "/api/v1/{rest+}")


### PR DESCRIPTION
## Summary

`{param+}` in firewall rule patterns was matching zero path segments, which is inconsistent with the `+` suffix semantics (one or more, not zero or more).

### Before
```
Rule: ANY /{path+}
GET /          → match (path="")     ← wrong
GET /foo       → match (path="foo")
GET /foo/bar   → match
```

### After
```
Rule: ANY /{path+}
GET /          → no match            ← correct
GET /foo       → match (path="foo")
GET /foo/bar   → match
```

## Test plan

- [x] Unit tests pass (82/82)
- [ ] E2E firewall tests pass

Closes #5108

🤖 Generated with [Claude Code](https://claude.com/claude-code)