### PR TITLE
feat(docs): add documentation for experimental_capabilities in vm0.yaml

### DIFF
--- a/turbo/apps/docs/content/docs/core-concept/capabilities.mdx
+++ b/turbo/apps/docs/content/docs/core-concept/capabilities.mdx
@@ -5,6 +5,10 @@ description: Control sandbox API access permissions for agents
 
 Capabilities control what API endpoints an agent can access from within its sandbox. By default, sandboxed agents cannot call the VM0 API. Adding capabilities grants specific permissions following the principle of least privilege.
 
+<Callout type="warn">
+Capabilities are currently an experimental feature. The field name and available capabilities may change in future versions.
+</Callout>
+
 ## How Capabilities Work
 
 1. **Define in `vm0.yaml`** - List the capabilities your agent needs under `experimental_capabilities`
@@ -37,9 +41,11 @@ If a request lacks the required capability, the API returns a `403 Forbidden` re
 
 All capabilities follow the `{resource}:{action}` format where action is either `read` or `write`.
 
+[Artifacts](/docs/core-concept/artifact) and [memories](/docs/core-concept/memory) are both runtime dynamic resources, so they share the `artifact:*` capability. Similarly, agent composes and [volumes](/docs/core-concept/volume) are agent static resources sharing the `agent:*` capability.
+
 ## Configuration
 
-Add capabilities to your agent in `vm0.yaml`:
+Add capabilities to your agent in [`vm0.yaml`](/docs/reference/configuration/vm0-yaml):
 
 ```yaml
 version: "1.0"
@@ -111,5 +117,5 @@ Older capability names are automatically normalized to their current equivalents
 | `memory:write` | `artifact:write` |
 
 <Callout type="info">
-Deprecated aliases work at runtime but should not be used in `vm0.yaml`. Use the current capability names in your configuration.
+These aliases still work in `vm0.yaml` for backward compatibility, but new configurations should use the current names listed above.
 </Callout>

--- a/turbo/apps/docs/content/docs/core-concept/capabilities.mdx
+++ b/turbo/apps/docs/content/docs/core-concept/capabilities.mdx
@@ -1,0 +1,115 @@
+---
+title: Capabilities
+description: Control sandbox API access permissions for agents
+---
+
+Capabilities control what API endpoints an agent can access from within its sandbox. By default, sandboxed agents cannot call the VM0 API. Adding capabilities grants specific permissions following the principle of least privilege.
+
+## How Capabilities Work
+
+1. **Define in `vm0.yaml`** - List the capabilities your agent needs under `experimental_capabilities`
+2. **Embedded in JWT** - When a run starts, capabilities are embedded in the sandbox token
+3. **Enforced per request** - Each API call from the sandbox is checked against the token's capabilities
+
+If a request lacks the required capability, the API returns a `403 Forbidden` response:
+
+```json
+{
+  "error": {
+    "message": "Missing required capability: artifact:read",
+    "code": "FORBIDDEN"
+  }
+}
+```
+
+## Available Capabilities
+
+| Capability | Category | Description |
+|------------|----------|-------------|
+| `agent:read` | Agent resources | Read agent composes and volumes |
+| `agent:write` | Agent resources | Create, update, and delete agent composes and volumes |
+| `artifact:read` | Runtime resources | Read artifacts and memories |
+| `artifact:write` | Runtime resources | Write artifacts and memories |
+| `agent-run:read` | Operational | List and view agent runs |
+| `agent-run:write` | Operational | Create and cancel agent runs |
+| `schedule:read` | Operational | List and view schedules |
+| `schedule:write` | Operational | Create, update, enable, and disable schedules |
+
+All capabilities follow the `{resource}:{action}` format where action is either `read` or `write`.
+
+## Configuration
+
+Add capabilities to your agent in `vm0.yaml`:
+
+```yaml
+version: "1.0"
+
+agents:
+  my-agent:
+    framework: claude-code
+    instructions: AGENTS.md
+    experimental_capabilities:
+      - artifact:read
+      - artifact:write
+    environment:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+```
+
+<Callout type="warn">
+Only the first agent's capabilities are used. This follows the current single-agent limitation of `vm0.yaml`.
+</Callout>
+
+## Example Configurations
+
+### Read-only access to artifacts
+
+An agent that reads artifacts but cannot modify them:
+
+```yaml
+experimental_capabilities:
+  - artifact:read
+```
+
+### Orchestrating sub-agents
+
+An agent that triggers and monitors other agent runs:
+
+```yaml
+experimental_capabilities:
+  - agent:read
+  - agent-run:read
+  - agent-run:write
+```
+
+### Full access
+
+An agent that needs complete API access:
+
+```yaml
+experimental_capabilities:
+  - agent:read
+  - agent:write
+  - artifact:read
+  - artifact:write
+  - agent-run:read
+  - agent-run:write
+  - schedule:read
+  - schedule:write
+```
+
+## Deprecated Aliases
+
+Older capability names are automatically normalized to their current equivalents:
+
+| Deprecated | Current |
+|------------|---------|
+| `storage:read` | `artifact:read` |
+| `storage:write` | `artifact:write` |
+| `volume:read` | `agent:read` |
+| `volume:write` | `agent:write` |
+| `memory:read` | `artifact:read` |
+| `memory:write` | `artifact:write` |
+
+<Callout type="info">
+Deprecated aliases work at runtime but should not be used in `vm0.yaml`. Use the current capability names in your configuration.
+</Callout>

--- a/turbo/apps/docs/content/docs/core-concept/meta.json
+++ b/turbo/apps/docs/content/docs/core-concept/meta.json
@@ -7,6 +7,7 @@
     "volume",
     "artifact",
     "memory",
-    "environment-variable"
+    "environment-variable",
+    "capabilities"
   ]
 }

--- a/turbo/apps/docs/content/docs/reference/configuration/vm0-yaml.mdx
+++ b/turbo/apps/docs/content/docs/reference/configuration/vm0-yaml.mdx
@@ -74,7 +74,7 @@ Each agent key must be a valid agent name: 3-64 characters, starting and ending 
 | `skills`                 | array  | No       | `[]`           | List of skill references. Supports bare names (e.g., `"slack"`) which resolve to `https://github.com/vm0-ai/vm0-skills/tree/main/slack`, or full GitHub URLs. See [Skills](/docs/core-concept/skills) |
 | `volumes`                | array  | No       | `[]`           | Volume mounts in format `name:path`. See [Volume](/docs/core-concept/volume)                      |
 | `environment`            | object | No       | `{}`           | Environment variables. See [Environment Variables](/docs/core-concept/environment-variable)       |
-| `experimental_capabilities` | array | No    | -              | Sandbox API access permissions. See [Capabilities](/docs/core-concept/capabilities)                       |
+| `experimental_capabilities` | array  | No       | `[]`           | Sandbox API access permissions. See [Capabilities](/docs/core-concept/capabilities)                       |
 | `experimental_runner`    | object | No       | -              | Self-hosted runner configuration. Object with `group` field in `org/name` format (e.g., `acme/production`) |
 
 ## Volume Fields

--- a/turbo/apps/docs/content/docs/reference/configuration/vm0-yaml.mdx
+++ b/turbo/apps/docs/content/docs/reference/configuration/vm0-yaml.mdx
@@ -33,6 +33,9 @@ agents:
       - https://github.com/vm0-ai/vm0-skills/tree/main/hackernews
     volumes:
       - my-volume:/home/user/.config
+    experimental_capabilities:
+      - artifact:read
+      - artifact:write
     environment:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
       MY_VAR: ${{ vars.MY_VAR }}
@@ -71,6 +74,7 @@ Each agent key must be a valid agent name: 3-64 characters, starting and ending 
 | `skills`                 | array  | No       | `[]`           | List of skill references. Supports bare names (e.g., `"slack"`) which resolve to `https://github.com/vm0-ai/vm0-skills/tree/main/slack`, or full GitHub URLs. See [Skills](/docs/core-concept/skills) |
 | `volumes`                | array  | No       | `[]`           | Volume mounts in format `name:path`. See [Volume](/docs/core-concept/volume)                      |
 | `environment`            | object | No       | `{}`           | Environment variables. See [Environment Variables](/docs/core-concept/environment-variable)       |
+| `experimental_capabilities` | array | No    | -              | Sandbox API access permissions. See [Capabilities](/docs/core-concept/capabilities)                       |
 | `experimental_runner`    | object | No       | -              | Self-hosted runner configuration. Object with `group` field in `org/name` format (e.g., `acme/production`) |
 
 ## Volume Fields


### PR DESCRIPTION
## Summary

- Add new Core Concept page (`capabilities.mdx`) documenting sandbox API access permissions
- Update `vm0-yaml.mdx` reference to include `experimental_capabilities` in Agent Fields table and Full Example
- Add `capabilities` to Core Concept navigation in `meta.json`

## Details

Documents the 8 available capabilities (`agent:read/write`, `artifact:read/write`, `agent-run:read/write`, `schedule:read/write`), configuration examples, deprecated aliases, and how the capability enforcement flow works (YAML → JWT → API).

Closes #5104

## Test plan

- [ ] Verify docs build succeeds
- [ ] Check capabilities page renders correctly at `/docs/core-concept/capabilities`
- [ ] Verify navigation includes new page in Core Concept section
- [ ] Confirm vm0-yaml reference page shows updated Agent Fields table

🤖 Generated with [Claude Code](https://claude.com/claude-code)