### PR TITLE
fix: add missing linear oauth scopes and force consent prompt

### DIFF
--- a/turbo/apps/web/src/lib/connector/providers/linear.ts
+++ b/turbo/apps/web/src/lib/connector/providers/linear.ts
@@ -45,6 +45,7 @@ export function buildLinearAuthorizationUrl(
     scope: oauthConfig.scopes.join(","),
     state,
     actor: "user",
+    prompt: "consent",
   });
 
   return `${oauthConfig.authorizationUrl}?${params.toString()}`;

--- a/turbo/packages/core/src/contracts/connectors.ts
+++ b/turbo/packages/core/src/contracts/connectors.ts
@@ -694,7 +694,13 @@ const CONNECTOR_TYPES_DEF = {
     oauth: {
       authorizationUrl: "https://linear.app/oauth/authorize",
       tokenUrl: "https://api.linear.app/oauth/token",
-      scopes: ["read", "write"],
+      scopes: [
+        "read",
+        "write",
+        "issues:create",
+        "comments:create",
+        "timeSchedule:write",
+      ],
       environmentMapping: {
         LINEAR_TOKEN: "$secrets.LINEAR_ACCESS_TOKEN",
       },


### PR DESCRIPTION
## Summary
- Add `issues:create`, `comments:create`, and `timeSchedule:write` scopes to the Linear connector OAuth configuration
- Add `prompt: "consent"` parameter to the Linear authorization URL to ensure users re-authorize with the expanded permissions

## Test plan
- [ ] Verify Linear OAuth flow triggers consent screen on re-authorization
- [ ] Confirm new scopes are included in the authorization request
- [ ] Test that existing Linear integrations prompt for expanded permissions

🤖 Generated with [Claude Code](https://claude.com/claude-code)