### PR TITLE
feat: support {param*} wildcard for zero-or-more path segments

### DIFF
--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -132,6 +132,7 @@ def match_path(path: str, pattern: str) -> dict | None:
     - Literal segments must match exactly.
     - {name} matches a single non-empty path segment.
     - {name+} matches the rest of the path (one or more segments). Must be last.
+    - {name*} matches the rest of the path (zero or more segments). Must be last.
     """
     path_segs = [s for s in path.split("/") if s]
     pattern_segs = [s for s in pattern.split("/") if s]
@@ -146,6 +147,10 @@ def match_path(path: str, pattern: str) -> dict | None:
                 # Greedy: consume rest of path (one or more segments)
                 if pi >= len(path_segs):
                     return None
+                params[name[:-1]] = "/".join(path_segs[pi:])
+                return params
+            if name.endswith("*"):
+                # Greedy: consume rest of path (zero or more segments)
                 params[name[:-1]] = "/".join(path_segs[pi:])
                 return params
             # Single segment

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -140,6 +140,8 @@ def match_path(path: str, pattern: str) -> dict | None:
     params: dict[str, str] = {}
     pi = 0
 
+    # Note: greedy params ({name+}, {name*}) must be the last segment.
+    # This invariant is enforced at compose time by validateRule() in firewall-expander.ts.
     for seg in pattern_segs:
         if seg.startswith("{") and seg.endswith("}"):
             name = seg[1:-1]

--- a/crates/runner/mitm-addon/tests/test_connectors.py
+++ b/crates/runner/mitm-addon/tests/test_connectors.py
@@ -69,6 +69,26 @@ class TestMatchPath:
         result = mitm_addon.match_path("/api/v1/anything/here", "/api/v1/{rest+}")
         assert result == {"rest": "anything/here"}
 
+    def test_star_param_matches_rest(self):
+        result = mitm_addon.match_path("/repos/octocat/hello-world", "/{path*}")
+        assert result == {"path": "repos/octocat/hello-world"}
+
+    def test_star_param_matches_single_segment(self):
+        result = mitm_addon.match_path("/foo", "/{path*}")
+        assert result == {"path": "foo"}
+
+    def test_star_param_matches_empty(self):
+        result = mitm_addon.match_path("/", "/{path*}")
+        assert result == {"path": ""}
+
+    def test_star_after_literal(self):
+        result = mitm_addon.match_path("/api/v1/anything/here", "/api/v1/{rest*}")
+        assert result == {"rest": "anything/here"}
+
+    def test_star_after_literal_empty(self):
+        result = mitm_addon.match_path("/api/v1", "/api/v1/{rest*}")
+        assert result == {"rest": ""}
+
     def test_path_too_short(self):
         assert mitm_addon.match_path("/repos", "/repos/{owner}/{repo}") is None
 

--- a/turbo/packages/core/src/contracts/__tests__/firewall-expander.test.ts
+++ b/turbo/packages/core/src/contracts/__tests__/firewall-expander.test.ts
@@ -330,6 +330,19 @@ describe("validateRule", () => {
     ).not.toThrow();
   });
 
+  it("should accept {param*} in last segment", () => {
+    expect(() => validateRule("ANY /{path*}", "p", "fw")).not.toThrow();
+    expect(() =>
+      validateRule("GET /repos/{owner}/{path*}", "p", "fw"),
+    ).not.toThrow();
+  });
+
+  it("should reject {param*} not in last segment", () => {
+    expect(() =>
+      validateRule("GET /foo/{path*}/bar", "read", "github"),
+    ).toThrow("{path*} must be the last segment");
+  });
+
   it("should reject duplicate parameter names", () => {
     expect(() => validateRule("GET /repos/{owner}/{owner}", "p", "fw")).toThrow(
       'duplicate parameter name "{owner}"',

--- a/turbo/packages/core/src/contracts/__tests__/firewall-expander.test.ts
+++ b/turbo/packages/core/src/contracts/__tests__/firewall-expander.test.ts
@@ -360,6 +360,12 @@ describe("validateRule", () => {
       "empty parameter name",
     );
   });
+
+  it("should reject empty star parameter name", () => {
+    expect(() => validateRule("GET /repos/{*}", "p", "fw")).toThrow(
+      "empty parameter name",
+    );
+  });
 });
 
 describe("validateBaseUrl", () => {

--- a/turbo/packages/core/src/contracts/firewall-expander.ts
+++ b/turbo/packages/core/src/contracts/firewall-expander.ts
@@ -49,7 +49,8 @@ export function validateRule(
     const seg = segments[i]!;
     if (seg.startsWith("{") && seg.endsWith("}")) {
       const name = seg.slice(1, -1);
-      const baseName = name.endsWith("+") ? name.slice(0, -1) : name;
+      const isGreedy = name.endsWith("+") || name.endsWith("*");
+      const baseName = isGreedy ? name.slice(0, -1) : name;
       if (!baseName) {
         throw new Error(
           `Invalid rule "${rule}" in permission "${permName}" of firewall "${serviceName}": empty parameter name`,
@@ -61,7 +62,7 @@ export function validateRule(
         );
       }
       paramNames.add(baseName);
-      if (name.endsWith("+") && i !== segments.length - 1) {
+      if (isGreedy && i !== segments.length - 1) {
         throw new Error(
           `Invalid rule "${rule}" in permission "${permName}" of firewall "${serviceName}": {${name}} must be the last segment`,
         );


### PR DESCRIPTION
## Summary

Add `{param*}` wildcard alongside existing `{param+}` in firewall rule path matching:

| Pattern | Semantics | Match `/` | Match `/foo` | Match `/foo/bar` |
|---------|-----------|-----------|--------------|------------------|
| `{path+}` | One or more | No | Yes | Yes |
| `{path*}` | Zero or more | Yes | Yes | Yes |

### Changes

- `mitm_addon.py` `match_path()` — add `{param*}` support
- `firewall-expander.ts` `validateRule()` — accept `{param*}` syntax
- Tests added in both Python and TypeScript

### Note

`FULL_ACCESS_PERMISSION` rules currently use `ANY /{path+}`. After this PR, they can be migrated to `ANY /{path*}` to correctly match the base URL root.

## Test plan

- [x] Python unit tests pass (54/54)
- [x] TypeScript unit tests pass (31/31)
- [ ] CI passes

Closes #5113

🤖 Generated with [Claude Code](https://claude.com/claude-code)