### PR TITLE
refactor: consolidate org resolution into single function

### DIFF
--- a/turbo/apps/web/app/api/org/invite/route.ts
+++ b/turbo/apps/web/app/api/org/invite/route.ts
@@ -2,9 +2,10 @@ import { NextResponse } from "next/server";
 import { z } from "zod";
 import { initServices } from "../../../../src/lib/init-services";
 import { getAuthContext } from "../../../../src/lib/auth/get-user-id";
-import { requireOrgFromRequest } from "../../../../src/lib/org/resolve-org";
+import { resolveOrg } from "../../../../src/lib/org/resolve-org";
 import { inviteMember } from "../../../../src/lib/org/org-member-service";
 import {
+  badRequest,
   isBadRequest,
   isNotFound,
   isForbidden,
@@ -40,7 +41,9 @@ export async function POST(request: Request) {
   const body = parseResult.data;
 
   try {
-    const { org, member } = await requireOrgFromRequest(request, userId);
+    const orgSlug = new URL(request.url).searchParams.get("org");
+    if (!orgSlug) throw badRequest("org query parameter is required");
+    const { org, member } = await resolveOrg(userId, orgSlug);
     await inviteMember(userId, org.orgId, member.role, body.email);
     return NextResponse.json({ message: `Invitation sent to ${body.email}` });
   } catch (error) {

--- a/turbo/apps/web/app/api/org/leave/route.ts
+++ b/turbo/apps/web/app/api/org/leave/route.ts
@@ -1,9 +1,10 @@
 import { NextResponse } from "next/server";
 import { initServices } from "../../../../src/lib/init-services";
 import { getAuthContext } from "../../../../src/lib/auth/get-user-id";
-import { requireOrgFromRequest } from "../../../../src/lib/org/resolve-org";
+import { resolveOrg } from "../../../../src/lib/org/resolve-org";
 import { leaveOrg } from "../../../../src/lib/org/org-member-service";
 import {
+  badRequest,
   isBadRequest,
   isNotFound,
   isForbidden,
@@ -26,7 +27,9 @@ export async function POST(request: Request) {
   const { userId } = authCtx;
 
   try {
-    const { org, member } = await requireOrgFromRequest(request, userId);
+    const orgSlug = new URL(request.url).searchParams.get("org");
+    if (!orgSlug) throw badRequest("org query parameter is required");
+    const { org, member } = await resolveOrg(userId, orgSlug);
     await leaveOrg(userId, org.orgId, member.role);
     return NextResponse.json({ message: "Left org" });
   } catch (error) {

--- a/turbo/apps/web/app/api/org/members/route.ts
+++ b/turbo/apps/web/app/api/org/members/route.ts
@@ -2,12 +2,13 @@ import { NextResponse } from "next/server";
 import { z } from "zod";
 import { initServices } from "../../../../src/lib/init-services";
 import { getAuthContext } from "../../../../src/lib/auth/get-user-id";
-import { requireOrgFromRequest } from "../../../../src/lib/org/resolve-org";
+import { resolveOrg } from "../../../../src/lib/org/resolve-org";
 import {
   getOrgMembers,
   removeMember,
 } from "../../../../src/lib/org/org-member-service";
 import {
+  badRequest,
   isBadRequest,
   isNotFound,
   isForbidden,
@@ -32,7 +33,9 @@ export async function GET(request: Request) {
   const { userId } = authCtx;
 
   try {
-    const { org } = await requireOrgFromRequest(request, userId);
+    const orgSlug = new URL(request.url).searchParams.get("org");
+    if (!orgSlug) throw badRequest("org query parameter is required");
+    const { org } = await resolveOrg(userId, orgSlug);
     const status = await getOrgMembers(userId, org.orgId, org.slug);
     return NextResponse.json(status);
   } catch (error) {
@@ -86,7 +89,9 @@ export async function DELETE(request: Request) {
   const body = parseResult.data;
 
   try {
-    const { org, member } = await requireOrgFromRequest(request, userId);
+    const orgSlug = new URL(request.url).searchParams.get("org");
+    if (!orgSlug) throw badRequest("org query parameter is required");
+    const { org, member } = await resolveOrg(userId, orgSlug);
     await removeMember(userId, org.orgId, member.role, body.email);
     return NextResponse.json({
       message: `Removed ${body.email} from org`,

--- a/turbo/apps/web/src/lib/org/__tests__/resolve-org.test.ts
+++ b/turbo/apps/web/src/lib/org/__tests__/resolve-org.test.ts
@@ -6,7 +6,7 @@ import {
   insertOrgMembersCacheEntry,
 } from "../../../__tests__/api-test-helpers";
 import { mockClerk } from "../../../__tests__/clerk-mock";
-import { resolveOrg, requireOrgFromRequest } from "../resolve-org";
+import { resolveOrg } from "../resolve-org";
 
 const context = testContext();
 
@@ -399,84 +399,5 @@ describe("resolveOrg", () => {
 
     expect(result.org.orgId).toBe(`org_mock_${slug1}`);
     expect(result.org.slug).toBe(slug1);
-  });
-});
-
-describe("requireOrgFromRequest", () => {
-  beforeEach(() => {
-    context.setupMocks();
-  });
-
-  it("resolves org via ?org= param", async () => {
-    const userId = uniqueId("test-user");
-    const slug = uniqueId("org");
-
-    // Set up Clerk org BEFORE creating org
-    mockClerk({ userId, clerkOrgs: testOrgs(slug) });
-    await createTestOrg(slug);
-
-    mockClerk({
-      userId,
-      orgId: `org_mock_${slug}`,
-      clerkOrgs: testOrgs(slug),
-    });
-
-    const request = new Request(
-      `http://localhost/api/test?org=org_mock_${slug}`,
-    );
-    const result = await requireOrgFromRequest(request, userId);
-
-    expect(result.org.orgId).toBe(`org_mock_${slug}`);
-    expect(result.org.slug).toBe(slug);
-  });
-
-  it("resolves org via ?org= slug param", async () => {
-    const userId = uniqueId("test-user");
-    const slug1 = uniqueId("org");
-
-    // createTestOrg derives orgId from auth().userId → org_mock_${userId}
-    const expectedOrgId = `org_mock_${userId}`;
-
-    // Set up Clerk org BEFORE creating org — use matching orgId
-    mockClerk({
-      userId,
-      clerkOrgs: [{ id: expectedOrgId, slug: slug1, name: slug1 }],
-    });
-    await createTestOrg(slug1);
-
-    mockClerk({
-      userId,
-      orgId: expectedOrgId,
-      clerkOrgs: [{ id: expectedOrgId, slug: slug1, name: slug1 }],
-    });
-
-    const request = new Request(`http://localhost/api/test?org=${slug1}`);
-    const result = await requireOrgFromRequest(request, userId);
-
-    expect(result.org.orgId).toBe(expectedOrgId);
-  });
-
-  it("throws 400 when ?org= not provided", async () => {
-    const userId = uniqueId("test-user");
-    mockClerk({ userId });
-
-    const request = new Request("http://localhost/api/test");
-
-    await expect(requireOrgFromRequest(request, userId)).rejects.toThrow(
-      "org query parameter is required",
-    );
-  });
-
-  it("throws 404 for non-existent ?org= value", async () => {
-    const userId = uniqueId("test-user");
-    mockClerk({ userId });
-
-    const request = new Request(
-      "http://localhost/api/test?org=org_nonexistent",
-    );
-
-    await expect(requireOrgFromRequest(request, userId)).rejects.toThrow(
-      "Org not found",
-    );
   });
 });

--- a/turbo/apps/web/src/lib/org/resolve-org.ts
+++ b/turbo/apps/web/src/lib/org/resolve-org.ts
@@ -1,12 +1,6 @@
 import { auth, clerkClient } from "@clerk/nextjs/server";
 import { eq, desc } from "drizzle-orm";
-import {
-  forbidden,
-  badRequest,
-  notFound,
-  isNotFound,
-  isForbidden,
-} from "../errors";
+import { forbidden, notFound, isNotFound, isForbidden } from "../errors";
 import { logger } from "../logger";
 import { orgMembersCache } from "../../db/schema/org-members-cache";
 import { getOrgBySlug, getOrgData } from "./org-cache-service";
@@ -272,35 +266,4 @@ export async function resolveCallerOrgId(
     if (isNotFound(error) || isForbidden(error)) return null;
     throw error;
   }
-}
-
-/**
- * Extract and validate org from a request's ?org= query parameter.
- * Throws if the param is missing, the org doesn't exist, or the user
- * is not a member.
- *
- * Use this in org routes that always require an explicit org parameter.
- */
-export async function requireOrgFromRequest(
-  request: Request,
-  userId: string,
-): Promise<{ org: ResolvedOrg; member: ResolvedMember }> {
-  const url = new URL(request.url);
-  const orgSlug = url.searchParams.get("org");
-
-  if (!orgSlug) {
-    throw badRequest("org query parameter is required");
-  }
-
-  // Try slug first, fall back to orgId (callers may pass either via ?org=)
-  const orgData =
-    (await getOrgBySlug(orgSlug)) ?? (await getOrgDataOrNull(orgSlug));
-
-  if (!orgData) {
-    throw notFound("Org not found");
-  }
-
-  const authResult = await auth();
-  const member = await verifyMembership(orgData, userId, authResult);
-  return { org: applyJwtTier(orgData, authResult), member };
 }

--- a/turbo/apps/web/src/lib/org/resolve-org.ts
+++ b/turbo/apps/web/src/lib/org/resolve-org.ts
@@ -1,6 +1,6 @@
 import { auth, clerkClient } from "@clerk/nextjs/server";
-import { eq, desc } from "drizzle-orm";
-import { forbidden, notFound, isNotFound, isForbidden } from "../errors";
+import { desc, eq } from "drizzle-orm";
+import { forbidden, isForbidden, isNotFound, notFound } from "../errors";
 import { logger } from "../logger";
 import { orgMembersCache } from "../../db/schema/org-members-cache";
 import { getOrgBySlug, getOrgData } from "./org-cache-service";


### PR DESCRIPTION
## Summary

- Remove `requireOrgFromRequest()` from `resolve-org.ts` — redundant after org resolution consolidation
- Replace 4 call sites in org management routes (`/api/org/invite`, `/api/org/leave`, `/api/org/members`) with inline `?org=` extraction + `resolveOrg()` calls
- Remove `requireOrgFromRequest` unit tests from `resolve-org.test.ts` (behavior is covered by existing route integration tests)

Closes #5112

## Test plan

- [x] All 17 org route integration tests pass (invite, leave, members, remove-member)
- [x] 11 of 15 resolve-org tests pass (4 pre-existing failures due to missing `send_mode` column — unrelated to this change)
- [x] TypeScript type check passes (web, cli)
- [x] ESLint + oxlint pass with 0 warnings
- [x] Knip finds no unused exports
- [x] Prettier formatting verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)