### PR TITLE
fix: add org-scoped filtering to run cancel endpoint

### DIFF
--- a/turbo/apps/web/app/api/agent/runs/[id]/cancel/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/cancel/__tests__/route.test.ts
@@ -5,11 +5,13 @@ import {
   createTestRequest,
   createTestCompose,
   createTestRun,
+  createTestRunInDb,
   createTestCallback,
   findTestQueueEntry,
   findTestRunRecord,
   findTestRunCallbacks,
   setTestRunStatus,
+  getOrgCacheEntry,
 } from "../../../../../../../src/__tests__/api-test-helpers";
 import { generateSandboxToken } from "../../../../../../../src/lib/auth/sandbox-token";
 import {
@@ -147,6 +149,55 @@ describe("POST /api/agent/runs/:id/cancel - Cancel Run", () => {
       // Verify callback was dispatched (status changed from "pending")
       const afterCallbacks = await findTestRunCallbacks(run.runId);
       expect(afterCallbacks[0]!.status).not.toBe("pending");
+    });
+  });
+
+  describe("Org-Scoped Filtering", () => {
+    it("should return 404 for run from a different org", async () => {
+      const otherOrg = await context.createAgentCompose(user.userId);
+      const { runId } = await createTestRunInDb(user.userId, otherOrg.id, {
+        status: "running",
+        prompt: "Other org run",
+      });
+
+      const request = createTestRequest(
+        `http://localhost:3000/api/agent/runs/${runId}/cancel`,
+        { method: "POST" },
+      );
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(404);
+      expect(data.error.code).toBe("NOT_FOUND");
+    });
+
+    it("should cancel run when switching to the correct org", async () => {
+      const otherOrg = await context.createAgentCompose(user.userId);
+      const { runId } = await createTestRunInDb(user.userId, otherOrg.id, {
+        status: "running",
+        prompt: "Other org run",
+      });
+
+      const orgEntry = await getOrgCacheEntry(otherOrg.orgId);
+      mockClerk({
+        userId: user.userId,
+        orgId: otherOrg.orgId,
+        orgSlug: orgEntry!.slug,
+        clerkOrgs: [
+          { id: otherOrg.orgId, slug: orgEntry!.slug, name: orgEntry!.slug },
+        ],
+      });
+
+      const request = createTestRequest(
+        `http://localhost:3000/api/agent/runs/${runId}/cancel?org=${orgEntry!.slug}`,
+        { method: "POST" },
+      );
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.id).toBe(runId);
+      expect(data.status).toBe("cancelled");
     });
   });
 

--- a/turbo/apps/web/app/api/agent/runs/[id]/cancel/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/cancel/route.ts
@@ -8,6 +8,7 @@ import {
   requireAuth,
   isAuthError,
 } from "../../../../../../src/lib/auth/require-auth";
+import { resolveOrg } from "../../../../../../src/lib/org/resolve-org";
 import { logger } from "../../../../../../src/lib/logger";
 import {
   transitionRunStatus,
@@ -20,7 +21,7 @@ import { after } from "next/server";
 const log = logger("api:runs:cancel");
 
 const router = tsr.router(runsCancelContract, {
-  cancel: async ({ params, headers }) => {
+  cancel: async ({ params, headers }, { request }) => {
     initServices();
 
     const authCtx = await requireAuth(headers.authorization, {
@@ -29,13 +30,22 @@ const router = tsr.router(runsCancelContract, {
     if (isAuthError(authCtx)) return authCtx;
     const { userId } = authCtx;
 
+    const orgSlug = new URL(request.url).searchParams.get("org");
+    const { org } = await resolveOrg(userId, orgSlug);
+
     const { id: runId } = params;
 
-    // Find the run
+    // Find the run - filter by userId and orgId for security
     const [run] = await globalThis.services.db
       .select()
       .from(agentRuns)
-      .where(and(eq(agentRuns.id, runId), eq(agentRuns.userId, userId)))
+      .where(
+        and(
+          eq(agentRuns.id, runId),
+          eq(agentRuns.userId, userId),
+          eq(agentRuns.orgId, org.orgId),
+        ),
+      )
       .limit(1);
 
     if (!run) {


### PR DESCRIPTION
## Summary

- Add `resolveOrg()` and `orgId` filter to the cancel endpoint query, preventing users from cancelling runs belonging to other organizations
- Add integration tests for cross-org isolation (404 for wrong org, success when switching to correct org)

Closes #5116

## Test plan

- [x] Existing cancel tests pass (13/13)
- [x] New org-scoped filtering tests pass
- [x] Lint passes
- [x] Type check passes (web)
- [x] Knip passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)