### PR TITLE
refactor: update vercel ai gateway to use anthropic/claude-sonnet-4.6

### DIFF
--- a/turbo/apps/web/src/lib/run/__tests__/create-run.test.ts
+++ b/turbo/apps/web/src/lib/run/__tests__/create-run.test.ts
@@ -739,8 +739,7 @@ describe("createRun()", () => {
         ANTHROPIC_AUTH_TOKEN: "test-gateway-key",
         ANTHROPIC_BASE_URL: "https://ai-gateway.vercel.sh",
         ANTHROPIC_API_KEY: "",
-        ANTHROPIC_MODEL: "moonshotai/kimi-k2.5",
-        ANTHROPIC_CUSTOM_HEADERS: "x-ai-gateway-providers-only: moonshot",
+        ANTHROPIC_MODEL: "anthropic/claude-sonnet-4.6",
       });
     });
   });

--- a/turbo/packages/core/src/contracts/model-providers.ts
+++ b/turbo/packages/core/src/contracts/model-providers.ts
@@ -174,8 +174,7 @@ export const MODEL_PROVIDER_TYPES = {
       ANTHROPIC_AUTH_TOKEN: "$secret",
       ANTHROPIC_BASE_URL: "https://ai-gateway.vercel.sh",
       ANTHROPIC_API_KEY: "",
-      ANTHROPIC_MODEL: "moonshotai/kimi-k2.5",
-      ANTHROPIC_CUSTOM_HEADERS: "x-ai-gateway-providers-only: moonshot",
+      ANTHROPIC_MODEL: "anthropic/claude-sonnet-4.6",
     } as Record<string, string>,
   },
   "azure-foundry": {


### PR DESCRIPTION
## Summary
- Remove `ANTHROPIC_CUSTOM_HEADERS: "x-ai-gateway-providers-only: moonshot"` from vercel-ai-gateway environment mapping
- Change `ANTHROPIC_MODEL` from `moonshotai/kimi-k2.5` to `anthropic/claude-sonnet-4.6`
- Update corresponding test expectations in create-run.test.ts

Closes #5119

## Test plan
- [x] All 38 existing tests in `create-run.test.ts` pass, including the Vercel AI Gateway env var injection test
- [x] Type check passes
- [x] Lint passes
- [x] Knip passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)