### PR TITLE
fix: capture response body and structured context in oauth error diagnostics

### DIFF
--- a/turbo/apps/web/src/lib/connector/connector-service.ts
+++ b/turbo/apps/web/src/lib/connector/connector-service.ts
@@ -565,7 +565,11 @@ export async function refreshConnectorAccessToken(
     return result.accessToken;
   } catch (err) {
     const message = err instanceof Error ? err.message : "Unknown error";
-    log.warn(`${connectorType} token refresh failed: ${message}`);
+    log.warn(`${connectorType} token refresh failed: ${message}`, {
+      connectorType,
+      orgId,
+      userId,
+    });
     return null;
   }
 }

--- a/turbo/apps/web/src/lib/connector/providers/__tests__/oauth-error.test.ts
+++ b/turbo/apps/web/src/lib/connector/providers/__tests__/oauth-error.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from "vitest";
+import { throwOAuthError } from "../oauth-error";
+
+function makeResponse(status: number, body: string): Response {
+  return new Response(body, { status, statusText: "Bad Request" });
+}
+
+describe("throwOAuthError", () => {
+  it("includes error and error_description from JSON response", async () => {
+    const response = makeResponse(
+      400,
+      JSON.stringify({
+        error: "invalid_grant",
+        error_description: "The refresh token is expired",
+      }),
+    );
+
+    await expect(
+      throwOAuthError("Notion", "refresh", response),
+    ).rejects.toThrow(
+      "Notion token refresh failed: 400 invalid_grant (The refresh token is expired)",
+    );
+  });
+
+  it("includes error code alone when no description", async () => {
+    const response = makeResponse(
+      401,
+      JSON.stringify({ error: "unauthorized_client" }),
+    );
+
+    await expect(
+      throwOAuthError("Figma", "exchange", response),
+    ).rejects.toThrow("Figma token exchange failed: 401 unauthorized_client");
+  });
+
+  it("includes raw text for non-JSON response", async () => {
+    const response = makeResponse(500, "Internal Server Error");
+
+    await expect(
+      throwOAuthError("GitHub", "exchange", response),
+    ).rejects.toThrow(
+      "GitHub token exchange failed: 500 Internal Server Error",
+    );
+  });
+
+  it("handles empty response body", async () => {
+    const response = makeResponse(502, "");
+
+    await expect(
+      throwOAuthError("Slack", "exchange", response),
+    ).rejects.toThrow("Slack token exchange failed: 502");
+  });
+
+  it("truncates long response bodies", async () => {
+    const longBody = "x".repeat(600);
+    const response = makeResponse(400, longBody);
+
+    const error = await throwOAuthError("Notion", "refresh", response).catch(
+      (e: Error) => e,
+    );
+
+    expect(error.message).toContain("Notion token refresh failed: 400 ");
+    expect(error.message).toMatch(/\.\.\.$/);
+    // 500 chars + "..." = truncated
+    const detail = error.message.replace(
+      "Notion token refresh failed: 400 ",
+      "",
+    );
+    expect(detail.length).toBeLessThanOrEqual(504); // 500 + "..."
+  });
+
+  it("includes full JSON body when no standard error fields", async () => {
+    const response = makeResponse(
+      400,
+      JSON.stringify({ message: "something went wrong", code: 123 }),
+    );
+
+    await expect(
+      throwOAuthError("Stripe", "refresh", response),
+    ).rejects.toThrow("Stripe token refresh failed: 400 ");
+  });
+});

--- a/turbo/apps/web/src/lib/connector/providers/ahrefs.ts
+++ b/turbo/apps/web/src/lib/connector/providers/ahrefs.ts
@@ -1,5 +1,6 @@
 import { getConnectorOAuthConfig } from "@vm0/core";
 import { z } from "zod";
+import { throwOAuthError } from "./oauth-error";
 
 const AHREFS_SUBSCRIPTION_URL =
   "https://api.ahrefs.com/v3/subscription-info/limits-and-usage";
@@ -77,7 +78,7 @@ export async function exchangeAhrefsCode(
   });
 
   if (!response.ok) {
-    throw new Error(`Ahrefs token exchange failed: ${response.status}`);
+    await throwOAuthError("Ahrefs", "exchange", response);
   }
 
   const data = z
@@ -139,7 +140,7 @@ export async function refreshAhrefsToken(
   });
 
   if (!response.ok) {
-    throw new Error(`Ahrefs token refresh failed: ${response.status}`);
+    await throwOAuthError("Ahrefs", "refresh", response);
   }
 
   const data = z

--- a/turbo/apps/web/src/lib/connector/providers/airtable.ts
+++ b/turbo/apps/web/src/lib/connector/providers/airtable.ts
@@ -1,5 +1,6 @@
 import { getConnectorOAuthConfig } from "@vm0/core";
 import { z } from "zod";
+import { throwOAuthError } from "./oauth-error";
 
 const AIRTABLE_WHOAMI_URL = "https://api.airtable.com/v0/meta/whoami";
 
@@ -118,7 +119,7 @@ export async function exchangeAirtableCode(
   });
 
   if (!response.ok) {
-    throw new Error(`Airtable token exchange failed: ${response.status}`);
+    await throwOAuthError("Airtable", "exchange", response);
   }
 
   const data = z
@@ -181,7 +182,7 @@ export async function refreshAirtableToken(
   });
 
   if (!response.ok) {
-    throw new Error(`Airtable token refresh failed: ${response.status}`);
+    await throwOAuthError("Airtable", "refresh", response);
   }
 
   const data = z

--- a/turbo/apps/web/src/lib/connector/providers/asana.ts
+++ b/turbo/apps/web/src/lib/connector/providers/asana.ts
@@ -1,5 +1,6 @@
 import { getConnectorOAuthConfig } from "@vm0/core";
 import { z } from "zod";
+import { throwOAuthError } from "./oauth-error";
 
 const ASANA_USER_URL = "https://app.asana.com/api/1.0/users/me";
 
@@ -74,7 +75,7 @@ export async function exchangeAsanaCode(
   });
 
   if (!response.ok) {
-    throw new Error(`Asana token exchange failed: ${response.status}`);
+    await throwOAuthError("Asana", "exchange", response);
   }
 
   const data = z
@@ -184,7 +185,7 @@ export async function refreshAsanaToken(
   });
 
   if (!response.ok) {
-    throw new Error(`Asana token refresh failed: ${response.status}`);
+    await throwOAuthError("Asana", "refresh", response);
   }
 
   const data = z

--- a/turbo/apps/web/src/lib/connector/providers/canva.ts
+++ b/turbo/apps/web/src/lib/connector/providers/canva.ts
@@ -1,5 +1,6 @@
 import { getConnectorOAuthConfig } from "@vm0/core";
 import { z } from "zod";
+import { throwOAuthError } from "./oauth-error";
 
 const CANVA_ME_URL = "https://api.canva.com/rest/v1/users/me";
 const CANVA_PROFILE_URL = "https://api.canva.com/rest/v1/users/me/profile";
@@ -116,7 +117,7 @@ export async function refreshCanvaToken(
   });
 
   if (!response.ok) {
-    throw new Error(`Canva token refresh failed: ${response.status}`);
+    await throwOAuthError("Canva", "refresh", response);
   }
 
   const data = z
@@ -179,7 +180,7 @@ export async function exchangeCanvaCode(
   });
 
   if (!response.ok) {
-    throw new Error(`Canva token exchange failed: ${response.status}`);
+    await throwOAuthError("Canva", "exchange", response);
   }
 
   const data = z

--- a/turbo/apps/web/src/lib/connector/providers/close.ts
+++ b/turbo/apps/web/src/lib/connector/providers/close.ts
@@ -1,5 +1,6 @@
 import { getConnectorOAuthConfig } from "@vm0/core";
 import { z } from "zod";
+import { throwOAuthError } from "./oauth-error";
 
 interface CloseUserInfo {
   id: string;
@@ -73,7 +74,7 @@ export async function exchangeCloseCode(
   });
 
   if (!response.ok) {
-    throw new Error(`Close token exchange failed: ${response.status}`);
+    await throwOAuthError("Close", "exchange", response);
   }
 
   const data = z
@@ -140,7 +141,7 @@ export async function refreshCloseToken(
   });
 
   if (!response.ok) {
-    throw new Error(`Close token refresh failed: ${response.status}`);
+    await throwOAuthError("Close", "refresh", response);
   }
 
   const data = z

--- a/turbo/apps/web/src/lib/connector/providers/deel.ts
+++ b/turbo/apps/web/src/lib/connector/providers/deel.ts
@@ -1,5 +1,6 @@
 import { getConnectorOAuthConfig } from "@vm0/core";
 import { z } from "zod";
+import { throwOAuthError } from "./oauth-error";
 
 const DEEL_PEOPLE_ME_URL = "https://api.letsdeel.com/rest/v2/people/me";
 
@@ -116,7 +117,7 @@ export async function refreshDeelToken(
   });
 
   if (!response.ok) {
-    throw new Error(`Deel token refresh failed: ${response.status}`);
+    await throwOAuthError("Deel", "refresh", response);
   }
 
   const data = z
@@ -179,7 +180,7 @@ export async function exchangeDeelCode(
   });
 
   if (!response.ok) {
-    throw new Error(`Deel token exchange failed: ${response.status}`);
+    await throwOAuthError("Deel", "exchange", response);
   }
 
   const data = z

--- a/turbo/apps/web/src/lib/connector/providers/docusign.ts
+++ b/turbo/apps/web/src/lib/connector/providers/docusign.ts
@@ -1,5 +1,6 @@
 import { getConnectorOAuthConfig } from "@vm0/core";
 import { z } from "zod";
+import { throwOAuthError } from "./oauth-error";
 
 const DOCUSIGN_USERINFO_URL = "https://account.docusign.com/oauth/userinfo";
 
@@ -119,10 +120,7 @@ export async function exchangeDocuSignCode(
   });
 
   if (!response.ok) {
-    const errorBody = await response.text();
-    throw new Error(
-      `DocuSign token exchange failed: ${response.status} ${errorBody}`,
-    );
+    await throwOAuthError("DocuSign", "exchange", response);
   }
 
   const data = z
@@ -188,7 +186,7 @@ export async function refreshDocuSignToken(
   });
 
   if (!response.ok) {
-    throw new Error(`DocuSign token refresh failed: ${response.status}`);
+    await throwOAuthError("DocuSign", "refresh", response);
   }
 
   const data = z

--- a/turbo/apps/web/src/lib/connector/providers/dropbox.ts
+++ b/turbo/apps/web/src/lib/connector/providers/dropbox.ts
@@ -1,5 +1,6 @@
 import { getConnectorOAuthConfig } from "@vm0/core";
 import { z } from "zod";
+import { throwOAuthError } from "./oauth-error";
 
 const DROPBOX_CURRENT_ACCOUNT_URL =
   "https://api.dropboxapi.com/2/users/get_current_account";
@@ -80,7 +81,7 @@ export async function exchangeDropboxCode(
   });
 
   if (!response.ok) {
-    throw new Error(`Dropbox token exchange failed: ${response.status}`);
+    await throwOAuthError("Dropbox", "exchange", response);
   }
 
   const data = z
@@ -142,7 +143,7 @@ export async function refreshDropboxToken(
   });
 
   if (!response.ok) {
-    throw new Error(`Dropbox token refresh failed: ${response.status}`);
+    await throwOAuthError("Dropbox", "refresh", response);
   }
 
   const data = z

--- a/turbo/apps/web/src/lib/connector/providers/figma.ts
+++ b/turbo/apps/web/src/lib/connector/providers/figma.ts
@@ -1,5 +1,6 @@
 import { getConnectorOAuthConfig } from "@vm0/core";
 import { z } from "zod";
+import { throwOAuthError } from "./oauth-error";
 
 const FIGMA_ME_URL = "https://api.figma.com/v1/me";
 
@@ -80,7 +81,7 @@ export async function exchangeFigmaCode(
   });
 
   if (!response.ok) {
-    throw new Error(`Figma token exchange failed: ${response.status}`);
+    await throwOAuthError("Figma", "exchange", response);
   }
 
   const data = z
@@ -145,7 +146,7 @@ export async function refreshFigmaToken(
   });
 
   if (!response.ok) {
-    throw new Error(`Figma token refresh failed: ${response.status}`);
+    await throwOAuthError("Figma", "refresh", response);
   }
 
   const data = z

--- a/turbo/apps/web/src/lib/connector/providers/garmin-connect.ts
+++ b/turbo/apps/web/src/lib/connector/providers/garmin-connect.ts
@@ -1,5 +1,6 @@
 import { getConnectorOAuthConfig } from "@vm0/core";
 import { z } from "zod";
+import { throwOAuthError } from "./oauth-error";
 
 const GARMIN_USER_ID_URL = "https://apis.garmin.com/wellness-api/rest/user/id";
 
@@ -116,7 +117,7 @@ export async function exchangeGarminConnectCode(
   });
 
   if (!response.ok) {
-    throw new Error(`Garmin Connect token exchange failed: ${response.status}`);
+    await throwOAuthError("Garmin Connect", "exchange", response);
   }
 
   const data = z
@@ -178,7 +179,7 @@ export async function refreshGarminConnectToken(
   });
 
   if (!response.ok) {
-    throw new Error(`Garmin Connect token refresh failed: ${response.status}`);
+    await throwOAuthError("Garmin Connect", "refresh", response);
   }
 
   const data = z

--- a/turbo/apps/web/src/lib/connector/providers/github.ts
+++ b/turbo/apps/web/src/lib/connector/providers/github.ts
@@ -1,5 +1,6 @@
 import { getConnectorOAuthConfig } from "@vm0/core";
 import { z } from "zod";
+import { throwOAuthError } from "./oauth-error";
 
 const GITHUB_API_BASE = "https://api.github.com";
 
@@ -61,7 +62,7 @@ export async function exchangeGitHubCode(
   });
 
   if (!response.ok) {
-    throw new Error(`GitHub token exchange failed: ${response.status}`);
+    await throwOAuthError("GitHub", "exchange", response);
   }
 
   const data = z

--- a/turbo/apps/web/src/lib/connector/providers/gmail.ts
+++ b/turbo/apps/web/src/lib/connector/providers/gmail.ts
@@ -1,5 +1,6 @@
 import { getConnectorOAuthConfig } from "@vm0/core";
 import { z } from "zod";
+import { throwOAuthError } from "./oauth-error";
 
 const GMAIL_PROFILE_URL =
   "https://www.googleapis.com/gmail/v1/users/me/profile";
@@ -75,7 +76,7 @@ export async function exchangeGmailCode(
   });
 
   if (!response.ok) {
-    throw new Error(`Gmail token exchange failed: ${response.status}`);
+    await throwOAuthError("Gmail", "exchange", response);
   }
 
   const data = z

--- a/turbo/apps/web/src/lib/connector/providers/google-oauth.ts
+++ b/turbo/apps/web/src/lib/connector/providers/google-oauth.ts
@@ -1,5 +1,6 @@
 import { type ConnectorType, getConnectorOAuthConfig } from "@vm0/core";
 import { z } from "zod";
+import { throwOAuthError } from "./oauth-error";
 
 const GOOGLE_USERINFO_URL = "https://www.googleapis.com/oauth2/v2/userinfo";
 
@@ -82,9 +83,7 @@ export async function exchangeGoogleOAuthCode(
   });
 
   if (!response.ok) {
-    throw new Error(
-      `${connectorType} token exchange failed: ${response.status}`,
-    );
+    await throwOAuthError(connectorType, "exchange", response);
   }
 
   const data = z
@@ -148,9 +147,7 @@ export async function refreshGoogleToken(
   });
 
   if (!response.ok) {
-    throw new Error(
-      `${connectorType} token refresh failed: ${response.status}`,
-    );
+    await throwOAuthError(connectorType, "refresh", response);
   }
 
   const data = z

--- a/turbo/apps/web/src/lib/connector/providers/hubspot.ts
+++ b/turbo/apps/web/src/lib/connector/providers/hubspot.ts
@@ -1,5 +1,6 @@
 import { getConnectorOAuthConfig } from "@vm0/core";
 import { z } from "zod";
+import { throwOAuthError } from "./oauth-error";
 
 const HUBSPOT_TOKEN_INFO_URL = "https://api.hubapi.com/oauth/v1/access-tokens";
 
@@ -75,7 +76,7 @@ export async function exchangeHubSpotCode(
   });
 
   if (!response.ok) {
-    throw new Error(`HubSpot token exchange failed: ${response.status}`);
+    await throwOAuthError("HubSpot", "exchange", response);
   }
 
   const data = z
@@ -135,7 +136,7 @@ export async function refreshHubSpotToken(
   });
 
   if (!response.ok) {
-    throw new Error(`HubSpot token refresh failed: ${response.status}`);
+    await throwOAuthError("HubSpot", "refresh", response);
   }
 
   const data = z

--- a/turbo/apps/web/src/lib/connector/providers/intervals-icu.ts
+++ b/turbo/apps/web/src/lib/connector/providers/intervals-icu.ts
@@ -1,5 +1,6 @@
 import { getConnectorOAuthConfig } from "@vm0/core";
 import { z } from "zod";
+import { throwOAuthError } from "./oauth-error";
 
 interface IntervalsIcuTokenResult {
   accessToken: string;
@@ -64,7 +65,7 @@ export async function exchangeIntervalsIcuCode(
   });
 
   if (!response.ok) {
-    throw new Error(`Intervals.icu token exchange failed: ${response.status}`);
+    await throwOAuthError("Intervals.icu", "exchange", response);
   }
 
   const data = z

--- a/turbo/apps/web/src/lib/connector/providers/linear.ts
+++ b/turbo/apps/web/src/lib/connector/providers/linear.ts
@@ -1,5 +1,6 @@
 import { getConnectorOAuthConfig } from "@vm0/core";
 import { z } from "zod";
+import { throwOAuthError } from "./oauth-error";
 
 // User info URL is not part of ConnectorOAuthConfig since it uses GraphQL (POST), not a standard
 // REST GET endpoint. Same pattern as GMAIL_PROFILE_URL in gmail.ts.
@@ -81,7 +82,7 @@ export async function exchangeLinearCode(
   });
 
   if (!response.ok) {
-    throw new Error(`Linear token exchange failed: ${response.status}`);
+    await throwOAuthError("Linear", "exchange", response);
   }
 
   const data = z
@@ -143,7 +144,7 @@ export async function refreshLinearToken(
   });
 
   if (!response.ok) {
-    throw new Error(`Linear token refresh failed: ${response.status}`);
+    await throwOAuthError("Linear", "refresh", response);
   }
 
   const data = z

--- a/turbo/apps/web/src/lib/connector/providers/mailchimp.ts
+++ b/turbo/apps/web/src/lib/connector/providers/mailchimp.ts
@@ -1,5 +1,6 @@
 import { getConnectorOAuthConfig } from "@vm0/core";
 import { z } from "zod";
+import { throwOAuthError } from "./oauth-error";
 
 const MAILCHIMP_METADATA_URL = "https://login.mailchimp.com/oauth2/metadata";
 
@@ -68,7 +69,7 @@ export async function exchangeMailchimpCode(
   });
 
   if (!response.ok) {
-    throw new Error(`Mailchimp token exchange failed: ${response.status}`);
+    await throwOAuthError("Mailchimp", "exchange", response);
   }
 
   const data = z

--- a/turbo/apps/web/src/lib/connector/providers/mercury.ts
+++ b/turbo/apps/web/src/lib/connector/providers/mercury.ts
@@ -1,5 +1,6 @@
 import { getConnectorOAuthConfig } from "@vm0/core";
 import { z } from "zod";
+import { throwOAuthError } from "./oauth-error";
 
 const MERCURY_ACCOUNTS_URL = "https://api.mercury.com/api/v1/accounts";
 
@@ -77,7 +78,7 @@ export async function exchangeMercuryCode(
   });
 
   if (!response.ok) {
-    throw new Error(`Mercury token exchange failed: ${response.status}`);
+    await throwOAuthError("Mercury", "exchange", response);
   }
 
   const data = z
@@ -139,7 +140,7 @@ export async function refreshMercuryToken(
   });
 
   if (!response.ok) {
-    throw new Error(`Mercury token refresh failed: ${response.status}`);
+    await throwOAuthError("Mercury", "refresh", response);
   }
 
   const data = z

--- a/turbo/apps/web/src/lib/connector/providers/meta-ads.ts
+++ b/turbo/apps/web/src/lib/connector/providers/meta-ads.ts
@@ -1,5 +1,6 @@
 import { getConnectorOAuthConfig } from "@vm0/core";
 import { z } from "zod";
+import { throwOAuthError } from "./oauth-error";
 
 const META_USER_URL = "https://graph.facebook.com/v22.0/me";
 
@@ -72,7 +73,7 @@ export async function exchangeMetaAdsCode(
   });
 
   if (!response.ok) {
-    throw new Error(`Meta Ads token exchange failed: ${response.status}`);
+    await throwOAuthError("Meta Ads", "exchange", response);
   }
 
   const data = z
@@ -138,9 +139,7 @@ async function exchangeForLongLivedToken(
   );
 
   if (!response.ok) {
-    throw new Error(
-      `Meta Ads long-lived token exchange failed: ${response.status}`,
-    );
+    await throwOAuthError("Meta Ads", "long-lived token exchange", response);
   }
 
   const data = z

--- a/turbo/apps/web/src/lib/connector/providers/microsoft-oauth.ts
+++ b/turbo/apps/web/src/lib/connector/providers/microsoft-oauth.ts
@@ -1,5 +1,6 @@
 import { type ConnectorType, getConnectorOAuthConfig } from "@vm0/core";
 import { z } from "zod";
+import { throwOAuthError } from "./oauth-error";
 
 const MICROSOFT_USERINFO_URL = "https://graph.microsoft.com/v1.0/me";
 
@@ -81,9 +82,7 @@ export async function exchangeMicrosoftOAuthCode(
   });
 
   if (!response.ok) {
-    throw new Error(
-      `${connectorType} token exchange failed: ${response.status}`,
-    );
+    await throwOAuthError(connectorType, "exchange", response);
   }
 
   const data = z
@@ -147,9 +146,7 @@ export async function refreshMicrosoftToken(
   });
 
   if (!response.ok) {
-    throw new Error(
-      `${connectorType} token refresh failed: ${response.status}`,
-    );
+    await throwOAuthError(connectorType, "refresh", response);
   }
 
   const data = z

--- a/turbo/apps/web/src/lib/connector/providers/monday.ts
+++ b/turbo/apps/web/src/lib/connector/providers/monday.ts
@@ -1,5 +1,6 @@
 import { getConnectorOAuthConfig } from "@vm0/core";
 import { z } from "zod";
+import { throwOAuthError } from "./oauth-error";
 
 interface MondayUserInfo {
   id: string;
@@ -77,7 +78,7 @@ export async function exchangeMondayCode(
   });
 
   if (!response.ok) {
-    throw new Error(`Monday.com token exchange failed: ${response.status}`);
+    await throwOAuthError("Monday.com", "exchange", response);
   }
 
   const data = z
@@ -138,7 +139,7 @@ export async function refreshMondayToken(
   });
 
   if (!response.ok) {
-    throw new Error(`Monday.com token refresh failed: ${response.status}`);
+    await throwOAuthError("Monday.com", "refresh", response);
   }
 
   const data = z

--- a/turbo/apps/web/src/lib/connector/providers/neon.ts
+++ b/turbo/apps/web/src/lib/connector/providers/neon.ts
@@ -1,5 +1,6 @@
 import { getConnectorOAuthConfig } from "@vm0/core";
 import { z } from "zod";
+import { throwOAuthError } from "./oauth-error";
 
 const NEON_USER_INFO_URL = "https://console.neon.tech/api/v2/users/me";
 
@@ -78,7 +79,7 @@ export async function exchangeNeonCode(
   });
 
   if (!response.ok) {
-    throw new Error(`Neon token exchange failed: ${response.status}`);
+    await throwOAuthError("Neon", "exchange", response);
   }
 
   const data = z
@@ -140,7 +141,7 @@ export async function refreshNeonToken(
   });
 
   if (!response.ok) {
-    throw new Error(`Neon token refresh failed: ${response.status}`);
+    await throwOAuthError("Neon", "refresh", response);
   }
 
   const data = z

--- a/turbo/apps/web/src/lib/connector/providers/notion.ts
+++ b/turbo/apps/web/src/lib/connector/providers/notion.ts
@@ -1,5 +1,6 @@
 import { getConnectorOAuthConfig } from "@vm0/core";
 import { z } from "zod";
+import { throwOAuthError } from "./oauth-error";
 
 interface NotionUserInfo {
   id: string;
@@ -82,7 +83,7 @@ export async function exchangeNotionCode(
   });
 
   if (!response.ok) {
-    throw new Error(`Notion token exchange failed: ${response.status}`);
+    await throwOAuthError("Notion", "exchange", response);
   }
 
   const data = z
@@ -155,7 +156,7 @@ export async function refreshNotionToken(
   });
 
   if (!response.ok) {
-    throw new Error(`Notion token refresh failed: ${response.status}`);
+    await throwOAuthError("Notion", "refresh", response);
   }
 
   const data = z

--- a/turbo/apps/web/src/lib/connector/providers/oauth-error.ts
+++ b/turbo/apps/web/src/lib/connector/providers/oauth-error.ts
@@ -1,0 +1,51 @@
+const MAX_BODY_LENGTH = 500;
+
+/**
+ * Read the response body from a failed OAuth request and throw an error
+ * with full diagnostic context (status code, error reason, description).
+ *
+ * Attempts to parse the body as JSON to extract standard OAuth error fields
+ * (`error`, `error_description`). Falls back to raw text if not JSON.
+ * Truncates long bodies to avoid noisy logs.
+ */
+export async function throwOAuthError(
+  provider: string,
+  operation: string,
+  response: Response,
+): Promise<never> {
+  const status = response.status;
+  let detail = "";
+
+  const raw = await response.text();
+  if (raw.length > 0) {
+    try {
+      const json: unknown = JSON.parse(raw);
+      if (typeof json === "object" && json !== null) {
+        const obj = json as Record<string, unknown>;
+        const errorCode =
+          typeof obj["error"] === "string" ? obj["error"] : null;
+        const errorDesc =
+          typeof obj["error_description"] === "string"
+            ? obj["error_description"]
+            : null;
+        if (errorCode) {
+          detail = errorDesc ? ` ${errorCode} (${errorDesc})` : ` ${errorCode}`;
+        } else {
+          const truncated =
+            raw.length > MAX_BODY_LENGTH
+              ? raw.slice(0, MAX_BODY_LENGTH) + "..."
+              : raw;
+          detail = ` ${truncated}`;
+        }
+      }
+    } catch {
+      const truncated =
+        raw.length > MAX_BODY_LENGTH
+          ? raw.slice(0, MAX_BODY_LENGTH) + "..."
+          : raw;
+      detail = ` ${truncated}`;
+    }
+  }
+
+  throw new Error(`${provider} token ${operation} failed: ${status}${detail}`);
+}

--- a/turbo/apps/web/src/lib/connector/providers/posthog.ts
+++ b/turbo/apps/web/src/lib/connector/providers/posthog.ts
@@ -1,5 +1,6 @@
 import { getConnectorOAuthConfig } from "@vm0/core";
 import { z } from "zod";
+import { throwOAuthError } from "./oauth-error";
 
 const POSTHOG_USER_INFO_URL = "https://us.posthog.com/api/users/@me/";
 
@@ -76,7 +77,7 @@ export async function exchangePosthogCode(
   });
 
   if (!response.ok) {
-    throw new Error(`PostHog token exchange failed: ${response.status}`);
+    await throwOAuthError("PostHog", "exchange", response);
   }
 
   const data = z
@@ -137,7 +138,7 @@ export async function refreshPosthogToken(
   });
 
   if (!response.ok) {
-    throw new Error(`PostHog token refresh failed: ${response.status}`);
+    await throwOAuthError("PostHog", "refresh", response);
   }
 
   const data = z

--- a/turbo/apps/web/src/lib/connector/providers/reddit.ts
+++ b/turbo/apps/web/src/lib/connector/providers/reddit.ts
@@ -1,5 +1,6 @@
 import { getConnectorOAuthConfig } from "@vm0/core";
 import { z } from "zod";
+import { throwOAuthError } from "./oauth-error";
 
 const REDDIT_USER_INFO_URL = "https://oauth.reddit.com/api/v1/me";
 const REDDIT_USER_AGENT = "web:vm0-reddit-connector:v1.0";
@@ -82,7 +83,7 @@ export async function exchangeRedditCode(
   });
 
   if (!response.ok) {
-    throw new Error(`Reddit token exchange failed: ${response.status}`);
+    await throwOAuthError("Reddit", "exchange", response);
   }
 
   const data = z
@@ -184,7 +185,7 @@ export async function refreshRedditToken(
   });
 
   if (!response.ok) {
-    throw new Error(`Reddit token refresh failed: ${response.status}`);
+    await throwOAuthError("Reddit", "refresh", response);
   }
 
   const data = z

--- a/turbo/apps/web/src/lib/connector/providers/sentry.ts
+++ b/turbo/apps/web/src/lib/connector/providers/sentry.ts
@@ -1,5 +1,6 @@
 import { getConnectorOAuthConfig } from "@vm0/core";
 import { z } from "zod";
+import { throwOAuthError } from "./oauth-error";
 
 interface SentryUserInfo {
   id: string;
@@ -75,7 +76,7 @@ export async function exchangeSentryCode(
   });
 
   if (!response.ok) {
-    throw new Error(`Sentry token exchange failed: ${response.status}`);
+    await throwOAuthError("Sentry", "exchange", response);
   }
 
   const data = z
@@ -150,7 +151,7 @@ export async function refreshSentryToken(
   });
 
   if (!response.ok) {
-    throw new Error(`Sentry token refresh failed: ${response.status}`);
+    await throwOAuthError("Sentry", "refresh", response);
   }
 
   const data = z

--- a/turbo/apps/web/src/lib/connector/providers/slack.ts
+++ b/turbo/apps/web/src/lib/connector/providers/slack.ts
@@ -1,5 +1,6 @@
 import { getConnectorOAuthConfig } from "@vm0/core";
 import { z } from "zod";
+import { throwOAuthError } from "./oauth-error";
 
 interface SlackTokenResult {
   accessToken: string;
@@ -66,7 +67,7 @@ export async function exchangeSlackCode(
   });
 
   if (!response.ok) {
-    throw new Error(`Slack token exchange failed: ${response.status}`);
+    await throwOAuthError("Slack", "exchange", response);
   }
 
   const data = z

--- a/turbo/apps/web/src/lib/connector/providers/strava.ts
+++ b/turbo/apps/web/src/lib/connector/providers/strava.ts
@@ -1,5 +1,6 @@
 import { getConnectorOAuthConfig } from "@vm0/core";
 import { z } from "zod";
+import { throwOAuthError } from "./oauth-error";
 
 const STRAVA_ATHLETE_URL = "https://www.strava.com/api/v3/athlete";
 
@@ -77,7 +78,7 @@ export async function exchangeStravaCode(
   });
 
   if (!response.ok) {
-    throw new Error(`Strava token exchange failed: ${response.status}`);
+    await throwOAuthError("Strava", "exchange", response);
   }
 
   const data = z
@@ -157,7 +158,7 @@ export async function refreshStravaToken(
   });
 
   if (!response.ok) {
-    throw new Error(`Strava token refresh failed: ${response.status}`);
+    await throwOAuthError("Strava", "refresh", response);
   }
 
   const data = z

--- a/turbo/apps/web/src/lib/connector/providers/stripe.ts
+++ b/turbo/apps/web/src/lib/connector/providers/stripe.ts
@@ -1,5 +1,6 @@
 import { getConnectorOAuthConfig } from "@vm0/core";
 import { z } from "zod";
+import { throwOAuthError } from "./oauth-error";
 
 const STRIPE_ACCOUNT_URL = "https://api.stripe.com/v1/account";
 
@@ -74,7 +75,7 @@ export async function exchangeStripeCode(
   });
 
   if (!response.ok) {
-    throw new Error(`Stripe token exchange failed: ${response.status}`);
+    await throwOAuthError("Stripe", "exchange", response);
   }
 
   const data = z
@@ -139,7 +140,7 @@ export async function refreshStripeToken(
   });
 
   if (!response.ok) {
-    throw new Error(`Stripe token refresh failed: ${response.status}`);
+    await throwOAuthError("Stripe", "refresh", response);
   }
 
   const data = z

--- a/turbo/apps/web/src/lib/connector/providers/supabase.ts
+++ b/turbo/apps/web/src/lib/connector/providers/supabase.ts
@@ -1,5 +1,6 @@
 import { getConnectorOAuthConfig } from "@vm0/core";
 import { z } from "zod";
+import { throwOAuthError } from "./oauth-error";
 
 const SUPABASE_ORGANIZATIONS_URL = "https://api.supabase.com/v1/organizations";
 
@@ -115,7 +116,7 @@ export async function refreshSupabaseToken(
   });
 
   if (!response.ok) {
-    throw new Error(`Supabase token refresh failed: ${response.status}`);
+    await throwOAuthError("Supabase", "refresh", response);
   }
 
   const data = z
@@ -179,7 +180,7 @@ export async function exchangeSupabaseCode(
   });
 
   if (!response.ok) {
-    throw new Error(`Supabase token exchange failed: ${response.status}`);
+    await throwOAuthError("Supabase", "exchange", response);
   }
 
   const data = z

--- a/turbo/apps/web/src/lib/connector/providers/todoist.ts
+++ b/turbo/apps/web/src/lib/connector/providers/todoist.ts
@@ -1,5 +1,6 @@
 import { getConnectorOAuthConfig } from "@vm0/core";
 import { z } from "zod";
+import { throwOAuthError } from "./oauth-error";
 
 const TODOIST_USER_URL = "https://api.todoist.com/api/v1/user";
 
@@ -67,7 +68,7 @@ export async function exchangeTodoistCode(
   });
 
   if (!response.ok) {
-    throw new Error(`Todoist token exchange failed: ${response.status}`);
+    await throwOAuthError("Todoist", "exchange", response);
   }
 
   const data = z

--- a/turbo/apps/web/src/lib/connector/providers/vercel.ts
+++ b/turbo/apps/web/src/lib/connector/providers/vercel.ts
@@ -1,5 +1,6 @@
 import { getConnectorOAuthConfig } from "@vm0/core";
 import { z } from "zod";
+import { throwOAuthError } from "./oauth-error";
 
 interface VercelUserInfo {
   id: string;
@@ -60,7 +61,7 @@ export async function exchangeVercelCode(
   });
 
   if (!response.ok) {
-    throw new Error(`Vercel token exchange failed: ${response.status}`);
+    await throwOAuthError("Vercel", "exchange", response);
   }
 
   const data = z

--- a/turbo/apps/web/src/lib/connector/providers/webflow.ts
+++ b/turbo/apps/web/src/lib/connector/providers/webflow.ts
@@ -1,5 +1,6 @@
 import { getConnectorOAuthConfig } from "@vm0/core";
 import { z } from "zod";
+import { throwOAuthError } from "./oauth-error";
 
 interface WebflowTokenResult {
   accessToken: string;
@@ -65,10 +66,7 @@ export async function exchangeWebflowCode(
   });
 
   if (!response.ok) {
-    const text = await response.text();
-    throw new Error(
-      `Webflow token exchange failed: ${response.status} ${text}`,
-    );
+    await throwOAuthError("Webflow", "exchange", response);
   }
 
   const data = z

--- a/turbo/apps/web/src/lib/connector/providers/x.ts
+++ b/turbo/apps/web/src/lib/connector/providers/x.ts
@@ -1,5 +1,6 @@
 import { getConnectorOAuthConfig } from "@vm0/core";
 import { z } from "zod";
+import { throwOAuthError } from "./oauth-error";
 
 const X_USERS_ME_URL =
   "https://api.twitter.com/2/users/me?user.fields=id,username,name";
@@ -116,7 +117,7 @@ export async function refreshXToken(
   });
 
   if (!response.ok) {
-    throw new Error(`X token refresh failed: ${response.status}`);
+    await throwOAuthError("X", "refresh", response);
   }
 
   const data = z
@@ -179,7 +180,7 @@ export async function exchangeXCode(
   });
 
   if (!response.ok) {
-    throw new Error(`X token exchange failed: ${response.status}`);
+    await throwOAuthError("X", "exchange", response);
   }
 
   const data = z

--- a/turbo/apps/web/src/lib/connector/providers/xero.ts
+++ b/turbo/apps/web/src/lib/connector/providers/xero.ts
@@ -1,5 +1,6 @@
 import { getConnectorOAuthConfig } from "@vm0/core";
 import { z } from "zod";
+import { throwOAuthError } from "./oauth-error";
 
 const XERO_USERINFO_URL = "https://identity.xero.com/connect/userinfo";
 
@@ -77,7 +78,7 @@ export async function exchangeXeroCode(
   });
 
   if (!response.ok) {
-    throw new Error(`Xero token exchange failed: ${response.status}`);
+    await throwOAuthError("Xero", "exchange", response);
   }
 
   const data = z
@@ -140,7 +141,7 @@ export async function refreshXeroToken(
   });
 
   if (!response.ok) {
-    throw new Error(`Xero token refresh failed: ${response.status}`);
+    await throwOAuthError("Xero", "refresh", response);
   }
 
   const data = z


### PR DESCRIPTION
## Summary
- Add `throwOAuthError` shared helper that reads HTTP response body, extracts standard OAuth error fields (`error`, `error_description`), truncates long bodies, and throws a descriptive error message
- Replace bare `throw new Error(...${response.status})` with `await throwOAuthError(...)` across all 35 OAuth provider files (covering both token exchange and token refresh paths)
- Add structured metadata (`connectorType`, `orgId`, `userId`) to the `log.warn` in `connector-service.ts` so failed refreshes can be traced to specific users/orgs

Closes #5125

## Test plan
- [x] New integration tests for `throwOAuthError` covering: JSON error response, non-JSON response, empty body, long body truncation, JSON without standard error fields
- [x] All existing tests pass
- [x] Type checking passes
- [x] Lint passes
- [x] Knip passes (no unused exports)

🤖 Generated with [Claude Code](https://claude.com/claude-code)