### PR TITLE
fix: count both issues and pull requests for worker load balancing

### DIFF
--- a/.claude/skills/coding-assign/SKILL.md
+++ b/.claude/skills/coding-assign/SKILL.md
@@ -49,15 +49,17 @@ ISSUE=<from conversation context>
 ME=$(gh api user --jq '.login')
 ```
 
-### Step 3: Count Issues Per Worker
+### Step 3: Count Issues and PRs Per Worker
 
-For each worker label (`vm01` through `vm0N`), count open issues assigned to the current user:
+For each worker label (`vm01` through `vm0N`), count **both** open issues and open PRs assigned to the current user:
 
 ```bash
 for i in $(seq 1 $MAX_WORKERS); do
   LABEL=$(printf "vm%02d" "$i")
-  COUNT=$(gh issue list --repo vm0-ai/vm0 --label "$LABEL" --assignee "$ME" --state open --json number --jq 'length')
-  echo "$LABEL: $COUNT"
+  ISSUE_COUNT=$(gh issue list --repo vm0-ai/vm0 --label "$LABEL" --assignee "$ME" --state open --json number --jq 'length')
+  PR_COUNT=$(gh pr list --repo vm0-ai/vm0 --label "$LABEL" --author "$ME" --state open --json number --jq 'length')
+  TOTAL=$((ISSUE_COUNT + PR_COUNT))
+  echo "$LABEL: $TOTAL (issues: $ISSUE_COUNT, PRs: $PR_COUNT)"
 done
 ```
 
@@ -65,7 +67,7 @@ done
 
 ### Step 4: Select Least-Loaded Worker
 
-Pick the worker label with the fewest open issues. If there's a tie, pick the lowest-numbered worker.
+Pick the worker label with the lowest total (issues + PRs). Prefer workers with **zero** total items. If there's a tie, pick the lowest-numbered worker.
 
 ### Step 5: Update Issue Labels
 
@@ -91,10 +93,10 @@ Output a summary:
 ```
 Issue #<NUMBER> assigned to worker <LABEL>
 
-Worker load:
-  vm01: 3 issues
-  vm02: 2 issues  <-- assigned here
-  vm03: 3 issues
+Worker load (issues + PRs):
+  vm01: 3 (issues: 2, PRs: 1)
+  vm02: 0 (issues: 0, PRs: 0)  <-- assigned here
+  vm03: 3 (issues: 1, PRs: 2)
   ...
 ```
 

--- a/.claude/skills/issue-handoff/SKILL.md
+++ b/.claude/skills/issue-handoff/SKILL.md
@@ -145,16 +145,18 @@ Extract the issue number from the `gh issue create` output.
 ME=$(gh api user --jq '.login')
 ```
 
-### Step 3: Count Issues Per Worker
+### Step 3: Count Issues and PRs Per Worker
 
-Using the worker count (default 4, or as specified in args):
+Using the worker count (default 4, or as specified in args), count **both** open issues and open PRs for each worker:
 
 ```bash
 MAX_WORKERS=<from args or 4>
 for i in $(seq 1 $MAX_WORKERS); do
   LABEL=$(printf "vm%02d" "$i")
-  COUNT=$(gh issue list --repo vm0-ai/vm0 --label "$LABEL" --assignee "$ME" --state open --json number --jq 'length')
-  echo "$LABEL: $COUNT"
+  ISSUE_COUNT=$(gh issue list --repo vm0-ai/vm0 --label "$LABEL" --assignee "$ME" --state open --json number --jq 'length')
+  PR_COUNT=$(gh pr list --repo vm0-ai/vm0 --label "$LABEL" --author "$ME" --state open --json number --jq 'length')
+  TOTAL=$((ISSUE_COUNT + PR_COUNT))
+  echo "$LABEL: $TOTAL (issues: $ISSUE_COUNT, PRs: $PR_COUNT)"
 done
 ```
 
@@ -162,7 +164,7 @@ done
 
 ### Step 4: Select Least-Loaded Worker
 
-Pick the worker label with the fewest open issues. Break ties by lowest number.
+Pick the worker label with the lowest total (issues + PRs). Prefer workers with **zero** total items. If there's a tie, pick the lowest-numbered worker.
 
 ### Step 5: Update Issue Labels
 
@@ -189,11 +191,11 @@ Output a combined summary:
 Issue created and assigned: https://github.com/owner/repo/issues/123
 Assigned to worker: <LABEL>
 
-Worker load:
-  vm01: 3 issues
-  vm02: 2 issues  <-- assigned here
-  vm03: 3 issues
-  vm04: 4 issues
+Worker load (issues + PRs):
+  vm01: 3 (issues: 2, PRs: 1)
+  vm02: 0 (issues: 0, PRs: 0)  <-- assigned here
+  vm03: 3 (issues: 1, PRs: 2)
+  vm04: 4 (issues: 3, PRs: 1)
 ```
 
 ---

--- a/.claude/skills/pr-handoff/SKILL.md
+++ b/.claude/skills/pr-handoff/SKILL.md
@@ -114,7 +114,7 @@ EXISTING_WORKER=$(echo "$PR_LABELS" | grep -E "^vm[0-9]{2}$" | head -1)
 
 If `EXISTING_WORKER` is set, skip Steps 4-5 and go directly to Step 6 (report).
 
-### Step 4: Get Current User and Count Issues Per Worker
+### Step 4: Get Current User and Count Issues + PRs Per Worker
 
 Only runs if PR has no existing worker label.
 
@@ -124,8 +124,10 @@ ME=$(gh api user --jq '.login')
 MAX_WORKERS=<from args or 4>
 for i in $(seq 1 $MAX_WORKERS); do
   LABEL=$(printf "vm%02d" "$i")
-  COUNT=$(gh issue list --repo vm0-ai/vm0 --label "$LABEL" --assignee "$ME" --state open --json number --jq 'length')
-  echo "$LABEL: $COUNT"
+  ISSUE_COUNT=$(gh issue list --repo vm0-ai/vm0 --label "$LABEL" --assignee "$ME" --state open --json number --jq 'length')
+  PR_COUNT=$(gh pr list --repo vm0-ai/vm0 --label "$LABEL" --author "$ME" --state open --json number --jq 'length')
+  TOTAL=$((ISSUE_COUNT + PR_COUNT))
+  echo "$LABEL: $TOTAL (issues: $ISSUE_COUNT, PRs: $PR_COUNT)"
 done
 ```
 
@@ -133,7 +135,7 @@ done
 
 ### Step 5: Apply Worker Label
 
-Pick the worker label with the fewest open issues. Break ties by lowest number.
+Pick the worker label with the lowest total (issues + PRs). Prefer workers with **zero** total items. Break ties by lowest number.
 
 ```bash
 gh label create "$SELECTED_LABEL" --description "Coding worker $SELECTED_LABEL" --color 0E8A16 2>/dev/null || true
@@ -156,11 +158,11 @@ Mode: <created / updated>
 Assigned to worker: <LABEL> <(existing) if kept>
 Pending label: <removed / not present>
 
-Worker load:
-  vm01: 3 issues
-  vm02: 2 issues  <-- assigned here
-  vm03: 3 issues
-  vm04: 4 issues
+Worker load (issues + PRs):
+  vm01: 3 (issues: 2, PRs: 1)
+  vm02: 0 (issues: 0, PRs: 0)  <-- assigned here
+  vm03: 3 (issues: 1, PRs: 2)
+  vm04: 4 (issues: 3, PRs: 1)
 ```
 
 ---


### PR DESCRIPTION
## Summary
- Updated worker load balancing in coding-assign, issue-handoff, and pr-handoff skills to count both open issues and open PRs when determining worker load
- Previously only issues were counted, causing workers with many open PRs but few issues to appear underloaded
- Workers with zero total items are now preferred during assignment

## Test plan
- [ ] Verify coding-assign skill correctly counts both issues and PRs per worker
- [ ] Verify issue-handoff skill correctly counts both issues and PRs per worker
- [ ] Verify pr-handoff skill correctly counts both issues and PRs per worker
- [ ] Confirm least-loaded worker selection prefers zero-total workers

🤖 Generated with [Claude Code](https://claude.com/claude-code)