### PR TITLE
fix: pass through descriptive error messages in schedule deploy route

### DIFF
--- a/turbo/apps/web/app/api/agent/schedules/route.ts
+++ b/turbo/apps/web/app/api/agent/schedules/route.ts
@@ -15,6 +15,7 @@ import {
   isNotFound,
   isBadRequest,
   isForbidden,
+  isSchedulePast,
 } from "../../../../src/lib/errors";
 import { resolveOrg } from "../../../../src/lib/org/resolve-org";
 
@@ -65,7 +66,7 @@ const router = tsr.router(schedulesMainContract, {
         return {
           status: 404 as const,
           body: {
-            error: { message: "Resource not found", code: "NOT_FOUND" },
+            error: { message: error.message, code: "NOT_FOUND" },
           },
         };
       }
@@ -73,7 +74,18 @@ const router = tsr.router(schedulesMainContract, {
         return {
           status: 400 as const,
           body: {
-            error: { message: "Invalid request", code: "BAD_REQUEST" },
+            error: { message: error.message, code: "BAD_REQUEST" },
+          },
+        };
+      }
+      if (isSchedulePast(error)) {
+        return {
+          status: 400 as const,
+          body: {
+            error: {
+              message: error.message,
+              code: "SCHEDULE_PAST",
+            },
           },
         };
       }


### PR DESCRIPTION
## Summary
- Pass through actual `error.message` instead of hardcoded "Invalid request" for `BadRequestError` and "Resource not found" for `NotFoundError` in the schedule deploy route
- Add missing `SchedulePastError` handler — previously uncaught, causing 500 when users selected the "Now" frequency

## Test plan
- [ ] Create schedule with "Every Day" frequency for an agent with missing secrets → should show specific missing secrets message instead of "Invalid request"
- [ ] Create schedule with "Now" frequency → should return 400 with descriptive message instead of 500
- [ ] Create schedule with invalid timezone → should show "Invalid timezone: ..." message
- [ ] Create schedule normally (happy path) → should still work as before

Closes #5071

🤖 Generated with [Claude Code](https://claude.com/claude-code)