### PR TITLE
fix(e2e): use colon format for firewall permission name

### DIFF
--- a/e2e/tests/03-experimental-runner/t42-firewall-placeholder.bats
+++ b/e2e/tests/03-experimental-runner/t42-firewall-placeholder.bats
@@ -133,7 +133,7 @@ agents:
     experimental_firewalls:
       github:
         permissions:
-          - metadata-read
+          - metadata:read
     environment:
       GITHUB_TOKEN: \${{ secrets.GITHUB_TOKEN }}
 EOF


### PR DESCRIPTION
## Summary

Update E2E firewall test permission name from `metadata-read` to `metadata:read` to match the current GitHub firewall config format.

## Test plan

- [ ] `t42-firewall-placeholder.bats` E2E test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)