### PR TITLE
fix: remove personal org concept from org leave and use commands

### DIFF
--- a/turbo/apps/cli/src/commands/org/__tests__/leave.test.ts
+++ b/turbo/apps/cli/src/commands/org/__tests__/leave.test.ts
@@ -38,11 +38,20 @@ describe("org leave command", () => {
     vi.stubEnv("VM0_TOKEN", "test-token");
   });
 
-  it("should leave org and show success", async () => {
+  it("should leave org and auto-switch to remaining org", async () => {
     server.use(
       http.post("http://localhost:3000/api/org/leave", () => {
         return HttpResponse.json({
           message: "Left organization",
+        });
+      }),
+      http.get("http://localhost:3000/api/org/list", () => {
+        return HttpResponse.json({
+          orgs: [
+            { slug: "other-org", role: "member" },
+            { slug: "another-org", role: "admin" },
+          ],
+          active: undefined,
         });
       }),
     );
@@ -51,7 +60,7 @@ describe("org leave command", () => {
 
     const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
     expect(logCalls).toContain("Left organization");
-    expect(logCalls).toContain("personal org");
+    expect(logCalls).toContain("Switched to: other-org");
   });
 
   it("should handle admin-cannot-leave error", async () => {

--- a/turbo/apps/cli/src/commands/org/__tests__/leave.test.ts
+++ b/turbo/apps/cli/src/commands/org/__tests__/leave.test.ts
@@ -63,6 +63,28 @@ describe("org leave command", () => {
     expect(logCalls).toContain("Switched to: other-org");
   });
 
+  it("should handle no remaining organizations after leaving", async () => {
+    server.use(
+      http.post("http://localhost:3000/api/org/leave", () => {
+        return HttpResponse.json({
+          message: "Left organization",
+        });
+      }),
+      http.get("http://localhost:3000/api/org/list", () => {
+        return HttpResponse.json({
+          orgs: [],
+          active: undefined,
+        });
+      }),
+    );
+
+    await leaveCommand.parseAsync(["node", "cli"]);
+
+    const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+    expect(logCalls).toContain("Left organization");
+    expect(logCalls).toContain("No remaining organizations");
+  });
+
   it("should handle admin-cannot-leave error", async () => {
     server.use(
       http.post("http://localhost:3000/api/org/leave", () => {

--- a/turbo/apps/cli/src/commands/org/__tests__/use.test.ts
+++ b/turbo/apps/cli/src/commands/org/__tests__/use.test.ts
@@ -54,21 +54,11 @@ describe("org use command", () => {
     expect(logCalls).toContain("my-org");
   });
 
-  it("should switch to personal org with --personal flag", async () => {
-    await useCommand.parseAsync(["node", "cli", "--personal"]);
-
-    const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
-    expect(logCalls).toContain("personal org");
-  });
-
-  it("should require slug argument without --personal", async () => {
+  it("should require slug argument", async () => {
     await expect(async () => {
       await useCommand.parseAsync(["node", "cli"]);
     }).rejects.toThrow("process.exit called");
 
-    expect(mockConsoleError).toHaveBeenCalledWith(
-      expect.stringContaining("Organization slug is required"),
-    );
     expect(mockExit).toHaveBeenCalledWith(1);
   });
 

--- a/turbo/apps/cli/src/commands/org/leave.ts
+++ b/turbo/apps/cli/src/commands/org/leave.ts
@@ -1,6 +1,6 @@
 import { Command } from "commander";
 import chalk from "chalk";
-import { leaveOrg } from "../../lib/api";
+import { leaveOrg, listOrgs } from "../../lib/api";
 import { saveConfig } from "../../lib/api/config";
 import { withErrorHandler } from "../../lib/command";
 
@@ -10,9 +10,19 @@ export const leaveCommand = new Command()
   .action(
     withErrorHandler(async () => {
       await leaveOrg();
-      await saveConfig({ activeOrg: undefined });
-      console.log(
-        chalk.green("✓ Left organization. Switched to personal org."),
-      );
+
+      const { orgs } = await listOrgs();
+      if (orgs.length === 0) {
+        await saveConfig({ activeOrg: undefined });
+        console.log(chalk.green("✓ Left organization."));
+        console.log(
+          chalk.yellow("No remaining organizations. Run: vm0 auth login"),
+        );
+        return;
+      }
+
+      const nextOrg = orgs[0]!.slug;
+      await saveConfig({ activeOrg: nextOrg });
+      console.log(chalk.green(`✓ Left organization. Switched to: ${nextOrg}`));
     }),
   );

--- a/turbo/apps/cli/src/commands/org/use.ts
+++ b/turbo/apps/cli/src/commands/org/use.ts
@@ -7,34 +7,17 @@ import { withErrorHandler } from "../../lib/command";
 export const useCommand = new Command()
   .name("use")
   .description("Switch to a different organization")
-  .argument("[slug]", "Organization slug to switch to")
-  .option("--personal", "Switch to personal org")
+  .argument("<slug>", "Organization slug to switch to")
   .action(
-    withErrorHandler(
-      async (slug: string | undefined, options: { personal?: boolean }) => {
-        if (options.personal) {
-          await saveConfig({ activeOrg: undefined });
-          console.log(chalk.green("✓ Switched to personal org."));
-          return;
-        }
+    withErrorHandler(async (slug: string) => {
+      // Verify the organization exists and user has access
+      const orgList = await listOrgs();
+      const target = orgList.orgs.find((s) => s.slug === slug);
+      if (!target) {
+        throw new Error(`Organization '${slug}' not found or not accessible.`);
+      }
 
-        if (!slug) {
-          throw new Error(
-            "Organization slug is required. Use --personal to switch to personal org.",
-          );
-        }
-
-        // Verify the organization exists and user has access
-        const orgList = await listOrgs();
-        const target = orgList.orgs.find((s) => s.slug === slug);
-        if (!target) {
-          throw new Error(
-            `Organization '${slug}' not found or not accessible.`,
-          );
-        }
-
-        await saveConfig({ activeOrg: slug });
-        console.log(chalk.green(`✓ Switched to organization: ${slug}`));
-      },
-    ),
+      await saveConfig({ activeOrg: slug });
+      console.log(chalk.green(`✓ Switched to organization: ${slug}`));
+    }),
   );

--- a/turbo/apps/docs/content/docs/reference/cli/index.mdx
+++ b/turbo/apps/docs/content/docs/reference/cli/index.mdx
@@ -123,7 +123,7 @@ Organizations are namespaces for organizing agents.
 | `vm0 org status` | Show current organization | - |
 | `vm0 org set <slug>` | Set the active organization | `--force` |
 | `vm0 org list` | List all accessible organizations | - |
-| `vm0 org use [slug]` | Switch to a different organization | `--personal` |
+| `vm0 org use <slug>` | Switch to a different organization | - |
 | `vm0 org members` | View organization members | - |
 | `vm0 org invite` | Invite a member to the current organization | `--email <email>` (required) |
 | `vm0 org remove <email>` | Remove a member from the current organization | - |


### PR DESCRIPTION
## Summary

- Remove `--personal` flag from `vm0 org use` — slug is now a required argument
- Fix `vm0 org leave` to auto-switch to another available org instead of clearing `activeOrg`
- Update CLI reference docs to remove `--personal` option
- Update tests to match new behavior

## Context

After #5110 (remove `resolveOrg` default fallback), API requests without `?org=` parameter will fail with 400 "Explicit org context required". The `--personal` flag and `org leave` both cleared `activeOrg`, which caused this.

Since all users are now required to be in an org (Clerk's `hidePersonal` setting), the "personal org" concept is obsolete.

## Test plan

- [x] `vm0 org use` no longer accepts `--personal` flag
- [x] `vm0 org use` requires `<slug>` argument (Commander enforces)
- [x] `vm0 org leave` auto-switches to first remaining org
- [x] All 25 org command tests pass
- [x] Full CLI test suite (914 tests) passes
- [x] Lint, type check, format, knip all pass

Closes #5145

🤖 Generated with [Claude Code](https://claude.com/claude-code)