### PR TITLE
fix: improve slack connect flow with loading state, install DM, and org check

### DIFF
--- a/turbo/apps/platform/src/signals/bootstrap.ts
+++ b/turbo/apps/platform/src/signals/bootstrap.ts
@@ -7,6 +7,7 @@ import { setupLoggers$ } from "./bootstrap/loggers.ts";
 import { setupZeroPage$ } from "./zero-page/zero-page.ts";
 import { setupZeroJobDetailRoute$ } from "./zero-page/zero-job-detail-route.ts";
 import { setupSelectOrgPage$ } from "./select-org/select-org-page.ts";
+import { setupSlackConnectPage$ } from "./zero-page/slack-connect-page.ts";
 
 const ROUTE_CONFIG = [
   {
@@ -24,6 +25,10 @@ const ROUTE_CONFIG = [
   {
     path: "/team/:name",
     setup: setupAuthPageWrapper(setupZeroJobDetailRoute$),
+  },
+  {
+    path: "/slack/connect",
+    setup: setupAuthPageWrapper(setupSlackConnectPage$),
   },
   {
     path: "/:tab/:sub",

--- a/turbo/apps/platform/src/signals/zero-page/slack-connect-page.ts
+++ b/turbo/apps/platform/src/signals/zero-page/slack-connect-page.ts
@@ -1,0 +1,8 @@
+import { command } from "ccstate";
+import { createElement } from "react";
+import { updatePage$ } from "../react-router.ts";
+import { ZeroSlackConnectPage } from "../../views/zero-page/zero-slack-connect-page.tsx";
+
+export const setupSlackConnectPage$ = command(({ set }) => {
+  set(updatePage$, createElement(ZeroSlackConnectPage));
+});

--- a/turbo/apps/platform/src/signals/zero-page/zero-slack.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-slack.ts
@@ -123,12 +123,8 @@ export const pollSlackConnection$ = command(
       const data = (await res.json()) as SlackOrgData;
       set(slackOrgState$, { data, loading: false, error: null });
 
-      if (data.isConnected || data.isInstalled) {
-        if (data.isConnected) {
-          toast.success("Slack connected successfully");
-        } else {
-          toast.success("Slack installed successfully");
-        }
+      if (data.isConnected) {
+        toast.success("Slack connected successfully");
         return;
       }
     }

--- a/turbo/apps/platform/src/signals/zero-page/zero-slack.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-slack.ts
@@ -1,5 +1,6 @@
 import { command, computed, state } from "ccstate";
 import { toast } from "@vm0/ui/components/ui/sonner";
+import { delay } from "signal-timers";
 import { fetch$ } from "../fetch.ts";
 
 interface SlackOrgData {
@@ -94,6 +95,45 @@ export const uninstallSlackOrg$ = command(async ({ get, set }) => {
   toast.success("Slack workspace uninstalled");
   await set(fetchSlackOrg$);
 });
+
+const POLL_INTERVAL_MS = 3000;
+
+/**
+ * Poll Slack connection status until connected or aborted.
+ * Used on the works page so that after the user completes OAuth in another tab
+ * the UI updates automatically without a manual refresh.
+ */
+export const pollSlackConnection$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    // Already connected — nothing to poll.
+    const current = get(slackOrgState$).data;
+    if (current?.isConnected) {
+      return;
+    }
+
+    while (!signal.aborted) {
+      await delay(POLL_INTERVAL_MS, { signal });
+
+      const fetchFn = get(fetch$);
+      const res = await fetchFn("/api/integrations/slack/org", { signal });
+      if (!res.ok) {
+        continue;
+      }
+
+      const data = (await res.json()) as SlackOrgData;
+      set(slackOrgState$, { data, loading: false, error: null });
+
+      if (data.isConnected || data.isInstalled) {
+        if (data.isConnected) {
+          toast.success("Slack connected successfully");
+        } else {
+          toast.success("Slack installed successfully");
+        }
+        return;
+      }
+    }
+  },
+);
 
 export const initSlackOrg$ = command(async ({ set }) => {
   await set(fetchSlackOrg$);

--- a/turbo/apps/platform/src/signals/zero-page/zero-slack.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-slack.ts
@@ -75,6 +75,7 @@ export const disconnectSlackOrg$ = command(async ({ get, set }) => {
     return;
   }
 
+  toast.success("Disconnected from Slack");
   await set(fetchSlackOrg$);
 });
 

--- a/turbo/apps/platform/src/types/route.ts
+++ b/turbo/apps/platform/src/types/route.ts
@@ -5,4 +5,5 @@ export type RoutePath =
   | "/chat/:sessionId"
   | "/team/:name"
   | "/talk/:name"
+  | "/slack/connect"
   | `/projects/${string}`;

--- a/turbo/apps/platform/src/views/zero-page/zero-onboarding.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-onboarding.tsx
@@ -307,7 +307,9 @@ export function ZeroOnboarding({
         await completeOnboarding(controller.signal);
         // Admin with install URL: open Slack OAuth install flow
         if (slackData?.isAdmin && slackData.installUrl) {
-          window.open(slackData.installUrl, "_blank");
+          const url = new URL(slackData.installUrl, window.location.origin);
+          url.searchParams.set("_t", String(Date.now()));
+          window.open(url.toString(), "_blank");
         }
         navigate("/works");
       })(),

--- a/turbo/apps/platform/src/views/zero-page/zero-slack-connect-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-slack-connect-page.tsx
@@ -15,7 +15,7 @@ import { Link } from "../router/link.tsx";
 function BackLink() {
   return (
     <Link
-      pathname="/zero/:tab"
+      pathname="/:tab"
       options={{ pathParams: { tab: "works" } }}
       className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors no-underline"
     >

--- a/turbo/apps/platform/src/views/zero-page/zero-slack-connect-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-slack-connect-page.tsx
@@ -36,9 +36,9 @@ function BackLink() {
  */
 export function ZeroSlackConnectPage() {
   const fetchFn = useGet(fetch$);
-  const status$ = useCCState<"idle" | "connecting" | "success" | "error">(
-    "idle",
-  );
+  const status$ = useCCState<
+    "idle" | "checking" | "connecting" | "success" | "error"
+  >("idle");
   const status = useGet(status$);
   const setStatus = useSet(status$);
   const errorMsg$ = useCCState("");
@@ -52,12 +52,42 @@ export function ZeroSlackConnectPage() {
   const initialError = params.get("error");
   const workspaceName = params.get("workspace");
 
+  // Check if already connected on mount
+  const checked$ = useCCState(false);
+  const checked = useGet(checked$);
+  const setChecked = useSet(checked$);
+  const alreadyConnected$ = useCCState(false);
+  const alreadyConnected = useGet(alreadyConnected$);
+  const setAlreadyConnected = useSet(alreadyConnected$);
+
+  if (!checked && !initialStatus && !initialError && workspaceId) {
+    queueMicrotask(() => {
+      setChecked(true);
+      setStatus("checking");
+      detach(
+        (async () => {
+          const res = await fetchFn("/api/integrations/slack/org/connect");
+          if (res.ok) {
+            const data = (await res.json()) as { isConnected?: boolean };
+            if (data.isConnected) {
+              setAlreadyConnected(true);
+              setStatus("success");
+              return;
+            }
+          }
+          setStatus("idle");
+        })(),
+        Reason.DomCallback,
+      );
+    });
+  }
+
   const effectiveStatus =
     initialStatus === "connected" ? "success" : initialError ? "error" : status;
   const effectiveError = initialError ?? errorMsg;
 
-  // Auto-open Slack on success
-  if (effectiveStatus === "success") {
+  // Auto-open Slack on success (redirect or connect button, not initial check)
+  if (effectiveStatus === "success" && !alreadyConnected) {
     queueMicrotask(() => {
       window.location.href = "slack://open";
     });
@@ -183,6 +213,23 @@ function PageContent({
           <div className="flex justify-center">
             <BackLink />
           </div>
+        </div>
+      </>
+    );
+  }
+
+  // Loading — checking login / connection status
+  if (effectiveStatus === "checking") {
+    return (
+      <>
+        <IconLoader2 size={40} className="text-muted-foreground animate-spin" />
+        <div className="text-center space-y-1.5">
+          <h2 className="text-base font-semibold text-foreground">
+            Checking account status…
+          </h2>
+          <p className="text-sm text-muted-foreground leading-relaxed">
+            Please wait while we verify your connection.
+          </p>
         </div>
       </>
     );

--- a/turbo/apps/platform/src/views/zero-page/zero-slack-connect-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-slack-connect-page.tsx
@@ -1,0 +1,236 @@
+import { useCCState } from "ccstate-react/experimental";
+import { useGet, useSet } from "ccstate-react";
+import {
+  IconBrandSlack,
+  IconLoader2,
+  IconAlertCircle,
+  IconCircleCheck,
+  IconArrowLeft,
+} from "@tabler/icons-react";
+import { Button } from "@vm0/ui";
+import { fetch$ } from "../../signals/fetch.ts";
+import { detach, Reason } from "../../signals/utils.ts";
+import { Link } from "../router/link.tsx";
+
+function BackLink() {
+  return (
+    <Link
+      pathname="/zero/:tab"
+      options={{ pathParams: { tab: "works" } }}
+      className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors no-underline"
+    >
+      <IconArrowLeft size={14} />
+      Back to settings
+    </Link>
+  );
+}
+
+/**
+ * Slack Connect page — handles connect confirmation, success, and error states.
+ *
+ * URL params:
+ * - w, u: workspace and slack user IDs (for manual connect flow from Slack)
+ * - status=connected: post-install or post-connect success
+ * - workspace: workspace name (for display after connect)
+ * - error: error message to display
+ */
+export function ZeroSlackConnectPage() {
+  const fetchFn = useGet(fetch$);
+  const status$ = useCCState<"idle" | "connecting" | "success" | "error">(
+    "idle",
+  );
+  const status = useGet(status$);
+  const setStatus = useSet(status$);
+  const errorMsg$ = useCCState("");
+  const errorMsg = useGet(errorMsg$);
+  const setErrorMsg = useSet(errorMsg$);
+
+  const params = new URLSearchParams(window.location.search);
+  const workspaceId = params.get("w");
+  const slackUserId = params.get("u");
+  const initialStatus = params.get("status");
+  const initialError = params.get("error");
+  const workspaceName = params.get("workspace");
+
+  const effectiveStatus =
+    initialStatus === "connected" ? "success" : initialError ? "error" : status;
+  const effectiveError = initialError ?? errorMsg;
+
+  // Auto-open Slack on success
+  if (effectiveStatus === "success") {
+    queueMicrotask(() => {
+      window.location.href = "slack://open";
+    });
+  }
+
+  const handleConnect = () => {
+    if (!workspaceId || !slackUserId) {
+      return;
+    }
+    setStatus("connecting");
+
+    detach(
+      (async () => {
+        const channelId = params.get("c");
+        const threadTs = params.get("t");
+        const res = await fetchFn("/api/integrations/slack/org/connect", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            workspaceId,
+            slackUserId,
+            ...(channelId ? { channelId } : {}),
+            ...(threadTs ? { threadTs } : {}),
+          }),
+        });
+
+        if (res.ok) {
+          setStatus("success");
+        } else {
+          const body = (await res.json().catch(() => ({}))) as {
+            error?: { message?: string };
+          };
+          setErrorMsg(
+            body.error?.message ?? "Failed to connect. Please try again.",
+          );
+          setStatus("error");
+        }
+      })(),
+      Reason.DomCallback,
+    );
+  };
+
+  return (
+    <div className="zero-app flex h-dvh w-full bg-background zero-workspace-bg">
+      <div className="flex flex-1 items-center justify-center p-4">
+        <div className="zero-card w-full max-w-sm rounded-xl border border-border bg-card p-8 flex flex-col items-center gap-6">
+          <PageContent
+            effectiveStatus={effectiveStatus}
+            effectiveError={effectiveError}
+            workspaceName={workspaceName}
+            workspaceId={workspaceId}
+            slackUserId={slackUserId}
+            connectStatus={status}
+            onConnect={handleConnect}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function PageContent({
+  effectiveStatus,
+  effectiveError,
+  workspaceName,
+  workspaceId,
+  slackUserId,
+  connectStatus,
+  onConnect,
+}: {
+  effectiveStatus: string;
+  effectiveError: string;
+  workspaceName: string | null;
+  workspaceId: string | null;
+  slackUserId: string | null;
+  connectStatus: string;
+  onConnect: () => void;
+}) {
+  // Error state
+  if (effectiveStatus === "error") {
+    return (
+      <>
+        <IconAlertCircle size={40} className="text-destructive" />
+        <div className="text-center space-y-1.5">
+          <h2 className="text-base font-semibold text-foreground">
+            Connection Failed
+          </h2>
+          <p className="text-sm text-muted-foreground leading-relaxed">
+            {effectiveError}
+          </p>
+        </div>
+        <BackLink />
+      </>
+    );
+  }
+
+  // Success state
+  if (effectiveStatus === "success") {
+    return (
+      <>
+        <IconCircleCheck size={40} className="text-emerald-500" />
+        <div className="text-center space-y-1.5">
+          <h2 className="text-base font-semibold text-foreground">
+            Connected to Slack!
+          </h2>
+          <p className="text-sm text-muted-foreground leading-relaxed">
+            {workspaceName ? `You're connected to ${workspaceName}. ` : ""}
+            Mention <strong>@Zero</strong> in any channel or send a DM to start
+            chatting.
+          </p>
+        </div>
+        <div className="flex flex-col gap-3 w-full">
+          <Button
+            size="default"
+            className="w-full gap-2"
+            onClick={() => {
+              window.location.href = "slack://open";
+            }}
+          >
+            <IconBrandSlack size={16} />
+            Open Slack
+          </Button>
+          <div className="flex justify-center">
+            <BackLink />
+          </div>
+        </div>
+      </>
+    );
+  }
+
+  // Connect confirmation (from Slack link with w + u params)
+  if (workspaceId && slackUserId) {
+    return (
+      <>
+        <IconBrandSlack size={40} className="text-foreground" />
+        <div className="text-center space-y-1.5">
+          <h2 className="text-base font-semibold text-foreground">
+            Connect to Slack
+          </h2>
+          <p className="text-sm text-muted-foreground leading-relaxed">
+            Link your account to this Slack workspace so you can interact with
+            your agent directly from Slack.
+          </p>
+        </div>
+        <Button
+          className="w-full"
+          size="default"
+          onClick={onConnect}
+          disabled={connectStatus === "connecting"}
+        >
+          {connectStatus === "connecting" ? (
+            <IconLoader2 size={16} className="animate-spin mr-2" />
+          ) : null}
+          {connectStatus === "connecting" ? "Connecting..." : "Connect"}
+        </Button>
+        <BackLink />
+      </>
+    );
+  }
+
+  // No params — invalid access
+  return (
+    <>
+      <IconAlertCircle size={40} className="text-muted-foreground/40" />
+      <div className="text-center space-y-1.5">
+        <h2 className="text-base font-semibold text-foreground">
+          Invalid Link
+        </h2>
+        <p className="text-sm text-muted-foreground leading-relaxed">
+          This page is meant to be opened from a Slack connect link.
+        </p>
+      </div>
+      <BackLink />
+    </>
+  );
+}

--- a/turbo/apps/platform/src/views/zero-page/zero-works-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-works-page.tsx
@@ -1,4 +1,4 @@
-import { useCCState } from "ccstate-react/experimental";
+import { useCCState, useCommand } from "ccstate-react/experimental";
 import { useGet, useSet, useLoadable } from "ccstate-react";
 import {
   IconCircleCheck,
@@ -24,8 +24,9 @@ import {
   slackOrgData$,
   disconnectSlackOrg$,
   uninstallSlackOrg$,
+  pollSlackConnection$,
 } from "../../signals/zero-page/zero-slack.ts";
-import { detach, Reason } from "../../signals/utils.ts";
+import { detach, onRef, Reason } from "../../signals/utils.ts";
 
 /** Append a cache-busting timestamp so the browser never reuses a cached OAuth redirect. */
 function openFreshOAuth(url: string) {
@@ -133,9 +134,22 @@ function SlackCard({ agentName }: { agentName: string }) {
   const isInstalled = slackData?.isInstalled ?? isConnected;
   const isAdmin = slackData?.isAdmin ?? false;
 
+  // Poll for Slack connection while not connected — auto-detects when the
+  // user completes OAuth in another tab.
+  const startPolling$ = useCommand(
+    ({ set }, _el: HTMLElement, signal: AbortSignal) => {
+      detach(set(pollSlackConnection$, signal), Reason.DomCallback);
+    },
+  );
+  const pollingRef$ = onRef(startPolling$);
+  const pollingRef = useSet(pollingRef$);
+
   return (
     <>
-      <div className="zero-card flex items-center gap-4 p-4">
+      <div
+        ref={isConnected ? undefined : pollingRef}
+        className="zero-card flex items-center gap-4 p-4"
+      >
         <div className="shrink-0">
           <img src="/slack-icon.svg" alt="" className="h-7 w-7" />
         </div>

--- a/turbo/apps/platform/src/views/zero-page/zero-works-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-works-page.tsx
@@ -27,6 +27,13 @@ import {
 } from "../../signals/zero-page/zero-slack.ts";
 import { detach, Reason } from "../../signals/utils.ts";
 
+/** Append a cache-busting timestamp so the browser never reuses a cached OAuth redirect. */
+function openFreshOAuth(url: string) {
+  const fresh = new URL(url, window.location.origin);
+  fresh.searchParams.set("_t", String(Date.now()));
+  window.open(fresh.toString(), "_blank");
+}
+
 function SlackCardActions({
   isConnected,
   isInstalled,
@@ -57,7 +64,7 @@ function SlackCardActions({
           variant="outline"
           size="sm"
           className="h-8 shrink-0 gap-1.5 rounded-lg"
-          onClick={() => window.open(installUrl, "_blank")}
+          onClick={() => openFreshOAuth(installUrl)}
         >
           <IconDownload size={14} stroke={1.5} />
           Install to Slack
@@ -68,7 +75,7 @@ function SlackCardActions({
           variant="outline"
           size="sm"
           className="h-8 shrink-0 gap-1.5 rounded-lg"
-          onClick={() => window.open(connectUrl, "_blank")}
+          onClick={() => openFreshOAuth(connectUrl)}
         >
           Connect
         </Button>

--- a/turbo/apps/web/app/api/integrations/slack/org/connect/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/integrations/slack/org/connect/__tests__/route.test.ts
@@ -1,5 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
-import { WebClient } from "@slack/web-api";
+import { describe, it, expect, beforeEach } from "vitest";
 import { GET, POST } from "../route";
 import {
   testContext,
@@ -40,31 +39,16 @@ async function givenBoundWorkspace(opts?: { isAdmin?: boolean }) {
 }
 
 /**
- * Helper — create an unbound Slack installation via OAuth callback (no orgId in state).
+ * Helper — set up an unbound Slack installation (no orgId).
  */
 async function givenUnboundWorkspace(opts?: { isAdmin?: boolean }) {
   const { isAdmin = true } = opts ?? {};
   const user = await context.setupUser();
   const org = await createTestOrg(uniqueId("org"));
 
-  // Create unbound installation via the oauth callback route (no state → null orgId)
-  const workspaceId = `T-${uniqueId("ws")}`;
-  const mockClient = vi.mocked(new WebClient(), true);
-  mockClient.oauth.v2.access.mockResolvedValueOnce({
-    ok: true,
-    access_token: "xoxb-unbound-token",
-    bot_user_id: "B-unbound",
-    team: { id: workspaceId, name: "Unbound Workspace" },
-    authed_user: { id: "U-installer" },
-  } as never);
-
-  const { GET: oauthCallback } = await import(
-    "../../../../../slack/org/oauth/callback/route"
-  );
-  const callbackReq = createTestRequest(
-    `http://localhost:3000/api/slack/org/oauth/callback?code=test-code`,
-  );
-  await oauthCallback(callbackReq);
+  const { slackWorkspaceId } = await createTestSlackOrgInstallation({
+    orgId: null,
+  });
 
   mockClerk({
     userId: user.userId,
@@ -72,7 +56,7 @@ async function givenUnboundWorkspace(opts?: { isAdmin?: boolean }) {
     orgRole: isAdmin ? "org:admin" : "org:member",
   });
 
-  return { user, org, workspaceId };
+  return { user, org, workspaceId: slackWorkspaceId };
 }
 
 describe("/api/integrations/slack/org/connect", () => {

--- a/turbo/apps/web/app/api/integrations/slack/org/connect/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/integrations/slack/org/connect/__tests__/route.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { WebClient } from "@slack/web-api";
 import { GET, POST } from "../route";
 import {
   testContext,
@@ -11,6 +12,7 @@ import {
   createTestSlackOrgConnection,
   createTestRequest,
   findTestSlackOrgConnection,
+  insertOrgCacheEntry,
 } from "../../../../../../../src/__tests__/api-test-helpers";
 
 const context = testContext();
@@ -38,30 +40,31 @@ async function givenBoundWorkspace(opts?: { isAdmin?: boolean }) {
 }
 
 /**
- * Helper — set up an unbound Slack installation (no orgId).
+ * Helper — create an unbound Slack installation via OAuth callback (no orgId in state).
  */
 async function givenUnboundWorkspace(opts?: { isAdmin?: boolean }) {
   const { isAdmin = true } = opts ?? {};
   const user = await context.setupUser();
   const org = await createTestOrg(uniqueId("org"));
 
-  const { slackWorkspaceId } = await createTestSlackOrgInstallation({
-    orgId: org.id,
-  });
+  // Create unbound installation via the oauth callback route (no state → null orgId)
+  const workspaceId = `T-${uniqueId("ws")}`;
+  const mockClient = vi.mocked(new WebClient(), true);
+  mockClient.oauth.v2.access.mockResolvedValueOnce({
+    ok: true,
+    access_token: "xoxb-unbound-token",
+    bot_user_id: "B-unbound",
+    team: { id: workspaceId, name: "Unbound Workspace" },
+    authed_user: { id: "U-installer" },
+  } as never);
 
-  // Unbind the workspace
-  const { initServices } = await import(
-    "../../../../../../../src/lib/init-services"
+  const { GET: oauthCallback } = await import(
+    "../../../../../slack/org/oauth/callback/route"
   );
-  const { slackOrgInstallations } = await import(
-    "../../../../../../../src/db/schema/slack-org-installation"
+  const callbackReq = createTestRequest(
+    `http://localhost:3000/api/slack/org/oauth/callback?code=test-code`,
   );
-  const { eq } = await import("drizzle-orm");
-  initServices();
-  await globalThis.services.db
-    .update(slackOrgInstallations)
-    .set({ orgId: null })
-    .where(eq(slackOrgInstallations.slackWorkspaceId, slackWorkspaceId));
+  await oauthCallback(callbackReq);
 
   mockClerk({
     userId: user.userId,
@@ -69,7 +72,7 @@ async function givenUnboundWorkspace(opts?: { isAdmin?: boolean }) {
     orgRole: isAdmin ? "org:admin" : "org:member",
   });
 
-  return { user, org, workspaceId: slackWorkspaceId };
+  return { user, org, workspaceId };
 }
 
 describe("/api/integrations/slack/org/connect", () => {
@@ -94,7 +97,7 @@ describe("/api/integrations/slack/org/connect", () => {
     });
 
     it("returns isConnected=false when user has no connection", async () => {
-      const { org } = await givenBoundWorkspace();
+      await givenBoundWorkspace();
 
       const request = new Request(
         "http://localhost:3000/api/integrations/slack/org/connect",
@@ -339,7 +342,7 @@ describe("/api/integrations/slack/org/connect", () => {
 
     it("returns 403 when workspace is bound to a different org", async () => {
       // Set up org A (admin) with a bound workspace
-      const userA = await context.setupUser();
+      await context.setupUser();
       const orgA = await createTestOrg(uniqueId("org-a"));
       const { slackWorkspaceId } = await createTestSlackOrgInstallation({
         orgId: orgA.id,
@@ -382,7 +385,7 @@ describe("/api/integrations/slack/org/connect", () => {
 
     it("returns 403 with switch-org message when user is member of target org but wrong active org", async () => {
       // User is a member of two orgs; workspace is bound to orgA
-      const user = await context.setupUser();
+      const { userId } = await context.setupUser();
       const orgASlug = uniqueId("org-a");
       const orgA = await createTestOrg(orgASlug);
       const { slackWorkspaceId } = await createTestSlackOrgInstallation({
@@ -392,13 +395,10 @@ describe("/api/integrations/slack/org/connect", () => {
       // Create a second org and set it as active (wrong active org)
       const orgBId = uniqueId("org-b");
       const orgBSlug = uniqueId("org-b");
-      const { insertOrgCacheEntry } = await import(
-        "../../../../../../../src/__tests__/api-test-helpers"
-      );
       await insertOrgCacheEntry({ orgId: orgBId, slug: orgBSlug });
 
       mockClerk({
-        userId: user.userId,
+        userId,
         orgId: orgBId,
         clerkOrgs: [
           { id: orgA.id, slug: orgASlug, name: orgASlug },
@@ -429,7 +429,7 @@ describe("/api/integrations/slack/org/connect", () => {
     });
 
     it("connect is idempotent — second connect returns success", async () => {
-      const { user, org, workspaceId } = await givenBoundWorkspace();
+      const { workspaceId } = await givenBoundWorkspace();
       const slackUserId = `U-${uniqueId("slack")}`;
 
       // First connect

--- a/turbo/apps/web/app/api/integrations/slack/org/connect/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/integrations/slack/org/connect/__tests__/route.test.ts
@@ -1,0 +1,461 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { GET, POST } from "../route";
+import {
+  testContext,
+  uniqueId,
+} from "../../../../../../../src/__tests__/test-helpers";
+import { mockClerk } from "../../../../../../../src/__tests__/clerk-mock";
+import {
+  createTestOrg,
+  createTestSlackOrgInstallation,
+  createTestSlackOrgConnection,
+  createTestRequest,
+  findTestSlackOrgConnection,
+} from "../../../../../../../src/__tests__/api-test-helpers";
+
+const context = testContext();
+
+/**
+ * Helper — set up an org with a Slack installation already bound to it.
+ * Returns identifiers needed for connect tests.
+ */
+async function givenBoundWorkspace(opts?: { isAdmin?: boolean }) {
+  const { isAdmin = true } = opts ?? {};
+  const user = await context.setupUser();
+  const org = await createTestOrg(uniqueId("org"));
+
+  const { slackWorkspaceId } = await createTestSlackOrgInstallation({
+    orgId: org.id,
+  });
+
+  mockClerk({
+    userId: user.userId,
+    orgId: org.id,
+    orgRole: isAdmin ? "org:admin" : "org:member",
+  });
+
+  return { user, org, workspaceId: slackWorkspaceId };
+}
+
+/**
+ * Helper — set up an unbound Slack installation (no orgId).
+ */
+async function givenUnboundWorkspace(opts?: { isAdmin?: boolean }) {
+  const { isAdmin = true } = opts ?? {};
+  const user = await context.setupUser();
+  const org = await createTestOrg(uniqueId("org"));
+
+  const { slackWorkspaceId } = await createTestSlackOrgInstallation({
+    orgId: org.id,
+  });
+
+  // Unbind the workspace
+  const { initServices } = await import(
+    "../../../../../../../src/lib/init-services"
+  );
+  const { slackOrgInstallations } = await import(
+    "../../../../../../../src/db/schema/slack-org-installation"
+  );
+  const { eq } = await import("drizzle-orm");
+  initServices();
+  await globalThis.services.db
+    .update(slackOrgInstallations)
+    .set({ orgId: null })
+    .where(eq(slackOrgInstallations.slackWorkspaceId, slackWorkspaceId));
+
+  mockClerk({
+    userId: user.userId,
+    orgId: org.id,
+    orgRole: isAdmin ? "org:admin" : "org:member",
+  });
+
+  return { user, org, workspaceId: slackWorkspaceId };
+}
+
+describe("/api/integrations/slack/org/connect", () => {
+  beforeEach(() => {
+    context.setupMocks();
+  });
+
+  // ─── GET (check connection status) ───────────────────────────────────
+
+  describe("GET", () => {
+    it("returns 401 when not authenticated", async () => {
+      mockClerk({ userId: null });
+
+      const request = new Request(
+        "http://localhost:3000/api/integrations/slack/org/connect",
+      );
+      const response = await GET(request);
+      const data = (await response.json()) as { error: { code: string } };
+
+      expect(response.status).toBe(401);
+      expect(data.error.code).toBe("UNAUTHORIZED");
+    });
+
+    it("returns isConnected=false when user has no connection", async () => {
+      const { org } = await givenBoundWorkspace();
+
+      const request = new Request(
+        "http://localhost:3000/api/integrations/slack/org/connect",
+      );
+      const response = await GET(request);
+      const data = (await response.json()) as { isConnected: boolean };
+
+      expect(response.status).toBe(200);
+      expect(data.isConnected).toBe(false);
+    });
+
+    it("returns isConnected=true with workspace info when connected", async () => {
+      const { user, org, workspaceId } = await givenBoundWorkspace();
+
+      await createTestSlackOrgConnection({
+        slackWorkspaceId: workspaceId,
+        vm0UserId: user.userId,
+        orgId: org.id,
+      });
+
+      const request = new Request(
+        "http://localhost:3000/api/integrations/slack/org/connect",
+      );
+      const response = await GET(request);
+      const data = (await response.json()) as {
+        isConnected: boolean;
+        workspaceName: string;
+      };
+
+      expect(response.status).toBe(200);
+      expect(data.isConnected).toBe(true);
+      expect(data.workspaceName).toBeDefined();
+    });
+
+    it("returns isAdmin=true for admin users", async () => {
+      await givenBoundWorkspace({ isAdmin: true });
+
+      const request = new Request(
+        "http://localhost:3000/api/integrations/slack/org/connect",
+      );
+      const response = await GET(request);
+      const data = (await response.json()) as { isAdmin: boolean };
+
+      expect(data.isAdmin).toBe(true);
+    });
+
+    it("returns isAdmin=false for member users", async () => {
+      await givenBoundWorkspace({ isAdmin: false });
+
+      const request = new Request(
+        "http://localhost:3000/api/integrations/slack/org/connect",
+      );
+      const response = await GET(request);
+      const data = (await response.json()) as { isAdmin: boolean };
+
+      expect(data.isAdmin).toBe(false);
+    });
+  });
+
+  // ─── POST (connect user to workspace) ────────────────────────────────
+
+  describe("POST", () => {
+    it("returns 401 when not authenticated", async () => {
+      mockClerk({ userId: null });
+
+      const request = createTestRequest(
+        "http://localhost:3000/api/integrations/slack/org/connect",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            workspaceId: "T-fake",
+            slackUserId: "U-fake",
+          }),
+        },
+      );
+      const response = await POST(request);
+      const data = (await response.json()) as { error: { code: string } };
+
+      expect(response.status).toBe(401);
+      expect(data.error.code).toBe("UNAUTHORIZED");
+    });
+
+    it("returns 400 when body is missing required fields", async () => {
+      await givenBoundWorkspace();
+
+      const request = createTestRequest(
+        "http://localhost:3000/api/integrations/slack/org/connect",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({}),
+        },
+      );
+      const response = await POST(request);
+      const data = (await response.json()) as { error: { code: string } };
+
+      expect(response.status).toBe(400);
+      expect(data.error.code).toBe("BAD_REQUEST");
+    });
+
+    it("returns 400 when body is not valid JSON", async () => {
+      await givenBoundWorkspace();
+
+      const request = createTestRequest(
+        "http://localhost:3000/api/integrations/slack/org/connect",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: "not-json",
+        },
+      );
+      const response = await POST(request);
+
+      expect(response.status).toBe(400);
+    });
+
+    it("returns 404 when workspace does not exist", async () => {
+      await givenBoundWorkspace();
+
+      const request = createTestRequest(
+        "http://localhost:3000/api/integrations/slack/org/connect",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            workspaceId: "T-nonexistent",
+            slackUserId: "U-someone",
+          }),
+        },
+      );
+      const response = await POST(request);
+      const data = (await response.json()) as { error: { code: string } };
+
+      expect(response.status).toBe(404);
+      expect(data.error.code).toBe("NOT_FOUND");
+    });
+
+    it("member connects successfully to a bound workspace", async () => {
+      const { user, org, workspaceId } = await givenBoundWorkspace({
+        isAdmin: false,
+      });
+      const slackUserId = `U-${uniqueId("slack")}`;
+
+      const request = createTestRequest(
+        "http://localhost:3000/api/integrations/slack/org/connect",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ workspaceId, slackUserId }),
+        },
+      );
+      const response = await POST(request);
+      const data = (await response.json()) as {
+        success: boolean;
+        role: string;
+      };
+
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
+      expect(data.role).toBe("member");
+
+      // Verify connection was created
+      const connection = await findTestSlackOrgConnection(
+        slackUserId,
+        workspaceId,
+      );
+      expect(connection).toBeDefined();
+      expect(connection!.vm0UserId).toBe(user.userId);
+      expect(connection!.orgId).toBe(org.id);
+    });
+
+    it("admin connects successfully to a bound workspace", async () => {
+      const { workspaceId } = await givenBoundWorkspace({ isAdmin: true });
+      const slackUserId = `U-${uniqueId("slack")}`;
+
+      const request = createTestRequest(
+        "http://localhost:3000/api/integrations/slack/org/connect",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ workspaceId, slackUserId }),
+        },
+      );
+      const response = await POST(request);
+      const data = (await response.json()) as {
+        success: boolean;
+        role: string;
+      };
+
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
+      expect(data.role).toBe("admin");
+    });
+
+    it("admin connects to an unbound workspace (binds it)", async () => {
+      const { workspaceId } = await givenUnboundWorkspace({ isAdmin: true });
+      const slackUserId = `U-${uniqueId("slack")}`;
+
+      const request = createTestRequest(
+        "http://localhost:3000/api/integrations/slack/org/connect",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ workspaceId, slackUserId }),
+        },
+      );
+      const response = await POST(request);
+      const data = (await response.json()) as {
+        success: boolean;
+        role: string;
+      };
+
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
+      expect(data.role).toBe("admin");
+    });
+
+    it("returns 403 when non-admin tries to connect unbound workspace", async () => {
+      const { workspaceId } = await givenUnboundWorkspace({ isAdmin: false });
+
+      const request = createTestRequest(
+        "http://localhost:3000/api/integrations/slack/org/connect",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            workspaceId,
+            slackUserId: "U-member",
+          }),
+        },
+      );
+      const response = await POST(request);
+      const data = (await response.json()) as {
+        error: { code: string; message: string };
+      };
+
+      expect(response.status).toBe(403);
+      expect(data.error.code).toBe("FORBIDDEN");
+      expect(data.error.message).toContain("Only org admins");
+    });
+
+    it("returns 403 when workspace is bound to a different org", async () => {
+      // Set up org A (admin) with a bound workspace
+      const userA = await context.setupUser();
+      const orgA = await createTestOrg(uniqueId("org-a"));
+      const { slackWorkspaceId } = await createTestSlackOrgInstallation({
+        orgId: orgA.id,
+      });
+
+      // Set up a completely separate user B in a different org
+      const userB = await context.setupUser({ prefix: "user-b" });
+
+      mockClerk({
+        userId: userB.userId,
+        orgId: userB.orgId,
+      });
+
+      const request = createTestRequest(
+        "http://localhost:3000/api/integrations/slack/org/connect",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            workspaceId: slackWorkspaceId,
+            slackUserId: "U-orgb-user",
+          }),
+        },
+      );
+      const response = await POST(request);
+      const data = (await response.json()) as {
+        error: { code: string; message: string };
+      };
+
+      expect(response.status).toBe(403);
+      expect(data.error.code).toBe("FORBIDDEN");
+
+      // Verify no connection was created
+      const connection = await findTestSlackOrgConnection(
+        "U-orgb-user",
+        slackWorkspaceId,
+      );
+      expect(connection).toBeUndefined();
+    });
+
+    it("returns 403 with switch-org message when user is member of target org but wrong active org", async () => {
+      // User is a member of two orgs; workspace is bound to orgA
+      const user = await context.setupUser();
+      const orgASlug = uniqueId("org-a");
+      const orgA = await createTestOrg(orgASlug);
+      const { slackWorkspaceId } = await createTestSlackOrgInstallation({
+        orgId: orgA.id,
+      });
+
+      // Create a second org and set it as active (wrong active org)
+      const orgBId = uniqueId("org-b");
+      const orgBSlug = uniqueId("org-b");
+      const { insertOrgCacheEntry } = await import(
+        "../../../../../../../src/__tests__/api-test-helpers"
+      );
+      await insertOrgCacheEntry({ orgId: orgBId, slug: orgBSlug });
+
+      mockClerk({
+        userId: user.userId,
+        orgId: orgBId,
+        clerkOrgs: [
+          { id: orgA.id, slug: orgASlug, name: orgASlug },
+          { id: orgBId, slug: orgBSlug, name: orgBSlug },
+        ],
+      });
+
+      const request = createTestRequest(
+        "http://localhost:3000/api/integrations/slack/org/connect",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            workspaceId: slackWorkspaceId,
+            slackUserId: "U-wrong-active",
+          }),
+        },
+      );
+      const response = await POST(request);
+      const data = (await response.json()) as {
+        error: { message: string };
+      };
+
+      expect(response.status).toBe(403);
+      expect(data.error.message).toContain(
+        "switch to the correct organization",
+      );
+    });
+
+    it("connect is idempotent — second connect returns success", async () => {
+      const { user, org, workspaceId } = await givenBoundWorkspace();
+      const slackUserId = `U-${uniqueId("slack")}`;
+
+      // First connect
+      const body = JSON.stringify({ workspaceId, slackUserId });
+      const req1 = createTestRequest(
+        "http://localhost:3000/api/integrations/slack/org/connect",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body,
+        },
+      );
+      const res1 = await POST(req1);
+      expect(res1.status).toBe(200);
+
+      // Second connect — same user, same workspace
+      const req2 = createTestRequest(
+        "http://localhost:3000/api/integrations/slack/org/connect",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body,
+        },
+      );
+      const res2 = await POST(req2);
+      expect(res2.status).toBe(200);
+    });
+  });
+});

--- a/turbo/apps/web/app/api/integrations/slack/org/connect/route.ts
+++ b/turbo/apps/web/app/api/integrations/slack/org/connect/route.ts
@@ -14,10 +14,103 @@ import {
   resolveDefaultComposeId,
   getWorkspaceAgent,
 } from "../../../../../../src/lib/slack-org/handlers/shared";
+import { refreshOrgAppHome } from "../../../../../../src/lib/slack-org/handlers/app-home";
+import { env } from "../../../../../../src/env";
+import { decryptSecretValue } from "../../../../../../src/lib/crypto/secrets-encryption";
+import {
+  createSlackClient,
+  postMessage,
+} from "../../../../../../src/lib/slack/client";
+import {
+  buildSuccessMessage,
+  buildWelcomeMessage,
+} from "../../../../../../src/lib/slack/blocks";
+import { logger } from "../../../../../../src/lib/logger";
+
+const log = logger("api:slack-org:connect");
+
+/**
+ * Send a Slack DM confirming successful connection and refresh App Home.
+ * Fire-and-forget to avoid delaying the API response.
+ */
+function notifySlackConnectSuccess(
+  installation: typeof slackOrgInstallations.$inferSelect,
+  slackUserId: string,
+  orgId: string,
+  channelId?: string | null,
+  threadTs?: string | null,
+): void {
+  void (async () => {
+    const { SECRETS_ENCRYPTION_KEY } = env();
+    const botToken = decryptSecretValue(
+      installation.encryptedBotToken,
+      SECRETS_ENCRYPTION_KEY,
+    );
+    const client = createSlackClient(botToken);
+
+    let agentName: string | undefined;
+    const composeId = await resolveDefaultComposeId(orgId);
+    if (composeId) {
+      const agent = await getWorkspaceAgent(composeId);
+      agentName = agent?.displayName ?? agent?.name;
+    }
+
+    const agentLine = agentName
+      ? `Your workspace agent is *${agentName}*.`
+      : `No workspace agent configured yet.`;
+
+    const blocks = buildSuccessMessage(
+      `You're connected! :tada:\n\n${agentLine}\nMention \`@Zero\` in any channel or send a DM to start chatting with your agent.`,
+    );
+
+    if (channelId) {
+      await client.chat.postEphemeral({
+        channel: channelId,
+        user: slackUserId,
+        text: "You're connected!",
+        blocks,
+        ...(threadTs ? { thread_ts: threadTs } : {}),
+      });
+    } else {
+      const connectMsg = await postMessage(
+        client,
+        slackUserId,
+        "You're connected!",
+        { blocks },
+      );
+
+      if (connectMsg?.ts) {
+        await postMessage(client, slackUserId, "Hi! I'm Zero.", {
+          threadTs: connectMsg.ts,
+          blocks: buildWelcomeMessage(agentName),
+        });
+      }
+
+      await globalThis.services.db
+        .update(slackOrgConnections)
+        .set({ dmWelcomeSent: true })
+        .where(
+          and(
+            eq(slackOrgConnections.slackUserId, slackUserId),
+            eq(
+              slackOrgConnections.slackWorkspaceId,
+              installation.slackWorkspaceId,
+            ),
+          ),
+        );
+    }
+
+    await refreshOrgAppHome(client, installation, slackUserId);
+  })().catch((err) =>
+    log.warn("Failed to notify connect success", { error: err }),
+  );
+}
 
 const connectBodySchema = z.object({
   workspaceId: z.string().min(1),
   slackUserId: z.string().min(1),
+  channelId: z.string().optional(),
+  threadTs: z.string().optional(),
 });
 
 /**
@@ -118,7 +211,7 @@ export async function POST(request: Request) {
     );
   }
 
-  const { workspaceId, slackUserId } = parseResult.data;
+  const { workspaceId, slackUserId, channelId, threadTs } = parseResult.data;
 
   // Resolve org and check membership
   const { org, member } = await resolveOrg(userId);
@@ -164,6 +257,14 @@ export async function POST(request: Request) {
       slackUserId,
     });
 
+    notifySlackConnectSuccess(
+      installation,
+      slackUserId,
+      org.orgId,
+      channelId,
+      threadTs,
+    );
+
     return NextResponse.json({
       success: true,
       connectionId: result.connection.id,
@@ -171,15 +272,23 @@ export async function POST(request: Request) {
     });
   }
 
-  // Already bound — member connect
+  // Already bound — verify org match
   if (installation.orgId !== org.orgId) {
+    // Check if user is a member of the workspace's org but has the wrong active org
+    let isMemberOfTargetOrg = false;
+    try {
+      await resolveOrg(userId, null, installation.orgId);
+      isMemberOfTargetOrg = true;
+    } catch {
+      // Not a member
+    }
+
+    const message = isMemberOfTargetOrg
+      ? "Your active organization doesn't match this Slack workspace. Please switch to the correct organization in the platform sidebar before connecting."
+      : "You don't have access to the organization this Slack workspace belongs to. Contact the organization admin for an invite.";
+
     return NextResponse.json(
-      {
-        error: {
-          message: "This workspace is connected to a different org",
-          code: "FORBIDDEN",
-        },
-      },
+      { error: { message, code: "FORBIDDEN" } },
       { status: 403 },
     );
   }
@@ -190,6 +299,14 @@ export async function POST(request: Request) {
     workspaceId,
     slackUserId,
   });
+
+  notifySlackConnectSuccess(
+    installation,
+    slackUserId,
+    org.orgId,
+    channelId,
+    threadTs,
+  );
 
   return NextResponse.json({
     success: true,

--- a/turbo/apps/web/app/api/integrations/slack/org/connect/route.ts
+++ b/turbo/apps/web/app/api/integrations/slack/org/connect/route.ts
@@ -9,102 +9,15 @@ import { slackOrgConnections } from "../../../../../../src/db/schema/slack-org-c
 import {
   adminConnect,
   memberConnect,
+  notifyConnectSuccess,
 } from "../../../../../../src/lib/slack-org/connect-service";
 import {
   resolveDefaultComposeId,
   getWorkspaceAgent,
 } from "../../../../../../src/lib/slack-org/handlers/shared";
-import { refreshOrgAppHome } from "../../../../../../src/lib/slack-org/handlers/app-home";
-import { env } from "../../../../../../src/env";
-import { decryptSecretValue } from "../../../../../../src/lib/crypto/secrets-encryption";
-import {
-  createSlackClient,
-  postMessage,
-} from "../../../../../../src/lib/slack/client";
-import {
-  buildSuccessMessage,
-  buildWelcomeMessage,
-} from "../../../../../../src/lib/slack/blocks";
 import { logger } from "../../../../../../src/lib/logger";
 
 const log = logger("api:slack-org:connect");
-
-/**
- * Send a Slack DM confirming successful connection and refresh App Home.
- * Fire-and-forget to avoid delaying the API response.
- */
-function notifySlackConnectSuccess(
-  installation: typeof slackOrgInstallations.$inferSelect,
-  slackUserId: string,
-  orgId: string,
-  channelId?: string | null,
-  threadTs?: string | null,
-): void {
-  void (async () => {
-    const { SECRETS_ENCRYPTION_KEY } = env();
-    const botToken = decryptSecretValue(
-      installation.encryptedBotToken,
-      SECRETS_ENCRYPTION_KEY,
-    );
-    const client = createSlackClient(botToken);
-
-    let agentName: string | undefined;
-    const composeId = await resolveDefaultComposeId(orgId);
-    if (composeId) {
-      const agent = await getWorkspaceAgent(composeId);
-      agentName = agent?.displayName ?? agent?.name;
-    }
-
-    const agentLine = agentName
-      ? `Your workspace agent is *${agentName}*.`
-      : `No workspace agent configured yet.`;
-
-    const blocks = buildSuccessMessage(
-      `You're connected! :tada:\n\n${agentLine}\nMention \`@Zero\` in any channel or send a DM to start chatting with your agent.`,
-    );
-
-    if (channelId) {
-      await client.chat.postEphemeral({
-        channel: channelId,
-        user: slackUserId,
-        text: "You're connected!",
-        blocks,
-        ...(threadTs ? { thread_ts: threadTs } : {}),
-      });
-    } else {
-      const connectMsg = await postMessage(
-        client,
-        slackUserId,
-        "You're connected!",
-        { blocks },
-      );
-
-      if (connectMsg?.ts) {
-        await postMessage(client, slackUserId, "Hi! I'm Zero.", {
-          threadTs: connectMsg.ts,
-          blocks: buildWelcomeMessage(agentName),
-        });
-      }
-
-      await globalThis.services.db
-        .update(slackOrgConnections)
-        .set({ dmWelcomeSent: true })
-        .where(
-          and(
-            eq(slackOrgConnections.slackUserId, slackUserId),
-            eq(
-              slackOrgConnections.slackWorkspaceId,
-              installation.slackWorkspaceId,
-            ),
-          ),
-        );
-    }
-
-    await refreshOrgAppHome(client, installation, slackUserId);
-  })().catch((err) =>
-    log.warn("Failed to notify connect success", { error: err }),
-  );
-}
 
 const connectBodySchema = z.object({
   workspaceId: z.string().min(1),
@@ -257,12 +170,14 @@ export async function POST(request: Request) {
       slackUserId,
     });
 
-    notifySlackConnectSuccess(
+    void notifyConnectSuccess({
       installation,
       slackUserId,
-      org.orgId,
+      orgId: org.orgId,
       channelId,
       threadTs,
+    }).catch((err) =>
+      log.warn("Failed to notify connect success", { error: err }),
     );
 
     return NextResponse.json({
@@ -300,12 +215,14 @@ export async function POST(request: Request) {
     slackUserId,
   });
 
-  notifySlackConnectSuccess(
+  void notifyConnectSuccess({
     installation,
     slackUserId,
-    org.orgId,
+    orgId: org.orgId,
     channelId,
     threadTs,
+  }).catch((err) =>
+    log.warn("Failed to notify connect success", { error: err }),
   );
 
   return NextResponse.json({

--- a/turbo/apps/web/app/api/integrations/slack/org/route.ts
+++ b/turbo/apps/web/app/api/integrations/slack/org/route.ts
@@ -94,7 +94,8 @@ export async function GET(request: Request) {
       installUrl = url.toString();
     }
 
-    // Build connect URL when workspace is installed but user not connected
+    // Build connect URL for users who haven't linked their Slack identity yet.
+    // Uses the OAuth connect flow to identify the user's Slack account.
     let connectUrl: string | null = null;
     if (installation && baseUrl) {
       const url = new URL(`${baseUrl}/api/slack/org/oauth/connect`);

--- a/turbo/apps/web/app/api/slack/org/connect/route.ts
+++ b/turbo/apps/web/app/api/slack/org/connect/route.ts
@@ -1,115 +1,18 @@
 import { NextResponse } from "next/server";
 import { auth } from "@clerk/nextjs/server";
-import { eq, and } from "drizzle-orm";
+import { eq } from "drizzle-orm";
 import { initServices } from "../../../../../src/lib/init-services";
-import { env } from "../../../../../src/env";
 import { resolveOrg } from "../../../../../src/lib/org/resolve-org";
 import { slackOrgInstallations } from "../../../../../src/db/schema/slack-org-installation";
-import { slackOrgConnections } from "../../../../../src/db/schema/slack-org-connection";
 import {
   adminConnect,
   memberConnect,
+  notifyConnectSuccess,
 } from "../../../../../src/lib/slack-org/connect-service";
-import { decryptSecretValue } from "../../../../../src/lib/crypto/secrets-encryption";
-import {
-  createSlackClient,
-  postMessage,
-} from "../../../../../src/lib/slack/client";
-import {
-  buildSuccessMessage,
-  buildWelcomeMessage,
-} from "../../../../../src/lib/slack/blocks";
-import {
-  resolveDefaultComposeId,
-  getWorkspaceAgent,
-} from "../../../../../src/lib/slack-org/handlers/shared";
-import { refreshOrgAppHome } from "../../../../../src/lib/slack-org/handlers/app-home";
 import { getPlatformUrl } from "../../../../../src/lib/url";
 import { logger } from "../../../../../src/lib/logger";
 
 const log = logger("slack-org:connect");
-
-/**
- * Send a Slack DM confirming successful connection and refresh App Home.
- * Fire-and-forget to avoid delaying the browser redirect.
- */
-function notifyConnectSuccess(
-  installation: typeof slackOrgInstallations.$inferSelect,
-  slackUserId: string,
-  channelId: string | null,
-  threadTs: string | null,
-  orgId: string,
-): void {
-  void (async () => {
-    const { SECRETS_ENCRYPTION_KEY } = env();
-    const botToken = decryptSecretValue(
-      installation.encryptedBotToken,
-      SECRETS_ENCRYPTION_KEY,
-    );
-    const client = createSlackClient(botToken);
-
-    // Resolve agent name for the message
-    let agentName: string | undefined;
-    const composeId = await resolveDefaultComposeId(orgId);
-    if (composeId) {
-      const agent = await getWorkspaceAgent(composeId);
-      agentName = agent?.displayName ?? agent?.name;
-    }
-
-    const agentLine = agentName
-      ? `Your workspace agent is *${agentName}*.`
-      : `No workspace agent configured yet.`;
-
-    const blocks = buildSuccessMessage(
-      `You're connected! :tada:\n\n${agentLine}\nMention \`@Zero\` in any channel or send a DM to start chatting with your agent.`,
-    );
-
-    if (channelId) {
-      // In a channel: use ephemeral so only this user sees it
-      await client.chat.postEphemeral({
-        channel: channelId,
-        user: slackUserId,
-        text: "You're connected!",
-        blocks,
-        ...(threadTs ? { thread_ts: threadTs } : {}),
-      });
-    } else {
-      // No channel context: DM the user, then send welcome in the same thread
-      const connectMsg = await postMessage(
-        client,
-        slackUserId,
-        "You're connected!",
-        { blocks },
-      );
-
-      // Send welcome message as a reply in the same thread
-      if (connectMsg?.ts) {
-        await postMessage(client, slackUserId, "Hi! I'm Zero.", {
-          threadTs: connectMsg.ts,
-          blocks: buildWelcomeMessage(agentName),
-        });
-      }
-
-      // Mark welcome as sent so handleOrgMessagesTabOpened doesn't send again
-      await globalThis.services.db
-        .update(slackOrgConnections)
-        .set({ dmWelcomeSent: true })
-        .where(
-          and(
-            eq(slackOrgConnections.slackUserId, slackUserId),
-            eq(
-              slackOrgConnections.slackWorkspaceId,
-              installation.slackWorkspaceId,
-            ),
-          ),
-        );
-    }
-
-    await refreshOrgAppHome(client, installation, slackUserId).catch((e) =>
-      log.warn("Failed to refresh App Home after connect", { error: e }),
-    );
-  })().catch((e) => log.warn("Failed to notify connect success", { error: e }));
-}
 
 /**
  * GET /api/slack/org/connect?w={workspaceId}&u={slackUserId}&c={channelId}
@@ -176,13 +79,13 @@ export async function GET(request: Request) {
       workspaceId,
     });
 
-    notifyConnectSuccess(
-      updatedInstallation,
+    void notifyConnectSuccess({
+      installation: updatedInstallation,
       slackUserId,
+      orgId: org.orgId,
       channelId,
       threadTs,
-      org.orgId,
-    );
+    }).catch((e) => log.warn("Failed to notify connect success", { error: e }));
     return NextResponse.redirect(
       `${platformUrl}/zero/slack/connect?status=connected`,
     );
@@ -244,13 +147,13 @@ export async function GET(request: Request) {
     role: member.role,
   });
 
-  notifyConnectSuccess(
+  void notifyConnectSuccess({
     installation,
     slackUserId,
+    orgId: org.orgId,
     channelId,
     threadTs,
-    org.orgId,
-  );
+  }).catch((e) => log.warn("Failed to notify connect success", { error: e }));
   return NextResponse.redirect(
     `${platformUrl}/zero/slack/connect?status=connected`,
   );

--- a/turbo/apps/web/app/api/slack/org/connect/route.ts
+++ b/turbo/apps/web/app/api/slack/org/connect/route.ts
@@ -41,7 +41,7 @@ export async function GET(request: Request) {
 
   if (!workspaceId || !slackUserId) {
     return NextResponse.redirect(
-      `${platformUrl}/zero/slack/connect?error=${encodeURIComponent("Invalid connect link.")}`,
+      `${platformUrl}/slack/connect?error=${encodeURIComponent("Invalid connect link.")}`,
     );
   }
 
@@ -53,7 +53,7 @@ export async function GET(request: Request) {
 
   if (!installation) {
     return NextResponse.redirect(
-      `${platformUrl}/zero/slack/connect?error=${encodeURIComponent("Workspace not found. Please install the Slack app first.")}`,
+      `${platformUrl}/slack/connect?error=${encodeURIComponent("Workspace not found. Please install the Slack app first.")}`,
     );
   }
 
@@ -62,7 +62,7 @@ export async function GET(request: Request) {
 
     if (member.role !== "admin") {
       return NextResponse.redirect(
-        `${platformUrl}/zero/slack/connect?error=${encodeURIComponent("Ask your org admin to connect first.")}`,
+        `${platformUrl}/slack/connect?error=${encodeURIComponent("Ask your org admin to connect first.")}`,
       );
     }
 
@@ -87,7 +87,7 @@ export async function GET(request: Request) {
       threadTs,
     }).catch((e) => log.warn("Failed to notify connect success", { error: e }));
     return NextResponse.redirect(
-      `${platformUrl}/zero/slack/connect?status=connected`,
+      `${platformUrl}/slack/connect?status=connected`,
     );
   }
 
@@ -118,7 +118,7 @@ export async function GET(request: Request) {
       : "You don't have access to the organization this Slack workspace belongs to. Contact the organization admin for an invite.";
 
     return NextResponse.redirect(
-      `${platformUrl}/zero/slack/connect?error=${encodeURIComponent(message)}`,
+      `${platformUrl}/slack/connect?error=${encodeURIComponent(message)}`,
     );
   }
 
@@ -154,7 +154,5 @@ export async function GET(request: Request) {
     channelId,
     threadTs,
   }).catch((e) => log.warn("Failed to notify connect success", { error: e }));
-  return NextResponse.redirect(
-    `${platformUrl}/zero/slack/connect?status=connected`,
-  );
+  return NextResponse.redirect(`${platformUrl}/slack/connect?status=connected`);
 }

--- a/turbo/apps/web/app/api/slack/org/connect/route.ts
+++ b/turbo/apps/web/app/api/slack/org/connect/route.ts
@@ -1,10 +1,11 @@
 import { NextResponse } from "next/server";
 import { auth } from "@clerk/nextjs/server";
-import { eq } from "drizzle-orm";
+import { eq, and } from "drizzle-orm";
 import { initServices } from "../../../../../src/lib/init-services";
 import { env } from "../../../../../src/env";
 import { resolveOrg } from "../../../../../src/lib/org/resolve-org";
 import { slackOrgInstallations } from "../../../../../src/db/schema/slack-org-installation";
+import { slackOrgConnections } from "../../../../../src/db/schema/slack-org-connection";
 import {
   adminConnect,
   memberConnect,
@@ -14,7 +15,10 @@ import {
   createSlackClient,
   postMessage,
 } from "../../../../../src/lib/slack/client";
-import { buildSuccessMessage } from "../../../../../src/lib/slack/blocks";
+import {
+  buildSuccessMessage,
+  buildWelcomeMessage,
+} from "../../../../../src/lib/slack/blocks";
 import {
   resolveDefaultComposeId,
   getWorkspaceAgent,
@@ -70,8 +74,35 @@ function notifyConnectSuccess(
         ...(threadTs ? { thread_ts: threadTs } : {}),
       });
     } else {
-      // No channel context: DM the user (DMs are already private)
-      await postMessage(client, slackUserId, "You're connected!", { blocks });
+      // No channel context: DM the user, then send welcome in the same thread
+      const connectMsg = await postMessage(
+        client,
+        slackUserId,
+        "You're connected!",
+        { blocks },
+      );
+
+      // Send welcome message as a reply in the same thread
+      if (connectMsg?.ts) {
+        await postMessage(client, slackUserId, "Hi! I'm Zero.", {
+          threadTs: connectMsg.ts,
+          blocks: buildWelcomeMessage(agentName),
+        });
+      }
+
+      // Mark welcome as sent so handleOrgMessagesTabOpened doesn't send again
+      await globalThis.services.db
+        .update(slackOrgConnections)
+        .set({ dmWelcomeSent: true })
+        .where(
+          and(
+            eq(slackOrgConnections.slackUserId, slackUserId),
+            eq(
+              slackOrgConnections.slackWorkspaceId,
+              installation.slackWorkspaceId,
+            ),
+          ),
+        );
     }
 
     await refreshOrgAppHome(client, installation, slackUserId).catch((e) =>
@@ -88,7 +119,7 @@ function notifyConnectSuccess(
  * creates the connection, and redirects to the platform.
  */
 export async function GET(request: Request) {
-  const { userId } = await auth();
+  const { userId, orgId: activeOrgId } = await auth();
 
   if (!userId) {
     const signInUrl = new URL("/sign-in", request.url);
@@ -107,7 +138,7 @@ export async function GET(request: Request) {
 
   if (!workspaceId || !slackUserId) {
     return NextResponse.redirect(
-      `${platformUrl}/zero/works?error=${encodeURIComponent("Invalid connect link.")}`,
+      `${platformUrl}/zero/slack/connect?error=${encodeURIComponent("Invalid connect link.")}`,
     );
   }
 
@@ -119,7 +150,7 @@ export async function GET(request: Request) {
 
   if (!installation) {
     return NextResponse.redirect(
-      `${platformUrl}/zero/works?error=${encodeURIComponent("Workspace not found. Please install the Slack app first.")}`,
+      `${platformUrl}/zero/slack/connect?error=${encodeURIComponent("Workspace not found. Please install the Slack app first.")}`,
     );
   }
 
@@ -128,7 +159,7 @@ export async function GET(request: Request) {
 
     if (member.role !== "admin") {
       return NextResponse.redirect(
-        `${platformUrl}/zero/works?error=${encodeURIComponent("Ask your org admin to connect first.")}`,
+        `${platformUrl}/zero/slack/connect?error=${encodeURIComponent("Ask your org admin to connect first.")}`,
       );
     }
 
@@ -152,7 +183,40 @@ export async function GET(request: Request) {
       threadTs,
       org.orgId,
     );
-    return NextResponse.redirect(`${platformUrl}/zero/works?connected=1`);
+    return NextResponse.redirect(
+      `${platformUrl}/zero/slack/connect?status=connected`,
+    );
+  }
+
+  // Verify the user is a member of the workspace's bound org AND their
+  // active org matches. Clerk sessions may differ across subdomains
+  // (platform.vm7.ai vs www.vm7.ai), so we also accept an explicit
+  // orgId query param from the platform as a trusted source.
+  const explicitOrgId = url.searchParams.get("orgId");
+  const effectiveOrgId = explicitOrgId ?? activeOrgId;
+  log.info("Org check", {
+    activeOrgId,
+    explicitOrgId,
+    installationOrgId: installation.orgId,
+    userId,
+  });
+  if (!effectiveOrgId || effectiveOrgId !== installation.orgId) {
+    // Distinguish: is the user a member of the workspace's org at all?
+    let isMember = false;
+    try {
+      await resolveOrg(userId, null, installation.orgId);
+      isMember = true;
+    } catch {
+      // Not a member
+    }
+
+    const message = isMember
+      ? "Your active organization doesn't match this Slack workspace. Please switch to the correct organization in the platform sidebar before connecting."
+      : "You don't have access to the organization this Slack workspace belongs to. Contact the organization admin for an invite.";
+
+    return NextResponse.redirect(
+      `${platformUrl}/zero/slack/connect?error=${encodeURIComponent(message)}`,
+    );
   }
 
   const { org, member } = await resolveOrg(userId, null, installation.orgId);
@@ -187,5 +251,7 @@ export async function GET(request: Request) {
     threadTs,
     org.orgId,
   );
-  return NextResponse.redirect(`${platformUrl}/zero/works?connected=1`);
+  return NextResponse.redirect(
+    `${platformUrl}/zero/slack/connect?status=connected`,
+  );
 }

--- a/turbo/apps/web/app/api/slack/org/oauth/callback/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/slack/org/oauth/callback/__tests__/route.test.ts
@@ -87,10 +87,10 @@ describe("/api/slack/org/oauth/callback", () => {
     );
     const response = await GET(request);
 
-    // Should redirect to /zero/works?installed=1
+    // Should redirect to /slack/connect?status=connected
     expect(response.status).toBe(307);
-    expect(response.headers.get("Location")).toBe(
-      "http://localhost:3001/zero/works?installed=1",
+    expect(response.headers.get("Location")).toContain(
+      "/slack/connect?status=connected",
     );
 
     // Verify installation was created with org_id
@@ -293,7 +293,7 @@ describe("/api/slack/org/oauth/callback", () => {
     const responseA = await GET(requestA);
     expect(responseA.status).toBe(307);
     expect(responseA.headers.get("Location")).toContain(
-      "/zero/works?installed=1",
+      "/slack/connect?status=connected",
     );
 
     // Second: Org B tries to install the same workspace
@@ -318,7 +318,7 @@ describe("/api/slack/org/oauth/callback", () => {
     // Should redirect to /zero/works with error
     expect(responseB.status).toBe(307);
     const location = responseB.headers.get("Location")!;
-    expect(location).toContain("/zero/works?error=");
+    expect(location).toContain("/slack/connect?error=");
     expect(decodeURIComponent(location)).toContain(
       "already installed by another organization",
     );
@@ -381,7 +381,7 @@ describe("/api/slack/org/oauth/callback", () => {
     // Should succeed
     expect(response.status).toBe(307);
     expect(response.headers.get("Location")).toContain(
-      "/zero/works?installed=1",
+      "/slack/connect?status=connected",
     );
 
     // Bot token should be updated
@@ -428,8 +428,8 @@ describe("/api/slack/org/oauth/callback", () => {
     const response = await GET(secondRequest);
 
     expect(response.status).toBe(307);
-    expect(response.headers.get("Location")).toBe(
-      "http://localhost:3001/zero/works?installed=1",
+    expect(response.headers.get("Location")).toContain(
+      "/slack/connect?status=connected",
     );
 
     // Should still have exactly one connection (onConflictDoNothing)

--- a/turbo/apps/web/app/api/slack/org/oauth/callback/route.ts
+++ b/turbo/apps/web/app/api/slack/org/oauth/callback/route.ts
@@ -63,7 +63,7 @@ function parseOAuthState(state: string | null): OAuthState {
  *    - User already has an installed workspace; just needs to link their Slack identity
  *    - Exchange code for authed_user.id
  *    - Look up installation for the org, create connection record
- *    - Redirect to /zero/works
+ *    - Redirect to /slack/connect
  */
 export async function GET(request: Request) {
   initServices();
@@ -192,8 +192,11 @@ export async function GET(request: Request) {
 
   // Platform install flow: verify admin and create connection
   if (state.orgId && state.vm0UserId) {
+    const orgId = state.orgId;
+    const vm0UserId = state.vm0UserId;
+
     // Verify user is org admin
-    const member = await requireOrgMember(state.orgId, state.vm0UserId);
+    const member = await requireOrgMember(orgId, vm0UserId);
     if (member.role !== "admin") {
       return NextResponse.redirect(
         `${platformUrl}/slack/failed?error=${encodeURIComponent("Only org admins can install Slack for an organization.")}`,
@@ -206,8 +209,8 @@ export async function GET(request: Request) {
       .values({
         slackUserId: oauthResult.authedUserId,
         slackWorkspaceId: oauthResult.teamId,
-        vm0UserId: state.vm0UserId,
-        orgId: state.orgId,
+        vm0UserId,
+        orgId,
       })
       .onConflictDoNothing();
 
@@ -221,7 +224,7 @@ export async function GET(request: Request) {
       void notifyConnectSuccess({
         installation: inst,
         slackUserId: oauthResult.authedUserId,
-        orgId: state.orgId!,
+        orgId,
       }).catch((err) =>
         log.warn("Failed to notify connect success after install", {
           error: err,

--- a/turbo/apps/web/app/api/slack/org/oauth/callback/route.ts
+++ b/turbo/apps/web/app/api/slack/org/oauth/callback/route.ts
@@ -152,7 +152,7 @@ export async function GET(request: Request) {
         requestedOrgId: state.orgId,
       });
       return NextResponse.redirect(
-        `${platformUrl}/zero/slack/connect?error=${encodeURIComponent("This Slack workspace is already installed by another organization. Please contact the workspace admin to uninstall first.")}`,
+        `${platformUrl}/slack/connect?error=${encodeURIComponent("This Slack workspace is already installed by another organization. Please contact the workspace admin to uninstall first.")}`,
       );
     }
 
@@ -230,7 +230,7 @@ export async function GET(request: Request) {
     }
 
     return NextResponse.redirect(
-      `${platformUrl}/zero/slack/connect?status=connected&workspace=${encodeURIComponent(oauthResult.teamName)}`,
+      `${platformUrl}/slack/connect?status=connected&workspace=${encodeURIComponent(oauthResult.teamName)}`,
     );
   }
 
@@ -260,7 +260,7 @@ async function handleConnectCallback(params: {
 
   if (!state.orgId || !state.vm0UserId) {
     return NextResponse.redirect(
-      `${platformUrl}/zero/slack/connect?error=${encodeURIComponent("Invalid connect state.")}`,
+      `${platformUrl}/slack/connect?error=${encodeURIComponent("Invalid connect state.")}`,
     );
   }
 
@@ -275,7 +275,7 @@ async function handleConnectCallback(params: {
   } catch (err) {
     log.error("Slack OAuth exchange failed (connect flow)", { error: err });
     return NextResponse.redirect(
-      `${platformUrl}/zero/slack/connect?error=${encodeURIComponent("Failed to connect Slack account. Please try again.")}`,
+      `${platformUrl}/slack/connect?error=${encodeURIComponent("Failed to connect Slack account. Please try again.")}`,
     );
   }
 
@@ -290,14 +290,14 @@ async function handleConnectCallback(params: {
 
   if (!installation) {
     return NextResponse.redirect(
-      `${platformUrl}/zero/slack/connect?error=${encodeURIComponent("No Slack workspace installed for this organization.")}`,
+      `${platformUrl}/slack/connect?error=${encodeURIComponent("No Slack workspace installed for this organization.")}`,
     );
   }
 
   // Verify workspace matches (user must have authed with the right workspace)
   if (userIdentity.teamId !== installation.slackWorkspaceId) {
     return NextResponse.redirect(
-      `${platformUrl}/zero/slack/connect?error=${encodeURIComponent("You authenticated with a different Slack workspace. Please use the workspace connected to your organization.")}`,
+      `${platformUrl}/slack/connect?error=${encodeURIComponent("You authenticated with a different Slack workspace. Please use the workspace connected to your organization.")}`,
     );
   }
 
@@ -336,6 +336,6 @@ async function handleConnectCallback(params: {
   );
 
   return NextResponse.redirect(
-    `${platformUrl}/zero/slack/connect?status=connected&workspace=${encodeURIComponent(installation.slackWorkspaceName ?? "")}`,
+    `${platformUrl}/slack/connect?status=connected&workspace=${encodeURIComponent(installation.slackWorkspaceName ?? "")}`,
   );
 }

--- a/turbo/apps/web/app/api/slack/org/oauth/callback/route.ts
+++ b/turbo/apps/web/app/api/slack/org/oauth/callback/route.ts
@@ -1,17 +1,32 @@
 import { NextResponse } from "next/server";
-import { eq } from "drizzle-orm";
+import { eq, and } from "drizzle-orm";
 import { initServices } from "../../../../../../src/lib/init-services";
 import { env } from "../../../../../../src/env";
 import {
   exchangeOAuthCode,
+  exchangeOAuthCodeForUser,
   getSlackRedirectBaseUrl,
   createSlackClient,
 } from "../../../../../../src/lib/slack";
+import { postMessage } from "../../../../../../src/lib/slack/client";
+import {
+  buildSuccessMessage,
+  buildWelcomeMessage,
+} from "../../../../../../src/lib/slack/blocks";
 import { encryptSecretValue } from "../../../../../../src/lib/crypto/secrets-encryption";
 import { slackOrgInstallations } from "../../../../../../src/db/schema/slack-org-installation";
 import { slackOrgConnections } from "../../../../../../src/db/schema/slack-org-connection";
 import { requireOrgMember } from "../../../../../../src/lib/org/org-member-service";
+import {
+  adminConnect,
+  memberConnect,
+} from "../../../../../../src/lib/slack-org/connect-service";
 import { refreshOrgAppHome } from "../../../../../../src/lib/slack-org/handlers/app-home";
+import {
+  resolveDefaultComposeId,
+  getWorkspaceAgent,
+} from "../../../../../../src/lib/slack-org/handlers/shared";
+import { decryptSecretValue } from "../../../../../../src/lib/crypto/secrets-encryption";
 import { getPlatformUrl } from "../../../../../../src/lib/url";
 import { logger } from "../../../../../../src/lib/logger";
 
@@ -20,21 +35,26 @@ const log = logger("slack-org:oauth-callback");
 interface OAuthState {
   orgId: string | null;
   vm0UserId: string | null;
+  flow: "install" | "connect";
 }
 
 function parseOAuthState(state: string | null): OAuthState {
-  if (!state) return { orgId: null, vm0UserId: null };
+  if (!state) {
+    return { orgId: null, vm0UserId: null, flow: "install" };
+  }
   try {
     const parsed = JSON.parse(state) as {
       orgId?: string;
       vm0UserId?: string;
+      flow?: string;
     };
     return {
       orgId: parsed.orgId ?? null,
       vm0UserId: parsed.vm0UserId ?? null,
+      flow: parsed.flow === "connect" ? "connect" : "install",
     };
   } catch {
-    return { orgId: null, vm0UserId: null };
+    return { orgId: null, vm0UserId: null, flow: "install" };
   }
 }
 
@@ -43,23 +63,18 @@ function parseOAuthState(state: string | null): OAuthState {
  *
  * GET /api/slack/org/oauth/callback
  *
- * Handles the OAuth redirect from Slack after app installation.
+ * Handles OAuth redirects from Slack for two flows:
  *
- * Platform flow (state has orgId + vm0UserId):
- *   - Verify user is org admin
- *   - Upsert installation with org_id and installed_by_user_id
- *   - Create connection record
- *   - Redirect to platform
+ * 1. Install flow (state.flow = "install", default):
+ *    - Upsert installation with bot token
+ *    - Platform flow (orgId + vm0UserId): verify admin, create connection
+ *    - Slack flow (no orgId): create unbound installation
  *
- * Slack flow (no orgId in state):
- *   - Upsert installation with org_id = NULL
- *   - Redirect to "workspace installed" page
- *
- * Re-install (installation exists with org_id):
- *   - Preserve org_id and installed_by_user_id
- *   - Update bot token only
- *
- * Note: User-level connect is handled by /api/slack/org/connect (cookie-based).
+ * 2. Connect flow (state.flow = "connect"):
+ *    - User already has an installed workspace; just needs to link their Slack identity
+ *    - Exchange code for authed_user.id
+ *    - Look up installation for the org, create connection record
+ *    - Redirect to /zero/works
  */
 export async function GET(request: Request) {
   initServices();
@@ -95,6 +110,20 @@ export async function GET(request: Request) {
 
   const state = parseOAuthState(url.searchParams.get("state"));
   const redirectUri = `${baseUrl}/api/slack/org/oauth/callback`;
+
+  // Connect flow uses a lightweight exchange that may not return bot tokens.
+  // We use a separate helper that tolerates missing bot fields.
+  if (state.flow === "connect") {
+    return handleConnectCallback({
+      code,
+      redirectUri,
+      state,
+      platformUrl,
+      clientId: SLACK_CLIENT_ID,
+      clientSecret: SLACK_CLIENT_SECRET,
+      encryptionKey: SECRETS_ENCRYPTION_KEY,
+    });
+  }
 
   let oauthResult;
   try {
@@ -135,7 +164,7 @@ export async function GET(request: Request) {
         requestedOrgId: state.orgId,
       });
       return NextResponse.redirect(
-        `${platformUrl}/zero/works?error=${encodeURIComponent("This Slack workspace is already installed by another organization. Please contact the workspace admin to uninstall first.")}`,
+        `${platformUrl}/zero/slack/connect?error=${encodeURIComponent("This Slack workspace is already installed by another organization. Please contact the workspace admin to uninstall first.")}`,
       );
     }
 
@@ -208,11 +237,168 @@ export async function GET(request: Request) {
       );
     }
 
-    return NextResponse.redirect(`${platformUrl}/zero/works?installed=1`);
+    return NextResponse.redirect(
+      `${platformUrl}/zero/slack/connect?status=connected&workspace=${encodeURIComponent(oauthResult.teamName)}`,
+    );
   }
 
   // Slack flow: redirect to success page
   return NextResponse.redirect(
     `${platformUrl}/slack/installed?workspace=${encodeURIComponent(oauthResult.teamName)}`,
+  );
+}
+
+/**
+ * Handle the OAuth callback for the "connect" flow.
+ *
+ * The connect flow is used when a workspace is already installed but the
+ * current user hasn't linked their Slack identity yet.  We exchange the
+ * OAuth code to learn the user's Slack ID, then create a connection record.
+ */
+async function handleConnectCallback(params: {
+  code: string;
+  redirectUri: string;
+  state: OAuthState;
+  platformUrl: string;
+  clientId: string;
+  clientSecret: string;
+  encryptionKey: string;
+}): Promise<NextResponse> {
+  const {
+    code,
+    redirectUri,
+    state,
+    platformUrl,
+    clientId,
+    clientSecret,
+    encryptionKey,
+  } = params;
+
+  if (!state.orgId || !state.vm0UserId) {
+    return NextResponse.redirect(
+      `${platformUrl}/zero/slack/connect?error=${encodeURIComponent("Invalid connect state.")}`,
+    );
+  }
+
+  let userIdentity;
+  try {
+    userIdentity = await exchangeOAuthCodeForUser(
+      clientId,
+      clientSecret,
+      code,
+      redirectUri,
+    );
+  } catch (err) {
+    log.error("Slack OAuth exchange failed (connect flow)", { error: err });
+    return NextResponse.redirect(
+      `${platformUrl}/zero/slack/connect?error=${encodeURIComponent("Failed to connect Slack account. Please try again.")}`,
+    );
+  }
+
+  const db = globalThis.services.db;
+
+  // Find the installation for this org
+  const [installation] = await db
+    .select()
+    .from(slackOrgInstallations)
+    .where(eq(slackOrgInstallations.orgId, state.orgId))
+    .limit(1);
+
+  if (!installation) {
+    return NextResponse.redirect(
+      `${platformUrl}/zero/slack/connect?error=${encodeURIComponent("No Slack workspace installed for this organization.")}`,
+    );
+  }
+
+  // Verify workspace matches (user must have authed with the right workspace)
+  if (userIdentity.teamId !== installation.slackWorkspaceId) {
+    return NextResponse.redirect(
+      `${platformUrl}/zero/slack/connect?error=${encodeURIComponent("You authenticated with a different Slack workspace. Please use the workspace connected to your organization.")}`,
+    );
+  }
+
+  // Create connection using the appropriate service function
+  const member = await requireOrgMember(state.orgId, state.vm0UserId);
+  if (member.role === "admin") {
+    await adminConnect({
+      userId: state.vm0UserId,
+      orgId: state.orgId,
+      workspaceId: installation.slackWorkspaceId,
+      slackUserId: userIdentity.authedUserId,
+    });
+  } else {
+    await memberConnect({
+      userId: state.vm0UserId,
+      orgId: state.orgId,
+      workspaceId: installation.slackWorkspaceId,
+      slackUserId: userIdentity.authedUserId,
+    });
+  }
+
+  log.info("User connected via OAuth", {
+    vm0UserId: state.vm0UserId,
+    orgId: state.orgId,
+    slackUserId: userIdentity.authedUserId,
+    workspaceId: installation.slackWorkspaceId,
+  });
+
+  // Send DM + refresh App Home (best-effort, fire-and-forget)
+  const botToken = decryptSecretValue(
+    installation.encryptedBotToken,
+    encryptionKey,
+  );
+  const client = createSlackClient(botToken);
+
+  void (async () => {
+    // Resolve agent name for the DM
+    let agentName: string | undefined;
+    const composeId = await resolveDefaultComposeId(state.orgId!);
+    if (composeId) {
+      const agent = await getWorkspaceAgent(composeId);
+      agentName = agent?.displayName ?? agent?.name;
+    }
+
+    const agentLine = agentName
+      ? `Your workspace agent is *${agentName}*.`
+      : `No workspace agent configured yet.`;
+
+    const connectMsg = await postMessage(
+      client,
+      userIdentity.authedUserId,
+      "You're connected!",
+      {
+        blocks: buildSuccessMessage(
+          `You're connected! :tada:\n\n${agentLine}\nMention \`@Zero\` in any channel or send a DM to start chatting with your agent.`,
+        ),
+      },
+    );
+
+    if (connectMsg?.ts) {
+      await postMessage(client, userIdentity.authedUserId, "Hi! I'm Zero.", {
+        threadTs: connectMsg.ts,
+        blocks: buildWelcomeMessage(agentName),
+      });
+    }
+
+    await globalThis.services.db
+      .update(slackOrgConnections)
+      .set({ dmWelcomeSent: true })
+      .where(
+        and(
+          eq(slackOrgConnections.slackUserId, userIdentity.authedUserId),
+          eq(
+            slackOrgConnections.slackWorkspaceId,
+            installation.slackWorkspaceId,
+          ),
+        ),
+      );
+
+    await refreshOrgAppHome(client, installation, userIdentity.authedUserId);
+  })().catch((err) =>
+    log.warn("Failed to notify connect success", { error: err }),
+  );
+
+  return NextResponse.redirect(
+    `${platformUrl}/zero/slack/connect?status=connected&workspace=${encodeURIComponent(installation.slackWorkspaceName ?? "")}`,
   );
 }

--- a/turbo/apps/web/app/api/slack/org/oauth/callback/route.ts
+++ b/turbo/apps/web/app/api/slack/org/oauth/callback/route.ts
@@ -1,18 +1,12 @@
 import { NextResponse } from "next/server";
-import { eq, and } from "drizzle-orm";
+import { eq } from "drizzle-orm";
 import { initServices } from "../../../../../../src/lib/init-services";
 import { env } from "../../../../../../src/env";
 import {
   exchangeOAuthCode,
   exchangeOAuthCodeForUser,
   getSlackRedirectBaseUrl,
-  createSlackClient,
 } from "../../../../../../src/lib/slack";
-import { postMessage } from "../../../../../../src/lib/slack/client";
-import {
-  buildSuccessMessage,
-  buildWelcomeMessage,
-} from "../../../../../../src/lib/slack/blocks";
 import { encryptSecretValue } from "../../../../../../src/lib/crypto/secrets-encryption";
 import { slackOrgInstallations } from "../../../../../../src/db/schema/slack-org-installation";
 import { slackOrgConnections } from "../../../../../../src/db/schema/slack-org-connection";
@@ -20,13 +14,8 @@ import { requireOrgMember } from "../../../../../../src/lib/org/org-member-servi
 import {
   adminConnect,
   memberConnect,
+  notifyConnectSuccess,
 } from "../../../../../../src/lib/slack-org/connect-service";
-import { refreshOrgAppHome } from "../../../../../../src/lib/slack-org/handlers/app-home";
-import {
-  resolveDefaultComposeId,
-  getWorkspaceAgent,
-} from "../../../../../../src/lib/slack-org/handlers/shared";
-import { decryptSecretValue } from "../../../../../../src/lib/crypto/secrets-encryption";
 import { getPlatformUrl } from "../../../../../../src/lib/url";
 import { logger } from "../../../../../../src/lib/logger";
 
@@ -121,7 +110,6 @@ export async function GET(request: Request) {
       platformUrl,
       clientId: SLACK_CLIENT_ID,
       clientSecret: SLACK_CLIENT_SECRET,
-      encryptionKey: SECRETS_ENCRYPTION_KEY,
     });
   }
 
@@ -223,17 +211,21 @@ export async function GET(request: Request) {
       })
       .onConflictDoNothing();
 
-    // Refresh App Home for the installing user (best-effort)
-    const client = createSlackClient(oauthResult.accessToken);
+    // Send DM + welcome and refresh App Home (best-effort, fire-and-forget)
     const [inst] = await db
       .select()
       .from(slackOrgInstallations)
       .where(eq(slackOrgInstallations.slackWorkspaceId, oauthResult.teamId))
       .limit(1);
     if (inst) {
-      await refreshOrgAppHome(client, inst, oauthResult.authedUserId).catch(
-        (err) =>
-          log.warn("Failed to refresh App Home after install", { error: err }),
+      void notifyConnectSuccess({
+        installation: inst,
+        slackUserId: oauthResult.authedUserId,
+        orgId: state.orgId!,
+      }).catch((err) =>
+        log.warn("Failed to notify connect success after install", {
+          error: err,
+        }),
       );
     }
 
@@ -262,17 +254,9 @@ async function handleConnectCallback(params: {
   platformUrl: string;
   clientId: string;
   clientSecret: string;
-  encryptionKey: string;
 }): Promise<NextResponse> {
-  const {
-    code,
-    redirectUri,
-    state,
-    platformUrl,
-    clientId,
-    clientSecret,
-    encryptionKey,
-  } = params;
+  const { code, redirectUri, state, platformUrl, clientId, clientSecret } =
+    params;
 
   if (!state.orgId || !state.vm0UserId) {
     return NextResponse.redirect(
@@ -343,58 +327,11 @@ async function handleConnectCallback(params: {
   });
 
   // Send DM + refresh App Home (best-effort, fire-and-forget)
-  const botToken = decryptSecretValue(
-    installation.encryptedBotToken,
-    encryptionKey,
-  );
-  const client = createSlackClient(botToken);
-
-  void (async () => {
-    // Resolve agent name for the DM
-    let agentName: string | undefined;
-    const composeId = await resolveDefaultComposeId(state.orgId!);
-    if (composeId) {
-      const agent = await getWorkspaceAgent(composeId);
-      agentName = agent?.displayName ?? agent?.name;
-    }
-
-    const agentLine = agentName
-      ? `Your workspace agent is *${agentName}*.`
-      : `No workspace agent configured yet.`;
-
-    const connectMsg = await postMessage(
-      client,
-      userIdentity.authedUserId,
-      "You're connected!",
-      {
-        blocks: buildSuccessMessage(
-          `You're connected! :tada:\n\n${agentLine}\nMention \`@Zero\` in any channel or send a DM to start chatting with your agent.`,
-        ),
-      },
-    );
-
-    if (connectMsg?.ts) {
-      await postMessage(client, userIdentity.authedUserId, "Hi! I'm Zero.", {
-        threadTs: connectMsg.ts,
-        blocks: buildWelcomeMessage(agentName),
-      });
-    }
-
-    await globalThis.services.db
-      .update(slackOrgConnections)
-      .set({ dmWelcomeSent: true })
-      .where(
-        and(
-          eq(slackOrgConnections.slackUserId, userIdentity.authedUserId),
-          eq(
-            slackOrgConnections.slackWorkspaceId,
-            installation.slackWorkspaceId,
-          ),
-        ),
-      );
-
-    await refreshOrgAppHome(client, installation, userIdentity.authedUserId);
-  })().catch((err) =>
+  void notifyConnectSuccess({
+    installation,
+    slackUserId: userIdentity.authedUserId,
+    orgId: state.orgId,
+  }).catch((err) =>
     log.warn("Failed to notify connect success", { error: err }),
   );
 

--- a/turbo/apps/web/app/api/slack/org/oauth/connect/route.ts
+++ b/turbo/apps/web/app/api/slack/org/oauth/connect/route.ts
@@ -13,9 +13,13 @@ import { getSlackRedirectBaseUrl } from "../../../../../../src/lib/slack";
  *
  * Unlike the install flow, no bot scopes are requested — the app is already
  * installed.  We only need Slack to authenticate the user.
+ *
+ * Uses Slack's OpenID Connect endpoint instead of the standard OAuth v2
+ * endpoint so we can pass `prompt=consent` to force the authorization screen
+ * every time (OAuth v2 silently auto-approves previously granted scopes).
  */
 
-const SLACK_OAUTH_URL = "https://slack.com/oauth/v2/authorize";
+const SLACK_OIDC_URL = "https://slack.com/openid/connect/authorize";
 
 export async function GET(request: Request) {
   const { SLACK_CLIENT_ID } = env();
@@ -43,14 +47,18 @@ export async function GET(request: Request) {
 
   const state = JSON.stringify({ orgId, vm0UserId, flow: "connect" });
 
-  const authUrl = new URL(SLACK_OAUTH_URL);
+  const authUrl = new URL(SLACK_OIDC_URL);
   authUrl.searchParams.set("client_id", SLACK_CLIENT_ID);
-  // No bot scopes — app is already installed.
-  // Request minimal user scope so Slack shows the consent screen and
-  // returns the authed_user.id we need to create the connection.
+  authUrl.searchParams.set("response_type", "code");
+  // openid is required for the OIDC endpoint; identity.basic gives us the
+  // authed_user.id via oauth.v2.access which the callback already uses.
+  authUrl.searchParams.set("scope", "openid");
   authUrl.searchParams.set("user_scope", "identity.basic");
   authUrl.searchParams.set("redirect_uri", redirectUri);
   authUrl.searchParams.set("state", state);
+  // Force Slack to always show the consent screen instead of silently
+  // auto-approving previously granted scopes.
+  authUrl.searchParams.set("prompt", "consent");
 
   return NextResponse.redirect(authUrl.toString(), {
     headers: { "Cache-Control": "no-store" },

--- a/turbo/apps/web/app/api/slack/org/oauth/connect/route.ts
+++ b/turbo/apps/web/app/api/slack/org/oauth/connect/route.ts
@@ -52,5 +52,7 @@ export async function GET(request: Request) {
   authUrl.searchParams.set("redirect_uri", redirectUri);
   authUrl.searchParams.set("state", state);
 
-  return NextResponse.redirect(authUrl.toString());
+  return NextResponse.redirect(authUrl.toString(), {
+    headers: { "Cache-Control": "no-store" },
+  });
 }

--- a/turbo/apps/web/app/api/slack/org/oauth/connect/route.ts
+++ b/turbo/apps/web/app/api/slack/org/oauth/connect/route.ts
@@ -1,0 +1,56 @@
+import { NextResponse } from "next/server";
+import { env } from "../../../../../../src/env";
+import { getSlackRedirectBaseUrl } from "../../../../../../src/lib/slack";
+
+/**
+ * Org-aware Slack OAuth Connect Endpoint
+ *
+ * GET /api/slack/org/oauth/connect?orgId=<orgId>&vm0UserId=<userId>
+ *
+ * Redirects to Slack's OAuth authorization page so that a non-admin org member
+ * can identify their Slack account.  The OAuth callback extracts the
+ * `authed_user.id` from the response to create a `slackOrgConnections` record.
+ *
+ * Unlike the install flow, no bot scopes are requested — the app is already
+ * installed.  We only need Slack to authenticate the user.
+ */
+
+const SLACK_OAUTH_URL = "https://slack.com/oauth/v2/authorize";
+
+export async function GET(request: Request) {
+  const { SLACK_CLIENT_ID } = env();
+
+  if (!SLACK_CLIENT_ID) {
+    return NextResponse.json(
+      { error: "Slack integration is not configured" },
+      { status: 503 },
+    );
+  }
+
+  const url = new URL(request.url);
+  const orgId = url.searchParams.get("orgId");
+  const vm0UserId = url.searchParams.get("vm0UserId");
+
+  if (!orgId || !vm0UserId) {
+    return NextResponse.json(
+      { error: "Missing orgId or vm0UserId" },
+      { status: 400 },
+    );
+  }
+
+  const baseUrl = getSlackRedirectBaseUrl(request.url);
+  const redirectUri = `${baseUrl}/api/slack/org/oauth/callback`;
+
+  const state = JSON.stringify({ orgId, vm0UserId, flow: "connect" });
+
+  const authUrl = new URL(SLACK_OAUTH_URL);
+  authUrl.searchParams.set("client_id", SLACK_CLIENT_ID);
+  // No bot scopes — app is already installed.
+  // Request minimal user scope so Slack shows the consent screen and
+  // returns the authed_user.id we need to create the connection.
+  authUrl.searchParams.set("user_scope", "identity.basic");
+  authUrl.searchParams.set("redirect_uri", redirectUri);
+  authUrl.searchParams.set("state", state);
+
+  return NextResponse.redirect(authUrl.toString());
+}

--- a/turbo/apps/web/app/api/slack/org/oauth/install/route.ts
+++ b/turbo/apps/web/app/api/slack/org/oauth/install/route.ts
@@ -64,5 +64,7 @@ export async function GET(request: Request) {
     authUrl.searchParams.set("state", state);
   }
 
-  return NextResponse.redirect(authUrl.toString());
+  return NextResponse.redirect(authUrl.toString(), {
+    headers: { "Cache-Control": "no-store" },
+  });
 }

--- a/turbo/apps/web/src/__tests__/api-test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers.ts
@@ -3166,7 +3166,7 @@ export async function findTestSystemStorages() {
 export async function createTestSlackOrgInstallation(opts: {
   workspaceId?: string;
   workspaceName?: string;
-  orgId: string;
+  orgId: string | null;
 }): Promise<{
   slackWorkspaceId: string;
   slackWorkspaceName: string;

--- a/turbo/apps/web/src/lib/slack-org/connect-service.ts
+++ b/turbo/apps/web/src/lib/slack-org/connect-service.ts
@@ -1,8 +1,17 @@
 import { eq, and, isNull } from "drizzle-orm";
 import { slackOrgInstallations } from "../../db/schema/slack-org-installation";
 import { slackOrgConnections } from "../../db/schema/slack-org-connection";
-import { ensureOrgArtifact } from "./handlers/shared";
+import {
+  ensureOrgArtifact,
+  resolveDefaultComposeId,
+  getWorkspaceAgent,
+} from "./handlers/shared";
+import { refreshOrgAppHome } from "./handlers/app-home";
 import { getOrgData } from "../org/org-cache-service";
+import { env } from "../../env";
+import { decryptSecretValue } from "../crypto/secrets-encryption";
+import { createSlackClient, postMessage } from "../slack/client";
+import { buildSuccessMessage, buildWelcomeMessage } from "../slack/blocks";
 import { logger } from "../logger";
 
 const log = logger("slack-org:connect");
@@ -204,4 +213,82 @@ export async function disconnect(params: {
     .where(eq(slackOrgConnections.id, connectionId));
 
   log.info("User disconnected from Slack", params);
+}
+
+/**
+ * Send a Slack DM confirming successful connection, a welcome thread,
+ * mark dmWelcomeSent, and refresh App Home.
+ *
+ * Fire-and-forget — callers should use `void notifyConnectSuccess(...)`.
+ * When channelId is provided, sends an ephemeral message in that channel
+ * instead of a DM.
+ */
+export async function notifyConnectSuccess(params: {
+  installation: typeof slackOrgInstallations.$inferSelect;
+  slackUserId: string;
+  orgId: string;
+  channelId?: string | null;
+  threadTs?: string | null;
+}): Promise<void> {
+  const { installation, slackUserId, orgId, channelId, threadTs } = params;
+  const { SECRETS_ENCRYPTION_KEY } = env();
+  const botToken = decryptSecretValue(
+    installation.encryptedBotToken,
+    SECRETS_ENCRYPTION_KEY,
+  );
+  const client = createSlackClient(botToken);
+
+  let agentName: string | undefined;
+  const composeId = await resolveDefaultComposeId(orgId);
+  if (composeId) {
+    const agent = await getWorkspaceAgent(composeId);
+    agentName = agent?.displayName ?? agent?.name;
+  }
+
+  const agentLine = agentName
+    ? `Your workspace agent is *${agentName}*.`
+    : `No workspace agent configured yet.`;
+
+  const blocks = buildSuccessMessage(
+    `You're connected! :tada:\n\n${agentLine}\nMention \`@Zero\` in any channel or send a DM to start chatting with your agent.`,
+  );
+
+  if (channelId) {
+    await client.chat.postEphemeral({
+      channel: channelId,
+      user: slackUserId,
+      text: "You're connected!",
+      blocks,
+      ...(threadTs ? { thread_ts: threadTs } : {}),
+    });
+  } else {
+    const connectMsg = await postMessage(
+      client,
+      slackUserId,
+      "You're connected!",
+      { blocks },
+    );
+
+    if (connectMsg?.ts) {
+      await postMessage(client, slackUserId, "Hi! I'm Zero.", {
+        threadTs: connectMsg.ts,
+        blocks: buildWelcomeMessage(agentName),
+      });
+    }
+
+    await globalThis.services.db
+      .update(slackOrgConnections)
+      .set({ dmWelcomeSent: true })
+      .where(
+        and(
+          eq(slackOrgConnections.slackUserId, slackUserId),
+          eq(
+            slackOrgConnections.slackWorkspaceId,
+            installation.slackWorkspaceId,
+          ),
+        ),
+      );
+  }
+
+  await refreshOrgAppHome(client, installation, slackUserId);
 }

--- a/turbo/apps/web/src/lib/slack-org/handlers/__tests__/shared.test.ts
+++ b/turbo/apps/web/src/lib/slack-org/handlers/__tests__/shared.test.ts
@@ -5,7 +5,7 @@ describe("buildOrgConnectUrl", () => {
   it("should point to platform slack connect page", () => {
     const url = buildOrgConnectUrl("T-workspace", "U-user", "C-channel");
 
-    expect(url).toContain("/zero/slack/connect");
+    expect(url).toContain("/slack/connect");
     expect(url).toContain("w=T-workspace");
     expect(url).toContain("u=U-user");
     expect(url).toContain("c=C-channel");
@@ -32,7 +32,7 @@ describe("buildOrgConnectUrl", () => {
     const url = buildOrgConnectUrl("T-ws", "U-usr", "");
 
     const parsed = new URL(url);
-    expect(parsed.pathname).toBe("/zero/slack/connect");
+    expect(parsed.pathname).toBe("/slack/connect");
     expect(parsed.searchParams.get("w")).toBe("T-ws");
     expect(parsed.searchParams.get("u")).toBe("U-usr");
     expect(parsed.searchParams.has("c")).toBe(false);

--- a/turbo/apps/web/src/lib/slack-org/handlers/__tests__/shared.test.ts
+++ b/turbo/apps/web/src/lib/slack-org/handlers/__tests__/shared.test.ts
@@ -2,12 +2,10 @@ import { describe, it, expect } from "vitest";
 import { buildOrgConnectUrl, buildLogsUrl, buildAgentLogsUrl } from "../shared";
 
 describe("buildOrgConnectUrl", () => {
-  it("should use platform URL with www hostname", () => {
+  it("should point to platform slack connect page", () => {
     const url = buildOrgConnectUrl("T-workspace", "U-user", "C-channel");
 
-    // NEXT_PUBLIC_PLATFORM_URL is http://localhost:3001 in test env
-    // "platform" is not in "localhost" so hostname stays the same
-    expect(url).toContain("/api/slack/org/connect");
+    expect(url).toContain("/zero/slack/connect");
     expect(url).toContain("w=T-workspace");
     expect(url).toContain("u=U-user");
     expect(url).toContain("c=C-channel");
@@ -30,16 +28,14 @@ describe("buildOrgConnectUrl", () => {
     expect(url).not.toContain("&t=");
   });
 
-  it("should replace platform with www in hostname", () => {
-    // The function does url.hostname.replace("platform", "www")
-    // With test env localhost:3001, this is a no-op since "platform" isn't in the hostname
-    // But we can verify the URL structure is correct
-    const url = new URL(buildOrgConnectUrl("T-ws", "U-usr", "C-ch"));
+  it("should not include empty channelId", () => {
+    const url = buildOrgConnectUrl("T-ws", "U-usr", "");
 
-    expect(url.pathname).toBe("/api/slack/org/connect");
-    expect(url.searchParams.get("w")).toBe("T-ws");
-    expect(url.searchParams.get("u")).toBe("U-usr");
-    expect(url.searchParams.get("c")).toBe("C-ch");
+    const parsed = new URL(url);
+    expect(parsed.pathname).toBe("/zero/slack/connect");
+    expect(parsed.searchParams.get("w")).toBe("T-ws");
+    expect(parsed.searchParams.get("u")).toBe("U-usr");
+    expect(parsed.searchParams.has("c")).toBe(false);
   });
 });
 

--- a/turbo/apps/web/src/lib/slack-org/handlers/shared.ts
+++ b/turbo/apps/web/src/lib/slack-org/handlers/shared.ts
@@ -197,7 +197,7 @@ export function buildOrgConnectUrl(
   if (threadTs) {
     params.set("t", threadTs);
   }
-  return `${platformUrl}/zero/slack/connect?${params.toString()}`;
+  return `${platformUrl}/slack/connect?${params.toString()}`;
 }
 
 /**

--- a/turbo/apps/web/src/lib/slack-org/handlers/shared.ts
+++ b/turbo/apps/web/src/lib/slack-org/handlers/shared.ts
@@ -186,17 +186,18 @@ export function buildOrgConnectUrl(
   channelId: string,
   threadTs?: string,
 ): string {
-  const url = new URL(getPlatformUrl());
-  url.hostname = url.hostname.replace("platform", "www");
+  const platformUrl = getPlatformUrl();
   const params = new URLSearchParams({
     w: workspaceId,
     u: slackUserId,
-    c: channelId,
   });
+  if (channelId) {
+    params.set("c", channelId);
+  }
   if (threadTs) {
     params.set("t", threadTs);
   }
-  return `${url.origin}/api/slack/org/connect?${params.toString()}`;
+  return `${platformUrl}/zero/slack/connect?${params.toString()}`;
 }
 
 /**

--- a/turbo/apps/web/src/lib/slack/client.ts
+++ b/turbo/apps/web/src/lib/slack/client.ts
@@ -133,6 +133,40 @@ export async function exchangeOAuthCode(
 }
 
 /**
+ * Exchange an OAuth code for user identity only (no bot token).
+ * Used by the connect flow where the app is already installed and we only
+ * need to identify which Slack user authorized.
+ */
+export async function exchangeOAuthCodeForUser(
+  clientId: string,
+  clientSecret: string,
+  code: string,
+  redirectUri: string,
+): Promise<{
+  teamId: string;
+  authedUserId: string;
+}> {
+  const client = new WebClient();
+  const result = await client.oauth.v2.access({
+    client_id: clientId,
+    client_secret: clientSecret,
+    code,
+    redirect_uri: redirectUri,
+  });
+
+  if (!result.ok || !result.authed_user?.id || !result.team?.id) {
+    throw new Error(
+      `OAuth user exchange failed: ${result.error ?? "unknown error"}`,
+    );
+  }
+
+  return {
+    teamId: result.team.id,
+    authedUserId: result.authed_user.id,
+  };
+}
+
+/**
  * Update an existing message in a Slack channel
  *
  * @param client - Slack WebClient

--- a/turbo/apps/web/src/lib/slack/index.ts
+++ b/turbo/apps/web/src/lib/slack/index.ts
@@ -28,4 +28,8 @@ export function getSlackRedirectBaseUrl(requestUrl?: string): string {
 }
 
 // Slack API client
-export { createSlackClient, exchangeOAuthCode } from "./client";
+export {
+  createSlackClient,
+  exchangeOAuthCode,
+  exchangeOAuthCodeForUser,
+} from "./client";


### PR DESCRIPTION
## Summary
- **Unified Slack connect page** on platform domain (`/slack/connect`) with support for connect confirmation, success, and error states
- **Loading check on connect page** — shows "Checking account status" spinner while verifying if user is already connected, preventing flash of Connect button
- **Send DM on admin install** — after admin completes OAuth install, send the same connect success DM + welcome message that the connect flow sends
- **Extract shared `notifyConnectSuccess`** into `connect-service.ts` — deduplicates DM notification logic across 3 route files
- **Poll slack connection status** on works page so UI updates automatically after OAuth completes in another tab
- **Force fresh consent** on every Slack OAuth connect attempt
- **Friendly error** when connecting Slack from wrong org instead of 500
- **Remove `/zero` prefix** from slack connect routes to align with main branch conventions

## Test plan
- [ ] Visit `/slack/connect?w=...&u=...` — see loading spinner, then Connect button (or success if already connected)
- [ ] Click Connect → success → auto-opens `slack://open`
- [ ] Admin installs Slack app → gets DM with "You're connected!" + welcome thread
- [ ] Member connects → gets same DM
- [ ] User in wrong org clicks connect link → sees clear error message
- [ ] Works page polls and updates when Slack connection completes in another tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)