### PR TITLE
fix(e2e): update firewall placeholder assertions to match vm0-firewalls repo

### DIFF
--- a/e2e/tests/03-experimental-runner/t42-firewall-placeholder.bats
+++ b/e2e/tests/03-experimental-runner/t42-firewall-placeholder.bats
@@ -115,8 +115,8 @@ EOF
     assert_success
     assert_output --partial "Run completed successfully"
 
-    assert_output --partial "GITHUB_TOKEN=gho_Vm0PlaceHolder0000000000000000000000"
-    assert_output --partial "SLACK_TOKEN=xoxb-0000-0000-Vm0PlaceHolder0000000000"
+    assert_output --partial "GITHUB_TOKEN=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"
+    assert_output --partial "SLACK_TOKEN=xoxb-000000000000-0000000000000-Vm0PlaceHolder0000000000"
 }
 
 @test "firewall: permission-based request matching" {


### PR DESCRIPTION
## Summary
- Update E2E firewall placeholder assertions to match current `vm0-ai/vm0-firewalls` repo values
- GitHub placeholder: `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`
- Slack placeholder: `xoxb-000000000000-0000000000000-Vm0PlaceHolder0000000000`

## Test plan
- [ ] `t42-firewall-placeholder.bats` passes in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)