### PR TITLE
feat(slack): add oauth connect endpoint for non-admin member linking

### DIFF
--- a/turbo/apps/web/app/api/slack/org/oauth/callback/route.ts
+++ b/turbo/apps/web/app/api/slack/org/oauth/callback/route.ts
@@ -4,6 +4,7 @@ import { initServices } from "../../../../../../src/lib/init-services";
 import { env } from "../../../../../../src/env";
 import {
   exchangeOAuthCode,
+  exchangeOAuthCodeForUser,
   getSlackRedirectBaseUrl,
   createSlackClient,
 } from "../../../../../../src/lib/slack";
@@ -268,9 +269,9 @@ async function handleConnectCallback(params: {
     );
   }
 
-  let oauthResult;
+  let userIdentity;
   try {
-    oauthResult = await exchangeOAuthCode(
+    userIdentity = await exchangeOAuthCodeForUser(
       clientId,
       clientSecret,
       code,
@@ -280,12 +281,6 @@ async function handleConnectCallback(params: {
     log.error("Slack OAuth exchange failed (connect flow)", { error: err });
     return NextResponse.redirect(
       `${platformUrl}/zero/works?error=${encodeURIComponent("Failed to connect Slack account. Please try again.")}`,
-    );
-  }
-
-  if (!oauthResult.authedUserId) {
-    return NextResponse.redirect(
-      `${platformUrl}/zero/works?error=${encodeURIComponent("Could not identify your Slack account.")}`,
     );
   }
 
@@ -305,7 +300,7 @@ async function handleConnectCallback(params: {
   }
 
   // Verify workspace matches (user must have authed with the right workspace)
-  if (oauthResult.teamId !== installation.slackWorkspaceId) {
+  if (userIdentity.teamId !== installation.slackWorkspaceId) {
     return NextResponse.redirect(
       `${platformUrl}/zero/works?error=${encodeURIComponent("You authenticated with a different Slack workspace. Please use the workspace connected to your organization.")}`,
     );
@@ -318,21 +313,21 @@ async function handleConnectCallback(params: {
       userId: state.vm0UserId,
       orgId: state.orgId,
       workspaceId: installation.slackWorkspaceId,
-      slackUserId: oauthResult.authedUserId,
+      slackUserId: userIdentity.authedUserId,
     });
   } else {
     await memberConnect({
       userId: state.vm0UserId,
       orgId: state.orgId,
       workspaceId: installation.slackWorkspaceId,
-      slackUserId: oauthResult.authedUserId,
+      slackUserId: userIdentity.authedUserId,
     });
   }
 
   log.info("User connected via OAuth", {
     vm0UserId: state.vm0UserId,
     orgId: state.orgId,
-    slackUserId: oauthResult.authedUserId,
+    slackUserId: userIdentity.authedUserId,
     workspaceId: installation.slackWorkspaceId,
   });
 
@@ -342,9 +337,12 @@ async function handleConnectCallback(params: {
     encryptionKey,
   );
   const client = createSlackClient(botToken);
-  await refreshOrgAppHome(client, installation, oauthResult.authedUserId).catch(
-    (err) =>
-      log.warn("Failed to refresh App Home after connect", { error: err }),
+  await refreshOrgAppHome(
+    client,
+    installation,
+    userIdentity.authedUserId,
+  ).catch((err) =>
+    log.warn("Failed to refresh App Home after connect", { error: err }),
   );
 
   return NextResponse.redirect(`${platformUrl}/zero/works?connected=1`);

--- a/turbo/apps/web/app/api/slack/org/oauth/callback/route.ts
+++ b/turbo/apps/web/app/api/slack/org/oauth/callback/route.ts
@@ -11,7 +11,12 @@ import { encryptSecretValue } from "../../../../../../src/lib/crypto/secrets-enc
 import { slackOrgInstallations } from "../../../../../../src/db/schema/slack-org-installation";
 import { slackOrgConnections } from "../../../../../../src/db/schema/slack-org-connection";
 import { requireOrgMember } from "../../../../../../src/lib/org/org-member-service";
+import {
+  adminConnect,
+  memberConnect,
+} from "../../../../../../src/lib/slack-org/connect-service";
 import { refreshOrgAppHome } from "../../../../../../src/lib/slack-org/handlers/app-home";
+import { decryptSecretValue } from "../../../../../../src/lib/crypto/secrets-encryption";
 import { getPlatformUrl } from "../../../../../../src/lib/url";
 import { logger } from "../../../../../../src/lib/logger";
 
@@ -20,21 +25,26 @@ const log = logger("slack-org:oauth-callback");
 interface OAuthState {
   orgId: string | null;
   vm0UserId: string | null;
+  flow: "install" | "connect";
 }
 
 function parseOAuthState(state: string | null): OAuthState {
-  if (!state) return { orgId: null, vm0UserId: null };
+  if (!state) {
+    return { orgId: null, vm0UserId: null, flow: "install" };
+  }
   try {
     const parsed = JSON.parse(state) as {
       orgId?: string;
       vm0UserId?: string;
+      flow?: string;
     };
     return {
       orgId: parsed.orgId ?? null,
       vm0UserId: parsed.vm0UserId ?? null,
+      flow: parsed.flow === "connect" ? "connect" : "install",
     };
   } catch {
-    return { orgId: null, vm0UserId: null };
+    return { orgId: null, vm0UserId: null, flow: "install" };
   }
 }
 
@@ -43,23 +53,18 @@ function parseOAuthState(state: string | null): OAuthState {
  *
  * GET /api/slack/org/oauth/callback
  *
- * Handles the OAuth redirect from Slack after app installation.
+ * Handles OAuth redirects from Slack for two flows:
  *
- * Platform flow (state has orgId + vm0UserId):
- *   - Verify user is org admin
- *   - Upsert installation with org_id and installed_by_user_id
- *   - Create connection record
- *   - Redirect to platform
+ * 1. Install flow (state.flow = "install", default):
+ *    - Upsert installation with bot token
+ *    - Platform flow (orgId + vm0UserId): verify admin, create connection
+ *    - Slack flow (no orgId): create unbound installation
  *
- * Slack flow (no orgId in state):
- *   - Upsert installation with org_id = NULL
- *   - Redirect to "workspace installed" page
- *
- * Re-install (installation exists with org_id):
- *   - Preserve org_id and installed_by_user_id
- *   - Update bot token only
- *
- * Note: User-level connect is handled by /api/slack/org/connect (cookie-based).
+ * 2. Connect flow (state.flow = "connect"):
+ *    - User already has an installed workspace; just needs to link their Slack identity
+ *    - Exchange code for authed_user.id
+ *    - Look up installation for the org, create connection record
+ *    - Redirect to /zero/works
  */
 export async function GET(request: Request) {
   initServices();
@@ -95,6 +100,20 @@ export async function GET(request: Request) {
 
   const state = parseOAuthState(url.searchParams.get("state"));
   const redirectUri = `${baseUrl}/api/slack/org/oauth/callback`;
+
+  // Connect flow uses a lightweight exchange that may not return bot tokens.
+  // We use a separate helper that tolerates missing bot fields.
+  if (state.flow === "connect") {
+    return handleConnectCallback({
+      code,
+      redirectUri,
+      state,
+      platformUrl,
+      clientId: SLACK_CLIENT_ID,
+      clientSecret: SLACK_CLIENT_SECRET,
+      encryptionKey: SECRETS_ENCRYPTION_KEY,
+    });
+  }
 
   let oauthResult;
   try {
@@ -215,4 +234,118 @@ export async function GET(request: Request) {
   return NextResponse.redirect(
     `${platformUrl}/slack/installed?workspace=${encodeURIComponent(oauthResult.teamName)}`,
   );
+}
+
+/**
+ * Handle the OAuth callback for the "connect" flow.
+ *
+ * The connect flow is used when a workspace is already installed but the
+ * current user hasn't linked their Slack identity yet.  We exchange the
+ * OAuth code to learn the user's Slack ID, then create a connection record.
+ */
+async function handleConnectCallback(params: {
+  code: string;
+  redirectUri: string;
+  state: OAuthState;
+  platformUrl: string;
+  clientId: string;
+  clientSecret: string;
+  encryptionKey: string;
+}): Promise<NextResponse> {
+  const {
+    code,
+    redirectUri,
+    state,
+    platformUrl,
+    clientId,
+    clientSecret,
+    encryptionKey,
+  } = params;
+
+  if (!state.orgId || !state.vm0UserId) {
+    return NextResponse.redirect(
+      `${platformUrl}/zero/works?error=${encodeURIComponent("Invalid connect state.")}`,
+    );
+  }
+
+  let oauthResult;
+  try {
+    oauthResult = await exchangeOAuthCode(
+      clientId,
+      clientSecret,
+      code,
+      redirectUri,
+    );
+  } catch (err) {
+    log.error("Slack OAuth exchange failed (connect flow)", { error: err });
+    return NextResponse.redirect(
+      `${platformUrl}/zero/works?error=${encodeURIComponent("Failed to connect Slack account. Please try again.")}`,
+    );
+  }
+
+  if (!oauthResult.authedUserId) {
+    return NextResponse.redirect(
+      `${platformUrl}/zero/works?error=${encodeURIComponent("Could not identify your Slack account.")}`,
+    );
+  }
+
+  const db = globalThis.services.db;
+
+  // Find the installation for this org
+  const [installation] = await db
+    .select()
+    .from(slackOrgInstallations)
+    .where(eq(slackOrgInstallations.orgId, state.orgId))
+    .limit(1);
+
+  if (!installation) {
+    return NextResponse.redirect(
+      `${platformUrl}/zero/works?error=${encodeURIComponent("No Slack workspace installed for this organization.")}`,
+    );
+  }
+
+  // Verify workspace matches (user must have authed with the right workspace)
+  if (oauthResult.teamId !== installation.slackWorkspaceId) {
+    return NextResponse.redirect(
+      `${platformUrl}/zero/works?error=${encodeURIComponent("You authenticated with a different Slack workspace. Please use the workspace connected to your organization.")}`,
+    );
+  }
+
+  // Create connection using the appropriate service function
+  const member = await requireOrgMember(state.orgId, state.vm0UserId);
+  if (member.role === "admin") {
+    await adminConnect({
+      userId: state.vm0UserId,
+      orgId: state.orgId,
+      workspaceId: installation.slackWorkspaceId,
+      slackUserId: oauthResult.authedUserId,
+    });
+  } else {
+    await memberConnect({
+      userId: state.vm0UserId,
+      orgId: state.orgId,
+      workspaceId: installation.slackWorkspaceId,
+      slackUserId: oauthResult.authedUserId,
+    });
+  }
+
+  log.info("User connected via OAuth", {
+    vm0UserId: state.vm0UserId,
+    orgId: state.orgId,
+    slackUserId: oauthResult.authedUserId,
+    workspaceId: installation.slackWorkspaceId,
+  });
+
+  // Refresh App Home (best-effort)
+  const botToken = decryptSecretValue(
+    installation.encryptedBotToken,
+    encryptionKey,
+  );
+  const client = createSlackClient(botToken);
+  await refreshOrgAppHome(client, installation, oauthResult.authedUserId).catch(
+    (err) =>
+      log.warn("Failed to refresh App Home after connect", { error: err }),
+  );
+
+  return NextResponse.redirect(`${platformUrl}/zero/works?connected=1`);
 }

--- a/turbo/apps/web/app/api/slack/org/oauth/connect/route.ts
+++ b/turbo/apps/web/app/api/slack/org/oauth/connect/route.ts
@@ -1,0 +1,56 @@
+import { NextResponse } from "next/server";
+import { env } from "../../../../../../src/env";
+import { getSlackRedirectBaseUrl } from "../../../../../../src/lib/slack";
+
+/**
+ * Org-aware Slack OAuth Connect Endpoint
+ *
+ * GET /api/slack/org/oauth/connect?orgId=<orgId>&vm0UserId=<userId>
+ *
+ * Redirects to Slack's OAuth authorization page so that a non-admin org member
+ * can identify their Slack account.  The OAuth callback extracts the
+ * `authed_user.id` from the response to create a `slackOrgConnections` record.
+ *
+ * Unlike the install flow, no bot scopes are requested — the app is already
+ * installed.  We only need Slack to authenticate the user.
+ */
+
+const SLACK_OAUTH_URL = "https://slack.com/oauth/v2/authorize";
+
+export async function GET(request: Request) {
+  const { SLACK_CLIENT_ID } = env();
+
+  if (!SLACK_CLIENT_ID) {
+    return NextResponse.json(
+      { error: "Slack integration is not configured" },
+      { status: 503 },
+    );
+  }
+
+  const url = new URL(request.url);
+  const orgId = url.searchParams.get("orgId");
+  const vm0UserId = url.searchParams.get("vm0UserId");
+
+  if (!orgId || !vm0UserId) {
+    return NextResponse.json(
+      { error: "Missing orgId or vm0UserId" },
+      { status: 400 },
+    );
+  }
+
+  const baseUrl = getSlackRedirectBaseUrl(request.url);
+  const redirectUri = `${baseUrl}/api/slack/org/oauth/callback`;
+
+  const state = JSON.stringify({ orgId, vm0UserId, flow: "connect" });
+
+  const authUrl = new URL(SLACK_OAUTH_URL);
+  authUrl.searchParams.set("client_id", SLACK_CLIENT_ID);
+  // No bot scopes — app is already installed.
+  // Request minimal user scope so Slack shows the consent screen and
+  // returns the authed_user.id we need to create the connection.
+  authUrl.searchParams.set("user_scope", "identity.basic");
+  authUrl.searchParams.set("redirect_uri", redirectUri);
+  authUrl.searchParams.set("state", state);
+
+  return NextResponse.redirect(authUrl.toString());
+}

--- a/turbo/apps/web/src/lib/slack/client.ts
+++ b/turbo/apps/web/src/lib/slack/client.ts
@@ -133,6 +133,40 @@ export async function exchangeOAuthCode(
 }
 
 /**
+ * Exchange an OAuth code for user identity only (no bot token).
+ * Used by the connect flow where the app is already installed and we only
+ * need to identify which Slack user authorized.
+ */
+export async function exchangeOAuthCodeForUser(
+  clientId: string,
+  clientSecret: string,
+  code: string,
+  redirectUri: string,
+): Promise<{
+  teamId: string;
+  authedUserId: string;
+}> {
+  const client = new WebClient();
+  const result = await client.oauth.v2.access({
+    client_id: clientId,
+    client_secret: clientSecret,
+    code,
+    redirect_uri: redirectUri,
+  });
+
+  if (!result.ok || !result.authed_user?.id || !result.team?.id) {
+    throw new Error(
+      `OAuth user exchange failed: ${result.error ?? "unknown error"}`,
+    );
+  }
+
+  return {
+    teamId: result.team.id,
+    authedUserId: result.authed_user.id,
+  };
+}
+
+/**
  * Update an existing message in a Slack channel
  *
  * @param client - Slack WebClient

--- a/turbo/apps/web/src/lib/slack/index.ts
+++ b/turbo/apps/web/src/lib/slack/index.ts
@@ -28,4 +28,8 @@ export function getSlackRedirectBaseUrl(requestUrl?: string): string {
 }
 
 // Slack API client
-export { createSlackClient, exchangeOAuthCode } from "./client";
+export {
+  createSlackClient,
+  exchangeOAuthCode,
+  exchangeOAuthCodeForUser,
+} from "./client";


### PR DESCRIPTION
## Summary

- Add `GET /api/slack/org/oauth/connect` endpoint that redirects users to Slack OAuth to identify their Slack account
- Extend `/api/slack/org/oauth/callback` to handle the "connect" flow (via `state.flow = "connect"`) separately from the "install" flow
- Connect flow: exchanges OAuth code for `authed_user.id`, finds the org's installation, creates a `slackOrgConnections` record, and redirects to `/zero/works?connected=1`

## Context

The integrations API (`/api/integrations/slack/org`) was building a `connectUrl` pointing to `/api/slack/org/oauth/connect`, but this endpoint never existed (introduced in #4715, commit `51962ec8c`). Non-admin members clicking "Connect" on the platform UI got a 404.

## Flow

1. Platform UI calls integrations API, gets `connectUrl` = `/api/slack/org/oauth/connect?orgId=...&vm0UserId=...`
2. User clicks the URL → redirected to Slack OAuth consent screen (with `user_scope=identity.basic`)
3. User authorizes → Slack redirects to `/api/slack/org/oauth/callback` with `state.flow = "connect"`
4. Callback exchanges code, gets `authed_user.id`, creates connection via `memberConnect()` / `adminConnect()`
5. User redirected to `/zero/works?connected=1`

## Test plan

- [x] Type check passes (no new errors in our files)
- [x] Lint passes
- [x] Knip passes
- [ ] Manual: non-admin member clicks Connect → lands on Slack OAuth → completes → redirected to /zero/works with connection created
- [ ] Manual: verify workspace mismatch shows error message
- [ ] Manual: verify already-connected user is handled idempotently

🤖 Generated with [Claude Code](https://claude.com/claude-code)