### PR TITLE
feat: shared sentinel infrastructure + org-level model-provider service

### DIFF
--- a/turbo/apps/web/src/lib/model-provider/__tests__/org-model-provider.test.ts
+++ b/turbo/apps/web/src/lib/model-provider/__tests__/org-model-provider.test.ts
@@ -50,7 +50,7 @@ describe("Org-level model provider service", () => {
 
       const providers = await listOrgModelProviders(orgId);
       expect(providers).toHaveLength(1);
-      expect(providers[0].type).toBe("anthropic-api-key");
+      expect(providers[0]?.type).toBe("anthropic-api-key");
     });
 
     it("should update existing org provider on re-upsert", async () => {
@@ -82,7 +82,7 @@ describe("Org-level model provider service", () => {
     it("should throw when deleting non-existent org provider", async () => {
       await expect(
         deleteOrgModelProvider(orgId, "anthropic-api-key"),
-      ).rejects.toThrow('Org model provider "anthropic-api-key" not found');
+      ).rejects.toThrow('Model provider "anthropic-api-key" not found');
     });
 
     it("should store selectedModel", async () => {
@@ -145,8 +145,8 @@ describe("Org-level model provider service", () => {
 
       const providers = await listOrgModelProviders(orgId);
       expect(providers).toHaveLength(1);
-      expect(providers[0].type).toBe("claude-code-oauth-token");
-      expect(providers[0].isDefault).toBe(true);
+      expect(providers[0]?.type).toBe("claude-code-oauth-token");
+      expect(providers[0]?.isDefault).toBe(true);
     });
 
     it("should get org default provider for framework", async () => {
@@ -247,7 +247,7 @@ describe("Org-level model provider service", () => {
 
       // Verify user default is unchanged
       const userProviders = await listModelProviders(user.orgId, user.userId);
-      expect(userProviders[0].isDefault).toBe(true);
+      expect(userProviders[0]?.isDefault).toBe(true);
     });
   });
 });

--- a/turbo/apps/web/src/lib/model-provider/__tests__/org-model-provider.test.ts
+++ b/turbo/apps/web/src/lib/model-provider/__tests__/org-model-provider.test.ts
@@ -1,0 +1,253 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { testContext } from "../../../__tests__/test-helpers";
+import {
+  listOrgModelProviders,
+  upsertOrgModelProvider,
+  upsertOrgMultiAuthModelProvider,
+  deleteOrgModelProvider,
+  setOrgModelProviderDefault,
+  getOrgDefaultModelProvider,
+  listModelProviders,
+  upsertModelProvider,
+} from "../model-provider-service";
+import type { ModelProviderType } from "@vm0/core";
+
+vi.mock("@axiomhq/logging");
+
+const context = testContext();
+
+describe("Org-level model provider service", () => {
+  let orgId: string;
+
+  beforeEach(async () => {
+    context.setupMocks();
+    const user = await context.setupUser();
+    orgId = user.orgId;
+  });
+
+  describe("CRUD lifecycle", () => {
+    it("should return empty list when no org providers exist", async () => {
+      const providers = await listOrgModelProviders(orgId);
+      expect(providers).toEqual([]);
+    });
+
+    it("should create an org provider", async () => {
+      const { provider, created } = await upsertOrgModelProvider(
+        orgId,
+        "anthropic-api-key",
+        "test-org-key",
+      );
+
+      expect(created).toBe(true);
+      expect(provider.type).toBe("anthropic-api-key");
+      expect(provider.framework).toBe("claude-code");
+      expect(provider.secretName).toBe("ANTHROPIC_API_KEY");
+      expect(provider.isDefault).toBe(true);
+    });
+
+    it("should list org providers", async () => {
+      await upsertOrgModelProvider(orgId, "anthropic-api-key", "test-org-key");
+
+      const providers = await listOrgModelProviders(orgId);
+      expect(providers).toHaveLength(1);
+      expect(providers[0].type).toBe("anthropic-api-key");
+    });
+
+    it("should update existing org provider on re-upsert", async () => {
+      const { provider: first } = await upsertOrgModelProvider(
+        orgId,
+        "anthropic-api-key",
+        "key-v1",
+      );
+
+      const { provider: second, created } = await upsertOrgModelProvider(
+        orgId,
+        "anthropic-api-key",
+        "key-v2",
+      );
+
+      expect(created).toBe(false);
+      expect(second.id).toBe(first.id);
+    });
+
+    it("should delete an org provider", async () => {
+      await upsertOrgModelProvider(orgId, "anthropic-api-key", "test-key");
+
+      await deleteOrgModelProvider(orgId, "anthropic-api-key");
+
+      const providers = await listOrgModelProviders(orgId);
+      expect(providers).toEqual([]);
+    });
+
+    it("should throw when deleting non-existent org provider", async () => {
+      await expect(
+        deleteOrgModelProvider(orgId, "anthropic-api-key"),
+      ).rejects.toThrow('Org model provider "anthropic-api-key" not found');
+    });
+
+    it("should store selectedModel", async () => {
+      const { provider } = await upsertOrgModelProvider(
+        orgId,
+        "moonshot-api-key",
+        "test-key",
+        "kimi-k2.5",
+      );
+
+      expect(provider.selectedModel).toBe("kimi-k2.5");
+    });
+  });
+
+  describe("org default assignment", () => {
+    it("should auto-set first org provider as default", async () => {
+      const { provider } = await upsertOrgModelProvider(
+        orgId,
+        "anthropic-api-key",
+        "test-key",
+      );
+
+      expect(provider.isDefault).toBe(true);
+    });
+
+    it("should not auto-set second org provider as default for same framework", async () => {
+      await upsertOrgModelProvider(orgId, "anthropic-api-key", "key-1");
+
+      const { provider: second } = await upsertOrgModelProvider(
+        orgId,
+        "claude-code-oauth-token",
+        "token-1",
+      );
+
+      expect(second.isDefault).toBe(false);
+    });
+
+    it("should switch org default with setOrgModelProviderDefault", async () => {
+      await upsertOrgModelProvider(orgId, "anthropic-api-key", "key-1");
+      await upsertOrgModelProvider(orgId, "claude-code-oauth-token", "token-1");
+
+      const updated = await setOrgModelProviderDefault(
+        orgId,
+        "claude-code-oauth-token",
+      );
+      expect(updated.isDefault).toBe(true);
+
+      const providers = await listOrgModelProviders(orgId);
+      const anthropic = providers.find((p) => p.type === "anthropic-api-key");
+      const oauth = providers.find((p) => p.type === "claude-code-oauth-token");
+      expect(anthropic!.isDefault).toBe(false);
+      expect(oauth!.isDefault).toBe(true);
+    });
+
+    it("should reassign org default on delete", async () => {
+      await upsertOrgModelProvider(orgId, "anthropic-api-key", "key-1");
+      await upsertOrgModelProvider(orgId, "claude-code-oauth-token", "token-1");
+
+      await deleteOrgModelProvider(orgId, "anthropic-api-key");
+
+      const providers = await listOrgModelProviders(orgId);
+      expect(providers).toHaveLength(1);
+      expect(providers[0].type).toBe("claude-code-oauth-token");
+      expect(providers[0].isDefault).toBe(true);
+    });
+
+    it("should get org default provider for framework", async () => {
+      await upsertOrgModelProvider(orgId, "anthropic-api-key", "test-key");
+
+      const defaultProvider = await getOrgDefaultModelProvider(
+        orgId,
+        "claude-code",
+      );
+      expect(defaultProvider).not.toBeNull();
+      expect(defaultProvider!.type).toBe("anthropic-api-key");
+      expect(defaultProvider!.isDefault).toBe(true);
+    });
+
+    it("should return null when no org default exists", async () => {
+      const defaultProvider = await getOrgDefaultModelProvider(
+        orgId,
+        "claude-code",
+      );
+      expect(defaultProvider).toBeNull();
+    });
+  });
+
+  describe("multi-auth provider", () => {
+    it("should create org-level AWS Bedrock provider", async () => {
+      const { provider, created } = await upsertOrgMultiAuthModelProvider(
+        orgId,
+        "aws-bedrock",
+        "access-keys",
+        {
+          AWS_ACCESS_KEY_ID: "test-access-key",
+          AWS_SECRET_ACCESS_KEY: "test-secret-key",
+          AWS_REGION: "us-east-1",
+        },
+      );
+
+      expect(created).toBe(true);
+      expect(provider.type).toBe("aws-bedrock");
+      expect(provider.authMethod).toBe("access-keys");
+      expect(provider.secretNames).toContain("AWS_ACCESS_KEY_ID");
+      expect(provider.secretNames).toContain("AWS_SECRET_ACCESS_KEY");
+      expect(provider.secretNames).toContain("AWS_REGION");
+    });
+
+    it("should reject single-secret provider type in multi-auth", async () => {
+      await expect(
+        upsertOrgMultiAuthModelProvider(
+          orgId,
+          "anthropic-api-key" as ModelProviderType,
+          "api-key",
+          { ANTHROPIC_API_KEY: "test" },
+        ),
+      ).rejects.toThrow("legacy single-secret provider");
+    });
+  });
+
+  describe("isolation", () => {
+    it("should not return org providers in user provider list", async () => {
+      const user = await context.setupUser();
+      await upsertOrgModelProvider(user.orgId, "anthropic-api-key", "org-key");
+
+      const userProviders = await listModelProviders(user.orgId, user.userId);
+      expect(userProviders).toEqual([]);
+    });
+
+    it("should not return user providers in org provider list", async () => {
+      const user = await context.setupUser();
+      await upsertModelProvider(
+        user.orgId,
+        user.userId,
+        "anthropic-api-key",
+        "user-key",
+      );
+
+      const orgProviders = await listOrgModelProviders(user.orgId);
+      expect(orgProviders).toEqual([]);
+    });
+
+    it("should keep org defaults independent from user defaults", async () => {
+      const user = await context.setupUser();
+
+      // Create user-level provider (auto-defaults)
+      await upsertModelProvider(
+        user.orgId,
+        user.userId,
+        "anthropic-api-key",
+        "user-key",
+      );
+
+      // Create org-level provider (should also auto-default independently)
+      const { provider: orgProvider } = await upsertOrgModelProvider(
+        user.orgId,
+        "claude-code-oauth-token",
+        "org-token",
+      );
+
+      expect(orgProvider.isDefault).toBe(true);
+
+      // Verify user default is unchanged
+      const userProviders = await listModelProviders(user.orgId, user.userId);
+      expect(userProviders[0].isDefault).toBe(true);
+    });
+  });
+});

--- a/turbo/apps/web/src/lib/model-provider/model-provider-service.ts
+++ b/turbo/apps/web/src/lib/model-provider/model-provider-service.ts
@@ -80,15 +80,19 @@ function getTypesForFramework(framework: ModelProviderFramework): string[] {
 
 /**
  * Atomically assign isDefault=true to a provider, but only if no other provider
- * for the same framework already has isDefault=true.
+ * for the same framework already has isDefault=true for the same userId scope.
  *
  * Uses a single UPDATE with NOT EXISTS subquery to prevent the race condition
  * where two concurrent inserts both set isDefault=true.
+ *
+ * The userId filter ensures org-level defaults (sentinel userId) and user-level
+ * defaults are independent — they do not interfere with each other.
  *
  * @returns true if isDefault was set, false if another default already exists
  */
 async function assignDefaultIfFirst(
   orgId: string,
+  userId: string,
   providerId: string,
   framework: ModelProviderFramework,
 ): Promise<boolean> {
@@ -107,44 +111,7 @@ async function assignDefaultIfFirst(
             .where(
               and(
                 eq(modelProviders.orgId, orgId),
-                eq(modelProviders.isDefault, true),
-                ne(modelProviders.id, providerId),
-                inArray(modelProviders.type, frameworkTypes),
-              ),
-            ),
-        ),
-      ),
-    );
-
-  return (result.rowCount ?? 0) > 0;
-}
-
-/**
- * Org-scoped variant of assignDefaultIfFirst.
- * Only considers org-level providers (sentinel userId) when checking for existing defaults,
- * ensuring org defaults are independent from user defaults.
- */
-async function assignOrgDefaultIfFirst(
-  orgId: string,
-  providerId: string,
-  framework: ModelProviderFramework,
-): Promise<boolean> {
-  const frameworkTypes = getTypesForFramework(framework);
-
-  const result = await globalThis.services.db
-    .update(modelProviders)
-    .set({ isDefault: true })
-    .where(
-      and(
-        eq(modelProviders.id, providerId),
-        notExists(
-          globalThis.services.db
-            .select({ id: sql`1` })
-            .from(modelProviders)
-            .where(
-              and(
-                eq(modelProviders.orgId, orgId),
-                eq(modelProviders.userId, ORG_SENTINEL_USER_ID),
+                eq(modelProviders.userId, userId),
                 eq(modelProviders.isDefault, true),
                 ne(modelProviders.id, providerId),
                 inArray(modelProviders.type, frameworkTypes),
@@ -332,6 +299,7 @@ export async function upsertModelProvider(
   if (!provider!.isDefault) {
     const isDefault = await assignDefaultIfFirst(
       orgId,
+      userId,
       provider!.id,
       framework,
     );
@@ -557,6 +525,7 @@ export async function upsertMultiAuthModelProvider(
   if (!provider!.isDefault) {
     const isDefault = await assignDefaultIfFirst(
       orgId,
+      userId,
       provider!.id,
       framework,
     );
@@ -893,532 +862,86 @@ export async function getDefaultModelProvider(
 
 // ============================================================================
 // Org-Level Model Provider Functions
+//
+// These delegate to the user-level functions using ORG_SENTINEL_USER_ID.
+// The sentinel userId ensures org and user providers are fully isolated.
 // ============================================================================
 
 /**
  * List all org-level model providers
  */
-export async function listOrgModelProviders(
+export function listOrgModelProviders(
   orgId: string,
 ): Promise<ModelProviderInfo[]> {
-  const result = await globalThis.services.db
-    .select({
-      id: modelProviders.id,
-      type: modelProviders.type,
-      isDefault: modelProviders.isDefault,
-      selectedModel: modelProviders.selectedModel,
-      authMethod: modelProviders.authMethod,
-      secretName: secrets.name,
-      createdAt: modelProviders.createdAt,
-      updatedAt: modelProviders.updatedAt,
-    })
-    .from(modelProviders)
-    .leftJoin(secrets, eq(modelProviders.secretId, secrets.id))
-    .where(
-      and(
-        eq(modelProviders.orgId, orgId),
-        eq(modelProviders.userId, ORG_SENTINEL_USER_ID),
-      ),
-    )
-    .orderBy(modelProviders.type);
-
-  return result.map((row) =>
-    toModelProviderInfo({
-      id: row.id,
-      type: row.type as ModelProviderType,
-      secretName: row.secretName,
-      authMethod: row.authMethod,
-      isDefault: row.isDefault,
-      selectedModel: row.selectedModel,
-      createdAt: row.createdAt,
-      updatedAt: row.updatedAt,
-    }),
-  );
+  return listModelProviders(orgId, ORG_SENTINEL_USER_ID);
 }
 
 /**
  * Create or update an org-level model provider (single-secret).
  * Uses ORG_SENTINEL_USER_ID for org-scoped storage.
  */
-export async function upsertOrgModelProvider(
+export function upsertOrgModelProvider(
   orgId: string,
   type: ModelProviderType,
   secret: string,
   selectedModel?: string,
 ): Promise<{ provider: ModelProviderInfo; created: boolean }> {
-  if (hasAuthMethods(type)) {
-    throw badRequest(
-      `Provider "${type}" requires multiple secrets. Use the multi-auth API instead.`,
-    );
-  }
-
-  const secretName = getSecretNameForType(type);
-  if (!secretName) {
-    throw badRequest(`Provider "${type}" does not have a secret name`);
-  }
-  const framework = getFrameworkForType(type);
-  const encryptionKey = globalThis.services.env.SECRETS_ENCRYPTION_KEY;
-  const encryptedValue = encryptSecretValue(secret, encryptionKey);
-
-  const userId = ORG_SENTINEL_USER_ID;
-
-  log.debug("upserting org model provider", { orgId, type, secretName });
-
-  const [existingProvider] = await globalThis.services.db
-    .select({ id: modelProviders.id })
-    .from(modelProviders)
-    .where(
-      and(
-        eq(modelProviders.orgId, orgId),
-        eq(modelProviders.userId, userId),
-        eq(modelProviders.type, type),
-      ),
-    )
-    .limit(1);
-
-  const [upsertedSecret] = await globalThis.services.db
-    .insert(secrets)
-    .values({
-      userId,
-      name: secretName,
-      encryptedValue,
-      type: "model-provider",
-      description: `Org model provider secret for ${MODEL_PROVIDER_TYPES[type].label}`,
-      orgId,
-    })
-    .onConflictDoUpdate({
-      target: [secrets.orgId, secrets.userId, secrets.name, secrets.type],
-      set: { encryptedValue, updatedAt: new Date() },
-    })
-    .returning();
-
-  const [provider] = await globalThis.services.db
-    .insert(modelProviders)
-    .values({
-      type,
-      userId,
-      secretId: upsertedSecret!.id,
-      isDefault: false,
-      selectedModel: selectedModel ?? null,
-      orgId,
-    })
-    .onConflictDoUpdate({
-      target: [
-        modelProviders.orgId,
-        modelProviders.userId,
-        modelProviders.type,
-      ],
-      set: {
-        secretId: upsertedSecret!.id,
-        selectedModel: selectedModel ?? null,
-        updatedAt: new Date(),
-      },
-    })
-    .returning();
-
-  const wasCreated = !existingProvider;
-
-  if (!provider!.isDefault) {
-    const isDefault = await assignOrgDefaultIfFirst(
-      orgId,
-      provider!.id,
-      framework,
-    );
-    if (isDefault) {
-      provider!.isDefault = true;
-    }
-  }
-
-  log.debug(
-    wasCreated ? "org model provider created" : "org model provider updated",
-    {
-      providerId: provider!.id,
-      type,
-      selectedModel,
-      isDefault: provider!.isDefault,
-    },
+  return upsertModelProvider(
+    orgId,
+    ORG_SENTINEL_USER_ID,
+    type,
+    secret,
+    selectedModel,
   );
-
-  return {
-    provider: toModelProviderInfo({
-      id: provider!.id,
-      type,
-      secretName,
-      isDefault: provider!.isDefault,
-      selectedModel: provider!.selectedModel,
-      createdAt: provider!.createdAt,
-      updatedAt: provider!.updatedAt,
-    }),
-    created: wasCreated,
-  };
 }
 
 /**
  * Create or update an org-level multi-auth model provider (e.g., aws-bedrock).
  * Uses ORG_SENTINEL_USER_ID for org-scoped storage.
  */
-export async function upsertOrgMultiAuthModelProvider(
+export function upsertOrgMultiAuthModelProvider(
   orgId: string,
   type: ModelProviderType,
   authMethod: string,
   secretValues: Record<string, string>,
   selectedModel?: string,
 ): Promise<{ provider: ModelProviderInfo; created: boolean }> {
-  if (!hasAuthMethods(type)) {
-    throw badRequest(
-      `Provider "${type}" is a legacy single-secret provider. Use the standard upsert API.`,
-    );
-  }
-
-  const authMethods = getAuthMethodsForType(type);
-  if (!authMethods || !(authMethod in authMethods)) {
-    const validMethods = authMethods ? Object.keys(authMethods).join(", ") : "";
-    throw badRequest(
-      `Invalid auth method "${authMethod}" for provider "${type}". Valid methods: ${validMethods}`,
-    );
-  }
-
-  const secretsConfig = getSecretsForAuthMethod(type, authMethod);
-  if (!secretsConfig) {
-    throw badRequest(`No secrets config found for auth method "${authMethod}"`);
-  }
-
-  const missingRequired: string[] = [];
-  for (const [name, config] of Object.entries(secretsConfig)) {
-    if (config.required && !secretValues[name]) {
-      missingRequired.push(name);
-    }
-  }
-
-  if (missingRequired.length > 0) {
-    throw badRequest(
-      `Missing required secrets for ${authMethod}: ${missingRequired.join(", ")}`,
-    );
-  }
-
-  const framework = getFrameworkForType(type);
-  const encryptionKey = globalThis.services.env.SECRETS_ENCRYPTION_KEY;
-  const userId = ORG_SENTINEL_USER_ID;
-
-  log.debug("upserting org multi-auth model provider", {
+  return upsertMultiAuthModelProvider(
     orgId,
+    ORG_SENTINEL_USER_ID,
     type,
     authMethod,
-    secretNames: Object.keys(secretValues),
-  });
-
-  const [existingProvider] = await globalThis.services.db
-    .select()
-    .from(modelProviders)
-    .where(
-      and(
-        eq(modelProviders.orgId, orgId),
-        eq(modelProviders.userId, userId),
-        eq(modelProviders.type, type),
-      ),
-    )
-    .limit(1);
-
-  if (existingProvider && existingProvider.authMethod !== authMethod) {
-    await cleanupOldAuthMethodSecrets(
-      orgId,
-      userId,
-      type,
-      existingProvider.authMethod ?? "",
-      Object.keys(secretValues),
-    );
-  }
-
-  const secretNames = Object.keys(secretValues);
-  const secretDescription = `${MODEL_PROVIDER_TYPES[type].label} secret (${authMethod})`;
-
-  for (const [name, value] of Object.entries(secretValues)) {
-    await upsertMultiAuthSecret(
-      orgId,
-      userId,
-      name,
-      value,
-      secretDescription,
-      encryptionKey,
-    );
-  }
-
-  const [provider] = await globalThis.services.db
-    .insert(modelProviders)
-    .values({
-      type,
-      userId,
-      authMethod,
-      isDefault: false,
-      selectedModel: selectedModel ?? null,
-      orgId,
-    })
-    .onConflictDoUpdate({
-      target: [
-        modelProviders.orgId,
-        modelProviders.userId,
-        modelProviders.type,
-      ],
-      set: {
-        authMethod,
-        selectedModel: selectedModel ?? null,
-        updatedAt: new Date(),
-      },
-    })
-    .returning();
-
-  const wasCreated = !existingProvider;
-
-  if (!provider!.isDefault) {
-    const isDefault = await assignOrgDefaultIfFirst(
-      orgId,
-      provider!.id,
-      framework,
-    );
-    if (isDefault) {
-      provider!.isDefault = true;
-    }
-  }
-
-  log.debug(
-    wasCreated
-      ? "org multi-auth model provider created"
-      : "org multi-auth model provider updated",
-    {
-      providerId: provider!.id,
-      type,
-      authMethod,
-      selectedModel,
-      isDefault: provider!.isDefault,
-    },
+    secretValues,
+    selectedModel,
   );
-
-  return {
-    provider: toModelProviderInfo({
-      id: provider!.id,
-      type,
-      authMethod,
-      secretNames,
-      isDefault: provider!.isDefault,
-      selectedModel: provider!.selectedModel,
-      createdAt: provider!.createdAt,
-      updatedAt: provider!.updatedAt,
-    }),
-    created: wasCreated,
-  };
 }
 
 /**
  * Delete an org-level model provider and its secrets
  */
-export async function deleteOrgModelProvider(
+export function deleteOrgModelProvider(
   orgId: string,
   type: ModelProviderType,
 ): Promise<void> {
-  const framework = getFrameworkForType(type);
-  const userId = ORG_SENTINEL_USER_ID;
-
-  const [provider] = await globalThis.services.db
-    .select()
-    .from(modelProviders)
-    .where(
-      and(
-        eq(modelProviders.orgId, orgId),
-        eq(modelProviders.userId, userId),
-        eq(modelProviders.type, type),
-      ),
-    )
-    .limit(1);
-
-  if (!provider) {
-    throw notFound(`Org model provider "${type}" not found`);
-  }
-
-  const wasDefault = provider.isDefault;
-  const secretId = provider.secretId;
-
-  if (secretId) {
-    await globalThis.services.db
-      .delete(secrets)
-      .where(eq(secrets.id, secretId));
-  } else {
-    if (provider.authMethod) {
-      const secretNames = getSecretNamesForAuthMethod(
-        type,
-        provider.authMethod,
-      );
-      if (secretNames && secretNames.length > 0) {
-        await globalThis.services.db
-          .delete(secrets)
-          .where(
-            and(
-              eq(secrets.orgId, orgId),
-              eq(secrets.userId, userId),
-              inArray(secrets.name, secretNames),
-            ),
-          );
-      }
-    }
-    await globalThis.services.db
-      .delete(modelProviders)
-      .where(eq(modelProviders.id, provider.id));
-  }
-
-  log.debug("org model provider deleted", { orgId, type });
-
-  if (wasDefault) {
-    const remaining = await globalThis.services.db
-      .select({ id: modelProviders.id, type: modelProviders.type })
-      .from(modelProviders)
-      .where(
-        and(eq(modelProviders.orgId, orgId), eq(modelProviders.userId, userId)),
-      )
-      .orderBy(modelProviders.createdAt);
-
-    const nextDefault = remaining.find(
-      (p) => getFrameworkForType(p.type as ModelProviderType) === framework,
-    );
-
-    if (nextDefault) {
-      await globalThis.services.db
-        .update(modelProviders)
-        .set({ isDefault: true, updatedAt: new Date() })
-        .where(eq(modelProviders.id, nextDefault.id));
-
-      log.debug("new org default assigned", {
-        framework,
-        newDefaultType: nextDefault.type,
-      });
-    }
-  }
+  return deleteModelProvider(orgId, ORG_SENTINEL_USER_ID, type);
 }
 
 /**
  * Set an org-level model provider as default for its framework
  */
-export async function setOrgModelProviderDefault(
+export function setOrgModelProviderDefault(
   orgId: string,
   type: ModelProviderType,
 ): Promise<ModelProviderInfo> {
-  const framework = getFrameworkForType(type);
-  const secretName = getSecretNameForType(type) ?? null;
-  const userId = ORG_SENTINEL_USER_ID;
-
-  const [target] = await globalThis.services.db
-    .select()
-    .from(modelProviders)
-    .where(
-      and(
-        eq(modelProviders.orgId, orgId),
-        eq(modelProviders.userId, userId),
-        eq(modelProviders.type, type),
-      ),
-    )
-    .limit(1);
-
-  if (!target) {
-    throw notFound(`Org model provider "${type}" not found`);
-  }
-
-  if (target.isDefault) {
-    return toModelProviderInfo({
-      id: target.id,
-      type,
-      secretName,
-      authMethod: target.authMethod,
-      isDefault: true,
-      selectedModel: target.selectedModel,
-      createdAt: target.createdAt,
-      updatedAt: target.updatedAt,
-    });
-  }
-
-  const allProviders = await globalThis.services.db
-    .select({ id: modelProviders.id, type: modelProviders.type })
-    .from(modelProviders)
-    .where(
-      and(eq(modelProviders.orgId, orgId), eq(modelProviders.userId, userId)),
-    );
-
-  const sameFrameworkIds = allProviders
-    .filter(
-      (p) => getFrameworkForType(p.type as ModelProviderType) === framework,
-    )
-    .map((p) => p.id);
-
-  await globalThis.services.db.transaction(async (tx) => {
-    if (sameFrameworkIds.length > 0) {
-      await tx
-        .update(modelProviders)
-        .set({ isDefault: false, updatedAt: new Date() })
-        .where(inArray(modelProviders.id, sameFrameworkIds));
-    }
-
-    await tx
-      .update(modelProviders)
-      .set({ isDefault: true, updatedAt: new Date() })
-      .where(eq(modelProviders.id, target.id));
-  });
-
-  log.debug("org model provider set as default", { type, framework });
-
-  return toModelProviderInfo({
-    id: target.id,
-    type,
-    secretName,
-    authMethod: target.authMethod,
-    isDefault: true,
-    selectedModel: target.selectedModel,
-    createdAt: target.createdAt,
-    updatedAt: new Date(),
-  });
+  return setModelProviderDefault(orgId, ORG_SENTINEL_USER_ID, type);
 }
 
 /**
  * Get the org-level default model provider for a framework
  */
-export async function getOrgDefaultModelProvider(
+export function getOrgDefaultModelProvider(
   orgId: string,
   framework: ModelProviderFramework,
 ): Promise<ModelProviderInfo | null> {
-  const allProviders = await globalThis.services.db
-    .select({
-      id: modelProviders.id,
-      type: modelProviders.type,
-      isDefault: modelProviders.isDefault,
-      selectedModel: modelProviders.selectedModel,
-      authMethod: modelProviders.authMethod,
-      secretName: secrets.name,
-      createdAt: modelProviders.createdAt,
-      updatedAt: modelProviders.updatedAt,
-    })
-    .from(modelProviders)
-    .leftJoin(secrets, eq(modelProviders.secretId, secrets.id))
-    .where(
-      and(
-        eq(modelProviders.orgId, orgId),
-        eq(modelProviders.userId, ORG_SENTINEL_USER_ID),
-      ),
-    );
-
-  const defaultProvider = allProviders.find(
-    (p) =>
-      p.isDefault &&
-      getFrameworkForType(p.type as ModelProviderType) === framework,
-  );
-
-  if (!defaultProvider) {
-    return null;
-  }
-
-  return toModelProviderInfo({
-    id: defaultProvider.id,
-    type: defaultProvider.type as ModelProviderType,
-    secretName: defaultProvider.secretName,
-    authMethod: defaultProvider.authMethod,
-    isDefault: defaultProvider.isDefault,
-    selectedModel: defaultProvider.selectedModel,
-    createdAt: defaultProvider.createdAt,
-    updatedAt: defaultProvider.updatedAt,
-  });
+  return getDefaultModelProvider(orgId, ORG_SENTINEL_USER_ID, framework);
 }

--- a/turbo/apps/web/src/lib/model-provider/model-provider-service.ts
+++ b/turbo/apps/web/src/lib/model-provider/model-provider-service.ts
@@ -15,6 +15,7 @@ import { secrets } from "../../db/schema/secret";
 import { encryptSecretValue } from "../crypto";
 import { badRequest, notFound } from "../errors";
 import { logger } from "../logger";
+import { ORG_SENTINEL_USER_ID } from "../org/org-sentinel";
 
 const log = logger("service:model-provider");
 
@@ -106,6 +107,44 @@ async function assignDefaultIfFirst(
             .where(
               and(
                 eq(modelProviders.orgId, orgId),
+                eq(modelProviders.isDefault, true),
+                ne(modelProviders.id, providerId),
+                inArray(modelProviders.type, frameworkTypes),
+              ),
+            ),
+        ),
+      ),
+    );
+
+  return (result.rowCount ?? 0) > 0;
+}
+
+/**
+ * Org-scoped variant of assignDefaultIfFirst.
+ * Only considers org-level providers (sentinel userId) when checking for existing defaults,
+ * ensuring org defaults are independent from user defaults.
+ */
+async function assignOrgDefaultIfFirst(
+  orgId: string,
+  providerId: string,
+  framework: ModelProviderFramework,
+): Promise<boolean> {
+  const frameworkTypes = getTypesForFramework(framework);
+
+  const result = await globalThis.services.db
+    .update(modelProviders)
+    .set({ isDefault: true })
+    .where(
+      and(
+        eq(modelProviders.id, providerId),
+        notExists(
+          globalThis.services.db
+            .select({ id: sql`1` })
+            .from(modelProviders)
+            .where(
+              and(
+                eq(modelProviders.orgId, orgId),
+                eq(modelProviders.userId, ORG_SENTINEL_USER_ID),
                 eq(modelProviders.isDefault, true),
                 ne(modelProviders.id, providerId),
                 inArray(modelProviders.type, frameworkTypes),
@@ -828,6 +867,538 @@ export async function getDefaultModelProvider(
     .leftJoin(secrets, eq(modelProviders.secretId, secrets.id))
     .where(
       and(eq(modelProviders.orgId, orgId), eq(modelProviders.userId, userId)),
+    );
+
+  const defaultProvider = allProviders.find(
+    (p) =>
+      p.isDefault &&
+      getFrameworkForType(p.type as ModelProviderType) === framework,
+  );
+
+  if (!defaultProvider) {
+    return null;
+  }
+
+  return toModelProviderInfo({
+    id: defaultProvider.id,
+    type: defaultProvider.type as ModelProviderType,
+    secretName: defaultProvider.secretName,
+    authMethod: defaultProvider.authMethod,
+    isDefault: defaultProvider.isDefault,
+    selectedModel: defaultProvider.selectedModel,
+    createdAt: defaultProvider.createdAt,
+    updatedAt: defaultProvider.updatedAt,
+  });
+}
+
+// ============================================================================
+// Org-Level Model Provider Functions
+// ============================================================================
+
+/**
+ * List all org-level model providers
+ */
+export async function listOrgModelProviders(
+  orgId: string,
+): Promise<ModelProviderInfo[]> {
+  const result = await globalThis.services.db
+    .select({
+      id: modelProviders.id,
+      type: modelProviders.type,
+      isDefault: modelProviders.isDefault,
+      selectedModel: modelProviders.selectedModel,
+      authMethod: modelProviders.authMethod,
+      secretName: secrets.name,
+      createdAt: modelProviders.createdAt,
+      updatedAt: modelProviders.updatedAt,
+    })
+    .from(modelProviders)
+    .leftJoin(secrets, eq(modelProviders.secretId, secrets.id))
+    .where(
+      and(
+        eq(modelProviders.orgId, orgId),
+        eq(modelProviders.userId, ORG_SENTINEL_USER_ID),
+      ),
+    )
+    .orderBy(modelProviders.type);
+
+  return result.map((row) =>
+    toModelProviderInfo({
+      id: row.id,
+      type: row.type as ModelProviderType,
+      secretName: row.secretName,
+      authMethod: row.authMethod,
+      isDefault: row.isDefault,
+      selectedModel: row.selectedModel,
+      createdAt: row.createdAt,
+      updatedAt: row.updatedAt,
+    }),
+  );
+}
+
+/**
+ * Create or update an org-level model provider (single-secret).
+ * Uses ORG_SENTINEL_USER_ID for org-scoped storage.
+ */
+export async function upsertOrgModelProvider(
+  orgId: string,
+  type: ModelProviderType,
+  secret: string,
+  selectedModel?: string,
+): Promise<{ provider: ModelProviderInfo; created: boolean }> {
+  if (hasAuthMethods(type)) {
+    throw badRequest(
+      `Provider "${type}" requires multiple secrets. Use the multi-auth API instead.`,
+    );
+  }
+
+  const secretName = getSecretNameForType(type);
+  if (!secretName) {
+    throw badRequest(`Provider "${type}" does not have a secret name`);
+  }
+  const framework = getFrameworkForType(type);
+  const encryptionKey = globalThis.services.env.SECRETS_ENCRYPTION_KEY;
+  const encryptedValue = encryptSecretValue(secret, encryptionKey);
+
+  const userId = ORG_SENTINEL_USER_ID;
+
+  log.debug("upserting org model provider", { orgId, type, secretName });
+
+  const [existingProvider] = await globalThis.services.db
+    .select({ id: modelProviders.id })
+    .from(modelProviders)
+    .where(
+      and(
+        eq(modelProviders.orgId, orgId),
+        eq(modelProviders.userId, userId),
+        eq(modelProviders.type, type),
+      ),
+    )
+    .limit(1);
+
+  const [upsertedSecret] = await globalThis.services.db
+    .insert(secrets)
+    .values({
+      userId,
+      name: secretName,
+      encryptedValue,
+      type: "model-provider",
+      description: `Org model provider secret for ${MODEL_PROVIDER_TYPES[type].label}`,
+      orgId,
+    })
+    .onConflictDoUpdate({
+      target: [secrets.orgId, secrets.userId, secrets.name, secrets.type],
+      set: { encryptedValue, updatedAt: new Date() },
+    })
+    .returning();
+
+  const [provider] = await globalThis.services.db
+    .insert(modelProviders)
+    .values({
+      type,
+      userId,
+      secretId: upsertedSecret!.id,
+      isDefault: false,
+      selectedModel: selectedModel ?? null,
+      orgId,
+    })
+    .onConflictDoUpdate({
+      target: [
+        modelProviders.orgId,
+        modelProviders.userId,
+        modelProviders.type,
+      ],
+      set: {
+        secretId: upsertedSecret!.id,
+        selectedModel: selectedModel ?? null,
+        updatedAt: new Date(),
+      },
+    })
+    .returning();
+
+  const wasCreated = !existingProvider;
+
+  if (!provider!.isDefault) {
+    const isDefault = await assignOrgDefaultIfFirst(
+      orgId,
+      provider!.id,
+      framework,
+    );
+    if (isDefault) {
+      provider!.isDefault = true;
+    }
+  }
+
+  log.debug(
+    wasCreated ? "org model provider created" : "org model provider updated",
+    {
+      providerId: provider!.id,
+      type,
+      selectedModel,
+      isDefault: provider!.isDefault,
+    },
+  );
+
+  return {
+    provider: toModelProviderInfo({
+      id: provider!.id,
+      type,
+      secretName,
+      isDefault: provider!.isDefault,
+      selectedModel: provider!.selectedModel,
+      createdAt: provider!.createdAt,
+      updatedAt: provider!.updatedAt,
+    }),
+    created: wasCreated,
+  };
+}
+
+/**
+ * Create or update an org-level multi-auth model provider (e.g., aws-bedrock).
+ * Uses ORG_SENTINEL_USER_ID for org-scoped storage.
+ */
+export async function upsertOrgMultiAuthModelProvider(
+  orgId: string,
+  type: ModelProviderType,
+  authMethod: string,
+  secretValues: Record<string, string>,
+  selectedModel?: string,
+): Promise<{ provider: ModelProviderInfo; created: boolean }> {
+  if (!hasAuthMethods(type)) {
+    throw badRequest(
+      `Provider "${type}" is a legacy single-secret provider. Use the standard upsert API.`,
+    );
+  }
+
+  const authMethods = getAuthMethodsForType(type);
+  if (!authMethods || !(authMethod in authMethods)) {
+    const validMethods = authMethods ? Object.keys(authMethods).join(", ") : "";
+    throw badRequest(
+      `Invalid auth method "${authMethod}" for provider "${type}". Valid methods: ${validMethods}`,
+    );
+  }
+
+  const secretsConfig = getSecretsForAuthMethod(type, authMethod);
+  if (!secretsConfig) {
+    throw badRequest(`No secrets config found for auth method "${authMethod}"`);
+  }
+
+  const missingRequired: string[] = [];
+  for (const [name, config] of Object.entries(secretsConfig)) {
+    if (config.required && !secretValues[name]) {
+      missingRequired.push(name);
+    }
+  }
+
+  if (missingRequired.length > 0) {
+    throw badRequest(
+      `Missing required secrets for ${authMethod}: ${missingRequired.join(", ")}`,
+    );
+  }
+
+  const framework = getFrameworkForType(type);
+  const encryptionKey = globalThis.services.env.SECRETS_ENCRYPTION_KEY;
+  const userId = ORG_SENTINEL_USER_ID;
+
+  log.debug("upserting org multi-auth model provider", {
+    orgId,
+    type,
+    authMethod,
+    secretNames: Object.keys(secretValues),
+  });
+
+  const [existingProvider] = await globalThis.services.db
+    .select()
+    .from(modelProviders)
+    .where(
+      and(
+        eq(modelProviders.orgId, orgId),
+        eq(modelProviders.userId, userId),
+        eq(modelProviders.type, type),
+      ),
+    )
+    .limit(1);
+
+  if (existingProvider && existingProvider.authMethod !== authMethod) {
+    await cleanupOldAuthMethodSecrets(
+      orgId,
+      userId,
+      type,
+      existingProvider.authMethod ?? "",
+      Object.keys(secretValues),
+    );
+  }
+
+  const secretNames = Object.keys(secretValues);
+  const secretDescription = `${MODEL_PROVIDER_TYPES[type].label} secret (${authMethod})`;
+
+  for (const [name, value] of Object.entries(secretValues)) {
+    await upsertMultiAuthSecret(
+      orgId,
+      userId,
+      name,
+      value,
+      secretDescription,
+      encryptionKey,
+    );
+  }
+
+  const [provider] = await globalThis.services.db
+    .insert(modelProviders)
+    .values({
+      type,
+      userId,
+      authMethod,
+      isDefault: false,
+      selectedModel: selectedModel ?? null,
+      orgId,
+    })
+    .onConflictDoUpdate({
+      target: [
+        modelProviders.orgId,
+        modelProviders.userId,
+        modelProviders.type,
+      ],
+      set: {
+        authMethod,
+        selectedModel: selectedModel ?? null,
+        updatedAt: new Date(),
+      },
+    })
+    .returning();
+
+  const wasCreated = !existingProvider;
+
+  if (!provider!.isDefault) {
+    const isDefault = await assignOrgDefaultIfFirst(
+      orgId,
+      provider!.id,
+      framework,
+    );
+    if (isDefault) {
+      provider!.isDefault = true;
+    }
+  }
+
+  log.debug(
+    wasCreated
+      ? "org multi-auth model provider created"
+      : "org multi-auth model provider updated",
+    {
+      providerId: provider!.id,
+      type,
+      authMethod,
+      selectedModel,
+      isDefault: provider!.isDefault,
+    },
+  );
+
+  return {
+    provider: toModelProviderInfo({
+      id: provider!.id,
+      type,
+      authMethod,
+      secretNames,
+      isDefault: provider!.isDefault,
+      selectedModel: provider!.selectedModel,
+      createdAt: provider!.createdAt,
+      updatedAt: provider!.updatedAt,
+    }),
+    created: wasCreated,
+  };
+}
+
+/**
+ * Delete an org-level model provider and its secrets
+ */
+export async function deleteOrgModelProvider(
+  orgId: string,
+  type: ModelProviderType,
+): Promise<void> {
+  const framework = getFrameworkForType(type);
+  const userId = ORG_SENTINEL_USER_ID;
+
+  const [provider] = await globalThis.services.db
+    .select()
+    .from(modelProviders)
+    .where(
+      and(
+        eq(modelProviders.orgId, orgId),
+        eq(modelProviders.userId, userId),
+        eq(modelProviders.type, type),
+      ),
+    )
+    .limit(1);
+
+  if (!provider) {
+    throw notFound(`Org model provider "${type}" not found`);
+  }
+
+  const wasDefault = provider.isDefault;
+  const secretId = provider.secretId;
+
+  if (secretId) {
+    await globalThis.services.db
+      .delete(secrets)
+      .where(eq(secrets.id, secretId));
+  } else {
+    if (provider.authMethod) {
+      const secretNames = getSecretNamesForAuthMethod(
+        type,
+        provider.authMethod,
+      );
+      if (secretNames && secretNames.length > 0) {
+        await globalThis.services.db
+          .delete(secrets)
+          .where(
+            and(
+              eq(secrets.orgId, orgId),
+              eq(secrets.userId, userId),
+              inArray(secrets.name, secretNames),
+            ),
+          );
+      }
+    }
+    await globalThis.services.db
+      .delete(modelProviders)
+      .where(eq(modelProviders.id, provider.id));
+  }
+
+  log.debug("org model provider deleted", { orgId, type });
+
+  if (wasDefault) {
+    const remaining = await globalThis.services.db
+      .select({ id: modelProviders.id, type: modelProviders.type })
+      .from(modelProviders)
+      .where(
+        and(eq(modelProviders.orgId, orgId), eq(modelProviders.userId, userId)),
+      )
+      .orderBy(modelProviders.createdAt);
+
+    const nextDefault = remaining.find(
+      (p) => getFrameworkForType(p.type as ModelProviderType) === framework,
+    );
+
+    if (nextDefault) {
+      await globalThis.services.db
+        .update(modelProviders)
+        .set({ isDefault: true, updatedAt: new Date() })
+        .where(eq(modelProviders.id, nextDefault.id));
+
+      log.debug("new org default assigned", {
+        framework,
+        newDefaultType: nextDefault.type,
+      });
+    }
+  }
+}
+
+/**
+ * Set an org-level model provider as default for its framework
+ */
+export async function setOrgModelProviderDefault(
+  orgId: string,
+  type: ModelProviderType,
+): Promise<ModelProviderInfo> {
+  const framework = getFrameworkForType(type);
+  const secretName = getSecretNameForType(type) ?? null;
+  const userId = ORG_SENTINEL_USER_ID;
+
+  const [target] = await globalThis.services.db
+    .select()
+    .from(modelProviders)
+    .where(
+      and(
+        eq(modelProviders.orgId, orgId),
+        eq(modelProviders.userId, userId),
+        eq(modelProviders.type, type),
+      ),
+    )
+    .limit(1);
+
+  if (!target) {
+    throw notFound(`Org model provider "${type}" not found`);
+  }
+
+  if (target.isDefault) {
+    return toModelProviderInfo({
+      id: target.id,
+      type,
+      secretName,
+      authMethod: target.authMethod,
+      isDefault: true,
+      selectedModel: target.selectedModel,
+      createdAt: target.createdAt,
+      updatedAt: target.updatedAt,
+    });
+  }
+
+  const allProviders = await globalThis.services.db
+    .select({ id: modelProviders.id, type: modelProviders.type })
+    .from(modelProviders)
+    .where(
+      and(eq(modelProviders.orgId, orgId), eq(modelProviders.userId, userId)),
+    );
+
+  const sameFrameworkIds = allProviders
+    .filter(
+      (p) => getFrameworkForType(p.type as ModelProviderType) === framework,
+    )
+    .map((p) => p.id);
+
+  await globalThis.services.db.transaction(async (tx) => {
+    if (sameFrameworkIds.length > 0) {
+      await tx
+        .update(modelProviders)
+        .set({ isDefault: false, updatedAt: new Date() })
+        .where(inArray(modelProviders.id, sameFrameworkIds));
+    }
+
+    await tx
+      .update(modelProviders)
+      .set({ isDefault: true, updatedAt: new Date() })
+      .where(eq(modelProviders.id, target.id));
+  });
+
+  log.debug("org model provider set as default", { type, framework });
+
+  return toModelProviderInfo({
+    id: target.id,
+    type,
+    secretName,
+    authMethod: target.authMethod,
+    isDefault: true,
+    selectedModel: target.selectedModel,
+    createdAt: target.createdAt,
+    updatedAt: new Date(),
+  });
+}
+
+/**
+ * Get the org-level default model provider for a framework
+ */
+export async function getOrgDefaultModelProvider(
+  orgId: string,
+  framework: ModelProviderFramework,
+): Promise<ModelProviderInfo | null> {
+  const allProviders = await globalThis.services.db
+    .select({
+      id: modelProviders.id,
+      type: modelProviders.type,
+      isDefault: modelProviders.isDefault,
+      selectedModel: modelProviders.selectedModel,
+      authMethod: modelProviders.authMethod,
+      secretName: secrets.name,
+      createdAt: modelProviders.createdAt,
+      updatedAt: modelProviders.updatedAt,
+    })
+    .from(modelProviders)
+    .leftJoin(secrets, eq(modelProviders.secretId, secrets.id))
+    .where(
+      and(
+        eq(modelProviders.orgId, orgId),
+        eq(modelProviders.userId, ORG_SENTINEL_USER_ID),
+      ),
     );
 
   const defaultProvider = allProviders.find(

--- a/turbo/apps/web/src/lib/org/org-sentinel.ts
+++ b/turbo/apps/web/src/lib/org/org-sentinel.ts
@@ -1,7 +1,2 @@
 /** Sentinel userId for org-level resources (model providers, secrets, variables) */
 export const ORG_SENTINEL_USER_ID = "__org__";
-
-/** Check if a userId represents an org-level resource */
-export function isOrgLevel(userId: string): boolean {
-  return userId === ORG_SENTINEL_USER_ID;
-}

--- a/turbo/apps/web/src/lib/org/org-sentinel.ts
+++ b/turbo/apps/web/src/lib/org/org-sentinel.ts
@@ -1,0 +1,7 @@
+/** Sentinel userId for org-level resources (model providers, secrets, variables) */
+export const ORG_SENTINEL_USER_ID = "__org__";
+
+/** Check if a userId represents an org-level resource */
+export function isOrgLevel(userId: string): boolean {
+  return userId === ORG_SENTINEL_USER_ID;
+}

--- a/turbo/knip.json
+++ b/turbo/knip.json
@@ -96,6 +96,7 @@
     "apps/platform/src/test/mocks/clerk-react-experimental.ts",
     "apps/web/src/lib/schedule/schedule-service.ts",
     "apps/web/src/lib/model-provider/model-provider-service.ts",
+    "apps/web/src/lib/org/org-sentinel.ts",
     "apps/cli/src/lib/api/api-client.ts",
     "apps/cli/src/lib/utils/paginate.ts",
     "apps/cli/src/commands/cook/cook.ts",

--- a/turbo/knip.json
+++ b/turbo/knip.json
@@ -96,7 +96,6 @@
     "apps/platform/src/test/mocks/clerk-react-experimental.ts",
     "apps/web/src/lib/schedule/schedule-service.ts",
     "apps/web/src/lib/model-provider/model-provider-service.ts",
-    "apps/web/src/lib/org/org-sentinel.ts",
     "apps/cli/src/lib/api/api-client.ts",
     "apps/cli/src/lib/utils/paginate.ts",
     "apps/cli/src/commands/cook/cook.ts",


### PR DESCRIPTION
## Summary

- Add `ORG_SENTINEL_USER_ID` constant (`"__org__"`) and `isOrgLevel()` utility in new `org-sentinel.ts`
- Implement 6 org-level model provider CRUD functions in `model-provider-service.ts`:
  - `listOrgModelProviders`, `upsertOrgModelProvider`, `upsertOrgMultiAuthModelProvider`
  - `deleteOrgModelProvider`, `setOrgModelProviderDefault`, `getOrgDefaultModelProvider`
- Add `assignOrgDefaultIfFirst` for org-scoped default assignment independent of user defaults
- 18 integration tests covering CRUD lifecycle, default assignment, multi-auth, and org/user isolation

Closes #5161

## Test plan

- [x] All 18 new org-level model provider tests pass
- [x] All 38 existing model provider tests pass (no regressions)
- [x] Knip, lint, and format checks pass
- [x] Org providers isolated from user providers (verified by isolation tests)
- [x] Org defaults independent from user defaults (verified by isolation tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)