### PR TITLE
docs: fix vm0 secret set syntax to use --body flag

### DIFF
--- a/turbo/apps/docs/content/docs/agent-skills/agentmail.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/agentmail.mdx
@@ -30,7 +30,7 @@ agents:
 Store your secret on the platform (recommended, one-time setup):
 
 ```bash
-vm0 secret set AGENTMAIL_API_KEY your-agentmail-api-key
+vm0 secret set AGENTMAIL_API_KEY --body "your-agentmail-api-key"
 ```
 
 Then run your agent - secrets are automatically loaded:

--- a/turbo/apps/docs/content/docs/agent-skills/apify.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/apify.mdx
@@ -28,7 +28,7 @@ agents:
 Store your secret on the platform (recommended, one-time setup):
 
 ```bash
-vm0 secret set APIFY_API_TOKEN your-apify-api-token
+vm0 secret set APIFY_API_TOKEN --body "your-apify-api-token"
 ```
 
 Then run your agent - secret is automatically loaded:

--- a/turbo/apps/docs/content/docs/agent-skills/axiom.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/axiom.mdx
@@ -30,8 +30,8 @@ agents:
 Store your secrets on the platform (recommended, one-time setup):
 
 ```bash
-vm0 secret set AXIOM_TOKEN your-axiom-api-token
-vm0 secret set AXIOM_PERSONAL_ACCESS_TOKEN your-axiom-personal-access-token
+vm0 secret set AXIOM_TOKEN --body "your-axiom-api-token"
+vm0 secret set AXIOM_PERSONAL_ACCESS_TOKEN --body "your-axiom-personal-access-token"
 ```
 
 Then run your agent - secrets are automatically loaded:

--- a/turbo/apps/docs/content/docs/agent-skills/bitrix.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/bitrix.mdx
@@ -28,7 +28,7 @@ agents:
 Store your secret on the platform (recommended, one-time setup):
 
 ```bash
-vm0 secret set BITRIX_WEBHOOK_URL your-bitrix-webhook-url
+vm0 secret set BITRIX_WEBHOOK_URL --body "your-bitrix-webhook-url"
 ```
 
 Then run your agent - secret is automatically loaded:

--- a/turbo/apps/docs/content/docs/agent-skills/brave-search.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/brave-search.mdx
@@ -28,7 +28,7 @@ agents:
 Store your secret on the platform (recommended, one-time setup):
 
 ```bash
-vm0 secret set BRAVE_API_KEY your-brave-api-key
+vm0 secret set BRAVE_API_KEY --body "your-brave-api-key"
 ```
 
 Then run your agent - secret is automatically loaded:

--- a/turbo/apps/docs/content/docs/agent-skills/bright-data.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/bright-data.mdx
@@ -28,7 +28,7 @@ agents:
 Store your secret on the platform (recommended, one-time setup):
 
 ```bash
-vm0 secret set BRIGHTDATA_TOKEN your-brightdata-api-key
+vm0 secret set BRIGHTDATA_TOKEN --body "your-brightdata-api-key"
 ```
 
 Then run your agent - secret is automatically loaded:

--- a/turbo/apps/docs/content/docs/agent-skills/browserbase.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/browserbase.mdx
@@ -29,8 +29,8 @@ agents:
 Store your secrets on the platform (recommended, one-time setup):
 
 ```bash
-vm0 secret set BROWSERBASE_API_KEY your-browserbase-api-key
-vm0 secret set BROWSERBASE_PROJECT_ID your-browserbase-project-id
+vm0 secret set BROWSERBASE_API_KEY --body "your-browserbase-api-key"
+vm0 secret set BROWSERBASE_PROJECT_ID --body "your-browserbase-project-id"
 ```
 
 Then run your agent - secrets are automatically loaded:

--- a/turbo/apps/docs/content/docs/agent-skills/browserless.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/browserless.mdx
@@ -28,7 +28,7 @@ agents:
 Store your secret on the platform (recommended, one-time setup):
 
 ```bash
-vm0 secret set BROWSERLESS_API_TOKEN your-browserless-api-token
+vm0 secret set BROWSERLESS_API_TOKEN --body "your-browserless-api-token"
 ```
 
 Then run your agent - secret is automatically loaded:

--- a/turbo/apps/docs/content/docs/agent-skills/chatwoot.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/chatwoot.mdx
@@ -30,7 +30,7 @@ agents:
 Store your secret on the platform (recommended, one-time setup):
 
 ```bash
-vm0 secret set CHATWOOT_API_TOKEN your-chatwoot-api-token
+vm0 secret set CHATWOOT_API_TOKEN --body "your-chatwoot-api-token"
 ```
 
 Then run your agent - secret is automatically loaded:

--- a/turbo/apps/docs/content/docs/agent-skills/clickup.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/clickup.mdx
@@ -28,7 +28,7 @@ agents:
 Store your secret on the platform (recommended, one-time setup):
 
 ```bash
-vm0 secret set CLICKUP_TOKEN your-clickup-api-token
+vm0 secret set CLICKUP_TOKEN --body "your-clickup-api-token"
 ```
 
 Then run your agent - secret is automatically loaded:

--- a/turbo/apps/docs/content/docs/agent-skills/cloudflare-tunnel.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/cloudflare-tunnel.mdx
@@ -35,8 +35,8 @@ agents:
 Store your secrets on the platform (recommended, one-time setup):
 
 ```bash
-vm0 secret set CF_ACCESS_CLIENT_ID your-client-id
-vm0 secret set CF_ACCESS_CLIENT_SECRET your-client-secret
+vm0 secret set CF_ACCESS_CLIENT_ID --body "your-client-id"
+vm0 secret set CF_ACCESS_CLIENT_SECRET --body "your-client-secret"
 ```
 
 Then run your agent - secrets are automatically loaded:

--- a/turbo/apps/docs/content/docs/agent-skills/cloudinary.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/cloudinary.mdx
@@ -30,8 +30,8 @@ agents:
 Store your secrets on the platform (recommended, one-time setup):
 
 ```bash
-vm0 secret set CLOUDINARY_API_KEY your-cloudinary-api-key
-vm0 secret set CLOUDINARY_API_SECRET your-cloudinary-api-secret
+vm0 secret set CLOUDINARY_API_KEY --body "your-cloudinary-api-key"
+vm0 secret set CLOUDINARY_API_SECRET --body "your-cloudinary-api-secret"
 ```
 
 Then run your agent - secrets are automatically loaded:

--- a/turbo/apps/docs/content/docs/agent-skills/cronlytic.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/cronlytic.mdx
@@ -29,7 +29,7 @@ agents:
 Store your secret on the platform (recommended, one-time setup):
 
 ```bash
-vm0 secret set CRONLYTIC_API_KEY your-cronlytic-api-key
+vm0 secret set CRONLYTIC_API_KEY --body "your-cronlytic-api-key"
 ```
 
 Then run your agent - secret is automatically loaded:

--- a/turbo/apps/docs/content/docs/agent-skills/deepseek.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/deepseek.mdx
@@ -28,7 +28,7 @@ agents:
 Store your secret on the platform (recommended, one-time setup):
 
 ```bash
-vm0 secret set DEEPSEEK_API_KEY your-deepseek-api-key
+vm0 secret set DEEPSEEK_API_KEY --body "your-deepseek-api-key"
 ```
 
 Then run your agent - secret is automatically loaded:

--- a/turbo/apps/docs/content/docs/agent-skills/devto.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/devto.mdx
@@ -28,7 +28,7 @@ agents:
 Store your secret on the platform (recommended, one-time setup):
 
 ```bash
-vm0 secret set DEVTO_API_KEY your-devto-api-key
+vm0 secret set DEVTO_API_KEY --body "your-devto-api-key"
 ```
 
 Then run your agent - secret is automatically loaded:

--- a/turbo/apps/docs/content/docs/agent-skills/discord-webhook.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/discord-webhook.mdx
@@ -28,7 +28,7 @@ agents:
 Store your secret on the platform (recommended, one-time setup):
 
 ```bash
-vm0 secret set DISCORD_WEBHOOK_URL your-discord-webhook-url
+vm0 secret set DISCORD_WEBHOOK_URL --body "your-discord-webhook-url"
 ```
 
 Then run your agent - secret is automatically loaded:

--- a/turbo/apps/docs/content/docs/agent-skills/discord.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/discord.mdx
@@ -28,7 +28,7 @@ agents:
 Store your secret on the platform (recommended, one-time setup):
 
 ```bash
-vm0 secret set DISCORD_BOT_TOKEN your-discord-bot-token
+vm0 secret set DISCORD_BOT_TOKEN --body "your-discord-bot-token"
 ```
 
 Then run your agent - secret is automatically loaded:

--- a/turbo/apps/docs/content/docs/agent-skills/elevenlabs.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/elevenlabs.mdx
@@ -28,7 +28,7 @@ agents:
 Store your secret on the platform (recommended, one-time setup):
 
 ```bash
-vm0 secret set ELEVENLABS_API_KEY your-elevenlabs-api-key
+vm0 secret set ELEVENLABS_API_KEY --body "your-elevenlabs-api-key"
 ```
 
 Then run your agent - secret is automatically loaded:

--- a/turbo/apps/docs/content/docs/agent-skills/fal-ai.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/fal-ai.mdx
@@ -28,7 +28,7 @@ agents:
 Store your secret on the platform (recommended, one-time setup):
 
 ```bash
-vm0 secret set FAL_TOKEN your-fal-key
+vm0 secret set FAL_TOKEN --body "your-fal-key"
 ```
 
 Then run your agent - secret is automatically loaded:

--- a/turbo/apps/docs/content/docs/agent-skills/figma.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/figma.mdx
@@ -28,7 +28,7 @@ agents:
 Store your secret on the platform (recommended, one-time setup):
 
 ```bash
-vm0 secret set FIGMA_API_TOKEN your-figma-api-token
+vm0 secret set FIGMA_API_TOKEN --body "your-figma-api-token"
 ```
 
 Then run your agent - secret is automatically loaded:

--- a/turbo/apps/docs/content/docs/agent-skills/firecrawl.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/firecrawl.mdx
@@ -28,7 +28,7 @@ agents:
 Store your secret on the platform (recommended, one-time setup):
 
 ```bash
-vm0 secret set FIRECRAWL_API_KEY your-firecrawl-api-key
+vm0 secret set FIRECRAWL_API_KEY --body "your-firecrawl-api-key"
 ```
 
 Then run your agent - secret is automatically loaded:

--- a/turbo/apps/docs/content/docs/agent-skills/github-copilot.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/github-copilot.mdx
@@ -28,7 +28,7 @@ agents:
 Store your secret on the platform (recommended, one-time setup):
 
 ```bash
-vm0 secret set GITHUB_TOKEN your-github-token
+vm0 secret set GITHUB_TOKEN --body "your-github-token"
 ```
 
 Then run your agent - secret is automatically loaded:

--- a/turbo/apps/docs/content/docs/agent-skills/github.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/github.mdx
@@ -28,7 +28,7 @@ agents:
 Store your secret on the platform (recommended, one-time setup):
 
 ```bash
-vm0 secret set GH_TOKEN your-gh-token
+vm0 secret set GH_TOKEN --body "your-gh-token"
 ```
 
 Then run your agent - secret is automatically loaded:

--- a/turbo/apps/docs/content/docs/agent-skills/gitlab.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/gitlab.mdx
@@ -29,7 +29,7 @@ agents:
 Store your secret on the platform (recommended, one-time setup):
 
 ```bash
-vm0 secret set GITLAB_TOKEN your-gitlab-token
+vm0 secret set GITLAB_TOKEN --body "your-gitlab-token"
 ```
 
 Then run your agent - secret is automatically loaded:

--- a/turbo/apps/docs/content/docs/agent-skills/gmail.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/gmail.mdx
@@ -39,8 +39,8 @@ agents:
 Store your secrets on the platform (recommended, one-time setup):
 
 ```bash
-vm0 secret set GMAIL_CLIENT_SECRET your-gmail-client-secret
-vm0 secret set GMAIL_REFRESH_TOKEN your-gmail-refresh-token
+vm0 secret set GMAIL_CLIENT_SECRET --body "your-gmail-client-secret"
+vm0 secret set GMAIL_REFRESH_TOKEN --body "your-gmail-refresh-token"
 ```
 
 Then run your agent - secrets are automatically loaded:

--- a/turbo/apps/docs/content/docs/agent-skills/google-calendar.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/google-calendar.mdx
@@ -32,7 +32,7 @@ agents:
 Store your secret on the platform (recommended, one-time setup):
 
 ```bash
-vm0 secret set GOOGLE_CALENDAR_TOKEN your-google-calendar-token
+vm0 secret set GOOGLE_CALENDAR_TOKEN --body "your-google-calendar-token"
 ```
 
 Then run your agent - secrets are automatically loaded:

--- a/turbo/apps/docs/content/docs/agent-skills/google-docs.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/google-docs.mdx
@@ -32,7 +32,7 @@ agents:
 Store your secret on the platform (recommended, one-time setup):
 
 ```bash
-vm0 secret set GOOGLE_DOCS_TOKEN your-google-docs-token
+vm0 secret set GOOGLE_DOCS_TOKEN --body "your-google-docs-token"
 ```
 
 Then run your agent - secrets are automatically loaded:

--- a/turbo/apps/docs/content/docs/agent-skills/google-drive.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/google-drive.mdx
@@ -32,7 +32,7 @@ agents:
 Store your secret on the platform (recommended, one-time setup):
 
 ```bash
-vm0 secret set GOOGLE_DRIVE_TOKEN your-google-drive-token
+vm0 secret set GOOGLE_DRIVE_TOKEN --body "your-google-drive-token"
 ```
 
 Then run your agent - secrets are automatically loaded:

--- a/turbo/apps/docs/content/docs/agent-skills/google-sheets.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/google-sheets.mdx
@@ -37,8 +37,8 @@ agents:
 Store your secrets on the platform (recommended, one-time setup):
 
 ```bash
-vm0 secret set GOOGLE_SHEETS_CLIENT_SECRET your-google-sheets-client-secret
-vm0 secret set GOOGLE_SHEETS_REFRESH_TOKEN your-google-sheets-refresh-token
+vm0 secret set GOOGLE_SHEETS_CLIENT_SECRET --body "your-google-sheets-client-secret"
+vm0 secret set GOOGLE_SHEETS_REFRESH_TOKEN --body "your-google-sheets-refresh-token"
 ```
 
 Then run your agent - secrets are automatically loaded:

--- a/turbo/apps/docs/content/docs/agent-skills/htmlcsstoimage.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/htmlcsstoimage.mdx
@@ -29,7 +29,7 @@ agents:
 Store your secret on the platform (recommended, one-time setup):
 
 ```bash
-vm0 secret set HCTI_API_KEY your-hcti-api-key
+vm0 secret set HCTI_API_KEY --body "your-hcti-api-key"
 ```
 
 Then run your agent - secret is automatically loaded:

--- a/turbo/apps/docs/content/docs/agent-skills/imgur.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/imgur.mdx
@@ -28,7 +28,7 @@ agents:
 Store your secret on the platform (recommended, one-time setup):
 
 ```bash
-vm0 secret set IMGUR_CLIENT_ID your-imgur-client-id
+vm0 secret set IMGUR_CLIENT_ID --body "your-imgur-client-id"
 ```
 
 Then run your agent - secret is automatically loaded:

--- a/turbo/apps/docs/content/docs/agent-skills/instagram.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/instagram.mdx
@@ -29,7 +29,7 @@ agents:
 Store your secret on the platform (recommended, one-time setup):
 
 ```bash
-vm0 secret set INSTAGRAM_ACCESS_TOKEN your-instagram-access-token
+vm0 secret set INSTAGRAM_ACCESS_TOKEN --body "your-instagram-access-token"
 ```
 
 Then run your agent - secret is automatically loaded:

--- a/turbo/apps/docs/content/docs/agent-skills/instantly.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/instantly.mdx
@@ -28,7 +28,7 @@ agents:
 Store your secret on the platform (recommended, one-time setup):
 
 ```bash
-vm0 secret set INSTANTLY_API_KEY your-instantly-api-key
+vm0 secret set INSTANTLY_API_KEY --body "your-instantly-api-key"
 ```
 
 Then run your agent - secret is automatically loaded:

--- a/turbo/apps/docs/content/docs/agent-skills/intercom.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/intercom.mdx
@@ -28,7 +28,7 @@ agents:
 Store your secret on the platform (recommended, one-time setup):
 
 ```bash
-vm0 secret set INTERCOM_ACCESS_TOKEN your-intercom-access-token
+vm0 secret set INTERCOM_ACCESS_TOKEN --body "your-intercom-access-token"
 ```
 
 Then run your agent - secret is automatically loaded:

--- a/turbo/apps/docs/content/docs/agent-skills/intervals-icu.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/intervals-icu.mdx
@@ -28,7 +28,7 @@ agents:
 Store your secret on the platform (recommended, one-time setup):
 
 ```bash
-vm0 secret set INTERVALS_ICU_TOKEN your-intervals-icu-token
+vm0 secret set INTERVALS_ICU_TOKEN --body "your-intervals-icu-token"
 ```
 
 Then run your agent - secrets are automatically loaded:

--- a/turbo/apps/docs/content/docs/agent-skills/jira.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/jira.mdx
@@ -30,7 +30,7 @@ agents:
 Store your secret on the platform (recommended, one-time setup):
 
 ```bash
-vm0 secret set JIRA_API_TOKEN your-jira-api-token
+vm0 secret set JIRA_API_TOKEN --body "your-jira-api-token"
 ```
 
 Then run your agent - secret is automatically loaded:

--- a/turbo/apps/docs/content/docs/agent-skills/kommo.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/kommo.mdx
@@ -29,7 +29,7 @@ agents:
 Store your secret on the platform (recommended, one-time setup):
 
 ```bash
-vm0 secret set KOMMO_API_KEY your-kommo-api-key
+vm0 secret set KOMMO_API_KEY --body "your-kommo-api-key"
 ```
 
 Then run your agent - secret is automatically loaded:

--- a/turbo/apps/docs/content/docs/agent-skills/lark.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/lark.mdx
@@ -29,7 +29,7 @@ agents:
 Store your secret on the platform (recommended, one-time setup):
 
 ```bash
-vm0 secret set LARK_APP_SECRET your-lark-app-secret
+vm0 secret set LARK_APP_SECRET --body "your-lark-app-secret"
 ```
 
 Then run your agent - secret is automatically loaded:

--- a/turbo/apps/docs/content/docs/agent-skills/linear.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/linear.mdx
@@ -28,7 +28,7 @@ agents:
 Store your secret on the platform (recommended, one-time setup):
 
 ```bash
-vm0 secret set LINEAR_TOKEN your-linear-api-key
+vm0 secret set LINEAR_TOKEN --body "your-linear-api-key"
 ```
 
 Then run your agent - secret is automatically loaded:

--- a/turbo/apps/docs/content/docs/agent-skills/mailsac.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/mailsac.mdx
@@ -30,7 +30,7 @@ agents:
 Store your secret on the platform (recommended, one-time setup):
 
 ```bash
-vm0 secret set MAILSAC_API_KEY your-mailsac-api-key
+vm0 secret set MAILSAC_API_KEY --body "your-mailsac-api-key"
 ```
 
 Then run your agent - secrets are automatically loaded:

--- a/turbo/apps/docs/content/docs/agent-skills/mercury.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/mercury.mdx
@@ -28,7 +28,7 @@ agents:
 Store your secret on the platform (recommended, one-time setup):
 
 ```bash
-vm0 secret set MERCURY_API_TOKEN your-mercury-api-token
+vm0 secret set MERCURY_API_TOKEN --body "your-mercury-api-token"
 ```
 
 Then run your agent - secret is automatically loaded:

--- a/turbo/apps/docs/content/docs/agent-skills/minimax.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/minimax.mdx
@@ -28,7 +28,7 @@ agents:
 Store your secret on the platform (recommended, one-time setup):
 
 ```bash
-vm0 secret set MINIMAX_API_KEY your-minimax-api-key
+vm0 secret set MINIMAX_API_KEY --body "your-minimax-api-key"
 ```
 
 Then run your agent - secret is automatically loaded:

--- a/turbo/apps/docs/content/docs/agent-skills/minio.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/minio.mdx
@@ -30,8 +30,8 @@ agents:
 Store your secrets on the platform (recommended, one-time setup):
 
 ```bash
-vm0 secret set MINIO_ACCESS_KEY your-minio-access-key
-vm0 secret set MINIO_SECRET_KEY your-minio-secret-key
+vm0 secret set MINIO_ACCESS_KEY --body "your-minio-access-key"
+vm0 secret set MINIO_SECRET_KEY --body "your-minio-secret-key"
 ```
 
 Then run your agent - secrets are automatically loaded:

--- a/turbo/apps/docs/content/docs/agent-skills/monday.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/monday.mdx
@@ -28,7 +28,7 @@ agents:
 Store your secret on the platform (recommended, one-time setup):
 
 ```bash
-vm0 secret set MONDAY_API_KEY your-monday-api-key
+vm0 secret set MONDAY_API_KEY --body "your-monday-api-key"
 ```
 
 Then run your agent - secret is automatically loaded:

--- a/turbo/apps/docs/content/docs/agent-skills/notion.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/notion.mdx
@@ -28,7 +28,7 @@ agents:
 Store your secret on the platform (recommended, one-time setup):
 
 ```bash
-vm0 secret set NOTION_API_KEY your-notion-api-key
+vm0 secret set NOTION_API_KEY --body "your-notion-api-key"
 ```
 
 Then run your agent - secret is automatically loaded:

--- a/turbo/apps/docs/content/docs/agent-skills/openai.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/openai.mdx
@@ -28,7 +28,7 @@ agents:
 Store your secret on the platform (recommended, one-time setup):
 
 ```bash
-vm0 secret set OPENAI_API_KEY your-openai-api-key
+vm0 secret set OPENAI_API_KEY --body "your-openai-api-key"
 ```
 
 Then run your agent - secret is automatically loaded:

--- a/turbo/apps/docs/content/docs/agent-skills/pdf4me.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/pdf4me.mdx
@@ -28,7 +28,7 @@ agents:
 Store your secret on the platform (recommended, one-time setup):
 
 ```bash
-vm0 secret set PDF4ME_API_KEY your-pdf4me-api-key
+vm0 secret set PDF4ME_API_KEY --body "your-pdf4me-api-key"
 ```
 
 Then run your agent - secret is automatically loaded:

--- a/turbo/apps/docs/content/docs/agent-skills/pdfco.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/pdfco.mdx
@@ -28,7 +28,7 @@ agents:
 Store your secret on the platform (recommended, one-time setup):
 
 ```bash
-vm0 secret set PDFCO_API_KEY your-pdfco-api-key
+vm0 secret set PDFCO_API_KEY --body "your-pdfco-api-key"
 ```
 
 Then run your agent - secret is automatically loaded:

--- a/turbo/apps/docs/content/docs/agent-skills/pdforge.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/pdforge.mdx
@@ -28,7 +28,7 @@ agents:
 Store your secret on the platform (recommended, one-time setup):
 
 ```bash
-vm0 secret set PDFORGE_API_KEY your-pdforge-api-key
+vm0 secret set PDFORGE_API_KEY --body "your-pdforge-api-key"
 ```
 
 Then run your agent - secret is automatically loaded:

--- a/turbo/apps/docs/content/docs/agent-skills/perplexity.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/perplexity.mdx
@@ -28,7 +28,7 @@ agents:
 Store your secret on the platform (recommended, one-time setup):
 
 ```bash
-vm0 secret set PERPLEXITY_API_KEY your-perplexity-api-key
+vm0 secret set PERPLEXITY_API_KEY --body "your-perplexity-api-key"
 ```
 
 Then run your agent - secret is automatically loaded:

--- a/turbo/apps/docs/content/docs/agent-skills/plausible.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/plausible.mdx
@@ -29,7 +29,7 @@ agents:
 Store your secret on the platform (recommended, one-time setup):
 
 ```bash
-vm0 secret set PLAUSIBLE_API_KEY your-plausible-api-key
+vm0 secret set PLAUSIBLE_API_KEY --body "your-plausible-api-key"
 ```
 
 Then run your agent - secret is automatically loaded:

--- a/turbo/apps/docs/content/docs/agent-skills/podchaser.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/podchaser.mdx
@@ -29,7 +29,7 @@ agents:
 Store your secret on the platform (recommended, one-time setup):
 
 ```bash
-vm0 secret set PODCHASER_CLIENT_SECRET your-podchaser-client-secret
+vm0 secret set PODCHASER_CLIENT_SECRET --body "your-podchaser-client-secret"
 ```
 
 Then run your agent - secret is automatically loaded:

--- a/turbo/apps/docs/content/docs/agent-skills/productlane.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/productlane.mdx
@@ -30,7 +30,7 @@ agents:
 Store your secret on the platform (recommended, one-time setup):
 
 ```bash
-vm0 secret set PRODUCTLANE_API_KEY your-productlane-api-key
+vm0 secret set PRODUCTLANE_API_KEY --body "your-productlane-api-key"
 ```
 
 Then run your agent - secrets are automatically loaded:

--- a/turbo/apps/docs/content/docs/agent-skills/pushinator.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/pushinator.mdx
@@ -28,7 +28,7 @@ agents:
 Store your secret on the platform (recommended, one-time setup):
 
 ```bash
-vm0 secret set PUSHINATOR_API_KEY your-pushinator-api-key
+vm0 secret set PUSHINATOR_API_KEY --body "your-pushinator-api-key"
 ```
 
 Then run your agent - secret is automatically loaded:

--- a/turbo/apps/docs/content/docs/agent-skills/qdrant.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/qdrant.mdx
@@ -29,7 +29,7 @@ agents:
 Store your secret on the platform (recommended, one-time setup):
 
 ```bash
-vm0 secret set QDRANT_API_KEY your-qdrant-api-key
+vm0 secret set QDRANT_API_KEY --body "your-qdrant-api-key"
 ```
 
 Then run your agent - secret is automatically loaded:

--- a/turbo/apps/docs/content/docs/agent-skills/qiita.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/qiita.mdx
@@ -28,7 +28,7 @@ agents:
 Store your secret on the platform (recommended, one-time setup):
 
 ```bash
-vm0 secret set QIITA_ACCESS_TOKEN your-qiita-access-token
+vm0 secret set QIITA_ACCESS_TOKEN --body "your-qiita-access-token"
 ```
 
 Then run your agent - secret is automatically loaded:

--- a/turbo/apps/docs/content/docs/agent-skills/reportei.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/reportei.mdx
@@ -28,7 +28,7 @@ agents:
 Store your secret on the platform (recommended, one-time setup):
 
 ```bash
-vm0 secret set REPORTEI_API_TOKEN your-reportei-api-token
+vm0 secret set REPORTEI_API_TOKEN --body "your-reportei-api-token"
 ```
 
 Then run your agent - secret is automatically loaded:

--- a/turbo/apps/docs/content/docs/agent-skills/resend.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/resend.mdx
@@ -28,7 +28,7 @@ agents:
 Store your secret on the platform (recommended, one-time setup):
 
 ```bash
-vm0 secret set RESEND_TOKEN your-resend-api-key
+vm0 secret set RESEND_TOKEN --body "your-resend-api-key"
 ```
 
 Then run your agent - secret is automatically loaded:

--- a/turbo/apps/docs/content/docs/agent-skills/runway.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/runway.mdx
@@ -28,7 +28,7 @@ agents:
 Store your secret on the platform (recommended, one-time setup):
 
 ```bash
-vm0 secret set RUNWAY_API_KEY your-runway-api-key
+vm0 secret set RUNWAY_API_KEY --body "your-runway-api-key"
 ```
 
 Then run your agent - secret is automatically loaded:

--- a/turbo/apps/docs/content/docs/agent-skills/scrapeninja.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/scrapeninja.mdx
@@ -28,7 +28,7 @@ agents:
 Store your secret on the platform (recommended, one-time setup):
 
 ```bash
-vm0 secret set SCRAPENINJA_API_KEY your-scrapeninja-api-key
+vm0 secret set SCRAPENINJA_API_KEY --body "your-scrapeninja-api-key"
 ```
 
 Then run your agent - secret is automatically loaded:

--- a/turbo/apps/docs/content/docs/agent-skills/sentry.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/sentry.mdx
@@ -30,7 +30,7 @@ agents:
 Store your secret on the platform (recommended, one-time setup):
 
 ```bash
-vm0 secret set SENTRY_TOKEN your-sentry-token
+vm0 secret set SENTRY_TOKEN --body "your-sentry-token"
 ```
 
 Then run your agent - secret is automatically loaded:

--- a/turbo/apps/docs/content/docs/agent-skills/serpapi.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/serpapi.mdx
@@ -28,7 +28,7 @@ agents:
 Store your secret on the platform (recommended, one-time setup):
 
 ```bash
-vm0 secret set SERPAPI_API_KEY your-serpapi-api-key
+vm0 secret set SERPAPI_API_KEY --body "your-serpapi-api-key"
 ```
 
 Then run your agent - secret is automatically loaded:

--- a/turbo/apps/docs/content/docs/agent-skills/shortio.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/shortio.mdx
@@ -30,7 +30,7 @@ agents:
 Store your secret on the platform (recommended, one-time setup):
 
 ```bash
-vm0 secret set SHORTIO_API_KEY your-shortio-api-key
+vm0 secret set SHORTIO_API_KEY --body "your-shortio-api-key"
 ```
 
 Then run your agent - secret is automatically loaded:

--- a/turbo/apps/docs/content/docs/agent-skills/slack-webhook.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/slack-webhook.mdx
@@ -28,7 +28,7 @@ agents:
 Store your secret on the platform (recommended, one-time setup):
 
 ```bash
-vm0 secret set SLACK_WEBHOOK_URL your-slack-webhook-url
+vm0 secret set SLACK_WEBHOOK_URL --body "your-slack-webhook-url"
 ```
 
 Then run your agent - secret is automatically loaded:

--- a/turbo/apps/docs/content/docs/agent-skills/slack.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/slack.mdx
@@ -28,7 +28,7 @@ agents:
 Store your secret on the platform (recommended, one-time setup):
 
 ```bash
-vm0 secret set SLACK_BOT_TOKEN your-slack-bot-token
+vm0 secret set SLACK_BOT_TOKEN --body "your-slack-bot-token"
 ```
 
 Then run your agent - secret is automatically loaded:

--- a/turbo/apps/docs/content/docs/agent-skills/strava.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/strava.mdx
@@ -28,7 +28,7 @@ agents:
 Store your secret on the platform (recommended, one-time setup):
 
 ```bash
-vm0 secret set STRAVA_TOKEN your-strava-token
+vm0 secret set STRAVA_TOKEN --body "your-strava-token"
 ```
 
 Then run your agent - secrets are automatically loaded:

--- a/turbo/apps/docs/content/docs/agent-skills/streak.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/streak.mdx
@@ -28,7 +28,7 @@ agents:
 Store your secret on the platform (recommended, one-time setup):
 
 ```bash
-vm0 secret set STREAK_API_KEY your-streak-api-key
+vm0 secret set STREAK_API_KEY --body "your-streak-api-key"
 ```
 
 Then run your agent - secret is automatically loaded:

--- a/turbo/apps/docs/content/docs/agent-skills/supabase.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/supabase.mdx
@@ -30,7 +30,7 @@ agents:
 Store your secret on the platform (recommended, one-time setup):
 
 ```bash
-vm0 secret set SUPABASE_SECRET_KEY your-supabase-secret-key
+vm0 secret set SUPABASE_SECRET_KEY --body "your-supabase-secret-key"
 ```
 
 Then run your agent - secret is automatically loaded:

--- a/turbo/apps/docs/content/docs/agent-skills/supadata.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/supadata.mdx
@@ -28,7 +28,7 @@ agents:
 Store your secret on the platform (recommended, one-time setup):
 
 ```bash
-vm0 secret set SUPADATA_API_KEY your-supadata-api-key
+vm0 secret set SUPADATA_API_KEY --body "your-supadata-api-key"
 ```
 
 Then run your agent - secret is automatically loaded:

--- a/turbo/apps/docs/content/docs/agent-skills/tavily.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/tavily.mdx
@@ -28,7 +28,7 @@ agents:
 Store your secret on the platform (recommended, one-time setup):
 
 ```bash
-vm0 secret set TAVILY_API_KEY your-tavily-api-key
+vm0 secret set TAVILY_API_KEY --body "your-tavily-api-key"
 ```
 
 Then run your agent - secret is automatically loaded:

--- a/turbo/apps/docs/content/docs/agent-skills/twenty.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/twenty.mdx
@@ -29,7 +29,7 @@ agents:
 Store your secret on the platform (recommended, one-time setup):
 
 ```bash
-vm0 secret set TWENTY_API_KEY your-twenty-api-key
+vm0 secret set TWENTY_API_KEY --body "your-twenty-api-key"
 ```
 
 Then run your agent - secret is automatically loaded:

--- a/turbo/apps/docs/content/docs/agent-skills/vercel.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/vercel.mdx
@@ -30,7 +30,7 @@ agents:
 Store your secret on the platform (recommended, one-time setup):
 
 ```bash
-vm0 secret set VERCEL_TOKEN your-vercel-token
+vm0 secret set VERCEL_TOKEN --body "your-vercel-token"
 ```
 
 Then run your agent - secrets are automatically loaded:

--- a/turbo/apps/docs/content/docs/agent-skills/x.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/x.mdx
@@ -30,7 +30,7 @@ agents:
 Store your secret on the platform (recommended, one-time setup):
 
 ```bash
-vm0 secret set X_ACCESS_TOKEN your-x-access-token
+vm0 secret set X_ACCESS_TOKEN --body "your-x-access-token"
 ```
 
 Then run your agent - secrets are automatically loaded:

--- a/turbo/apps/docs/content/docs/agent-skills/xero.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/xero.mdx
@@ -34,7 +34,7 @@ agents:
 Store your secret on the platform (recommended, one-time setup):
 
 ```bash
-vm0 secret set XERO_TOKEN your-xero-token
+vm0 secret set XERO_TOKEN --body "your-xero-token"
 ```
 
 Then run your agent - secrets are automatically loaded:

--- a/turbo/apps/docs/content/docs/agent-skills/youtube.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/youtube.mdx
@@ -28,7 +28,7 @@ agents:
 Store your secret on the platform (recommended, one-time setup):
 
 ```bash
-vm0 secret set YOUTUBE_API_KEY your-youtube-api-key
+vm0 secret set YOUTUBE_API_KEY --body "your-youtube-api-key"
 ```
 
 Then run your agent - secret is automatically loaded:

--- a/turbo/apps/docs/content/docs/agent-skills/zapsign.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/zapsign.mdx
@@ -28,7 +28,7 @@ agents:
 Store your secret on the platform (recommended, one-time setup):
 
 ```bash
-vm0 secret set ZAPSIGN_API_TOKEN your-zapsign-api-token
+vm0 secret set ZAPSIGN_API_TOKEN --body "your-zapsign-api-token"
 ```
 
 Then run your agent - secret is automatically loaded:

--- a/turbo/apps/docs/content/docs/agent-skills/zendesk.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/zendesk.mdx
@@ -30,7 +30,7 @@ agents:
 Store your secret on the platform (recommended, one-time setup):
 
 ```bash
-vm0 secret set ZENDESK_API_TOKEN your-zendesk-api-token
+vm0 secret set ZENDESK_API_TOKEN --body "your-zendesk-api-token"
 ```
 
 Then run your agent - secret is automatically loaded:

--- a/turbo/apps/docs/content/docs/agent-skills/zeptomail.mdx
+++ b/turbo/apps/docs/content/docs/agent-skills/zeptomail.mdx
@@ -28,7 +28,7 @@ agents:
 Store your secret on the platform (recommended, one-time setup):
 
 ```bash
-vm0 secret set ZEPTOMAIL_API_KEY your-zeptomail-api-key
+vm0 secret set ZEPTOMAIL_API_KEY --body "your-zeptomail-api-key"
 ```
 
 Then run your agent - secret is automatically loaded:

--- a/turbo/apps/docs/content/docs/core-concept/environment-variable.mdx
+++ b/turbo/apps/docs/content/docs/core-concept/environment-variable.mdx
@@ -47,10 +47,10 @@ Store values once and use them across all agent runs.
 
 ```bash
 # Store a secret
-vm0 secret set MY_API_KEY sk-xxx
+vm0 secret set MY_API_KEY --body "sk-xxx"
 
 # With optional description
-vm0 secret set MY_API_KEY sk-xxx -d "OpenAI API key for production"
+vm0 secret set MY_API_KEY --body "sk-xxx" -d "OpenAI API key for production"
 
 # List all secrets (values are hidden)
 vm0 secret list
@@ -142,7 +142,7 @@ The CLI resolves values locally (steps 1-3), then sends them to the server where
 Example:
 
 ```bash
-# Platform has: vm0 secret set API_KEY stored-value
+# Platform has: vm0 secret set API_KEY --body "stored-value"
 # .env file contains: API_KEY=from-env-file
 # Shell environment has: export API_KEY=from-shell-env
 
@@ -172,7 +172,7 @@ For API keys you use repeatedly across multiple runs:
 
 ```bash
 # Set once
-vm0 secret set ANTHROPIC_API_KEY sk-xxx
+vm0 secret set ANTHROPIC_API_KEY --body "sk-xxx"
 ```
 
 Then use in any agent:

--- a/turbo/apps/docs/content/docs/tutorial/research-capabilities.mdx
+++ b/turbo/apps/docs/content/docs/tutorial/research-capabilities.mdx
@@ -107,8 +107,8 @@ VM0 is asking you to approve the new secrets required by these skills. This is a
 Before running, store your API keys on the platform (one-time setup):
 
 ```bash
-vm0 secret set FIRECRAWL_API_KEY fc-xxx
-vm0 secret set TAVILY_API_KEY tvly-xxx
+vm0 secret set FIRECRAWL_API_KEY --body "fc-xxx"
+vm0 secret set TAVILY_API_KEY --body "tvly-xxx"
 ```
 
 This stores your secrets securely on VM0's servers. They'll be automatically loaded whenever you run your agent.

--- a/turbo/apps/docs/content/docs/usage/run-agent.mdx
+++ b/turbo/apps/docs/content/docs/usage/run-agent.mdx
@@ -42,7 +42,7 @@ vm0 run my-agent:abc123 "build a todo app"
 
 ```bash
 vm0 variable set ENV production
-vm0 secret set API_KEY sk-xxx
+vm0 secret set API_KEY --body "sk-xxx"
 ```
 
 Then run your agent - values are automatically loaded:
@@ -178,8 +178,8 @@ Store values once and they're automatically loaded on every run:
 ```bash
 vm0 variable set ENV production
 vm0 variable set REGION us-west
-vm0 secret set API_KEY sk-xxx
-vm0 secret set DB_PASSWORD pwd123
+vm0 secret set API_KEY --body "sk-xxx"
+vm0 secret set DB_PASSWORD --body "pwd123"
 ```
 
 Then just run:

--- a/turbo/apps/docs/content/docs/usage/schedule-agent.mdx
+++ b/turbo/apps/docs/content/docs/usage/schedule-agent.mdx
@@ -143,7 +143,7 @@ Variables and secrets for scheduled runs are inherited from the agent's platform
 
 ```bash
 vm0 variable set ENV production
-vm0 secret set API_KEY sk-xxx
+vm0 secret set API_KEY --body "sk-xxx"
 ```
 
 Then set up your schedule:

--- a/turbo/apps/docs/content/docs/usage/using-skills.mdx
+++ b/turbo/apps/docs/content/docs/usage/using-skills.mdx
@@ -75,9 +75,9 @@ agents:
 First, store your secrets on the platform (one-time setup):
 
 ```bash
-vm0 secret set FIRECRAWL_API_KEY fc-xxx
-vm0 secret set NOTION_API_KEY secret_xxx
-vm0 secret set SLACK_BOT_TOKEN xoxb-xxx
+vm0 secret set FIRECRAWL_API_KEY --body "fc-xxx"
+vm0 secret set NOTION_API_KEY --body "secret_xxx"
+vm0 secret set SLACK_BOT_TOKEN --body "xoxb-xxx"
 ```
 
 Then run your agent - secrets are automatically loaded:
@@ -129,9 +129,9 @@ Help the agent understand where and how to use each skill:
 Store required credentials on the platform (recommended, one-time setup):
 
 ```bash
-vm0 secret set GOOGLE_SHEETS_CLIENT_ID xxx
-vm0 secret set GOOGLE_SHEETS_CLIENT_SECRET xxx
-vm0 secret set GOOGLE_SHEETS_REFRESH_TOKEN xxx
+vm0 secret set GOOGLE_SHEETS_CLIENT_ID --body "xxx"
+vm0 secret set GOOGLE_SHEETS_CLIENT_SECRET --body "xxx"
+vm0 secret set GOOGLE_SHEETS_REFRESH_TOKEN --body "xxx"
 ```
 
 Then run your agent - secrets are automatically loaded:


### PR DESCRIPTION
## Summary

- Fix incorrect `vm0 secret set` syntax across 83 documentation files
- All examples previously showed value as positional argument (`vm0 secret set KEY value`), which is not supported by the CLI
- Updated to correct syntax using `--body` flag: `vm0 secret set KEY --body "value"`
- `vm0 variable set` examples left unchanged (positional value is correct for variables)

Closes #5173

## Test plan

- [ ] Verify all `vm0 secret set` examples now use `--body` flag
- [ ] Verify `vm0 variable set` examples are unchanged
- [ ] Verify no other content was modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)