### PR TITLE
feat(docs): add missing --memory option to vm0 run documentation

### DIFF
--- a/turbo/apps/docs/content/docs/reference/cli/index.mdx
+++ b/turbo/apps/docs/content/docs/reference/cli/index.mdx
@@ -159,6 +159,7 @@ Organizations are namespaces for organizing agents.
 | `--artifact-name <name>` | Artifact storage name |
 | `--artifact-version <hash>` | Artifact version hash (defaults to latest) |
 | `--volume-version <name=version>` | Volume version override (repeatable) |
+| `--memory <name>` | Memory storage name |
 | `--conversation <id>` | Resume from conversation ID |
 | `--model-provider <type>` | Override model provider |
 | `--verbose` | Show full tool inputs and outputs |

--- a/turbo/apps/docs/content/docs/usage/run-agent.mdx
+++ b/turbo/apps/docs/content/docs/usage/run-agent.mdx
@@ -31,6 +31,7 @@ vm0 run my-agent:abc123 "build a todo app"
 | `--artifact-version <hash>`      | Use specific artifact version                                        |
 | `--env-file <path>`              | Load environment variables from file (priority: CLI flags > file > env vars) |
 | `--volume-version <name=version>` | Volume version override (repeatable, format: volumeName=version)     |
+| `--memory <name>`                | Memory storage name                                                  |
 | `--conversation <id>`            | Resume from conversation ID (for fine-grained control)               |
 | `--model-provider <type>`        | Override model provider (e.g., anthropic-api-key)                    |
 | `--verbose`                      | Show full tool inputs and outputs                                    |


### PR DESCRIPTION
## Summary
- Add `--memory <name>` option to the CLI reference `vm0 run` options table
- Add `--memory <name>` option to the run-agent usage page options table

Closes #5175

## Test plan
- [ ] Verify `--memory <name>` appears in CLI reference page options table
- [ ] Verify `--memory <name>` appears in run-agent page options table
- [ ] Verify no other content changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)