### PR TITLE
feat: add org-level secrets and variables service functions

### DIFF
--- a/turbo/apps/web/src/lib/secret/__tests__/org-secret-service.test.ts
+++ b/turbo/apps/web/src/lib/secret/__tests__/org-secret-service.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { testContext } from "../../../__tests__/test-helpers";
+import {
+  listOrgSecrets,
+  setOrgSecret,
+  deleteOrgSecret,
+  listSecrets,
+  setSecret,
+} from "../secret-service";
+
+vi.mock("@axiomhq/logging");
+
+const context = testContext();
+
+describe("Org-level secret service", () => {
+  let orgId: string;
+
+  beforeEach(async () => {
+    context.setupMocks();
+    const user = await context.setupUser();
+    orgId = user.orgId;
+  });
+
+  describe("CRUD lifecycle", () => {
+    it("should return empty list when no org secrets exist", async () => {
+      const secrets = await listOrgSecrets(orgId);
+      expect(secrets).toEqual([]);
+    });
+
+    it("should create an org secret", async () => {
+      const secret = await setOrgSecret(orgId, "ORG_API_KEY", "test-value");
+
+      expect(secret.name).toBe("ORG_API_KEY");
+      expect(secret.type).toBe("user");
+      expect(secret.id).toBeDefined();
+    });
+
+    it("should list org secrets", async () => {
+      await setOrgSecret(orgId, "ORG_API_KEY", "test-value");
+
+      const secrets = await listOrgSecrets(orgId);
+      expect(secrets).toHaveLength(1);
+      expect(secrets[0]?.name).toBe("ORG_API_KEY");
+    });
+
+    it("should update existing org secret on re-upsert", async () => {
+      const first = await setOrgSecret(orgId, "ORG_API_KEY", "value-v1");
+      const second = await setOrgSecret(orgId, "ORG_API_KEY", "value-v2");
+
+      expect(second.id).toBe(first.id);
+    });
+
+    it("should delete an org secret", async () => {
+      await setOrgSecret(orgId, "ORG_API_KEY", "test-value");
+
+      await deleteOrgSecret(orgId, "ORG_API_KEY");
+
+      const secrets = await listOrgSecrets(orgId);
+      expect(secrets).toEqual([]);
+    });
+
+    it("should throw when deleting non-existent org secret", async () => {
+      await expect(deleteOrgSecret(orgId, "ORG_API_KEY")).rejects.toThrow(
+        'Secret "ORG_API_KEY" not found',
+      );
+    });
+  });
+
+  describe("isolation", () => {
+    it("should not return org secrets in user secret list", async () => {
+      const user = await context.setupUser();
+      await setOrgSecret(user.orgId, "SHARED_KEY", "org-value");
+
+      const userSecrets = await listSecrets(user.orgId, user.userId);
+      expect(userSecrets).toEqual([]);
+    });
+
+    it("should not return user secrets in org secret list", async () => {
+      const user = await context.setupUser();
+      await setSecret(user.orgId, user.userId, "USER_KEY", "user-value");
+
+      const orgSecrets = await listOrgSecrets(user.orgId);
+      expect(orgSecrets).toEqual([]);
+    });
+
+    it("should allow same-name secret for both org and user", async () => {
+      const user = await context.setupUser();
+      await setOrgSecret(user.orgId, "API_KEY", "org-value");
+      await setSecret(user.orgId, user.userId, "API_KEY", "user-value");
+
+      const orgSecrets = await listOrgSecrets(user.orgId);
+      const userSecrets = await listSecrets(user.orgId, user.userId);
+
+      expect(orgSecrets).toHaveLength(1);
+      expect(orgSecrets[0]?.name).toBe("API_KEY");
+
+      expect(userSecrets).toHaveLength(1);
+      expect(userSecrets[0]?.name).toBe("API_KEY");
+
+      expect(orgSecrets[0]?.id).not.toBe(userSecrets[0]?.id);
+    });
+  });
+});

--- a/turbo/apps/web/src/lib/secret/secret-service.ts
+++ b/turbo/apps/web/src/lib/secret/secret-service.ts
@@ -4,6 +4,7 @@ import { secrets } from "../../db/schema/secret";
 import { encryptSecretValue, decryptSecretValue } from "../crypto";
 import { badRequest, notFound } from "../errors";
 import { logger } from "../logger";
+import { ORG_SENTINEL_USER_ID } from "../org/org-sentinel";
 
 const log = logger("service:secret");
 
@@ -290,4 +291,37 @@ export async function deleteSecret(
   await globalThis.services.db.delete(secrets).where(eq(secrets.id, secret.id));
 
   log.debug("secret deleted", { orgId, name });
+}
+
+// ============================================================================
+// Org-Level Secret Functions
+//
+// These delegate to the user-level functions using ORG_SENTINEL_USER_ID.
+// The sentinel userId ensures org and user secrets are fully isolated.
+// ============================================================================
+
+/**
+ * List all org-level secrets (metadata only, no values)
+ */
+export function listOrgSecrets(orgId: string): Promise<SecretInfo[]> {
+  return listSecrets(orgId, ORG_SENTINEL_USER_ID);
+}
+
+/**
+ * Create or update an org-level secret
+ */
+export function setOrgSecret(
+  orgId: string,
+  name: string,
+  value: string,
+  description?: string,
+): Promise<SecretInfo> {
+  return setSecret(orgId, ORG_SENTINEL_USER_ID, name, value, description);
+}
+
+/**
+ * Delete an org-level secret by name
+ */
+export function deleteOrgSecret(orgId: string, name: string): Promise<void> {
+  return deleteSecret(orgId, ORG_SENTINEL_USER_ID, name);
 }

--- a/turbo/apps/web/src/lib/variable/__tests__/org-variable-service.test.ts
+++ b/turbo/apps/web/src/lib/variable/__tests__/org-variable-service.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { testContext } from "../../../__tests__/test-helpers";
+import {
+  listOrgVariables,
+  setOrgVariable,
+  deleteOrgVariable,
+  listVariables,
+  setVariable,
+} from "../variable-service";
+
+vi.mock("@axiomhq/logging");
+
+const context = testContext();
+
+describe("Org-level variable service", () => {
+  let orgId: string;
+
+  beforeEach(async () => {
+    context.setupMocks();
+    const user = await context.setupUser();
+    orgId = user.orgId;
+  });
+
+  describe("CRUD lifecycle", () => {
+    it("should return empty list when no org variables exist", async () => {
+      const vars = await listOrgVariables(orgId);
+      expect(vars).toEqual([]);
+    });
+
+    it("should create an org variable", async () => {
+      const variable = await setOrgVariable(
+        orgId,
+        "ORG_ENV",
+        "production",
+        "Org environment",
+      );
+
+      expect(variable.name).toBe("ORG_ENV");
+      expect(variable.value).toBe("production");
+      expect(variable.description).toBe("Org environment");
+      expect(variable.id).toBeDefined();
+    });
+
+    it("should list org variables", async () => {
+      await setOrgVariable(orgId, "ORG_ENV", "production");
+
+      const vars = await listOrgVariables(orgId);
+      expect(vars).toHaveLength(1);
+      expect(vars[0]?.name).toBe("ORG_ENV");
+    });
+
+    it("should update existing org variable on re-upsert", async () => {
+      const first = await setOrgVariable(orgId, "ORG_ENV", "staging");
+      const second = await setOrgVariable(orgId, "ORG_ENV", "production");
+
+      expect(second.id).toBe(first.id);
+      expect(second.value).toBe("production");
+    });
+
+    it("should delete an org variable", async () => {
+      await setOrgVariable(orgId, "ORG_ENV", "production");
+
+      await deleteOrgVariable(orgId, "ORG_ENV");
+
+      const vars = await listOrgVariables(orgId);
+      expect(vars).toEqual([]);
+    });
+
+    it("should throw when deleting non-existent org variable", async () => {
+      await expect(deleteOrgVariable(orgId, "ORG_ENV")).rejects.toThrow(
+        'Variable "ORG_ENV" not found',
+      );
+    });
+  });
+
+  describe("isolation", () => {
+    it("should not return org variables in user variable list", async () => {
+      const user = await context.setupUser();
+      await setOrgVariable(user.orgId, "SHARED_VAR", "org-value");
+
+      const userVars = await listVariables(user.orgId, user.userId);
+      expect(userVars).toEqual([]);
+    });
+
+    it("should not return user variables in org variable list", async () => {
+      const user = await context.setupUser();
+      await setVariable(user.orgId, user.userId, "USER_VAR", "user-value");
+
+      const orgVars = await listOrgVariables(user.orgId);
+      expect(orgVars).toEqual([]);
+    });
+
+    it("should allow same-name variable for both org and user", async () => {
+      const user = await context.setupUser();
+      await setOrgVariable(user.orgId, "MY_VAR", "org-value");
+      await setVariable(user.orgId, user.userId, "MY_VAR", "user-value");
+
+      const orgVars = await listOrgVariables(user.orgId);
+      const userVars = await listVariables(user.orgId, user.userId);
+
+      expect(orgVars).toHaveLength(1);
+      expect(orgVars[0]?.name).toBe("MY_VAR");
+      expect(orgVars[0]?.value).toBe("org-value");
+
+      expect(userVars).toHaveLength(1);
+      expect(userVars[0]?.name).toBe("MY_VAR");
+      expect(userVars[0]?.value).toBe("user-value");
+
+      expect(orgVars[0]?.id).not.toBe(userVars[0]?.id);
+    });
+  });
+});

--- a/turbo/apps/web/src/lib/variable/variable-service.ts
+++ b/turbo/apps/web/src/lib/variable/variable-service.ts
@@ -2,6 +2,7 @@ import { eq, and } from "drizzle-orm";
 import { variables } from "../../db/schema/variable";
 import { badRequest, notFound } from "../errors";
 import { logger } from "../logger";
+import { ORG_SENTINEL_USER_ID } from "../org/org-sentinel";
 
 const log = logger("service:variable");
 
@@ -197,4 +198,37 @@ export async function deleteVariable(
     .where(eq(variables.id, variable.id));
 
   log.debug("variable deleted", { orgId, name });
+}
+
+// ============================================================================
+// Org-Level Variable Functions
+//
+// These delegate to the user-level functions using ORG_SENTINEL_USER_ID.
+// The sentinel userId ensures org and user variables are fully isolated.
+// ============================================================================
+
+/**
+ * List all org-level variables (includes values)
+ */
+export function listOrgVariables(orgId: string): Promise<VariableInfo[]> {
+  return listVariables(orgId, ORG_SENTINEL_USER_ID);
+}
+
+/**
+ * Create or update an org-level variable
+ */
+export function setOrgVariable(
+  orgId: string,
+  name: string,
+  value: string,
+  description?: string,
+): Promise<VariableInfo> {
+  return setVariable(orgId, ORG_SENTINEL_USER_ID, name, value, description);
+}
+
+/**
+ * Delete an org-level variable by name
+ */
+export function deleteOrgVariable(orgId: string, name: string): Promise<void> {
+  return deleteVariable(orgId, ORG_SENTINEL_USER_ID, name);
 }


### PR DESCRIPTION
## Summary

- Add 3 org-level secret functions (`listOrgSecrets`, `setOrgSecret`, `deleteOrgSecret`) to `secret-service.ts`
- Add 3 org-level variable functions (`listOrgVariables`, `setOrgVariable`, `deleteOrgVariable`) to `variable-service.ts`
- Uses the sentinel userId pattern from #5161 — each wrapper delegates to the existing user-level function with `ORG_SENTINEL_USER_ID`
- Integration tests for both services covering CRUD lifecycle, isolation, and same-name coexistence

Closes #5171

## Test plan

- [x] 18 integration tests passing (9 per service)
- [x] CRUD lifecycle: create → list → update (re-upsert) → delete
- [x] Isolation: org resources invisible to user queries and vice versa
- [x] Same-name coexistence: org and user resources with identical names are independent
- [x] Pre-commit hooks pass (prettier, knip, commitlint)
- [x] TypeScript type check passes for web and cli workspaces
- [x] Lint passes for web workspace

🤖 Generated with [Claude Code](https://claude.com/claude-code)