### PR TITLE
fix: add /export to skip-i18n prefixes to prevent redirect 404

### DIFF
--- a/turbo/apps/web/proxy.layers.ts
+++ b/turbo/apps/web/proxy.layers.ts
@@ -21,6 +21,7 @@ const SKIP_I18N_PREFIXES = [
   "/sign-up",
   "/privacy-policy",
   "/terms-of-use",
+  "/export",
 ] as const;
 
 const STATIC_FILE_RE = /\.(ico|png|jpg|jpeg|svg|gif|webp|woff|woff2|ttf|eot)$/i;


### PR DESCRIPTION
## Summary

- Add `/export` to `SKIP_I18N_PREFIXES` in `proxy.layers.ts` to prevent the i18n middleware from redirecting `/export` to `/en/export` (which does not exist and causes a 404)
- The `/export` page lives outside `app/[locale]/` (same as `/sign-in`, `/cli-auth`, etc.) and should bypass i18n processing

Closes #5180

## Test plan

- [ ] Verify accessing `/export` no longer redirects to `/en/export`
- [ ] Verify the export page renders correctly
- [ ] Existing proxy layer tests pass (47 tests confirmed passing locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)