### PR TITLE
feat: add org-level fallback for model providers, secrets, and variables

### DIFF
--- a/turbo/apps/web/src/lib/run/__tests__/build-context-org.test.ts
+++ b/turbo/apps/web/src/lib/run/__tests__/build-context-org.test.ts
@@ -1,0 +1,327 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  testContext,
+  uniqueId,
+  type UserContext,
+} from "../../../__tests__/test-helpers";
+import {
+  createTestCompose,
+  createTestModelProvider,
+  createTestSecret,
+  createTestVariable,
+  findTestRunnerJobEntry,
+} from "../../../__tests__/api-test-helpers";
+import { createRun, type CreateRunParams } from "../run-service";
+import { upsertOrgModelProvider } from "../../model-provider/model-provider-service";
+import { upsertSecretByOrg } from "../../secret/secret-service";
+import { setVariable } from "../../variable/variable-service";
+import { ORG_SENTINEL_USER_ID } from "../../org/org-sentinel";
+import { isBadRequest } from "../../errors";
+
+const context = testContext();
+
+describe("Org-Level Runtime Resolution", () => {
+  let user: UserContext;
+  let versionId: string;
+
+  beforeEach(async () => {
+    context.setupMocks();
+    user = await context.setupUser();
+    const compose = await createTestCompose(uniqueId("agent"));
+    versionId = compose.versionId;
+  });
+
+  function baseParams(overrides?: Partial<CreateRunParams>): CreateRunParams {
+    return {
+      userId: user.userId,
+      agentComposeVersionId: versionId,
+      prompt: "Hello, world!",
+      orgId: user.orgId,
+      ...overrides,
+    };
+  }
+
+  describe("Model Provider Fallback", () => {
+    it("should use user default provider when user has one", async () => {
+      const noKeyCompose = await createTestCompose(uniqueId("no-key-agent"), {
+        skipDefaultApiKey: true,
+      });
+
+      // Create both user and org providers
+      await createTestModelProvider("anthropic-api-key", "user-api-key");
+      await upsertOrgModelProvider(
+        user.orgId,
+        "anthropic-api-key",
+        "org-api-key",
+      );
+
+      const result = await createRun(
+        baseParams({ agentComposeVersionId: noKeyCompose.versionId }),
+      );
+
+      const job = await findTestRunnerJobEntry(result.runId);
+      expect(job).toBeDefined();
+      // User's key should be used, not org's
+      expect(job!.executionContext.environment).toMatchObject({
+        ANTHROPIC_API_KEY: "user-api-key",
+      });
+    });
+
+    it("should fall back to org default provider when user has none", async () => {
+      const noKeyCompose = await createTestCompose(uniqueId("no-key-agent"), {
+        skipDefaultApiKey: true,
+      });
+
+      // Only create org provider (no user provider)
+      await upsertOrgModelProvider(
+        user.orgId,
+        "anthropic-api-key",
+        "org-api-key",
+      );
+
+      const result = await createRun(
+        baseParams({ agentComposeVersionId: noKeyCompose.versionId }),
+      );
+
+      const job = await findTestRunnerJobEntry(result.runId);
+      expect(job).toBeDefined();
+      expect(job!.executionContext.environment).toMatchObject({
+        ANTHROPIC_API_KEY: "org-api-key",
+      });
+    });
+
+    it("should error when neither user nor org has default provider", async () => {
+      const noKeyCompose = await createTestCompose(uniqueId("no-key-agent"), {
+        skipDefaultApiKey: true,
+      });
+
+      // No providers at all
+      await expect(
+        createRun(
+          baseParams({ agentComposeVersionId: noKeyCompose.versionId }),
+        ),
+      ).rejects.toSatisfy(isBadRequest);
+    });
+  });
+
+  describe("Secret Merge", () => {
+    it("should merge org and user secrets with user priority", async () => {
+      const compose = await createTestCompose(uniqueId("secret-agent"), {
+        overrides: {
+          environment: {
+            ANTHROPIC_API_KEY: "test-api-key",
+            SHARED_KEY: "${{ secrets.SHARED_KEY }}",
+          },
+        },
+      });
+
+      // Both org and user have the same secret name
+      await upsertSecretByOrg(
+        user.orgId,
+        ORG_SENTINEL_USER_ID,
+        "SHARED_KEY",
+        "org-value",
+        "user",
+        "Org shared key",
+      );
+      await createTestSecret("SHARED_KEY", "user-value");
+
+      const result = await createRun(
+        baseParams({ agentComposeVersionId: compose.versionId }),
+      );
+
+      const job = await findTestRunnerJobEntry(result.runId);
+      expect(job).toBeDefined();
+      // User value should win
+      expect(job!.executionContext.environment).toMatchObject({
+        SHARED_KEY: "user-value",
+      });
+    });
+
+    it("should include org secret when user has no override", async () => {
+      const compose = await createTestCompose(uniqueId("secret-agent"), {
+        overrides: {
+          environment: {
+            ANTHROPIC_API_KEY: "test-api-key",
+            ORG_ONLY: "${{ secrets.ORG_ONLY }}",
+            USER_ONLY: "${{ secrets.USER_ONLY }}",
+          },
+        },
+      });
+
+      await upsertSecretByOrg(
+        user.orgId,
+        ORG_SENTINEL_USER_ID,
+        "ORG_ONLY",
+        "org-secret",
+        "user",
+        "Org-only secret",
+      );
+      await createTestSecret("USER_ONLY", "user-secret");
+
+      const result = await createRun(
+        baseParams({ agentComposeVersionId: compose.versionId }),
+      );
+
+      const job = await findTestRunnerJobEntry(result.runId);
+      expect(job).toBeDefined();
+      expect(job!.executionContext.environment).toMatchObject({
+        ORG_ONLY: "org-secret",
+        USER_ONLY: "user-secret",
+      });
+    });
+
+    it("should let CLI secret override both org and user secrets", async () => {
+      const compose = await createTestCompose(uniqueId("secret-agent"), {
+        overrides: {
+          environment: {
+            ANTHROPIC_API_KEY: "test-api-key",
+            MY_SECRET: "${{ secrets.MY_SECRET }}",
+          },
+        },
+      });
+
+      await upsertSecretByOrg(
+        user.orgId,
+        ORG_SENTINEL_USER_ID,
+        "MY_SECRET",
+        "org-value",
+        "user",
+        "Org secret",
+      );
+      await createTestSecret("MY_SECRET", "user-value");
+
+      const result = await createRun(
+        baseParams({
+          agentComposeVersionId: compose.versionId,
+          secrets: { MY_SECRET: "cli-value" },
+        }),
+      );
+
+      const job = await findTestRunnerJobEntry(result.runId);
+      expect(job).toBeDefined();
+      expect(job!.executionContext.environment).toMatchObject({
+        MY_SECRET: "cli-value",
+      });
+    });
+  });
+
+  describe("Variable Merge", () => {
+    it("should merge org and user variables with user priority", async () => {
+      const compose = await createTestCompose(uniqueId("var-agent"), {
+        overrides: {
+          environment: {
+            ANTHROPIC_API_KEY: "test-api-key",
+            MY_VAR: "${{ vars.MY_VAR }}",
+          },
+        },
+      });
+
+      await setVariable(
+        user.orgId,
+        ORG_SENTINEL_USER_ID,
+        "MY_VAR",
+        "org-value",
+      );
+      await createTestVariable("MY_VAR", "user-value");
+
+      const result = await createRun(
+        baseParams({
+          agentComposeVersionId: compose.versionId,
+          checkEnv: true,
+        }),
+      );
+
+      const job = await findTestRunnerJobEntry(result.runId);
+      expect(job).toBeDefined();
+      expect(job!.executionContext.environment).toMatchObject({
+        MY_VAR: "user-value",
+      });
+    });
+
+    it("should include org variable when user has no override", async () => {
+      const compose = await createTestCompose(uniqueId("var-agent"), {
+        overrides: {
+          environment: {
+            ANTHROPIC_API_KEY: "test-api-key",
+            ORG_VAR: "${{ vars.ORG_VAR }}",
+          },
+        },
+      });
+
+      await setVariable(
+        user.orgId,
+        ORG_SENTINEL_USER_ID,
+        "ORG_VAR",
+        "org-value",
+      );
+
+      const result = await createRun(
+        baseParams({
+          agentComposeVersionId: compose.versionId,
+          checkEnv: true,
+        }),
+      );
+
+      const job = await findTestRunnerJobEntry(result.runId);
+      expect(job).toBeDefined();
+      expect(job!.executionContext.environment).toMatchObject({
+        ORG_VAR: "org-value",
+      });
+    });
+
+    it("should let CLI variable override both org and user variables", async () => {
+      const compose = await createTestCompose(uniqueId("var-agent"), {
+        overrides: {
+          environment: {
+            ANTHROPIC_API_KEY: "test-api-key",
+            MY_VAR: "${{ vars.MY_VAR }}",
+          },
+        },
+      });
+
+      await setVariable(
+        user.orgId,
+        ORG_SENTINEL_USER_ID,
+        "MY_VAR",
+        "org-value",
+      );
+      await createTestVariable("MY_VAR", "user-value");
+
+      const result = await createRun(
+        baseParams({
+          agentComposeVersionId: compose.versionId,
+          vars: { MY_VAR: "cli-value" },
+          checkEnv: true,
+        }),
+      );
+
+      const job = await findTestRunnerJobEntry(result.runId);
+      expect(job).toBeDefined();
+      expect(job!.executionContext.environment).toMatchObject({
+        MY_VAR: "cli-value",
+      });
+    });
+  });
+
+  describe("No Org Resources (Regression)", () => {
+    it("should have no behavior change when no org resources exist", async () => {
+      const noKeyCompose = await createTestCompose(uniqueId("no-key-agent"), {
+        skipDefaultApiKey: true,
+      });
+
+      // Only user-level provider
+      await createTestModelProvider("anthropic-api-key", "user-api-key");
+
+      const result = await createRun(
+        baseParams({ agentComposeVersionId: noKeyCompose.versionId }),
+      );
+
+      const job = await findTestRunnerJobEntry(result.runId);
+      expect(job).toBeDefined();
+      expect(job!.executionContext.environment).toMatchObject({
+        ANTHROPIC_API_KEY: "user-api-key",
+      });
+    });
+  });
+});

--- a/turbo/apps/web/src/lib/run/build-context.ts
+++ b/turbo/apps/web/src/lib/run/build-context.ts
@@ -33,7 +33,11 @@ import { expandEnvironmentFromCompose } from "./environment";
 import { getUserPreferences } from "../user/user-preferences-service";
 import { getSecretValue, getSecretValues } from "../secret/secret-service";
 import { getVariableValues } from "../variable/variable-service";
-import { getDefaultModelProvider } from "../model-provider/model-provider-service";
+import {
+  getDefaultModelProvider,
+  getOrgDefaultModelProvider,
+} from "../model-provider/model-provider-service";
+import { ORG_SENTINEL_USER_ID } from "../org/org-sentinel";
 import { connectors } from "../../db/schema/connector";
 import { PROVIDER_HANDLERS } from "../connector/provider-registry";
 import { refreshConnectorAccessToken } from "../connector/connector-service";
@@ -194,12 +198,22 @@ async function resolveModelProviderSecrets(
     return { secrets, injectedEnvironment: undefined };
   }
 
-  // Fetch default provider once (used for type resolution, model selection, and auth method)
-  const defaultProvider = await getDefaultModelProvider(
+  // Fetch default provider: try user-level first, fall back to org-level
+  const userProvider = await getDefaultModelProvider(
     orgId,
     userId,
     framework as ModelProviderFramework,
   );
+  const defaultProvider =
+    userProvider ??
+    (await getOrgDefaultModelProvider(
+      orgId,
+      framework as ModelProviderFramework,
+    ));
+
+  // Secrets must match the provider's ownership scope:
+  // user provider → user secrets, org provider → org secrets
+  const secretUserId = userProvider ? userId : ORG_SENTINEL_USER_ID;
 
   const providerType = resolveProviderType(
     framework,
@@ -225,10 +239,10 @@ async function resolveModelProviderSecrets(
       return { secrets, injectedEnvironment: undefined };
     }
 
-    // Fetch all model-provider secrets by name
+    // Fetch all model-provider secrets by name (scoped to provider owner)
     const allSecretValues = await getSecretValues(
       orgId,
-      userId,
+      secretUserId,
       "model-provider",
     );
     const secretsMap: Record<string, string> = {};
@@ -276,7 +290,7 @@ async function resolveModelProviderSecrets(
 
   const secretValue = await getSecretValue(
     orgId,
-    userId,
+    secretUserId,
     secretName,
     "model-provider",
   );
@@ -441,12 +455,16 @@ async function fetchReferencedSecrets(
   const referencedNames = grouped.secrets.map((r) => r.name);
   log.debug(`Secrets referenced in environment: ${referencedNames.join(", ")}`);
 
-  // Only fetch user secrets for variable expansion (model-provider secrets are isolated)
-  const userSecrets = await getSecretValues(orgId, userId, "user");
+  // Fetch org and user secrets in parallel, merge with user > org priority
+  const [orgSecrets, userSecrets] = await Promise.all([
+    getSecretValues(orgId, ORG_SENTINEL_USER_ID, "user"),
+    getSecretValues(orgId, userId, "user"),
+  ]);
+  const mergedSecrets = { ...orgSecrets, ...userSecrets };
   log.debug(
-    `Fetched ${Object.keys(userSecrets).length} user secret(s) for org ${orgId}`,
+    `Fetched ${Object.keys(mergedSecrets).length} user secret(s) for org ${orgId}`,
   );
-  return userSecrets;
+  return mergedSecrets;
 }
 
 /**
@@ -462,7 +480,12 @@ async function fetchAndMergeVariables(
   userId: string,
   cliVars: Record<string, string> | undefined,
 ): Promise<Record<string, string> | undefined> {
-  const storedVars = await getVariableValues(orgId, userId);
+  // Fetch org and user variables in parallel, merge with user > org priority
+  const [orgVars, userVars] = await Promise.all([
+    getVariableValues(orgId, ORG_SENTINEL_USER_ID),
+    getVariableValues(orgId, userId),
+  ]);
+  const storedVars = { ...orgVars, ...userVars };
   if (Object.keys(storedVars).length === 0) {
     return cliVars;
   }

--- a/turbo/apps/web/src/lib/run/run-service.ts
+++ b/turbo/apps/web/src/lib/run/run-service.ts
@@ -32,6 +32,7 @@ import { extractTemplateVars } from "../config-validator";
 import { canAccessCompose } from "../agent/compose-access";
 
 import { getVariableValues } from "../variable/variable-service";
+import { ORG_SENTINEL_USER_ID } from "../org/org-sentinel";
 import { encryptSecretValue } from "../crypto/secrets-encryption";
 import { type OrgTier } from "@vm0/core";
 
@@ -436,8 +437,11 @@ async function validateComposeRequirements(
   if (checkEnv) {
     const requiredVars = extractTemplateVars(composeContent);
     if (requiredVars.length > 0) {
-      const storedVars = await getVariableValues(orgId, userId);
-      const allVars = { ...storedVars, ...vars };
+      const [orgVars, userVars] = await Promise.all([
+        getVariableValues(orgId, ORG_SENTINEL_USER_ID),
+        getVariableValues(orgId, userId),
+      ]);
+      const allVars = { ...orgVars, ...userVars, ...vars };
       const missingVars = requiredVars.filter(
         (varName) => allVars[varName] === undefined,
       );


### PR DESCRIPTION
## Summary

- Model provider resolution falls back to org default when user has no personal default
- Secrets merge org + user secrets with user > org priority
- Variables merge org + user variables with user > org priority  
- Pre-flight validation (`checkEnv`) also checks org-level variables

## Changes

| File | Change |
|------|--------|
| `build-context.ts` | Org fallback for model provider, secrets merge, variables merge |
| `run-service.ts` | Org variable check in `validateComposeRequirements` |
| `build-context-org.test.ts` | 10 integration tests for org fallback scenarios |

## Test plan

- [x] Model provider: user default wins over org default
- [x] Model provider: falls back to org default when user has none
- [x] Model provider: error when neither user nor org has default
- [x] Secrets: user wins on same-name conflict
- [x] Secrets: org secret available when user has no override
- [x] Secrets: CLI secret overrides both
- [x] Variables: user wins on same-name conflict
- [x] Variables: org variable available when user has no override
- [x] Variables: CLI variable overrides both
- [x] Regression: no behavior change when no org resources exist

Closes #5168

🤖 Generated with [Claude Code](https://claude.com/claude-code)