### PR TITLE
feat: add org model-provider management api (admin-only)

### DIFF
--- a/turbo/apps/web/app/api/org/model-providers/[type]/model/route.ts
+++ b/turbo/apps/web/app/api/org/model-providers/[type]/model/route.ts
@@ -1,0 +1,80 @@
+import { createHandler, tsr } from "../../../../../../src/lib/ts-rest-handler";
+import {
+  orgModelProvidersUpdateModelContract,
+  createErrorResponse,
+} from "@vm0/core";
+import { initServices } from "../../../../../../src/lib/init-services";
+import { getAuthContext } from "../../../../../../src/lib/auth/get-user-id";
+import { resolveOrg } from "../../../../../../src/lib/org/resolve-org";
+import { updateModelProviderModel } from "../../../../../../src/lib/model-provider/model-provider-service";
+import { ORG_SENTINEL_USER_ID } from "../../../../../../src/lib/org/org-sentinel";
+import { logger } from "../../../../../../src/lib/logger";
+import { isNotFound } from "../../../../../../src/lib/errors";
+
+const log = logger("api:org-model-providers");
+
+const router = tsr.router(orgModelProvidersUpdateModelContract, {
+  /**
+   * PATCH /api/org/model-providers/:type/model - Update org provider model selection
+   * Admin only.
+   */
+  updateModel: async ({ params, body, headers }, { request }) => {
+    initServices();
+
+    const authCtx = await getAuthContext(headers.authorization);
+    if (!authCtx) {
+      return createErrorResponse("UNAUTHORIZED", "Not authenticated");
+    }
+    const { userId } = authCtx;
+
+    const orgSlug = new URL(request.url).searchParams.get("org");
+    const { org, member } = await resolveOrg(userId, orgSlug);
+
+    if (member.role !== "admin") {
+      return createErrorResponse(
+        "FORBIDDEN",
+        "Only admins can manage org model providers",
+      );
+    }
+
+    log.debug("updating org model provider model", {
+      orgId: org.orgId,
+      type: params.type,
+      selectedModel: body.selectedModel,
+    });
+
+    try {
+      const provider = await updateModelProviderModel(
+        org.orgId,
+        ORG_SENTINEL_USER_ID,
+        params.type,
+        body.selectedModel,
+      );
+
+      return {
+        status: 200 as const,
+        body: {
+          id: provider.id,
+          type: provider.type,
+          framework: provider.framework,
+          secretName: provider.secretName,
+          authMethod: provider.authMethod ?? null,
+          secretNames: provider.secretNames ?? null,
+          isDefault: provider.isDefault,
+          selectedModel: provider.selectedModel,
+          createdAt: provider.createdAt.toISOString(),
+          updatedAt: provider.updatedAt.toISOString(),
+        },
+      };
+    } catch (error) {
+      if (isNotFound(error)) {
+        return createErrorResponse("NOT_FOUND", "Resource not found");
+      }
+      throw error;
+    }
+  },
+});
+
+const handler = createHandler(orgModelProvidersUpdateModelContract, router);
+
+export { handler as PATCH };

--- a/turbo/apps/web/app/api/org/model-providers/[type]/model/route.ts
+++ b/turbo/apps/web/app/api/org/model-providers/[type]/model/route.ts
@@ -6,8 +6,7 @@ import {
 import { initServices } from "../../../../../../src/lib/init-services";
 import { getAuthContext } from "../../../../../../src/lib/auth/get-user-id";
 import { resolveOrg } from "../../../../../../src/lib/org/resolve-org";
-import { updateModelProviderModel } from "../../../../../../src/lib/model-provider/model-provider-service";
-import { ORG_SENTINEL_USER_ID } from "../../../../../../src/lib/org/org-sentinel";
+import { updateOrgModelProviderModel } from "../../../../../../src/lib/model-provider/model-provider-service";
 import { logger } from "../../../../../../src/lib/logger";
 import { isNotFound } from "../../../../../../src/lib/errors";
 
@@ -44,9 +43,8 @@ const router = tsr.router(orgModelProvidersUpdateModelContract, {
     });
 
     try {
-      const provider = await updateModelProviderModel(
+      const provider = await updateOrgModelProviderModel(
         org.orgId,
-        ORG_SENTINEL_USER_ID,
         params.type,
         body.selectedModel,
       );

--- a/turbo/apps/web/app/api/org/model-providers/[type]/route.ts
+++ b/turbo/apps/web/app/api/org/model-providers/[type]/route.ts
@@ -1,0 +1,62 @@
+import { createHandler, tsr } from "../../../../../src/lib/ts-rest-handler";
+import {
+  orgModelProvidersByTypeContract,
+  createErrorResponse,
+} from "@vm0/core";
+import { initServices } from "../../../../../src/lib/init-services";
+import { getAuthContext } from "../../../../../src/lib/auth/get-user-id";
+import { resolveOrg } from "../../../../../src/lib/org/resolve-org";
+import { deleteOrgModelProvider } from "../../../../../src/lib/model-provider/model-provider-service";
+import { logger } from "../../../../../src/lib/logger";
+import { isNotFound } from "../../../../../src/lib/errors";
+
+const log = logger("api:org-model-providers");
+
+const router = tsr.router(orgModelProvidersByTypeContract, {
+  /**
+   * DELETE /api/org/model-providers/:type - Delete an org-level model provider
+   * Admin only.
+   */
+  delete: async ({ params, headers }, { request }) => {
+    initServices();
+
+    const authCtx = await getAuthContext(headers.authorization);
+    if (!authCtx) {
+      return createErrorResponse("UNAUTHORIZED", "Not authenticated");
+    }
+    const { userId } = authCtx;
+
+    const orgSlug = new URL(request.url).searchParams.get("org");
+    const { org, member } = await resolveOrg(userId, orgSlug);
+
+    if (member.role !== "admin") {
+      return createErrorResponse(
+        "FORBIDDEN",
+        "Only admins can manage org model providers",
+      );
+    }
+
+    log.debug("deleting org model provider", {
+      orgId: org.orgId,
+      type: params.type,
+    });
+
+    try {
+      await deleteOrgModelProvider(org.orgId, params.type);
+
+      return {
+        status: 204 as const,
+        body: undefined,
+      };
+    } catch (error) {
+      if (isNotFound(error)) {
+        return createErrorResponse("NOT_FOUND", "Resource not found");
+      }
+      throw error;
+    }
+  },
+});
+
+const handler = createHandler(orgModelProvidersByTypeContract, router);
+
+export { handler as DELETE };

--- a/turbo/apps/web/app/api/org/model-providers/[type]/set-default/route.ts
+++ b/turbo/apps/web/app/api/org/model-providers/[type]/set-default/route.ts
@@ -1,0 +1,73 @@
+import { createHandler, tsr } from "../../../../../../src/lib/ts-rest-handler";
+import {
+  orgModelProvidersSetDefaultContract,
+  createErrorResponse,
+} from "@vm0/core";
+import { initServices } from "../../../../../../src/lib/init-services";
+import { getAuthContext } from "../../../../../../src/lib/auth/get-user-id";
+import { resolveOrg } from "../../../../../../src/lib/org/resolve-org";
+import { setOrgModelProviderDefault } from "../../../../../../src/lib/model-provider/model-provider-service";
+import { logger } from "../../../../../../src/lib/logger";
+import { isNotFound } from "../../../../../../src/lib/errors";
+
+const log = logger("api:org-model-providers");
+
+const router = tsr.router(orgModelProvidersSetDefaultContract, {
+  /**
+   * POST /api/org/model-providers/:type/set-default - Set org provider as default
+   * Admin only.
+   */
+  setDefault: async ({ params, headers }, { request }) => {
+    initServices();
+
+    const authCtx = await getAuthContext(headers.authorization);
+    if (!authCtx) {
+      return createErrorResponse("UNAUTHORIZED", "Not authenticated");
+    }
+    const { userId } = authCtx;
+
+    const orgSlug = new URL(request.url).searchParams.get("org");
+    const { org, member } = await resolveOrg(userId, orgSlug);
+
+    if (member.role !== "admin") {
+      return createErrorResponse(
+        "FORBIDDEN",
+        "Only admins can manage org model providers",
+      );
+    }
+
+    log.debug("setting org model provider as default", {
+      orgId: org.orgId,
+      type: params.type,
+    });
+
+    try {
+      const provider = await setOrgModelProviderDefault(org.orgId, params.type);
+
+      return {
+        status: 200 as const,
+        body: {
+          id: provider.id,
+          type: provider.type,
+          framework: provider.framework,
+          secretName: provider.secretName,
+          authMethod: provider.authMethod ?? null,
+          secretNames: provider.secretNames ?? null,
+          isDefault: provider.isDefault,
+          selectedModel: provider.selectedModel,
+          createdAt: provider.createdAt.toISOString(),
+          updatedAt: provider.updatedAt.toISOString(),
+        },
+      };
+    } catch (error) {
+      if (isNotFound(error)) {
+        return createErrorResponse("NOT_FOUND", "Resource not found");
+      }
+      throw error;
+    }
+  },
+});
+
+const handler = createHandler(orgModelProvidersSetDefaultContract, router);
+
+export { handler as POST };

--- a/turbo/apps/web/app/api/org/model-providers/route.ts
+++ b/turbo/apps/web/app/api/org/model-providers/route.ts
@@ -1,0 +1,156 @@
+import { createHandler, tsr } from "../../../../src/lib/ts-rest-handler";
+import {
+  orgModelProvidersMainContract,
+  createErrorResponse,
+  hasAuthMethods,
+} from "@vm0/core";
+import { initServices } from "../../../../src/lib/init-services";
+import { getAuthContext } from "../../../../src/lib/auth/get-user-id";
+import { resolveOrg } from "../../../../src/lib/org/resolve-org";
+import {
+  listOrgModelProviders,
+  upsertOrgModelProvider,
+  upsertOrgMultiAuthModelProvider,
+} from "../../../../src/lib/model-provider/model-provider-service";
+import { logger } from "../../../../src/lib/logger";
+import { isBadRequest } from "../../../../src/lib/errors";
+
+const log = logger("api:org-model-providers");
+
+const router = tsr.router(orgModelProvidersMainContract, {
+  /**
+   * GET /api/org/model-providers - List org-level model providers
+   * Any org member can list.
+   */
+  list: async ({ headers }, { request }) => {
+    initServices();
+
+    const authCtx = await getAuthContext(headers.authorization);
+    if (!authCtx) {
+      return createErrorResponse("UNAUTHORIZED", "Not authenticated");
+    }
+    const { userId } = authCtx;
+
+    const orgSlug = new URL(request.url).searchParams.get("org");
+    const { org } = await resolveOrg(userId, orgSlug);
+    const providers = await listOrgModelProviders(org.orgId);
+
+    return {
+      status: 200 as const,
+      body: {
+        modelProviders: providers.map((p) => ({
+          id: p.id,
+          type: p.type,
+          framework: p.framework,
+          secretName: p.secretName,
+          authMethod: p.authMethod ?? null,
+          secretNames: p.secretNames ?? null,
+          isDefault: p.isDefault,
+          selectedModel: p.selectedModel,
+          createdAt: p.createdAt.toISOString(),
+          updatedAt: p.updatedAt.toISOString(),
+        })),
+      },
+    };
+  },
+
+  /**
+   * PUT /api/org/model-providers - Create or update an org-level model provider
+   * Admin only.
+   */
+  upsert: async ({ body, headers }, { request }) => {
+    initServices();
+
+    const authCtx = await getAuthContext(headers.authorization);
+    if (!authCtx) {
+      return createErrorResponse("UNAUTHORIZED", "Not authenticated");
+    }
+    const { userId } = authCtx;
+
+    const orgSlug = new URL(request.url).searchParams.get("org");
+    const { org, member } = await resolveOrg(userId, orgSlug);
+
+    if (member.role !== "admin") {
+      return createErrorResponse(
+        "FORBIDDEN",
+        "Only admins can manage org model providers",
+      );
+    }
+
+    const { type, secret, authMethod, secrets, selectedModel } = body;
+
+    log.debug("upserting org model provider", {
+      orgId: org.orgId,
+      type,
+      selectedModel,
+    });
+
+    try {
+      const isMultiAuth = hasAuthMethods(type);
+
+      let provider;
+      let created: boolean;
+
+      if (isMultiAuth) {
+        if (!authMethod || !secrets) {
+          return createErrorResponse(
+            "BAD_REQUEST",
+            `Provider "${type}" requires authMethod and secrets`,
+          );
+        }
+        const result = await upsertOrgMultiAuthModelProvider(
+          org.orgId,
+          type,
+          authMethod,
+          secrets,
+          selectedModel,
+        );
+        provider = result.provider;
+        created = result.created;
+      } else {
+        if (!secret) {
+          return createErrorResponse(
+            "BAD_REQUEST",
+            `Provider "${type}" requires a secret`,
+          );
+        }
+        const result = await upsertOrgModelProvider(
+          org.orgId,
+          type,
+          secret,
+          selectedModel,
+        );
+        provider = result.provider;
+        created = result.created;
+      }
+
+      return {
+        status: (created ? 201 : 200) as 200 | 201,
+        body: {
+          provider: {
+            id: provider.id,
+            type: provider.type,
+            framework: provider.framework,
+            secretName: provider.secretName,
+            authMethod: provider.authMethod ?? null,
+            secretNames: provider.secretNames ?? null,
+            isDefault: provider.isDefault,
+            selectedModel: provider.selectedModel,
+            createdAt: provider.createdAt.toISOString(),
+            updatedAt: provider.updatedAt.toISOString(),
+          },
+          created,
+        },
+      };
+    } catch (error) {
+      if (isBadRequest(error)) {
+        return createErrorResponse("BAD_REQUEST", "Invalid request");
+      }
+      throw error;
+    }
+  },
+});
+
+const handler = createHandler(orgModelProvidersMainContract, router);
+
+export { handler as GET, handler as PUT };

--- a/turbo/apps/web/src/__tests__/org-model-providers-api.test.ts
+++ b/turbo/apps/web/src/__tests__/org-model-providers-api.test.ts
@@ -1,0 +1,366 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { GET, PUT } from "../../app/api/org/model-providers/route";
+import { DELETE } from "../../app/api/org/model-providers/[type]/route";
+import { POST as setDefaultRoute } from "../../app/api/org/model-providers/[type]/set-default/route";
+import { PATCH as updateModelRoute } from "../../app/api/org/model-providers/[type]/model/route";
+import { createTestRequest, createTestOrg } from "./api-test-helpers";
+import { testContext, uniqueId } from "./test-helpers";
+import { mockClerk } from "./clerk-mock";
+
+const context = testContext();
+
+/**
+ * Setup an org with the given user as admin or member.
+ * Uses mockClerk directly with orgRole so resolveOrg JWT fast path
+ * returns the correct role.
+ */
+async function setupOrg(userId: string, role: "org:admin" | "org:member") {
+  const slug = uniqueId("orgmp");
+  const orgId = `org_mock_${userId}`;
+
+  mockClerk({ userId, orgId, orgRole: role });
+  await createTestOrg(slug);
+
+  return { slug, orgId };
+}
+
+function orgUrl(path: string, slug: string): string {
+  return `http://localhost:3000/api/org/model-providers${path}?org=${slug}`;
+}
+
+describe("Org model-provider API", () => {
+  beforeEach(() => {
+    context.setupMocks();
+  });
+
+  describe("GET /api/org/model-providers", () => {
+    it("should return empty list initially", async () => {
+      const userId = uniqueId("omp-list");
+      const { slug } = await setupOrg(userId, "org:admin");
+
+      const response = await GET(createTestRequest(orgUrl("", slug)));
+      expect(response.status).toBe(200);
+
+      const data = await response.json();
+      expect(data.modelProviders).toEqual([]);
+    });
+
+    it("should allow member to list org providers", async () => {
+      const userId = uniqueId("omp-member-list");
+      const { slug } = await setupOrg(userId, "org:member");
+
+      const response = await GET(createTestRequest(orgUrl("", slug)));
+      expect(response.status).toBe(200);
+
+      const data = await response.json();
+      expect(data.modelProviders).toEqual([]);
+    });
+
+    it("should reject unauthenticated requests", async () => {
+      mockClerk({ userId: null });
+
+      const response = await GET(
+        createTestRequest(
+          "http://localhost:3000/api/org/model-providers?org=test",
+        ),
+      );
+      expect(response.status).toBe(401);
+    });
+  });
+
+  describe("PUT /api/org/model-providers", () => {
+    it("should create org provider as admin", async () => {
+      const userId = uniqueId("omp-create");
+      const { slug } = await setupOrg(userId, "org:admin");
+
+      const response = await PUT(
+        createTestRequest(orgUrl("", slug), {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            type: "anthropic-api-key",
+            secret: "test-org-key",
+          }),
+        }),
+      );
+      expect(response.status).toBe(201);
+
+      const data = await response.json();
+      expect(data.provider.type).toBe("anthropic-api-key");
+      expect(data.provider.framework).toBe("claude-code");
+      expect(data.provider.isDefault).toBe(true);
+      expect(data.created).toBe(true);
+    });
+
+    it("should update existing org provider", async () => {
+      const userId = uniqueId("omp-update");
+      const { slug } = await setupOrg(userId, "org:admin");
+
+      // Create
+      await PUT(
+        createTestRequest(orgUrl("", slug), {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            type: "anthropic-api-key",
+            secret: "key-v1",
+          }),
+        }),
+      );
+
+      // Update
+      const response = await PUT(
+        createTestRequest(orgUrl("", slug), {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            type: "anthropic-api-key",
+            secret: "key-v2",
+          }),
+        }),
+      );
+      expect(response.status).toBe(200);
+
+      const data = await response.json();
+      expect(data.created).toBe(false);
+    });
+
+    it("should return 403 for non-admin member", async () => {
+      const userId = uniqueId("omp-member-put");
+      const { slug } = await setupOrg(userId, "org:member");
+
+      const response = await PUT(
+        createTestRequest(orgUrl("", slug), {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            type: "anthropic-api-key",
+            secret: "test-key",
+          }),
+        }),
+      );
+      expect(response.status).toBe(403);
+
+      const data = await response.json();
+      expect(data.error.code).toBe("FORBIDDEN");
+    });
+
+    it("should return 401 for unauthenticated", async () => {
+      mockClerk({ userId: null });
+
+      const response = await PUT(
+        createTestRequest(
+          "http://localhost:3000/api/org/model-providers?org=test",
+          {
+            method: "PUT",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              type: "anthropic-api-key",
+              secret: "test-key",
+            }),
+          },
+        ),
+      );
+      expect(response.status).toBe(401);
+    });
+  });
+
+  describe("DELETE /api/org/model-providers/:type", () => {
+    it("should delete org provider as admin", async () => {
+      const userId = uniqueId("omp-delete");
+      const { slug } = await setupOrg(userId, "org:admin");
+
+      // Create first
+      await PUT(
+        createTestRequest(orgUrl("", slug), {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            type: "anthropic-api-key",
+            secret: "test-key",
+          }),
+        }),
+      );
+
+      // Delete
+      const response = await DELETE(
+        createTestRequest(orgUrl("/anthropic-api-key", slug), {
+          method: "DELETE",
+        }),
+      );
+      expect(response.status).toBe(204);
+
+      // Verify deletion
+      const listRes = await GET(createTestRequest(orgUrl("", slug)));
+      const listData = await listRes.json();
+      expect(listData.modelProviders).toEqual([]);
+    });
+
+    it("should return 404 for non-existent provider", async () => {
+      const userId = uniqueId("omp-del-404");
+      const { slug } = await setupOrg(userId, "org:admin");
+
+      const response = await DELETE(
+        createTestRequest(orgUrl("/anthropic-api-key", slug), {
+          method: "DELETE",
+        }),
+      );
+      expect(response.status).toBe(404);
+    });
+
+    it("should return 403 for non-admin member", async () => {
+      const userId = uniqueId("omp-del-member");
+      const { slug } = await setupOrg(userId, "org:member");
+
+      const response = await DELETE(
+        createTestRequest(orgUrl("/anthropic-api-key", slug), {
+          method: "DELETE",
+        }),
+      );
+      expect(response.status).toBe(403);
+    });
+  });
+
+  describe("POST /api/org/model-providers/:type/set-default", () => {
+    it("should set org provider as default", async () => {
+      const userId = uniqueId("omp-default");
+      const { slug } = await setupOrg(userId, "org:admin");
+
+      // Create two providers
+      await PUT(
+        createTestRequest(orgUrl("", slug), {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            type: "anthropic-api-key",
+            secret: "key-1",
+          }),
+        }),
+      );
+      await PUT(
+        createTestRequest(orgUrl("", slug), {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            type: "claude-code-oauth-token",
+            secret: "token-1",
+          }),
+        }),
+      );
+
+      // Set second as default
+      const response = await setDefaultRoute(
+        createTestRequest(
+          orgUrl("/claude-code-oauth-token/set-default", slug),
+          { method: "POST" },
+        ),
+      );
+      expect(response.status).toBe(200);
+
+      const data = await response.json();
+      expect(data.isDefault).toBe(true);
+      expect(data.type).toBe("claude-code-oauth-token");
+
+      // Verify first is no longer default
+      const listRes = await GET(createTestRequest(orgUrl("", slug)));
+      const listData = await listRes.json();
+      const anthropic = listData.modelProviders.find(
+        (p: { type: string }) => p.type === "anthropic-api-key",
+      );
+      expect(anthropic.isDefault).toBe(false);
+    });
+
+    it("should return 403 for non-admin member", async () => {
+      const userId = uniqueId("omp-def-member");
+      const { slug } = await setupOrg(userId, "org:member");
+
+      const response = await setDefaultRoute(
+        createTestRequest(orgUrl("/anthropic-api-key/set-default", slug), {
+          method: "POST",
+        }),
+      );
+      expect(response.status).toBe(403);
+    });
+  });
+
+  describe("PATCH /api/org/model-providers/:type/model", () => {
+    it("should update model selection", async () => {
+      const userId = uniqueId("omp-model");
+      const { slug } = await setupOrg(userId, "org:admin");
+
+      // Create provider with model
+      await PUT(
+        createTestRequest(orgUrl("", slug), {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            type: "moonshot-api-key",
+            secret: "test-key",
+            selectedModel: "kimi-k2.5",
+          }),
+        }),
+      );
+
+      // Update model
+      const response = await updateModelRoute(
+        createTestRequest(orgUrl("/moonshot-api-key/model", slug), {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            selectedModel: "kimi-k2-thinking",
+          }),
+        }),
+      );
+      expect(response.status).toBe(200);
+
+      const data = await response.json();
+      expect(data.selectedModel).toBe("kimi-k2-thinking");
+    });
+
+    it("should return 403 for non-admin member", async () => {
+      const userId = uniqueId("omp-mod-member");
+      const { slug } = await setupOrg(userId, "org:member");
+
+      const response = await updateModelRoute(
+        createTestRequest(orgUrl("/anthropic-api-key/model", slug), {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ selectedModel: "some-model" }),
+        }),
+      );
+      expect(response.status).toBe(403);
+    });
+  });
+
+  describe("list after CRUD operations", () => {
+    it("should list created org providers", async () => {
+      const userId = uniqueId("omp-listcrud");
+      const { slug } = await setupOrg(userId, "org:admin");
+
+      // Create a provider
+      await PUT(
+        createTestRequest(orgUrl("", slug), {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            type: "anthropic-api-key",
+            secret: "test-key",
+          }),
+        }),
+      );
+
+      const response = await GET(createTestRequest(orgUrl("", slug)));
+      expect(response.status).toBe(200);
+
+      const data = await response.json();
+      expect(data.modelProviders).toHaveLength(1);
+      expect(data.modelProviders[0].type).toBe("anthropic-api-key");
+      expect(data.modelProviders[0].framework).toBe("claude-code");
+      expect(data.modelProviders[0].secretName).toBe("ANTHROPIC_API_KEY");
+      expect(data.modelProviders[0].isDefault).toBe(true);
+      expect(data.modelProviders[0].id).toBeDefined();
+      expect(data.modelProviders[0].createdAt).toBeDefined();
+      expect(data.modelProviders[0].updatedAt).toBeDefined();
+    });
+  });
+});

--- a/turbo/apps/web/src/__tests__/org-model-providers-api.test.ts
+++ b/turbo/apps/web/src/__tests__/org-model-providers-api.test.ts
@@ -267,6 +267,7 @@ describe("Org model-provider API", () => {
       const anthropic = listData.modelProviders.find(
         (p: { type: string }) => p.type === "anthropic-api-key",
       );
+      expect(anthropic).toBeDefined();
       expect(anthropic.isDefault).toBe(false);
     });
 

--- a/turbo/apps/web/src/lib/model-provider/model-provider-service.ts
+++ b/turbo/apps/web/src/lib/model-provider/model-provider-service.ts
@@ -937,6 +937,22 @@ export function setOrgModelProviderDefault(
 }
 
 /**
+ * Update model selection for an org-level provider
+ */
+export function updateOrgModelProviderModel(
+  orgId: string,
+  type: ModelProviderType,
+  selectedModel?: string,
+): Promise<ModelProviderInfo> {
+  return updateModelProviderModel(
+    orgId,
+    ORG_SENTINEL_USER_ID,
+    type,
+    selectedModel,
+  );
+}
+
+/**
  * Get the org-level default model provider for a framework
  */
 export function getOrgDefaultModelProvider(

--- a/turbo/packages/core/src/contracts/index.ts
+++ b/turbo/packages/core/src/contracts/index.ts
@@ -511,3 +511,13 @@ export {
   skillFrontmatterSchema,
   type SkillsResolveContract,
 } from "./skills";
+export {
+  orgModelProvidersMainContract,
+  orgModelProvidersByTypeContract,
+  orgModelProvidersSetDefaultContract,
+  orgModelProvidersUpdateModelContract,
+  type OrgModelProvidersMainContract,
+  type OrgModelProvidersByTypeContract,
+  type OrgModelProvidersSetDefaultContract,
+  type OrgModelProvidersUpdateModelContract,
+} from "./org-model-providers";

--- a/turbo/packages/core/src/contracts/org-model-providers.ts
+++ b/turbo/packages/core/src/contracts/org-model-providers.ts
@@ -1,0 +1,134 @@
+import { z } from "zod";
+import { authHeadersSchema, initContract } from "./base";
+import { apiErrorSchema } from "./errors";
+import {
+  modelProviderListResponseSchema,
+  upsertModelProviderRequestSchema,
+  upsertModelProviderResponseSchema,
+  modelProviderResponseSchema,
+  modelProviderTypeSchema,
+  updateModelRequestSchema,
+} from "./model-providers";
+
+const c = initContract();
+
+/**
+ * Org model providers main contract for /api/org/model-providers
+ *
+ * GET: List org-level model providers (any member)
+ * PUT: Create or update an org-level model provider (admin only)
+ */
+export const orgModelProvidersMainContract = c.router({
+  list: {
+    method: "GET",
+    path: "/api/org/model-providers",
+    headers: authHeadersSchema,
+    responses: {
+      200: modelProviderListResponseSchema,
+      401: apiErrorSchema,
+      500: apiErrorSchema,
+    },
+    summary: "List org-level model providers",
+  },
+  upsert: {
+    method: "PUT",
+    path: "/api/org/model-providers",
+    headers: authHeadersSchema,
+    body: upsertModelProviderRequestSchema,
+    responses: {
+      200: upsertModelProviderResponseSchema,
+      201: upsertModelProviderResponseSchema,
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      500: apiErrorSchema,
+    },
+    summary: "Create or update an org-level model provider (admin only)",
+  },
+});
+
+export type OrgModelProvidersMainContract =
+  typeof orgModelProvidersMainContract;
+
+/**
+ * Org model providers by type contract for /api/org/model-providers/:type
+ *
+ * DELETE: Delete an org-level model provider (admin only)
+ */
+export const orgModelProvidersByTypeContract = c.router({
+  delete: {
+    method: "DELETE",
+    path: "/api/org/model-providers/:type",
+    headers: authHeadersSchema,
+    pathParams: z.object({
+      type: modelProviderTypeSchema,
+    }),
+    responses: {
+      204: c.noBody(),
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      404: apiErrorSchema,
+      500: apiErrorSchema,
+    },
+    summary: "Delete an org-level model provider (admin only)",
+  },
+});
+
+export type OrgModelProvidersByTypeContract =
+  typeof orgModelProvidersByTypeContract;
+
+/**
+ * Org model providers set default contract for /api/org/model-providers/:type/set-default
+ *
+ * POST: Set org-level model provider as default (admin only)
+ */
+export const orgModelProvidersSetDefaultContract = c.router({
+  setDefault: {
+    method: "POST",
+    path: "/api/org/model-providers/:type/set-default",
+    headers: authHeadersSchema,
+    pathParams: z.object({
+      type: modelProviderTypeSchema,
+    }),
+    body: z.undefined(),
+    responses: {
+      200: modelProviderResponseSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      404: apiErrorSchema,
+      500: apiErrorSchema,
+    },
+    summary: "Set org-level model provider as default (admin only)",
+  },
+});
+
+export type OrgModelProvidersSetDefaultContract =
+  typeof orgModelProvidersSetDefaultContract;
+
+/**
+ * Org model providers update model contract for /api/org/model-providers/:type/model
+ *
+ * PATCH: Update model selection for org-level provider (admin only)
+ */
+export const orgModelProvidersUpdateModelContract = c.router({
+  updateModel: {
+    method: "PATCH",
+    path: "/api/org/model-providers/:type/model",
+    headers: authHeadersSchema,
+    pathParams: z.object({
+      type: modelProviderTypeSchema,
+    }),
+    body: updateModelRequestSchema,
+    responses: {
+      200: modelProviderResponseSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      404: apiErrorSchema,
+      500: apiErrorSchema,
+    },
+    summary: "Update model selection for org-level provider (admin only)",
+  },
+});
+
+export type OrgModelProvidersUpdateModelContract =
+  typeof orgModelProvidersUpdateModelContract;


### PR DESCRIPTION
## Summary

- Add admin-only API routes for managing org-level model providers with RBAC enforcement
- Implement 5 endpoints: list (GET), upsert (PUT), delete (DELETE), set-default (POST), update-model (PATCH)
- Any org member can list org providers; write operations require admin role

## Changes

### New files
- `packages/core/src/contracts/org-model-providers.ts` — ts-rest contracts (4 contracts reusing existing model-provider schemas)
- `apps/web/app/api/org/model-providers/route.ts` — GET list + PUT upsert
- `apps/web/app/api/org/model-providers/[type]/route.ts` — DELETE
- `apps/web/app/api/org/model-providers/[type]/set-default/route.ts` — POST set-default
- `apps/web/app/api/org/model-providers/[type]/model/route.ts` — PATCH update-model
- `apps/web/src/__tests__/org-model-providers-api.test.ts` — 15 integration tests

### Modified files
- `packages/core/src/contracts/index.ts` — export new contracts

## Test plan

- [x] Admin can list, create, update, delete, set-default, and update-model for org providers
- [x] Member can list org providers (200)
- [x] Member gets 403 on all write operations (PUT, DELETE, POST, PATCH)
- [x] Unauthenticated requests get 401
- [x] Response format matches existing model-provider API shape
- [x] All 15 integration tests pass

Closes #5167

🤖 Generated with [Claude Code](https://claude.com/claude-code)