### PR TITLE
feat(docs): remove empty best-practices directory

### DIFF
--- a/turbo/apps/docs/content/docs/best-practices/meta.json
+++ b/turbo/apps/docs/content/docs/best-practices/meta.json
@@ -1,4 +1,0 @@
-{
-  "title": "Best Practices",
-  "pages": []
-}


### PR DESCRIPTION
## Summary
- Remove the empty `best-practices` directory under `turbo/apps/docs/content/docs/`
- The directory only contained a `meta.json` with an empty pages array, serving no purpose

## Test plan
- [x] Verified no other files reference the `best-practices` directory
- [x] Knip check passed with no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)