### PR TITLE
feat(docs): update outdated date in schedule one-time example

### DIFF
--- a/turbo/apps/docs/content/docs/usage/schedule-agent.mdx
+++ b/turbo/apps/docs/content/docs/usage/schedule-agent.mdx
@@ -88,7 +88,7 @@ vm0 schedule setup my-agent --frequency monthly --day 1 --time 09:00
 
 ### One-Time
 ```bash
-vm0 schedule setup my-agent --frequency once --day 2024-12-25 --time 09:00
+vm0 schedule setup my-agent --frequency once --day 2025-12-25 --time 09:00
 ```
 
 ### Loop


### PR DESCRIPTION
## Summary
- Update the one-time schedule example date from `2024-12-25` to `2025-12-25` in `schedule-agent.mdx` to avoid showing an already-expired date

## Test plan
- [ ] Verify the docs page renders correctly with the updated date

🤖 Generated with [Claude Code](https://claude.com/claude-code)