### PR TITLE
feat: add lighthouse score comments to pull requests

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1539,19 +1539,29 @@ jobs:
         env:
           WEB_URL: ${{ needs.deploy-web.outputs.preview-url }}
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
-      - name: Upload Lighthouse report (web)
+      - name: Locate LHCI output (web)
+        id: lhci-dir-web
         if: always()
+        run: |
+          for d in e2e/lighthouse/.lighthouseci .lighthouseci; do
+            if [ -f "$d/manifest.json" ]; then
+              echo "dir=$d" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          done
+          echo "dir=" >> "$GITHUB_OUTPUT"
+      - name: Upload Lighthouse report (web)
+        if: always() && steps.lhci-dir-web.outputs.dir != ''
         uses: actions/upload-artifact@v4
         with:
           name: lighthouse-report-web
-          path: e2e/lighthouse/.lighthouseci/
+          path: ${{ steps.lhci-dir-web.outputs.dir }}/
           retention-days: 7
       - name: Format Lighthouse comment (web)
-        if: success() && github.event_name == 'pull_request'
+        if: success() && github.event_name == 'pull_request' && steps.lhci-dir-web.outputs.dir != ''
         id: lighthouse-comment-web
-        working-directory: e2e/lighthouse
         run: |
-          comment=$(node format-report.cjs "Web")
+          comment=$(node e2e/lighthouse/format-report.cjs "Web" "${{ steps.lhci-dir-web.outputs.dir }}")
           {
             echo "body<<LIGHTHOUSE_EOF"
             echo "$comment"
@@ -1597,19 +1607,29 @@ jobs:
           WEB_URL: ${{ needs.deploy-web.outputs.preview-url }}
           PLATFORM_URL: ${{ needs.prepare.outputs.platform-preview-url }}
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
-      - name: Upload Lighthouse report (platform)
+      - name: Locate LHCI output (platform)
+        id: lhci-dir-platform
         if: always()
+        run: |
+          for d in e2e/lighthouse/.lighthouseci .lighthouseci; do
+            if [ -f "$d/manifest.json" ]; then
+              echo "dir=$d" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          done
+          echo "dir=" >> "$GITHUB_OUTPUT"
+      - name: Upload Lighthouse report (platform)
+        if: always() && steps.lhci-dir-platform.outputs.dir != ''
         uses: actions/upload-artifact@v4
         with:
           name: lighthouse-report-platform
-          path: e2e/lighthouse/.lighthouseci/
+          path: ${{ steps.lhci-dir-platform.outputs.dir }}/
           retention-days: 7
       - name: Format Lighthouse comment (platform)
-        if: success() && github.event_name == 'pull_request'
+        if: success() && github.event_name == 'pull_request' && steps.lhci-dir-platform.outputs.dir != ''
         id: lighthouse-comment-platform
-        working-directory: e2e/lighthouse
         run: |
-          comment=$(node format-report.cjs "Platform")
+          comment=$(node e2e/lighthouse/format-report.cjs "Platform" "${{ steps.lhci-dir-platform.outputs.dir }}")
           {
             echo "body<<LIGHTHOUSE_EOF"
             echo "$comment"

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1544,8 +1544,25 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: lighthouse-report-web
-          path: e2e/lighthouse/lighthouse-reports/web/
+          path: e2e/lighthouse/.lighthouseci/
           retention-days: 7
+      - name: Format Lighthouse comment (web)
+        if: success() && github.event_name == 'pull_request'
+        id: lighthouse-comment-web
+        working-directory: e2e/lighthouse
+        run: |
+          comment=$(node format-report.cjs "Web")
+          {
+            echo "body<<LIGHTHOUSE_EOF"
+            echo "$comment"
+            echo "LIGHTHOUSE_EOF"
+          } >> "$GITHUB_OUTPUT"
+      - name: Post Lighthouse comment (web)
+        if: steps.lighthouse-comment-web.outcome == 'success'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: lighthouse-web
+          message: ${{ steps.lighthouse-comment-web.outputs.body }}
 
   # Lighthouse CI audit for platform homepage (failure blocks merge, skip is allowed)
   lighthouse-platform:
@@ -1585,8 +1602,25 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: lighthouse-report-platform
-          path: e2e/lighthouse/lighthouse-reports/platform/
+          path: e2e/lighthouse/.lighthouseci/
           retention-days: 7
+      - name: Format Lighthouse comment (platform)
+        if: success() && github.event_name == 'pull_request'
+        id: lighthouse-comment-platform
+        working-directory: e2e/lighthouse
+        run: |
+          comment=$(node format-report.cjs "Platform")
+          {
+            echo "body<<LIGHTHOUSE_EOF"
+            echo "$comment"
+            echo "LIGHTHOUSE_EOF"
+          } >> "$GITHUB_OUTPUT"
+      - name: Post Lighthouse comment (platform)
+        if: steps.lighthouse-comment-platform.outcome == 'success'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: lighthouse-platform
+          message: ${{ steps.lighthouse-comment-platform.outputs.body }}
 
   # CI Gate: single required check for merge queue
   # Aggregates all job results — must ALWAYS run to report explicit success/failure.

--- a/e2e/lighthouse/format-report.cjs
+++ b/e2e/lighthouse/format-report.cjs
@@ -1,0 +1,60 @@
+/**
+ * Formats Lighthouse CI results into a markdown PR comment.
+ *
+ * Reads manifest.json and links.json from the .lighthouseci/ directory
+ * (created by `lhci collect` + `lhci upload --target=temporary-public-storage`).
+ *
+ * Usage:
+ *   node format-report.cjs <app-name>
+ *
+ * Outputs markdown to stdout.
+ */
+
+const fs = require("fs");
+const path = require("path");
+
+const appName = process.argv[2];
+if (!appName) {
+  console.error("Usage: node format-report.cjs <app-name>");
+  process.exit(1);
+}
+
+const lhciDir = path.resolve(".lighthouseci");
+const manifest = JSON.parse(
+  fs.readFileSync(path.join(lhciDir, "manifest.json"), "utf8"),
+);
+const links = JSON.parse(
+  fs.readFileSync(path.join(lhciDir, "links.json"), "utf8"),
+);
+
+const formatScore = (score) => Math.round(score * 100);
+const emojiScore = (score) =>
+  score >= 0.9 ? "🟢" : score >= 0.5 ? "🟠" : "🔴";
+const scoreRow = (label, score) =>
+  `| ${emojiScore(score)} ${label} | ${formatScore(score)} |`;
+
+// manifest[0] is the representative (median) run
+const { summary } = manifest[0];
+const [[testedUrl, reportUrl]] = Object.entries(links);
+
+const categories = [
+  ["Performance", summary.performance],
+  ["Accessibility", summary.accessibility],
+  ["Best Practices", summary["best-practices"]],
+];
+
+if (summary.seo !== undefined) {
+  categories.push(["SEO", summary.seo]);
+}
+
+const rows = categories.map(([label, score]) => scoreRow(label, score));
+
+const comment = `## ⚡ Lighthouse — ${appName}
+
+| Category | Score |
+| -------- | ----- |
+${rows.join("\n")}
+
+*Tested URL: [${testedUrl}](${testedUrl}) · [Full report](${reportUrl})*`;
+
+console.log(comment);

--- a/e2e/lighthouse/format-report.cjs
+++ b/e2e/lighthouse/format-report.cjs
@@ -15,11 +15,11 @@ const path = require("path");
 
 const appName = process.argv[2];
 if (!appName) {
-  console.error("Usage: node format-report.cjs <app-name>");
+  console.error("Usage: node format-report.cjs <app-name> [lhci-dir]");
   process.exit(1);
 }
 
-const lhciDir = path.resolve(".lighthouseci");
+const lhciDir = path.resolve(process.argv[3] || ".lighthouseci");
 const manifest = JSON.parse(
   fs.readFileSync(path.join(lhciDir, "manifest.json"), "utf8"),
 );

--- a/e2e/lighthouse/lighthouserc-platform.json
+++ b/e2e/lighthouse/lighthouserc-platform.json
@@ -11,8 +11,7 @@
       "puppeteerScript": "./puppeteer-auth.js"
     },
     "upload": {
-      "target": "filesystem",
-      "outputDir": "lighthouse-reports/platform"
+      "target": "temporary-public-storage"
     }
   }
 }

--- a/e2e/lighthouse/lighthouserc-web.json
+++ b/e2e/lighthouse/lighthouserc-web.json
@@ -15,8 +15,7 @@
       "puppeteerScript": "./puppeteer-bypass.js"
     },
     "upload": {
-      "target": "filesystem",
-      "outputDir": "lighthouse-reports/web"
+      "target": "temporary-public-storage"
     }
   }
 }


### PR DESCRIPTION
## Summary

- Add sticky PR comments showing Lighthouse scores (performance, accessibility, best practices, SEO) for both web and platform audits
- Switch Lighthouse upload target from filesystem to `temporary-public-storage` for shareable report links
- Add `format-report.cjs` script that reads LHCI manifest/links and formats a markdown score table

## Test plan

- [ ] Open a PR and verify the `lighthouse-web` and `lighthouse-platform` CI jobs run
- [ ] Confirm sticky comments appear on the PR with score tables and report links
- [ ] Verify report links resolve to the temporary public storage viewer

🤖 Generated with [Claude Code](https://claude.com/claude-code)