### PR TITLE
refactor(sandbox-fc): replace target-size pool pre-warming with fixed buffer

### DIFF
--- a/crates/runner/src/cmd/benchmark.rs
+++ b/crates/runner/src/cmd/benchmark.rs
@@ -86,7 +86,7 @@ pub async fn run_benchmark(args: BenchmarkArgs) -> RunnerResult<ExitCode> {
     info!(proxy_ms, port = mitm.port(), "proxy ready");
 
     // 3. Factory init (with proxy port)
-    let fc_config = runner_config.firecracker_config(&default_profile, &home, 1, Some(mitm.port()));
+    let fc_config = runner_config.firecracker_config(&default_profile, &home, Some(mitm.port()));
 
     let t = Instant::now();
     let mut factory = FirecrackerFactory::new(fc_config).await?;

--- a/crates/runner/src/cmd/start.rs
+++ b/crates/runner/src/cmd/start.rs
@@ -188,26 +188,27 @@ pub async fn run_start(args: StartArgs) -> RunnerResult<()> {
         "resource budget initialized"
     );
 
-    // Factory concurrency hint for pool sizing (overlay + netns pre-warming).
-    assert!(vcpu > 0, "profile vcpu must be > 0");
-    assert!(memory_mb > 0, "profile memory_mb must be > 0");
-    let resource_limit = std::cmp::min(
-        budget.effective_vcpu() as usize / vcpu as usize,
-        budget.effective_memory_mb() as usize / memory_mb as usize,
-    )
-    .max(1);
-    let concurrency = if max_concurrent > 0 {
-        std::cmp::min(resource_limit, max_concurrent)
-    } else {
-        resource_limit
-    };
-
     // Build firecracker config with all parameters resolved.
-    let fc_config =
-        runner_config.firecracker_config(default_profile, &home, concurrency, Some(mitm.port()));
+    let fc_config = runner_config.firecracker_config(default_profile, &home, Some(mitm.port()));
     let is_snapshot = fc_config.snapshot.is_some();
 
-    let mut status = StatusTracker::new(paths.status(), concurrency);
+    // Estimated capacity: theoretical max concurrent VMs from resource budget.
+    // Used for status reporting only — actual admission is controlled by ResourceBudget.
+    assert!(vcpu > 0, "profile vcpu must be > 0");
+    assert!(memory_mb > 0, "profile memory_mb must be > 0");
+    let estimated_capacity = {
+        let resource_limit = std::cmp::min(
+            budget.effective_vcpu() as usize / vcpu as usize,
+            budget.effective_memory_mb() as usize / memory_mb as usize,
+        )
+        .max(1);
+        if max_concurrent > 0 {
+            std::cmp::min(resource_limit, max_concurrent)
+        } else {
+            resource_limit
+        }
+    };
+    let mut status = StatusTracker::new(paths.status(), estimated_capacity);
     status.set_proxy_port(mitm.port()).await;
     let status = Arc::new(status);
 

--- a/crates/runner/src/config.rs
+++ b/crates/runner/src/config.rs
@@ -207,7 +207,6 @@ impl RunnerConfig {
         &self,
         profile: &ProfileConfig,
         home: &HomePaths,
-        concurrency: usize,
         proxy_port: Option<u16>,
     ) -> sandbox_fc::FirecrackerConfig {
         let rootfs_paths = RootfsPaths::new(home, &profile.rootfs_hash);
@@ -221,7 +220,6 @@ impl RunnerConfig {
             kernel_path: self.firecracker.kernel.clone(),
             rootfs_path: rootfs_paths.rootfs(),
             base_dir: self.base_dir.clone(),
-            concurrency,
             proxy_port,
             snapshot,
         }
@@ -635,7 +633,7 @@ profiles:
         };
 
         let profile = &config.profiles["vm0/default"];
-        let fc = config.firecracker_config(profile, &home, 4, Some(8080));
+        let fc = config.firecracker_config(profile, &home, Some(8080));
 
         assert_eq!(fc.binary_path, dir.path().join("firecracker"));
         assert_eq!(fc.kernel_path, dir.path().join("vmlinux"));
@@ -643,7 +641,6 @@ profiles:
             fc.rootfs_path,
             home.rootfs_dir().join("abc123").join("rootfs.squashfs")
         );
-        assert_eq!(fc.concurrency, 4);
         assert_eq!(fc.proxy_port, Some(8080));
         assert!(fc.snapshot.is_some());
     }

--- a/crates/sandbox-fc/src/config.rs
+++ b/crates/sandbox-fc/src/config.rs
@@ -7,8 +7,6 @@ pub struct FirecrackerConfig {
     pub rootfs_path: PathBuf,
     /// Base directory for runtime data (workspaces, overlays, etc.).
     pub base_dir: PathBuf,
-    /// Number of VMs that can run concurrently (determines pool pre-warm size).
-    pub concurrency: usize,
     /// Port of the HTTP/HTTPS proxy. When set, iptables rules redirect traffic through it.
     pub proxy_port: Option<u16>,
     /// Snapshot to restore from. When set, VMs boot via snapshot restore instead of fresh boot.

--- a/crates/sandbox-fc/src/factory.rs
+++ b/crates/sandbox-fc/src/factory.rs
@@ -172,18 +172,15 @@ impl SandboxFactory for FirecrackerFactory {
             ));
         }
 
-        let concurrency = self.config.concurrency.max(1);
-
         let t = std::time::Instant::now();
         let mut netns_pool = NetnsPool::create(NetnsPoolConfig {
-            size: concurrency,
             proxy_port: self.config.proxy_port,
         })
         .await
         .map_err(|e| SandboxError::CreationFailed(format!("netns pool: {e}")))?;
         info!(
             elapsed_ms = t.elapsed().as_millis() as u64,
-            concurrency, "netns pool created"
+            "netns pool created"
         );
 
         let overlay_creator: Box<dyn OverlayCreator> = match &self.config.snapshot {
@@ -193,8 +190,6 @@ impl SandboxFactory for FirecrackerFactory {
 
         let t = std::time::Instant::now();
         let overlay_pool = match OverlayPool::create(OverlayPoolConfig {
-            size: concurrency,
-            replenish_threshold: (concurrency / 2).max(1),
             pool_dir: self.factory_paths.overlays(),
             creator: overlay_creator,
         })
@@ -210,7 +205,7 @@ impl SandboxFactory for FirecrackerFactory {
         };
         info!(
             elapsed_ms = t.elapsed().as_millis() as u64,
-            concurrency, "overlay pool created"
+            "overlay pool created"
         );
 
         self.netns_pool = Some(tokio::sync::Mutex::new(netns_pool));
@@ -221,7 +216,7 @@ impl SandboxFactory for FirecrackerFactory {
         } else {
             "fresh"
         };
-        info!(concurrency, mode, "factory started");
+        info!(mode, "factory started");
 
         Ok(())
     }

--- a/crates/sandbox-fc/src/network/pool.rs
+++ b/crates/sandbox-fc/src/network/pool.rs
@@ -63,9 +63,10 @@ const IP_PREFIX: &str = "10.200";
 const MAX_POOLS: u32 = 64;
 /// Maximum namespaces a single pool can own (index 0x00–0xff).
 const MAX_NAMESPACES: u32 = 256;
-/// Number of namespaces to pre-warm per queue at startup.
-/// Remaining namespaces are created lazily via background replenishment.
-const INITIAL_POOL_SIZE: usize = 4;
+/// Number of ready namespaces to keep in each pool queue.
+/// The pool pre-warms this many at startup and replenishes to
+/// maintain this level after each acquire.
+const BUFFER_SIZE: usize = 4;
 
 // Compile-time check: all /30 subnets fit within `10.200.0.0/16`.
 // 64 pools × 256 ns × 4 addresses per /30 = 65536 = exactly 2^16.
@@ -90,11 +91,9 @@ pub struct PooledNetns {
 
 /// Configuration for creating a [`NetnsPool`].
 ///
-/// When `proxy_port` is set, the pool pre-warms **two** queues of `size`
-/// namespaces each (plain + proxy), doubling the total namespace count.
+/// When `proxy_port` is set, the pool maintains **two** queues
+/// (plain + proxy), each buffering [`BUFFER_SIZE`] namespaces.
 pub struct NetnsPoolConfig {
-    /// Number of namespaces to pre-create per queue.
-    pub size: usize,
     /// Proxy port for HTTP/HTTPS redirect (only adds redirect rules when set).
     pub proxy_port: Option<u16>,
 }
@@ -532,11 +531,10 @@ fn acquire_pool_lock(locks: &LockPaths) -> Result<(u32, Flock<File>)> {
 
 /// Pre-warmed pool of network namespaces for Firecracker VMs.
 ///
-/// Uses lazy initialization: only [`INITIAL_POOL_SIZE`] namespaces are
-/// pre-warmed at startup. Additional namespaces are created in the
-/// background on each [`acquire`](Self::acquire) call until `target_size`
-/// is reached. After that, namespaces are recycled via
-/// [`release`](Self::release) with no further background creation.
+/// Maintains a buffer of [`BUFFER_SIZE`] ready namespaces per queue.
+/// After each [`acquire`](Self::acquire), the pool spawns a background
+/// task to replenish the buffer. Namespaces returned via
+/// [`release`](Self::release) are recycled back into the queue.
 pub struct NetnsPool {
     active: bool,
     plain_queue: VecDeque<PooledNetns>,
@@ -549,24 +547,17 @@ pub struct NetnsPool {
     pool_index: u32,
     proxy_port: Option<u16>,
     default_iface: String,
-    /// Target pool size per queue (from config).
-    target_size: usize,
-    /// Plain namespaces successfully created or in-flight (decremented on
-    /// failure). Compared against `target_size` to gate background replenishment.
-    created_plain: usize,
-    /// Proxy namespaces successfully created or in-flight (decremented on
-    /// failure). Compared against `target_size` to gate background replenishment.
-    created_proxy: usize,
     /// Held for the lifetime of the pool to reserve the pool index.
     _lock: Flock<File>,
 }
 
 impl NetnsPool {
-    /// Create a new pool with lazy initialization.
+    /// Create a new pool with a small pre-warmed buffer.
     ///
-    /// Only [`INITIAL_POOL_SIZE`] namespaces are pre-warmed per queue at
-    /// startup. The remaining namespaces (up to `config.size`) are created
-    /// lazily via background replenishment on each [`acquire`](Self::acquire).
+    /// Pre-warms [`BUFFER_SIZE`] namespaces per queue at startup.
+    /// After each [`acquire`](Self::acquire), the pool replenishes to
+    /// maintain the buffer level. Namespaces returned via
+    /// [`release`](Self::release) are recycled back into the queue.
     ///
     /// Automatically acquires a unique pool index (0–63) via flock. Enables
     /// host IP forwarding and cleans up orphaned resources from the acquired
@@ -575,13 +566,7 @@ impl NetnsPool {
         let lock_paths = LockPaths::new();
         let (index, lock) = acquire_pool_lock(&lock_paths)?;
 
-        let initial = config.size.min(INITIAL_POOL_SIZE);
-        info!(
-            index,
-            size = config.size,
-            initial,
-            "initializing namespace pool"
-        );
+        info!(index, buffer = BUFFER_SIZE, "initializing namespace pool");
 
         // Enable host-level IP forwarding (idempotent, needed once per host).
         exec("sysctl", &["-w", "net.ipv4.ip_forward=1"], Privilege::Sudo).await?;
@@ -593,9 +578,9 @@ impl NetnsPool {
 
         let mut pool = Self {
             active: true,
-            plain_queue: VecDeque::with_capacity(config.size),
+            plain_queue: VecDeque::with_capacity(BUFFER_SIZE),
             proxy_queue: VecDeque::with_capacity(if config.proxy_port.is_some() {
-                config.size
+                BUFFER_SIZE
             } else {
                 0
             }),
@@ -605,20 +590,16 @@ impl NetnsPool {
             pool_index: index,
             proxy_port: config.proxy_port,
             default_iface,
-            target_size: config.size,
-            created_plain: 0,
-            created_proxy: 0,
             _lock: lock,
         };
 
-        // Pre-warm only `initial` namespaces per queue (not all `size`).
-        // The rest are created lazily via background replenishment.
-        if initial > 0 {
+        // Pre-warm the buffer.
+        if BUFFER_SIZE > 0 {
             let mut plain_set = tokio::task::JoinSet::new();
             let mut proxy_set = tokio::task::JoinSet::new();
 
             // Plain namespaces (connectivity only).
-            for _ in 0..initial {
+            for _ in 0..BUFFER_SIZE {
                 let ns_index = pool.next_ns_index;
                 pool.next_ns_index += 1;
                 let pool_index = pool.pool_index;
@@ -633,7 +614,7 @@ impl NetnsPool {
 
             // Proxy namespaces (connectivity + REDIRECT rules).
             if let Some(proxy_port) = pool.proxy_port {
-                for _ in 0..initial {
+                for _ in 0..BUFFER_SIZE {
                     let ns_index = pool.next_ns_index;
                     pool.next_ns_index += 1;
                     let pool_index = pool.pool_index;
@@ -663,13 +644,10 @@ impl NetnsPool {
             }
         }
 
-        pool.created_plain = pool.plain_queue.len();
-        pool.created_proxy = pool.proxy_queue.len();
-
         info!(
             plain = pool.plain_queue.len(),
             proxy = pool.proxy_queue.len(),
-            target = pool.target_size,
+            buffer = BUFFER_SIZE,
             "namespace pool initialized"
         );
         Ok(pool)
@@ -683,7 +661,7 @@ impl NetnsPool {
     /// 3. Create on-demand as fallback
     ///
     /// After acquisition, spawns a background replenishment task if the
-    /// total created count hasn't reached `target_size`.
+    /// buffer is below [`BUFFER_SIZE`].
     ///
     /// The two queues are completely independent — `use_proxy=true` only
     /// touches the proxy queue, `use_proxy=false` only touches the plain queue.
@@ -728,20 +706,13 @@ impl NetnsPool {
                     self.maybe_replenish_plain();
                     return Ok(ns);
                 }
-                Ok(Err(e)) => {
-                    self.created_plain = self.created_plain.saturating_sub(1);
-                    error!(error = %e, "pending namespace creation failed");
-                }
-                Err(e) => {
-                    self.created_plain = self.created_plain.saturating_sub(1);
-                    error!(error = %e, "pending namespace task panicked");
-                }
+                Ok(Err(e)) => error!(error = %e, "pending namespace creation failed"),
+                Err(e) => error!(error = %e, "pending namespace task panicked"),
             }
         }
         // Tier 3: on-demand.
         info!("pool exhausted, creating namespace on-demand");
         let ns = self.create_on_demand(None).await?;
-        self.created_plain += 1;
         self.maybe_replenish_plain();
         Ok(ns)
     }
@@ -769,20 +740,13 @@ impl NetnsPool {
                     self.maybe_replenish_proxy();
                     return Ok(ns);
                 }
-                Ok(Err(e)) => {
-                    self.created_proxy = self.created_proxy.saturating_sub(1);
-                    error!(error = %e, "pending proxy namespace creation failed");
-                }
-                Err(e) => {
-                    self.created_proxy = self.created_proxy.saturating_sub(1);
-                    error!(error = %e, "pending proxy namespace task panicked");
-                }
+                Ok(Err(e)) => error!(error = %e, "pending proxy namespace creation failed"),
+                Err(e) => error!(error = %e, "pending proxy namespace task panicked"),
             }
         }
         // Tier 3: on-demand.
         info!("proxy pool exhausted, creating namespace on-demand");
         let ns = self.create_on_demand(self.proxy_port).await?;
-        self.created_proxy += 1;
         self.maybe_replenish_proxy();
         Ok(ns)
     }
@@ -808,43 +772,30 @@ impl NetnsPool {
     /// Move completed background tasks into their respective queues.
     ///
     /// Uses `try_join_next()` to avoid blocking — only drains tasks that
-    /// have already finished. Decrements the created counter on failure so
-    /// the slot can be retried on the next replenishment cycle.
+    /// have already finished.
     fn drain_completed(&mut self) {
         while let Some(result) = self.pending_plain.try_join_next() {
             match result {
                 Ok(Ok(ns)) => self.plain_queue.push_back(ns),
-                Ok(Err(e)) => {
-                    self.created_plain = self.created_plain.saturating_sub(1);
-                    error!(error = %e, "background namespace creation failed");
-                }
-                Err(e) => {
-                    self.created_plain = self.created_plain.saturating_sub(1);
-                    error!(error = %e, "background namespace creation panicked");
-                }
+                Ok(Err(e)) => error!(error = %e, "background namespace creation failed"),
+                Err(e) => error!(error = %e, "background namespace creation panicked"),
             }
         }
         while let Some(result) = self.pending_proxy.try_join_next() {
             match result {
                 Ok(Ok(ns)) => self.proxy_queue.push_back(ns),
-                Ok(Err(e)) => {
-                    self.created_proxy = self.created_proxy.saturating_sub(1);
-                    error!(error = %e, "background proxy namespace creation failed");
-                }
-                Err(e) => {
-                    self.created_proxy = self.created_proxy.saturating_sub(1);
-                    error!(error = %e, "background proxy namespace creation panicked");
-                }
+                Ok(Err(e)) => error!(error = %e, "background proxy namespace creation failed"),
+                Err(e) => error!(error = %e, "background proxy namespace creation panicked"),
             }
         }
     }
 
     /// Spawn a background plain namespace creation task if needed.
     ///
-    /// Skips if: total created already reached target, a task is already
-    /// in-flight, or namespace index limit reached.
+    /// Skips if: buffer is full, a task is already in-flight, or
+    /// namespace index limit reached.
     fn maybe_replenish_plain(&mut self) {
-        if self.created_plain >= self.target_size
+        if self.plain_queue.len() + self.pending_plain.len() >= BUFFER_SIZE
             || !self.pending_plain.is_empty()
             || self.next_ns_index >= MAX_NAMESPACES
         {
@@ -852,7 +803,6 @@ impl NetnsPool {
         }
         let ns_index = self.next_ns_index;
         self.next_ns_index += 1;
-        self.created_plain += 1;
         let pool_index = self.pool_index;
         let default_iface = self.default_iface.clone();
         self.pending_plain.spawn(create_single_namespace(
@@ -865,13 +815,13 @@ impl NetnsPool {
 
     /// Spawn a background proxy namespace creation task if needed.
     ///
-    /// Skips if: no proxy port configured, total created already reached
-    /// target, a task is already in-flight, or namespace index limit reached.
+    /// Skips if: no proxy port configured, buffer is full, a task is
+    /// already in-flight, or namespace index limit reached.
     fn maybe_replenish_proxy(&mut self) {
         let Some(proxy_port) = self.proxy_port else {
             return;
         };
-        if self.created_proxy >= self.target_size
+        if self.proxy_queue.len() + self.pending_proxy.len() >= BUFFER_SIZE
             || !self.pending_proxy.is_empty()
             || self.next_ns_index >= MAX_NAMESPACES
         {
@@ -879,7 +829,6 @@ impl NetnsPool {
         }
         let ns_index = self.next_ns_index;
         self.next_ns_index += 1;
-        self.created_proxy += 1;
         let pool_index = self.pool_index;
         let default_iface = self.default_iface.clone();
         self.pending_proxy.spawn(create_single_namespace(

--- a/crates/sandbox-fc/src/overlay/pool.rs
+++ b/crates/sandbox-fc/src/overlay/pool.rs
@@ -21,9 +21,10 @@ const OVERLAY_PREFIX: &str = "overlay-";
 /// File extension for overlay files.
 const OVERLAY_EXT: &str = ".ext4";
 
-/// Number of overlay files to pre-warm (blocking) at startup.
-/// Remaining files are created lazily via background replenishment.
-const INITIAL_POOL_SIZE: usize = 4;
+/// Number of ready overlay files to keep in the pool buffer.
+/// The pool pre-warms this many at startup and replenishes to
+/// maintain this level after each acquire.
+const BUFFER_SIZE: usize = 4;
 
 /// Maximum overlay files to create per replenishment cycle.
 const REPLENISH_BATCH: usize = 4;
@@ -133,10 +134,6 @@ async fn clean_stale_files(dir: &Path) {
 
 /// Configuration for creating an [`OverlayPool`].
 pub struct OverlayPoolConfig {
-    /// Number of overlay files to pre-create.
-    pub size: usize,
-    /// Start replenishment when available count drops below this.
-    pub replenish_threshold: usize,
     /// Directory in which overlay files are stored.
     pub pool_dir: PathBuf,
     /// Strategy for creating overlay files.
@@ -165,24 +162,19 @@ pub struct OverlayPool {
     /// access pool state directly.
     pending: tokio::task::JoinSet<Result<PathBuf>>,
     pool_dir: PathBuf,
-    size: usize,
-    replenish_threshold: usize,
     creator: Arc<dyn OverlayCreator>,
 }
 
 impl OverlayPool {
-    /// Create a new pool with lazy initialization.
+    /// Create a new pool with a small pre-warmed buffer.
     ///
     /// Creates the pool directory if it doesn't exist, removes stale files
-    /// from previous runs, and pre-creates a small batch of overlay files
-    /// (up to [`INITIAL_POOL_SIZE`]). Remaining files are created lazily
-    /// via background replenishment on each [`acquire`](Self::acquire).
+    /// from previous runs, and pre-creates [`BUFFER_SIZE`] overlay files.
+    /// After each [`acquire`](Self::acquire), the pool replenishes to
+    /// maintain the buffer level.
     pub async fn create(config: OverlayPoolConfig) -> Result<Self> {
-        let initial = config.size.min(INITIAL_POOL_SIZE);
         info!(
-            size = config.size,
-            initial,
-            threshold = config.replenish_threshold,
+            buffer = BUFFER_SIZE,
             dir = %config.pool_dir.display(),
             "initializing overlay pool"
         );
@@ -194,12 +186,12 @@ impl OverlayPool {
         clean_stale_files(&config.pool_dir).await;
 
         let creator: Arc<dyn OverlayCreator> = Arc::from(config.creator);
-        let mut queue = VecDeque::with_capacity(config.size);
+        let mut queue = VecDeque::with_capacity(BUFFER_SIZE);
 
-        // Pre-warm only `initial` files (blocking).
-        if initial > 0 {
+        // Pre-warm the buffer.
+        if BUFFER_SIZE > 0 {
             let mut join_set = tokio::task::JoinSet::new();
-            for _ in 0..initial {
+            for _ in 0..BUFFER_SIZE {
                 let dir = config.pool_dir.clone();
                 let c = Arc::clone(&creator);
                 join_set.spawn(async move {
@@ -216,38 +208,23 @@ impl OverlayPool {
             }
             if queue.is_empty() {
                 warn!(
-                    attempted = initial,
+                    attempted = BUFFER_SIZE,
                     "all initial overlay pre-warm tasks failed, pool starting with 0 ready files"
                 );
             }
         }
 
-        // Spawn a batch of background tasks for the remaining files.
-        let mut pending = tokio::task::JoinSet::new();
-        let background = config.size.saturating_sub(initial).min(REPLENISH_BATCH);
-        for _ in 0..background {
-            let dir = config.pool_dir.clone();
-            let c = Arc::clone(&creator);
-            pending.spawn(async move {
-                let path = dir.join(generate_file_name());
-                c.create(&path).await.map(|()| path)
-            });
-        }
-
         info!(
             available = queue.len(),
-            pending = background,
-            target = config.size,
+            buffer = BUFFER_SIZE,
             "overlay pool initialized"
         );
 
         Ok(Self {
             active: true,
             queue,
-            pending,
+            pending: tokio::task::JoinSet::new(),
             pool_dir: config.pool_dir,
-            size: config.size,
-            replenish_threshold: config.replenish_threshold,
             creator,
         })
     }
@@ -342,22 +319,16 @@ impl OverlayPool {
         self.queue.len()
     }
 
-    /// Spawn background creation tasks if the pool is running low.
+    /// Spawn background creation tasks if the buffer is running low.
     ///
     /// Spawns at most [`REPLENISH_BATCH`] tasks per call to avoid
-    /// bursting I/O. Subsequent [`acquire`](Self::acquire) calls will
-    /// trigger further batches until the pool reaches `size`.
-    ///
-    /// Trade-off: the pool may operate below target capacity for several
-    /// acquire cycles after startup or heavy consumption. This is acceptable
-    /// because Tier 2/3 fallbacks ensure `acquire` never fails due to an
-    /// empty pool.
+    /// bursting I/O. Maintains a ready buffer of [`BUFFER_SIZE`] files.
     fn maybe_replenish(&mut self) {
         let total = self.queue.len() + self.pending.len();
-        if total >= self.replenish_threshold {
+        if total >= BUFFER_SIZE {
             return;
         }
-        let needed = self.size.saturating_sub(total).min(REPLENISH_BATCH);
+        let needed = BUFFER_SIZE.saturating_sub(total).min(REPLENISH_BATCH);
         for _ in 0..needed {
             let dir = self.pool_dir.clone();
             let c = Arc::clone(&self.creator);
@@ -415,10 +386,8 @@ mod tests {
         }
     }
 
-    fn test_config(dir: &Path, size: usize, threshold: usize) -> OverlayPoolConfig {
+    fn test_config(dir: &Path) -> OverlayPoolConfig {
         OverlayPoolConfig {
-            size,
-            replenish_threshold: threshold,
             pool_dir: dir.to_path_buf(),
             creator: Box::new(TestCreator),
         }
@@ -453,17 +422,17 @@ mod tests {
     #[tokio::test]
     async fn create_prewarms_files() {
         let tmp = tempfile::tempdir().expect("tempdir");
-        let mut pool = OverlayPool::create(test_config(tmp.path(), 3, 1))
+        let mut pool = OverlayPool::create(test_config(tmp.path()))
             .await
             .expect("create");
 
-        assert_eq!(pool.available_count(), 3);
+        assert_eq!(pool.available_count(), BUFFER_SIZE);
 
         let entries: Vec<_> = std::fs::read_dir(tmp.path())
             .expect("read_dir")
             .filter_map(|e| e.ok())
             .collect();
-        assert_eq!(entries.len(), 3);
+        assert_eq!(entries.len(), BUFFER_SIZE);
         for entry in &entries {
             assert!(is_overlay_file(&entry.file_name().to_string_lossy()));
         }
@@ -472,20 +441,17 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn create_lazy_init_large_pool() {
+    async fn acquire_beyond_buffer_uses_replenish_and_on_demand() {
         let tmp = tempfile::tempdir().expect("tempdir");
-        // size=10 > INITIAL_POOL_SIZE(4): only 4 should be pre-warmed,
-        // remaining created lazily via pending + replenishment.
-        let mut pool = OverlayPool::create(test_config(tmp.path(), 10, 5))
+        let mut pool = OverlayPool::create(test_config(tmp.path()))
             .await
             .expect("create");
 
-        // Only INITIAL_POOL_SIZE files are ready in the queue.
-        assert_eq!(pool.available_count(), INITIAL_POOL_SIZE);
-
-        // But we can still acquire all 10 (from queue + pending + replenish).
+        // Buffer is BUFFER_SIZE. Acquiring more than that exercises
+        // replenishment (Tier 2) and on-demand creation (Tier 3).
+        let count = BUFFER_SIZE + 4;
         let mut paths = Vec::new();
-        for i in 0..10 {
+        for i in 0..count {
             let path = pool.acquire().await.unwrap_or_else(|e| {
                 panic!("acquire {i} failed: {e}");
             });
@@ -512,12 +478,12 @@ mod tests {
         std::fs::write(&stale, b"stale").expect("write");
         assert!(stale.exists());
 
-        let mut pool = OverlayPool::create(test_config(tmp.path(), 1, 1))
+        let mut pool = OverlayPool::create(test_config(tmp.path()))
             .await
             .expect("create");
 
-        // Stale file should be gone; only the newly created one remains.
-        assert_eq!(pool.available_count(), 1);
+        // Stale file should be gone; only the newly created files remain.
+        assert_eq!(pool.available_count(), BUFFER_SIZE);
         assert!(!stale.exists());
 
         pool.cleanup().await;
@@ -526,7 +492,7 @@ mod tests {
     #[tokio::test]
     async fn acquire_returns_file() {
         let tmp = tempfile::tempdir().expect("tempdir");
-        let mut pool = OverlayPool::create(test_config(tmp.path(), 2, 1))
+        let mut pool = OverlayPool::create(test_config(tmp.path()))
             .await
             .expect("create");
 
@@ -542,7 +508,7 @@ mod tests {
     #[tokio::test]
     async fn acquire_returns_unique_files() {
         let tmp = tempfile::tempdir().expect("tempdir");
-        let mut pool = OverlayPool::create(test_config(tmp.path(), 3, 1))
+        let mut pool = OverlayPool::create(test_config(tmp.path()))
             .await
             .expect("create");
 
@@ -560,17 +526,20 @@ mod tests {
     #[tokio::test]
     async fn acquire_when_queue_exhausted() {
         let tmp = tempfile::tempdir().expect("tempdir");
-        let mut pool = OverlayPool::create(test_config(tmp.path(), 1, 1))
+        let mut pool = OverlayPool::create(test_config(tmp.path()))
             .await
             .expect("create");
 
-        let _first = pool.acquire().await.expect("acquire pooled");
+        // Drain the entire buffer.
+        for _ in 0..BUFFER_SIZE {
+            pool.acquire().await.expect("drain buffer");
+        }
         assert_eq!(pool.available_count(), 0);
 
-        // Queue is empty but maybe_replenish spawned a pending task,
-        // so the second acquire comes from Tier 2 (pending).
-        let second = pool.acquire().await.expect("acquire from pending");
-        assert!(second.exists());
+        // Queue is empty but maybe_replenish spawned pending tasks,
+        // so the next acquire comes from Tier 2 (pending).
+        let path = pool.acquire().await.expect("acquire from pending");
+        assert!(path.exists());
 
         pool.cleanup().await;
     }
@@ -578,35 +547,18 @@ mod tests {
     #[tokio::test]
     async fn acquire_from_replenished_pending() {
         let tmp = tempfile::tempdir().expect("tempdir");
-        // size=2, threshold=2: acquiring the first file triggers replenishment,
-        // so the second acquire should come from a pending task (Tier 2).
-        let mut pool = OverlayPool::create(test_config(tmp.path(), 2, 2))
+        let mut pool = OverlayPool::create(test_config(tmp.path()))
             .await
             .expect("create");
 
-        let first = pool.acquire().await.expect("acquire 1 (pooled)");
-        assert!(first.exists());
+        // Drain the entire buffer so replenishment kicks in.
+        for _ in 0..BUFFER_SIZE {
+            pool.acquire().await.expect("drain buffer");
+        }
 
         // Queue is now empty, but maybe_replenish() should have spawned tasks.
-        // The second acquire hits Tier 2 (pending JoinSet).
-        let second = pool.acquire().await.expect("acquire 2 (replenished)");
-        assert!(second.exists());
-        assert_ne!(first, second);
-
-        pool.cleanup().await;
-    }
-
-    #[tokio::test]
-    async fn create_with_size_zero() {
-        let tmp = tempfile::tempdir().expect("tempdir");
-        let mut pool = OverlayPool::create(test_config(tmp.path(), 0, 0))
-            .await
-            .expect("create");
-
-        assert_eq!(pool.available_count(), 0);
-
-        // acquire still works via on-demand (Tier 3).
-        let path = pool.acquire().await.expect("acquire on-demand");
+        // The next acquire hits Tier 2 (pending JoinSet).
+        let path = pool.acquire().await.expect("acquire from replenished");
         assert!(path.exists());
 
         pool.cleanup().await;
@@ -616,8 +568,6 @@ mod tests {
     async fn create_succeeds_when_all_prewarm_fail() {
         let tmp = tempfile::tempdir().expect("tempdir");
         let config = OverlayPoolConfig {
-            size: 3,
-            replenish_threshold: 1,
             pool_dir: tmp.path().to_path_buf(),
             creator: Box::new(FailingCreator),
         };
@@ -632,7 +582,7 @@ mod tests {
     #[tokio::test]
     async fn cleanup_deletes_files() {
         let tmp = tempfile::tempdir().expect("tempdir");
-        let mut pool = OverlayPool::create(test_config(tmp.path(), 3, 1))
+        let mut pool = OverlayPool::create(test_config(tmp.path()))
             .await
             .expect("create");
 
@@ -650,7 +600,7 @@ mod tests {
     #[tokio::test]
     async fn cleanup_noop_after_cleanup() {
         let tmp = tempfile::tempdir().expect("tempdir");
-        let mut pool = OverlayPool::create(test_config(tmp.path(), 2, 1))
+        let mut pool = OverlayPool::create(test_config(tmp.path()))
             .await
             .expect("create");
 
@@ -663,7 +613,7 @@ mod tests {
     #[tokio::test]
     async fn acquire_after_cleanup_errors() {
         let tmp = tempfile::tempdir().expect("tempdir");
-        let mut pool = OverlayPool::create(test_config(tmp.path(), 2, 1))
+        let mut pool = OverlayPool::create(test_config(tmp.path()))
             .await
             .expect("create");
 

--- a/crates/sandbox-fc/src/snapshot.rs
+++ b/crates/sandbox-fc/src/snapshot.rs
@@ -123,12 +123,9 @@ pub async fn create_snapshot(
     info!("overlay created");
 
     // 3. Create network namespace (pool of 1, index auto-allocated via flock).
-    let mut netns_pool = NetnsPool::create(NetnsPoolConfig {
-        size: 1,
-        proxy_port: None,
-    })
-    .await
-    .map_err(|e| SnapshotError::Setup(format!("netns pool: {e}")))?;
+    let mut netns_pool = NetnsPool::create(NetnsPoolConfig { proxy_port: None })
+        .await
+        .map_err(|e| SnapshotError::Setup(format!("netns pool: {e}")))?;
 
     // Guard: ensure netns cleanup on any exit path.
     let result =


### PR DESCRIPTION
## Summary

- Replace target-size pool pre-warming with a fixed `BUFFER_SIZE = 4` buffer
- Pools previously pre-created resources up to `vm_capacity` (8-16 on typical hosts), wasting netns/overlay resources that were rarely all used concurrently
- Now pools self-manage: pre-warm 4 at startup, replenish to maintain buffer level, on-demand fallback for bursts
- Remove `concurrency` from `FirecrackerConfig`, `size` from pool configs — pools are fully self-managing

## Changes

- **NetnsPool**: remove `target_size`, `created_plain`, `created_proxy` tracking; replenish gate changed from `created >= target` to `queue + pending >= BUFFER_SIZE`
- **OverlayPool**: remove `size`, `replenish_threshold`; replenish targets `BUFFER_SIZE` instead of configured size
- **FirecrackerConfig**: remove `concurrency` field (no longer needed by pools)
- **start.rs**: `estimated_capacity` computed for status reporting only; actual admission controlled by `ResourceBudget`

## Test plan

- [ ] 288 existing tests pass (191 runner + 97 sandbox-fc)
- [ ] Clippy clean
- [ ] Verify pool pre-warms exactly `BUFFER_SIZE` files at startup
- [ ] Verify acquire beyond buffer exercises replenishment and on-demand tiers

🤖 Generated with [Claude Code](https://claude.com/claude-code)