### PR TITLE
chore: untrack docs next-env.d.ts already in gitignore

### DIFF
--- a/turbo/apps/docs/next-env.d.ts
+++ b/turbo/apps/docs/next-env.d.ts
@@ -1,6 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
## Summary
- Remove `turbo/apps/docs/next-env.d.ts` from git tracking — it was already in `.gitignore` but still tracked
- Next.js auto-regenerates this file on dev server start or build, so no impact to other developers

## Test plan
- [x] File is removed from git index
- [x] `.gitignore` rule `apps/*/next-env.d.ts` already exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)