### PR TITLE
feat(platform): add schedule creation dialog and improve pinned agents ux

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/zero-schedule-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-schedule-page.tsx
@@ -5,6 +5,7 @@ import {
   IconList,
   IconLayoutGrid,
   IconTrash,
+  IconPlus,
 } from "@tabler/icons-react";
 import { LoadingSwitch } from "../components/loading-switch.tsx";
 import {
@@ -639,6 +640,166 @@ function ScheduleEditDialog(props: ScheduleEditDialogProps) {
 }
 
 // ---------------------------------------------------------------------------
+// Create dialog
+// ---------------------------------------------------------------------------
+
+interface ScheduleCreateDialogProps {
+  open: boolean;
+  onClose: () => void;
+  onSave: (params: ZeroScheduleSaveParams & { composeId: string }) => void;
+  saving: boolean;
+  agents: { id: string; name: string; displayName?: string | null }[];
+  defaultComposeId: string | null;
+}
+
+function ScheduleCreateDialogInner({
+  onClose,
+  onSave,
+  saving,
+  agents,
+  defaultComposeId,
+}: Omit<ScheduleCreateDialogProps, "open">) {
+  const prompt$ = useCCState("");
+  const prompt = useGet(prompt$);
+  const setPrompt = useSet(prompt$);
+  const composeId$ = useCCState(defaultComposeId ?? agents[0]?.id ?? "");
+  const composeId = useGet(composeId$);
+  const setComposeId = useSet(composeId$);
+  const freq$ = useCCState("every_day");
+  const freq = useGet(freq$);
+  const setFreq = useSet(freq$);
+  const date$ = useCCState(new Date().toISOString().slice(0, 10));
+  const date = useGet(date$);
+  const setDate = useSet(date$);
+  const hour$ = useCCState(9);
+  const hour = useGet(hour$);
+  const setHour = useSet(hour$);
+  const minute$ = useCCState(0);
+  const minute = useGet(minute$);
+  const setMinute = useSet(minute$);
+  const timezone$ = useCCState(
+    Intl.DateTimeFormat().resolvedOptions().timeZone,
+  );
+  const timezone = useGet(timezone$);
+  const setTimezone = useSet(timezone$);
+  const loopMinutes$ = useCCState(15);
+  const loopMinutes = useGet(loopMinutes$);
+  const setLoopMinutes = useSet(loopMinutes$);
+
+  const handleSave = () => {
+    if (!prompt.trim() || !composeId) {
+      return;
+    }
+    onSave({
+      prompt: prompt.trim(),
+      freq,
+      date,
+      hour,
+      minute,
+      timezone,
+      intervalSeconds: loopMinutes * 60,
+      composeId,
+    });
+  };
+
+  return (
+    <DialogContent className="sm:max-w-md gap-6">
+      <DialogHeader>
+        <DialogTitle>New schedule</DialogTitle>
+      </DialogHeader>
+      <div className="flex flex-col gap-4">
+        <div className="flex flex-col gap-2">
+          <label
+            htmlFor="schedule-create-agent"
+            className="text-sm font-medium text-foreground"
+          >
+            Agent
+          </label>
+          <Select value={composeId} onValueChange={setComposeId}>
+            <SelectTrigger id="schedule-create-agent" className="h-9">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {agents.map((a) => (
+                <SelectItem key={a.id} value={a.id}>
+                  {a.displayName ?? a.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        <div className="flex flex-col gap-2">
+          <label
+            htmlFor="schedule-create-prompt"
+            className="text-sm font-medium text-foreground"
+          >
+            Prompt
+          </label>
+          <textarea
+            id="schedule-create-prompt"
+            value={prompt}
+            onChange={(e) => setPrompt(e.target.value)}
+            placeholder="Describe your task and instruction"
+            rows={3}
+            className="w-full rounded-lg border border-border bg-input px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground outline-none transition-colors focus:border-primary focus:ring-2 focus:ring-primary/20 resize-y min-h-[72px]"
+          />
+        </div>
+        <ScheduleEditFields
+          freq={freq}
+          setFreq={setFreq}
+          loopMinutes={loopMinutes}
+          setLoopMinutes={setLoopMinutes}
+          date={date}
+          setDate={setDate}
+          hour={hour}
+          setHour={setHour}
+          minute={minute}
+          setMinute={setMinute}
+          timezone={timezone}
+          setTimezone={setTimezone}
+        />
+      </div>
+      <DialogFooter>
+        <Button
+          type="button"
+          variant="outline"
+          className="zero-btn-morandi"
+          onClick={onClose}
+        >
+          Cancel
+        </Button>
+        <Button
+          type="button"
+          onClick={handleSave}
+          disabled={!prompt.trim() || !composeId || saving}
+        >
+          {saving ? "Creating\u2026" : "Create"}
+        </Button>
+      </DialogFooter>
+    </DialogContent>
+  );
+}
+
+function ScheduleCreateDialog({
+  open,
+  onClose,
+  ...rest
+}: ScheduleCreateDialogProps) {
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(isOpen) => {
+        if (!isOpen) {
+          onClose();
+        }
+      }}
+    >
+      {open && <ScheduleCreateDialogInner onClose={onClose} {...rest} />}
+    </Dialog>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Skeleton
 // ---------------------------------------------------------------------------
 
@@ -711,11 +872,13 @@ function ScheduleListView({
   onEdit,
   onToggle,
   onDelete,
+  onNew,
 }: {
   combinedSchedule: CombinedEntry[];
   onEdit: (entry: CombinedEntry) => void;
   onToggle: (entry: CombinedEntry, enabled: boolean) => Promise<void>;
   onDelete: (entry: CombinedEntry) => void;
+  onNew?: () => void;
 }) {
   const togglingIds$ = useCCState<Set<string>>(new Set());
   const togglingIds = useGet(togglingIds$);
@@ -737,6 +900,17 @@ function ScheduleListView({
             Set up a schedule and your agents will handle the rest.
           </p>
         </div>
+        {onNew && (
+          <Button
+            variant="outline"
+            size="sm"
+            className="zero-btn-morandi mt-2 h-9 gap-2 rounded-lg border"
+            onClick={onNew}
+          >
+            <IconPlus size={14} stroke={2} />
+            Add schedule
+          </Button>
+        )}
       </div>
     );
   }
@@ -857,6 +1031,9 @@ export function ZeroSchedulePage() {
   const saving$ = useCCState(false);
   const saving = useGet(saving$);
   const setSaving = useSet(saving$);
+  const createOpen$ = useCCState(false);
+  const createOpen = useGet(createOpen$);
+  const setCreateOpen = useSet(createOpen$);
 
   const combinedSchedule = buildCombinedSchedule(
     entries,
@@ -871,6 +1048,22 @@ export function ZeroSchedulePage() {
 
   const openEditSchedule = (entry: CombinedEntry) => {
     setEditingEntry(entry);
+  };
+
+  const handleCreateSave = (
+    params: ZeroScheduleSaveParams & { composeId: string },
+  ) => {
+    setSaving(true);
+    detach(
+      saveSchedule(params)
+        .then(() => {
+          setCreateOpen(false);
+        })
+        .finally(() => {
+          setSaving(false);
+        }),
+      Reason.DomCallback,
+    );
   };
 
   const handleDialogSave = (
@@ -922,28 +1115,41 @@ export function ZeroSchedulePage() {
               Automated tasks scheduled across all agents in your workspace.
             </p>
           </div>
-          <Tabs
-            value={scheduleViewMode}
-            onValueChange={(v) => setScheduleViewMode(v as "list" | "calendar")}
-            className="shrink-0"
-          >
-            <TabsList className="zero-tabs h-9 gap-1 px-1 py-1">
-              <TabsTrigger
-                value="list"
-                className="gap-1.5 text-sm data-[state=active]:bg-background px-3"
-              >
-                <IconList size={14} stroke={1.5} />
-                List
-              </TabsTrigger>
-              <TabsTrigger
-                value="calendar"
-                className="gap-1.5 text-sm data-[state=active]:bg-background px-3"
-              >
-                <IconLayoutGrid size={14} stroke={1.5} />
-                Calendar
-              </TabsTrigger>
-            </TabsList>
-          </Tabs>
+          <div className="flex items-center gap-2 shrink-0">
+            <Button
+              variant="outline"
+              size="sm"
+              className="zero-btn-morandi h-9 gap-2 shrink-0 rounded-lg border"
+              onClick={() => setCreateOpen(true)}
+            >
+              <IconPlus size={14} stroke={2} />
+              Add schedule
+            </Button>
+            <Tabs
+              value={scheduleViewMode}
+              onValueChange={(v) =>
+                setScheduleViewMode(v as "list" | "calendar")
+              }
+              className="shrink-0"
+            >
+              <TabsList className="zero-tabs h-9 gap-1 px-1 py-1">
+                <TabsTrigger
+                  value="list"
+                  className="gap-1.5 text-sm data-[state=active]:bg-background px-3"
+                >
+                  <IconList size={14} stroke={1.5} />
+                  List
+                </TabsTrigger>
+                <TabsTrigger
+                  value="calendar"
+                  className="gap-1.5 text-sm data-[state=active]:bg-background px-3"
+                >
+                  <IconLayoutGrid size={14} stroke={1.5} />
+                  Calendar
+                </TabsTrigger>
+              </TabsList>
+            </Tabs>
+          </div>
         </div>
       </header>
 
@@ -963,6 +1169,7 @@ export function ZeroSchedulePage() {
                   onEdit={openEditSchedule}
                   onToggle={handleToggle}
                   onDelete={handleDelete}
+                  onNew={() => setCreateOpen(true)}
                 />
               ) : (
                 <ScheduleCalendarView
@@ -981,6 +1188,14 @@ export function ZeroSchedulePage() {
         onClose={() => setEditingEntry(null)}
         onSave={handleDialogSave}
         saving={saving}
+      />
+      <ScheduleCreateDialog
+        open={createOpen}
+        onClose={() => setCreateOpen(false)}
+        onSave={handleCreateSave}
+        saving={saving}
+        agents={agents}
+        defaultComposeId={defaultComposeId}
       />
     </div>
   );

--- a/turbo/apps/platform/src/views/zero-page/zero-schedule-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-schedule-page.tsx
@@ -678,7 +678,7 @@ function ScheduleCreateDialogInner({
   const minute = useGet(minute$);
   const setMinute = useSet(minute$);
   const timezone$ = useCCState(
-    Intl.DateTimeFormat().resolvedOptions().timeZone,
+    new Intl.DateTimeFormat().resolvedOptions().timeZone,
   );
   const timezone = useGet(timezone$);
   const setTimezone = useSet(timezone$);

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -27,6 +27,7 @@ import {
   IconGripVertical,
   IconLayoutSidebarLeftCollapse,
   IconDatabaseExport,
+  IconCrown,
 } from "@tabler/icons-react";
 import {
   DndContext,
@@ -642,11 +643,25 @@ function ManagePinnedAgentsDialog({
   pinnedIds: string[];
   onPinnedIdsChange: (ids: string[]) => void;
 }) {
-  const orderedPinned = pinnedIds
+  const draftIds$ = useCCState(pinnedIds);
+  const draftIds = useGet(draftIds$);
+  const setDraftIds = useSet(draftIds$);
+
+  const prevOpen$ = useCCState(false);
+  const prevOpen = useGet(prevOpen$);
+  const setPrevOpen = useSet(prevOpen$);
+  if (open && !prevOpen) {
+    setDraftIds(pinnedIds);
+  }
+  if (open !== prevOpen) {
+    setPrevOpen(open);
+  }
+
+  const orderedPinned = draftIds
     .map((id) => subagents.find((a) => a.id === id))
     .filter((a): a is SubagentInfo => a !== undefined);
 
-  const unpinned = subagents.filter((a) => !pinnedIds.includes(a.id));
+  const unpinned = subagents.filter((a) => !draftIds.includes(a.id));
 
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 4 } }),
@@ -660,23 +675,28 @@ function ManagePinnedAgentsDialog({
     if (!over || active.id === over.id) {
       return;
     }
-    const oldIndex = pinnedIds.indexOf(String(active.id));
-    const newIndex = pinnedIds.indexOf(String(over.id));
+    const oldIndex = draftIds.indexOf(String(active.id));
+    const newIndex = draftIds.indexOf(String(over.id));
     if (oldIndex === -1 || newIndex === -1) {
       return;
     }
-    const next = [...pinnedIds];
+    const next = [...draftIds];
     next.splice(oldIndex, 1);
-    next.splice(newIndex, 0, pinnedIds[oldIndex]!);
-    onPinnedIdsChange(next);
+    next.splice(newIndex, 0, draftIds[oldIndex]!);
+    setDraftIds(next);
   };
 
   const togglePin = (agentId: string) => {
-    if (pinnedIds.includes(agentId)) {
-      onPinnedIdsChange(pinnedIds.filter((id) => id !== agentId));
-    } else if (pinnedIds.length < MAX_PINNED) {
-      onPinnedIdsChange([...pinnedIds, agentId]);
+    if (draftIds.includes(agentId)) {
+      setDraftIds(draftIds.filter((id) => id !== agentId));
+    } else if (draftIds.length < MAX_PINNED) {
+      setDraftIds([...draftIds, agentId]);
     }
+  };
+
+  const handleSave = () => {
+    onPinnedIdsChange(draftIds);
+    onOpenChange(false);
   };
 
   return (
@@ -709,7 +729,12 @@ function ManagePinnedAgentsDialog({
             <span className="text-sm font-medium text-foreground flex-1 truncate">
               {displayName}
             </span>
-            <span className="text-[11px] text-muted-foreground/60 mr-0.5">
+            <span className="zero-pill inline-flex items-center gap-1.5 rounded-lg border px-2 py-0.5 text-xs font-medium bg-background">
+              <IconCrown
+                size={12}
+                stroke={1.8}
+                className="shrink-0 text-amber-500 dark:text-amber-400"
+              />
               Lead
             </span>
           </div>
@@ -766,12 +791,12 @@ function ManagePinnedAgentsDialog({
                     type="button"
                     className={cn(
                       "transition-colors px-2 py-0.5 rounded-md text-xs font-medium",
-                      pinnedIds.length >= MAX_PINNED
+                      draftIds.length >= MAX_PINNED
                         ? "text-muted-foreground/30 cursor-not-allowed"
                         : "text-primary hover:text-primary/80 hover:bg-primary/10",
                     )}
                     onClick={() => togglePin(agent.id)}
-                    disabled={pinnedIds.length >= MAX_PINNED}
+                    disabled={draftIds.length >= MAX_PINNED}
                   >
                     Pin
                   </button>
@@ -789,12 +814,16 @@ function ManagePinnedAgentsDialog({
           </div>
         )}
 
-        <div className="px-5 pb-5 pt-2">
+        <div className="px-5 pb-5 pt-2 flex justify-end gap-2">
           <Button
-            className="w-full"
+            variant="outline"
+            size="sm"
+            className="zero-btn-morandi"
             onClick={() => onOpenChange(false)}
-            disabled={saving}
           >
+            Cancel
+          </Button>
+          <Button size="sm" onClick={handleSave} disabled={saving}>
             {saving ? "Saving…" : "Save"}
           </Button>
         </div>


### PR DESCRIPTION
## Summary
- Add "Add schedule" button and create dialog to the scheduled tasks page with agent selector, prompt, frequency, and timezone fields
- Add empty state CTA button for quick schedule creation
- Defer pinned agents save to explicit "Save" click instead of auto-saving on drag/reorder, with Cancel/Save button pair
- Style Lead pill badge with crown icon matching the profile page

## Test plan
- [ ] Open scheduled tasks page, verify "Add schedule" button appears in header
- [ ] Click "Add schedule", verify dialog opens with agent selector, prompt, time, timezone fields
- [ ] Create a schedule and verify it appears in the list
- [ ] Verify empty state shows "Add schedule" CTA button
- [ ] Open "Manage pinned agents" dialog, drag to reorder, verify changes are local until Save is clicked
- [ ] Click Cancel in pinned agents dialog, verify changes are discarded
- [ ] Verify Lead pill badge has crown icon and background fill

Made with [Cursor](https://cursor.com)