### PR TITLE
feat: add org model-provider cli commands

### DIFF
--- a/turbo/apps/cli/src/commands/model-provider/shared.ts
+++ b/turbo/apps/cli/src/commands/model-provider/shared.ts
@@ -162,8 +162,10 @@ export function handleNonInteractiveMode(options: {
   secret: string[];
   authMethod?: string;
   model?: string;
+  commandPrefix?: string;
 }): SetupInput {
   const type = validateProviderType(options.type);
+  const cmdPrefix = options.commandPrefix ?? "vm0 model-provider setup";
 
   let selectedModel: string | undefined;
 
@@ -197,7 +199,7 @@ export function handleNonInteractiveMode(options: {
           `--auth-method is required for "${type}" (multiple auth methods available)`,
           {
             cause: new Error(
-              `Available: ${methods}. Example: vm0 model-provider setup --type ${type} --auth-method ${authMethodNames[0]} --secret KEY=VALUE`,
+              `Available: ${methods}. Example: ${cmdPrefix} --type ${type} --auth-method ${authMethodNames[0]} --secret KEY=VALUE`,
             ),
           },
         );

--- a/turbo/apps/cli/src/commands/model-provider/shared.ts
+++ b/turbo/apps/cli/src/commands/model-provider/shared.ts
@@ -1,0 +1,414 @@
+import chalk from "chalk";
+import prompts from "prompts";
+import {
+  MODEL_PROVIDER_TYPES,
+  getModels,
+  getDefaultModel,
+  hasModelSelection,
+  allowsCustomModel,
+  getCustomModelPlaceholder,
+  hasAuthMethods,
+  getAuthMethodsForType,
+  getDefaultAuthMethod,
+  getSecretsForAuthMethod,
+  type ModelProviderType,
+} from "@vm0/core";
+
+export interface SetupInput {
+  type: ModelProviderType;
+  secret?: string;
+  // Multi-auth support
+  authMethod?: string;
+  secrets?: Record<string, string>;
+  selectedModel?: string;
+  keepExistingSecret?: boolean;
+  isInteractiveMode?: boolean;
+}
+
+function validateProviderType(typeStr: string): ModelProviderType {
+  if (!Object.keys(MODEL_PROVIDER_TYPES).includes(typeStr)) {
+    const validTypes = Object.keys(MODEL_PROVIDER_TYPES).join(", ");
+    throw new Error(`Invalid type "${typeStr}"`, {
+      cause: new Error(`Valid types: ${validTypes}`),
+    });
+  }
+  return typeStr as ModelProviderType;
+}
+
+function validateModel(
+  type: ModelProviderType,
+  modelStr: string,
+): string | never {
+  const models = getModels(type);
+
+  // Allow any model if provider supports custom models
+  if (allowsCustomModel(type)) {
+    return modelStr;
+  }
+
+  if (models && !models.includes(modelStr)) {
+    throw new Error(`Invalid model "${modelStr}"`, {
+      cause: new Error(`Valid models: ${models.join(", ")}`),
+    });
+  }
+  return modelStr;
+}
+
+function validateAuthMethod(
+  type: ModelProviderType,
+  authMethodStr: string,
+): string | never {
+  const authMethods = getAuthMethodsForType(type);
+  if (!authMethods || !(authMethodStr in authMethods)) {
+    const validMethods = authMethods
+      ? Object.keys(authMethods).join(", ")
+      : "none";
+    throw new Error(`Invalid auth method "${authMethodStr}"`, {
+      cause: new Error(`Valid auth methods: ${validMethods}`),
+    });
+  }
+  return authMethodStr;
+}
+
+/**
+ * Parse secret arguments into a secrets object.
+ * Supports two formats:
+ * - Single value (e.g., "sk-xxx") - auto-mapped to the provider's secret name
+ * - KEY=VALUE format (e.g., "AWS_REGION=us-east-1") - explicit mapping
+ */
+function parseSecrets(
+  type: ModelProviderType,
+  authMethod: string,
+  secretArgs: string[],
+): Record<string, string> {
+  const secretsConfig = getSecretsForAuthMethod(type, authMethod);
+  if (!secretsConfig) {
+    throw new Error(`Invalid auth method "${authMethod}"`);
+  }
+
+  const secretNames = Object.keys(secretsConfig);
+
+  // Single value without = sign: only allowed for single-secret auth methods
+  const firstArg = secretArgs[0];
+  if (secretArgs.length === 1 && firstArg && !firstArg.includes("=")) {
+    if (secretNames.length !== 1) {
+      throw new Error(
+        "Must use KEY=VALUE format for multi-secret auth methods",
+        { cause: new Error(`Required secrets: ${secretNames.join(", ")}`) },
+      );
+    }
+    const firstSecretName = secretNames[0];
+    if (!firstSecretName) {
+      throw new Error("No secrets defined for this auth method");
+    }
+    return { [firstSecretName]: firstArg };
+  }
+
+  // KEY=VALUE format
+  const secrets: Record<string, string> = {};
+  for (const arg of secretArgs) {
+    const eqIndex = arg.indexOf("=");
+    if (eqIndex === -1) {
+      throw new Error(`Invalid secret format "${arg}"`, {
+        cause: new Error("Use KEY=VALUE format (e.g., AWS_REGION=us-east-1)"),
+      });
+    }
+    const key = arg.slice(0, eqIndex);
+    const value = arg.slice(eqIndex + 1);
+    secrets[key] = value;
+  }
+  return secrets;
+}
+
+/**
+ * Validate secrets against the auth method config.
+ */
+function validateSecrets(
+  type: ModelProviderType,
+  authMethod: string,
+  secrets: Record<string, string>,
+): void {
+  const secretsConfig = getSecretsForAuthMethod(type, authMethod);
+  if (!secretsConfig) {
+    throw new Error(`Invalid auth method "${authMethod}"`);
+  }
+
+  // Check required fields
+  for (const [name, fieldConfig] of Object.entries(secretsConfig)) {
+    if (fieldConfig.required && !secrets[name]) {
+      const requiredNames = Object.entries(secretsConfig)
+        .filter(([, fc]) => fc.required)
+        .map(([n]) => n)
+        .join(", ");
+      throw new Error(`Missing required secret: ${name}`, {
+        cause: new Error(`Required secrets: ${requiredNames}`),
+      });
+    }
+  }
+
+  // Check for unknown fields
+  for (const name of Object.keys(secrets)) {
+    if (!(name in secretsConfig)) {
+      const validNames = Object.keys(secretsConfig).join(", ");
+      throw new Error(`Unknown secret: ${name}`, {
+        cause: new Error(`Valid secrets: ${validNames}`),
+      });
+    }
+  }
+}
+
+export function handleNonInteractiveMode(options: {
+  type: string;
+  secret: string[];
+  authMethod?: string;
+  model?: string;
+}): SetupInput {
+  const type = validateProviderType(options.type);
+
+  let selectedModel: string | undefined;
+
+  if (options.model) {
+    selectedModel = validateModel(type, options.model);
+  } else if (hasModelSelection(type)) {
+    const defaultModel = getDefaultModel(type);
+    // Empty defaultModel means "auto" mode - don't set selectedModel
+    selectedModel = defaultModel || undefined;
+  }
+
+  // Handle multi-auth providers
+  if (hasAuthMethods(type)) {
+    // Determine auth method
+    let authMethod: string;
+    if (options.authMethod) {
+      authMethod = validateAuthMethod(type, options.authMethod);
+    } else {
+      const defaultAuthMethod = getDefaultAuthMethod(type);
+      const authMethods = getAuthMethodsForType(type);
+      if (!defaultAuthMethod || !authMethods) {
+        throw new Error(`Provider "${type}" requires --auth-method`);
+      }
+      // If there's only one auth method, use it; otherwise require explicit selection
+      const authMethodNames = Object.keys(authMethods);
+      if (authMethodNames.length === 1) {
+        authMethod = authMethodNames[0]!;
+      } else {
+        const methods = authMethodNames.join(", ");
+        throw new Error(
+          `--auth-method is required for "${type}" (multiple auth methods available)`,
+          {
+            cause: new Error(
+              `Available: ${methods}. Example: vm0 model-provider setup --type ${type} --auth-method ${authMethodNames[0]} --secret KEY=VALUE`,
+            ),
+          },
+        );
+      }
+    }
+
+    // Parse and validate secrets
+    const secrets = parseSecrets(type, authMethod, options.secret);
+    validateSecrets(type, authMethod, secrets);
+
+    return {
+      type,
+      authMethod,
+      secrets,
+      selectedModel,
+      isInteractiveMode: false,
+    };
+  }
+
+  // Single-secret provider (legacy)
+  // Accept single value or KEY=VALUE format
+  const secretArgs = options.secret;
+  const firstArg = secretArgs[0];
+  if (!firstArg) {
+    throw new Error("Secret is required");
+  }
+
+  // If KEY=VALUE format, extract the value
+  let secret: string;
+  if (firstArg.includes("=")) {
+    secret = firstArg.slice(firstArg.indexOf("=") + 1);
+  } else {
+    secret = firstArg;
+  }
+
+  return {
+    type,
+    secret,
+    selectedModel,
+    isInteractiveMode: false,
+  };
+}
+
+export async function promptForModelSelection(
+  type: ModelProviderType,
+): Promise<string | undefined> {
+  if (!hasModelSelection(type)) {
+    return undefined;
+  }
+
+  const models = getModels(type) ?? [];
+  const defaultModel = getDefaultModel(type);
+  const supportsCustomModel = allowsCustomModel(type);
+
+  // Build choices
+  const modelChoices: { title: string; value: string }[] = [];
+
+  // Add auto option if defaultModel is empty string
+  if (defaultModel === "") {
+    modelChoices.push({ title: "auto (Recommended)", value: "" });
+  }
+
+  // Add predefined models
+  for (const model of models) {
+    modelChoices.push({
+      title: model === defaultModel ? `${model} (Recommended)` : model,
+      value: model,
+    });
+  }
+
+  // Add custom model option if supported
+  if (supportsCustomModel) {
+    modelChoices.push({ title: "Custom model ID", value: "__custom__" });
+  }
+
+  const modelResponse = await prompts(
+    {
+      type: "select",
+      name: "model",
+      message: "Select model:",
+      choices: modelChoices,
+    },
+    { onCancel: () => process.exit(0) },
+  );
+
+  const selected = modelResponse.model as string;
+
+  // Handle custom model input
+  if (selected === "__custom__") {
+    const placeholder = getCustomModelPlaceholder(type);
+    if (placeholder) {
+      console.log(chalk.dim(`Example: ${placeholder}`));
+    }
+    const customResponse = await prompts(
+      {
+        type: "text",
+        name: "customModel",
+        message: "Enter model ID:",
+        validate: (value: string) => value.length > 0 || "Model ID is required",
+      },
+      { onCancel: () => process.exit(0) },
+    );
+    return customResponse.customModel as string;
+  }
+
+  // Return undefined for auto mode (empty string)
+  return selected === "" ? undefined : selected;
+}
+
+/**
+ * Prompt for auth method selection (only for multi-auth providers)
+ */
+export async function promptForAuthMethod(
+  type: ModelProviderType,
+): Promise<string> {
+  const authMethods = getAuthMethodsForType(type);
+  const defaultAuthMethod = getDefaultAuthMethod(type);
+
+  if (!authMethods) {
+    return "default";
+  }
+
+  const choices = Object.entries(authMethods).map(([method, config]) => ({
+    title:
+      method === defaultAuthMethod
+        ? `${config.label} (Recommended)`
+        : config.label,
+    value: method,
+  }));
+
+  const response = await prompts(
+    {
+      type: "select",
+      name: "authMethod",
+      message: "Select authentication method:",
+      choices,
+    },
+    { onCancel: () => process.exit(0) },
+  );
+
+  return response.authMethod as string;
+}
+
+/**
+ * Determine if a secret should be masked (password type)
+ * Non-secret values like region should be visible
+ */
+function isSensitiveSecret(name: string): boolean {
+  const nonSecretPatterns = ["REGION", "ENDPOINT", "URL"];
+  return !nonSecretPatterns.some((pattern) =>
+    name.toUpperCase().includes(pattern),
+  );
+}
+
+export async function promptForSecrets(
+  type: ModelProviderType,
+  authMethod: string,
+): Promise<Record<string, string>> {
+  const secretsConfig = getSecretsForAuthMethod(type, authMethod);
+
+  if (!secretsConfig) {
+    throw new Error(`Invalid auth method "${authMethod}"`);
+  }
+
+  const secrets: Record<string, string> = {};
+
+  for (const [name, fieldConfig] of Object.entries(secretsConfig)) {
+    if (fieldConfig.helpText) {
+      console.log(chalk.dim(fieldConfig.helpText));
+    }
+
+    const isSensitive = isSensitiveSecret(name);
+    const placeholder =
+      "placeholder" in fieldConfig ? (fieldConfig.placeholder as string) : "";
+
+    if (fieldConfig.required) {
+      const response = await prompts(
+        {
+          type: isSensitive ? "password" : "text",
+          name: "value",
+          message: `${fieldConfig.label}:`,
+          initial: placeholder ? "" : undefined,
+          validate: (value: string) =>
+            value.length > 0 || `${fieldConfig.label} is required`,
+        },
+        { onCancel: () => process.exit(0) },
+      );
+      secrets[name] = response.value as string;
+    } else {
+      // Optional field
+      const response = await prompts(
+        {
+          type: isSensitive ? "password" : "text",
+          name: "value",
+          message: `${fieldConfig.label} (optional):`,
+        },
+        { onCancel: () => process.exit(0) },
+      );
+      const value = response.value as string;
+      if (value && value.trim()) {
+        secrets[name] = value.trim();
+      }
+    }
+  }
+
+  return secrets;
+}
+
+/**
+ * Collect secret values from repeatable --secret option
+ */
+export function collectSecrets(value: string, previous: string[]): string[] {
+  return previous.concat([value]);
+}

--- a/turbo/apps/cli/src/commands/org/index.ts
+++ b/turbo/apps/cli/src/commands/org/index.ts
@@ -9,6 +9,7 @@ import { removeCommand } from "./remove";
 import { leaveCommand } from "./leave";
 import { orgSecretCommand } from "./secret";
 import { orgVariableCommand } from "./variable";
+import { modelProviderCommand } from "./model-provider";
 
 export const orgCommand = new Command()
   .name("org")
@@ -22,4 +23,5 @@ export const orgCommand = new Command()
   .addCommand(removeCommand)
   .addCommand(leaveCommand)
   .addCommand(orgSecretCommand)
-  .addCommand(orgVariableCommand);
+  .addCommand(orgVariableCommand)
+  .addCommand(modelProviderCommand);

--- a/turbo/apps/cli/src/commands/org/model-provider/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/org/model-provider/__tests__/index.test.ts
@@ -1,0 +1,17 @@
+/**
+ * Tests for org model-provider command group structure
+ */
+
+import { describe, it, expect } from "vitest";
+import { modelProviderCommand } from "..";
+
+describe("org model-provider command group", () => {
+  it("should have correct subcommands", () => {
+    const subcommands = modelProviderCommand.commands.map((c) => c.name());
+    expect(subcommands).toContain("list");
+    expect(subcommands).toContain("setup");
+    expect(subcommands).toContain("remove");
+    expect(subcommands).toContain("set-default");
+    expect(subcommands).toHaveLength(4);
+  });
+});

--- a/turbo/apps/cli/src/commands/org/model-provider/__tests__/list.test.ts
+++ b/turbo/apps/cli/src/commands/org/model-provider/__tests__/list.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Tests for org model-provider list command
+ *
+ * Tests command-level behavior via parseAsync() following CLI testing principles:
+ * - Entry point: command.parseAsync()
+ * - Mock (external): Web API via MSW
+ * - Real (internal): All CLI code, formatters, validators
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../../mocks/server";
+import { listCommand } from "../list";
+import chalk from "chalk";
+
+describe("org model-provider list command", () => {
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  beforeEach(() => {
+    chalk.level = 0;
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("VM0_TOKEN", "test-token");
+  });
+
+  describe("successful list", () => {
+    it("should list org model providers grouped by framework", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/org/model-providers", () => {
+          return HttpResponse.json({
+            modelProviders: [
+              {
+                id: "1",
+                type: "anthropic-api-key",
+                framework: "claude-code",
+                selectedModel: "claude-sonnet-4-5-20250514",
+                isDefault: true,
+                createdAt: "2025-01-01T00:00:00Z",
+                updatedAt: "2025-01-01T00:00:00Z",
+              },
+              {
+                id: "2",
+                type: "openai-api-key",
+                framework: "claude-code",
+                selectedModel: "gpt-4",
+                isDefault: false,
+                createdAt: "2025-01-01T00:00:00Z",
+                updatedAt: "2025-01-01T00:00:00Z",
+              },
+            ],
+          });
+        }),
+      );
+
+      await listCommand.parseAsync(["node", "cli"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("Org Model Providers");
+      expect(logCalls).toContain("claude-code");
+      expect(logCalls).toContain("anthropic-api-key");
+      expect(logCalls).toContain("openai-api-key");
+      expect(logCalls).toContain("(default)");
+      expect(logCalls).toContain("claude-sonnet-4-5-20250514");
+      expect(logCalls).toContain("gpt-4");
+      expect(logCalls).toContain("2 provider(s)");
+    });
+
+    it("should show empty state when no org providers configured", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/org/model-providers", () => {
+          return HttpResponse.json({ modelProviders: [] });
+        }),
+      );
+
+      await listCommand.parseAsync(["node", "cli"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("No org-level model providers configured");
+      expect(logCalls).toContain("vm0 org model-provider setup");
+    });
+  });
+
+  describe("error handling", () => {
+    it("should handle authentication error", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/org/model-providers", () => {
+          return HttpResponse.json(
+            {
+              error: {
+                message: "Not authenticated",
+                code: "UNAUTHORIZED",
+              },
+            },
+            { status: 401 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await listCommand.parseAsync(["node", "cli"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Not authenticated"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should handle generic API error", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/org/model-providers", () => {
+          return HttpResponse.json(
+            {
+              error: {
+                message: "Internal server error",
+                code: "SERVER_ERROR",
+              },
+            },
+            { status: 500 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await listCommand.parseAsync(["node", "cli"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Internal server error"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe("alias", () => {
+    it("should have ls alias", () => {
+      expect(listCommand.alias()).toBe("ls");
+    });
+  });
+});

--- a/turbo/apps/cli/src/commands/org/model-provider/__tests__/remove.test.ts
+++ b/turbo/apps/cli/src/commands/org/model-provider/__tests__/remove.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Tests for org model-provider remove command
+ *
+ * Tests command-level behavior via parseAsync() following CLI testing principles:
+ * - Entry point: command.parseAsync()
+ * - Mock (external): Web API via MSW
+ * - Real (internal): All CLI code, formatters, validators
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../../mocks/server";
+import { removeCommand } from "../remove";
+
+describe("org model-provider remove command", () => {
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  beforeEach(() => {
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("VM0_TOKEN", "test-token");
+  });
+
+  describe("successful removal", () => {
+    it("should show success message on successful removal", async () => {
+      server.use(
+        http.delete(
+          "http://localhost:3000/api/org/model-providers/:type",
+          () => {
+            return new HttpResponse(null, { status: 204 });
+          },
+        ),
+      );
+
+      await removeCommand.parseAsync(["node", "cli", "anthropic-api-key"]);
+
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'Org model provider "anthropic-api-key" removed',
+        ),
+      );
+      expect(mockExit).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("input validation", () => {
+    it("should reject invalid provider type", async () => {
+      await expect(async () => {
+        await removeCommand.parseAsync(["node", "cli", "invalid-type"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining('Invalid type "invalid-type"'),
+      );
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Valid types:"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe("error handling", () => {
+    it("should handle not found error", async () => {
+      server.use(
+        http.delete(
+          "http://localhost:3000/api/org/model-providers/:type",
+          () => {
+            return HttpResponse.json(
+              {
+                error: {
+                  message: "Model provider not found",
+                  code: "NOT_FOUND",
+                },
+              },
+              { status: 404 },
+            );
+          },
+        ),
+      );
+
+      await expect(async () => {
+        await removeCommand.parseAsync(["node", "cli", "anthropic-api-key"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("not found"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should handle forbidden error for non-admin", async () => {
+      server.use(
+        http.delete(
+          "http://localhost:3000/api/org/model-providers/:type",
+          () => {
+            return HttpResponse.json(
+              {
+                error: {
+                  message: "Admin access required",
+                  code: "FORBIDDEN",
+                },
+              },
+              { status: 403 },
+            );
+          },
+        ),
+      );
+
+      await expect(async () => {
+        await removeCommand.parseAsync(["node", "cli", "anthropic-api-key"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Admin access required"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should handle authentication error", async () => {
+      server.use(
+        http.delete(
+          "http://localhost:3000/api/org/model-providers/:type",
+          () => {
+            return HttpResponse.json(
+              {
+                error: {
+                  message: "Not authenticated",
+                  code: "UNAUTHORIZED",
+                },
+              },
+              { status: 401 },
+            );
+          },
+        ),
+      );
+
+      await expect(async () => {
+        await removeCommand.parseAsync(["node", "cli", "anthropic-api-key"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Not authenticated"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+});

--- a/turbo/apps/cli/src/commands/org/model-provider/__tests__/set-default.test.ts
+++ b/turbo/apps/cli/src/commands/org/model-provider/__tests__/set-default.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Tests for org model-provider set-default command
+ *
+ * Tests command-level behavior via parseAsync() following CLI testing principles:
+ * - Entry point: command.parseAsync()
+ * - Mock (external): Web API via MSW
+ * - Real (internal): All CLI code, formatters, validators
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../../mocks/server";
+import { setDefaultCommand } from "../set-default";
+
+describe("org model-provider set-default command", () => {
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  beforeEach(() => {
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("VM0_TOKEN", "test-token");
+  });
+
+  describe("successful set-default", () => {
+    it("should show success message with framework", async () => {
+      server.use(
+        http.post(
+          "http://localhost:3000/api/org/model-providers/:type/set-default",
+          () => {
+            return HttpResponse.json({
+              id: "1",
+              type: "anthropic-api-key",
+              framework: "claude-code",
+              isDefault: true,
+              selectedModel: null,
+              createdAt: "2025-01-01T00:00:00Z",
+              updatedAt: "2025-01-01T00:00:00Z",
+            });
+          },
+        ),
+      );
+
+      await setDefaultCommand.parseAsync(["node", "cli", "anthropic-api-key"]);
+
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'Default for claude-code set to "anthropic-api-key"',
+        ),
+      );
+      expect(mockExit).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("input validation", () => {
+    it("should reject invalid provider type", async () => {
+      await expect(async () => {
+        await setDefaultCommand.parseAsync(["node", "cli", "invalid-type"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining('Invalid type "invalid-type"'),
+      );
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Valid types:"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe("error handling", () => {
+    it("should handle not found error", async () => {
+      server.use(
+        http.post(
+          "http://localhost:3000/api/org/model-providers/:type/set-default",
+          () => {
+            return HttpResponse.json(
+              {
+                error: {
+                  message: "Model provider not found",
+                  code: "NOT_FOUND",
+                },
+              },
+              { status: 404 },
+            );
+          },
+        ),
+      );
+
+      await expect(async () => {
+        await setDefaultCommand.parseAsync([
+          "node",
+          "cli",
+          "anthropic-api-key",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("not found"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should handle forbidden error for non-admin", async () => {
+      server.use(
+        http.post(
+          "http://localhost:3000/api/org/model-providers/:type/set-default",
+          () => {
+            return HttpResponse.json(
+              {
+                error: {
+                  message: "Admin access required",
+                  code: "FORBIDDEN",
+                },
+              },
+              { status: 403 },
+            );
+          },
+        ),
+      );
+
+      await expect(async () => {
+        await setDefaultCommand.parseAsync([
+          "node",
+          "cli",
+          "anthropic-api-key",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Admin access required"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+});

--- a/turbo/apps/cli/src/commands/org/model-provider/__tests__/setup.test.ts
+++ b/turbo/apps/cli/src/commands/org/model-provider/__tests__/setup.test.ts
@@ -1,0 +1,250 @@
+/**
+ * Tests for org model-provider setup command (non-interactive mode)
+ *
+ * Tests command-level behavior via parseAsync() following CLI testing principles:
+ * - Entry point: command.parseAsync()
+ * - Mock (external): Web API via MSW
+ * - Real (internal): All CLI code, formatters, validators
+ *
+ * Interactive mode helpers are tested via model-provider/setup.test.ts
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../../mocks/server";
+import { setupCommand } from "../setup";
+
+describe("org model-provider setup command", () => {
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  beforeEach(() => {
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("VM0_TOKEN", "test-token");
+  });
+
+  describe("non-interactive mode", () => {
+    it("should create single-secret provider", async () => {
+      server.use(
+        http.put("http://localhost:3000/api/org/model-providers", () => {
+          return HttpResponse.json(
+            {
+              provider: {
+                id: "1",
+                type: "anthropic-api-key",
+                framework: "claude-code",
+                isDefault: true,
+                selectedModel: null,
+                createdAt: "2025-01-01T00:00:00Z",
+                updatedAt: "2025-01-01T00:00:00Z",
+              },
+              created: true,
+            },
+            { status: 201 },
+          );
+        }),
+      );
+
+      await setupCommand.parseAsync([
+        "node",
+        "cli",
+        "--type",
+        "anthropic-api-key",
+        "--secret",
+        "sk-ant-test123",
+      ]);
+
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'Org model provider "anthropic-api-key" created',
+        ),
+      );
+      expect(mockExit).not.toHaveBeenCalled();
+    });
+
+    it("should create provider with model selection", async () => {
+      server.use(
+        http.put("http://localhost:3000/api/org/model-providers", () => {
+          return HttpResponse.json(
+            {
+              provider: {
+                id: "1",
+                type: "moonshot-api-key",
+                framework: "claude-code",
+                isDefault: true,
+                selectedModel: "kimi-k2.5",
+                createdAt: "2025-01-01T00:00:00Z",
+                updatedAt: "2025-01-01T00:00:00Z",
+              },
+              created: true,
+            },
+            { status: 201 },
+          );
+        }),
+      );
+
+      await setupCommand.parseAsync([
+        "node",
+        "cli",
+        "--type",
+        "moonshot-api-key",
+        "--secret",
+        "sk-test",
+        "--model",
+        "kimi-k2.5",
+      ]);
+
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'Org model provider "moonshot-api-key" created',
+        ),
+      );
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("kimi-k2.5"),
+      );
+      expect(mockExit).not.toHaveBeenCalled();
+    });
+
+    it("should update existing provider", async () => {
+      server.use(
+        http.put("http://localhost:3000/api/org/model-providers", () => {
+          return HttpResponse.json({
+            provider: {
+              id: "1",
+              type: "anthropic-api-key",
+              framework: "claude-code",
+              isDefault: false,
+              selectedModel: null,
+              createdAt: "2025-01-01T00:00:00Z",
+              updatedAt: "2025-01-01T00:00:00Z",
+            },
+            created: false,
+          });
+        }),
+      );
+
+      await setupCommand.parseAsync([
+        "node",
+        "cli",
+        "--type",
+        "anthropic-api-key",
+        "--secret",
+        "sk-ant-updated",
+      ]);
+
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'Org model provider "anthropic-api-key" updated',
+        ),
+      );
+      expect(mockExit).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("input validation", () => {
+    it("should require both --type and --secret", async () => {
+      await expect(async () => {
+        await setupCommand.parseAsync([
+          "node",
+          "cli",
+          "--type",
+          "anthropic-api-key",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Both --type and --secret are required"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should reject invalid provider type", async () => {
+      await expect(async () => {
+        await setupCommand.parseAsync([
+          "node",
+          "cli",
+          "--type",
+          "invalid-type",
+          "--secret",
+          "sk-test",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining('Invalid type "invalid-type"'),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe("error handling", () => {
+    it("should handle forbidden error for non-admin", async () => {
+      server.use(
+        http.put("http://localhost:3000/api/org/model-providers", () => {
+          return HttpResponse.json(
+            {
+              error: {
+                message: "Admin access required",
+                code: "FORBIDDEN",
+              },
+            },
+            { status: 403 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await setupCommand.parseAsync([
+          "node",
+          "cli",
+          "--type",
+          "anthropic-api-key",
+          "--secret",
+          "sk-ant-test",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Admin access required"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should handle authentication error", async () => {
+      server.use(
+        http.put("http://localhost:3000/api/org/model-providers", () => {
+          return HttpResponse.json(
+            {
+              error: {
+                message: "Not authenticated",
+                code: "UNAUTHORIZED",
+              },
+            },
+            { status: 401 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await setupCommand.parseAsync([
+          "node",
+          "cli",
+          "--type",
+          "anthropic-api-key",
+          "--secret",
+          "sk-ant-test",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Not authenticated"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+});

--- a/turbo/apps/cli/src/commands/org/model-provider/index.ts
+++ b/turbo/apps/cli/src/commands/org/model-provider/index.ts
@@ -1,0 +1,13 @@
+import { Command } from "commander";
+import { listCommand } from "./list";
+import { setupCommand } from "./setup";
+import { removeCommand } from "./remove";
+import { setDefaultCommand } from "./set-default";
+
+export const modelProviderCommand = new Command()
+  .name("model-provider")
+  .description("Manage org-level model providers")
+  .addCommand(listCommand)
+  .addCommand(setupCommand)
+  .addCommand(removeCommand)
+  .addCommand(setDefaultCommand);

--- a/turbo/apps/cli/src/commands/org/model-provider/list.ts
+++ b/turbo/apps/cli/src/commands/org/model-provider/list.ts
@@ -1,0 +1,61 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import { listOrgModelProviders } from "../../../lib/api";
+import { withErrorHandler } from "../../../lib/command";
+
+export const listCommand = new Command()
+  .name("list")
+  .alias("ls")
+  .description("List all org-level model providers")
+  .action(
+    withErrorHandler(async () => {
+      const result = await listOrgModelProviders();
+
+      if (result.modelProviders.length === 0) {
+        console.log(chalk.dim("No org-level model providers configured"));
+        console.log();
+        console.log("To add an org-level model provider:");
+        console.log(chalk.cyan("  vm0 org model-provider setup"));
+        return;
+      }
+
+      // Group by framework
+      const byFramework = result.modelProviders.reduce(
+        (acc, p) => {
+          const fw = p.framework;
+          if (!acc[fw]) {
+            acc[fw] = [];
+          }
+          acc[fw].push(p);
+          return acc;
+        },
+        {} as Record<string, typeof result.modelProviders>,
+      );
+
+      console.log(chalk.bold("Org Model Providers:"));
+      console.log();
+
+      for (const [framework, providers] of Object.entries(byFramework)) {
+        console.log(`  ${chalk.cyan(framework)}:`);
+        for (const provider of providers) {
+          const defaultTag = provider.isDefault
+            ? chalk.green(" (default)")
+            : "";
+          const modelTag = provider.selectedModel
+            ? chalk.dim(` [${provider.selectedModel}]`)
+            : "";
+          console.log(`    ${provider.type}${defaultTag}${modelTag}`);
+          console.log(
+            chalk.dim(
+              `      Updated: ${new Date(provider.updatedAt).toLocaleString()}`,
+            ),
+          );
+        }
+        console.log();
+      }
+
+      console.log(
+        chalk.dim(`Total: ${result.modelProviders.length} provider(s)`),
+      );
+    }),
+  );

--- a/turbo/apps/cli/src/commands/org/model-provider/remove.ts
+++ b/turbo/apps/cli/src/commands/org/model-provider/remove.ts
@@ -1,0 +1,23 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import { deleteOrgModelProvider } from "../../../lib/api";
+import { withErrorHandler } from "../../../lib/command";
+import { MODEL_PROVIDER_TYPES, type ModelProviderType } from "@vm0/core";
+
+export const removeCommand = new Command()
+  .name("remove")
+  .description("Remove an org-level model provider")
+  .argument("<type>", "Model provider type to remove")
+  .action(
+    withErrorHandler(async (type: string) => {
+      if (!Object.keys(MODEL_PROVIDER_TYPES).includes(type)) {
+        const validTypes = Object.keys(MODEL_PROVIDER_TYPES).join(", ");
+        throw new Error(`Invalid type "${type}"`, {
+          cause: new Error(`Valid types: ${validTypes}`),
+        });
+      }
+
+      await deleteOrgModelProvider(type as ModelProviderType);
+      console.log(chalk.green(`✓ Org model provider "${type}" removed`));
+    }),
+  );

--- a/turbo/apps/cli/src/commands/org/model-provider/set-default.ts
+++ b/turbo/apps/cli/src/commands/org/model-provider/set-default.ts
@@ -1,0 +1,29 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import { setOrgModelProviderDefault } from "../../../lib/api";
+import { withErrorHandler } from "../../../lib/command";
+import { MODEL_PROVIDER_TYPES, type ModelProviderType } from "@vm0/core";
+
+export const setDefaultCommand = new Command()
+  .name("set-default")
+  .description("Set an org-level model provider as default for its framework")
+  .argument("<type>", "Model provider type to set as default")
+  .action(
+    withErrorHandler(async (type: string) => {
+      if (!Object.keys(MODEL_PROVIDER_TYPES).includes(type)) {
+        const validTypes = Object.keys(MODEL_PROVIDER_TYPES).join(", ");
+        throw new Error(`Invalid type "${type}"`, {
+          cause: new Error(`Valid types: ${validTypes}`),
+        });
+      }
+
+      const provider = await setOrgModelProviderDefault(
+        type as ModelProviderType,
+      );
+      console.log(
+        chalk.green(
+          `✓ Default for ${provider.framework} set to "${provider.type}"`,
+        ),
+      );
+    }),
+  );

--- a/turbo/apps/cli/src/commands/org/model-provider/setup.ts
+++ b/turbo/apps/cli/src/commands/org/model-provider/setup.ts
@@ -197,6 +197,7 @@ export const setupCommand = new Command()
             secret: secretArgs,
             authMethod: options.authMethod,
             model: options.model,
+            commandPrefix: "vm0 org model-provider setup",
           });
         } else if (options.type || secretArgs.length > 0) {
           throw new Error("Both --type and --secret are required");

--- a/turbo/apps/cli/src/commands/org/model-provider/setup.ts
+++ b/turbo/apps/cli/src/commands/org/model-provider/setup.ts
@@ -2,20 +2,19 @@ import { Command } from "commander";
 import chalk from "chalk";
 import prompts from "prompts";
 import {
-  upsertModelProvider,
-  checkModelProviderSecret,
-  listModelProviders,
-  updateModelProviderModel,
-  setModelProviderDefault,
-} from "../../lib/api";
+  listOrgModelProviders,
+  upsertOrgModelProvider,
+  updateOrgModelProviderModel,
+  setOrgModelProviderDefault,
+} from "../../../lib/api";
 import {
   MODEL_PROVIDER_TYPES,
   hasModelSelection,
   hasAuthMethods,
   type ModelProviderType,
 } from "@vm0/core";
-import { isInteractive } from "../../lib/utils/prompt-utils";
-import { withErrorHandler } from "../../lib/command";
+import { isInteractive } from "../../../lib/utils/prompt-utils";
+import { withErrorHandler } from "../../../lib/command";
 import {
   type SetupInput,
   handleNonInteractiveMode,
@@ -23,19 +22,19 @@ import {
   promptForAuthMethod,
   promptForSecrets,
   collectSecrets,
-} from "./shared";
+} from "../../model-provider/shared";
 
 async function handleInteractiveMode(): Promise<SetupInput | null> {
   if (!isInteractive()) {
     throw new Error("Interactive mode requires a TTY", {
       cause: new Error(
-        'Use non-interactive mode: vm0 model-provider setup --type <type> --secret "<value>"',
+        'Use non-interactive mode: vm0 org model-provider setup --type <type> --secret "<value>"',
       ),
     });
   }
 
-  // Fetch configured providers to annotate choices
-  const { modelProviders: configuredProviders } = await listModelProviders();
+  // Fetch configured org providers to annotate choices
+  const { modelProviders: configuredProviders } = await listOrgModelProviders();
   const configuredTypes = new Set(configuredProviders.map((p) => p.type));
 
   // Build provider choices with configuration status
@@ -69,11 +68,10 @@ async function handleInteractiveMode(): Promise<SetupInput | null> {
 
   const type = typeResponse.type as ModelProviderType;
 
-  // Check if secret already exists
-  const checkResult = await checkModelProviderSecret(type);
+  // Check if provider is already configured using the list we already fetched
+  const existingProvider = configuredProviders.find((p) => p.type === type);
 
-  // Handle existing model-provider secret
-  if (checkResult.exists) {
+  if (existingProvider) {
     console.log();
     console.log(`"${type}" is already configured`);
     console.log();
@@ -92,7 +90,6 @@ async function handleInteractiveMode(): Promise<SetupInput | null> {
     );
 
     if (actionResponse.action === "keep") {
-      // Keep existing secret - only prompt for model if applicable
       const selectedModel = await promptForModelSelection(type);
       return {
         type,
@@ -163,14 +160,14 @@ async function promptSetAsDefault(
   );
 
   if (response.setDefault) {
-    await setModelProviderDefault(type);
+    await setOrgModelProviderDefault(type);
     console.log(chalk.green(`✓ Default for ${framework} set to "${type}"`));
   }
 }
 
 export const setupCommand = new Command()
   .name("setup")
-  .description("Configure a model provider")
+  .description("Configure an org-level model provider")
   .option("-t, --type <type>", "Provider type (for non-interactive mode)")
   .option(
     "-s, --secret <value>",
@@ -206,14 +203,14 @@ export const setupCommand = new Command()
         } else {
           const result = await handleInteractiveMode();
           if (result === null) {
-            return; // Conversion was done
+            return;
           }
           input = result;
         }
 
         // Handle "keep existing secret" flow
         if (input.keepExistingSecret) {
-          const provider = await updateModelProviderModel(
+          const provider = await updateOrgModelProviderModel(
             input.type,
             input.selectedModel,
           );
@@ -225,15 +222,14 @@ export const setupCommand = new Command()
             ? ` with model: ${provider.selectedModel}`
             : "";
 
-          // If no model selection, show "unchanged" message
           if (!hasModelSelection(input.type)) {
             console.log(
-              chalk.green(`✓ Model provider "${input.type}" unchanged`),
+              chalk.green(`✓ Org model provider "${input.type}" unchanged`),
             );
           } else {
             console.log(
               chalk.green(
-                `✓ Model provider "${input.type}" updated${defaultNote}${modelNote}`,
+                `✓ Org model provider "${input.type}" updated${defaultNote}${modelNote}`,
               ),
             );
           }
@@ -248,7 +244,7 @@ export const setupCommand = new Command()
         }
 
         // Standard upsert flow with secret
-        const { provider, created } = await upsertModelProvider({
+        const { provider, created } = await upsertOrgModelProvider({
           type: input.type,
           secret: input.secret,
           authMethod: input.authMethod,
@@ -265,7 +261,7 @@ export const setupCommand = new Command()
           : "";
         console.log(
           chalk.green(
-            `✓ Model provider "${input.type}" ${action}${defaultNote}${modelNote}`,
+            `✓ Org model provider "${input.type}" ${action}${defaultNote}${modelNote}`,
           ),
         );
         if (input.isInteractiveMode) {

--- a/turbo/apps/cli/src/lib/api/domains/org-model-providers.ts
+++ b/turbo/apps/cli/src/lib/api/domains/org-model-providers.ts
@@ -1,0 +1,112 @@
+import { initClient } from "@ts-rest/core";
+import {
+  orgModelProvidersMainContract,
+  orgModelProvidersByTypeContract,
+  orgModelProvidersSetDefaultContract,
+  orgModelProvidersUpdateModelContract,
+  type ModelProviderType,
+  type ModelProviderListResponse,
+  type ModelProviderResponse,
+  type UpsertModelProviderResponse,
+} from "@vm0/core";
+import { getClientConfig, handleError } from "../core/client-factory";
+
+/**
+ * List all org-level model providers
+ */
+export async function listOrgModelProviders(): Promise<ModelProviderListResponse> {
+  const config = await getClientConfig();
+  const client = initClient(orgModelProvidersMainContract, config);
+
+  const result = await client.list({ headers: {} });
+
+  if (result.status === 200) {
+    return result.body;
+  }
+
+  handleError(result, "Failed to list org model providers");
+}
+
+/**
+ * Create or update an org-level model provider (admin only)
+ */
+export async function upsertOrgModelProvider(body: {
+  type: ModelProviderType;
+  secret?: string;
+  authMethod?: string;
+  secrets?: Record<string, string>;
+  selectedModel?: string;
+}): Promise<UpsertModelProviderResponse> {
+  const config = await getClientConfig();
+  const client = initClient(orgModelProvidersMainContract, config);
+
+  const result = await client.upsert({ body });
+
+  if (result.status === 200 || result.status === 201) {
+    return result.body;
+  }
+
+  handleError(result, "Failed to set org model provider");
+}
+
+/**
+ * Delete an org-level model provider (admin only)
+ */
+export async function deleteOrgModelProvider(
+  type: ModelProviderType,
+): Promise<void> {
+  const config = await getClientConfig();
+  const client = initClient(orgModelProvidersByTypeContract, config);
+
+  const result = await client.delete({
+    params: { type },
+  });
+
+  if (result.status === 204) {
+    return;
+  }
+
+  handleError(result, `Org model provider "${type}" not found`);
+}
+
+/**
+ * Set an org-level model provider as default for its framework (admin only)
+ */
+export async function setOrgModelProviderDefault(
+  type: ModelProviderType,
+): Promise<ModelProviderResponse> {
+  const config = await getClientConfig();
+  const client = initClient(orgModelProvidersSetDefaultContract, config);
+
+  const result = await client.setDefault({
+    params: { type },
+  });
+
+  if (result.status === 200) {
+    return result.body;
+  }
+
+  handleError(result, "Failed to set default org model provider");
+}
+
+/**
+ * Update model selection for an existing org-level provider (admin only)
+ */
+export async function updateOrgModelProviderModel(
+  type: ModelProviderType,
+  selectedModel?: string,
+): Promise<ModelProviderResponse> {
+  const config = await getClientConfig();
+  const client = initClient(orgModelProvidersUpdateModelContract, config);
+
+  const result = await client.updateModel({
+    params: { type },
+    body: { selectedModel },
+  });
+
+  if (result.status === 200) {
+    return result.body;
+  }
+
+  handleError(result, "Failed to update org model provider");
+}

--- a/turbo/apps/cli/src/lib/api/index.ts
+++ b/turbo/apps/cli/src/lib/api/index.ts
@@ -84,6 +84,15 @@ export {
   updateModelProviderModel,
 } from "./domains/model-providers";
 
+// Domain modules - Org Model Providers
+export {
+  listOrgModelProviders,
+  upsertOrgModelProvider,
+  deleteOrgModelProvider,
+  setOrgModelProviderDefault,
+  updateOrgModelProviderModel,
+} from "./domains/org-model-providers";
+
 // Domain modules - Connectors
 export {
   listConnectors,


### PR DESCRIPTION
## Summary

- Add `vm0 org model-provider` subcommands for admin management of org-level model providers: `list`, `setup`, `remove`, `set-default`
- Extract shared setup helpers from `model-provider/setup.ts` into `shared.ts` for code reuse
- Create org model provider API client using existing org-level contracts

Closes #5199

## Changes

| File | Change |
|------|--------|
| `commands/model-provider/shared.ts` | New: shared helpers extracted from setup.ts |
| `commands/model-provider/setup.ts` | Refactored to import from shared |
| `lib/api/domains/org-model-providers.ts` | New: org API client (5 functions) |
| `lib/api/index.ts` | Export org model provider functions |
| `commands/org/model-provider/index.ts` | New: command group |
| `commands/org/model-provider/list.ts` | New: list org providers |
| `commands/org/model-provider/setup.ts` | New: setup org provider (admin) |
| `commands/org/model-provider/remove.ts` | New: remove org provider (admin) |
| `commands/org/model-provider/set-default.ts` | New: set default (admin) |
| `commands/org/index.ts` | Register model-provider subcommand |

## Test plan

- [x] 22 new integration tests for org model-provider commands
- [x] All 48 existing model-provider tests pass (no regressions from shared extraction)
- [x] Lint, type-check, knip all pass
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)