### PR TITLE
feat: remove vercel ai gateway feature flag

### DIFF
--- a/turbo/packages/core/src/contracts/model-providers.ts
+++ b/turbo/packages/core/src/contracts/model-providers.ts
@@ -450,6 +450,7 @@ export function allowsCustomModel(type: ModelProviderType): boolean {
 export function getProviderFeatureFlag(
   _type: ModelProviderType,
 ): FeatureSwitchKey | undefined {
+  void _type;
   return undefined;
 }
 

--- a/turbo/packages/core/src/contracts/model-providers.ts
+++ b/turbo/packages/core/src/contracts/model-providers.ts
@@ -169,7 +169,6 @@ export const MODEL_PROVIDER_TYPES = {
     label: "Vercel AI Gateway",
     secretLabel: "API key",
     helpText: "Get your API key from the Vercel AI Gateway dashboard",
-    featureFlag: FeatureSwitchKey.VercelAiGateway,
     environmentMapping: {
       ANTHROPIC_AUTH_TOKEN: "$secret",
       ANTHROPIC_BASE_URL: "https://ai-gateway.vercel.sh",
@@ -449,10 +448,9 @@ export function allowsCustomModel(type: ModelProviderType): boolean {
  * Returns undefined for providers without feature gating.
  */
 export function getProviderFeatureFlag(
-  type: ModelProviderType,
+  _type: ModelProviderType,
 ): FeatureSwitchKey | undefined {
-  const config = MODEL_PROVIDER_TYPES[type];
-  return "featureFlag" in config ? config.featureFlag : undefined;
+  return undefined;
 }
 
 /**

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -39,6 +39,5 @@ export enum FeatureSwitchKey {
   ResendConnector = "resendConnector",
   GitHubIntegration = "githubIntegration",
   TelegramIntegration = "telegramIntegration",
-  VercelAiGateway = "vercelAiGateway",
   DataExport = "dataExport",
 }

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -210,11 +210,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledUserHashes: STAFF_USER_HASHES,
   },
-  [FeatureSwitchKey.VercelAiGateway]: {
-    maintainer: "ethan@vm0.ai",
-    enabled: false,
-    enabledUserHashes: STAFF_USER_HASHES,
-  },
   [FeatureSwitchKey.DataExport]: {
     maintainer: "ethan@vm0.ai",
     enabled: false,


### PR DESCRIPTION
## Summary

- Remove the `VercelAiGateway` feature flag so the Vercel AI Gateway model provider is visible and available to all users
- Remove `VercelAiGateway` from `FeatureSwitchKey` enum and feature switch registry
- Remove `featureFlag` property from the `vercel-ai-gateway` provider configuration
- Simplify `getProviderFeatureFlag` since no providers currently use feature flags

## Test plan

- [x] `pnpm turbo run lint` passes
- [x] `pnpm check-types` passes
- [x] `pnpm vitest` passes (3481/3481)
- [x] `pnpm knip` passes
- [x] Verified `vercel-ai-gateway` provider no longer has `featureFlag` property

Closes #5203

🤖 Generated with [Claude Code](https://claude.com/claude-code)