### PR TITLE
feat: add org secret and variable api routes and cli commands

### DIFF
--- a/turbo/apps/cli/src/commands/org/index.ts
+++ b/turbo/apps/cli/src/commands/org/index.ts
@@ -7,6 +7,8 @@ import { membersCommand } from "./members";
 import { inviteCommand } from "./invite";
 import { removeCommand } from "./remove";
 import { leaveCommand } from "./leave";
+import { orgSecretCommand } from "./secret";
+import { orgVariableCommand } from "./variable";
 
 export const orgCommand = new Command()
   .name("org")
@@ -18,4 +20,6 @@ export const orgCommand = new Command()
   .addCommand(membersCommand)
   .addCommand(inviteCommand)
   .addCommand(removeCommand)
-  .addCommand(leaveCommand);
+  .addCommand(leaveCommand)
+  .addCommand(orgSecretCommand)
+  .addCommand(orgVariableCommand);

--- a/turbo/apps/cli/src/commands/org/secret/index.ts
+++ b/turbo/apps/cli/src/commands/org/secret/index.ts
@@ -1,0 +1,11 @@
+import { Command } from "commander";
+import { listCommand } from "./list";
+import { setCommand } from "./set";
+import { removeCommand } from "./remove";
+
+export const orgSecretCommand = new Command()
+  .name("secret")
+  .description("Manage org-level secrets (admin)")
+  .addCommand(listCommand)
+  .addCommand(setCommand)
+  .addCommand(removeCommand);

--- a/turbo/apps/cli/src/commands/org/secret/list.ts
+++ b/turbo/apps/cli/src/commands/org/secret/list.ts
@@ -1,0 +1,40 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import { listOrgSecrets } from "../../../lib/api";
+import { withErrorHandler } from "../../../lib/command";
+
+export const listCommand = new Command()
+  .name("list")
+  .alias("ls")
+  .description("List all org-level secrets")
+  .action(
+    withErrorHandler(async () => {
+      const result = await listOrgSecrets();
+
+      if (result.secrets.length === 0) {
+        console.log(chalk.dim("No org secrets found"));
+        console.log();
+        console.log("To add an org secret:");
+        console.log(
+          chalk.cyan("  vm0 org secret set MY_API_KEY --body <value>"),
+        );
+        return;
+      }
+
+      console.log(chalk.bold("Org Secrets:"));
+      console.log();
+
+      for (const secret of result.secrets) {
+        console.log(`  ${chalk.cyan(secret.name)}`);
+        if (secret.description) {
+          console.log(`    ${chalk.dim(secret.description)}`);
+        }
+        console.log(
+          `    ${chalk.dim(`Updated: ${new Date(secret.updatedAt).toLocaleString()}`)}`,
+        );
+        console.log();
+      }
+
+      console.log(chalk.dim(`Total: ${result.secrets.length} secret(s)`));
+    }),
+  );

--- a/turbo/apps/cli/src/commands/org/secret/remove.ts
+++ b/turbo/apps/cli/src/commands/org/secret/remove.ts
@@ -1,0 +1,33 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import { deleteOrgSecret } from "../../../lib/api";
+import { isInteractive, promptConfirm } from "../../../lib/utils/prompt-utils";
+import { withErrorHandler } from "../../../lib/command";
+
+export const removeCommand = new Command()
+  .name("remove")
+  .description("Delete an org-level secret (admin only)")
+  .argument("<name>", "Secret name to delete")
+  .option("-y, --yes", "Skip confirmation prompt")
+  .action(
+    withErrorHandler(async (name: string, options: { yes?: boolean }) => {
+      if (!options.yes) {
+        if (!isInteractive()) {
+          throw new Error("--yes flag is required in non-interactive mode");
+        }
+
+        const confirmed = await promptConfirm(
+          `Are you sure you want to delete org secret "${name}"?`,
+          false,
+        );
+
+        if (!confirmed) {
+          console.log(chalk.dim("Cancelled"));
+          return;
+        }
+      }
+
+      await deleteOrgSecret(name);
+      console.log(chalk.green(`✓ Org secret "${name}" deleted`));
+    }),
+  );

--- a/turbo/apps/cli/src/commands/org/secret/set.ts
+++ b/turbo/apps/cli/src/commands/org/secret/set.ts
@@ -1,0 +1,68 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import { setOrgSecret } from "../../../lib/api";
+import { isInteractive, promptPassword } from "../../../lib/utils/prompt-utils";
+import { withErrorHandler } from "../../../lib/command";
+
+export const setCommand = new Command()
+  .name("set")
+  .description("Create or update an org-level secret (admin only)")
+  .argument("<name>", "Secret name (uppercase, e.g., MY_API_KEY)")
+  .option(
+    "-b, --body <value>",
+    "Secret value (required in non-interactive mode)",
+  )
+  .option("-d, --description <description>", "Optional description")
+  .action(
+    withErrorHandler(
+      async (
+        name: string,
+        options: { body?: string; description?: string },
+      ) => {
+        let value: string;
+
+        if (options.body !== undefined) {
+          value = options.body;
+        } else if (isInteractive()) {
+          const prompted = await promptPassword("Enter secret value:");
+          if (prompted === undefined) {
+            process.exit(0);
+          }
+          value = prompted;
+        } else {
+          throw new Error("--body is required in non-interactive mode", {
+            cause: new Error(
+              `Usage: vm0 org secret set ${name} --body "your-secret-value"`,
+            ),
+          });
+        }
+
+        let secret;
+        try {
+          secret = await setOrgSecret({
+            name,
+            value,
+            description: options.description,
+          });
+        } catch (error) {
+          if (
+            error instanceof Error &&
+            error.message.includes("must contain only uppercase")
+          ) {
+            throw new Error(error.message, {
+              cause: new Error(
+                "Examples of valid secret names: MY_API_KEY, GITHUB_TOKEN, AWS_ACCESS_KEY_ID",
+              ),
+            });
+          }
+          throw error;
+        }
+
+        console.log(chalk.green(`✓ Org secret "${secret.name}" saved`));
+        console.log();
+        console.log("Use in vm0.yaml:");
+        console.log(chalk.cyan(`  environment:`));
+        console.log(chalk.cyan(`    ${name}: \${{ secrets.${name} }}`));
+      },
+    ),
+  );

--- a/turbo/apps/cli/src/commands/org/variable/index.ts
+++ b/turbo/apps/cli/src/commands/org/variable/index.ts
@@ -1,0 +1,11 @@
+import { Command } from "commander";
+import { listCommand } from "./list";
+import { setCommand } from "./set";
+import { removeCommand } from "./remove";
+
+export const orgVariableCommand = new Command()
+  .name("variable")
+  .description("Manage org-level variables (admin)")
+  .addCommand(listCommand)
+  .addCommand(setCommand)
+  .addCommand(removeCommand);

--- a/turbo/apps/cli/src/commands/org/variable/list.ts
+++ b/turbo/apps/cli/src/commands/org/variable/list.ts
@@ -1,0 +1,49 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import { listOrgVariables } from "../../../lib/api";
+import { withErrorHandler } from "../../../lib/command";
+
+/**
+ * Truncate value for display if too long
+ */
+function truncateValue(value: string, maxLength: number = 60): string {
+  if (value.length <= maxLength) {
+    return value;
+  }
+  return value.slice(0, maxLength - 15) + "... [truncated]";
+}
+
+export const listCommand = new Command()
+  .name("list")
+  .alias("ls")
+  .description("List all org-level variables")
+  .action(
+    withErrorHandler(async () => {
+      const result = await listOrgVariables();
+
+      if (result.variables.length === 0) {
+        console.log(chalk.dim("No org variables found"));
+        console.log();
+        console.log("To add an org variable:");
+        console.log(chalk.cyan("  vm0 org variable set MY_VAR <value>"));
+        return;
+      }
+
+      console.log(chalk.bold("Org Variables:"));
+      console.log();
+
+      for (const variable of result.variables) {
+        const displayValue = truncateValue(variable.value);
+        console.log(`  ${chalk.cyan(variable.name)} = ${displayValue}`);
+        if (variable.description) {
+          console.log(`    ${chalk.dim(variable.description)}`);
+        }
+        console.log(
+          `    ${chalk.dim(`Updated: ${new Date(variable.updatedAt).toLocaleString()}`)}`,
+        );
+        console.log();
+      }
+
+      console.log(chalk.dim(`Total: ${result.variables.length} variable(s)`));
+    }),
+  );

--- a/turbo/apps/cli/src/commands/org/variable/remove.ts
+++ b/turbo/apps/cli/src/commands/org/variable/remove.ts
@@ -1,0 +1,33 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import { deleteOrgVariable } from "../../../lib/api";
+import { isInteractive, promptConfirm } from "../../../lib/utils/prompt-utils";
+import { withErrorHandler } from "../../../lib/command";
+
+export const removeCommand = new Command()
+  .name("remove")
+  .description("Delete an org-level variable (admin only)")
+  .argument("<name>", "Variable name to delete")
+  .option("-y, --yes", "Skip confirmation prompt")
+  .action(
+    withErrorHandler(async (name: string, options: { yes?: boolean }) => {
+      if (!options.yes) {
+        if (!isInteractive()) {
+          throw new Error("--yes flag is required in non-interactive mode");
+        }
+
+        const confirmed = await promptConfirm(
+          `Are you sure you want to delete org variable "${name}"?`,
+          false,
+        );
+
+        if (!confirmed) {
+          console.log(chalk.dim("Cancelled"));
+          return;
+        }
+      }
+
+      await deleteOrgVariable(name);
+      console.log(chalk.green(`✓ Org variable "${name}" deleted`));
+    }),
+  );

--- a/turbo/apps/cli/src/commands/org/variable/set.ts
+++ b/turbo/apps/cli/src/commands/org/variable/set.ts
@@ -1,0 +1,47 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import { setOrgVariable } from "../../../lib/api";
+import { withErrorHandler } from "../../../lib/command";
+
+export const setCommand = new Command()
+  .name("set")
+  .description("Create or update an org-level variable (admin only)")
+  .argument("<name>", "Variable name (uppercase, e.g., MY_VAR)")
+  .argument("<value>", "Variable value")
+  .option("-d, --description <description>", "Optional description")
+  .action(
+    withErrorHandler(
+      async (
+        name: string,
+        value: string,
+        options: { description?: string },
+      ) => {
+        let variable;
+        try {
+          variable = await setOrgVariable({
+            name,
+            value,
+            description: options.description,
+          });
+        } catch (error) {
+          if (
+            error instanceof Error &&
+            error.message.includes("must contain only uppercase")
+          ) {
+            throw new Error(error.message, {
+              cause: new Error(
+                "Examples of valid variable names: MY_VAR, API_URL, DEBUG_MODE",
+              ),
+            });
+          }
+          throw error;
+        }
+
+        console.log(chalk.green(`✓ Org variable "${variable.name}" saved`));
+        console.log();
+        console.log("Use in vm0.yaml:");
+        console.log(chalk.cyan(`  environment:`));
+        console.log(chalk.cyan(`    ${name}: \${{ vars.${name} }}`));
+      },
+    ),
+  );

--- a/turbo/apps/cli/src/lib/api/domains/org-secrets.ts
+++ b/turbo/apps/cli/src/lib/api/domains/org-secrets.ts
@@ -1,0 +1,58 @@
+import { initClient } from "@ts-rest/core";
+import { orgSecretsMainContract, orgSecretsByNameContract } from "@vm0/core";
+import type { SecretResponse, SecretListResponse } from "@vm0/core";
+import { getClientConfig, handleError } from "../core/client-factory";
+
+/**
+ * List org-level secrets (metadata only, no values)
+ */
+export async function listOrgSecrets(): Promise<SecretListResponse> {
+  const config = await getClientConfig();
+  const client = initClient(orgSecretsMainContract, config);
+
+  const result = await client.list({ headers: {} });
+
+  if (result.status === 200) {
+    return result.body;
+  }
+
+  handleError(result, "Failed to list org secrets");
+}
+
+/**
+ * Set (create or update) an org-level secret
+ */
+export async function setOrgSecret(body: {
+  name: string;
+  value: string;
+  description?: string;
+}): Promise<SecretResponse> {
+  const config = await getClientConfig();
+  const client = initClient(orgSecretsMainContract, config);
+
+  const result = await client.set({ body });
+
+  if (result.status === 200 || result.status === 201) {
+    return result.body;
+  }
+
+  handleError(result, "Failed to set org secret");
+}
+
+/**
+ * Delete an org-level secret by name
+ */
+export async function deleteOrgSecret(name: string): Promise<void> {
+  const config = await getClientConfig();
+  const client = initClient(orgSecretsByNameContract, config);
+
+  const result = await client.delete({
+    params: { name },
+  });
+
+  if (result.status === 204) {
+    return;
+  }
+
+  handleError(result, `Org secret "${name}" not found`);
+}

--- a/turbo/apps/cli/src/lib/api/domains/org-variables.ts
+++ b/turbo/apps/cli/src/lib/api/domains/org-variables.ts
@@ -1,0 +1,61 @@
+import { initClient } from "@ts-rest/core";
+import {
+  orgVariablesMainContract,
+  orgVariablesByNameContract,
+} from "@vm0/core";
+import type { VariableResponse, VariableListResponse } from "@vm0/core";
+import { getClientConfig, handleError } from "../core/client-factory";
+
+/**
+ * List org-level variables (includes values)
+ */
+export async function listOrgVariables(): Promise<VariableListResponse> {
+  const config = await getClientConfig();
+  const client = initClient(orgVariablesMainContract, config);
+
+  const result = await client.list({ headers: {} });
+
+  if (result.status === 200) {
+    return result.body;
+  }
+
+  handleError(result, "Failed to list org variables");
+}
+
+/**
+ * Set (create or update) an org-level variable
+ */
+export async function setOrgVariable(body: {
+  name: string;
+  value: string;
+  description?: string;
+}): Promise<VariableResponse> {
+  const config = await getClientConfig();
+  const client = initClient(orgVariablesMainContract, config);
+
+  const result = await client.set({ body });
+
+  if (result.status === 200 || result.status === 201) {
+    return result.body;
+  }
+
+  handleError(result, "Failed to set org variable");
+}
+
+/**
+ * Delete an org-level variable by name
+ */
+export async function deleteOrgVariable(name: string): Promise<void> {
+  const config = await getClientConfig();
+  const client = initClient(orgVariablesByNameContract, config);
+
+  const result = await client.delete({
+    params: { name },
+  });
+
+  if (result.status === 204) {
+    return;
+  }
+
+  handleError(result, `Org variable "${name}" not found`);
+}

--- a/turbo/apps/cli/src/lib/api/index.ts
+++ b/turbo/apps/cli/src/lib/api/index.ts
@@ -100,5 +100,19 @@ export {
   updateUserPreferences,
 } from "./domains/user-preferences";
 
+// Domain modules - Org Secrets
+export {
+  listOrgSecrets,
+  setOrgSecret,
+  deleteOrgSecret,
+} from "./domains/org-secrets";
+
+// Domain modules - Org Variables
+export {
+  listOrgVariables,
+  setOrgVariable,
+  deleteOrgVariable,
+} from "./domains/org-variables";
+
 // Domain modules - Skills
 export { resolveSkills } from "./domains/skills";

--- a/turbo/apps/web/app/api/org/secrets/[name]/route.ts
+++ b/turbo/apps/web/app/api/org/secrets/[name]/route.ts
@@ -1,0 +1,93 @@
+import {
+  createHandler,
+  tsr,
+  TsRestResponse,
+} from "../../../../../src/lib/ts-rest-handler";
+import {
+  orgSecretsByNameContract,
+  createErrorResponse,
+  ApiError,
+} from "@vm0/core";
+import { initServices } from "../../../../../src/lib/init-services";
+import { getAuthContext } from "../../../../../src/lib/auth/get-user-id";
+import { resolveOrg } from "../../../../../src/lib/org/resolve-org";
+import { deleteOrgSecret } from "../../../../../src/lib/secret/secret-service";
+import { logger } from "../../../../../src/lib/logger";
+import { isNotFound } from "../../../../../src/lib/errors";
+
+const log = logger("api:org-secrets");
+
+const router = tsr.router(orgSecretsByNameContract, {
+  /**
+   * DELETE /api/org/secrets/:name - Delete an org-level secret
+   * Admin only.
+   */
+  delete: async ({ params, headers }, { request }) => {
+    initServices();
+
+    const authCtx = await getAuthContext(headers.authorization);
+    if (!authCtx) {
+      return createErrorResponse("UNAUTHORIZED", "Not authenticated");
+    }
+    const { userId } = authCtx;
+
+    const orgSlug = new URL(request.url).searchParams.get("org");
+    const { org, member } = await resolveOrg(userId, orgSlug);
+
+    if (member.role !== "admin") {
+      return createErrorResponse(
+        "FORBIDDEN",
+        "Only admins can manage org secrets",
+      );
+    }
+
+    log.debug("deleting org secret", { orgId: org.orgId, name: params.name });
+
+    try {
+      await deleteOrgSecret(org.orgId, params.name);
+
+      return {
+        status: 204 as const,
+        body: undefined,
+      };
+    } catch (error) {
+      if (isNotFound(error)) {
+        return createErrorResponse("NOT_FOUND", "Resource not found");
+      }
+      throw error;
+    }
+  },
+});
+
+/**
+ * Custom error handler for org secrets by name API
+ */
+function errorHandler(err: unknown): TsRestResponse | void {
+  if (err && typeof err === "object" && "pathParamsError" in err) {
+    const validationError = err as {
+      pathParamsError: {
+        issues: Array<{ path: string[]; message: string }>;
+      } | null;
+    };
+
+    if (validationError.pathParamsError) {
+      const issue = validationError.pathParamsError.issues[0];
+      if (issue) {
+        return TsRestResponse.fromJson(
+          {
+            error: { message: issue.message, code: ApiError.BAD_REQUEST.code },
+          },
+          { status: ApiError.BAD_REQUEST.status },
+        );
+      }
+    }
+  }
+
+  return undefined;
+}
+
+const handler = createHandler(orgSecretsByNameContract, router, {
+  errorHandler,
+});
+
+export { handler as DELETE };

--- a/turbo/apps/web/app/api/org/secrets/route.ts
+++ b/turbo/apps/web/app/api/org/secrets/route.ts
@@ -1,0 +1,141 @@
+import {
+  createHandler,
+  tsr,
+  TsRestResponse,
+} from "../../../../src/lib/ts-rest-handler";
+import {
+  orgSecretsMainContract,
+  createErrorResponse,
+  ApiError,
+} from "@vm0/core";
+import { initServices } from "../../../../src/lib/init-services";
+import { getAuthContext } from "../../../../src/lib/auth/get-user-id";
+import { resolveOrg } from "../../../../src/lib/org/resolve-org";
+import {
+  listOrgSecrets,
+  setOrgSecret,
+} from "../../../../src/lib/secret/secret-service";
+import { logger } from "../../../../src/lib/logger";
+import { isBadRequest } from "../../../../src/lib/errors";
+
+const log = logger("api:org-secrets");
+
+const router = tsr.router(orgSecretsMainContract, {
+  /**
+   * GET /api/org/secrets - List org-level secrets
+   * Any org member can list.
+   */
+  list: async ({ headers }, { request }) => {
+    initServices();
+
+    const authCtx = await getAuthContext(headers.authorization);
+    if (!authCtx) {
+      return createErrorResponse("UNAUTHORIZED", "Not authenticated");
+    }
+    const { userId } = authCtx;
+
+    const orgSlug = new URL(request.url).searchParams.get("org");
+    const { org } = await resolveOrg(userId, orgSlug);
+    const secrets = await listOrgSecrets(org.orgId);
+
+    return {
+      status: 200 as const,
+      body: {
+        secrets: secrets.map((s) => ({
+          id: s.id,
+          name: s.name,
+          description: s.description,
+          type: s.type,
+          createdAt: s.createdAt.toISOString(),
+          updatedAt: s.updatedAt.toISOString(),
+        })),
+      },
+    };
+  },
+
+  /**
+   * PUT /api/org/secrets - Create or update an org-level secret
+   * Admin only.
+   */
+  set: async ({ body, headers }, { request }) => {
+    initServices();
+
+    const authCtx = await getAuthContext(headers.authorization);
+    if (!authCtx) {
+      return createErrorResponse("UNAUTHORIZED", "Not authenticated");
+    }
+    const { userId } = authCtx;
+
+    const orgSlug = new URL(request.url).searchParams.get("org");
+    const { org, member } = await resolveOrg(userId, orgSlug);
+
+    if (member.role !== "admin") {
+      return createErrorResponse(
+        "FORBIDDEN",
+        "Only admins can manage org secrets",
+      );
+    }
+
+    const { name, value, description } = body;
+
+    log.debug("setting org secret", { orgId: org.orgId, name });
+
+    try {
+      const secret = await setOrgSecret(org.orgId, name, value, description);
+
+      return {
+        status: 200 as const,
+        body: {
+          id: secret.id,
+          name: secret.name,
+          description: secret.description,
+          type: secret.type,
+          createdAt: secret.createdAt.toISOString(),
+          updatedAt: secret.updatedAt.toISOString(),
+        },
+      };
+    } catch (error) {
+      if (isBadRequest(error)) {
+        return createErrorResponse("BAD_REQUEST", "Invalid request");
+      }
+      throw error;
+    }
+  },
+});
+
+/**
+ * Custom error handler for org secrets API
+ */
+function errorHandler(err: unknown): TsRestResponse | void {
+  if (
+    err &&
+    typeof err === "object" &&
+    "bodyError" in err &&
+    "queryError" in err
+  ) {
+    const validationError = err as {
+      bodyError: { issues: Array<{ path: string[]; message: string }> } | null;
+      queryError: { issues: Array<{ path: string[]; message: string }> } | null;
+    };
+
+    if (validationError.bodyError) {
+      const issue = validationError.bodyError.issues[0];
+      if (issue) {
+        return TsRestResponse.fromJson(
+          {
+            error: { message: issue.message, code: ApiError.BAD_REQUEST.code },
+          },
+          { status: ApiError.BAD_REQUEST.status },
+        );
+      }
+    }
+  }
+
+  return undefined;
+}
+
+const handler = createHandler(orgSecretsMainContract, router, {
+  errorHandler,
+});
+
+export { handler as GET, handler as PUT };

--- a/turbo/apps/web/app/api/org/variables/[name]/route.ts
+++ b/turbo/apps/web/app/api/org/variables/[name]/route.ts
@@ -1,0 +1,96 @@
+import {
+  createHandler,
+  tsr,
+  TsRestResponse,
+} from "../../../../../src/lib/ts-rest-handler";
+import {
+  orgVariablesByNameContract,
+  createErrorResponse,
+  ApiError,
+} from "@vm0/core";
+import { initServices } from "../../../../../src/lib/init-services";
+import { getAuthContext } from "../../../../../src/lib/auth/get-user-id";
+import { resolveOrg } from "../../../../../src/lib/org/resolve-org";
+import { deleteOrgVariable } from "../../../../../src/lib/variable/variable-service";
+import { logger } from "../../../../../src/lib/logger";
+import { isNotFound } from "../../../../../src/lib/errors";
+
+const log = logger("api:org-variables");
+
+const router = tsr.router(orgVariablesByNameContract, {
+  /**
+   * DELETE /api/org/variables/:name - Delete an org-level variable
+   * Admin only.
+   */
+  delete: async ({ params, headers }, { request }) => {
+    initServices();
+
+    const authCtx = await getAuthContext(headers.authorization);
+    if (!authCtx) {
+      return createErrorResponse("UNAUTHORIZED", "Not authenticated");
+    }
+    const { userId } = authCtx;
+
+    const orgSlug = new URL(request.url).searchParams.get("org");
+    const { org, member } = await resolveOrg(userId, orgSlug);
+
+    if (member.role !== "admin") {
+      return createErrorResponse(
+        "FORBIDDEN",
+        "Only admins can manage org variables",
+      );
+    }
+
+    log.debug("deleting org variable", {
+      orgId: org.orgId,
+      name: params.name,
+    });
+
+    try {
+      await deleteOrgVariable(org.orgId, params.name);
+
+      return {
+        status: 204 as const,
+        body: undefined,
+      };
+    } catch (error) {
+      if (isNotFound(error)) {
+        return createErrorResponse("NOT_FOUND", "Resource not found");
+      }
+      throw error;
+    }
+  },
+});
+
+/**
+ * Custom error handler for org variables by name API
+ */
+function errorHandler(err: unknown): TsRestResponse | void {
+  if (err && typeof err === "object" && "pathParamsError" in err) {
+    const validationError = err as {
+      pathParamsError: {
+        issues: Array<{ path: string[]; message: string }>;
+      } | null;
+    };
+
+    if (validationError.pathParamsError) {
+      const issue = validationError.pathParamsError.issues[0];
+      if (issue) {
+        return TsRestResponse.fromJson(
+          {
+            error: { message: issue.message, code: ApiError.BAD_REQUEST.code },
+          },
+          { status: ApiError.BAD_REQUEST.status },
+        );
+      }
+    }
+  }
+
+  return undefined;
+}
+
+const handler = createHandler(orgVariablesByNameContract, router, {
+  errorHandler,
+});
+
+export { handler as DELETE };

--- a/turbo/apps/web/app/api/org/variables/route.ts
+++ b/turbo/apps/web/app/api/org/variables/route.ts
@@ -1,0 +1,146 @@
+import {
+  createHandler,
+  tsr,
+  TsRestResponse,
+} from "../../../../src/lib/ts-rest-handler";
+import {
+  orgVariablesMainContract,
+  createErrorResponse,
+  ApiError,
+} from "@vm0/core";
+import { initServices } from "../../../../src/lib/init-services";
+import { getAuthContext } from "../../../../src/lib/auth/get-user-id";
+import { resolveOrg } from "../../../../src/lib/org/resolve-org";
+import {
+  listOrgVariables,
+  setOrgVariable,
+} from "../../../../src/lib/variable/variable-service";
+import { logger } from "../../../../src/lib/logger";
+import { isBadRequest } from "../../../../src/lib/errors";
+
+const log = logger("api:org-variables");
+
+const router = tsr.router(orgVariablesMainContract, {
+  /**
+   * GET /api/org/variables - List org-level variables
+   * Any org member can list.
+   */
+  list: async ({ headers }, { request }) => {
+    initServices();
+
+    const authCtx = await getAuthContext(headers.authorization);
+    if (!authCtx) {
+      return createErrorResponse("UNAUTHORIZED", "Not authenticated");
+    }
+    const { userId } = authCtx;
+
+    const orgSlug = new URL(request.url).searchParams.get("org");
+    const { org } = await resolveOrg(userId, orgSlug);
+    const vars = await listOrgVariables(org.orgId);
+
+    return {
+      status: 200 as const,
+      body: {
+        variables: vars.map((v) => ({
+          id: v.id,
+          name: v.name,
+          value: v.value,
+          description: v.description,
+          createdAt: v.createdAt.toISOString(),
+          updatedAt: v.updatedAt.toISOString(),
+        })),
+      },
+    };
+  },
+
+  /**
+   * PUT /api/org/variables - Create or update an org-level variable
+   * Admin only.
+   */
+  set: async ({ body, headers }, { request }) => {
+    initServices();
+
+    const authCtx = await getAuthContext(headers.authorization);
+    if (!authCtx) {
+      return createErrorResponse("UNAUTHORIZED", "Not authenticated");
+    }
+    const { userId } = authCtx;
+
+    const orgSlug = new URL(request.url).searchParams.get("org");
+    const { org, member } = await resolveOrg(userId, orgSlug);
+
+    if (member.role !== "admin") {
+      return createErrorResponse(
+        "FORBIDDEN",
+        "Only admins can manage org variables",
+      );
+    }
+
+    const { name, value, description } = body;
+
+    log.debug("setting org variable", { orgId: org.orgId, name });
+
+    try {
+      const variable = await setOrgVariable(
+        org.orgId,
+        name,
+        value,
+        description,
+      );
+
+      return {
+        status: 200 as const,
+        body: {
+          id: variable.id,
+          name: variable.name,
+          value: variable.value,
+          description: variable.description,
+          createdAt: variable.createdAt.toISOString(),
+          updatedAt: variable.updatedAt.toISOString(),
+        },
+      };
+    } catch (error) {
+      if (isBadRequest(error)) {
+        return createErrorResponse("BAD_REQUEST", "Invalid request");
+      }
+      throw error;
+    }
+  },
+});
+
+/**
+ * Custom error handler for org variables API
+ */
+function errorHandler(err: unknown): TsRestResponse | void {
+  if (
+    err &&
+    typeof err === "object" &&
+    "bodyError" in err &&
+    "queryError" in err
+  ) {
+    const validationError = err as {
+      bodyError: { issues: Array<{ path: string[]; message: string }> } | null;
+      queryError: { issues: Array<{ path: string[]; message: string }> } | null;
+    };
+
+    if (validationError.bodyError) {
+      const issue = validationError.bodyError.issues[0];
+      if (issue) {
+        return TsRestResponse.fromJson(
+          {
+            error: { message: issue.message, code: ApiError.BAD_REQUEST.code },
+          },
+          { status: ApiError.BAD_REQUEST.status },
+        );
+      }
+    }
+  }
+
+  return undefined;
+}
+
+const handler = createHandler(orgVariablesMainContract, router, {
+  errorHandler,
+});
+
+export { handler as GET, handler as PUT };

--- a/turbo/apps/web/src/__tests__/org-secrets-api.test.ts
+++ b/turbo/apps/web/src/__tests__/org-secrets-api.test.ts
@@ -1,0 +1,249 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { GET, PUT } from "../../app/api/org/secrets/route";
+import { DELETE } from "../../app/api/org/secrets/[name]/route";
+import { createTestRequest, createTestOrg } from "./api-test-helpers";
+import { testContext, uniqueId } from "./test-helpers";
+import { mockClerk } from "./clerk-mock";
+
+const context = testContext();
+
+/**
+ * Setup an org with the given user as admin or member.
+ */
+async function setupOrg(userId: string, role: "org:admin" | "org:member") {
+  const slug = uniqueId("orgsec");
+  const orgId = `org_mock_${userId}`;
+
+  mockClerk({ userId, orgId, orgRole: role });
+  await createTestOrg(slug);
+
+  return { slug, orgId };
+}
+
+function orgUrl(path: string, slug: string): string {
+  return `http://localhost:3000/api/org/secrets${path}?org=${slug}`;
+}
+
+describe("Org secrets API", () => {
+  beforeEach(() => {
+    context.setupMocks();
+  });
+
+  describe("GET /api/org/secrets", () => {
+    it("should return empty list initially", async () => {
+      const userId = uniqueId("os-list");
+      const { slug } = await setupOrg(userId, "org:admin");
+
+      const response = await GET(createTestRequest(orgUrl("", slug)));
+      expect(response.status).toBe(200);
+
+      const data = await response.json();
+      expect(data.secrets).toEqual([]);
+    });
+
+    it("should allow member to list org secrets", async () => {
+      const userId = uniqueId("os-member-list");
+      const { slug } = await setupOrg(userId, "org:member");
+
+      const response = await GET(createTestRequest(orgUrl("", slug)));
+      expect(response.status).toBe(200);
+
+      const data = await response.json();
+      expect(data.secrets).toEqual([]);
+    });
+
+    it("should reject unauthenticated requests", async () => {
+      mockClerk({ userId: null });
+
+      const response = await GET(
+        createTestRequest("http://localhost:3000/api/org/secrets?org=test"),
+      );
+      expect(response.status).toBe(401);
+    });
+  });
+
+  describe("PUT /api/org/secrets", () => {
+    it("should create org secret as admin", async () => {
+      const userId = uniqueId("os-create");
+      const { slug } = await setupOrg(userId, "org:admin");
+
+      const response = await PUT(
+        createTestRequest(orgUrl("", slug), {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            name: "ORG_API_KEY",
+            value: "test-org-secret-value",
+            description: "Test org secret",
+          }),
+        }),
+      );
+      expect(response.status).toBe(200);
+
+      const data = await response.json();
+      expect(data.name).toBe("ORG_API_KEY");
+      expect(data.description).toBe("Test org secret");
+      expect(data.type).toBe("user");
+      expect(data.id).toBeDefined();
+      expect(data.createdAt).toBeDefined();
+      expect(data.updatedAt).toBeDefined();
+    });
+
+    it("should update existing org secret", async () => {
+      const userId = uniqueId("os-update");
+      const { slug } = await setupOrg(userId, "org:admin");
+
+      // Create
+      await PUT(
+        createTestRequest(orgUrl("", slug), {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            name: "ORG_SECRET_V",
+            value: "value-v1",
+          }),
+        }),
+      );
+
+      // Update
+      const response = await PUT(
+        createTestRequest(orgUrl("", slug), {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            name: "ORG_SECRET_V",
+            value: "value-v2",
+          }),
+        }),
+      );
+      expect(response.status).toBe(200);
+
+      const data = await response.json();
+      expect(data.name).toBe("ORG_SECRET_V");
+    });
+
+    it("should return 403 for non-admin member", async () => {
+      const userId = uniqueId("os-member-put");
+      const { slug } = await setupOrg(userId, "org:member");
+
+      const response = await PUT(
+        createTestRequest(orgUrl("", slug), {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            name: "ORG_SECRET",
+            value: "test-value",
+          }),
+        }),
+      );
+      expect(response.status).toBe(403);
+
+      const data = await response.json();
+      expect(data.error.code).toBe("FORBIDDEN");
+    });
+
+    it("should return 401 for unauthenticated", async () => {
+      mockClerk({ userId: null });
+
+      const response = await PUT(
+        createTestRequest("http://localhost:3000/api/org/secrets?org=test", {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            name: "ORG_SECRET",
+            value: "test-value",
+          }),
+        }),
+      );
+      expect(response.status).toBe(401);
+    });
+  });
+
+  describe("DELETE /api/org/secrets/:name", () => {
+    it("should delete org secret as admin", async () => {
+      const userId = uniqueId("os-delete");
+      const { slug } = await setupOrg(userId, "org:admin");
+
+      // Create first
+      await PUT(
+        createTestRequest(orgUrl("", slug), {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            name: "ORG_DELETE_ME",
+            value: "delete-this",
+          }),
+        }),
+      );
+
+      // Delete
+      const response = await DELETE(
+        createTestRequest(orgUrl("/ORG_DELETE_ME", slug), {
+          method: "DELETE",
+        }),
+      );
+      expect(response.status).toBe(204);
+
+      // Verify deletion
+      const listRes = await GET(createTestRequest(orgUrl("", slug)));
+      const listData = await listRes.json();
+      expect(listData.secrets).toEqual([]);
+    });
+
+    it("should return 404 for non-existent secret", async () => {
+      const userId = uniqueId("os-del-404");
+      const { slug } = await setupOrg(userId, "org:admin");
+
+      const response = await DELETE(
+        createTestRequest(orgUrl("/NONEXISTENT", slug), {
+          method: "DELETE",
+        }),
+      );
+      expect(response.status).toBe(404);
+    });
+
+    it("should return 403 for non-admin member", async () => {
+      const userId = uniqueId("os-del-member");
+      const { slug } = await setupOrg(userId, "org:member");
+
+      const response = await DELETE(
+        createTestRequest(orgUrl("/SOME_SECRET", slug), {
+          method: "DELETE",
+        }),
+      );
+      expect(response.status).toBe(403);
+    });
+  });
+
+  describe("list after CRUD operations", () => {
+    it("should list created org secrets", async () => {
+      const userId = uniqueId("os-listcrud");
+      const { slug } = await setupOrg(userId, "org:admin");
+
+      // Create a secret
+      await PUT(
+        createTestRequest(orgUrl("", slug), {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            name: "ORG_LISTED_SECRET",
+            value: "listed-value",
+            description: "A listed secret",
+          }),
+        }),
+      );
+
+      const response = await GET(createTestRequest(orgUrl("", slug)));
+      expect(response.status).toBe(200);
+
+      const data = await response.json();
+      expect(data.secrets).toHaveLength(1);
+      expect(data.secrets[0].name).toBe("ORG_LISTED_SECRET");
+      expect(data.secrets[0].description).toBe("A listed secret");
+      expect(data.secrets[0].type).toBe("user");
+      expect(data.secrets[0].id).toBeDefined();
+      expect(data.secrets[0].createdAt).toBeDefined();
+      expect(data.secrets[0].updatedAt).toBeDefined();
+    });
+  });
+});

--- a/turbo/apps/web/src/__tests__/org-variables-api.test.ts
+++ b/turbo/apps/web/src/__tests__/org-variables-api.test.ts
@@ -1,0 +1,250 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { GET, PUT } from "../../app/api/org/variables/route";
+import { DELETE } from "../../app/api/org/variables/[name]/route";
+import { createTestRequest, createTestOrg } from "./api-test-helpers";
+import { testContext, uniqueId } from "./test-helpers";
+import { mockClerk } from "./clerk-mock";
+
+const context = testContext();
+
+/**
+ * Setup an org with the given user as admin or member.
+ */
+async function setupOrg(userId: string, role: "org:admin" | "org:member") {
+  const slug = uniqueId("orgvar");
+  const orgId = `org_mock_${userId}`;
+
+  mockClerk({ userId, orgId, orgRole: role });
+  await createTestOrg(slug);
+
+  return { slug, orgId };
+}
+
+function orgUrl(path: string, slug: string): string {
+  return `http://localhost:3000/api/org/variables${path}?org=${slug}`;
+}
+
+describe("Org variables API", () => {
+  beforeEach(() => {
+    context.setupMocks();
+  });
+
+  describe("GET /api/org/variables", () => {
+    it("should return empty list initially", async () => {
+      const userId = uniqueId("ov-list");
+      const { slug } = await setupOrg(userId, "org:admin");
+
+      const response = await GET(createTestRequest(orgUrl("", slug)));
+      expect(response.status).toBe(200);
+
+      const data = await response.json();
+      expect(data.variables).toEqual([]);
+    });
+
+    it("should allow member to list org variables", async () => {
+      const userId = uniqueId("ov-member-list");
+      const { slug } = await setupOrg(userId, "org:member");
+
+      const response = await GET(createTestRequest(orgUrl("", slug)));
+      expect(response.status).toBe(200);
+
+      const data = await response.json();
+      expect(data.variables).toEqual([]);
+    });
+
+    it("should reject unauthenticated requests", async () => {
+      mockClerk({ userId: null });
+
+      const response = await GET(
+        createTestRequest("http://localhost:3000/api/org/variables?org=test"),
+      );
+      expect(response.status).toBe(401);
+    });
+  });
+
+  describe("PUT /api/org/variables", () => {
+    it("should create org variable as admin", async () => {
+      const userId = uniqueId("ov-create");
+      const { slug } = await setupOrg(userId, "org:admin");
+
+      const response = await PUT(
+        createTestRequest(orgUrl("", slug), {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            name: "ORG_API_URL",
+            value: "https://api.example.com",
+            description: "Test org variable",
+          }),
+        }),
+      );
+      expect(response.status).toBe(200);
+
+      const data = await response.json();
+      expect(data.name).toBe("ORG_API_URL");
+      expect(data.value).toBe("https://api.example.com");
+      expect(data.description).toBe("Test org variable");
+      expect(data.id).toBeDefined();
+      expect(data.createdAt).toBeDefined();
+      expect(data.updatedAt).toBeDefined();
+    });
+
+    it("should update existing org variable", async () => {
+      const userId = uniqueId("ov-update");
+      const { slug } = await setupOrg(userId, "org:admin");
+
+      // Create
+      await PUT(
+        createTestRequest(orgUrl("", slug), {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            name: "ORG_VAR_V",
+            value: "value-v1",
+          }),
+        }),
+      );
+
+      // Update
+      const response = await PUT(
+        createTestRequest(orgUrl("", slug), {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            name: "ORG_VAR_V",
+            value: "value-v2",
+          }),
+        }),
+      );
+      expect(response.status).toBe(200);
+
+      const data = await response.json();
+      expect(data.name).toBe("ORG_VAR_V");
+      expect(data.value).toBe("value-v2");
+    });
+
+    it("should return 403 for non-admin member", async () => {
+      const userId = uniqueId("ov-member-put");
+      const { slug } = await setupOrg(userId, "org:member");
+
+      const response = await PUT(
+        createTestRequest(orgUrl("", slug), {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            name: "ORG_VAR",
+            value: "test-value",
+          }),
+        }),
+      );
+      expect(response.status).toBe(403);
+
+      const data = await response.json();
+      expect(data.error.code).toBe("FORBIDDEN");
+    });
+
+    it("should return 401 for unauthenticated", async () => {
+      mockClerk({ userId: null });
+
+      const response = await PUT(
+        createTestRequest("http://localhost:3000/api/org/variables?org=test", {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            name: "ORG_VAR",
+            value: "test-value",
+          }),
+        }),
+      );
+      expect(response.status).toBe(401);
+    });
+  });
+
+  describe("DELETE /api/org/variables/:name", () => {
+    it("should delete org variable as admin", async () => {
+      const userId = uniqueId("ov-delete");
+      const { slug } = await setupOrg(userId, "org:admin");
+
+      // Create first
+      await PUT(
+        createTestRequest(orgUrl("", slug), {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            name: "ORG_DELETE_VAR",
+            value: "delete-this",
+          }),
+        }),
+      );
+
+      // Delete
+      const response = await DELETE(
+        createTestRequest(orgUrl("/ORG_DELETE_VAR", slug), {
+          method: "DELETE",
+        }),
+      );
+      expect(response.status).toBe(204);
+
+      // Verify deletion
+      const listRes = await GET(createTestRequest(orgUrl("", slug)));
+      const listData = await listRes.json();
+      expect(listData.variables).toEqual([]);
+    });
+
+    it("should return 404 for non-existent variable", async () => {
+      const userId = uniqueId("ov-del-404");
+      const { slug } = await setupOrg(userId, "org:admin");
+
+      const response = await DELETE(
+        createTestRequest(orgUrl("/NONEXISTENT", slug), {
+          method: "DELETE",
+        }),
+      );
+      expect(response.status).toBe(404);
+    });
+
+    it("should return 403 for non-admin member", async () => {
+      const userId = uniqueId("ov-del-member");
+      const { slug } = await setupOrg(userId, "org:member");
+
+      const response = await DELETE(
+        createTestRequest(orgUrl("/SOME_VAR", slug), {
+          method: "DELETE",
+        }),
+      );
+      expect(response.status).toBe(403);
+    });
+  });
+
+  describe("list after CRUD operations", () => {
+    it("should list created org variables", async () => {
+      const userId = uniqueId("ov-listcrud");
+      const { slug } = await setupOrg(userId, "org:admin");
+
+      // Create a variable
+      await PUT(
+        createTestRequest(orgUrl("", slug), {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            name: "ORG_LISTED_VAR",
+            value: "listed-value",
+            description: "A listed variable",
+          }),
+        }),
+      );
+
+      const response = await GET(createTestRequest(orgUrl("", slug)));
+      expect(response.status).toBe(200);
+
+      const data = await response.json();
+      expect(data.variables).toHaveLength(1);
+      expect(data.variables[0].name).toBe("ORG_LISTED_VAR");
+      expect(data.variables[0].value).toBe("listed-value");
+      expect(data.variables[0].description).toBe("A listed variable");
+      expect(data.variables[0].id).toBeDefined();
+      expect(data.variables[0].createdAt).toBeDefined();
+      expect(data.variables[0].updatedAt).toBeDefined();
+    });
+  });
+});

--- a/turbo/packages/core/src/contracts/index.ts
+++ b/turbo/packages/core/src/contracts/index.ts
@@ -521,3 +521,15 @@ export {
   type OrgModelProvidersSetDefaultContract,
   type OrgModelProvidersUpdateModelContract,
 } from "./org-model-providers";
+export {
+  orgSecretsMainContract,
+  orgSecretsByNameContract,
+  type OrgSecretsMainContract,
+  type OrgSecretsByNameContract,
+} from "./org-secrets";
+export {
+  orgVariablesMainContract,
+  orgVariablesByNameContract,
+  type OrgVariablesMainContract,
+  type OrgVariablesByNameContract,
+} from "./org-variables";

--- a/turbo/packages/core/src/contracts/org-secrets.ts
+++ b/turbo/packages/core/src/contracts/org-secrets.ts
@@ -1,0 +1,74 @@
+import { z } from "zod";
+import { authHeadersSchema, initContract } from "./base";
+import { apiErrorSchema } from "./errors";
+import {
+  secretListResponseSchema,
+  secretResponseSchema,
+  setSecretRequestSchema,
+  secretNameSchema,
+} from "./secrets";
+
+const c = initContract();
+
+/**
+ * Org secrets main contract for /api/org/secrets
+ *
+ * GET: List org-level secrets (any member)
+ * PUT: Create or update an org-level secret (admin only)
+ */
+export const orgSecretsMainContract = c.router({
+  list: {
+    method: "GET",
+    path: "/api/org/secrets",
+    headers: authHeadersSchema,
+    responses: {
+      200: secretListResponseSchema,
+      401: apiErrorSchema,
+      500: apiErrorSchema,
+    },
+    summary: "List org-level secrets (metadata only)",
+  },
+  set: {
+    method: "PUT",
+    path: "/api/org/secrets",
+    headers: authHeadersSchema,
+    body: setSecretRequestSchema,
+    responses: {
+      200: secretResponseSchema,
+      201: secretResponseSchema,
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      500: apiErrorSchema,
+    },
+    summary: "Create or update an org-level secret (admin only)",
+  },
+});
+
+export type OrgSecretsMainContract = typeof orgSecretsMainContract;
+
+/**
+ * Org secrets by name contract for /api/org/secrets/:name
+ *
+ * DELETE: Delete an org-level secret (admin only)
+ */
+export const orgSecretsByNameContract = c.router({
+  delete: {
+    method: "DELETE",
+    path: "/api/org/secrets/:name",
+    headers: authHeadersSchema,
+    pathParams: z.object({
+      name: secretNameSchema,
+    }),
+    responses: {
+      204: c.noBody(),
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      404: apiErrorSchema,
+      500: apiErrorSchema,
+    },
+    summary: "Delete an org-level secret (admin only)",
+  },
+});
+
+export type OrgSecretsByNameContract = typeof orgSecretsByNameContract;

--- a/turbo/packages/core/src/contracts/org-variables.ts
+++ b/turbo/packages/core/src/contracts/org-variables.ts
@@ -1,0 +1,74 @@
+import { z } from "zod";
+import { authHeadersSchema, initContract } from "./base";
+import { apiErrorSchema } from "./errors";
+import {
+  variableListResponseSchema,
+  variableResponseSchema,
+  setVariableRequestSchema,
+  variableNameSchema,
+} from "./variables";
+
+const c = initContract();
+
+/**
+ * Org variables main contract for /api/org/variables
+ *
+ * GET: List org-level variables (any member)
+ * PUT: Create or update an org-level variable (admin only)
+ */
+export const orgVariablesMainContract = c.router({
+  list: {
+    method: "GET",
+    path: "/api/org/variables",
+    headers: authHeadersSchema,
+    responses: {
+      200: variableListResponseSchema,
+      401: apiErrorSchema,
+      500: apiErrorSchema,
+    },
+    summary: "List org-level variables (includes values)",
+  },
+  set: {
+    method: "PUT",
+    path: "/api/org/variables",
+    headers: authHeadersSchema,
+    body: setVariableRequestSchema,
+    responses: {
+      200: variableResponseSchema,
+      201: variableResponseSchema,
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      500: apiErrorSchema,
+    },
+    summary: "Create or update an org-level variable (admin only)",
+  },
+});
+
+export type OrgVariablesMainContract = typeof orgVariablesMainContract;
+
+/**
+ * Org variables by name contract for /api/org/variables/:name
+ *
+ * DELETE: Delete an org-level variable (admin only)
+ */
+export const orgVariablesByNameContract = c.router({
+  delete: {
+    method: "DELETE",
+    path: "/api/org/variables/:name",
+    headers: authHeadersSchema,
+    pathParams: z.object({
+      name: variableNameSchema,
+    }),
+    responses: {
+      204: c.noBody(),
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      404: apiErrorSchema,
+      500: apiErrorSchema,
+    },
+    summary: "Delete an org-level variable (admin only)",
+  },
+});
+
+export type OrgVariablesByNameContract = typeof orgVariablesByNameContract;


### PR DESCRIPTION
## Summary

- Add admin-only API routes for org-level secrets and variables (`/api/org/secrets`, `/api/org/variables`)
- Add CLI commands: `vm0 org secret list/set/remove` and `vm0 org variable list/set/remove`
- Add ts-rest contracts (`org-secrets.ts`, `org-variables.ts`) reusing existing schemas
- Add integration tests (22 tests covering CRUD, auth, and admin enforcement)

## Test plan

- [x] API integration tests for org secrets (11 tests: list, create, update, delete, 401, 403, 404)
- [x] API integration tests for org variables (11 tests: list, create, update, delete, 401, 403, 404)
- [x] Type checks pass for core, cli, and web packages
- [x] Lint and knip checks pass
- [x] Format checks pass

Closes #5200

🤖 Generated with [Claude Code](https://claude.com/claude-code)