### PR TITLE
fix: error when active org is not set instead of silently skipping

### DIFF
--- a/turbo/apps/cli/src/commands/org/__tests__/list.test.ts
+++ b/turbo/apps/cli/src/commands/org/__tests__/list.test.ts
@@ -37,6 +37,7 @@ describe("org list command", () => {
     chalk.level = 0;
     vi.stubEnv("VM0_API_URL", "http://localhost:3000");
     vi.stubEnv("VM0_TOKEN", "test-token");
+    vi.stubEnv("VM0_ACTIVE_ORG", "my-org");
     const configDir = path.join(TEST_HOME, ".vm0");
     await mkdir(configDir, { recursive: true });
     await writeFile(

--- a/turbo/apps/cli/src/commands/org/__tests__/status.test.ts
+++ b/turbo/apps/cli/src/commands/org/__tests__/status.test.ts
@@ -39,6 +39,22 @@ describe("org status command", () => {
     });
   });
 
+  describe("no active organization", () => {
+    it("should exit with error if no active org configured", async () => {
+      vi.stubEnv("VM0_ACTIVE_ORG", "");
+      vi.stubEnv("HOME", "/tmp/test-no-org-config");
+
+      await expect(async () => {
+        await statusCommand.parseAsync(["node", "cli"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("No active organization configured"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+
   describe("no organization configured", () => {
     it("should show helpful message when user has no organization", async () => {
       server.use(

--- a/turbo/apps/cli/src/lib/api/core/client-factory.ts
+++ b/turbo/apps/cli/src/lib/api/core/client-factory.ts
@@ -59,23 +59,24 @@ export async function getClientConfig() {
   const baseHeaders = await getHeaders();
 
   const activeOrg = await getActiveOrg();
-
-  if (activeOrg) {
-    return {
-      baseUrl,
-      baseHeaders,
-      jsonQuery: false as const,
-      api: async (args: Parameters<typeof tsRestFetchApi>[0]) => {
-        const separator = args.path.includes("?") ? "&" : "?";
-        if (!args.path.includes("org=")) {
-          args.path = `${args.path}${separator}org=${encodeURIComponent(activeOrg)}`;
-        }
-        return tsRestFetchApi(args);
-      },
-    };
+  if (!activeOrg) {
+    throw new Error(
+      "No active organization configured. Run: vm0 org use <slug>",
+    );
   }
 
-  return { baseUrl, baseHeaders, jsonQuery: false as const };
+  return {
+    baseUrl,
+    baseHeaders,
+    jsonQuery: false as const,
+    api: async (args: Parameters<typeof tsRestFetchApi>[0]) => {
+      const separator = args.path.includes("?") ? "&" : "?";
+      if (!args.path.includes("org=")) {
+        args.path = `${args.path}${separator}org=${encodeURIComponent(activeOrg)}`;
+      }
+      return tsRestFetchApi(args);
+    },
+  };
 }
 
 /**

--- a/turbo/apps/cli/src/lib/api/core/http.ts
+++ b/turbo/apps/cli/src/lib/api/core/http.ts
@@ -8,7 +8,9 @@ import { getActiveToken, getActiveOrg } from "../config";
 async function appendOrgParam(path: string): Promise<string> {
   const activeOrg = await getActiveOrg();
   if (!activeOrg) {
-    return path;
+    throw new Error(
+      "No active organization configured. Run: vm0 org use <slug>",
+    );
   }
 
   // Check if org param already exists

--- a/turbo/apps/cli/src/test/setup.ts
+++ b/turbo/apps/cli/src/test/setup.ts
@@ -6,10 +6,11 @@ beforeAll(() => {
   server.listen({ onUnhandledRequest: "error" });
 });
 
-// Baseline: no auth, no API URL. Test files override in their own beforeEach.
+// Baseline: no auth, no API URL, default org. Test files override in their own beforeEach.
 beforeEach(() => {
   vi.stubEnv("VM0_API_URL", undefined);
   vi.stubEnv("VM0_TOKEN", "");
+  vi.stubEnv("VM0_ACTIVE_ORG", "test-org");
   vi.stubEnv("SENTRY_DSN", "");
 });
 


### PR DESCRIPTION
## Summary
- Throw a clear error in `getClientConfig()` and `appendOrgParam()` when `activeOrg` is undefined, instead of silently sending API requests without org context
- After #5110 removed server-side resolveOrg fallback, missing `?org=` causes 400 errors with no helpful CLI message
- Add integration test for the new error path and update test setup with default `VM0_ACTIVE_ORG`

Closes #5206

## Test plan
- [x] New integration test: `org status` with no active org shows "No active organization configured" error
- [x] All 916 existing CLI tests pass (79 test files)
- [x] Lint and type check pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)