### PR TITLE
fix: add cache and security headers to platform vercel.json

### DIFF
--- a/turbo/apps/platform/src/__tests__/vercel-headers.test.ts
+++ b/turbo/apps/platform/src/__tests__/vercel-headers.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import vercelConfig from "../../vercel.json";
+
+interface HeaderPair {
+  key: string;
+  value: string;
+}
+
+interface VercelHeaderEntry {
+  source: string;
+  headers: HeaderPair[];
+}
+
+const entries =
+  (vercelConfig as { headers?: VercelHeaderEntry[] }).headers ?? [];
+
+function findHeaderEntry(source: string): VercelHeaderEntry | undefined {
+  return entries.find((e) => e.source === source);
+}
+
+function findHeader(headers: HeaderPair[], name: string): string | undefined {
+  return headers.find((h) => h.key === name)?.value;
+}
+
+describe("platform vercel.json headers", () => {
+  it("should set immutable cache headers for hashed assets", () => {
+    const assetEntry = findHeaderEntry("/assets/(.*)");
+
+    expect(assetEntry).toBeDefined();
+    expect(findHeader(assetEntry!.headers, "Cache-Control")).toBe(
+      "max-age=31536000, immutable",
+    );
+  });
+
+  it("should include security headers for all routes", () => {
+    const catchAll = findHeaderEntry("/(.*)");
+
+    expect(catchAll).toBeDefined();
+    expect(findHeader(catchAll!.headers, "X-Frame-Options")).toBe("DENY");
+    expect(findHeader(catchAll!.headers, "X-Content-Type-Options")).toBe(
+      "nosniff",
+    );
+    expect(findHeader(catchAll!.headers, "Referrer-Policy")).toBe(
+      "strict-origin-when-cross-origin",
+    );
+    expect(findHeader(catchAll!.headers, "Strict-Transport-Security")).toBe(
+      "max-age=31536000; includeSubDomains",
+    );
+  });
+
+  it("should place asset cache rule before catch-all so it takes priority", () => {
+    const assetIndex = entries.findIndex((e) => e.source === "/assets/(.*)");
+    const catchAllIndex = entries.findIndex((e) => e.source === "/(.*)");
+
+    expect(assetIndex).toBeGreaterThanOrEqual(0);
+    expect(catchAllIndex).toBeGreaterThanOrEqual(0);
+    expect(assetIndex).toBeLessThan(catchAllIndex);
+  });
+});

--- a/turbo/apps/platform/vercel.json
+++ b/turbo/apps/platform/vercel.json
@@ -2,6 +2,38 @@
   "buildCommand": "cd ../.. && pnpm run build --filter=@vm0/platform",
   "installCommand": "cd ../.. && pnpm install",
   "outputDirectory": "dist",
+  "headers": [
+    {
+      "source": "/assets/(.*)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "max-age=31536000, immutable"
+        }
+      ]
+    },
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "X-Frame-Options",
+          "value": "DENY"
+        },
+        {
+          "key": "X-Content-Type-Options",
+          "value": "nosniff"
+        },
+        {
+          "key": "Referrer-Policy",
+          "value": "strict-origin-when-cross-origin"
+        },
+        {
+          "key": "Strict-Transport-Security",
+          "value": "max-age=31536000; includeSubDomains"
+        }
+      ]
+    }
+  ],
   "rewrites": [
     {
       "source": "/(.*)",


### PR DESCRIPTION
## Summary

- Add `Cache-Control: max-age=31536000, immutable` for `/assets/*` (Vite content-hashed files)
- Add security headers (X-Frame-Options, X-Content-Type-Options, Referrer-Policy, HSTS) for all routes, matching the web app's configuration
- Add integration test to verify headers configuration

Closes #5208

## Test plan

- [x] Integration test validates cache headers for hashed assets
- [x] Integration test validates security headers for all routes
- [x] Integration test validates asset cache rule ordering (before catch-all)
- [ ] After deploy, verify with `curl -I https://platform.vm0.ai/assets/<hash>.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)