### PR TITLE
refactor: add explicit org slug to all resolve-org calls without org parameter

### DIFF
--- a/turbo/apps/web/app/api/compose/jobs/route.ts
+++ b/turbo/apps/web/app/api/compose/jobs/route.ts
@@ -45,7 +45,7 @@ function formatJobResponse(job: {
 }
 
 const router = tsr.router(composeJobsMainContract, {
-  create: async ({ body, headers }) => {
+  create: async ({ body, headers }, { request }) => {
     initServices();
 
     const authCtx = await getAuthContext(headers.authorization);
@@ -60,7 +60,8 @@ const router = tsr.router(composeJobsMainContract, {
     const { userId } = authCtx;
 
     // Resolve the caller's org
-    const { org } = await resolveOrg(userId);
+    const orgSlug = new URL(request.url).searchParams.get("org");
+    const { org } = await resolveOrg(userId, orgSlug);
 
     // Dispatch based on input type: GitHub URL or platform content
     const isGitHubInput = "githubUrl" in body;

--- a/turbo/apps/web/app/api/connectors/[type]/callback/route.ts
+++ b/turbo/apps/web/app/api/connectors/[type]/callback/route.ts
@@ -200,7 +200,8 @@ export async function GET(
     // when the code adds new scopes and prompt users to re-authorize.
     // Note: do not read "scope" from the callback URL — OAuth providers (e.g., Monday.com)
     // may append OAuth scopes as ?scope=... which would be mistaken for an app scope slug.
-    const { org } = await resolveOrg(userId);
+    const orgSlug = url.searchParams.get("org");
+    const { org } = await resolveOrg(userId, orgSlug);
     const { created } = await upsertOAuthConnector(
       org.orgId,
       userId,

--- a/turbo/apps/web/app/api/integrations/github/route.ts
+++ b/turbo/apps/web/app/api/integrations/github/route.ts
@@ -123,7 +123,8 @@ export async function GET(request: Request) {
   }
 
   // Resolve user's org for resource queries
-  const { org } = await resolveOrg(userId);
+  const orgSlugParam = new URL(request.url).searchParams.get("org");
+  const { org } = await resolveOrg(userId, orgSlugParam);
 
   // Get user's existing secrets, vars, connectors
   const [userSecrets, userVars, userConnectors] = await Promise.all([
@@ -344,7 +345,8 @@ export async function PATCH(request: Request) {
     }
     targetOrgId = targetOrg.orgId;
   } else {
-    const { org } = await resolveOrg(userId);
+    const urlOrgSlug = new URL(request.url).searchParams.get("org");
+    const { org } = await resolveOrg(userId, urlOrgSlug);
     targetOrgId = org.orgId;
   }
 

--- a/turbo/apps/web/app/api/integrations/github/route.ts
+++ b/turbo/apps/web/app/api/integrations/github/route.ts
@@ -101,7 +101,9 @@ export async function GET(request: Request) {
     .where(eq(agentComposes.id, installation.defaultComposeId))
     .limit(1);
 
-  const orgSlug = compose ? (await getOrgData(compose.orgId)).slug : null;
+  const composeOrgSlug = compose
+    ? (await getOrgData(compose.orgId)).slug
+    : null;
 
   // Extract required secrets/vars from agent compose
   let requiredSecrets: string[] = [];
@@ -158,7 +160,9 @@ export async function GET(request: Request) {
       targetType: installation.targetType,
       isAdmin,
     },
-    agent: compose ? { id: compose.id, name: compose.name, orgSlug } : null,
+    agent: compose
+      ? { id: compose.id, name: compose.name, orgSlug: composeOrgSlug }
+      : null,
     environment: {
       requiredSecrets,
       requiredVars,

--- a/turbo/apps/web/app/api/integrations/github/route.ts
+++ b/turbo/apps/web/app/api/integrations/github/route.ts
@@ -123,8 +123,8 @@ export async function GET(request: Request) {
   }
 
   // Resolve user's org for resource queries
-  const orgSlugParam = new URL(request.url).searchParams.get("org");
-  const { org } = await resolveOrg(userId, orgSlugParam);
+  const orgSlug = new URL(request.url).searchParams.get("org");
+  const { org } = await resolveOrg(userId, orgSlug);
 
   // Get user's existing secrets, vars, connectors
   const [userSecrets, userVars, userConnectors] = await Promise.all([

--- a/turbo/apps/web/app/api/integrations/slack/org/connect/route.ts
+++ b/turbo/apps/web/app/api/integrations/slack/org/connect/route.ts
@@ -44,8 +44,8 @@ export async function GET(request: Request) {
   }
 
   const { userId } = authCtx;
-  const orgSlugParam = new URL(request.url).searchParams.get("org");
-  const { org, member } = await resolveOrg(userId, orgSlugParam);
+  const orgSlug = new URL(request.url).searchParams.get("org");
+  const { org, member } = await resolveOrg(userId, orgSlug);
 
   // Find user's connection in any workspace bound to this org
   const [connection] = await globalThis.services.db
@@ -128,8 +128,8 @@ export async function POST(request: Request) {
   const { workspaceId, slackUserId, channelId, threadTs } = parseResult.data;
 
   // Resolve org and check membership
-  const orgSlugParam = new URL(request.url).searchParams.get("org");
-  const { org, member } = await resolveOrg(userId, orgSlugParam);
+  const orgSlug = new URL(request.url).searchParams.get("org");
+  const { org, member } = await resolveOrg(userId, orgSlug);
 
   // Check installation exists
   const [installation] = await globalThis.services.db

--- a/turbo/apps/web/app/api/integrations/slack/org/connect/route.ts
+++ b/turbo/apps/web/app/api/integrations/slack/org/connect/route.ts
@@ -44,7 +44,8 @@ export async function GET(request: Request) {
   }
 
   const { userId } = authCtx;
-  const { org, member } = await resolveOrg(userId);
+  const orgSlugParam = new URL(request.url).searchParams.get("org");
+  const { org, member } = await resolveOrg(userId, orgSlugParam);
 
   // Find user's connection in any workspace bound to this org
   const [connection] = await globalThis.services.db
@@ -127,7 +128,8 @@ export async function POST(request: Request) {
   const { workspaceId, slackUserId, channelId, threadTs } = parseResult.data;
 
   // Resolve org and check membership
-  const { org, member } = await resolveOrg(userId);
+  const orgSlugParam = new URL(request.url).searchParams.get("org");
+  const { org, member } = await resolveOrg(userId, orgSlugParam);
 
   // Check installation exists
   const [installation] = await globalThis.services.db

--- a/turbo/apps/web/app/api/integrations/slack/org/route.ts
+++ b/turbo/apps/web/app/api/integrations/slack/org/route.ts
@@ -55,7 +55,8 @@ export async function GET(request: Request) {
   }
 
   const { userId } = authCtx;
-  const { org, member } = await resolveOrg(userId);
+  const orgSlugParam = new URL(request.url).searchParams.get("org");
+  const { org, member } = await resolveOrg(userId, orgSlugParam);
 
   const db = globalThis.services.db;
 
@@ -223,16 +224,20 @@ export async function DELETE(request: Request) {
 
   const url = new URL(request.url);
   const action = url.searchParams.get("action");
+  const orgSlug = url.searchParams.get("org");
 
   if (action === "uninstall") {
-    return handleUninstall(authCtx);
+    return handleUninstall(authCtx, orgSlug);
   }
-  return handleDisconnect(authCtx);
+  return handleDisconnect(authCtx, orgSlug);
 }
 
-async function handleUninstall(authCtx: { userId: string }) {
+async function handleUninstall(
+  authCtx: { userId: string },
+  orgSlug: string | null,
+) {
   const { userId } = authCtx;
-  const { org, member } = await resolveOrg(userId);
+  const { org, member } = await resolveOrg(userId, orgSlug);
 
   if (member.role !== "admin") {
     return NextResponse.json(
@@ -321,9 +326,12 @@ async function handleUninstall(authCtx: { userId: string }) {
   return NextResponse.json({ ok: true });
 }
 
-async function handleDisconnect(authCtx: { userId: string }) {
+async function handleDisconnect(
+  authCtx: { userId: string },
+  orgSlug: string | null,
+) {
   const { userId } = authCtx;
-  const { org } = await resolveOrg(userId);
+  const { org } = await resolveOrg(userId, orgSlug);
   const { SECRETS_ENCRYPTION_KEY } = env();
   const db = globalThis.services.db;
 

--- a/turbo/apps/web/app/api/integrations/slack/org/route.ts
+++ b/turbo/apps/web/app/api/integrations/slack/org/route.ts
@@ -55,8 +55,8 @@ export async function GET(request: Request) {
   }
 
   const { userId } = authCtx;
-  const orgSlugParam = new URL(request.url).searchParams.get("org");
-  const { org, member } = await resolveOrg(userId, orgSlugParam);
+  const orgSlug = new URL(request.url).searchParams.get("org");
+  const { org, member } = await resolveOrg(userId, orgSlug);
 
   const db = globalThis.services.db;
 

--- a/turbo/apps/web/app/api/integrations/telegram/route.ts
+++ b/turbo/apps/web/app/api/integrations/telegram/route.ts
@@ -100,7 +100,9 @@ export async function GET(request: Request) {
     .where(eq(agentComposes.id, installation.defaultComposeId))
     .limit(1);
 
-  const orgSlug = compose ? (await getOrgData(compose.orgId)).slug : null;
+  const composeOrgSlug = compose
+    ? (await getOrgData(compose.orgId)).slug
+    : null;
 
   // Extract required secrets/vars from agent compose
   let requiredSecrets: string[] = [];
@@ -161,7 +163,9 @@ export async function GET(request: Request) {
       id: installation.telegramBotId,
       username: installation.botUsername,
     },
-    agent: compose ? { id: compose.id, name: compose.name, orgSlug } : null,
+    agent: compose
+      ? { id: compose.id, name: compose.name, orgSlug: composeOrgSlug }
+      : null,
     isAdmin,
     isConnected,
     domainConfigured,

--- a/turbo/apps/web/app/api/integrations/telegram/route.ts
+++ b/turbo/apps/web/app/api/integrations/telegram/route.ts
@@ -122,7 +122,8 @@ export async function GET(request: Request) {
   }
 
   // Resolve user's default org and get existing secrets, vars, connectors
-  const { org } = await resolveOrg(userId);
+  const orgSlugParam = new URL(request.url).searchParams.get("org");
+  const { org } = await resolveOrg(userId, orgSlugParam);
   const [userSecrets, userVars, userConnectors] = await Promise.all([
     listSecrets(org.orgId, userId),
     listVariables(org.orgId, userId),
@@ -267,7 +268,8 @@ export async function PATCH(request: Request) {
     targetOrg = resolved;
   } else {
     try {
-      ({ org: targetOrg } = await resolveOrg(userId));
+      const urlOrgSlug = new URL(request.url).searchParams.get("org");
+      ({ org: targetOrg } = await resolveOrg(userId, urlOrgSlug));
     } catch (error) {
       if (isNotFound(error)) {
         return NextResponse.json(

--- a/turbo/apps/web/app/api/integrations/telegram/route.ts
+++ b/turbo/apps/web/app/api/integrations/telegram/route.ts
@@ -122,8 +122,8 @@ export async function GET(request: Request) {
   }
 
   // Resolve user's default org and get existing secrets, vars, connectors
-  const orgSlugParam = new URL(request.url).searchParams.get("org");
-  const { org } = await resolveOrg(userId, orgSlugParam);
+  const orgSlug = new URL(request.url).searchParams.get("org");
+  const { org } = await resolveOrg(userId, orgSlug);
   const [userSecrets, userVars, userConnectors] = await Promise.all([
     listSecrets(org.orgId, userId),
     listVariables(org.orgId, userId),

--- a/turbo/apps/web/app/api/onboarding/status/route.ts
+++ b/turbo/apps/web/app/api/onboarding/status/route.ts
@@ -14,7 +14,7 @@ import { agentComposeApiContentSchema } from "@vm0/core";
 import { auth } from "@clerk/nextjs/server";
 
 const router = tsr.router(onboardingStatusContract, {
-  getStatus: async ({ headers }) => {
+  getStatus: async ({ headers }, { request }) => {
     initServices();
 
     const userId = await getUserId(headers.authorization);
@@ -39,8 +39,9 @@ const router = tsr.router(onboardingStatusContract, {
       sound?: string;
     } | null = null;
 
+    const orgSlug = new URL(request.url).searchParams.get("org");
     try {
-      const { org: resolvedOrg } = await resolveOrg(userId);
+      const { org: resolvedOrg } = await resolveOrg(userId, orgSlug);
       hasOrg = true;
 
       // Check model provider

--- a/turbo/apps/web/app/api/platform/logs/[id]/route.ts
+++ b/turbo/apps/web/app/api/platform/logs/[id]/route.ts
@@ -106,7 +106,7 @@ function notFoundResponse() {
 }
 
 const router = tsr.router(platformLogsByIdContract, {
-  getById: async ({ params, headers }) => {
+  getById: async ({ params, headers }, { request }) => {
     initServices();
 
     const authCtx = await getAuthContext(headers.authorization);
@@ -117,8 +117,9 @@ const router = tsr.router(platformLogsByIdContract, {
 
     // Resolve active org from JWT / CLI token / default
     let orgId: string;
+    const orgSlug = new URL(request.url).searchParams.get("org");
     try {
-      const { org: resolvedOrg } = await resolveOrg(userId);
+      const { org: resolvedOrg } = await resolveOrg(userId, orgSlug);
       orgId = resolvedOrg.orgId;
     } catch (error) {
       if (isNotFound(error) || isForbidden(error)) {

--- a/turbo/apps/web/app/api/slack/org/connect/route.ts
+++ b/turbo/apps/web/app/api/slack/org/connect/route.ts
@@ -58,7 +58,8 @@ export async function GET(request: Request) {
   }
 
   if (!installation.orgId) {
-    const { org, member } = await resolveOrg(userId);
+    const orgSlug = url.searchParams.get("org");
+    const { org, member } = await resolveOrg(userId, orgSlug);
 
     if (member.role !== "admin") {
       return NextResponse.redirect(

--- a/turbo/apps/web/app/api/user/export/route.ts
+++ b/turbo/apps/web/app/api/user/export/route.ts
@@ -29,7 +29,8 @@ export async function POST(request: Request) {
   const { userId } = ctx;
 
   // Resolve orgId via resolveOrg (works for both Clerk sessions and CLI tokens)
-  const { org } = await resolveOrg(userId);
+  const orgSlug = new URL(request.url).searchParams.get("org");
+  const { org } = await resolveOrg(userId, orgSlug);
   const resolvedOrgId = org.orgId;
 
   const db = globalThis.services.db;


### PR DESCRIPTION
## Summary

- Extract `?org=` query parameter from request URL and pass to `resolveOrg()` at all 15 call sites across 10 files
- For standard route handlers (7 files): add inline `orgSlug` extraction from `request.url`
- For ts-rest handlers (3 files): add `{ request }` second parameter + inline extraction
- For Slack DELETE helpers: pass `orgSlug` as function parameter from DELETE handler

## Context

After removing Tier 3/4 fallback in #5110/#5121, `resolveOrg(userId)` requires explicit org context. These 13 callers relied solely on JWT Tier 2 and would fail with 400 when called from CLI tokens without an active org in session.

Closes #5205

## Test plan

- [x] TypeScript compilation passes (no new type errors in source files)
- [x] Lint passes clean (0 warnings, 0 errors)
- [x] Knip finds no unused code issues
- [x] All related integration tests pass (slack-org-connect, org-model-providers, build-context-org, org-secret-service, org-variable-service, model-providers list-upsert)
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)