### PR TITLE
refactor: reorder token checks to skip auth() for vm0 tokens

### DIFF
--- a/turbo/apps/web/src/lib/auth/__tests__/get-user-id.spec.ts
+++ b/turbo/apps/web/src/lib/auth/__tests__/get-user-id.spec.ts
@@ -177,3 +177,46 @@ describe("getAuthContext with acceptAnySandboxCapability", () => {
     expect(result?.capabilities).toBeUndefined();
   });
 });
+
+describe("getAuthContext auth() call optimization", () => {
+  const mockAuth = vi.mocked(auth);
+
+  beforeEach(() => {
+    mockAuth.mockResolvedValue({
+      userId: null,
+    } as Awaited<ReturnType<typeof auth>>);
+  });
+
+  it("should not call auth() when sandbox token is provided", async () => {
+    const token = await generateSandboxToken("user-1", "run-1", [
+      "artifact:read",
+    ]);
+    await getAuthContext(`Bearer ${token}`, {
+      requiredCapability: "artifact:read",
+    });
+    expect(mockAuth).not.toHaveBeenCalled();
+  });
+
+  it("should not call auth() when sandbox token is rejected", async () => {
+    const token = await generateSandboxToken("user-1", "run-1", [
+      "artifact:read",
+    ]);
+    await getAuthContext(`Bearer ${token}`);
+    expect(mockAuth).not.toHaveBeenCalled();
+  });
+
+  it("should call auth() when no auth header provided", async () => {
+    await getAuthContext();
+    expect(mockAuth).toHaveBeenCalled();
+  });
+
+  it("should call auth() when non-Bearer auth header provided", async () => {
+    await getAuthContext("Basic sometoken");
+    expect(mockAuth).toHaveBeenCalled();
+  });
+
+  it("should call auth() for unknown Bearer token", async () => {
+    await getAuthContext("Bearer unknown_token_format");
+    expect(mockAuth).toHaveBeenCalled();
+  });
+});

--- a/turbo/apps/web/src/lib/auth/get-user-id.ts
+++ b/turbo/apps/web/src/lib/auth/get-user-id.ts
@@ -33,90 +33,97 @@ export async function getAuthContext(
     acceptAnySandboxCapability?: boolean;
   },
 ): Promise<AuthContext | null> {
-  // Session auth via Clerk
+  // Check Bearer token prefixes first (fast, no external calls)
+  if (authHeader?.startsWith("Bearer ")) {
+    const token = authHeader.substring(7); // Remove "Bearer "
+
+    if (isSandboxToken(token)) {
+      // Without any sandbox opt-in, reject sandbox tokens (existing behavior)
+      if (
+        !options?.requiredCapability &&
+        !options?.acceptAnySandboxCapability
+      ) {
+        log.debug("Rejected sandbox JWT token on normal API endpoint");
+        return null;
+      }
+
+      // Verify sandbox token signature and expiry
+      const sandboxAuth = verifySandboxToken(token);
+      if (!sandboxAuth) {
+        log.debug("Invalid or expired sandbox token");
+        return null;
+      }
+
+      // acceptAnySandboxCapability: accept if token has any capability
+      if (options?.acceptAnySandboxCapability) {
+        if (
+          !sandboxAuth.capabilities ||
+          sandboxAuth.capabilities.length === 0
+        ) {
+          log.debug("Sandbox token has no capabilities");
+          return null;
+        }
+        return {
+          userId: sandboxAuth.userId,
+          runId: sandboxAuth.runId,
+          capabilities: [...sandboxAuth.capabilities],
+        };
+      }
+
+      // requiredCapability: check specific capability
+      const hasCap = sandboxAuth.capabilities?.some(
+        (cap) => cap === options.requiredCapability,
+      );
+      if (!hasCap) {
+        log.debug(
+          `Sandbox token missing required capability: ${options.requiredCapability}`,
+        );
+        return null;
+      }
+
+      return {
+        userId: sandboxAuth.userId,
+        runId: sandboxAuth.runId,
+        capabilities: sandboxAuth.capabilities
+          ? [...sandboxAuth.capabilities]
+          : undefined,
+      };
+    }
+
+    // Check for CLI token format (vm0_live_)
+    if (token.startsWith("vm0_live_")) {
+      const [tokenRecord] = await globalThis.services.db
+        .select()
+        .from(cliTokens)
+        .where(
+          and(eq(cliTokens.token, token), gt(cliTokens.expiresAt, new Date())),
+        )
+        .limit(1);
+
+      if (!tokenRecord) {
+        return null;
+      }
+
+      // Update last used timestamp (non-blocking)
+      globalThis.services.db
+        .update(cliTokens)
+        .set({ lastUsedAt: new Date() })
+        .where(eq(cliTokens.token, token))
+        .catch((err) => log.error("Failed to update token lastUsedAt:", err));
+
+      return {
+        userId: tokenRecord.userId,
+      };
+    }
+  }
+
+  // Fall back to Clerk session auth
   const { userId } = await auth();
   if (userId) {
     return { userId };
   }
 
-  if (!authHeader?.startsWith("Bearer ")) {
-    return null;
-  }
-
-  const token = authHeader.substring(7); // Remove "Bearer "
-
-  if (isSandboxToken(token)) {
-    // Without any sandbox opt-in, reject sandbox tokens (existing behavior)
-    if (!options?.requiredCapability && !options?.acceptAnySandboxCapability) {
-      log.debug("Rejected sandbox JWT token on normal API endpoint");
-      return null;
-    }
-
-    // Verify sandbox token signature and expiry
-    const sandboxAuth = verifySandboxToken(token);
-    if (!sandboxAuth) {
-      log.debug("Invalid or expired sandbox token");
-      return null;
-    }
-
-    // acceptAnySandboxCapability: accept if token has any capability
-    if (options?.acceptAnySandboxCapability) {
-      if (!sandboxAuth.capabilities || sandboxAuth.capabilities.length === 0) {
-        log.debug("Sandbox token has no capabilities");
-        return null;
-      }
-      return {
-        userId: sandboxAuth.userId,
-        runId: sandboxAuth.runId,
-        capabilities: [...sandboxAuth.capabilities],
-      };
-    }
-
-    // requiredCapability: check specific capability
-    const hasCap = sandboxAuth.capabilities?.some(
-      (cap) => cap === options.requiredCapability,
-    );
-    if (!hasCap) {
-      log.debug(
-        `Sandbox token missing required capability: ${options.requiredCapability}`,
-      );
-      return null;
-    }
-
-    return {
-      userId: sandboxAuth.userId,
-      runId: sandboxAuth.runId,
-      capabilities: sandboxAuth.capabilities
-        ? [...sandboxAuth.capabilities]
-        : undefined,
-    };
-  }
-
-  // Check for CLI token format (vm0_live_)
-  if (!token.startsWith("vm0_live_")) {
-    return null;
-  }
-
-  const [tokenRecord] = await globalThis.services.db
-    .select()
-    .from(cliTokens)
-    .where(and(eq(cliTokens.token, token), gt(cliTokens.expiresAt, new Date())))
-    .limit(1);
-
-  if (!tokenRecord) {
-    return null;
-  }
-
-  // Update last used timestamp (non-blocking)
-  globalThis.services.db
-    .update(cliTokens)
-    .set({ lastUsedAt: new Date() })
-    .where(eq(cliTokens.token, token))
-    .catch((err) => log.error("Failed to update token lastUsedAt:", err));
-
-  return {
-    userId: tokenRecord.userId,
-  };
+  return null;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Reorder `getAuthContext()` to check Bearer token prefixes (`vm0_sandbox_*`, `vm0_live_*`) before calling Clerk's `auth()`, eliminating a wasted `auth()` call for all non-Clerk token requests
- Add 5 new tests verifying `auth()` is skipped for vm0 tokens and called for Clerk sessions
- No behavioral change for any real-world scenario — same inputs produce same outputs

Closes #5215

## Test plan

- [x] All 18 `get-user-id.spec.ts` tests pass (13 existing + 5 new)
- [x] All 11 `require-auth.test.ts` tests pass unchanged
- [x] Lint, type-check, format, and knip all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)