### PR TITLE
feat(runner): profile-aware discovery, budget reservation, and per-profile factory

### DIFF
--- a/crates/runner/src/cmd/benchmark.rs
+++ b/crates/runner/src/cmd/benchmark.rs
@@ -89,7 +89,7 @@ pub async fn run_benchmark(args: BenchmarkArgs) -> RunnerResult<ExitCode> {
     let fc_config = runner_config.firecracker_config(&default_profile, &home, Some(mitm.port()));
 
     let t = Instant::now();
-    let mut factory = FirecrackerFactory::new(fc_config).await?;
+    let mut factory = FirecrackerFactory::new(fc_config, None).await?;
     factory.startup().await?;
     let factory_ms = t.elapsed().as_millis();
     info!(factory_ms, "factory ready");

--- a/crates/runner/src/cmd/start.rs
+++ b/crates/runner/src/cmd/start.rs
@@ -9,7 +9,7 @@ use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info, warn};
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 use crate::config::{self, ProfileConfig};
 use crate::deps;
@@ -309,7 +309,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
     } = config;
 
     // Build per-profile factories with shared netns pool.
-    let mut factories: HashMap<String, Arc<FirecrackerFactory>> = HashMap::new();
+    let mut factories: BTreeMap<String, Arc<FirecrackerFactory>> = BTreeMap::new();
     for (profile_name, profile_config) in &profiles {
         let fc_config = config::RunnerConfig::build_firecracker_config(
             &firecracker,
@@ -538,10 +538,10 @@ struct JobProfile {
 
 /// Shut down all factories and clean up the shared netns pool.
 async fn shutdown_factories(
-    factories: &mut HashMap<String, Arc<FirecrackerFactory>>,
+    factories: &mut BTreeMap<String, Arc<FirecrackerFactory>>,
     shared_netns: &Arc<tokio::sync::Mutex<sandbox_fc::NetnsPool>>,
 ) {
-    for (name, factory) in factories.drain() {
+    for (name, factory) in std::mem::take(factories) {
         match Arc::try_unwrap(factory) {
             Ok(mut f) => f.shutdown().await,
             Err(_) => warn!(profile = %name, "factory still referenced at shutdown"),
@@ -573,8 +573,12 @@ fn spawn_job(
     let run_id = context.run_id;
     let vcpu = job_profile.vcpu;
     let memory_mb = job_profile.memory_mb;
-    let use_snapshot = job_profile.use_snapshot;
     let factory = job_profile.factory;
+    let params = executor::JobParams {
+        vcpu,
+        memory_mb,
+        use_snapshot: job_profile.use_snapshot,
+    };
 
     let provider = Arc::clone(provider);
     let exec_config = Arc::clone(exec_config);
@@ -585,15 +589,7 @@ fn spawn_job(
         // Inner spawn isolates panics: if execute_job panics, the outer task
         // still reports completion and releases budget.
         let inner = tokio::spawn(async move {
-            executor::execute_job(
-                factory.as_ref(),
-                context,
-                &exec_config,
-                vcpu,
-                memory_mb,
-                use_snapshot,
-            )
-            .await
+            executor::execute_job(factory.as_ref(), context, &exec_config, &params).await
         });
 
         let (exit_code, err) = match inner.await {

--- a/crates/runner/src/cmd/start.rs
+++ b/crates/runner/src/cmd/start.rs
@@ -9,7 +9,9 @@ use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info, warn};
 
-use crate::config;
+use std::collections::HashMap;
+
+use crate::config::{self, ProfileConfig};
 use crate::deps;
 use crate::error::{RunnerError, RunnerResult};
 use crate::executor::{self, ExecutorConfig};
@@ -18,7 +20,6 @@ use crate::http::HttpClient;
 use crate::lock;
 use crate::paths::{HomePaths, LogPaths, RunnerPaths, touch_mtime};
 use crate::prefetch;
-use crate::profile;
 use crate::provider::{ApiProvider, JobProvider, LocalProvider};
 use crate::proxy;
 use crate::resource_budget::ResourceBudget;
@@ -134,18 +135,20 @@ pub async fn run_start(args: StartArgs) -> RunnerResult<()> {
         }
     }
 
-    // Use the default profile for vcpu/memory (used for budget and pool sizing).
-    let default_profile = runner_config
+    // Compute the smallest profile resources for budget pre-check.
+    // When budget is exhausted for all profiles, we wait instead of polling.
+    let min_vcpu = runner_config
         .profiles
-        .get(profile::DEFAULT_PROFILE)
-        .ok_or_else(|| {
-            RunnerError::Config(format!(
-                "profile '{}' not found in config",
-                profile::DEFAULT_PROFILE
-            ))
-        })?;
-    let vcpu = default_profile.vcpu;
-    let memory_mb = default_profile.memory_mb;
+        .values()
+        .map(|p| p.vcpu)
+        .min()
+        .unwrap_or(1);
+    let min_memory_mb = runner_config
+        .profiles
+        .values()
+        .map(|p| p.memory_mb)
+        .min()
+        .unwrap_or(1);
 
     // Start proxy before factory so proxy_port is available for netns pool.
     let paths = RunnerPaths::new(runner_config.base_dir.clone());
@@ -179,27 +182,20 @@ pub async fn run_start(args: StartArgs) -> RunnerResult<()> {
     info!(
         host_cpus,
         host_memory_mb,
-        vcpu,
-        memory_mb,
         concurrency_factor,
         max_concurrent,
         effective_vcpu = budget.effective_vcpu(),
         effective_memory_mb = budget.effective_memory_mb(),
+        profiles = runner_config.profiles.len(),
         "resource budget initialized"
     );
 
-    // Build firecracker config with all parameters resolved.
-    let fc_config = runner_config.firecracker_config(default_profile, &home, Some(mitm.port()));
-    let is_snapshot = fc_config.snapshot.is_some();
-
-    // Estimated capacity: theoretical max concurrent VMs from resource budget.
-    // Used for status reporting only — actual admission is controlled by ResourceBudget.
-    assert!(vcpu > 0, "profile vcpu must be > 0");
-    assert!(memory_mb > 0, "profile memory_mb must be > 0");
+    // Estimated capacity for status reporting.
+    // Derived from the smallest profile to cover the worst case.
     let estimated_capacity = {
         let resource_limit = std::cmp::min(
-            budget.effective_vcpu() as usize / vcpu as usize,
-            budget.effective_memory_mb() as usize / memory_mb as usize,
+            budget.effective_vcpu() as usize / min_vcpu as usize,
+            budget.effective_memory_mb() as usize / min_memory_mb as usize,
         )
         .max(1);
         if max_concurrent > 0 {
@@ -208,6 +204,15 @@ pub async fn run_start(args: StartArgs) -> RunnerResult<()> {
             resource_limit
         }
     };
+
+    // Build per-profile netns pool (shared).
+    let netns_pool = sandbox_fc::NetnsPool::create(sandbox_fc::NetnsPoolConfig {
+        proxy_port: Some(mitm.port()),
+    })
+    .await
+    .map_err(|e| RunnerError::Internal(format!("netns pool: {e}")))?;
+    let shared_netns = Arc::new(tokio::sync::Mutex::new(netns_pool));
+
     let mut status = StatusTracker::new(paths.status(), estimated_capacity);
     status.set_proxy_port(mitm.port()).await;
     let status = Arc::new(status);
@@ -232,9 +237,6 @@ pub async fn run_start(args: StartArgs) -> RunnerResult<()> {
 
     let exec_config = Arc::new(ExecutorConfig {
         api_url: server.url,
-        vcpu,
-        memory_mb,
-        is_snapshot,
         registry: registry_handle,
         http,
         log_paths,
@@ -243,7 +245,10 @@ pub async fn run_start(args: StartArgs) -> RunnerResult<()> {
     let config = RunConfig {
         name,
         group: group_name,
-        fc_config,
+        profiles: runner_config.profiles,
+        shared_netns,
+        home,
+        proxy_port: mitm.port(),
         budget,
         status,
         mitm,
@@ -251,6 +256,10 @@ pub async fn run_start(args: StartArgs) -> RunnerResult<()> {
         provider,
         cancel,
         exec_config,
+        firecracker: runner_config.firecracker,
+        base_dir: runner_config.base_dir,
+        min_vcpu,
+        min_memory_mb,
     };
 
     run(config).await
@@ -259,7 +268,10 @@ pub async fn run_start(args: StartArgs) -> RunnerResult<()> {
 struct RunConfig {
     name: String,
     group: String,
-    fc_config: sandbox_fc::FirecrackerConfig,
+    profiles: std::collections::BTreeMap<String, ProfileConfig>,
+    shared_netns: Arc<tokio::sync::Mutex<sandbox_fc::NetnsPool>>,
+    home: HomePaths,
+    proxy_port: u16,
     budget: Arc<ResourceBudget>,
     status: Arc<StatusTracker>,
     mitm: proxy::MitmProxy,
@@ -267,6 +279,10 @@ struct RunConfig {
     provider: Arc<dyn JobProvider>,
     cancel: CancellationToken,
     exec_config: Arc<ExecutorConfig>,
+    firecracker: config::FirecrackerConfig,
+    base_dir: std::path::PathBuf,
+    min_vcpu: u32,
+    min_memory_mb: u32,
 }
 
 type MitmRestartHandle = tokio::task::JoinHandle<RunnerResult<tokio::process::Child>>;
@@ -275,7 +291,10 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
     let RunConfig {
         name,
         group,
-        fc_config,
+        profiles,
+        shared_netns,
+        home,
+        proxy_port,
         budget,
         status,
         mut mitm,
@@ -283,14 +302,40 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
         provider,
         cancel,
         exec_config,
+        firecracker,
+        base_dir,
+        min_vcpu,
+        min_memory_mb,
     } = config;
 
-    let vcpu = exec_config.vcpu;
-    let memory_mb = exec_config.memory_mb;
-
-    let mut factory = FirecrackerFactory::new(fc_config).await?;
-    factory.startup().await?;
-    let factory = Arc::new(factory);
+    // Build per-profile factories with shared netns pool.
+    let mut factories: HashMap<String, Arc<FirecrackerFactory>> = HashMap::new();
+    for (profile_name, profile_config) in &profiles {
+        let fc_config = config::RunnerConfig::build_firecracker_config(
+            &firecracker,
+            &base_dir,
+            profile_config,
+            &home,
+            Some(proxy_port),
+        );
+        let factory_result = async {
+            let mut factory =
+                FirecrackerFactory::new(fc_config, Some(Arc::clone(&shared_netns))).await?;
+            factory.startup().await?;
+            Ok::<_, sandbox::SandboxError>(factory)
+        }
+        .await;
+        let factory = match factory_result {
+            Ok(f) => f,
+            Err(e) => {
+                // Clean up already-started factories before propagating.
+                shutdown_factories(&mut factories, &shared_netns).await;
+                return Err(e.into());
+            }
+        };
+        factories.insert(profile_name.clone(), Arc::new(factory));
+        info!(profile = %profile_name, "factory started");
+    }
 
     let mut jobs = JoinSet::new();
 
@@ -359,8 +404,8 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
         // Spawn background restart task when timer fires
         maybe_spawn_mitm_restart(&mut mitm, &mut mitm_crash_rx, &mut mitm_retry).await;
 
-        // If budget is exhausted, wait for a job to finish or mode change
-        if !budget.can_afford(vcpu, memory_mb) {
+        // If budget is exhausted for all profiles, wait for a job to finish
+        if !budget.can_afford(min_vcpu, min_memory_mb) {
             tokio::select! {
                 _ = mode_rx.changed() => {}
                 result = jobs.join_next() => {
@@ -384,22 +429,40 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
             // Job discovery via provider (Ably push + poll).
             // discover() has no server-side side effects — safe to cancel.
             discovered = provider.discover() => {
-                let Some(run_id) = discovered else { break }; // provider shutdown
+                let Some((run_id, profile_name)) = discovered else { break };
+                // Look up profile config for resource requirements.
+                let Some(profile_config) = profiles.get(&profile_name) else {
+                    warn!(run_id = %run_id, profile = %profile_name, "unknown profile, skipping");
+                    continue;
+                };
+                let job_vcpu = profile_config.vcpu;
+                let job_memory = profile_config.memory_mb;
+                // Look up factory for this profile.
+                let Some(factory) = factories.get(&profile_name) else {
+                    warn!(run_id = %run_id, profile = %profile_name, "no factory for profile, skipping");
+                    continue;
+                };
                 // Reserve resources before claiming so we don't waste a job
                 // that another runner could handle.
-                if !budget.try_reserve(vcpu, memory_mb) {
+                if !budget.try_reserve(job_vcpu, job_memory) {
                     continue;
                 }
                 // claim() runs in the branch handler — non-interruptible,
                 // so a successful claim is always paired with complete().
                 let Some(context) = provider.claim(run_id).await else {
-                    budget.release(vcpu, memory_mb); // rollback on 409
+                    budget.release(job_vcpu, job_memory); // rollback on 409
                     continue;
                 };
-                info!(run_id = %run_id, "job claimed, spawning executor");
+                info!(run_id = %run_id, profile = %profile_name, "job claimed, spawning executor");
                 status.add_run(run_id).await;
+                let job_profile = JobProfile {
+                    vcpu: job_vcpu,
+                    memory_mb: job_memory,
+                    use_snapshot: factory.has_snapshot(),
+                    factory: Arc::clone(factory),
+                };
                 spawn_job(
-                    context, &provider, &factory, &exec_config,
+                    context, job_profile, &provider, &exec_config,
                     &budget, &mut jobs, &status,
                 );
             }
@@ -451,10 +514,8 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
         h.abort();
     }
 
-    info!("shutting down factory");
-    let mut factory = Arc::try_unwrap(factory)
-        .map_err(|_| RunnerError::Internal("factory still referenced at shutdown".into()))?;
-    factory.shutdown().await;
+    info!("shutting down factories");
+    shutdown_factories(&mut factories, &shared_netns).await;
 
     // Stop proxy after all jobs have drained and factory is shut down.
     if let Err(e) = mitm.stop().await {
@@ -467,6 +528,34 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
     Ok(())
 }
 
+/// Per-job profile parameters resolved from the profile config.
+struct JobProfile {
+    vcpu: u32,
+    memory_mb: u32,
+    use_snapshot: bool,
+    factory: Arc<FirecrackerFactory>,
+}
+
+/// Shut down all factories and clean up the shared netns pool.
+async fn shutdown_factories(
+    factories: &mut HashMap<String, Arc<FirecrackerFactory>>,
+    shared_netns: &Arc<tokio::sync::Mutex<sandbox_fc::NetnsPool>>,
+) {
+    for (name, factory) in factories.drain() {
+        match Arc::try_unwrap(factory) {
+            Ok(mut f) => f.shutdown().await,
+            Err(_) => warn!(profile = %name, "factory still referenced at shutdown"),
+        }
+    }
+    // Clean up shared netns pool after all factories released their references.
+    // Cannot try_unwrap here because the caller still holds a reference;
+    // lock and clean up in-place instead.
+    let mut pool = shared_netns.lock().await;
+    if let Err(e) = pool.cleanup().await {
+        warn!(error = %e, "failed to cleanup shared netns pool");
+    }
+}
+
 /// Spawn a job executor task.
 ///
 /// The provider has already claimed the job and the caller has reserved
@@ -474,19 +563,20 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
 /// completion via the provider, and releases the budget when done.
 fn spawn_job(
     context: ExecutionContext,
+    job_profile: JobProfile,
     provider: &Arc<dyn JobProvider>,
-    factory: &Arc<FirecrackerFactory>,
     exec_config: &Arc<ExecutorConfig>,
     budget: &Arc<ResourceBudget>,
     jobs: &mut JoinSet<()>,
     status: &Arc<StatusTracker>,
 ) {
     let run_id = context.run_id;
-    let vcpu = exec_config.vcpu;
-    let memory_mb = exec_config.memory_mb;
+    let vcpu = job_profile.vcpu;
+    let memory_mb = job_profile.memory_mb;
+    let use_snapshot = job_profile.use_snapshot;
+    let factory = job_profile.factory;
 
     let provider = Arc::clone(provider);
-    let factory = Arc::clone(factory);
     let exec_config = Arc::clone(exec_config);
     let budget = Arc::clone(budget);
     let status = Arc::clone(status);
@@ -495,7 +585,15 @@ fn spawn_job(
         // Inner spawn isolates panics: if execute_job panics, the outer task
         // still reports completion and releases budget.
         let inner = tokio::spawn(async move {
-            executor::execute_job(factory.as_ref(), context, &exec_config).await
+            executor::execute_job(
+                factory.as_ref(),
+                context,
+                &exec_config,
+                vcpu,
+                memory_mb,
+                use_snapshot,
+            )
+            .await
         });
 
         let (exit_code, err) = match inner.await {

--- a/crates/runner/src/config.rs
+++ b/crates/runner/src/config.rs
@@ -209,6 +209,20 @@ impl RunnerConfig {
         home: &HomePaths,
         proxy_port: Option<u16>,
     ) -> sandbox_fc::FirecrackerConfig {
+        Self::build_firecracker_config(&self.firecracker, &self.base_dir, profile, home, proxy_port)
+    }
+
+    /// Build a `sandbox_fc::FirecrackerConfig` from components.
+    ///
+    /// Static variant of [`firecracker_config`](Self::firecracker_config) for
+    /// use after `RunnerConfig` has been destructured.
+    pub fn build_firecracker_config(
+        firecracker: &FirecrackerConfig,
+        base_dir: &Path,
+        profile: &ProfileConfig,
+        home: &HomePaths,
+        proxy_port: Option<u16>,
+    ) -> sandbox_fc::FirecrackerConfig {
         let rootfs_paths = RootfsPaths::new(home, &profile.rootfs_hash);
         let snapshot = profile.snapshot_hash.as_ref().map(|hash| {
             let snapshot_output =
@@ -216,10 +230,10 @@ impl RunnerConfig {
             snapshot_output.snapshot_config(hash)
         });
         sandbox_fc::FirecrackerConfig {
-            binary_path: self.firecracker.binary.clone(),
-            kernel_path: self.firecracker.kernel.clone(),
+            binary_path: firecracker.binary.clone(),
+            kernel_path: firecracker.kernel.clone(),
             rootfs_path: rootfs_paths.rootfs(),
-            base_dir: self.base_dir.clone(),
+            base_dir: base_dir.to_path_buf(),
             proxy_port,
             snapshot,
         }

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -22,12 +22,9 @@ use crate::proxy::{self, ProxyRegistryHandle};
 use crate::telemetry::JobTelemetry;
 use crate::types::{ExecutionContext, ResumeSession, StorageManifest};
 
-/// Configuration for a single execution.
+/// Shared configuration for all executions (profile-independent).
 pub struct ExecutorConfig {
     pub api_url: String,
-    pub vcpu: u32,
-    pub memory_mb: u32,
-    pub is_snapshot: bool,
     pub registry: ProxyRegistryHandle,
     pub http: HttpClient,
     pub log_paths: LogPaths,
@@ -42,6 +39,9 @@ pub async fn execute_job(
     factory: &dyn SandboxFactory,
     context: ExecutionContext,
     config: &ExecutorConfig,
+    vcpu: u32,
+    memory_mb: u32,
+    use_snapshot: bool,
 ) -> (i32, Option<String>) {
     let run_id = context.run_id;
     let mut telemetry =
@@ -60,7 +60,17 @@ pub async fn execute_job(
         );
     }
 
-    let (exit_code, err) = match execute_inner(factory, &context, config, &mut telemetry).await {
+    let (exit_code, err) = match execute_inner(
+        factory,
+        &context,
+        config,
+        vcpu,
+        memory_mb,
+        use_snapshot,
+        &mut telemetry,
+    )
+    .await
+    {
         Ok((code, stderr)) => (code, stderr),
         Err(e) => {
             error!(run_id = %run_id, error = %e, "job execution failed");
@@ -78,14 +88,17 @@ async fn execute_inner(
     factory: &dyn SandboxFactory,
     context: &ExecutionContext,
     config: &ExecutorConfig,
+    vcpu: u32,
+    memory_mb: u32,
+    use_snapshot: bool,
     telemetry: &mut JobTelemetry,
 ) -> RunnerResult<(i32, Option<String>)> {
     let sandbox_id = context.run_id;
     let sandbox_config = SandboxConfig {
         id: sandbox_id,
         resources: sandbox::ResourceLimits {
-            cpu_count: config.vcpu,
-            memory_mb: config.memory_mb,
+            cpu_count: vcpu,
+            memory_mb,
         },
         use_proxy: true,
     };
@@ -133,7 +146,7 @@ async fn execute_inner(
     }
 
     // Run job inside sandbox, then destroy regardless of outcome
-    let result = run_in_sandbox(sandbox.as_ref(), context, config, telemetry).await;
+    let result = run_in_sandbox(sandbox.as_ref(), context, config, use_snapshot, telemetry).await;
 
     // Copy guest logs to host log directory (best-effort).
     copy_guest_logs(sandbox.as_ref(), context, &config.log_paths).await;
@@ -180,13 +193,14 @@ async fn run_in_sandbox(
     sandbox: &dyn Sandbox,
     context: &ExecutionContext,
     config: &ExecutorConfig,
+    use_snapshot: bool,
     telemetry: &mut JobTelemetry,
 ) -> RunnerResult<(i32, Option<String>)> {
     // System log file — all guest process output goes here for telemetry upload.
     let log_file = format!("/tmp/vm0-system-{}.log", context.run_id);
 
     // 1. Fix guest clock after snapshot restore (must happen before HTTPS calls)
-    if config.is_snapshot {
+    if use_snapshot {
         fix_guest_clock(sandbox).await?;
     }
 

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -30,6 +30,13 @@ pub struct ExecutorConfig {
     pub log_paths: LogPaths,
 }
 
+/// Per-job VM parameters resolved from the profile config.
+pub struct JobParams {
+    pub vcpu: u32,
+    pub memory_mb: u32,
+    pub use_snapshot: bool,
+}
+
 /// Execute a single job inside a Firecracker VM.
 ///
 /// Returns `(exit_code, error_message)`. The caller is responsible for
@@ -39,9 +46,7 @@ pub async fn execute_job(
     factory: &dyn SandboxFactory,
     context: ExecutionContext,
     config: &ExecutorConfig,
-    vcpu: u32,
-    memory_mb: u32,
-    use_snapshot: bool,
+    params: &JobParams,
 ) -> (i32, Option<String>) {
     let run_id = context.run_id;
     let mut telemetry =
@@ -60,23 +65,14 @@ pub async fn execute_job(
         );
     }
 
-    let (exit_code, err) = match execute_inner(
-        factory,
-        &context,
-        config,
-        vcpu,
-        memory_mb,
-        use_snapshot,
-        &mut telemetry,
-    )
-    .await
-    {
-        Ok((code, stderr)) => (code, stderr),
-        Err(e) => {
-            error!(run_id = %run_id, error = %e, "job execution failed");
-            (1, Some(e.to_string()))
-        }
-    };
+    let (exit_code, err) =
+        match execute_inner(factory, &context, config, params, &mut telemetry).await {
+            Ok((code, stderr)) => (code, stderr),
+            Err(e) => {
+                error!(run_id = %run_id, error = %e, "job execution failed");
+                (1, Some(e.to_string()))
+            }
+        };
 
     info!(run_id = %run_id, exit_code, "job finished");
     telemetry.flush().await;
@@ -88,17 +84,15 @@ async fn execute_inner(
     factory: &dyn SandboxFactory,
     context: &ExecutionContext,
     config: &ExecutorConfig,
-    vcpu: u32,
-    memory_mb: u32,
-    use_snapshot: bool,
+    params: &JobParams,
     telemetry: &mut JobTelemetry,
 ) -> RunnerResult<(i32, Option<String>)> {
     let sandbox_id = context.run_id;
     let sandbox_config = SandboxConfig {
         id: sandbox_id,
         resources: sandbox::ResourceLimits {
-            cpu_count: vcpu,
-            memory_mb,
+            cpu_count: params.vcpu,
+            memory_mb: params.memory_mb,
         },
         use_proxy: true,
     };
@@ -146,7 +140,14 @@ async fn execute_inner(
     }
 
     // Run job inside sandbox, then destroy regardless of outcome
-    let result = run_in_sandbox(sandbox.as_ref(), context, config, use_snapshot, telemetry).await;
+    let result = run_in_sandbox(
+        sandbox.as_ref(),
+        context,
+        config,
+        params.use_snapshot,
+        telemetry,
+    )
+    .await;
 
     // Copy guest logs to host log directory (best-effort).
     copy_guest_logs(sandbox.as_ref(), context, &config.log_paths).await;

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -103,7 +103,7 @@ impl ApiProvider {
 
 #[async_trait::async_trait]
 impl JobProvider for ApiProvider {
-    async fn discover(&self) -> Option<Uuid> {
+    async fn discover(&self) -> Option<(Uuid, String)> {
         let mut state = self.discovery.lock().await;
         loop {
             // Check shutdown
@@ -140,8 +140,9 @@ impl JobProvider for ApiProvider {
                     match event {
                         Some(ably_subscriber::Event::Message(msg)) => {
                             if let Some(notif) = parse_job_notification(&msg) {
-                                info!(run_id = %notif.run_id, profile = ?notif.profile, "ably: job notification");
-                                return Some(notif.run_id);
+                                let profile = notif.profile.unwrap_or_else(|| crate::profile::DEFAULT_PROFILE.to_owned());
+                                info!(run_id = %notif.run_id, %profile, "ably: job notification");
+                                return Some((notif.run_id, profile));
                             }
                         }
                         Some(ably_subscriber::Event::Connected) => {
@@ -177,9 +178,10 @@ impl JobProvider for ApiProvider {
                     *poll_now = false;
                     match self.api.poll(&self.group).await {
                         Ok(Some(job)) => {
-                            info!(run_id = %job.run_id, "poll: job found");
+                            let profile = job.experimental_profile.unwrap_or_else(|| crate::profile::DEFAULT_PROFILE.to_owned());
+                            info!(run_id = %job.run_id, %profile, "poll: job found");
                             *poll_now = true;
-                            return Some(job.run_id);
+                            return Some((job.run_id, profile));
                         }
                         Ok(None) => {}
                         Err(e) => {

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -140,6 +140,8 @@ impl JobProvider for ApiProvider {
                     match event {
                         Some(ably_subscriber::Event::Message(msg)) => {
                             if let Some(notif) = parse_job_notification(&msg) {
+                                // Fall back to default profile when server doesn't send one
+                                // (backwards compat with pre-profile API).
                                 let profile = notif.profile.unwrap_or_else(|| crate::profile::DEFAULT_PROFILE.to_owned());
                                 info!(run_id = %notif.run_id, %profile, "ably: job notification");
                                 return Some((notif.run_id, profile));
@@ -178,6 +180,8 @@ impl JobProvider for ApiProvider {
                     *poll_now = false;
                     match self.api.poll(&self.group).await {
                         Ok(Some(job)) => {
+                            // Fall back to default profile when server doesn't send one
+                            // (backwards compat with pre-profile API).
                             let profile = job.experimental_profile.unwrap_or_else(|| crate::profile::DEFAULT_PROFILE.to_owned());
                             info!(run_id = %job.run_id, %profile, "poll: job found");
                             *poll_now = true;

--- a/crates/runner/src/provider/local.rs
+++ b/crates/runner/src/provider/local.rs
@@ -91,14 +91,14 @@ impl LocalProvider {
 
 #[async_trait::async_trait]
 impl JobProvider for LocalProvider {
-    async fn discover(&self) -> Option<Uuid> {
+    async fn discover(&self) -> Option<(Uuid, String)> {
         loop {
             if self.cancel.is_cancelled() {
                 return None;
             }
             if let Some(job_id) = self.find_unclaimed_job() {
                 info!(run_id = %job_id, "local: job discovered");
-                return Some(job_id);
+                return Some((job_id, crate::profile::DEFAULT_PROFILE.to_owned()));
             }
             tokio::select! {
                 () = self.cancel.cancelled() => return None,
@@ -228,8 +228,9 @@ mod tests {
         let job_id = Uuid::new_v4();
         write_job(dir.path(), job_id, "hello world");
 
-        let run_id = provider.discover().await.unwrap();
+        let (run_id, profile) = provider.discover().await.unwrap();
         assert_eq!(run_id, job_id);
+        assert_eq!(profile, crate::profile::DEFAULT_PROFILE);
 
         let ctx = provider.claim(run_id).await.unwrap();
         assert_eq!(ctx.run_id, run_id);
@@ -265,7 +266,7 @@ mod tests {
         write_job(dir.path(), job2, "available");
         std::fs::write(dir.path().join(format!("{job1}.claim")), b"").unwrap();
 
-        let run_id = provider.discover().await.unwrap();
+        let (run_id, _) = provider.discover().await.unwrap();
         assert_eq!(run_id, job2);
     }
 
@@ -279,13 +280,13 @@ mod tests {
         let job2 = Uuid::new_v4();
         write_job(dir.path(), job1, "job1");
 
-        let run_id1 = provider.discover().await.unwrap();
+        let (run_id1, _) = provider.discover().await.unwrap();
         let ctx1 = provider.claim(run_id1).await.unwrap();
         assert_eq!(ctx1.prompt, "job1");
 
         write_job(dir.path(), job2, "job2");
 
-        let run_id2 = provider.discover().await.unwrap();
+        let (run_id2, _) = provider.discover().await.unwrap();
         let ctx2 = provider.claim(run_id2).await.unwrap();
         assert_eq!(ctx2.prompt, "job2");
         assert_ne!(run_id1, run_id2);
@@ -313,8 +314,8 @@ mod tests {
         let job_id = Uuid::new_v4();
         write_job(dir.path(), job_id, "shared");
 
-        let id_a = provider_a.discover().await.unwrap();
-        let id_b = provider_b.discover().await.unwrap();
+        let (id_a, _) = provider_a.discover().await.unwrap();
+        let (id_b, _) = provider_b.discover().await.unwrap();
         assert_eq!(id_a, job_id);
         assert_eq!(id_b, job_id);
 

--- a/crates/runner/src/provider/mod.rs
+++ b/crates/runner/src/provider/mod.rs
@@ -30,12 +30,13 @@ pub trait JobProvider: Send + Sync {
     /// Wait for the next job candidate. Returns `None` on shutdown signal.
     ///
     /// Implementations handle discovery (push/poll) internally. The returned
-    /// `Uuid` is a candidate `run_id` ready to be claimed via
+    /// tuple contains the candidate `run_id` and the profile name (e.g.
+    /// `"vm0/default"`) for resource-budget pre-checking before
     /// [`claim()`](JobProvider::claim).
     ///
     /// This method has **no server-side side effects** and can be safely
     /// dropped (cancelled) at any `.await` point.
-    async fn discover(&self) -> Option<Uuid>;
+    async fn discover(&self) -> Option<(Uuid, String)>;
 
     /// Claim a discovered job. Returns `None` if the job was already claimed
     /// by another runner or an error occurred.

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -17,8 +17,6 @@ pub struct PollResponse {
 #[serde(rename_all = "camelCase")]
 pub struct Job {
     pub run_id: Uuid,
-    // Not yet used by runner — profile for resource-aware claiming
-    #[allow(dead_code)]
     #[serde(default)]
     pub experimental_profile: Option<String>,
 }
@@ -83,7 +81,6 @@ pub struct ExecutionContext {
     pub experimental_firewalls: Option<Vec<Firewall>>,
     #[serde(default)]
     pub experimental_capabilities: Option<Vec<String>>,
-    // Not yet used by runner — VM profile for resource allocation (e.g., "vm0/default", "vm0/browser")
     #[allow(dead_code)]
     #[serde(default)]
     pub experimental_profile: Option<String>,

--- a/crates/sandbox-fc/src/factory.rs
+++ b/crates/sandbox-fc/src/factory.rs
@@ -106,14 +106,20 @@ pub struct FirecrackerFactory {
     config: FirecrackerConfig,
     factory_paths: FactoryPaths,
     runtime_paths: RuntimePaths,
-    netns_pool: Option<tokio::sync::Mutex<NetnsPool>>,
+    netns_pool: Option<std::sync::Arc<tokio::sync::Mutex<NetnsPool>>>,
     overlay_pool: Option<tokio::sync::Mutex<OverlayPool>>,
 }
 
 impl FirecrackerFactory {
     /// Create a new factory without allocating system resources.
     /// Call `startup()` to initialize pools before use.
-    pub async fn new(config: FirecrackerConfig) -> Result<Self, SandboxError> {
+    ///
+    /// When `netns_pool` is provided, the factory shares it instead of
+    /// creating a new one in `startup()` (used for multi-profile runners).
+    pub async fn new(
+        config: FirecrackerConfig,
+        netns_pool: Option<std::sync::Arc<tokio::sync::Mutex<NetnsPool>>>,
+    ) -> Result<Self, SandboxError> {
         let t = std::time::Instant::now();
         prerequisites::check_prerequisites(&prerequisites::PrerequisiteConfig {
             binary_path: &config.binary_path,
@@ -134,15 +140,20 @@ impl FirecrackerFactory {
             config,
             factory_paths,
             runtime_paths,
-            netns_pool: None,
+            netns_pool,
             overlay_pool: None,
         })
+    }
+
+    /// Whether this factory uses snapshot restore (vs fresh boot).
+    pub fn has_snapshot(&self) -> bool {
+        self.config.snapshot.is_some()
     }
 
     /// # Panics
     /// Panics if called before `startup()` — this is a programming error.
     #[allow(clippy::expect_used)]
-    fn netns_pool(&self) -> &tokio::sync::Mutex<NetnsPool> {
+    fn netns_pool(&self) -> &std::sync::Arc<tokio::sync::Mutex<NetnsPool>> {
         self.netns_pool.as_ref().expect("factory not started")
     }
 
@@ -165,23 +176,28 @@ impl SandboxFactory for FirecrackerFactory {
     }
 
     async fn startup(&mut self) -> sandbox::Result<()> {
-        // Both pools are always set together, so checking one is sufficient.
-        if self.netns_pool.is_some() {
+        // Overlay pool signals startup completion — check it, not netns
+        // (netns may already be set via new_with_netns).
+        if self.overlay_pool.is_some() {
             return Err(SandboxError::CreationFailed(
                 "factory already started".into(),
             ));
         }
 
-        let t = std::time::Instant::now();
-        let mut netns_pool = NetnsPool::create(NetnsPoolConfig {
-            proxy_port: self.config.proxy_port,
-        })
-        .await
-        .map_err(|e| SandboxError::CreationFailed(format!("netns pool: {e}")))?;
-        info!(
-            elapsed_ms = t.elapsed().as_millis() as u64,
-            "netns pool created"
-        );
+        // Create netns pool only if not provided externally (shared pool case).
+        if self.netns_pool.is_none() {
+            let t = std::time::Instant::now();
+            let netns_pool = NetnsPool::create(NetnsPoolConfig {
+                proxy_port: self.config.proxy_port,
+            })
+            .await
+            .map_err(|e| SandboxError::CreationFailed(format!("netns pool: {e}")))?;
+            info!(
+                elapsed_ms = t.elapsed().as_millis() as u64,
+                "netns pool created"
+            );
+            self.netns_pool = Some(std::sync::Arc::new(tokio::sync::Mutex::new(netns_pool)));
+        }
 
         let overlay_creator: Box<dyn OverlayCreator> = match &self.config.snapshot {
             Some(snapshot) => Box::new(SnapshotCopyCreator::new(snapshot.overlay_path.clone())),
@@ -197,8 +213,13 @@ impl SandboxFactory for FirecrackerFactory {
         {
             Ok(pool) => pool,
             Err(e) => {
-                if let Err(cleanup_err) = netns_pool.cleanup().await {
-                    warn!(error = %cleanup_err, "failed to cleanup netns pool during rollback");
+                // Roll back: clean up netns pool if we created it ourselves.
+                // For shared pools (new_with_netns), the caller manages cleanup.
+                if let Some(Ok(mutex)) = self.netns_pool.take().map(std::sync::Arc::try_unwrap) {
+                    let mut pool = mutex.into_inner();
+                    if let Err(cleanup_err) = pool.cleanup().await {
+                        warn!(error = %cleanup_err, "failed to cleanup netns pool during rollback");
+                    }
                 }
                 return Err(SandboxError::CreationFailed(format!("overlay pool: {e}")));
             }
@@ -208,7 +229,6 @@ impl SandboxFactory for FirecrackerFactory {
             "overlay pool created"
         );
 
-        self.netns_pool = Some(tokio::sync::Mutex::new(netns_pool));
         self.overlay_pool = Some(tokio::sync::Mutex::new(overlay_pool));
 
         let mode = if self.config.snapshot.is_some() {
@@ -330,8 +350,10 @@ impl SandboxFactory for FirecrackerFactory {
     }
 
     async fn shutdown(&mut self) {
-        if let Some(netns_pool) = self.netns_pool.take() {
-            let mut pool = netns_pool.into_inner();
+        // Clean up netns pool only if we hold the last reference.
+        // When shared across multiple factories, the caller manages cleanup.
+        if let Some(Ok(mutex)) = self.netns_pool.take().map(std::sync::Arc::try_unwrap) {
+            let mut pool = mutex.into_inner();
             if let Err(e) = pool.cleanup().await {
                 warn!(error = %e, "failed to cleanup netns pool");
             }

--- a/crates/sandbox-fc/src/lib.rs
+++ b/crates/sandbox-fc/src/lib.rs
@@ -15,6 +15,7 @@ mod snapshot;
 pub use api::{ApiClient, ApiError, BalloonStatistics};
 pub use config::{FirecrackerConfig, SnapshotConfig};
 pub use factory::{FirecrackerFactory, PREWARM_SCRIPT, config_hash};
+pub use network::{NetnsPool, NetnsPoolConfig};
 pub use paths::{
     FactoryPaths, LockPaths, RuntimePaths, SandboxPaths, SnapshotOutputPaths, SockPaths,
 };


### PR DESCRIPTION
## Summary

- Runner uses profile field from discover for resource-aware job scheduling
- Per-profile `FirecrackerFactory` instances with shared `NetnsPool`
- `ResourceBudget` reserves per-job vcpu/memory based on profile config
- `FirecrackerFactory::new()` unified constructor with optional shared netns pool

## Changes

- **discover()** returns `(run_id, profile_name)` from Ably/poll, defaulting to `vm0/default`
- **start.rs**: per-profile factory loop with shared netns, `shutdown_factories` helper for cleanup
- **executor.rs**: `ExecutorConfig` split — shared config + per-job `vcpu`, `memory_mb`, `use_snapshot`
- **config.rs**: `build_firecracker_config()` static method for post-destructure use
- **factory.rs**: `new()` takes `Option<Arc<Mutex<NetnsPool>>>`, merged `new_with_netns`
- **provider/**: `discover()` signature changed to `Option<(Uuid, String)>`

## Part of

#4500 (profile-based VM configuration)

## Test plan

- [ ] 288 tests pass (191 runner + 97 sandbox-fc)
- [ ] Clippy clean
- [ ] Profile lookup from discover maps to correct factory and resource budget
- [ ] Unknown profile skipped with warning
- [ ] Budget release on claim failure (409)
- [ ] Factory startup partial failure cleans up already-started factories

🤖 Generated with [Claude Code](https://claude.com/claude-code)