### PR TITLE
feat(runner): add profile support to local provider and submit command

### DIFF
--- a/crates/runner/src/cmd/submit.rs
+++ b/crates/runner/src/cmd/submit.rs
@@ -39,6 +39,14 @@ pub struct SubmitArgs {
 }
 
 pub async fn run_submit(args: SubmitArgs) -> RunnerResult<ExitCode> {
+    if let Some(ref profile) = args.profile
+        && !crate::profile::validate_name(profile)
+    {
+        return Err(RunnerError::Config(format!(
+            "invalid profile name: {profile} (must be org/name format, lowercase alphanumeric + hyphens)"
+        )));
+    }
+
     let home = HomePaths::new()?;
     let group_dir = home.groups_dir().join(&args.group);
 

--- a/crates/runner/src/cmd/submit.rs
+++ b/crates/runner/src/cmd/submit.rs
@@ -30,6 +30,9 @@ pub struct SubmitArgs {
     /// Agent type
     #[arg(long, default_value = "claude-code")]
     cli_agent_type: String,
+    /// VM profile to use (e.g. "vm0/default", "vm0/browser")
+    #[arg(long)]
+    profile: Option<String>,
     /// Timeout in seconds waiting for a runner to complete the job
     #[arg(long, default_value_t = 300)]
     timeout: u64,
@@ -52,6 +55,7 @@ pub async fn run_submit(args: SubmitArgs) -> RunnerResult<ExitCode> {
         vars: None,
         environment: None,
         user_timezone: None,
+        profile: args.profile,
     };
 
     let json = serde_json::to_vec(&request)

--- a/crates/runner/src/cmd/submit.rs
+++ b/crates/runner/src/cmd/submit.rs
@@ -118,3 +118,42 @@ pub async fn run_submit(args: SubmitArgs) -> RunnerResult<ExitCode> {
         Ok(ExitCode::FAILURE)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn rejects_invalid_profile_name() {
+        let args = SubmitArgs {
+            group: "test/group".into(),
+            prompt: "hello".into(),
+            working_dir: "/workspace".into(),
+            cli_agent_type: "claude-code".into(),
+            profile: Some("bad-name".into()),
+            timeout: 1,
+        };
+        let err = run_submit(args).await.unwrap_err();
+        assert!(
+            err.to_string().contains("invalid profile name"),
+            "got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn accepts_valid_profile_name() {
+        let args = SubmitArgs {
+            group: "test/group".into(),
+            prompt: "hello".into(),
+            working_dir: "/workspace".into(),
+            cli_agent_type: "claude-code".into(),
+            profile: Some("vm0/browser".into()),
+            timeout: 1,
+        };
+        // Should pass validation and fail later (HomePaths or timeout), not on profile.
+        let result = run_submit(args).await;
+        if let Err(e) = &result {
+            assert!(!e.to_string().contains("invalid profile name"), "got: {e}");
+        }
+    }
+}

--- a/crates/runner/src/provider/local.rs
+++ b/crates/runner/src/provider/local.rs
@@ -168,7 +168,7 @@ impl JobProvider for LocalProvider {
             memory_name: None,
             experimental_firewalls: None,
             experimental_capabilities: None,
-            experimental_profile: None,
+            experimental_profile: req.profile,
         })
     }
 

--- a/crates/runner/src/provider/local.rs
+++ b/crates/runner/src/provider/local.rs
@@ -33,6 +33,8 @@ pub(crate) struct JobRequest {
     pub(crate) environment: Option<HashMap<String, String>>,
     #[serde(default)]
     pub(crate) user_timezone: Option<String>,
+    #[serde(default)]
+    pub(crate) profile: Option<String>,
 }
 
 /// Job response written by the runner as a `{job_id}.result` file.
@@ -61,7 +63,8 @@ impl LocalProvider {
     }
 
     /// Find the first `.job` file that has no corresponding `.claim` file.
-    fn find_unclaimed_job(&self) -> Option<Uuid> {
+    /// Reads the job file to extract the profile (defaults to `DEFAULT_PROFILE`).
+    fn find_unclaimed_job(&self) -> Option<(Uuid, String)> {
         let entries = match std::fs::read_dir(&self.group_dir) {
             Ok(e) => e,
             Err(e) => {
@@ -82,7 +85,12 @@ impl LocalProvider {
             };
             let claim_path = self.group_dir.join(format!("{job_id}.claim"));
             if !claim_path.exists() {
-                return Some(job_id);
+                let profile = std::fs::read(&path)
+                    .ok()
+                    .and_then(|buf| serde_json::from_slice::<JobRequest>(&buf).ok())
+                    .and_then(|req| req.profile)
+                    .unwrap_or_else(|| crate::profile::DEFAULT_PROFILE.to_owned());
+                return Some((job_id, profile));
             }
         }
         None
@@ -96,9 +104,9 @@ impl JobProvider for LocalProvider {
             if self.cancel.is_cancelled() {
                 return None;
             }
-            if let Some(job_id) = self.find_unclaimed_job() {
-                info!(run_id = %job_id, "local: job discovered");
-                return Some((job_id, crate::profile::DEFAULT_PROFILE.to_owned()));
+            if let Some((job_id, profile)) = self.find_unclaimed_job() {
+                info!(run_id = %job_id, %profile, "local: job discovered");
+                return Some((job_id, profile));
             }
             tokio::select! {
                 () = self.cancel.cancelled() => return None,
@@ -199,6 +207,16 @@ mod tests {
 
     /// Write a job file into the group directory.
     fn write_job(dir: &std::path::Path, job_id: Uuid, prompt: &str) {
+        write_job_with_profile(dir, job_id, prompt, None);
+    }
+
+    /// Write a job file with an optional profile.
+    fn write_job_with_profile(
+        dir: &std::path::Path,
+        job_id: Uuid,
+        prompt: &str,
+        profile: Option<&str>,
+    ) {
         let req = JobRequest {
             job_id,
             prompt: prompt.into(),
@@ -207,6 +225,7 @@ mod tests {
             vars: None,
             environment: None,
             user_timezone: None,
+            profile: profile.map(String::from),
         };
         let json = serde_json::to_vec(&req).unwrap();
         std::fs::write(dir.join(format!("{job_id}.job")), &json).unwrap();
@@ -326,5 +345,33 @@ mod tests {
             claim_a.is_some() ^ claim_b.is_some(),
             "exactly one runner should win the claim"
         );
+    }
+
+    #[tokio::test]
+    async fn discover_returns_profile_from_job() {
+        let dir = tempfile::tempdir().unwrap();
+        let cancel = CancellationToken::new();
+        let provider = LocalProvider::new(dir.path().to_path_buf(), cancel);
+
+        let job_id = Uuid::new_v4();
+        write_job_with_profile(dir.path(), job_id, "browser job", Some("vm0/browser"));
+
+        let (run_id, profile) = provider.discover().await.unwrap();
+        assert_eq!(run_id, job_id);
+        assert_eq!(profile, "vm0/browser");
+    }
+
+    #[tokio::test]
+    async fn discover_defaults_profile_when_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let cancel = CancellationToken::new();
+        let provider = LocalProvider::new(dir.path().to_path_buf(), cancel);
+
+        let job_id = Uuid::new_v4();
+        write_job(dir.path(), job_id, "default job");
+
+        let (run_id, profile) = provider.discover().await.unwrap();
+        assert_eq!(run_id, job_id);
+        assert_eq!(profile, crate::profile::DEFAULT_PROFILE);
     }
 }

--- a/crates/runner/src/provider/local.rs
+++ b/crates/runner/src/provider/local.rs
@@ -368,6 +368,9 @@ mod tests {
         let (run_id, profile) = provider.discover().await.unwrap();
         assert_eq!(run_id, job_id);
         assert_eq!(profile, "vm0/browser");
+
+        let ctx = provider.claim(run_id).await.unwrap();
+        assert_eq!(ctx.experimental_profile.as_deref(), Some("vm0/browser"));
     }
 
     #[tokio::test]

--- a/crates/runner/src/provider/local.rs
+++ b/crates/runner/src/provider/local.rs
@@ -85,11 +85,20 @@ impl LocalProvider {
             };
             let claim_path = self.group_dir.join(format!("{job_id}.claim"));
             if !claim_path.exists() {
-                let profile = std::fs::read(&path)
-                    .ok()
-                    .and_then(|buf| serde_json::from_slice::<JobRequest>(&buf).ok())
-                    .and_then(|req| req.profile)
-                    .unwrap_or_else(|| crate::profile::DEFAULT_PROFILE.to_owned());
+                let profile = match std::fs::read(&path) {
+                    Ok(buf) => match serde_json::from_slice::<JobRequest>(&buf) {
+                        Ok(req) => req.profile,
+                        Err(e) => {
+                            warn!(run_id = %job_id, error = %e, "local: failed to parse job file, using default profile");
+                            None
+                        }
+                    },
+                    Err(e) => {
+                        warn!(run_id = %job_id, error = %e, "local: failed to read job file, using default profile");
+                        None
+                    }
+                }
+                .unwrap_or_else(|| crate::profile::DEFAULT_PROFILE.to_owned());
                 return Some((job_id, profile));
             }
         }


### PR DESCRIPTION
## Summary

- Add optional `profile` field to `JobRequest` for local file-queue provider
- `discover()` reads job file to extract profile instead of hardcoding `DEFAULT_PROFILE`
- `runner submit` accepts `--profile` flag to target specific VM profiles

## Changes

- **local.rs**: `JobRequest.profile` field, `find_unclaimed_job()` reads profile from job file
- **submit.rs**: `--profile` CLI flag passed through to `JobRequest`
- 2 new tests: `discover_returns_profile_from_job`, `discover_defaults_profile_when_missing`

Closes #5210

## Test plan

- [x] 7 local provider tests pass (5 existing + 2 new)
- [x] Clippy clean
- [x] Backwards compatible — missing profile defaults to `vm0/default`

🤖 Generated with [Claude Code](https://claude.com/claude-code)