### PR TITLE
fix: add org-scoped filtering to /api/logs/search

### DIFF
--- a/turbo/apps/cli/src/lib/api/api-client.ts
+++ b/turbo/apps/cli/src/lib/api/api-client.ts
@@ -30,7 +30,7 @@ import {
 } from "@vm0/core";
 import type { z } from "zod";
 import { getApiUrl, getActiveToken } from "./config";
-import { handleError } from "./core/client-factory";
+import { getClientConfig, handleError } from "./core/client-factory";
 
 // Import types from @vm0/core contracts
 import type {
@@ -1095,14 +1095,9 @@ class ApiClient {
     before?: number;
     after?: number;
   }): Promise<LogsSearchResponse> {
-    const baseUrl = await this.getBaseUrl();
-    const headers = await this.getHeaders();
+    const config = await getClientConfig();
 
-    const client = initClient(logsSearchContract, {
-      baseUrl,
-      baseHeaders: headers,
-      jsonQuery: false,
-    });
+    const client = initClient(logsSearchContract, config);
 
     const result = await client.searchLogs({
       query: {

--- a/turbo/apps/web/app/api/logs/search/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/logs/search/__tests__/route.test.ts
@@ -4,6 +4,7 @@ import {
   createTestRequest,
   createTestCompose,
   createTestRun,
+  createTestRunInDb,
 } from "../../../../../src/__tests__/api-test-helpers";
 import { testContext } from "../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../src/__tests__/clerk-mock";
@@ -234,5 +235,62 @@ describe("GET /api/logs/search", () => {
     const data = await response.json();
     expect(data.results).toHaveLength(2);
     expect(data.hasMore).toBe(true);
+  });
+
+  it("should not return runs from a different org", async () => {
+    const user = await context.setupUser();
+
+    // Create a compose + run in a different org
+    const otherOrg = await context.createAgentCompose(user.userId);
+    const { runId: otherOrgRunId } = await createTestRunInDb(
+      user.userId,
+      otherOrg.id,
+    );
+
+    // Mock Axiom to return events for the default org run only
+    // (in production, the APL runId filter would exclude other-org runs)
+    context.mocks.axiom.queryAxiom.mockResolvedValueOnce([
+      createAxiomAgentEvent(testRunId, 1, "Default org event"),
+    ]);
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/logs/search?keyword=event",
+    );
+
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.results).toHaveLength(1);
+    expect(data.results[0].runId).toBe(testRunId);
+
+    // Verify the Axiom APL query only contains the default org's run ID
+    const aplQuery = context.mocks.axiom.queryAxiom.mock.calls[0]![0] as string;
+    expect(aplQuery).toContain(testRunId);
+    expect(aplQuery).not.toContain(otherOrgRunId);
+  });
+
+  it("should return empty when searching by runId from a different org", async () => {
+    const user = await context.setupUser();
+
+    // Create a run in a different org
+    const otherOrg = await context.createAgentCompose(user.userId);
+    const { runId: otherOrgRunId } = await createTestRunInDb(
+      user.userId,
+      otherOrg.id,
+    );
+
+    const request = createTestRequest(
+      `http://localhost:3000/api/logs/search?keyword=test&runId=${otherOrgRunId}`,
+    );
+
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.results).toEqual([]);
+    expect(data.hasMore).toBe(false);
+    // Axiom should not be called since the run doesn't belong to the active org
+    expect(context.mocks.axiom.queryAxiom).not.toHaveBeenCalled();
   });
 });

--- a/turbo/apps/web/app/api/logs/search/route.ts
+++ b/turbo/apps/web/app/api/logs/search/route.ts
@@ -12,6 +12,7 @@ import {
 import { agentRuns } from "../../../../src/db/schema/agent-run";
 import { and, eq, inArray, gte } from "drizzle-orm";
 import { getUserId } from "../../../../src/lib/auth/get-user-id";
+import { resolveOrg } from "../../../../src/lib/org/resolve-org";
 import {
   queryAxiom,
   getDatasetName,
@@ -36,6 +37,7 @@ function escapeApl(value: string): string {
 async function getAgentNames(
   runIds: string[],
   userId: string,
+  orgId: string,
 ): Promise<Map<string, string>> {
   const result = new Map<string, string>();
   if (runIds.length === 0) return result;
@@ -54,7 +56,13 @@ async function getAgentNames(
       agentComposes,
       eq(agentComposeVersions.composeId, agentComposes.id),
     )
-    .where(and(inArray(agentRuns.id, runIds), eq(agentRuns.userId, userId)));
+    .where(
+      and(
+        inArray(agentRuns.id, runIds),
+        eq(agentRuns.userId, userId),
+        eq(agentRuns.orgId, orgId),
+      ),
+    );
 
   for (const row of rows) {
     result.set(row.runId, row.composeName || "unknown");
@@ -65,11 +73,13 @@ async function getAgentNames(
 
 async function getUserRunIds(
   userId: string,
+  orgId: string,
   since: Date,
   agentName?: string,
 ): Promise<string[]> {
   const conditions = [
     eq(agentRuns.userId, userId),
+    eq(agentRuns.orgId, orgId),
     gte(agentRuns.createdAt, since),
   ];
 
@@ -165,7 +175,7 @@ function toRunEvent(event: AxiomAgentEvent): RunEvent {
 }
 
 const router = tsr.router(logsSearchContract, {
-  searchLogs: async ({ query, headers }) => {
+  searchLogs: async ({ query, headers }, { request }) => {
     initServices();
 
     const userId = await getUserId(headers.authorization);
@@ -177,6 +187,9 @@ const router = tsr.router(logsSearchContract, {
         },
       };
     }
+
+    const orgSlug = new URL(request.url).searchParams.get("org");
+    const { org } = await resolveOrg(userId, orgSlug);
 
     const { keyword, agent, runId, limit, before, after } = query;
     const since = query.since ?? Date.now() - SEVEN_DAYS_MS;
@@ -190,7 +203,13 @@ const router = tsr.router(logsSearchContract, {
       const [run] = await globalThis.services.db
         .select({ id: agentRuns.id })
         .from(agentRuns)
-        .where(and(eq(agentRuns.id, runId), eq(agentRuns.userId, userId)))
+        .where(
+          and(
+            eq(agentRuns.id, runId),
+            eq(agentRuns.userId, userId),
+            eq(agentRuns.orgId, org.orgId),
+          ),
+        )
         .limit(1);
 
       if (!run) {
@@ -201,7 +220,7 @@ const router = tsr.router(logsSearchContract, {
       }
       targetRunIds = [runId];
     } else {
-      targetRunIds = await getUserRunIds(userId, sinceDate, agent);
+      targetRunIds = await getUserRunIds(userId, org.orgId, sinceDate, agent);
       if (targetRunIds.length === 0) {
         return {
           status: 200 as const,
@@ -240,7 +259,7 @@ const router = tsr.router(logsSearchContract, {
 
     // Assemble results
     const matchedRunIds = [...new Set(matches.map((e) => e.runId))];
-    const agentNames = await getAgentNames(matchedRunIds, userId);
+    const agentNames = await getAgentNames(matchedRunIds, userId, org.orgId);
 
     const results = matches.map((match) => {
       const contextBefore: RunEvent[] = [];


### PR DESCRIPTION
## Summary

- Add `resolveOrg(userId, orgSlug)` to the `/api/logs/search` handler to enforce org-scoped access
- Pass `orgId` to all three DB query paths: `getUserRunIds`, `getAgentNames`, and single-run lookup
- Add integration tests for cross-org isolation and runId org boundary

Closes #5229

## Test plan

- [x] All 9 existing tests pass (org resolution falls back to session active org)
- [x] New test: runs from a different org are excluded from search results
- [x] New test: searching by runId from a different org returns empty results
- [x] Type checking passes
- [x] Lint passes
- [x] Knip passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)