### PR TITLE
feat: add credit processing service with org-level advisory lock

### DIFF
--- a/turbo/apps/web/app/api/agent/runs/[id]/cancel/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/cancel/route.ts
@@ -137,9 +137,7 @@ const router = tsr.router(runsCancelContract, {
           : undefined,
       );
       if (shouldDrain) {
-        await processOrgCredits(run.orgId).catch((err) =>
-          log.error("Failed to process credits", { err }),
-        );
+        await processOrgCredits(run.orgId);
       }
     });
 

--- a/turbo/apps/web/app/api/agent/runs/[id]/cancel/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/cancel/route.ts
@@ -18,6 +18,7 @@ import {
 } from "../../../../../../src/lib/run/run-status";
 import { drainOrgQueue } from "../../../../../../src/lib/run/run-queue-service";
 import { dispatchQueuedRun } from "../../../../../../src/lib/run/run-service";
+import { processOrgCredits } from "../../../../../../src/lib/credit/credit-service";
 import { after } from "next/server";
 
 const log = logger("api:runs:cancel");
@@ -135,6 +136,11 @@ const router = tsr.router(runsCancelContract, {
           ? () => drainOrgQueue(run.orgId, dispatchQueuedRun)
           : undefined,
       );
+      if (shouldDrain) {
+        await processOrgCredits(run.orgId).catch((err) =>
+          log.error("Failed to process credits", { err }),
+        );
+      }
     });
 
     log.debug(

--- a/turbo/apps/web/app/api/cron/cleanup-sandboxes/route.ts
+++ b/turbo/apps/web/app/api/cron/cleanup-sandboxes/route.ts
@@ -240,9 +240,7 @@ const router = tsr.router(cronCleanupSandboxesContract, {
             () => drainOrgQueue(run.orgId, dispatchQueuedRun),
           );
 
-          await processOrgCredits(run.orgId).catch((err) =>
-            log.error("Failed to process credits for timed out run", { err }),
-          );
+          await processOrgCredits(run.orgId);
 
           const isDebug =
             run.composeName?.startsWith(DEBUG_COMPOSE_PREFIX) ?? false;

--- a/turbo/apps/web/app/api/cron/cleanup-sandboxes/route.ts
+++ b/turbo/apps/web/app/api/cron/cleanup-sandboxes/route.ts
@@ -20,6 +20,7 @@ import {
   drainOrgQueue,
 } from "../../../../src/lib/run/run-queue-service";
 import { dispatchQueuedRun } from "../../../../src/lib/run/run-service";
+import { processOrgCredits } from "../../../../src/lib/credit/credit-service";
 import { logger } from "../../../../src/lib/logger";
 import { env } from "../../../../src/env";
 
@@ -237,6 +238,10 @@ const router = tsr.router(cronCleanupSandboxesContract, {
             "timeout",
             timeoutReason,
             () => drainOrgQueue(run.orgId, dispatchQueuedRun),
+          );
+
+          await processOrgCredits(run.orgId).catch((err) =>
+            log.error("Failed to process credits for timed out run", { err }),
           );
 
           const isDebug =

--- a/turbo/apps/web/app/api/cron/process-credits/route.ts
+++ b/turbo/apps/web/app/api/cron/process-credits/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from "next/server";
+import { initServices } from "../../../../src/lib/init-services";
+import { processStaleCredits } from "../../../../src/lib/credit/credit-service";
+import { logger } from "../../../../src/lib/logger";
+import { env } from "../../../../src/env";
+
+const log = logger("cron:process-credits");
+
+export async function GET(request: Request): Promise<Response> {
+  initServices();
+
+  const authHeader = request.headers.get("authorization");
+  const cronSecret = env().CRON_SECRET;
+
+  if (!cronSecret || authHeader !== `Bearer ${cronSecret}`) {
+    return NextResponse.json(
+      { error: { message: "Invalid cron secret", code: "UNAUTHORIZED" } },
+      { status: 401 },
+    );
+  }
+
+  const processed = await processStaleCredits();
+
+  if (processed > 0) {
+    log.debug("Credit processing cron completed", { processed });
+  }
+
+  return NextResponse.json({ success: true, processed });
+}

--- a/turbo/apps/web/app/api/webhooks/agent/complete/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/complete/route.ts
@@ -92,9 +92,7 @@ function scheduleTerminalSideEffects(
     await dispatchTerminalSideEffects(runId, status, errorMsg, () =>
       drainOrgQueue(orgId, dispatchQueuedRun),
     );
-    await processOrgCredits(orgId).catch((err) =>
-      log.error("Failed to process credits", { err }),
-    );
+    await processOrgCredits(orgId);
   });
 }
 

--- a/turbo/apps/web/app/api/webhooks/agent/complete/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/complete/route.ts
@@ -22,6 +22,7 @@ import type { RunResult } from "../../../../../src/lib/run/types";
 import { logger } from "../../../../../src/lib/logger";
 import { drainOrgQueue } from "../../../../../src/lib/run/run-queue-service";
 import { dispatchQueuedRun } from "../../../../../src/lib/run/run-service";
+import { processOrgCredits } from "../../../../../src/lib/credit/credit-service";
 import { appendChatMessages } from "../../../../../src/lib/agent-session/agent-session-service";
 import {
   queryAxiom,
@@ -90,6 +91,9 @@ function scheduleTerminalSideEffects(
   after(async () => {
     await dispatchTerminalSideEffects(runId, status, errorMsg, () =>
       drainOrgQueue(orgId, dispatchQueuedRun),
+    );
+    await processOrgCredits(orgId).catch((err) =>
+      log.error("Failed to process credits", { err }),
     );
   });
 }

--- a/turbo/apps/web/src/__tests__/api-test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers.ts
@@ -16,6 +16,7 @@ import {
 } from "../lib/auth/sandbox-token";
 import { server } from "../mocks/server";
 import { reloadEnv } from "../env";
+import { randomBytes } from "crypto";
 import { cliTokens } from "../db/schema/cli-tokens";
 import { deviceCodes } from "../db/schema/device-codes";
 import { agentRuns } from "../db/schema/agent-run";
@@ -42,6 +43,8 @@ import { telegramUserLinks } from "../db/schema/telegram-user-link";
 import { orgCache } from "../db/schema/org-cache";
 import { orgMembersCache } from "../db/schema/org-members-cache";
 import { userCache } from "../db/schema/user-cache";
+import { creditUsage } from "../db/schema/credit-usage";
+import { creditPricing } from "../db/schema/credit-pricing";
 import { and, eq, inArray, like, or, sql } from "drizzle-orm";
 import { generateCallbackSecret } from "../lib/callback/hmac";
 import { initServices } from "../lib/init-services";
@@ -3230,4 +3233,123 @@ export async function createTestSlackOrgConnection(opts: {
     .returning({ id: slackOrgConnections.id });
 
   return { slackUserId, connectionId: connection!.id };
+}
+
+/**
+ * Insert a credit_pricing record for testing.
+ * Uses upsert so tests can safely set pricing for the same model.
+ */
+export async function insertTestCreditPricing(
+  model: string,
+  options?: {
+    inputTokenPrice?: number;
+    outputTokenPrice?: number;
+    turnPrice?: number;
+  },
+): Promise<void> {
+  initServices();
+  const inputTokenPrice = options?.inputTokenPrice ?? 100;
+  const outputTokenPrice = options?.outputTokenPrice ?? 200;
+  const turnPrice = options?.turnPrice ?? 50;
+
+  await globalThis.services.db
+    .insert(creditPricing)
+    .values({ model, inputTokenPrice, outputTokenPrice, turnPrice })
+    .onConflictDoUpdate({
+      target: creditPricing.model,
+      set: { inputTokenPrice, outputTokenPrice, turnPrice },
+    });
+}
+
+/**
+ * Insert a credit_usage record for testing.
+ * Creates the required compose, version, and run records as FK dependencies.
+ *
+ * @returns The credit_usage record ID
+ */
+export async function insertTestCreditUsage(
+  orgId: string,
+  options: {
+    userId?: string;
+    model?: string;
+    inputTokens?: number;
+    outputTokens?: number;
+    numTurns?: number;
+    status?: string;
+    creditsCharged?: number;
+  },
+): Promise<string> {
+  initServices();
+  const userId = options.userId ?? "test-user";
+
+  // Create compose for the run
+  const composeName = `compose-${randomBytes(4).toString("hex")}`;
+  const [compose] = await globalThis.services.db
+    .insert(agentComposes)
+    .values({ userId, orgId, name: composeName })
+    .returning();
+
+  // agentComposeVersions.id is a content-addressed SHA-256 hash
+  const versionId = randomBytes(32).toString("hex");
+  await globalThis.services.db.insert(agentComposeVersions).values({
+    id: versionId,
+    composeId: compose!.id,
+    content: {},
+    createdBy: userId,
+  });
+
+  // Create a run (FK required by credit_usage)
+  const [run] = await globalThis.services.db
+    .insert(agentRuns)
+    .values({
+      userId,
+      orgId,
+      agentComposeVersionId: versionId,
+      prompt: "test",
+      status: "completed",
+    })
+    .returning();
+
+  const [record] = await globalThis.services.db
+    .insert(creditUsage)
+    .values({
+      runId: run!.id,
+      orgId,
+      userId,
+      model: options.model ?? "gpt-4",
+      inputTokens: options.inputTokens ?? 1000,
+      outputTokens: options.outputTokens ?? 500,
+      numTurns: options.numTurns ?? 2,
+      status: options.status ?? "pending",
+      creditsCharged: options.creditsCharged ?? null,
+    })
+    .returning();
+
+  return record!.id;
+}
+
+/**
+ * Read a credit_usage record by ID.
+ */
+export async function findTestCreditUsage(id: string): Promise<
+  | {
+      id: string;
+      status: string;
+      creditsCharged: number | null;
+      processedAt: Date | null;
+    }
+  | undefined
+> {
+  initServices();
+  const [record] = await globalThis.services.db
+    .select({
+      id: creditUsage.id,
+      status: creditUsage.status,
+      creditsCharged: creditUsage.creditsCharged,
+      processedAt: creditUsage.processedAt,
+    })
+    .from(creditUsage)
+    .where(eq(creditUsage.id, id))
+    .limit(1);
+  return record;
 }

--- a/turbo/apps/web/src/lib/credit/__tests__/credit-service.test.ts
+++ b/turbo/apps/web/src/lib/credit/__tests__/credit-service.test.ts
@@ -1,0 +1,266 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { clerkClient } from "@clerk/nextjs/server";
+import {
+  testContext,
+  uniqueId,
+  type UserContext,
+} from "../../../__tests__/test-helpers";
+import {
+  insertOrgCacheEntry,
+  insertTestCreditPricing,
+  insertTestCreditUsage,
+  findTestCreditUsage,
+  getOrgCacheEntry,
+} from "../../../__tests__/api-test-helpers";
+import { processOrgCredits, processStaleCredits } from "../credit-service";
+
+const context = testContext();
+
+type ClerkOrg = Awaited<
+  ReturnType<
+    Awaited<ReturnType<typeof clerkClient>>["organizations"]["getOrganization"]
+  >
+>;
+
+describe("credit-service", () => {
+  let user: UserContext;
+
+  beforeEach(async () => {
+    context.setupMocks();
+    user = await context.setupUser();
+  });
+
+  describe("processOrgCredits", () => {
+    it("no-ops when no pending records exist", async () => {
+      await processOrgCredits(user.orgId);
+
+      // Verify no Clerk calls were made
+      const client = await clerkClient();
+      expect(client.organizations.getOrganization).not.toHaveBeenCalled();
+    });
+
+    it("processes a single pending record with correct calculation", async () => {
+      // Set up pricing: input=100/M, output=200/M, turn=50
+      await insertTestCreditPricing("gpt-4", {
+        inputTokenPrice: 100,
+        outputTokenPrice: 200,
+        turnPrice: 50,
+      });
+
+      // Insert usage: 1000 input, 500 output, 2 turns
+      const usageId = await insertTestCreditUsage(user.orgId, {
+        userId: user.userId,
+        model: "gpt-4",
+        inputTokens: 1000,
+        outputTokens: 500,
+        numTurns: 2,
+      });
+
+      // Mock Clerk to return current balance
+      const client = await clerkClient();
+      vi.mocked(client.organizations.getOrganization).mockResolvedValueOnce({
+        id: user.orgId,
+        privateMetadata: { credits: 10000 },
+      } as unknown as ClerkOrg);
+
+      await processOrgCredits(user.orgId);
+
+      // Verify calculation:
+      // input: ceil(1000 * 100 / 1_000_000) = ceil(0.1) = 1
+      // output: ceil(500 * 200 / 1_000_000) = ceil(0.1) = 1
+      // turns: 2 * 50 = 100
+      // total: 1 + 1 + 100 = 102
+      const record = await findTestCreditUsage(usageId);
+      expect(record!.status).toBe("processed");
+      expect(record!.creditsCharged).toBe(102);
+      expect(record!.processedAt).toBeInstanceOf(Date);
+
+      // Verify Clerk was called with correct balance deduction
+      expect(
+        client.organizations.updateOrganizationMetadata,
+      ).toHaveBeenCalledWith(user.orgId, {
+        privateMetadata: { credits: 10000 - 102 },
+      });
+
+      // Verify org cache was invalidated
+      const cacheEntry = await getOrgCacheEntry(user.orgId);
+      expect(cacheEntry).toBeNull();
+    });
+
+    it("processes multiple pending records in a batch", async () => {
+      await insertTestCreditPricing("gpt-4", {
+        inputTokenPrice: 1_000_000,
+        outputTokenPrice: 1_000_000,
+        turnPrice: 10,
+      });
+
+      // Insert two usage records
+      const id1 = await insertTestCreditUsage(user.orgId, {
+        userId: user.userId,
+        model: "gpt-4",
+        inputTokens: 100,
+        outputTokens: 100,
+        numTurns: 1,
+      });
+      const id2 = await insertTestCreditUsage(user.orgId, {
+        userId: user.userId,
+        model: "gpt-4",
+        inputTokens: 200,
+        outputTokens: 200,
+        numTurns: 2,
+      });
+
+      const client = await clerkClient();
+      vi.mocked(client.organizations.getOrganization).mockResolvedValueOnce({
+        id: user.orgId,
+        privateMetadata: { credits: 50000 },
+      } as unknown as ClerkOrg);
+
+      await processOrgCredits(user.orgId);
+
+      // Record 1: ceil(100*1M/1M) + ceil(100*1M/1M) + 1*10 = 100 + 100 + 10 = 210
+      const record1 = await findTestCreditUsage(id1);
+      expect(record1!.status).toBe("processed");
+      expect(record1!.creditsCharged).toBe(210);
+
+      // Record 2: ceil(200*1M/1M) + ceil(200*1M/1M) + 2*10 = 200 + 200 + 20 = 420
+      const record2 = await findTestCreditUsage(id2);
+      expect(record2!.status).toBe("processed");
+      expect(record2!.creditsCharged).toBe(420);
+
+      // Total: 210 + 420 = 630
+      expect(
+        client.organizations.updateOrganizationMetadata,
+      ).toHaveBeenCalledWith(user.orgId, {
+        privateMetadata: { credits: 50000 - 630 },
+      });
+    });
+
+    it("skips already-processed records", async () => {
+      await insertTestCreditPricing("gpt-4");
+
+      // Insert a processed record
+      const usageId = await insertTestCreditUsage(user.orgId, {
+        userId: user.userId,
+        model: "gpt-4",
+        status: "processed",
+        creditsCharged: 500,
+      });
+
+      await processOrgCredits(user.orgId);
+
+      // Record should be unchanged
+      const record = await findTestCreditUsage(usageId);
+      expect(record!.status).toBe("processed");
+      expect(record!.creditsCharged).toBe(500);
+
+      // No Clerk calls since nothing to process
+      const client = await clerkClient();
+      expect(client.organizations.getOrganization).not.toHaveBeenCalled();
+    });
+
+    it("skips records with missing pricing and leaves them as pending", async () => {
+      // No pricing for "unknown-model"
+      const usageId = await insertTestCreditUsage(user.orgId, {
+        userId: user.userId,
+        model: "unknown-model",
+      });
+
+      await processOrgCredits(user.orgId);
+
+      // Record should still be pending
+      const record = await findTestCreditUsage(usageId);
+      expect(record!.status).toBe("pending");
+      expect(record!.creditsCharged).toBeNull();
+
+      // No Clerk calls since nothing was actually processed
+      const client = await clerkClient();
+      expect(client.organizations.getOrganization).not.toHaveBeenCalled();
+    });
+
+    it("concurrent calls serialize via advisory lock (no double-processing)", async () => {
+      await insertTestCreditPricing("gpt-4", {
+        inputTokenPrice: 1_000_000,
+        outputTokenPrice: 1_000_000,
+        turnPrice: 0,
+      });
+
+      const usageId = await insertTestCreditUsage(user.orgId, {
+        userId: user.userId,
+        model: "gpt-4",
+        inputTokens: 100,
+        outputTokens: 100,
+        numTurns: 0,
+      });
+
+      const client = await clerkClient();
+      vi.mocked(client.organizations.getOrganization).mockResolvedValue({
+        id: user.orgId,
+        privateMetadata: { credits: 10000 },
+      } as unknown as ClerkOrg);
+
+      // Run two concurrent calls
+      await Promise.all([
+        processOrgCredits(user.orgId),
+        processOrgCredits(user.orgId),
+      ]);
+
+      // Record should be processed exactly once
+      const record = await findTestCreditUsage(usageId);
+      expect(record!.status).toBe("processed");
+      expect(record!.creditsCharged).toBe(200);
+
+      // Clerk should have been called exactly once (second call is a no-op)
+      expect(
+        client.organizations.updateOrganizationMetadata,
+      ).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("processStaleCredits", () => {
+    it("finds and processes all orgs with pending records", async () => {
+      await insertTestCreditPricing("gpt-4", {
+        inputTokenPrice: 1_000_000,
+        outputTokenPrice: 1_000_000,
+        turnPrice: 0,
+      });
+
+      // Create a second org
+      const org2Id = uniqueId("org");
+      await insertOrgCacheEntry({ orgId: org2Id, slug: uniqueId("slug") });
+
+      // Insert records for both orgs
+      const id1 = await insertTestCreditUsage(user.orgId, {
+        userId: user.userId,
+        model: "gpt-4",
+        inputTokens: 100,
+        outputTokens: 0,
+        numTurns: 0,
+      });
+      const id2 = await insertTestCreditUsage(org2Id, {
+        userId: user.userId,
+        model: "gpt-4",
+        inputTokens: 200,
+        outputTokens: 0,
+        numTurns: 0,
+      });
+
+      const client = await clerkClient();
+      vi.mocked(client.organizations.getOrganization).mockResolvedValue({
+        id: "any",
+        privateMetadata: { credits: 99999 },
+      } as unknown as ClerkOrg);
+
+      const count = await processStaleCredits();
+
+      // At least 2 orgs processed (may include leftover records from other tests)
+      expect(count).toBeGreaterThanOrEqual(2);
+
+      const record1 = await findTestCreditUsage(id1);
+      expect(record1!.status).toBe("processed");
+
+      const record2 = await findTestCreditUsage(id2);
+      expect(record2!.status).toBe("processed");
+    });
+  });
+});

--- a/turbo/apps/web/src/lib/credit/credit-service.ts
+++ b/turbo/apps/web/src/lib/credit/credit-service.ts
@@ -1,0 +1,160 @@
+import { eq, and, sql } from "drizzle-orm";
+import { clerkClient } from "@clerk/nextjs/server";
+import { creditUsage } from "../../db/schema/credit-usage";
+import { creditPricing } from "../../db/schema/credit-pricing";
+import { invalidateOrgCache } from "../org/org-cache-service";
+import { logger } from "../logger";
+
+const log = logger("service:credit");
+
+interface CreditAtomicResult {
+  totalCredits: number;
+  processedCount: number;
+}
+
+/**
+ * Atomically process pending credit_usage records for an org.
+ *
+ * Within a single advisory-locked transaction:
+ * 1. Acquire org-level lock (independent from run queue lock)
+ * 2. Fetch pending records and pricing
+ * 3. Calculate and update each record
+ * 4. Skip records with missing pricing (left as pending for retry)
+ *
+ * Returns the total credits charged and count, or undefined if nothing to process.
+ */
+async function creditAtomic(
+  db: typeof globalThis.services.db,
+  orgId: string,
+): Promise<CreditAtomicResult | undefined> {
+  return db.transaction(async (tx) => {
+    // Org-level lock independent from run queue (which uses hashtext(orgId))
+    await tx.execute(
+      sql`SELECT pg_advisory_xact_lock(hashtext('credit_' || ${orgId}))`,
+    );
+
+    // Fetch pending records for this org
+    const pendingRecords = await tx
+      .select()
+      .from(creditUsage)
+      .where(
+        and(eq(creditUsage.orgId, orgId), eq(creditUsage.status, "pending")),
+      );
+
+    if (pendingRecords.length === 0) {
+      return undefined;
+    }
+
+    // Fetch all pricing records and build lookup map
+    const pricingRecords = await tx.select().from(creditPricing);
+    const pricingByModel = new Map(pricingRecords.map((p) => [p.model, p]));
+
+    let totalCredits = 0;
+    let processedCount = 0;
+
+    for (const record of pendingRecords) {
+      const pricing = pricingByModel.get(record.model);
+      if (!pricing) {
+        // Skip records with missing pricing — cron retries next minute
+        log.debug("Skipping credit record with missing pricing", {
+          recordId: record.id,
+          model: record.model,
+        });
+        continue;
+      }
+
+      // Calculate credits: ceil(inputTokens * inputTokenPrice / 1_000_000) +
+      //                     ceil(outputTokens * outputTokenPrice / 1_000_000) +
+      //                     numTurns * turnPrice
+      const inputCredits = Math.ceil(
+        (record.inputTokens * pricing.inputTokenPrice) / 1_000_000,
+      );
+      const outputCredits = Math.ceil(
+        (record.outputTokens * pricing.outputTokenPrice) / 1_000_000,
+      );
+      const turnCredits = record.numTurns * pricing.turnPrice;
+      const creditsCharged = inputCredits + outputCredits + turnCredits;
+
+      await tx
+        .update(creditUsage)
+        .set({
+          creditsCharged,
+          status: "processed",
+          processedAt: new Date(),
+        })
+        .where(eq(creditUsage.id, record.id));
+
+      totalCredits += creditsCharged;
+      processedCount++;
+    }
+
+    if (processedCount === 0) {
+      return undefined;
+    }
+
+    return { totalCredits, processedCount };
+  });
+}
+
+/**
+ * Process pending credit records for an org and deduct from Clerk balance.
+ *
+ * 1. Atomically mark pending records as processed (under advisory lock)
+ * 2. Read current Clerk balance and deduct
+ * 3. Invalidate org_cache so next read re-fetches
+ */
+export async function processOrgCredits(orgId: string): Promise<void> {
+  const result = await creditAtomic(globalThis.services.db, orgId);
+  if (!result) return;
+
+  const { totalCredits, processedCount } = result;
+
+  // Read current balance from Clerk (outside transaction)
+  const client = await clerkClient();
+  const org = await client.organizations.getOrganization({
+    organizationId: orgId,
+  });
+
+  const privateMetadata = org.privateMetadata as
+    | Record<string, unknown>
+    | undefined;
+  const currentCredits =
+    typeof privateMetadata?.credits === "number" ? privateMetadata.credits : 0;
+  const newBalance = currentCredits - totalCredits;
+
+  // Write updated balance back to Clerk
+  await client.organizations.updateOrganizationMetadata(orgId, {
+    privateMetadata: { credits: newBalance },
+  });
+
+  // Invalidate cache so next read re-fetches from Clerk
+  await invalidateOrgCache(orgId);
+
+  log.debug("Processed org credits", {
+    orgId,
+    processedCount,
+    totalCredits,
+    newBalance,
+  });
+}
+
+/**
+ * Cron entry point: find all orgs with pending credit records and process them.
+ *
+ * @returns Number of orgs processed
+ */
+export async function processStaleCredits(): Promise<number> {
+  const db = globalThis.services.db;
+
+  // Find distinct orgs with pending credit usage
+  const orgs = await db
+    .selectDistinct({ orgId: creditUsage.orgId })
+    .from(creditUsage)
+    .where(eq(creditUsage.status, "pending"));
+
+  for (const { orgId } of orgs) {
+    await processOrgCredits(orgId);
+  }
+
+  return orgs.length;
+}

--- a/turbo/apps/web/vercel.json
+++ b/turbo/apps/web/vercel.json
@@ -26,6 +26,10 @@
     {
       "path": "/api/cron/sync-skills",
       "schedule": "* * * * *"
+    },
+    {
+      "path": "/api/cron/process-credits",
+      "schedule": "* * * * *"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Add credit deduction processor (`credit-service.ts`) with three functions: `creditAtomic` (transactional processing under advisory lock), `processOrgCredits` (Clerk balance deduction wrapper), and `processStaleCredits` (cron entry point)
- Add cron route at `/api/cron/process-credits` running every minute with advisory lock idempotency
- Wire `processOrgCredits` into completion webhook, cancel handler (running/pending only), and cleanup cron timeout path
- Add 7 integration tests covering calculation correctness, concurrency serialization, missing pricing skip, and multi-org processing

## Test plan

- [x] `processOrgCredits` no-ops when no pending records exist
- [x] Single pending record processed with correct `ceil()` calculation
- [x] Multiple pending records processed in batch with correct totals
- [x] Already-processed records are skipped
- [x] Records with missing pricing are left as pending for retry
- [x] Concurrent calls serialize via advisory lock (no double-processing)
- [x] `processStaleCredits` finds and processes all orgs with pending records
- [ ] CI passes (lint, types, tests, knip)

Closes #5235

🤖 Generated with [Claude Code](https://claude.com/claude-code)