### PR TITLE
fix: remove /zero prefix from audit links in notifications

### DIFF
--- a/turbo/apps/web/app/api/internal/callbacks/github/issues/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/github/issues/route.ts
@@ -84,7 +84,7 @@ function formatGitHubComment(opts: {
 }): string {
   const { status, agentName, runId, output, error, triggerCommentBody } = opts;
   const platformUrl = getPlatformUrl();
-  const logsUrl = `${platformUrl}/agents/${encodeURIComponent(agentName)}/logs/${encodeURIComponent(runId)}`;
+  const logsUrl = `${platformUrl}/activity/${encodeURIComponent(runId)}`;
   const content =
     status === "completed"
       ? (output ?? "Task completed successfully.")

--- a/turbo/apps/web/src/lib/email/handlers/shared.ts
+++ b/turbo/apps/web/src/lib/email/handlers/shared.ts
@@ -373,7 +373,7 @@ export function buildFromAddress(localPart: string): string {
  * Build the logs URL for a run, linking to the agent detail logs page.
  */
 export function buildLogsUrl(runId: string): string {
-  return `${getPlatformUrl()}/zero/activity/${encodeURIComponent(runId)}`;
+  return `${getPlatformUrl()}/activity/${encodeURIComponent(runId)}`;
 }
 
 // ============================================================================

--- a/turbo/apps/web/src/lib/slack-org/handlers/__tests__/shared.test.ts
+++ b/turbo/apps/web/src/lib/slack-org/handlers/__tests__/shared.test.ts
@@ -40,25 +40,23 @@ describe("buildOrgConnectUrl", () => {
 });
 
 describe("buildLogsUrl", () => {
-  it("should return platform URL with zero/activity path", () => {
+  it("should return platform URL with activity path", () => {
     const url = buildLogsUrl("run-123");
 
-    expect(url).toBe("http://localhost:3001/zero/activity/run-123");
+    expect(url).toBe("http://localhost:3001/activity/run-123");
   });
 
   it("should encode run ID in URL", () => {
     const url = buildLogsUrl("run/with/slashes");
 
-    expect(url).toBe(
-      "http://localhost:3001/zero/activity/run%2Fwith%2Fslashes",
-    );
+    expect(url).toBe("http://localhost:3001/activity/run%2Fwith%2Fslashes");
   });
 });
 
 describe("buildAgentLogsUrl", () => {
-  it("should return platform URL with zero/activity path", () => {
+  it("should return platform URL with activity path", () => {
     const url = buildAgentLogsUrl();
 
-    expect(url).toBe("http://localhost:3001/zero/activity");
+    expect(url).toBe("http://localhost:3001/activity");
   });
 });

--- a/turbo/apps/web/src/lib/slack-org/handlers/shared.ts
+++ b/turbo/apps/web/src/lib/slack-org/handlers/shared.ts
@@ -224,12 +224,12 @@ export {
  * Build the logs URL for a run in the org flow.
  */
 export function buildLogsUrl(runId: string): string {
-  return `${getPlatformUrl()}/zero/activity/${encodeURIComponent(runId)}`;
+  return `${getPlatformUrl()}/activity/${encodeURIComponent(runId)}`;
 }
 
 /**
  * Build the agent-level activity URL (no specific run).
  */
 export function buildAgentLogsUrl(): string {
-  return `${getPlatformUrl()}/zero/activity`;
+  return `${getPlatformUrl()}/activity`;
 }

--- a/turbo/apps/web/src/lib/slack/__tests__/blocks.test.ts
+++ b/turbo/apps/web/src/lib/slack/__tests__/blocks.test.ts
@@ -232,7 +232,7 @@ describe("buildAppHomeView", () => {
       text: { type: "plain_text", text: "Open Zero Settings" },
       style: "primary",
     });
-    expect("url" in button && button.url).toContain("/zero/works");
+    expect("url" in button && button.url).toContain("/works");
   });
 
   it("should show not-connected state when isLinked is false and isInstalled is not false", () => {

--- a/turbo/apps/web/src/lib/slack/blocks.ts
+++ b/turbo/apps/web/src/lib/slack/blocks.ts
@@ -63,7 +63,7 @@ export function buildAppHomeView(options: {
               type: "plain_text",
               text: "Open Zero Settings",
             },
-            url: `${getPlatformUrl()}/zero/works`,
+            url: `${getPlatformUrl()}/works`,
             action_id: "home_open_settings",
             style: "primary",
           },
@@ -143,7 +143,7 @@ export function buildAppHomeView(options: {
       accessory: {
         type: "button",
         text: { type: "plain_text", text: "Settings" },
-        url: `${getPlatformUrl()}/zero/works`,
+        url: `${getPlatformUrl()}/works`,
         action_id: "home_environment_setup",
       },
     });

--- a/turbo/apps/web/src/lib/telegram/handlers/shared.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/shared.ts
@@ -168,14 +168,14 @@ export async function storeTelegramMessage(
  * Build the logs URL for a run, linking to the agent detail logs page.
  */
 export function buildLogsUrl(runId: string): string {
-  return `${getPlatformUrl()}/zero/activity/${encodeURIComponent(runId)}`;
+  return `${getPlatformUrl()}/activity/${encodeURIComponent(runId)}`;
 }
 
 /**
  * Build the agent logs page URL (no specific run).
  */
 export function buildAgentLogsUrl(): string {
-  return `${getPlatformUrl()}/zero/activity`;
+  return `${getPlatformUrl()}/activity`;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Remove the `/zero` path prefix from all notification audit links (Slack, email, Telegram, GitHub) so they correctly resolve to the platform's `/:tab/:sub` routes
- Change GitHub issues callback URL from `/agents/:name/logs/:runId` to `/activity/:runId` to match the platform routing
- Update corresponding test assertions

Closes #5245

## Test plan
- [x] Existing tests for `buildLogsUrl`, `buildAgentLogsUrl` updated and passing
- [x] Existing tests for `buildAppHomeView` (Slack blocks) updated and passing
- [x] Type check, lint, knip all passing
- [ ] Verify notification links in staging reach the correct activity page

🤖 Generated with [Claude Code](https://claude.com/claude-code)