### PR TITLE
fix: remove /zero/ path prefix from deep-links, oauth redirects, and slack commands

### DIFF
--- a/turbo/apps/web/app/api/email/unsubscribe/route.ts
+++ b/turbo/apps/web/app/api/email/unsubscribe/route.ts
@@ -72,7 +72,7 @@ export async function GET(request: Request): Promise<Response> {
   <div class="card">
     <h1>You have been unsubscribed</h1>
     <p>You will no longer receive system-initiated email notifications from VM0.</p>
-    <p><a href="${platformUrl}/zero/settings">Manage notification preferences</a></p>
+    <p><a href="${platformUrl}/settings">Manage notification preferences</a></p>
   </div>
 </body>
 </html>`;

--- a/turbo/apps/web/app/api/github/oauth/callback/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/github/oauth/callback/__tests__/route.test.ts
@@ -79,7 +79,7 @@ describe("/api/github/oauth/callback", () => {
 
     expect(response.status).toBe(307);
     const location = response.headers.get("Location");
-    expect(location).toContain("zero/works");
+    expect(location).toContain("works");
     expect(location).toContain("error=");
     expect(location).toContain("Missing%20installation%20ID");
   });
@@ -109,7 +109,7 @@ describe("/api/github/oauth/callback", () => {
 
     expect(response.status).toBe(307);
     const location = response.headers.get("Location");
-    expect(location).toContain("zero/works");
+    expect(location).toContain("works");
     expect(location).not.toContain("error=");
   });
 
@@ -159,7 +159,7 @@ describe("/api/github/oauth/callback", () => {
 
     expect(response.status).toBe(307);
     const location = response.headers.get("Location");
-    expect(location).toContain("zero/works");
+    expect(location).toContain("works");
     expect(location).not.toContain("error=");
 
     const installations = await findTestGitHubInstallations(installationId);
@@ -187,7 +187,7 @@ describe("/api/github/oauth/callback", () => {
 
     expect(response.status).toBe(307);
     const location = response.headers.get("Location");
-    expect(location).toContain("zero/works");
+    expect(location).toContain("works");
     expect(location).toContain("pending=true");
     expect(location).not.toContain("error=");
 
@@ -210,7 +210,7 @@ describe("/api/github/oauth/callback", () => {
 
     expect(response.status).toBe(307);
     const location = response.headers.get("Location");
-    expect(location).toContain("zero/works");
+    expect(location).toContain("works");
     expect(location).toContain("error=");
     expect(location).toContain("Invalid%20OAuth%20state");
   });
@@ -237,7 +237,7 @@ describe("/api/github/oauth/callback", () => {
 
     expect(response2.status).toBe(307);
     const location = response2.headers.get("Location");
-    expect(location).toContain("zero/works");
+    expect(location).toContain("works");
     expect(location).not.toContain("error=");
 
     const installations = await findTestGitHubInstallations(installationId);

--- a/turbo/apps/web/app/api/github/oauth/callback/route.ts
+++ b/turbo/apps/web/app/api/github/oauth/callback/route.ts
@@ -63,7 +63,7 @@ export async function GET(request: Request) {
 
   if (!GITHUB_APP_ID || !GITHUB_APP_PRIVATE_KEY) {
     return NextResponse.redirect(
-      `${platformUrl}/zero/works?error=${encodeURIComponent("GitHub App integration is not configured")}`,
+      `${platformUrl}/works?error=${encodeURIComponent("GitHub App integration is not configured")}`,
     );
   }
 
@@ -73,7 +73,7 @@ export async function GET(request: Request) {
 
   // Handle update action (permission changes) — no state needed
   if (setupAction === "update") {
-    return NextResponse.redirect(`${platformUrl}/zero/works`);
+    return NextResponse.redirect(`${platformUrl}/works`);
   }
 
   let state: OAuthState;
@@ -81,7 +81,7 @@ export async function GET(request: Request) {
     state = parseOAuthState(url.searchParams.get("state"));
   } catch {
     return NextResponse.redirect(
-      `${platformUrl}/zero/works?error=${encodeURIComponent("Invalid OAuth state. Please try installing again from the Platform.")}`,
+      `${platformUrl}/works?error=${encodeURIComponent("Invalid OAuth state. Please try installing again from the Platform.")}`,
     );
   }
 
@@ -99,7 +99,7 @@ export async function GET(request: Request) {
 
     if (!sigValid) {
       return NextResponse.redirect(
-        `${platformUrl}/zero/works?error=${encodeURIComponent("Invalid state signature. Please try installing again from the Platform.")}`,
+        `${platformUrl}/works?error=${encodeURIComponent("Invalid state signature. Please try installing again from the Platform.")}`,
       );
     }
   }
@@ -112,7 +112,7 @@ export async function GET(request: Request) {
 
   if (!composeId) {
     return NextResponse.redirect(
-      `${platformUrl}/zero/works?error=${encodeURIComponent("Missing default agent. Please set VM0_DEFAULT_AGENT or select an agent before connecting GitHub.")}`,
+      `${platformUrl}/works?error=${encodeURIComponent("Missing default agent. Please set VM0_DEFAULT_AGENT or select an agent before connecting GitHub.")}`,
     );
   }
 
@@ -131,13 +131,13 @@ export async function GET(request: Request) {
       defaultComposeId: composeId,
     });
 
-    return NextResponse.redirect(`${platformUrl}/zero/works?pending=true`);
+    return NextResponse.redirect(`${platformUrl}/works?pending=true`);
   }
 
   // For install action, installation_id is required
   if (!installationId) {
     return NextResponse.redirect(
-      `${platformUrl}/zero/works?error=${encodeURIComponent("Missing installation ID from GitHub")}`,
+      `${platformUrl}/works?error=${encodeURIComponent("Missing installation ID from GitHub")}`,
     );
   }
 
@@ -155,7 +155,7 @@ export async function GET(request: Request) {
     if (state.vm0UserId) {
       await linkVm0User(db, existing.id, state.vm0UserId);
     }
-    return NextResponse.redirect(`${platformUrl}/zero/works`);
+    return NextResponse.redirect(`${platformUrl}/works`);
   }
 
   // Get installation info from GitHub API (target type, ID, name)
@@ -235,7 +235,7 @@ export async function GET(request: Request) {
     await linkVm0User(db, installRecordId, state.vm0UserId, adminGithubUserId);
   }
 
-  return NextResponse.redirect(`${platformUrl}/zero/works`);
+  return NextResponse.redirect(`${platformUrl}/works`);
 }
 
 /**

--- a/turbo/apps/web/app/api/slack/org/commands/route.ts
+++ b/turbo/apps/web/app/api/slack/org/commands/route.ts
@@ -165,7 +165,7 @@ function buildNotInstalledMessage(detail?: string): unknown[] {
         {
           type: "button",
           text: { type: "plain_text", text: "Set up on Platform" },
-          url: `${platformUrl}/zero/works`,
+          url: `${platformUrl}/works`,
           action_id: "open_platform_setup",
         },
       ],
@@ -188,8 +188,8 @@ async function handleSettings(
     }
   }
   const settingsPath = agentName
-    ? `/zero/team/${encodeURIComponent(agentName)}?tab=connectors`
-    : "/zero/team";
+    ? `/team/${encodeURIComponent(agentName)}?tab=connectors`
+    : "/team";
   return ephemeral([
     {
       type: "section",

--- a/turbo/apps/web/app/api/slack/org/oauth/callback/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/slack/org/oauth/callback/__tests__/route.test.ts
@@ -315,7 +315,7 @@ describe("/api/slack/org/oauth/callback", () => {
     );
     const responseB = await GET(requestB);
 
-    // Should redirect to /zero/works with error
+    // Should redirect to /works with error
     expect(responseB.status).toBe(307);
     const location = responseB.headers.get("Location")!;
     expect(location).toContain("/slack/connect?error=");

--- a/turbo/apps/web/app/api/telegram/webhook/__tests__/commands.test.ts
+++ b/turbo/apps/web/app/api/telegram/webhook/__tests__/commands.test.ts
@@ -386,7 +386,7 @@ describe("Telegram bot commands", () => {
 
       expect(sendMsg.mocked).toHaveBeenCalled();
       expect(sendMsg.calls[0]?.text).toContain("Settings");
-      expect(sendMsg.calls[0]?.text).toContain("zero/works");
+      expect(sendMsg.calls[0]?.text).toContain("works");
     });
   });
 

--- a/turbo/apps/web/src/lib/deep-links.ts
+++ b/turbo/apps/web/src/lib/deep-links.ts
@@ -47,13 +47,13 @@ const KEYWORD_LINK_MAPPINGS: readonly KeywordLinkMapping[] = Object.freeze([
 
 function buildPath(category: KeywordCategory, agentName?: string): string {
   if (category === "provider") {
-    return "/zero/settings";
+    return "/settings";
   }
   // Connector links route to the agent's team page with connectors tab
   if (agentName) {
-    return `/zero/team/${encodeURIComponent(agentName)}?tab=connectors`;
+    return `/team/${encodeURIComponent(agentName)}?tab=connectors`;
   }
-  return "/zero/team";
+  return "/team";
 }
 
 /**
@@ -63,7 +63,7 @@ function buildPath(category: KeywordCategory, agentName?: string): string {
  * matching platform deep links (deduplicated by destination path).
  *
  * When `agentName` is provided, connector links point to
- * `/zero/team/{agentName}?tab=connectors` instead of the generic team page.
+ * `/team/{agentName}?tab=connectors` instead of the generic team page.
  */
 export function detectDeepLinks(
   responseText: string,

--- a/turbo/apps/web/src/lib/slack/__tests__/blocks.test.ts
+++ b/turbo/apps/web/src/lib/slack/__tests__/blocks.test.ts
@@ -131,7 +131,7 @@ describe("detectDeepLinks", () => {
     expect(links[0]).toEqual({
       emoji: "🔑",
       label: "Configure model providers",
-      url: `${platformUrl}/zero/settings`,
+      url: `${platformUrl}/settings`,
     });
   });
 
@@ -145,7 +145,7 @@ describe("detectDeepLinks", () => {
     expect(links[0]).toEqual({
       emoji: "🔌",
       label: "Configure connectors",
-      url: `${platformUrl}/zero/team/my-agent?tab=connectors`,
+      url: `${platformUrl}/team/my-agent?tab=connectors`,
     });
   });
 
@@ -158,7 +158,7 @@ describe("detectDeepLinks", () => {
     expect(links[0]).toEqual({
       emoji: "🔌",
       label: "Configure connectors",
-      url: `${platformUrl}/zero/team`,
+      url: `${platformUrl}/team`,
     });
   });
 
@@ -179,9 +179,7 @@ describe("detectDeepLinks", () => {
       "my-agent",
     );
     expect(links).toHaveLength(1);
-    expect(links[0]?.url).toBe(
-      `${platformUrl}/zero/team/my-agent?tab=connectors`,
-    );
+    expect(links[0]?.url).toBe(`${platformUrl}/team/my-agent?tab=connectors`);
   });
 
   it("should return multiple links for different destinations", () => {
@@ -192,8 +190,8 @@ describe("detectDeepLinks", () => {
     );
     expect(links).toHaveLength(2);
     const urls = links.map((l) => l.url);
-    expect(urls).toContain(`${platformUrl}/zero/settings`);
-    expect(urls).toContain(`${platformUrl}/zero/team/my-agent?tab=connectors`);
+    expect(urls).toContain(`${platformUrl}/settings`);
+    expect(urls).toContain(`${platformUrl}/team/my-agent?tab=connectors`);
   });
 
   it("should encode special characters in agent name", () => {
@@ -204,7 +202,7 @@ describe("detectDeepLinks", () => {
     );
     expect(links).toHaveLength(1);
     expect(links[0]?.url).toBe(
-      `${platformUrl}/zero/team/agent%20with%20spaces?tab=connectors`,
+      `${platformUrl}/team/agent%20with%20spaces?tab=connectors`,
     );
   });
 });

--- a/turbo/apps/web/src/lib/telegram/handlers/commands.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/commands.ts
@@ -218,7 +218,7 @@ export async function handleSettingsCommand(
   await sendMessage(
     client,
     chatId,
-    `⚙️ <b>Settings</b>\n\n${escapeHtml(desc)}\n\n<a href="${escapeHtml(platformUrl)}/zero/works">Open Platform</a>`,
+    `⚙️ <b>Settings</b>\n\n${escapeHtml(desc)}\n\n<a href="${escapeHtml(platformUrl)}/works">Open Platform</a>`,
     replyOptions,
   );
 }


### PR DESCRIPTION
## Summary
- Remove obsolete `/zero/` prefix from all URL paths across deep-links, GitHub OAuth callbacks, Slack org commands, email unsubscribe, and Telegram command handlers
- Update all corresponding test assertions to match the new paths
- Follows up on #5245 and PR #5246

Closes #5247

## Test plan
- [x] All 45 affected tests pass (blocks, GitHub OAuth callback, Telegram commands)
- [x] Type check passes
- [x] Lint passes
- [x] Knip passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)