### PR TITLE
test: add missing cli tests for org secret and org variable commands

### DIFF
--- a/turbo/apps/cli/src/commands/org/secret/__tests__/list.test.ts
+++ b/turbo/apps/cli/src/commands/org/secret/__tests__/list.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Tests for org secret list command
+ *
+ * Tests command-level behavior via parseAsync() following CLI testing principles:
+ * - Entry point: command.parseAsync()
+ * - Mock (external): Web API via MSW
+ * - Real (internal): All CLI code, formatters, validators
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../../mocks/server";
+import { listCommand } from "../list";
+import chalk from "chalk";
+
+describe("org secret list command", () => {
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  beforeEach(() => {
+    chalk.level = 0;
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("VM0_TOKEN", "test-token");
+  });
+
+  describe("successful list", () => {
+    it("should list org secrets with metadata", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/org/secrets", () => {
+          return HttpResponse.json({
+            secrets: [
+              {
+                name: "MY_API_KEY",
+                description: "API key for service",
+                updatedAt: "2025-01-01T00:00:00Z",
+              },
+              {
+                name: "DB_PASSWORD",
+                updatedAt: "2025-01-01T00:00:00Z",
+              },
+            ],
+          });
+        }),
+      );
+
+      await listCommand.parseAsync(["node", "cli"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("Org Secrets");
+      expect(logCalls).toContain("MY_API_KEY");
+      expect(logCalls).toContain("API key for service");
+      expect(logCalls).toContain("DB_PASSWORD");
+      expect(logCalls).toContain("2 secret(s)");
+    });
+
+    it("should show empty state when no secrets exist", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/org/secrets", () => {
+          return HttpResponse.json({ secrets: [] });
+        }),
+      );
+
+      await listCommand.parseAsync(["node", "cli"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("No org secrets found");
+      expect(logCalls).toContain("vm0 org secret set");
+    });
+  });
+
+  describe("error handling", () => {
+    it("should handle authentication error", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/org/secrets", () => {
+          return HttpResponse.json(
+            {
+              error: {
+                message: "Not authenticated",
+                code: "UNAUTHORIZED",
+              },
+            },
+            { status: 401 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await listCommand.parseAsync(["node", "cli"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Not authenticated"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should handle generic API error", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/org/secrets", () => {
+          return HttpResponse.json(
+            {
+              error: {
+                message: "Internal server error",
+                code: "SERVER_ERROR",
+              },
+            },
+            { status: 500 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await listCommand.parseAsync(["node", "cli"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Internal server error"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe("alias", () => {
+    it("should have ls alias", () => {
+      expect(listCommand.alias()).toBe("ls");
+    });
+  });
+});

--- a/turbo/apps/cli/src/commands/org/secret/__tests__/remove.test.ts
+++ b/turbo/apps/cli/src/commands/org/secret/__tests__/remove.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Tests for org secret remove command
+ *
+ * Tests command-level behavior via parseAsync() following CLI testing principles:
+ * - Entry point: command.parseAsync()
+ * - Mock (external): Web API via MSW
+ * - Real (internal): All CLI code, formatters, validators
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../../mocks/server";
+import { removeCommand } from "../remove";
+
+describe("org secret remove command", () => {
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  beforeEach(() => {
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("VM0_TOKEN", "test-token");
+  });
+
+  describe("successful removal", () => {
+    it("should remove a secret with --yes flag", async () => {
+      server.use(
+        http.delete("http://localhost:3000/api/org/secrets/:name", () => {
+          return new HttpResponse(null, { status: 204 });
+        }),
+      );
+
+      await removeCommand.parseAsync(["node", "cli", "MY_API_KEY", "--yes"]);
+
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining('Org secret "MY_API_KEY" deleted'),
+      );
+      expect(mockExit).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("non-interactive mode", () => {
+    it("should require --yes flag in non-interactive mode", async () => {
+      await expect(async () => {
+        await removeCommand.parseAsync(["node", "cli", "MY_API_KEY"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "--yes flag is required in non-interactive mode",
+        ),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe("error handling", () => {
+    it("should handle not found error", async () => {
+      server.use(
+        http.delete("http://localhost:3000/api/org/secrets/:name", () => {
+          return HttpResponse.json(
+            {
+              error: {
+                message: "Secret not found",
+                code: "NOT_FOUND",
+              },
+            },
+            { status: 404 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await removeCommand.parseAsync(["node", "cli", "MY_API_KEY", "--yes"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("not found"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should handle forbidden error for non-admin", async () => {
+      server.use(
+        http.delete("http://localhost:3000/api/org/secrets/:name", () => {
+          return HttpResponse.json(
+            {
+              error: {
+                message: "Admin access required",
+                code: "FORBIDDEN",
+              },
+            },
+            { status: 403 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await removeCommand.parseAsync(["node", "cli", "MY_API_KEY", "--yes"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Admin access required"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should handle authentication error", async () => {
+      server.use(
+        http.delete("http://localhost:3000/api/org/secrets/:name", () => {
+          return HttpResponse.json(
+            {
+              error: {
+                message: "Not authenticated",
+                code: "UNAUTHORIZED",
+              },
+            },
+            { status: 401 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await removeCommand.parseAsync(["node", "cli", "MY_API_KEY", "--yes"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Not authenticated"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should handle generic API error", async () => {
+      server.use(
+        http.delete("http://localhost:3000/api/org/secrets/:name", () => {
+          return HttpResponse.json(
+            {
+              error: {
+                message: "Internal server error",
+                code: "SERVER_ERROR",
+              },
+            },
+            { status: 500 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await removeCommand.parseAsync(["node", "cli", "MY_API_KEY", "--yes"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Internal server error"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+});

--- a/turbo/apps/cli/src/commands/org/secret/__tests__/set.test.ts
+++ b/turbo/apps/cli/src/commands/org/secret/__tests__/set.test.ts
@@ -1,0 +1,240 @@
+/**
+ * Tests for org secret set command
+ *
+ * Tests command-level behavior via parseAsync() following CLI testing principles:
+ * - Entry point: command.parseAsync()
+ * - Mock (external): Web API via MSW
+ * - Real (internal): All CLI code, formatters, validators
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../../mocks/server";
+import { setCommand } from "../set";
+import chalk from "chalk";
+
+describe("org secret set command", () => {
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  beforeEach(() => {
+    chalk.level = 0;
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("VM0_TOKEN", "test-token");
+  });
+
+  describe("successful set", () => {
+    it("should set a secret with --body flag", async () => {
+      server.use(
+        http.put("http://localhost:3000/api/org/secrets", () => {
+          return HttpResponse.json(
+            {
+              name: "MY_API_KEY",
+              updatedAt: "2025-01-01T00:00:00Z",
+            },
+            { status: 201 },
+          );
+        }),
+      );
+
+      await setCommand.parseAsync([
+        "node",
+        "cli",
+        "MY_API_KEY",
+        "--body",
+        "secret-value",
+      ]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain('Org secret "MY_API_KEY" saved');
+      expect(logCalls).toContain("secrets.MY_API_KEY");
+    });
+
+    it("should set a secret with --body and --description", async () => {
+      let capturedBody: Record<string, unknown> | undefined;
+
+      server.use(
+        http.put(
+          "http://localhost:3000/api/org/secrets",
+          async ({ request }) => {
+            capturedBody = (await request.json()) as Record<string, unknown>;
+            return HttpResponse.json(
+              {
+                name: "MY_API_KEY",
+                description: "API key for external service",
+                updatedAt: "2025-01-01T00:00:00Z",
+              },
+              { status: 201 },
+            );
+          },
+        ),
+      );
+
+      await setCommand.parseAsync([
+        "node",
+        "cli",
+        "MY_API_KEY",
+        "--body",
+        "secret-value",
+        "--description",
+        "API key for external service",
+      ]);
+
+      expect(capturedBody).toMatchObject({
+        name: "MY_API_KEY",
+        value: "secret-value",
+        description: "API key for external service",
+      });
+    });
+  });
+
+  describe("non-interactive mode", () => {
+    it("should require --body flag in non-interactive mode", async () => {
+      await expect(async () => {
+        await setCommand.parseAsync(["node", "cli", "MY_API_KEY"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("required in non-interactive mode"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe("input validation", () => {
+    it("should show helpful hint for invalid secret name", async () => {
+      server.use(
+        http.put("http://localhost:3000/api/org/secrets", () => {
+          return HttpResponse.json(
+            {
+              error: {
+                message:
+                  "Name must contain only uppercase letters, digits, and underscores",
+                code: "BAD_REQUEST",
+              },
+            },
+            { status: 400 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await setCommand.parseAsync([
+          "node",
+          "cli",
+          "my-invalid-key",
+          "--body",
+          "value",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("must contain only uppercase"),
+      );
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("MY_API_KEY"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe("error handling", () => {
+    it("should handle authentication error", async () => {
+      server.use(
+        http.put("http://localhost:3000/api/org/secrets", () => {
+          return HttpResponse.json(
+            {
+              error: {
+                message: "Not authenticated",
+                code: "UNAUTHORIZED",
+              },
+            },
+            { status: 401 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await setCommand.parseAsync([
+          "node",
+          "cli",
+          "MY_API_KEY",
+          "--body",
+          "value",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Not authenticated"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should handle forbidden error for non-admin", async () => {
+      server.use(
+        http.put("http://localhost:3000/api/org/secrets", () => {
+          return HttpResponse.json(
+            {
+              error: {
+                message: "Admin access required",
+                code: "FORBIDDEN",
+              },
+            },
+            { status: 403 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await setCommand.parseAsync([
+          "node",
+          "cli",
+          "MY_API_KEY",
+          "--body",
+          "value",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Admin access required"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should handle generic API error", async () => {
+      server.use(
+        http.put("http://localhost:3000/api/org/secrets", () => {
+          return HttpResponse.json(
+            {
+              error: {
+                message: "Internal server error",
+                code: "SERVER_ERROR",
+              },
+            },
+            { status: 500 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await setCommand.parseAsync([
+          "node",
+          "cli",
+          "MY_API_KEY",
+          "--body",
+          "value",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Internal server error"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+});

--- a/turbo/apps/cli/src/commands/org/variable/__tests__/list.test.ts
+++ b/turbo/apps/cli/src/commands/org/variable/__tests__/list.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Tests for org variable list command
+ *
+ * Tests command-level behavior via parseAsync() following CLI testing principles:
+ * - Entry point: command.parseAsync()
+ * - Mock (external): Web API via MSW
+ * - Real (internal): All CLI code, formatters, validators
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../../mocks/server";
+import { listCommand } from "../list";
+import chalk from "chalk";
+
+describe("org variable list command", () => {
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  beforeEach(() => {
+    chalk.level = 0;
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("VM0_TOKEN", "test-token");
+  });
+
+  describe("successful list", () => {
+    it("should list org variables with values", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/org/variables", () => {
+          return HttpResponse.json({
+            variables: [
+              {
+                name: "MY_VAR",
+                value: "some-value",
+                description: "A test variable",
+                updatedAt: "2025-01-01T00:00:00Z",
+              },
+              {
+                name: "API_URL",
+                value: "https://api.example.com",
+                updatedAt: "2025-01-01T00:00:00Z",
+              },
+            ],
+          });
+        }),
+      );
+
+      await listCommand.parseAsync(["node", "cli"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("Org Variables");
+      expect(logCalls).toContain("MY_VAR");
+      expect(logCalls).toContain("some-value");
+      expect(logCalls).toContain("A test variable");
+      expect(logCalls).toContain("API_URL");
+      expect(logCalls).toContain("https://api.example.com");
+      expect(logCalls).toContain("2 variable(s)");
+    });
+
+    it("should truncate long variable values", async () => {
+      const longValue = "a".repeat(100);
+
+      server.use(
+        http.get("http://localhost:3000/api/org/variables", () => {
+          return HttpResponse.json({
+            variables: [
+              {
+                name: "LONG_VAR",
+                value: longValue,
+                updatedAt: "2025-01-01T00:00:00Z",
+              },
+            ],
+          });
+        }),
+      );
+
+      await listCommand.parseAsync(["node", "cli"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("LONG_VAR");
+      expect(logCalls).toContain("[truncated]");
+      expect(logCalls).not.toContain(longValue);
+    });
+
+    it("should show empty state when no variables exist", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/org/variables", () => {
+          return HttpResponse.json({ variables: [] });
+        }),
+      );
+
+      await listCommand.parseAsync(["node", "cli"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("No org variables found");
+      expect(logCalls).toContain("vm0 org variable set");
+    });
+  });
+
+  describe("error handling", () => {
+    it("should handle authentication error", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/org/variables", () => {
+          return HttpResponse.json(
+            {
+              error: {
+                message: "Not authenticated",
+                code: "UNAUTHORIZED",
+              },
+            },
+            { status: 401 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await listCommand.parseAsync(["node", "cli"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Not authenticated"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should handle generic API error", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/org/variables", () => {
+          return HttpResponse.json(
+            {
+              error: {
+                message: "Internal server error",
+                code: "SERVER_ERROR",
+              },
+            },
+            { status: 500 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await listCommand.parseAsync(["node", "cli"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Internal server error"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe("alias", () => {
+    it("should have ls alias", () => {
+      expect(listCommand.alias()).toBe("ls");
+    });
+  });
+});

--- a/turbo/apps/cli/src/commands/org/variable/__tests__/remove.test.ts
+++ b/turbo/apps/cli/src/commands/org/variable/__tests__/remove.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Tests for org variable remove command
+ *
+ * Tests command-level behavior via parseAsync() following CLI testing principles:
+ * - Entry point: command.parseAsync()
+ * - Mock (external): Web API via MSW
+ * - Real (internal): All CLI code, formatters, validators
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../../mocks/server";
+import { removeCommand } from "../remove";
+
+describe("org variable remove command", () => {
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  beforeEach(() => {
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("VM0_TOKEN", "test-token");
+  });
+
+  describe("successful removal", () => {
+    it("should remove a variable with --yes flag", async () => {
+      server.use(
+        http.delete("http://localhost:3000/api/org/variables/:name", () => {
+          return new HttpResponse(null, { status: 204 });
+        }),
+      );
+
+      await removeCommand.parseAsync(["node", "cli", "MY_VAR", "--yes"]);
+
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining('Org variable "MY_VAR" deleted'),
+      );
+      expect(mockExit).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("non-interactive mode", () => {
+    it("should require --yes flag in non-interactive mode", async () => {
+      await expect(async () => {
+        await removeCommand.parseAsync(["node", "cli", "MY_VAR"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "--yes flag is required in non-interactive mode",
+        ),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe("error handling", () => {
+    it("should handle not found error", async () => {
+      server.use(
+        http.delete("http://localhost:3000/api/org/variables/:name", () => {
+          return HttpResponse.json(
+            {
+              error: {
+                message: "Variable not found",
+                code: "NOT_FOUND",
+              },
+            },
+            { status: 404 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await removeCommand.parseAsync(["node", "cli", "MY_VAR", "--yes"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("not found"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should handle forbidden error for non-admin", async () => {
+      server.use(
+        http.delete("http://localhost:3000/api/org/variables/:name", () => {
+          return HttpResponse.json(
+            {
+              error: {
+                message: "Admin access required",
+                code: "FORBIDDEN",
+              },
+            },
+            { status: 403 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await removeCommand.parseAsync(["node", "cli", "MY_VAR", "--yes"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Admin access required"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should handle authentication error", async () => {
+      server.use(
+        http.delete("http://localhost:3000/api/org/variables/:name", () => {
+          return HttpResponse.json(
+            {
+              error: {
+                message: "Not authenticated",
+                code: "UNAUTHORIZED",
+              },
+            },
+            { status: 401 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await removeCommand.parseAsync(["node", "cli", "MY_VAR", "--yes"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Not authenticated"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should handle generic API error", async () => {
+      server.use(
+        http.delete("http://localhost:3000/api/org/variables/:name", () => {
+          return HttpResponse.json(
+            {
+              error: {
+                message: "Internal server error",
+                code: "SERVER_ERROR",
+              },
+            },
+            { status: 500 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await removeCommand.parseAsync(["node", "cli", "MY_VAR", "--yes"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Internal server error"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+});

--- a/turbo/apps/cli/src/commands/org/variable/__tests__/set.test.ts
+++ b/turbo/apps/cli/src/commands/org/variable/__tests__/set.test.ts
@@ -1,0 +1,198 @@
+/**
+ * Tests for org variable set command
+ *
+ * Tests command-level behavior via parseAsync() following CLI testing principles:
+ * - Entry point: command.parseAsync()
+ * - Mock (external): Web API via MSW
+ * - Real (internal): All CLI code, formatters, validators
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../../mocks/server";
+import { setCommand } from "../set";
+import chalk from "chalk";
+
+describe("org variable set command", () => {
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  beforeEach(() => {
+    chalk.level = 0;
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("VM0_TOKEN", "test-token");
+  });
+
+  describe("successful set", () => {
+    it("should set a variable with name and value", async () => {
+      server.use(
+        http.put("http://localhost:3000/api/org/variables", () => {
+          return HttpResponse.json(
+            {
+              name: "MY_VAR",
+              value: "my-value",
+              updatedAt: "2025-01-01T00:00:00Z",
+            },
+            { status: 201 },
+          );
+        }),
+      );
+
+      await setCommand.parseAsync(["node", "cli", "MY_VAR", "my-value"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain('Org variable "MY_VAR" saved');
+      expect(logCalls).toContain("vars.MY_VAR");
+    });
+
+    it("should set a variable with --description", async () => {
+      let capturedBody: Record<string, unknown> | undefined;
+
+      server.use(
+        http.put(
+          "http://localhost:3000/api/org/variables",
+          async ({ request }) => {
+            capturedBody = (await request.json()) as Record<string, unknown>;
+            return HttpResponse.json(
+              {
+                name: "MY_VAR",
+                value: "my-value",
+                description: "A test variable",
+                updatedAt: "2025-01-01T00:00:00Z",
+              },
+              { status: 201 },
+            );
+          },
+        ),
+      );
+
+      await setCommand.parseAsync([
+        "node",
+        "cli",
+        "MY_VAR",
+        "my-value",
+        "--description",
+        "A test variable",
+      ]);
+
+      expect(capturedBody).toMatchObject({
+        name: "MY_VAR",
+        value: "my-value",
+        description: "A test variable",
+      });
+    });
+  });
+
+  describe("input validation", () => {
+    it("should show helpful hint for invalid variable name", async () => {
+      server.use(
+        http.put("http://localhost:3000/api/org/variables", () => {
+          return HttpResponse.json(
+            {
+              error: {
+                message:
+                  "Name must contain only uppercase letters, digits, and underscores",
+                code: "BAD_REQUEST",
+              },
+            },
+            { status: 400 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await setCommand.parseAsync(["node", "cli", "my-invalid-var", "value"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("must contain only uppercase"),
+      );
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("MY_VAR"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe("error handling", () => {
+    it("should handle authentication error", async () => {
+      server.use(
+        http.put("http://localhost:3000/api/org/variables", () => {
+          return HttpResponse.json(
+            {
+              error: {
+                message: "Not authenticated",
+                code: "UNAUTHORIZED",
+              },
+            },
+            { status: 401 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await setCommand.parseAsync(["node", "cli", "MY_VAR", "value"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Not authenticated"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should handle forbidden error for non-admin", async () => {
+      server.use(
+        http.put("http://localhost:3000/api/org/variables", () => {
+          return HttpResponse.json(
+            {
+              error: {
+                message: "Admin access required",
+                code: "FORBIDDEN",
+              },
+            },
+            { status: 403 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await setCommand.parseAsync(["node", "cli", "MY_VAR", "value"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Admin access required"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should handle generic API error", async () => {
+      server.use(
+        http.put("http://localhost:3000/api/org/variables", () => {
+          return HttpResponse.json(
+            {
+              error: {
+                message: "Internal server error",
+                code: "SERVER_ERROR",
+              },
+            },
+            { status: 500 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await setCommand.parseAsync(["node", "cli", "MY_VAR", "value"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Internal server error"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add integration tests for `vm0 org secret` commands (list, set, remove) — 19 test cases
- Add integration tests for `vm0 org variable` commands (list, set, remove) — 17 test cases
- Tests follow the established `org model-provider` test pattern using MSW for API mocking

## Test plan

- [x] All 36 tests pass locally (`pnpm vitest run`)
- [x] Lint passes (`pnpm turbo run lint`)
- [x] Type check passes (`pnpm check-types --filter=@vm0/cli`)
- [x] Knip passes (no unused exports/files)
- [x] Prettier formatting verified

Closes #5258

🤖 Generated with [Claude Code](https://claude.com/claude-code)