### PR TITLE
fix: revert merged provider list to return only user providers

### DIFF
--- a/turbo/apps/platform/src/mocks/handlers/api-model-providers.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-model-providers.ts
@@ -19,7 +19,6 @@ const DUMMY_MODEL_PROVIDER: ModelProviderResponse = {
   secretNames: null,
   isDefault: false,
   selectedModel: null,
-  scope: "user",
   createdAt: new Date().toISOString(),
   updatedAt: new Date().toISOString(),
 };
@@ -68,7 +67,6 @@ export const apiModelProvidersHandlers = [
       isDefault:
         mockModelProviders.length === 0 || existing?.isDefault || false,
       selectedModel: null,
-      scope: "user",
       createdAt: existing?.createdAt ?? now,
       updatedAt: now,
     };

--- a/turbo/apps/platform/src/mocks/handlers/api-org-model-providers.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-org-model-providers.ts
@@ -56,7 +56,6 @@ export const apiOrgModelProvidersHandlers = [
       isDefault:
         mockOrgModelProviders.length === 0 || existing?.isDefault || false,
       selectedModel: body.selectedModel ?? null,
-      scope: "org",
       createdAt: existing?.createdAt ?? now,
       updatedAt: now,
     };

--- a/turbo/apps/web/app/api/model-providers/__tests__/list-upsert.test.ts
+++ b/turbo/apps/web/app/api/model-providers/__tests__/list-upsert.test.ts
@@ -9,7 +9,6 @@ import {
 } from "../../../../src/__tests__/api-test-helpers";
 import { testContext } from "../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../src/__tests__/clerk-mock";
-import { upsertOrgModelProvider } from "../../../../src/lib/model-provider/model-provider-service";
 
 vi.mock("@axiomhq/logging");
 
@@ -65,7 +64,6 @@ describe("GET /api/model-providers", () => {
     expect(body.modelProviders[0].framework).toBe("claude-code");
     expect(body.modelProviders[0].secretName).toBe("ANTHROPIC_API_KEY");
     expect(body.modelProviders[0].isDefault).toBe(true);
-    expect(body.modelProviders[0].scope).toBe("user");
   });
 
   it("should return selectedModel in provider list", async () => {
@@ -87,50 +85,6 @@ describe("GET /api/model-providers", () => {
 
     expect(response.status).toBe(200);
     expect(body.modelProviders[0].selectedModel).toBeNull();
-  });
-});
-
-describe("GET /api/model-providers (merged scope)", () => {
-  beforeEach(async () => {
-    context.setupMocks();
-    await context.setupUser();
-  });
-
-  it("should return merged list with org providers first", async () => {
-    const user = await context.setupUser();
-    await upsertOrgModelProvider(user.orgId, "deepseek-api-key", "org-key");
-    await createTestModelProvider("anthropic-api-key", "user-key");
-
-    const response = await listProviders();
-    const body = await response.json();
-
-    expect(body.modelProviders).toHaveLength(2);
-    expect(body.modelProviders[0].scope).toBe("org");
-    expect(body.modelProviders[0].type).toBe("deepseek-api-key");
-    expect(body.modelProviders[1].scope).toBe("user");
-    expect(body.modelProviders[1].type).toBe("anthropic-api-key");
-  });
-
-  it("should return only org providers when user has none", async () => {
-    const user = await context.setupUser();
-    await upsertOrgModelProvider(user.orgId, "anthropic-api-key", "org-key");
-
-    const response = await listProviders();
-    const body = await response.json();
-
-    expect(body.modelProviders).toHaveLength(1);
-    expect(body.modelProviders[0].scope).toBe("org");
-    expect(body.modelProviders[0].type).toBe("anthropic-api-key");
-  });
-
-  it("should return only user providers when org has none", async () => {
-    await createTestModelProvider("anthropic-api-key", "user-key");
-
-    const response = await listProviders();
-    const body = await response.json();
-
-    expect(body.modelProviders).toHaveLength(1);
-    expect(body.modelProviders[0].scope).toBe("user");
   });
 });
 

--- a/turbo/apps/web/app/api/model-providers/route.ts
+++ b/turbo/apps/web/app/api/model-providers/route.ts
@@ -9,7 +9,6 @@ import { getAuthContext } from "../../../src/lib/auth/get-user-id";
 import { resolveOrg } from "../../../src/lib/org/resolve-org";
 import {
   listModelProviders,
-  listOrgModelProviders,
   upsertModelProvider,
   upsertMultiAuthModelProvider,
 } from "../../../src/lib/model-provider/model-provider-service";
@@ -33,33 +32,23 @@ const router = tsr.router(modelProvidersMainContract, {
 
     const orgSlug = new URL(request.url).searchParams.get("org");
     const { org } = await resolveOrg(userId, orgSlug);
-    const userProviders = await listModelProviders(org.orgId, userId);
-    const orgProviders = await listOrgModelProviders(org.orgId);
-
-    const mapProvider = (
-      p: (typeof userProviders)[number],
-      scope: "org" | "user",
-    ) => ({
-      id: p.id,
-      type: p.type,
-      framework: p.framework,
-      secretName: p.secretName,
-      authMethod: p.authMethod ?? null,
-      secretNames: p.secretNames ?? null,
-      isDefault: p.isDefault,
-      selectedModel: p.selectedModel,
-      scope,
-      createdAt: p.createdAt.toISOString(),
-      updatedAt: p.updatedAt.toISOString(),
-    });
+    const providers = await listModelProviders(org.orgId, userId);
 
     return {
       status: 200 as const,
       body: {
-        modelProviders: [
-          ...orgProviders.map((p) => mapProvider(p, "org")),
-          ...userProviders.map((p) => mapProvider(p, "user")),
-        ],
+        modelProviders: providers.map((p) => ({
+          id: p.id,
+          type: p.type,
+          framework: p.framework,
+          secretName: p.secretName,
+          authMethod: p.authMethod ?? null,
+          secretNames: p.secretNames ?? null,
+          isDefault: p.isDefault,
+          selectedModel: p.selectedModel,
+          createdAt: p.createdAt.toISOString(),
+          updatedAt: p.updatedAt.toISOString(),
+        })),
       },
     };
   },
@@ -139,7 +128,6 @@ const router = tsr.router(modelProvidersMainContract, {
             secretNames: provider.secretNames ?? null,
             isDefault: provider.isDefault,
             selectedModel: provider.selectedModel,
-            scope: "user" as const,
             createdAt: provider.createdAt.toISOString(),
             updatedAt: provider.updatedAt.toISOString(),
           },

--- a/turbo/packages/core/src/contracts/model-providers.ts
+++ b/turbo/packages/core/src/contracts/model-providers.ts
@@ -491,7 +491,6 @@ export const modelProviderResponseSchema = z.object({
   secretNames: z.array(z.string()).nullable(), // For multi-auth providers
   isDefault: z.boolean(),
   selectedModel: z.string().nullable(),
-  scope: z.enum(["org", "user"]).optional(), // Optional for backward compat
   createdAt: z.string(),
   updatedAt: z.string(),
 });


### PR DESCRIPTION
## Summary

- Remove org provider fetching from `GET /api/model-providers` — endpoint now returns only user's own providers
- Remove `scope` field from `modelProviderResponseSchema` in contracts
- Update tests: remove merged scope test block and scope assertions
- Update platform mocks: remove `scope` from user and org mock handlers

Closes #5259

## Test plan

- [x] Integration tests pass (15/15 in `list-upsert.test.ts`)
- [x] Lint clean (0 warnings, 0 errors)
- [x] Knip clean (no unused exports)
- [ ] CI pipeline passes
- [ ] Verify `GET /api/model-providers` returns only user providers
- [ ] Verify `GET /api/org/model-providers` still works independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)