### PR TITLE
feat: support app subdomain alongside platform subdomain

### DIFF
--- a/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
@@ -1053,7 +1053,7 @@ describe("logs command", () => {
       expect(logCalls).not.toContain("View on platform:");
     });
 
-    it("should transform www.vm0.ai to platform.vm0.ai", async () => {
+    it("should transform www.vm0.ai to app.vm0.ai", async () => {
       vi.stubEnv("VM0_API_URL", "https://www.vm0.ai");
 
       server.use(
@@ -1082,10 +1082,10 @@ describe("logs command", () => {
       await logsCommand.parseAsync(["node", "cli", "run-123"]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
-      expect(logCalls).toContain("https://platform.vm0.ai/logs/run-123");
+      expect(logCalls).toContain("https://app.vm0.ai/logs/run-123");
     });
 
-    it("should transform vm7.ai:8443 to platform.vm7.ai:8443", async () => {
+    it("should transform vm7.ai:8443 to app.vm7.ai:8443", async () => {
       vi.stubEnv("VM0_API_URL", "https://www.vm7.ai:8443");
 
       server.use(
@@ -1114,7 +1114,7 @@ describe("logs command", () => {
       await logsCommand.parseAsync(["node", "cli", "run-123"]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
-      expect(logCalls).toContain("https://platform.vm7.ai:8443/logs/run-123");
+      expect(logCalls).toContain("https://app.vm7.ai:8443/logs/run-123");
     });
   });
 

--- a/turbo/apps/cli/src/commands/logs/index.ts
+++ b/turbo/apps/cli/src/commands/logs/index.ts
@@ -33,13 +33,13 @@ function buildPlatformLogsUrl(apiUrl: string, runId: string): string {
     return `http://${hostname}:3001/logs/${runId}`;
   }
 
-  // Transform: www.vm0.ai → platform.vm0.ai
-  //            vm0.ai → platform.vm0.ai
+  // Transform: www.vm0.ai → app.vm0.ai
+  //            vm0.ai → app.vm0.ai
   const parts = hostname.split(".");
   if (parts[0] === "www") {
-    parts[0] = "platform";
+    parts[0] = "app";
   } else {
-    parts.unshift("platform");
+    parts.unshift("app");
   }
 
   const platformHost = parts.join(".");

--- a/turbo/apps/platform/.env.example
+++ b/turbo/apps/platform/.env.example
@@ -18,8 +18,9 @@ VITE_CLERK_PUBLISHABLE_KEY=pk_test_your_key_here
 # - Production: https://www.vm0.ai (set automatically in CI)
 #
 # When set to http://localhost:3000, the app will automatically derive the API URL
-# from the current browser origin by replacing "platform" with "www" in the hostname.
-# For example: https://platform.vm7.ai:8443 -> https://www.vm7.ai:8443
+# from the current browser origin by replacing "platform" or "app" with "www" in the hostname.
+# For example: https://app.vm7.ai:8443 -> https://www.vm7.ai:8443
+#              https://platform.vm7.ai:8443 -> https://www.vm7.ai:8443 (backward compat)
 #
 # Required: Yes (app will fail to load without this)
 VITE_API_URL=http://localhost:3000

--- a/turbo/apps/platform/src/signals/auth.ts
+++ b/turbo/apps/platform/src/signals/auth.ts
@@ -6,7 +6,7 @@ const reload$ = state(0);
 
 /**
  * Resolve the web app origin from the current platform origin.
- * Replaces "platform" with "www" in the hostname so sign-in/sign-out
+ * Replaces "platform" or "app" with "www" in the hostname so sign-in/sign-out
  * redirects land on the web app where auth pages live.
  */
 function resolveWebOrigin(): string {
@@ -15,7 +15,7 @@ function resolveWebOrigin(): string {
     return "";
   }
   const url = new URL(origin);
-  url.hostname = url.hostname.replace("platform", "www");
+  url.hostname = url.hostname.replace(/^(platform|app)\./, "www.");
   return url.origin;
 }
 

--- a/turbo/apps/platform/src/signals/fetch.ts
+++ b/turbo/apps/platform/src/signals/fetch.ts
@@ -15,7 +15,7 @@ const CONFIGURED_API_URL = getConfiguredApiUrl();
 /**
  * API base URL for opening external navigation (e.g. connector OAuth popup).
  * - On localhost: use VITE_API_URL so the popup hits the configured API (e.g. :3000).
- * - On a non-localhost host (e.g. platform.vm7.ai): derive from current origin
+ * - On a non-localhost host (e.g. app.vm7.ai): derive from current origin
  *   (e.g. www.vm7.ai) so we never open a localhost URL when the user is remote.
  */
 export const apiBaseForNavigation$ = computed(() => {
@@ -31,21 +31,21 @@ export const apiBaseForNavigation$ = computed(() => {
     return base.endsWith("/") ? base.slice(0, -1) : base;
   }
   const url = new URL(location.origin);
-  url.hostname = url.hostname.replace("platform", "www");
+  url.hostname = url.hostname.replace(/^(platform|app)\./, "www.");
   return url.origin;
 });
 
 /**
  * Resolves the API base URL.
  * If VITE_API_URL is http://localhost:3000, derives the URL from the current browser origin
- * by replacing "platform" with "www" in the hostname.
+ * by replacing "platform" or "app" with "www" in the hostname.
  * Otherwise, uses VITE_API_URL directly.
  */
 function resolveApiBase(): string {
   if (CONFIGURED_API_URL === "http://localhost:3000") {
     const currentOrigin = location.origin;
     const url = new URL(currentOrigin);
-    url.hostname = url.hostname.replace("platform", "www");
+    url.hostname = url.hostname.replace(/^(platform|app)\./, "www.");
     return url.origin;
   }
   return CONFIGURED_API_URL;

--- a/turbo/apps/platform/vite.config.ts
+++ b/turbo/apps/platform/vite.config.ts
@@ -26,7 +26,7 @@ export default defineConfig({
     port: 3002,
     strictPort: true,
     host: true,
-    allowedHosts: ["platform.vm7.ai"],
+    allowedHosts: ["platform.vm7.ai", "app.vm7.ai"],
   },
   build: {
     outDir: "dist",


### PR DESCRIPTION
## Summary
- Replace naive `.replace("platform", "www")` with anchored regex `/^(platform|app)\./` → `"www."` in auth and fetch signals, so both `platform.DOMAIN` and `app.DOMAIN` work during the migration transition
- Update CLI `buildPlatformLogsUrl` to generate `app.DOMAIN` URLs instead of `platform.DOMAIN`
- Add `app.vm7.ai` to vite `allowedHosts` for dev server access

Closes #5266

## Test plan
- [x] All 39 logs command tests pass (2 updated from `platform.` to `app.` expectations)
- [x] Type check passes
- [x] Lint passes
- [x] Knip passes
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)