### PR TITLE
fix: prevent double-prefix in cli platform logs url builder

### DIFF
--- a/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
@@ -1085,6 +1085,72 @@ describe("logs command", () => {
       expect(logCalls).toContain("https://app.vm0.ai/logs/run-123");
     });
 
+    it("should not double-prefix when input URL already has app subdomain", async () => {
+      vi.stubEnv("VM0_API_URL", "https://app.vm0.ai");
+
+      server.use(
+        http.get(
+          "https://app.vm0.ai/api/agent/runs/:id/telemetry/agent",
+          () => {
+            return HttpResponse.json({
+              events: [
+                {
+                  sequenceNumber: 1,
+                  eventType: "assistant",
+                  createdAt: "2024-01-15T10:30:00Z",
+                  eventData: {
+                    type: "assistant",
+                    message: { content: [{ type: "text", text: "Test" }] },
+                  },
+                },
+              ],
+              framework: "claude-code",
+              hasMore: false,
+            });
+          },
+        ),
+      );
+
+      await logsCommand.parseAsync(["node", "cli", "run-123"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("https://app.vm0.ai/logs/run-123");
+      expect(logCalls).not.toContain("app.app.");
+    });
+
+    it("should replace platform subdomain with app", async () => {
+      vi.stubEnv("VM0_API_URL", "https://platform.vm0.ai");
+
+      server.use(
+        http.get(
+          "https://platform.vm0.ai/api/agent/runs/:id/telemetry/agent",
+          () => {
+            return HttpResponse.json({
+              events: [
+                {
+                  sequenceNumber: 1,
+                  eventType: "assistant",
+                  createdAt: "2024-01-15T10:30:00Z",
+                  eventData: {
+                    type: "assistant",
+                    message: { content: [{ type: "text", text: "Test" }] },
+                  },
+                },
+              ],
+              framework: "claude-code",
+              hasMore: false,
+            });
+          },
+        ),
+      );
+
+      await logsCommand.parseAsync(["node", "cli", "run-123"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("https://app.vm0.ai/logs/run-123");
+      expect(logCalls).not.toContain("app.platform.");
+    });
+
     it("should transform vm7.ai:8443 to app.vm7.ai:8443", async () => {
       vi.stubEnv("VM0_API_URL", "https://www.vm7.ai:8443");
 

--- a/turbo/apps/cli/src/commands/logs/index.ts
+++ b/turbo/apps/cli/src/commands/logs/index.ts
@@ -36,7 +36,7 @@ function buildPlatformLogsUrl(apiUrl: string, runId: string): string {
   // Transform: www.vm0.ai → app.vm0.ai
   //            vm0.ai → app.vm0.ai
   const parts = hostname.split(".");
-  if (parts[0] === "www") {
+  if (parts[0] === "www" || parts[0] === "app" || parts[0] === "platform") {
     parts[0] = "app";
   } else {
     parts.unshift("app");


### PR DESCRIPTION
## Summary
- Fix `buildPlatformLogsUrl()` to recognize existing `app.` and `platform.` subdomain prefixes and replace them instead of prepending, which produced malformed hostnames like `app.app.vm0.ai`
- Add test cases for `app.vm0.ai` and `platform.vm0.ai` input URLs

## Test plan
- [x] New test: input `https://app.vm0.ai` produces `https://app.vm0.ai/logs/<runId>` (no double prefix)
- [x] New test: input `https://platform.vm0.ai` produces `https://app.vm0.ai/logs/<runId>` (replace, not prepend)
- [x] Existing tests for `www.vm0.ai` and `localhost` continue to pass
- [x] All 41 tests pass

Closes #5268

🤖 Generated with [Claude Code](https://claude.com/claude-code)