### PR TITLE
refactor: rename getPlatformUrl to getAppUrl across web app

### DIFF
--- a/turbo/apps/web/app/api/email/unsubscribe/route.ts
+++ b/turbo/apps/web/app/api/email/unsubscribe/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 import { initServices } from "../../../../src/lib/init-services";
 import { verifyUnsubscribeToken } from "../../../../src/lib/email/handlers/shared";
 import { unsubscribeUser } from "../../../../src/lib/email/unsubscribe-service";
-import { getPlatformUrl } from "../../../../src/lib/url";
+import { getAppUrl } from "../../../../src/lib/url";
 
 /**
  * Email Unsubscribe Endpoint
@@ -52,7 +52,7 @@ export async function GET(request: Request): Promise<Response> {
 
   await unsubscribeUser(userId);
 
-  const platformUrl = getPlatformUrl();
+  const appUrl = getAppUrl();
 
   const html = `<!DOCTYPE html>
 <html>
@@ -72,7 +72,7 @@ export async function GET(request: Request): Promise<Response> {
   <div class="card">
     <h1>You have been unsubscribed</h1>
     <p>You will no longer receive system-initiated email notifications from VM0.</p>
-    <p><a href="${platformUrl}/settings">Manage notification preferences</a></p>
+    <p><a href="${appUrl}/settings">Manage notification preferences</a></p>
   </div>
 </body>
 </html>`;

--- a/turbo/apps/web/app/api/github/oauth/callback/route.ts
+++ b/turbo/apps/web/app/api/github/oauth/callback/route.ts
@@ -11,7 +11,7 @@ import {
   getInstallationAccessToken,
   getInstallationInfo,
 } from "../../../../../src/lib/github/github-app";
-import { getPlatformUrl } from "../../../../../src/lib/url";
+import { getAppUrl } from "../../../../../src/lib/url";
 import { resolveDefaultAgentComposeId } from "../../../../../src/lib/agent-compose/resolve-default";
 
 /**
@@ -59,11 +59,11 @@ export async function GET(request: Request) {
   const { GITHUB_APP_ID, GITHUB_APP_PRIVATE_KEY, SECRETS_ENCRYPTION_KEY } =
     env();
 
-  const platformUrl = getPlatformUrl();
+  const appUrl = getAppUrl();
 
   if (!GITHUB_APP_ID || !GITHUB_APP_PRIVATE_KEY) {
     return NextResponse.redirect(
-      `${platformUrl}/works?error=${encodeURIComponent("GitHub App integration is not configured")}`,
+      `${appUrl}/works?error=${encodeURIComponent("GitHub App integration is not configured")}`,
     );
   }
 
@@ -73,7 +73,7 @@ export async function GET(request: Request) {
 
   // Handle update action (permission changes) — no state needed
   if (setupAction === "update") {
-    return NextResponse.redirect(`${platformUrl}/works`);
+    return NextResponse.redirect(`${appUrl}/works`);
   }
 
   let state: OAuthState;
@@ -81,7 +81,7 @@ export async function GET(request: Request) {
     state = parseOAuthState(url.searchParams.get("state"));
   } catch {
     return NextResponse.redirect(
-      `${platformUrl}/works?error=${encodeURIComponent("Invalid OAuth state. Please try installing again from the Platform.")}`,
+      `${appUrl}/works?error=${encodeURIComponent("Invalid OAuth state. Please try installing again from the Platform.")}`,
     );
   }
 
@@ -99,7 +99,7 @@ export async function GET(request: Request) {
 
     if (!sigValid) {
       return NextResponse.redirect(
-        `${platformUrl}/works?error=${encodeURIComponent("Invalid state signature. Please try installing again from the Platform.")}`,
+        `${appUrl}/works?error=${encodeURIComponent("Invalid state signature. Please try installing again from the Platform.")}`,
       );
     }
   }
@@ -112,7 +112,7 @@ export async function GET(request: Request) {
 
   if (!composeId) {
     return NextResponse.redirect(
-      `${platformUrl}/works?error=${encodeURIComponent("Missing default agent. Please set VM0_DEFAULT_AGENT or select an agent before connecting GitHub.")}`,
+      `${appUrl}/works?error=${encodeURIComponent("Missing default agent. Please set VM0_DEFAULT_AGENT or select an agent before connecting GitHub.")}`,
     );
   }
 
@@ -131,13 +131,13 @@ export async function GET(request: Request) {
       defaultComposeId: composeId,
     });
 
-    return NextResponse.redirect(`${platformUrl}/works?pending=true`);
+    return NextResponse.redirect(`${appUrl}/works?pending=true`);
   }
 
   // For install action, installation_id is required
   if (!installationId) {
     return NextResponse.redirect(
-      `${platformUrl}/works?error=${encodeURIComponent("Missing installation ID from GitHub")}`,
+      `${appUrl}/works?error=${encodeURIComponent("Missing installation ID from GitHub")}`,
     );
   }
 
@@ -155,7 +155,7 @@ export async function GET(request: Request) {
     if (state.vm0UserId) {
       await linkVm0User(db, existing.id, state.vm0UserId);
     }
-    return NextResponse.redirect(`${platformUrl}/works`);
+    return NextResponse.redirect(`${appUrl}/works`);
   }
 
   // Get installation info from GitHub API (target type, ID, name)
@@ -235,7 +235,7 @@ export async function GET(request: Request) {
     await linkVm0User(db, installRecordId, state.vm0UserId, adminGithubUserId);
   }
 
-  return NextResponse.redirect(`${platformUrl}/works`);
+  return NextResponse.redirect(`${appUrl}/works`);
 }
 
 /**

--- a/turbo/apps/web/app/api/github/oauth/install/route.ts
+++ b/turbo/apps/web/app/api/github/oauth/install/route.ts
@@ -4,7 +4,7 @@ import { eq } from "drizzle-orm";
 import { initServices } from "../../../../../src/lib/init-services";
 import { env } from "../../../../../src/env";
 import { getApiUrl } from "../../../../../src/lib/callback";
-import { getPlatformUrl } from "../../../../../src/lib/url";
+import { getAppUrl } from "../../../../../src/lib/url";
 import { encryptSecretValue } from "../../../../../src/lib/crypto/secrets-encryption";
 import { githubInstallations } from "../../../../../src/db/schema/github-installation";
 import {
@@ -153,7 +153,7 @@ async function tryLinkFromLocalRecord(
       .where(eq(githubInstallations.id, existing.id));
   }
 
-  return `${getPlatformUrl()}/settings?tab=integrations`;
+  return `${getAppUrl()}/settings?tab=integrations`;
 }
 
 /**
@@ -186,7 +186,7 @@ async function tryLinkFromGitHubApi(
   }
 
   const db = globalThis.services.db;
-  const platformUrl = getPlatformUrl();
+  const appUrl = getAppUrl();
 
   // Check if any GitHub installation is already tracked locally
   for (const ghInstall of installations) {
@@ -201,7 +201,7 @@ async function tryLinkFromGitHubApi(
     if (existing) {
       const linked = await linkVm0User(db, existing.id, vm0UserId);
       if (linked) {
-        return `${platformUrl}/settings?tab=integrations`;
+        return `${appUrl}/settings?tab=integrations`;
       }
       // Link failed — fall through to GitHub redirect
       return null;
@@ -255,5 +255,5 @@ async function tryLinkFromGitHubApi(
 
   await linkVm0User(db, newInstall.id, vm0UserId, adminGithubUserId);
 
-  return `${platformUrl}/settings?tab=integrations`;
+  return `${appUrl}/settings?tab=integrations`;
 }

--- a/turbo/apps/web/app/api/internal/callbacks/github/issues/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/github/issues/route.ts
@@ -12,7 +12,7 @@ import {
   removeCommentReaction,
 } from "../../../../../../src/lib/github/api";
 import { getRunResultData } from "../../../../../../src/lib/slack/handlers/run-agent";
-import { getPlatformUrl } from "../../../../../../src/lib/url";
+import { getAppUrl } from "../../../../../../src/lib/url";
 import { detectDeepLinks } from "../../../../../../src/lib/deep-links";
 import { env } from "../../../../../../src/env";
 import { logger } from "../../../../../../src/lib/logger";
@@ -83,8 +83,8 @@ function formatGitHubComment(opts: {
   triggerCommentBody?: string;
 }): string {
   const { status, agentName, runId, output, error, triggerCommentBody } = opts;
-  const platformUrl = getPlatformUrl();
-  const logsUrl = `${platformUrl}/activity/${encodeURIComponent(runId)}`;
+  const appUrl = getAppUrl();
+  const logsUrl = `${appUrl}/activity/${encodeURIComponent(runId)}`;
   const content =
     status === "completed"
       ? (output ?? "Task completed successfully.")
@@ -104,7 +104,7 @@ function formatGitHubComment(opts: {
   parts.push(`<sub>🤖 **${agentName}**</sub>`, "", content, "");
 
   // Detect deep links for missing connectors, model providers, etc.
-  const deepLinks = detectDeepLinks(content, platformUrl, agentName);
+  const deepLinks = detectDeepLinks(content, appUrl, agentName);
   if (deepLinks.length > 0) {
     const linkText = deepLinks
       .map((link) => `${link.emoji} [${link.label}](${link.url})`)

--- a/turbo/apps/web/app/api/internal/callbacks/slack/org/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/slack/org/route.ts
@@ -26,7 +26,7 @@ import {
   saveThreadSession,
   buildLogsUrl,
 } from "../../../../../../src/lib/slack-org/handlers/shared";
-import { getPlatformUrl } from "../../../../../../src/lib/url";
+import { getAppUrl } from "../../../../../../src/lib/url";
 import { env } from "../../../../../../src/env";
 import { logger } from "../../../../../../src/lib/logger";
 import type { WebClient } from "@slack/web-api";
@@ -297,7 +297,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     const logsUrl = buildLogsUrl(runId);
     const deepLinks = detectDeepLinks(
       responseText,
-      getPlatformUrl(),
+      getAppUrl(),
       payload.agentName,
     );
     await postMessage(client, payload.channelId, responseText, {

--- a/turbo/apps/web/app/api/internal/callbacks/telegram/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/telegram/route.ts
@@ -20,7 +20,7 @@ import {
   buildTelegramErrorResponse,
 } from "../../../../../src/lib/telegram/format";
 import { detectDeepLinks } from "../../../../../src/lib/deep-links";
-import { getPlatformUrl } from "../../../../../src/lib/url";
+import { getAppUrl } from "../../../../../src/lib/url";
 import { getRunOutput } from "../../../../../src/lib/slack/handlers/run-agent";
 import {
   saveTelegramThreadSession,
@@ -153,11 +153,7 @@ async function handleCompletion(ctx: CompletionContext): Promise<void> {
   let responseText: string | undefined;
   if (status === "completed") {
     responseText = output ?? "Task completed successfully.";
-    const deepLinks = detectDeepLinks(
-      responseText,
-      getPlatformUrl(),
-      agentName,
-    );
+    const deepLinks = detectDeepLinks(responseText, getAppUrl(), agentName);
     htmlOutput = buildTelegramResponse(
       responseText,
       agentName,

--- a/turbo/apps/web/app/api/slack/org/commands/route.ts
+++ b/turbo/apps/web/app/api/slack/org/commands/route.ts
@@ -23,7 +23,7 @@ import {
   buildOrgConnectUrl,
   getWorkspaceAgent,
 } from "../../../../../src/lib/slack-org/handlers/shared";
-import { getPlatformUrl } from "../../../../../src/lib/url";
+import { getAppUrl } from "../../../../../src/lib/url";
 import { logger } from "../../../../../src/lib/logger";
 
 const log = logger("slack-org:commands");
@@ -148,7 +148,7 @@ async function handleDisconnect(
 }
 
 function buildNotInstalledMessage(detail?: string): unknown[] {
-  const platformUrl = getPlatformUrl();
+  const appUrl = getAppUrl();
   return [
     {
       type: "section",
@@ -165,7 +165,7 @@ function buildNotInstalledMessage(detail?: string): unknown[] {
         {
           type: "button",
           text: { type: "plain_text", text: "Set up on Platform" },
-          url: `${platformUrl}/works`,
+          url: `${appUrl}/works`,
           action_id: "open_platform_setup",
         },
       ],
@@ -176,7 +176,7 @@ function buildNotInstalledMessage(detail?: string): unknown[] {
 async function handleSettings(
   installation: typeof slackOrgInstallations.$inferSelect,
 ): Promise<NextResponse> {
-  const platformUrl = getPlatformUrl();
+  const appUrl = getAppUrl();
   let agentLabel = "Agent";
   let agentName: string | undefined;
   if (installation.orgId) {
@@ -204,7 +204,7 @@ async function handleSettings(
         {
           type: "button",
           text: { type: "plain_text", text: `Configure ${agentLabel}` },
-          url: `${platformUrl}${settingsPath}`,
+          url: `${appUrl}${settingsPath}`,
           action_id: "open_platform_settings",
         },
       ],

--- a/turbo/apps/web/app/api/slack/org/connect/route.ts
+++ b/turbo/apps/web/app/api/slack/org/connect/route.ts
@@ -9,7 +9,7 @@ import {
   memberConnect,
   notifyConnectSuccess,
 } from "../../../../../src/lib/slack-org/connect-service";
-import { getPlatformUrl } from "../../../../../src/lib/url";
+import { getAppUrl } from "../../../../../src/lib/url";
 import { logger } from "../../../../../src/lib/logger";
 
 const log = logger("slack-org:connect");
@@ -37,11 +37,11 @@ export async function GET(request: Request) {
   const slackUserId = url.searchParams.get("u");
   const channelId = url.searchParams.get("c");
   const threadTs = url.searchParams.get("t");
-  const platformUrl = getPlatformUrl();
+  const appUrl = getAppUrl();
 
   if (!workspaceId || !slackUserId) {
     return NextResponse.redirect(
-      `${platformUrl}/slack/connect?error=${encodeURIComponent("Invalid connect link.")}`,
+      `${appUrl}/slack/connect?error=${encodeURIComponent("Invalid connect link.")}`,
     );
   }
 
@@ -53,7 +53,7 @@ export async function GET(request: Request) {
 
   if (!installation) {
     return NextResponse.redirect(
-      `${platformUrl}/slack/connect?error=${encodeURIComponent("Workspace not found. Please install the Slack app first.")}`,
+      `${appUrl}/slack/connect?error=${encodeURIComponent("Workspace not found. Please install the Slack app first.")}`,
     );
   }
 
@@ -63,7 +63,7 @@ export async function GET(request: Request) {
 
     if (member.role !== "admin") {
       return NextResponse.redirect(
-        `${platformUrl}/slack/connect?error=${encodeURIComponent("Ask your org admin to connect first.")}`,
+        `${appUrl}/slack/connect?error=${encodeURIComponent("Ask your org admin to connect first.")}`,
       );
     }
 
@@ -87,9 +87,7 @@ export async function GET(request: Request) {
       channelId,
       threadTs,
     }).catch((e) => log.warn("Failed to notify connect success", { error: e }));
-    return NextResponse.redirect(
-      `${platformUrl}/slack/connect?status=connected`,
-    );
+    return NextResponse.redirect(`${appUrl}/slack/connect?status=connected`);
   }
 
   // Verify the user is a member of the workspace's bound org AND their
@@ -119,7 +117,7 @@ export async function GET(request: Request) {
       : "You don't have access to the organization this Slack workspace belongs to. Contact the organization admin for an invite.";
 
     return NextResponse.redirect(
-      `${platformUrl}/slack/connect?error=${encodeURIComponent(message)}`,
+      `${appUrl}/slack/connect?error=${encodeURIComponent(message)}`,
     );
   }
 
@@ -155,5 +153,5 @@ export async function GET(request: Request) {
     channelId,
     threadTs,
   }).catch((e) => log.warn("Failed to notify connect success", { error: e }));
-  return NextResponse.redirect(`${platformUrl}/slack/connect?status=connected`);
+  return NextResponse.redirect(`${appUrl}/slack/connect?status=connected`);
 }

--- a/turbo/apps/web/app/api/slack/org/oauth/callback/route.ts
+++ b/turbo/apps/web/app/api/slack/org/oauth/callback/route.ts
@@ -16,7 +16,7 @@ import {
   memberConnect,
   notifyConnectSuccess,
 } from "../../../../../../src/lib/slack-org/connect-service";
-import { getPlatformUrl } from "../../../../../../src/lib/url";
+import { getAppUrl } from "../../../../../../src/lib/url";
 import { logger } from "../../../../../../src/lib/logger";
 
 const log = logger("slack-org:oauth-callback");
@@ -82,11 +82,11 @@ export async function GET(request: Request) {
   const code = url.searchParams.get("code");
   const error = url.searchParams.get("error");
   const baseUrl = getSlackRedirectBaseUrl(request.url);
-  const platformUrl = getPlatformUrl();
+  const appUrl = getAppUrl();
 
   if (error) {
     return NextResponse.redirect(
-      `${platformUrl}/slack/failed?error=${encodeURIComponent(error)}`,
+      `${appUrl}/slack/failed?error=${encodeURIComponent(error)}`,
     );
   }
 
@@ -107,7 +107,7 @@ export async function GET(request: Request) {
       code,
       redirectUri,
       state,
-      platformUrl,
+      appUrl,
       clientId: SLACK_CLIENT_ID,
       clientSecret: SLACK_CLIENT_SECRET,
     });
@@ -124,7 +124,7 @@ export async function GET(request: Request) {
   } catch (err) {
     log.error("Slack OAuth exchange failed", { error: err });
     return NextResponse.redirect(
-      `${platformUrl}/slack/failed?error=${encodeURIComponent("Failed to complete Slack installation. Please try again.")}`,
+      `${appUrl}/slack/failed?error=${encodeURIComponent("Failed to complete Slack installation. Please try again.")}`,
     );
   }
 
@@ -152,7 +152,7 @@ export async function GET(request: Request) {
         requestedOrgId: state.orgId,
       });
       return NextResponse.redirect(
-        `${platformUrl}/slack/connect?error=${encodeURIComponent("This Slack workspace is already installed by another organization. Please contact the workspace admin to uninstall first.")}`,
+        `${appUrl}/slack/connect?error=${encodeURIComponent("This Slack workspace is already installed by another organization. Please contact the workspace admin to uninstall first.")}`,
       );
     }
 
@@ -199,7 +199,7 @@ export async function GET(request: Request) {
     const member = await requireOrgMember(orgId, vm0UserId);
     if (member.role !== "admin") {
       return NextResponse.redirect(
-        `${platformUrl}/slack/failed?error=${encodeURIComponent("Only org admins can install Slack for an organization.")}`,
+        `${appUrl}/slack/failed?error=${encodeURIComponent("Only org admins can install Slack for an organization.")}`,
       );
     }
 
@@ -233,13 +233,13 @@ export async function GET(request: Request) {
     }
 
     return NextResponse.redirect(
-      `${platformUrl}/slack/connect?status=connected&workspace=${encodeURIComponent(oauthResult.teamName)}`,
+      `${appUrl}/slack/connect?status=connected&workspace=${encodeURIComponent(oauthResult.teamName)}`,
     );
   }
 
   // Slack flow: redirect to success page
   return NextResponse.redirect(
-    `${platformUrl}/slack/installed?workspace=${encodeURIComponent(oauthResult.teamName)}`,
+    `${appUrl}/slack/installed?workspace=${encodeURIComponent(oauthResult.teamName)}`,
   );
 }
 
@@ -254,16 +254,15 @@ async function handleConnectCallback(params: {
   code: string;
   redirectUri: string;
   state: OAuthState;
-  platformUrl: string;
+  appUrl: string;
   clientId: string;
   clientSecret: string;
 }): Promise<NextResponse> {
-  const { code, redirectUri, state, platformUrl, clientId, clientSecret } =
-    params;
+  const { code, redirectUri, state, appUrl, clientId, clientSecret } = params;
 
   if (!state.orgId || !state.vm0UserId) {
     return NextResponse.redirect(
-      `${platformUrl}/slack/connect?error=${encodeURIComponent("Invalid connect state.")}`,
+      `${appUrl}/slack/connect?error=${encodeURIComponent("Invalid connect state.")}`,
     );
   }
 
@@ -278,7 +277,7 @@ async function handleConnectCallback(params: {
   } catch (err) {
     log.error("Slack OAuth exchange failed (connect flow)", { error: err });
     return NextResponse.redirect(
-      `${platformUrl}/slack/connect?error=${encodeURIComponent("Failed to connect Slack account. Please try again.")}`,
+      `${appUrl}/slack/connect?error=${encodeURIComponent("Failed to connect Slack account. Please try again.")}`,
     );
   }
 
@@ -293,14 +292,14 @@ async function handleConnectCallback(params: {
 
   if (!installation) {
     return NextResponse.redirect(
-      `${platformUrl}/slack/connect?error=${encodeURIComponent("No Slack workspace installed for this organization.")}`,
+      `${appUrl}/slack/connect?error=${encodeURIComponent("No Slack workspace installed for this organization.")}`,
     );
   }
 
   // Verify workspace matches (user must have authed with the right workspace)
   if (userIdentity.teamId !== installation.slackWorkspaceId) {
     return NextResponse.redirect(
-      `${platformUrl}/slack/connect?error=${encodeURIComponent("You authenticated with a different Slack workspace. Please use the workspace connected to your organization.")}`,
+      `${appUrl}/slack/connect?error=${encodeURIComponent("You authenticated with a different Slack workspace. Please use the workspace connected to your organization.")}`,
     );
   }
 
@@ -339,6 +338,6 @@ async function handleConnectCallback(params: {
   );
 
   return NextResponse.redirect(
-    `${platformUrl}/slack/connect?status=connected&workspace=${encodeURIComponent(installation.slackWorkspaceName ?? "")}`,
+    `${appUrl}/slack/connect?status=connected&workspace=${encodeURIComponent(installation.slackWorkspaceName ?? "")}`,
   );
 }

--- a/turbo/apps/web/app/components/LandingPage.tsx
+++ b/turbo/apps/web/app/components/LandingPage.tsx
@@ -7,7 +7,7 @@ import { IconChevronDown, IconFile } from "@tabler/icons-react";
 import Navbar from "./Navbar";
 import Footer from "./Footer";
 import AnnouncementBanner from "./AnnouncementBanner";
-import { getPlatformUrl } from "../../src/lib/url";
+import { getAppUrl } from "../../src/lib/url";
 import { useUser } from "@clerk/nextjs";
 
 const TYPED_TEXT = "Help me build an agent for tech news aggregation";
@@ -220,7 +220,7 @@ function HeroSection({ isSignedIn }: { isSignedIn: boolean }) {
           <div className="w-full max-w-[566px]">
             {isSignedIn ? (
               <a
-                href={getPlatformUrl()}
+                href={getAppUrl()}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="bg-[#ed4e01] hover:bg-[#ff6a1f] !text-white w-full px-[24px] py-[12px] rounded-[10px] flex items-center justify-center transition-colors"
@@ -2344,7 +2344,7 @@ function FinalCtaSection({ isSignedIn }: { isSignedIn: boolean }) {
             <div className="flex flex-col sm:flex-row gap-[12px] sm:gap-[20px]">
               {isSignedIn ? (
                 <a
-                  href={getPlatformUrl()}
+                  href={getAppUrl()}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="bg-[#ed4e01] hover:bg-[#ff6a1f] !text-white px-[24px] py-[12px] rounded-[10px] font-medium text-[18px] leading-[28px] w-full sm:w-[160px] transition-colors flex items-center justify-center"

--- a/turbo/apps/web/app/components/Navbar.tsx
+++ b/turbo/apps/web/app/components/Navbar.tsx
@@ -10,7 +10,7 @@ import { IconArrowRight } from "@tabler/icons-react";
 import ThemeToggle from "./ThemeToggle";
 import LanguageSwitcher from "./LanguageSwitcher";
 import { useUser, useClerk } from "@clerk/nextjs";
-import { getPlatformUrl } from "../../src/lib/url";
+import { getAppUrl } from "../../src/lib/url";
 import { isBlogEnabled } from "../../src/env";
 
 export default function Navbar() {
@@ -128,7 +128,7 @@ export default function Navbar() {
                   Sign out
                 </button>
                 <a
-                  href={getPlatformUrl()}
+                  href={getAppUrl()}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="btn-get-access nav-desktop group"
@@ -230,7 +230,7 @@ export default function Navbar() {
                   Sign out
                 </button>
                 <a
-                  href={getPlatformUrl()}
+                  href={getAppUrl()}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="mobile-menu-link group"

--- a/turbo/apps/web/app/layout.tsx
+++ b/turbo/apps/web/app/layout.tsx
@@ -9,7 +9,7 @@ import {
 } from "next/font/google";
 import { ClerkProvider } from "@clerk/nextjs";
 import { getClerkPublishableKey } from "../src/lib/clerk-config";
-import { getPlatformUrl } from "../src/lib/url";
+import { getAppUrl } from "../src/lib/url";
 import { ThemeProvider } from "./components/ThemeProvider";
 import "./globals.css";
 import "./landing.css";
@@ -136,9 +136,9 @@ export default function RootLayout({
       publishableKey={getClerkPublishableKey()}
       signInUrl="/sign-in"
       signUpUrl="/sign-up"
-      signInForceRedirectUrl={getPlatformUrl()}
-      signUpForceRedirectUrl={getPlatformUrl()}
-      allowedRedirectOrigins={[getPlatformUrl()]}
+      signInForceRedirectUrl={getAppUrl()}
+      signUpForceRedirectUrl={getAppUrl()}
+      allowedRedirectOrigins={[getAppUrl()]}
     >
       <html lang="en" data-theme="dark" suppressHydrationWarning>
         <head>

--- a/turbo/apps/web/src/lib/deep-links.ts
+++ b/turbo/apps/web/src/lib/deep-links.ts
@@ -67,7 +67,7 @@ function buildPath(category: KeywordCategory, agentName?: string): string {
  */
 export function detectDeepLinks(
   responseText: string,
-  platformUrl: string,
+  appUrl: string,
   agentName?: string,
 ): DeepLink[] {
   const lowerText = responseText.toLowerCase();
@@ -85,7 +85,7 @@ export function detectDeepLinks(
       links.push({
         emoji: mapping.emoji,
         label: mapping.label,
-        url: `${platformUrl}${path}`,
+        url: `${appUrl}${path}`,
       });
     }
   }

--- a/turbo/apps/web/src/lib/email/handlers/shared.ts
+++ b/turbo/apps/web/src/lib/email/handlers/shared.ts
@@ -4,7 +4,7 @@ import { emailThreadSessions } from "../../../db/schema/email-thread-session";
 import { agentComposes } from "../../../db/schema/agent-compose";
 import { getOrgBySlug } from "../../org/org-cache-service";
 import { env } from "../../../env";
-import { getPlatformUrl } from "../../url";
+import { getAppUrl } from "../../url";
 import { getApiUrl } from "../../callback/dispatcher";
 import { enqueueEmail } from "../outbox-service";
 
@@ -373,7 +373,7 @@ export function buildFromAddress(localPart: string): string {
  * Build the logs URL for a run, linking to the agent detail logs page.
  */
 export function buildLogsUrl(runId: string): string {
-  return `${getPlatformUrl()}/activity/${encodeURIComponent(runId)}`;
+  return `${getAppUrl()}/activity/${encodeURIComponent(runId)}`;
 }
 
 // ============================================================================

--- a/turbo/apps/web/src/lib/slack-org/handlers/direct-message.ts
+++ b/turbo/apps/web/src/lib/slack-org/handlers/direct-message.ts
@@ -26,7 +26,7 @@ import {
   getWorkspaceAgent,
   resolveSessionCompose,
 } from "./shared";
-import { getPlatformUrl } from "../../url";
+import { getAppUrl } from "../../url";
 import { logger } from "../../logger";
 
 const log = logger("slack-org:dm");
@@ -197,7 +197,7 @@ export async function handleOrgDirectMessage(
   } else if (status === "failed") {
     const errorText = response ?? "Sorry, an error occurred. Please try again.";
     const logsUrl = runId ? buildLogsUrl(runId) : buildAgentLogsUrl();
-    const deepLinks = detectDeepLinks(errorText, getPlatformUrl(), agentName);
+    const deepLinks = detectDeepLinks(errorText, getAppUrl(), agentName);
     await postMessage(client, context.channelId, errorText, {
       threadTs,
       blocks: buildAgentResponseMessage(errorText, logsUrl, deepLinks),

--- a/turbo/apps/web/src/lib/slack-org/handlers/mention.ts
+++ b/turbo/apps/web/src/lib/slack-org/handlers/mention.ts
@@ -22,7 +22,7 @@ import {
   getWorkspaceAgent,
   resolveSessionCompose,
 } from "./shared";
-import { getPlatformUrl } from "../../url";
+import { getAppUrl } from "../../url";
 import { logger } from "../../logger";
 
 const log = logger("slack-org:mention");
@@ -196,7 +196,7 @@ export async function handleOrgMention(
     log.error("Failed to dispatch agent run", { response });
     const errorText = response ?? "Sorry, an error occurred. Please try again.";
     const logsUrl = runId ? buildLogsUrl(runId) : buildAgentLogsUrl();
-    const deepLinks = detectDeepLinks(errorText, getPlatformUrl(), agentName);
+    const deepLinks = detectDeepLinks(errorText, getAppUrl(), agentName);
     await client.chat.postMessage({
       channel: context.channelId,
       thread_ts: threadTs,

--- a/turbo/apps/web/src/lib/slack-org/handlers/shared.ts
+++ b/turbo/apps/web/src/lib/slack-org/handlers/shared.ts
@@ -3,7 +3,7 @@ import { clerkClient } from "@clerk/nextjs/server";
 import { slackOrgInstallations } from "../../../db/schema/slack-org-installation";
 import { slackOrgConnections } from "../../../db/schema/slack-org-connection";
 import { slackOrgThreadSessions } from "../../../db/schema/slack-org-thread-session";
-import { getPlatformUrl } from "../../url";
+import { getAppUrl } from "../../url";
 import { resolveDefaultAgentComposeId } from "../../agent-compose/resolve-default";
 import { ensureStorageExists } from "../../storage/storage-service";
 
@@ -186,7 +186,7 @@ export function buildOrgConnectUrl(
   channelId: string,
   threadTs?: string,
 ): string {
-  const platformUrl = getPlatformUrl();
+  const appUrl = getAppUrl();
   const params = new URLSearchParams({
     w: workspaceId,
     u: slackUserId,
@@ -197,7 +197,7 @@ export function buildOrgConnectUrl(
   if (threadTs) {
     params.set("t", threadTs);
   }
-  return `${platformUrl}/slack/connect?${params.toString()}`;
+  return `${appUrl}/slack/connect?${params.toString()}`;
 }
 
 /**
@@ -224,12 +224,12 @@ export {
  * Build the logs URL for a run in the org flow.
  */
 export function buildLogsUrl(runId: string): string {
-  return `${getPlatformUrl()}/activity/${encodeURIComponent(runId)}`;
+  return `${getAppUrl()}/activity/${encodeURIComponent(runId)}`;
 }
 
 /**
  * Build the agent-level activity URL (no specific run).
  */
 export function buildAgentLogsUrl(): string {
-  return `${getPlatformUrl()}/activity`;
+  return `${getAppUrl()}/activity`;
 }

--- a/turbo/apps/web/src/lib/slack/__tests__/blocks.test.ts
+++ b/turbo/apps/web/src/lib/slack/__tests__/blocks.test.ts
@@ -112,60 +112,54 @@ describe("buildSuccessMessage", () => {
 });
 
 describe("detectDeepLinks", () => {
-  const platformUrl = "https://platform.vm0.ai";
+  const appUrl = "https://app.vm0.ai";
 
   it("should return empty array when no keywords match", () => {
-    const links = detectDeepLinks(
-      "Hello, everything is working fine!",
-      platformUrl,
-    );
+    const links = detectDeepLinks("Hello, everything is working fine!", appUrl);
     expect(links).toEqual([]);
   });
 
   it("should detect provider-related keywords", () => {
     const links = detectDeepLinks(
       "The model provider is not configured",
-      platformUrl,
+      appUrl,
     );
     expect(links).toHaveLength(1);
     expect(links[0]).toEqual({
       emoji: "🔑",
       label: "Configure model providers",
-      url: `${platformUrl}/settings`,
+      url: `${appUrl}/settings`,
     });
   });
 
   it("should route connector links to team page with agent name", () => {
     const links = detectDeepLinks(
       "Error: missing variable DATABASE_URL",
-      platformUrl,
+      appUrl,
       "my-agent",
     );
     expect(links).toHaveLength(1);
     expect(links[0]).toEqual({
       emoji: "🔌",
       label: "Configure connectors",
-      url: `${platformUrl}/team/my-agent?tab=connectors`,
+      url: `${appUrl}/team/my-agent?tab=connectors`,
     });
   });
 
   it("should route connector links to generic team page without agent name", () => {
-    const links = detectDeepLinks(
-      "The MCP server connection failed",
-      platformUrl,
-    );
+    const links = detectDeepLinks("The MCP server connection failed", appUrl);
     expect(links).toHaveLength(1);
     expect(links[0]).toEqual({
       emoji: "🔌",
       label: "Configure connectors",
-      url: `${platformUrl}/team`,
+      url: `${appUrl}/team`,
     });
   });
 
   it("should match case-insensitively", () => {
     const links = detectDeepLinks(
       "API_KEY is not configured",
-      platformUrl,
+      appUrl,
       "test-agent",
     );
     expect(links).toHaveLength(1);
@@ -175,34 +169,34 @@ describe("detectDeepLinks", () => {
   it("should deduplicate by path", () => {
     const links = detectDeepLinks(
       "The api key is missing and the secret is not configured and the apikey is invalid",
-      platformUrl,
+      appUrl,
       "my-agent",
     );
     expect(links).toHaveLength(1);
-    expect(links[0]?.url).toBe(`${platformUrl}/team/my-agent?tab=connectors`);
+    expect(links[0]?.url).toBe(`${appUrl}/team/my-agent?tab=connectors`);
   });
 
   it("should return multiple links for different destinations", () => {
     const links = detectDeepLinks(
       "The model provider is missing. Also the api key is not set and the MCP server is down.",
-      platformUrl,
+      appUrl,
       "my-agent",
     );
     expect(links).toHaveLength(2);
     const urls = links.map((l) => l.url);
-    expect(urls).toContain(`${platformUrl}/settings`);
-    expect(urls).toContain(`${platformUrl}/team/my-agent?tab=connectors`);
+    expect(urls).toContain(`${appUrl}/settings`);
+    expect(urls).toContain(`${appUrl}/team/my-agent?tab=connectors`);
   });
 
   it("should encode special characters in agent name", () => {
     const links = detectDeepLinks(
       "connector not found",
-      platformUrl,
+      appUrl,
       "agent with spaces",
     );
     expect(links).toHaveLength(1);
     expect(links[0]?.url).toBe(
-      `${platformUrl}/team/agent%20with%20spaces?tab=connectors`,
+      `${appUrl}/team/agent%20with%20spaces?tab=connectors`,
     );
   });
 });

--- a/turbo/apps/web/src/lib/slack/blocks.ts
+++ b/turbo/apps/web/src/lib/slack/blocks.ts
@@ -8,7 +8,7 @@ import type {
   Checkboxes,
   Option,
 } from "@slack/web-api";
-import { getPlatformUrl } from "../url";
+import { getAppUrl } from "../url";
 import type { DeepLink } from "../deep-links";
 
 /**
@@ -63,7 +63,7 @@ export function buildAppHomeView(options: {
               type: "plain_text",
               text: "Open Zero Settings",
             },
-            url: `${getPlatformUrl()}/works`,
+            url: `${getAppUrl()}/works`,
             action_id: "home_open_settings",
             style: "primary",
           },
@@ -143,7 +143,7 @@ export function buildAppHomeView(options: {
       accessory: {
         type: "button",
         text: { type: "plain_text", text: "Settings" },
-        url: `${getPlatformUrl()}/works`,
+        url: `${getAppUrl()}/works`,
         action_id: "home_environment_setup",
       },
     });

--- a/turbo/apps/web/src/lib/telegram/check-domain.ts
+++ b/turbo/apps/web/src/lib/telegram/check-domain.ts
@@ -10,10 +10,10 @@ const log = logger("telegram:check-domain");
  */
 export async function checkTelegramDomain(
   telegramBotId: string,
-  platformUrl: string,
+  appUrl: string,
 ): Promise<boolean> {
   try {
-    const probeOrigin = encodeURIComponent(platformUrl);
+    const probeOrigin = encodeURIComponent(appUrl);
     const probeUrl = `${TELEGRAM_OAUTH_BASE_URL}?bot_id=${telegramBotId}&origin=${probeOrigin}`;
     const probeResp = await fetch(probeUrl, {
       method: "HEAD",

--- a/turbo/apps/web/src/lib/telegram/handlers/commands.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/commands.ts
@@ -6,7 +6,7 @@ import { env } from "../../../env";
 import { createTelegramClient, sendMessage } from "../client";
 import { resolveUserLink, getWorkspaceAgent, buildConnectUrl } from "./shared";
 import { escapeHtml } from "../format";
-import { getPlatformUrl } from "../../url";
+import { getAppUrl } from "../../url";
 import { logger } from "../../logger";
 import type { TelegramHandlerUpdate } from "./types";
 
@@ -210,7 +210,7 @@ export async function handleSettingsCommand(
   }
 
   const isAdmin = userLink.vm0UserId === installation.adminUserId;
-  const platformUrl = getPlatformUrl();
+  const appUrl = getAppUrl();
   const desc = isAdmin
     ? "Configure secrets, variables, and select the workspace agent on the VM0 platform."
     : "Configure your environment variables and secrets on the VM0 platform.";
@@ -218,7 +218,7 @@ export async function handleSettingsCommand(
   await sendMessage(
     client,
     chatId,
-    `⚙️ <b>Settings</b>\n\n${escapeHtml(desc)}\n\n<a href="${escapeHtml(platformUrl)}/works">Open Platform</a>`,
+    `⚙️ <b>Settings</b>\n\n${escapeHtml(desc)}\n\n<a href="${escapeHtml(appUrl)}/works">Open Platform</a>`,
     replyOptions,
   );
 }

--- a/turbo/apps/web/src/lib/telegram/handlers/shared.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/shared.ts
@@ -3,7 +3,7 @@ import { telegramThreadSessions } from "../../../db/schema/telegram-thread-sessi
 import { telegramMessages } from "../../../db/schema/telegram-message";
 import { telegramUserLinks } from "../../../db/schema/telegram-user-link";
 import { agentComposes } from "../../../db/schema/agent-compose";
-import { getPlatformUrl } from "../../url";
+import { getAppUrl } from "../../url";
 import { resolveOrgOrNull } from "../../org/resolve-org";
 import { validateAgentSession } from "../../run";
 import { ensureStorageExists } from "../../storage/storage-service";
@@ -168,14 +168,14 @@ export async function storeTelegramMessage(
  * Build the logs URL for a run, linking to the agent detail logs page.
  */
 export function buildLogsUrl(runId: string): string {
-  return `${getPlatformUrl()}/activity/${encodeURIComponent(runId)}`;
+  return `${getAppUrl()}/activity/${encodeURIComponent(runId)}`;
 }
 
 /**
  * Build the agent logs page URL (no specific run).
  */
 export function buildAgentLogsUrl(): string {
-  return `${getPlatformUrl()}/activity`;
+  return `${getAppUrl()}/activity`;
 }
 
 /**
@@ -297,10 +297,10 @@ export function buildConnectUrl(
   telegramUserId: string,
   botToken: string,
 ): string {
-  const platformUrl = getPlatformUrl();
+  const appUrl = getAppUrl();
   const ts = Math.floor(Date.now() / 1000);
   const sig = signConnectParams(installationId, telegramUserId, ts, botToken);
-  return `${platformUrl}/telegram/connect?bot=${telegramBotId}&tgUser=${telegramUserId}&ts=${ts}&sig=${sig}`;
+  return `${appUrl}/telegram/connect?bot=${telegramBotId}&tgUser=${telegramUserId}&ts=${ts}&sig=${sig}`;
 }
 
 /**

--- a/turbo/apps/web/src/lib/url.ts
+++ b/turbo/apps/web/src/lib/url.ts
@@ -1,5 +1,5 @@
 import { env } from "../env";
 
-export function getPlatformUrl(): string {
+export function getAppUrl(): string {
   return env().NEXT_PUBLIC_PLATFORM_URL;
 }


### PR DESCRIPTION
## Summary

- Renames `getPlatformUrl()` to `getAppUrl()` in `src/lib/url.ts` and all 20+ import/call sites
- Renames local `platformUrl` variables to `appUrl` in route handlers and messaging libs
- Renames `platformUrl` parameter to `appUrl` in `deep-links.ts` and `check-domain.ts`
- Updates test fixture URL from `https://platform.vm0.ai` to `https://app.vm0.ai`
- Environment variable names (`NEXT_PUBLIC_PLATFORM_URL`, `PLATFORM_URL`) remain unchanged

Part of platform → app subdomain migration Phase 2.

Closes #5271

## Test plan

- [x] All 20 tests in `blocks.test.ts` pass (including `detectDeepLinks` tests with new `appUrl` variable and `https://app.vm0.ai` fixture)
- [x] Lint passes with zero warnings
- [x] Type check passes (no new errors)
- [x] Knip finds no unused exports
- [ ] CI pipeline passes all checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)