### PR TITLE
fix(e2e): match app subdomain in sign-in test

### DIFF
--- a/e2e/sign-in.spec.ts
+++ b/e2e/sign-in.spec.ts
@@ -62,7 +62,7 @@ test("sign-in flow", async ({ page, baseURL }) => {
   // checking for either: redirect to platform URL, or the Platform button in navbar.
   await expect(async () => {
     const url = page.url();
-    const onPlatform = /platform/.test(url);
+    const onPlatform = /\b(platform|app)\./.test(url);
     const onWebApp = !onPlatform;
     if (onWebApp) {
       // Still on web app — the Platform button should be visible for authenticated users


### PR DESCRIPTION
## Summary
- The platform subdomain was renamed to `app` in #5275, but `e2e/sign-in.spec.ts` still only matched `/platform/` in the post-login URL check
- Updated regex to match both `platform.` and `app.` subdomains

## Test plan
- [ ] `e2e-auth` job passes on CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)