### PR TITLE
fix(ci): replace deprecated npm --production with --omit=dev

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -907,7 +907,7 @@ jobs:
       - name: Build CLI
         run: cd turbo && pnpm --filter @vm0/cli build
       - name: Install CLI production dependencies
-        run: cd turbo/apps/cli/dist && npm install --production
+        run: cd turbo/apps/cli/dist && npm install --omit=dev
       - name: Upload CLI artifact
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Summary

Replace `npm install --production` with `npm install --omit=dev` in the `build-cli` job. The `--production` flag is deprecated in npm and was causing 409 Conflict errors from the registry.

## Test plan

- [ ] `build-cli` job installs production deps successfully
- [ ] CLI artifact works correctly in downstream e2e jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)