### PR TITLE
fix: correct display name extraction path in platform logs api

### DIFF
--- a/turbo/apps/web/app/api/app/logs/[id]/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/app/logs/[id]/__tests__/route.test.ts
@@ -140,7 +140,7 @@ describe("GET /api/app/logs/[id]", () => {
     await completeTestRun(user.userId, runId);
 
     const request = createTestRequest(
-      `http://localhost:3000/api/platform/logs/${runId}`,
+      `http://localhost:3000/api/app/logs/${runId}`,
     );
     const response = await GET(request);
     const data = await response.json();
@@ -155,7 +155,7 @@ describe("GET /api/app/logs/[id]", () => {
     await completeTestRun(user.userId, runId);
 
     const request = createTestRequest(
-      `http://localhost:3000/api/platform/logs/${runId}`,
+      `http://localhost:3000/api/app/logs/${runId}`,
     );
     const response = await GET(request);
     const data = await response.json();

--- a/turbo/apps/web/app/api/app/logs/[id]/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/app/logs/[id]/__tests__/route.test.ts
@@ -131,6 +131,40 @@ describe("GET /api/app/logs/[id]", () => {
     expect(data.sessionId).toBeDefined();
   });
 
+  it("should return displayName from agent metadata", async () => {
+    const agentName = `display-name-id-${randomUUID().slice(0, 8)}`;
+    const { composeId } = await createTestCompose(agentName, {
+      metadata: { displayName: "Agent Display Name" },
+    });
+    const { runId } = await createTestRun(composeId, "Test prompt");
+    await completeTestRun(user.userId, runId);
+
+    const request = createTestRequest(
+      `http://localhost:3000/api/platform/logs/${runId}`,
+    );
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.id).toBe(runId);
+    expect(data.displayName).toBe("Agent Display Name");
+  });
+
+  it("should return null displayName when agent metadata has none", async () => {
+    const { runId } = await createTestRun(testComposeId, "Test prompt");
+    await completeTestRun(user.userId, runId);
+
+    const request = createTestRequest(
+      `http://localhost:3000/api/platform/logs/${runId}`,
+    );
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.id).toBe(runId);
+    expect(data.displayName).toBeNull();
+  });
+
   it("should handle pending run status", async () => {
     // Create run but don't complete it (stays in pending status)
     const { runId, status } = await createTestRun(testComposeId, "Test prompt");

--- a/turbo/apps/web/app/api/app/logs/[id]/route.ts
+++ b/turbo/apps/web/app/api/app/logs/[id]/route.ts
@@ -36,9 +36,20 @@ interface ComposeContent {
     string,
     {
       framework?: string;
+      metadata?: { displayName?: string };
     }
   >;
-  metadata?: { displayName?: string };
+}
+
+/**
+ * Extract display name from compose content agents metadata.
+ */
+function extractDisplayName(content: ComposeContent | null): string | null {
+  if (!content?.agents) return null;
+  const firstAgentKey = Object.keys(content.agents)[0];
+  if (!firstAgentKey) return null;
+  const dn = content.agents[firstAgentKey]?.metadata?.displayName;
+  return typeof dn === "string" ? dn : null;
 }
 
 /**
@@ -169,10 +180,7 @@ const router = tsr.router(platformLogsByIdContract, {
         id: run.id,
         sessionId: runResult?.agentSessionId ?? null,
         agentName: compose?.name ?? "unknown",
-        displayName:
-          typeof composeContent?.metadata?.displayName === "string"
-            ? composeContent.metadata.displayName
-            : null,
+        displayName: extractDisplayName(composeContent),
         framework: extractFramework(composeContent),
         modelProvider: run.modelProvider ?? null,
         status: run.status as

--- a/turbo/apps/web/app/api/app/logs/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/app/logs/__tests__/route.test.ts
@@ -337,9 +337,7 @@ describe("GET /api/app/logs", () => {
     const { runId } = await createTestRun(composeId, "Test prompt");
     await completeTestRun(user.userId, runId);
 
-    const request = createTestRequest(
-      "http://localhost:3000/api/platform/logs",
-    );
+    const request = createTestRequest("http://localhost:3000/api/app/logs");
     const response = await GET(request);
     const data = await response.json();
 
@@ -355,9 +353,7 @@ describe("GET /api/app/logs", () => {
     const { runId } = await createTestRun(composeId, "Test prompt");
     await completeTestRun(user.userId, runId);
 
-    const request = createTestRequest(
-      "http://localhost:3000/api/platform/logs",
-    );
+    const request = createTestRequest("http://localhost:3000/api/app/logs");
     const response = await GET(request);
     const data = await response.json();
 

--- a/turbo/apps/web/app/api/app/logs/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/app/logs/__tests__/route.test.ts
@@ -329,6 +329,44 @@ describe("GET /api/app/logs", () => {
     });
   });
 
+  it("should return displayName from agent metadata", async () => {
+    const agentName = `display-name-test-${randomUUID().slice(0, 8)}`;
+    const { composeId } = await createTestCompose(agentName, {
+      metadata: { displayName: "My Display Name" },
+    });
+    const { runId } = await createTestRun(composeId, "Test prompt");
+    await completeTestRun(user.userId, runId);
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/platform/logs",
+    );
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    const run = data.data.find((r: { id: string }) => r.id === runId);
+    expect(run).toBeDefined();
+    expect(run.displayName).toBe("My Display Name");
+  });
+
+  it("should return null displayName when agent metadata has none", async () => {
+    const agentName = `no-display-name-${randomUUID().slice(0, 8)}`;
+    const { composeId } = await createTestCompose(agentName);
+    const { runId } = await createTestRun(composeId, "Test prompt");
+    await completeTestRun(user.userId, runId);
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/platform/logs",
+    );
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    const run = data.data.find((r: { id: string }) => r.id === runId);
+    expect(run).toBeDefined();
+    expect(run.displayName).toBeNull();
+  });
+
   it("should return 400 for invalid limit", async () => {
     const request = createTestRequest(
       "http://localhost:3000/api/app/logs?limit=0",

--- a/turbo/apps/web/app/api/app/logs/route.ts
+++ b/turbo/apps/web/app/api/app/logs/route.ts
@@ -27,8 +27,10 @@ const log = logger("api:platform:logs");
 
 // Minimal type for extracting framework and displayName from compose content
 interface AgentComposeContent {
-  agents: Record<string, { framework: string }>;
-  metadata?: { displayName?: string };
+  agents: Record<
+    string,
+    { framework: string; metadata?: { displayName?: string } }
+  >;
 }
 
 interface LogsQuery {
@@ -126,9 +128,11 @@ function extractFramework(composeContent: unknown): string | null {
  */
 function extractDisplayName(composeContent: unknown): string | null {
   const content = composeContent as AgentComposeContent | null;
-  return typeof content?.metadata?.displayName === "string"
-    ? content.metadata.displayName
-    : null;
+  const agentNames = content?.agents ? Object.keys(content.agents) : [];
+  const firstAgent =
+    agentNames.length > 0 ? content?.agents[agentNames[0]!] : null;
+  const displayName = firstAgent?.metadata?.displayName;
+  return typeof displayName === "string" ? displayName : null;
 }
 
 const router = tsr.router(platformLogsListContract, {


### PR DESCRIPTION
## Summary

- Fixed `extractDisplayName` in both `logs/route.ts` and `logs/[id]/route.ts` to read `displayName` from `content.agents[firstKey].metadata.displayName` (agent-level) instead of `content.metadata.displayName` (top-level)
- Updated `AgentComposeContent` / `ComposeContent` type definitions to reflect that `metadata` lives under each agent entry, not at the top level
- The bug caused `displayName` to always return `null` in the activity view

## Test plan
- [ ] Verify activity view shows correct display names for platform log entries
- [ ] Confirm `extractDisplayName` returns non-null value when agent metadata contains `displayName`
- [ ] Check that `extractFramework` is unaffected and still returns correct values

🤖 Generated with [Claude Code](https://claude.com/claude-code)