### PR TITLE
fix(app): resolve web origin for preview environment hostnames

### DIFF
--- a/turbo/apps/platform/src/signals/auth.ts
+++ b/turbo/apps/platform/src/signals/auth.ts
@@ -15,7 +15,7 @@ function resolveWebOrigin(): string {
     return "";
   }
   const url = new URL(origin);
-  url.hostname = url.hostname.replace(/^(platform|app)\./, "www.");
+  url.hostname = url.hostname.replace(/(^|-)(platform|app)\./, "$1www.");
   return url.origin;
 }
 

--- a/turbo/apps/platform/src/signals/fetch.ts
+++ b/turbo/apps/platform/src/signals/fetch.ts
@@ -31,7 +31,7 @@ export const apiBaseForNavigation$ = computed(() => {
     return base.endsWith("/") ? base.slice(0, -1) : base;
   }
   const url = new URL(location.origin);
-  url.hostname = url.hostname.replace(/^(platform|app)\./, "www.");
+  url.hostname = url.hostname.replace(/(^|-)(platform|app)\./, "$1www.");
   return url.origin;
 });
 
@@ -45,7 +45,7 @@ function resolveApiBase(): string {
   if (CONFIGURED_API_URL === "http://localhost:3000") {
     const currentOrigin = location.origin;
     const url = new URL(currentOrigin);
-    url.hostname = url.hostname.replace(/^(platform|app)\./, "www.");
+    url.hostname = url.hostname.replace(/(^|-)(platform|app)\./, "$1www.");
     return url.origin;
   }
   return CONFIGURED_API_URL;


### PR DESCRIPTION
## Summary
- Fix infinite sign-in redirect loop in preview environments (e.g. `pr-1234-app.vm6.ai`)
- The hostname regex `^(platform|app)\.` only matched subdomain-prefix format (`app.vm7.ai`) but not preview format (`pr-1234-app.vm6.ai`)
- Updated to `(^|-)(platform|app)\.` so `pr-1234-app.vm6.ai` correctly resolves to `pr-1234-www.vm6.ai`
- Applied fix to all three occurrences in `auth.ts` and `fetch.ts`

## Test plan
- [ ] Verify `app.vm7.ai` still resolves to `www.vm7.ai` (local dev)
- [ ] Verify `pr-XXXX-app.vm6.ai` resolves to `pr-XXXX-www.vm6.ai` (preview)
- [ ] Verify lighthouse-app CI check passes without infinite redirect

🤖 Generated with [Claude Code](https://claude.com/claude-code)