### PR TITLE
refactor: simplify build-context to org-only model provider resolution

### DIFF
--- a/turbo/apps/web/app/api/agent/runs/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/__tests__/route.test.ts
@@ -9,8 +9,8 @@ import {
   createTestCompose,
   createTestCliToken,
   deleteTestCliToken,
-  createTestModelProvider,
-  createTestMultiAuthModelProvider,
+  createTestOrgModelProvider,
+  createTestOrgMultiAuthModelProvider,
   createTestConnector,
   createTestRun,
   createTestRunInDb,
@@ -693,8 +693,8 @@ describe("POST /api/agent/runs - Internal Runs API", () => {
 
   describe("Model Provider Injection", () => {
     it("should succeed when model provider is configured and no API key in compose", async () => {
-      // Create model provider
-      await createTestModelProvider("anthropic-api-key", "test-api-key");
+      // Create org-level model provider (build-context resolves org-only)
+      await createTestOrgModelProvider("anthropic-api-key", "test-api-key");
 
       // Create compose without API key
       const { composeId } = await createTestCompose(uniqueId("mp-agent"), {
@@ -734,8 +734,8 @@ describe("POST /api/agent/runs - Internal Runs API", () => {
     });
 
     it("should use specified model provider when passed", async () => {
-      // Create model provider
-      await createTestModelProvider("anthropic-api-key", "test-api-key");
+      // Create org-level model provider (build-context resolves org-only)
+      await createTestOrgModelProvider("anthropic-api-key", "test-api-key");
 
       // Create compose without API key
       const { composeId } = await createTestCompose(uniqueId("mp-select"), {
@@ -791,8 +791,8 @@ describe("POST /api/agent/runs - Internal Runs API", () => {
     });
 
     it("should auto-inject model provider when no environment block exists", async () => {
-      // Create model provider
-      await createTestModelProvider(
+      // Create org-level model provider (build-context resolves org-only)
+      await createTestOrgModelProvider(
         "claude-code-oauth-token",
         "test-oauth-token",
       );
@@ -814,8 +814,8 @@ describe("POST /api/agent/runs - Internal Runs API", () => {
     });
 
     it("should succeed when aws-bedrock provider is configured and no API key in compose", async () => {
-      // Create aws-bedrock provider
-      await createTestMultiAuthModelProvider("aws-bedrock", "api-key", {
+      // Create org-level aws-bedrock provider (build-context resolves org-only)
+      await createTestOrgMultiAuthModelProvider("aws-bedrock", "api-key", {
         AWS_BEARER_TOKEN_BEDROCK: "bedrock-token",
         AWS_REGION: "us-east-1",
       });

--- a/turbo/apps/web/src/__tests__/api-test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers.ts
@@ -61,6 +61,7 @@ import { POST as createComposeRoute } from "../../app/api/agent/composes/route";
 import { POST as createRunRoute } from "../../app/api/agent/runs/route";
 import { GET as getRunByIdRoute } from "../../app/api/agent/runs/[id]/route";
 import { PUT as upsertModelProviderRoute } from "../../app/api/model-providers/route";
+import { PUT as upsertOrgModelProviderRoute } from "../../app/api/org/model-providers/route";
 import { POST as checkpointWebhook } from "../../app/api/webhooks/agent/checkpoints/route";
 import { POST as completeWebhook } from "../../app/api/webhooks/agent/complete/route";
 import {
@@ -459,6 +460,89 @@ export async function createTestMultiAuthModelProvider(
     const error = await response.json();
     throw new Error(
       `Failed to create multi-auth model provider: ${error.error?.message || response.status}`,
+    );
+  }
+  const data = await response.json();
+  return data.provider;
+}
+
+/**
+ * Create a test org-level model provider via API route handler.
+ * This creates an org-scoped provider (using ORG_SENTINEL_USER_ID internally).
+ *
+ * @param type - The provider type
+ * @param secretValue - The secret value
+ * @param selectedModel - Optional selected model for providers with model selection
+ * @returns The created provider with id and type
+ */
+export async function createTestOrgModelProvider(
+  type: string,
+  secretValue: string,
+  selectedModel?: string,
+): Promise<{ id: string; type: string; selectedModel: string | null }> {
+  const request = createTestRequest(
+    "http://localhost:3000/api/org/model-providers",
+    {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        type,
+        secret: secretValue,
+        selectedModel,
+      }),
+    },
+  );
+  const response = await upsertOrgModelProviderRoute(request);
+  if (!response.ok) {
+    const error = await response.json();
+    throw new Error(
+      `Failed to create org model provider: ${error.error?.message || response.status}`,
+    );
+  }
+  const data = await response.json();
+  return data.provider;
+}
+
+/**
+ * Create a test org-level multi-auth model provider via API route handler.
+ * This creates an org-scoped provider (using ORG_SENTINEL_USER_ID internally).
+ *
+ * @param type - The provider type (e.g., "aws-bedrock")
+ * @param authMethod - The auth method (e.g., "api-key", "access-keys")
+ * @param secrets - Map of secret names to values
+ * @param selectedModel - Optional selected model
+ * @returns The created provider with id and type
+ */
+export async function createTestOrgMultiAuthModelProvider(
+  type: string,
+  authMethod: string,
+  secrets: Record<string, string>,
+  selectedModel?: string,
+): Promise<{
+  id: string;
+  type: string;
+  authMethod: string | null;
+  secretNames: string[] | null;
+  selectedModel: string | null;
+}> {
+  const request = createTestRequest(
+    "http://localhost:3000/api/org/model-providers",
+    {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        type,
+        authMethod,
+        secrets,
+        selectedModel,
+      }),
+    },
+  );
+  const response = await upsertOrgModelProviderRoute(request);
+  if (!response.ok) {
+    const error = await response.json();
+    throw new Error(
+      `Failed to create org multi-auth model provider: ${error.error?.message || response.status}`,
     );
   }
   const data = await response.json();

--- a/turbo/apps/web/src/lib/run/__tests__/build-context-org.test.ts
+++ b/turbo/apps/web/src/lib/run/__tests__/build-context-org.test.ts
@@ -41,38 +41,12 @@ describe("Org-Level Runtime Resolution", () => {
     };
   }
 
-  describe("Model Provider Fallback", () => {
-    it("should use user default provider when user has one", async () => {
+  describe("Model Provider Resolution", () => {
+    it("should use org default provider", async () => {
       const noKeyCompose = await createTestCompose(uniqueId("no-key-agent"), {
         skipDefaultApiKey: true,
       });
 
-      // Create both user and org providers
-      await createTestModelProvider("anthropic-api-key", "user-api-key");
-      await upsertOrgModelProvider(
-        user.orgId,
-        "anthropic-api-key",
-        "org-api-key",
-      );
-
-      const result = await createRun(
-        baseParams({ agentComposeVersionId: noKeyCompose.versionId }),
-      );
-
-      const job = await findTestRunnerJobEntry(result.runId);
-      expect(job).toBeDefined();
-      // User's key should be used, not org's
-      expect(job!.executionContext.environment).toMatchObject({
-        ANTHROPIC_API_KEY: "user-api-key",
-      });
-    });
-
-    it("should fall back to org default provider when user has none", async () => {
-      const noKeyCompose = await createTestCompose(uniqueId("no-key-agent"), {
-        skipDefaultApiKey: true,
-      });
-
-      // Only create org provider (no user provider)
       await upsertOrgModelProvider(
         user.orgId,
         "anthropic-api-key",
@@ -90,12 +64,39 @@ describe("Org-Level Runtime Resolution", () => {
       });
     });
 
-    it("should error when neither user nor org has default provider", async () => {
+    it("should use org provider even when user provider exists", async () => {
       const noKeyCompose = await createTestCompose(uniqueId("no-key-agent"), {
         skipDefaultApiKey: true,
       });
 
-      // No providers at all
+      // Create both user and org providers — org should be used
+      await createTestModelProvider("anthropic-api-key", "user-api-key");
+      await upsertOrgModelProvider(
+        user.orgId,
+        "anthropic-api-key",
+        "org-api-key",
+      );
+
+      const result = await createRun(
+        baseParams({ agentComposeVersionId: noKeyCompose.versionId }),
+      );
+
+      const job = await findTestRunnerJobEntry(result.runId);
+      expect(job).toBeDefined();
+      // Org key should be used, not user's
+      expect(job!.executionContext.environment).toMatchObject({
+        ANTHROPIC_API_KEY: "org-api-key",
+      });
+    });
+
+    it("should error when no org default provider exists", async () => {
+      const noKeyCompose = await createTestCompose(uniqueId("no-key-agent"), {
+        skipDefaultApiKey: true,
+      });
+
+      // No org provider — should error even if user provider exists
+      await createTestModelProvider("anthropic-api-key", "user-api-key");
+
       await expect(
         createRun(
           baseParams({ agentComposeVersionId: noKeyCompose.versionId }),
@@ -304,24 +305,20 @@ describe("Org-Level Runtime Resolution", () => {
     });
   });
 
-  describe("No Org Resources (Regression)", () => {
-    it("should have no behavior change when no org resources exist", async () => {
+  describe("No Org Resources", () => {
+    it("should error when only user-level provider exists (no org provider)", async () => {
       const noKeyCompose = await createTestCompose(uniqueId("no-key-agent"), {
         skipDefaultApiKey: true,
       });
 
-      // Only user-level provider
+      // Only user-level provider — org-only resolution should error
       await createTestModelProvider("anthropic-api-key", "user-api-key");
 
-      const result = await createRun(
-        baseParams({ agentComposeVersionId: noKeyCompose.versionId }),
-      );
-
-      const job = await findTestRunnerJobEntry(result.runId);
-      expect(job).toBeDefined();
-      expect(job!.executionContext.environment).toMatchObject({
-        ANTHROPIC_API_KEY: "user-api-key",
-      });
+      await expect(
+        createRun(
+          baseParams({ agentComposeVersionId: noKeyCompose.versionId }),
+        ),
+      ).rejects.toSatisfy(isBadRequest);
     });
   });
 });

--- a/turbo/apps/web/src/lib/run/__tests__/create-run.test.ts
+++ b/turbo/apps/web/src/lib/run/__tests__/create-run.test.ts
@@ -12,7 +12,7 @@ import {
   createTestRequest,
   createTestSandboxToken,
   createTestRun,
-  createTestModelProvider,
+  createTestOrgModelProvider,
   insertStalePendingRun,
   findTestRunRecord,
   findTestRunCallbacks,
@@ -823,7 +823,7 @@ describe("createRun()", () => {
         skipDefaultApiKey: true,
       });
 
-      await createTestModelProvider("vercel-ai-gateway", "test-gateway-key");
+      await createTestOrgModelProvider("vercel-ai-gateway", "test-gateway-key");
 
       const result = await createRun(
         baseParams({ agentComposeVersionId: noKeyCompose.versionId }),

--- a/turbo/apps/web/src/lib/run/build-context.ts
+++ b/turbo/apps/web/src/lib/run/build-context.ts
@@ -33,10 +33,7 @@ import { expandEnvironmentFromCompose } from "./environment";
 import { getUserPreferences } from "../user/user-preferences-service";
 import { getSecretValue, getSecretValues } from "../secret/secret-service";
 import { getVariableValues } from "../variable/variable-service";
-import {
-  getDefaultModelProvider,
-  getOrgDefaultModelProvider,
-} from "../model-provider/model-provider-service";
+import { getOrgDefaultModelProvider } from "../model-provider/model-provider-service";
 import { ORG_SENTINEL_USER_ID } from "../org/org-sentinel";
 import { connectors } from "../../db/schema/connector";
 import { PROVIDER_HANDLERS } from "../connector/provider-registry";
@@ -77,7 +74,7 @@ const MODEL_PROVIDER_ENV_VARS = [
  */
 function resolveProviderType(
   framework: string,
-  defaultProvider: Awaited<ReturnType<typeof getDefaultModelProvider>>,
+  defaultProvider: Awaited<ReturnType<typeof getOrgDefaultModelProvider>>,
   explicitModelProvider?: string,
 ): ModelProviderType {
   let providerType: ModelProviderType;
@@ -94,7 +91,7 @@ function resolveProviderType(
   } else {
     throw badRequest(
       "No model provider configured. " +
-        "Run 'vm0 model-provider setup' to configure one, " +
+        "Run 'vm0 org model-provider setup' to configure one, " +
         "or add environment variables to your vm0.yaml.",
     );
   }
@@ -186,7 +183,6 @@ interface ModelProviderSecretResult {
  */
 async function resolveModelProviderSecrets(
   orgId: string,
-  userId: string,
   framework: string,
   hasExplicitModelProviderConfig: boolean,
   explicitModelProvider?: string,
@@ -198,22 +194,13 @@ async function resolveModelProviderSecrets(
     return { secrets, injectedEnvironment: undefined };
   }
 
-  // Fetch default provider: try user-level first, fall back to org-level
-  const userProvider = await getDefaultModelProvider(
+  // Fetch org-level default provider
+  const defaultProvider = await getOrgDefaultModelProvider(
     orgId,
-    userId,
     framework as ModelProviderFramework,
   );
-  const defaultProvider =
-    userProvider ??
-    (await getOrgDefaultModelProvider(
-      orgId,
-      framework as ModelProviderFramework,
-    ));
 
-  // Secrets must match the provider's ownership scope:
-  // user provider → user secrets, org provider → org secrets
-  const secretUserId = userProvider ? userId : ORG_SENTINEL_USER_ID;
+  const secretUserId = ORG_SENTINEL_USER_ID;
 
   const providerType = resolveProviderType(
     framework,
@@ -621,7 +608,6 @@ async function resolveSecretsAndEnvironment(
       fetchReferencedSecrets(orgId, userId, firstAgent?.environment),
       resolveModelProviderSecrets(
         orgId,
-        userId,
         framework,
         hasExplicitModelProviderConfig,
         modelProvider,


### PR DESCRIPTION
## Summary

- Remove user-level model provider fallback from `resolveModelProviderSecrets` in `build-context.ts`
- Only query org-level default provider via `getOrgDefaultModelProvider` (no more user → org fallback chain)
- Hardcode `secretUserId` to `ORG_SENTINEL_USER_ID` for model provider secrets
- Update error message to reference `vm0 org model-provider setup`
- Update tests to reflect org-only resolution behavior

Closes #5292
Part of #5290

## Test plan

- [x] Existing org-level tests updated and passing (10/10)
- [x] Type check passes
- [x] Lint passes
- [x] Knip passes (no unused exports)

🤖 Generated with [Claude Code](https://claude.com/claude-code)