### PR TITLE
refactor: replace auth() in canAccessCompose with explicit orgId parameter

### DIFF
--- a/turbo/apps/web/app/api/agent/composes/[id]/__tests__/permission.test.ts
+++ b/turbo/apps/web/app/api/agent/composes/[id]/__tests__/permission.test.ts
@@ -3,7 +3,6 @@ import { GET as getCompose } from "../route";
 import {
   createTestRequest,
   createTestCompose,
-  insertOrgMembersCacheEntry,
 } from "../../../../../../src/__tests__/api-test-helpers";
 import {
   testContext,
@@ -30,7 +29,7 @@ describe("Agent Compose Permission Checks", () => {
     // Note: API returns 404 (not 403) for unauthorized access to prevent
     // information leakage about existence of private agents
     it("should deny access to another user's private compose (returns 404)", async () => {
-      // Switch to another user
+      // Switch to another user (different org)
       await context.setupUser({ prefix: "other-user" });
 
       const request = createTestRequest(
@@ -46,9 +45,9 @@ describe("Agent Compose Permission Checks", () => {
       expect(data.error.message).toContain("not found");
     });
 
-    it("should allow access when user is a member of the same org (JWT fast path)", async () => {
-      // Switch to another user whose active org matches the compose's org
-      // This exercises the JWT fast path (authResult.orgId === compose.orgId)
+    it("should allow access when user is a member of the same org", async () => {
+      // Switch to another user whose active org matches the compose's org.
+      // Compose access is org-scoped: same org = access granted.
       mockClerk({
         userId: "other-user-123",
         orgId: ownerOrgId,
@@ -73,10 +72,10 @@ describe("Agent Compose Permission Checks", () => {
       expect(data.id).toBe(testComposeId);
     });
 
-    it("should allow access via Clerk API fallback when active org differs", async () => {
-      // Switch to another user who belongs to the owner's org but has a
-      // different active org in their session. This exercises the Clerk API
-      // fallback path (users.getOrganizationMembershipList).
+    it("should deny access when active org differs from compose org", async () => {
+      // User is a member of the owner's org, but their active org is different.
+      // Compose access is scoped to the caller's active org — cross-org access
+      // is not allowed even if the user is a member of the compose's org.
       const differentOrgId = "org_different_active";
       mockClerk({
         userId: "other-user-456",
@@ -103,104 +102,7 @@ describe("Agent Compose Permission Checks", () => {
       const response = await getCompose(request);
       const data = await response.json();
 
-      expect(response.status).toBe(200);
-      expect(data.id).toBe(testComposeId);
-    });
-
-    it("should allow access from cache without calling Clerk API", async () => {
-      // Pre-seed a fresh cache entry for a user who is NOT in the clerkOrgs list.
-      // If the cache is working, the user gets access without Clerk API finding membership.
-      const cacheUserId = "cache-user-789";
-      await insertOrgMembersCacheEntry({
-        orgId: ownerOrgId,
-        userId: cacheUserId,
-        cachedAt: new Date(), // fresh
-      });
-
-      // Mock user with a different active org and NO membership in the owner's org
-      mockClerk({
-        userId: cacheUserId,
-        orgId: "org_unrelated",
-        clerkOrgs: [
-          { id: "org_unrelated", slug: "unrelated", name: "Unrelated Org" },
-        ],
-      });
-
-      const request = createTestRequest(
-        `http://localhost:3000/api/agent/composes/${testComposeId}`,
-        { method: "GET" },
-      );
-
-      const response = await getCompose(request);
-      const data = await response.json();
-
-      // Access granted via cache hit — no Clerk API call needed
-      expect(response.status).toBe(200);
-      expect(data.id).toBe(testComposeId);
-    });
-
-    it("should re-query Clerk API when cache entry is stale", async () => {
-      // Pre-seed a stale cache entry (older than 1 minute TTL)
-      const staleUserId = "stale-cache-user-101";
-      const staleCachedAt = new Date(Date.now() - 120_000); // 2 minutes ago
-      await insertOrgMembersCacheEntry({
-        orgId: ownerOrgId,
-        userId: staleUserId,
-        cachedAt: staleCachedAt,
-      });
-
-      // Mock user with a different active org but WITH membership in owner's org
-      // so the Clerk API fallback succeeds
-      mockClerk({
-        userId: staleUserId,
-        orgId: "org_other_active",
-        clerkOrgs: [
-          { id: "org_other_active", slug: "other", name: "Other Org" },
-          { id: ownerOrgId, slug: "shared-org", name: "Shared Org" },
-        ],
-      });
-
-      const request = createTestRequest(
-        `http://localhost:3000/api/agent/composes/${testComposeId}`,
-        { method: "GET" },
-      );
-
-      const response = await getCompose(request);
-      const data = await response.json();
-
-      // Access granted via Clerk API fallback (stale cache was bypassed)
-      expect(response.status).toBe(200);
-      expect(data.id).toBe(testComposeId);
-    });
-
-    it("should deny access when cache is stale and user is not a member", async () => {
-      // Pre-seed a stale cache entry
-      const nonMemberUserId = "non-member-user-202";
-      const staleCachedAt = new Date(Date.now() - 120_000); // 2 minutes ago
-      await insertOrgMembersCacheEntry({
-        orgId: ownerOrgId,
-        userId: nonMemberUserId,
-        cachedAt: staleCachedAt,
-      });
-
-      // Mock user with NO membership in the owner's org
-      mockClerk({
-        userId: nonMemberUserId,
-        orgId: "org_unrelated",
-        clerkOrgs: [
-          { id: "org_unrelated", slug: "unrelated", name: "Unrelated Org" },
-        ],
-      });
-
-      const request = createTestRequest(
-        `http://localhost:3000/api/agent/composes/${testComposeId}`,
-        { method: "GET" },
-      );
-
-      const response = await getCompose(request);
-      const data = await response.json();
-
-      // Stale cache does not grant access; Clerk API says not a member → denied
+      // Active org differs from compose's org — denied
       expect(response.status).toBe(404);
       expect(data.error.message).toContain("not found");
     });

--- a/turbo/apps/web/app/api/agent/composes/[id]/instructions/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/composes/[id]/instructions/__tests__/route.test.ts
@@ -164,8 +164,9 @@ describe("GET /api/agent/composes/:id/instructions", () => {
     const storageName = getInstructionsStorageName(agentName);
     await createTestVolume(storageName);
 
-    // Switch to the org member user
-    mockClerk({ userId: user.userId });
+    // Switch to the org member user with active org set to the owner's org
+    // (compose access is scoped to the caller's active org)
+    mockClerk({ userId: user.userId, orgId: owner.orgId });
 
     context.mocks.s3.downloadManifest.mockResolvedValueOnce({
       version: "a".repeat(64),

--- a/turbo/apps/web/app/api/agent/composes/[id]/instructions/route.ts
+++ b/turbo/apps/web/app/api/agent/composes/[id]/instructions/route.ts
@@ -25,6 +25,7 @@ import {
   isAuthError,
 } from "../../../../../../src/lib/auth/require-auth";
 import { canAccessCompose } from "../../../../../../src/lib/agent/compose-access";
+import { resolveOrg } from "../../../../../../src/lib/org/resolve-org";
 import {
   downloadManifest,
   downloadS3Buffer,
@@ -80,8 +81,13 @@ export async function GET(
     );
   }
 
-  // Check access (owner or org member)
-  const hasAccess = await canAccessCompose(userId, result);
+  // Check access (owner or org member).
+  // Sandbox tokens (with capabilities) are already authorized via requireAuth;
+  // use the compose's orgId since sandbox tokens lack org context.
+  const orgId = authResult.capabilities
+    ? result.orgId
+    : (await resolveOrg(authResult)).org.orgId;
+  const hasAccess = canAccessCompose(userId, orgId, result);
   if (!hasAccess) {
     return NextResponse.json(
       { error: { message: "Agent compose not found", code: "NOT_FOUND" } },

--- a/turbo/apps/web/app/api/agent/composes/[id]/route.ts
+++ b/turbo/apps/web/app/api/agent/composes/[id]/route.ts
@@ -17,6 +17,7 @@ import {
   isAuthError,
 } from "../../../../../src/lib/auth/require-auth";
 import { canAccessCompose } from "../../../../../src/lib/agent/compose-access";
+import { resolveOrg } from "../../../../../src/lib/org/resolve-org";
 import {
   listS3Objects,
   deleteS3Objects,
@@ -62,8 +63,13 @@ const router = tsr.router(composesByIdContract, {
       };
     }
 
-    // Check permission to access this compose
-    const hasAccess = await canAccessCompose(userId, result);
+    // Check permission to access this compose.
+    // Sandbox tokens (with capabilities) are already authorized via requireAuth;
+    // use the compose's orgId since sandbox tokens lack org context.
+    const orgId = authResult.capabilities
+      ? result.orgId
+      : (await resolveOrg(authResult)).org.orgId;
+    const hasAccess = canAccessCompose(userId, orgId, result);
     if (!hasAccess) {
       return {
         status: 404 as const,

--- a/turbo/apps/web/app/api/agent/composes/route.ts
+++ b/turbo/apps/web/app/api/agent/composes/route.ts
@@ -24,12 +24,13 @@ import {
 } from "../../../../src/lib/auth/require-auth";
 import { eq, and } from "drizzle-orm";
 import { computeComposeVersionId } from "../../../../src/lib/agent-compose/content-hash";
-import {
-  resolveOrg,
-  getOrgDataOrNull,
-} from "../../../../src/lib/org/resolve-org";
+import { resolveOrg } from "../../../../src/lib/org/resolve-org";
 import { getOrgBySlug } from "../../../../src/lib/org/org-cache-service";
-import { canAccessCompose } from "../../../../src/lib/agent/compose-access";
+import {
+  isNotFound,
+  isForbidden,
+  isBadRequest,
+} from "../../../../src/lib/errors";
 import type { AgentComposeYaml } from "../../../../src/types/agent-compose";
 
 const router = tsr.router(composesMainContract, {
@@ -40,19 +41,26 @@ const router = tsr.router(composesMainContract, {
       requiredCapability: "agent:read",
     });
     if (isAuthError(authCtx)) return authCtx;
-    const { userId } = authCtx;
 
-    // Resolve org: for cross-org lookups (org member agents), skip membership
-    // check and rely on canAccessCompose for authorization instead.
-    // isCrossOrgLookup is true when an explicit org param is provided,
-    // which requires canAccessCompose authorization below.
-    const isCrossOrgLookup = Boolean(query.org);
+    // Resolve org and verify membership. For cross-org lookups (?org=),
+    // resolveOrg verifies the caller is a member of the target org,
+    // replacing the previous canAccessCompose authorization.
+    // ?org= supports both slug and orgId formats.
     let orgId: string;
-    if (query.org) {
-      // Try slug first, fall back to orgId (callers may pass either via ?org=)
-      const orgData =
-        (await getOrgBySlug(query.org)) ?? (await getOrgDataOrNull(query.org));
-      if (!orgData) {
+    try {
+      if (query.org) {
+        // Try slug first, fall back to orgId (callers may pass either via ?org=)
+        const orgBySlug = await getOrgBySlug(query.org);
+        const { org } = orgBySlug
+          ? await resolveOrg(authCtx, query.org)
+          : await resolveOrg(authCtx, undefined, query.org);
+        orgId = org.orgId;
+      } else {
+        const { org } = await resolveOrg(authCtx);
+        orgId = org.orgId;
+      }
+    } catch (error) {
+      if (isNotFound(error) || isForbidden(error) || isBadRequest(error)) {
         return {
           status: 404 as const,
           body: {
@@ -63,10 +71,7 @@ const router = tsr.router(composesMainContract, {
           },
         };
       }
-      orgId = orgData.orgId;
-    } else {
-      const { org: resolvedOrg } = await resolveOrg(authCtx);
-      orgId = resolvedOrg.orgId;
+      throw error;
     }
 
     // JOIN compose + version in a single query
@@ -101,22 +106,6 @@ const router = tsr.router(composesMainContract, {
           },
         },
       };
-    }
-
-    // Check permission to access this compose (for cross-org lookups)
-    if (isCrossOrgLookup) {
-      const hasAccess = await canAccessCompose(userId, result);
-      if (!hasAccess) {
-        return {
-          status: 404 as const,
-          body: {
-            error: {
-              message: `Agent compose not found: ${query.name}`,
-              code: "NOT_FOUND",
-            },
-          },
-        };
-      }
     }
 
     return {

--- a/turbo/apps/web/src/lib/agent/compose-access.ts
+++ b/turbo/apps/web/src/lib/agent/compose-access.ts
@@ -1,82 +1,16 @@
-import { eq, and } from "drizzle-orm";
-import { auth, clerkClient } from "@clerk/nextjs/server";
-import { orgMembersCache } from "../../db/schema/org-members-cache";
-import { logger } from "../logger";
-
-const log = logger("agent:compose-access");
-
-/** Cache TTL aligned with Clerk JWT TTL */
-const CACHE_TTL_MS = 60_000; // 1 minute
-
 /**
  * Check if a user can access an agent compose.
  *
  * Access is granted if:
- * 1. User is the owner of the compose
- * 2. User is a member of the same Clerk organization
+ * 1. The compose belongs to the caller's active org
+ * 2. The user is the owner of the compose
  */
-export async function canAccessCompose(
+export function canAccessCompose(
   userId: string,
+  orgId: string,
   compose: { id: string; userId: string; orgId: string },
-): Promise<boolean> {
-  // 1. Owner always has access
+): boolean {
+  if (compose.orgId === orgId) return true;
   if (compose.userId === userId) return true;
-
-  // 2. Check org membership via Clerk
-  const authResult = await auth();
-
-  // JWT fast path: active org matches → trust JWT, no API call
-  if (authResult.orgId === compose.orgId) {
-    return true;
-  }
-
-  // Cache-backed Clerk API fallback for cross-org or non-session contexts
-  if (!compose.orgId.startsWith("pending_")) {
-    // Check org_members_cache first (DB read, no Clerk API call)
-    const [cached] = await globalThis.services.db
-      .select({ cachedAt: orgMembersCache.cachedAt })
-      .from(orgMembersCache)
-      .where(
-        and(
-          eq(orgMembersCache.orgId, compose.orgId),
-          eq(orgMembersCache.userId, userId),
-        ),
-      )
-      .limit(1);
-
-    if (cached && Date.now() - cached.cachedAt.getTime() < CACHE_TTL_MS) {
-      return true;
-    }
-
-    // Cache miss or stale — call Clerk API and update cache
-    const client = await clerkClient();
-    const memberships = await client.users.getOrganizationMembershipList({
-      userId,
-      limit: 100,
-    });
-    const isMember = memberships.data.some(
-      (m) => m.organization.id === compose.orgId,
-    );
-    if (isMember) {
-      // Fire-and-forget: cache write is non-critical, don't block access
-      const now = new Date();
-      void globalThis.services.db
-        .insert(orgMembersCache)
-        .values({
-          orgId: compose.orgId,
-          userId,
-          cachedAt: now,
-        })
-        .onConflictDoUpdate({
-          target: [orgMembersCache.orgId, orgMembersCache.userId],
-          set: { cachedAt: now },
-        })
-        .catch((err: unknown) => {
-          log.warn("Failed to update org_members_cache", { err });
-        });
-      return true;
-    }
-  }
-
   return false;
 }

--- a/turbo/apps/web/src/lib/email/handlers/inbound-trigger.ts
+++ b/turbo/apps/web/src/lib/email/handlers/inbound-trigger.ts
@@ -171,7 +171,7 @@ export async function handleInboundEmailTrigger(
   }
 
   // 4. Check permission
-  const hasAccess = await canAccessCompose(userId, {
+  const hasAccess = canAccessCompose(userId, runtimeOrgId, {
     id: compose.composeId,
     userId: compose.userId,
     orgId: compose.orgId,

--- a/turbo/apps/web/src/lib/run/run-service.ts
+++ b/turbo/apps/web/src/lib/run/run-service.ts
@@ -404,11 +404,12 @@ async function loadCompose(
   };
 }
 
-async function authorizeCompose(
+function authorizeCompose(
   userId: string,
+  orgId: string,
   compose: { id: string; userId: string; orgId: string },
-): Promise<void> {
-  const hasAccess = await canAccessCompose(userId, compose);
+): void {
+  const hasAccess = canAccessCompose(userId, orgId, compose);
   if (!hasAccess) {
     throw forbidden("You do not have permission to access this agent");
   }
@@ -700,7 +701,7 @@ export async function createRun(
     agentComposeVersionId,
     params.composeId,
   );
-  await authorizeCompose(userId, compose);
+  authorizeCompose(userId, params.orgId, compose);
   const authorizeTime = Date.now();
 
   // Step 3: Validate template vars and image access (for new runs only)
@@ -819,7 +820,7 @@ export async function dispatchQueuedRun(
     agentComposeVersionId,
     params.composeId,
   );
-  await authorizeCompose(userId, queuedCompose);
+  authorizeCompose(userId, params.orgId, queuedCompose);
   const authorizeTime = Date.now();
 
   // Validate template vars and image access (for new runs only)


### PR DESCRIPTION
## Summary

Closes #5300

- Refactored `canAccessCompose()` from a 3-tier async I/O function (Clerk auth + DB cache + Clerk API) into a pure synchronous function with an explicit `orgId` parameter
- Updated all 5 callers to pass their already-available orgId from `resolveOrg` or request context
- Removed cross-org compose access (intentional behavior change: compose access is now scoped to the caller's active org)
- Eliminates the last direct `auth()` call outside of `getAuthContext()`

### Key Changes

| File | Change |
|------|--------|
| `src/lib/agent/compose-access.ts` | 82 lines → 15 lines, pure sync function, zero imports |
| `src/lib/run/run-service.ts` | `authorizeCompose` now takes `orgId`, passes `params.orgId` |
| `src/lib/email/handlers/inbound-trigger.ts` | Passes `runtimeOrgId` |
| `app/api/agent/composes/route.ts` | Uses `resolveOrg` for membership verification, removes `canAccessCompose` |
| `app/api/agent/composes/[id]/route.ts` | Adds `resolveOrg`, sandbox token passthrough |
| `app/api/agent/composes/[id]/instructions/route.ts` | Adds `resolveOrg`, sandbox token passthrough |

### Behavior Change

Cross-org compose access is intentionally removed. A compose in org B is no longer accessible when the caller's active org is A, even if the caller is a member of org B. This aligns with the principle that all operations should be scoped to the caller's active org.

## Test plan

- [x] Permission tests updated to reflect org-scoped access model
- [x] All 113 compose-related tests pass
- [x] All 358 directly relevant tests pass (composes, runs, email, auth)
- [x] Sandbox token tests pass (sandbox tokens bypass resolveOrg)
- [x] Lint, format, knip all pass
- [x] Cross-org access correctly denied
- [x] Same-org member access still works
- [x] Owner access always granted

🤖 Generated with [Claude Code](https://claude.com/claude-code)