### PR TITLE
fix: remove secrets/vars validation when deploying a schedule

### DIFF
--- a/turbo/apps/web/app/api/agent/schedules/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/schedules/__tests__/route.test.ts
@@ -863,7 +863,7 @@ describe("POST /api/agent/schedules - Platform Configuration Validation", () => 
     expect(data.schedule.name).toBe("secret-test-schedule");
   });
 
-  it("should reject schedule when required secrets missing from platform", async () => {
+  it("should allow schedule when required secrets missing from platform", async () => {
     // Create compose with secret reference that doesn't exist in platform
     const { composeId } = await createTestCompose(
       uniqueId("missing-secret-agent"),
@@ -878,7 +878,7 @@ describe("POST /api/agent/schedules - Platform Configuration Validation", () => 
 
     // Do NOT create the platform secret
 
-    // Try to create schedule - should fail
+    // Schedule creation should succeed - validation removed per #5179
     const request = createTestRequest(
       "http://localhost:3000/api/agent/schedules",
       {
@@ -897,8 +897,9 @@ describe("POST /api/agent/schedules - Platform Configuration Validation", () => 
     const response = await POST(request);
     const data = await response.json();
 
-    expect(response.status).toBe(400);
-    expect(data.error.code).toBe("BAD_REQUEST");
+    expect(response.status).toBe(201);
+    expect(data.created).toBe(true);
+    expect(data.schedule.name).toBe("missing-secret-schedule");
   });
 
   it("should accept schedule when required vars exist in platform", async () => {
@@ -937,7 +938,7 @@ describe("POST /api/agent/schedules - Platform Configuration Validation", () => 
     expect(data.created).toBe(true);
   });
 
-  it("should reject schedule when required vars missing from platform", async () => {
+  it("should allow schedule when required vars missing from platform", async () => {
     // Create compose with var reference that doesn't exist in platform
     const { composeId } = await createTestCompose(
       uniqueId("missing-var-agent"),
@@ -952,7 +953,7 @@ describe("POST /api/agent/schedules - Platform Configuration Validation", () => 
 
     // Do NOT create the platform variable
 
-    // Try to create schedule - should fail
+    // Schedule creation should succeed - validation removed per #5179
     const request = createTestRequest(
       "http://localhost:3000/api/agent/schedules",
       {
@@ -971,8 +972,9 @@ describe("POST /api/agent/schedules - Platform Configuration Validation", () => 
     const response = await POST(request);
     const data = await response.json();
 
-    expect(response.status).toBe(400);
-    expect(data.error.code).toBe("BAD_REQUEST");
+    expect(response.status).toBe(201);
+    expect(data.created).toBe(true);
+    expect(data.schedule.name).toBe("missing-var-schedule");
   });
 });
 

--- a/turbo/apps/web/src/lib/schedule/schedule-service.ts
+++ b/turbo/apps/web/src/lib/schedule/schedule-service.ts
@@ -1,24 +1,14 @@
 import { eq, and, lte, inArray, desc } from "drizzle-orm";
 import { Cron } from "croner";
-import {
-  extractAndGroupVariables,
-  getConnectorProvidedSecretNames,
-  orgTierSchema,
-} from "@vm0/core";
+import { orgTierSchema } from "@vm0/core";
 import { agentSchedules } from "../../db/schema/agent-schedule";
-import {
-  agentComposes,
-  agentComposeVersions,
-} from "../../db/schema/agent-compose";
+import { agentComposes } from "../../db/schema/agent-compose";
 import { agentRuns } from "../../db/schema/agent-run";
-import { connectors } from "../../db/schema/connector";
 import { decryptSecretsMap } from "../crypto";
 import { getOrgData } from "../org/org-cache-service";
 import { notFound, badRequest, schedulePast } from "../errors";
 import { logger } from "../logger";
 import { createRun } from "../run/run-service";
-import { getSecretValues } from "../secret/secret-service";
-import { getVariableValues } from "../variable/variable-service";
 import { getUserPreferences } from "../user/user-preferences-service";
 import { generateCallbackSecret, getApiUrl } from "../callback";
 
@@ -98,46 +88,6 @@ function isValidTimezone(timezone: string): boolean {
   } catch {
     return false;
   }
-}
-
-/**
- * Extract required configuration from compose content
- */
-function extractRequiredConfiguration(composeContent: unknown): {
-  secrets: string[];
-  vars: string[];
-} {
-  const result = {
-    secrets: [] as string[],
-    vars: [] as string[],
-  };
-  if (!composeContent) return result;
-
-  const grouped = extractAndGroupVariables(composeContent);
-
-  result.secrets = grouped.secrets.map((r) => r.name);
-  result.vars = grouped.vars.map((r) => r.name);
-
-  return result;
-}
-
-/**
- * Build error message for missing configuration
- */
-function buildMissingConfigError(missing: {
-  secrets: string[];
-  vars: string[];
-}): string {
-  const parts: string[] = [];
-
-  if (missing.secrets.length > 0) {
-    parts.push(`Secrets: ${missing.secrets.join(", ")}`);
-  }
-  if (missing.vars.length > 0) {
-    parts.push(`Vars: ${missing.vars.join(", ")}`);
-  }
-
-  return `Missing required configuration:\n  ${parts.join("\n  ")}`;
 }
 
 /**
@@ -263,67 +213,6 @@ async function verifyScheduleOwnership(
   const orgSlug = await getOrgSlug(orgId);
 
   return { schedule, compose, orgSlug };
-}
-
-/**
- * Validate that all required secrets/vars are available in platform tables.
- * Uses the schedule's orgId + userId (not compose's) for cross-org support.
- */
-async function validateRequiredConfig(
-  compose: typeof agentComposes.$inferSelect,
-  orgId: string,
-  userId: string,
-): Promise<void> {
-  if (!compose.headVersionId) return;
-
-  const [version] = await globalThis.services.db
-    .select()
-    .from(agentComposeVersions)
-    .where(eq(agentComposeVersions.id, compose.headVersionId))
-    .limit(1);
-
-  if (!version) return;
-
-  const required = extractRequiredConfiguration(version.content);
-
-  // Fetch platform-managed secrets and vars from schedule's org + user
-  const platformSecrets = await getSecretValues(orgId, userId, "user");
-  const platformSecretNames = Object.keys(platformSecrets);
-  log.debug(
-    `Fetched ${platformSecretNames.length} platform secret(s) for validation`,
-  );
-
-  const platformVars = await getVariableValues(orgId, userId);
-  const platformVarNames = Object.keys(platformVars);
-  log.debug(
-    `Fetched ${platformVarNames.length} platform variable(s) for validation`,
-  );
-
-  // Query connected connectors to exclude their provided secrets
-  const userConnectors = await globalThis.services.db
-    .select({ type: connectors.type })
-    .from(connectors)
-    .where(and(eq(connectors.orgId, orgId), eq(connectors.userId, userId)));
-  const connectorProvidedNames = getConnectorProvidedSecretNames(
-    userConnectors.map((c) => c.type),
-  );
-
-  const missingSecrets = required.secrets.filter(
-    (name) =>
-      !platformSecretNames.includes(name) && !connectorProvidedNames.has(name),
-  );
-  const missingVars = required.vars.filter(
-    (name) => !platformVarNames.includes(name),
-  );
-
-  if (missingSecrets.length > 0 || missingVars.length > 0) {
-    throw badRequest(
-      buildMissingConfigError({
-        secrets: missingSecrets,
-        vars: missingVars,
-      }),
-    );
-  }
 }
 
 /**
@@ -489,9 +378,6 @@ export async function deploySchedule(
       ),
     )
     .limit(1);
-
-  // Validate required secrets/vars against schedule's org + user
-  await validateRequiredConfig(compose, orgId, userId);
 
   const { triggerType, nextRunAt } = resolveTrigger(request);
 


### PR DESCRIPTION
## Summary
- Remove `validateRequiredConfig()` call from `deploySchedule()` so schedule creation no longer blocks on missing secrets/vars
- Delete dead code: `extractRequiredConfiguration()`, `buildMissingConfigError()`, `validateRequiredConfig()` functions
- Remove unused imports (`extractAndGroupVariables`, `getConnectorProvidedSecretNames`, `getSecretValues`, `getVariableValues`, `connectors`, `agentComposeVersions`)
- Update 2 tests to expect `201` success instead of `400` rejection when secrets/vars are missing

## Test plan
- [x] All 37 existing schedule route tests pass
- [x] Type check passes for web package
- [x] Lint passes with zero warnings
- [x] Knip finds no unused code issues
- [ ] CI pipeline passes

Closes #5179

🤖 Generated with [Claude Code](https://claude.com/claude-code)