### PR TITLE
feat(runner): add vm0/browser profile with dockerfile and ci integration

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -321,7 +321,7 @@ jobs:
           ssh $REMOTE "${BIN_DIR}/runner benchmark \
             --config ${RUNNER_DIR}/runner.yaml \
             --profile vm0/browser \
-            'agent-browser open https://httpbin.org/get && agent-browser get title && agent-browser close'"
+            'agent-browser open http://httpbin.org/get && agent-browser get title && agent-browser close'"
 
   runner-exec:
     runs-on: ubuntu-latest

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -143,8 +143,10 @@ jobs:
     outputs:
       host: ${{ steps.host.outputs.host }}
       job-ref: ${{ steps.host.outputs.job-ref }}
-      rootfs-hash: ${{ steps.build.outputs.rootfs-hash }}
-      snapshot-hash: ${{ steps.build.outputs.snapshot-hash }}
+      default-rootfs-hash: ${{ steps.build.outputs.default-rootfs-hash }}
+      default-snapshot-hash: ${{ steps.build.outputs.default-snapshot-hash }}
+      browser-rootfs-hash: ${{ steps.build.outputs.browser-rootfs-hash }}
+      browser-snapshot-hash: ${{ steps.build.outputs.browser-snapshot-hash }}
     steps:
       - uses: actions/checkout@v6
 
@@ -239,24 +241,37 @@ jobs:
 
           # Run build (rootfs via Docker + snapshot via Firecracker)
           # Use tee to stream output in real-time while capturing for hash extraction
-          echo "=== Running build ==="
-          BUILD_LOG=$(mktemp)
-          ssh $REMOTE "${BIN_DIR}/runner build --profile vm0/default" | tee "$BUILD_LOG"
-          ROOTFS_HASH=$(grep '^rootfs_hash=' "$BUILD_LOG" | cut -d= -f2)
-          SNAPSHOT_HASH=$(grep '^snapshot_hash=' "$BUILD_LOG" | cut -d= -f2)
-          rm -f "$BUILD_LOG"
+          echo "=== Building vm0/default ==="
+          BUILD_LOG_DEFAULT=$(mktemp)
+          ssh $REMOTE "${BIN_DIR}/runner build --profile vm0/default" | tee "$BUILD_LOG_DEFAULT"
+          DEFAULT_ROOTFS_HASH=$(grep '^rootfs_hash=' "$BUILD_LOG_DEFAULT" | cut -d= -f2)
+          DEFAULT_SNAPSHOT_HASH=$(grep '^snapshot_hash=' "$BUILD_LOG_DEFAULT" | cut -d= -f2)
+          rm -f "$BUILD_LOG_DEFAULT"
 
-          if [ -z "$ROOTFS_HASH" ] || [ -z "$SNAPSHOT_HASH" ]; then
-            echo "ERROR: Failed to extract build hashes"
+          echo "=== Building vm0/browser ==="
+          BUILD_LOG_BROWSER=$(mktemp)
+          ssh $REMOTE "${BIN_DIR}/runner build --profile vm0/browser" | tee "$BUILD_LOG_BROWSER"
+          BROWSER_ROOTFS_HASH=$(grep '^rootfs_hash=' "$BUILD_LOG_BROWSER" | cut -d= -f2)
+          BROWSER_SNAPSHOT_HASH=$(grep '^snapshot_hash=' "$BUILD_LOG_BROWSER" | cut -d= -f2)
+          rm -f "$BUILD_LOG_BROWSER"
+
+          if [ -z "$DEFAULT_ROOTFS_HASH" ] || [ -z "$DEFAULT_SNAPSHOT_HASH" ]; then
+            echo "ERROR: Failed to extract default build hashes"
             exit 1
           fi
-          echo "rootfs-hash=${ROOTFS_HASH}" >> "$GITHUB_OUTPUT"
-          echo "snapshot-hash=${SNAPSHOT_HASH}" >> "$GITHUB_OUTPUT"
+          if [ -z "$BROWSER_ROOTFS_HASH" ] || [ -z "$BROWSER_SNAPSHOT_HASH" ]; then
+            echo "ERROR: Failed to extract browser build hashes"
+            exit 1
+          fi
+          echo "default-rootfs-hash=${DEFAULT_ROOTFS_HASH}" >> "$GITHUB_OUTPUT"
+          echo "default-snapshot-hash=${DEFAULT_SNAPSHOT_HASH}" >> "$GITHUB_OUTPUT"
+          echo "browser-rootfs-hash=${BROWSER_ROOTFS_HASH}" >> "$GITHUB_OUTPUT"
+          echo "browser-snapshot-hash=${BROWSER_SNAPSHOT_HASH}" >> "$GITHUB_OUTPUT"
 
   runner-benchmark:
     runs-on: ubuntu-latest
     needs: [runner-build]
-    timeout-minutes: 5
+    timeout-minutes: 8
     steps:
       - uses: actions/checkout@v6
 
@@ -273,8 +288,10 @@ jobs:
           OFFICIAL_RUNNER_SECRET: ${{ secrets.OFFICIAL_RUNNER_SECRET }}
           HOST: ${{ needs.runner-build.outputs.host }}
           JOB_REF: ${{ needs.runner-build.outputs.job-ref }}
-          ROOTFS_HASH: ${{ needs.runner-build.outputs.rootfs-hash }}
-          SNAPSHOT_HASH: ${{ needs.runner-build.outputs.snapshot-hash }}
+          DEFAULT_ROOTFS_HASH: ${{ needs.runner-build.outputs.default-rootfs-hash }}
+          DEFAULT_SNAPSHOT_HASH: ${{ needs.runner-build.outputs.default-snapshot-hash }}
+          BROWSER_ROOTFS_HASH: ${{ needs.runner-build.outputs.browser-rootfs-hash }}
+          BROWSER_SNAPSHOT_HASH: ${{ needs.runner-build.outputs.browser-snapshot-hash }}
         run: |
           REMOTE="${METAL_USER}@${HOST}"
           BIN_DIR="~/.vm0-runner/bin/${JOB_REF}"
@@ -283,19 +300,28 @@ jobs:
           echo "=== Generating config ==="
           ssh $REMOTE "${BIN_DIR}/runner config \
             --profile vm0/default \
-            --rootfs-hash ${ROOTFS_HASH} \
-            --snapshot-hash ${SNAPSHOT_HASH} \
+            --rootfs-hash ${DEFAULT_ROOTFS_HASH} \
+            --snapshot-hash ${DEFAULT_SNAPSHOT_HASH} \
+            --profile vm0/browser \
+            --rootfs-hash ${BROWSER_ROOTFS_HASH} \
+            --snapshot-hash ${BROWSER_SNAPSHOT_HASH} \
             --name ${JOB_REF}-bench \
             --group vm0/development-${JOB_REF} \
             --runner-dirname ${JOB_REF}-bench \
             --api-url https://not-a-real-server.test \
             --token vm0_official_${OFFICIAL_RUNNER_SECRET}"
 
-          echo "=== Running benchmark ==="
+          echo "=== Running benchmark (default) ==="
           ssh $REMOTE "${BIN_DIR}/runner benchmark \
             --config ${RUNNER_DIR}/runner.yaml \
             --profile vm0/default \
             'curl -sf --max-time 10 https://httpbin.org/get'"
+
+          echo "=== Running benchmark (browser) ==="
+          ssh $REMOTE "${BIN_DIR}/runner benchmark \
+            --config ${RUNNER_DIR}/runner.yaml \
+            --profile vm0/browser \
+            'agent-browser open https://httpbin.org/get && agent-browser get title && agent-browser close'"
 
   runner-exec:
     runs-on: ubuntu-latest
@@ -317,8 +343,8 @@ jobs:
           OFFICIAL_RUNNER_SECRET: ${{ secrets.OFFICIAL_RUNNER_SECRET }}
           HOST: ${{ needs.runner-build.outputs.host }}
           JOB_REF: ${{ needs.runner-build.outputs.job-ref }}
-          ROOTFS_HASH: ${{ needs.runner-build.outputs.rootfs-hash }}
-          SNAPSHOT_HASH: ${{ needs.runner-build.outputs.snapshot-hash }}
+          DEFAULT_ROOTFS_HASH: ${{ needs.runner-build.outputs.default-rootfs-hash }}
+          DEFAULT_SNAPSHOT_HASH: ${{ needs.runner-build.outputs.default-snapshot-hash }}
         run: |
           REMOTE="${METAL_USER}@${HOST}"
           BIN_DIR="~/.vm0-runner/bin/${JOB_REF}"
@@ -326,8 +352,8 @@ jobs:
           echo "=== Generating config ==="
           ssh $REMOTE "${BIN_DIR}/runner config \
             --profile vm0/default \
-            --rootfs-hash ${ROOTFS_HASH} \
-            --snapshot-hash ${SNAPSHOT_HASH} \
+            --rootfs-hash ${DEFAULT_ROOTFS_HASH} \
+            --snapshot-hash ${DEFAULT_SNAPSHOT_HASH} \
             --name ${JOB_REF}-exec \
             --group vm0/exec-${JOB_REF} \
             --runner-dirname ${JOB_REF}-exec \
@@ -418,8 +444,8 @@ jobs:
           OFFICIAL_RUNNER_SECRET: ${{ secrets.OFFICIAL_RUNNER_SECRET }}
           HOST: ${{ needs.runner-build.outputs.host }}
           JOB_REF: ${{ needs.runner-build.outputs.job-ref }}
-          ROOTFS_HASH: ${{ needs.runner-build.outputs.rootfs-hash }}
-          SNAPSHOT_HASH: ${{ needs.runner-build.outputs.snapshot-hash }}
+          DEFAULT_ROOTFS_HASH: ${{ needs.runner-build.outputs.default-rootfs-hash }}
+          DEFAULT_SNAPSHOT_HASH: ${{ needs.runner-build.outputs.default-snapshot-hash }}
         run: |
           REMOTE="${METAL_USER}@${HOST}"
           BIN_DIR="~/.vm0-runner/bin/${JOB_REF}"
@@ -427,8 +453,8 @@ jobs:
           echo "=== Generating config ==="
           ssh $REMOTE "${BIN_DIR}/runner config \
             --profile vm0/default \
-            --rootfs-hash ${ROOTFS_HASH} \
-            --snapshot-hash ${SNAPSHOT_HASH} \
+            --rootfs-hash ${DEFAULT_ROOTFS_HASH} \
+            --snapshot-hash ${DEFAULT_SNAPSHOT_HASH} \
             --name ${JOB_REF}-balloon \
             --group vm0/balloon-${JOB_REF} \
             --runner-dirname ${JOB_REF}-balloon \
@@ -596,8 +622,8 @@ jobs:
           OFFICIAL_RUNNER_SECRET: ${{ secrets.OFFICIAL_RUNNER_SECRET }}
           HOST: ${{ needs.runner-build.outputs.host }}
           JOB_REF: ${{ needs.runner-build.outputs.job-ref }}
-          ROOTFS_HASH: ${{ needs.runner-build.outputs.rootfs-hash }}
-          SNAPSHOT_HASH: ${{ needs.runner-build.outputs.snapshot-hash }}
+          DEFAULT_ROOTFS_HASH: ${{ needs.runner-build.outputs.default-rootfs-hash }}
+          DEFAULT_SNAPSHOT_HASH: ${{ needs.runner-build.outputs.default-snapshot-hash }}
         run: |
           REMOTE="${METAL_USER}@${HOST}"
           BIN_DIR="~/.vm0-runner/bin/${JOB_REF}"
@@ -607,8 +633,8 @@ jobs:
           for SUFFIX in upgrade-a upgrade-b; do
             ssh $REMOTE "${BIN_DIR}/runner config \
               --profile vm0/default \
-              --rootfs-hash ${ROOTFS_HASH} \
-              --snapshot-hash ${SNAPSHOT_HASH} \
+              --rootfs-hash ${DEFAULT_ROOTFS_HASH} \
+              --snapshot-hash ${DEFAULT_SNAPSHOT_HASH} \
               --name ${JOB_REF}-${SUFFIX} \
               --group ${GROUP} \
               --runner-dirname ${JOB_REF}-${SUFFIX} \

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -321,7 +321,7 @@ jobs:
           ssh $REMOTE "${BIN_DIR}/runner benchmark \
             --config ${RUNNER_DIR}/runner.yaml \
             --profile vm0/browser \
-            'agent-browser open https://httpbin.org/get && agent-browser get title && agent-browser close'"
+            'agent-browser open https://github.com/ && agent-browser get title && agent-browser close'"
 
   runner-exec:
     runs-on: ubuntu-latest

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -321,7 +321,7 @@ jobs:
           ssh $REMOTE "${BIN_DIR}/runner benchmark \
             --config ${RUNNER_DIR}/runner.yaml \
             --profile vm0/browser \
-            'agent-browser open http://httpbin.org/get && agent-browser get title && agent-browser close'"
+            'agent-browser open https://httpbin.org/get && agent-browser get title && agent-browser close'"
 
   runner-exec:
     runs-on: ubuntu-latest

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -7,11 +7,6 @@ on:
       - main
   merge_group:
 
-env:
-  # Sandbox VM parameters for runner build
-  RUNNER_VCPU: 2
-  RUNNER_MEMORY_MB: 2048
-
 concurrency:
   group: ${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || (github.event_name == 'merge_group' && format('merge-queue-{0}', github.run_id) || 'staging') }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
@@ -1020,8 +1015,10 @@ jobs:
       runner-dir: ${{ steps.host.outputs.runner-dir }}
       runner-matrix: ${{ steps.runner-matrix.outputs.matrix }}
       chunk-count: ${{ steps.runner-matrix.outputs.chunk-count }}
-      rootfs-hash: ${{ steps.deploy.outputs.rootfs-hash }}
-      snapshot-hash: ${{ steps.deploy.outputs.snapshot-hash }}
+      default-rootfs-hash: ${{ steps.deploy.outputs.default-rootfs-hash }}
+      default-snapshot-hash: ${{ steps.deploy.outputs.default-snapshot-hash }}
+      browser-rootfs-hash: ${{ steps.deploy.outputs.browser-rootfs-hash }}
+      browser-snapshot-hash: ${{ steps.deploy.outputs.browser-snapshot-hash }}
     steps:
       - uses: actions/checkout@v6
 
@@ -1167,6 +1164,7 @@ jobs:
 
             # Run build to create rootfs + snapshot (outputs hashes to stdout)
             ssh $REMOTE "${BIN_DIR}/runner build --profile vm0/default"
+            ssh $REMOTE "${BIN_DIR}/runner build --profile vm0/browser"
             echo "=== Done deploying to ${HOST} ==="
           }
 
@@ -1195,17 +1193,26 @@ jobs:
             exit 1
           fi
 
-          # Extract build hashes from any host's log (all hosts produce identical hashes)
+          # Extract build hashes from any host's log (all hosts produce identical hashes).
+          # Two builds run sequentially per host: default first, then browser.
           FIRST_LOG=$(ls ${LOG_DIR}/*.log | head -1)
-          ROOTFS_HASH=$(grep '^rootfs_hash=' "$FIRST_LOG" | cut -d= -f2)
-          SNAPSHOT_HASH=$(grep '^snapshot_hash=' "$FIRST_LOG" | cut -d= -f2)
+          DEFAULT_ROOTFS_HASH=$(grep '^rootfs_hash=' "$FIRST_LOG" | head -1 | cut -d= -f2)
+          DEFAULT_SNAPSHOT_HASH=$(grep '^snapshot_hash=' "$FIRST_LOG" | head -1 | cut -d= -f2)
+          BROWSER_ROOTFS_HASH=$(grep '^rootfs_hash=' "$FIRST_LOG" | tail -1 | cut -d= -f2)
+          BROWSER_SNAPSHOT_HASH=$(grep '^snapshot_hash=' "$FIRST_LOG" | tail -1 | cut -d= -f2)
           rm -rf "$LOG_DIR"
-          if [ -z "$ROOTFS_HASH" ] || [ -z "$SNAPSHOT_HASH" ]; then
-            echo "::error::Failed to extract build hashes from log"
+          if [ -z "$DEFAULT_ROOTFS_HASH" ] || [ -z "$DEFAULT_SNAPSHOT_HASH" ]; then
+            echo "::error::Failed to extract default build hashes from log"
             exit 1
           fi
-          echo "rootfs-hash=${ROOTFS_HASH}" >> "$GITHUB_OUTPUT"
-          echo "snapshot-hash=${SNAPSHOT_HASH}" >> "$GITHUB_OUTPUT"
+          if [ -z "$BROWSER_ROOTFS_HASH" ] || [ -z "$BROWSER_SNAPSHOT_HASH" ]; then
+            echo "::error::Failed to extract browser build hashes from log"
+            exit 1
+          fi
+          echo "default-rootfs-hash=${DEFAULT_ROOTFS_HASH}" >> "$GITHUB_OUTPUT"
+          echo "default-snapshot-hash=${DEFAULT_SNAPSHOT_HASH}" >> "$GITHUB_OUTPUT"
+          echo "browser-rootfs-hash=${BROWSER_ROOTFS_HASH}" >> "$GITHUB_OUTPUT"
+          echo "browser-snapshot-hash=${BROWSER_SNAPSHOT_HASH}" >> "$GITHUB_OUTPUT"
 
   # Deploy runner start: generate config with real preview URL and start service
   # Waits for both deploy-runner-prepare (binaries + rootfs/snapshot) and deploy-web (preview URL)
@@ -1244,8 +1251,10 @@ jobs:
           JOB_REF: ${{ needs.prepare.outputs.job-ref }}
           BIN_DIR: ${{ needs.deploy-runner-prepare.outputs.bin-dir }}
           RUNNER_DIR: ${{ needs.deploy-runner-prepare.outputs.runner-dir }}
-          ROOTFS_HASH: ${{ needs.deploy-runner-prepare.outputs.rootfs-hash }}
-          SNAPSHOT_HASH: ${{ needs.deploy-runner-prepare.outputs.snapshot-hash }}
+          DEFAULT_ROOTFS_HASH: ${{ needs.deploy-runner-prepare.outputs.default-rootfs-hash }}
+          DEFAULT_SNAPSHOT_HASH: ${{ needs.deploy-runner-prepare.outputs.default-snapshot-hash }}
+          BROWSER_ROOTFS_HASH: ${{ needs.deploy-runner-prepare.outputs.browser-rootfs-hash }}
+          BROWSER_SNAPSHOT_HASH: ${{ needs.deploy-runner-prepare.outputs.browser-snapshot-hash }}
           PREVIEW_URL: ${{ needs.deploy-web.outputs.preview-url }}
           VERCEL_BYPASS: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
         run: |
@@ -1265,8 +1274,11 @@ jobs:
             # Generate runner.yaml with real preview URL (no build needed, uses cached hashes)
             ssh $REMOTE "${BIN_DIR}/runner config \
               --profile vm0/default \
-              --rootfs-hash ${ROOTFS_HASH} \
-              --snapshot-hash ${SNAPSHOT_HASH} \
+              --rootfs-hash ${DEFAULT_ROOTFS_HASH} \
+              --snapshot-hash ${DEFAULT_SNAPSHOT_HASH} \
+              --profile vm0/browser \
+              --rootfs-hash ${BROWSER_ROOTFS_HASH} \
+              --snapshot-hash ${BROWSER_SNAPSHOT_HASH} \
               --name ${RUNNER_NAME} \
               --group vm0/development-${JOB_REF} \
               --runner-dirname ${JOB_REF} \

--- a/ansible/playbooks/deploy-runner.yml
+++ b/ansible/playbooks/deploy-runner.yml
@@ -23,8 +23,6 @@
   vars:
     runner_name: "v{{ runner_version }}"
     runner_group: vm0/production
-    vcpu: 2
-    memory_mb: 2048
     home_dir: "{{ ansible_facts['env']['HOME'] }}"
     bin_dir: "{{ home_dir }}/.vm0-runner/bin/{{ runner_name }}"
     runner_dir: "{{ home_dir }}/.vm0-runner/runners/{{ runner_name }}"
@@ -51,16 +49,27 @@
     - name: Download dependencies (Firecracker, kernel, mitmproxy)
       command: "{{ bin_dir }}/runner setup"
 
-    - name: Build rootfs and snapshot
+    - name: Build default rootfs and snapshot
       command: >
         {{ bin_dir }}/runner build
         --profile vm0/default
-      register: build_output
+      register: default_build_output
 
-    - name: Parse build hashes
+    - name: Parse default build hashes
       set_fact:
-        rootfs_hash: "{{ build_output.stdout_lines | select('match', '^rootfs_hash=') | first | regex_replace('^rootfs_hash=', '') }}"
-        snapshot_hash: "{{ build_output.stdout_lines | select('match', '^snapshot_hash=') | first | regex_replace('^snapshot_hash=', '') }}"
+        default_rootfs_hash: "{{ default_build_output.stdout_lines | select('match', '^rootfs_hash=') | first | regex_replace('^rootfs_hash=', '') }}"
+        default_snapshot_hash: "{{ default_build_output.stdout_lines | select('match', '^snapshot_hash=') | first | regex_replace('^snapshot_hash=', '') }}"
+
+    - name: Build browser rootfs and snapshot
+      command: >
+        {{ bin_dir }}/runner build
+        --profile vm0/browser
+      register: browser_build_output
+
+    - name: Parse browser build hashes
+      set_fact:
+        browser_rootfs_hash: "{{ browser_build_output.stdout_lines | select('match', '^rootfs_hash=') | first | regex_replace('^rootfs_hash=', '') }}"
+        browser_snapshot_hash: "{{ browser_build_output.stdout_lines | select('match', '^snapshot_hash=') | first | regex_replace('^snapshot_hash=', '') }}"
 
     # ========================================
     # Phase 3: Configure + Install
@@ -69,8 +78,11 @@
       command: >
         {{ bin_dir }}/runner config
         --profile vm0/default
-        --rootfs-hash {{ rootfs_hash }}
-        --snapshot-hash {{ snapshot_hash }}
+        --rootfs-hash {{ default_rootfs_hash }}
+        --snapshot-hash {{ default_snapshot_hash }}
+        --profile vm0/browser
+        --rootfs-hash {{ browser_rootfs_hash }}
+        --snapshot-hash {{ browser_snapshot_hash }}
         --name {{ runner_name }}
         --group {{ runner_group }}
         --runner-dirname {{ runner_name }}

--- a/crates/runner/scripts/rootfs-browser.Dockerfile
+++ b/crates/runner/scripts/rootfs-browser.Dockerfile
@@ -46,9 +46,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # root CAs. Replacing it with p11-kit's module makes NSS read from the same
 # store as OpenSSL (/etc/ssl/certs/), so proxy CA certs injected via
 # update-ca-certificates are trusted by all applications.
-RUN MULTIARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH) \
-    && ln -sf /usr/lib/${MULTIARCH}/pkcs11/p11-kit-trust.so \
-              /usr/lib/${MULTIARCH}/nss/libnssckbi.so
+RUN ARCH=$(dpkg --print-architecture) \
+    && ln -sf /usr/lib/${ARCH}-linux-gnu/pkcs11/p11-kit-trust.so \
+              /usr/lib/${ARCH}-linux-gnu/nss/libnssckbi.so
 
 # Install Claude Code CLI as a standalone Bun-compiled binary.
 # The binary bundles Bun runtime (JSC) + application code into a single executable,

--- a/crates/runner/scripts/rootfs-browser.Dockerfile
+++ b/crates/runner/scripts/rootfs-browser.Dockerfile
@@ -98,7 +98,8 @@ ENV LANG=C.UTF-8
 # Install agent-browser CLI and Chrome/Chromium.
 # Chrome for Testing (used by `agent-browser install`) only supports x86_64.
 # On ARM64, fall back to system Chromium from apt.
-RUN npm install -g agent-browser \
+ARG AGENT_BROWSER_VERSION=0.21.0
+RUN npm install -g agent-browser@${AGENT_BROWSER_VERSION} \
     && ARCH=$(dpkg --print-architecture) \
     && if [ "$ARCH" = "arm64" ]; then \
          apt-get update \

--- a/crates/runner/scripts/rootfs-browser.Dockerfile
+++ b/crates/runner/scripts/rootfs-browser.Dockerfile
@@ -42,6 +42,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && apt-get clean
 
 # Make NSS-based applications (Chromium, Firefox) trust the system CA store.
+# By default NSS uses a built-in trust module (libnssckbi.so) with Mozilla's
+# root CAs. Replacing it with p11-kit's module makes NSS read from the same
+# store as OpenSSL (/etc/ssl/certs/), so proxy CA certs injected via
+# update-ca-certificates are trusted by all applications.
 RUN MULTIARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH) \
     && ln -sf /usr/lib/${MULTIARCH}/pkcs11/p11-kit-trust.so \
               /usr/lib/${MULTIARCH}/nss/libnssckbi.so

--- a/crates/runner/scripts/rootfs-browser.Dockerfile
+++ b/crates/runner/scripts/rootfs-browser.Dockerfile
@@ -1,14 +1,8 @@
-# Firecracker VM rootfs image
-# Based on Node.js 24 with Python 3.11+, guest-init, and agent CLIs
+# Firecracker VM rootfs image — browser profile
+# Based on the default profile (Node.js 24, Python 3.11+, Claude Code, GitHub CLI)
+# with Chromium and agent-browser for browser automation.
 #
-# Included CLIs:
-# - Claude Code CLI (@anthropic-ai/claude-code)
-# - GitHub CLI (gh) for apps: [github]
-#
-# This mirrors the e2b template configurations for consistency.
-# See: turbo/scripts/e2b/vm0-*/template.ts
-#
-# Build: docker build -t vm0-rootfs .
+# Build: docker build -t vm0-rootfs-browser .
 # Export: See build-rootfs.sh
 
 FROM node:24-bookworm-slim
@@ -88,3 +82,9 @@ RUN userdel -r node 2>/dev/null || true \
 RUN mkdir -p /rom /rw /mnt/root
 
 ENV LANG=C.UTF-8
+
+# === Browser profile: Chromium + agent-browser ===
+
+# Install agent-browser CLI, Chrome, and system deps (requires root for apt).
+RUN npm install -g agent-browser \
+    && agent-browser install --with-deps

--- a/crates/runner/scripts/rootfs-browser.Dockerfile
+++ b/crates/runner/scripts/rootfs-browser.Dockerfile
@@ -85,6 +85,15 @@ ENV LANG=C.UTF-8
 
 # === Browser profile: Chromium + agent-browser ===
 
-# Install agent-browser CLI, Chrome, and system deps (requires root for apt).
+# Install agent-browser CLI and Chrome/Chromium.
+# Chrome for Testing (used by `agent-browser install`) only supports x86_64.
+# On ARM64, fall back to system Chromium from apt.
 RUN npm install -g agent-browser \
-    && agent-browser install --with-deps
+    && ARCH=$(dpkg --print-architecture) \
+    && if [ "$ARCH" = "arm64" ]; then \
+         apt-get update \
+         && apt-get install -y --no-install-recommends chromium \
+         && rm -rf /var/lib/apt/lists/*; \
+       else \
+         agent-browser install --with-deps; \
+       fi

--- a/crates/runner/scripts/rootfs-browser.Dockerfile
+++ b/crates/runner/scripts/rootfs-browser.Dockerfile
@@ -46,9 +46,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # root CAs. Replacing it with p11-kit's module makes NSS read from the same
 # store as OpenSSL (/etc/ssl/certs/), so proxy CA certs injected via
 # update-ca-certificates are trusted by all applications.
-RUN ARCH=$(dpkg --print-architecture) \
-    && ln -sf /usr/lib/${ARCH}-linux-gnu/pkcs11/p11-kit-trust.so \
-              /usr/lib/${ARCH}-linux-gnu/nss/libnssckbi.so
+RUN find /usr/lib -name libnssckbi.so -exec sh -c \
+    'p11=$(find /usr/lib -name p11-kit-trust.so | head -1) && ln -sf "$p11" "$1"' _ {} \;
 
 # Install Claude Code CLI as a standalone Bun-compiled binary.
 # The binary bundles Bun runtime (JSC) + application code into a single executable,

--- a/crates/runner/scripts/rootfs-browser.Dockerfile
+++ b/crates/runner/scripts/rootfs-browser.Dockerfile
@@ -95,16 +95,10 @@ ENV LANG=C.UTF-8
 
 # === Browser profile: Chromium + agent-browser ===
 
-# Install agent-browser CLI and Chrome/Chromium.
-# Chrome for Testing (used by `agent-browser install`) only supports x86_64.
-# On ARM64, fall back to system Chromium from apt.
+# Install agent-browser CLI and system Chromium.
+# System Chromium is used on all architectures for version consistency.
 ARG AGENT_BROWSER_VERSION=0.21.0
 RUN npm install -g agent-browser@${AGENT_BROWSER_VERSION} \
-    && ARCH=$(dpkg --print-architecture) \
-    && if [ "$ARCH" = "arm64" ]; then \
-         apt-get update \
-         && apt-get install -y --no-install-recommends chromium \
-         && rm -rf /var/lib/apt/lists/*; \
-       else \
-         agent-browser install --with-deps; \
-       fi
+    && apt-get update \
+    && apt-get install -y --no-install-recommends chromium \
+    && rm -rf /var/lib/apt/lists/*

--- a/crates/runner/scripts/rootfs-browser.Dockerfile
+++ b/crates/runner/scripts/rootfs-browser.Dockerfile
@@ -36,8 +36,15 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     iproute2 \
     ca-certificates \
     sudo \
+    libnss3 \
+    p11-kit-modules \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get clean
+
+# Make NSS-based applications (Chromium, Firefox) trust the system CA store.
+RUN MULTIARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH) \
+    && ln -sf /usr/lib/${MULTIARCH}/pkcs11/p11-kit-trust.so \
+              /usr/lib/${MULTIARCH}/nss/libnssckbi.so
 
 # Install Claude Code CLI as a standalone Bun-compiled binary.
 # The binary bundles Bun runtime (JSC) + application code into a single executable,

--- a/crates/runner/scripts/rootfs-default.Dockerfile
+++ b/crates/runner/scripts/rootfs-default.Dockerfile
@@ -49,9 +49,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # root CAs. Replacing it with p11-kit's module makes NSS read from the same
 # store as OpenSSL (/etc/ssl/certs/), so proxy CA certs injected via
 # update-ca-certificates are trusted by all applications.
-RUN MULTIARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH) \
-    && ln -sf /usr/lib/${MULTIARCH}/pkcs11/p11-kit-trust.so \
-              /usr/lib/${MULTIARCH}/nss/libnssckbi.so
+RUN ARCH=$(dpkg --print-architecture) \
+    && ln -sf /usr/lib/${ARCH}-linux-gnu/pkcs11/p11-kit-trust.so \
+              /usr/lib/${ARCH}-linux-gnu/nss/libnssckbi.so
 
 # Install Claude Code CLI as a standalone Bun-compiled binary.
 # The binary bundles Bun runtime (JSC) + application code into a single executable,

--- a/crates/runner/scripts/rootfs-default.Dockerfile
+++ b/crates/runner/scripts/rootfs-default.Dockerfile
@@ -1,0 +1,87 @@
+# Firecracker VM rootfs image — default profile
+# Based on Node.js 24 with Python 3.11+, guest-init, and agent CLIs
+#
+# Included CLIs:
+# - Claude Code CLI (@anthropic-ai/claude-code)
+# - GitHub CLI (gh)
+#
+# Build: docker build -t vm0-rootfs-default .
+# Export: See build-rootfs.sh
+
+FROM node:24-bookworm-slim
+
+# Avoid interactive prompts during package installation
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install required packages
+# Core:
+# - python3: Python 3.11+ for agent scripts
+# - procps: Process utilities (pgrep, free) needed by metrics and executor
+# Development tools (matching e2b template):
+# - curl: HTTP client
+# - git: Version control
+# - ripgrep: Fast code search (used by Claude Code)
+# - jq: JSON processing
+# - file: File type detection
+# System utilities:
+# - iproute2: Network utilities (ip command)
+# - ca-certificates: SSL certificates for HTTPS
+# - sudo: For privileged operations
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    python3 \
+    python3-pip \
+    procps \
+    curl \
+    git \
+    ripgrep \
+    jq \
+    file \
+    iproute2 \
+    ca-certificates \
+    sudo \
+    && rm -rf /var/lib/apt/lists/* \
+    && apt-get clean
+
+# Install Claude Code CLI as a standalone Bun-compiled binary.
+# The binary bundles Bun runtime (JSC) + application code into a single executable,
+# eliminating module resolution overhead and reducing CLI cold-start time.
+ARG CLAUDE_CODE_VERSION=2.1.75
+RUN ARCH=$(dpkg --print-architecture) \
+    && case "$ARCH" in amd64) PLATFORM="linux-x64" ;; arm64) PLATFORM="linux-arm64" ;; *) echo "Unsupported architecture: $ARCH" >&2; exit 1 ;; esac \
+    && GCS_BUCKET="https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases" \
+    && curl -fsSL "${GCS_BUCKET}/${CLAUDE_CODE_VERSION}/${PLATFORM}/claude" -o /usr/local/bin/claude \
+    && CHECKSUM=$(curl -fsSL "${GCS_BUCKET}/${CLAUDE_CODE_VERSION}/manifest.json" \
+       | jq -r ".platforms[\"$PLATFORM\"].checksum") \
+    && echo "${CHECKSUM}  /usr/local/bin/claude" | sha256sum -c - \
+    && chmod +x /usr/local/bin/claude
+
+# Install GitHub CLI (included in base image)
+# See: turbo/scripts/e2b/vm0-claude-code/template.ts
+# https://github.com/cli/cli/blob/trunk/docs/install_linux.md
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+    | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+    | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+    && apt-get update \
+    && apt-get install -y gh \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create 'user' account (UID 1000) matching E2B sandbox default
+# - Home directory at /home/user
+# - Add to sudo group for privileged operations
+# Note: node:24-bookworm-slim has 'node' user at UID 1000, so we delete it first
+RUN userdel -r node 2>/dev/null || true \
+    && useradd -m -u 1000 -s /bin/bash user \
+    && usermod -aG sudo user \
+    && echo 'user ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers \
+    && passwd -d user
+
+# NOTE: DNS configuration is handled in build-rootfs.sh after export
+# /etc/resolv.conf is read-only during Docker build
+
+# Create directories for guest-init (squashfs is read-only at boot)
+# These are needed by /sbin/guest-init to set up overlayfs
+RUN mkdir -p /rom /rw /mnt/root
+
+ENV LANG=C.UTF-8

--- a/crates/runner/scripts/rootfs-default.Dockerfile
+++ b/crates/runner/scripts/rootfs-default.Dockerfile
@@ -49,9 +49,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # root CAs. Replacing it with p11-kit's module makes NSS read from the same
 # store as OpenSSL (/etc/ssl/certs/), so proxy CA certs injected via
 # update-ca-certificates are trusted by all applications.
-RUN ARCH=$(dpkg --print-architecture) \
-    && ln -sf /usr/lib/${ARCH}-linux-gnu/pkcs11/p11-kit-trust.so \
-              /usr/lib/${ARCH}-linux-gnu/nss/libnssckbi.so
+RUN find /usr/lib -name libnssckbi.so -exec sh -c \
+    'p11=$(find /usr/lib -name p11-kit-trust.so | head -1) && ln -sf "$p11" "$1"' _ {} \;
 
 # Install Claude Code CLI as a standalone Bun-compiled binary.
 # The binary bundles Bun runtime (JSC) + application code into a single executable,

--- a/crates/runner/scripts/rootfs-default.Dockerfile
+++ b/crates/runner/scripts/rootfs-default.Dockerfile
@@ -39,8 +39,19 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     iproute2 \
     ca-certificates \
     sudo \
+    libnss3 \
+    p11-kit-modules \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get clean
+
+# Make NSS-based applications (Chromium, Firefox) trust the system CA store.
+# By default NSS uses a built-in trust module (libnssckbi.so) with Mozilla's
+# root CAs. Replacing it with p11-kit's module makes NSS read from the same
+# store as OpenSSL (/etc/ssl/certs/), so proxy CA certs injected via
+# update-ca-certificates are trusted by all applications.
+RUN MULTIARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH) \
+    && ln -sf /usr/lib/${MULTIARCH}/pkcs11/p11-kit-trust.so \
+              /usr/lib/${MULTIARCH}/nss/libnssckbi.so
 
 # Install Claude Code CLI as a standalone Bun-compiled binary.
 # The binary bundles Bun runtime (JSC) + application code into a single executable,

--- a/crates/runner/src/cmd/start.rs
+++ b/crates/runner/src/cmd/start.rs
@@ -231,7 +231,9 @@ pub async fn run_start(args: StartArgs) -> RunnerResult<()> {
         (provider, group)
     } else {
         let group_name = group.clone();
-        let provider = ApiProvider::new(http.clone(), server.token, group, cancel.clone()).await;
+        let profiles: Vec<String> = runner_config.profiles.keys().cloned().collect();
+        let provider =
+            ApiProvider::new(http.clone(), server.token, group, profiles, cancel.clone()).await;
         (provider, group_name)
     };
 

--- a/crates/runner/src/profile.rs
+++ b/crates/runner/src/profile.rs
@@ -1,6 +1,7 @@
 use crate::error::{RunnerError, RunnerResult};
 
-const EMBEDDED_DOCKERFILE_DEFAULT: &str = include_str!("../scripts/rootfs.Dockerfile");
+const EMBEDDED_DOCKERFILE_DEFAULT: &str = include_str!("../scripts/rootfs-default.Dockerfile");
+const EMBEDDED_DOCKERFILE_BROWSER: &str = include_str!("../scripts/rootfs-browser.Dockerfile");
 
 /// A platform-defined profile specifying rootfs image and VM resources.
 pub struct ProfileDef {
@@ -22,12 +23,17 @@ pub fn get(name: &str) -> RunnerResult<&'static ProfileDef> {
         memory_mb: 2048,
     };
 
-    // Phase 1: only vm0/default is buildable. vm0/browser will be added
-    // in PR 5 when rootfs-browser.Dockerfile is created.
+    static BROWSER: ProfileDef = ProfileDef {
+        dockerfile: EMBEDDED_DOCKERFILE_BROWSER,
+        vcpu: 4,
+        memory_mb: 4096,
+    };
+
     match name {
         "vm0/default" => Ok(&DEFAULT),
+        "vm0/browser" => Ok(&BROWSER),
         _ => Err(RunnerError::Config(format!(
-            "unknown profile: {name}. available profiles: vm0/default"
+            "unknown profile: {name}. available profiles: vm0/default, vm0/browser"
         ))),
     }
 }
@@ -67,8 +73,15 @@ mod tests {
     }
 
     #[test]
+    fn get_browser_profile() {
+        let def = get("vm0/browser").unwrap();
+        assert_eq!(def.vcpu, 4);
+        assert_eq!(def.memory_mb, 4096);
+        assert!(!def.dockerfile.is_empty());
+    }
+
+    #[test]
     fn get_unknown_profile_fails() {
-        assert!(get("vm0/browser").is_err());
         assert!(get("unknown").is_err());
     }
 

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -42,6 +42,9 @@ const ABLY_BACKOFF_MAX: Duration = Duration::from_secs(60);
 pub struct ApiProvider {
     api: ApiClient,
     group: String,
+    /// Profile names this runner supports (e.g., ["vm0/default", "vm0/browser"]).
+    /// Sent in poll requests so the server only returns jobs this runner can handle.
+    profiles: Vec<String>,
     /// Mutable discovery state, behind Mutex for `&self` compatibility.
     /// Only one caller (main loop) — never contended in practice.
     discovery: tokio::sync::Mutex<DiscoveryState>,
@@ -67,6 +70,7 @@ impl ApiProvider {
         http: HttpClient,
         token: String,
         group: String,
+        profiles: Vec<String>,
         cancel: CancellationToken,
     ) -> Arc<Self> {
         let api = ApiClient::new(http, token);
@@ -89,6 +93,7 @@ impl ApiProvider {
         Arc::new(Self {
             api,
             group,
+            profiles,
             discovery: tokio::sync::Mutex::new(DiscoveryState {
                 ably,
                 ably_retry,
@@ -178,7 +183,7 @@ impl JobProvider for ApiProvider {
                 // Poll fallback (adaptive interval)
                 () = tokio::time::sleep(sleep_dur) => {
                     *poll_now = false;
-                    match self.api.poll(&self.group).await {
+                    match self.api.poll(&self.group, &self.profiles).await {
                         Ok(Some(job)) => {
                             // Fall back to default profile when server doesn't send one
                             // (backwards compat with pre-profile API).
@@ -406,11 +411,11 @@ impl ApiClient {
     }
 
     /// Poll for a pending job. Returns `Ok(None)` when no work is available.
-    async fn poll(&self, group: &str) -> RunnerResult<Option<Job>> {
+    async fn poll(&self, group: &str, profiles: &[String]) -> RunnerResult<Option<Job>> {
         let resp = self
             .http
             .request(reqeast::Method::POST, "/api/runners/poll", &self.token)
-            .json(&serde_json::json!({ "group": group }))
+            .json(&serde_json::json!({ "group": group, "profiles": profiles }))
             .send()
             .await
             .map_err(|e| RunnerError::Api(format!("poll: {e}")))?;

--- a/crates/sandbox-fc/src/api.rs
+++ b/crates/sandbox-fc/src/api.rs
@@ -74,6 +74,10 @@ pub struct BalloonStatistics {
 /// Per-request timeout matching the TS client (30s).
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 
+/// Extended timeout for snapshot creation. Writing a full memory dump
+/// (up to 4 GiB for browser profile) can exceed the default 30s timeout.
+const SNAPSHOT_CREATE_TIMEOUT: Duration = Duration::from_secs(120);
+
 /// Minimal HTTP-over-Unix-socket client for the Firecracker API.
 pub struct ApiClient<'a> {
     socket_path: &'a Path,
@@ -125,7 +129,8 @@ impl<'a> ApiClient<'a> {
 
     /// Load a snapshot and resume the VM via PUT /snapshot/load.
     pub async fn load_snapshot(&self, snapshot_path: &str, mem_path: &str) -> Result<(), ApiError> {
-        self.put_json(
+        self.send_json(
+            "PUT",
             "/snapshot/load",
             &serde_json::json!({
                 "snapshot_path": snapshot_path,
@@ -135,6 +140,7 @@ impl<'a> ApiClient<'a> {
                 },
                 "resume_vm": true,
             }),
+            REQUEST_TIMEOUT,
         )
         .await
     }
@@ -143,25 +149,35 @@ impl<'a> ApiClient<'a> {
     ///
     /// The VM must be paused before creating a snapshot.
     pub async fn pause(&self) -> Result<(), ApiError> {
-        self.request_with_timeout("PATCH", "/vm", Some(br#"{"state":"Paused"}"#))
-            .await
+        self.send(
+            "PATCH",
+            "/vm",
+            Some(br#"{"state":"Paused"}"#),
+            REQUEST_TIMEOUT,
+        )
+        .await?;
+        Ok(())
     }
 
     /// Create a snapshot via PUT /snapshot/create.
     ///
     /// The VM must be paused first (see [`Self::pause`]).
+    /// Uses an extended timeout because writing a full memory dump to disk
+    /// can take well over 30s for large VMs (e.g. 4 GiB for browser profile).
     pub async fn create_snapshot(
         &self,
         snapshot_path: &str,
         mem_path: &str,
     ) -> Result<(), ApiError> {
-        self.put_json(
+        self.send_json(
+            "PUT",
             "/snapshot/create",
             &serde_json::json!({
                 "snapshot_type": "Full",
                 "snapshot_path": snapshot_path,
                 "mem_file_path": mem_path,
             }),
+            SNAPSHOT_CREATE_TIMEOUT,
         )
         .await
     }
@@ -172,12 +188,14 @@ impl<'a> ApiClient<'a> {
         vcpu_count: u32,
         mem_size_mib: u32,
     ) -> Result<(), ApiError> {
-        self.put_json(
+        self.send_json(
+            "PUT",
             "/machine-config",
             &serde_json::json!({
                 "vcpu_count": vcpu_count,
                 "mem_size_mib": mem_size_mib,
             }),
+            REQUEST_TIMEOUT,
         )
         .await
     }
@@ -188,12 +206,14 @@ impl<'a> ApiClient<'a> {
         kernel_image_path: &str,
         boot_args: &str,
     ) -> Result<(), ApiError> {
-        self.put_json(
+        self.send_json(
+            "PUT",
             "/boot-source",
             &serde_json::json!({
                 "kernel_image_path": kernel_image_path,
                 "boot_args": boot_args,
             }),
+            REQUEST_TIMEOUT,
         )
         .await
     }
@@ -207,7 +227,8 @@ impl<'a> ApiClient<'a> {
         is_read_only: bool,
     ) -> Result<(), ApiError> {
         let path = format!("/drives/{drive_id}");
-        self.put_json(
+        self.send_json(
+            "PUT",
             &path,
             &serde_json::json!({
                 "drive_id": drive_id,
@@ -215,6 +236,7 @@ impl<'a> ApiClient<'a> {
                 "is_root_device": is_root_device,
                 "is_read_only": is_read_only,
             }),
+            REQUEST_TIMEOUT,
         )
         .await
     }
@@ -227,25 +249,29 @@ impl<'a> ApiClient<'a> {
         host_dev_name: &str,
     ) -> Result<(), ApiError> {
         let path = format!("/network-interfaces/{iface_id}");
-        self.put_json(
+        self.send_json(
+            "PUT",
             &path,
             &serde_json::json!({
                 "iface_id": iface_id,
                 "guest_mac": guest_mac,
                 "host_dev_name": host_dev_name,
             }),
+            REQUEST_TIMEOUT,
         )
         .await
     }
 
     /// Configure the vsock device via PUT /vsock.
     pub async fn configure_vsock(&self, guest_cid: u32, uds_path: &str) -> Result<(), ApiError> {
-        self.put_json(
+        self.send_json(
+            "PUT",
             "/vsock",
             &serde_json::json!({
                 "guest_cid": guest_cid,
                 "uds_path": uds_path,
             }),
+            REQUEST_TIMEOUT,
         )
         .await
     }
@@ -255,11 +281,13 @@ impl<'a> ApiClient<'a> {
     /// Unlike [`Self::configure_balloon`] (PUT, pre-boot only), this can be called
     /// while the VM is running to dynamically inflate or deflate the balloon.
     pub async fn patch_balloon(&self, amount_mib: u32) -> Result<(), ApiError> {
-        let body = serde_json::json!({ "amount_mib": amount_mib });
-        let bytes =
-            serde_json::to_string(&body).map_err(|e| ApiError::Other(format!("json: {e}")))?;
-        self.request_with_timeout("PATCH", "/balloon", Some(bytes.as_bytes()))
-            .await
+        self.send_json(
+            "PATCH",
+            "/balloon",
+            &serde_json::json!({ "amount_mib": amount_mib }),
+            REQUEST_TIMEOUT,
+        )
+        .await
     }
 
     /// Retrieve balloon device statistics via GET /balloon/statistics.
@@ -268,7 +296,7 @@ impl<'a> ApiClient<'a> {
     /// [`Self::configure_balloon`]. Returns an error if statistics were not enabled.
     pub async fn get_balloon_statistics(&self) -> Result<BalloonStatistics, ApiError> {
         let body = self
-            .request_with_timeout_body("GET", "/balloon/statistics", None)
+            .send("GET", "/balloon/statistics", None, REQUEST_TIMEOUT)
             .await?;
         serde_json::from_str(&body)
             .map_err(|e| ApiError::Other(format!("parse balloon statistics: {e}")))
@@ -285,56 +313,57 @@ impl<'a> ApiClient<'a> {
         deflate_on_oom: bool,
         stats_polling_interval_s: u32,
     ) -> Result<(), ApiError> {
-        self.put_json(
+        self.send_json(
+            "PUT",
             "/balloon",
             &serde_json::json!({
                 "amount_mib": amount_mib,
                 "deflate_on_oom": deflate_on_oom,
                 "stats_polling_interval_s": stats_polling_interval_s,
             }),
+            REQUEST_TIMEOUT,
         )
         .await
     }
 
     /// Start the VM instance via PUT /actions.
     pub async fn start_instance(&self) -> Result<(), ApiError> {
-        self.request_with_timeout(
+        self.send(
             "PUT",
             "/actions",
             Some(br#"{"action_type":"InstanceStart"}"#),
+            REQUEST_TIMEOUT,
         )
-        .await
-    }
-
-    /// Send a request with the standard timeout and return the response body.
-    async fn request_with_timeout_body(
-        &self,
-        method: &str,
-        path: &str,
-        body: Option<&[u8]>,
-    ) -> Result<String, ApiError> {
-        tokio::time::timeout(REQUEST_TIMEOUT, self.request(method, path, body))
-            .await
-            .map_err(|_| ApiError::Other(format!("request timed out after {REQUEST_TIMEOUT:?}")))?
-    }
-
-    /// Send a request with the standard timeout, discarding the response body.
-    async fn request_with_timeout(
-        &self,
-        method: &str,
-        path: &str,
-        body: Option<&[u8]>,
-    ) -> Result<(), ApiError> {
-        self.request_with_timeout_body(method, path, body).await?;
+        .await?;
         Ok(())
     }
 
-    /// Serialize a JSON value and PUT it to the given path.
-    async fn put_json(&self, path: &str, value: &serde_json::Value) -> Result<(), ApiError> {
+    /// Send a request with a timeout and return the response body.
+    async fn send(
+        &self,
+        method: &str,
+        path: &str,
+        body: Option<&[u8]>,
+        timeout: Duration,
+    ) -> Result<String, ApiError> {
+        tokio::time::timeout(timeout, self.request(method, path, body))
+            .await
+            .map_err(|_| ApiError::Other(format!("request timed out after {timeout:?}")))?
+    }
+
+    /// Serialize a JSON value and send it with the given method and timeout.
+    async fn send_json(
+        &self,
+        method: &str,
+        path: &str,
+        value: &serde_json::Value,
+        timeout: Duration,
+    ) -> Result<(), ApiError> {
         let body =
             serde_json::to_string(value).map_err(|e| ApiError::Other(format!("json: {e}")))?;
-        self.request_with_timeout("PUT", path, Some(body.as_bytes()))
-            .await
+        self.send(method, path, Some(body.as_bytes()), timeout)
+            .await?;
+        Ok(())
     }
 
     /// Send a raw HTTP/1.1 request over a Unix domain socket.

--- a/crates/vsock-guest/src/lib.rs
+++ b/crates/vsock-guest/src/lib.rs
@@ -49,7 +49,7 @@ fn to_io_error(e: ProtocolError) -> io::Error {
 /// - Release builds: Some("user") (run as user via su - user -c)
 ///
 /// The rootfs must have the "user" account (UID 1000) configured with passwordless sudo.
-/// See: crates/runner/scripts/rootfs.Dockerfile for user account setup.
+/// See: crates/runner/scripts/rootfs-default.Dockerfile for user account setup.
 fn get_exec_user() -> Option<&'static str> {
     #[cfg(debug_assertions)]
     {

--- a/e2e/tests/03-experimental-runner/t44-vm0-profile.bats
+++ b/e2e/tests/03-experimental-runner/t44-vm0-profile.bats
@@ -66,8 +66,7 @@ EOF
 
     run $CLI_COMMAND run "$AGENT_NAME" \
         --artifact-name "$ARTIFACT_NAME" \
-        "agent-browser --version && chromium --version"
+        "agent-browser open https://example.com && agent-browser get title && agent-browser close"
     assert_success
-    assert_output --partial "agent-browser"
-    assert_output --partial "Chromium"
+    assert_output --partial "Example Domain"
 }

--- a/e2e/tests/03-experimental-runner/t44-vm0-profile.bats
+++ b/e2e/tests/03-experimental-runner/t44-vm0-profile.bats
@@ -1,7 +1,7 @@
 #!/usr/bin/env bats
 
 # Test VM0 profile support (E2E happy path only)
-# Verifies that browser profile boots a VM with Chromium + agent-browser.
+# Verifies that explicit profile selection works for both default and browser.
 # Profile validation (org/name format) is tested via Rust unit tests.
 
 load '../../helpers/setup'
@@ -14,6 +14,34 @@ setup() {
 
 teardown() {
     [ -n "$TEST_DIR" ] && [ -d "$TEST_DIR" ] && rm -rf "$TEST_DIR"
+}
+
+@test "vm0 run with default profile has claude and gh cli" {
+    cat > "$TEST_DIR/vm0.yaml" <<EOF
+version: "1.0"
+
+agents:
+  $AGENT_NAME:
+    description: "Test agent with default profile"
+    framework: claude-code
+    experimental_profile: vm0/default
+EOF
+
+    run $CLI_COMMAND compose "$TEST_DIR/vm0.yaml"
+    assert_success
+
+    mkdir -p "$TEST_DIR/$ARTIFACT_NAME"
+    cd "$TEST_DIR/$ARTIFACT_NAME"
+    $CLI_COMMAND artifact init --name "$ARTIFACT_NAME" >/dev/null
+    run $CLI_COMMAND artifact push
+    assert_success
+
+    run $CLI_COMMAND run "$AGENT_NAME" \
+        --artifact-name "$ARTIFACT_NAME" \
+        "claude --version && gh --version"
+    assert_success
+    assert_output --partial "claude"
+    assert_output --partial "gh version"
 }
 
 @test "vm0 run with browser profile has agent-browser and chromium" {

--- a/e2e/tests/03-experimental-runner/t44-vm0-profile.bats
+++ b/e2e/tests/03-experimental-runner/t44-vm0-profile.bats
@@ -35,7 +35,7 @@ EOF
     assert_output --partial "Compose"
 }
 
-@test "vm0 run with browser profile has agent-browser installed" {
+@test "vm0 run with browser profile has agent-browser and chromium" {
     cat > "$TEST_DIR/vm0.yaml" <<EOF
 version: "1.0"
 
@@ -57,33 +57,7 @@ EOF
 
     run $CLI_COMMAND run "$AGENT_NAME" \
         --artifact-name "$ARTIFACT_NAME" \
-        "agent-browser --version"
+        "agent-browser --version && (which chromium || which chrome || which google-chrome || ls /root/.cache/puppeteer/chrome/*/chrome-linux64/chrome)"
     assert_success
     assert_output --partial "agent-browser"
-}
-
-@test "vm0 run with browser profile has chromium available" {
-    cat > "$TEST_DIR/vm0.yaml" <<EOF
-version: "1.0"
-
-agents:
-  $AGENT_NAME:
-    description: "Test agent with browser profile"
-    framework: claude-code
-    experimental_profile: vm0/browser
-EOF
-
-    run $CLI_COMMAND compose "$TEST_DIR/vm0.yaml"
-    assert_success
-
-    mkdir -p "$TEST_DIR/$ARTIFACT_NAME"
-    cd "$TEST_DIR/$ARTIFACT_NAME"
-    $CLI_COMMAND artifact init --name "$ARTIFACT_NAME" >/dev/null
-    run $CLI_COMMAND artifact push
-    assert_success
-
-    run $CLI_COMMAND run "$AGENT_NAME" \
-        --artifact-name "$ARTIFACT_NAME" \
-        "which chromium || which chrome || which google-chrome || ls /root/.cache/puppeteer/chrome/*/chrome-linux64/chrome"
-    assert_success
 }

--- a/e2e/tests/03-experimental-runner/t44-vm0-profile.bats
+++ b/e2e/tests/03-experimental-runner/t44-vm0-profile.bats
@@ -1,11 +1,8 @@
 #!/usr/bin/env bats
 
 # Test VM0 profile support (E2E happy path only)
-# This test verifies that:
-# 1. vm0 compose accepts experimental_profile field
-# 2. vm0 run with browser profile boots a VM with Chromium + agent-browser
-#
-# Note: Profile validation (org/name format) is tested via Rust unit tests.
+# Verifies that browser profile boots a VM with Chromium + agent-browser.
+# Profile validation (org/name format) is tested via Rust unit tests.
 
 load '../../helpers/setup'
 
@@ -17,22 +14,6 @@ setup() {
 
 teardown() {
     [ -n "$TEST_DIR" ] && [ -d "$TEST_DIR" ] && rm -rf "$TEST_DIR"
-}
-
-@test "vm0 compose with experimental_profile succeeds" {
-    cat > "$TEST_DIR/vm0.yaml" <<EOF
-version: "1.0"
-
-agents:
-  $AGENT_NAME:
-    description: "Test agent with browser profile"
-    framework: claude-code
-    experimental_profile: vm0/browser
-EOF
-
-    run $CLI_COMMAND compose "$TEST_DIR/vm0.yaml"
-    assert_success
-    assert_output --partial "Compose"
 }
 
 @test "vm0 run with browser profile has agent-browser and chromium" {

--- a/e2e/tests/03-experimental-runner/t44-vm0-profile.bats
+++ b/e2e/tests/03-experimental-runner/t44-vm0-profile.bats
@@ -1,0 +1,89 @@
+#!/usr/bin/env bats
+
+# Test VM0 profile support (E2E happy path only)
+# This test verifies that:
+# 1. vm0 compose accepts experimental_profile field
+# 2. vm0 run with browser profile boots a VM with Chromium + agent-browser
+#
+# Note: Profile validation (org/name format) is tested via Rust unit tests.
+
+load '../../helpers/setup'
+
+setup() {
+    export TEST_DIR="$(mktemp -d)"
+    export AGENT_NAME="e2e-profile-$(date +%s%3N)-$RANDOM"
+    export ARTIFACT_NAME="e2e-profile-art-$(date +%s%3N)-$RANDOM"
+}
+
+teardown() {
+    [ -n "$TEST_DIR" ] && [ -d "$TEST_DIR" ] && rm -rf "$TEST_DIR"
+}
+
+@test "vm0 compose with experimental_profile succeeds" {
+    cat > "$TEST_DIR/vm0.yaml" <<EOF
+version: "1.0"
+
+agents:
+  $AGENT_NAME:
+    description: "Test agent with browser profile"
+    framework: claude-code
+    experimental_profile: vm0/browser
+EOF
+
+    run $CLI_COMMAND compose "$TEST_DIR/vm0.yaml"
+    assert_success
+    assert_output --partial "Compose"
+}
+
+@test "vm0 run with browser profile has agent-browser installed" {
+    cat > "$TEST_DIR/vm0.yaml" <<EOF
+version: "1.0"
+
+agents:
+  $AGENT_NAME:
+    description: "Test agent with browser profile"
+    framework: claude-code
+    experimental_profile: vm0/browser
+EOF
+
+    run $CLI_COMMAND compose "$TEST_DIR/vm0.yaml"
+    assert_success
+
+    mkdir -p "$TEST_DIR/$ARTIFACT_NAME"
+    cd "$TEST_DIR/$ARTIFACT_NAME"
+    $CLI_COMMAND artifact init --name "$ARTIFACT_NAME" >/dev/null
+    run $CLI_COMMAND artifact push
+    assert_success
+
+    run $CLI_COMMAND run "$AGENT_NAME" \
+        --artifact-name "$ARTIFACT_NAME" \
+        "agent-browser --version"
+    assert_success
+    assert_output --partial "agent-browser"
+}
+
+@test "vm0 run with browser profile has chromium available" {
+    cat > "$TEST_DIR/vm0.yaml" <<EOF
+version: "1.0"
+
+agents:
+  $AGENT_NAME:
+    description: "Test agent with browser profile"
+    framework: claude-code
+    experimental_profile: vm0/browser
+EOF
+
+    run $CLI_COMMAND compose "$TEST_DIR/vm0.yaml"
+    assert_success
+
+    mkdir -p "$TEST_DIR/$ARTIFACT_NAME"
+    cd "$TEST_DIR/$ARTIFACT_NAME"
+    $CLI_COMMAND artifact init --name "$ARTIFACT_NAME" >/dev/null
+    run $CLI_COMMAND artifact push
+    assert_success
+
+    run $CLI_COMMAND run "$AGENT_NAME" \
+        --artifact-name "$ARTIFACT_NAME" \
+        "which chromium || which chrome || which google-chrome || ls /root/.cache/puppeteer/chrome/*/chrome-linux64/chrome"
+    assert_success
+}

--- a/e2e/tests/03-experimental-runner/t44-vm0-profile.bats
+++ b/e2e/tests/03-experimental-runner/t44-vm0-profile.bats
@@ -66,7 +66,8 @@ EOF
 
     run $CLI_COMMAND run "$AGENT_NAME" \
         --artifact-name "$ARTIFACT_NAME" \
-        "agent-browser --version && (which chromium || which chrome || which google-chrome || ls /root/.cache/puppeteer/chrome/*/chrome-linux64/chrome)"
+        "agent-browser --version && chromium --version"
     assert_success
     assert_output --partial "agent-browser"
+    assert_output --partial "Chromium"
 }

--- a/scripts/dev-runner.sh
+++ b/scripts/dev-runner.sh
@@ -85,29 +85,34 @@ cmd_deploy() {
   log "Running setup..."
   ssh_cmd "$RUNNER_BIN setup"
 
-  # Clean up old rootfs/snapshots
+  # Clean up old rootfs/snapshots (2 profiles × 3 deploys = 6)
   ssh_cmd "$RUNNER_BIN gc --keep-latest 6"
 
-  # Build rootfs + snapshot
-  log "Building rootfs and snapshot..."
-  BUILD_LOG=$(mktemp)
-  ssh_cmd "$RUNNER_BIN build --profile vm0/default" | tee "$BUILD_LOG"
-  ROOTFS_HASH=$(grep '^rootfs_hash=' "$BUILD_LOG" | cut -d= -f2)
-  SNAPSHOT_HASH=$(grep '^snapshot_hash=' "$BUILD_LOG" | cut -d= -f2)
-  rm -f "$BUILD_LOG"
+  # Build rootfs + snapshot for all profiles
+  PROFILES=("vm0/default" "vm0/browser")
+  CONFIG_ARGS=""
 
-  if [[ -z "$ROOTFS_HASH" || -z "$SNAPSHOT_HASH" ]]; then
-    log "Error: failed to extract build hashes"
-    exit 1
-  fi
-  log "Hashes: rootfs=$ROOTFS_HASH snapshot=$SNAPSHOT_HASH"
+  for PROFILE in "${PROFILES[@]}"; do
+    log "Building $PROFILE..."
+    BUILD_LOG=$(mktemp)
+    ssh_cmd "$RUNNER_BIN build --profile $PROFILE" | tee "$BUILD_LOG"
+    ROOTFS_HASH=$(grep '^rootfs_hash=' "$BUILD_LOG" | cut -d= -f2)
+    SNAPSHOT_HASH=$(grep '^snapshot_hash=' "$BUILD_LOG" | cut -d= -f2)
+    rm -f "$BUILD_LOG"
+
+    if [[ -z "$ROOTFS_HASH" || -z "$SNAPSHOT_HASH" ]]; then
+      log "Error: failed to extract build hashes for $PROFILE"
+      exit 1
+    fi
+    log "$PROFILE: rootfs=$ROOTFS_HASH snapshot=$SNAPSHOT_HASH"
+
+    CONFIG_ARGS+=" --profile $PROFILE --rootfs-hash $ROOTFS_HASH --snapshot-hash $SNAPSHOT_HASH"
+  done
 
   # Generate config
   log "Generating config..."
   ssh_cmd "$RUNNER_BIN config \
-    --profile vm0/default \
-    --rootfs-hash $ROOTFS_HASH \
-    --snapshot-hash $SNAPSHOT_HASH \
+    $CONFIG_ARGS \
     --name $RUNNER_NAME \
     --group $RUNNER_GROUP \
     --runner-dirname $RUNNER_NAME \

--- a/turbo/apps/cli/src/lib/domain/compose-types.ts
+++ b/turbo/apps/cli/src/lib/domain/compose-types.ts
@@ -18,6 +18,7 @@ export interface AgentDefinition {
   experimental_runner?: {
     group: string;
   };
+  experimental_profile?: string;
 }
 
 /**

--- a/turbo/apps/web/src/lib/run/context/execution-preparer.ts
+++ b/turbo/apps/web/src/lib/run/context/execution-preparer.ts
@@ -31,11 +31,9 @@ function resolveRunnerGroup(agentCompose: unknown): string | null {
 }
 
 /**
- * Known profiles (hardcoded for Phase 1).
- * Add "vm0/browser" here when rootfs-browser.Dockerfile lands (PR 5).
- * Must stay in sync with Rust: crates/runner/src/profile.rs
+ * Known profiles. Must stay in sync with Rust: crates/runner/src/profile.rs
  */
-const KNOWN_PROFILES = [DEFAULT_PROFILE];
+const KNOWN_PROFILES = [DEFAULT_PROFILE, "vm0/browser"];
 
 /**
  * Resolve runner profile from agent compose config


### PR DESCRIPTION
## Summary

- Add `rootfs-browser.Dockerfile` with Chromium + agent-browser for browser automation in VMs
- Rename `rootfs.Dockerfile` → `rootfs-default.Dockerfile` for naming consistency
- Register `vm0/browser` profile (4 vCPU, 4096 MiB) in Rust (`profile.rs`) and TypeScript (`execution-preparer.ts`)
- Update CI workflows (`crates.yml`, `turbo.yml`) and Ansible playbook for dual-profile build/deploy
- Add browser benchmark job that validates agent-browser + Chromium functionality

PR 5 in the #4500 series (profile-based VM configuration).

Closes #5074

## Test plan

- [ ] `cargo test -p runner` — profile registration tests pass
- [ ] CI `runner-build` job builds both default and browser rootfs/snapshots
- [ ] CI `runner-benchmark` job runs browser benchmark (`agent-browser open/get title/close`)
- [ ] `turbo.yml` deploy jobs correctly build and configure both profiles on dev machines
- [ ] Ansible playbook deploys both profiles to production runners

🤖 Generated with [Claude Code](https://claude.com/claude-code)