### PR TITLE
fix(web): trigger release for slack org_id column fix

### DIFF
--- a/turbo/apps/web/app/api/integrations/slack/org/route.ts
+++ b/turbo/apps/web/app/api/integrations/slack/org/route.ts
@@ -60,6 +60,8 @@ export async function GET(request: Request) {
 
   const db = globalThis.services.db;
 
+  log.info("Fetching Slack org status", { orgId: org.orgId, userId });
+
   // Find the workspace installation for this org
   const [orgInstallation] = await db
     .select()


### PR DESCRIPTION
## Summary

- Adds a log message in the Slack org GET endpoint to trigger a new release
- The fix in #5288 (removing redundant `org_id` column from slack org tables) is on main but unreleased
- Production is reporting Sentry errors on `GET /api/integrations/slack/org` due to the non-existent column

Closes #5313

## Test plan

- [ ] CI passes (lint, types, tests)
- [ ] release-please creates a new release PR after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)