### PR TITLE
fix: hardcode production app url in release-please workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -287,7 +287,7 @@ jobs:
             STRIPE_OAUTH_CLIENT_SECRET=${{ secrets.STRIPE_OAUTH_CLIENT_SECRET }}
             NGROK_API_KEY=${{ secrets.NGROK_API_KEY }}
             NGROK_COMPUTER_CONNECTOR_DOMAIN=${{ vars.NGROK_COMPUTER_CONNECTOR_DOMAIN }}
-            APP_URL=${{ vars.APP_URL }}
+            APP_URL=https://app.vm0.ai
             RESEND_API_KEY=${{ secrets.RESEND_API_KEY }}
             RESEND_WEBHOOK_SECRET=${{ secrets.RESEND_WEBHOOK_SECRET }}
             RESEND_FROM_DOMAIN=${{ vars.RESEND_FROM_DOMAIN }}


### PR DESCRIPTION
## Summary
- Replace `${{ vars.APP_URL }}` with `https://app.vm0.ai` in the `release-please.yml` workflow
- The production APP_URL is a known constant and does not need GitHub variable indirection
- The PR/preview workflow (`turbo.yml`) correctly uses dynamic preview URLs, so this change only affects production deploys

Closes #5318

## Test plan
- [ ] Verify the `release-please.yml` workflow file has the hardcoded URL
- [ ] Confirm CI passes (no functional change, just config simplification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)