### PR TITLE
fix: check org-level model provider in onboarding status

### DIFF
--- a/turbo/apps/web/app/api/onboarding/status/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/onboarding/status/__tests__/route.test.ts
@@ -9,6 +9,7 @@ import { testContext } from "../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../src/__tests__/clerk-mock";
 import { PUT as setDefaultAgent } from "../../../../api/orgs/default-agent/route";
 import { POST as completeOnboarding } from "../../complete/route";
+import { PUT as upsertOrgModelProvider } from "../../../../api/org/model-providers/route";
 
 const context = testContext();
 
@@ -75,6 +76,39 @@ describe("GET /api/onboarding/status", () => {
   it("should return hasModelProvider=true, hasDefaultAgent=false when provider exists but no default agent", async () => {
     await context.setupUser();
     await createTestModelProvider("anthropic-api-key", "test-secret-key");
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/onboarding/status",
+    );
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.hasOrg).toBe(true);
+    expect(data.hasModelProvider).toBe(true);
+    expect(data.hasDefaultAgent).toBe(false);
+    expect(data.needsOnboarding).toBe(true);
+  });
+
+  it("should return hasModelProvider=true when org-level provider exists", async () => {
+    await context.setupUser();
+
+    // Create org-level model provider (not user-level)
+    const orgProviderRequest = createTestRequest(
+      "http://localhost:3000/api/org/model-providers",
+      {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          type: "anthropic-api-key",
+          secret: "test-org-secret-key",
+        }),
+      },
+    );
+    const orgProviderResponse =
+      await upsertOrgModelProvider(orgProviderRequest);
+    expect(orgProviderResponse.status).toBeGreaterThanOrEqual(200);
+    expect(orgProviderResponse.status).toBeLessThan(300);
 
     const request = createTestRequest(
       "http://localhost:3000/api/onboarding/status",

--- a/turbo/apps/web/app/api/onboarding/status/route.ts
+++ b/turbo/apps/web/app/api/onboarding/status/route.ts
@@ -9,7 +9,8 @@ import {
   agentComposes,
   agentComposeVersions,
 } from "../../../../src/db/schema/agent-compose";
-import { eq, and } from "drizzle-orm";
+import { eq, and, or } from "drizzle-orm";
+import { ORG_SENTINEL_USER_ID } from "../../../../src/lib/org/org-sentinel";
 import { agentComposeApiContentSchema } from "@vm0/core";
 import { auth, clerkClient } from "@clerk/nextjs/server";
 import { orgMembersCache } from "../../../../src/db/schema/org-members-cache";
@@ -85,14 +86,17 @@ const router = tsr.router(onboardingStatusContract, {
       resolvedOrgId = resolvedOrg.orgId;
       isAdmin = member.role === "admin";
 
-      // Check model provider for this user (not org-wide)
+      // Check model provider for this user or org-level (matches runtime fallback in build-context.ts)
       const [provider] = await globalThis.services.db
         .select({ id: modelProviders.id })
         .from(modelProviders)
         .where(
           and(
             eq(modelProviders.orgId, resolvedOrg.orgId),
-            eq(modelProviders.userId, authCtx.userId),
+            or(
+              eq(modelProviders.userId, authCtx.userId),
+              eq(modelProviders.userId, ORG_SENTINEL_USER_ID),
+            ),
           ),
         )
         .limit(1);


### PR DESCRIPTION
## Summary
- The onboarding status endpoint previously only checked for user-level model providers when determining `hasModelProvider`
- Updated the query to also check for org-level providers (using `ORG_SENTINEL_USER_ID`), matching the runtime fallback behavior in `build-context.ts`
- Added integration test verifying org-level provider detection

## Test plan
- [ ] Verify `hasModelProvider` returns `true` when only an org-level provider exists (new test)
- [ ] Verify existing tests still pass (user-level provider, full onboarding flow)
- [ ] Confirm onboarding flow works correctly in staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)