### PR TITLE
feat(docs): update model provider references from user-level to org-level commands

### DIFF
--- a/turbo/apps/docs/content/docs/model-selection/aws-bedrock.mdx
+++ b/turbo/apps/docs/content/docs/model-selection/aws-bedrock.mdx
@@ -12,7 +12,7 @@ AWS Bedrock support is experimental and may change in future releases.
 ## Quick Setup
 
 ```bash
-vm0 model-provider setup --type aws-bedrock
+vm0 org model-provider setup --type aws-bedrock
 ```
 
 You'll be prompted to choose an authentication method and provide the required credentials.
@@ -28,7 +28,7 @@ Use a Bedrock API key for simple authentication.
 - **AWS_REGION** - AWS region (e.g., `us-east-1`, `us-west-2`)
 
 ```bash
-vm0 model-provider setup --type aws-bedrock --auth-method api-key \
+vm0 org model-provider setup --type aws-bedrock --auth-method api-key \
   --secret AWS_BEARER_TOKEN_BEDROCK=your-api-key \
   --secret AWS_REGION=us-east-1
 ```
@@ -46,7 +46,7 @@ Use IAM credentials for authentication.
 - **AWS_SESSION_TOKEN** - For temporary credentials (e.g., from STS)
 
 ```bash
-vm0 model-provider setup --type aws-bedrock --auth-method access-keys \
+vm0 org model-provider setup --type aws-bedrock --auth-method access-keys \
   --secret AWS_ACCESS_KEY_ID=your-access-key \
   --secret AWS_SECRET_ACCESS_KEY=your-secret-key \
   --secret AWS_REGION=us-east-1
@@ -55,7 +55,7 @@ vm0 model-provider setup --type aws-bedrock --auth-method access-keys \
 With session token (temporary credentials):
 
 ```bash
-vm0 model-provider setup --type aws-bedrock --auth-method access-keys \
+vm0 org model-provider setup --type aws-bedrock --auth-method access-keys \
   --secret AWS_ACCESS_KEY_ID=your-access-key \
   --secret AWS_SECRET_ACCESS_KEY=your-secret-key \
   --secret AWS_SESSION_TOKEN=your-session-token \
@@ -67,7 +67,7 @@ vm0 model-provider setup --type aws-bedrock --auth-method access-keys \
 AWS Bedrock supports custom model IDs. During setup, you can specify a model:
 
 ```bash
-vm0 model-provider setup --type aws-bedrock --auth-method api-key \
+vm0 org model-provider setup --type aws-bedrock --auth-method api-key \
   --secret AWS_BEARER_TOKEN_BEDROCK=xxx \
   --secret AWS_REGION=us-east-1 \
   --model anthropic.claude-sonnet-4-20250514-v1:0

--- a/turbo/apps/docs/content/docs/model-selection/azure-foundry.mdx
+++ b/turbo/apps/docs/content/docs/model-selection/azure-foundry.mdx
@@ -12,7 +12,7 @@ Azure Foundry support is experimental and may change in future releases.
 ## Quick Setup
 
 ```bash
-vm0 model-provider setup --type azure-foundry
+vm0 org model-provider setup --type azure-foundry
 ```
 
 You'll be prompted for:
@@ -30,7 +30,7 @@ You'll be prompted for:
 ## Non-Interactive Setup
 
 ```bash
-vm0 model-provider setup --type azure-foundry \
+vm0 org model-provider setup --type azure-foundry \
   --secret ANTHROPIC_FOUNDRY_API_KEY=your-api-key \
   --secret ANTHROPIC_FOUNDRY_RESOURCE=your-resource-name \
   --model claude-sonnet-4-6

--- a/turbo/apps/docs/content/docs/model-selection/claude.mdx
+++ b/turbo/apps/docs/content/docs/model-selection/claude.mdx
@@ -9,10 +9,10 @@ Use Claude models directly from Anthropic with full control over model selection
 
 ```bash
 # Using OAuth token (requires Claude Pro/Max subscription)
-vm0 model-provider setup --type claude-code-oauth-token
+vm0 org model-provider setup --type claude-code-oauth-token
 
 # Using API key (pay-per-token)
-vm0 model-provider setup --type anthropic-api-key
+vm0 org model-provider setup --type anthropic-api-key
 ```
 
 Once configured, run agents without any additional configuration.
@@ -36,10 +36,10 @@ Do not set both OAuth token and API key at the same time. This will cause authen
 
 ```bash
 # OAuth token
-vm0 model-provider setup --type claude-code-oauth-token --secret "your-oauth-token"
+vm0 org model-provider setup --type claude-code-oauth-token --secret "your-oauth-token"
 
 # API key
-vm0 model-provider setup --type anthropic-api-key --secret "sk-ant-xxx"
+vm0 org model-provider setup --type anthropic-api-key --secret "sk-ant-xxx"
 ```
 
 ## Model Tier Configuration

--- a/turbo/apps/docs/content/docs/model-selection/deepseek.mdx
+++ b/turbo/apps/docs/content/docs/model-selection/deepseek.mdx
@@ -8,7 +8,7 @@ description: Use DeepSeek models with VM0
 ## Quick Setup
 
 ```bash
-vm0 model-provider setup --type deepseek-api-key
+vm0 org model-provider setup --type deepseek-api-key
 ```
 
 You'll be prompted for your API key.
@@ -26,7 +26,7 @@ Visit the [DeepSeek Platform](https://platform.deepseek.com/api_keys) to create 
 ## Non-Interactive Setup
 
 ```bash
-vm0 model-provider setup --type deepseek-api-key --secret "sk-xxx"
+vm0 org model-provider setup --type deepseek-api-key --secret "sk-xxx"
 ```
 
 ## Run

--- a/turbo/apps/docs/content/docs/model-selection/index.mdx
+++ b/turbo/apps/docs/content/docs/model-selection/index.mdx
@@ -10,7 +10,7 @@ VM0 agents use model providers to connect to AI models. The **model provider sys
 Configure a model provider with a single command:
 
 ```bash
-vm0 model-provider setup
+vm0 org model-provider setup
 ```
 
 This interactive command will:
@@ -45,10 +45,10 @@ For CI/CD or scripting, provide credentials via flags:
 
 ```bash
 # Simple providers (single credential)
-vm0 model-provider setup --type anthropic-api-key --secret "sk-xxx"
+vm0 org model-provider setup --type anthropic-api-key --secret "sk-xxx"
 
 # With model selection
-vm0 model-provider setup --type openrouter-api-key --secret "sk-xxx" --model "anthropic/claude-sonnet-4.5"
+vm0 org model-provider setup --type openrouter-api-key --secret "sk-xxx" --model "anthropic/claude-sonnet-4.5"
 ```
 
 ## Model Selection
@@ -69,13 +69,13 @@ Some providers support choosing specific models. During setup, you'll be prompte
 
 ```bash
 # List all configured providers
-vm0 model-provider list
+vm0 org model-provider list
 
 # Set a provider as default
-vm0 model-provider set-default openrouter-api-key
+vm0 org model-provider set-default openrouter-api-key
 
 # Delete a provider
-vm0 model-provider delete anthropic-api-key
+vm0 org model-provider remove anthropic-api-key
 ```
 
 <Callout type="info" title="How Credential Injection Works">
@@ -96,7 +96,7 @@ vm0 run my-agent "build a todo app" --model-provider openrouter-api-key
 ## Advanced: Manual Configuration
 
 <Callout type="warning">
-For most users, `vm0 model-provider setup` is the recommended approach. Manual configuration is only needed for advanced use cases.
+For most users, `vm0 org model-provider setup` is the recommended approach. Manual configuration is only needed for advanced use cases.
 </Callout>
 
 If you need per-agent authentication overrides or custom configurations, you can set environment variables directly in your `vm0.yaml`:

--- a/turbo/apps/docs/content/docs/model-selection/minimax.mdx
+++ b/turbo/apps/docs/content/docs/model-selection/minimax.mdx
@@ -8,7 +8,7 @@ description: Use MiniMax M2.1 model with VM0
 ## Quick Setup
 
 ```bash
-vm0 model-provider setup --type minimax-api-key
+vm0 org model-provider setup --type minimax-api-key
 ```
 
 You'll be prompted for your API key.
@@ -26,7 +26,7 @@ Visit the [MiniMax Platform](https://platform.minimax.io/user-center/basic-infor
 ## Non-Interactive Setup
 
 ```bash
-vm0 model-provider setup --type minimax-api-key --secret "xxx"
+vm0 org model-provider setup --type minimax-api-key --secret "xxx"
 ```
 
 ## Run

--- a/turbo/apps/docs/content/docs/model-selection/moonshot.mdx
+++ b/turbo/apps/docs/content/docs/model-selection/moonshot.mdx
@@ -8,7 +8,7 @@ description: Use Kimi K2 models with VM0
 ## Quick Setup
 
 ```bash
-vm0 model-provider setup --type moonshot-api-key
+vm0 org model-provider setup --type moonshot-api-key
 ```
 
 You'll be prompted for your API key and model selection.
@@ -29,10 +29,10 @@ Visit the [Moonshot Platform](https://platform.moonshot.ai/console/api-keys) to 
 
 ```bash
 # With default model
-vm0 model-provider setup --type moonshot-api-key --secret "sk-xxx"
+vm0 org model-provider setup --type moonshot-api-key --secret "sk-xxx"
 
 # With specific model
-vm0 model-provider setup --type moonshot-api-key --secret "sk-xxx" --model "kimi-k2-thinking-turbo"
+vm0 org model-provider setup --type moonshot-api-key --secret "sk-xxx" --model "kimi-k2-thinking-turbo"
 ```
 
 ## Run

--- a/turbo/apps/docs/content/docs/model-selection/openrouter.mdx
+++ b/turbo/apps/docs/content/docs/model-selection/openrouter.mdx
@@ -8,7 +8,7 @@ description: Use Claude models through OpenRouter
 ## Quick Setup
 
 ```bash
-vm0 model-provider setup --type openrouter-api-key
+vm0 org model-provider setup --type openrouter-api-key
 ```
 
 You'll be prompted for your API key and model selection.
@@ -35,10 +35,10 @@ If no model is specified during setup, Claude Code uses its built-in default mod
 
 ```bash
 # With recommended model
-vm0 model-provider setup --type openrouter-api-key --secret "sk-or-xxx" --model "anthropic/claude-sonnet-4.5"
+vm0 org model-provider setup --type openrouter-api-key --secret "sk-or-xxx" --model "anthropic/claude-sonnet-4.5"
 
 # Without model (Claude Code uses its built-in default)
-vm0 model-provider setup --type openrouter-api-key --secret "sk-or-xxx"
+vm0 org model-provider setup --type openrouter-api-key --secret "sk-or-xxx"
 ```
 
 ## Run

--- a/turbo/apps/docs/content/docs/model-selection/zai.mdx
+++ b/turbo/apps/docs/content/docs/model-selection/zai.mdx
@@ -8,7 +8,7 @@ description: Use GLM models with VM0
 ## Quick Setup
 
 ```bash
-vm0 model-provider setup --type zai-api-key
+vm0 org model-provider setup --type zai-api-key
 ```
 
 You'll be prompted for your API key and model selection.
@@ -29,10 +29,10 @@ Visit the [Z.AI Platform](https://z.ai/model-api) to create and obtain an API ke
 
 ```bash
 # With default model
-vm0 model-provider setup --type zai-api-key --secret "xxx"
+vm0 org model-provider setup --type zai-api-key --secret "xxx"
 
 # With specific model
-vm0 model-provider setup --type zai-api-key --secret "xxx" --model "glm-4.5-air"
+vm0 org model-provider setup --type zai-api-key --secret "xxx" --model "glm-4.5-air"
 ```
 
 ## Run

--- a/turbo/apps/docs/content/docs/quick-start.mdx
+++ b/turbo/apps/docs/content/docs/quick-start.mdx
@@ -31,7 +31,7 @@ vm0 auth login
 Configure your model provider credentials (one-time setup):
 
 ```bash
-vm0 model-provider setup
+vm0 org model-provider setup
 ```
 
 This interactive command will prompt you to select a provider and enter your credentials. The credentials are stored securely on VM0's servers and automatically used in all your agent runs.

--- a/turbo/apps/docs/content/docs/reference/cli/index.mdx
+++ b/turbo/apps/docs/content/docs/reference/cli/index.mdx
@@ -35,28 +35,28 @@ Manage third-party service connections.
 | `vm0 connector disconnect <type>` | Disconnect a third-party service | - |
 | `vm0 connector status <type>` | Show detailed status of a connector | - |
 
-## Model Provider Management
+## Organization Model Provider Management
 
-Configure model providers for agent runs.
+Configure model providers for agent runs at the organization level.
 
 | Command | Description | Options |
 | ------- | ----------- | ------- |
-| `vm0 model-provider list` | List configured model providers | - |
-| `vm0 model-provider setup` | Configure a model provider | `-t, --type <type>`, `-s, --secret <value>`, `-a, --auth-method <method>`, `-m, --model <model>` |
-| `vm0 model-provider delete <type>` | Delete a model provider | - |
-| `vm0 model-provider set-default <type>` | Set a model provider as default for its framework | - |
+| `vm0 org model-provider list` | List configured model providers | - |
+| `vm0 org model-provider setup` | Configure a model provider | `-t, --type <type>`, `-s, --secret <value>`, `-a, --auth-method <method>`, `-m, --model <model>` |
+| `vm0 org model-provider remove <type>` | Remove a model provider | - |
+| `vm0 org model-provider set-default <type>` | Set a model provider as default for its framework | - |
 
-### `vm0 model-provider setup` Examples
+### `vm0 org model-provider setup` Examples
 
 ```bash
 # Interactive setup
-vm0 model-provider setup
+vm0 org model-provider setup
 
 # Non-interactive setup
-vm0 model-provider setup --type anthropic-api-key --secret "sk-ant-xxx"
+vm0 org model-provider setup --type anthropic-api-key --secret "sk-ant-xxx"
 
 # Non-interactive with auth method and model
-vm0 model-provider setup --type aws-bedrock --auth-method iam --secret "AWS_ACCESS_KEY_ID=xxx" --secret "AWS_SECRET_ACCESS_KEY=yyy" --model claude-sonnet-4-20250514
+vm0 org model-provider setup --type aws-bedrock --auth-method iam --secret "AWS_ACCESS_KEY_ID=xxx" --secret "AWS_SECRET_ACCESS_KEY=yyy" --model claude-sonnet-4-20250514
 ```
 
 ## Secret Management

--- a/turbo/apps/docs/content/docs/tutorial/my-first-agent.mdx
+++ b/turbo/apps/docs/content/docs/tutorial/my-first-agent.mdx
@@ -10,7 +10,7 @@ In this guide, you'll create your first VM0 agent, configure it, and run it to s
 Before starting, make sure you have:
 - VM0 CLI installed (`npm install -g @vm0/cli`)
 - Authenticated with VM0 (`vm0 auth login`)
-- Model provider configured (`vm0 model-provider setup`) - see [Quick Start](/docs/quick-start) if you haven't done this yet
+- Model provider configured (`vm0 org model-provider setup`) - see [Quick Start](/docs/quick-start) if you haven't done this yet
 
 ## Step 1: Create Your Project
 

--- a/turbo/apps/web/app/api/model-providers/[type]/convert/route.ts
+++ b/turbo/apps/web/app/api/model-providers/[type]/convert/route.ts
@@ -27,7 +27,7 @@ const router = tsr.router(modelProvidersConvertContract, {
     return createErrorResponse(
       "BAD_REQUEST",
       "Credential conversion is no longer needed. User secrets and model provider secrets are now isolated by type. " +
-        "Simply configure your model provider directly with `vm0 model-provider setup`.",
+        "Simply configure your model provider directly with `vm0 org model-provider setup`.",
     );
   },
 });

--- a/turbo/apps/web/src/lib/model-provider/model-provider-service.ts
+++ b/turbo/apps/web/src/lib/model-provider/model-provider-service.ts
@@ -569,7 +569,7 @@ export async function upsertMultiAuthModelProvider(
 export async function convertSecretToModelProvider(): Promise<never> {
   throw badRequest(
     "Secret conversion is no longer needed. User secrets and model provider secrets are now isolated by type. " +
-      "Simply configure your model provider directly with `vm0 model-provider setup`.",
+      "Simply configure your model provider directly with `vm0 org model-provider setup`.",
   );
 }
 


### PR DESCRIPTION
## Summary

- Replace all `vm0 model-provider` references with `vm0 org model-provider` across 12 docs files and 2 web files
- Update `vm0 model-provider delete` to `vm0 org model-provider remove` to match org-level command naming
- Update CLI reference table and section header for org-level model provider commands

Closes #5323

## Test plan

- [x] Docs build passes
- [x] No remaining `vm0 model-provider` (without `org`) references in docs or web
- [x] No double-replacement (`vm0 org org`) issues
- [x] Pre-commit checks (prettier, knip, commitlint) all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)