### PR TITLE
refactor: remove model provider step from member onboarding flow

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/zero-onboarding.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-onboarding.tsx
@@ -722,9 +722,7 @@ export function MemberWelcome({
   agentName?: string;
   zeroAvatarSrc?: string;
 }) {
-  const step$ = useCCState<"welcome" | "provider" | "connectors" | "where">(
-    "welcome",
-  );
+  const step$ = useCCState<"welcome" | "connectors" | "where">("welcome");
   const step = useGet(step$);
   const setStep = useSet(step$);
   const completeMember = useSet(completeMemberOnboarding$);
@@ -736,27 +734,6 @@ export function MemberWelcome({
   const setSelected = useSet(setSelectedConnectorType$);
   const connectConnectorFn = useSet(connectConnector$);
   const pageSignal = useGet(pageSignal$);
-
-  // Model provider state
-  const hasModelProviderLoadable = useLastLoadable(zeroHasModelProvider$);
-  const hasModelProvider =
-    hasModelProviderLoadable.state === "hasData" &&
-    hasModelProviderLoadable.data === true;
-  const providerType = useGet(zeroProviderType$);
-  const formValues = useGet(zeroFormValues$);
-  const saving = useGet(zeroSaving$);
-  const canSave = useGet(zeroCanSave$);
-  const setProviderType = useSet(setZeroProviderType$);
-  const setSecret = useSet(setZeroSecret$);
-  const setModel = useSet(setZeroModel$);
-  const setUseDefaultModel = useSet(setZeroUseDefaultModel$);
-  const setAuthMethod = useSet(setZeroAuthMethod$);
-  const setSecretField = useSet(setZeroSecretField$);
-  const saveModelProvider = useSet(saveZeroModelProvider$);
-  const features = useLastResolved(featureSwitch$);
-  const providerPicked$ = useCCState(false);
-  const providerPicked = useGet(providerPicked$);
-  const setProviderPicked = useSet(providerPicked$);
 
   // Get the default agent's skills from onboarding status
   const onboardingStatus = useLastResolved(zeroOnboardingStatus$);
@@ -842,9 +819,7 @@ export function MemberWelcome({
           <div className={`${footerClass} justify-end`}>
             <Button
               onClick={() => {
-                if (!hasModelProvider) {
-                  setStep("provider");
-                } else if (memberSkills.length > 0) {
+                if (memberSkills.length > 0) {
                   setStep("connectors");
                 } else {
                   setStep("where");
@@ -858,114 +833,7 @@ export function MemberWelcome({
         </DialogContent>
       </Dialog>
 
-      {/* Step 2: Add model provider */}
-      <Dialog open={step === "provider"}>
-        <DialogContent
-          className={`${dialogBaseClass} zero-onboarding-dialog`}
-          onPointerDownOutside={(e) => e.preventDefault()}
-          onEscapeKeyDown={(e) => e.preventDefault()}
-          aria-describedby={undefined}
-        >
-          <div className="flex-1 min-h-0 overflow-y-auto flex flex-col justify-center px-8 pt-8 pb-8">
-            {providerPicked ? (
-              <div className="flex flex-col items-center pt-10">
-                <div className="flex items-center justify-center gap-3 mb-6">
-                  <span className="flex h-10 w-10 shrink-0 items-center justify-center overflow-hidden">
-                    <ProviderIcon type={providerType} size={28} />
-                  </span>
-                  <h2 className="text-xl font-semibold tracking-tight text-foreground">
-                    {getUILabel(providerType)}
-                  </h2>
-                </div>
-                <div className="w-full max-w-md flex flex-col gap-4 text-left">
-                  <ProviderFormFields
-                    providerType={providerType}
-                    formValues={formValues}
-                    onProviderTypeChange={() => {}}
-                    onSecretChange={setSecret}
-                    onModelChange={setModel}
-                    onUseDefaultModelChange={setUseDefaultModel}
-                    onAuthMethodChange={setAuthMethod}
-                    onSecretFieldChange={setSecretField}
-                    isLoading={saving}
-                  />
-                </div>
-              </div>
-            ) : (
-              <div className="flex flex-col items-center text-center">
-                <DialogHeader className="space-y-2">
-                  <DialogTitle className="text-xl font-semibold tracking-tight">
-                    Add model provider
-                  </DialogTitle>
-                </DialogHeader>
-                <p className="text-sm text-muted-foreground leading-relaxed mt-1 mb-6 max-w-[400px]">
-                  Bring your own model. We never charge for chat. Pick a
-                  provider below to get started.
-                </p>
-                <div className="w-full flex flex-wrap justify-center gap-3">
-                  {MODEL_PROVIDER_LIST.filter((type) =>
-                    isProviderVisible(type, features ?? {}),
-                  ).map((type) => {
-                    const config = MODEL_PROVIDER_TYPES[type];
-                    return (
-                      <button
-                        key={type}
-                        type="button"
-                        onClick={() => {
-                          setProviderType(type);
-                          setProviderPicked(true);
-                        }}
-                        className="zero-card flex items-center gap-2 rounded-xl border border-border px-3 py-2 min-w-0 hover:border-primary/30 hover:bg-muted/30 transition-colors text-left"
-                      >
-                        <span className="flex h-8 w-8 shrink-0 items-center justify-center overflow-hidden">
-                          <ProviderIcon type={type} size={18} />
-                        </span>
-                        <span className="text-sm font-medium text-foreground whitespace-nowrap">
-                          {config.label}
-                        </span>
-                      </button>
-                    );
-                  })}
-                </div>
-              </div>
-            )}
-          </div>
-          <div className={`${footerClass} justify-between`}>
-            <Button
-              variant="ghost"
-              className="rounded-lg text-muted-foreground"
-              onClick={() => {
-                if (providerPicked) {
-                  setProviderPicked(false);
-                } else {
-                  setStep("welcome");
-                }
-              }}
-              disabled={saving}
-            >
-              Back
-            </Button>
-            <Button
-              onClick={() => {
-                const controller = new AbortController();
-                detach(
-                  (async () => {
-                    await saveModelProvider(controller.signal);
-                    setStep(memberSkills.length > 0 ? "connectors" : "where");
-                  })(),
-                  Reason.DomCallback,
-                );
-              }}
-              className="rounded-lg min-w-[100px]"
-              disabled={!providerPicked || !canSave || saving}
-            >
-              {saving ? "Saving\u2026" : "Next"}
-            </Button>
-          </div>
-        </DialogContent>
-      </Dialog>
-
-      {/* Step 3: Connect your tools */}
+      {/* Step 2: Connect your tools */}
       <Dialog open={step === "connectors"}>
         <DialogContent
           className={`${dialogBaseClass} zero-onboarding-dialog`}
@@ -1036,7 +904,7 @@ export function MemberWelcome({
             <Button
               variant="ghost"
               className="rounded-lg text-muted-foreground"
-              onClick={() => setStep(hasModelProvider ? "welcome" : "provider")}
+              onClick={() => setStep("welcome")}
             >
               Back
             </Button>
@@ -1132,8 +1000,6 @@ export function MemberWelcome({
               onClick={() => {
                 if (memberSkills.length > 0) {
                   setStep("connectors");
-                } else if (!hasModelProvider) {
-                  setStep("provider");
                 } else {
                   setStep("welcome");
                 }

--- a/turbo/apps/web/app/api/onboarding/status/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/onboarding/status/__tests__/route.test.ts
@@ -3,6 +3,7 @@ import { GET } from "../route";
 import {
   createTestRequest,
   createTestCompose,
+  createTestModelProvider,
 } from "../../../../../src/__tests__/api-test-helpers";
 import { upsertOrgModelProvider } from "../../../../../src/lib/model-provider/model-provider-service";
 import { testContext } from "../../../../../src/__tests__/test-helpers";
@@ -72,13 +73,10 @@ describe("GET /api/onboarding/status", () => {
     expect(data.needsOnboarding).toBe(true);
   });
 
-  it("should return hasModelProvider=true, hasDefaultAgent=false when provider exists but no default agent", async () => {
-    const user = await context.setupUser();
-    await upsertOrgModelProvider(
-      user.orgId,
-      "anthropic-api-key",
-      "test-secret-key",
-    );
+  it("should return hasModelProvider=false when only user-level provider exists (org-level required)", async () => {
+    await context.setupUser();
+    // createTestModelProvider creates a user-level provider, not org-level
+    await createTestModelProvider("anthropic-api-key", "test-secret-key");
 
     const request = createTestRequest(
       "http://localhost:3000/api/onboarding/status",
@@ -88,7 +86,7 @@ describe("GET /api/onboarding/status", () => {
 
     expect(response.status).toBe(200);
     expect(data.hasOrg).toBe(true);
-    expect(data.hasModelProvider).toBe(true);
+    expect(data.hasModelProvider).toBe(false);
     expect(data.hasDefaultAgent).toBe(false);
     expect(data.needsOnboarding).toBe(true);
   });
@@ -116,13 +114,8 @@ describe("GET /api/onboarding/status", () => {
     expect(data.needsOnboarding).toBe(true);
   });
 
-  it("should return needsOnboarding=false when all conditions met", async () => {
+  it("should return needsOnboarding=false when default agent is configured", async () => {
     const user = await context.setupUser();
-    await upsertOrgModelProvider(
-      user.orgId,
-      "anthropic-api-key",
-      "test-secret-key",
-    );
 
     // Create a compose and set as default via API
     const compose = await createTestCompose("test-agent");
@@ -156,7 +149,7 @@ describe("GET /api/onboarding/status", () => {
       needsOnboarding: false,
       isAdmin: true,
       hasOrg: true,
-      hasModelProvider: true,
+      hasModelProvider: false,
       hasDefaultAgent: true,
       defaultAgentName: "test-agent",
       defaultAgentComposeId: compose.composeId,
@@ -167,11 +160,6 @@ describe("GET /api/onboarding/status", () => {
 
   it("should return defaultAgentMetadata when compose has metadata", async () => {
     const user = await context.setupUser();
-    await upsertOrgModelProvider(
-      user.orgId,
-      "anthropic-api-key",
-      "test-secret-key",
-    );
 
     // Create a compose with metadata
     const compose = await createTestCompose("test-agent", {
@@ -206,13 +194,49 @@ describe("GET /api/onboarding/status", () => {
       needsOnboarding: false,
       isAdmin: true,
       hasOrg: true,
-      hasModelProvider: true,
+      hasModelProvider: false,
       hasDefaultAgent: true,
       defaultAgentName: "test-agent",
       defaultAgentComposeId: compose.composeId,
       defaultAgentMetadata: { displayName: "My Agent", sound: "friendly" },
       defaultAgentSkills: [],
     });
+  });
+
+  it("should return needsOnboarding=false for admin with default agent but no model provider", async () => {
+    const user = await context.setupUser();
+
+    // Create a compose and set as default via API (no model provider created)
+    const compose = await createTestCompose("test-agent");
+
+    const setDefaultRequest = createTestRequest(
+      "http://localhost:3000/api/orgs/default-agent",
+      {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ agentComposeId: compose.composeId }),
+      },
+    );
+    const setDefaultResponse = await setDefaultAgent(setDefaultRequest);
+    expect(setDefaultResponse.status).toBe(200);
+
+    // Re-mock Clerk so the JWT session claim includes the compose ID
+    mockClerk({
+      userId: user.userId,
+      orgDefaultAgentComposeId: compose.composeId,
+    });
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/onboarding/status",
+    );
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.hasOrg).toBe(true);
+    expect(data.hasModelProvider).toBe(false);
+    expect(data.hasDefaultAgent).toBe(true);
+    expect(data.needsOnboarding).toBe(false);
   });
 
   it("should return needsOnboarding=true for non-admin member who has not completed onboarding", async () => {

--- a/turbo/apps/web/app/api/onboarding/status/route.ts
+++ b/turbo/apps/web/app/api/onboarding/status/route.ts
@@ -5,12 +5,12 @@ import { getAuthContext } from "../../../../src/lib/auth/get-auth-context";
 import { resolveOrg } from "../../../../src/lib/org/resolve-org";
 import { isBadRequest, isNotFound } from "../../../../src/lib/errors";
 import { modelProviders } from "../../../../src/db/schema/model-provider";
+import { ORG_SENTINEL_USER_ID } from "../../../../src/lib/org/org-sentinel";
 import {
   agentComposes,
   agentComposeVersions,
 } from "../../../../src/db/schema/agent-compose";
-import { eq, and, or } from "drizzle-orm";
-import { ORG_SENTINEL_USER_ID } from "../../../../src/lib/org/org-sentinel";
+import { eq, and } from "drizzle-orm";
 import { agentComposeApiContentSchema } from "@vm0/core";
 import { clerkClient } from "@clerk/nextjs/server";
 import { orgMembersCache } from "../../../../src/db/schema/org-members-cache";
@@ -85,17 +85,14 @@ const router = tsr.router(onboardingStatusContract, {
       resolvedOrgId = resolvedOrg.orgId;
       isAdmin = member.role === "admin";
 
-      // Check model provider for this user or org-level (matches runtime fallback in build-context.ts)
+      // Check if the org has an org-level model provider configured
       const [provider] = await globalThis.services.db
         .select({ id: modelProviders.id })
         .from(modelProviders)
         .where(
           and(
             eq(modelProviders.orgId, resolvedOrg.orgId),
-            or(
-              eq(modelProviders.userId, authCtx.userId),
-              eq(modelProviders.userId, ORG_SENTINEL_USER_ID),
-            ),
+            eq(modelProviders.userId, ORG_SENTINEL_USER_ID),
           ),
         )
         .limit(1);
@@ -149,14 +146,14 @@ const router = tsr.router(onboardingStatusContract, {
       // Org not found or no explicit org context — all flags stay false
     }
 
-    // Admins need onboarding when org setup is incomplete.
+    // Admins need onboarding when no default agent is configured.
     // Members need onboarding when they haven't completed the member welcome flow
     // (tracked via Clerk membership metadata `onboarding_done`).
     let needsOnboarding: boolean;
     if (!hasOrg) {
       needsOnboarding = true;
     } else if (isAdmin) {
-      needsOnboarding = !hasModelProvider || !hasDefaultAgent;
+      needsOnboarding = !hasDefaultAgent;
     } else {
       // resolvedOrgId is set whenever hasOrg is true (both come from the same try block)
       if (!resolvedOrgId) {

--- a/turbo/apps/web/app/api/orgs/default-agent/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/orgs/default-agent/__tests__/route.test.ts
@@ -48,19 +48,19 @@ describe("PUT /api/orgs/default-agent", () => {
     expect(data.agentComposeId).toBe(compose.composeId);
   });
 
-  it("should allow admin to unset default agent", async () => {
+  it("should return 409 when trying to unset an already-configured default agent", async () => {
     await context.setupUser();
     const compose = await createTestCompose("test-agent");
 
     // Set first
     await putDefaultAgent(undefined, compose.composeId);
 
-    // Then unset
+    // Attempt to unset — blocked by 409 guard
     const response = await putDefaultAgent(undefined, null);
-    expect(response.status).toBe(200);
+    expect(response.status).toBe(409);
 
     const data = await response.json();
-    expect(data.agentComposeId).toBeNull();
+    expect(data.error.code).toBe("CONFLICT");
   });
 
   it("should reject non-admin members", async () => {
@@ -101,22 +101,28 @@ describe("PUT /api/orgs/default-agent", () => {
     });
   });
 
-  it("should dual-write null to Clerk org metadata when unsetting", async () => {
+  it("should not update Clerk metadata when 409 conflict prevents unsetting", async () => {
     await context.setupUser();
     const compose = await createTestCompose("test-agent");
 
     await putDefaultAgent(undefined, compose.composeId);
-    await putDefaultAgent(undefined, null);
 
     const client = await vi.mocked(clerkClient)();
+    const callCountAfterSet = vi.mocked(
+      client.organizations.updateOrganizationMetadata,
+    ).mock.calls.length;
+
+    // Attempt to unset — should be rejected with 409
+    const response = await putDefaultAgent(undefined, null);
+    expect(response.status).toBe(409);
+
+    // updateOrganizationMetadata should not have been called again
     expect(
       client.organizations.updateOrganizationMetadata,
-    ).toHaveBeenLastCalledWith(expect.any(String), {
-      publicMetadata: { default_agent_compose_id: null },
-    });
+    ).toHaveBeenCalledTimes(callCountAfterSet);
   });
 
-  it("should return 200 when setting same agent twice", async () => {
+  it("should return 409 when setting default agent twice", async () => {
     await context.setupUser();
     const compose = await createTestCompose("test-agent");
 
@@ -124,11 +130,23 @@ describe("PUT /api/orgs/default-agent", () => {
     const response1 = await putDefaultAgent(undefined, compose.composeId);
     expect(response1.status).toBe(200);
 
-    // Set same default again (idempotent)
+    // Attempt to set again — blocked by 409 guard
     const response2 = await putDefaultAgent(undefined, compose.composeId);
-    expect(response2.status).toBe(200);
+    expect(response2.status).toBe(409);
 
     const data = await response2.json();
+    expect(data.error.code).toBe("CONFLICT");
+  });
+
+  it("should allow setting default agent when none is configured", async () => {
+    await context.setupUser();
+    const compose = await createTestCompose("test-agent");
+
+    // No default agent configured yet — should succeed
+    const response = await putDefaultAgent(undefined, compose.composeId);
+    expect(response.status).toBe(200);
+
+    const data = await response.json();
     expect(data.agentComposeId).toBe(compose.composeId);
   });
 });

--- a/turbo/apps/web/app/api/orgs/default-agent/route.ts
+++ b/turbo/apps/web/app/api/orgs/default-agent/route.ts
@@ -37,8 +37,7 @@ const router = tsr.router(orgDefaultAgentContract, {
 
     const { agentComposeId } = body;
 
-    // Prevent overwriting an existing default agent with a different one.
-    // Allow: unsetting (null), or setting the same agent again (idempotent).
+    // Once a default agent is configured, prevent any further changes.
     const client = await clerkClient();
     const clerkOrg = await client.organizations.getOrganization({
       organizationId: org.orgId,
@@ -46,11 +45,7 @@ const router = tsr.router(orgDefaultAgentContract, {
     const existingComposeId = (
       clerkOrg.publicMetadata as Record<string, unknown>
     )?.default_agent_compose_id;
-    if (
-      existingComposeId &&
-      agentComposeId !== null &&
-      existingComposeId !== agentComposeId
-    ) {
+    if (existingComposeId) {
       return {
         status: 409 as const,
         body: {

--- a/turbo/apps/web/app/api/orgs/default-agent/route.ts
+++ b/turbo/apps/web/app/api/orgs/default-agent/route.ts
@@ -37,7 +37,8 @@ const router = tsr.router(orgDefaultAgentContract, {
 
     const { agentComposeId } = body;
 
-    // Prevent overwriting an existing default agent
+    // Prevent overwriting an existing default agent with a different one.
+    // Allow: unsetting (null), or setting the same agent again (idempotent).
     const client = await clerkClient();
     const clerkOrg = await client.organizations.getOrganization({
       organizationId: org.orgId,
@@ -45,7 +46,11 @@ const router = tsr.router(orgDefaultAgentContract, {
     const existingComposeId = (
       clerkOrg.publicMetadata as Record<string, unknown>
     )?.default_agent_compose_id;
-    if (existingComposeId) {
+    if (
+      existingComposeId &&
+      agentComposeId !== null &&
+      existingComposeId !== agentComposeId
+    ) {
       return {
         status: 409 as const,
         body: {

--- a/turbo/apps/web/app/api/orgs/default-agent/route.ts
+++ b/turbo/apps/web/app/api/orgs/default-agent/route.ts
@@ -37,6 +37,26 @@ const router = tsr.router(orgDefaultAgentContract, {
 
     const { agentComposeId } = body;
 
+    // Prevent overwriting an existing default agent
+    const client = await clerkClient();
+    const clerkOrg = await client.organizations.getOrganization({
+      organizationId: org.orgId,
+    });
+    const existingComposeId = (
+      clerkOrg.publicMetadata as Record<string, unknown>
+    )?.default_agent_compose_id;
+    if (existingComposeId) {
+      return {
+        status: 409 as const,
+        body: {
+          error: {
+            message: "A default agent is already configured for this org",
+            code: "CONFLICT",
+          },
+        },
+      };
+    }
+
     if (agentComposeId !== null) {
       // Verify agent exists and belongs to this org
       const [compose] = await globalThis.services.db
@@ -63,7 +83,6 @@ const router = tsr.router(orgDefaultAgentContract, {
       }
     }
 
-    const client = await clerkClient();
     await client.organizations.updateOrganizationMetadata(org.orgId, {
       publicMetadata: { default_agent_compose_id: agentComposeId },
     });

--- a/turbo/packages/core/src/contracts/orgs.ts
+++ b/turbo/packages/core/src/contracts/orgs.ts
@@ -122,6 +122,7 @@ export const orgDefaultAgentContract = c.router({
       401: apiErrorSchema,
       403: apiErrorSchema,
       404: apiErrorSchema,
+      409: apiErrorSchema,
     },
     summary: "Set or unset the default agent for an org",
   },


### PR DESCRIPTION
## Summary

- Removes the "provider" step from the `MemberWelcome` onboarding dialog, simplifying the flow from welcome → provider → connectors → where to welcome → connectors → where
- Updates the onboarding status API to check for an org-level model provider (via `ORG_SENTINEL_USER_ID`) instead of a user-level one
- Fixes the admin onboarding condition to only require a default agent to be configured (no longer gating on model provider presence)
- Adds a 409 Conflict guard to the `PUT /api/orgs/default-agent` route to prevent overwriting an already-configured default agent, and exposes this in the contract type

## Test plan

- [ ] Sign up as a new member and verify the model provider step no longer appears in onboarding
- [ ] Verify the "Back" button on the connectors step returns to the welcome step (not the removed provider step)
- [ ] Verify the "Back" button on the "where" step skips the provider step correctly
- [ ] As an admin with no default agent configured, confirm onboarding is shown
- [ ] As an admin with a default agent configured, confirm onboarding is not shown
- [ ] Call `PUT /api/orgs/default-agent` twice and verify the second call returns 409

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #5241
Closes #5324