### PR TITLE
fix(web): skip clerk middleware for sandbox token requests

### DIFF
--- a/turbo/apps/web/__tests__/proxy.sandbox-token.test.ts
+++ b/turbo/apps/web/__tests__/proxy.sandbox-token.test.ts
@@ -58,7 +58,7 @@ describe("proxy middleware: sandbox token handling", () => {
     capturedClerkRequest = undefined;
   });
 
-  it("should strip sandbox token before Clerk and restore it after", async () => {
+  it("should skip Clerk for sandbox tokens and preserve authorization header", async () => {
     const token = "Bearer vm0_sandbox_header.payload.signature";
     const request = new NextRequest("https://www.vm0.ai/api/sandbox/webhook", {
       headers: { authorization: token },
@@ -66,23 +66,11 @@ describe("proxy middleware: sandbox token handling", () => {
 
     const response = await middleware(request, createMockEvent());
 
-    // Clerk should NOT see the Authorization header
-    expect(capturedClerkRequest).toBeDefined();
-    expect(capturedClerkRequest!.headers.get("authorization")).toBeNull();
+    // Clerk should NOT be called for sandbox token requests
+    expect(capturedClerkRequest).toBeUndefined();
 
-    // Clerk should see the original token in x-vm0-authorization
-    expect(capturedClerkRequest!.headers.get("x-vm0-authorization")).toBe(
-      token,
-    );
-
-    // Response should restore the Authorization header for the route handler
+    // Response should be a pass-through (NextResponse.next())
     expect(response).toBeDefined();
-    expect(response!.headers.get("x-middleware-request-authorization")).toBe(
-      token,
-    );
-    expect(
-      response!.headers.get("x-middleware-request-x-vm0-authorization"),
-    ).toBe(token);
   });
 
   it("should pass non-sandbox tokens through to Clerk unchanged", async () => {

--- a/turbo/apps/web/proxy.ts
+++ b/turbo/apps/web/proxy.ts
@@ -1,6 +1,6 @@
 import { clerkMiddleware, createRouteMatcher } from "@clerk/nextjs/server";
 import type { NextFetchEvent } from "next/server";
-import { NextRequest } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import {
   runLayers,
   corsLayer,
@@ -97,29 +97,11 @@ export default async function middleware(
     authHeader?.startsWith("Bearer " + SANDBOX_TOKEN_PREFIX) ?? false;
 
   if (hasSandboxToken) {
-    // Clone the request without the Authorization header
-    const headers = new Headers(request.headers);
-    headers.delete("authorization");
-    headers.set("x-vm0-authorization", authHeader!);
-
-    const rewritten = new NextRequest(request.url, {
-      method: request.method,
-      headers,
-      body: request.body,
-      duplex: "half",
-    });
-
-    const response = await clerk(rewritten, event);
-
-    // Restore the original Authorization header for the route handler
-    if (response) {
-      response.headers.set("x-middleware-request-authorization", authHeader!);
-      response.headers.set(
-        "x-middleware-request-x-vm0-authorization",
-        authHeader!,
-      );
-    }
-    return response;
+    // Sandbox tokens are used by webhook endpoints which don't need Clerk auth.
+    // Skip Clerk entirely and pass the request through with the original
+    // Authorization header intact. This avoids relying on x-middleware-request-*
+    // header restoration which doesn't work reliably in Next.js dev mode.
+    return NextResponse.next();
   }
 
   return clerk(request, event);


### PR DESCRIPTION
## Summary

- Sandbox token (`vm0_sandbox_*`) requests now skip Clerk middleware entirely via `NextResponse.next()`, preserving the original `Authorization` header
- Previously, the proxy middleware stripped the header before Clerk and restored it via `x-middleware-request-*` headers, which doesn't work reliably in Next.js dev mode (turbopack)
- This caused all webhook endpoints (heartbeat, telemetry, complete) to return 401 in local development

## Test plan

- [x] `proxy.sandbox-token.test.ts` updated and passing
- [x] Type check passing
- [x] Lint passing
- [x] Knip passing
- [x] Verified locally: sandbox webhook requests (heartbeat, telemetry, complete) return 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)