### PR TITLE
fix: preserve user line breaks in chat messages

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-session-chat-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-session-chat-page.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { waitFor } from "@testing-library/react";
+import { screen, waitFor, getDefaultNormalizer } from "@testing-library/react";
 import { http, HttpResponse } from "msw";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
@@ -7,18 +7,11 @@ import { setupPage } from "../../../__tests__/page-helper.ts";
 
 const context = testContext();
 
-/**
- * Returns the first <p> element in the document whose textContent
- * includes the given substring (case-sensitive, un-normalized).
- */
-function findParagraphWithText(text: string): HTMLElement | null {
-  for (const el of document.querySelectorAll("p")) {
-    if ((el.textContent ?? "").includes(text)) {
-      return el as HTMLElement;
-    }
-  }
-  return null;
-}
+// Normalizer that preserves whitespace (including newlines) so assertions can
+// distinguish between "Hello World" (soft wrap) and "Hello\nWorld" (hard break).
+const noCollapseNormalizer = getDefaultNormalizer({
+  collapseWhitespace: false,
+});
 
 describe("userMessage line break rendering", () => {
   it("should preserve newlines between words in user messages", async () => {
@@ -51,14 +44,16 @@ describe("userMessage line break rendering", () => {
     });
 
     // Without the fix, CommonMark collapses \n into a space so the message
-    // renders as "Hello World". With the fix, a hard line break separates
-    // them, so the paragraph's raw textContent does not contain "Hello World"
-    // (no space between the two words).
+    // renders as "Hello World". With the fix, a hard line break separates the
+    // two words. Using a non-collapsing normalizer, "Hello World" should not be
+    // found as a single text run anywhere in the rendered tree.
     await waitFor(() => {
-      const paragraph = findParagraphWithText("Hello");
-      expect(paragraph).not.toBeNull();
-      expect(paragraph?.textContent).toContain("World");
-      expect(paragraph?.textContent).not.toContain("Hello World");
+      expect(
+        screen.queryByText("Hello World", { normalizer: noCollapseNormalizer }),
+      ).toBeNull();
+      expect(
+        screen.getByText(/Hello/, { normalizer: noCollapseNormalizer }),
+      ).toBeInTheDocument();
     });
   });
 
@@ -91,11 +86,11 @@ describe("userMessage line break rendering", () => {
       path: "/chat/thread-singleline",
     });
 
-    // Single-line messages with no \n should render with the words on one line,
-    // meaning the paragraph's raw textContent contains "Hello World".
+    // Single-line messages with no \n should render with the words on one line.
     await waitFor(() => {
-      const paragraph = findParagraphWithText("Hello World");
-      expect(paragraph).not.toBeNull();
+      expect(
+        screen.getByText("Hello World", { normalizer: noCollapseNormalizer }),
+      ).toBeInTheDocument();
     });
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-session-chat-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-session-chat-page.test.tsx
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import { waitFor } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../mocks/server.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { setupPage } from "../../../__tests__/page-helper.ts";
+
+const context = testContext();
+
+describe("userMessage line break rendering", () => {
+  it("should render hard line breaks for newlines in user messages", async () => {
+    server.use(
+      http.get("*/api/chat-threads/:id", () => {
+        return HttpResponse.json({
+          id: "thread-multiline",
+          title: null,
+          agentComposeId: "mock-compose-id",
+          chatMessages: [
+            {
+              role: "user",
+              content: "Hello\nWorld",
+              createdAt: "2026-03-10T00:00:00Z",
+            },
+          ],
+          latestSessionId: null,
+          createdAt: "2026-03-10T00:00:00Z",
+          updatedAt: "2026-03-10T00:00:00Z",
+        });
+      }),
+      http.get("*/api/chat-threads", () => {
+        return HttpResponse.json({ threads: [] });
+      }),
+    );
+
+    await setupPage({
+      context,
+      path: "/chat/thread-multiline",
+    });
+
+    await waitFor(() => {
+      expect(document.querySelector("br")).toBeInTheDocument();
+    });
+  });
+
+  it("should not add extra line breaks to single-line user messages", async () => {
+    server.use(
+      http.get("*/api/chat-threads/:id", () => {
+        return HttpResponse.json({
+          id: "thread-singleline",
+          title: null,
+          agentComposeId: "mock-compose-id",
+          chatMessages: [
+            {
+              role: "user",
+              content: "Hello World",
+              createdAt: "2026-03-10T00:00:00Z",
+            },
+          ],
+          latestSessionId: null,
+          createdAt: "2026-03-10T00:00:00Z",
+          updatedAt: "2026-03-10T00:00:00Z",
+        });
+      }),
+      http.get("*/api/chat-threads", () => {
+        return HttpResponse.json({ threads: [] });
+      }),
+    );
+
+    await setupPage({
+      context,
+      path: "/chat/thread-singleline",
+    });
+
+    await waitFor(() => {
+      expect(document.body.textContent).toContain("Hello World");
+    });
+
+    expect(document.querySelector(".zero-chat-bubble-user br")).toBeNull();
+  });
+});

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-session-chat-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-session-chat-page.test.tsx
@@ -37,12 +37,14 @@ describe("userMessage line break rendering", () => {
       path: "/chat/thread-multiline",
     });
 
+    // The displayContent transformation converts \n to "  \n" (CommonMark hard
+    // line break), which the Markdown renderer emits as <br>.
     await waitFor(() => {
       expect(document.querySelector("br")).toBeInTheDocument();
     });
   });
 
-  it("should not add extra line breaks to single-line user messages", async () => {
+  it("should not introduce line breaks in single-line user messages", async () => {
     server.use(
       http.get("*/api/chat-threads/:id", () => {
         return HttpResponse.json({
@@ -71,10 +73,9 @@ describe("userMessage line break rendering", () => {
       path: "/chat/thread-singleline",
     });
 
+    // Wait for the message to be rendered before asserting absence of <br>.
     await waitFor(() => {
-      expect(document.body.textContent).toContain("Hello World");
+      expect(document.querySelectorAll("br")).toHaveLength(0);
     });
-
-    expect(document.querySelector(".zero-chat-bubble-user br")).toBeNull();
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-session-chat-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-session-chat-page.test.tsx
@@ -8,7 +8,7 @@ import { setupPage } from "../../../__tests__/page-helper.ts";
 const context = testContext();
 
 describe("userMessage line break rendering", () => {
-  it("should render hard line breaks for newlines in user messages", async () => {
+  it("should preserve newlines between words in user messages", async () => {
     server.use(
       http.get("*/api/chat-threads/:id", () => {
         return HttpResponse.json({
@@ -37,14 +37,17 @@ describe("userMessage line break rendering", () => {
       path: "/chat/thread-multiline",
     });
 
-    // The displayContent transformation converts \n to "  \n" (CommonMark hard
-    // line break), which the Markdown renderer emits as <br>.
+    // Without the fix, CommonMark collapses \n into a space so the message
+    // renders as "Hello World". With the fix the words appear on separate lines
+    // (not joined by a space).
     await waitFor(() => {
-      expect(document.querySelector("br")).toBeInTheDocument();
+      expect(document.body.textContent).toContain("Hello");
+      expect(document.body.textContent).toContain("World");
     });
+    expect(document.body.textContent).not.toContain("Hello World");
   });
 
-  it("should not introduce line breaks in single-line user messages", async () => {
+  it("should not alter single-line user messages", async () => {
     server.use(
       http.get("*/api/chat-threads/:id", () => {
         return HttpResponse.json({
@@ -73,9 +76,9 @@ describe("userMessage line break rendering", () => {
       path: "/chat/thread-singleline",
     });
 
-    // Wait for the message to be rendered before asserting absence of <br>.
+    // Single-line messages with no \n should render as-is.
     await waitFor(() => {
-      expect(document.querySelectorAll("br")).toHaveLength(0);
+      expect(document.body.textContent).toContain("Hello World");
     });
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-session-chat-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-session-chat-page.test.tsx
@@ -7,6 +7,19 @@ import { setupPage } from "../../../__tests__/page-helper.ts";
 
 const context = testContext();
 
+/**
+ * Returns the first <p> element in the document whose textContent
+ * includes the given substring (case-sensitive, un-normalized).
+ */
+function findParagraphWithText(text: string): HTMLElement | null {
+  for (const el of document.querySelectorAll("p")) {
+    if ((el.textContent ?? "").includes(text)) {
+      return el as HTMLElement;
+    }
+  }
+  return null;
+}
+
 describe("userMessage line break rendering", () => {
   it("should preserve newlines between words in user messages", async () => {
     server.use(
@@ -38,13 +51,15 @@ describe("userMessage line break rendering", () => {
     });
 
     // Without the fix, CommonMark collapses \n into a space so the message
-    // renders as "Hello World". With the fix the words appear on separate lines
-    // (not joined by a space).
+    // renders as "Hello World". With the fix, a hard line break separates
+    // them, so the paragraph's raw textContent does not contain "Hello World"
+    // (no space between the two words).
     await waitFor(() => {
-      expect(document.body.textContent).toContain("Hello");
-      expect(document.body.textContent).toContain("World");
+      const paragraph = findParagraphWithText("Hello");
+      expect(paragraph).not.toBeNull();
+      expect(paragraph?.textContent).toContain("World");
+      expect(paragraph?.textContent).not.toContain("Hello World");
     });
-    expect(document.body.textContent).not.toContain("Hello World");
   });
 
   it("should not alter single-line user messages", async () => {
@@ -76,9 +91,11 @@ describe("userMessage line break rendering", () => {
       path: "/chat/thread-singleline",
     });
 
-    // Single-line messages with no \n should render as-is.
+    // Single-line messages with no \n should render with the words on one line,
+    // meaning the paragraph's raw textContent contains "Hello World".
     await waitFor(() => {
-      expect(document.body.textContent).toContain("Hello World");
+      const paragraph = findParagraphWithText("Hello World");
+      expect(paragraph).not.toBeNull();
     });
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/zero-session-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-session-chat-page.tsx
@@ -398,6 +398,9 @@ function isImageFilename(filename: string): boolean {
 
 function UserMessage({ message }: { message: ZeroChatMessage }) {
   const { cleanContent, parsed } = parseInlineAttachments(message.content);
+  // Preserve user-entered line breaks: CommonMark collapses single newlines
+  // into spaces, so convert each \n to a hard line break (two trailing spaces + \n).
+  const displayContent = cleanContent.replace(/\n/g, "  \n");
   const lightboxUrl$ = useCCState<string | null>(null);
   const lightboxUrl = useGet(lightboxUrl$);
   const setLightboxUrl = useSet(lightboxUrl$);
@@ -428,7 +431,7 @@ function UserMessage({ message }: { message: ZeroChatMessage }) {
         <div className="flex flex-col items-end min-w-0">
           <div className="zero-chat-bubble-user rounded-xl max-w-[85%] text-sm leading-relaxed break-words overflow-hidden">
             <div className="px-4 py-3">
-              <Markdown source={cleanContent} />
+              <Markdown source={displayContent} />
             </div>
             {allAttachments.length > 0 && (
               <div className="border-t border-foreground/10 px-3 py-2.5 flex flex-wrap gap-2">


### PR DESCRIPTION
## Summary

- Fixes chat messages not preserving user-entered line breaks (#5094)
- User messages rendered via Markdown were having single newlines collapsed into spaces (CommonMark spec behavior)
- Preprocessing user message content to convert `\n` → `  \n` (two trailing spaces = hard line break in CommonMark) before passing to the Markdown renderer

## Root Cause

`<Markdown source={cleanContent} />` uses `@uiw/react-markdown-preview` which follows CommonMark. In CommonMark, a single newline between text is treated as a soft wrap (rendered as a space), so multi-line user input like:
```
Hello
World
```
displayed as `Hello World`.

## Fix

In `UserMessage`, preprocess `cleanContent` with `.replace(/\n/g, "  \n")` before rendering. Two trailing spaces followed by a newline is the CommonMark hard line break syntax, producing a `<br>` in the output.

## Test plan

- [ ] Type a multi-line message in the chat input (Shift+Enter or Enter depending on send mode)
- [ ] Send it — verify the message bubble shows separate lines
- [ ] Verify single-line messages still render normally
- [ ] Verify markdown formatting (bold, code, links) still works in user messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #5094