### PR TITLE
fix: sub-agent connector display, back button history, and unsaved changes guard

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-nav.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-nav.test.ts
@@ -8,7 +8,6 @@ import {
   zeroChatAgentName$,
   zeroChatAgentId$,
   setZeroChatAgent$,
-  navigateFromZeroSession$,
 } from "../zero-nav.ts";
 
 const context = testContext();
@@ -139,48 +138,6 @@ describe("zero-nav", () => {
       });
       context.store.set(setZeroChatAgent$, null);
       expect(context.store.get(zeroChatAgentId$)).toBeNull();
-    });
-  });
-
-  describe("navigateFromZeroSession$", () => {
-    it("should navigate to / when no agent was selected", () => {
-      const pushStateMock = createPushStateMock(context.signal);
-      mockLocation({ pathname: "/chat/session-1", search: "" }, context.signal);
-
-      context.store.set(setZeroChatAgent$, null);
-      context.store.set(navigateFromZeroSession$);
-
-      expect(pushStateMock).toHaveBeenCalledWith({}, "", "/");
-    });
-
-    it("should navigate to /talk/:name when agent was selected", () => {
-      const pushStateMock = createPushStateMock(context.signal);
-      mockLocation({ pathname: "/chat/session-1", search: "" }, context.signal);
-
-      context.store.set(setZeroChatAgent$, {
-        id: "agent-123",
-        name: "my-agent",
-      });
-      context.store.set(navigateFromZeroSession$);
-
-      expect(pushStateMock).toHaveBeenCalledWith({}, "", "/talk/my-agent");
-    });
-
-    it("should encode agent names with special characters", () => {
-      const pushStateMock = createPushStateMock(context.signal);
-      mockLocation({ pathname: "/chat/session-1", search: "" }, context.signal);
-
-      context.store.set(setZeroChatAgent$, {
-        id: "agent-456",
-        name: "agent with spaces",
-      });
-      context.store.set(navigateFromZeroSession$);
-
-      expect(pushStateMock).toHaveBeenCalledWith(
-        {},
-        "",
-        "/talk/agent%20with%20spaces",
-      );
     });
   });
 });

--- a/turbo/apps/platform/src/signals/zero-page/zero-nav.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-nav.ts
@@ -72,13 +72,6 @@ export const zeroChatAgentId$ = computed((get): string | null => {
 });
 
 /**
- * Last chat agent name, preserved across non-chat navigation.
- * Used to maintain recent chat context when visiting schedule/team pages,
- * and to navigate back from sessions to the correct talk route.
- */
-const internalLastChatAgentName$ = state<string | null>(null);
-
-/**
  * Navigate to a zero tab — updates the URL path to `/:tab`.
  * "chat" maps to `/` (the default, no suffix needed).
  */
@@ -103,7 +96,6 @@ export const zeroTalkAgentResolved$ = computed((get) =>
 export const setZeroChatAgent$ = command(
   ({ set }, agent: { id: string; name: string } | null) => {
     set(internalChatAgentId$, agent?.id ?? null);
-    set(internalLastChatAgentName$, agent?.name ?? null);
     set(internalTalkAgentResolved$, true);
   },
 );
@@ -126,14 +118,8 @@ export const navigateToZeroSession$ = command(({ set }, sessionId: string) => {
 });
 
 /**
- * Navigate back from a chat session to the chat home.
- * Returns to `/talk/:name` if a team agent was selected, otherwise `/`.
+ * Navigate back from a chat session to the previous route in browser history.
  */
-export const navigateFromZeroSession$ = command(({ get, set }) => {
-  const agentName = get(internalLastChatAgentName$);
-  if (agentName) {
-    set(updatePathname$, `/talk/${encodeURIComponent(agentName)}`);
-  } else {
-    set(updatePathname$, "/");
-  }
+export const navigateFromZeroSession$ = command(() => {
+  window.history.back();
 });


### PR DESCRIPTION
## Summary

- **Issue #5244**: Fix sub-agent connector display in chat page — `zeroComposeId$` (in `zero-skills.ts`, renamed from `zero-meet.ts`) now checks `zeroChatAgentId$` first before falling back to the default agent's compose ID
- **Issue #5026 Fix 1**: `navigateFromZeroSession$` now calls `window.history.back()` for proper browser history navigation instead of going to a hardcoded route
- **Issue #5026 Fix 2**: Add unsaved changes guard to team detail page — navigation from breadcrumb or "Chat with agent" link is blocked when any tab (Connectors, Instructions, Profile) has unsaved changes; the unsaved bar shakes to draw attention

## Implementation Details

- Renamed `zero-meet.ts` → `zero-skills.ts` (+ test file) to reflect actual responsibilities
- Added two CSS animation variants (`zero-shake` / `zero-shake-alt`) that alternate on each navigation block, forcing a CSS animation restart without needing `useEffect` or timers
- Added `shakeKey` prop to `ZeroUnsavedBar`, `ZeroSkillsTab`, `ZeroInstructionsTab`, `ZeroSettingsTab`
- Added `onDirtyChange` callback to `ZeroSettingsTab` using `queueMicrotask` pattern (matching existing code style, avoids restricted `useEffect`/`useState` from `react`)
- `ZeroJobDetailPage` reads dirty state from `zeroJobSkillsDirty$` and `zeroJobInstructionsDirty$` signals directly, and receives settings dirty state via callback

## Test plan

- [ ] Navigate to a team member's detail page
- [ ] Make changes in Connectors tab → click "Zero's team" breadcrumb → unsaved bar shakes, navigation is blocked
- [ ] Make changes in Instructions tab → click "Chat with agent" → unsaved bar shakes, navigation is blocked
- [ ] Save changes → navigation works normally
- [ ] In chat session, click Back → returns to previous route (not home)
- [ ] When chatting with a sub-agent, their specific connectors/skills are shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)