### PR TITLE
fix(runner): increase gc keep-latest for dual-profile builds

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -230,8 +230,8 @@ jobs:
           ssh $REMOTE "rm -rf ${BIN_DIR} ~/.vm0-runner/runners/${JOB_REF}-bench ~/.vm0-runner/runners/${JOB_REF}-local && mkdir -p ${BIN_DIR}"
           scp "${TARGET_DIR}/runner" "${REMOTE}:${BIN_DIR}/"
 
-          # Clean up old rootfs/snapshots, keep the 3 most recent
-          ssh $REMOTE "${BIN_DIR}/runner gc --keep-latest 3"
+          # Clean up old rootfs/snapshots, keep the 6 most recent (3 deploys × 2 profiles)
+          ssh $REMOTE "${BIN_DIR}/runner gc --keep-latest 6"
 
           # Run setup (downloads firecracker/kernel/mitmdump, cached + idempotent)
           echo "=== Running setup ==="

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1159,8 +1159,8 @@ jobs:
             ssh $REMOTE "rm -rf ${BIN_DIR} ${RUNNER_DIR} && mkdir -p ${BIN_DIR}"
             scp "${TARGET_DIR}/runner" "${REMOTE}:${BIN_DIR}/"
 
-            # Clean up old rootfs/snapshots, keep the 3 most recent
-            ssh $REMOTE "${BIN_DIR}/runner gc --keep-latest 3"
+            # Clean up old rootfs/snapshots, keep the 6 most recent (3 deploys × 2 profiles)
+            ssh $REMOTE "${BIN_DIR}/runner gc --keep-latest 6"
 
             # Run setup (downloads firecracker/kernel/mitmdump, cached + idempotent)
             ssh $REMOTE "${BIN_DIR}/runner setup"

--- a/ansible/playbooks/deploy-runner.yml
+++ b/ansible/playbooks/deploy-runner.yml
@@ -108,7 +108,7 @@
       ignore_errors: true
 
     - name: Garbage collect old artifacts
-      command: "{{ bin_dir }}/runner gc --keep-latest 2"
+      command: "{{ bin_dir }}/runner gc --keep-latest 6"
 
     # ========================================
     # Phase 6: Final health check

--- a/scripts/dev-runner.sh
+++ b/scripts/dev-runner.sh
@@ -86,7 +86,7 @@ cmd_deploy() {
   ssh_cmd "$RUNNER_BIN setup"
 
   # Clean up old rootfs/snapshots
-  ssh_cmd "$RUNNER_BIN gc --keep-latest 2"
+  ssh_cmd "$RUNNER_BIN gc --keep-latest 6"
 
   # Build rootfs + snapshot
   log "Building rootfs and snapshot..."


### PR DESCRIPTION
## Summary

- Increase `runner gc --keep-latest` from 2-3 to 6 across all 4 callers
- With dual-profile builds (vm0/default + vm0/browser), each deploy produces 2 rootfs + 2 snapshot artifacts
- `--keep-latest 6` maintains 3 deploys of rollback capacity (6 ÷ 2 profiles = 3 deploys)

Closes #5344

## Files changed

| File | Old | New |
|------|-----|-----|
| `.github/workflows/crates.yml` | 3 | 6 |
| `.github/workflows/turbo.yml` | 3 | 6 |
| `ansible/playbooks/deploy-runner.yml` | 2 | 6 |
| `scripts/dev-runner.sh` | 2 | 6 |

## Test plan

- [ ] No functional changes — only gc retention count increased
- [ ] Verify `runner gc --keep-latest 6` keeps correct number of artifacts after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)