### PR TITLE
feat(platform): add experimental capabilities support for zero agents

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-job-detail.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-job-detail.test.ts
@@ -31,8 +31,14 @@ import {
   removeZeroJobSkill$,
   saveZeroJobSkills$,
   discardZeroJobSkills$,
+  zeroJobCapabilities$,
+  zeroJobCapabilitiesDirty$,
+  toggleZeroJobCapability$,
+  saveZeroJobCapabilities$,
+  discardZeroJobCapabilities$,
   type ZeroJobScheduleSaveParams,
 } from "../zero-job-detail";
+import { injectDefaultCapabilities } from "../compose-job";
 
 const context = testContext();
 
@@ -976,6 +982,199 @@ describe("zero-job-detail signals", () => {
       await context.store.set(saveZeroJobSkills$);
 
       expect(context.store.get(zeroJobSettingsSaving$)).toBeFalsy();
+    });
+  });
+
+  describe("capabilities management", () => {
+    function mockAgentWithCapabilities(caps?: string[]) {
+      return {
+        id: "compose-1",
+        name: "my-agent",
+        headVersionId: "v1",
+        content: {
+          version: "1",
+          agents: {
+            main: {
+              description: "A test agent",
+              framework: "claude-code",
+              ...(caps ? { experimental_capabilities: caps } : {}),
+            },
+          },
+        },
+        createdAt: "2024-01-01T00:00:00Z",
+        updatedAt: "2024-06-15T12:00:00Z",
+      };
+    }
+
+    async function setupWithCapabilities(caps?: string[]) {
+      server.use(
+        http.get("http://localhost:3000/api/agent/composes", () => {
+          return HttpResponse.json(mockAgentWithCapabilities(caps));
+        }),
+        http.get(
+          "http://localhost:3000/api/agent/composes/compose-1/instructions",
+          () => {
+            return HttpResponse.json(mockInstructions());
+          },
+        ),
+        http.get("http://localhost:3000/api/agent/schedules", () => {
+          return HttpResponse.json({ schedules: [] });
+        }),
+      );
+
+      await setupPage({ context, path: "/", withoutRender: true });
+      await context.store.set(fetchZeroJobData$, "my-agent");
+    }
+
+    it("should seed capabilities from compose content", async () => {
+      await setupWithCapabilities(["agent:read", "artifact:write"]);
+
+      const caps = context.store.get(zeroJobCapabilities$);
+      expect(caps).toStrictEqual(["agent:read", "artifact:write"]);
+      expect(context.store.get(zeroJobCapabilitiesDirty$)).toBeFalsy();
+    });
+
+    it("should default to empty when not in compose", async () => {
+      await setupWithCapabilities();
+
+      const caps = context.store.get(zeroJobCapabilities$);
+      expect(caps).toStrictEqual([]);
+      expect(context.store.get(zeroJobCapabilitiesDirty$)).toBeFalsy();
+    });
+
+    it("should toggle capability and track dirty state", async () => {
+      await setupWithCapabilities(["agent:read"]);
+
+      context.store.set(toggleZeroJobCapability$, "artifact:write");
+
+      expect(context.store.get(zeroJobCapabilities$)).toStrictEqual([
+        "agent:read",
+        "artifact:write",
+      ]);
+      expect(context.store.get(zeroJobCapabilitiesDirty$)).toBeTruthy();
+
+      // Toggle off
+      context.store.set(toggleZeroJobCapability$, "agent:read");
+
+      expect(context.store.get(zeroJobCapabilities$)).toStrictEqual([
+        "artifact:write",
+      ]);
+    });
+
+    it("should discard capability changes", async () => {
+      await setupWithCapabilities(["agent:read"]);
+
+      context.store.set(toggleZeroJobCapability$, "artifact:write");
+      expect(context.store.get(zeroJobCapabilitiesDirty$)).toBeTruthy();
+
+      context.store.set(discardZeroJobCapabilities$);
+
+      expect(context.store.get(zeroJobCapabilities$)).toStrictEqual([
+        "agent:read",
+      ]);
+      expect(context.store.get(zeroJobCapabilitiesDirty$)).toBeFalsy();
+    });
+
+    it("should save capabilities via compose job", async () => {
+      let capturedJobBody: Record<string, unknown> = {};
+
+      await setupWithCapabilities(["agent:read"]);
+
+      server.use(
+        http.post(
+          "http://localhost:3000/api/compose/jobs",
+          async ({ request }) => {
+            capturedJobBody = (await request.json()) as Record<string, unknown>;
+            return HttpResponse.json({
+              jobId: "job-1",
+              status: "completed",
+              result: {
+                composeId: "compose-1",
+                composeName: "my-agent",
+                versionId: "v2",
+                warnings: [],
+              },
+            });
+          },
+        ),
+        http.get("http://localhost:3000/api/agent/composes", () => {
+          return HttpResponse.json(
+            mockAgentWithCapabilities(["agent:read", "artifact:write"]),
+          );
+        }),
+        http.get(
+          "http://localhost:3000/api/agent/composes/compose-1/instructions",
+          () => {
+            return HttpResponse.json(mockInstructions());
+          },
+        ),
+      );
+
+      context.store.set(toggleZeroJobCapability$, "artifact:write");
+      await context.store.set(saveZeroJobCapabilities$);
+
+      // Verify capabilities were sent in the compose content
+      const content = capturedJobBody["content"] as Record<string, unknown>;
+      const agents = content["agents"] as Record<
+        string,
+        Record<string, unknown>
+      >;
+      const mainAgent = agents["main"];
+      expect(mainAgent["experimental_capabilities"]).toStrictEqual([
+        "agent:read",
+        "artifact:write",
+      ]);
+
+      // After save, dirty state should be reset
+      expect(context.store.get(zeroJobCapabilitiesDirty$)).toBeFalsy();
+      expect(context.store.get(zeroJobSettingsSaving$)).toBeFalsy();
+    });
+  });
+
+  describe("injectDefaultCapabilities", () => {
+    it("should inject all capabilities when none present", () => {
+      const content = {
+        version: "1",
+        agents: { main: { framework: "claude-code" } },
+      };
+      const result = injectDefaultCapabilities(content) as typeof content & {
+        agents: {
+          main: { experimental_capabilities: string[] };
+        };
+      };
+      expect(result.agents.main.experimental_capabilities).toHaveLength(8);
+      expect(result.agents.main.experimental_capabilities).toContain(
+        "agent:read",
+      );
+      expect(result.agents.main.experimental_capabilities).toContain(
+        "schedule:write",
+      );
+    });
+
+    it("should preserve existing capabilities", () => {
+      const content = {
+        version: "1",
+        agents: {
+          main: {
+            framework: "claude-code",
+            experimental_capabilities: ["agent:read"],
+          },
+        },
+      };
+      const result = injectDefaultCapabilities(content);
+      expect(result).toBe(content); // same reference, no modification
+    });
+
+    it("should return content unchanged when no agents key", () => {
+      const content = { version: "1" };
+      const result = injectDefaultCapabilities(content);
+      expect(result).toBe(content);
+    });
+
+    it("should return content unchanged when agents is empty", () => {
+      const content = { version: "1", agents: {} };
+      const result = injectDefaultCapabilities(content);
+      expect(result).toBe(content);
     });
   });
 });

--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-job-detail.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-job-detail.test.ts
@@ -1129,6 +1129,53 @@ describe("zero-job-detail signals", () => {
       expect(context.store.get(zeroJobCapabilitiesDirty$)).toBeFalsy();
       expect(context.store.get(zeroJobSettingsSaving$)).toBeFalsy();
     });
+
+    it("should save empty capabilities array when all disabled", async () => {
+      let capturedJobBody: Record<string, unknown> = {};
+
+      await setupWithCapabilities(["agent:read"]);
+
+      server.use(
+        http.post(
+          "http://localhost:3000/api/compose/jobs",
+          async ({ request }) => {
+            capturedJobBody = (await request.json()) as Record<string, unknown>;
+            return HttpResponse.json({
+              jobId: "job-1",
+              status: "completed",
+              result: {
+                composeId: "compose-1",
+                composeName: "my-agent",
+                versionId: "v2",
+                warnings: [],
+              },
+            });
+          },
+        ),
+        http.get("http://localhost:3000/api/agent/composes", () => {
+          return HttpResponse.json(mockAgentWithCapabilities([]));
+        }),
+        http.get(
+          "http://localhost:3000/api/agent/composes/compose-1/instructions",
+          () => {
+            return HttpResponse.json(mockInstructions());
+          },
+        ),
+      );
+
+      // Toggle off the only capability
+      context.store.set(toggleZeroJobCapability$, "agent:read");
+      await context.store.set(saveZeroJobCapabilities$);
+
+      // Should send empty array, NOT undefined
+      const content = capturedJobBody["content"] as Record<string, unknown>;
+      const agents = content["agents"] as Record<
+        string,
+        Record<string, unknown>
+      >;
+      const mainAgent = agents["main"];
+      expect(mainAgent["experimental_capabilities"]).toStrictEqual([]);
+    });
   });
 
   describe("injectDefaultCapabilities", () => {
@@ -1175,6 +1222,20 @@ describe("zero-job-detail signals", () => {
       const content = { version: "1", agents: {} };
       const result = injectDefaultCapabilities(content);
       expect(result).toBe(content);
+    });
+
+    it("should preserve empty array (user disabled all capabilities)", () => {
+      const content = {
+        version: "1",
+        agents: {
+          main: {
+            framework: "claude-code",
+            experimental_capabilities: [] as string[],
+          },
+        },
+      };
+      const result = injectDefaultCapabilities(content);
+      expect(result).toBe(content); // same reference, not re-injected
     });
   });
 });

--- a/turbo/apps/platform/src/signals/zero-page/agent-types.ts
+++ b/turbo/apps/platform/src/signals/zero-page/agent-types.ts
@@ -21,6 +21,7 @@ interface AgentDefinition {
   environment?: Record<string, string>;
   metadata?: { displayName?: string; sound?: string; description?: string };
   experimental_runner?: { group: string };
+  experimental_capabilities?: string[];
 }
 
 interface VolumeConfig {

--- a/turbo/apps/platform/src/signals/zero-page/compose-job.ts
+++ b/turbo/apps/platform/src/signals/zero-page/compose-job.ts
@@ -2,6 +2,47 @@
  * Helper for triggering and polling compose jobs from the app UI.
  */
 import { delay } from "signal-timers";
+import { VALID_CAPABILITIES } from "@vm0/core";
+
+interface ComposeContent {
+  agents?: Record<
+    string,
+    { experimental_capabilities?: string[]; [key: string]: unknown }
+  >;
+  [key: string]: unknown;
+}
+
+/**
+ * Ensure the first agent in `content` has `experimental_capabilities`.
+ * If already present, the existing value is preserved.
+ */
+export function injectDefaultCapabilities(content: object): object {
+  const c = content as ComposeContent;
+  if (!c.agents) {
+    return content;
+  }
+
+  const agentKey = Object.keys(c.agents)[0];
+  if (!agentKey) {
+    return content;
+  }
+
+  const agent = c.agents[agentKey];
+  if (agent.experimental_capabilities) {
+    return content;
+  }
+
+  return {
+    ...c,
+    agents: {
+      ...c.agents,
+      [agentKey]: {
+        ...agent,
+        experimental_capabilities: [...VALID_CAPABILITIES],
+      },
+    },
+  };
+}
 
 interface ComposeJobResponse {
   jobId: string;
@@ -24,12 +65,17 @@ export async function triggerAndPollComposeJob(
   content: object,
   instructions?: string,
 ): Promise<ComposeJobResponse> {
+  // Ensure capabilities are present for Zero agents
+  const resolvedContent = injectDefaultCapabilities(content);
+
   // Create compose job
   const createResponse = await fetchFn("/api/compose/jobs", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(
-      instructions !== undefined ? { content, instructions } : { content },
+      instructions !== undefined
+        ? { content: resolvedContent, instructions }
+        : { content: resolvedContent },
     ),
   });
 

--- a/turbo/apps/platform/src/signals/zero-page/zero-job-detail.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-job-detail.ts
@@ -472,6 +472,129 @@ export const saveZeroJobSkills$ = command(async ({ get, set }) => {
 });
 
 // ---------------------------------------------------------------------------
+// Capabilities management
+// ---------------------------------------------------------------------------
+
+const internalCapabilities$ = state<string[] | null>(null);
+
+const seededCapabilities$ = computed((get) => {
+  const detail = get(zeroJobDetail$);
+  if (!detail?.content) {
+    return [];
+  }
+  const agentKey = Object.keys(detail.content.agents)[0];
+  if (!agentKey) {
+    return [];
+  }
+  return detail.content.agents[agentKey]?.experimental_capabilities ?? [];
+});
+
+export const zeroJobCapabilities$ = computed((get) => {
+  const local = get(internalCapabilities$);
+  if (local !== null) {
+    return local;
+  }
+  return get(seededCapabilities$);
+});
+
+export const zeroJobCapabilitiesDirty$ = computed((get) => {
+  const local = get(internalCapabilities$);
+  if (local === null) {
+    return false;
+  }
+  const seeded = get(seededCapabilities$);
+  if (local.length !== seeded.length) {
+    return true;
+  }
+  const sorted = [...local].sort();
+  const seededSorted = [...seeded].sort();
+  return sorted.some((s, i) => s !== seededSorted[i]);
+});
+
+export const toggleZeroJobCapability$ = command(
+  ({ get, set }, capability: string) => {
+    if (get(internalCapabilities$) === null) {
+      set(internalCapabilities$, get(seededCapabilities$));
+    }
+    set(internalCapabilities$, (prev) => {
+      const list = prev ?? [];
+      return list.includes(capability)
+        ? list.filter((c) => c !== capability)
+        : [...list, capability];
+    });
+  },
+);
+
+export const discardZeroJobCapabilities$ = command(({ set }) => {
+  set(internalCapabilities$, null);
+});
+
+export const saveZeroJobCapabilities$ = command(async ({ get, set }) => {
+  const detail = get(zeroJobDetail$);
+  if (!detail?.content) {
+    throw new Error("No compose content found");
+  }
+
+  const agentKey = Object.keys(detail.content.agents)[0];
+  if (!agentKey) {
+    throw new Error("No agent found in compose");
+  }
+
+  set(internalSaving$, true);
+  try {
+    const newCapabilities = get(internalCapabilities$) ?? [];
+    const agent = detail.content.agents[agentKey];
+    const newContent = {
+      ...detail.content,
+      agents: {
+        [agentKey]: {
+          ...agent,
+          experimental_capabilities:
+            newCapabilities.length > 0 ? newCapabilities : undefined,
+        },
+      },
+    };
+
+    const fetchFn = get(fetch$);
+    const instructions = await resolveExistingInstructions(
+      get,
+      fetchFn,
+      detail.id,
+    );
+
+    // Ensure instructions field
+    const updatedAgent = newContent.agents[agentKey];
+    if (updatedAgent && !("instructions" in updatedAgent)) {
+      newContent.agents[agentKey] = {
+        ...updatedAgent,
+        instructions: getInstructionsFilename(updatedAgent.framework),
+      };
+    }
+
+    const job = await triggerAndPollComposeJob(
+      fetchFn,
+      newContent,
+      instructions ?? "",
+    );
+    if (!job.result) {
+      throw new Error("Build completed without result");
+    }
+
+    set(internalCapabilities$, null);
+    await set(fetchZeroJobDetail$);
+    toast.success("Capabilities saved");
+  } catch (error) {
+    throwIfAbort(error);
+    L.error("Failed to save capabilities:", error);
+    toast.error(
+      error instanceof Error ? error.message : "Failed to save capabilities",
+    );
+  } finally {
+    set(internalSaving$, false);
+  }
+});
+
+// ---------------------------------------------------------------------------
 // Agent schedule
 // ---------------------------------------------------------------------------
 
@@ -783,6 +906,7 @@ export const fetchZeroJobData$ = command(async ({ set }, agentName: string) => {
   set(scheduleState$, { schedules: [], error: null });
   set(editedContent$, null);
   set(internalAddedSkills$, null);
+  set(internalCapabilities$, null);
   set(internalBuildError$, null);
   set(jobBuilding$, false);
   set(internalSaving$, false);

--- a/turbo/apps/platform/src/signals/zero-page/zero-job-detail.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-job-detail.ts
@@ -549,8 +549,7 @@ export const saveZeroJobCapabilities$ = command(async ({ get, set }) => {
       agents: {
         [agentKey]: {
           ...agent,
-          experimental_capabilities:
-            newCapabilities.length > 0 ? newCapabilities : undefined,
+          experimental_capabilities: newCapabilities,
         },
       },
     };

--- a/turbo/apps/platform/src/views/zero-page/zero-experimental-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-experimental-tab.tsx
@@ -1,0 +1,100 @@
+import { Card, CardContent } from "@vm0/ui";
+import { LoadingSwitch } from "../components/loading-switch.tsx";
+import { ZeroUnsavedBar } from "./zero-unsaved-bar.tsx";
+
+interface ZeroExperimentalTabProps {
+  capabilities: string[];
+  capabilitiesDirty: boolean;
+  capabilitiesSaving: boolean;
+  onToggleCapability: (capability: string) => void;
+  onSaveCapabilities: () => void;
+  onDiscardCapabilities: () => void;
+}
+
+export function ZeroExperimentalTab({
+  capabilities,
+  capabilitiesDirty,
+  capabilitiesSaving,
+  onToggleCapability,
+  onSaveCapabilities,
+  onDiscardCapabilities,
+}: ZeroExperimentalTabProps) {
+  const capabilityGroups = [
+    {
+      label: "Agent Resources",
+      capabilities: [
+        { key: "agent:read", label: "Read agents & volumes" },
+        { key: "agent:write", label: "Write agents & volumes" },
+      ],
+    },
+    {
+      label: "Artifacts & Memories",
+      capabilities: [
+        { key: "artifact:read", label: "Read artifacts & memories" },
+        { key: "artifact:write", label: "Write artifacts & memories" },
+      ],
+    },
+    {
+      label: "Operations",
+      capabilities: [
+        { key: "agent-run:read", label: "View agent runs" },
+        { key: "agent-run:write", label: "Create & cancel runs" },
+        { key: "schedule:read", label: "View schedules" },
+        { key: "schedule:write", label: "Manage schedules" },
+      ],
+    },
+  ];
+
+  return (
+    <>
+      <div className="mx-auto max-w-[900px]">
+        <div className="mb-4">
+          <h2 className="text-sm font-medium text-foreground">
+            VM0 Capabilities
+          </h2>
+          <p className="text-sm text-muted-foreground mt-1">
+            Control what your agent can do on the VM0 platform
+          </p>
+        </div>
+
+        <div className="flex flex-col gap-4">
+          {capabilityGroups.map((group) => (
+            <Card key={group.label} className="zero-card-white">
+              <CardContent className="py-4">
+                <h3 className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-3">
+                  {group.label}
+                </h3>
+                <div className="flex flex-col divide-y divide-border">
+                  {group.capabilities.map((cap) => (
+                    <div
+                      key={cap.key}
+                      className="flex items-center justify-between py-2.5 first:pt-0 last:pb-0"
+                    >
+                      <span className="text-sm text-foreground">
+                        {cap.label}
+                      </span>
+                      <LoadingSwitch
+                        checked={capabilities.includes(cap.key)}
+                        loading={capabilitiesSaving}
+                        onCheckedChange={() => onToggleCapability(cap.key)}
+                        ariaLabel={cap.label}
+                      />
+                    </div>
+                  ))}
+                </div>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      </div>
+
+      {(capabilitiesDirty || capabilitiesSaving) && (
+        <ZeroUnsavedBar
+          onDiscard={onDiscardCapabilities}
+          onSave={onSaveCapabilities}
+          saving={capabilitiesSaving}
+        />
+      )}
+    </>
+  );
+}

--- a/turbo/apps/platform/src/views/zero-page/zero-job-detail-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-job-detail-page.tsx
@@ -8,6 +8,7 @@ import {
   IconMessageCircle,
   IconUsers,
   IconMoodSad,
+  IconFlask,
 } from "@tabler/icons-react";
 import {
   Tabs,
@@ -24,6 +25,7 @@ import { ZeroScheduleTab } from "./zero-schedule-tab.tsx";
 import { ZeroSkillsTab } from "./zero-skills-tab.tsx";
 import { ZeroInstructionsTab } from "./zero-instructions-tab.tsx";
 import { ZeroSettingsTab } from "./zero-settings-tab.tsx";
+import { ZeroExperimentalTab } from "./zero-experimental-tab.tsx";
 import { TONE_OPTIONS, type Tone } from "./zero-tone-constants.ts";
 import type { ScheduleEntry } from "./zero-schedule-card.tsx";
 import {
@@ -53,6 +55,11 @@ import {
   removeZeroJobSkill$,
   saveZeroJobSkills$,
   discardZeroJobSkills$,
+  zeroJobCapabilities$,
+  zeroJobCapabilitiesDirty$,
+  toggleZeroJobCapability$,
+  saveZeroJobCapabilities$,
+  discardZeroJobCapabilities$,
 } from "../../signals/zero-page/zero-job-detail.ts";
 import type { AgentDetail } from "../../signals/zero-page/agent-types.ts";
 import { Link } from "../router/link.tsx";
@@ -183,7 +190,8 @@ function isValidTab(tab: string): boolean {
     tab === "connectors" ||
     tab === "schedule" ||
     tab === "profile" ||
-    tab === "instructions"
+    tab === "instructions" ||
+    tab === "experimental"
   );
 }
 
@@ -317,6 +325,26 @@ function JobInstructionsTab() {
   );
 }
 
+function JobExperimentalTab() {
+  const capabilities = useGet(zeroJobCapabilities$);
+  const capabilitiesDirty = useGet(zeroJobCapabilitiesDirty$);
+  const capabilitiesSaving = useGet(zeroJobSettingsSaving$);
+  const toggleCapability = useSet(toggleZeroJobCapability$);
+  const saveCapabilities = useSet(saveZeroJobCapabilities$);
+  const discardCapabilities = useSet(discardZeroJobCapabilities$);
+
+  return (
+    <ZeroExperimentalTab
+      capabilities={capabilities}
+      capabilitiesDirty={capabilitiesDirty}
+      capabilitiesSaving={capabilitiesSaving}
+      onToggleCapability={toggleCapability}
+      onSaveCapabilities={() => detach(saveCapabilities(), Reason.DomCallback)}
+      onDiscardCapabilities={() => discardCapabilities()}
+    />
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Main page
 // ---------------------------------------------------------------------------
@@ -423,6 +451,10 @@ export function ZeroJobDetailPage({
                   <IconFileText size={14} stroke={1.5} />
                   Instructions
                 </TabsTrigger>
+                <TabsTrigger value="experimental" className={TAB_TRIGGER_CLASS}>
+                  <IconFlask size={14} stroke={1.5} />
+                  Experimental
+                </TabsTrigger>
               </TabsList>
             </Tabs>
             <TooltipProvider delayDuration={300}>
@@ -466,6 +498,8 @@ export function ZeroJobDetailPage({
         )}
 
         {activeTab === "instructions" && <JobInstructionsTab />}
+
+        {activeTab === "experimental" && <JobExperimentalTab />}
       </main>
     </div>
   );


### PR DESCRIPTION
## Summary
- Auto-inject all 8 VM0 capabilities (`agent:read/write`, `artifact:read/write`, `agent-run:read/write`, `schedule:read/write`) for Zero Platform agents when composing via `triggerAndPollComposeJob()`
- Add `experimental_capabilities` field to the platform's `AgentDefinition` type
- Add new "Experimental" tab to the agent detail page with toggle UI for configuring capabilities per-agent
- Follow established save/discard pattern with `ZeroUnsavedBar` and `LoadingSwitch` components
- Add comprehensive integration tests for capabilities state management and auto-injection

Closes #5335

## Test plan
- [x] All 35 zero-job-detail tests pass (including 10 new capability tests)
- [x] Full platform test suite passes (255 tests across 29 files)
- [x] TypeScript type check passes
- [x] Lint passes (oxlint + eslint)
- [x] Knip passes (no unused exports)
- [ ] Manual verification of Experimental tab UI in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)