### PR TITLE
refactor: remove deprecated image and working_dir fields from compose

### DIFF
--- a/e2e/tests/01-serial/ser-t02-vm0-org.bats
+++ b/e2e/tests/01-serial/ser-t02-vm0-org.bats
@@ -49,32 +49,10 @@ teardown() {
 }
 
 # ============================================
-# Image Field Deprecation Tests
+# Compose Tests
 # ============================================
 
-@test "vm0 compose with deprecated image field shows warning but succeeds" {
-    # Create a test config with deprecated image field
-    TEST_DIR="$(mktemp -d)"
-    cat > "$TEST_DIR/vm0.yaml" <<EOF
-version: "1.0"
-
-agents:
-  test-agent:
-    framework: claude-code
-    image: "some-image"
-EOF
-
-    # Should succeed with deprecation warning
-    # Server now resolves image based on framework, ignoring the image field
-    run $CLI_COMMAND compose "$TEST_DIR/vm0.yaml"
-    assert_success
-    # Should show deprecation warning
-    assert_output --partial "deprecated"
-
-    rm -rf "$TEST_DIR"
-}
-
-@test "vm0 compose without image field succeeds" {
+@test "vm0 compose succeeds with minimal config" {
     TEST_DIR="$(mktemp -d)"
     cat > "$TEST_DIR/vm0.yaml" <<EOF
 version: "1.0"

--- a/turbo/apps/cli/src/commands/agent/__tests__/clone.test.ts
+++ b/turbo/apps/cli/src/commands/agent/__tests__/clone.test.ts
@@ -152,8 +152,6 @@ describe("agent clone command", () => {
                 agents: {
                   "test-agent": {
                     framework: "claude-code",
-                    image: "deprecated-image", // Should be removed
-                    working_dir: "/deprecated", // Should be removed
                     description: "My agent",
                   },
                 },
@@ -173,8 +171,7 @@ describe("agent clone command", () => {
       await cloneCommand.parseAsync(["node", "cli", "test-agent", dest]);
 
       const yamlContent = fs.readFileSync(path.join(dest, "vm0.yaml"), "utf8");
-      expect(yamlContent).not.toContain("image:");
-      expect(yamlContent).not.toContain("working_dir:");
+      expect(yamlContent).toContain("framework: claude-code");
       expect(yamlContent).toContain("description: My agent");
     });
 

--- a/turbo/apps/cli/src/commands/agent/clone.ts
+++ b/turbo/apps/cli/src/commands/agent/clone.ts
@@ -9,27 +9,45 @@ import * as tar from "tar";
 import { stringify as yamlStringify } from "yaml";
 import { getComposeByName, getStorageDownload } from "../../lib/api";
 import { getInstructionsStorageName } from "@vm0/core";
-import type { AgentComposeContent } from "../../lib/domain/compose-types";
+import type {
+  AgentComposeContent,
+  AgentDefinition,
+} from "../../lib/domain/compose-types";
 import { withErrorHandler } from "../../lib/command";
 
 /**
  * Clean compose content for local use.
- * Strips any extra fields not part of the agent definition schema.
+ * Strips any extra fields not part of the agent definition schema
+ * (e.g., deprecated fields from old stored composes).
  */
 function cleanComposeContent(
   content: AgentComposeContent,
 ): AgentComposeContent {
-  const cleaned: AgentComposeContent = {
-    version: content.version,
-    agents: { ...content.agents },
-  };
-
-  // Keep volumes section if it exists
-  if (content.volumes) {
-    cleaned.volumes = content.volumes;
+  const agents: Record<string, AgentDefinition> = {};
+  for (const [name, agent] of Object.entries(content.agents)) {
+    const cleaned: AgentDefinition = {
+      framework: agent.framework,
+    };
+    if (agent.description) cleaned.description = agent.description;
+    if (agent.volumes) cleaned.volumes = agent.volumes;
+    if (agent.environment) cleaned.environment = agent.environment;
+    if (agent.instructions) cleaned.instructions = agent.instructions;
+    if (agent.skills) cleaned.skills = agent.skills;
+    if (agent.experimental_runner)
+      cleaned.experimental_runner = agent.experimental_runner;
+    agents[name] = cleaned;
   }
 
-  return cleaned;
+  const result: AgentComposeContent = {
+    version: content.version,
+    agents,
+  };
+
+  if (content.volumes) {
+    result.volumes = content.volumes;
+  }
+
+  return result;
 }
 
 /**
@@ -132,7 +150,7 @@ export const cloneCommand = new Command()
 
       const content = compose.content as AgentComposeContent;
 
-      // Clean up deprecated fields
+      // Strip any extra fields not part of the agent definition schema
       const cleanedContent = cleanComposeContent(content);
 
       // Convert to YAML

--- a/turbo/apps/cli/src/commands/agent/clone.ts
+++ b/turbo/apps/cli/src/commands/agent/clone.ts
@@ -13,23 +13,16 @@ import type { AgentComposeContent } from "../../lib/domain/compose-types";
 import { withErrorHandler } from "../../lib/command";
 
 /**
- * Remove deprecated fields from compose content
+ * Clean compose content for local use.
+ * Strips any extra fields not part of the agent definition schema.
  */
 function cleanComposeContent(
   content: AgentComposeContent,
 ): AgentComposeContent {
   const cleaned: AgentComposeContent = {
     version: content.version,
-    agents: {},
+    agents: { ...content.agents },
   };
-
-  for (const [agentName, agent] of Object.entries(content.agents)) {
-    // Destructure to exclude deprecated fields
-    const { image, working_dir: workingDir, ...rest } = agent;
-    void image;
-    void workingDir;
-    cleaned.agents[agentName] = rest;
-  }
 
   // Keep volumes section if it exists
   if (content.volumes) {

--- a/turbo/apps/cli/src/commands/agent/status.ts
+++ b/turbo/apps/cli/src/commands/agent/status.ts
@@ -74,14 +74,6 @@ function formatAgentDetails(
   console.log(`  ${chalk.cyan(agentName)}:`);
   console.log(`    Framework: ${agent.framework}`);
 
-  if (agent.image) {
-    console.log(`    Image:    ${agent.image}`);
-  }
-
-  if (agent.working_dir) {
-    console.log(`    Working Dir: ${agent.working_dir}`);
-  }
-
   formatVolumes(agent.volumes ?? [], volumeConfigs);
   formatListSection("Skills", agent.skills ?? []);
 

--- a/turbo/apps/cli/src/commands/compose/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/compose/__tests__/index.test.ts
@@ -174,7 +174,7 @@ describe("compose command", () => {
     it("should read file when it exists", async () => {
       await fs.writeFile(
         path.join(tempDir, "config.yaml"),
-        `version: "1.0"\nagents:\n  test:\n    framework: claude-code\n    working_dir: /`,
+        `version: "1.0"\nagents:\n  test:\n    framework: claude-code`,
       );
       server.use(
         http.post("http://localhost:3000/api/agent/composes", () => {
@@ -203,7 +203,7 @@ describe("compose command", () => {
     it("should use vm0.yaml by default when no argument provided", async () => {
       await fs.writeFile(
         path.join(tempDir, "vm0.yaml"),
-        `version: "1.0"\nagents:\n  test:\n    framework: claude-code\n    working_dir: /`,
+        `version: "1.0"\nagents:\n  test:\n    framework: claude-code`,
       );
       server.use(
         http.post("http://localhost:3000/api/agent/composes", () => {
@@ -242,11 +242,11 @@ describe("compose command", () => {
       // Create both files to verify explicit takes precedence
       await fs.writeFile(
         path.join(tempDir, "vm0.yaml"),
-        `version: "1.0"\nagents:\n  default-agent:\n    framework: claude-code\n    working_dir: /`,
+        `version: "1.0"\nagents:\n  default-agent:\n    framework: claude-code`,
       );
       await fs.writeFile(
         path.join(tempDir, "custom.yaml"),
-        `version: "1.0"\nagents:\n  custom-agent:\n    framework: claude-code\n    working_dir: /`,
+        `version: "1.0"\nagents:\n  custom-agent:\n    framework: claude-code`,
       );
 
       let capturedBody: unknown;
@@ -301,7 +301,7 @@ describe("compose command", () => {
     it("should parse valid YAML", async () => {
       await fs.writeFile(
         path.join(tempDir, "config.yaml"),
-        `version: "1.0"\nagents:\n  test:\n    framework: claude-code\n    working_dir: /`,
+        `version: "1.0"\nagents:\n  test:\n    framework: claude-code`,
       );
       server.use(
         http.post("http://localhost:3000/api/agent/composes", () => {
@@ -351,7 +351,7 @@ describe("compose command", () => {
       // Create YAML with invalid agent name (too short)
       await fs.writeFile(
         path.join(tempDir, "config.yaml"),
-        `version: "1.0"\nagents:\n  ab:\n    working_dir: /`,
+        `version: "1.0"\nagents:\n  ab:\n    framework: claude-code`,
       );
 
       await expect(async () => {
@@ -367,7 +367,7 @@ describe("compose command", () => {
     it("should proceed with valid compose", async () => {
       await fs.writeFile(
         path.join(tempDir, "config.yaml"),
-        `version: "1.0"\nagents:\n  test:\n    framework: claude-code\n    working_dir: /`,
+        `version: "1.0"\nagents:\n  test:\n    framework: claude-code`,
       );
       let composeApiCalled = false;
       server.use(
@@ -562,7 +562,7 @@ describe("compose command", () => {
     beforeEach(async () => {
       await fs.writeFile(
         path.join(tempDir, "config.yaml"),
-        `version: "1.0"\nagents:\n  test:\n    framework: claude-code\n    working_dir: /`,
+        `version: "1.0"\nagents:\n  test:\n    framework: claude-code`,
       );
       server.use(
         http.get("http://localhost:3000/api/org", () => {
@@ -661,7 +661,7 @@ describe("compose command", () => {
     beforeEach(async () => {
       await fs.writeFile(
         path.join(tempDir, "config.yaml"),
-        `version: "1.0"\nagents:\n  test:\n    framework: claude-code\n    working_dir: /`,
+        `version: "1.0"\nagents:\n  test:\n    framework: claude-code`,
       );
     });
 
@@ -773,7 +773,7 @@ agents:
       expect(mockExit).toHaveBeenCalledWith(1);
     });
 
-    it("should accept supported framework without image/working_dir", async () => {
+    it("should accept supported framework", async () => {
       await fs.writeFile(
         path.join(tempDir, "vm0.yaml"),
         `version: "1.0"
@@ -819,7 +819,6 @@ agents:
 agents:
   test-agent:
     framework: claude-code
-    image: "vm0/claude-code:dev"
     skills:
       - https://example.com/not-a-github-url`,
       );
@@ -841,7 +840,6 @@ agents:
 agents:
   test-agent:
     framework: claude-code
-    image: "vm0/claude-code:dev"
     skills:
       - https://github.com/vm0-ai/vm0-skills/blob/main/github`,
       );
@@ -864,7 +862,6 @@ agents:
 agents:
   test-agent:
     framework: claude-code
-    image: "vm0/claude-code:dev"
     instructions: ""`,
       );
 
@@ -885,7 +882,6 @@ agents:
 agents:
   test-agent:
     framework: claude-code
-    image: "vm0/claude-code:dev"
     instructions: nonexistent-file.md`,
       );
 
@@ -1089,80 +1085,6 @@ agents:
       const runHint = allLogs.find((log) => log.includes("vm0 run"));
       expect(runHint).toBeDefined();
       expect(runHint).toContain(":deadbeef");
-    });
-  });
-
-  describe("deprecation warnings", () => {
-    it("should show deprecation warning when image field is explicitly set", async () => {
-      await fs.writeFile(
-        path.join(tempDir, "vm0.yaml"),
-        `version: "1.0"
-agents:
-  test-agent:
-    description: "Test agent with explicit image"
-    framework: claude-code
-    image: "vm0/claude-code:dev"`,
-      );
-
-      server.use(
-        http.post("http://localhost:3000/api/agent/composes", () => {
-          return HttpResponse.json({
-            composeId: "cmp-123",
-            name: "test-agent",
-            versionId: "a1b2c3d4e5f6g7h8" + "0".repeat(48),
-            action: "created",
-          });
-        }),
-        http.get("http://localhost:3000/api/org", () => {
-          return HttpResponse.json(orgResponse);
-        }),
-      );
-
-      await composeCommand.parseAsync(["node", "cli", "vm0.yaml"]);
-
-      const allLogs = mockConsoleLog.mock.calls.map(
-        (call) => call[0] as string,
-      );
-      const hasDeprecationWarning = allLogs.some(
-        (log) => log.includes("deprecated") && log.includes("image"),
-      );
-      expect(hasDeprecationWarning).toBe(true);
-    });
-
-    it("should still succeed compose even with deprecation warning", async () => {
-      await fs.writeFile(
-        path.join(tempDir, "vm0.yaml"),
-        `version: "1.0"
-agents:
-  test-agent:
-    description: "Test agent with explicit image"
-    framework: claude-code
-    image: "vm0/claude-code:dev"`,
-      );
-
-      server.use(
-        http.post("http://localhost:3000/api/agent/composes", () => {
-          return HttpResponse.json({
-            composeId: "cmp-123",
-            name: "test-agent",
-            versionId: "a1b2c3d4e5f6g7h8" + "0".repeat(48),
-            action: "created",
-          });
-        }),
-        http.get("http://localhost:3000/api/org", () => {
-          return HttpResponse.json(orgResponse);
-        }),
-      );
-
-      await composeCommand.parseAsync(["node", "cli", "vm0.yaml"]);
-
-      const allLogs = mockConsoleLog.mock.calls.map(
-        (call) => call[0] as string,
-      );
-      const hasComposeSuccess = allLogs.some((log) =>
-        log.includes("Compose created"),
-      );
-      expect(hasComposeSuccess).toBe(true);
     });
   });
 
@@ -1623,7 +1545,7 @@ agents:
     it("should output JSON result on success", async () => {
       await fs.writeFile(
         path.join(tempDir, "vm0.yaml"),
-        `version: "1.0"\nagents:\n  test-agent:\n    framework: claude-code\n    working_dir: /`,
+        `version: "1.0"\nagents:\n  test-agent:\n    framework: claude-code`,
       );
       server.use(
         http.post("http://localhost:3000/api/agent/composes", () => {
@@ -1664,7 +1586,7 @@ agents:
     it("should suppress intermediate output in JSON mode", async () => {
       await fs.writeFile(
         path.join(tempDir, "vm0.yaml"),
-        `version: "1.0"\nagents:\n  test-agent:\n    framework: claude-code\n    working_dir: /`,
+        `version: "1.0"\nagents:\n  test-agent:\n    framework: claude-code`,
       );
       server.use(
         http.post("http://localhost:3000/api/agent/composes", () => {
@@ -1720,7 +1642,7 @@ agents:
       // by checking that no confirmation prompts appear in JSON output
       await fs.writeFile(
         path.join(tempDir, "vm0.yaml"),
-        `version: "1.0"\nagents:\n  test-agent:\n    framework: claude-code\n    working_dir: /`,
+        `version: "1.0"\nagents:\n  test-agent:\n    framework: claude-code`,
       );
       server.use(
         http.post("http://localhost:3000/api/agent/composes", () => {
@@ -1748,7 +1670,7 @@ agents:
     it("should not call getOrg or checkMissingItems in --json mode", async () => {
       await fs.writeFile(
         path.join(tempDir, "vm0.yaml"),
-        `version: "1.0"\nagents:\n  test-agent:\n    framework: claude-code\n    working_dir: /`,
+        `version: "1.0"\nagents:\n  test-agent:\n    framework: claude-code`,
       );
 
       let orgCalled = false;
@@ -1798,7 +1720,7 @@ agents:
     it("should skip auto-update in JSON mode", async () => {
       await fs.writeFile(
         path.join(tempDir, "vm0.yaml"),
-        `version: "1.0"\nagents:\n  test-agent:\n    framework: claude-code\n    working_dir: /`,
+        `version: "1.0"\nagents:\n  test-agent:\n    framework: claude-code`,
       );
 
       // Set up a newer version available
@@ -1826,7 +1748,7 @@ agents:
     it("should show deprecation warning for --porcelain", async () => {
       await fs.writeFile(
         path.join(tempDir, "vm0.yaml"),
-        `version: "1.0"\nagents:\n  test-agent:\n    framework: claude-code\n    working_dir: /`,
+        `version: "1.0"\nagents:\n  test-agent:\n    framework: claude-code`,
       );
       server.use(
         http.post("http://localhost:3000/api/agent/composes", () => {
@@ -2710,7 +2632,6 @@ agents:
           agents: {
             test: {
               framework: "claude-code",
-              working_dir: "/",
               environment: {
                 API_KEY: "${{ secrets.API_KEY }}",
                 DB_URL: "${{ secrets.DB_URL }}",
@@ -2749,7 +2670,6 @@ agents:
           agents: {
             test: {
               framework: "claude-code",
-              working_dir: "/",
               environment: {
                 API_KEY: "${{ secrets.API_KEY }}",
               },
@@ -2792,7 +2712,6 @@ agents:
           agents: {
             test: {
               framework: "claude-code",
-              working_dir: "/",
               environment: {
                 API_KEY: "${{ secrets.API_KEY }}",
                 REGION: "${{ vars.REGION }}",
@@ -2829,7 +2748,6 @@ agents:
           agents: {
             test: {
               framework: "claude-code",
-              working_dir: "/",
               environment: {
                 API_KEY: "${{ secrets.API_KEY }}",
               },
@@ -2866,7 +2784,6 @@ agents:
           agents: {
             test: {
               framework: "claude-code",
-              working_dir: "/",
               environment: {
                 STATIC: "static-value",
               },
@@ -2903,7 +2820,6 @@ agents:
           agents: {
             test: {
               framework: "claude-code",
-              working_dir: "/",
               environment: {
                 EXISTING_KEY: "${{ secrets.EXISTING_KEY }}",
                 MISSING_KEY: "${{ secrets.MISSING_KEY }}",
@@ -2944,7 +2860,6 @@ agents:
           agents: {
             test: {
               framework: "claude-code",
-              working_dir: "/",
               environment: {
                 GH_TOKEN: "${{ secrets.GH_TOKEN }}",
                 OTHER_KEY: "${{ secrets.OTHER_KEY }}",

--- a/turbo/apps/cli/src/commands/compose/index.ts
+++ b/turbo/apps/cli/src/commands/compose/index.ts
@@ -5,7 +5,6 @@ import { existsSync } from "fs";
 import { dirname, join } from "path";
 import { parse as parseYaml } from "yaml";
 import {
-  getLegacySystemTemplateWarning,
   extractAndGroupVariables,
   resolveSkillRef,
   expandFirewallConfigs,
@@ -133,29 +132,6 @@ function hasVolumes(config: unknown): boolean {
     volumes !== null &&
     Object.keys(volumes).length > 0
   );
-}
-
-/**
- * Check for legacy image format and show deprecation warnings.
- */
-function checkLegacyImageFormat(config: unknown): void {
-  const cfg = config as Record<string, unknown>;
-  const agentsConfig = cfg.agents as Record<string, Record<string, unknown>>;
-
-  for (const [name, agentConfig] of Object.entries(agentsConfig)) {
-    const image = agentConfig.image as string | undefined;
-    if (image) {
-      console.log(
-        chalk.yellow(
-          `⚠ Agent "${name}": 'image' field is deprecated and will be ignored. The server resolves the image based on the framework.`,
-        ),
-      );
-      const warning = getLegacySystemTemplateWarning(image);
-      if (warning) {
-        console.log(chalk.yellow(`  ${warning}`));
-      }
-    }
-  }
 }
 
 /**
@@ -646,11 +622,6 @@ async function handleGitHubCompose(
       });
     }
 
-    // Check for legacy image format (skip in JSON mode)
-    if (!options.json) {
-      checkLegacyImageFormat(config);
-    }
-
     // Upload instructions and skills
     const skillResults = await uploadAssets(
       agentName,
@@ -739,11 +710,6 @@ export const composeCommand = new Command()
             // 1. Load and validate config
             const { config, agentName, agent, basePath } =
               await loadAndValidateConfig(resolvedConfigFile);
-
-            // 2. Check for legacy image format (skip in JSON mode)
-            if (!options.json) {
-              checkLegacyImageFormat(config);
-            }
 
             // 3. Upload instructions and skills
             const skillResults = await uploadAssets(

--- a/turbo/apps/cli/src/commands/cook/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/cook/__tests__/index.test.ts
@@ -159,7 +159,7 @@ describe("cook command", () => {
     it("should exit with error on invalid agent name", async () => {
       await fs.writeFile(
         path.join(tempDir, "vm0.yaml"),
-        `version: "1.0"\nagents:\n  ab:\n    framework: claude-code\n    working_dir: /`,
+        `version: "1.0"\nagents:\n  ab:\n    framework: claude-code`,
       );
 
       await expect(async () => {
@@ -313,7 +313,6 @@ describe("cook command", () => {
 agents:
   test-agent:
     framework: claude-code
-    working_dir: /workspace
 `,
       );
 
@@ -359,7 +358,6 @@ agents:
 agents:
   test-agent:
     framework: claude-code
-    working_dir: /workspace
 `,
       );
 
@@ -753,7 +751,6 @@ agents:
 agents:
   test-agent:
     framework: claude-code
-    working_dir: /workspace
     volumes:
       - mydata:/data
 volumes:
@@ -1038,7 +1035,6 @@ Checkpoint ID: checkpoint-ghi789`,
 agents:
   test-agent:
     framework: claude-code
-    working_dir: /workspace
     volumes:
       - nonexistent:/data
 volumes:
@@ -1071,7 +1067,6 @@ volumes:
 agents:
   test-agent:
     framework: claude-code
-    working_dir: /workspace
     volumes:
       - vol1:/data1
       - vol2:/data2
@@ -1117,7 +1112,6 @@ volumes:
 agents:
   test-agent:
     framework: claude-code
-    working_dir: /workspace
 `,
       );
 
@@ -1181,7 +1175,6 @@ agents:
 agents:
   test-agent:
     framework: claude-code
-    working_dir: /workspace
 `,
       );
     });

--- a/turbo/apps/cli/src/commands/cook/cook.ts
+++ b/turbo/apps/cli/src/commands/cook/cook.ts
@@ -29,9 +29,7 @@ interface VolumeConfig {
 interface AgentConfig {
   description?: string;
   framework: string;
-  image: string;
   volumes?: string[];
-  working_dir: string;
   environment?: Record<string, string>;
 }
 

--- a/turbo/apps/cli/src/commands/schedule/__tests__/setup-command.test.ts
+++ b/turbo/apps/cli/src/commands/schedule/__tests__/setup-command.test.ts
@@ -57,8 +57,6 @@ function createMockCompose(overrides: Record<string, unknown> = {}) {
         "test-agent": {
           description: "Test agent",
           framework: "claude-code",
-          image: "vm0/claude-code:dev",
-          working_dir: "/home/user/workspace",
         },
       },
     },

--- a/turbo/apps/cli/src/lib/domain/compose-types.ts
+++ b/turbo/apps/cli/src/lib/domain/compose-types.ts
@@ -18,10 +18,6 @@ export interface AgentDefinition {
   experimental_runner?: {
     group: string;
   };
-  /** @deprecated Server-resolved field */
-  image?: string;
-  /** @deprecated Server-resolved field */
-  working_dir?: string;
 }
 
 /**

--- a/turbo/apps/cli/src/lib/domain/source-derivation.ts
+++ b/turbo/apps/cli/src/lib/domain/source-derivation.ts
@@ -14,10 +14,8 @@ import {
  */
 interface AgentDefinition {
   description?: string;
-  image?: string;
   framework: string;
   volumes?: string[];
-  working_dir?: string;
   environment?: Record<string, string>;
   instructions?: string;
   skills?: string[];

--- a/turbo/apps/cli/src/lib/domain/yaml-validator.ts
+++ b/turbo/apps/cli/src/lib/domain/yaml-validator.ts
@@ -21,8 +21,8 @@ const cliAgentNameSchema = z
 /**
  * CLI-extended agent definition schema with skills URL validation
  *
- * Note: Framework validation (image, working_dir) is now handled server-side.
- * The server rejects unsupported frameworks and resolves image/working_dir automatically.
+ * Note: Framework validation is handled server-side.
+ * The server rejects unsupported frameworks.
  */
 const cliAgentDefinitionSchema = agentDefinitionSchema.superRefine(
   (agent, ctx) => {

--- a/turbo/apps/web/app/api/agent/composes/__tests__/upsert.test.ts
+++ b/turbo/apps/web/app/api/agent/composes/__tests__/upsert.test.ts
@@ -50,8 +50,8 @@ describe("Agent Compose Upsert Behavior", () => {
       expect(data.updatedAt).toBeDefined();
     });
 
-    it("should resolve image and working_dir server-side", async () => {
-      const agentName = `test-server-resolve-${Date.now()}`;
+    it("should store compose content without image or working_dir", async () => {
+      const agentName = `test-no-deprecated-fields-${Date.now()}`;
       const config = {
         version: "1.0",
         agents: {
@@ -75,7 +75,7 @@ describe("Agent Compose Upsert Behavior", () => {
 
       expect(response.status).toBe(201);
 
-      // Get the created compose to verify resolved values
+      // Get the created compose to verify no deprecated fields
       const getRequest = createTestRequest(
         `http://localhost:3000/api/agent/composes/${data.composeId}`,
         { method: "GET" },
@@ -84,10 +84,10 @@ describe("Agent Compose Upsert Behavior", () => {
       const getResponse = await GET(getRequest);
       const composeData = await getResponse.json();
 
-      // Verify server resolved image and working_dir
       const agent = composeData.content.agents[agentName];
-      expect(agent.image).toMatch(/^vm0\/claude-code:/);
-      expect(agent.working_dir).toBe("/home/user/workspace");
+      expect(agent.framework).toBe("claude-code");
+      expect(agent.image).toBeUndefined();
+      expect(agent.working_dir).toBeUndefined();
     });
 
     it("should silently ignore apps field in config", async () => {
@@ -112,32 +112,16 @@ describe("Agent Compose Upsert Behavior", () => {
       );
 
       const response = await POST(request);
-      const data = await response.json();
-
       expect(response.status).toBe(201);
-
-      // Get the created compose to verify resolved values
-      const getRequest = createTestRequest(
-        `http://localhost:3000/api/agent/composes/${data.composeId}`,
-        { method: "GET" },
-      );
-
-      const getResponse = await GET(getRequest);
-      const composeData = await getResponse.json();
-
-      // apps field is silently ignored — always resolves to base image
-      const agent = composeData.content.agents[agentName];
-      expect(agent.image).toMatch(/^vm0\/claude-code:/);
     });
 
-    it("should ignore deprecated image and working_dir fields from input", async () => {
-      const agentName = `test-ignore-deprecated-${Date.now()}`;
+    it("should strip unknown fields like image and working_dir from input", async () => {
+      const agentName = `test-strip-unknown-${Date.now()}`;
       const config = {
         version: "1.0",
         agents: {
           [agentName]: {
             framework: "claude-code",
-            // These deprecated fields should be ignored
             image: "custom/image:v1",
             working_dir: "/custom/path",
           },
@@ -158,7 +142,7 @@ describe("Agent Compose Upsert Behavior", () => {
 
       expect(response.status).toBe(201);
 
-      // Get the created compose to verify server-resolved values (not user-provided)
+      // Get the created compose to verify unknown fields were stripped
       const getRequest = createTestRequest(
         `http://localhost:3000/api/agent/composes/${data.composeId}`,
         { method: "GET" },
@@ -167,12 +151,10 @@ describe("Agent Compose Upsert Behavior", () => {
       const getResponse = await GET(getRequest);
       const composeData = await getResponse.json();
 
-      // Verify server resolved values, not user-provided deprecated values
       const agent = composeData.content.agents[agentName];
-      expect(agent.image).toMatch(/^vm0\/claude-code:/);
-      expect(agent.image).not.toBe("custom/image:v1");
-      expect(agent.working_dir).toBe("/home/user/workspace");
-      expect(agent.working_dir).not.toBe("/custom/path");
+      expect(agent.framework).toBe("claude-code");
+      expect(agent.image).toBeUndefined();
+      expect(agent.working_dir).toBeUndefined();
     });
 
     it("should update existing compose when name matches", async () => {

--- a/turbo/apps/web/app/api/agent/composes/route.ts
+++ b/turbo/apps/web/app/api/agent/composes/route.ts
@@ -9,10 +9,6 @@ import {
   SUPPORTED_FRAMEWORKS,
   isSupportedFramework,
 } from "@vm0/core";
-import {
-  resolveFrameworkImage,
-  resolveFrameworkWorkingDir,
-} from "../../../../src/lib/framework/framework-config";
 import { initServices } from "../../../../src/lib/init-services";
 import {
   agentComposes,
@@ -220,18 +216,12 @@ const router = tsr.router(composesMainContract, {
       };
     }
 
-    // Resolve image and working_dir server-side based on framework
-    const resolvedImage = resolveFrameworkImage(framework);
-    const resolvedWorkingDir = resolveFrameworkWorkingDir(framework);
-
-    // Build resolved content with server-determined image and working_dir
+    // Build resolved content with normalized agent name
     const resolvedContent = {
       ...content,
       agents: {
         [normalizedAgentName]: {
           ...agent,
-          image: resolvedImage,
-          working_dir: resolvedWorkingDir,
         },
       },
     };

--- a/turbo/apps/web/app/api/agent/runs/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/__tests__/route.test.ts
@@ -1198,9 +1198,7 @@ describe("POST /api/agent/runs - Internal Runs API", () => {
               version: "1.0",
               agents: {
                 "test-agent": {
-                  image: "vm0/claude-code:latest",
                   framework: "claude-code",
-                  working_dir: "/home/user/workspace",
                   environment: { ANTHROPIC_API_KEY: "test-key" },
                   volumes: ["data:/mnt/data"],
                 },
@@ -1243,9 +1241,7 @@ describe("POST /api/agent/runs - Internal Runs API", () => {
               version: "1.0",
               agents: {
                 "test-agent": {
-                  image: "vm0/claude-code:latest",
                   framework: "claude-code",
-                  working_dir: "/home/user/workspace",
                   environment: { ANTHROPIC_API_KEY: "test-key" },
                   volumes: ["data:/mnt/data"],
                 },
@@ -1302,9 +1298,7 @@ describe("POST /api/agent/runs - Internal Runs API", () => {
               version: "1.0",
               agents: {
                 [agentName]: {
-                  image: "vm0/claude-code:latest",
                   framework: "claude-code",
-                  working_dir: "/home/user/workspace",
                   environment: { ANTHROPIC_API_KEY: "test-key" },
                   volumes: ["undefined-vol:/mnt/data"],
                 },

--- a/turbo/apps/web/src/__tests__/api-test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers.ts
@@ -153,9 +153,7 @@ export function createDefaultComposeConfig(
 
   // Build base agent config without environment
   const baseAgent: Record<string, unknown> = {
-    image: "vm0/claude-code:latest",
     framework: "claude-code",
-    working_dir: "/home/user/workspace",
   };
 
   // Add environment unless noEnvironmentBlock is set

--- a/turbo/apps/web/src/lib/agent-compose/__tests__/content-hash.test.ts
+++ b/turbo/apps/web/src/lib/agent-compose/__tests__/content-hash.test.ts
@@ -18,9 +18,7 @@ describe("content-hash", () => {
         version: "1.0",
         agents: {
           "test-agent": {
-            image: "test-image",
             framework: "claude-code",
-            working_dir: "/workspace",
           },
         },
       };
@@ -36,9 +34,7 @@ describe("content-hash", () => {
         version: "1.0",
         agents: {
           "my-agent": {
-            image: "ubuntu",
             framework: "claude-code",
-            working_dir: "/home",
           },
         },
       };
@@ -47,9 +43,7 @@ describe("content-hash", () => {
         version: "1.0",
         agents: {
           "my-agent": {
-            image: "ubuntu",
             framework: "claude-code",
-            working_dir: "/home",
           },
         },
       };
@@ -65,9 +59,8 @@ describe("content-hash", () => {
         version: "1.0",
         agents: {
           agent1: {
-            working_dir: "/workspace",
-            image: "test",
             framework: "claude-code",
+            description: "test",
           },
         },
       } as AgentComposeYaml;
@@ -75,9 +68,8 @@ describe("content-hash", () => {
       const content2 = {
         agents: {
           agent1: {
-            image: "test",
+            description: "test",
             framework: "claude-code",
-            working_dir: "/workspace",
           },
         },
         version: "1.0",
@@ -93,9 +85,8 @@ describe("content-hash", () => {
         version: "1.0",
         agents: {
           agent1: {
-            image: "image-a",
             framework: "claude-code",
-            working_dir: "/workspace",
+            description: "agent-a",
           },
         },
       };
@@ -104,9 +95,8 @@ describe("content-hash", () => {
         version: "1.0",
         agents: {
           agent1: {
-            image: "image-b",
             framework: "claude-code",
-            working_dir: "/workspace",
+            description: "agent-b",
           },
         },
       };
@@ -121,9 +111,7 @@ describe("content-hash", () => {
         version: "1.0",
         agents: {
           agent1: {
-            image: "test",
             framework: "claude-code",
-            working_dir: "/workspace",
             environment: {
               FOO: "bar",
               BAZ: "qux",
@@ -140,9 +128,7 @@ describe("content-hash", () => {
         version: "1.0",
         agents: {
           agent1: {
-            working_dir: "/workspace",
             framework: "claude-code",
-            image: "test",
             environment: {
               BAZ: "qux",
               FOO: "bar",

--- a/turbo/apps/web/src/lib/compose/server-side-compose.ts
+++ b/turbo/apps/web/src/lib/compose/server-side-compose.ts
@@ -8,10 +8,6 @@ import {
   type SupportedFramework,
 } from "@vm0/core";
 import type { AgentComposeYaml } from "../../types/agent-compose";
-import {
-  resolveFrameworkImage,
-  resolveFrameworkWorkingDir,
-} from "../framework/framework-config";
 import { uploadInstructionsServerSide } from "../storage/instruction-upload";
 import { computeComposeVersionId } from "../agent-compose/content-hash";
 import {
@@ -219,7 +215,7 @@ export async function serverSideCompose(params: {
   const contentCopy = structuredClone(content);
   await expandFirewallConfigs(contentCopy);
 
-  // 5. Build resolved content with server-determined image and working_dir
+  // 5. Build resolved content with normalized agent name
   const agentsCopy = contentCopy.agents as Record<
     string,
     Record<string, unknown>
@@ -231,8 +227,6 @@ export async function serverSideCompose(params: {
       [normalizedName]: {
         ...agentsCopy[agentName],
         environment,
-        image: resolveFrameworkImage(framework),
-        working_dir: resolveFrameworkWorkingDir(framework),
       },
     },
   } as AgentComposeYaml;

--- a/turbo/apps/web/src/lib/framework/framework-config.ts
+++ b/turbo/apps/web/src/lib/framework/framework-config.ts
@@ -1,7 +1,7 @@
 /**
  * Server-side framework configuration
  *
- * Provides image and working directory resolution based on framework.
+ * Provides working directory resolution based on framework.
  * Uses SUPPORTED_FRAMEWORKS from @vm0/core as the source of truth.
  */
 
@@ -12,29 +12,16 @@ import type { SupportedFramework } from "@vm0/core";
  */
 interface FrameworkDefaults {
   workingDir: string;
-  image: string;
 }
 
 /**
  * Default configurations for each supported framework
- * Note: All images use :latest tag. The :dev tag is no longer supported.
  */
 const FRAMEWORK_DEFAULTS: Record<SupportedFramework, FrameworkDefaults> = {
   "claude-code": {
     workingDir: "/home/user/workspace",
-    image: "vm0/claude-code:latest",
   },
 };
-
-/**
- * Resolve the image for a framework
- *
- * @param framework - The supported framework
- * @returns The resolved image string (always uses :latest tag)
- */
-export function resolveFrameworkImage(framework: SupportedFramework): string {
-  return FRAMEWORK_DEFAULTS[framework].image;
-}
 
 /**
  * Resolve the working directory for a framework

--- a/turbo/apps/web/src/lib/run/__tests__/create-run.test.ts
+++ b/turbo/apps/web/src/lib/run/__tests__/create-run.test.ts
@@ -411,9 +411,7 @@ describe("createRun()", () => {
         version: "1.0",
         agents: {
           [agentName]: {
-            image: "vm0/claude-code:latest",
             framework: "claude-code",
-            working_dir: "/home/user/workspace",
             environment: { ANTHROPIC_API_KEY: "test-api-key" },
             volumes: agentVolumes,
           },

--- a/turbo/apps/web/src/lib/run/context/execution-preparer.ts
+++ b/turbo/apps/web/src/lib/run/context/execution-preparer.ts
@@ -7,7 +7,8 @@ import {
   ensureStorageExists,
 } from "../../storage/storage-service";
 import type { StorageManifest } from "../../storage/types";
-import { DEFAULT_PROFILE } from "@vm0/core";
+import { DEFAULT_PROFILE, isSupportedFramework } from "@vm0/core";
+import { resolveFrameworkWorkingDir } from "../../framework/framework-config";
 import { badRequest } from "../../errors";
 import { logger } from "../../logger";
 import {
@@ -20,24 +21,33 @@ import { extractCliAgentType } from "../utils";
 const log = logger("context:preparer");
 
 /**
- * Extract working directory from agent compose config
- * This is required for resume and storage operations
+ * Resolve working directory from agent compose config.
+ * Resolves from framework at runtime via framework-config.
+ * Falls back to legacy working_dir field for old stored composes.
  */
 function extractWorkingDir(agentCompose: unknown): string {
   const compose = agentCompose as AgentComposeYaml | undefined;
   if (!compose?.agents) {
-    throw badRequest(
-      "Agent must have working_dir configured (no default allowed)",
-    );
+    throw badRequest("Agent compose must have agents configured");
   }
   const agents = Object.values(compose.agents);
-  const workingDir = agents[0]?.working_dir;
-  if (!workingDir) {
-    throw badRequest(
-      "Agent must have working_dir configured (no default allowed)",
-    );
+  const agent = agents[0];
+  if (!agent) {
+    throw badRequest("Agent compose must have at least one agent");
   }
-  return workingDir;
+
+  // Resolve from framework (primary path)
+  if (agent.framework && isSupportedFramework(agent.framework)) {
+    return resolveFrameworkWorkingDir(agent.framework);
+  }
+
+  // Fallback for legacy stored composes that still have working_dir
+  const legacy = (agent as unknown as Record<string, unknown>).working_dir;
+  if (typeof legacy === "string") {
+    return legacy;
+  }
+
+  throw badRequest("Agent must have a supported framework configured");
 }
 
 /**

--- a/turbo/apps/web/src/lib/run/context/execution-preparer.ts
+++ b/turbo/apps/web/src/lib/run/context/execution-preparer.ts
@@ -7,10 +7,10 @@ import {
   ensureStorageExists,
 } from "../../storage/storage-service";
 import type { StorageManifest } from "../../storage/types";
-import { DEFAULT_PROFILE, isSupportedFramework } from "@vm0/core";
-import { resolveFrameworkWorkingDir } from "../../framework/framework-config";
+import { DEFAULT_PROFILE } from "@vm0/core";
 import { badRequest } from "../../errors";
 import { logger } from "../../logger";
+import { extractWorkingDir } from "../utils/extract-working-dir";
 import {
   agentComposes,
   agentComposeVersions,
@@ -19,36 +19,6 @@ import { getOrgData } from "../../org/org-cache-service";
 import { extractCliAgentType } from "../utils";
 
 const log = logger("context:preparer");
-
-/**
- * Resolve working directory from agent compose config.
- * Resolves from framework at runtime via framework-config.
- * Falls back to legacy working_dir field for old stored composes.
- */
-function extractWorkingDir(agentCompose: unknown): string {
-  const compose = agentCompose as AgentComposeYaml | undefined;
-  if (!compose?.agents) {
-    throw badRequest("Agent compose must have agents configured");
-  }
-  const agents = Object.values(compose.agents);
-  const agent = agents[0];
-  if (!agent) {
-    throw badRequest("Agent compose must have at least one agent");
-  }
-
-  // Resolve from framework (primary path)
-  if (agent.framework && isSupportedFramework(agent.framework)) {
-    return resolveFrameworkWorkingDir(agent.framework);
-  }
-
-  // Fallback for legacy stored composes that still have working_dir
-  const legacy = (agent as unknown as Record<string, unknown>).working_dir;
-  if (typeof legacy === "string") {
-    return legacy;
-  }
-
-  throw badRequest("Agent must have a supported framework configured");
-}
 
 /**
  * Resolve runner group from agent compose config

--- a/turbo/apps/web/src/lib/run/environment/__tests__/expand-environment.test.ts
+++ b/turbo/apps/web/src/lib/run/environment/__tests__/expand-environment.test.ts
@@ -12,7 +12,6 @@ function makeCompose(
       test: {
         description: "test",
         framework: "claude-code" as const,
-        working_dir: "/home/user",
         environment,
         ...(firewallConfigs ? { experimental_firewalls: firewallConfigs } : {}),
       },

--- a/turbo/apps/web/src/lib/run/utils/extract-working-dir.ts
+++ b/turbo/apps/web/src/lib/run/utils/extract-working-dir.ts
@@ -1,7 +1,10 @@
 import { isSupportedFramework } from "@vm0/core";
 import { resolveFrameworkWorkingDir } from "../../framework/framework-config";
 import { badRequest } from "../../errors";
+import { logger } from "../../logger";
 import type { AgentComposeYaml } from "../../../types/agent-compose";
+
+const log = logger("extract-working-dir");
 
 /**
  * Extract working directory from agent config.
@@ -29,8 +32,12 @@ export function extractWorkingDir(config: unknown): string {
   }
 
   // Fallback for legacy stored composes that still have working_dir
+  // TODO: Remove after data migration of old composes to use framework field
   const legacy = (agent as unknown as Record<string, unknown>).working_dir;
   if (typeof legacy === "string") {
+    log.warn(
+      "Using deprecated working_dir field from stored compose. Migrate compose to use framework field instead.",
+    );
     return legacy;
   }
 

--- a/turbo/apps/web/src/lib/run/utils/extract-working-dir.ts
+++ b/turbo/apps/web/src/lib/run/utils/extract-working-dir.ts
@@ -1,27 +1,38 @@
+import { isSupportedFramework } from "@vm0/core";
+import { resolveFrameworkWorkingDir } from "../../framework/framework-config";
 import { badRequest } from "../../errors";
 import type { AgentComposeYaml } from "../../../types/agent-compose";
 
 /**
- * Extract working directory from agent config
- * Throws BadRequestError if working_dir is not configured
+ * Extract working directory from agent config.
+ * Resolves from framework at runtime via framework-config.
+ * Falls back to legacy working_dir field for old stored composes.
  *
  * @param config Agent compose configuration
  * @returns Working directory path
- * @throws BadRequestError if working_dir is not configured
+ * @throws BadRequestError if framework is unsupported and no legacy fallback
  */
 export function extractWorkingDir(config: unknown): string {
   const compose = config as AgentComposeYaml | undefined;
   if (!compose?.agents) {
-    throw badRequest(
-      "Agent compose must have agents configured with working_dir",
-    );
+    throw badRequest("Agent compose must have agents configured");
   }
   const agents = Object.values(compose.agents);
-  const firstAgent = agents[0];
-  if (!firstAgent?.working_dir) {
-    throw badRequest(
-      "Agent must have working_dir configured (no default allowed)",
-    );
+  const agent = agents[0];
+  if (!agent) {
+    throw badRequest("Agent compose must have at least one agent");
   }
-  return firstAgent.working_dir;
+
+  // Resolve from framework (primary path)
+  if (agent.framework && isSupportedFramework(agent.framework)) {
+    return resolveFrameworkWorkingDir(agent.framework);
+  }
+
+  // Fallback for legacy stored composes that still have working_dir
+  const legacy = (agent as unknown as Record<string, unknown>).working_dir;
+  if (typeof legacy === "string") {
+    return legacy;
+  }
+
+  throw badRequest("Agent must have a supported framework configured");
 }

--- a/turbo/apps/web/src/lib/storage/storage-resolver.ts
+++ b/turbo/apps/web/src/lib/storage/storage-resolver.ts
@@ -288,6 +288,7 @@ function resolveInstructionsAndSkills(
  * @param artifactVersion - Optional artifact version (defaults to "latest")
  * @param skipArtifact - Skip artifact resolution (used when resuming from checkpoint)
  * @param volumeVersionOverrides - Optional volume version overrides (volume name -> version)
+ * @param workingDir - Working directory for artifact mount path
  * @returns Resolution result with resolved volumes, artifact, and errors
  */
 export function resolveVolumes(
@@ -297,6 +298,7 @@ export function resolveVolumes(
   artifactVersion?: string,
   skipArtifact?: boolean,
   volumeVersionOverrides?: Record<string, string>,
+  workingDir?: string,
 ): VolumeResolutionResult {
   const volumes: ResolvedVolume[] = [];
   const errors: VolumeError[] = [];
@@ -305,9 +307,6 @@ export function resolveVolumes(
   // Get first agent (currently only support one agent)
   const agentValues = config.agents ? Object.values(config.agents) : [];
   const agent = agentValues[0];
-
-  // Get working_dir from agent config for validation
-  const workingDir = agent?.working_dir;
 
   // Process volume declarations
   if (agent?.volumes && agent.volumes.length > 0) {

--- a/turbo/apps/web/src/lib/storage/storage-service.ts
+++ b/turbo/apps/web/src/lib/storage/storage-service.ts
@@ -319,6 +319,7 @@ export async function prepareStorageManifest(
         skipArtifact ? undefined : effectiveArtifactVersion,
         skipArtifact,
         volumeVersionOverrides,
+        resumeArtifactMountPath,
       )
     : { volumes: [], artifact: null, errors: [] };
 

--- a/turbo/apps/web/src/lib/storage/storage-service.ts
+++ b/turbo/apps/web/src/lib/storage/storage-service.ts
@@ -310,7 +310,9 @@ export async function prepareStorageManifest(
     return { storages: [], artifact: null, memory: null };
   }
 
-  // Resolve volumes from agent config
+  // Resolve volumes from agent config.
+  // resumeArtifactMountPath is the working directory from the previous run's artifact,
+  // used as workingDir for artifact mount path resolution during checkpoint resume.
   const volumeResult = agentConfig
     ? resolveVolumes(
         agentConfig,

--- a/turbo/apps/web/src/lib/storage/types.ts
+++ b/turbo/apps/web/src/lib/storage/types.ts
@@ -33,7 +33,7 @@ export interface ResolvedVolume {
  */
 export interface ResolvedArtifact {
   driver: StorageDriver;
-  mountPath: string; // Same as working_dir
+  mountPath: string; // Resolved from framework config
   vasStorageName: string;
   vasVersion: string; // Version hash or "latest"
 }
@@ -70,7 +70,6 @@ export interface AgentVolumeConfig {
     {
       framework?: string; // Framework name (e.g., "claude-code") for mount path resolution
       volumes?: string[];
-      working_dir?: string; // Optional when framework supports auto-config
       instructions?: string; // Path to instructions file (stored as agent-instructions@{name} volume)
       skills?: string[]; // GitHub tree URLs (stored as agent-skills@{path} volumes)
     }

--- a/turbo/apps/web/src/types/agent-compose.ts
+++ b/turbo/apps/web/src/types/agent-compose.ts
@@ -21,10 +21,8 @@ export interface VolumeConfig {
  */
 interface AgentDefinition {
   description?: string;
-  image?: string; // Optional when framework supports auto-config
   framework: string;
   volumes?: string[]; // Format: "volume-key:/mount/path"
-  working_dir?: string; // Optional when framework supports auto-config
   environment?: Record<string, string>; // Environment variables using ${{ vars.X }}, ${{ secrets.X }} syntax
   /**
    * Path to instructions file (e.g., AGENTS.md).

--- a/turbo/packages/core/src/contracts/composes.ts
+++ b/turbo/packages/core/src/contracts/composes.ts
@@ -70,10 +70,6 @@ const volumeConfigSchema = z.object({
 
 /**
  * Agent definition schema
- *
- * Note: `image` and `working_dir` are deprecated fields.
- * The server resolves these values based on the framework.
- * User-provided values are ignored - server always overwrites them.
  */
 const agentDefinitionSchema = z.object({
   description: z.string().optional(),
@@ -159,16 +155,6 @@ const agentDefinitionSchema = z.object({
       sound: z.string().optional(),
     })
     .optional(),
-  /**
-   * @deprecated Server-resolved field. User input is ignored.
-   * @internal
-   */
-  image: z.string().optional(),
-  /**
-   * @deprecated Server-resolved field. User input is ignored.
-   * @internal
-   */
-  working_dir: z.string().optional(),
 });
 
 /**


### PR DESCRIPTION
## Summary

Closes #5332

- Remove deprecated `image` and `working_dir` fields from agent definition schema (Zod), TypeScript types, and all CLI/server code
- Server no longer writes these fields to stored compose content; `working_dir` is resolved at runtime from `framework` via `resolveFrameworkWorkingDir()`
- Legacy fallback: execution code reads `working_dir` from old stored composes that still contain the field
- Remove `resolveFrameworkImage()` (unused after removal) and `checkLegacyImageFormat()` deprecation warning
- Update ~15 test files to remove deprecated field references from fixtures and assertions

## Changes

**Schema & Types (core cleanup):**
- `packages/core/src/contracts/composes.ts` — Remove `image` and `working_dir` from `agentDefinitionSchema`
- `apps/web/src/types/agent-compose.ts` — Remove from `AgentDefinition` interface
- `apps/cli/src/lib/domain/compose-types.ts` — Remove from CLI `AgentDefinition`
- `apps/cli/src/lib/domain/source-derivation.ts` — Remove from local `AgentDefinition`
- `apps/web/src/lib/storage/types.ts` — Remove `working_dir` from `AgentVolumeConfig`

**Server-side (stop writing deprecated fields):**
- `apps/web/app/api/agent/composes/route.ts` — Stop injecting `image`/`working_dir` into stored content
- `apps/web/src/lib/compose/server-side-compose.ts` — Same for platform compose path
- `apps/web/src/lib/framework/framework-config.ts` — Remove unused `resolveFrameworkImage()`

**Execution (resolve at runtime):**
- `apps/web/src/lib/run/context/execution-preparer.ts` — Resolve `workingDir` from framework at runtime with legacy fallback
- `apps/web/src/lib/run/utils/extract-working-dir.ts` — Same pattern
- `apps/web/src/lib/storage/storage-resolver.ts` — Accept `workingDir` as parameter instead of reading from config
- `apps/web/src/lib/storage/storage-service.ts` — Pass `workingDir` through to resolver

**CLI (remove deprecated references):**
- `apps/cli/src/commands/compose/index.ts` — Remove `checkLegacyImageFormat()` and its calls
- `apps/cli/src/commands/agent/clone.ts` — Simplify `cleanComposeContent()`
- `apps/cli/src/commands/agent/status.ts` — Remove image/working_dir display
- `apps/cli/src/commands/cook/cook.ts` — Remove from `AgentConfig` interface
- `apps/cli/src/lib/domain/yaml-validator.ts` — Update comment

## Test plan

- [x] All 2089 web tests pass (177 test files)
- [x] Lint: 0 errors, 0 warnings across core, cli, web
- [x] Type check: clean for core, cli, web
- [x] Knip: no unused exports detected
- [x] Format: all files clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)