### PR TITLE
feat: auto-disconnect existing connector in /authorize endpoint

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/zero-skills-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-skills-tab.tsx
@@ -215,13 +215,7 @@ export function ZeroSkillsTab({
           onClose={() => setScopeReviewType(null)}
           onReconnect={(type) => {
             setScopeReviewType(null);
-            detach(
-              (async () => {
-                await disconnect(type);
-                await connect(type, signal);
-              })(),
-              Reason.DomCallback,
-            );
+            detach(connect(type, signal), Reason.DomCallback);
           }}
         />
       )}

--- a/turbo/apps/web/app/api/connectors/[type]/authorize/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/connectors/[type]/authorize/__tests__/route.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { GET } from "../route";
-import { createTestRequest } from "../../../../../../src/__tests__/api-test-helpers";
+import {
+  createTestRequest,
+  findTestConnectorTokenExpiresAt,
+} from "../../../../../../src/__tests__/api-test-helpers";
 import { testContext } from "../../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
 import { reloadEnv } from "../../../../../../src/env";
@@ -298,6 +301,48 @@ describe("GET /api/connectors/:type/authorize - OAuth Authorize", () => {
       expect(location).toContain("code_challenge=");
       expect(location).toContain("code_challenge_method=S256");
       expect(location).toContain("state=");
+    });
+  });
+
+  describe("auto-disconnect on reconnect", () => {
+    it("should delete existing connector before redirecting to OAuth", async () => {
+      const user = await context.setupUser();
+      await context.createConnector(user.orgId, {
+        userId: user.userId,
+        type: "github",
+        authMethod: "oauth",
+      });
+
+      const request = createTestRequest(
+        "http://localhost:3000/api/connectors/github/authorize",
+      );
+      const response = await GET(request, {
+        params: Promise.resolve({ type: "github" }),
+      });
+
+      expect(response.status).toBe(307);
+
+      // Verify connector was deleted (undefined means no record found)
+      const tokenExpiresAt = await findTestConnectorTokenExpiresAt(
+        user.orgId,
+        "github",
+      );
+      expect(tokenExpiresAt).toBeUndefined();
+    });
+
+    it("should succeed for first-time connect with no existing connector", async () => {
+      await context.setupUser();
+
+      const request = createTestRequest(
+        "http://localhost:3000/api/connectors/github/authorize",
+      );
+      const response = await GET(request, {
+        params: Promise.resolve({ type: "github" }),
+      });
+
+      expect(response.status).toBe(307);
+      const location = response.headers.get("location");
+      expect(location).toContain("https://github.com/login/oauth/authorize");
     });
   });
 });

--- a/turbo/apps/web/app/api/connectors/[type]/authorize/route.ts
+++ b/turbo/apps/web/app/api/connectors/[type]/authorize/route.ts
@@ -2,12 +2,15 @@ import { NextResponse } from "next/server";
 import { connectorTypeSchema } from "@vm0/core";
 import { env } from "../../../../../src/env";
 import { initServices } from "../../../../../src/lib/init-services";
-import { getUserIdFromRequest } from "../../../../../src/lib/auth/get-auth-context";
+import { getAuthContext } from "../../../../../src/lib/auth/get-auth-context";
+import { resolveOrg } from "../../../../../src/lib/org/resolve-org";
 import { getOrigin } from "../../../../../src/lib/request/get-origin";
 import {
   type AuthUrlResult,
   PROVIDER_HANDLERS,
 } from "../../../../../src/lib/connector/provider-registry";
+import { deleteConnector } from "../../../../../src/lib/connector/connector-service";
+import { isNotFound } from "../../../../../src/lib/errors";
 
 /**
  * Connector OAuth Authorize Endpoint
@@ -76,8 +79,9 @@ export async function GET(
   const origin = getOrigin(request);
 
   // Verify user is authenticated
-  const userId = await getUserIdFromRequest(request);
-  if (!userId) {
+  const authHeader = request.headers.get("authorization") ?? undefined;
+  const authCtx = await getAuthContext(authHeader);
+  if (!authCtx) {
     // Redirect to login page using correct origin (not localhost behind tunnel)
     const loginUrl = new URL("/sign-in", origin);
     const authorizeUrl = new URL(url.pathname + url.search, origin);
@@ -91,6 +95,17 @@ export async function GET(
       { error: "Computer connector does not use OAuth" },
       { status: 400 },
     );
+  }
+
+  // Auto-disconnect existing connector before re-authorizing.
+  // This ensures old provider tokens are revoked during reconnect flows.
+  // For first-time connects, deleteConnector throws NotFound — safe to ignore.
+  const orgSlug = url.searchParams.get("org");
+  const { org } = await resolveOrg(authCtx, orgSlug);
+  try {
+    await deleteConnector(org.orgId, authCtx.userId, connectorType);
+  } catch (e: unknown) {
+    if (!isNotFound(e)) throw e;
   }
 
   // Generate state for CSRF protection

--- a/turbo/apps/web/src/lib/auth/get-auth-context.ts
+++ b/turbo/apps/web/src/lib/auth/get-auth-context.ts
@@ -157,14 +157,3 @@ export async function getUserId(
   const ctx = await getAuthContext(authHeader, options);
   return ctx?.userId ?? null;
 }
-
-/**
- * Get user ID from a Request object
- * Used for API routes that receive the full Request
- */
-export async function getUserIdFromRequest(
-  request: Request,
-): Promise<string | null> {
-  const authHeader = request.headers.get("authorization") ?? undefined;
-  return getUserId(authHeader);
-}


### PR DESCRIPTION
## Summary
- Unify OAuth reconnect flows: `/authorize` endpoint now auto-disconnects existing connectors server-side before redirecting to the OAuth provider, ensuring old tokens are properly revoked
- Remove frontend `disconnect()` call from `ScopeReviewModal` `onReconnect` handler since the server handles it
- Clean up unused `getUserIdFromRequest` function

Closes #5343

## Test plan
- [x] Existing authorize route tests pass (14 tests)
- [x] New test: verifies existing connector is deleted before OAuth redirect
- [x] New test: verifies first-time connect (no existing connector) still works
- [x] Lint, type-check, knip all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)