### PR TITLE
feat: change schedule minute picker to 5-minute step intervals

### DIFF
--- a/turbo/apps/cli/src/commands/schedule/__tests__/setup.test.ts
+++ b/turbo/apps/cli/src/commands/schedule/__tests__/setup.test.ts
@@ -34,7 +34,7 @@ describe("schedule setup utilities", () => {
       expect(generateCronExpression("daily", "09:00")).toBe("0 9 * * *");
       expect(generateCronExpression("daily", "14:30")).toBe("30 14 * * *");
       expect(generateCronExpression("daily", "00:00")).toBe("0 0 * * *");
-      expect(generateCronExpression("daily", "23:59")).toBe("59 23 * * *");
+      expect(generateCronExpression("daily", "23:55")).toBe("55 23 * * *");
     });
 
     it("should generate weekly cron expression", () => {
@@ -81,7 +81,7 @@ describe("schedule setup utilities", () => {
       expect(validateTimeFormat("09:00")).toBe(true);
       expect(validateTimeFormat("9:00")).toBe(true);
       expect(validateTimeFormat("00:00")).toBe(true);
-      expect(validateTimeFormat("23:59")).toBe(true);
+      expect(validateTimeFormat("23:55")).toBe(true);
       expect(validateTimeFormat("12:30")).toBe(true);
     });
 
@@ -108,6 +108,18 @@ describe("schedule setup utilities", () => {
     it("should reject out of range minutes", () => {
       expect(validateTimeFormat("09:60")).toBe("Minute must be 0-59");
       expect(validateTimeFormat("09:99")).toBe("Minute must be 0-59");
+    });
+
+    it("should reject minutes that are not multiples of 5", () => {
+      expect(validateTimeFormat("09:01")).toBe(
+        "Minute must be a multiple of 5 (0, 5, 10, ..., 55)",
+      );
+      expect(validateTimeFormat("09:07")).toBe(
+        "Minute must be a multiple of 5 (0, 5, 10, ..., 55)",
+      );
+      expect(validateTimeFormat("09:59")).toBe(
+        "Minute must be a multiple of 5 (0, 5, 10, ..., 55)",
+      );
     });
   });
 

--- a/turbo/apps/cli/src/lib/domain/schedule-utils.ts
+++ b/turbo/apps/cli/src/lib/domain/schedule-utils.ts
@@ -194,6 +194,9 @@ export function validateTimeFormat(time: string): boolean | string {
   if (minute < 0 || minute > 59) {
     return "Minute must be 0-59";
   }
+  if (minute % 5 !== 0) {
+    return "Minute must be a multiple of 5 (0, 5, 10, ..., 55)";
+  }
 
   return true;
 }

--- a/turbo/apps/platform/src/views/zero-page/zero-schedule-card.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-schedule-card.tsx
@@ -60,10 +60,22 @@ export const HOUR_OPTIONS: readonly number[] = Array.from(
   { length: 24 },
   (_, i) => i,
 );
-export const MINUTE_OPTIONS: readonly number[] = Array.from(
-  { length: 60 },
-  (_, i) => i,
+const MINUTE_OPTIONS: readonly number[] = Array.from(
+  { length: 12 },
+  (_, i) => i * 5,
 );
+
+/**
+ * Build the minute dropdown options, inserting a non-standard value (e.g. an
+ * existing schedule whose minute is not a multiple of 5) so the schedule
+ * remains editable.
+ */
+export function getMinuteOptions(currentMinute?: number): readonly number[] {
+  if (currentMinute === undefined || MINUTE_OPTIONS.includes(currentMinute)) {
+    return MINUTE_OPTIONS;
+  }
+  return [...MINUTE_OPTIONS, currentMinute].sort((a, b) => a - b);
+}
 
 export const WEEKDAY_LABELS = [
   "Mon",
@@ -1102,7 +1114,7 @@ export function ZeroScheduleCard({
                       <SelectValue />
                     </SelectTrigger>
                     <SelectContent>
-                      {MINUTE_OPTIONS.map((m) => (
+                      {getMinuteOptions(scheduleMinute).map((m) => (
                         <SelectItem key={m} value={String(m)}>
                           {m.toString().padStart(2, "0")}
                         </SelectItem>

--- a/turbo/apps/platform/src/views/zero-page/zero-schedule-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-schedule-page.tsx
@@ -45,7 +45,7 @@ import {
   SCHEDULE_FREQUENCY_OPTIONS,
   SCHEDULE_LOOP_MINUTES,
   HOUR_OPTIONS,
-  MINUTE_OPTIONS,
+  getMinuteOptions,
   type ScheduleEntry,
 } from "./zero-schedule-card";
 import { agentDisplayName$ } from "../../signals/zero-page/zero-agent-name.ts";
@@ -450,7 +450,7 @@ function ScheduleEditFields({
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
-                {MINUTE_OPTIONS.map((m) => (
+                {getMinuteOptions(minute).map((m) => (
                   <SelectItem key={m} value={String(m)}>
                     {m.toString().padStart(2, "0")}
                   </SelectItem>


### PR DESCRIPTION
## Summary
- Change minute picker options from 1-minute (0-59) to 5-minute increments (0, 5, 10, ..., 55) in both platform UI dropdowns and CLI validation
- Dynamically insert non-standard minute values into the dropdown when editing existing schedules so they remain editable
- Make `MINUTE_OPTIONS` private, expose `getMinuteOptions()` as the public API

Closes #5355

## Test plan
- [x] Existing schedule setup tests updated and passing (98/98)
- [x] Lint, format, and knip all pass
- [ ] Verify minute dropdown in platform UI shows 5-minute intervals
- [ ] Verify editing a schedule with minute=7 shows [0, 5, 7, 10, ...] in dropdown
- [ ] Verify CLI rejects non-multiple-of-5 minute values (e.g. `--time 09:07`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)