### PR TITLE
fix: drop residual zero prefix from queue session link and stale comment

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/zero-nav.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-nav.ts
@@ -89,7 +89,7 @@ export const setZeroActiveId$ = command(({ set }, id: ZeroNavId) => {
 
 /**
  * Whether the talk agent has been resolved from the URL.
- * Set to true after setupZeroPage$ processes the /zero/talk/:name route.
+ * Set to true after setupZeroPage$ processes the /talk/:name route.
  */
 const internalTalkAgentResolved$ = state(false);
 export const zeroTalkAgentResolved$ = computed((get) =>

--- a/turbo/apps/web/app/api/agent/runs/queue/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/queue/__tests__/route.test.ts
@@ -362,6 +362,31 @@ describe("GET /api/agent/runs/queue", () => {
     expect(data.estimatedTimePerRun).toBe(90000);
   });
 
+  it("produces sessionLink without /zero prefix for own runs with continuedFromSessionId", async () => {
+    const sessionId = crypto.randomUUID();
+
+    await createTestRunInDb(user.userId, testComposeId, {
+      status: "queued",
+      continuedFromSessionId: sessionId,
+    });
+
+    await insertUserCacheEntry({
+      userId: user.userId,
+      email: "test@example.com",
+    });
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/agent/runs/queue",
+    );
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.queue).toHaveLength(1);
+    expect(data.queue[0].sessionLink).toBe(`/chat/${sessionId}`);
+    expect(data.queue[0].sessionLink).not.toContain("/zero");
+  });
+
   it("truncates long prompts at 200 characters for own runs", async () => {
     const longPrompt = "a".repeat(250);
 

--- a/turbo/apps/web/app/api/agent/runs/queue/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/queue/route.ts
@@ -195,7 +195,7 @@ const router = tsr.router(runsQueueContract, {
         triggerSource: isOwner ? inferTriggerSource(run) : null,
         sessionLink:
           isOwner && run.continuedFromSessionId
-            ? `/zero/chat/${run.continuedFromSessionId}`
+            ? `/chat/${run.continuedFromSessionId}`
             : null,
       };
     });

--- a/turbo/apps/web/src/__tests__/api-test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers.ts
@@ -665,6 +665,7 @@ export async function createTestRunInDb(
   options?: {
     status?: string;
     prompt?: string;
+    continuedFromSessionId?: string;
     createdAt?: Date;
     orgId?: string;
     startedAt?: Date;
@@ -690,6 +691,7 @@ export async function createTestRunInDb(
     {
       status: options?.status ?? "pending",
       prompt: options?.prompt ?? "test prompt",
+      continuedFromSessionId: options?.continuedFromSessionId,
       createdAt: options?.createdAt,
       startedAt: options?.startedAt,
       completedAt: options?.completedAt,


### PR DESCRIPTION
## Summary

- Remove `/zero` prefix from `sessionLink` in queue API route (`/zero/chat/{id}` -> `/chat/{id}`)
- Fix stale comment in `zero-nav.ts` referencing `/zero/talk/:name` (now `/talk/:name`)
- Add test asserting `sessionLink` produces `/chat/{id}` without `/zero` prefix

Closes #5356

## Test plan

- [x] Existing queue route tests pass (15/15)
- [x] New test verifies `sessionLink` path does not contain `/zero`
- [x] Lint, knip, and format checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)