### PR TITLE
refactor: remove legacy working_dir fallback from extract-working-dir

### DIFF
--- a/turbo/apps/web/src/lib/run/utils/extract-working-dir.ts
+++ b/turbo/apps/web/src/lib/run/utils/extract-working-dir.ts
@@ -1,19 +1,15 @@
 import { isSupportedFramework } from "@vm0/core";
 import { resolveFrameworkWorkingDir } from "../../framework/framework-config";
 import { badRequest } from "../../errors";
-import { logger } from "../../logger";
 import type { AgentComposeYaml } from "../../../types/agent-compose";
-
-const log = logger("extract-working-dir");
 
 /**
  * Extract working directory from agent config.
  * Resolves from framework at runtime via framework-config.
- * Falls back to legacy working_dir field for old stored composes.
  *
  * @param config Agent compose configuration
  * @returns Working directory path
- * @throws BadRequestError if framework is unsupported and no legacy fallback
+ * @throws BadRequestError if framework is unsupported
  */
 export function extractWorkingDir(config: unknown): string {
   const compose = config as AgentComposeYaml | undefined;
@@ -26,19 +22,8 @@ export function extractWorkingDir(config: unknown): string {
     throw badRequest("Agent compose must have at least one agent");
   }
 
-  // Resolve from framework (primary path)
   if (agent.framework && isSupportedFramework(agent.framework)) {
     return resolveFrameworkWorkingDir(agent.framework);
-  }
-
-  // Fallback for legacy stored composes that still have working_dir
-  // TODO: Remove after data migration of old composes to use framework field
-  const legacy = (agent as unknown as Record<string, unknown>).working_dir;
-  if (typeof legacy === "string") {
-    log.warn(
-      "Using deprecated working_dir field from stored compose. Migrate compose to use framework field instead.",
-    );
-    return legacy;
   }
 
   throw badRequest("Agent must have a supported framework configured");


### PR DESCRIPTION
## Summary

- Remove the legacy `working_dir` fallback path from `extractWorkingDir()` — the working directory is always resolved from the framework config
- Remove unused `logger` import that was only used by the fallback warning

Follows up on #5332 / #5352.

## Test plan

- [x] Type check passes (core, cli, web)
- [x] Knip: no unused exports
- [x] Prettier: formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)