### PR TITLE
refactor(platform): derive capability groups from valid capabilities constant

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/zero-experimental-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-experimental-tab.tsx
@@ -1,3 +1,4 @@
+import { VALID_CAPABILITIES, CAPABILITY_META } from "@vm0/core";
 import { Card, CardContent } from "@vm0/ui";
 import { LoadingSwitch } from "../components/loading-switch.tsx";
 import { ZeroUnsavedBar } from "./zero-unsaved-bar.tsx";
@@ -11,6 +12,24 @@ interface ZeroExperimentalTabProps {
   onDiscardCapabilities: () => void;
 }
 
+// Derive groups from VALID_CAPABILITIES, preserving declaration order
+function buildCapabilityGroups() {
+  const groups: {
+    label: string;
+    capabilities: { key: string; label: string }[];
+  }[] = [];
+  for (const key of VALID_CAPABILITIES) {
+    const meta = CAPABILITY_META[key];
+    let group = groups.find((g) => g.label === meta.group);
+    if (!group) {
+      group = { label: meta.group, capabilities: [] };
+      groups.push(group);
+    }
+    group.capabilities.push({ key, label: meta.label });
+  }
+  return groups;
+}
+
 export function ZeroExperimentalTab({
   capabilities,
   capabilitiesDirty,
@@ -19,31 +38,7 @@ export function ZeroExperimentalTab({
   onSaveCapabilities,
   onDiscardCapabilities,
 }: ZeroExperimentalTabProps) {
-  const capabilityGroups = [
-    {
-      label: "Agent Resources",
-      capabilities: [
-        { key: "agent:read", label: "Read agents & volumes" },
-        { key: "agent:write", label: "Write agents & volumes" },
-      ],
-    },
-    {
-      label: "Artifacts & Memories",
-      capabilities: [
-        { key: "artifact:read", label: "Read artifacts & memories" },
-        { key: "artifact:write", label: "Write artifacts & memories" },
-      ],
-    },
-    {
-      label: "Operations",
-      capabilities: [
-        { key: "agent-run:read", label: "View agent runs" },
-        { key: "agent-run:write", label: "Create & cancel runs" },
-        { key: "schedule:read", label: "View schedules" },
-        { key: "schedule:write", label: "Manage schedules" },
-      ],
-    },
-  ];
+  const capabilityGroups = buildCapabilityGroups();
 
   return (
     <>

--- a/turbo/packages/core/src/contracts/__tests__/composes.test.ts
+++ b/turbo/packages/core/src/contracts/__tests__/composes.test.ts
@@ -3,6 +3,7 @@ import {
   agentDefinitionSchema,
   agentComposeApiContentSchema,
   VALID_CAPABILITIES,
+  CAPABILITY_META,
 } from "../composes";
 
 const baseAgent = {
@@ -26,6 +27,16 @@ describe("VALID_CAPABILITIES", () => {
   it("all follow resource:action format", () => {
     for (const cap of VALID_CAPABILITIES) {
       expect(cap).toMatch(/^[a-z-]+:(read|write)$/);
+    }
+  });
+});
+
+describe("CAPABILITY_META", () => {
+  it("has an entry for every VALID_CAPABILITIES member", () => {
+    for (const cap of VALID_CAPABILITIES) {
+      expect(CAPABILITY_META[cap]).toBeDefined();
+      expect(CAPABILITY_META[cap].group).toBeTruthy();
+      expect(CAPABILITY_META[cap].label).toBeTruthy();
     }
   });
 });

--- a/turbo/packages/core/src/contracts/composes.ts
+++ b/turbo/packages/core/src/contracts/composes.ts
@@ -43,6 +43,37 @@ export const VALID_CAPABILITIES = [
   "schedule:write",
 ] as const;
 
+/** Inferred union type of all valid capability strings. */
+export type ValidCapability = (typeof VALID_CAPABILITIES)[number];
+
+/** Metadata for a single capability — group label and human-readable label. */
+export interface CapabilityMeta {
+  group: string;
+  label: string;
+}
+
+/**
+ * Exhaustive mapping from every valid capability to its UI group and label.
+ * Adding a new capability to VALID_CAPABILITIES without updating this record
+ * will produce a TypeScript compile error.
+ */
+export const CAPABILITY_META: Record<ValidCapability, CapabilityMeta> = {
+  "agent:read": { group: "Agent Resources", label: "Read agents & volumes" },
+  "agent:write": { group: "Agent Resources", label: "Write agents & volumes" },
+  "artifact:read": {
+    group: "Artifacts & Memories",
+    label: "Read artifacts & memories",
+  },
+  "artifact:write": {
+    group: "Artifacts & Memories",
+    label: "Write artifacts & memories",
+  },
+  "agent-run:read": { group: "Operations", label: "View agent runs" },
+  "agent-run:write": { group: "Operations", label: "Create & cancel runs" },
+  "schedule:read": { group: "Operations", label: "View schedules" },
+  "schedule:write": { group: "Operations", label: "Manage schedules" },
+};
+
 /**
  * Agent name validation schema
  * - Must be 3-64 characters

--- a/turbo/packages/core/src/contracts/index.ts
+++ b/turbo/packages/core/src/contracts/index.ts
@@ -37,6 +37,9 @@ export {
   composeResponseSchema,
   composeListItemSchema,
   VALID_CAPABILITIES,
+  CAPABILITY_META,
+  type ValidCapability,
+  type CapabilityMeta,
   // Inferred types
   type ComposeResponse,
   type ComposeListItem,


### PR DESCRIPTION
## Summary

- Add `CAPABILITY_META` exhaustive `Record` mapping in `@vm0/core` that maps every valid capability to its UI group and human-readable label
- Refactor `ZeroExperimentalTab` to derive capability groups from `VALID_CAPABILITIES` + `CAPABILITY_META` instead of hardcoding
- TypeScript `Record<ValidCapability, CapabilityMeta>` enforces compile-time exhaustiveness — adding a new capability without updating the mapping produces a type error

## Test plan

- [x] Existing `composes.test.ts` tests pass (13 tests)
- [x] New `CAPABILITY_META` test verifies all capabilities have non-empty group and label
- [x] TypeScript type check passes across all packages
- [x] Lint, format, and knip all clean

Closes #5364

🤖 Generated with [Claude Code](https://claude.com/claude-code)