### PR TITLE
feat: add op service account token to dev container remote env

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -22,7 +22,8 @@
     "PATH": "/home/vscode/.cache/cargo/bin:/home/vscode/.local/bin:${containerWorkspaceFolder}/bin:${containerEnv:PATH}",
     "VM0_API_URL": "https://www.vm7.ai:8443",
     "AGENT_BROWSER_PROFILE": "/home/vscode/.local/share/agent-browser/profile",
-    "AGENT_BROWSER_ARGS": "--disable-blink-features=AutomationControlled"
+    "AGENT_BROWSER_ARGS": "--disable-blink-features=AutomationControlled",
+    "OP_SERVICE_ACCOUNT_TOKEN": "${localEnv:VM0_DEV_CONTAINER_SERVICE_ACCOUNT_TOKEN}"
   },
   "mounts": [
     "source=config,target=/home/vscode/.config",


### PR DESCRIPTION
## Summary

- Add `OP_SERVICE_ACCOUNT_TOKEN` to `devcontainer.json` `remoteEnv`, mapped from the host-side `VM0_DEV_CONTAINER_SERVICE_ACCOUNT_TOKEN` variable
- Enables the `op` CLI to authenticate automatically inside dev containers without `op signin`

## Test plan

- [ ] Rebuild dev container with `VM0_DEV_CONTAINER_SERVICE_ACCOUNT_TOKEN` set on the host — verify `echo $OP_SERVICE_ACCOUNT_TOKEN` shows the value inside the container
- [ ] Rebuild dev container without the host variable set — verify `OP_SERVICE_ACCOUNT_TOKEN` is empty and nothing breaks

Closes #5366

🤖 Generated with [Claude Code](https://claude.com/claude-code)