### PR TITLE
refactor: pass op service account token via remote-env flag

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -22,8 +22,7 @@
     "PATH": "/home/vscode/.cache/cargo/bin:/home/vscode/.local/bin:${containerWorkspaceFolder}/bin:${containerEnv:PATH}",
     "VM0_API_URL": "https://www.vm7.ai:8443",
     "AGENT_BROWSER_PROFILE": "/home/vscode/.local/share/agent-browser/profile",
-    "AGENT_BROWSER_ARGS": "--disable-blink-features=AutomationControlled",
-    "OP_SERVICE_ACCOUNT_TOKEN": "${localEnv:VM0_DEV_CONTAINER_SERVICE_ACCOUNT_TOKEN}"
+    "AGENT_BROWSER_ARGS": "--disable-blink-features=AutomationControlled"
   },
   "mounts": [
     "source=config,target=/home/vscode/.config",

--- a/bin/dcu
+++ b/bin/dcu
@@ -8,4 +8,5 @@ FOLDER="$VM0_WORKSPACES/$1"
 (cd "$FOLDER" && git pull)
 npx @devcontainers/cli up --workspace-folder "$FOLDER" \
     --dotfiles-repository $VM0_DOTFILES \
+    --remote-env "OP_SERVICE_ACCOUNT_TOKEN=$VM0_DEV_CONTAINER_SERVICE_ACCOUNT_TOKEN" \
     --remove-existing-container


### PR DESCRIPTION
## Summary
- Remove `OP_SERVICE_ACCOUNT_TOKEN` from `.devcontainer/devcontainer.json` static env vars
- Pass it instead via `--remote-env` flag in the `bin/dcu` script
- Keeps the token out of the checked-in devcontainer config while still making it available at container creation time

## Test plan
- [ ] Verify `dcu` script creates a devcontainer with `OP_SERVICE_ACCOUNT_TOKEN` available in the environment
- [ ] Confirm devcontainer starts without errors after removing the env var from `devcontainer.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)