### PR TITLE
feat(cli): add --append-system-prompt flag to run commands

### DIFF
--- a/turbo/apps/cli/src/commands/run/__tests__/continue.test.ts
+++ b/turbo/apps/cli/src/commands/run/__tests__/continue.test.ts
@@ -170,6 +170,35 @@ describe("run continue command", () => {
       expect(capturedBody).not.toHaveProperty("volumeVersions");
     });
 
+    it("should pass append-system-prompt to API", async () => {
+      let capturedBody: Record<string, unknown> | undefined;
+
+      server.use(
+        http.post(
+          "http://localhost:3000/api/agent/runs",
+          async ({ request }) => {
+            capturedBody = (await request.json()) as Record<string, unknown>;
+            return HttpResponse.json(defaultRunResponse, { status: 201 });
+          },
+        ),
+      );
+
+      await continueCommand.parseAsync([
+        "node",
+        "cli",
+        testSessionId,
+        "test prompt",
+        "--append-system-prompt",
+        "Your name is Aria.",
+      ]);
+
+      expect(capturedBody).toEqual(
+        expect.objectContaining({
+          appendSystemPrompt: "Your name is Aria.",
+        }),
+      );
+    });
+
     it("should pass model provider option to API", async () => {
       let capturedBody: Record<string, unknown> | undefined;
 

--- a/turbo/apps/cli/src/commands/run/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/run/__tests__/index.test.ts
@@ -788,6 +788,37 @@ describe("run command", () => {
     });
   });
 
+  describe("--append-system-prompt flag", () => {
+    it("should pass append-system-prompt to API", async () => {
+      let capturedBody: Record<string, unknown> | undefined;
+
+      server.use(
+        http.post(
+          "http://localhost:3000/api/agent/runs",
+          async ({ request }) => {
+            capturedBody = (await request.json()) as Record<string, unknown>;
+            return HttpResponse.json(defaultRunResponse, { status: 201 });
+          },
+        ),
+      );
+
+      await runCommand.parseAsync([
+        "node",
+        "cli",
+        testUuid,
+        "test prompt",
+        "--append-system-prompt",
+        "Your name is Aria.",
+      ]);
+
+      expect(capturedBody).toEqual(
+        expect.objectContaining({
+          appendSystemPrompt: "Your name is Aria.",
+        }),
+      );
+    });
+  });
+
   describe("error handling", () => {
     it("should handle authentication errors", async () => {
       server.use(

--- a/turbo/apps/cli/src/commands/run/__tests__/resume.test.ts
+++ b/turbo/apps/cli/src/commands/run/__tests__/resume.test.ts
@@ -177,6 +177,35 @@ describe("run resume command", () => {
       );
     });
 
+    it("should pass append-system-prompt to API", async () => {
+      let capturedBody: Record<string, unknown> | undefined;
+
+      server.use(
+        http.post(
+          "http://localhost:3000/api/agent/runs",
+          async ({ request }) => {
+            capturedBody = (await request.json()) as Record<string, unknown>;
+            return HttpResponse.json(defaultRunResponse, { status: 201 });
+          },
+        ),
+      );
+
+      await resumeCommand.parseAsync([
+        "node",
+        "cli",
+        testCheckpointId,
+        "test prompt",
+        "--append-system-prompt",
+        "Your name is Aria.",
+      ]);
+
+      expect(capturedBody).toEqual(
+        expect.objectContaining({
+          appendSystemPrompt: "Your name is Aria.",
+        }),
+      );
+    });
+
     it("should pass model provider option to API", async () => {
       let capturedBody: Record<string, unknown> | undefined;
 

--- a/turbo/apps/cli/src/commands/run/continue.ts
+++ b/turbo/apps/cli/src/commands/run/continue.ts
@@ -37,6 +37,10 @@ export const continueCommand = new Command()
     "--model-provider <type>",
     "Override model provider (e.g., anthropic-api-key)",
   )
+  .option(
+    "--append-system-prompt <text>",
+    "Append text to the agent's system prompt",
+  )
   .option("--verbose", "Show full tool inputs and outputs")
   .option("--check-env", "Validate secrets and vars before running")
   .addOption(new Option("--debug-no-mock-claude").hideHelp())
@@ -50,6 +54,7 @@ export const continueCommand = new Command()
           vars: Record<string, string>;
           secrets: Record<string, string>;
           modelProvider?: string;
+          appendSystemPrompt?: string;
           verbose?: boolean;
           checkEnv?: boolean;
           debugNoMockClaude?: boolean;
@@ -63,6 +68,7 @@ export const continueCommand = new Command()
           vars: Record<string, string>;
           secrets: Record<string, string>;
           modelProvider?: string;
+          appendSystemPrompt?: string;
           verbose?: boolean;
           checkEnv?: boolean;
           debugNoMockClaude?: boolean;
@@ -97,6 +103,8 @@ export const continueCommand = new Command()
           vars: Object.keys(vars).length > 0 ? vars : undefined,
           secrets: loadedSecrets,
           modelProvider: options.modelProvider || allOpts.modelProvider,
+          appendSystemPrompt:
+            options.appendSystemPrompt || allOpts.appendSystemPrompt,
           checkEnv: options.checkEnv || allOpts.checkEnv || undefined,
           debugNoMockClaude:
             options.debugNoMockClaude || allOpts.debugNoMockClaude || undefined,

--- a/turbo/apps/cli/src/commands/run/resume.ts
+++ b/turbo/apps/cli/src/commands/run/resume.ts
@@ -42,6 +42,10 @@ export const resumeCommand = new Command()
     "--model-provider <type>",
     "Override model provider (e.g., anthropic-api-key)",
   )
+  .option(
+    "--append-system-prompt <text>",
+    "Append text to the agent's system prompt",
+  )
   .option("--verbose", "Show full tool inputs and outputs")
   .option("--check-env", "Validate secrets and vars before running")
   .addOption(new Option("--debug-no-mock-claude").hideHelp())
@@ -55,6 +59,7 @@ export const resumeCommand = new Command()
           vars: Record<string, string>;
           secrets: Record<string, string>;
           modelProvider?: string;
+          appendSystemPrompt?: string;
           verbose?: boolean;
           checkEnv?: boolean;
           debugNoMockClaude?: boolean;
@@ -69,6 +74,7 @@ export const resumeCommand = new Command()
           secrets: Record<string, string>;
           volumeVersion: Record<string, string>;
           modelProvider?: string;
+          appendSystemPrompt?: string;
           verbose?: boolean;
           checkEnv?: boolean;
           debugNoMockClaude?: boolean;
@@ -107,6 +113,8 @@ export const resumeCommand = new Command()
               ? allOpts.volumeVersion
               : undefined,
           modelProvider: options.modelProvider || allOpts.modelProvider,
+          appendSystemPrompt:
+            options.appendSystemPrompt || allOpts.appendSystemPrompt,
           checkEnv: options.checkEnv || allOpts.checkEnv || undefined,
           debugNoMockClaude:
             options.debugNoMockClaude || allOpts.debugNoMockClaude || undefined,

--- a/turbo/apps/cli/src/commands/run/run.ts
+++ b/turbo/apps/cli/src/commands/run/run.ts
@@ -69,6 +69,10 @@ export const mainRunCommand = new Command()
     "--model-provider <type>",
     "Override model provider (e.g., anthropic-api-key)",
   )
+  .option(
+    "--append-system-prompt <text>",
+    "Append text to the agent's system prompt",
+  )
   .option("--verbose", "Show full tool inputs and outputs")
   .option("--check-env", "Validate secrets and vars before running")
   .addOption(new Option("--debug-no-mock-claude").hideHelp())
@@ -88,6 +92,7 @@ export const mainRunCommand = new Command()
           volumeVersion: Record<string, string>;
           conversation?: string;
           modelProvider?: string;
+          appendSystemPrompt?: string;
           verbose?: boolean;
           checkEnv?: boolean;
           debugNoMockClaude?: boolean;
@@ -171,6 +176,7 @@ export const mainRunCommand = new Command()
               : undefined,
           conversationId: options.conversation,
           modelProvider: options.modelProvider,
+          appendSystemPrompt: options.appendSystemPrompt,
           checkEnv: options.checkEnv || undefined,
           debugNoMockClaude: options.debugNoMockClaude || undefined,
         });

--- a/turbo/apps/cli/src/lib/api/domains/runs.ts
+++ b/turbo/apps/cli/src/lib/api/domains/runs.ts
@@ -36,6 +36,8 @@ export async function createRun(body: {
   debugNoMockClaude?: boolean;
   // Environment validation flag - when true, validates secrets/vars before running
   checkEnv?: boolean;
+  // Append text to the agent's system prompt
+  appendSystemPrompt?: string;
   // Required
   prompt: string;
 }): Promise<CreateRunResponse> {


### PR DESCRIPTION
## Summary
- Add `--append-system-prompt <text>` option to `vm0 run`, `vm0 run continue`, and `vm0 run resume` commands
- CLI passes the value through to the API request body as `appendSystemPrompt`
- Fully backwards-compatible: if API doesn't support the field yet, it's silently ignored

Part of #5371. Closes #5376.

## Test plan
- [x] Integration test for `vm0 run --append-system-prompt` verifies field sent in API body
- [x] Integration test for `vm0 run continue --append-system-prompt` verifies field sent in API body
- [x] Integration test for `vm0 run resume --append-system-prompt` verifies field sent in API body
- [x] All 80 existing CLI run tests pass
- [x] Type check passes
- [x] Lint passes (0 warnings, 0 errors)
- [x] Knip passes (no unused code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)