### PR TITLE
refactor: move op service account token to exec and remove manual signin

### DIFF
--- a/bin/dcu
+++ b/bin/dcu
@@ -8,5 +8,4 @@ FOLDER="$VM0_WORKSPACES/$1"
 (cd "$FOLDER" && git pull)
 npx @devcontainers/cli up --workspace-folder "$FOLDER" \
     --dotfiles-repository $VM0_DOTFILES \
-    --remote-env "OP_SERVICE_ACCOUNT_TOKEN=$VM0_DEV_CONTAINER_SERVICE_ACCOUNT_TOKEN" \
     --remove-existing-container

--- a/bin/dcz
+++ b/bin/dcz
@@ -5,4 +5,6 @@ set -eu
 VM0_WORKSPACES="${VM0_WORKSPACES:-$HOME/workspaces}"
 FOLDER="$VM0_WORKSPACES/$1"
 
-npx @devcontainers/cli exec --workspace-folder "$FOLDER" zsh
+npx @devcontainers/cli exec --workspace-folder "$FOLDER" \
+    --remote-env "OP_SERVICE_ACCOUNT_TOKEN=$VM0_DEV_CONTAINER_SERVICE_ACCOUNT_TOKEN" \
+    zsh

--- a/scripts/sync-env.sh
+++ b/scripts/sync-env.sh
@@ -17,9 +17,6 @@ sync_with_1password() {
     exit 1
   fi
 
-  echo "Signing in to 1Password..."
-  eval "$(op signin)"
-
   echo "Syncing all environment templates..."
 
   while IFS= read -r tpl_file; do


### PR DESCRIPTION
## Summary
- Move `OP_SERVICE_ACCOUNT_TOKEN` remote-env flag from `dcu` (container up) to `dcz` (container exec) so the token is available at shell time
- Remove manual `op signin` step from `sync-env.sh` since the service account token is now injected automatically
- Fix missing newline at end of file in `bin/dcu` and `bin/dcz`

## Test plan
- [ ] Verify `dcu` still creates containers without the token flag
- [ ] Verify `dcz` injects the OP token into the exec session
- [ ] Verify `sync-env.sh` works without manual signin when service account token is set

🤖 Generated with [Claude Code](https://claude.com/claude-code)