### PR TITLE
feat: add append-system-prompt support to runner and guest-agent

### DIFF
--- a/crates/guest-agent/src/cli.rs
+++ b/crates/guest-agent/src/cli.rs
@@ -21,7 +21,8 @@ pub fn build_cli_command() -> Result<Vec<String>, AgentError> {
     Ok(build_claude_command(env::use_mock_claude()))
 }
 
-fn build_claude_command(use_mock: bool) -> Vec<String> {
+/// Build the argument list from explicit parameters (testable).
+fn build_claude_args(resume_id: &str, append_system_prompt: &str, prompt: &str) -> Vec<String> {
     let mut args = vec![
         "--print".to_string(),
         "--verbose".to_string(),
@@ -30,14 +31,30 @@ fn build_claude_command(use_mock: bool) -> Vec<String> {
         "--dangerously-skip-permissions".to_string(),
     ];
 
-    let resume = env::resume_session_id();
-    if !resume.is_empty() {
-        log_info!(LOG_TAG, "Resuming session: {resume}");
+    if !resume_id.is_empty() {
+        log_info!(LOG_TAG, "Resuming session: {resume_id}");
         args.push("--resume".to_string());
-        args.push(resume.to_string());
+        args.push(resume_id.to_string());
     } else {
         log_info!(LOG_TAG, "Starting new session");
     }
+
+    if !append_system_prompt.is_empty() {
+        args.push("--append-system-prompt".to_string());
+        args.push(append_system_prompt.to_string());
+    }
+
+    // Prompt must be the last positional argument
+    args.push(prompt.to_string());
+    args
+}
+
+fn build_claude_command(use_mock: bool) -> Vec<String> {
+    let args = build_claude_args(
+        env::resume_session_id(),
+        env::append_system_prompt(),
+        env::prompt(),
+    );
 
     let bin = if use_mock {
         log_info!(LOG_TAG, "Using mock-claude for testing");
@@ -46,10 +63,8 @@ fn build_claude_command(use_mock: bool) -> Vec<String> {
         "claude".to_string()
     };
 
-    args.push(env::prompt().to_string());
-
     let mut cmd = vec![bin];
-    cmd.append(&mut args);
+    cmd.extend(args);
     cmd
 }
 
@@ -297,4 +312,59 @@ pub async fn execute_cli(
     event_result?;
 
     Ok((exit_code, stderr_lines))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_claude_args_basic() {
+        let args = build_claude_args("", "", "hello world");
+        assert!(args.contains(&"--print".to_string()));
+        assert!(args.contains(&"--dangerously-skip-permissions".to_string()));
+        assert_eq!(args.last().unwrap(), "hello world");
+        assert!(!args.contains(&"--append-system-prompt".to_string()));
+        assert!(!args.contains(&"--resume".to_string()));
+    }
+
+    #[test]
+    fn build_claude_args_with_append_system_prompt() {
+        let args = build_claude_args("", "Your name is Aria.", "analyze this");
+        let asp_idx = args
+            .iter()
+            .position(|a| a == "--append-system-prompt")
+            .unwrap();
+        assert_eq!(args[asp_idx + 1], "Your name is Aria.");
+        // Prompt must be AFTER --append-system-prompt value
+        let prompt_idx = args.iter().position(|a| a == "analyze this").unwrap();
+        assert!(prompt_idx > asp_idx + 1);
+        assert_eq!(args.last().unwrap(), "analyze this");
+    }
+
+    #[test]
+    fn build_claude_args_empty_append_system_prompt_omitted() {
+        let args = build_claude_args("", "", "test");
+        assert!(!args.contains(&"--append-system-prompt".to_string()));
+    }
+
+    #[test]
+    fn build_claude_args_with_resume_and_append() {
+        let args = build_claude_args("sess-123", "Be helpful.", "prompt");
+        assert!(args.contains(&"--resume".to_string()));
+        assert!(args.contains(&"--append-system-prompt".to_string()));
+        assert_eq!(args.last().unwrap(), "prompt");
+    }
+
+    #[test]
+    fn build_claude_command_uses_claude_binary() {
+        let cmd = build_claude_command(false);
+        assert_eq!(cmd[0], "claude");
+    }
+
+    #[test]
+    fn build_claude_command_uses_mock_binary() {
+        let cmd = build_claude_command(true);
+        assert_eq!(cmd[0], "/usr/local/bin/guest-mock-claude");
+    }
 }

--- a/crates/guest-agent/src/env.rs
+++ b/crates/guest-agent/src/env.rs
@@ -16,6 +16,8 @@ static RUN_ID: LazyLock<String> = LazyLock::new(|| env_or_empty("VM0_RUN_ID"));
 static API_URL: LazyLock<String> = LazyLock::new(|| env_or_empty("VM0_API_URL"));
 static API_TOKEN: LazyLock<String> = LazyLock::new(|| env_or_empty("VM0_API_TOKEN"));
 static PROMPT: LazyLock<String> = LazyLock::new(|| env_or_empty("VM0_PROMPT"));
+static APPEND_SYSTEM_PROMPT: LazyLock<String> =
+    LazyLock::new(|| env_or_empty("VM0_APPEND_SYSTEM_PROMPT"));
 static VERCEL_BYPASS: LazyLock<String> = LazyLock::new(|| env_or_empty("VERCEL_PROTECTION_BYPASS"));
 static RESUME_SESSION_ID: LazyLock<String> =
     LazyLock::new(|| env_or_empty("VM0_RESUME_SESSION_ID"));
@@ -79,6 +81,9 @@ pub fn api_token() -> &'static str {
 }
 pub fn prompt() -> &'static str {
     &PROMPT
+}
+pub fn append_system_prompt() -> &'static str {
+    &APPEND_SYSTEM_PROMPT
 }
 pub fn vercel_bypass() -> &'static str {
     &VERCEL_BYPASS

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -544,6 +544,11 @@ fn build_env_json(context: &ExecutionContext, api_url: &str) -> HashMap<String, 
     env.insert("VM0_RUN_ID".into(), context.run_id.to_string());
     env.insert("VM0_API_TOKEN".into(), context.sandbox_token.clone());
     env.insert("VM0_PROMPT".into(), context.prompt.clone());
+    if let Some(asp) = &context.append_system_prompt
+        && !asp.is_empty()
+    {
+        env.insert("VM0_APPEND_SYSTEM_PROMPT".into(), asp.clone());
+    }
     env.insert("VM0_WORKING_DIR".into(), context.working_dir.clone());
     env.insert(
         "VM0_API_START_TIME".into(),
@@ -667,6 +672,7 @@ mod tests {
         ExecutionContext {
             run_id: Uuid::nil(),
             prompt: "test prompt".into(),
+            append_system_prompt: None,
             agent_compose_version_id: None,
             vars: None,
             checkpoint_id: None,
@@ -815,6 +821,32 @@ mod tests {
 
         let env = build_env_json(&ctx, "http://localhost");
         assert!(!env.contains_key("VM0_SECRET_VALUES"));
+    }
+
+    #[test]
+    fn build_env_json_with_append_system_prompt() {
+        let mut ctx = minimal_context();
+        ctx.append_system_prompt = Some("Your name is Aria.".into());
+        let env = build_env_json(&ctx, "http://localhost");
+        assert_eq!(
+            env.get("VM0_APPEND_SYSTEM_PROMPT").unwrap(),
+            "Your name is Aria."
+        );
+    }
+
+    #[test]
+    fn build_env_json_without_append_system_prompt() {
+        let ctx = minimal_context();
+        let env = build_env_json(&ctx, "http://localhost");
+        assert!(!env.contains_key("VM0_APPEND_SYSTEM_PROMPT"));
+    }
+
+    #[test]
+    fn build_env_json_empty_append_system_prompt_omitted() {
+        let mut ctx = minimal_context();
+        ctx.append_system_prompt = Some("".into());
+        let env = build_env_json(&ctx, "http://localhost");
+        assert!(!env.contains_key("VM0_APPEND_SYSTEM_PROMPT"));
     }
 
     #[test]

--- a/crates/runner/src/provider/local.rs
+++ b/crates/runner/src/provider/local.rs
@@ -157,6 +157,7 @@ impl JobProvider for LocalProvider {
         Some(ExecutionContext {
             run_id,
             prompt: req.prompt,
+            append_system_prompt: None,
             agent_compose_version_id: None,
             vars: req.vars,
             checkpoint_id: None,

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -31,6 +31,8 @@ pub struct Job {
 pub struct ExecutionContext {
     pub run_id: Uuid,
     pub prompt: String,
+    #[serde(default)]
+    pub append_system_prompt: Option<String>,
     // Not yet used by runner — compose version for traceability
     #[allow(dead_code)]
     #[serde(default)]

--- a/turbo/packages/core/src/contracts/runners.ts
+++ b/turbo/packages/core/src/contracts/runners.ts
@@ -138,6 +138,8 @@ export const storedExecutionContextSchema = z.object({
 export const executionContextSchema = z.object({
   runId: z.uuid(),
   prompt: z.string(),
+  // System prompt appended to agent instructions (passed as --append-system-prompt to Claude CLI)
+  appendSystemPrompt: z.string().optional(),
   agentComposeVersionId: z.string().nullable(),
   vars: z.record(z.string(), z.string()).nullable(),
   checkpointId: z.uuid().nullable(),


### PR DESCRIPTION
## Summary
- Add `append_system_prompt` field to runner `ExecutionContext` with `#[serde(default)]`
- Inject `VM0_APPEND_SYSTEM_PROMPT` env var in `build_env_json()` (system tier, cannot be overridden by user env)
- Add `LazyLock` accessor in guest-agent `env.rs`
- Refactor `build_claude_command()` into testable `build_claude_args()` helper
- Pass `--append-system-prompt` flag to Claude CLI before the prompt positional argument
- Add `appendSystemPrompt` to TypeScript `executionContextSchema`

## Test plan
- [x] 3 unit tests for `build_env_json()` (present, absent, empty string guard)
- [x] 6 unit tests for `build_claude_args()` (basic, with flag, empty omitted, resume+append, binary selection)
- [x] `cargo test -p runner -p guest-agent` all pass
- [x] `pnpm check-types` passes for web, cli, core
- [x] Knip clean, clippy clean, fmt clean

Closes #5375

🤖 Generated with [Claude Code](https://claude.com/claude-code)