### PR TITLE
fix: add scroll constraint to connector popover for long lists

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -225,9 +225,13 @@ function ConnectorsPopoverButton({
           </TooltipContent>
         </Tooltip>
       </TooltipProvider>
-      <PopoverContent side="top" align="start" className="w-64 p-0 rounded-xl">
+      <PopoverContent
+        side="top"
+        align="start"
+        className="w-64 p-0 rounded-xl flex flex-col max-h-[min(60vh,400px)]"
+      >
         {connectors.length > 0 && (
-          <div className="p-2">
+          <div className="p-2 overflow-y-auto min-h-0">
             <div className="flex flex-col">
               {connectors.map((item) => (
                 <div
@@ -280,7 +284,7 @@ function ConnectorsPopoverButton({
         )}
         <div
           className={cn(
-            "p-2 flex flex-col",
+            "p-2 flex flex-col shrink-0",
             connectors.length > 0 && "border-t border-border/50",
           )}
         >


### PR DESCRIPTION
## Summary
- Adds `max-h-[min(60vh,400px)]` and `flex flex-col` to the connector popover to constrain its height when many connectors are present
- Makes the connector list section scrollable with `overflow-y-auto` and `min-h-0`
- Prevents the bottom action section from shrinking with `shrink-0`, keeping it always visible

## Test plan
- [ ] Open the zero chat composer with many connectors configured
- [ ] Verify the popover does not overflow the viewport and is scrollable
- [ ] Verify the bottom section (add connector button) remains visible and accessible
- [ ] Verify the popover looks correct with few connectors (no unnecessary scroll)

🤖 Generated with [Claude Code](https://claude.com/claude-code)