### PR TITLE
fix: verify r2 archives exist before skipping skill sync

### DIFF
--- a/turbo/apps/web/app/api/cron/sync-skills/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/cron/sync-skills/__tests__/route.test.ts
@@ -190,6 +190,31 @@ describe("GET /api/cron/sync-skills", () => {
       expect(data2.skipped).toBe(0);
       expect(data2.total).toBe(0);
     });
+
+    it("should force re-sync when commit SHA matches but R2 archive is missing", async () => {
+      const tarball = createMockTarball(MOCK_SKILLS);
+      setupMswHandlers(TEST_COMMIT_SHA, tarball);
+
+      // First sync — populates DB and "uploads" to S3
+      const response1 = await GET(cronRequest(cronSecret));
+      expect(response1.status).toBe(200);
+      const data1 = await response1.json();
+      expect(data1.synced).toBe(2);
+
+      // Simulate R2 bucket wipe: s3ObjectExists returns false
+      context.mocks.s3.s3ObjectExists.mockResolvedValueOnce(false);
+
+      // Second sync with same commit SHA — should detect missing R2 and re-sync
+      context.mocks.s3.putS3Object.mockClear();
+      const response2 = await GET(cronRequest(cronSecret));
+      expect(response2.status).toBe(200);
+      const data2 = await response2.json();
+      expect(data2.synced).toBe(2);
+      expect(data2.total).toBe(2);
+
+      // S3 uploads should have happened (2 skills × 2 files = 4)
+      expect(context.mocks.s3.putS3Object).toHaveBeenCalledTimes(4);
+    });
   });
 
   describe("Full sync", () => {

--- a/turbo/apps/web/src/lib/skills/sync-skills.ts
+++ b/turbo/apps/web/src/lib/skills/sync-skills.ts
@@ -33,7 +33,7 @@ import {
   computeSystemSkillHash,
   type FileEntryWithHash,
 } from "../storage/content-hash";
-import { putS3Object } from "../s3/s3-client";
+import { putS3Object, s3ObjectExists } from "../s3/s3-client";
 import { skills } from "../../db/schema/skill";
 import { storages, storageVersions } from "../../db/schema/storage";
 import { env } from "../../env";
@@ -69,12 +69,33 @@ export async function syncSkills(): Promise<SyncResult> {
 
   // 2. Check stored commit SHA from any existing skill row
   const [existing] = await db
-    .select({ commitSha: skills.commitSha })
+    .select({ commitSha: skills.commitSha, s3Key: skills.s3Key })
     .from(skills)
     .limit(1);
 
+  let forceReupload = false;
+
   if (existing?.commitSha === headSha) {
-    return { commitSha: headSha, synced: 0, skipped: 0, failed: 0, total: 0 };
+    // Spot-check: verify R2 archives still exist.
+    // When R2 bucket is cleared (common in dev/preview), DB records become stale.
+    if (existing.s3Key) {
+      const archiveKey = `${existing.s3Key}/archive.tar.gz`;
+      const bucketName = env().R2_USER_STORAGES_BUCKET_NAME;
+      const archiveExists = await s3ObjectExists(bucketName, archiveKey);
+      if (archiveExists) {
+        return {
+          commitSha: headSha,
+          synced: 0,
+          skipped: 0,
+          failed: 0,
+          total: 0,
+        };
+      }
+      log.warn(
+        "R2 archive missing despite matching commit SHA, forcing full re-sync",
+      );
+    }
+    forceReupload = true;
   }
 
   // 3. Download and extract tarball
@@ -87,7 +108,12 @@ export async function syncSkills(): Promise<SyncResult> {
 
   for (const extracted of extractedSkills) {
     try {
-      const wasUpdated = await syncSingleSkill(db, extracted, headSha);
+      const wasUpdated = await syncSingleSkill(
+        db,
+        extracted,
+        headSha,
+        forceReupload,
+      );
       if (wasUpdated) {
         synced++;
       } else {
@@ -129,6 +155,7 @@ async function syncSingleSkill(
   db: typeof globalThis.services.db,
   extracted: ExtractedSkill,
   commitSha: string,
+  forceReupload: boolean,
 ): Promise<boolean> {
   const { skillName, files } = extracted;
   const skillUrl = `https://github.com/${DEFAULT_SKILLS_OWNER}/${DEFAULT_SKILLS_REPO}/tree/${DEFAULT_SKILLS_BRANCH}/${skillName}`;
@@ -156,7 +183,7 @@ async function syncSingleSkill(
     .where(eq(skills.url, skillUrl))
     .limit(1);
 
-  if (existingSkill?.versionHash === versionHash) {
+  if (!forceReupload && existingSkill?.versionHash === versionHash) {
     // Content unchanged — just update commitSha
     await db
       .update(skills)


### PR DESCRIPTION
## Summary

- Add R2 `HeadObject` spot-check when `syncSkills()` SHA gate matches — detects stale DB records pointing to missing R2 archives
- Introduce `forceReupload` flag that bypasses both SHA gate and per-skill version hash optimization when R2 archive is missing
- Prevents sandbox download 404 errors in dev/preview environments where R2 bucket gets cleared

Closes #5386

## Test plan

- [x] New integration test: R2 missing with same commit SHA triggers full re-sync
- [x] Existing test: SHA gate skip still works when R2 is healthy (9 tests pass)
- [ ] CI pipeline passes (lint, type-check, tests, knip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)