### PR TITLE
fix(platform): remove leftover /zero prefix from activity log link

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/zero-session-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-session-chat-page.tsx
@@ -631,7 +631,7 @@ function AssistantMessage({ message, zeroAvatarSrc }: AssistantMessageProps) {
           <Tooltip>
             <TooltipTrigger asChild>
               <SimpleLink
-                href={`/zero/activity/${message.runId}`}
+                href={`/activity/${message.runId}`}
                 className="p-1 rounded-md text-muted-foreground/60 hover:text-foreground hover:bg-muted/50 transition-colors duration-150"
                 aria-label="View run logs"
               >


### PR DESCRIPTION
## Summary
- Remove the leftover `/zero/` prefix from the "View activity logs" link in assistant chat messages
- PR #5155 removed `/zero/` from all platform routes, but this link was missed

Closes #5391

## Test plan
- [ ] Navigate to a chat session with assistant messages that have a `runId`
- [ ] Hover over a message and click the activity log icon
- [ ] Verify navigation goes to `/activity/{runId}` (not `/zero/activity/{runId}`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)