### PR TITLE
fix: allow re-setting default agent when previous compose was deleted

### DIFF
--- a/turbo/apps/web/app/api/orgs/default-agent/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/orgs/default-agent/__tests__/route.test.ts
@@ -7,6 +7,8 @@ import {
 } from "../../../../../src/__tests__/api-test-helpers";
 import { testContext } from "../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../src/__tests__/clerk-mock";
+import { agentComposes } from "../../../../../src/db/schema/agent-compose";
+import { eq } from "drizzle-orm";
 
 const context = testContext();
 
@@ -136,6 +138,28 @@ describe("PUT /api/orgs/default-agent", () => {
 
     const data = await response2.json();
     expect(data.error.code).toBe("CONFLICT");
+  });
+
+  it("should allow re-setting default agent when previous compose was deleted", async () => {
+    await context.setupUser();
+    const compose1 = await createTestCompose("agent-1");
+
+    // Set first default agent
+    const response1 = await putDefaultAgent(undefined, compose1.composeId);
+    expect(response1.status).toBe(200);
+
+    // Delete the compose from DB (simulating user deleting the agent)
+    await globalThis.services.db
+      .delete(agentComposes)
+      .where(eq(agentComposes.id, compose1.composeId));
+
+    // Setting a new default should succeed since the old one no longer exists
+    const compose2 = await createTestCompose("agent-2");
+    const response2 = await putDefaultAgent(undefined, compose2.composeId);
+    expect(response2.status).toBe(200);
+
+    const data = await response2.json();
+    expect(data.agentComposeId).toBe(compose2.composeId);
   });
 
   it("should allow setting default agent when none is configured", async () => {

--- a/turbo/apps/web/app/api/orgs/default-agent/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/orgs/default-agent/__tests__/route.test.ts
@@ -4,11 +4,10 @@ import { PUT } from "../route";
 import {
   createTestRequest,
   createTestCompose,
+  deleteTestCompose,
 } from "../../../../../src/__tests__/api-test-helpers";
 import { testContext } from "../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../src/__tests__/clerk-mock";
-import { agentComposes } from "../../../../../src/db/schema/agent-compose";
-import { eq } from "drizzle-orm";
 
 const context = testContext();
 
@@ -149,9 +148,7 @@ describe("PUT /api/orgs/default-agent", () => {
     expect(response1.status).toBe(200);
 
     // Delete the compose from DB (simulating user deleting the agent)
-    await globalThis.services.db
-      .delete(agentComposes)
-      .where(eq(agentComposes.id, compose1.composeId));
+    await deleteTestCompose(compose1.composeId);
 
     // Setting a new default should succeed since the old one no longer exists
     const compose2 = await createTestCompose("agent-2");

--- a/turbo/apps/web/app/api/orgs/default-agent/route.ts
+++ b/turbo/apps/web/app/api/orgs/default-agent/route.ts
@@ -45,16 +45,29 @@ const router = tsr.router(orgDefaultAgentContract, {
     const existingComposeId = (
       clerkOrg.publicMetadata as Record<string, unknown>
     )?.default_agent_compose_id;
-    if (existingComposeId) {
-      return {
-        status: 409 as const,
-        body: {
-          error: {
-            message: "A default agent is already configured for this org",
-            code: "CONFLICT",
+    if (typeof existingComposeId === "string" && existingComposeId) {
+      // Verify the existing compose still exists — if it was deleted, allow re-setting.
+      const [existing] = await globalThis.services.db
+        .select({ id: agentComposes.id })
+        .from(agentComposes)
+        .where(
+          and(
+            eq(agentComposes.id, existingComposeId),
+            eq(agentComposes.orgId, org.orgId),
+          ),
+        )
+        .limit(1);
+      if (existing) {
+        return {
+          status: 409 as const,
+          body: {
+            error: {
+              message: "A default agent is already configured for this org",
+              code: "CONFLICT",
+            },
           },
-        },
-      };
+        };
+      }
     }
 
     if (agentComposeId !== null) {

--- a/turbo/apps/web/src/__tests__/api-test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers.ts
@@ -3366,3 +3366,14 @@ export async function findTestCreditUsageByRunId(runId: string): Promise<
     .limit(1);
   return record;
 }
+
+/**
+ * Delete a compose from the database.
+ * Used to simulate a user deleting an agent compose.
+ */
+export async function deleteTestCompose(composeId: string): Promise<void> {
+  initServices();
+  await globalThis.services.db
+    .delete(agentComposes)
+    .where(eq(agentComposes.id, composeId));
+}


### PR DESCRIPTION
## Summary
- The 409 guard in `PUT /api/orgs/default-agent` checked Clerk org metadata for an existing compose ID but never verified the compose still exists in the database
- When a default agent was deleted, the org was permanently locked out from setting a new one
- Now the guard queries the DB and only returns 409 if the referenced compose actually exists; otherwise it falls through and allows re-setting

## Test plan
- [x] Added integration test: "should allow re-setting default agent when previous compose was deleted"
- [x] All 10 existing tests pass (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)