### PR TITLE
fix: remove environment-variables-setup url from compose output

### DIFF
--- a/turbo/apps/cli/src/commands/compose/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/compose/__tests__/index.test.ts
@@ -2624,7 +2624,7 @@ agents:
       return HttpResponse.json(orgResponse);
     });
 
-    it("should show setup URL when secrets are missing", async () => {
+    it("should show missing secrets warning when secrets are missing", async () => {
       await fs.writeFile(
         path.join(tempDir, "vm0.yaml"),
         yaml.stringify({
@@ -2656,13 +2656,11 @@ agents:
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("Missing secrets/variables detected");
-      expect(logCalls).toContain("environment-variables-setup");
-      expect(logCalls).toContain("secrets=");
       expect(logCalls).toContain("API_KEY");
       expect(logCalls).toContain("DB_URL");
     });
 
-    it("should not show setup URL when all secrets exist", async () => {
+    it("should not show missing secrets warning when all secrets exist", async () => {
       await fs.writeFile(
         path.join(tempDir, "vm0.yaml"),
         yaml.stringify({
@@ -2701,10 +2699,9 @@ agents:
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).not.toContain("Missing secrets/variables detected");
-      expect(logCalls).not.toContain("environment-variables-setup");
     });
 
-    it("should show setup URL with both secrets and vars when missing", async () => {
+    it("should show missing secrets and vars when both are missing", async () => {
       await fs.writeFile(
         path.join(tempDir, "vm0.yaml"),
         yaml.stringify({
@@ -2736,11 +2733,11 @@ agents:
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("Missing secrets/variables detected");
-      expect(logCalls).toContain("secrets=API_KEY");
-      expect(logCalls).toContain("vars=REGION");
+      expect(logCalls).toContain("API_KEY");
+      expect(logCalls).toContain("REGION");
     });
 
-    it("should include setupUrl in JSON output when items are missing", async () => {
+    it("should not include missing items in JSON output", async () => {
       await fs.writeFile(
         path.join(tempDir, "vm0.yaml"),
         yaml.stringify({
@@ -2773,10 +2770,9 @@ agents:
       const result = JSON.parse(jsonOutputCall![0] as string);
       // In --json mode, missing items check is skipped for performance
       expect(result.missingSecrets).toBeUndefined();
-      expect(result.setupUrl).toBeUndefined();
     });
 
-    it("should not include setupUrl in JSON output when no items missing", async () => {
+    it("should not include missing items in JSON output when no items missing", async () => {
       await fs.writeFile(
         path.join(tempDir, "vm0.yaml"),
         yaml.stringify({
@@ -2809,7 +2805,6 @@ agents:
       const result = JSON.parse(jsonOutputCall![0] as string);
       expect(result.missingSecrets).toBeUndefined();
       expect(result.missingVars).toBeUndefined();
-      expect(result.setupUrl).toBeUndefined();
     });
 
     it("should only show missing items, not already configured ones", async () => {
@@ -2849,7 +2844,7 @@ agents:
       // In --json mode, missing items check is skipped for performance
       expect(result.missingSecrets).toBeUndefined();
       expect(result.missingVars).toBeUndefined();
-      expect(result.setupUrl).toBeUndefined();
+      expect(result).not.toHaveProperty("setupUrl");
     });
 
     it("should not include connector or secrets info in JSON output", async () => {
@@ -2886,7 +2881,7 @@ agents:
       const result = JSON.parse(jsonOutputCall![0] as string);
       // In --json mode, missing items check is skipped for performance
       expect(result.missingSecrets).toBeUndefined();
-      expect(result.setupUrl).toBeUndefined();
+      expect(result).not.toHaveProperty("setupUrl");
     });
   });
 });

--- a/turbo/apps/cli/src/commands/compose/index.ts
+++ b/turbo/apps/cli/src/commands/compose/index.ts
@@ -19,7 +19,6 @@ import {
   listConnectors,
   resolveSkills,
 } from "../../lib/api";
-import { getApiUrl } from "../../lib/api/config";
 import { validateAgentCompose } from "../../lib/domain/yaml-validator";
 import {
   downloadGitHubDirectory,
@@ -372,16 +371,9 @@ function mergeSkillVariables(
 /**
  * Derive the app URL from the API URL by replacing "www" with "app" in the hostname.
  */
-function getAppUrl(apiUrl: string): string {
-  const url = new URL(apiUrl);
-  url.hostname = url.hostname.replace("www", "app");
-  return url.origin;
-}
-
 interface MissingItemsResult {
   missingSecrets: string[];
   missingVars: string[];
-  setupUrl?: string;
 }
 
 /**
@@ -429,29 +421,19 @@ async function checkAndPromptMissingItems(
     return { missingSecrets: [], missingVars: [] };
   }
 
-  const apiUrl = await getApiUrl();
-  const appUrl = getAppUrl(apiUrl);
-  const params = new URLSearchParams();
-  if (missingSecrets.length > 0) {
-    params.set("secrets", missingSecrets.join(","));
-  }
-  if (missingVars.length > 0) {
-    params.set("vars", missingVars.join(","));
-  }
-  const setupUrl = `${appUrl}/environment-variables-setup?${params.toString()}`;
-
   if (!options.json) {
     console.log();
-    console.log(
-      chalk.yellow(
-        "⚠ Missing secrets/variables detected. Set them up before running your agent:",
-      ),
-    );
-    console.log(chalk.cyan(`  ${setupUrl}`));
+    console.log(chalk.yellow("⚠ Missing secrets/variables detected:"));
+    if (missingSecrets.length > 0) {
+      console.log(chalk.yellow(`  Secrets: ${missingSecrets.join(", ")}`));
+    }
+    if (missingVars.length > 0) {
+      console.log(chalk.yellow(`  Variables: ${missingVars.join(", ")}`));
+    }
     console.log();
   }
 
-  return { missingSecrets, missingVars, setupUrl };
+  return { missingSecrets, missingVars };
 }
 
 /**
@@ -465,7 +447,6 @@ interface ComposeResult {
   displayName: string;
   missingSecrets?: string[];
   missingVars?: string[];
-  setupUrl?: string;
 }
 
 /**
@@ -521,7 +502,6 @@ async function finalizeCompose(
     ) {
       result.missingSecrets = missingItems.missingSecrets;
       result.missingVars = missingItems.missingVars;
-      result.setupUrl = missingItems.setupUrl;
     }
   }
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-skill-card.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-skill-card.test.tsx
@@ -171,14 +171,14 @@ describe("zero skill card status display", () => {
     });
   });
 
-  it("shows Add API key button for not-connected API-token-only connector", async () => {
+  it("shows Connect button for not-connected API-token-only connector", async () => {
     mockConnectors([]);
 
     await renderTeamPage(["axiom"]);
 
     await waitFor(() => {
       expect(
-        screen.getByRole("button", { name: "Add API key" }),
+        screen.getByRole("button", { name: "Connect" }),
       ).toBeInTheDocument();
     });
   });
@@ -230,15 +230,15 @@ describe("zero skill card button clicks", () => {
     });
   });
 
-  it("opens ConnectModal when Add API key is clicked", async () => {
+  it("opens ConnectModal when Connect is clicked for API-token connector", async () => {
     mockConnectors([]);
     await renderTeamPage(["axiom"]);
 
-    const addApiKeyButton = await waitFor(() =>
-      screen.getByRole("button", { name: "Add API key" }),
+    const connectButton = await waitFor(() =>
+      screen.getByRole("button", { name: "Connect" }),
     );
 
-    fireEvent.click(addApiKeyButton);
+    fireEvent.click(connectButton);
 
     // ConnectModal should open showing the connector's dialog
     await waitFor(() => {


### PR DESCRIPTION
## Summary

- Remove the `environment-variables-setup` URL from CLI `compose` output — the page was already deleted in #5095
- Now displays missing secrets/variables as an inline list instead of a dead URL
- Remove `setupUrl` field from `MissingItemsResult` and `ComposeResult` interfaces
- Remove unused `getAppUrl` helper and `getApiUrl` import

## Test plan

- [x] All 92 compose tests pass
- [x] Knip reports no unused exports
- [ ] Run `vm0 compose` with missing secrets and verify the warning lists them without a URL

Closes #5092

🤖 Generated with [Claude Code](https://claude.com/claude-code)