### PR TITLE
fix: set active org in dev-auth script config

### DIFF
--- a/scripts/dev-auth.sh
+++ b/scripts/dev-auth.sh
@@ -33,8 +33,9 @@ if [[ "$HTTP_CODE" != "200" ]]; then
   exit 1
 fi
 
-# Extract token from response
+# Extract token and org_slug from response
 TOKEN=$(echo "$BODY" | grep -o '"access_token":"[^"]*"' | cut -d'"' -f4)
+ORG_SLUG=$(echo "$BODY" | grep -o '"org_slug":"[^"]*"' | cut -d'"' -f4)
 
 if [[ -z "$TOKEN" ]]; then
   echo "❌ Error: Failed to extract token from response"
@@ -48,13 +49,26 @@ CONFIG_FILE="$CONFIG_DIR/config.json"
 
 mkdir -p "$CONFIG_DIR"
 
-cat > "$CONFIG_FILE" << EOF
+if [[ -n "$ORG_SLUG" ]]; then
+  cat > "$CONFIG_FILE" << EOF
+{
+  "token": "$TOKEN",
+  "apiUrl": "$VM0_API_URL",
+  "activeOrg": "$ORG_SLUG"
+}
+EOF
+else
+  cat > "$CONFIG_FILE" << EOF
 {
   "token": "$TOKEN",
   "apiUrl": "$VM0_API_URL"
 }
 EOF
+fi
 
 echo ""
 echo "✅ Authenticated successfully!"
 echo "Config saved to: $CONFIG_FILE"
+if [[ -n "$ORG_SLUG" ]]; then
+  echo "Active org: $ORG_SLUG"
+fi


### PR DESCRIPTION
## Summary

- Extract `org_slug` from the `POST /api/cli/auth/test-token` response in `scripts/dev-auth.sh`
- Write it as `activeOrg` in `~/.vm0/config.json` when present
- Display the active org in the success output

Previously, `pnpm dev:auth` only saved `token` and `apiUrl`, causing all CLI commands (except `org list` and `org use`) to fail with "No active organization configured". This matches the pattern already used in `e2e/scripts/generate-test-token.sh`.

## Test plan

- [ ] Start dev server with `pnpm dev`
- [ ] Run `pnpm dev:auth` and verify output shows "Active org: xxx"
- [ ] Check `~/.vm0/config.json` contains `activeOrg` field
- [ ] Run a CLI command (e.g. `vm0 org list`) — should work without "No active organization" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)