### PR TITLE
fix(platform): pass memory name when creating agent runs from zero chat

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-chat.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-chat.test.ts
@@ -416,6 +416,7 @@ describe("zero-chat signals", () => {
       expect(capturedRunBody).toBeTruthy();
       expect(capturedRunBody!.agentComposeId).toBe("mock-compose-id");
       expect(capturedRunBody!.prompt).toBe("What can you do?");
+      expect(capturedRunBody!.memoryName).toBe("memory");
 
       expect(context.store.get(zeroChatSending$)).toBeFalsy();
       expect(context.store.get(zeroChatThreadId$)).toBe("thread-new");

--- a/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
@@ -142,6 +142,7 @@ async function startAgentRun(
   const body: Record<string, string> = {
     agentComposeId: composeId,
     prompt: prompt.trim(),
+    memoryName: "memory",
   };
   if (sessionId) {
     body.sessionId = sessionId;


### PR DESCRIPTION
## Summary

- Add `memoryName: "memory"` to the `startAgentRun()` request body in `zero-chat.ts`, aligning platform chat with Slack, Telegram, and Email integrations that already pass this field
- Add test assertion to verify `memoryName` is included in the agent run request payload

Closes #5408

## Test plan

- [x] Existing `zero-chat.test.ts` tests pass (15/15)
- [x] New assertion verifies `memoryName: "memory"` is sent in the request body
- [ ] Manual: Start an agent run from platform chat, verify the agent has persistent memory across runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)