### PR TITLE
fix(sandbox-fc): use per-profile overlay directories to prevent cross-deletion

### DIFF
--- a/crates/runner/src/cmd/benchmark.rs
+++ b/crates/runner/src/cmd/benchmark.rs
@@ -86,7 +86,8 @@ pub async fn run_benchmark(args: BenchmarkArgs) -> RunnerResult<ExitCode> {
     info!(proxy_ms, port = mitm.port(), "proxy ready");
 
     // 3. Factory init (with proxy port)
-    let fc_config = runner_config.firecracker_config(&default_profile, &home, Some(mitm.port()));
+    let fc_config =
+        runner_config.firecracker_config(&args.profile, &default_profile, &home, Some(mitm.port()));
 
     let t = Instant::now();
     let mut factory = FirecrackerFactory::new(fc_config, None).await?;

--- a/crates/runner/src/cmd/start.rs
+++ b/crates/runner/src/cmd/start.rs
@@ -314,6 +314,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
         let fc_config = config::RunnerConfig::build_firecracker_config(
             &firecracker,
             &base_dir,
+            profile_name,
             profile_config,
             &home,
             Some(proxy_port),

--- a/crates/runner/src/config.rs
+++ b/crates/runner/src/config.rs
@@ -205,11 +205,19 @@ impl RunnerConfig {
     /// using the standard content-addressed storage layout.
     pub fn firecracker_config(
         &self,
+        profile_name: &str,
         profile: &ProfileConfig,
         home: &HomePaths,
         proxy_port: Option<u16>,
     ) -> sandbox_fc::FirecrackerConfig {
-        Self::build_firecracker_config(&self.firecracker, &self.base_dir, profile, home, proxy_port)
+        Self::build_firecracker_config(
+            &self.firecracker,
+            &self.base_dir,
+            profile_name,
+            profile,
+            home,
+            proxy_port,
+        )
     }
 
     /// Build a `sandbox_fc::FirecrackerConfig` from components.
@@ -219,6 +227,7 @@ impl RunnerConfig {
     pub fn build_firecracker_config(
         firecracker: &FirecrackerConfig,
         base_dir: &Path,
+        profile_name: &str,
         profile: &ProfileConfig,
         home: &HomePaths,
         proxy_port: Option<u16>,
@@ -234,6 +243,7 @@ impl RunnerConfig {
             kernel_path: firecracker.kernel.clone(),
             rootfs_path: rootfs_paths.rootfs(),
             base_dir: base_dir.to_path_buf(),
+            profile: profile_name.to_string(),
             proxy_port,
             snapshot,
         }
@@ -647,7 +657,7 @@ profiles:
         };
 
         let profile = &config.profiles["vm0/default"];
-        let fc = config.firecracker_config(profile, &home, Some(8080));
+        let fc = config.firecracker_config("vm0/default", profile, &home, Some(8080));
 
         assert_eq!(fc.binary_path, dir.path().join("firecracker"));
         assert_eq!(fc.kernel_path, dir.path().join("vmlinux"));
@@ -655,6 +665,7 @@ profiles:
             fc.rootfs_path,
             home.rootfs_dir().join("abc123").join("rootfs.squashfs")
         );
+        assert_eq!(fc.profile, "vm0/default");
         assert_eq!(fc.proxy_port, Some(8080));
         assert!(fc.snapshot.is_some());
     }

--- a/crates/sandbox-fc/src/config.rs
+++ b/crates/sandbox-fc/src/config.rs
@@ -7,6 +7,8 @@ pub struct FirecrackerConfig {
     pub rootfs_path: PathBuf,
     /// Base directory for runtime data (workspaces, overlays, etc.).
     pub base_dir: PathBuf,
+    /// Profile name (e.g., "vm0/default", "vm0/browser") used for per-profile overlay isolation.
+    pub profile: String,
     /// Port of the HTTP/HTTPS proxy. When set, iptables rules redirect traffic through it.
     pub proxy_port: Option<u16>,
     /// Snapshot to restore from. When set, VMs boot via snapshot restore instead of fresh boot.

--- a/crates/sandbox-fc/src/factory.rs
+++ b/crates/sandbox-fc/src/factory.rs
@@ -206,7 +206,7 @@ impl SandboxFactory for FirecrackerFactory {
 
         let t = std::time::Instant::now();
         let overlay_pool = match OverlayPool::create(OverlayPoolConfig {
-            pool_dir: self.factory_paths.overlays(),
+            pool_dir: self.factory_paths.overlays(&self.config.profile),
             creator: overlay_creator,
         })
         .await

--- a/crates/sandbox-fc/src/overlay/pool.rs
+++ b/crates/sandbox-fc/src/overlay/pool.rs
@@ -626,4 +626,42 @@ mod tests {
             "expected NotInitialized, got {result:?}"
         );
     }
+
+    #[tokio::test]
+    async fn separate_subdirs_isolate_pools() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+
+        // Create two pools in sibling subdirectories under the same parent.
+        let dir_a = tmp.path().join("pool-a");
+        let dir_b = tmp.path().join("pool-b");
+
+        let mut pool_a = OverlayPool::create(OverlayPoolConfig {
+            pool_dir: dir_a.clone(),
+            creator: Box::new(TestCreator),
+        })
+        .await
+        .expect("create pool_a");
+        assert_eq!(pool_a.available_count(), BUFFER_SIZE);
+
+        // Creating pool_b must NOT delete pool_a's files.
+        let mut pool_b = OverlayPool::create(OverlayPoolConfig {
+            pool_dir: dir_b.clone(),
+            creator: Box::new(TestCreator),
+        })
+        .await
+        .expect("create pool_b");
+        assert_eq!(pool_b.available_count(), BUFFER_SIZE);
+
+        // pool_a files still exist and acquirable.
+        let path_a = pool_a.acquire().await.expect("acquire from pool_a");
+        assert!(path_a.exists());
+        assert!(path_a.starts_with(&dir_a));
+
+        let path_b = pool_b.acquire().await.expect("acquire from pool_b");
+        assert!(path_b.exists());
+        assert!(path_b.starts_with(&dir_b));
+
+        pool_a.cleanup().await;
+        pool_b.cleanup().await;
+    }
 }

--- a/crates/sandbox-fc/src/paths.rs
+++ b/crates/sandbox-fc/src/paths.rs
@@ -80,8 +80,12 @@ impl FactoryPaths {
         self.base_dir.join("workspaces")
     }
 
-    pub fn overlays(&self) -> PathBuf {
-        self.base_dir.join("overlays")
+    /// Per-profile overlay directory: `base_dir/overlays/{profile}/`.
+    ///
+    /// Each profile gets its own subdirectory so that [`OverlayPool`]'s
+    /// `clean_stale_files()` only deletes files belonging to this profile.
+    pub fn overlays(&self, profile: &str) -> PathBuf {
+        self.base_dir.join("overlays").join(profile)
     }
 
     pub fn workspace(&self, id: &str) -> PathBuf {


### PR DESCRIPTION
## Summary

- Fix overlay pool shared directory bug where `clean_stale_files()` in one profile's pool deletes another profile's pre-warmed overlays on startup, causing mount failures and sandbox timeouts
- Add `profile` parameter to `FactoryPaths::overlays()` so each profile gets an isolated subdirectory (e.g. `overlays/vm0/default/`, `overlays/vm0/browser/`)
- Add `profile` field to `FirecrackerConfig` to carry the profile name through to the factory

## Test plan

- [x] New test `separate_subdirs_isolate_pools` verifies two pools in sibling directories don't interfere
- [x] Existing `firecracker_config_resolves_paths` test updated with `fc.profile` assertion
- [x] All sandbox-fc and runner tests pass
- [ ] CI runner E2E tests with dual-profile (default + browser) should no longer timeout

Closes #5405

🤖 Generated with [Claude Code](https://claude.com/claude-code)