### PR TITLE
fix: use pnpm deploy for cli build to resolve missing dependency files

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -907,7 +907,7 @@ jobs:
       - name: Build CLI
         run: cd turbo && pnpm --filter @vm0/cli build
       - name: Deploy CLI with production dependencies
-        run: cd turbo && pnpm deploy --filter @vm0/cli --prod --legacy /tmp/cli-deploy
+        run: cd turbo && pnpm deploy --filter @vm0/cli --prod --legacy --config.node-linker=hoisted /tmp/cli-deploy
       - name: Upload CLI artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -855,9 +855,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: cli-dist
-          path: turbo/apps/cli/dist
+          path: /tmp/cli-deploy
       - name: Link CLI globally
-        run: cd turbo/apps/cli/dist && sudo npm link
+        run: cd /tmp/cli-deploy && sudo npm link
       - name: Install E2E dependencies
         run: cd e2e && npm install
       - name: Install Playwright system dependencies
@@ -906,13 +906,13 @@ jobs:
         run: cd turbo && pnpm install --frozen-lockfile --filter @vm0/cli
       - name: Build CLI
         run: cd turbo && pnpm --filter @vm0/cli build
-      - name: Install CLI production dependencies
-        run: cd turbo/apps/cli/dist && npm install --omit=dev
+      - name: Deploy CLI with production dependencies
+        run: cd turbo && pnpm deploy --filter @vm0/cli --prod --legacy /tmp/cli-deploy
       - name: Upload CLI artifact
         uses: actions/upload-artifact@v4
         with:
           name: cli-dist
-          path: turbo/apps/cli/dist
+          path: /tmp/cli-deploy
           retention-days: 1
 
   # Run CLI E2E tests - Phase 1: Serial tests (org/provider CRUD)
@@ -953,9 +953,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: cli-dist
-          path: turbo/apps/cli/dist
+          path: /tmp/cli-deploy
       - name: Link CLI globally
-        run: cd turbo/apps/cli/dist && sudo npm link
+        run: cd /tmp/cli-deploy && sudo npm link
       - name: Download E2E test tokens
         uses: actions/download-artifact@v4
         with:
@@ -1367,9 +1367,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: cli-dist
-          path: turbo/apps/cli/dist
+          path: /tmp/cli-deploy
       - name: Link CLI globally
-        run: cd turbo/apps/cli/dist && sudo npm link
+        run: cd /tmp/cli-deploy && sudo npm link
       - name: Install GNU parallel for bats
         run: sudo curl -sL https://raw.githubusercontent.com/martinda/gnu-parallel/master/src/parallel -o /usr/local/bin/parallel && sudo chmod +x /usr/local/bin/parallel
       - name: Download E2E test tokens


### PR DESCRIPTION
## Summary
- Replace `npm install --omit=dev` with `pnpm deploy --prod --legacy` in the `build-cli` job
- Update all e2e jobs to download CLI artifact to `/tmp/cli-deploy` and `npm link` from there

## Problem
`npm install --omit=dev` in `dist/` without a lockfile resolved a different dependency tree than pnpm. This caused `@sentry/node` to pull in `@fastify/otel` as a transitive dependency, but the package was installed incompletely (missing `index.js`), leading to ENOENT errors in e2e tests.

## Fix
`pnpm deploy --prod --legacy` uses the workspace lockfile to install exact production dependencies, eliminating version drift and broken optional dependencies.

## Test plan
- [ ] `build-cli` job completes successfully
- [ ] All `cli-e2e-*` jobs pass without ENOENT errors

Fixes #5417

🤖 Generated with [Claude Code](https://claude.com/claude-code)