### PR TITLE
fix(platform): unblock server-side compose from sandbox job concurrency limit

### DIFF
--- a/turbo/apps/web/app/api/compose/jobs/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/compose/jobs/__tests__/route.test.ts
@@ -217,8 +217,21 @@ describe("POST /api/compose/jobs", () => {
       expect(data.source).toBe("platform");
     });
 
-    it("should return existing platform job for idempotency", async () => {
-      // Create first platform job
+    it("should return existing platform sandbox job for idempotency", async () => {
+      // Create first platform job (uncached skill forces sandbox path)
+      const sandboxContent = {
+        version: "1",
+        agents: {
+          "my-agent": {
+            framework: "claude-code",
+            description: "A test agent",
+            skills: [
+              "https://github.com/vm0-ai/vm0-skills/tree/main/uncached-for-test",
+            ],
+          },
+        },
+      };
+
       const request1 = createTestRequest(
         `http://localhost:3000/api/compose/jobs?org=${testOrgSlug}`,
         {
@@ -227,15 +240,16 @@ describe("POST /api/compose/jobs", () => {
             "Content-Type": "application/json",
             Authorization: `Bearer ${testCliToken}`,
           },
-          body: JSON.stringify({ content: testContent }),
+          body: JSON.stringify({ content: sandboxContent }),
         },
       );
 
       const response1 = await POST(request1);
       expect(response1.status).toBe(201);
       const data1 = await response1.json();
+      expect(data1.status).toBe("pending");
 
-      // Second request should return same job
+      // Second sandbox request should return same job
       const request2 = createTestRequest(
         `http://localhost:3000/api/compose/jobs?org=${testOrgSlug}`,
         {
@@ -244,12 +258,7 @@ describe("POST /api/compose/jobs", () => {
             "Content-Type": "application/json",
             Authorization: `Bearer ${testCliToken}`,
           },
-          body: JSON.stringify({
-            content: {
-              version: "1",
-              agents: { other: { framework: "claude-code" } },
-            },
-          }),
+          body: JSON.stringify({ content: sandboxContent }),
         },
       );
 

--- a/turbo/apps/web/app/api/compose/jobs/__tests__/server-side-compose.test.ts
+++ b/turbo/apps/web/app/api/compose/jobs/__tests__/server-side-compose.test.ts
@@ -177,7 +177,7 @@ describe("Server-side compose", () => {
   });
 
   describe("idempotency", () => {
-    it("should return existing active job instead of creating server-side compose", async () => {
+    it("should complete server-side compose even when a sandbox job is running", async () => {
       // Create a sandbox job first (uncached skill triggers sandbox)
       const content = makeContent({
         skills: ["https://github.com/vm0-ai/vm0-skills/tree/main/uncached"],
@@ -191,10 +191,36 @@ describe("Server-side compose", () => {
       const data1 = await response1.json();
       expect(data1.status).toBe("pending");
 
-      // Second request should return existing job, even though we could do server-side
+      // Second request with no skills (server-side eligible) — should NOT be blocked
       const content2 = makeContent();
       const response2 = await postComposeJob(
         { content: content2 },
+        testCliToken,
+        testOrgSlug,
+      );
+      expect(response2.status).toBe(201);
+      const data2 = await response2.json();
+      expect(data2.status).toBe("completed");
+      expect(data2.jobId).not.toBe(data1.jobId);
+    });
+
+    it("should return existing sandbox job when falling back to sandbox", async () => {
+      // Create a sandbox job first (uncached skill triggers sandbox)
+      const content = makeContent({
+        skills: ["https://github.com/vm0-ai/vm0-skills/tree/main/uncached"],
+      });
+      const response1 = await postComposeJob(
+        { content },
+        testCliToken,
+        testOrgSlug,
+      );
+      expect(response1.status).toBe(201);
+      const data1 = await response1.json();
+      expect(data1.status).toBe("pending");
+
+      // Second sandbox-eligible request — should return existing job
+      const response2 = await postComposeJob(
+        { content },
         testCliToken,
         testOrgSlug,
       );

--- a/turbo/apps/web/app/api/compose/jobs/route.ts
+++ b/turbo/apps/web/app/api/compose/jobs/route.ts
@@ -68,29 +68,11 @@ const router = tsr.router(composeJobsMainContract, {
 
     // Try server-side compose for platform mode (bypasses E2B sandbox)
     if (!isGitHubInput) {
-      // Check for existing active job first (preserve idempotency)
-      const [existingActiveJob] = await globalThis.services.db
-        .select()
-        .from(composeJobs)
-        .where(
-          and(
-            eq(composeJobs.userId, userId),
-            inArray(composeJobs.status, ["pending", "running"]),
-          ),
-        )
-        .limit(1);
-
-      if (existingActiveJob) {
-        log.debug(
-          `Returning existing active job ${existingActiveJob.id} for user ${userId}`,
-        );
-        return {
-          status: 200 as const,
-          body: formatJobResponse(existingActiveJob),
-        };
-      }
-
-      // Attempt server-side compose — returns null if fallback needed
+      // Attempt server-side compose first — synchronous, no sandbox resources needed.
+      // This runs before the active-job check because server-side compose creates
+      // "completed" records directly, which don't conflict with the partial unique
+      // index (pending/running only). A running sandbox job should not block the
+      // fast path.
       const serverResult = await serverSideCompose({
         userId,
         orgId: org.orgId,
@@ -140,7 +122,30 @@ const router = tsr.router(composeJobsMainContract, {
         };
       }
 
-      // Server-side compose not possible — fall back to sandbox
+      // Server-side compose not possible — check for active sandbox job before
+      // falling back. This preserves the per-user sandbox concurrency limit.
+      const [existingActiveJob] = await globalThis.services.db
+        .select()
+        .from(composeJobs)
+        .where(
+          and(
+            eq(composeJobs.userId, userId),
+            inArray(composeJobs.status, ["pending", "running"]),
+          ),
+        )
+        .limit(1);
+
+      if (existingActiveJob) {
+        log.debug(
+          `Returning existing active job ${existingActiveJob.id} for user ${userId}`,
+        );
+        return {
+          status: 200 as const,
+          body: formatJobResponse(existingActiveJob),
+        };
+      }
+
+      // Fall through to sandbox path
       log.info(
         `Server-side compose not possible for user ${userId}, falling back to sandbox`,
       );


### PR DESCRIPTION
## Summary

- Reorder compose job route logic: attempt server-side compose **before** checking for active sandbox jobs
- Server-side compose creates `completed` records directly, which don't conflict with the partial unique index (`pending`/`running` only)
- A running sandbox job no longer blocks the fast (server-side) compose path
- Sandbox-to-sandbox concurrency limit (1 per user) is preserved

Closes #5414

## Test plan

- [x] Updated existing idempotency test to verify server-side compose succeeds while sandbox job runs
- [x] Added new test verifying sandbox-to-sandbox idempotency still works
- [x] All 35 compose job tests pass
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)