### PR TITLE
fix(platform): navigate to /talk/:name from agent detail chat button

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/zero-job-detail-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-job-detail-page.tsx
@@ -429,8 +429,8 @@ export function ZeroJobDetailPage({
               <Tooltip>
                 <TooltipTrigger asChild>
                   <Link
-                    pathname="/:tab"
-                    options={{ pathParams: { tab: "chat" } }}
+                    pathname="/talk/:name"
+                    options={{ pathParams: { name: agentName } }}
                     className="zero-btn-morandi h-9 shrink-0 gap-2 rounded-lg px-4 transition-colors inline-flex items-center justify-center border text-sm font-medium hover:bg-accent"
                   >
                     <IconMessageCircle size={14} stroke={1.5} />


### PR DESCRIPTION
## Summary
- The "Chat with XX" button on the agent detail page (`/team/:name`) was navigating to `/:tab` with `tab="chat"`, which goes to the generic chat page
- Changed to `/talk/:name` with the agent's name so it opens a conversation with that specific agent

Closes #5418

## Test plan
- [ ] Navigate to an agent's detail page → click "Chat with XX" → verify it goes to `/talk/{agent-name}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)