### PR TITLE
feat: refactor vnc to foreground process and add cdp browser login

### DIFF
--- a/.claude/skills/dev-browser/SKILL.md
+++ b/.claude/skills/dev-browser/SKILL.md
@@ -21,34 +21,66 @@ Use the `/dev-start` skill to start the dev server if not already running. Wait 
 
 ### Step 2: Start VNC + Chrome
 
-Run the VNC startup script to launch the headed Chrome browser:
+Start the VNC stack in the background using Bash `run_in_background`. The script stays alive and all child processes (Xvfb, Chrome, etc.) are cleaned up when the task is stopped.
 
 ```bash
 PROJECT_ROOT=$(git rev-parse --show-toplevel)
-cd "$PROJECT_ROOT" && VNC_URL=$(scripts/start-vnc.sh) && echo "$VNC_URL"
+cd "$PROJECT_ROOT" && scripts/start-vnc.sh
 ```
 
-After VNC starts, verify Chrome is reachable via CDP:
+Run this command with `run_in_background: true`. It will output the noVNC URL.
+
+After starting, wait a few seconds then verify Chrome is reachable via CDP:
 
 ```bash
 curl -sf http://localhost:9222/json/version > /dev/null || { echo "❌ CDP not ready"; exit 1; }
 ```
 
-If CDP is not ready, Playwright Chromium may not be installed. Install it and re-run the VNC script:
+If CDP is not ready, Playwright Chromium may not be installed. Install it and restart the VNC task:
 
 ```bash
 PROJECT_ROOT=$(git rev-parse --show-toplevel)
 cd "$PROJECT_ROOT/e2e" && pnpm exec playwright install chromium
-cd "$PROJECT_ROOT" && scripts/start-vnc.sh
 ```
+
+Then stop and re-run the VNC background task.
 
 Tell the user the noVNC URL so they can watch:
 
 > The browser is running in headed mode with noVNC. Open this URL to view and interact:
 >
-> `<vnc-url>/vnc.html`
+> `http://localhost:6080/vnc.html`
 
-### Step 3: Start Video Recording
+### Step 3: Authenticate Browser
+
+Use the e2e auth automation script to log in to the platform app via CDP. This reuses the same Clerk login flow that CI verifies.
+
+Build the test email from `git config user.email` prefix + hostname:
+
+```bash
+PROJECT_ROOT=$(git rev-parse --show-toplevel)
+GIT_EMAIL_PREFIX=$(git config user.email | sed 's/@.*//')
+HOSTNAME=$(hostname)
+TEST_EMAIL="${GIT_EMAIL_PREFIX}-${HOSTNAME}+clerk_test@vm0.ai"
+
+cd "$PROJECT_ROOT/e2e" && npx tsx cli-auth-automation.ts --cdp "https://app.vm7.ai:8443" --port 9222 --email "$TEST_EMAIL"
+```
+
+This will:
+- Connect to the existing Chrome via CDP port 9222
+- Navigate to the Clerk sign-in page
+- Authenticate using the test email and OTP code `424242`
+- Skip login if the browser is already authenticated
+- Leave the browser open for agent-browser to use
+
+If the script fails with a database error (e.g., missing `org_cache` table), run migrations first:
+
+```bash
+PROJECT_ROOT=$(git rev-parse --show-toplevel)
+cd "$PROJECT_ROOT/turbo" && pnpm --filter web db:migrate
+```
+
+### Step 4: Start Video Recording
 
 Before performing any browser actions, start recording the session. Use the task name (a short English description of what you're doing) and a timestamp for the filename:
 

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -23,7 +23,7 @@ echo "✓ Locale configured"
 # Add vm7.ai domains to /etc/hosts (Caddy reverse proxy listens on 127.0.0.1)
 echo "🌐 Configuring vm7.ai hosts..."
 if ! grep -q "vm7.ai" /etc/hosts 2>/dev/null; then
-  echo "127.0.0.1 vm7.ai www.vm7.ai docs.vm7.ai app.vm7.ai" | sudo tee -a /etc/hosts > /dev/null
+  echo "127.0.0.1 vm7.ai www.vm7.ai docs.vm7.ai app.vm7.ai platform.vm7.ai" | sudo tee -a /etc/hosts > /dev/null
   echo "✓ vm7.ai domains added to /etc/hosts"
 else
   echo "✓ vm7.ai domains already in /etc/hosts"

--- a/e2e/cli-auth-automation.ts
+++ b/e2e/cli-auth-automation.ts
@@ -1,4 +1,4 @@
-import { chromium } from "playwright";
+import { chromium, type Browser, type Page } from "playwright";
 import { spawn, ChildProcess } from "child_process";
 import * as dotenv from "dotenv";
 import * as os from "os";
@@ -7,6 +7,87 @@ import * as path from "path";
 
 // Load environment variables
 dotenv.config({ path: ".env.local" });
+
+// ---------------------------------------------------------------------------
+// Shared: Clerk sign-in flow (used by both CLI auth and CDP browser login)
+// ---------------------------------------------------------------------------
+
+/**
+ * Sign in to a VM0 app via Clerk email + OTP.
+ *
+ * Steps:
+ * 1. Navigate to /sign-in
+ * 2. Enter email → Continue
+ * 3. "Use another method" → "Email code"
+ * 4. Enter OTP 424242 (Clerk dev mode test code)
+ * 5. Wait for redirect away from /sign-in
+ *
+ * This function is shared between `automateCliAuth` (CI e2e-auth job)
+ * and `browserLogin` (local agent-browser CDP login), so its correctness
+ * is continuously verified by CI.
+ */
+export async function clerkLogin(page: Page, baseUrl: string, email: string) {
+  const OTP = "424242";
+
+  // If Vercel bypass secret is available, set bypass cookie
+  const bypassSecret = process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
+  if (bypassSecret) {
+    const bypassUrl = `${baseUrl}?x-vercel-set-bypass-cookie=samesitenone&x-vercel-protection-bypass=${bypassSecret}`;
+    console.log("🔓 Setting Vercel bypass cookie via query parameter");
+    await page.goto(bypassUrl);
+  }
+
+  // Navigate to sign-in page
+  await page.goto(`${baseUrl}/sign-in`);
+  await page.waitForLoadState("domcontentloaded");
+
+  // Wait for Clerk to render sign-in form (or skip if already signed in)
+  const emailInput = page.locator('input[name="identifier"]');
+  const hasSignIn = await emailInput.isVisible({ timeout: 10000 }).catch(() => false);
+  if (!hasSignIn) {
+    console.log(`✅ Already signed in (current URL: ${page.url()})`);
+    return;
+  }
+
+  // Enter email address
+  await emailInput.fill(email);
+  console.log(`📧 Using test email: ${email}`);
+
+  // Click Continue button
+  await page.locator('.cl-formButtonPrimary').click();
+  console.log("➡️ Clicked Continue");
+
+  // Clerk shows password by default; switch to email code method
+  const useAnotherMethod = page.locator('a:has-text("Use another method"), button:has-text("Use another method")');
+  await useAnotherMethod.waitFor({ state: "visible", timeout: 10000 });
+  await useAnotherMethod.click();
+  console.log("🔄 Clicked 'Use another method'");
+
+  // Select email code option
+  const emailCodeOption = page.locator('button:has-text("Email code")');
+  await emailCodeOption.waitFor({ state: "visible", timeout: 10000 });
+  await emailCodeOption.click();
+  console.log("📧 Selected 'Email code'");
+
+  // Wait for OTP input to appear and Clerk to finish sending the code
+  const otpInput = page.locator('input[data-input-otp="true"]');
+  await otpInput.waitFor({ state: "attached", timeout: 10000 });
+  // Wait for Clerk to complete the "prepare" step (sending the email)
+  await page.waitForTimeout(2000);
+
+  // Enter test OTP code 424242 (Clerk accepts this in development mode)
+  await otpInput.focus();
+  await page.keyboard.type(OTP);
+  console.log("🔢 Entered OTP code");
+
+  // Wait for Clerk to complete authentication (should redirect away from /sign-in)
+  await page.waitForURL((url) => !url.pathname.includes('/sign-in'), { timeout: 15000 });
+  console.log(`✅ Clerk login successful (redirected to ${page.url()})`);
+}
+
+// ---------------------------------------------------------------------------
+// Mode 1: CLI device-code authentication (used by CI e2e-auth job)
+// ---------------------------------------------------------------------------
 
 /**
  * Automate CLI authentication flow
@@ -23,7 +104,7 @@ dotenv.config({ path: ".env.local" });
  */
 export async function automateCliAuth(apiHost?: string) {
   let cliProcess: ChildProcess | null = null;
-  let browser = null;
+  let browser: Browser | null = null;
 
   try {
     console.log("🚀 Starting CLI authentication flow...");
@@ -132,64 +213,13 @@ export async function automateCliAuth(apiHost?: string) {
     const context = await browser.newContext();
     const page = await context.newPage();
 
-    // Step 4: Login via Clerk email + OTP code
-    const baseUrl = apiUrl;
-
-    // If Vercel bypass secret is available, set bypass cookie via query parameter
-    // This avoids CORS issues that occur when using HTTP headers
-    const bypassSecret = process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
-    if (bypassSecret) {
-      const bypassUrl = `${baseUrl}?x-vercel-set-bypass-cookie=samesitenone&x-vercel-protection-bypass=${bypassSecret}`;
-      console.log("🔓 Setting Vercel bypass cookie via query parameter");
-      await page.goto(bypassUrl);
-    }
-
-    // Navigate to sign-in page
-    await page.goto(`${baseUrl}/sign-in`);
-    await page.waitForLoadState("domcontentloaded");
-
-    // Enter email address
-    const emailInput = page.locator('input[name="identifier"]');
-    await emailInput.waitFor({ state: "visible", timeout: 10000 });
+    // Step 4: Login via Clerk
     const testEmail = "e2e+clerk_test@vm0.ai";
-    await emailInput.fill(testEmail);
-    console.log(`📧 Using test email: ${testEmail}`);
-    console.log("📧 Entered email address");
-
-    // Click Continue button
-    await page.locator('.cl-formButtonPrimary').click();
-    console.log("➡️ Clicked Continue");
-
-    // Clerk shows password by default; switch to email code method
-    const useAnotherMethod = page.locator('a:has-text("Use another method"), button:has-text("Use another method")');
-    await useAnotherMethod.waitFor({ state: "visible", timeout: 10000 });
-    await useAnotherMethod.click();
-    console.log("🔄 Clicked 'Use another method'");
-
-    // Select email code option
-    const emailCodeOption = page.locator('button:has-text("Email code")');
-    await emailCodeOption.waitFor({ state: "visible", timeout: 10000 });
-    await emailCodeOption.click();
-    console.log("📧 Selected 'Email code'");
-
-    // Wait for OTP input to appear and Clerk to finish sending the code
-    const otpInput = page.locator('input[data-input-otp="true"]');
-    await otpInput.waitFor({ state: "attached", timeout: 10000 });
-    // Wait for Clerk to complete the "prepare" step (sending the email)
-    await page.waitForTimeout(2000);
-
-    // Enter test OTP code 424242 (Clerk accepts this in development mode)
-    await otpInput.focus();
-    await page.keyboard.type("424242");
-    console.log("🔢 Entered OTP code");
-
-    // Wait for Clerk to complete authentication (should redirect away from /sign-in)
-    await page.waitForURL((url) => !url.pathname.includes('/sign-in'), { timeout: 15000 });
-    console.log(`✅ Clerk login successful (redirected to ${page.url()})`);
-    console.log(`🔗 Visiting auth page: ${baseUrl}/cli-auth`);
+    await clerkLogin(page, apiUrl, testEmail);
+    console.log(`🔗 Visiting auth page: ${apiUrl}/cli-auth`);
 
     // Step 6: Visit CLI auth page
-    await page.goto(`${baseUrl}/cli-auth`);
+    await page.goto(`${apiUrl}/cli-auth`);
     await page.waitForLoadState("domcontentloaded");
 
     // Step 7: Enter device code
@@ -307,18 +337,91 @@ export async function automateCliAuth(apiHost?: string) {
   }
 }
 
-// If running this script directly
-if (require.main === module) {
-  // Can specify VM0_API_URL via command line argument or environment variable
-  const apiHost = process.argv[2] || process.env.VM0_API_URL;
+// ---------------------------------------------------------------------------
+// Mode 2: CDP browser login (for agent-browser / local dev)
+// ---------------------------------------------------------------------------
 
-  automateCliAuth(apiHost)
-    .then(() => {
-      console.log("✅ Automated authentication completed successfully");
-      process.exit(0);
-    })
-    .catch((error) => {
-      console.error("❌ Automated authentication failed:", error);
-      process.exit(1);
-    });
+/**
+ * Login to a VM0 app via an already-running Chrome instance (CDP).
+ *
+ * Connects to the Chrome started by scripts/start-vnc.sh and runs the
+ * same Clerk sign-in flow used by the CI e2e-auth job.
+ *
+ * NOTE: Playwright's connectOverCDP may not see Clerk-rendered DOM in
+ * headed Chrome (known issue with shared CDP sessions). If login fails,
+ * fall back to manual agent-browser commands.
+ *
+ * Usage:
+ *   npx tsx e2e/cli-auth-automation.ts --cdp [base-url] [--port 9222] [--email user@example.com]
+ */
+export async function browserLogin(opts: {
+  baseUrl: string;
+  cdpPort: number;
+  email: string;
+}) {
+  const cdpUrl = `http://localhost:${opts.cdpPort}`;
+  console.log(`🔗 Connecting to CDP at ${cdpUrl}`);
+  const browser = await chromium.connectOverCDP(cdpUrl);
+
+  const contexts = browser.contexts();
+  const context = contexts[0] ?? await browser.newContext();
+  const page = context.pages()[0] ?? await context.newPage();
+
+  try {
+    await clerkLogin(page, opts.baseUrl, opts.email);
+  } finally {
+    // Disconnect without killing — browser stays open for agent-browser
+    await browser.close();
+    console.log("🔌 Disconnected from CDP (browser stays open)");
+  }
+}
+
+// ---------------------------------------------------------------------------
+// CLI entry point
+// ---------------------------------------------------------------------------
+
+if (require.main === module) {
+  const args = process.argv.slice(2);
+  const isCdpMode = args.includes("--cdp");
+
+  if (isCdpMode) {
+    // --cdp mode: connect to existing Chrome and login
+    const filtered = args.filter(a => a !== "--cdp");
+    let baseUrl = "https://app.vm7.ai:8443";
+    let cdpPort = 9222;
+    let email = `${os.hostname()}+clerk_test@vm0.ai`;
+
+    for (let i = 0; i < filtered.length; i++) {
+      if (filtered[i] === "--port" && filtered[i + 1]) {
+        cdpPort = parseInt(filtered[++i], 10);
+      } else if (filtered[i] === "--email" && filtered[i + 1]) {
+        email = filtered[++i];
+      } else if (!filtered[i].startsWith("--")) {
+        baseUrl = filtered[i];
+      }
+    }
+
+    browserLogin({ baseUrl, cdpPort, email })
+      .then(() => {
+        console.log("✅ Browser login complete");
+        process.exit(0);
+      })
+      .catch((error) => {
+        console.error("❌ Browser login failed:", error);
+        process.exit(1);
+      });
+  } else {
+    // Default mode: CLI device-code auth
+    const apiHost = args[0] || process.env.VM0_API_URL;
+
+    automateCliAuth(apiHost)
+      .then(() => {
+        console.log("✅ Automated authentication completed successfully");
+        process.exit(0);
+      })
+      .catch((error) => {
+        console.error("❌ Automated authentication failed:", error);
+        process.exit(1);
+      });
+  }
 }

--- a/scripts/start-vnc.sh
+++ b/scripts/start-vnc.sh
@@ -1,12 +1,15 @@
 #!/bin/bash
 # Start the noVNC stack (Xvfb + openbox + x11vnc + websockify) and launch Chrome.
 #
+# The script stays in the foreground. Ctrl-C (or SIGTERM) cleanly shuts down
+# all child processes. This makes it safe to run via `run_in_background` in
+# Claude Code — when the task is stopped the whole VNC stack goes away.
+#
 # If CF_ACCESS_TOKEN is set, also creates a Cloudflare Tunnel with Access
 # protection (only your email can access). Otherwise, noVNC is local-only
 # (use `dcvnc <vm>` to open it from the host).
 #
 # Outputs the access URL to stdout. All other messages go to stderr.
-# Idempotent — safe to call multiple times; skips already-running processes.
 #
 # Usage: scripts/start-vnc.sh
 #
@@ -29,6 +32,22 @@ SCREEN_RES="${SCREEN_RES:-1344x840x24}"
 
 log() { echo -e "[vnc] $1" >&2; }
 
+# Track child PIDs for cleanup
+PIDS=()
+
+cleanup() {
+  log "Shutting down VNC stack..."
+  for pid in "${PIDS[@]}"; do
+    kill "$pid" 2>/dev/null || true
+  done
+  # Also kill any Chrome we started (matched by CDP port)
+  pkill -f "chrome.*--remote-debugging-port=${CDP_PORT:-9222}" 2>/dev/null || true
+  wait 2>/dev/null || true
+  log "All processes stopped."
+}
+
+trap cleanup EXIT INT TERM
+
 # --- Install dependencies if missing ---
 MISSING=()
 command -v x11vnc >/dev/null 2>&1 || MISSING+=(x11vnc)
@@ -42,54 +61,45 @@ if [[ ${#MISSING[@]} -gt 0 ]]; then
   sudo apt-get install -y -qq "${MISSING[@]}"
 fi
 
+# --- Kill any leftover processes from previous runs ---
+pkill -x Xvfb 2>/dev/null || true
+pkill -x openbox 2>/dev/null || true
+pkill -x x11vnc 2>/dev/null || true
+pkill -f websockify 2>/dev/null || true
+pkill -f "chrome.*--remote-debugging-port=${CDP_PORT:-9222}" 2>/dev/null || true
+sleep 1
+
 # --- Start Xvfb ---
-if pgrep -x Xvfb >/dev/null; then
-  log "Xvfb already running"
-else
-  log "Starting Xvfb on ${DISPLAY} (${SCREEN_RES})"
-  Xvfb "$DISPLAY" -screen 0 "$SCREEN_RES" >/dev/null 2>&1 &
-  sleep 1
-fi
+log "Starting Xvfb on ${DISPLAY} (${SCREEN_RES})"
+Xvfb "$DISPLAY" -screen 0 "$SCREEN_RES" >/dev/null 2>&1 &
+PIDS+=($!)
+sleep 1
 
 # --- Start openbox (window manager) ---
-if pgrep -x openbox >/dev/null; then
-  log "openbox already running"
-else
-  log "Starting openbox"
-  DISPLAY="$DISPLAY" openbox >/dev/null 2>&1 &
-  sleep 1
-fi
+log "Starting openbox"
+DISPLAY="$DISPLAY" openbox >/dev/null 2>&1 &
+PIDS+=($!)
+sleep 1
 
 # --- Start x11vnc ---
-if pgrep -x x11vnc >/dev/null; then
-  log "x11vnc already running"
-else
-  log "Starting x11vnc on port ${VNC_PORT}"
-  x11vnc -display "$DISPLAY" -nopw -forever -shared -rfbport "$VNC_PORT" >/dev/null 2>&1 &
-  sleep 1
-fi
+log "Starting x11vnc on port ${VNC_PORT}"
+x11vnc -display "$DISPLAY" -nopw -forever -shared -rfbport "$VNC_PORT" >/dev/null 2>&1 &
+PIDS+=($!)
+sleep 1
 
 # --- Start websockify (noVNC) ---
-if pgrep -f websockify >/dev/null; then
-  log "websockify already running"
-else
-  log "Starting websockify on 0.0.0.0:${NOVNC_PORT} -> localhost:${VNC_PORT}"
-  websockify --web /usr/share/novnc/ "0.0.0.0:${NOVNC_PORT}" "localhost:${VNC_PORT}" >/dev/null 2>&1 &
-  sleep 1
-fi
+log "Starting websockify on 0.0.0.0:${NOVNC_PORT} -> localhost:${VNC_PORT}"
+websockify --web /usr/share/novnc/ "0.0.0.0:${NOVNC_PORT}" "localhost:${VNC_PORT}" >/dev/null 2>&1 &
+PIDS+=($!)
+sleep 1
 
 # --- Launch Chrome with CDP (remote debugging) ---
-# Chrome is started with --remote-debugging-port so that agent-browser can
-# connect to the same instance via --cdp. This ensures the user watching
-# noVNC and the agent share the exact same browser.
 CDP_PORT="${CDP_PORT:-9222}"
 CHROME_BIN=$(find "$HOME/.cache/ms-playwright" -name chrome -type f 2>/dev/null | head -1)
 CHROME_PROFILE="${AGENT_BROWSER_PROFILE:-$HOME/.local/share/agent-browser/profile}"
 
 if [[ -z "$CHROME_BIN" ]]; then
   log "Warning: Chrome not found in Playwright cache, skipping"
-elif pgrep -f "chrome.*--remote-debugging-port=${CDP_PORT}" >/dev/null 2>&1; then
-  log "Chrome already running (CDP port ${CDP_PORT})"
 else
   # Clear stale profile locks from other VMs
   rm -f "${CHROME_PROFILE}/SingletonLock" "${CHROME_PROFILE}/SingletonCookie" "${CHROME_PROFILE}/SingletonSocket" 2>/dev/null
@@ -102,6 +112,7 @@ else
     --disable-blink-features=AutomationControlled \
     --start-maximized \
     >/dev/null 2>&1 &
+  PIDS+=($!)
   sleep 2
 fi
 
@@ -119,8 +130,6 @@ log "noVNC stack ready — local viewer at http://localhost:${NOVNC_PORT}/vnc.ht
 
 # --- Cloudflare Tunnel + Access (only when CF_ACCESS_TOKEN is set) ---
 if [[ -n "${CF_ACCESS_TOKEN:-}" ]]; then
-  # Compute tunnel hostname for VNC
-  # Format: <username>-<hostname>.vnc.vm7.ai (e.g., ethan-vm04.vnc.vm7.ai)
   if [[ -z "${TUNNEL_HOSTNAME:-}" ]]; then
     EMAIL=$(git config user.email 2>/dev/null || true)
     DOMAIN="${EMAIL##*@}"
@@ -139,7 +148,6 @@ if [[ -n "${CF_ACCESS_TOKEN:-}" ]]; then
     TUNNEL_URL=$(TUNNEL_HOSTNAME="${TUNNEL_HOSTNAME:-}" "${SCRIPT_DIR}/tunnel.sh" "$NOVNC_PORT")
   fi
 
-  # Apply Cloudflare Access protection
   if [[ -n "${TUNNEL_HOSTNAME:-}" ]]; then
     "${SCRIPT_DIR}/tunnel-access.sh" "$TUNNEL_HOSTNAME"
   fi
@@ -151,3 +159,7 @@ else
   log "Use 'dcvnc $(hostname)' from the host to open noVNC"
   echo "http://localhost:${NOVNC_PORT}"
 fi
+
+# --- Stay in foreground until signalled ---
+log "Press Ctrl-C to stop."
+wait


### PR DESCRIPTION
## Summary
- Rewrite `scripts/start-vnc.sh` to run in the foreground with trap-based cleanup, making it compatible with Claude Code `run_in_background` (kills all child processes on stop)
- Extract the Clerk sign-in flow into a shared `clerkLogin()` function in `e2e/cli-auth-automation.ts`, reused by both the CI e2e-auth job and a new `browserLogin()` CDP mode for local agent-browser authentication
- Update dev-browser skill docs to reflect the new foreground VNC process and authentication step
- Add `platform.vm7.ai` to devcontainer `/etc/hosts` setup

## Test plan
- [ ] Run `scripts/start-vnc.sh` and verify it stays in foreground, Ctrl-C cleans up all processes
- [ ] Run `npx tsx e2e/cli-auth-automation.ts --cdp https://app.vm7.ai:8443` against a running Chrome to verify CDP login
- [ ] Verify existing CI e2e-auth job still passes (uses `automateCliAuth` which now delegates to `clerkLogin`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)