### PR TITLE
test: add e2e and integration tests for --append-system-prompt

### DIFF
--- a/crates/guest-mock-claude/src/main.rs
+++ b/crates/guest-mock-claude/src/main.rs
@@ -37,7 +37,7 @@ fn parse_args(args: &[String]) -> ParsedArgs {
                     i += 1;
                 }
             }
-            "--resume" => {
+            "--resume" | "--append-system-prompt" => {
                 // Parsed for CLI compat but not used by mock-claude
                 if args.get(i + 1).is_some() {
                     i += 2;
@@ -323,6 +323,8 @@ mod tests {
             "--dangerously-skip-permissions",
             "--resume",
             "session-abc",
+            "--append-system-prompt",
+            "Your name is Aria.",
             "ls -la",
         ]
         .into_iter()
@@ -373,6 +375,16 @@ mod tests {
             .collect();
         let result = parse_args(&args);
         // --resume and its value are consumed, not treated as prompt
+        assert_eq!(result.prompt, "echo hi");
+    }
+
+    #[test]
+    fn parse_args_append_system_prompt_skipped() {
+        let args: Vec<String> = vec!["--append-system-prompt", "Your name is Aria.", "echo hi"]
+            .into_iter()
+            .map(String::from)
+            .collect();
+        let result = parse_args(&args);
         assert_eq!(result.prompt, "echo hi");
     }
 

--- a/e2e/tests/03-experimental-runner/t44-vm0-append-system-prompt.bats
+++ b/e2e/tests/03-experimental-runner/t44-vm0-append-system-prompt.bats
@@ -1,0 +1,68 @@
+#!/usr/bin/env bats
+
+# Test VM0 --append-system-prompt flag (E2E happy path only)
+# This test verifies that:
+# 1. vm0 run with --append-system-prompt flag succeeds
+# 2. The agent run completes successfully (full CLI → API → runner → sandbox pipeline)
+#
+# Note: mock-claude does not use the append-system-prompt value, so we cannot
+# verify the text reached Claude. The value is validated to reach the sandbox
+# via integration tests in create-run.test.ts and claim route.test.ts.
+
+load '../../helpers/setup'
+
+setup_file() {
+    # Unique agent name for this test file
+    export AGENT_NAME="e2e-t44-$(date +%s%3N)-$RANDOM"
+    # Create shared test directory for this file
+    export TEST_DIR="$(mktemp -d)"
+    export TEST_CONFIG="$TEST_DIR/vm0.yaml"
+
+    # Create unique volume for this test file
+    export VOLUME_NAME="e2e-vol-t44-$(date +%s%3N)-$RANDOM"
+    mkdir -p "$TEST_DIR/$VOLUME_NAME"
+    cd "$TEST_DIR/$VOLUME_NAME"
+    cat > CLAUDE.md << 'VOLEOF'
+This is a test file for the volume.
+VOLEOF
+    $CLI_COMMAND volume init --name "$VOLUME_NAME" >/dev/null
+    $CLI_COMMAND volume push >/dev/null
+    cd - >/dev/null
+
+    # Create inline config with unique agent name
+    cat > "$TEST_CONFIG" <<EOF
+version: "1.0"
+agents:
+  ${AGENT_NAME}:
+    description: "E2E test agent for append-system-prompt"
+    framework: claude-code
+    volumes:
+      - claude-files:/home/user/.claude
+    working_dir: /home/user/workspace
+volumes:
+  claude-files:
+    name: $VOLUME_NAME
+    version: latest
+EOF
+
+    # Compose agent once for all tests in this file
+    $CLI_COMMAND compose "$TEST_CONFIG" >/dev/null
+}
+
+teardown_file() {
+    # Clean up shared test directory
+    if [ -n "$TEST_DIR" ] && [ -d "$TEST_DIR" ]; then
+        rm -rf "$TEST_DIR"
+    fi
+}
+
+@test "t44-1: run with --append-system-prompt succeeds" {
+    run $CLI_COMMAND run "$AGENT_NAME" \
+        --append-system-prompt "Your name is Aria." \
+        "echo hello"
+
+    assert_success
+    assert_output --partial "● Bash("
+    assert_output --partial "echo hello"
+    assert_output --partial "◆ Claude Code Completed"
+}

--- a/turbo/apps/web/app/api/runners/jobs/[id]/claim/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/runners/jobs/[id]/claim/__tests__/route.test.ts
@@ -309,6 +309,70 @@ describe("POST /api/runners/jobs/:id/claim", () => {
       expect(data.agentName).toBeUndefined();
       expect(data.agentOrgSlug).toBeUndefined();
     });
+
+    it("should return appendSystemPrompt in claim response", async () => {
+      const { composeId, versionId } = await createTestCompose("test-asp");
+      const composeInfo = await findTestComposeWithOrg(composeId);
+      const orgSlug = composeInfo!.orgSlug;
+
+      const { runId } = await createTestRunnerJob(
+        user.userId,
+        versionId,
+        `${orgSlug}/default`,
+        undefined,
+        { appendSystemPrompt: "Your name is Aria." },
+      );
+
+      const token = await createTestCliToken(user.userId);
+      const request = createTestRequest(
+        `http://localhost:3000/api/runners/jobs/${runId}/claim`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({}),
+        },
+      );
+
+      const response = await POST(request);
+      expect(response.status).toBe(200);
+
+      const data = await response.json();
+      expect(data.appendSystemPrompt).toBe("Your name is Aria.");
+    });
+
+    it("should return null appendSystemPrompt when not set", async () => {
+      const { composeId, versionId } = await createTestCompose("test-asp-null");
+      const composeInfo = await findTestComposeWithOrg(composeId);
+      const orgSlug = composeInfo!.orgSlug;
+
+      const { runId } = await createTestRunnerJob(
+        user.userId,
+        versionId,
+        `${orgSlug}/default`,
+      );
+
+      const token = await createTestCliToken(user.userId);
+      const request = createTestRequest(
+        `http://localhost:3000/api/runners/jobs/${runId}/claim`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({}),
+        },
+      );
+
+      const response = await POST(request);
+      expect(response.status).toBe(200);
+
+      const data = await response.json();
+      expect(data.appendSystemPrompt).toBeNull();
+    });
   });
 
   describe("Claim flow - capabilities in sandbox token", () => {

--- a/turbo/apps/web/src/__tests__/api-test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers.ts
@@ -2247,6 +2247,7 @@ export async function findTestComposeWithOrg(composeId: string) {
  * @param versionId - The agent compose version ID
  * @param runnerGroup - The runner group (e.g., "org-slug/default")
  * @param contextOverrides - Optional overrides for the stored execution context
+ * @param runOverrides - Optional overrides for the agent run record (e.g., appendSystemPrompt)
  * @returns The created run ID
  */
 export async function createTestRunnerJob(
@@ -2254,6 +2255,7 @@ export async function createTestRunnerJob(
   versionId: string,
   runnerGroup: string,
   contextOverrides?: Partial<StoredExecutionContext>,
+  runOverrides?: { appendSystemPrompt?: string },
 ): Promise<{ runId: string }> {
   const orgId = await getOrgIdFromVersion(versionId);
 
@@ -2265,6 +2267,7 @@ export async function createTestRunnerJob(
       agentComposeVersionId: versionId,
       status: "pending",
       prompt: "test prompt",
+      ...runOverrides,
     })
     .returning({ id: agentRuns.id });
 

--- a/turbo/apps/web/src/lib/run/__tests__/create-run.test.ts
+++ b/turbo/apps/web/src/lib/run/__tests__/create-run.test.ts
@@ -93,6 +93,21 @@ describe("createRun()", () => {
       expect(run!.appendSystemPrompt).toBeNull();
     });
 
+    it("should propagate appendSystemPrompt through runner job dispatch", async () => {
+      vi.stubEnv("RUNNER_DEFAULT_GROUP", "vm0/production");
+      reloadEnv();
+
+      const result = await createRun(
+        baseParams({ appendSystemPrompt: "Your name is Aria." }),
+      );
+
+      const run = await findTestRunRecord(result.runId);
+      expect(run!.appendSystemPrompt).toBe("Your name is Aria.");
+
+      const job = await findTestRunnerJobEntry(result.runId);
+      expect(job).toBeDefined();
+    });
+
     it("should always set lastHeartbeatAt", async () => {
       const result = await createRun(baseParams());
 


### PR DESCRIPTION
## Summary
- Add E2E bats test (`t44`) verifying `--append-system-prompt` flag works through the full CLI → API → runner → sandbox pipeline
- Add claim route integration tests verifying `appendSystemPrompt` is returned correctly (both set and null cases)
- Add create-run integration test verifying `appendSystemPrompt` propagates through runner job dispatch
- Extend `createTestRunnerJob` helper with `runOverrides` parameter

Closes #5421

## Test plan
- [x] E2E bats test `t44-vm0-append-system-prompt.bats` — new file, 1 test
- [x] Claim route tests — 2 new tests in existing file (18 total pass)
- [x] Create-run test — 1 new test in existing file (45 total pass)
- [x] Lint passes
- [x] Type check passes (web package)
- [x] Knip passes
- [x] Full vitest suite — all pre-existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)