### PR TITLE
feat: block agent deletion for sandbox tokens

### DIFF
--- a/turbo/apps/docs/content/docs/core-concept/capabilities.mdx
+++ b/turbo/apps/docs/content/docs/core-concept/capabilities.mdx
@@ -31,7 +31,7 @@ If a request lacks the required capability, the API returns a `403 Forbidden` re
 | Capability | Category | Description |
 |------------|----------|-------------|
 | `agent:read` | Agent resources | Read agent composes and volumes |
-| `agent:write` | Agent resources | Create, update, and delete agent composes and volumes |
+| `agent:write` | Agent resources | Create and update agent composes and volumes |
 | `artifact:read` | Runtime resources | Read artifacts and memories |
 | `artifact:write` | Runtime resources | Write artifacts and memories |
 | `agent-run:read` | Operational | List and view agent runs |
@@ -42,6 +42,10 @@ If a request lacks the required capability, the API returns a `403 Forbidden` re
 All capabilities follow the `{resource}:{action}` format where action is either `read` or `write`.
 
 [Artifacts](/docs/core-concept/artifact) and [memories](/docs/core-concept/memory) are both runtime dynamic resources, so they share the `artifact:*` capability. Similarly, agent composes and [volumes](/docs/core-concept/volume) are agent static resources sharing the `agent:*` capability.
+
+<Callout type="info">
+Agent deletion is not available from sandbox. Deleting agents requires the CLI or web UI.
+</Callout>
 
 ## Configuration
 

--- a/turbo/apps/web/app/api/agent/composes/[id]/route.ts
+++ b/turbo/apps/web/app/api/agent/composes/[id]/route.ts
@@ -16,6 +16,7 @@ import {
   requireAuth,
   isAuthError,
 } from "../../../../../src/lib/auth/require-auth";
+import { isSandboxAuth } from "../../../../../src/lib/auth/capability-check";
 import { canAccessCompose } from "../../../../../src/lib/agent/compose-access";
 import { resolveOrg } from "../../../../../src/lib/org/resolve-org";
 import {
@@ -102,7 +103,20 @@ const router = tsr.router(composesByIdContract, {
     if (isAuthError(authResult)) return authResult;
     const { userId } = authResult;
 
-    // 2. Verify ownership (only owner can delete)
+    // 2. Block sandbox tokens — agents cannot delete other agents
+    if (isSandboxAuth(authResult)) {
+      return {
+        status: 403 as const,
+        body: {
+          error: {
+            message: "Agent deletion is not available from sandbox",
+            code: "FORBIDDEN",
+          },
+        },
+      };
+    }
+
+    // 3. Verify ownership (only owner can delete)
     const [compose] = await globalThis.services.db
       .select()
       .from(agentComposes)
@@ -120,7 +134,7 @@ const router = tsr.router(composesByIdContract, {
       };
     }
 
-    // 3. Check for running/pending runs
+    // 4. Check for running/pending runs
     const runningRuns = await globalThis.services.db
       .select({ id: agentRuns.id })
       .from(agentRuns)
@@ -148,12 +162,12 @@ const router = tsr.router(composesByIdContract, {
       };
     }
 
-    // 4. Delete agent (cascades handle related data)
+    // 5. Delete agent (cascades handle related data)
     await globalThis.services.db
       .delete(agentComposes)
       .where(eq(agentComposes.id, params.id));
 
-    // 5. Clean up agent-instructions volume (DB + S3)
+    // 6. Clean up agent-instructions volume (DB + S3)
     const storageName = getInstructionsStorageName(compose.name);
     const [storage] = await globalThis.services.db
       .select({ id: storages.id, s3Prefix: storages.s3Prefix })

--- a/turbo/apps/web/app/api/agent/composes/__tests__/sandbox-capability.test.ts
+++ b/turbo/apps/web/app/api/agent/composes/__tests__/sandbox-capability.test.ts
@@ -252,7 +252,7 @@ describe("Sandbox capability enforcement on compose routes", () => {
   });
 
   describe("DELETE /api/agent/composes/:id", () => {
-    it("sandbox token with agent:write can delete compose", async () => {
+    it("sandbox token with agent:write cannot delete compose", async () => {
       const agentName = `test-sandbox-delete-${Date.now()}`;
       const { composeId } = await createTestCompose(agentName);
 
@@ -270,7 +270,38 @@ describe("Sandbox capability enforcement on compose routes", () => {
       );
 
       const response = await deleteDELETE(request);
-      expect(response.status).toBe(204);
+      expect(response.status).toBe(403);
+
+      const data = await response.json();
+      expect(data.error.message).toContain("sandbox");
+    });
+
+    it("sandbox token with all capabilities cannot delete compose", async () => {
+      const agentName = `test-sandbox-delete-all-caps-${Date.now()}`;
+      const { composeId } = await createTestCompose(agentName);
+
+      mockClerk({ userId: null });
+      const token = await generateSandboxToken(user.userId, "run-123", [
+        "agent:read",
+        "agent:write",
+        "artifact:read",
+        "artifact:write",
+        "agent-run:read",
+        "agent-run:write",
+        "schedule:read",
+        "schedule:write",
+      ]);
+
+      const request = createTestRequest(
+        `http://localhost:3000/api/agent/composes/${composeId}`,
+        {
+          method: "DELETE",
+          headers: { Authorization: `Bearer ${token}` },
+        },
+      );
+
+      const response = await deleteDELETE(request);
+      expect(response.status).toBe(403);
     });
 
     it("sandbox token without agent:write gets 403", async () => {


### PR DESCRIPTION
## Summary

- Block sandbox tokens from deleting agent composes via `DELETE /api/agent/composes/:id`
- `agent:write` capability continues to allow create/update agents and write volumes
- Agent deletion is now a user-only operation (CLI token or web UI session)

Closes #5425

## Test plan

- [x] Existing test updated: sandbox token with `agent:write` now expects 403 on delete (was 204)
- [x] New test: sandbox token with all capabilities still gets 403 on delete
- [x] Existing test preserved: sandbox token without `agent:write` still gets 403
- [x] All 15 sandbox capability tests pass
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)