### PR TITLE
feat(platform): optimize zero chat connector popover and schedule dialogs

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/components/settings/add-connection-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/add-connection-dialog.tsx
@@ -505,6 +505,7 @@ export function AddConnectionDialog({
   excludeTypes,
   onConnectSuccess,
   onAdd,
+  agentName,
 }: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -512,6 +513,7 @@ export function AddConnectionDialog({
   excludeTypes?: ReadonlySet<string>;
   onConnectSuccess?: (type: ConnectorType) => void;
   onAdd?: (type: ConnectorType) => void;
+  agentName?: string;
 }) {
   const isZero = variant === "zero";
 
@@ -523,6 +525,7 @@ export function AddConnectionDialog({
         excludeTypes={excludeTypes}
         onConnectSuccess={onConnectSuccess}
         onAdd={onAdd}
+        agentName={agentName}
       />
     );
   }
@@ -612,20 +615,25 @@ function ZeroAddConnectionDialog({
   excludeTypes,
   onConnectSuccess,
   onAdd,
+  agentName,
 }: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   excludeTypes?: ReadonlySet<string>;
   onConnectSuccess?: (type: ConnectorType) => void;
   onAdd?: (type: ConnectorType) => void;
+  agentName?: string;
 }) {
   const connectorTypes = useLastResolved(allConnectorTypes$);
   const search$ = useCCState("");
   const search = useGet(search$);
   const setSearch = useSet(search$);
+  const tab$ = useCCState<"not-connected" | "connected">("not-connected");
+  const tab = useGet(tab$);
+  const setTab = useSet(tab$);
   const types = Object.keys(CONNECTOR_TYPES) as ConnectorType[];
 
-  const filteredTypes = connectorTypes
+  const baseFiltered = connectorTypes
     ?.filter((item) => !excludeTypes || !excludeTypes.has(item.type))
     .filter((item) => {
       if (!search.trim()) {
@@ -639,37 +647,67 @@ function ZeroAddConnectionDialog({
       );
     });
 
+  const notConnected = baseFiltered?.filter((item) => !item.connected);
+  const connected = baseFiltered?.filter((item) => item.connected);
+  const filteredTypes = tab === "connected" ? connected : notConnected;
+
+  const notConnectedCount =
+    connectorTypes
+      ?.filter((item) => !excludeTypes || !excludeTypes.has(item.type))
+      .filter((item) => !item.connected).length ?? 0;
+  const connectedCount =
+    connectorTypes
+      ?.filter((item) => !excludeTypes || !excludeTypes.has(item.type))
+      .filter((item) => item.connected).length ?? 0;
+
   return (
     <Dialog
       open={open}
       onOpenChange={(v) => {
         if (!v) {
           setSearch("");
+          setTab("not-connected");
         }
         onOpenChange(v);
       }}
     >
       <DialogContent className="max-w-2xl h-[85vh] flex flex-col overflow-hidden pr-0 pb-0 zero-app">
         <DialogHeader>
-          <DialogTitle>Add connector</DialogTitle>
+          <DialogTitle>Add connector to {agentName ?? "agent"}</DialogTitle>
         </DialogHeader>
         <p className="text-sm text-muted-foreground pr-6">
           Connectors let your agents access and interact with third-party
           services.
         </p>
-        <div className="relative pr-6">
-          <IconSearch
-            size={16}
-            stroke={1.5}
-            className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground"
-          />
-          <input
-            type="text"
-            value={search}
-            onChange={(e) => setSearch(e.target.value)}
-            placeholder="Search connectors..."
-            className="w-full rounded-lg border border-border bg-background py-2 pl-9 pr-3 text-sm text-foreground placeholder:text-muted-foreground outline-none transition-colors focus:border-primary focus:ring-2 focus:ring-primary/20"
-          />
+        <div className="flex items-center gap-3 pr-6">
+          <div className="relative flex-1">
+            <IconSearch
+              size={16}
+              stroke={1.5}
+              className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground"
+            />
+            <input
+              type="text"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="Search..."
+              className="w-full rounded-lg border border-border bg-background py-2 pl-9 pr-3 text-sm text-foreground placeholder:text-muted-foreground outline-none transition-colors focus:border-primary focus:ring-2 focus:ring-primary/20"
+            />
+          </div>
+          <Tabs
+            value={tab}
+            onValueChange={(v) => setTab(v as "not-connected" | "connected")}
+          >
+            <TabsList className="w-fit">
+              <TabsTrigger value="not-connected">
+                Not connected
+                {notConnectedCount > 0 ? ` (${notConnectedCount})` : ""}
+              </TabsTrigger>
+              <TabsTrigger value="connected">
+                Connected{connectedCount > 0 ? ` (${connectedCount})` : ""}
+              </TabsTrigger>
+            </TabsList>
+          </Tabs>
         </div>
         <div className="flex-1 min-h-0 overflow-y-auto">
           <div className="pt-4 pb-6 pr-6">

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -168,15 +168,26 @@ function ConnectorTriggerIcons({
   connectors: ComposerConnectorItem[];
 }) {
   const connected = connectors.filter((c) => c.connected).slice(0, 3);
+  const hasDisconnected = connectors.some((c) => !c.connected);
   if (connected.length === 0) {
-    return <IconPlug size={18} stroke={1.5} />;
+    return (
+      <span className="relative">
+        <IconPlug size={18} stroke={1.5} />
+        {hasDisconnected && (
+          <span className="absolute -top-0.5 -right-0.5 h-2 w-2 rounded-full bg-red-500" />
+        )}
+      </span>
+    );
   }
   return (
     <span className="flex items-center -space-x-1.5">
-      {connected.map((c) => (
+      {connected.map((c, i) => (
         <span
           key={c.type}
-          className="flex h-7 w-7 items-center justify-center rounded-full bg-background"
+          className={cn(
+            "flex h-7 w-7 items-center justify-center rounded-full bg-background",
+            i === connected.length - 1 && "relative",
+          )}
           style={{ border: "0.7px solid hsl(var(--gray-400))" }}
         >
           {c.iconUrl ? (
@@ -184,25 +195,86 @@ function ConnectorTriggerIcons({
           ) : (
             <ConnectorIcon type={c.type as ConnectorType} size={16} />
           )}
+          {hasDisconnected && i === connected.length - 1 && (
+            <span className="absolute top-0 right-0 h-2 w-2 rounded-full bg-red-500 z-10" />
+          )}
         </span>
       ))}
     </span>
   );
 }
 
+function ConnectorRow({
+  item,
+  action,
+  tooltip,
+}: {
+  item: ComposerConnectorItem;
+  action?: { label: string; onClick: () => void };
+  tooltip?: string;
+}) {
+  const row = (
+    <div className="flex items-center gap-2 px-2 py-1.5 rounded-md hover:bg-muted/50 transition-colors">
+      <span className="flex h-4 w-4 shrink-0 items-center justify-center">
+        {item.iconUrl ? (
+          <img src={item.iconUrl} alt="" className="h-4 w-4" />
+        ) : (
+          <ConnectorIcon type={item.type as ConnectorType} size={16} />
+        )}
+      </span>
+      <span
+        className={cn(
+          "text-sm flex-1 truncate",
+          item.connected ? "text-foreground" : "text-muted-foreground",
+        )}
+      >
+        {item.label}
+      </span>
+      {action && (
+        <button
+          type="button"
+          className="shrink-0 rounded-md border border-border px-2 py-0.5 text-[11px] font-medium text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
+          onClick={(e) => {
+            e.stopPropagation();
+            action.onClick();
+          }}
+        >
+          {action.label}
+        </button>
+      )}
+    </div>
+  );
+
+  if (!tooltip) {
+    return row;
+  }
+
+  return (
+    <TooltipProvider delayDuration={400}>
+      <Tooltip>
+        <TooltipTrigger asChild>{row}</TooltipTrigger>
+        <TooltipContent side="right" className="max-w-[200px] text-xs">
+          {tooltip}
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}
+
 function ConnectorsPopoverButton({
-  connectors,
+  agentConnectors,
   onOpenAddDialog,
   onConnect,
   onManageConnectors,
   agentName,
 }: {
-  connectors: ComposerConnectorItem[];
+  agentConnectors: ComposerConnectorItem[];
   onOpenAddDialog: () => void;
   onConnect: (type: string) => void;
   onManageConnectors?: () => void;
   agentName: string;
 }) {
+  const hasAgentConnectors = agentConnectors.length > 0;
   return (
     <Popover>
       <TooltipProvider delayDuration={300}>
@@ -213,7 +285,7 @@ function ConnectorsPopoverButton({
                 type="button"
                 className="inline-flex shrink-0 items-center justify-center rounded-lg h-9 min-w-9 px-1.5 hover:bg-accent transition-colors"
               >
-                <ConnectorTriggerIcons connectors={connectors} />
+                <ConnectorTriggerIcons connectors={agentConnectors} />
               </button>
             </TooltipTrigger>
           </PopoverTrigger>
@@ -222,76 +294,53 @@ function ConnectorsPopoverButton({
           </TooltipContent>
         </Tooltip>
       </TooltipProvider>
-      <PopoverContent
-        side="top"
-        align="start"
-        className="w-64 p-0 rounded-xl flex flex-col max-h-[min(60vh,400px)]"
-      >
-        {connectors.length > 0 && (
-          <div className="p-2 overflow-y-auto min-h-0">
+      <PopoverContent side="top" align="start" className="w-64 p-0 rounded-lg">
+        {hasAgentConnectors && (
+          <div
+            className="max-h-[200px] overflow-y-auto py-1 pl-1"
+            style={{ scrollbarWidth: "thin" }}
+          >
+            <div className="px-2 pt-1 pb-1">
+              <span className="text-[11px] font-medium text-muted-foreground/70 uppercase tracking-wider">
+                Connectors used by {agentName}
+              </span>
+            </div>
             <div className="flex flex-col">
-              {connectors.map((item) => (
-                <div
+              {agentConnectors.map((item) => (
+                <ConnectorRow
                   key={item.type}
-                  className="flex items-center gap-2.5 px-3 py-2.5 rounded-lg hover:bg-muted/50 transition-colors"
-                >
-                  <span
-                    className={cn(
-                      "flex h-5 w-5 shrink-0 items-center justify-center",
-                      !item.connected && "opacity-40",
-                    )}
-                  >
-                    {item.iconUrl ? (
-                      <img src={item.iconUrl} alt="" className="h-5 w-5" />
-                    ) : (
-                      <ConnectorIcon
-                        type={item.type as ConnectorType}
-                        size={20}
-                      />
-                    )}
-                  </span>
-                  <span
-                    className={cn(
-                      "text-sm flex-1",
-                      item.connected
-                        ? "text-foreground"
-                        : "text-muted-foreground",
-                    )}
-                  >
-                    {item.label}
-                  </span>
-                  {item.connected ? (
-                    <span className="h-1.5 w-1.5 rounded-full bg-emerald-500 shrink-0" />
-                  ) : (
-                    <button
-                      type="button"
-                      className="text-sm font-medium text-muted-foreground hover:text-foreground transition-colors"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        onConnect(item.type);
-                      }}
-                    >
-                      Connect
-                    </button>
-                  )}
-                </div>
+                  item={item}
+                  action={
+                    item.connected
+                      ? undefined
+                      : {
+                          label: "Connect",
+                          onClick: () => onConnect(item.type),
+                        }
+                  }
+                  tooltip={
+                    item.connected
+                      ? undefined
+                      : "This connector is used by the agent but not connected. Click Connect to set it up, or go to Manage connectors for bulk setup."
+                  }
+                />
               ))}
             </div>
           </div>
         )}
         <div
           className={cn(
-            "p-2 flex flex-col shrink-0",
-            connectors.length > 0 && "border-t border-border/50",
+            "p-1 flex flex-col",
+            hasAgentConnectors && "border-t border-border/50",
           )}
         >
           <button
             type="button"
-            className="flex w-full items-center gap-2.5 px-3 py-2 rounded-lg text-sm text-foreground hover:bg-accent transition-colors"
+            className="flex w-full items-center gap-2 px-2 py-1.5 rounded-md text-sm text-foreground hover:bg-accent transition-colors"
             onClick={() => onOpenAddDialog()}
           >
             <IconPlus
-              size={20}
+              size={18}
               stroke={1.5}
               className="shrink-0 text-muted-foreground"
             />
@@ -300,11 +349,11 @@ function ConnectorsPopoverButton({
           {onManageConnectors && (
             <button
               type="button"
-              className="flex w-full items-center gap-2.5 px-3 py-2 rounded-lg text-sm text-foreground hover:bg-accent transition-colors"
+              className="flex w-full items-center gap-2 px-2 py-1.5 rounded-md text-sm text-foreground hover:bg-accent transition-colors"
               onClick={onManageConnectors}
             >
               <IconPlug
-                size={20}
+                size={18}
                 stroke={1.5}
                 className="shrink-0 text-muted-foreground"
               />
@@ -379,11 +428,12 @@ export function ZeroChatComposer({
     addedSkillsLoadable.state === "hasData" ? addedSkillsLoadable.data : [];
   const addedSet = new Set(addedSkills);
 
-  const composerConnectors: ComposerConnectorItem[] = addedSkills
+  const agentConnectors: ComposerConnectorItem[] = addedSkills
     .filter((name) => connectorMap.has(name as ConnectorType))
     .map((name) =>
       buildConnectorItem(name, skillMap, connectorMap, optimisticConnected),
-    );
+    )
+    .sort((a, b) => Number(a.connected) - Number(b.connected));
 
   const handleConnectSuccess = (type: string) => {
     const label = resolveConnectorLabel(type, skillMap, connectorMap);
@@ -487,7 +537,7 @@ export function ZeroChatComposer({
                   <IconPaperclip size={18} stroke={1.5} />
                 </button>
                 <ConnectorsPopoverButton
-                  connectors={composerConnectors}
+                  agentConnectors={agentConnectors}
                   onOpenAddDialog={() => setAddDialogOpen(true)}
                   onConnect={handleConnectConnector}
                   onManageConnectors={onManageConnectors}
@@ -548,6 +598,7 @@ export function ZeroChatComposer({
         excludeTypes={addedSet}
         onConnectSuccess={handleConnectSuccess}
         onAdd={handleConnectSuccess}
+        agentName={agentName}
       />
       {selectedConnType && !isOnboarding && (
         <ConnectModal

--- a/turbo/apps/platform/src/views/zero-page/zero-job-detail-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-job-detail-page.tsx
@@ -24,6 +24,7 @@ import { ZeroScheduleTab } from "./zero-schedule-tab.tsx";
 import { ZeroSkillsTab } from "./zero-skills-tab.tsx";
 import { ZeroInstructionsTab } from "./zero-instructions-tab.tsx";
 import { ZeroSettingsTab } from "./zero-settings-tab.tsx";
+
 import { TONE_OPTIONS, type Tone } from "./zero-tone-constants.ts";
 import type { ScheduleEntry } from "./zero-schedule-card.tsx";
 import {
@@ -229,7 +230,7 @@ function extractAgentFields(detail: AgentDetail | null, fallbackName: string) {
 // Tab wrappers — resolve signals into shared component props
 // ---------------------------------------------------------------------------
 
-function JobSkillsTab() {
+function JobSkillsTab({ agentName }: { agentName: string }) {
   const addedSkills = useGet(zeroJobAddedSkills$);
   const skillsDirty = useGet(zeroJobSkillsDirty$);
   const skillsSaving = useGet(zeroJobSettingsSaving$);
@@ -244,6 +245,7 @@ function JobSkillsTab() {
       addedSkillsLoading={false}
       skillsDirty={skillsDirty}
       skillsSaving={skillsSaving}
+      agentName={agentName}
       onAddSkill={addSkill}
       onRemoveSkill={removeSkill}
       onSaveSkills={() => detach(saveSkills(), Reason.DomCallback)}
@@ -466,7 +468,7 @@ export function ZeroJobDetailPage({
       </header>
 
       <main className="shrink-0 px-4 sm:px-6 pt-4 pb-16">
-        {activeTab === "connectors" && <JobSkillsTab />}
+        {activeTab === "connectors" && <JobSkillsTab agentName={displayName} />}
 
         {activeTab === "schedule" && <JobScheduleTab agentName={displayName} />}
 

--- a/turbo/apps/platform/src/views/zero-page/zero-schedule-card.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-schedule-card.tsx
@@ -927,7 +927,7 @@ export function ZeroScheduleCard({
           }
         }}
       >
-        <DialogContent className="sm:max-w-md gap-6">
+        <DialogContent className="sm:max-w-lg gap-6">
           <DialogHeader>
             <DialogTitle>
               {editingScheduleId ? "Edit schedule" : "Add schedule"}
@@ -946,8 +946,8 @@ export function ZeroScheduleCard({
                 value={newSchedulePrompt}
                 onChange={(e) => setNewSchedulePrompt(e.target.value)}
                 placeholder="Describe your task and instruction"
-                rows={3}
-                className="w-full rounded-lg border border-border bg-input px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground outline-none transition-colors focus:border-primary focus:ring-2 focus:ring-primary/20 resize-y min-h-[72px]"
+                rows={5}
+                className="w-full rounded-lg border border-border bg-input px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground outline-none transition-colors focus:border-primary focus:ring-2 focus:ring-primary/20 resize-y min-h-[120px]"
               />
             </div>
             <div className="flex flex-col gap-2">

--- a/turbo/apps/platform/src/views/zero-page/zero-schedule-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-schedule-page.tsx
@@ -552,7 +552,7 @@ function ScheduleEditDialogInner({
   };
 
   return (
-    <DialogContent className="sm:max-w-md gap-6">
+    <DialogContent className="sm:max-w-lg gap-6">
       <DialogHeader>
         <DialogTitle>Edit schedule</DialogTitle>
       </DialogHeader>
@@ -569,8 +569,8 @@ function ScheduleEditDialogInner({
             value={prompt}
             onChange={(e) => setPrompt(e.target.value)}
             placeholder="Describe your task and instruction"
-            rows={3}
-            className="w-full rounded-lg border border-border bg-input px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground outline-none transition-colors focus:border-primary focus:ring-2 focus:ring-primary/20 resize-y min-h-[72px]"
+            rows={5}
+            className="w-full rounded-lg border border-border bg-input px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground outline-none transition-colors focus:border-primary focus:ring-2 focus:ring-primary/20 resize-y min-h-[120px]"
           />
         </div>
         <ScheduleEditFields
@@ -704,7 +704,7 @@ function ScheduleCreateDialogInner({
   };
 
   return (
-    <DialogContent className="sm:max-w-md gap-6">
+    <DialogContent className="sm:max-w-lg gap-6">
       <DialogHeader>
         <DialogTitle>New schedule</DialogTitle>
       </DialogHeader>
@@ -741,8 +741,8 @@ function ScheduleCreateDialogInner({
             value={prompt}
             onChange={(e) => setPrompt(e.target.value)}
             placeholder="Describe your task and instruction"
-            rows={3}
-            className="w-full rounded-lg border border-border bg-input px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground outline-none transition-colors focus:border-primary focus:ring-2 focus:ring-primary/20 resize-y min-h-[72px]"
+            rows={5}
+            className="w-full rounded-lg border border-border bg-input px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground outline-none transition-colors focus:border-primary focus:ring-2 focus:ring-primary/20 resize-y min-h-[120px]"
           />
         </div>
         <ScheduleEditFields

--- a/turbo/apps/platform/src/views/zero-page/zero-skill-card.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-skill-card.tsx
@@ -36,7 +36,10 @@ export function ZeroSkillCard({
   const isPolling = pollingType === name;
 
   return (
-    <div className="flex flex-col rounded-[var(--zero-card-radius)] border border-[var(--zero-card-border)] bg-card shadow-[var(--zero-card-shadow)]">
+    <div
+      className="flex flex-col rounded-[var(--zero-card-radius)] bg-card shadow-[var(--zero-card-shadow)]"
+      style={{ border: "0.7px solid hsl(var(--gray-400))" }}
+    >
       <div className="flex h-14 items-center gap-2.5 px-5">
         <span className="flex h-7 w-7 shrink-0 items-center justify-center">
           {name in CONNECTOR_TYPES ? (

--- a/turbo/apps/platform/src/views/zero-page/zero-skills-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-skills-tab.tsx
@@ -35,6 +35,7 @@ interface ZeroSkillsTabProps {
   onRemoveSkill: (name: string) => void;
   onSaveSkills: () => void;
   onDiscardSkills: () => void;
+  agentName?: string;
 }
 
 export function ZeroSkillsTab({
@@ -42,6 +43,7 @@ export function ZeroSkillsTab({
   addedSkillsLoading,
   skillsDirty,
   skillsSaving,
+  agentName,
   onAddSkill,
   onRemoveSkill,
   onSaveSkills,
@@ -196,6 +198,7 @@ export function ZeroSkillsTab({
         excludeTypes={addedSet}
         onConnectSuccess={handleConnectSuccess}
         onAdd={handleConnectSuccess}
+        agentName={agentName}
       />
 
       {selectedType && (


### PR DESCRIPTION
## Summary

- **Connector popover redesign**: Sorted connector list (disconnected first), red dot indicator for disconnected connectors, per-item tooltips, dynamic "Connectors used by {agent}" header, refined spacing/sizing for visual consistency with model provider selector
- **Add connector dialog**: Tabbed view (Not connected / Connected) with counts, search repositioned to left, dynamic "Add connector to {agent}" title
- **Schedule dialogs**: Widened from `sm:max-w-md` to `sm:max-w-lg`, enlarged prompt textarea (rows 3→5, min-height 72→120px)
- **Connector card borders**: Unified to 0.7px solid gray-400 for visual consistency

## Test plan

- [ ] Open zero chat, verify connector popover shows correct connectors sorted by status
- [ ] Verify red dot indicator appears on trigger icons when any connector is disconnected
- [ ] Hover disconnected connector to confirm tooltip appears
- [ ] Open "Add connector" dialog and verify tabbed layout with search
- [ ] Create/edit schedule and verify wider dialog with larger prompt input
- [ ] Check connector cards have consistent thin borders

Made with [Cursor](https://cursor.com)