### PR TITLE
fix: use www domain for cdp browser login

### DIFF
--- a/.claude/skills/dev-browser/SKILL.md
+++ b/.claude/skills/dev-browser/SKILL.md
@@ -63,12 +63,14 @@ GIT_EMAIL_PREFIX=$(git config user.email | sed 's/@.*//')
 HOSTNAME=$(hostname)
 TEST_EMAIL="${GIT_EMAIL_PREFIX}-${HOSTNAME}+clerk_test@vm0.ai"
 
-cd "$PROJECT_ROOT/e2e" && npx tsx cli-auth-automation.ts --cdp "https://app.vm7.ai:8443" --port 9222 --email "$TEST_EMAIL"
+cd "$PROJECT_ROOT/e2e" && npx tsx cli-auth-automation.ts --cdp "https://www.vm7.ai:8443" --port 9222 --email "$TEST_EMAIL"
 ```
+
+**Important:** Use `www.vm7.ai:8443` (not `app.vm7.ai:8443`). The Clerk sign-in page lives on the www domain. Using the app domain causes a cross-domain redirect that Playwright over CDP cannot follow.
 
 This will:
 - Connect to the existing Chrome via CDP port 9222
-- Navigate to the Clerk sign-in page
+- Navigate to the Clerk sign-in page on www.vm7.ai
 - Authenticate using the test email and OTP code `424242`
 - Skip login if the browser is already authenticated
 - Leave the browser open for agent-browser to use

--- a/e2e/cli-auth-automation.ts
+++ b/e2e/cli-auth-automation.ts
@@ -387,7 +387,7 @@ if (require.main === module) {
   if (isCdpMode) {
     // --cdp mode: connect to existing Chrome and login
     const filtered = args.filter(a => a !== "--cdp");
-    let baseUrl = "https://app.vm7.ai:8443";
+    let baseUrl = "https://www.vm7.ai:8443";
     let cdpPort = 9222;
     let email = `${os.hostname()}+clerk_test@vm0.ai`;
 


### PR DESCRIPTION
## Summary
- Change default CDP browser login URL from `app.vm7.ai:8443` to `www.vm7.ai:8443`
- The Clerk sign-in page lives on the www domain; using the app domain causes a cross-domain redirect that Playwright over CDP cannot follow, silently failing login
- Update dev-browser skill docs with the correct domain and a warning

## Test plan
- [x] Verified `npx tsx cli-auth-automation.ts --cdp "https://www.vm7.ai:8443"` completes full Clerk OTP login flow successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)