### PR TITLE
fix(e2e): replace instant visibility check with polling wait in clerk login

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -844,7 +844,8 @@ jobs:
       needs.prepare.outputs.job-ref != '' && (
         needs.prepare.outputs.web-changed == 'true' ||
         needs.prepare.outputs.cli-changed == 'true' ||
-        needs.prepare.outputs.ci-changed == 'true'
+        needs.prepare.outputs.ci-changed == 'true' ||
+        needs.prepare.outputs.e2e-changed == 'true'
       )
     steps:
       - uses: actions/checkout@v6

--- a/e2e/cli-auth-automation.ts
+++ b/e2e/cli-auth-automation.ts
@@ -43,7 +43,10 @@ export async function clerkLogin(page: Page, baseUrl: string, email: string) {
 
   // Wait for Clerk to render sign-in form (or skip if already signed in)
   const emailInput = page.locator('input[name="identifier"]');
-  const hasSignIn = await emailInput.isVisible({ timeout: 10000 }).catch(() => false);
+  const hasSignIn = await emailInput
+    .waitFor({ state: "visible", timeout: 10000 })
+    .then(() => true)
+    .catch(() => false);
   if (!hasSignIn) {
     console.log(`✅ Already signed in (current URL: ${page.url()})`);
     return;


### PR DESCRIPTION
## Summary

- Fix `clerkLogin()` in `e2e/cli-auth-automation.ts` to use `waitFor({ state: "visible" })` instead of `isVisible()` for detecting the Clerk sign-in form
- `isVisible()` returns immediately without waiting — the `timeout` parameter is silently ignored by Playwright
- This caused all e2e-auth CI runs to fail since PR #5420 was merged, as the function falsely concluded "already signed in" when Clerk JS simply hadn't rendered the form yet

## Root Cause

PR #5420 refactored the Clerk sign-in logic into a shared `clerkLogin()` function but changed `waitFor()` (polling wait) to `isVisible()` (instant check). Every e2e-auth run after 11:11 UTC today has failed with the same pattern:

```
✅ Already signed in (current URL: https://pr-XXXX-www.vm6.ai/sign-in)
⚠️ Expected 8 input boxes, found 0. Trying single input fallback.
❌ Submit button not found
```

## Test plan

- [ ] e2e-auth CI job passes on this PR
- [ ] Verify the Clerk sign-in flow completes (email → OTP → redirect) in CI logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)