### PR TITLE
chore(crates): bump tokio-tungstenite from 0.28 to 0.29

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -2044,9 +2044,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
+checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
 dependencies = [
  "futures-util",
  "log",
@@ -2194,9 +2194,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tungstenite"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
+checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
 dependencies = [
  "bytes",
  "data-encoding",
@@ -2208,7 +2208,6 @@ dependencies = [
  "rustls-pki-types",
  "sha1",
  "thiserror 2.0.18",
- "utf-8",
 ]
 
 [[package]]

--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -63,7 +63,7 @@ rustls = { version = "0.23", default-features = false, features = ["ring", "std"
 hmac = "0.12"
 sha2 = "0.10"
 tokio-util = "0.7"
-tokio-tungstenite = { version = "0.28", default-features = false }
+tokio-tungstenite = { version = "0.29", default-features = false }
 rmp-serde = "1"
 rmpv = "1"
 futures-util = "0.3"


### PR DESCRIPTION
## Summary
- Bump `tokio-tungstenite` from 0.28 to 0.29 (and `tungstenite` 0.28 → 0.29)
- Raises MSRV to 1.71, permits non-visible ASCII in HTTP headers
- Drops `utf-8` transitive dependency

🤖 Generated with [Claude Code](https://claude.com/claude-code)