### PR TITLE
refactor: remove instructions metadata injection system

### DIFF
--- a/turbo/apps/cli/src/commands/compose/index.ts
+++ b/turbo/apps/cli/src/commands/compose/index.ts
@@ -71,7 +71,6 @@ interface AgentConfig {
   framework?: string;
   skills?: string[];
   environment?: Record<string, string>;
-  metadata?: { displayName?: string; sound?: string };
   experimental_firewalls?: Record<string, FirewallSelection>;
 }
 
@@ -151,7 +150,6 @@ async function uploadAssets(
       agent.instructions,
       basePath,
       agent.framework,
-      agent.metadata,
     );
     if (!jsonMode) {
       console.log(

--- a/turbo/apps/cli/src/lib/storage/system-storage.ts
+++ b/turbo/apps/cli/src/lib/storage/system-storage.ts
@@ -11,7 +11,7 @@ import {
   type SkillFrontmatter,
 } from "../domain/github-skills";
 import { directUpload } from "./direct-upload";
-import { getInstructionsFilename, injectMetadataFrontmatter } from "@vm0/core";
+import { getInstructionsFilename } from "@vm0/core";
 
 interface StorageUploadResult {
   name: string;
@@ -45,7 +45,6 @@ export async function uploadInstructions(
   instructionsFilePath: string,
   basePath: string,
   framework?: string,
-  metadata?: { displayName?: string; sound?: string },
 ): Promise<StorageUploadResult> {
   // Normalize agent name to lowercase to match server's normalization behavior
   // Server normalizes agent names to lowercase when storing compose configs
@@ -56,9 +55,8 @@ export async function uploadInstructions(
     ? instructionsFilePath
     : path.join(basePath, instructionsFilePath);
 
-  // Read the instructions file and inject metadata frontmatter
-  const rawContent = await fs.readFile(absolutePath, "utf8");
-  const content = injectMetadataFrontmatter(rawContent, metadata);
+  // Read the instructions file
+  const content = await fs.readFile(absolutePath, "utf8");
 
   // Create a temporary directory with the file
   const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "vm0-instructions-"));

--- a/turbo/apps/platform/src/signals/zero-page/zero-job-detail.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-job-detail.ts
@@ -5,7 +5,7 @@ import { throwIfAbort } from "../utils.ts";
 import { logger } from "../log.ts";
 import type { AgentDetail, AgentInstructions } from "./agent-types.ts";
 import { triggerAndPollComposeJob } from "./compose-job.ts";
-import { getInstructionsFilename, stripMetadataFrontmatter } from "@vm0/core";
+import { getInstructionsFilename } from "@vm0/core";
 import { skillValueToUrl, skillUrlToValue } from "../../data/skills.ts";
 import {
   buildCronExpression,
@@ -160,12 +160,12 @@ async function resolveExistingInstructions(
 ): Promise<string | undefined> {
   const instrContent = get(instructionsState$).instructions?.content;
   if (instrContent) {
-    return stripMetadataFrontmatter(instrContent);
+    return instrContent;
   }
   const resp = await fetchFn(`/api/agent/composes/${composeId}/instructions`);
   if (resp.ok) {
     const data = (await resp.json()) as AgentInstructions;
-    return data.content ? stripMetadataFrontmatter(data.content) : undefined;
+    return data.content ?? undefined;
   }
   return undefined;
 }
@@ -181,7 +181,7 @@ export const zeroJobEditedContent$ = computed((get) => get(editedContent$));
 export const zeroJobInstructionsDirty$ = computed((get) => {
   const edited = get(editedContent$);
   const instructions = get(instructionsState$).instructions;
-  const savedBody = stripMetadataFrontmatter(instructions?.content ?? "");
+  const savedBody = instructions?.content ?? "";
   return edited !== null && edited !== savedBody;
 });
 

--- a/turbo/apps/platform/src/signals/zero-page/zero-skills.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-skills.ts
@@ -9,7 +9,7 @@ import { triggerAndPollComposeJob } from "./compose-job.ts";
 import type { AgentInstructions } from "./agent-types.ts";
 import { throwIfAbort } from "../utils.ts";
 import { logger } from "../log.ts";
-import { getInstructionsFilename, stripMetadataFrontmatter } from "@vm0/core";
+import { getInstructionsFilename } from "@vm0/core";
 import { skillValueToUrl, skillUrlToValue } from "../../data/skills.ts";
 import { zeroChatAgentId$ } from "./zero-nav.ts";
 
@@ -167,9 +167,7 @@ async function resolveInstructionsContent(
     const data = (await resp.json()) as AgentInstructions;
     raw = data.content ?? undefined;
   }
-  // Strip any existing metadata (legacy frontmatter or profile block)
-  // so the server can inject a clean copy from compose metadata.
-  return raw ? stripMetadataFrontmatter(raw) : undefined;
+  return raw ?? undefined;
 }
 
 // ---------------------------------------------------------------------------

--- a/turbo/apps/platform/src/views/zero-page/zero-instructions-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-instructions-tab.tsx
@@ -1,4 +1,3 @@
-import { stripMetadataFrontmatter } from "@vm0/core";
 import { Card, CardContent } from "@vm0/ui";
 import type { AgentInstructions } from "../../signals/zero-page/agent-types.ts";
 import { ZeroUnsavedBar } from "./zero-unsaved-bar.tsx";
@@ -29,8 +28,7 @@ export function ZeroInstructionsTab({
   onBuild,
 }: ZeroInstructionsTabProps) {
   const rawContent = instructions?.content ?? "";
-  const strippedContent = stripMetadataFrontmatter(rawContent);
-  const displayContent = editedContent ?? strippedContent;
+  const displayContent = editedContent ?? rawContent;
 
   return (
     <div className="mx-auto max-w-[900px]">

--- a/turbo/packages/core/src/__tests__/instructions-frontmatter.spec.ts
+++ b/turbo/packages/core/src/__tests__/instructions-frontmatter.spec.ts
@@ -1,112 +1,5 @@
 import { describe, it, expect } from "vitest";
-import {
-  injectMetadataFrontmatter,
-  stripMetadataFrontmatter,
-} from "../instructions-frontmatter";
-
-describe("injectMetadataFrontmatter", () => {
-  it("should return content unchanged when metadata is undefined", () => {
-    const content = "# Instructions\nDo stuff.";
-    expect(injectMetadataFrontmatter(content)).toBe(content);
-  });
-
-  it("should return content unchanged when metadata is null", () => {
-    const content = "# Instructions\nDo stuff.";
-    expect(injectMetadataFrontmatter(content, null)).toBe(content);
-  });
-
-  it("should return content unchanged when metadata is empty", () => {
-    const content = "# Instructions\nDo stuff.";
-    expect(injectMetadataFrontmatter(content, {})).toBe(content);
-  });
-
-  it("should return content unchanged when metadata has only falsy fields", () => {
-    const content = "# Instructions";
-    expect(
-      injectMetadataFrontmatter(content, { displayName: "", sound: "" }),
-    ).toBe(content);
-  });
-
-  it("should prepend profile block with full metadata as natural language", () => {
-    const content = "# Instructions\nDo stuff.";
-    const result = injectMetadataFrontmatter(content, {
-      displayName: "Aria",
-      sound: "professional",
-    });
-    expect(result).toBe(
-      "[AGENT_PROFILE]\nYour name is Aria. Communicate in a clear, polished, and business-appropriate tone. This should be reflected in all your responses.\n[/AGENT_PROFILE]\n\n# Instructions\nDo stuff.",
-    );
-  });
-
-  it("should prepend profile block with only displayName", () => {
-    const content = "# Instructions";
-    const result = injectMetadataFrontmatter(content, {
-      displayName: "Aria",
-    });
-    expect(result).toBe(
-      "[AGENT_PROFILE]\nYour name is Aria.\n[/AGENT_PROFILE]\n\n# Instructions",
-    );
-  });
-
-  it("should prepend profile block with only sound", () => {
-    const content = "# Instructions";
-    const result = injectMetadataFrontmatter(content, {
-      sound: "friendly",
-    });
-    expect(result).toBe(
-      "[AGENT_PROFILE]\nCommunicate in a warm, approachable, and conversational tone. This should be reflected in all your responses.\n[/AGENT_PROFILE]\n\n# Instructions",
-    );
-  });
-
-  it("should use sound value directly for unknown tones", () => {
-    const content = "# Instructions";
-    const result = injectMetadataFrontmatter(content, {
-      sound: "playful",
-    });
-    expect(result).toContain("Communicate in a playful tone.");
-  });
-
-  it("should replace existing profile block", () => {
-    const content =
-      "[AGENT_PROFILE]\nYour name is OldName.\n[/AGENT_PROFILE]\n\n# Instructions\nDo stuff.";
-    const result = injectMetadataFrontmatter(content, {
-      displayName: "NewName",
-      sound: "direct",
-    });
-    expect(result).toContain("Your name is NewName.");
-    expect(result).toContain("concise, to the point, and no-nonsense");
-    expect(result).not.toContain("OldName");
-  });
-
-  it("should replace legacy HTML comment profile block", () => {
-    const content =
-      "# Instructions\nDo stuff.\n\n<!-- ZERO_PROFILE\nYour name is OldName.\nZERO_PROFILE -->\n";
-    const result = injectMetadataFrontmatter(content, {
-      displayName: "NewName",
-    });
-    expect(result).toContain("Your name is NewName.");
-    expect(result).toContain("[AGENT_PROFILE]");
-    expect(result).not.toContain("ZERO_PROFILE");
-    expect(result).not.toContain("OldName");
-  });
-
-  it("should handle empty content with metadata", () => {
-    const result = injectMetadataFrontmatter("", {
-      displayName: "Aria",
-    });
-    expect(result).toBe(
-      "[AGENT_PROFILE]\nYour name is Aria.\n[/AGENT_PROFILE]\n",
-    );
-  });
-
-  it("should describe all known tones correctly", () => {
-    for (const tone of ["professional", "friendly", "direct", "supportive"]) {
-      const result = injectMetadataFrontmatter("test", { sound: tone });
-      expect(result).toContain("Communicate in a ");
-      expect(result).toContain("tone.");
-    }
-  });
-});
+import { stripMetadataFrontmatter } from "../instructions-frontmatter";
 
 describe("stripMetadataFrontmatter", () => {
   it("should return content unchanged when no profile block", () => {
@@ -135,15 +28,6 @@ describe("stripMetadataFrontmatter", () => {
   it("should handle content with only profile block", () => {
     const content = "[AGENT_PROFILE]\nYour name is Aria.\n[/AGENT_PROFILE]\n";
     expect(stripMetadataFrontmatter(content)).toBe("");
-  });
-
-  it("should be the inverse of injectMetadataFrontmatter", () => {
-    const original = "# Instructions\nDo stuff.";
-    const injected = injectMetadataFrontmatter(original, {
-      displayName: "Aria",
-      sound: "professional",
-    });
-    expect(stripMetadataFrontmatter(injected)).toBe(original);
   });
 
   it("should strip legacy YAML frontmatter with name and tone", () => {
@@ -202,17 +86,6 @@ describe("ReDoS regression", () => {
     expect(result).not.toContain("AGENT_PROFILE");
   });
 
-  it("should handle injectMetadataFrontmatter with repeated markers in linear time", () => {
-    const malicious = "[AGENT_PROFILE]\n".repeat(10000);
-    const start = performance.now();
-    const result = injectMetadataFrontmatter(malicious, {
-      displayName: "Test",
-    });
-    const elapsed = performance.now() - start;
-    expect(elapsed).toBeLessThan(100);
-    expect(result).toContain("Your name is Test.");
-  });
-
   it("should handle legacy markers in linear time", () => {
     const malicious = "<!-- ZERO_PROFILE\n".repeat(10000);
     const start = performance.now();
@@ -220,31 +93,5 @@ describe("ReDoS regression", () => {
     const elapsed = performance.now() - start;
     expect(elapsed).toBeLessThan(100);
     expect(result).toBe(malicious.trim());
-  });
-});
-
-describe("legacy migration", () => {
-  it("should replace old frontmatter with new profile block on inject", () => {
-    const content =
-      "---\nname: OldName\ntone: casual\n---\n\n# Instructions\nDo stuff.";
-    const result = injectMetadataFrontmatter(content, {
-      displayName: "NewName",
-      sound: "professional",
-    });
-    expect(result).not.toContain("---");
-    expect(result).toContain("[AGENT_PROFILE]");
-    expect(result).toContain("Your name is NewName.");
-    expect(result).toContain("# Instructions\nDo stuff.");
-  });
-
-  it("should migrate legacy HTML comment format on inject", () => {
-    const content =
-      "# Instructions\n\n<!-- ZERO_PROFILE\nYour name is OldName.\nZERO_PROFILE -->\n";
-    const result = injectMetadataFrontmatter(content, {
-      displayName: "NewName",
-    });
-    expect(result).toContain("[AGENT_PROFILE]");
-    expect(result).not.toContain("<!-- ZERO_PROFILE");
-    expect(result).toContain("Your name is NewName.");
   });
 });

--- a/turbo/packages/core/src/instructions-frontmatter.ts
+++ b/turbo/packages/core/src/instructions-frontmatter.ts
@@ -1,9 +1,3 @@
-interface AgentMetadata {
-  displayName?: string;
-  description?: string;
-  sound?: string;
-}
-
 // Legacy HTML comment markers (for backward-compatible stripping)
 const LEGACY_PROFILE_START = "<!-- ZERO_PROFILE";
 const LEGACY_PROFILE_END = "ZERO_PROFILE -->";
@@ -94,86 +88,14 @@ function stripLegacyFrontmatter(content: string): string {
   return `---\n${remaining}\n---${body}`;
 }
 
-const TONE_DESCRIPTIONS: Record<string, string> = {
-  professional: "clear, polished, and business-appropriate",
-  friendly: "warm, approachable, and conversational",
-  direct: "concise, to the point, and no-nonsense",
-  supportive: "encouraging, empathetic, and reassuring",
-};
-
-function buildProfileParagraph(metadata: AgentMetadata): string | null {
-  const parts: string[] = [];
-
-  if (metadata.displayName) {
-    parts.push(`Your name is ${metadata.displayName}.`);
-  }
-
-  if (metadata.description) {
-    parts.push(metadata.description);
-  }
-
-  if (metadata.sound) {
-    const desc = TONE_DESCRIPTIONS[metadata.sound] ?? metadata.sound;
-    parts.push(
-      `Communicate in a ${desc} tone. This should be reflected in all your responses.`,
-    );
-  }
-
-  if (parts.length === 0) {
-    return null;
-  }
-
-  return parts.join(" ");
-}
-
-/**
- * Inject agent metadata into instructions content as a profile block.
- *
- * The block uses plain-text markers so it is fully visible to the agent
- * at runtime. It can be stripped before displaying in the instructions editor.
- *
- * Format:
- * ```
- * [AGENT_PROFILE]
- * Your name is Aria. Communicate in a clear, polished, and business-appropriate tone.
- * This should be reflected in all your responses.
- * [/AGENT_PROFILE]
- * ```
- *
- * - If metadata is undefined/null or has no truthy fields, returns content unchanged.
- * - If content already has a profile block, replaces it.
- * - Otherwise prepends it at the beginning.
- */
-export function injectMetadataFrontmatter(
-  content: string,
-  metadata?: AgentMetadata | null,
-): string {
-  if (!metadata) {
-    return content;
-  }
-
-  const paragraph = buildProfileParagraph(metadata);
-  if (!paragraph) {
-    return content;
-  }
-
-  const block = `${PROFILE_START}\n${paragraph}\n${PROFILE_END}`;
-
-  // Remove any existing profile block and legacy frontmatter first
-  const stripped = stripProfileBlocks(
-    stripLegacyFrontmatter(content),
-  ).trimStart();
-
-  if (!stripped) {
-    return `${block}\n`;
-  }
-
-  return `${block}\n\n${stripped}`;
-}
-
 /**
  * Strip the profile block (and legacy YAML frontmatter) from
  * instructions content for display in the editor.
+ *
+ * Kept for transition: existing S3 archives may still have baked-in
+ * `[AGENT_PROFILE]` blocks from before metadata was moved to the
+ * `zero_agents` table. Once all instructions have been re-uploaded
+ * without the block, this function can be removed entirely.
  */
 export function stripMetadataFrontmatter(content: string): string {
   return stripProfileBlocks(stripLegacyFrontmatter(content)).trim();


### PR DESCRIPTION
## Summary

- Delete `injectMetadataFrontmatter` and all its helpers (`AgentMetadata`, `TONE_DESCRIPTIONS`, `buildProfileParagraph`) from `@vm0/core`
- Remove metadata injection from CLI write path (`system-storage.ts`, `compose/index.ts`)
- Remove `stripMetadataFrontmatter` calls from all platform read paths (`zero-job-detail.ts`, `zero-skills.ts`, `zero-instructions-tab.tsx`) — the API already returns clean content
- Delete all `injectMetadataFrontmatter` tests; keep `stripMetadataFrontmatter` tests for the transition period

`stripMetadataFrontmatter` is intentionally kept for transition: existing S3 archives may still have baked-in `[AGENT_PROFILE]` blocks that the instructions GET route strips before returning.

Depends on: #5379 (merged)
Closes #5380

## Test plan

- [x] Type check passes (`pnpm check-types`)
- [x] Lint passes (`pnpm turbo run lint`)
- [x] Knip passes (no unused exports)
- [x] `instructions-frontmatter.spec.ts` — 12 tests pass (strip + ReDoS regression)
- [x] `instruction-upload.test.ts` — 4 tests pass (no metadata injection verified)
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)