### PR TITLE
chore(runner): remove standalone ca cert from rootfs

### DIFF
--- a/crates/runner/scripts/build-rootfs.sh
+++ b/crates/runner/scripts/build-rootfs.sh
@@ -199,8 +199,10 @@ extract_and_inject() {
   sudo cp "$ca_cert" "$ca_target"
   sudo chmod 644 "$ca_target"
 
-  # Update system CA bundle
+  # Update system CA bundle, then remove the standalone file (only the
+  # merged bundle at /etc/ssl/certs/ca-certificates.crt is needed at runtime)
   sudo chroot "$EXTRACT_DIR" update-ca-certificates
+  sudo rm -f "$ca_target"
 
   echo "[OK] proxy CA installed and system bundle updated"
 }

--- a/crates/runner/scripts/verify-rootfs.sh
+++ b/crates/runner/scripts/verify-rootfs.sh
@@ -6,7 +6,7 @@
 # invalidate the rootfs cache.
 #
 # Usage:
-#   bash verify-rootfs.sh --rootfs /path/to/rootfs.squashfs
+#   bash verify-rootfs.sh --rootfs /path/to/rootfs.squashfs --ca-cert /path/to/ca-cert.pem
 
 set -euo pipefail
 
@@ -15,24 +15,22 @@ set -euo pipefail
 # ---------------------------------------------------------------------------
 
 ROOTFS=""
+CA_CERT=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --rootfs) ROOTFS="$2"; shift 2 ;;
+    --ca-cert) CA_CERT="$2"; shift 2 ;;
     *) echo "error: unknown argument: $1" >&2; exit 1 ;;
   esac
 done
 
-if [[ -z "$ROOTFS" ]]; then
-  echo "error: --rootfs is required" >&2
-  exit 1
-fi
-
-# ---------------------------------------------------------------------------
-# Constants
-# ---------------------------------------------------------------------------
-
-CA_ROOTFS_DEST="usr/local/share/ca-certificates/vm0-proxy-ca.crt"
+for var in ROOTFS CA_CERT; do
+  if [[ -z "${!var}" ]]; then
+    echo "error: --$(echo "$var" | tr '_' '-' | tr '[:upper:]' '[:lower:]') is required" >&2
+    exit 1
+  fi
+done
 
 # ---------------------------------------------------------------------------
 # Cleanup
@@ -113,25 +111,16 @@ else
   errors+=("gh CLI not found at /usr/bin/gh")
 fi
 
-# Check proxy CA certificate file
-ca_path="${MOUNT_DIR}/${CA_ROOTFS_DEST}"
-if [[ -f "$ca_path" ]]; then
-  echo "  proxy CA file: found"
-else
-  errors+=("proxy CA certificate not found")
-fi
-
-# Check proxy CA in system bundle
+# Check proxy CA in system bundle (compare against host CA cert)
 bundle_path="${MOUNT_DIR}/etc/ssl/certs/ca-certificates.crt"
 if [[ ! -f "$bundle_path" ]]; then
   errors+=("system CA bundle not found at /etc/ssl/certs/ca-certificates.crt")
-elif [[ -f "$ca_path" ]]; then
-  # Read second line of CA cert as a unique identifier
-  ca_line=$(sed -n '2p' "$ca_path")
+else
+  ca_line=$(sed -n '2p' "$CA_CERT")
   if [[ -z "$ca_line" ]]; then
     errors+=("proxy CA cert appears empty or malformed")
   elif grep -qF "$ca_line" "$bundle_path"; then
-    echo "  proxy CA bundle: updated"
+    echo "  proxy CA bundle: present"
   else
     errors+=("proxy CA not found in system CA bundle (update-ca-certificates may have failed)")
   fi

--- a/crates/runner/src/cmd/rootfs.rs
+++ b/crates/runner/src/cmd/rootfs.rs
@@ -241,9 +241,12 @@ pub async fn run_rootfs(args: RootfsArgs) -> RunnerResult<String> {
     let verify_path = work_dir.path().join("verify-rootfs.sh");
     let rootfs_str = rootfs_path.to_string_lossy();
 
+    let ca_cert_path = paths.ca_dir().join("mitmproxy-ca-cert.pem");
+    let ca_cert_str = ca_cert_path.to_string_lossy();
+
     let status = tokio::process::Command::new("bash")
         .arg(&verify_path)
-        .args(["--rootfs", &rootfs_str])
+        .args(["--rootfs", &rootfs_str, "--ca-cert", &ca_cert_str])
         .stdin(std::process::Stdio::null())
         .status()
         .await


### PR DESCRIPTION
## Summary
- Remove standalone proxy CA cert file from rootfs after `update-ca-certificates` merges it into the system bundle — the standalone file served no runtime purpose
- Update `verify-rootfs.sh` to verify CA presence in the system bundle using the host CA cert file (`--ca-cert`) instead of the now-removed rootfs copy
- Pass `--ca-cert` to verify script from `rootfs.rs`

Closes #5440

## Test plan
- [ ] `runner build` succeeds with the standalone cert removed
- [ ] `verify-rootfs.sh` correctly validates CA presence in system bundle using host cert
- [ ] All HTTPS connections from within the VM still work (mitmproxy CA trusted via system bundle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)