### PR TITLE
fix: improve line break test assertions to check dom structure directly

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-session-chat-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-session-chat-page.test.tsx
@@ -1,17 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { screen, waitFor, getDefaultNormalizer } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 import { http, HttpResponse } from "msw";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { setupPage } from "../../../__tests__/page-helper.ts";
 
 const context = testContext();
-
-// Normalizer that preserves whitespace (including newlines) so assertions can
-// distinguish between "Hello World" (soft wrap) and "Hello\nWorld" (hard break).
-const noCollapseNormalizer = getDefaultNormalizer({
-  collapseWhitespace: false,
-});
 
 describe("userMessage line break rendering", () => {
   it("should preserve newlines between words in user messages", async () => {
@@ -43,17 +37,13 @@ describe("userMessage line break rendering", () => {
       path: "/chat/thread-multiline",
     });
 
-    // Without the fix, CommonMark collapses \n into a space so the message
-    // renders as "Hello World". With the fix, a hard line break separates the
-    // two words. Using a non-collapsing normalizer, "Hello World" should not be
-    // found as a single text run anywhere in the rendered tree.
+    // Find the <p> element that the Markdown renderer creates for the user
+    // message (selector: "p" scopes to paragraph elements only).
+    // Then assert that a <br> exists within that paragraph — <br> is the
+    // correct HTML representation of a hard line break (CommonMark "  \n").
     await waitFor(() => {
-      expect(
-        screen.queryByText("Hello World", { normalizer: noCollapseNormalizer }),
-      ).toBeNull();
-      expect(
-        screen.getByText(/Hello/, { normalizer: noCollapseNormalizer }),
-      ).toBeInTheDocument();
+      const paragraph = screen.getByText(/Hello/, { selector: "p" });
+      expect(paragraph.querySelector("br")).toBeInTheDocument();
     });
   });
 
@@ -86,11 +76,9 @@ describe("userMessage line break rendering", () => {
       path: "/chat/thread-singleline",
     });
 
-    // Single-line messages with no \n should render with the words on one line.
+    // Single-line messages with no \n should render as-is.
     await waitFor(() => {
-      expect(
-        screen.getByText("Hello World", { normalizer: noCollapseNormalizer }),
-      ).toBeInTheDocument();
+      expect(screen.getByText("Hello World")).toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
## Summary
- Replace `getDefaultNormalizer` approach with direct DOM assertions using `selector: "p"` and `querySelector("br")` for more reliable line break detection in user message rendering tests
- Remove unused `within` import and simplify single-line message test assertion
- Follow-up cleanup to #5334

## Test plan
- [ ] CI passes (lint, type-check, tests)
- [ ] Line break rendering tests still validate correct behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)