### PR TITLE
feat: add provider compatibility utility (#5448)

### DIFF
--- a/turbo/packages/core/src/contracts/__tests__/model-providers.test.ts
+++ b/turbo/packages/core/src/contracts/__tests__/model-providers.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from "vitest";
+import {
+  getProviderBaseUrl,
+  areProvidersCompatible,
+  type ModelProviderType,
+} from "../model-providers";
+
+describe("getProviderBaseUrl", () => {
+  it.each([
+    "claude-code-oauth-token",
+    "anthropic-api-key",
+    "azure-foundry",
+    "aws-bedrock",
+  ] as ModelProviderType[])("returns null for %s", (type) => {
+    expect(getProviderBaseUrl(type)).toBeNull();
+  });
+
+  it.each([
+    ["openrouter-api-key", "https://openrouter.ai/api"],
+    ["moonshot-api-key", "https://api.moonshot.ai/anthropic"],
+    ["minimax-api-key", "https://api.minimax.io/anthropic"],
+    ["deepseek-api-key", "https://api.deepseek.com/anthropic"],
+    ["zai-api-key", "https://api.z.ai/api/anthropic"],
+    ["vercel-ai-gateway", "https://ai-gateway.vercel.sh"],
+  ] as [ModelProviderType, string][])(
+    "returns correct URL for %s",
+    (type, expectedUrl) => {
+      expect(getProviderBaseUrl(type)).toBe(expectedUrl);
+    },
+  );
+});
+
+describe("areProvidersCompatible", () => {
+  const anthropicNative: ModelProviderType[] = [
+    "claude-code-oauth-token",
+    "anthropic-api-key",
+    "azure-foundry",
+    "aws-bedrock",
+  ];
+
+  const thirdParty: ModelProviderType[] = [
+    "openrouter-api-key",
+    "moonshot-api-key",
+    "minimax-api-key",
+    "deepseek-api-key",
+    "zai-api-key",
+    "vercel-ai-gateway",
+  ];
+
+  it("all Anthropic-native providers are mutually compatible", () => {
+    for (const a of anthropicNative) {
+      for (const b of anthropicNative) {
+        expect(areProvidersCompatible(a, b)).toBe(true);
+      }
+    }
+  });
+
+  it("every provider is compatible with itself", () => {
+    for (const p of [...anthropicNative, ...thirdParty]) {
+      expect(areProvidersCompatible(p, p)).toBe(true);
+    }
+  });
+
+  it("Anthropic-native is incompatible with third-party providers", () => {
+    for (const native of anthropicNative) {
+      for (const tp of thirdParty) {
+        expect(areProvidersCompatible(native, tp)).toBe(false);
+        expect(areProvidersCompatible(tp, native)).toBe(false);
+      }
+    }
+  });
+
+  it("different third-party providers are incompatible", () => {
+    expect(areProvidersCompatible("moonshot-api-key", "deepseek-api-key")).toBe(
+      false,
+    );
+    expect(
+      areProvidersCompatible("openrouter-api-key", "vercel-ai-gateway"),
+    ).toBe(false);
+    expect(areProvidersCompatible("minimax-api-key", "zai-api-key")).toBe(
+      false,
+    );
+  });
+});

--- a/turbo/packages/core/src/contracts/index.ts
+++ b/turbo/packages/core/src/contracts/index.ts
@@ -229,6 +229,9 @@ export {
   hasModelSelection,
   allowsCustomModel,
   getCustomModelPlaceholder,
+  // Provider compatibility
+  getProviderBaseUrl,
+  areProvidersCompatible,
   // Feature-gated provider support
   getProviderFeatureFlag,
   isProviderVisible,

--- a/turbo/packages/core/src/contracts/model-providers.ts
+++ b/turbo/packages/core/src/contracts/model-providers.ts
@@ -402,6 +402,28 @@ export function getEnvironmentMapping(
 }
 
 /**
+ * Get the ANTHROPIC_BASE_URL for a model provider type.
+ * Returns null for Anthropic-native providers (no base URL override).
+ */
+export function getProviderBaseUrl(type: ModelProviderType): string | null {
+  const config = MODEL_PROVIDER_TYPES[type];
+  if (!("environmentMapping" in config)) return null;
+  const url = config.environmentMapping["ANTHROPIC_BASE_URL"];
+  return url ?? null;
+}
+
+/**
+ * Check if two model providers are compatible for session continuation.
+ * Providers are compatible if they resolve to the same ANTHROPIC_BASE_URL.
+ */
+export function areProvidersCompatible(
+  a: ModelProviderType,
+  b: ModelProviderType,
+): boolean {
+  return getProviderBaseUrl(a) === getProviderBaseUrl(b);
+}
+
+/**
  * Get available models for a model provider type
  * Returns undefined for providers without model selection
  */


### PR DESCRIPTION
## Summary

- Add `getProviderBaseUrl()` to extract `ANTHROPIC_BASE_URL` from a model provider's `environmentMapping` (returns `null` for Anthropic-native providers)
- Add `areProvidersCompatible()` to check if two providers are compatible for session continuation by comparing their base URLs
- Unit tests covering all 10 provider types, Anthropic-native mutual compatibility, self-compatibility, and cross-group incompatibility

Closes #5448
Part of epic #5446

## Test plan

- [x] All 14 unit tests pass (`pnpm vitest run packages/core/src/contracts/__tests__/model-providers.test.ts`)
- [x] Type check passes for `@vm0/core`
- [x] Lint passes for `@vm0/core`
- [x] Knip finds no unused exports

🤖 Generated with [Claude Code](https://claude.com/claude-code)