### PR TITLE
feat: add friendly frontend error for provider incompatibility

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-session-chat-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-session-chat-page.test.tsx
@@ -94,3 +94,74 @@ describe("userMessage line break rendering", () => {
     });
   });
 });
+
+describe("provider incompatibility error", () => {
+  it("should show friendly message for API-level provider incompatibility", async () => {
+    server.use(
+      http.get("*/api/chat-threads/:id", () => {
+        return HttpResponse.json({
+          id: "thread-provider-error",
+          title: null,
+          agentComposeId: "mock-compose-id",
+          chatMessages: [],
+          latestSessionId: null,
+          unsavedRuns: [
+            {
+              runId: "run-incompatible",
+              status: "failed",
+              prompt: "hello",
+              error:
+                "Cannot continue session: this session was created with Moonshot (Kimi) and cannot be continued with Anthropic API Key.",
+            },
+          ],
+          createdAt: "2026-03-10T00:00:00Z",
+          updatedAt: "2026-03-10T00:00:00Z",
+        });
+      }),
+      http.get("*/api/chat-threads", () => {
+        return HttpResponse.json({ threads: [] });
+      }),
+    );
+
+    await setupPage({ context, path: "/chat/thread-provider-error" });
+
+    await waitFor(() => {
+      expect(screen.getByText(/different model provider/)).toBeInTheDocument();
+      expect(screen.getByText(/Start a new session/)).toBeInTheDocument();
+    });
+  });
+
+  it("should show friendly message for thinking block signature error", async () => {
+    server.use(
+      http.get("*/api/chat-threads/:id", () => {
+        return HttpResponse.json({
+          id: "thread-signature-error",
+          title: null,
+          agentComposeId: "mock-compose-id",
+          chatMessages: [],
+          latestSessionId: null,
+          unsavedRuns: [
+            {
+              runId: "run-signature",
+              status: "failed",
+              prompt: "hello",
+              error: "Invalid signature in thinking block",
+            },
+          ],
+          createdAt: "2026-03-10T00:00:00Z",
+          updatedAt: "2026-03-10T00:00:00Z",
+        });
+      }),
+      http.get("*/api/chat-threads", () => {
+        return HttpResponse.json({ threads: [] });
+      }),
+    );
+
+    await setupPage({ context, path: "/chat/thread-signature-error" });
+
+    await waitFor(() => {
+      expect(screen.getByText(/different model provider/)).toBeInTheDocument();
+      expect(screen.getByText(/Start a new session/)).toBeInTheDocument();
+    });
+  });
+});

--- a/turbo/apps/platform/src/views/zero-page/zero-session-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-session-chat-page.tsx
@@ -672,6 +672,9 @@ function AssistantMessage({ message, zeroAvatarSrc }: AssistantMessageProps) {
     const isNoModelProvider = message.error.includes(
       "No model provider configured",
     );
+    const isProviderIncompatible =
+      message.error.includes("Cannot continue session") ||
+      message.error.includes("Invalid signature in thinking block");
     return (
       <div className="group flex flex-col gap-1 animate-in fade-in slide-in-from-bottom-2 duration-300">
         <div className="grid grid-cols-[36px_1fr] gap-2.5 items-start">
@@ -697,6 +700,24 @@ function AssistantMessage({ message, zeroAvatarSrc }: AssistantMessageProps) {
                     <IconSettings size={13} />
                   </Link>{" "}
                   to get started.
+                </span>
+              </div>
+            ) : isProviderIncompatible ? (
+              <div className="flex items-start gap-2 text-foreground">
+                <IconAlertCircle
+                  size={16}
+                  className="shrink-0 mt-[3px] text-amber-500"
+                />
+                <span>
+                  This session was started with a different model provider and
+                  can&apos;t be continued with the current one.{" "}
+                  <Link
+                    pathname="/:tab"
+                    options={{ pathParams: { tab: "chat" } }}
+                    className="inline-flex items-center gap-1 text-amber-500 underline underline-offset-2 hover:text-amber-400"
+                  >
+                    Start a new session
+                  </Link>
                 </span>
               </div>
             ) : (


### PR DESCRIPTION
## Summary

- Add user-friendly amber warning when a session cannot be continued due to a model provider mismatch
- Detect both "Cannot continue session" (API-level block) and "Invalid signature in thinking block" (sandbox-level failure) error patterns
- Show actionable "Start a new session" link instead of raw error text
- Follow existing "No model provider configured" UX pattern for consistency

## Test plan

- [x] Integration test: API-level provider incompatibility error shows friendly message
- [x] Integration test: Thinking block signature error shows friendly message
- [x] Existing tests still pass (line break rendering)
- [x] Type check passes
- [x] Lint passes
- [x] Knip passes (no unused exports)

Closes #5450

🤖 Generated with [Claude Code](https://claude.com/claude-code)