### PR TITLE
feat(run): store resolved model provider on agent runs

### DIFF
--- a/turbo/apps/web/src/lib/run/__tests__/create-run.test.ts
+++ b/turbo/apps/web/src/lib/run/__tests__/create-run.test.ts
@@ -872,6 +872,39 @@ describe("createRun()", () => {
         ANTHROPIC_MODEL: "anthropic/claude-sonnet-4.6",
       });
     });
+
+    it("should store resolved model provider on run record when using org default", async () => {
+      const noKeyCompose = await createTestCompose(uniqueId("no-key-agent"), {
+        skipDefaultApiKey: true,
+      });
+
+      await createTestOrgModelProvider("vercel-ai-gateway", "test-gateway-key");
+
+      const result = await createRun(
+        baseParams({ agentComposeVersionId: noKeyCompose.versionId }),
+      );
+
+      const run = await findTestRunRecord(result.runId);
+      expect(run!.modelProvider).toBe("vercel-ai-gateway");
+    });
+
+    it("should preserve explicit model provider on run record", async () => {
+      const noKeyCompose = await createTestCompose(uniqueId("no-key-agent"), {
+        skipDefaultApiKey: true,
+      });
+
+      await createTestOrgModelProvider("vercel-ai-gateway", "test-gateway-key");
+
+      const result = await createRun(
+        baseParams({
+          agentComposeVersionId: noKeyCompose.versionId,
+          modelProvider: "vercel-ai-gateway",
+        }),
+      );
+
+      const run = await findTestRunRecord(result.runId);
+      expect(run!.modelProvider).toBe("vercel-ai-gateway");
+    });
   });
 
   describe("Connector Secret Injection", () => {

--- a/turbo/apps/web/src/lib/run/build-context.ts
+++ b/turbo/apps/web/src/lib/run/build-context.ts
@@ -173,6 +173,9 @@ interface ModelProviderSecretResult {
    *  Secret-derived values use ${{ secrets.X }} references so they go through
    *  servicePlaceholders logic; literals (base URLs, model names) are plain strings. */
   injectedEnvironment: Record<string, string> | undefined;
+  /** The resolved model provider type (e.g. "anthropic", "vercel-ai-gateway").
+   *  Undefined when provider resolution was skipped (explicit env vars or non-claude-code). */
+  resolvedModelProvider: string | undefined;
 }
 
 /**
@@ -191,7 +194,11 @@ async function resolveModelProviderSecrets(
 
   // Skip if explicit model provider config exists or framework doesn't use model providers
   if (hasExplicitModelProviderConfig || framework !== "claude-code") {
-    return { secrets, injectedEnvironment: undefined };
+    return {
+      secrets,
+      injectedEnvironment: undefined,
+      resolvedModelProvider: undefined,
+    };
   }
 
   // Fetch org-level default provider
@@ -216,14 +223,22 @@ async function resolveModelProviderSecrets(
       log.debug(
         `Multi-auth provider ${providerType} has no auth method configured`,
       );
-      return { secrets, injectedEnvironment: undefined };
+      return {
+        secrets,
+        injectedEnvironment: undefined,
+        resolvedModelProvider: providerType,
+      };
     }
 
     // Get secret names for this auth method
     const secretNames = getSecretNamesForAuthMethod(providerType, authMethod);
     if (!secretNames || secretNames.length === 0) {
       log.debug(`No secret names found for ${providerType}/${authMethod}`);
-      return { secrets, injectedEnvironment: undefined };
+      return {
+        secrets,
+        injectedEnvironment: undefined,
+        resolvedModelProvider: providerType,
+      };
     }
 
     // Fetch all model-provider secrets by name (scoped to provider owner)
@@ -246,7 +261,11 @@ async function resolveModelProviderSecrets(
     }
 
     if (!hasAllRequired) {
-      return { secrets, injectedEnvironment: undefined };
+      return {
+        secrets,
+        injectedEnvironment: undefined,
+        resolvedModelProvider: providerType,
+      };
     }
 
     // Store secrets for masking
@@ -266,13 +285,21 @@ async function resolveModelProviderSecrets(
       `Resolved multi-auth model provider env: ${Object.keys(injectedEnvironment).join(", ")}`,
     );
 
-    return { secrets, injectedEnvironment };
+    return {
+      secrets,
+      injectedEnvironment,
+      resolvedModelProvider: providerType,
+    };
   }
 
   // Handle single-secret providers
   const secretName = getSecretNameForType(providerType);
   if (!secretName) {
-    return { secrets, injectedEnvironment: undefined };
+    return {
+      secrets,
+      injectedEnvironment: undefined,
+      resolvedModelProvider: providerType,
+    };
   }
 
   const secretValue = await getSecretValue(
@@ -283,7 +310,11 @@ async function resolveModelProviderSecrets(
   );
 
   if (!secretValue) {
-    return { secrets, injectedEnvironment: undefined };
+    return {
+      secrets,
+      injectedEnvironment: undefined,
+      resolvedModelProvider: providerType,
+    };
   }
 
   // Store secret in secrets map for masking
@@ -301,7 +332,7 @@ async function resolveModelProviderSecrets(
     `Resolved model provider env: ${Object.keys(injectedEnvironment).join(", ")}`,
   );
 
-  return { secrets, injectedEnvironment };
+  return { secrets, injectedEnvironment, resolvedModelProvider: providerType };
 }
 
 /**
@@ -594,6 +625,7 @@ async function resolveSecretsAndEnvironment(
   secrets: Record<string, string> | undefined;
   environment: Record<string, string> | undefined;
   secretConnectorMap: Record<string, string> | undefined;
+  resolvedModelProvider: string | undefined;
 }> {
   // Model provider secret injection
   const hasExplicitModelProviderConfig = MODEL_PROVIDER_ENV_VARS.some(
@@ -669,7 +701,12 @@ async function resolveSecretsAndEnvironment(
     modelProviderResult.injectedEnvironment,
   );
 
-  return { secrets, environment, secretConnectorMap };
+  return {
+    secrets,
+    environment,
+    secretConnectorMap,
+    resolvedModelProvider: modelProviderResult.resolvedModelProvider,
+  };
 }
 
 /**
@@ -762,6 +799,8 @@ interface BuildContextResult {
   context: ExecutionContext;
   runtimeOrg: RuntimeOrg;
   timings: BuildContextTimings;
+  /** The resolved model provider type, if provider resolution ran during context build. */
+  resolvedModelProvider: string | undefined;
 }
 
 /**
@@ -914,7 +953,8 @@ export async function buildExecutionContext(
   ]);
   const resolveSecretsEnd = Date.now();
 
-  const { secrets, environment, secretConnectorMap } = secretsResult;
+  const { secrets, environment, secretConnectorMap, resolvedModelProvider } =
+    secretsResult;
   const userTimezone = userPrefs?.timezone ?? undefined;
 
   // Build experimental firewall manifest (base + auth entries for the runner)
@@ -961,5 +1001,6 @@ export async function buildExecutionContext(
       resolveSourceAndOrg: resolveEnd - resolveStart,
       resolveSecrets: resolveSecretsEnd - resolveSecretsStart,
     },
+    resolvedModelProvider,
   };
 }

--- a/turbo/apps/web/src/lib/run/run-service.ts
+++ b/turbo/apps/web/src/lib/run/run-service.ts
@@ -580,6 +580,7 @@ async function buildAndDispatchRun(opts: {
       context,
       runtimeOrg,
       timings: buildContextTimings,
+      resolvedModelProvider,
     } = await buildContext({
       checkpointId: params.checkpointId,
       sessionId: params.sessionId,
@@ -612,9 +613,16 @@ async function buildAndDispatchRun(opts: {
     // Refresh heartbeat after the heaviest pipeline step to prevent the
     // cleanup cron from timing out runs whose dispatch takes > 5 minutes.
     // Status guard avoids touching runs cancelled/failed while in-flight.
+    // Also persist the resolved model provider type (when the user selected
+    // "Default", the INSERT stored null — this UPDATE writes the actual value).
     await globalThis.services.db
       .update(agentRuns)
-      .set({ lastHeartbeatAt: new Date() })
+      .set({
+        lastHeartbeatAt: new Date(),
+        ...(resolvedModelProvider
+          ? { modelProvider: resolvedModelProvider }
+          : {}),
+      })
       .where(
         and(
           eq(agentRuns.id, runId),


### PR DESCRIPTION
## Summary

Closes #5451

- Thread `resolvedModelProvider` from `resolveProviderType()` through the build-context return chain
- Persist the resolved value via the existing heartbeat UPDATE in `buildAndDispatchRun()`
- When user selects "Default", `agentRuns.modelProvider` now stores the actual resolved provider type instead of `null`

## Changes

- **`build-context.ts`**: Add `resolvedModelProvider` field to `ModelProviderSecretResult`, `resolveSecretsAndEnvironment()`, and `BuildContextResult`. All return paths in `resolveModelProviderSecrets()` now include the resolved provider type.
- **`run-service.ts`**: Extend the post-`buildContext()` heartbeat UPDATE to also persist `modelProvider` when a resolved value is available.
- **`create-run.test.ts`**: Add 2 integration tests verifying the run record stores the resolved model provider.

## Test plan

- [x] `should store resolved model provider on run record when using org default` — verifies `modelProvider` is written when user selects "Default"
- [x] `should preserve explicit model provider on run record` — verifies explicit provider choice is preserved
- [x] All 47 existing tests pass (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)