### PR TITLE
chore: use task list to find dev server in dev-logs skill

### DIFF
--- a/.claude/skills/dev-logs/SKILL.md
+++ b/.claude/skills/dev-logs/SKILL.md
@@ -20,23 +20,19 @@ Your args are: `$ARGUMENTS`
 
 ## Workflow
 
-### Step 1: Check Dev Server is Running
+### Step 1: Find the Dev Server Task
 
-```bash
-curl -k -s --connect-timeout 3 https://www.vm7.ai:8443/ > /dev/null 2>&1 && echo "✅ Dev server is running" || echo "❌ Dev server is not running. Please run /dev-start first."
-```
+Use **TaskList** to find the dev server background task. Look for a task whose command contains `pnpm dev` — this is the task created by `/dev-start`.
 
-### Step 2: Read Background Task Output
+This approach survives conversation compaction, since TaskList always reflects the current task state regardless of whether the original task_id was preserved in the summary.
 
-Use TaskOutput to read the dev server's background task output. The task_id comes from the `run_in_background` Bash call that started the server.
+If no matching task is found, inform the user:
+- "No dev server background task found in this session. Please run `/dev-start` to start the server."
 
-If no task_id is available (e.g., server was started in a previous conversation), inform the user that logs are only available within the same session that started the server.
+### Step 2: Read Task Output
 
-### Step 3: Display Output
+Use **TaskOutput** with the task_id from Step 1 to read the dev server logs.
+
+### Step 2: Display Output
 
 Show the output in readable format. If a filter pattern was provided, grep the output for matching lines.
-
-## Notes
-
-- Dev server logs are only accessible via TaskOutput within the same session
-- For persistent logs, check individual service outputs or use the Turbo TUI


### PR DESCRIPTION
## Summary
- Replace curl-based health check with TaskList lookup in the dev-logs skill
- The skill now finds the dev server background task by searching for a task whose command contains `pnpm dev`, making it resilient to conversation compaction where the original task_id may be lost

## Test plan
- [ ] Run `/dev-start` followed by `/dev-logs` and verify logs are displayed correctly
- [ ] Verify `/dev-logs` provides a helpful message when no dev server task is running

🤖 Generated with [Claude Code](https://claude.com/claude-code)