### PR TITLE
refactor: migrate e2e auth to agent-browser

### DIFF
--- a/.claude/skills/dev-browser/SKILL.md
+++ b/.claude/skills/dev-browser/SKILL.md
@@ -30,30 +30,11 @@ cd "$PROJECT_ROOT" && scripts/start-vnc.sh
 
 Run this command with `run_in_background: true`. It will output the noVNC URL.
 
-After starting, wait a few seconds then verify Chrome is reachable via CDP:
-
-```bash
-curl -sf http://localhost:9222/json/version > /dev/null || { echo "❌ CDP not ready"; exit 1; }
-```
-
-If CDP is not ready, Playwright Chromium may not be installed. Install it and restart the VNC task:
-
-```bash
-PROJECT_ROOT=$(git rev-parse --show-toplevel)
-cd "$PROJECT_ROOT/e2e" && pnpm exec playwright install chromium
-```
-
-Then stop and re-run the VNC background task.
-
-Tell the user the noVNC URL so they can watch:
-
-> The browser is running in headed mode with noVNC. Open this URL to view and interact:
->
-> `http://localhost:6080/vnc.html`
+The browser is running in headed mode with noVNC. Use `dcvnc <current-hostname>` to connect the vnc in browser.
 
 ### Step 3: Authenticate Browser
 
-Use the e2e auth automation script to log in to the platform app via CDP. This reuses the same Clerk login flow that CI verifies.
+Use the e2e auth automation script to log in to the platform app.
 
 Build the test email from `git config user.email` prefix + hostname:
 
@@ -63,24 +44,15 @@ GIT_EMAIL_PREFIX=$(git config user.email | sed 's/@.*//')
 HOSTNAME=$(hostname)
 TEST_EMAIL="${GIT_EMAIL_PREFIX}-${HOSTNAME}+clerk_test@vm0.ai"
 
-cd "$PROJECT_ROOT/e2e" && npx tsx cli-auth-automation.ts --cdp "https://www.vm7.ai:8443" --port 9222 --email "$TEST_EMAIL"
+cd "$PROJECT_ROOT/e2e" && bash cli-auth-automation.sh "https://www.vm7.ai:8443" --email "$TEST_EMAIL"
 ```
 
-**Important:** Use `www.vm7.ai:8443` (not `app.vm7.ai:8443`). The Clerk sign-in page lives on the www domain. Using the app domain causes a cross-domain redirect that Playwright over CDP cannot follow.
-
 This will:
-- Connect to the existing Chrome via CDP port 9222
+
 - Navigate to the Clerk sign-in page on www.vm7.ai
 - Authenticate using the test email and OTP code `424242`
 - Skip login if the browser is already authenticated
 - Leave the browser open for agent-browser to use
-
-If the script fails with a database error (e.g., missing `org_cache` table), run migrations first:
-
-```bash
-PROJECT_ROOT=$(git rev-parse --show-toplevel)
-cd "$PROJECT_ROOT/turbo" && pnpm --filter web db:migrate
-```
 
 ### Step 4: Start Video Recording
 
@@ -98,13 +70,14 @@ agent-browser record restart "$PROJECT_ROOT/tmp/${TASK_NAME}-${TIMESTAMP}.webm"
 
 **CRITICAL: Always use the local vm7.ai domains with HTTPS port 8443.** These domains are mapped to `127.0.0.1` locally via the Caddy reverse proxy.
 
-| Service  | URL                              |
-|----------|----------------------------------|
-| Web      | `https://www.vm7.ai:8443`       |
-| App      | `https://app.vm7.ai:8443`       |
-| Docs     | `https://docs.vm7.ai:8443`      |
+| Service | URL                        |
+| ------- | -------------------------- |
+| Web     | `https://www.vm7.ai:8443`  |
+| App     | `https://app.vm7.ai:8443`  |
+| Docs    | `https://docs.vm7.ai:8443` |
 
 **DO NOT use:**
+
 - `localhost:3000`, `localhost:3001`, `localhost:3002` — these bypass the proxy and may cause redirect/CORS issues
 - `tunnel-*.vm7.ai` — tunnel URLs are for external webhook access only, not for browser automation
 
@@ -149,6 +122,7 @@ agent-browser screenshot "$PROJECT_ROOT/tmp/${TASK_NAME}-${TIMESTAMP}-03-form.pn
 ```
 
 **Naming rules:**
+
 - Format: `<task-name>-<YYYYMMDD-HHMMSS>-<step-number>-<description>.png`
 - Task name: short English kebab-case description (e.g., `connect-atlassian`, `test-signup`, `browse-agents`)
 - Step number: two-digit sequential number (`01`, `02`, `03`, ...)
@@ -188,7 +162,6 @@ Video:
 
 ## Important Notes
 
-- **Do NOT use `agent-browser close`** — that kills the shared Chrome and breaks the user's noVNC view
 - **Always re-snapshot** after clicking links/buttons that cause navigation or DOM changes
 - **Verify page state with snapshot** — use `agent-browser snapshot -i` after navigation instead of `wait --load networkidle` (which frequently times out)
 - **Scroll within modals** — use `agent-browser scroll down 500 --selector "<modal-selector>"` for content inside modals, not plain `scroll down`

--- a/.claude/skills/dev-server/SKILL.md
+++ b/.claude/skills/dev-server/SKILL.md
@@ -78,6 +78,18 @@ Next steps:
 - Use `/dev-stop` to stop the server
 ```
 
+If the script fails with error:
+- a database error (e.g., missing `org_cache` table)
+- missing environment variables
+- missing npm modules
+
+Then the user likely needs to set up their environment. run prepare.sh, this will setup .env.local, set up the database, run migrations, and install npm dependencies. it may cost minutes to run, wait for it to complete:
+
+```bash
+PROJECT_ROOT=$(git rev-parse --show-toplevel)
+cd "$PROJECT_ROOT" && bash scripts/prepare.sh
+```
+
 ## Notes
 
 - Use TaskOutput with the task_id from `run_in_background` to check server output

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,7 +11,14 @@
   },
   "remoteUser": "vscode",
   "forwardPorts": [6080, 8443],
-  "runArgs": ["-p", "6080", "-p", "8443", "--hostname", "${localWorkspaceFolderBasename}"],
+  "runArgs": [
+    "-p",
+    "6080",
+    "-p",
+    "8443",
+    "--hostname",
+    "${localWorkspaceFolderBasename}"
+  ],
   "remoteEnv": {
     "CLAUDE_CONFIG_DIR": "/home/vscode/.config/claude",
     "CRUSH_GLOBAL_CONFIG": "/home/vscode/.config/crush",
@@ -21,8 +28,7 @@
     "CARGO_HOME": "/home/vscode/.cache/cargo",
     "PATH": "/home/vscode/.cache/cargo/bin:/home/vscode/.local/bin:${containerWorkspaceFolder}/bin:${containerEnv:PATH}",
     "VM0_API_URL": "https://www.vm7.ai:8443",
-    "AGENT_BROWSER_PROFILE": "/home/vscode/.local/share/agent-browser/profile",
-    "AGENT_BROWSER_ARGS": "--disable-blink-features=AutomationControlled"
+    "AGENT_BROWSER_HEADED": "1"
   },
   "mounts": [
     "source=config,target=/home/vscode/.config",

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -170,7 +170,6 @@ jobs:
             echo "Preview URL not set (PREVIEW_DOMAIN or job-ref is empty)"
           fi
 
-
   file-size-check:
     runs-on: ubuntu-latest
     # Skip for release-please commits (only version bumps and changelogs)
@@ -854,29 +853,13 @@ jobs:
       - name: Link CLI globally
         run: cd /tmp/cli-deploy && sudo npm link
       - name: Install E2E dependencies
-        run: cd e2e && npm install
-      - name: Install Playwright system dependencies
-        run: cd e2e && sudo npx playwright install-deps chromium
-      - name: Install Playwright browsers
-        run: cd e2e && npx playwright install chromium
-
+        run: npm install -g agent-browser
       - name: Verify device flow authentication
         run: |
           echo "Verifying device flow with ${{ needs.deploy-web.outputs.preview-url }}"
-          cd e2e && npm run auth
+          cd e2e && bash cli-auth-automation.sh ${{ needs.deploy-web.outputs.preview-url }}
         env:
           VM0_API_URL: ${{ needs.deploy-web.outputs.preview-url }}
-          CLERK_PUBLISHABLE_KEY: ${{ vars.CLERK_PUBLISHABLE_KEY }}
-          CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
-          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
-
-      - name: Verify sign-in flow
-        run: cd e2e && npx playwright test sign-in.spec.ts
-        env:
-          VM0_API_URL: ${{ needs.deploy-web.outputs.preview-url }}
-          CLERK_PUBLISHABLE_KEY: ${{ vars.CLERK_PUBLISHABLE_KEY }}
-          CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
-          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
 
   # Build CLI once and share via artifact — e2e jobs download instead of rebuilding
   build-cli:
@@ -986,7 +969,6 @@ jobs:
             kill "$CRON_SIMULATOR_PID" 2>/dev/null || true
             echo "Cron simulator stopped"
           fi
-
 
   # Deploy runner prepare: cross-compile, deploy to all metal hosts, build rootfs/snapshot with mock URL
   # Runs in parallel with deploy-web since rootfs/snapshot don't need the preview URL
@@ -1689,4 +1671,3 @@ jobs:
 
           echo "::endgroup::"
           exit $FAILED
-

--- a/e2e/cli-auth-automation.sh
+++ b/e2e/cli-auth-automation.sh
@@ -1,0 +1,478 @@
+#!/usr/bin/env bash
+# cli-auth-automation.sh — Clerk sign-in/sign-up + CLI device-code auth via agent-browser
+#
+# Usage:
+#   bash cli-auth-automation.sh <base-url> [--email <email>]
+#
+# Example:
+#   bash cli-auth-automation.sh "https://www.vm7.ai:8443" --email "user+clerk_test@vm0.ai"
+#
+# Flow:
+#   1. Start `vm0 auth login` in background, capture device code
+#   2. Open browser → Clerk sign-in via email code (or sign-up if account doesn't exist)
+#   3. Navigate to /cli-auth, enter device code, click Verify
+#   4. Wait for CLI to confirm authentication
+#   5. Verify ~/.vm0/config.json was created
+#
+# Sign-in always uses the email code (OTP) flow, never password.
+# Sign-up uses a randomly generated password + OTP verification.
+#
+# Uses agent-browser's built-in browser. No CDP/Playwright needed.
+
+set -euo pipefail
+
+OTP="424242"
+BASE_URL=""
+EMAIL=""
+
+# ---------------------------------------------------------------------------
+# Parse arguments
+# ---------------------------------------------------------------------------
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --email)
+      EMAIL="$2"
+      shift 2
+      ;;
+    --*)
+      echo "Unknown option: $1" >&2
+      exit 1
+      ;;
+    *)
+      BASE_URL="$1"
+      shift
+      ;;
+  esac
+done
+
+if [[ -z "$BASE_URL" ]]; then
+  echo "❌ Usage: bash cli-auth-automation.sh <base-url> [--email <email>]" >&2
+  exit 1
+fi
+
+if [[ -z "$EMAIL" ]]; then
+  # Email must contain "+clerk_test" for Clerk dev-mode OTP (424242) to work.
+  # Use a random prefix so each run can sign up a fresh account if needed.
+  RANDOM_PREFIX=$(head -c 8 /dev/urandom | od -An -tx1 | tr -d ' \n' | head -c 8)
+  EMAIL="${RANDOM_PREFIX}+clerk_test@vm0.ai"
+fi
+
+echo "🚀 CLI authentication via agent-browser"
+echo "   URL:   $BASE_URL"
+echo "   Email: $EMAIL"
+
+# ---------------------------------------------------------------------------
+# Helper: extract @eN ref from a snapshot line containing [ref=eN]
+# ---------------------------------------------------------------------------
+extract_ref() {
+  echo "$1" | grep -oE '\[ref=e[0-9]+\]' | head -1 | sed 's/\[ref=/@/; s/\]//'
+}
+
+# ---------------------------------------------------------------------------
+# Helper: get full snapshot text (for detecting error messages etc.)
+# ---------------------------------------------------------------------------
+full_snapshot() {
+  agent-browser snapshot 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# Helper: wait until URL no longer contains a pattern
+# ---------------------------------------------------------------------------
+wait_for_redirect_away() {
+  local pattern="$1"
+  local timeout_secs="${2:-30}"
+  for _i in $(seq 1 "$timeout_secs"); do
+    CURRENT_URL=$(agent-browser get url 2>/dev/null || true)
+    if [[ -n "$CURRENT_URL" && ! "$CURRENT_URL" =~ $pattern ]]; then
+      echo "$CURRENT_URL"
+      return 0
+    fi
+    sleep 1
+  done
+  return 1
+}
+
+# ---------------------------------------------------------------------------
+# Helper: enter OTP verification code
+# ---------------------------------------------------------------------------
+enter_otp() {
+  local code="$1"
+  echo "🔢 Entering OTP verification code"
+
+  SNAP_I=$(agent-browser snapshot -i 2>/dev/null || true)
+  local otp_line otp_ref
+  otp_line=$(echo "$SNAP_I" | grep -i "verification code" || true)
+  otp_ref=$(extract_ref "$otp_line")
+
+  if [[ -n "$otp_ref" ]]; then
+    agent-browser click "$otp_ref"
+    agent-browser wait 300
+    agent-browser type "$otp_ref" "$code"
+  else
+    agent-browser find first "input" click
+    agent-browser wait 300
+    for digit in $(echo "$code" | grep -o .); do
+      agent-browser press "$digit"
+    done
+  fi
+  agent-browser wait 5000
+}
+
+# ---------------------------------------------------------------------------
+# Helper: generate random password for sign-up
+# ---------------------------------------------------------------------------
+generate_password() {
+  # 20-char password: alphanumeric + symbols, satisfies Clerk requirements
+  head -c 32 /dev/urandom | base64 | tr -d '/+\n' | head -c 16
+  echo '!Aa1'  # append guaranteed symbol + upper + lower + digit
+}
+
+# ---------------------------------------------------------------------------
+# Cleanup handler
+# ---------------------------------------------------------------------------
+CLI_PID=""
+CLI_LOG=""
+cleanup() {
+  if [[ -n "$CLI_PID" ]]; then
+    kill "$CLI_PID" 2>/dev/null || true
+    wait "$CLI_PID" 2>/dev/null || true
+  fi
+  if [[ -n "$CLI_LOG" ]]; then
+    rm -f "$CLI_LOG"
+  fi
+}
+trap cleanup EXIT
+
+# ===========================================================================
+# Phase 1: Start `vm0 auth login` and capture device code
+# ===========================================================================
+echo ""
+echo "📡 Phase 1: Starting vm0 auth login..."
+
+CLI_LOG=$(mktemp)
+NODE_TLS_REJECT_UNAUTHORIZED=0 VM0_API_URL="$BASE_URL" vm0 auth login > "$CLI_LOG" 2>&1 &
+CLI_PID=$!
+
+DEVICE_CODE=""
+for i in $(seq 1 30); do
+  if [[ -n "$(grep -oE '[A-Z0-9]{4}-[A-Z0-9]{4}' "$CLI_LOG" 2>/dev/null || true)" ]]; then
+    DEVICE_CODE=$(grep -oE '[A-Z0-9]{4}-[A-Z0-9]{4}' "$CLI_LOG" | head -1)
+    break
+  fi
+  if ! kill -0 "$CLI_PID" 2>/dev/null; then
+    echo "❌ vm0 auth login exited unexpectedly:" >&2
+    cat "$CLI_LOG" >&2
+    exit 1
+  fi
+  sleep 1
+done
+
+if [[ -z "$DEVICE_CODE" ]]; then
+  echo "❌ Failed to get device code within 30s" >&2
+  cat "$CLI_LOG" >&2
+  exit 1
+fi
+
+echo "✅ Got device code: $DEVICE_CODE"
+
+# ===========================================================================
+# Phase 2: Clerk sign-in (or sign-up) via browser
+# ===========================================================================
+echo ""
+echo "🔐 Phase 2: Clerk authentication..."
+
+echo "🌐 Navigating to $BASE_URL/sign-in"
+agent-browser open "$BASE_URL/sign-in" --ignore-https-errors
+agent-browser wait 3000
+
+# Check if already signed in (redirected away from /sign-in)
+CURRENT_URL=$(agent-browser get url 2>/dev/null || true)
+if [[ -n "$CURRENT_URL" && ! "$CURRENT_URL" =~ sign-in ]]; then
+  echo "✅ Already signed in (redirected to $CURRENT_URL)"
+else
+  # Wait for Clerk sign-in form
+  echo "⏳ Waiting for Clerk sign-in form..."
+  for i in $(seq 1 10); do
+    SNAP=$(agent-browser snapshot -i 2>/dev/null || true)
+    if echo "$SNAP" | grep -qi "email address"; then
+      break
+    fi
+    if [[ $i -eq 10 ]]; then
+      echo "❌ Clerk sign-in form did not appear within 30s" >&2
+      exit 1
+    fi
+    sleep 3
+  done
+
+  # -----------------------------------------------------------------------
+  # Sign-in: email only → Continue (email code flow, no password)
+  # -----------------------------------------------------------------------
+  SNAP_I=$(agent-browser snapshot -i 2>/dev/null || true)
+  EMAIL_REF=$(extract_ref "$(echo "$SNAP_I" | grep -i 'Email address' || true)")
+  CONTINUE_REF=$(extract_ref "$(echo "$SNAP_I" | grep -i '"Continue"' || true)")
+
+  echo "📧 Entering email: $EMAIL"
+  agent-browser fill "$EMAIL_REF" "$EMAIL"
+  agent-browser wait 300
+  agent-browser click "$CONTINUE_REF"
+  agent-browser wait 5000
+
+  CURRENT_URL=$(agent-browser get url 2>/dev/null || true)
+
+  if [[ -n "$CURRENT_URL" && ! "$CURRENT_URL" =~ sign-in && ! "$CURRENT_URL" =~ sign-up ]]; then
+    # Redirected away — sign-in succeeded (e.g. Clerk dev mode)
+    echo "✅ Sign-in successful!"
+  else
+    SNAP=$(full_snapshot)
+
+    # ----- Account not found → sign-up flow -----
+    if echo "$SNAP" | grep -qi "couldn.t find your account"; then
+      echo "📝 Account not found — switching to sign-up flow"
+
+      SIGNUP_PASSWORD="$(generate_password)"
+
+      agent-browser open "$BASE_URL/sign-up"
+      agent-browser wait 3000
+
+      for i in $(seq 1 10); do
+        SNAP=$(agent-browser snapshot -i 2>/dev/null || true)
+        if echo "$SNAP" | grep -qi "email address"; then
+          break
+        fi
+        if [[ $i -eq 10 ]]; then
+          echo "❌ Sign-up form did not appear" >&2
+          exit 1
+        fi
+        sleep 3
+      done
+
+      echo "📧 Filling sign-up form"
+      SNAP_I=$(agent-browser snapshot -i 2>/dev/null || true)
+      EMAIL_REF=$(extract_ref "$(echo "$SNAP_I" | grep -i 'Email address' || true)")
+      PASS_REF=$(extract_ref "$(echo "$SNAP_I" | grep -i 'textbox "Password"' || true)")
+      CONTINUE_REF=$(extract_ref "$(echo "$SNAP_I" | grep -i '"Continue"' || true)")
+
+      agent-browser fill "$EMAIL_REF" "$EMAIL"
+      agent-browser wait 300
+      agent-browser fill "$PASS_REF" "$SIGNUP_PASSWORD"
+      agent-browser wait 300
+      agent-browser click "$CONTINUE_REF"
+      agent-browser wait 5000
+
+      SNAP=$(full_snapshot)
+      if echo "$SNAP" | grep -qi "verify your email\|verification code"; then
+        enter_otp "$OTP"
+      fi
+
+      REDIRECT_URL=$(wait_for_redirect_away "sign-up" 15 || true)
+      if [[ -z "$REDIRECT_URL" ]]; then
+        echo "❌ Sign-up did not complete" >&2
+        agent-browser screenshot /tmp/clerk-auth-failure.png 2>/dev/null || true
+        exit 1
+      fi
+      echo "✅ Sign-up successful!"
+
+    # ----- "Use another method" → email code flow -----
+    elif echo "$SNAP" | grep -qi "use another method"; then
+      echo "🔄 Clicking 'Use another method'"
+      SNAP_I=$(agent-browser snapshot -i 2>/dev/null || true)
+      UAM_REF=$(extract_ref "$(echo "$SNAP_I" | grep -i 'use another method' || true)")
+      agent-browser click "$UAM_REF"
+      agent-browser wait 2000
+
+      echo "📧 Selecting 'Email code'"
+      SNAP_I=$(agent-browser snapshot -i 2>/dev/null || true)
+      EC_REF=$(extract_ref "$(echo "$SNAP_I" | grep -i 'email code' || true)")
+      if [[ -n "$EC_REF" ]]; then
+        agent-browser click "$EC_REF"
+        agent-browser wait 3000
+      fi
+
+      enter_otp "$OTP"
+
+      REDIRECT_URL=$(wait_for_redirect_away "sign-in" 15 || true)
+      if [[ -z "$REDIRECT_URL" ]]; then
+        echo "❌ Email code sign-in did not complete" >&2
+        agent-browser screenshot /tmp/clerk-auth-failure.png 2>/dev/null || true
+        exit 1
+      fi
+      echo "✅ Sign-in via email code successful!"
+
+    # ----- Already on verification code screen -----
+    elif echo "$SNAP" | grep -qi "verify\|verification code\|enter.*code"; then
+      enter_otp "$OTP"
+
+      REDIRECT_URL=$(wait_for_redirect_away "sign-in" 15 || true)
+      if [[ -z "$REDIRECT_URL" ]]; then
+        echo "❌ OTP verification did not complete" >&2
+        agent-browser screenshot /tmp/clerk-auth-failure.png 2>/dev/null || true
+        exit 1
+      fi
+      echo "✅ Sign-in via OTP successful!"
+
+    # ----- Password required (enter empty and try email code) -----
+    elif echo "$SNAP" | grep -qi "password"; then
+      echo "🔄 Password screen detected — looking for email code option"
+      SNAP_I=$(agent-browser snapshot -i 2>/dev/null || true)
+
+      # Try "Use another method" or "Email code" link/button
+      UAM_REF=$(extract_ref "$(echo "$SNAP_I" | grep -i 'use another method\|email code\|forgot password' || true)")
+      if [[ -n "$UAM_REF" ]]; then
+        agent-browser click "$UAM_REF"
+        agent-browser wait 2000
+        SNAP_I=$(agent-browser snapshot -i 2>/dev/null || true)
+        EC_REF=$(extract_ref "$(echo "$SNAP_I" | grep -i 'email code' || true)")
+        if [[ -n "$EC_REF" ]]; then
+          agent-browser click "$EC_REF"
+          agent-browser wait 3000
+        fi
+      fi
+
+      enter_otp "$OTP"
+
+      REDIRECT_URL=$(wait_for_redirect_away "sign-in" 15 || true)
+      if [[ -z "$REDIRECT_URL" ]]; then
+        echo "❌ Email code sign-in did not complete" >&2
+        agent-browser screenshot /tmp/clerk-auth-failure.png 2>/dev/null || true
+        exit 1
+      fi
+      echo "✅ Sign-in via email code successful!"
+
+    else
+      echo "❌ Unexpected state after sign-in attempt" >&2
+      echo "$SNAP" >&2
+      agent-browser screenshot /tmp/clerk-auth-failure.png 2>/dev/null || true
+      exit 1
+    fi
+  fi
+fi
+
+# ===========================================================================
+# Phase 3: Enter device code on /cli-auth page
+# ===========================================================================
+echo ""
+echo "🔑 Phase 3: Entering device code on /cli-auth..."
+
+agent-browser open "$BASE_URL/cli-auth"
+agent-browser wait 3000
+
+# Wait for the code input fields to appear
+echo "⏳ Waiting for device code form..."
+for i in $(seq 1 10); do
+  SNAP=$(agent-browser snapshot -i 2>/dev/null || true)
+  if echo "$SNAP" | grep -qi "Authorize.*CLI\|Verify"; then
+    break
+  fi
+  if [[ $i -eq 10 ]]; then
+    echo "❌ CLI auth page did not load" >&2
+    exit 1
+  fi
+  sleep 2
+done
+
+# Get snapshot and find the 8 textbox refs for device code
+SNAP_I=$(agent-browser snapshot -i 2>/dev/null || true)
+
+# Extract all textbox refs (should be 8 code inputs)
+CODE_REFS=()
+while IFS= read -r line; do
+  ref=$(extract_ref "$line")
+  if [[ -n "$ref" ]]; then
+    CODE_REFS+=("$ref")
+  fi
+done < <(echo "$SNAP_I" | grep -i 'textbox \[ref=' || echo "$SNAP_I" | grep -iE '^\- textbox' || true)
+
+# Remove hyphen from device code → 8 characters
+CODE_CHARS=$(echo "$DEVICE_CODE" | tr -d '-')
+echo "📝 Entering device code: $DEVICE_CODE"
+
+if [[ ${#CODE_REFS[@]} -ge 8 ]]; then
+  for idx in 0 1 2 3 4 5 6 7; do
+    char="${CODE_CHARS:$idx:1}"
+    agent-browser fill "${CODE_REFS[$idx]}" "$char"
+    agent-browser wait 100
+  done
+else
+  echo "⚠️ Expected 8 input refs, found ${#CODE_REFS[@]}. Using keyboard fallback."
+  if [[ ${#CODE_REFS[@]} -gt 0 ]]; then
+    agent-browser click "${CODE_REFS[0]}"
+  else
+    agent-browser find first "input" click
+  fi
+  agent-browser wait 300
+  for char in $(echo "$CODE_CHARS" | grep -o .); do
+    agent-browser press "$char"
+    agent-browser wait 100
+  done
+fi
+
+echo "✅ Device code entered"
+agent-browser wait 1000
+
+# Click Verify button
+SNAP_I=$(agent-browser snapshot -i 2>/dev/null || true)
+VERIFY_REF=$(extract_ref "$(echo "$SNAP_I" | grep -i '"Verify"' || true)")
+
+if [[ -n "$VERIFY_REF" ]]; then
+  agent-browser click "$VERIFY_REF"
+  echo "➡️ Clicked Verify"
+else
+  AUTH_REF=$(extract_ref "$(echo "$SNAP_I" | grep -i '"Authorize Device"' || true)")
+  if [[ -n "$AUTH_REF" ]]; then
+    agent-browser click "$AUTH_REF"
+    echo "➡️ Clicked Authorize Device"
+  else
+    echo "❌ Verify button not found" >&2
+    echo "$SNAP_I" >&2
+    exit 1
+  fi
+fi
+
+agent-browser wait 3000
+
+# ===========================================================================
+# Phase 4: Wait for CLI authentication to complete
+# ===========================================================================
+echo ""
+echo "⏳ Phase 4: Waiting for CLI authentication..."
+
+for i in $(seq 1 30); do
+  if grep -qi "authentication successful\|successfully authenticated\|credentials have been saved" "$CLI_LOG" 2>/dev/null; then
+    echo "✅ CLI authentication successful!"
+    break
+  fi
+  if ! kill -0 "$CLI_PID" 2>/dev/null; then
+    wait "$CLI_PID" 2>/dev/null && EXIT_CODE=$? || EXIT_CODE=$?
+    CLI_PID=""
+    if [[ $EXIT_CODE -eq 0 ]]; then
+      echo "✅ CLI process exited successfully"
+      break
+    else
+      echo "❌ CLI process exited with code $EXIT_CODE" >&2
+      cat "$CLI_LOG" >&2
+      exit 1
+    fi
+  fi
+  if [[ $i -eq 30 ]]; then
+    echo "❌ CLI authentication did not complete within 30s" >&2
+    cat "$CLI_LOG" >&2
+    exit 1
+  fi
+  sleep 1
+done
+
+# ===========================================================================
+# Phase 5: Verify auth config
+# ===========================================================================
+CONFIG_FILE="$HOME/.vm0/config.json"
+if [[ -f "$CONFIG_FILE" ]]; then
+  echo "✅ Auth config saved to $CONFIG_FILE"
+  if grep -q '"token"' "$CONFIG_FILE" 2>/dev/null; then
+    echo "✅ Auth token present"
+  fi
+else
+  echo "⚠️ Auth config file not found at $CONFIG_FILE"
+fi
+
+echo ""
+echo "🎉 CLI authentication flow complete!"

--- a/e2e/cli-auth-automation.sh
+++ b/e2e/cli-auth-automation.sh
@@ -19,7 +19,7 @@
 #
 # Uses agent-browser's built-in browser. No CDP/Playwright needed.
 
-set -euo pipefail
+set -eu
 
 OTP="424242"
 BASE_URL=""
@@ -62,10 +62,21 @@ echo "   URL:   $BASE_URL"
 echo "   Email: $EMAIL"
 
 # ---------------------------------------------------------------------------
+# Helper: check if string contains pattern (avoids pipe + grep in conditionals)
+# ---------------------------------------------------------------------------
+contains() {
+  [[ "$(echo "$1" | grep -ci "$2" 2>/dev/null)" -gt 0 ]]
+}
+
+# ---------------------------------------------------------------------------
 # Helper: extract @eN ref from a snapshot line containing [ref=eN]
 # ---------------------------------------------------------------------------
 extract_ref() {
-  echo "$1" | grep -oE '\[ref=e[0-9]+\]' | head -1 | sed 's/\[ref=/@/; s/\]//'
+  local match
+  match=$(echo "$1" | grep -oE '\[ref=e[0-9]+\]' 2>/dev/null | head -1) || true
+  if [[ -n "$match" ]]; then
+    echo "$match" | sed 's/\[ref=/@/; s/\]//'
+  fi
 }
 
 # ---------------------------------------------------------------------------
@@ -122,9 +133,10 @@ enter_otp() {
 # Helper: generate random password for sign-up
 # ---------------------------------------------------------------------------
 generate_password() {
-  # 20-char password: alphanumeric + symbols, satisfies Clerk requirements
-  head -c 32 /dev/urandom | base64 | tr -d '/+\n' | head -c 16
-  echo '!Aa1'  # append guaranteed symbol + upper + lower + digit
+  # 20-char password: random alphanumeric + guaranteed symbol/upper/lower/digit
+  local rand
+  rand=$(head -c 32 /dev/urandom | base64 | tr -d '/+=\n')
+  echo "${rand:0:16}!Aa1"
 }
 
 # ---------------------------------------------------------------------------
@@ -194,7 +206,7 @@ else
   echo "⏳ Waiting for Clerk sign-in form..."
   for i in $(seq 1 10); do
     SNAP=$(agent-browser snapshot -i 2>/dev/null || true)
-    if echo "$SNAP" | grep -qi "email address"; then
+    if contains "$SNAP" "email address"; then
       break
     fi
     if [[ $i -eq 10 ]]; then
@@ -226,7 +238,7 @@ else
     SNAP=$(full_snapshot)
 
     # ----- Account not found → sign-up flow -----
-    if echo "$SNAP" | grep -qi "couldn.t find your account"; then
+    if contains "$SNAP" "couldn.t find your account"; then
       echo "📝 Account not found — switching to sign-up flow"
 
       SIGNUP_PASSWORD="$(generate_password)"
@@ -236,7 +248,7 @@ else
 
       for i in $(seq 1 10); do
         SNAP=$(agent-browser snapshot -i 2>/dev/null || true)
-        if echo "$SNAP" | grep -qi "email address"; then
+        if contains "$SNAP" "email address"; then
           break
         fi
         if [[ $i -eq 10 ]]; then
@@ -260,7 +272,7 @@ else
       agent-browser wait 5000
 
       SNAP=$(full_snapshot)
-      if echo "$SNAP" | grep -qi "verify your email\|verification code"; then
+      if contains "$SNAP" "verify your email\|verification code"; then
         enter_otp "$OTP"
       fi
 
@@ -273,7 +285,7 @@ else
       echo "✅ Sign-up successful!"
 
     # ----- "Use another method" → email code flow -----
-    elif echo "$SNAP" | grep -qi "use another method"; then
+    elif contains "$SNAP" "use another method"; then
       echo "🔄 Clicking 'Use another method'"
       SNAP_I=$(agent-browser snapshot -i 2>/dev/null || true)
       UAM_REF=$(extract_ref "$(echo "$SNAP_I" | grep -i 'use another method' || true)")
@@ -299,7 +311,7 @@ else
       echo "✅ Sign-in via email code successful!"
 
     # ----- Already on verification code screen -----
-    elif echo "$SNAP" | grep -qi "verify\|verification code\|enter.*code"; then
+    elif contains "$SNAP" "verify\|verification code\|enter.*code"; then
       enter_otp "$OTP"
 
       REDIRECT_URL=$(wait_for_redirect_away "sign-in" 15 || true)
@@ -311,7 +323,7 @@ else
       echo "✅ Sign-in via OTP successful!"
 
     # ----- Password required (enter empty and try email code) -----
-    elif echo "$SNAP" | grep -qi "password"; then
+    elif contains "$SNAP" "password"; then
       echo "🔄 Password screen detected — looking for email code option"
       SNAP_I=$(agent-browser snapshot -i 2>/dev/null || true)
 
@@ -360,7 +372,7 @@ agent-browser wait 3000
 echo "⏳ Waiting for device code form..."
 for i in $(seq 1 10); do
   SNAP=$(agent-browser snapshot -i 2>/dev/null || true)
-  if echo "$SNAP" | grep -qi "Authorize.*CLI\|Verify"; then
+  if contains "$SNAP" "Authorize.*CLI\|Verify"; then
     break
   fi
   if [[ $i -eq 10 ]]; then

--- a/scripts/start-vnc.sh
+++ b/scripts/start-vnc.sh
@@ -40,8 +40,8 @@ cleanup() {
   for pid in "${PIDS[@]}"; do
     kill "$pid" 2>/dev/null || true
   done
-  # Also kill any Chrome we started (matched by CDP port)
-  pkill -f "chrome.*--remote-debugging-port=${CDP_PORT:-9222}" 2>/dev/null || true
+
+  agent-browser close 2>/dev/null || true
   wait 2>/dev/null || true
   log "All processes stopped."
 }
@@ -66,7 +66,7 @@ pkill -x Xvfb 2>/dev/null || true
 pkill -x openbox 2>/dev/null || true
 pkill -x x11vnc 2>/dev/null || true
 pkill -f websockify 2>/dev/null || true
-pkill -f "chrome.*--remote-debugging-port=${CDP_PORT:-9222}" 2>/dev/null || true
+agent-browser close 2>/dev/null || true
 sleep 1
 
 # --- Start Xvfb ---
@@ -92,29 +92,6 @@ log "Starting websockify on 0.0.0.0:${NOVNC_PORT} -> localhost:${VNC_PORT}"
 websockify --web /usr/share/novnc/ "0.0.0.0:${NOVNC_PORT}" "localhost:${VNC_PORT}" >/dev/null 2>&1 &
 PIDS+=($!)
 sleep 1
-
-# --- Launch Chrome with CDP (remote debugging) ---
-CDP_PORT="${CDP_PORT:-9222}"
-CHROME_BIN=$(find "$HOME/.cache/ms-playwright" -name chrome -type f 2>/dev/null | head -1)
-CHROME_PROFILE="${AGENT_BROWSER_PROFILE:-$HOME/.local/share/agent-browser/profile}"
-
-if [[ -z "$CHROME_BIN" ]]; then
-  log "Warning: Chrome not found in Playwright cache, skipping"
-else
-  # Clear stale profile locks from other VMs
-  rm -f "${CHROME_PROFILE}/SingletonLock" "${CHROME_PROFILE}/SingletonCookie" "${CHROME_PROFILE}/SingletonSocket" 2>/dev/null
-  log "Starting Chrome (profile: ${CHROME_PROFILE}, CDP port: ${CDP_PORT})"
-  DISPLAY="$DISPLAY" "$CHROME_BIN" \
-    --user-data-dir="$CHROME_PROFILE" \
-    --remote-debugging-port="$CDP_PORT" \
-    --no-first-run \
-    --no-default-browser-check \
-    --disable-blink-features=AutomationControlled \
-    --start-maximized \
-    >/dev/null 2>&1 &
-  PIDS+=($!)
-  sleep 2
-fi
 
 # --- Verify VNC stack ---
 if ! pgrep -x Xvfb >/dev/null; then


### PR DESCRIPTION
## Summary
- Replace Playwright/CDP-based CLI auth automation with a pure `agent-browser` shell script (`e2e/cli-auth-automation.sh`), eliminating Playwright browser install and system deps in CI
- Simplify `scripts/start-vnc.sh` by removing manual Chrome launch (agent-browser manages its own browser instance)
- Streamline `.github/workflows/turbo.yml` cli-e2e job: install `agent-browser` instead of Playwright, remove Clerk secret env vars and separate sign-in test
- Update devcontainer env vars (`AGENT_BROWSER_HEADED=1` replaces profile/args vars) and skill docs

## Test plan
- [ ] CI `cli-e2e` job passes with the new auth script
- [ ] Local `bash e2e/cli-auth-automation.sh` completes sign-in and device code flow
- [ ] VNC setup still works via `scripts/start-vnc.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)