### PR TITLE
fix(cli): preserve experimental fields in agent clone

### DIFF
--- a/turbo/apps/cli/src/commands/agent/__tests__/clone.test.ts
+++ b/turbo/apps/cli/src/commands/agent/__tests__/clone.test.ts
@@ -218,6 +218,53 @@ describe("agent clone command", () => {
       expect(yamlContent).toContain("vars.DEBUG");
     });
 
+    it("should preserve experimental_capabilities and experimental_firewalls", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/agent/composes", ({ request }) => {
+          const url = new URL(request.url);
+          if (url.searchParams.get("name") === "test-agent") {
+            return HttpResponse.json({
+              id: "cmp-123",
+              name: "test-agent",
+              headVersionId:
+                "abc123def456789012345678901234567890123456789012345678901234",
+              content: {
+                version: "1",
+                agents: {
+                  "test-agent": {
+                    framework: "claude-code",
+                    experimental_capabilities: [
+                      "artifact:read",
+                      "artifact:write",
+                    ],
+                    experimental_firewalls: {
+                      slack: { permissions: ["all"] },
+                    },
+                  },
+                },
+              },
+              createdAt: new Date().toISOString(),
+              updatedAt: new Date().toISOString(),
+            });
+          }
+          return HttpResponse.json(
+            { error: { message: "Not found", code: "NOT_FOUND" } },
+            { status: 400 },
+          );
+        }),
+      );
+
+      const dest = path.join(tempDir, "test-agent");
+      await cloneCommand.parseAsync(["node", "cli", "test-agent", dest]);
+
+      const yamlContent = fs.readFileSync(path.join(dest, "vm0.yaml"), "utf8");
+      expect(yamlContent).toContain("experimental_capabilities:");
+      expect(yamlContent).toContain("artifact:read");
+      expect(yamlContent).toContain("artifact:write");
+      expect(yamlContent).toContain("experimental_firewalls:");
+      expect(yamlContent).toContain("slack:");
+    });
+
     it("should preserve volumes section", async () => {
       server.use(
         http.get("http://localhost:3000/api/agent/composes", ({ request }) => {

--- a/turbo/apps/cli/src/commands/agent/clone.ts
+++ b/turbo/apps/cli/src/commands/agent/clone.ts
@@ -35,6 +35,13 @@ function cleanComposeContent(
     if (agent.skills) cleaned.skills = agent.skills;
     if (agent.experimental_runner)
       cleaned.experimental_runner = agent.experimental_runner;
+    if (agent.experimental_profile)
+      cleaned.experimental_profile = agent.experimental_profile;
+    if (agent.experimental_capabilities)
+      cleaned.experimental_capabilities = agent.experimental_capabilities;
+    if (agent.experimental_firewalls)
+      cleaned.experimental_firewalls = agent.experimental_firewalls;
+    if (agent.metadata) cleaned.metadata = agent.metadata;
     agents[name] = cleaned;
   }
 

--- a/turbo/apps/cli/src/lib/domain/compose-types.ts
+++ b/turbo/apps/cli/src/lib/domain/compose-types.ts
@@ -19,6 +19,13 @@ export interface AgentDefinition {
     group: string;
   };
   experimental_profile?: string;
+  experimental_capabilities?: string[];
+  experimental_firewalls?: Record<string, { permissions: string[] | "all" }>;
+  metadata?: {
+    displayName?: string;
+    description?: string;
+    sound?: string;
+  };
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add `experimental_capabilities`, `experimental_firewalls`, `experimental_profile`, and `metadata` to `cleanComposeContent()` whitelist in `clone.ts`
- Update `AgentDefinition` type in `compose-types.ts` to include the missing fields
- Add integration test verifying experimental fields are preserved in cloned vm0.yaml

Closes #5468

## Test plan
- [x] New test: `should preserve experimental_capabilities and experimental_firewalls`
- [x] All 14 existing clone tests pass
- [x] Lint passes
- [x] Type check passes
- [x] Knip passes (no unused exports)

🤖 Generated with [Claude Code](https://claude.com/claude-code)