### PR TITLE
feat(ci): add codecov coverage reporting to vitest test jobs

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -292,12 +292,12 @@ jobs:
           DATABASE_URL: postgresql://postgres@postgres:5432/postgres
         run: pnpm vitest run --project=web --coverage.enabled --coverage.reporter=json
       - name: Upload coverage to Codecov
-        if: always()
+        if: success() || failure()
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: web
-          files: turbo/apps/web/coverage/coverage-final.json
+          files: turbo/coverage/coverage-final.json
 
   test-migrate:
     needs: prepare
@@ -336,12 +336,12 @@ jobs:
         working-directory: turbo
         run: pnpm vitest run --project=@vm0/cli --coverage.enabled --coverage.reporter=json
       - name: Upload coverage to Codecov
-        if: always()
+        if: success() || failure()
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: cli
-          files: turbo/apps/cli/coverage/coverage-final.json
+          files: turbo/coverage/coverage-final.json
 
   test-app:
     runs-on: ubuntu-latest
@@ -354,12 +354,12 @@ jobs:
         working-directory: turbo
         run: pnpm vitest run --project=@vm0/app --coverage.enabled --coverage.reporter=json
       - name: Upload coverage to Codecov
-        if: always()
+        if: success() || failure()
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: app
-          files: turbo/apps/platform/coverage/coverage-final.json
+          files: turbo/coverage/coverage-final.json
 
   test-other:
     runs-on: ubuntu-latest
@@ -372,12 +372,12 @@ jobs:
         working-directory: turbo
         run: pnpm vitest run --project=@vm0/core --project=@vm0/ui --coverage.enabled --coverage.reporter=json
       - name: Upload coverage to Codecov
-        if: always()
+        if: success() || failure()
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: core-ui
-          files: turbo/packages/core/coverage/coverage-final.json,turbo/packages/ui/coverage/coverage-final.json
+          files: turbo/coverage/coverage-final.json
 
   # Deploy web application with database
   deploy-web:

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -290,7 +290,14 @@ jobs:
         working-directory: turbo
         env:
           DATABASE_URL: postgresql://postgres@postgres:5432/postgres
-        run: pnpm vitest run --project=web
+        run: pnpm vitest run --project=web --coverage.enabled --coverage.reporter=json
+      - name: Upload coverage to Codecov
+        if: always()
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: web
+          files: turbo/apps/web/coverage/coverage-final.json
 
   test-migrate:
     needs: prepare
@@ -327,7 +334,14 @@ jobs:
       - uses: ./.github/actions/toolchain-init
       - name: Test CLI
         working-directory: turbo
-        run: pnpm vitest run --project=@vm0/cli
+        run: pnpm vitest run --project=@vm0/cli --coverage.enabled --coverage.reporter=json
+      - name: Upload coverage to Codecov
+        if: always()
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: cli
+          files: turbo/apps/cli/coverage/coverage-final.json
 
   test-app:
     runs-on: ubuntu-latest
@@ -338,7 +352,14 @@ jobs:
       - uses: ./.github/actions/toolchain-init
       - name: Test App
         working-directory: turbo
-        run: pnpm vitest run --project=@vm0/app
+        run: pnpm vitest run --project=@vm0/app --coverage.enabled --coverage.reporter=json
+      - name: Upload coverage to Codecov
+        if: always()
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: app
+          files: turbo/apps/platform/coverage/coverage-final.json
 
   test-other:
     runs-on: ubuntu-latest
@@ -349,7 +370,14 @@ jobs:
       - uses: ./.github/actions/toolchain-init
       - name: Test Other Packages
         working-directory: turbo
-        run: pnpm vitest run --project=@vm0/core --project=@vm0/ui
+        run: pnpm vitest run --project=@vm0/core --project=@vm0/ui --coverage.enabled --coverage.reporter=json
+      - name: Upload coverage to Codecov
+        if: always()
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: core-ui
+          files: turbo/packages/core/coverage/coverage-final.json,turbo/packages/ui/coverage/coverage-final.json
 
   # Deploy web application with database
   deploy-web:

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,13 @@
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true
+
+comment:
+  layout: "reach,diff,flags,files"
+  behavior: default
+  require_changes: true


### PR DESCRIPTION
## Summary

- Enable v8 coverage collection (`--coverage.enabled --coverage.reporter=json`) in all 4 vitest test jobs: `test-web`, `test-cli`, `test-app`, `test-other`
- Upload coverage results to Codecov with per-job flags (`web`, `cli`, `app`, `core-ui`)
- Add `codecov.yml` config with informational-only status checks (no CI gate, no merge blocking)
- Coverage uploads run with `if: always()` so partial coverage is reported even on test failures

## Prerequisites

- [ ] Register project on [codecov.io](https://codecov.io) and obtain upload token
- [ ] Add `CODECOV_TOKEN` as a GitHub repo secret

## Test plan

- [ ] Verify all 4 test jobs produce `coverage-final.json` in CI
- [ ] Verify Codecov receives uploads from all 4 jobs with correct flags
- [ ] Verify PR comments show coverage delta with flag breakdown
- [ ] Verify CI gate behavior is unchanged (coverage failures don't block merge)
- [ ] Verify test job duration increase is minimal (<10% overhead from v8 coverage)

Closes #5473

🤖 Generated with [Claude Code](https://claude.com/claude-code)