### PR TITLE
chore: add slash command shortcuts for main and rebase-main

### DIFF
--- a/.claude/commands/main.md
+++ b/.claude/commands/main.md
@@ -1,0 +1,6 @@
+---
+command: main
+description: Switch to main branch and pull latest changes
+---
+
+Run `git checkout main && git pull` to switch to main and pull latest changes.

--- a/.claude/commands/rebase-main.md
+++ b/.claude/commands/rebase-main.md
@@ -1,0 +1,8 @@
+---
+command: rebase-main
+description: Rebase current branch onto origin/main and resolve conflicts
+---
+
+1. Run `git fetch origin main` to get latest main.
+2. Run `git rebase origin/main` to rebase current branch.
+3. If there are conflicts, resolve them by reading the conflicted files, making the correct edits, then `git add` and `git rebase --continue`. Repeat until rebase completes.


### PR DESCRIPTION
## Summary
- Add `/main` command shortcut to switch to main branch and pull latest changes
- Add `/rebase-main` command shortcut to rebase current branch onto origin/main with conflict resolution

These commands provide quick access to common git workflow operations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)