### PR TITLE
refactor(sandbox): remove dead use_proxy field from sandbox config

### DIFF
--- a/crates/runner/src/cmd/benchmark.rs
+++ b/crates/runner/src/cmd/benchmark.rs
@@ -102,7 +102,6 @@ pub async fn run_benchmark(args: BenchmarkArgs) -> RunnerResult<ExitCode> {
             cpu_count: default_profile.vcpu,
             memory_mb: default_profile.memory_mb,
         },
-        use_proxy: true,
     };
     let (result, timing) = run_sandbox(&args, &factory, &mitm, sandbox_config, is_snapshot).await;
     let total_ms = total.elapsed().as_millis();

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -94,7 +94,6 @@ async fn execute_inner(
             cpu_count: params.vcpu,
             memory_mb: params.memory_mb,
         },
-        use_proxy: true,
     };
 
     // Create and start sandbox
@@ -574,7 +573,7 @@ fn build_env_json(context: &ExecutionContext, api_url: &str) -> HashMap<String, 
     }
 
     // Tell Node.js/Bun to trust the proxy CA. All VMs route through
-    // mitmproxy (use_proxy is always true), so the CA cert is always needed.
+    // mitmproxy, so the CA cert is always needed.
     // The certificate is pre-baked into the rootfs at build time.
     env.insert("NODE_EXTRA_CA_CERTS".into(), VM_PROXY_CA_PATH.into());
 

--- a/crates/sandbox-fc/src/factory.rs
+++ b/crates/sandbox-fc/src/factory.rs
@@ -266,7 +266,7 @@ impl SandboxFactory for FirecrackerFactory {
             .netns_pool()
             .lock()
             .await
-            .acquire(config.use_proxy)
+            .acquire()
             .await
             .map_err(|e| SandboxError::CreationFailed(format!("acquire netns: {e}")))?;
 
@@ -276,7 +276,7 @@ impl SandboxFactory for FirecrackerFactory {
             Err(e) => {
                 // Roll back: return netns to pool before propagating error.
                 let mut netns_pool = self.netns_pool().lock().await;
-                if let Err(rel_err) = netns_pool.release(network, config.use_proxy).await {
+                if let Err(rel_err) = netns_pool.release(network).await {
                     warn!(error = %rel_err, "failed to release netns during rollback");
                 }
                 return Err(SandboxError::CreationFailed(format!(
@@ -318,7 +318,6 @@ impl SandboxFactory for FirecrackerFactory {
         // all fields intact, so we cannot move them out.
         let sandbox_id = sandbox.id.clone();
         let network = sandbox.network.clone();
-        let use_proxy = sandbox.config.use_proxy;
         let overlay = sandbox.overlay.clone();
         let sock_dir = sandbox.sock_paths.dir().to_owned();
         let workspace = sandbox.sandbox_paths.workspace().to_owned();
@@ -326,7 +325,7 @@ impl SandboxFactory for FirecrackerFactory {
 
         // Return the network namespace to the pool.
         let mut netns_pool = self.netns_pool().lock().await;
-        if let Err(e) = netns_pool.release(network, use_proxy).await {
+        if let Err(e) = netns_pool.release(network).await {
             warn!(id = %sandbox_id, error = %e, "failed to release netns");
         }
         drop(netns_pool);

--- a/crates/sandbox-fc/src/network/pool.rs
+++ b/crates/sandbox-fc/src/network/pool.rs
@@ -38,7 +38,7 @@ use std::collections::VecDeque;
 use std::fs::File;
 
 use nix::fcntl::{Flock, FlockArg};
-use tracing::{debug, error, info, trace, warn};
+use tracing::{error, info, trace, warn};
 
 use crate::command::{Privilege, exec, exec_ignore_errors};
 use crate::paths::LockPaths;
@@ -663,22 +663,16 @@ impl NetnsPool {
     /// After acquisition, spawns a background replenishment task if the
     /// buffer is below [`BUFFER_SIZE`].
     ///
-    /// The two queues are completely independent — `use_proxy=true` only
-    /// touches the proxy queue, `use_proxy=false` only touches the plain queue.
-    pub async fn acquire(&mut self, use_proxy: bool) -> Result<PooledNetns> {
+    /// When `proxy_port` is configured, acquires from the proxy queue
+    /// (namespaces with iptables REDIRECT rules). Otherwise acquires from
+    /// the plain queue.
+    pub async fn acquire(&mut self) -> Result<PooledNetns> {
         // Move completed background tasks into queues before checking.
         self.drain_completed();
 
-        // Intentional graceful degradation: when `use_proxy=true` but no
-        // proxy port is configured, fall back to the plain queue.  Callers
-        // (e.g. executor) always set `use_proxy=true` without knowing
-        // whether the factory was started with a proxy — the pool decides.
-        if use_proxy && self.proxy_port.is_some() {
+        if self.proxy_port.is_some() {
             self.acquire_proxy().await
         } else {
-            if use_proxy {
-                debug!("use_proxy=true but no proxy port configured, falling back to plain");
-            }
             self.acquire_plain().await
         }
     }
@@ -841,15 +835,16 @@ impl NetnsPool {
 
     /// Return a namespace to the pool, or delete it if the pool is inactive.
     ///
-    /// When `has_proxy` is true and a proxy port is configured, the namespace
-    /// is returned to [`Self::proxy_queue`] so its REDIRECT rules are reused.
-    pub async fn release(&mut self, ns: PooledNetns, has_proxy: bool) -> Result<()> {
+    /// When `proxy_port` is configured, the namespace is returned to
+    /// [`Self::proxy_queue`] so its REDIRECT rules are reused.
+    pub async fn release(&mut self, ns: PooledNetns) -> Result<()> {
         if !self.active {
             delete_namespace_resources(&ns.name, &ns.host_device).await;
             return Ok(());
         }
 
-        let target_queue = if has_proxy && self.proxy_port.is_some() {
+        let has_proxy = self.proxy_port.is_some();
+        let target_queue = if has_proxy {
             &mut self.proxy_queue
         } else {
             &mut self.plain_queue

--- a/crates/sandbox-fc/src/snapshot.rs
+++ b/crates/sandbox-fc/src/snapshot.rs
@@ -153,7 +153,7 @@ async fn run_snapshot_workflow(
     netns_pool: &mut NetnsPool,
 ) -> Result<SnapshotConfig, SnapshotError> {
     let network = netns_pool
-        .acquire(false)
+        .acquire()
         .await
         .map_err(|e| SnapshotError::Setup(format!("acquire netns: {e}")))?;
 

--- a/crates/sandbox/src/config.rs
+++ b/crates/sandbox/src/config.rs
@@ -6,5 +6,4 @@ pub struct ResourceLimits {
 pub struct SandboxConfig {
     pub id: uuid::Uuid,
     pub resources: ResourceLimits,
-    pub use_proxy: bool,
 }


### PR DESCRIPTION
## Summary

- Remove `SandboxConfig.use_proxy` field — it was always set to `true` in every call site
- Simplify `NetnsPool::acquire()` and `release()` by removing the `use_proxy`/`has_proxy` parameters
- The proxy/plain queue selection is now solely driven by `proxy_port.is_some()` inside the pool, which was already the real source of truth

The two-queue system (proxy vs plain) is preserved — snapshot creation uses `proxy_port: None` and correctly gets plain namespaces, while `runner start`/`runner benchmark` always configure a proxy port.

Closes #5481

## Test plan

- [x] `cargo check -p runner -p sandbox-fc` passes
- [x] `cargo clippy -p runner -p sandbox-fc -p sandbox` clean
- [x] All 98 tests pass (`cargo test -p runner -p sandbox-fc`)
- [ ] CI e2e tests confirm no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)