### PR TITLE
refactor: consolidate run creation into single entry point

### DIFF
--- a/turbo/apps/web/app/api/agent/runs/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/route.ts
@@ -3,12 +3,7 @@ import {
   tsr,
   TsRestResponse,
 } from "../../../../src/lib/ts-rest-handler";
-import {
-  runsMainContract,
-  ALL_RUN_STATUSES,
-  orgTierSchema,
-  type RunStatus,
-} from "@vm0/core";
+import { runsMainContract, ALL_RUN_STATUSES, type RunStatus } from "@vm0/core";
 import { initServices } from "../../../../src/lib/init-services";
 import {
   agentComposes,
@@ -16,12 +11,7 @@ import {
 } from "../../../../src/db/schema/agent-compose";
 import { agentRuns } from "../../../../src/db/schema/agent-run";
 import { and, eq, inArray, desc, gte, lte } from "drizzle-orm";
-import {
-  validateCheckpoint,
-  validateAgentSession,
-  createRun,
-  type RunDispatchError,
-} from "../../../../src/lib/run";
+import { startRun, type RunDispatchError } from "../../../../src/lib/run";
 import {
   requireAuth,
   isAuthError,
@@ -31,225 +21,11 @@ import {
   isForbidden,
   isBadRequest,
   isNotFound,
+  isUnauthorized,
 } from "../../../../src/lib/errors";
 import { resolveOrg } from "../../../../src/lib/org/resolve-org";
 
 const log = logger("api:runs");
-
-interface ResolvedCompose {
-  agentComposeVersionId: string;
-  agentComposeName?: string;
-  composeId?: string;
-  composeOrgId?: string;
-}
-
-type ErrorResponse = {
-  status: 400 | 404;
-  body: { error: { message: string; code: string } };
-};
-
-/**
- * Resolve compose version ID from request body parameters.
- * Handles new runs, checkpoint resumes, and session continues.
- */
-async function resolveComposeVersion(
-  body: {
-    agentComposeId?: string;
-    agentComposeVersionId?: string;
-    checkpointId?: string;
-    sessionId?: string;
-  },
-  userId: string,
-): Promise<ResolvedCompose | ErrorResponse> {
-  const isCheckpointResume = !!body.checkpointId;
-  const isSessionContinue = !!body.sessionId;
-
-  if (!isCheckpointResume && !isSessionContinue) {
-    return resolveNewRun(body);
-  }
-
-  if (isCheckpointResume) {
-    return resolveCheckpointResume(body.checkpointId!, userId);
-  }
-
-  return resolveSessionContinue(body.sessionId!, userId);
-}
-
-async function resolveNewRun(body: {
-  agentComposeId?: string;
-  agentComposeVersionId?: string;
-}): Promise<ResolvedCompose | ErrorResponse> {
-  if (body.agentComposeVersionId) {
-    const [versionRow] = await globalThis.services.db
-      .select({
-        composeName: agentComposes.name,
-        composeOrgId: agentComposes.orgId,
-        composeId: agentComposes.id,
-      })
-      .from(agentComposeVersions)
-      .leftJoin(
-        agentComposes,
-        eq(agentComposeVersions.composeId, agentComposes.id),
-      )
-      .where(eq(agentComposeVersions.id, body.agentComposeVersionId))
-      .limit(1);
-
-    return {
-      agentComposeVersionId: body.agentComposeVersionId,
-      agentComposeName: versionRow?.composeName || undefined,
-      composeId: versionRow?.composeId || undefined,
-      composeOrgId: versionRow?.composeOrgId || undefined,
-    };
-  }
-
-  const composeId = body.agentComposeId!;
-  const [compose] = await globalThis.services.db
-    .select({
-      name: agentComposes.name,
-      headVersionId: agentComposes.headVersionId,
-      orgId: agentComposes.orgId,
-    })
-    .from(agentComposes)
-    .where(eq(agentComposes.id, composeId))
-    .limit(1);
-
-  if (!compose) {
-    return {
-      status: 404 as const,
-      body: {
-        error: { message: "Agent compose not found", code: "NOT_FOUND" },
-      },
-    };
-  }
-
-  if (!compose.headVersionId) {
-    return {
-      status: 400 as const,
-      body: {
-        error: {
-          message: "Agent compose has no versions. Run 'vm0 build' first.",
-          code: "BAD_REQUEST",
-        },
-      },
-    };
-  }
-
-  return {
-    agentComposeVersionId: compose.headVersionId,
-    agentComposeName: compose.name || undefined,
-    composeId,
-    composeOrgId: compose.orgId,
-  };
-}
-
-async function resolveCheckpointResume(
-  checkpointId: string,
-  userId: string,
-): Promise<ResolvedCompose | ErrorResponse> {
-  let agentComposeVersionId: string;
-  try {
-    const checkpointData = await validateCheckpoint(checkpointId, userId);
-    agentComposeVersionId = checkpointData.agentComposeVersionId;
-  } catch {
-    return {
-      status: 404 as const,
-      body: {
-        error: {
-          message: "Resource not found",
-          code: "NOT_FOUND",
-        },
-      },
-    };
-  }
-
-  const [versionWithCompose] = await globalThis.services.db
-    .select({
-      composeName: agentComposes.name,
-      composeOrgId: agentComposes.orgId,
-      composeId: agentComposes.id,
-    })
-    .from(agentComposeVersions)
-    .leftJoin(
-      agentComposes,
-      eq(agentComposeVersions.composeId, agentComposes.id),
-    )
-    .where(eq(agentComposeVersions.id, agentComposeVersionId))
-    .limit(1);
-
-  return {
-    agentComposeVersionId,
-    agentComposeName: versionWithCompose?.composeName || undefined,
-    composeId: versionWithCompose?.composeId || undefined,
-    composeOrgId: versionWithCompose?.composeOrgId || undefined,
-  };
-}
-
-async function resolveSessionContinue(
-  sessionId: string,
-  userId: string,
-): Promise<ResolvedCompose | ErrorResponse> {
-  let sessionData;
-  try {
-    sessionData = await validateAgentSession(sessionId, userId);
-  } catch {
-    return {
-      status: 404 as const,
-      body: {
-        error: {
-          message: "Resource not found",
-          code: "NOT_FOUND",
-        },
-      },
-    };
-  }
-
-  const [compose] = await globalThis.services.db
-    .select({
-      name: agentComposes.name,
-      headVersionId: agentComposes.headVersionId,
-      orgId: agentComposes.orgId,
-    })
-    .from(agentComposes)
-    .where(eq(agentComposes.id, sessionData.agentComposeId))
-    .limit(1);
-
-  if (!compose) {
-    return {
-      status: 404 as const,
-      body: {
-        error: {
-          message: "Agent compose for session not found",
-          code: "NOT_FOUND",
-        },
-      },
-    };
-  }
-
-  if (!compose.headVersionId) {
-    return {
-      status: 400 as const,
-      body: {
-        error: {
-          message: "Agent compose has no versions. Run 'vm0 build' first.",
-          code: "BAD_REQUEST",
-        },
-      },
-    };
-  }
-
-  return {
-    agentComposeVersionId: compose.headVersionId,
-    agentComposeName: compose.name || undefined,
-    composeId: sessionData.agentComposeId,
-    composeOrgId: compose.orgId,
-  };
-}
-
-function isErrorResponse(
-  result: ResolvedCompose | ErrorResponse,
-): result is ErrorResponse {
-  return "status" in result;
-}
 
 /**
  * Translate createRun() errors into API response format
@@ -268,6 +44,15 @@ function handleCreateRunError(error: unknown) {
     };
   }
 
+  // Map unauthorized to 404 for security (don't leak resource existence).
+  // This covers checkpoint/session validation failures where the resource
+  // belongs to a different user.
+  if (isUnauthorized(error)) {
+    return {
+      status: 404 as const,
+      body: { error: { message: "Resource not found", code: "NOT_FOUND" } },
+    };
+  }
   if (isForbidden(error)) {
     return {
       status: 403 as const,
@@ -277,13 +62,13 @@ function handleCreateRunError(error: unknown) {
   if (isBadRequest(error)) {
     return {
       status: 400 as const,
-      body: { error: { message: "Invalid request", code: "BAD_REQUEST" } },
+      body: { error: { message: error.message, code: "BAD_REQUEST" } },
     };
   }
   if (isNotFound(error)) {
     return {
       status: 404 as const,
-      body: { error: { message: "Resource not found", code: "NOT_FOUND" } },
+      body: { error: { message: error.message, code: "NOT_FOUND" } },
     };
   }
 
@@ -418,73 +203,22 @@ const router = tsr.router(runsMainContract, {
     if (isAuthError(authCtx)) return authCtx;
     const { userId } = authCtx;
 
-    // Validate mutually exclusive shortcuts
-    if (body.checkpointId && body.sessionId) {
-      return {
-        status: 400 as const,
-        body: {
-          error: {
-            message:
-              "Cannot specify both checkpointId and sessionId. Use one or the other.",
-            code: "BAD_REQUEST",
-          },
-        },
-      };
-    }
-
-    // For new runs, require either agentComposeId or agentComposeVersionId
-    if (!body.checkpointId && !body.sessionId) {
-      if (!body.agentComposeId && !body.agentComposeVersionId) {
-        return {
-          status: 400 as const,
-          body: {
-            error: {
-              message:
-                "Missing agentComposeId or agentComposeVersionId. For new runs, one is required.",
-              code: "BAD_REQUEST",
-            },
-          },
-        };
-      }
-    }
+    // Resolve caller's org for authorization (ensures org membership)
+    const orgSlug = new URL(request.url).searchParams.get("org");
+    const { org } = await resolveOrg(authCtx, orgSlug);
 
     log.debug(
       `Creating run - mode: ${body.checkpointId ? "checkpoint" : body.sessionId ? "session" : "new"}`,
     );
 
-    // Resolve compose version ID for the run
-    const resolved = await resolveComposeVersion(body, userId);
-    if (isErrorResponse(resolved)) {
-      return resolved;
-    }
-
-    log.debug(
-      `Resolved agentComposeVersionId: ${resolved.agentComposeVersionId}`,
-    );
-
-    // Resolve org for variable/secret resolution.
-    // The actual variable fetching happens in build-context.ts.
-    const orgSlug = new URL(request.url).searchParams.get("org");
-    const { org } = await resolveOrg(authCtx, orgSlug);
-
-    // Cross-org session access check: session's compose must belong to the resolved org
-    if (resolved.composeOrgId && resolved.composeOrgId !== org.orgId) {
-      return {
-        status: 404 as const,
-        body: {
-          error: { message: "Resource not found", code: "NOT_FOUND" },
-        },
-      };
-    }
-
-    // Delegate run creation, validation, and dispatch to createRun()
+    // Delegate all resolution, validation, and dispatch to startRun()
     try {
-      const result = await createRun({
+      const result = await startRun({
         userId,
-        agentComposeVersionId: resolved.agentComposeVersionId,
         prompt: body.prompt,
         appendSystemPrompt: body.appendSystemPrompt,
-        composeId: resolved.composeId,
+        composeId: body.agentComposeId,
+        agentComposeVersionId: body.agentComposeVersionId,
         checkpointId: body.checkpointId,
         sessionId: body.sessionId,
         conversationId: body.conversationId,
@@ -494,14 +228,10 @@ const router = tsr.router(runsMainContract, {
         artifactVersion: body.artifactVersion,
         memoryName: body.memoryName,
         volumeVersions: body.volumeVersions,
-        resumedFromCheckpointId: body.checkpointId,
-        agentName: resolved.agentComposeName,
         debugNoMockClaude: body.debugNoMockClaude,
         modelProvider: body.modelProvider,
         checkEnv: body.checkEnv,
-        orgSlug: org.slug,
-        orgId: org.orgId,
-        orgTier: orgTierSchema.parse(org.tier),
+        callerOrgId: org.orgId,
       });
 
       log.debug(

--- a/turbo/apps/web/app/api/telegram/webhook/__tests__/commands.test.ts
+++ b/turbo/apps/web/app/api/telegram/webhook/__tests__/commands.test.ts
@@ -544,7 +544,7 @@ describe("Telegram bot commands", () => {
       const editMsg = telegramEditMessageText();
       server.use(sendMsg.handler, editMsg.handler);
 
-      vi.spyOn(runModule, "createRun").mockResolvedValue({
+      vi.spyOn(runModule, "startRun").mockResolvedValue({
         runId: "mock-run-id",
         status: "queued",
         createdAt: new Date(),
@@ -579,7 +579,7 @@ describe("Telegram bot commands", () => {
       const editMsg = telegramEditMessageText();
       server.use(sendMsg.handler, editMsg.handler);
 
-      vi.spyOn(runModule, "createRun").mockResolvedValue({
+      vi.spyOn(runModule, "startRun").mockResolvedValue({
         runId: "mock-run-id",
         status: "queued",
         createdAt: new Date(),

--- a/turbo/apps/web/app/api/webhooks/github/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/github/__tests__/route.test.ts
@@ -18,10 +18,10 @@ import { POST } from "../route";
 import * as runModule from "../../../../../src/lib/run";
 import { reloadEnv } from "../../../../../src/env";
 
-// Note: createRun is spied on (rather than exercised with real DB + executor)
+// Note: startRun is spied on (rather than exercised with real DB + executor)
 // because this test file focuses on the webhook routing layer: signature
 // verification, event routing, trigger conditions, and callback context
-// construction.  Real createRun integration is covered by its own dedicated
+// construction.  Real run creation integration is covered by its own dedicated
 // tests in src/lib/run/__tests__/create-run.test.ts.  The same boundary is
 // used in the Slack webhook tests (slack/handlers/__tests__/run-agent.test.ts).
 
@@ -154,7 +154,7 @@ function buildIssueCommentPayload(overrides?: CommentPayloadOverrides) {
 }
 
 describe("POST /api/webhooks/github", () => {
-  let createRunSpy: ReturnType<typeof vi.spyOn>;
+  let startRunSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
     afterPromises.length = 0;
@@ -183,8 +183,8 @@ describe("POST /api/webhooks/github", () => {
       ),
     );
 
-    // Mock createRun to prevent actual sandbox dispatch
-    createRunSpy = vi.spyOn(runModule, "createRun").mockResolvedValue({
+    // Mock startRun to prevent actual sandbox dispatch
+    startRunSpy = vi.spyOn(runModule, "startRun").mockResolvedValue({
       runId: "test-run-id",
       status: "running",
       createdAt: new Date(),
@@ -261,8 +261,8 @@ describe("POST /api/webhooks/github", () => {
       await flushAfterCallbacks();
 
       // Then createRun should have been called
-      expect(createRunSpy).toHaveBeenCalledTimes(1);
-      const callArgs = createRunSpy.mock.calls[0]![0] as {
+      expect(startRunSpy).toHaveBeenCalledTimes(1);
+      const callArgs = startRunSpy.mock.calls[0]![0] as {
         prompt: string;
         callbacks: Array<{ payload: { issueNumber: number } }>;
       };
@@ -292,7 +292,7 @@ describe("POST /api/webhooks/github", () => {
 
       await flushAfterCallbacks();
 
-      expect(createRunSpy).toHaveBeenCalledTimes(1);
+      expect(startRunSpy).toHaveBeenCalledTimes(1);
     });
 
     it("should NOT trigger agent for opened issue without app slug label", async () => {
@@ -313,7 +313,7 @@ describe("POST /api/webhooks/github", () => {
 
       await flushAfterCallbacks();
 
-      expect(createRunSpy).not.toHaveBeenCalled();
+      expect(startRunSpy).not.toHaveBeenCalled();
     });
 
     it("should NOT trigger agent when a non-app slug label is added", async () => {
@@ -338,7 +338,7 @@ describe("POST /api/webhooks/github", () => {
 
       await flushAfterCallbacks();
 
-      expect(createRunSpy).not.toHaveBeenCalled();
+      expect(startRunSpy).not.toHaveBeenCalled();
     });
 
     it("should ignore closed/edited/other issue actions", async () => {
@@ -346,7 +346,7 @@ describe("POST /api/webhooks/github", () => {
         await givenGitHubInstallation();
 
       for (const action of ["closed", "edited", "reopened", "deleted"]) {
-        createRunSpy.mockClear();
+        startRunSpy.mockClear();
 
         const request = createGitHubWebhookRequest(
           "issues",
@@ -362,7 +362,7 @@ describe("POST /api/webhooks/github", () => {
 
         await flushAfterCallbacks();
 
-        expect(createRunSpy).not.toHaveBeenCalled();
+        expect(startRunSpy).not.toHaveBeenCalled();
       }
     });
 
@@ -385,8 +385,8 @@ describe("POST /api/webhooks/github", () => {
 
       await flushAfterCallbacks();
 
-      expect(createRunSpy).toHaveBeenCalledTimes(1);
-      const callArgs = createRunSpy.mock.calls[0]![0] as { prompt: string };
+      expect(startRunSpy).toHaveBeenCalledTimes(1);
+      const callArgs = startRunSpy.mock.calls[0]![0] as { prompt: string };
       // When body is null, falls back to issue title
       expect(callArgs.prompt).toContain("Test Issue");
       expect(callArgs.prompt).toContain(
@@ -415,7 +415,7 @@ describe("POST /api/webhooks/github", () => {
       await flushAfterCallbacks();
 
       // Label alone should NOT trigger — bot mention is required
-      expect(createRunSpy).not.toHaveBeenCalled();
+      expect(startRunSpy).not.toHaveBeenCalled();
     });
 
     it("should trigger agent for comment mentioning @bot", async () => {
@@ -436,7 +436,7 @@ describe("POST /api/webhooks/github", () => {
 
       await flushAfterCallbacks();
 
-      expect(createRunSpy).toHaveBeenCalledTimes(1);
+      expect(startRunSpy).toHaveBeenCalledTimes(1);
     });
 
     it("should NOT trigger for comment without label or mention", async () => {
@@ -457,7 +457,7 @@ describe("POST /api/webhooks/github", () => {
 
       await flushAfterCallbacks();
 
-      expect(createRunSpy).not.toHaveBeenCalled();
+      expect(startRunSpy).not.toHaveBeenCalled();
     });
 
     it("should prevent self-triggering from bot comments", async () => {
@@ -480,7 +480,7 @@ describe("POST /api/webhooks/github", () => {
 
       await flushAfterCallbacks();
 
-      expect(createRunSpy).not.toHaveBeenCalled();
+      expect(startRunSpy).not.toHaveBeenCalled();
     });
 
     it("should ignore non-created comment actions", async () => {
@@ -488,7 +488,7 @@ describe("POST /api/webhooks/github", () => {
         await givenGitHubInstallation();
 
       for (const action of ["edited", "deleted"]) {
-        createRunSpy.mockClear();
+        startRunSpy.mockClear();
 
         const request = createGitHubWebhookRequest(
           "issue_comment",
@@ -504,7 +504,7 @@ describe("POST /api/webhooks/github", () => {
 
         await flushAfterCallbacks();
 
-        expect(createRunSpy).not.toHaveBeenCalled();
+        expect(startRunSpy).not.toHaveBeenCalled();
       }
     });
   });
@@ -525,7 +525,7 @@ describe("POST /api/webhooks/github", () => {
       // The error thrown in dispatchAgentRun is caught by the .catch() in route.ts
       await flushAfterCallbacks();
 
-      expect(createRunSpy).not.toHaveBeenCalled();
+      expect(startRunSpy).not.toHaveBeenCalled();
     });
   });
 
@@ -686,8 +686,8 @@ describe("POST /api/webhooks/github", () => {
 
       await flushAfterCallbacks();
 
-      expect(createRunSpy).toHaveBeenCalledTimes(1);
-      const callArgs = createRunSpy.mock.calls[0]![0] as {
+      expect(startRunSpy).toHaveBeenCalledTimes(1);
+      const callArgs = startRunSpy.mock.calls[0]![0] as {
         callbacks: Array<{
           url: string;
           secret: string;

--- a/turbo/apps/web/src/lib/email/handlers/inbound-reply.ts
+++ b/turbo/apps/web/src/lib/email/handlers/inbound-reply.ts
@@ -1,5 +1,3 @@
-import { eq } from "drizzle-orm";
-import { agentComposes } from "../../../db/schema/agent-compose";
 import { getReceivedEmail } from "../client";
 import { processEmailAttachments } from "../attachment";
 import { extractEmailBody } from "../content-extract";
@@ -11,7 +9,7 @@ import {
   getFromDomain,
   type HandlerResult,
 } from "./shared";
-import { createRun } from "../../run";
+import { startRun } from "../../run";
 import { buildIntegrationContext } from "../../integration-context";
 import { generateCallbackSecret, getApiUrl } from "../../callback";
 import { getUserIdByEmail } from "../../auth/get-user-id-by-email";
@@ -161,28 +159,7 @@ export async function handleInboundEmailReply(
     replyContent = `${replyContent}\n\n${attachmentText}`;
   }
 
-  // 10. Get compose to find agent name, version, and org (fallback for legacy sessions)
-  const [compose] = await globalThis.services.db
-    .select({
-      name: agentComposes.name,
-      headVersionId: agentComposes.headVersionId,
-      orgId: agentComposes.orgId,
-    })
-    .from(agentComposes)
-    .where(eq(agentComposes.id, session.composeId))
-    .limit(1);
-
-  if (!compose) {
-    log.error("Compose not found for email reply", {
-      composeId: session.composeId,
-    });
-    return {
-      ok: false,
-      errorMessage: "The agent for this conversation has been removed.",
-    };
-  }
-
-  // 11. Build callbacks for email reply notification
+  // 10. Build callbacks for email reply notification
   const callbacks = [
     {
       url: `${getApiUrl()}/api/internal/callbacks/email/reply`,
@@ -198,26 +175,21 @@ export async function handleInboundEmailReply(
     },
   ];
 
-  // 12. Resolve runtime org: prefer session.orgId, fall back to compose.orgId
-  const runtimeOrgId = session.orgId ?? compose.orgId;
-
-  // 13. Inject integration context and create run
+  // 11. Inject integration context and create run
+  // startRun resolves compose version + org internally
   const fullPrompt = `${buildIntegrationContext("Email")}\n\n# User Prompt\n\n${replyContent}`;
-  const result = await createRun({
+  const result = await startRun({
     userId: session.userId,
-    agentComposeVersionId: compose.headVersionId ?? "",
     prompt: fullPrompt,
     composeId: session.composeId,
     sessionId: session.agentSessionId,
-    agentName: compose.name,
-    orgId: runtimeOrgId,
     callbacks,
   });
 
   log.info("Dispatched agent run from email reply", {
     runId: result.runId,
     emailId,
-    agentName: compose.name,
+    composeId: session.composeId,
   });
 
   return { ok: true };

--- a/turbo/apps/web/src/lib/email/handlers/inbound-trigger.ts
+++ b/turbo/apps/web/src/lib/email/handlers/inbound-trigger.ts
@@ -10,7 +10,7 @@ import {
   getFromDomain,
   type HandlerResult,
 } from "./shared";
-import { createRun } from "../../run";
+import { startRun } from "../../run";
 import { buildIntegrationContext } from "../../integration-context";
 import { generateCallbackSecret, getApiUrl } from "../../callback";
 import { getUserIdByEmail } from "../../auth/get-user-id-by-email";
@@ -276,16 +276,10 @@ export async function handleInboundEmailTrigger(
 
   // 12. Inject integration context and create run
   const fullPrompt = `${buildIntegrationContext("Email")}\n\n# User Prompt\n\n${prompt}`;
-  const result = await createRun({
+  const result = await startRun({
     userId,
-    agentComposeVersionId: compose.headVersionId,
     prompt: fullPrompt,
     composeId: compose.composeId,
-    agentName,
-    artifactName: "artifact",
-    memoryName: "memory",
-    orgId: runtimeOrgId,
-    orgSlug: runtimeOrgSlug,
     callbacks,
   });
 

--- a/turbo/apps/web/src/lib/errors.ts
+++ b/turbo/apps/web/src/lib/errors.ts
@@ -121,6 +121,10 @@ export function concurrentRunLimit(
 // Type Guards
 // ============================================================================
 
+export function isUnauthorized(e: unknown): e is UnauthorizedError {
+  return e instanceof Error && e.name === "UnauthorizedError";
+}
+
 export function isNotFound(e: unknown): e is NotFoundError {
   return e instanceof Error && e.name === "NotFoundError";
 }

--- a/turbo/apps/web/src/lib/github/handlers/issue-event.ts
+++ b/turbo/apps/web/src/lib/github/handlers/issue-event.ts
@@ -1,13 +1,10 @@
 import { z } from "zod";
-import { eq, and, desc } from "drizzle-orm";
+import { eq, and } from "drizzle-orm";
 import { githubInstallations } from "../../../db/schema/github-installation";
 import { githubUserLinks } from "../../../db/schema/github-user-link";
 import { githubIssueSessions } from "../../../db/schema/github-issue-session";
-import {
-  agentComposes,
-  agentComposeVersions,
-} from "../../../db/schema/agent-compose";
-import { createRun, validateAgentSession } from "../../run";
+import { agentComposes } from "../../../db/schema/agent-compose";
+import { startRun, validateAgentSession } from "../../run";
 import { buildIntegrationContext } from "../../integration-context";
 import { generateCallbackSecret, getApiUrl } from "../../callback";
 import { getInstallationAccessToken } from "../github-app";
@@ -20,8 +17,6 @@ import {
 } from "../api";
 import { env } from "../../../env";
 import { logger } from "../../logger";
-import { getOrgData } from "../../org/org-cache-service";
-import { orgTierSchema } from "@vm0/core";
 
 const log = logger("github:issue-event");
 
@@ -226,28 +221,6 @@ interface DispatchParams {
   comment?: GitHubComment;
   forceNewSession?: boolean;
   appSlug: string | undefined;
-}
-
-/**
- * Resolve the compose version ID, falling back to the latest version.
- */
-async function resolveVersionId(compose: {
-  id: string;
-  headVersionId: string | null;
-}): Promise<string> {
-  if (compose.headVersionId) return compose.headVersionId;
-
-  const [latestVersion] = await globalThis.services.db
-    .select({ id: agentComposeVersions.id })
-    .from(agentComposeVersions)
-    .where(eq(agentComposeVersions.composeId, compose.id))
-    .orderBy(desc(agentComposeVersions.createdAt))
-    .limit(1);
-
-  if (!latestVersion) {
-    throw new Error(`Agent compose has no versions: composeId=${compose.id}`);
-  }
-  return latestVersion.id;
 }
 
 /**
@@ -457,13 +430,11 @@ async function dispatchAgentRun(params: DispatchParams): Promise<void> {
 
   const vm0UserId = userLink.vm0UserId;
 
-  // 3. Resolve agent compose and version
+  // 3. Resolve agent compose (version + org resolved by startRun)
   const [compose] = await globalThis.services.db
     .select({
       id: agentComposes.id,
       name: agentComposes.name,
-      headVersionId: agentComposes.headVersionId,
-      orgId: agentComposes.orgId,
     })
     .from(agentComposes)
     .where(eq(agentComposes.id, installation.defaultComposeId))
@@ -474,8 +445,6 @@ async function dispatchAgentRun(params: DispatchParams): Promise<void> {
       `Agent compose not found: composeId=${installation.defaultComposeId}`,
     );
   }
-
-  const versionId = await resolveVersionId(compose);
 
   // 4. Look up existing session
   let existingSessionId: string | undefined;
@@ -524,22 +493,12 @@ async function dispatchAgentRun(params: DispatchParams): Promise<void> {
     triggerReactionId: reactionId,
   };
 
-  // Resolve org context from compose
-  const orgData = await getOrgData(compose.orgId);
-  const orgTier = orgTierSchema.parse(orgData.tier);
-
   try {
-    const result = await createRun({
+    const result = await startRun({
       userId: vm0UserId,
-      agentComposeVersionId: versionId,
       prompt: fullPrompt,
       composeId: compose.id,
       sessionId: existingSessionId,
-      agentName: compose.name,
-      artifactName: "artifact",
-      orgId: compose.orgId,
-      orgSlug: orgData.slug,
-      orgTier,
       callbacks: [
         {
           url: callbackUrl,

--- a/turbo/apps/web/src/lib/run/index.ts
+++ b/turbo/apps/web/src/lib/run/index.ts
@@ -7,7 +7,7 @@ export {
   validateCheckpoint,
   validateAgentSession,
   startRun,
-  createRun,
   isRunDispatchError,
   type RunDispatchError,
+  type StartRunParams,
 } from "./run-service";

--- a/turbo/apps/web/src/lib/run/run-service.ts
+++ b/turbo/apps/web/src/lib/run/run-service.ts
@@ -832,6 +832,9 @@ async function resolveStartRunCompose(
       params.agentComposeVersionId,
       params.composeId,
     );
+    if (!meta.orgId) {
+      throw notFound("Agent compose version not found");
+    }
     return { agentComposeVersionId: params.agentComposeVersionId, ...meta };
   }
 

--- a/turbo/apps/web/src/lib/run/run-service.ts
+++ b/turbo/apps/web/src/lib/run/run-service.ts
@@ -320,18 +320,45 @@ export interface CreateRunParams {
 }
 
 /**
- * Simplified run params — callers provide composeId and the function
+ * High-level run params — callers provide a compose identifier and startRun()
  * resolves version + org internally.
+ *
+ * Compose resolution modes (mutually exclusive):
+ * - composeId: new run from compose (resolves headVersionId)
+ * - agentComposeVersionId: new run from pinned version (SDK/CLI)
+ * - checkpointId: resume from checkpoint (resolves version from checkpoint)
+ * - sessionId: continue session (resolves version from session's compose)
  */
-interface StartRunParams {
+export interface StartRunParams {
   userId: string;
-  composeId: string;
   prompt: string;
+
+  // --- Compose resolution (mutually exclusive) ---
+  composeId?: string;
+  agentComposeVersionId?: string;
+  checkpointId?: string;
   sessionId?: string;
-  modelProvider?: string;
-  callbacks?: Array<{ url: string; secret: string; payload: unknown }>;
+
+  // --- Caller-validated org (optional, for API routes with org membership) ---
+  // When provided, startRun() verifies the compose belongs to this org
+  // and uses it for authorization. When omitted, org is auto-resolved
+  // from the compose (used by integration callers that verify access upstream).
+  callerOrgId?: string;
+
+  // --- Optional params (forwarded to createRun) ---
+  appendSystemPrompt?: string;
+  conversationId?: string;
+  vars?: Record<string, string>;
+  secrets?: Record<string, string>;
   artifactName?: string;
+  artifactVersion?: string;
   memoryName?: string;
+  volumeVersions?: Record<string, string>;
+  scheduleId?: string;
+  callbacks?: Array<{ url: string; secret: string; payload: unknown }>;
+  modelProvider?: string;
+  debugNoMockClaude?: boolean;
+  checkEnv?: boolean;
 }
 
 export interface CreateRunResult {
@@ -687,18 +714,49 @@ async function buildAndDispatchRun(opts: {
 }
 
 /**
- * High-level run entry point.
- *
- * Resolves compose version + org context from composeId, then delegates
- * to createRun(). Callers only need composeId — no manual DB queries.
- *
- * @throws NotFoundError - compose not found or has no versions
+ * Resolved compose metadata from one of the 4 resolution modes.
  */
-export async function startRun(
-  params: StartRunParams,
-): Promise<CreateRunResult> {
-  const { userId, composeId, prompt } = params;
+interface ResolvedStartRunCompose {
+  agentComposeVersionId: string;
+  composeId?: string;
+  agentName?: string;
+  orgId: string;
+}
 
+/**
+ * Look up compose metadata from a version ID (shared by checkpoint + versionId paths).
+ */
+async function lookupComposeByVersion(
+  versionId: string,
+  fallbackComposeId?: string,
+): Promise<{ composeId?: string; agentName?: string; orgId: string }> {
+  const [row] = await globalThis.services.db
+    .select({
+      composeName: agentComposes.name,
+      composeOrgId: agentComposes.orgId,
+      composeId: agentComposes.id,
+    })
+    .from(agentComposeVersions)
+    .leftJoin(
+      agentComposes,
+      eq(agentComposeVersions.composeId, agentComposes.id),
+    )
+    .where(eq(agentComposeVersions.id, versionId))
+    .limit(1);
+
+  return {
+    composeId: row?.composeId ?? fallbackComposeId,
+    agentName: row?.composeName ?? undefined,
+    orgId: row?.composeOrgId ?? "",
+  };
+}
+
+/**
+ * Resolve compose by composeId → headVersionId.
+ */
+async function resolveByComposeId(
+  composeId: string,
+): Promise<ResolvedStartRunCompose> {
   const [compose] = await globalThis.services.db
     .select({
       id: agentComposes.id,
@@ -717,23 +775,131 @@ export async function startRun(
     throw badRequest("Agent compose has no versions. Run 'vm0 build' first.");
   }
 
-  const orgData = await getOrgData(compose.orgId);
+  return {
+    agentComposeVersionId: compose.headVersionId,
+    composeId: compose.id,
+    agentName: compose.name ?? undefined,
+    orgId: compose.orgId,
+  };
+}
+
+/**
+ * Resolve compose version + org ID from StartRunParams.
+ *
+ * Handles 4 mutually exclusive resolution modes:
+ * 1. checkpointId → validate checkpoint → get version, then look up compose
+ * 2. sessionId → validate session → get compose → use headVersionId
+ * 3. agentComposeVersionId → use directly, look up compose metadata
+ * 4. composeId → load compose → use headVersionId
+ */
+async function resolveStartRunCompose(
+  params: StartRunParams,
+): Promise<ResolvedStartRunCompose> {
+  // Validate mutual exclusivity before resolution
+  if (params.checkpointId && params.sessionId) {
+    throw badRequest(
+      "Cannot specify both checkpointId and sessionId. Use one or the other.",
+    );
+  }
+
+  if (params.checkpointId) {
+    const checkpointData = await validateCheckpoint(
+      params.checkpointId,
+      params.userId,
+    );
+    const meta = await lookupComposeByVersion(
+      checkpointData.agentComposeVersionId,
+    );
+    if (!meta.orgId) {
+      throw notFound("Agent compose version not found");
+    }
+    return {
+      agentComposeVersionId: checkpointData.agentComposeVersionId,
+      ...meta,
+    };
+  }
+
+  if (params.sessionId) {
+    const sessionData = await validateAgentSession(
+      params.sessionId,
+      params.userId,
+    );
+    return resolveByComposeId(sessionData.agentComposeId);
+  }
+
+  if (params.agentComposeVersionId) {
+    const meta = await lookupComposeByVersion(
+      params.agentComposeVersionId,
+      params.composeId,
+    );
+    return { agentComposeVersionId: params.agentComposeVersionId, ...meta };
+  }
+
+  if (!params.composeId) {
+    throw badRequest(
+      "Missing agentComposeId or agentComposeVersionId. Provide composeId, agentComposeVersionId, checkpointId, or sessionId.",
+    );
+  }
+
+  return resolveByComposeId(params.composeId);
+}
+
+/**
+ * High-level run entry point — the single public API for all run creation.
+ *
+ * Resolves compose version + org context internally, then delegates to
+ * createRun(). Callers only need a compose identifier (composeId, versionId,
+ * checkpointId, or sessionId) — no manual DB queries or org resolution.
+ *
+ * @throws NotFoundError - compose/version/checkpoint/session not found
+ * @throws BadRequestError - compose has no versions, or missing identifier
+ * @throws ForbiddenError - user cannot access compose
+ * @throws Error - dispatch failure
+ */
+export async function startRun(
+  params: StartRunParams,
+): Promise<CreateRunResult> {
+  // 1. Resolve compose version
+  const resolved = await resolveStartRunCompose(params);
+
+  // 2. Cross-org check: if caller provides a validated orgId, ensure
+  //    the compose belongs to that org. This prevents users from accessing
+  //    composes in orgs they don't belong to (used by API routes).
+  if (params.callerOrgId && resolved.orgId !== params.callerOrgId) {
+    throw notFound("Resource not found");
+  }
+
+  // 3. Resolve org context (use callerOrgId for authorization when available)
+  const authOrgId = params.callerOrgId ?? resolved.orgId;
+  const orgData = await getOrgData(authOrgId);
   const orgTier = orgTierSchema.parse(orgData.tier);
 
+  // 4. Delegate to createRun with fully resolved params
   return createRun({
-    userId,
-    agentComposeVersionId: compose.headVersionId,
-    prompt,
-    composeId: compose.id,
-    agentName: compose.name,
-    orgId: compose.orgId,
-    orgSlug: orgData.slug,
-    orgTier,
+    userId: params.userId,
+    agentComposeVersionId: resolved.agentComposeVersionId,
+    prompt: params.prompt,
+    appendSystemPrompt: params.appendSystemPrompt,
+    composeId: resolved.composeId,
+    checkpointId: params.checkpointId,
     sessionId: params.sessionId,
-    modelProvider: params.modelProvider,
-    callbacks: params.callbacks,
+    conversationId: params.conversationId,
+    vars: params.vars,
+    secrets: params.secrets,
     artifactName: params.artifactName ?? "artifact",
+    artifactVersion: params.artifactVersion,
     memoryName: params.memoryName ?? "memory",
+    volumeVersions: params.volumeVersions,
+    scheduleId: params.scheduleId,
+    callbacks: params.callbacks,
+    resumedFromCheckpointId: params.checkpointId,
+    agentName: resolved.agentName,
+    modelProvider: params.modelProvider,
+    debugNoMockClaude: params.debugNoMockClaude,
+    checkEnv: params.checkEnv,
+    orgSlug: orgData.slug,
+    orgId: authOrgId,
+    orgTier,
   });
 }
 

--- a/turbo/apps/web/src/lib/schedule/schedule-service.ts
+++ b/turbo/apps/web/src/lib/schedule/schedule-service.ts
@@ -1,6 +1,5 @@
 import { eq, and, lte, inArray, desc } from "drizzle-orm";
 import { Cron } from "croner";
-import { orgTierSchema } from "@vm0/core";
 import { agentSchedules } from "../../db/schema/agent-schedule";
 import { agentComposes } from "../../db/schema/agent-compose";
 import { agentRuns } from "../../db/schema/agent-run";
@@ -8,7 +7,7 @@ import { decryptSecretsMap } from "../crypto";
 import { getOrgData } from "../org/org-cache-service";
 import { notFound, badRequest, schedulePast } from "../errors";
 import { logger } from "../logger";
-import { createRun } from "../run/run-service";
+import { startRun } from "../run/run-service";
 import { getUserPreferences } from "../user/user-preferences-service";
 import { generateCallbackSecret, getApiUrl } from "../callback";
 
@@ -843,12 +842,11 @@ async function executeSchedule(
     });
   }
 
-  // Delegate run creation, validation, and dispatch to createRun()
+  // Delegate run creation, validation, and dispatch to startRun()
   let runId: string;
   try {
-    const result = await createRun({
+    const result = await startRun({
       userId: schedule.userId,
-      agentComposeVersionId: compose.headVersionId,
       prompt: schedule.prompt,
       appendSystemPrompt: schedule.appendSystemPrompt ?? undefined,
       composeId: compose.id,
@@ -856,11 +854,7 @@ async function executeSchedule(
       artifactName: schedule.artifactName ?? undefined,
       artifactVersion: schedule.artifactVersion ?? undefined,
       volumeVersions: schedule.volumeVersions ?? undefined,
-      agentName: compose.name,
       callbacks,
-      orgSlug: orgData.slug,
-      orgId: orgData.orgId,
-      orgTier: orgTierSchema.parse(orgData.tier),
     });
     runId = result.runId;
   } catch (error) {

--- a/turbo/apps/web/src/lib/slack/handlers/__tests__/run-agent.test.ts
+++ b/turbo/apps/web/src/lib/slack/handlers/__tests__/run-agent.test.ts
@@ -16,15 +16,15 @@ describe("runAgentForSlack", () => {
     context.setupMocks();
   });
 
-  it("should pass artifactName and memoryName conventions to createRun", async () => {
+  it("should call startRun with correct composeId and prompt", async () => {
     // Given a user with an agent compose (created via API so it has a version)
     const userId = uniqueId("test-user");
     mockClerk({ userId });
     await createTestOrg(uniqueId("org"));
     const { composeId } = await createTestCompose("test-agent");
 
-    // And createRun is spied on to capture the call without executing
-    const createRunSpy = vi.spyOn(runModule, "createRun").mockResolvedValue({
+    // And startRun is spied on to capture the call without executing
+    const startRunSpy = vi.spyOn(runModule, "startRun").mockResolvedValue({
       runId: "mock-run-id",
       status: "running",
       createdAt: new Date(),
@@ -54,17 +54,13 @@ describe("runAgentForSlack", () => {
     // Then the run should be dispatched
     expect(result.status).toBe("dispatched");
 
-    // And createRun should receive artifactName: "artifact"
-    expect(createRunSpy).toHaveBeenCalledTimes(1);
-    const callArgs = createRunSpy.mock.calls[0]![0] as {
+    // And startRun should receive the correct composeId and prompt
+    expect(startRunSpy).toHaveBeenCalledTimes(1);
+    const callArgs = startRunSpy.mock.calls[0]![0] as {
+      composeId: string;
       prompt: string;
-      artifactName: string;
-      memoryName: string;
     };
-    expect(callArgs).toMatchObject({
-      artifactName: "artifact",
-      memoryName: "memory",
-    });
+    expect(callArgs.composeId).toBe(composeId);
 
     // And the prompt should contain integration context
     expect(callArgs.prompt).toContain(

--- a/turbo/apps/web/src/lib/slack/handlers/run-agent.ts
+++ b/turbo/apps/web/src/lib/slack/handlers/run-agent.ts
@@ -1,14 +1,7 @@
-import { eq, desc } from "drizzle-orm";
-import {
-  agentComposes,
-  agentComposeVersions,
-} from "../../../db/schema/agent-compose";
-import { createRun, isRunDispatchError } from "../../run";
+import { startRun, isRunDispatchError } from "../../run";
 import { buildIntegrationContext } from "../../integration-context";
 import { logger } from "../../logger";
 import { generateCallbackSecret, getApiUrl } from "../../callback";
-import { getOrgData } from "../../org/org-cache-service";
-import { orgTierSchema } from "@vm0/core";
 
 const log = logger("slack:run-agent");
 
@@ -62,45 +55,6 @@ export async function runAgentForSlack(
   } = params;
 
   try {
-    // Get compose and latest version
-    const [compose] = await globalThis.services.db
-      .select({
-        id: agentComposes.id,
-        headVersionId: agentComposes.headVersionId,
-        orgId: agentComposes.orgId,
-      })
-      .from(agentComposes)
-      .where(eq(agentComposes.id, composeId))
-      .limit(1);
-
-    if (!compose) {
-      return {
-        status: "failed",
-        response: "Error: Agent configuration not found.",
-        runId: undefined,
-      };
-    }
-
-    // Get latest version (using headVersionId if available, otherwise query)
-    let versionId = compose.headVersionId;
-    if (!versionId) {
-      const [latestVersion] = await globalThis.services.db
-        .select({ id: agentComposeVersions.id })
-        .from(agentComposeVersions)
-        .where(eq(agentComposeVersions.composeId, compose.id))
-        .orderBy(desc(agentComposeVersions.createdAt))
-        .limit(1);
-
-      if (!latestVersion) {
-        return {
-          status: "failed",
-          response: "Error: Agent has no versions configured.",
-          runId: undefined,
-        };
-      }
-      versionId = latestVersion.id;
-    }
-
     // Build the full prompt with integration context and thread context
     const integrationContext = buildIntegrationContext("Slack");
     const fullPrompt = threadContext
@@ -111,23 +65,11 @@ export async function runAgentForSlack(
     const callbackUrl = `${getApiUrl()}/api/internal/callbacks/slack`;
     const callbackSecret = generateCallbackSecret();
 
-    // Resolve org context from compose
-    const orgData = await getOrgData(compose.orgId);
-    const orgTier = orgTierSchema.parse(orgData.tier);
-
-    // Delegate all orchestration to createRun()
-    const result = await createRun({
+    const result = await startRun({
       userId,
-      agentComposeVersionId: versionId,
+      composeId,
       prompt: fullPrompt,
-      composeId: compose.id,
       sessionId,
-      agentName,
-      artifactName: "artifact",
-      memoryName: "memory",
-      orgId: compose.orgId,
-      orgSlug: orgData.slug,
-      orgTier,
       callbacks: [
         {
           url: callbackUrl,

--- a/turbo/apps/web/src/lib/telegram/handlers/run-agent.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/run-agent.ts
@@ -1,15 +1,8 @@
-import { eq, desc } from "drizzle-orm";
-import {
-  agentComposes,
-  agentComposeVersions,
-} from "../../../db/schema/agent-compose";
-import { createRun, isRunDispatchError } from "../../run";
+import { startRun, isRunDispatchError } from "../../run";
 import { buildIntegrationContext } from "../../integration-context";
 import { isConcurrentRunLimit } from "../../errors";
 import { logger } from "../../logger";
 import { generateCallbackSecret, getApiUrl } from "../../callback";
-import { getOrgData } from "../../org/org-cache-service";
-import { orgTierSchema } from "@vm0/core";
 
 const log = logger("telegram:run-agent");
 
@@ -64,47 +57,6 @@ export async function runAgentForTelegram(
     callbackContext,
   } = params;
 
-  const [compose] = await globalThis.services.db
-    .select({
-      id: agentComposes.id,
-      headVersionId: agentComposes.headVersionId,
-      orgId: agentComposes.orgId,
-    })
-    .from(agentComposes)
-    .where(eq(agentComposes.id, composeId))
-    .limit(1);
-
-  if (!compose) {
-    log.error("Agent compose not found", { composeId, agentName });
-    return {
-      status: "failed",
-      response:
-        "The agent configuration could not be found. Please contact the workspace admin.",
-      runId: undefined,
-    };
-  }
-
-  let versionId = compose.headVersionId;
-  if (!versionId) {
-    const [latestVersion] = await globalThis.services.db
-      .select({ id: agentComposeVersions.id })
-      .from(agentComposeVersions)
-      .where(eq(agentComposeVersions.composeId, compose.id))
-      .orderBy(desc(agentComposeVersions.createdAt))
-      .limit(1);
-
-    if (!latestVersion) {
-      log.error("Agent has no published versions", { composeId, agentName });
-      return {
-        status: "failed",
-        response:
-          "The agent has no published versions. Please publish a version in the dashboard first.",
-        runId: undefined,
-      };
-    }
-    versionId = latestVersion.id;
-  }
-
   const integrationContext = buildIntegrationContext("Telegram");
   const fullPrompt = threadContext
     ? `${integrationContext}\n\n${threadContext}\n\n# User Prompt\n\n${prompt}`
@@ -113,23 +65,12 @@ export async function runAgentForTelegram(
   const callbackUrl = `${getApiUrl()}/api/internal/callbacks/telegram`;
   const callbackSecret = generateCallbackSecret();
 
-  // Resolve org context from compose
-  const orgData = await getOrgData(compose.orgId);
-  const orgTier = orgTierSchema.parse(orgData.tier);
-
   try {
-    const result = await createRun({
+    const result = await startRun({
       userId,
-      agentComposeVersionId: versionId,
+      composeId,
       prompt: fullPrompt,
-      composeId: compose.id,
       sessionId,
-      agentName,
-      artifactName: "artifact",
-      memoryName: "memory",
-      orgId: compose.orgId,
-      orgSlug: orgData.slug,
-      orgTier,
       callbacks: [
         {
           url: callbackUrl,


### PR DESCRIPTION
## Summary

- Consolidates all 8 run creation callers (web chat, Slack, Telegram, GitHub, email trigger, email reply, schedule, Slack org) into using `startRun()` as the single entry point
- Moves compose resolution, org/tier resolution, and version lookup into `startRun()`, removing ~300 lines of duplicated logic across callers
- Demotes `createRun()` to an internal function (no longer exported)
- Fixes pre-existing bugs where email handlers skipped org tier resolution (breaking concurrency limits) and missed `orgSlug`, `artifactName`, `memoryName` defaults

## Changes

- **`run-service.ts`**: Expanded `startRun()` with 4 compose resolution modes (composeId, agentComposeVersionId, checkpointId, sessionId), cross-org authorization check via `callerOrgId`, and automatic org data resolution
- **`route.ts`** (web chat API): Removed ~200 lines of compose resolution functions, now delegates to `startRun()`
- **Integration handlers** (Slack, Telegram, GitHub, email): Each simplified by 30-60 lines, removing compose/version/org queries
- **`schedule-service.ts`**: Switched from `createRun()` to `startRun()`
- **`errors.ts`**: Added `isUnauthorized` type guard for proper error mapping
- **Tests**: Updated all affected test files (route, GitHub webhook, Telegram, Slack) to spy on `startRun` instead of `createRun`

## Test plan

- [x] All 64 route tests pass
- [x] All 45 create-run tests pass
- [x] All 15 queue service tests pass
- [x] All 22 GitHub webhook tests pass
- [x] All 17 Telegram command tests pass
- [x] Slack run-agent test passes
- [x] Build context org tests pass (8/8)
- [x] Lint, type-check, format, knip all pass

Closes #5474

🤖 Generated with [Claude Code](https://claude.com/claude-code)