### PR TITLE
feat(slack): use native markdown block for agent response rendering

### DIFF
--- a/turbo/apps/web/src/lib/slack/__tests__/blocks.test.ts
+++ b/turbo/apps/web/src/lib/slack/__tests__/blocks.test.ts
@@ -1,11 +1,12 @@
 import { describe, it, expect } from "vitest";
-import type { SectionBlock, ActionsBlock } from "@slack/web-api";
+import type { SectionBlock, ActionsBlock, MarkdownBlock } from "@slack/web-api";
 import {
   buildAppHomeView,
   buildErrorMessage,
   buildLoginPromptMessage,
   buildHelpMessage,
   buildSuccessMessage,
+  buildAgentResponseMessage,
   detectDeepLinks,
 } from "../blocks";
 
@@ -111,6 +112,93 @@ describe("buildSuccessMessage", () => {
   });
 });
 
+describe("buildAgentResponseMessage", () => {
+  it("should use markdown block type for agent content", () => {
+    const blocks = buildAgentResponseMessage("Hello **world**");
+
+    const markdownBlock = blocks.find((b) => b.type === "markdown");
+    expect(markdownBlock).toBeDefined();
+    expect((markdownBlock as MarkdownBlock).text).toBe("Hello **world**");
+  });
+
+  it("should pass raw markdown without conversion", () => {
+    const content = "## Header\n\n| Col1 | Col2 |\n|------|------|\n| a | b |";
+    const blocks = buildAgentResponseMessage(content);
+
+    const markdownBlock = blocks.find(
+      (b) => b.type === "markdown",
+    ) as MarkdownBlock;
+    expect(markdownBlock.text).toBe(content);
+  });
+
+  it("should include context block with logs url when provided", () => {
+    const blocks = buildAgentResponseMessage(
+      "Response text",
+      "https://app.vm0.ai/audit/123",
+    );
+
+    const contextBlock = blocks.find((b) => b.type === "context");
+    expect(contextBlock).toBeDefined();
+    expect(contextBlock).toMatchObject({
+      type: "context",
+      elements: [
+        {
+          type: "mrkdwn",
+          text: expect.stringContaining("Audit"),
+        },
+      ],
+    });
+  });
+
+  it("should include deep link context blocks when provided", () => {
+    const deepLinks = [
+      {
+        emoji: "\u{1F511}",
+        label: "Configure providers",
+        url: "https://app.vm0.ai/settings",
+      },
+    ];
+    const blocks = buildAgentResponseMessage(
+      "Response text",
+      undefined,
+      deepLinks,
+    );
+
+    const contextBlock = blocks.find((b) => b.type === "context");
+    expect(contextBlock).toBeDefined();
+    expect(contextBlock).toMatchObject({
+      type: "context",
+      elements: [
+        {
+          type: "mrkdwn",
+          text: expect.stringContaining("Configure providers"),
+        },
+      ],
+    });
+  });
+
+  it("should truncate content exceeding 12000 characters", () => {
+    const longContent = "x".repeat(13000);
+    const blocks = buildAgentResponseMessage(longContent);
+
+    const markdownBlock = blocks.find(
+      (b) => b.type === "markdown",
+    ) as MarkdownBlock;
+    expect(markdownBlock.text.length).toBeLessThanOrEqual(12000);
+    expect(markdownBlock.text).toContain("truncated");
+  });
+
+  it("should not truncate content under 12000 characters", () => {
+    const content = "x".repeat(11000);
+    const blocks = buildAgentResponseMessage(content);
+
+    const markdownBlock = blocks.find(
+      (b) => b.type === "markdown",
+    ) as MarkdownBlock;
+    expect(markdownBlock.text).toBe(content);
+  });
+});
+
 describe("detectDeepLinks", () => {
   const appUrl = "https://app.vm0.ai";
 
@@ -126,7 +214,7 @@ describe("detectDeepLinks", () => {
     );
     expect(links).toHaveLength(1);
     expect(links[0]).toEqual({
-      emoji: "🔑",
+      emoji: "\u{1F511}",
       label: "Configure model providers",
       url: `${appUrl}/settings`,
     });
@@ -140,7 +228,7 @@ describe("detectDeepLinks", () => {
     );
     expect(links).toHaveLength(1);
     expect(links[0]).toEqual({
-      emoji: "🔌",
+      emoji: "\u{1F50C}",
       label: "Configure connectors",
       url: `${appUrl}/team/my-agent?tab=connectors`,
     });
@@ -150,7 +238,7 @@ describe("detectDeepLinks", () => {
     const links = detectDeepLinks("The MCP server connection failed", appUrl);
     expect(links).toHaveLength(1);
     expect(links[0]).toEqual({
-      emoji: "🔌",
+      emoji: "\u{1F50C}",
       label: "Configure connectors",
       url: `${appUrl}/team`,
     });

--- a/turbo/apps/web/src/lib/slack/blocks.ts
+++ b/turbo/apps/web/src/lib/slack/blocks.ts
@@ -2,10 +2,10 @@ import type {
   Block,
   KnownBlock,
   View,
-  SectionBlock,
   ActionsBlock,
   Button,
   Checkboxes,
+  MarkdownBlock,
   Option,
 } from "@slack/web-api";
 import { getAppUrl } from "../url";
@@ -383,77 +383,36 @@ export function buildSuccessMessage(message: string): (Block | KnownBlock)[] {
 }
 
 /**
- * Build markdown message blocks
- * Splits long content into multiple section blocks (Slack limit: 3000 chars per block)
+ * Build markdown message blocks using Slack's native markdown block type.
+ * Slack's markdown block accepts standard markdown (including tables, code blocks,
+ * lists, blockquotes) and handles rendering internally.
  *
- * @param content - Markdown content
+ * @see https://docs.slack.dev/reference/block-kit/blocks/markdown-block/
+ *
+ * @param content - Standard markdown content
  * @returns Block Kit blocks
  */
-/**
- * Convert standard Markdown to Slack mrkdwn format
- */
-function convertToSlackMarkdown(content: string): string {
-  let result = content;
-
-  // Convert headers (## Header -> *Header*)
-  result = result.replace(/^#{1,6}\s+(.+)$/gm, "*$1*");
-
-  // Convert bold (**text** -> *text*)
-  result = result.replace(/\*\*([^*]+)\*\*/g, "*$1*");
-
-  // Convert links [text](url) -> <url|text>
-  result = result.replace(/\[([^\]]+)\]\(([^)]+)\)/g, "<$2|$1>");
-
-  // Convert inline code (already works in Slack)
-  // `code` stays as `code`
-
-  // Convert horizontal rules (--- or ***) to divider-like text
-  result = result.replace(/^[-*]{3,}$/gm, "───────────────");
-
-  return result;
-}
+const MARKDOWN_BLOCK_MAX_LENGTH = 12000;
 
 function buildMarkdownMessage(content: string): (Block | KnownBlock)[] {
-  const MAX_BLOCK_LENGTH = 2900; // Leave some margin below 3000
-  const blocks: SectionBlock[] = [];
+  // Markdown blocks have a cumulative 12,000 character limit per message.
+  // If content exceeds that, truncate and indicate there is more.
+  const truncationSuffix =
+    "\n\n_(Response truncated. View the full output in audit logs.)_";
+  const truncated =
+    content.length > MARKDOWN_BLOCK_MAX_LENGTH
+      ? content.substring(
+          0,
+          MARKDOWN_BLOCK_MAX_LENGTH - truncationSuffix.length,
+        ) + truncationSuffix
+      : content;
 
-  // Convert standard Markdown to Slack mrkdwn
-  const slackContent = convertToSlackMarkdown(content);
+  const block: MarkdownBlock = {
+    type: "markdown",
+    text: truncated,
+  };
 
-  // Split content into chunks if too long
-  let remaining = slackContent;
-  while (remaining.length > 0) {
-    if (remaining.length <= MAX_BLOCK_LENGTH) {
-      blocks.push({
-        type: "section",
-        text: {
-          type: "mrkdwn",
-          text: remaining,
-        },
-      });
-      break;
-    }
-
-    // Find a good split point (newline or space)
-    let splitIndex = remaining.lastIndexOf("\n", MAX_BLOCK_LENGTH);
-    if (splitIndex === -1 || splitIndex < MAX_BLOCK_LENGTH / 2) {
-      splitIndex = remaining.lastIndexOf(" ", MAX_BLOCK_LENGTH);
-    }
-    if (splitIndex === -1 || splitIndex < MAX_BLOCK_LENGTH / 2) {
-      splitIndex = MAX_BLOCK_LENGTH;
-    }
-
-    blocks.push({
-      type: "section",
-      text: {
-        type: "mrkdwn",
-        text: remaining.substring(0, splitIndex),
-      },
-    });
-    remaining = remaining.substring(splitIndex).trimStart();
-  }
-
-  return blocks;
+  return [block];
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Replace the manual `convertToSlackMarkdown()` + `section`/`mrkdwn` pipeline with Slack's native `type: "markdown"` block for agent responses
- Slack's markdown block accepts standard markdown (tables, code blocks, lists, blockquotes) and handles rendering internally, eliminating lossy format conversions
- Add 12,000 character overflow handling with truncation and audit log link fallback

## Details

The `MarkdownBlock` type is already available in our installed `@slack/types@2.19.0` (re-exported via `@slack/web-api`). The markdown block is Slack's recommended approach for AI applications.

### Changes
- **`blocks.ts`**: Deleted `convertToSlackMarkdown()`, replaced `buildMarkdownMessage()` to emit a single `{ type: "markdown", text }` block, updated `buildAgentResponseMessage()` accordingly
- **`blocks.test.ts`**: Added tests for markdown block output, raw markdown passthrough, truncation behavior, and context blocks

### What stays the same
- Context blocks (deep links, audit log) remain unchanged as `type: "context"` with `mrkdwn` elements
- All callers (`route.ts`, `direct-message.ts`, `mention.ts`) use `buildAgentResponseMessage()` unchanged

Closes #5486

## Test plan

- [x] All 26 existing + new tests pass
- [x] Type checking passes
- [x] Lint passes
- [x] Knip passes
- [ ] CI pipeline validates end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)