### PR TITLE
feat: reply all result events to Slack instead of only the last one

### DIFF
--- a/turbo/apps/web/app/api/internal/callbacks/slack/org/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/slack/org/route.ts
@@ -18,7 +18,7 @@ import {
 } from "../../../../../../src/lib/slack/blocks";
 import type { AskUserQuestion } from "../../../../../../src/lib/slack/blocks";
 import {
-  extractRunOutput,
+  extractAllRunOutputs,
   formatAskUserDenials,
   buildDeepLinksFromFlags,
 } from "../../../../../../src/lib/run/extract-run-output";
@@ -30,7 +30,10 @@ import { getAppUrl } from "../../../../../../src/lib/url";
 import { env } from "../../../../../../src/env";
 import { logger } from "../../../../../../src/lib/logger";
 import type { WebClient } from "@slack/web-api";
-import type { PermissionDenial } from "../../../../../../src/lib/run/extract-run-output";
+import type {
+  PermissionDenial,
+  RunOutput,
+} from "../../../../../../src/lib/run/extract-run-output";
 
 const log = logger("callback:slack-org");
 
@@ -150,7 +153,7 @@ async function postAskUserInteractiveCard(
 function buildResponseText(
   status: string,
   error: string | undefined,
-  resultData: Awaited<ReturnType<typeof extractRunOutput>>,
+  resultData: RunOutput,
 ): string {
   if (status !== "completed") {
     return `Error: ${error ?? "Agent execution failed."}`;
@@ -281,21 +284,25 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   );
   const client = createSlackClient(botToken);
 
-  const resultData = await extractRunOutput(runId, error);
-  const hasAskUserDenials = resultData.askUserDenials.length > 0;
-  const responseText = buildResponseText(status, error, resultData);
+  const allOutputs = await extractAllRunOutputs(runId, error);
+  const lastOutput = allOutputs[allOutputs.length - 1]!;
+  const hasAskUserDenials = lastOutput.askUserDenials.length > 0;
 
   // Resolve session before posting interactive card
   const resolvedSessionId = await saveOrgThreadSession(payload, runId, status);
 
-  // Post text response
-  if (responseText) {
-    const logsUrl = buildLogsUrl(runId);
-    const deepLinks = buildDeepLinksFromFlags(
-      resultData,
-      getAppUrl(),
-      payload.agentName,
-    );
+  // Post each result as a separate Slack reply (in order)
+  for (let i = 0; i < allOutputs.length; i++) {
+    const output = allOutputs[i]!;
+    const responseText = buildResponseText(status, error, output);
+    if (!responseText) continue;
+
+    const isLast = i === allOutputs.length - 1;
+    const logsUrl = isLast ? buildLogsUrl(runId) : undefined;
+    const deepLinks = isLast
+      ? buildDeepLinksFromFlags(output, getAppUrl(), payload.agentName)
+      : [];
+
     await postMessage(client, payload.channelId, responseText, {
       threadTs: payload.threadTs,
       blocks: buildAgentResponseMessage(responseText, logsUrl, deepLinks),
@@ -306,7 +313,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   if (hasAskUserDenials) {
     await postAskUserInteractiveCard(
       client,
-      resultData,
+      lastOutput,
       payload,
       runId,
       resolvedSessionId,

--- a/turbo/apps/web/app/api/internal/callbacks/slack/org/schedule/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/slack/org/schedule/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { eq } from "drizzle-orm";
+import type { Block, KnownBlock } from "@slack/web-api";
 import { initServices } from "../../../../../../../src/lib/init-services";
 import { verifyCallback } from "../../../../../../../src/lib/callback";
 import { decryptSecretValue } from "../../../../../../../src/lib/crypto/secrets-encryption";
@@ -10,7 +11,7 @@ import {
   createSlackClient,
   postMessage,
 } from "../../../../../../../src/lib/slack/client";
-import { getRunOutputText } from "../../../../../../../src/lib/run/extract-run-output";
+import { getAllRunOutputTexts } from "../../../../../../../src/lib/run/extract-run-output";
 import {
   saveThreadSession,
   buildLogsUrl,
@@ -58,6 +59,81 @@ function extractAgentSessionId(result: unknown): string | undefined {
     return result.agentSessionId;
   }
   return undefined;
+}
+
+/**
+ * Post all result texts as a threaded Slack conversation.
+ *
+ * The first message includes the header; subsequent results are threaded replies.
+ * Only the last message includes the audit link.
+ */
+async function postScheduleResults(
+  client: ReturnType<typeof createSlackClient>,
+  channel: string,
+  displayName: string,
+  texts: string[],
+  logsUrl: string,
+): Promise<{ messageTs: string | undefined; dmChannelId: string | undefined }> {
+  let messageTs: string | undefined;
+  let dmChannelId: string | undefined;
+
+  for (let i = 0; i < texts.length; i++) {
+    const rawOutput = texts[i]!;
+    const truncatedOutput =
+      rawOutput.length > 2000 ? `${rawOutput.slice(0, 2000)}…` : rawOutput;
+
+    const isFirst = i === 0;
+    const isLast = i === texts.length - 1;
+
+    const blocks: (Block | KnownBlock)[] = [];
+
+    if (isFirst) {
+      blocks.push({
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: `:white_check_mark: *Scheduled run for \`${displayName}\` completed*`,
+        },
+      });
+    }
+
+    blocks.push({
+      type: "section",
+      text: { type: "mrkdwn", text: truncatedOutput },
+    });
+
+    if (isLast) {
+      blocks.push({
+        type: "context",
+        elements: [
+          {
+            type: "mrkdwn",
+            text: `<${logsUrl}|Audit> · Reply in this thread to continue the conversation`,
+          },
+        ],
+      });
+    }
+
+    const threadTs = messageTs;
+    const result = await postMessage(
+      client,
+      dmChannelId ?? channel,
+      isFirst
+        ? `Scheduled run for "${displayName}" completed`
+        : truncatedOutput,
+      {
+        ...(threadTs ? { threadTs } : {}),
+        blocks,
+      },
+    );
+
+    if (isFirst) {
+      messageTs = result.ts;
+      dmChannelId = result.channel;
+    }
+  }
+
+  return { messageTs, dmChannelId };
 }
 
 /**
@@ -131,44 +207,17 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   const displayName = agentInfo?.displayName ?? composeName;
 
   if (status === "completed") {
-    const rawOutput = await getRunOutputText(runId);
-    const truncatedOutput = rawOutput
-      ? rawOutput.length > 2000
-        ? `${rawOutput.slice(0, 2000)}…`
-        : rawOutput
-      : "Task completed successfully.";
+    const allTexts = await getAllRunOutputTexts(runId);
+    if (allTexts.length === 0) {
+      allTexts.push("Task completed successfully.");
+    }
 
-    const { ts: messageTs, channel: dmChannelId } = await postMessage(
+    const { messageTs, dmChannelId } = await postScheduleResults(
       client,
       connection.slackUserId,
-      `Scheduled run for "${displayName}" completed`,
-      {
-        blocks: [
-          {
-            type: "section",
-            text: {
-              type: "mrkdwn",
-              text: `:white_check_mark: *Scheduled run for \`${displayName}\` completed*`,
-            },
-          },
-          {
-            type: "section",
-            text: {
-              type: "mrkdwn",
-              text: truncatedOutput,
-            },
-          },
-          {
-            type: "context",
-            elements: [
-              {
-                type: "mrkdwn",
-                text: `<${logsUrl}|Audit> · Reply in this thread to continue the conversation`,
-              },
-            ],
-          },
-        ],
-      },
+      displayName,
+      allTexts,
+      logsUrl,
     );
 
     // Create thread session so user can reply to continue

--- a/turbo/apps/web/src/lib/run/__tests__/extract-run-output.test.ts
+++ b/turbo/apps/web/src/lib/run/__tests__/extract-run-output.test.ts
@@ -1,12 +1,15 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-vi.mock("../../axiom", () => ({
-  queryAxiom: vi.fn(),
-  getDatasetName: (base: string) => `test-${base}`,
-  DATASETS: { AGENT_RUN_EVENTS: "agent-run-events" },
+// Mock @axiomhq/js at the package boundary (not internal modules).
+// We provide a controllable `query` method that returns Axiom-shaped responses.
+const mockQuery = vi.fn();
+vi.mock("@axiomhq/js", () => ({
+  Axiom: vi.fn().mockImplementation(function () {
+    return { query: mockQuery };
+  }),
 }));
 
-import { queryAxiom } from "../../axiom";
+import { reloadEnv } from "../../../env";
 import {
   extractRunOutput,
   extractAllRunOutputs,
@@ -16,10 +19,26 @@ import {
   type RunOutput,
 } from "../extract-run-output";
 
-const mockQueryAxiom = vi.mocked(queryAxiom);
+/**
+ * Helper to build an Axiom query response in the shape returned by the SDK.
+ * Each item becomes a match entry with `_time` and `data`.
+ */
+function axiomResponse(events: Array<Record<string, unknown>>): {
+  matches: Array<{ _time: string; data: Record<string, unknown> }>;
+} {
+  return {
+    matches: events.map((data) => ({
+      _time: new Date().toISOString(),
+      data,
+    })),
+  };
+}
 
 beforeEach(() => {
-  mockQueryAxiom.mockReset();
+  vi.stubEnv("AXIOM_TOKEN_SESSIONS", "test-axiom-token");
+  // Reload env() cache after stubbing the token so the axiom client sees it
+  reloadEnv();
+  mockQuery.mockReset();
 });
 
 // ---------------------------------------------------------------------------
@@ -28,7 +47,7 @@ beforeEach(() => {
 
 describe("extractRunOutput", () => {
   it("returns empty output when no events found", async () => {
-    mockQueryAxiom.mockResolvedValue([]);
+    mockQuery.mockResolvedValue(axiomResponse([]));
 
     const output = await extractRunOutput("run-1");
 
@@ -41,20 +60,19 @@ describe("extractRunOutput", () => {
     });
   });
 
-  it("returns the last event when multiple exist", async () => {
-    mockQueryAxiom.mockResolvedValue([
-      { eventData: { result: "first" } },
-      { eventData: { result: "second" } },
-      { eventData: { result: "last" } },
-    ]);
+  it("returns the result from the single event returned by the limit-1 query", async () => {
+    // queryResultEvent uses `limit 1 + order by desc` so Axiom returns only the latest event
+    mockQuery.mockResolvedValue(
+      axiomResponse([{ eventData: { result: "latest" } }]),
+    );
 
     const output = await extractRunOutput("run-1");
 
-    expect(output.result).toBe("last");
+    expect(output.result).toBe("latest");
   });
 
   it("passes error through", async () => {
-    mockQueryAxiom.mockResolvedValue([]);
+    mockQuery.mockResolvedValue(axiomResponse([]));
 
     const output = await extractRunOutput("run-1", "sandbox crashed");
 
@@ -63,9 +81,11 @@ describe("extractRunOutput", () => {
   });
 
   it("detects model provider issues in result text", async () => {
-    mockQueryAxiom.mockResolvedValue([
-      { eventData: { result: "model provider not configured" } },
-    ]);
+    mockQuery.mockResolvedValue(
+      axiomResponse([
+        { eventData: { result: "model provider not configured" } },
+      ]),
+    );
 
     const output = await extractRunOutput("run-1");
 
@@ -74,9 +94,11 @@ describe("extractRunOutput", () => {
   });
 
   it("detects connector issues in result text", async () => {
-    mockQueryAxiom.mockResolvedValue([
-      { eventData: { result: "missing variable for connector" } },
-    ]);
+    mockQuery.mockResolvedValue(
+      axiomResponse([
+        { eventData: { result: "missing variable for connector" } },
+      ]),
+    );
 
     const output = await extractRunOutput("run-1");
 
@@ -84,20 +106,22 @@ describe("extractRunOutput", () => {
   });
 
   it("filters AskUserQuestion denials from permission_denials", async () => {
-    mockQueryAxiom.mockResolvedValue([
-      {
-        eventData: {
-          result: "done",
-          permission_denials: [
-            {
-              tool_name: "AskUserQuestion",
-              tool_input: { questions: [{ question: "Pick one" }] },
-            },
-            { tool_name: "Bash" },
-          ],
+    mockQuery.mockResolvedValue(
+      axiomResponse([
+        {
+          eventData: {
+            result: "done",
+            permission_denials: [
+              {
+                tool_name: "AskUserQuestion",
+                tool_input: { questions: [{ question: "Pick one" }] },
+              },
+              { tool_name: "Bash" },
+            ],
+          },
         },
-      },
-    ]);
+      ]),
+    );
 
     const output = await extractRunOutput("run-1");
 
@@ -112,7 +136,7 @@ describe("extractRunOutput", () => {
 
 describe("extractAllRunOutputs", () => {
   it("returns one empty output when no events found", async () => {
-    mockQueryAxiom.mockResolvedValue([]);
+    mockQuery.mockResolvedValue(axiomResponse([]));
 
     const outputs = await extractAllRunOutputs("run-1");
 
@@ -122,7 +146,7 @@ describe("extractAllRunOutputs", () => {
   });
 
   it("returns one empty output with error when no events found", async () => {
-    mockQueryAxiom.mockResolvedValue([]);
+    mockQuery.mockResolvedValue(axiomResponse([]));
 
     const outputs = await extractAllRunOutputs("run-1", "timeout");
 
@@ -131,11 +155,13 @@ describe("extractAllRunOutputs", () => {
   });
 
   it("returns one output per event in order", async () => {
-    mockQueryAxiom.mockResolvedValue([
-      { eventData: { result: "step 1 done" } },
-      { eventData: { result: "step 2 done" } },
-      { eventData: { result: "final summary" } },
-    ]);
+    mockQuery.mockResolvedValue(
+      axiomResponse([
+        { eventData: { result: "step 1 done" } },
+        { eventData: { result: "step 2 done" } },
+        { eventData: { result: "final summary" } },
+      ]),
+    );
 
     const outputs = await extractAllRunOutputs("run-1");
 
@@ -148,10 +174,12 @@ describe("extractAllRunOutputs", () => {
   });
 
   it("handles events with missing result gracefully", async () => {
-    mockQueryAxiom.mockResolvedValue([
-      { eventData: {} },
-      { eventData: { result: "has result" } },
-    ]);
+    mockQuery.mockResolvedValue(
+      axiomResponse([
+        { eventData: {} },
+        { eventData: { result: "has result" } },
+      ]),
+    );
 
     const outputs = await extractAllRunOutputs("run-1");
 
@@ -167,7 +195,7 @@ describe("extractAllRunOutputs", () => {
 
 describe("getAllRunOutputTexts", () => {
   it("returns empty array when all events have no result", async () => {
-    mockQueryAxiom.mockResolvedValue([{ eventData: {} }]);
+    mockQuery.mockResolvedValue(axiomResponse([{ eventData: {} }]));
 
     const texts = await getAllRunOutputTexts("run-1");
 
@@ -175,10 +203,12 @@ describe("getAllRunOutputTexts", () => {
   });
 
   it("returns text for each event with a result", async () => {
-    mockQueryAxiom.mockResolvedValue([
-      { eventData: { result: "first result" } },
-      { eventData: { result: "second result" } },
-    ]);
+    mockQuery.mockResolvedValue(
+      axiomResponse([
+        { eventData: { result: "first result" } },
+        { eventData: { result: "second result" } },
+      ]),
+    );
 
     const texts = await getAllRunOutputTexts("run-1");
 
@@ -186,19 +216,21 @@ describe("getAllRunOutputTexts", () => {
   });
 
   it("skips events without result but includes those with denials only", async () => {
-    mockQueryAxiom.mockResolvedValue([
-      { eventData: { result: "ok" } },
-      {
-        eventData: {
-          permission_denials: [
-            {
-              tool_name: "AskUserQuestion",
-              tool_input: { questions: [{ question: "Choose color" }] },
-            },
-          ],
+    mockQuery.mockResolvedValue(
+      axiomResponse([
+        { eventData: { result: "ok" } },
+        {
+          eventData: {
+            permission_denials: [
+              {
+                tool_name: "AskUserQuestion",
+                tool_input: { questions: [{ question: "Choose color" }] },
+              },
+            ],
+          },
         },
-      },
-    ]);
+      ]),
+    );
 
     const texts = await getAllRunOutputTexts("run-1");
 
@@ -208,19 +240,21 @@ describe("getAllRunOutputTexts", () => {
   });
 
   it("appends formatted denials to result text", async () => {
-    mockQueryAxiom.mockResolvedValue([
-      {
-        eventData: {
-          result: "Need input",
-          permission_denials: [
-            {
-              tool_name: "AskUserQuestion",
-              tool_input: { questions: [{ question: "Yes or no?" }] },
-            },
-          ],
+    mockQuery.mockResolvedValue(
+      axiomResponse([
+        {
+          eventData: {
+            result: "Need input",
+            permission_denials: [
+              {
+                tool_name: "AskUserQuestion",
+                tool_input: { questions: [{ question: "Yes or no?" }] },
+              },
+            ],
+          },
         },
-      },
-    ]);
+      ]),
+    );
 
     const texts = await getAllRunOutputTexts("run-1");
 

--- a/turbo/apps/web/src/lib/run/__tests__/extract-run-output.test.ts
+++ b/turbo/apps/web/src/lib/run/__tests__/extract-run-output.test.ts
@@ -1,0 +1,320 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../../axiom", () => ({
+  queryAxiom: vi.fn(),
+  getDatasetName: (base: string) => `test-${base}`,
+  DATASETS: { AGENT_RUN_EVENTS: "agent-run-events" },
+}));
+
+import { queryAxiom } from "../../axiom";
+import {
+  extractRunOutput,
+  extractAllRunOutputs,
+  getAllRunOutputTexts,
+  formatAskUserDenials,
+  buildDeepLinksFromFlags,
+  type RunOutput,
+} from "../extract-run-output";
+
+const mockQueryAxiom = vi.mocked(queryAxiom);
+
+beforeEach(() => {
+  mockQueryAxiom.mockReset();
+});
+
+// ---------------------------------------------------------------------------
+// extractRunOutput (single — last event)
+// ---------------------------------------------------------------------------
+
+describe("extractRunOutput", () => {
+  it("returns empty output when no events found", async () => {
+    mockQueryAxiom.mockResolvedValue([]);
+
+    const output = await extractRunOutput("run-1");
+
+    expect(output).toEqual({
+      result: null,
+      askUserDenials: [],
+      modelProviderIssue: false,
+      connectorIssue: false,
+      error: null,
+    });
+  });
+
+  it("returns the last event when multiple exist", async () => {
+    mockQueryAxiom.mockResolvedValue([
+      { eventData: { result: "first" } },
+      { eventData: { result: "second" } },
+      { eventData: { result: "last" } },
+    ]);
+
+    const output = await extractRunOutput("run-1");
+
+    expect(output.result).toBe("last");
+  });
+
+  it("passes error through", async () => {
+    mockQueryAxiom.mockResolvedValue([]);
+
+    const output = await extractRunOutput("run-1", "sandbox crashed");
+
+    expect(output.error).toBe("sandbox crashed");
+    expect(output.result).toBeNull();
+  });
+
+  it("detects model provider issues in result text", async () => {
+    mockQueryAxiom.mockResolvedValue([
+      { eventData: { result: "model provider not configured" } },
+    ]);
+
+    const output = await extractRunOutput("run-1");
+
+    expect(output.modelProviderIssue).toBe(true);
+    expect(output.connectorIssue).toBe(false);
+  });
+
+  it("detects connector issues in result text", async () => {
+    mockQueryAxiom.mockResolvedValue([
+      { eventData: { result: "missing variable for connector" } },
+    ]);
+
+    const output = await extractRunOutput("run-1");
+
+    expect(output.connectorIssue).toBe(true);
+  });
+
+  it("filters AskUserQuestion denials from permission_denials", async () => {
+    mockQueryAxiom.mockResolvedValue([
+      {
+        eventData: {
+          result: "done",
+          permission_denials: [
+            {
+              tool_name: "AskUserQuestion",
+              tool_input: { questions: [{ question: "Pick one" }] },
+            },
+            { tool_name: "Bash" },
+          ],
+        },
+      },
+    ]);
+
+    const output = await extractRunOutput("run-1");
+
+    expect(output.askUserDenials).toHaveLength(1);
+    expect(output.askUserDenials[0]!.tool_name).toBe("AskUserQuestion");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractAllRunOutputs (multi)
+// ---------------------------------------------------------------------------
+
+describe("extractAllRunOutputs", () => {
+  it("returns one empty output when no events found", async () => {
+    mockQueryAxiom.mockResolvedValue([]);
+
+    const outputs = await extractAllRunOutputs("run-1");
+
+    expect(outputs).toHaveLength(1);
+    expect(outputs[0]!.result).toBeNull();
+    expect(outputs[0]!.error).toBeNull();
+  });
+
+  it("returns one empty output with error when no events found", async () => {
+    mockQueryAxiom.mockResolvedValue([]);
+
+    const outputs = await extractAllRunOutputs("run-1", "timeout");
+
+    expect(outputs).toHaveLength(1);
+    expect(outputs[0]!.error).toBe("timeout");
+  });
+
+  it("returns one output per event in order", async () => {
+    mockQueryAxiom.mockResolvedValue([
+      { eventData: { result: "step 1 done" } },
+      { eventData: { result: "step 2 done" } },
+      { eventData: { result: "final summary" } },
+    ]);
+
+    const outputs = await extractAllRunOutputs("run-1");
+
+    expect(outputs).toHaveLength(3);
+    expect(outputs.map((o) => o.result)).toEqual([
+      "step 1 done",
+      "step 2 done",
+      "final summary",
+    ]);
+  });
+
+  it("handles events with missing result gracefully", async () => {
+    mockQueryAxiom.mockResolvedValue([
+      { eventData: {} },
+      { eventData: { result: "has result" } },
+    ]);
+
+    const outputs = await extractAllRunOutputs("run-1");
+
+    expect(outputs).toHaveLength(2);
+    expect(outputs[0]!.result).toBeNull();
+    expect(outputs[1]!.result).toBe("has result");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getAllRunOutputTexts
+// ---------------------------------------------------------------------------
+
+describe("getAllRunOutputTexts", () => {
+  it("returns empty array when all events have no result", async () => {
+    mockQueryAxiom.mockResolvedValue([{ eventData: {} }]);
+
+    const texts = await getAllRunOutputTexts("run-1");
+
+    expect(texts).toEqual([]);
+  });
+
+  it("returns text for each event with a result", async () => {
+    mockQueryAxiom.mockResolvedValue([
+      { eventData: { result: "first result" } },
+      { eventData: { result: "second result" } },
+    ]);
+
+    const texts = await getAllRunOutputTexts("run-1");
+
+    expect(texts).toEqual(["first result", "second result"]);
+  });
+
+  it("skips events without result but includes those with denials only", async () => {
+    mockQueryAxiom.mockResolvedValue([
+      { eventData: { result: "ok" } },
+      {
+        eventData: {
+          permission_denials: [
+            {
+              tool_name: "AskUserQuestion",
+              tool_input: { questions: [{ question: "Choose color" }] },
+            },
+          ],
+        },
+      },
+    ]);
+
+    const texts = await getAllRunOutputTexts("run-1");
+
+    expect(texts).toHaveLength(2);
+    expect(texts[0]).toBe("ok");
+    expect(texts[1]).toContain("Choose color");
+  });
+
+  it("appends formatted denials to result text", async () => {
+    mockQueryAxiom.mockResolvedValue([
+      {
+        eventData: {
+          result: "Need input",
+          permission_denials: [
+            {
+              tool_name: "AskUserQuestion",
+              tool_input: { questions: [{ question: "Yes or no?" }] },
+            },
+          ],
+        },
+      },
+    ]);
+
+    const texts = await getAllRunOutputTexts("run-1");
+
+    expect(texts).toHaveLength(1);
+    expect(texts[0]).toContain("Need input");
+    expect(texts[0]).toContain("Yes or no?");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatAskUserDenials
+// ---------------------------------------------------------------------------
+
+describe("formatAskUserDenials", () => {
+  it("returns undefined for empty denials", () => {
+    expect(formatAskUserDenials([])).toBeUndefined();
+  });
+
+  it("returns undefined when denials have no questions", () => {
+    expect(
+      formatAskUserDenials([{ tool_name: "AskUserQuestion" }]),
+    ).toBeUndefined();
+  });
+
+  it("formats question with options", () => {
+    const result = formatAskUserDenials([
+      {
+        tool_name: "AskUserQuestion",
+        tool_input: {
+          questions: [
+            {
+              question: "Pick a color",
+              options: [
+                { label: "Red", description: "Warm" },
+                { label: "Blue" },
+              ],
+            },
+          ],
+        },
+      },
+    ]);
+
+    expect(result).toContain("Pick a color");
+    expect(result).toContain("Red — Warm");
+    expect(result).toContain("Blue");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildDeepLinksFromFlags
+// ---------------------------------------------------------------------------
+
+describe("buildDeepLinksFromFlags", () => {
+  const baseOutput: RunOutput = {
+    result: null,
+    askUserDenials: [],
+    modelProviderIssue: false,
+    connectorIssue: false,
+    error: null,
+  };
+
+  it("returns empty array when no issues", () => {
+    expect(buildDeepLinksFromFlags(baseOutput, "https://app.vm0.ai")).toEqual(
+      [],
+    );
+  });
+
+  it("returns provider link when modelProviderIssue is true", () => {
+    const links = buildDeepLinksFromFlags(
+      { ...baseOutput, modelProviderIssue: true },
+      "https://app.vm0.ai",
+    );
+
+    expect(links).toHaveLength(1);
+    expect(links[0]!.url).toBe("https://app.vm0.ai/settings");
+  });
+
+  it("returns connector link with agent name", () => {
+    const links = buildDeepLinksFromFlags(
+      { ...baseOutput, connectorIssue: true },
+      "https://app.vm0.ai",
+      "my-agent",
+    );
+
+    expect(links).toHaveLength(1);
+    expect(links[0]!.url).toContain("/team/my-agent?tab=connectors");
+  });
+
+  it("returns both links when both issues present", () => {
+    const links = buildDeepLinksFromFlags(
+      { ...baseOutput, modelProviderIssue: true, connectorIssue: true },
+      "https://app.vm0.ai",
+    );
+
+    expect(links).toHaveLength(2);
+  });
+});

--- a/turbo/apps/web/src/lib/run/extract-run-output.ts
+++ b/turbo/apps/web/src/lib/run/extract-run-output.ts
@@ -44,8 +44,15 @@ interface ResultEvent {
 async function queryResultEvent(
   runId: string,
 ): Promise<ResultEvent | undefined> {
-  const events = await queryAllResultEvents(runId);
-  return events[events.length - 1];
+  const dataset = getDatasetName(DATASETS.AGENT_RUN_EVENTS);
+  const apl = `['${dataset}']
+| where runId == "${runId}"
+| where eventType == "result"
+| order by sequenceNumber desc
+| limit 1`;
+
+  const events = await queryAxiom<ResultEvent>(apl);
+  return events[0];
 }
 
 async function queryAllResultEvents(runId: string): Promise<ResultEvent[]> {

--- a/turbo/apps/web/src/lib/run/extract-run-output.ts
+++ b/turbo/apps/web/src/lib/run/extract-run-output.ts
@@ -44,15 +44,18 @@ interface ResultEvent {
 async function queryResultEvent(
   runId: string,
 ): Promise<ResultEvent | undefined> {
+  const events = await queryAllResultEvents(runId);
+  return events[events.length - 1];
+}
+
+async function queryAllResultEvents(runId: string): Promise<ResultEvent[]> {
   const dataset = getDatasetName(DATASETS.AGENT_RUN_EVENTS);
   const apl = `['${dataset}']
 | where runId == "${runId}"
 | where eventType == "result"
-| order by sequenceNumber desc
-| limit 1`;
+| order by sequenceNumber asc`;
 
-  const events = await queryAxiom<ResultEvent>(apl);
-  return events[0];
+  return queryAxiom<ResultEvent>(apl);
 }
 
 // ---------------------------------------------------------------------------
@@ -73,31 +76,96 @@ export async function extractRunOutput(
   error?: string | null,
 ): Promise<RunOutput> {
   const event = await queryResultEvent(runId);
-  const result =
-    typeof event?.eventData?.result === "string"
-      ? event.eventData.result
-      : null;
 
-  const allDenials = event?.eventData?.permission_denials ?? [];
+  if (!event) {
+    return {
+      result: null,
+      askUserDenials: [],
+      modelProviderIssue: false,
+      connectorIssue: false,
+      error: error ?? null,
+    };
+  }
+
+  return buildRunOutput(event, error);
+}
+
+/**
+ * Extract ALL structured run outputs from Axiom (ordered by sequence number).
+ *
+ * A run may produce multiple result events (e.g. intermediate task
+ * notifications followed by a final summary). This returns one RunOutput
+ * per result event so callers can post each one individually.
+ */
+export async function extractAllRunOutputs(
+  runId: string,
+  error?: string | null,
+): Promise<RunOutput[]> {
+  const events = await queryAllResultEvents(runId);
+
+  if (events.length === 0) {
+    return [
+      {
+        result: null,
+        askUserDenials: [],
+        modelProviderIssue: false,
+        connectorIssue: false,
+        error: error ?? null,
+      },
+    ];
+  }
+
+  return events.map((event) => buildRunOutput(event, error));
+}
+
+function buildRunOutput(event: ResultEvent, error?: string | null): RunOutput {
+  const result =
+    typeof event.eventData?.result === "string" ? event.eventData.result : null;
+
+  const allDenials = event.eventData?.permission_denials ?? [];
   const askUserDenials = allDenials.filter(
     (d) => d.tool_name === "AskUserQuestion",
   );
 
-  // Detect issue flags from result text using keyword category matching
   const textToScan = result ?? error ?? "";
   const categories = textToScan
     ? detectIssueCategories(textToScan)
     : new Set<never>();
-  const modelProviderIssue = categories.has("provider");
-  const connectorIssue = categories.has("connector");
 
   return {
     result,
     askUserDenials,
-    modelProviderIssue,
-    connectorIssue,
+    modelProviderIssue: categories.has("provider"),
+    connectorIssue: categories.has("connector"),
     error: error ?? null,
   };
+}
+
+/**
+ * Get ALL formatted run output texts (one per result event).
+ *
+ * Convenience wrapper for channels that post each result as a separate message.
+ */
+export async function getAllRunOutputTexts(runId: string): Promise<string[]> {
+  const outputs = await extractAllRunOutputs(runId);
+  const texts: string[] = [];
+
+  for (const output of outputs) {
+    let text = output.result ?? undefined;
+
+    if (output.askUserDenials.length > 0) {
+      const formatted = formatAskUserDenials(output.askUserDenials);
+      if (formatted) {
+        text = text ? `${text}\n\n${formatted}` : formatted;
+      }
+    }
+
+    if (text) {
+      texts.push(text);
+    }
+  }
+
+  return texts;
 }
 
 /**


### PR DESCRIPTION
## Summary

Closes #5443

- **Query all result events** from Axiom instead of only the last one (`limit 1` → ordered ascending, no limit)
- **Slack org callback**: Posts each result event as a separate thread reply, with logs URL and deep links only on the final message
- **Slack schedule callback**: Posts each result as a threaded reply under the initial notification message
- Added `extractAllRunOutputs()` and `getAllRunOutputTexts()` convenience functions; existing single-result API (`extractRunOutput`, `getRunOutputText`) remains backward-compatible for other consumers (email, telegram, GitHub issues)

## Test plan

- [ ] Trigger a run that produces multiple result events and verify all results appear as separate Slack replies in order
- [ ] Verify single-result runs still work correctly (no regression)
- [ ] Verify scheduled run notifications post all results threaded under the initial DM
- [ ] Verify logs URL and deep links only appear on the last message
- [ ] Verify AskUserQuestion interactive cards still work (posted after last result)

🤖 Generated with [Claude Code](https://claude.com/claude-code)