### PR TITLE
refactor(platform): simplify settings update to use metadata api

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-job-detail.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-job-detail.test.ts
@@ -752,37 +752,22 @@ describe("zero-job-detail signals", () => {
       await context.store.set(fetchZeroJobData$, "my-agent");
     }
 
-    it("should update settings via compose job and refetch", async () => {
-      let capturedJobBody: Record<string, unknown> = {};
+    it("should update settings via metadata PATCH and refetch", async () => {
+      let capturedBody: Record<string, unknown> = {};
 
       await setupWithAgent();
 
       server.use(
-        http.post(
-          "http://localhost:3000/api/compose/jobs",
+        http.patch(
+          "http://localhost:3000/api/agent/composes/compose-1/metadata",
           async ({ request }) => {
-            capturedJobBody = (await request.json()) as Record<string, unknown>;
-            return HttpResponse.json({
-              jobId: "job-1",
-              status: "completed",
-              result: {
-                composeId: "compose-1",
-                composeName: "my-agent",
-                versionId: "v2",
-                warnings: [],
-              },
-            });
+            capturedBody = (await request.json()) as Record<string, unknown>;
+            return new HttpResponse(null, { status: 204 });
           },
         ),
         http.get("http://localhost:3000/api/agent/composes", () => {
           return HttpResponse.json(mockAgentResponse());
         }),
-        http.get(
-          "http://localhost:3000/api/agent/composes/compose-1/instructions",
-          () => {
-            return HttpResponse.json(mockInstructions());
-          },
-        ),
       );
 
       await context.store.set(zeroJobUpdateSettings$, {
@@ -790,50 +775,49 @@ describe("zero-job-detail signals", () => {
         sound: "friendly",
       });
 
-      // Should have sent updated content with new metadata
-      const content = capturedJobBody["content"] as Record<string, unknown>;
-      const agents = content["agents"] as Record<
-        string,
-        Record<string, unknown>
-      >;
-      const mainAgent = agents["main"];
-      const metadata = mainAgent["metadata"] as Record<string, string>;
-      expect(metadata["displayName"]).toBe("New Name");
-      expect(metadata["sound"]).toBe("friendly");
+      // Should have sent the update fields directly to the metadata endpoint
+      expect(capturedBody["displayName"]).toBe("New Name");
+      expect(capturedBody["sound"]).toBe("friendly");
 
       // Saving state should be reset
       expect(context.store.get(zeroJobSettingsSaving$)).toBeFalsy();
     });
 
-    it("should skip update when metadata has not changed", async () => {
-      let composeJobCalled = false;
+    it("should send empty update via metadata PATCH", async () => {
+      let patchCalled = false;
 
       await setupWithAgent();
 
       server.use(
-        http.post("http://localhost:3000/api/compose/jobs", () => {
-          composeJobCalled = true;
-          return HttpResponse.json({ jobId: "job-1", status: "completed" });
+        http.patch(
+          "http://localhost:3000/api/agent/composes/compose-1/metadata",
+          () => {
+            patchCalled = true;
+            return new HttpResponse(null, { status: 204 });
+          },
+        ),
+        http.get("http://localhost:3000/api/agent/composes", () => {
+          return HttpResponse.json(mockAgentResponse());
         }),
       );
 
-      // Default sound is "professional" (from extractAgentFields fallback)
-      // and no displayName is set — pass same values
       await context.store.set(zeroJobUpdateSettings$, {});
 
-      expect(composeJobCalled).toBeFalsy();
+      // The PATCH is always sent — idempotency is handled server-side
+      expect(patchCalled).toBeTruthy();
+      expect(context.store.get(zeroJobSettingsSaving$)).toBeFalsy();
     });
 
-    it("should show error toast on compose job failure", async () => {
+    it("should show error toast on metadata PATCH failure", async () => {
       await setupWithAgent();
 
       server.use(
-        http.post("http://localhost:3000/api/compose/jobs", () => {
-          return HttpResponse.json(
-            { error: { message: "Internal error" } },
-            { status: 500, statusText: "Internal Server Error" },
-          );
-        }),
+        http.patch(
+          "http://localhost:3000/api/agent/composes/compose-1/metadata",
+          () => {
+            return new HttpResponse("Internal error", { status: 500 });
+          },
+        ),
       );
 
       // Should not throw — errors are caught and shown via toast

--- a/turbo/apps/platform/src/signals/zero-page/zero-job-detail.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-job-detail.ts
@@ -271,72 +271,28 @@ interface ZeroJobSettingsUpdate {
 export const zeroJobUpdateSettings$ = command(
   async ({ get, set }, update: ZeroJobSettingsUpdate) => {
     const detail = get(zeroJobDetail$);
-    if (!detail?.content) {
-      throw new Error("No compose content found");
-    }
-
-    const agentKey = Object.keys(detail.content.agents)[0];
-    if (!agentKey) {
-      throw new Error("No agent found in compose");
-    }
-
-    const agentConfig = detail.content.agents[agentKey];
-    const currentMetadata = agentConfig.metadata ?? {};
-    const newMetadata = { ...currentMetadata };
-    if (update.displayName !== undefined) {
-      newMetadata.displayName = update.displayName;
-    }
-    if (update.description !== undefined) {
-      newMetadata.description = update.description;
-    }
-    if (update.sound !== undefined) {
-      newMetadata.sound = update.sound;
-    }
-
-    if (
-      newMetadata.displayName === currentMetadata.displayName &&
-      newMetadata.description === currentMetadata.description &&
-      newMetadata.sound === currentMetadata.sound
-    ) {
-      return;
+    if (!detail) {
+      throw new Error("No compose detail found");
     }
 
     set(internalSaving$, true);
     try {
       const fetchFn = get(fetch$);
-      const newContent = {
-        ...detail.content,
-        agents: {
-          [agentKey]: { ...agentConfig, metadata: newMetadata },
+      const response = await fetchFn(
+        `/api/agent/composes/${detail.id}/metadata`,
+        {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(update),
         },
-      };
-
-      const instructions =
-        (await resolveExistingInstructions(get, fetchFn, detail.id)) ?? "";
-
-      // Ensure instructions field in content
-      const agent = newContent.agents[agentKey];
-      if (agent && !("instructions" in agent)) {
-        newContent.agents[agentKey] = {
-          ...agent,
-          instructions: getInstructionsFilename(agent.framework),
-        };
-      }
-
-      const job = await triggerAndPollComposeJob(
-        fetchFn,
-        newContent,
-        instructions,
       );
-      if (!job.result) {
-        throw new Error("Build completed without result");
+      if (!response.ok) {
+        const text = await response.text();
+        throw new Error(text || `HTTP ${response.status}`);
       }
 
       await set(fetchZeroJobDetail$);
-      await Promise.all([
-        set(fetchZeroJobInstructions$),
-        set(fetchAgentsList$),
-      ]);
+      await set(fetchAgentsList$);
       toast.success("Profile saved");
     } catch (error) {
       throwIfAbort(error);


### PR DESCRIPTION
## Summary
- Replace inline compose rebuild logic in `zeroJobUpdateSettings$` with a single `PATCH` call to `/api/agent/composes/:id/metadata`
- Remove unnecessary instructions resolution and full compose job trigger for simple metadata changes (displayName, description, sound)
- Simplify error handling and post-save refresh flow

## Test plan
- [ ] Verify updating agent display name, description, and sound via the settings UI works correctly
- [ ] Confirm the PATCH endpoint `/api/agent/composes/:id/metadata` handles all three fields
- [ ] Check that the agent list refreshes after a successful save

🤖 Generated with [Claude Code](https://claude.com/claude-code)