### PR TITLE
ci: make e2e-auth script non-blocking with || true

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -885,7 +885,7 @@ jobs:
       - name: Verify device flow authentication
         run: |
           echo "Verifying device flow with ${{ needs.deploy-web.outputs.preview-url }}"
-          cd e2e && bash cli-auth-automation.sh ${{ needs.deploy-web.outputs.preview-url }}
+          cd e2e && bash cli-auth-automation.sh ${{ needs.deploy-web.outputs.preview-url }} || true
         env:
           VM0_API_URL: ${{ needs.deploy-web.outputs.preview-url }}
 


### PR DESCRIPTION
## Summary
- Add `|| true` to the e2e-auth script execution step so the job always reports success regardless of script outcome
- The job is already configured as "may-skip" in the CI gate, but script failure still caused the job to report `failure` instead of `success`

Closes #5502

## Test plan
- [ ] Verify the `e2e-auth` job completes with success status even when the auth script fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)