### PR TITLE
fix: override mitmproxy bundled certificate store with system ca bundle

### DIFF
--- a/crates/runner/src/cmd/setup.rs
+++ b/crates/runner/src/cmd/setup.rs
@@ -8,8 +8,8 @@ use tokio::io::AsyncWriteExt;
 use crate::deps::{
     FIRECRACKER_SHA256_AARCH64, FIRECRACKER_SHA256_X86_64, FIRECRACKER_VERSION,
     KERNEL_SHA256_AARCH64, KERNEL_SHA256_X86_64, KERNEL_VERSION, MITMDUMP_SHA256_AARCH64,
-    MITMDUMP_SHA256_X86_64, MITMDUMP_TAR_ENTRY, MITMPROXY_VERSION, firecracker_tar_entry,
-    firecracker_url, kernel_url, mitmdump_url,
+    MITMDUMP_SHA256_X86_64, MITMDUMP_TAR_ENTRY, MITMPROXY_VERSION, SYSTEM_CA_BUNDLE,
+    firecracker_tar_entry, firecracker_url, kernel_url, mitmdump_url,
 };
 use crate::error::{RunnerError, RunnerResult};
 use crate::paths::HomePaths;
@@ -23,6 +23,7 @@ pub async fn run_setup() -> RunnerResult<()> {
     download_firecracker(&paths, arch).await?;
     download_kernel(&paths, arch).await?;
     download_mitmdump(&paths, arch).await?;
+    check_system_ca_bundle()?;
     check_kvm();
 
     if !missing_required.is_empty() {
@@ -451,6 +452,18 @@ async fn download_mitmdump(paths: &HomePaths, arch: &str) -> RunnerResult<()> {
 // ---------------------------------------------------------------------------
 // Host checks
 // ---------------------------------------------------------------------------
+
+fn check_system_ca_bundle() -> RunnerResult<()> {
+    if Path::new(SYSTEM_CA_BUNDLE).exists() {
+        tracing::info!("[OK] system CA bundle found at {SYSTEM_CA_BUNDLE}");
+        Ok(())
+    } else {
+        Err(RunnerError::Config(format!(
+            "system CA bundle not found at {SYSTEM_CA_BUNDLE} — \
+             install ca-certificates: sudo apt install ca-certificates"
+        )))
+    }
+}
 
 fn check_kvm() {
     use std::fs::File;

--- a/crates/runner/src/deps.rs
+++ b/crates/runner/src/deps.rs
@@ -18,6 +18,10 @@ pub const MITMDUMP_SHA256_X86_64: &str =
 pub const MITMDUMP_SHA256_AARCH64: &str =
     "48fb2cd30945f03faa5cc2797dd6e5762f09ebe8754da87ac8c372dc82e694df";
 
+/// System CA certificate bundle path. The standalone mitmproxy binary bundles its
+/// own (incomplete) certifi CA store; we override it with the host's system store.
+pub const SYSTEM_CA_BUNDLE: &str = "/etc/ssl/certs/ca-certificates.crt";
+
 /// "v1.14.1" → "v1.14"
 const FIRECRACKER_MINOR: &str = strip_patch(FIRECRACKER_VERSION);
 

--- a/crates/runner/src/proxy.rs
+++ b/crates/runner/src/proxy.rs
@@ -255,7 +255,12 @@ pub(crate) async fn spawn_mitmdump(
         ))
         .arg("--scripts")
         .arg(&config.addon_path)
-        .arg("--quiet");
+        .arg("--quiet")
+        .arg("--set")
+        .arg(format!(
+            "ssl_verify_upstream_trusted_ca={}",
+            crate::deps::SYSTEM_CA_BUNDLE
+        ));
     if let Some(url) = &config.api_url {
         cmd.arg("--set").arg(format!("vm0_api_url={url}"));
     }


### PR DESCRIPTION
## Summary

- The standalone mitmproxy binary bundles an incomplete certifi CA store (missing root CAs like SSL.com), causing **502 Bad Gateway** when intercepting HTTPS traffic to affected sites (e.g. example.com via Cloudflare)
- Pass `ssl_verify_upstream_trusted_ca` to mitmdump pointing to the host's `/etc/ssl/certs/ca-certificates.crt`
- Add `check_system_ca_bundle()` to `runner setup` that **fails early** if the CA bundle is missing

## Test plan

- [x] Verified on `local-1.aws.vm3.ai`: `example.com` returns HTTP 200 after the fix
- [ ] `cargo check -p runner` passes
- [ ] Deploy runner and verify HTTPS sites work through mitmproxy

Closes #5524

🤖 Generated with [Claude Code](https://claude.com/claude-code)