### PR TITLE
feat(run): block incompatible provider switch on session continue

### DIFF
--- a/turbo/apps/web/app/api/agent/runs/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/route.ts
@@ -32,6 +32,19 @@ const log = logger("api:runs");
  * Translate createRun() errors into API response format
  */
 function handleCreateRunError(error: unknown) {
+  // Provider incompatibility must be checked before RunDispatchError:
+  // the error is thrown inside buildAndDispatchRun (after run INSERT),
+  // so markRunFailed attaches runId. Without this early check,
+  // dispatchError.runId would match first and return a generic 201 "Run failed".
+  if (isProviderIncompatible(error)) {
+    return {
+      status: 400 as const,
+      body: {
+        error: { message: error.message, code: "PROVIDER_INCOMPATIBLE" },
+      },
+    };
+  }
+
   const dispatchError = error as RunDispatchError;
   if (dispatchError.runId) {
     return {
@@ -58,14 +71,6 @@ function handleCreateRunError(error: unknown) {
     return {
       status: 403 as const,
       body: { error: { message: "Access denied", code: "FORBIDDEN" } },
-    };
-  }
-  if (isProviderIncompatible(error)) {
-    return {
-      status: 400 as const,
-      body: {
-        error: { message: error.message, code: "PROVIDER_INCOMPATIBLE" },
-      },
     };
   }
   if (isBadRequest(error)) {

--- a/turbo/apps/web/app/api/agent/runs/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/route.ts
@@ -22,6 +22,7 @@ import {
   isBadRequest,
   isNotFound,
   isUnauthorized,
+  isProviderIncompatible,
 } from "../../../../src/lib/errors";
 import { resolveOrg } from "../../../../src/lib/org/resolve-org";
 
@@ -57,6 +58,14 @@ function handleCreateRunError(error: unknown) {
     return {
       status: 403 as const,
       body: { error: { message: "Access denied", code: "FORBIDDEN" } },
+    };
+  }
+  if (isProviderIncompatible(error)) {
+    return {
+      status: 400 as const,
+      body: {
+        error: { message: error.message, code: "PROVIDER_INCOMPATIBLE" },
+      },
     };
   }
   if (isBadRequest(error)) {

--- a/turbo/apps/web/src/lib/errors.ts
+++ b/turbo/apps/web/src/lib/errors.ts
@@ -53,6 +53,12 @@ interface ConcurrentRunLimitError extends ApiErrorBase {
   readonly code: "TOO_MANY_REQUESTS";
 }
 
+interface ProviderIncompatibleError extends ApiErrorBase {
+  readonly name: "ProviderIncompatibleError";
+  readonly statusCode: 400;
+  readonly code: "PROVIDER_INCOMPATIBLE";
+}
+
 // ============================================================================
 // Factory Functions
 // ============================================================================
@@ -117,6 +123,16 @@ export function concurrentRunLimit(
   return error;
 }
 
+export function providerIncompatible(
+  message: string,
+): ProviderIncompatibleError {
+  const error = new Error(message) as ProviderIncompatibleError;
+  (error as { name: string }).name = "ProviderIncompatibleError";
+  (error as { statusCode: number }).statusCode = 400;
+  (error as { code: string }).code = "PROVIDER_INCOMPATIBLE";
+  return error;
+}
+
 // ============================================================================
 // Type Guards
 // ============================================================================
@@ -147,4 +163,10 @@ export function isSchedulePast(e: unknown): e is SchedulePastError {
 
 export function isConcurrentRunLimit(e: unknown): e is ConcurrentRunLimitError {
   return e instanceof Error && e.name === "ConcurrentRunLimitError";
+}
+
+export function isProviderIncompatible(
+  e: unknown,
+): e is ProviderIncompatibleError {
+  return e instanceof Error && e.name === "ProviderIncompatibleError";
 }

--- a/turbo/apps/web/src/lib/run/__tests__/create-run.test.ts
+++ b/turbo/apps/web/src/lib/run/__tests__/create-run.test.ts
@@ -1004,7 +1004,7 @@ describe("createRun()", () => {
         agentSessionId: string;
       };
 
-      // Continue with explicit compatible provider (aws-bedrock — same Anthropic-native group)
+      // Continue with explicit compatible provider (claude-code-oauth-token — same Anthropic-native group)
       const continueResult = await createRun(
         baseParams({
           agentComposeVersionId: noKeyCompose.versionId,

--- a/turbo/apps/web/src/lib/run/__tests__/create-run.test.ts
+++ b/turbo/apps/web/src/lib/run/__tests__/create-run.test.ts
@@ -27,7 +27,11 @@ import {
   type CreateRunParams,
   type CreateRunResult,
 } from "../run-service";
-import { isForbidden, isBadRequest } from "../../errors";
+import {
+  isForbidden,
+  isBadRequest,
+  isProviderIncompatible,
+} from "../../errors";
 import { POST as createComposeRoute } from "../../../../app/api/agent/composes/route";
 import { POST as pollRoute } from "../../../../app/api/runners/poll/route";
 import { mockClerk } from "../../../__tests__/clerk-mock";
@@ -905,6 +909,113 @@ describe("createRun()", () => {
 
       const run = await findTestRunRecord(result.runId);
       expect(run!.modelProvider).toBe("vercel-ai-gateway");
+    });
+
+    it("should reject session continue with incompatible model provider", async () => {
+      vi.stubEnv("CONCURRENT_RUN_LIMIT_CAP", "0");
+      reloadEnv();
+
+      const noKeyCompose = await createTestCompose(uniqueId("incompat-agent"), {
+        skipDefaultApiKey: true,
+      });
+
+      // Initial run with anthropic-api-key provider
+      await createTestOrgModelProvider("anthropic-api-key", "test-key");
+
+      const { runId } = await createTestRun(
+        noKeyCompose.composeId,
+        "Initial run",
+      );
+      const sandboxToken = await createTestSandboxToken(user.userId, runId);
+
+      const checkpointRequest = createTestRequest(
+        "http://localhost:3000/api/webhooks/agent/checkpoints",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${sandboxToken}`,
+          },
+          body: JSON.stringify({
+            runId,
+            cliAgentType: "claude-code",
+            cliAgentSessionId: "session-incompat",
+            cliAgentSessionHistory: JSON.stringify([]),
+          }),
+        },
+      );
+      const checkpointResponse = await checkpointWebhook(checkpointRequest);
+      expect(checkpointResponse.status).toBe(200);
+
+      const { agentSessionId } = (await checkpointResponse.json()) as {
+        agentSessionId: string;
+      };
+
+      // Continue session with explicit incompatible provider (moonshot)
+      await expect(
+        createRun(
+          baseParams({
+            agentComposeVersionId: noKeyCompose.versionId,
+            sessionId: agentSessionId,
+            prompt: "Continue",
+            modelProvider: "moonshot-api-key",
+          }),
+        ),
+      ).rejects.toSatisfy(isProviderIncompatible);
+    });
+
+    it("should allow session continue with compatible model provider", async () => {
+      vi.stubEnv("CONCURRENT_RUN_LIMIT_CAP", "0");
+      reloadEnv();
+
+      const noKeyCompose = await createTestCompose(uniqueId("compat-agent"), {
+        skipDefaultApiKey: true,
+      });
+
+      // Initial run with anthropic-api-key provider
+      await createTestOrgModelProvider("anthropic-api-key", "test-key");
+
+      const { runId } = await createTestRun(
+        noKeyCompose.composeId,
+        "Initial run",
+      );
+      const sandboxToken = await createTestSandboxToken(user.userId, runId);
+
+      const checkpointRequest = createTestRequest(
+        "http://localhost:3000/api/webhooks/agent/checkpoints",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${sandboxToken}`,
+          },
+          body: JSON.stringify({
+            runId,
+            cliAgentType: "claude-code",
+            cliAgentSessionId: "session-compat",
+            cliAgentSessionHistory: JSON.stringify([]),
+          }),
+        },
+      );
+      const checkpointResponse = await checkpointWebhook(checkpointRequest);
+      expect(checkpointResponse.status).toBe(200);
+
+      const { agentSessionId } = (await checkpointResponse.json()) as {
+        agentSessionId: string;
+      };
+
+      // Continue with explicit compatible provider (aws-bedrock — same Anthropic-native group)
+      const continueResult = await createRun(
+        baseParams({
+          agentComposeVersionId: noKeyCompose.versionId,
+          sessionId: agentSessionId,
+          prompt: "Continue",
+          modelProvider: "claude-code-oauth-token",
+        }),
+      );
+
+      expect(continueResult.runId).toBeDefined();
+      expect(continueResult.status).toBe("pending");
     });
   });
 

--- a/turbo/apps/web/src/lib/run/build-context.ts
+++ b/turbo/apps/web/src/lib/run/build-context.ts
@@ -12,6 +12,7 @@ import {
   MODEL_PROVIDER_TYPES,
   VALID_CAPABILITIES,
   getModelProviderFirewall,
+  areProvidersCompatible,
   type ExperimentalFirewalls,
   type ExpandedFirewallConfig,
   type ConnectorType,
@@ -20,7 +21,7 @@ import {
 } from "@vm0/core";
 import { agentComposeVersions } from "../../db/schema/agent-compose";
 import type { AgentComposeYaml } from "../../types/agent-compose";
-import { badRequest, notFound } from "../errors";
+import { badRequest, notFound, providerIncompatible } from "../errors";
 import { getOrgData } from "../org/org-cache-service";
 import { logger } from "../logger";
 import type { ExecutionContext, ResumeSession, RuntimeOrg } from "./types";
@@ -971,6 +972,26 @@ export async function buildExecutionContext(
     modelProviderFirewall,
   } = secretsResult;
   const userTimezone = userPrefs?.timezone ?? undefined;
+
+  // Step 5: Provider compatibility check for session continues.
+  // When resuming a session, verify the new provider is compatible with the
+  // original provider to avoid mid-conversation base URL mismatches.
+  if (
+    resolution?.originalModelProvider &&
+    resolvedModelProvider &&
+    resolution.originalModelProvider in MODEL_PROVIDER_TYPES
+  ) {
+    const originalType = resolution.originalModelProvider as ModelProviderType;
+    const newType = resolvedModelProvider as ModelProviderType;
+    if (!areProvidersCompatible(originalType, newType)) {
+      const originalLabel = MODEL_PROVIDER_TYPES[originalType].label;
+      const newLabel = MODEL_PROVIDER_TYPES[newType].label;
+      throw providerIncompatible(
+        `Cannot continue session: this session was created with ${originalLabel} and cannot be continued with ${newLabel}. ` +
+          `Please start a new session or switch back to a compatible model.`,
+      );
+    }
+  }
 
   // Build experimental firewall manifest (base + auth entries for the runner).
   // Merge compose-declared firewalls with auto-generated model provider firewall.

--- a/turbo/apps/web/src/lib/run/resolvers/resolve-session.ts
+++ b/turbo/apps/web/src/lib/run/resolvers/resolve-session.ts
@@ -106,9 +106,12 @@ export async function resolveSession(
       conversation.cliAgentSessionHistoryHash,
       conversation.cliAgentSessionHistory,
     ),
-    // Last run vars as fallback for continue operations
+    // Last run vars and model provider as fallback for continue operations
     globalThis.services.db
-      .select({ vars: agentRuns.vars })
+      .select({
+        vars: agentRuns.vars,
+        modelProvider: agentRuns.modelProvider,
+      })
       .from(agentRuns)
       .where(eq(agentRuns.id, conversation.runId))
       .limit(1),
@@ -134,5 +137,6 @@ export async function resolveSession(
     vars: lastRunVars,
     volumeVersions: undefined,
     buildResumeArtifact: !!session.artifactName,
+    originalModelProvider: lastRun?.modelProvider ?? undefined,
   };
 }

--- a/turbo/apps/web/src/lib/run/resolvers/types.ts
+++ b/turbo/apps/web/src/lib/run/resolvers/types.ts
@@ -19,4 +19,6 @@ export interface ConversationResolution {
   vars?: Record<string, string>;
   volumeVersions?: Record<string, string>;
   buildResumeArtifact: boolean;
+  /** Model provider from the previous run (null for runs before provider tracking) */
+  originalModelProvider?: string;
 }


### PR DESCRIPTION
## Summary

Closes #5449

- Add `PROVIDER_INCOMPATIBLE` error code with dedicated `providerIncompatible()` factory for frontend-reliable matching
- Extend `ConversationResolution` with `originalModelProvider` from the previous run's `agentRuns.modelProvider`
- Add compatibility check in `buildExecutionContext()` after provider resolution using `areProvidersCompatible()`
- Update route error handler to map the new error type to `{ code: "PROVIDER_INCOMPATIBLE" }` API response
- Integration tests for both incompatible (reject) and compatible (allow) session continue scenarios

## Test plan

- [x] `should reject session continue with incompatible model provider` — anthropic-api-key → moonshot-api-key throws `ProviderIncompatibleError`
- [x] `should allow session continue with compatible model provider` — anthropic-api-key → claude-code-oauth-token succeeds
- [x] All 49 existing create-run tests pass
- [x] Lint, format, knip all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)