### PR TITLE
feat(platform): auto-pin on chat, remove pin limit, fix team nav

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/zero-nav.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-nav.ts
@@ -1,5 +1,5 @@
 import { command, computed, state } from "ccstate";
-import { pathname$, updatePathname$ } from "../route.ts";
+import { pathname$, updatePathname$, navigateInReact$ } from "../route.ts";
 import type { ZeroNavId } from "../../views/zero-page/zero-sidebar.tsx";
 
 function isValidTab(tab: string): tab is ZeroNavId {
@@ -75,9 +75,22 @@ export const zeroChatAgentId$ = computed((get): string | null => {
  * Navigate to a zero tab — updates the URL path to `/:tab`.
  * "chat" maps to `/` (the default, no suffix needed).
  */
-export const setZeroActiveId$ = command(({ set }, id: ZeroNavId) => {
-  const newPath = id === "chat" ? "/" : `/${id}`;
-  set(updatePathname$, newPath);
+export const setZeroActiveId$ = command(({ get, set }, id: ZeroNavId) => {
+  const currentPath = get(pathname$);
+  const currentSegments = currentPath.split("/").filter(Boolean);
+  // When the current path has a sub-segment (e.g. /team/:name), use full
+  // navigation so the route handler re-runs. For flat paths (e.g. /team →
+  // /schedule) a lightweight pathname update suffices.
+  if (currentSegments.length >= 2) {
+    if (id === "chat") {
+      set(navigateInReact$, "/");
+    } else {
+      set(navigateInReact$, "/:tab", { pathParams: { tab: id } });
+    }
+  } else {
+    const newPath = id === "chat" ? "/" : `/${id}`;
+    set(updatePathname$, newPath);
+  }
 });
 
 /**

--- a/turbo/apps/platform/src/signals/zero-page/zero-page.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-page.ts
@@ -9,6 +9,10 @@ import { initZeroActivity$ } from "./zero-activity.ts";
 import { initSlackOrg$ } from "./zero-slack.ts";
 import { zeroChatAgentName$, zeroInChat$ } from "./zero-nav.ts";
 import { switchActiveAgent$ } from "./zero-chat.ts";
+import {
+  pinnedAgentIds$,
+  updatePinnedAgentIds$,
+} from "./zero-pinned-agents.ts";
 import { logger } from "../log.ts";
 import { pathname$ } from "../route.ts";
 import { Reason, detach } from "../utils.ts";
@@ -69,6 +73,14 @@ async function resolveAndSwitchAgent(
       const agent = subagents.find((a) => a.name === agentName);
       if (agent) {
         set(switchActiveAgent$, { id: agent.id, name: agent.name });
+        // Auto-pin agent if not already pinned
+        const pinned = await get(pinnedAgentIds$);
+        if (!pinned.includes(agent.id)) {
+          detach(
+            set(updatePinnedAgentIds$, [...pinned, agent.id]),
+            Reason.DomCallback,
+          );
+        }
       } else {
         // Unknown agent → redirect to default
         set(switchActiveAgent$, null);

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -510,6 +510,12 @@ function RecentChatSection({
         <div
           className="shrink-0 flex items-center gap-2 h-7 rounded-lg px-2.5 bg-sidebar-accent/60"
           style={{ border: "0.7px solid hsl(var(--gray-400))" }}
+          onBlur={(e) => {
+            if (!e.currentTarget.contains(e.relatedTarget)) {
+              setSearchOpen(false);
+              setSearchTerm("");
+            }
+          }}
         >
           <IconSearch
             size={14}

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -27,6 +27,7 @@ import {
   IconLayoutSidebarLeftCollapse,
   IconDatabaseExport,
   IconCrown,
+  IconPin,
 } from "@tabler/icons-react";
 import {
   DndContext,
@@ -62,7 +63,6 @@ import {
   DialogContent,
   DialogHeader,
   DialogTitle,
-  cn,
   Button,
 } from "@vm0/ui";
 import slackIcon from "./components/settings/icons/slack.svg";
@@ -84,9 +84,6 @@ import { agentAvatarOverrides$ } from "../../signals/zero-page/zero-agent-avatar
 import { Link, SimpleLink } from "../router/link.tsx";
 import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
 import { apiBaseForNavigation$ } from "../../signals/fetch.ts";
-
-/** Max pinned sub-agents (default agent counts as 1, total slots = 5). */
-const MAX_PINNED = 4;
 
 export const AGENT_AVATARS = [
   avatar1Img,
@@ -511,7 +508,7 @@ function RecentChatSection({
     <div className="mt-4 flex flex-col min-h-0 flex-1">
       {searchOpen ? (
         <div
-          className="shrink-0 flex items-center gap-2 h-8 rounded-lg px-2.5 bg-sidebar-accent/60"
+          className="shrink-0 flex items-center gap-2 h-7 rounded-lg px-2.5 bg-sidebar-accent/60"
           style={{ border: "0.7px solid hsl(var(--gray-400))" }}
         >
           <IconSearch
@@ -551,7 +548,7 @@ function RecentChatSection({
               className="flex h-7 w-7 items-center justify-center rounded-lg text-sidebar-foreground/70 hover:text-sidebar-foreground hover:bg-sidebar-accent transition-colors"
               aria-label="Search chats"
             >
-              <IconSearch size={16} />
+              <IconSearch size={14} />
             </button>
           </div>
         </div>
@@ -718,7 +715,7 @@ function ManagePinnedAgentsDialog({
   const togglePin = (agentId: string) => {
     if (draftIds.includes(agentId)) {
       setDraftIds(draftIds.filter((id) => id !== agentId));
-    } else if (draftIds.length < MAX_PINNED) {
+    } else {
       setDraftIds([...draftIds, agentId]);
     }
   };
@@ -744,7 +741,7 @@ function ManagePinnedAgentsDialog({
             )}
           </div>
           <p className="text-sm text-muted-foreground mt-1">
-            Reorder or add agents to your sidebar (max {MAX_PINNED}).
+            Reorder or add agents to your sidebar.
           </p>
         </DialogHeader>
 
@@ -818,14 +815,8 @@ function ManagePinnedAgentsDialog({
                   </span>
                   <button
                     type="button"
-                    className={cn(
-                      "transition-colors px-2 py-0.5 rounded-md text-xs font-medium",
-                      draftIds.length >= MAX_PINNED
-                        ? "text-muted-foreground/30 cursor-not-allowed"
-                        : "text-primary hover:text-primary/80 hover:bg-primary/10",
-                    )}
+                    className="transition-colors px-2 py-0.5 rounded-md text-xs font-medium text-primary hover:text-primary/80 hover:bg-primary/10"
                     onClick={() => togglePin(agent.id)}
-                    disabled={draftIds.length >= MAX_PINNED}
                   >
                     Pin
                   </button>
@@ -885,11 +876,19 @@ function TalkToSection({
   return (
     <div className="shrink-0 mt-4">
       <div className="h-7 flex items-center pl-2">
-        <span className="text-[13px] leading-4 text-sidebar-foreground/50 font-medium truncate">
+        <span className="text-[13px] leading-4 text-sidebar-foreground/50 font-medium truncate flex-1">
           Talk to {talkToLabel}
         </span>
+        <button
+          type="button"
+          className="flex h-7 w-7 items-center justify-center rounded-lg text-sidebar-foreground/70 hover:text-sidebar-foreground hover:bg-sidebar-accent transition-colors"
+          aria-label="Manage pinned agents"
+          onClick={onManagePinned}
+        >
+          <IconPin size={14} />
+        </button>
       </div>
-      <div className="flex flex-col gap-0.5">
+      <div className="flex flex-col gap-0.5 max-h-[170px] overflow-y-auto">
         <Link
           pathname={defaultAgentRawName ? "/talk/:name" : "/"}
           options={
@@ -897,7 +896,7 @@ function TalkToSection({
               ? { pathParams: { name: defaultAgentRawName } }
               : undefined
           }
-          className={`flex w-full h-8 items-center gap-2 rounded-lg px-2 text-left text-sm leading-5 no-underline transition-colors duration-200 ${
+          className={`flex w-full h-8 shrink-0 items-center gap-2 rounded-lg px-2 text-left text-sm leading-5 no-underline transition-colors duration-200 ${
             activeId === "chat" &&
             !selectedRecentId &&
             currentChatAgentId === null
@@ -917,7 +916,7 @@ function TalkToSection({
             key={agent.id}
             pathname="/talk/:name"
             options={{ pathParams: { name: agent.name } }}
-            className={`flex w-full h-8 items-center gap-2 rounded-lg px-2 text-left text-sm leading-5 no-underline transition-colors duration-200 ${
+            className={`flex w-full h-8 shrink-0 items-center gap-2 rounded-lg px-2 text-left text-sm leading-5 no-underline transition-colors duration-200 ${
               activeId === "chat" &&
               !selectedRecentId &&
               currentChatAgentId === agent.id
@@ -933,17 +932,6 @@ function TalkToSection({
             <span className="truncate">{agent.displayName ?? agent.name}</span>
           </Link>
         ))}
-        <button
-          type="button"
-          className="flex w-full h-8 items-center gap-2 rounded-lg px-2 text-left text-sm leading-5 text-sidebar-foreground/50 hover:text-sidebar-foreground hover:bg-sidebar-accent transition-colors duration-200"
-          aria-label="Manage pinned agents"
-          onClick={onManagePinned}
-        >
-          <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-md bg-sidebar-accent">
-            <IconPlus size={12} />
-          </span>
-          <span className="truncate">Pin agent</span>
-        </button>
       </div>
     </div>
   );

--- a/turbo/apps/web/app/api/user/preferences/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/user/preferences/__tests__/route.test.ts
@@ -589,7 +589,7 @@ describe("PUT /api/user/preferences", () => {
     expect(data.pinnedAgentIds).toEqual(["agent-a", "agent-b", "agent-c"]);
   });
 
-  it("should enforce max 4 pinned agents", async () => {
+  it("should accept more than 4 pinned agents", async () => {
     const user = await context.setupUser();
     mockClerk({ userId: user.userId, orgId: user.orgId });
 
@@ -605,7 +605,9 @@ describe("PUT /api/user/preferences", () => {
     );
     const response = await PUT(request);
 
-    expect(response.status).toBe(400);
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.pinnedAgentIds).toEqual(["a1", "a2", "a3", "a4", "a5"]);
   });
 
   it("should update pinnedAgentIds without affecting other preferences", async () => {

--- a/turbo/packages/core/src/contracts/user-preferences.ts
+++ b/turbo/packages/core/src/contracts/user-preferences.ts
@@ -30,7 +30,7 @@ export const updateUserPreferencesRequestSchema = z
     timezone: z.string().min(1).optional(),
     notifyEmail: z.boolean().optional(),
     notifySlack: z.boolean().optional(),
-    pinnedAgentIds: z.array(z.string()).max(4).optional(),
+    pinnedAgentIds: z.array(z.string()).optional(),
     sendMode: sendModeSchema.optional(),
   })
   .refine(


### PR DESCRIPTION
## Summary
- Auto-pin sub-agents to sidebar when navigating to `/talk/:name` if not already pinned
- Remove the max 4 pinned agents limit (frontend UI + backend zod schema)
- Add scrollable "Talk to" section with max height for 5 visible items
- Move pin button to "Talk to" header row as an icon
- Fix navigation from `/team/:name` back to `/team` list (was using lightweight `updatePathname$` which skipped route re-evaluation; now uses `navigateInReact$` for full route matching)
- Align sidebar icon sizes (pin + search both 14px), fix search bar height jitter
- Close search bar on blur outside

## Test plan
- [ ] Navigate to `/talk/:subagent` — verify agent auto-pins in sidebar
- [ ] Pin more than 4 agents — verify no limit enforced
- [ ] Verify "Talk to" section scrolls when agents exceed 5
- [ ] Click "Zero's team" breadcrumb from `/team/:id` — verify returns to team list
- [ ] Click search icon, then click outside — verify search closes
- [ ] Verify pin and search icons are same size

🤖 Generated with [Claude Code](https://claude.com/claude-code)