### PR TITLE
fix: register vm in proxy before sandbox start to prevent missing network logs

### DIFF
--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -107,16 +107,10 @@ async fn execute_inner(
         }
     };
 
-    if let Err(e) = sandbox.start().await {
-        telemetry.record("vm_create", t.elapsed(), false, Some(&e.to_string()));
-        factory.destroy(sandbox).await;
-        return Err(e.into());
-    }
-    telemetry.record("vm_create", t.elapsed(), true, None);
-
-    // Register VM in proxy registry for network logging and firewall enforcement.
-    // All VMs are registered so mitmproxy can log network activity regardless of
-    // whether firewall rules are configured.
+    // Register VM in proxy registry BEFORE starting the sandbox so that
+    // mitmproxy can intercept traffic from the very first request.
+    // source_ip is available after create() — it's assigned during network
+    // namespace allocation, before the VM boots.
     let source_ip = sandbox.source_ip().to_string();
     let network_log_path = config.log_paths.network_log(context.run_id);
 
@@ -132,6 +126,17 @@ async fn execute_inner(
     if let Err(e) = config.registry.register_vm(&source_ip, &registration).await {
         warn!(run_id = %context.run_id, error = %e, "failed to register VM in proxy");
     }
+
+    if let Err(e) = sandbox.start().await {
+        telemetry.record("vm_create", t.elapsed(), false, Some(&e.to_string()));
+        // Unregister on start failure
+        if let Err(e) = config.registry.unregister_vm(&source_ip).await {
+            warn!(run_id = %context.run_id, error = %e, "failed to unregister VM from proxy");
+        }
+        factory.destroy(sandbox).await;
+        return Err(e.into());
+    }
+    telemetry.record("vm_create", t.elapsed(), true, None);
 
     // Run job inside sandbox, then destroy regardless of outcome
     let result = run_in_sandbox(


### PR DESCRIPTION
## Summary

- Move `register_vm()` before `sandbox.start()` to eliminate a race condition where mitmproxy permanently ignores connections from unregistered VMs
- The source IP is available after `factory.create()` (network namespace allocation), so registration can safely precede boot
- Add `unregister_vm()` cleanup in the `start()` failure path

## Problem

The previous ordering was: `start()` → `register_vm()`. If the VM issued an HTTPS request before registration, mitmproxy's `tls_clienthello` handler would set `ignore_connection = True` for the unknown IP — **permanently** bypassing interception for that connection, even after the VM registered later.

## Verification

Deployed on `local-1.aws.vm3.ai` with `pnpm runner:local`. Service logs confirm registration now precedes VM start:

```
13:579  creating sandbox          ← create()
13:581  registered VM in proxy    ← register_vm() ✅ before start
13:621  API server started        ← firecracker launching
13:659  sandbox started           ← start() complete
```

Network log for `curl -sI https://example.com` captured successfully.

## Test plan

- [x] Deployed and verified on metal host — registration precedes VM boot
- [x] Network log captures all traffic from first request
- [ ] CI passes

Closes #5535

🤖 Generated with [Claude Code](https://claude.com/claude-code)