### PR TITLE
ci: shard test-web into 4 parallel matrix jobs

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -266,6 +266,9 @@ jobs:
     runs-on: ubuntu-latest
     # Skip for release-please commits (only version bumps and changelogs)
     if: "${{ github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore: release') }}"
+    strategy:
+      matrix:
+        shard: [1, 2, 3, 4]
     container:
       image: ghcr.io/vm0-ai/vm0-toolchain:20260310
     services:
@@ -290,7 +293,7 @@ jobs:
         working-directory: turbo
         env:
           DATABASE_URL: postgresql://postgres@postgres:5432/postgres
-        run: pnpm vitest run --project=web --coverage.enabled --coverage.reporter=json
+        run: pnpm vitest run --project=web --shard=${{ matrix.shard }}/4 --coverage.enabled --coverage.reporter=json
       - name: Upload coverage to Codecov
         if: success() || failure()
         uses: codecov/codecov-action@v5


### PR DESCRIPTION
## Summary
- Split `test-web` CI job into 4 parallel shards using vitest's native `--shard` flag and GitHub Actions matrix strategy
- Reduces wall-clock time for 176 web integration tests by running ~44 tests per shard concurrently
- No changes needed to ci-gate — GitHub Actions matrix is transparent to `needs` references

## Test plan
- [ ] All 4 test-web shards pass in CI
- [ ] Coverage still uploads correctly to Codecov
- [ ] ci-gate passes without modification

🤖 Generated with [Claude Code](https://claude.com/claude-code)