### PR TITLE
fix(docker): use system chromium for arm64 compatibility in toolchain

### DIFF
--- a/docker/toolchain/Dockerfile
+++ b/docker/toolchain/Dockerfile
@@ -125,8 +125,10 @@ RUN curl -fsSL https://downloads.1password.com/linux/keys/1password.asc | gpg --
     && rm -rf /var/lib/apt/lists/*
 
 # Install agent-browser for browser automation
-RUN npm install -g agent-browser \
-    && agent-browser install --with-deps
+# Use system chromium instead of Chrome for Testing (no ARM64 builds)
+RUN apt-get update && apt-get install -y chromium-browser \
+    && rm -rf /var/lib/apt/lists/* \
+    && npm install -g agent-browser
 
 # Install AWS CLI v2
 RUN apt-get update && apt-get install -y unzip \


### PR DESCRIPTION
## Summary
- Replace Chrome for Testing with system `chromium-browser` package in the toolchain Dockerfile
- Chrome for Testing does not provide ARM64 builds, causing `agent-browser install --with-deps` to fail on ARM64 hosts
- System chromium is installed via apt and agent-browser is installed separately without `--with-deps`

## Test plan
- [ ] Build the toolchain Docker image on an ARM64 host
- [ ] Verify agent-browser works with system chromium
- [ ] Verify the image still builds on x86_64

🤖 Generated with [Claude Code](https://claude.com/claude-code)