### PR TITLE
feat(ci): add codecov test analytics with junit reporting

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -298,6 +298,13 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: web
           files: turbo/coverage/coverage-final.json
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: web
+          files: turbo/junit.xml
 
   test-migrate:
     needs: prepare
@@ -342,6 +349,13 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: cli
           files: turbo/coverage/coverage-final.json
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: cli
+          files: turbo/junit.xml
 
   test-app:
     runs-on: ubuntu-latest
@@ -360,6 +374,13 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: app
           files: turbo/coverage/coverage-final.json
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: app
+          files: turbo/junit.xml
 
   test-other:
     runs-on: ubuntu-latest
@@ -378,6 +399,13 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: core-ui
           files: turbo/coverage/coverage-final.json
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: core-ui
+          files: turbo/junit.xml
 
   # Deploy web application with database
   deploy-web:

--- a/.gitignore
+++ b/.gitignore
@@ -188,3 +188,4 @@ debug-*.png
 tmp/
 
 *.sarif
+junit.xml

--- a/turbo/vitest.config.ts
+++ b/turbo/vitest.config.ts
@@ -25,7 +25,12 @@ export default defineConfig({
       ],
     },
 
-    reporters: process.env.CI ? ["default", "github-actions"] : ["default"],
+    reporters: process.env.CI
+      ? ["default", "github-actions", "junit"]
+      : ["default"],
+    outputFile: {
+      junit: "junit.xml",
+    },
 
     projects: ["packages/*", "apps/*"],
   },


### PR DESCRIPTION
## Summary

- Add `junit` reporter to vitest CI configuration with `outputFile` for `junit.xml`
- Add `codecov/test-results-action@v1` upload step to all 4 test jobs (web, cli, app, core-ui) with matching flags
- Add `junit.xml` to `.gitignore` to prevent committing generated files

Closes #5527

## Test plan

- [ ] Verify CI pipeline passes (no functional changes to tests themselves)
- [ ] After merge, confirm test results appear in Codecov Test Analytics dashboard
- [ ] Verify `junit.xml` is generated during CI test runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)