### PR TITLE
fix(platform): adjust activity detail page spacing for mobile layout

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/components/logs/grouped-message-card.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/logs/grouped-message-card.tsx
@@ -166,13 +166,13 @@ function ResultMessageCard({
               {timestamp}
             </span>
           </div>
-          <div className="text-xs text-muted-foreground pl-[14px] mt-1 sm:hidden">
+          <div className="text-xs text-muted-foreground pl-5 mt-1 sm:hidden">
             {timestamp}
           </div>
         </summary>
         {/* Vertical line from dot to content */}
         <div className="absolute left-[2px] top-[2.25rem] bottom-0 w-[1px] bg-border/70 group-open:block hidden" />
-        <div className="ml-[16px] mt-2 relative pl-[14px]">
+        <div className="ml-[18px] mt-2 relative">
           <ResultEventContent eventData={eventData} />
         </div>
       </details>

--- a/turbo/apps/platform/src/views/zero-page/zero-activity-detail-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-activity-detail-page.tsx
@@ -143,7 +143,7 @@ export function ZeroActivityDetailPage() {
             {agentName}
           </span>
         </nav>
-        <div className="mx-auto w-full max-w-[900px] pt-4 pb-8">
+        <div className="mx-auto w-full max-w-[900px] px-4 sm:px-6 pt-4 pb-8">
           {/* Compact header card */}
           <div className="zero-card shrink-0 px-4 py-3">
             <div className="flex flex-wrap items-center gap-y-2">
@@ -272,7 +272,7 @@ function ActivitySkeleton() {
           <span className="text-muted-foreground/40 select-none">/</span>
           <div className="h-4 w-20 rounded bg-muted/50 animate-pulse" />
         </nav>
-        <div className="mx-auto max-w-[900px] pt-4 pb-8 w-full">
+        <div className="mx-auto max-w-[900px] px-4 sm:px-6 pt-4 pb-8 w-full">
           {/* Header card skeleton */}
           <div className="zero-card shrink-0 px-4 py-3">
             <div className="flex flex-wrap items-center gap-y-2 gap-x-3">


### PR DESCRIPTION
## Summary
- Add responsive horizontal padding (`px-4 sm:px-6`) to the activity detail page content container and its skeleton for better mobile layout
- Fix alignment of result message card content by adjusting margin/padding values in grouped-message-card

## Test plan
- [ ] Verify activity detail page looks correct on mobile viewport widths
- [ ] Verify activity detail page looks correct on desktop
- [ ] Verify result message card content aligns properly with the timeline dot/line

🤖 Generated with [Claude Code](https://claude.com/claude-code)