### PR TITLE
fix(runner): include runner log files in gc cleanup

### DIFF
--- a/crates/runner/src/cmd/gc.rs
+++ b/crates/runner/src/cmd/gc.rs
@@ -267,10 +267,10 @@ async fn gc_orphaned_locks(home: &HomePaths, dry_run: bool) -> RunnerResult<u64>
     Ok(removed)
 }
 
-/// Delete stale per-job log files (older than [`JOB_LOG_MAX_AGE`]).
+/// Delete stale log files (older than [`JOB_LOG_MAX_AGE`]).
 ///
-/// Per-job log files (`network-*.jsonl`, `system-*.log`, `metrics-*.jsonl`)
-/// accumulate across runs. Returns `(files_removed, bytes_freed)`.
+/// Covers per-job logs (`network-*.jsonl`, `system-*.log`, `metrics-*.jsonl`)
+/// and runner instance logs (`runner-*.log`). Returns `(files_removed, bytes_freed)`.
 async fn gc_job_logs(home: &HomePaths, dry_run: bool) -> RunnerResult<(u64, u64)> {
     let logs_dir = home.logs_dir();
     let mut entries = match tokio::fs::read_dir(&logs_dir).await {
@@ -292,8 +292,7 @@ async fn gc_job_logs(home: &HomePaths, dry_run: bool) -> RunnerResult<(u64, u64)
         let name = entry.file_name();
         let Some(name) = name.to_str() else { continue };
 
-        // Only target per-job log files, not runner logs.
-        if !LogPaths::is_job_log(name) {
+        if !LogPaths::is_gc_eligible_log(name) {
             continue;
         }
 
@@ -782,7 +781,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn gc_job_logs_ignores_runner_logs() {
+    async fn gc_job_logs_deletes_stale_runner_logs() {
         use std::fs::FileTimes;
         use std::time::Duration;
 
@@ -791,7 +790,7 @@ mod tests {
         let logs_dir = home.logs_dir();
         std::fs::create_dir_all(&logs_dir).unwrap();
 
-        // Old runner log file — must NOT be deleted.
+        // Old runner log file — should be deleted.
         let runner_log = logs_dir.join("runner-default.2026-02-10.log");
         std::fs::write(&runner_log, "log content").unwrap();
         let old_time = SystemTime::now() - Duration::from_secs(30 * 24 * 3600);
@@ -799,6 +798,22 @@ mod tests {
             .unwrap()
             .set_times(FileTimes::new().set_modified(old_time))
             .unwrap();
+
+        let (removed, _) = gc_job_logs(&home, false).await.unwrap();
+        assert_eq!(removed, 1);
+        assert!(!runner_log.exists());
+    }
+
+    #[tokio::test]
+    async fn gc_job_logs_keeps_recent_runner_logs() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = test_home(dir.path());
+        let logs_dir = home.logs_dir();
+        std::fs::create_dir_all(&logs_dir).unwrap();
+
+        // Recent runner log — should be kept.
+        let runner_log = logs_dir.join("runner-default.2026-03-19.log");
+        std::fs::write(&runner_log, "log content").unwrap();
 
         let (removed, _) = gc_job_logs(&home, false).await.unwrap();
         assert_eq!(removed, 0);

--- a/crates/runner/src/paths.rs
+++ b/crates/runner/src/paths.rs
@@ -190,10 +190,14 @@ impl LogPaths {
         self.dir.join(format!("metrics-{run_id}.jsonl"))
     }
 
-    /// Whether `name` matches any per-job log file pattern.
-    pub fn is_job_log(name: &str) -> bool {
+    /// Whether `name` matches any GC-eligible log file pattern.
+    ///
+    /// Includes per-job logs (`network-*`, `system-*`, `metrics-*`) and
+    /// runner instance logs (`runner-*.log`).
+    pub fn is_gc_eligible_log(name: &str) -> bool {
         (name.starts_with("network-") && name.ends_with(".jsonl"))
             || (name.starts_with("system-") && name.ends_with(".log"))
             || (name.starts_with("metrics-") && name.ends_with(".jsonl"))
+            || (name.starts_with("runner-") && name.ends_with(".log"))
     }
 }


### PR DESCRIPTION
## Summary

- Runner instance logs (`runner-*.log`) were not matched by GC's `is_job_log()`, causing unbounded accumulation on metal hosts (~50k files, ~1GB on dev-1)
- Rename `is_job_log` → `is_gc_eligible_log` and add `runner-*.log` pattern
- Same 7-day retention as other log files

Closes #5555

## Test plan

- [x] Existing GC tests updated and passing (26/26)
- [x] Clippy clean
- [ ] Verify on metal host: `runner gc --dry-run` shows runner logs as eligible

🤖 Generated with [Claude Code](https://claude.com/claude-code)