### PR TITLE
refactor: remove metadata field from compose pipeline

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-skills.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-skills.test.ts
@@ -26,7 +26,6 @@ function mockComposeApi(content: {
     {
       framework: string;
       skills?: string[];
-      metadata?: { displayName?: string; sound?: string };
     }
   >;
 }) {

--- a/turbo/apps/platform/src/signals/zero-page/agent-types.ts
+++ b/turbo/apps/platform/src/signals/zero-page/agent-types.ts
@@ -19,7 +19,6 @@ interface AgentDefinition {
   instructions?: string;
   skills?: string[];
   environment?: Record<string, string>;
-  metadata?: { displayName?: string; sound?: string; description?: string };
   experimental_runner?: { group: string };
   experimental_capabilities?: string[];
 }

--- a/turbo/apps/web/src/lib/compose/server-side-compose.ts
+++ b/turbo/apps/web/src/lib/compose/server-side-compose.ts
@@ -4,7 +4,6 @@ import {
   AGENT_NAME_REGEX,
   isSupportedFramework,
   expandFirewallConfigs,
-  agentDefinitionSchema,
   type SkillFrontmatter,
   type SupportedFramework,
 } from "@vm0/core";
@@ -15,7 +14,6 @@ import {
   agentComposes,
   agentComposeVersions,
 } from "../../db/schema/agent-compose";
-import { zeroAgents } from "../../db/schema/zero-agent";
 import { skills } from "../../db/schema/skill";
 import { logger } from "../logger";
 
@@ -223,7 +221,6 @@ export async function serverSideCompose(params: {
     Record<string, unknown>
   >;
   const agentDef = { ...agentsCopy[agentName]! };
-  delete agentDef.metadata;
   const resolvedContent = {
     ...contentCopy,
     version: contentCopy.version as string,
@@ -254,32 +251,6 @@ export async function serverSideCompose(params: {
     resolvedContent,
     versionId,
   });
-
-  // 8. Upsert agent metadata into zero_agents
-  const metadataResult = agentDefinitionSchema.shape.metadata.safeParse(
-    agent.metadata,
-  );
-  const metadata = metadataResult.success ? metadataResult.data : undefined;
-  if (metadata) {
-    await db
-      .insert(zeroAgents)
-      .values({
-        orgId,
-        name: normalizedName,
-        displayName: metadata.displayName ?? null,
-        description: metadata.description ?? null,
-        sound: metadata.sound ?? null,
-      })
-      .onConflictDoUpdate({
-        target: [zeroAgents.orgId, zeroAgents.name],
-        set: {
-          displayName: metadata.displayName ?? null,
-          description: metadata.description ?? null,
-          sound: metadata.sound ?? null,
-          updatedAt: new Date(),
-        },
-      });
-  }
 
   log.info(
     `Server-side compose completed: ${normalizedName} (${versionId.slice(0, 8)})`,

--- a/turbo/apps/web/src/types/agent-compose.ts
+++ b/turbo/apps/web/src/types/agent-compose.ts
@@ -59,14 +59,6 @@ interface AgentDefinition {
    * Validated at compose time against VALID_CAPABILITIES.
    */
   experimental_capabilities?: (typeof VALID_CAPABILITIES)[number][];
-  /**
-   * Agent metadata for display and personalization.
-   */
-  metadata?: {
-    displayName?: string;
-    description?: string;
-    sound?: string;
-  };
 }
 
 export interface AgentComposeYaml {

--- a/turbo/packages/core/src/contracts/composes.ts
+++ b/turbo/packages/core/src/contracts/composes.ts
@@ -174,18 +174,6 @@ const agentDefinitionSchema = z.object({
       message: "Duplicate capabilities are not allowed",
     })
     .optional(),
-  /**
-   * Agent metadata for display and personalization.
-   * - displayName: Human-readable name shown in the UI (preserves original casing).
-   * - sound: Communication tone (e.g., "professional", "friendly").
-   */
-  metadata: z
-    .object({
-      displayName: z.string().optional(),
-      description: z.string().optional(),
-      sound: z.string().optional(),
-    })
-    .optional(),
 });
 
 /**


### PR DESCRIPTION
## Summary

Closes #5549

- Remove `metadata` field from `agentDefinitionSchema` (core Zod schema) and `AgentDefinition` interface (web + platform types)
- Remove metadata stripping (`delete agentDef.metadata`) and `zero_agents` upsert from server-side compose — the metadata PATCH API is now the sole write path
- Update platform onboarding to save metadata (displayName, sound) via `PATCH /api/agent/composes/:id/metadata` after compose creation instead of embedding it in compose content
- Update platform tests to mock the metadata PATCH endpoint

## Test plan

- [x] Core compose schema tests pass (13 tests)
- [x] All compose API tests pass (87 tests)
- [x] Onboarding status tests pass (12 tests)
- [x] Lint, type-check, format, and knip all pass
- [ ] Platform onboarding tests blocked by pre-existing `@tiptap/react` dependency issue (unrelated to this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)