### PR TITLE
fix: always include seed skills and add chat avatar navigation

### DIFF
--- a/.claude/skills/dev-logs/SKILL.md
+++ b/.claude/skills/dev-logs/SKILL.md
@@ -22,17 +22,24 @@ Your args are: `$ARGUMENTS`
 
 ### Step 1: Find the Dev Server Task
 
-Use **TaskList** to find the dev server background task. Look for a task whose command contains `pnpm dev` — this is the task created by `/dev-start`.
+First, try to read the persisted task ID from the local file:
 
-This approach survives conversation compaction, since TaskList always reflects the current task state regardless of whether the original task_id was preserved in the summary.
+```bash
+PROJECT_ROOT=$(git rev-parse --show-toplevel)
+cat "$PROJECT_ROOT/turbo/.dev-task-id" 2>/dev/null
+```
 
-If no matching task is found, inform the user:
-- "No dev server background task found in this session. Please run `/dev-start` to start the server."
+If the file exists and contains a task ID, use that ID directly.
+
+If the file does not exist, fall back to **TaskList** to find the dev server background task. Look for a task whose command contains `pnpm dev` — this is the task created by `/dev-start`.
+
+If neither method finds a task, inform the user:
+- "No dev server task found. Please run `/dev-start` to start the server."
 
 ### Step 2: Read Task Output
 
-Use **TaskOutput** with the task_id from Step 1 to read the dev server logs.
+Use **TaskOutput** with the task_id from Step 1 to read the dev server logs. Use `block: false` to avoid waiting.
 
-### Step 2: Display Output
+### Step 3: Display Output
 
 Show the output in readable format. If a filter pattern was provided, grep the output for matching lines.

--- a/.claude/skills/dev-server/SKILL.md
+++ b/.claude/skills/dev-server/SKILL.md
@@ -61,6 +61,13 @@ cd "$PROJECT_ROOT/turbo" && pnpm dev
 
 This will return a task_id for monitoring.
 
+**Save the task_id** to a local file so `/dev-logs` can find it across conversation sessions:
+
+```bash
+PROJECT_ROOT=$(git rev-parse --show-toplevel)
+echo "<task_id>" > "$PROJECT_ROOT/turbo/.dev-task-id"
+```
+
 ### Step 3: Display Results
 
 Once the server is confirmed running, display the URLs:

--- a/turbo/.gitignore
+++ b/turbo/.gitignore
@@ -48,5 +48,8 @@ yarn-error.log*
 *.pem
 .env*.local
 
+# Dev server task ID (written by /dev-start, read by /dev-logs)
+.dev-task-id
+
 # SBOM
 sbom.json

--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-job-detail.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-job-detail.test.ts
@@ -34,6 +34,7 @@ import {
   type ZeroJobScheduleSaveParams,
 } from "../zero-job-detail";
 import { injectDefaultCapabilities } from "../compose-job";
+import { SEED_SKILLS } from "../../../data/the-seed.ts";
 
 const context = testContext();
 
@@ -854,9 +855,8 @@ describe("zero-job-detail signals", () => {
       await setupWithAgent();
 
       const skills = context.store.get(zeroJobAddedSkills$);
-      // mockAgentResponse has skills: ["search"], skillUrlToValue returns the value as-is
-      // since "search" doesn't start with the GitHub URL prefix
-      expect(skills).toStrictEqual(["search"]);
+      // Seed skills are always included, plus compose-specific "search"
+      expect(skills).toStrictEqual([...SEED_SKILLS, "search"]);
       expect(context.store.get(zeroJobSkillsDirty$)).toBeFalsy();
     });
 
@@ -866,6 +866,7 @@ describe("zero-job-detail signals", () => {
       context.store.set(addZeroJobSkill$, "gmail");
 
       expect(context.store.get(zeroJobAddedSkills$)).toStrictEqual([
+        ...SEED_SKILLS,
         "search",
         "gmail",
       ]);
@@ -873,7 +874,10 @@ describe("zero-job-detail signals", () => {
 
       context.store.set(removeZeroJobSkill$, "search");
 
-      expect(context.store.get(zeroJobAddedSkills$)).toStrictEqual(["gmail"]);
+      expect(context.store.get(zeroJobAddedSkills$)).toStrictEqual([
+        ...SEED_SKILLS,
+        "gmail",
+      ]);
       expect(context.store.get(zeroJobSkillsDirty$)).toBeTruthy();
     });
 
@@ -885,7 +889,10 @@ describe("zero-job-detail signals", () => {
 
       context.store.set(discardZeroJobSkills$);
 
-      expect(context.store.get(zeroJobAddedSkills$)).toStrictEqual(["search"]);
+      expect(context.store.get(zeroJobAddedSkills$)).toStrictEqual([
+        ...SEED_SKILLS,
+        "search",
+      ]);
       expect(context.store.get(zeroJobSkillsDirty$)).toBeFalsy();
     });
 
@@ -933,10 +940,11 @@ describe("zero-job-detail signals", () => {
       >;
       const mainAgent = agents["main"];
       const skills = mainAgent["skills"] as string[];
-      expect(skills).toHaveLength(2);
+      // All seed skills + "search" (from compose) + "gmail" (added)
+      expect(skills).toHaveLength(SEED_SKILLS.length + 2);
       // Skills should be converted to URLs via skillValueToUrl
-      expect(skills[0]).toContain("search");
-      expect(skills[1]).toContain("gmail");
+      expect(skills).toContainEqual(expect.stringContaining("search"));
+      expect(skills).toContainEqual(expect.stringContaining("gmail"));
 
       // After save, dirty state should be reset
       expect(context.store.get(zeroJobSkillsDirty$)).toBeFalsy();

--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-job-detail.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-job-detail.test.ts
@@ -855,7 +855,7 @@ describe("zero-job-detail signals", () => {
       await setupWithAgent();
 
       const skills = context.store.get(zeroJobAddedSkills$);
-      // Seed skills are always included, plus compose-specific "search"
+      // SEED_SKILLS are always included, plus agent-specific skills
       expect(skills).toStrictEqual([...SEED_SKILLS, "search"]);
       expect(context.store.get(zeroJobSkillsDirty$)).toBeFalsy();
     });
@@ -940,7 +940,7 @@ describe("zero-job-detail signals", () => {
       >;
       const mainAgent = agents["main"];
       const skills = mainAgent["skills"] as string[];
-      // All seed skills + "search" (from compose) + "gmail" (added)
+      // All SEED_SKILLS plus agent-specific skills are saved, converted to URLs
       expect(skills).toHaveLength(SEED_SKILLS.length + 2);
       // Skills should be converted to URLs via skillValueToUrl
       expect(skills).toContainEqual(expect.stringContaining("search"));

--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-skills.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-skills.test.ts
@@ -9,6 +9,7 @@ import {
   saveZeroSkills$,
 } from "../zero-skills.ts";
 import { setZeroChatAgent$ } from "../zero-nav.ts";
+import { SEED_SKILLS } from "../../../data/the-seed.ts";
 
 const context = testContext();
 
@@ -59,10 +60,11 @@ describe("zeroAddedSkills$", () => {
     await setupPage({ context, path: "/", withoutRender: true });
 
     const skills = await context.store.get(zeroAddedSkills$);
-    expect(skills).toStrictEqual(["slack", "github"]);
+    // Seed skills are always included, plus compose-specific skills
+    expect(skills).toStrictEqual([...SEED_SKILLS, "slack", "github"]);
   });
 
-  it("should return empty array when compose has no skills", async () => {
+  it("should return seed skills when compose has no skills", async () => {
     mockComposeApi({
       agents: { zero: { framework: "claude-code" } },
     });
@@ -70,7 +72,7 @@ describe("zeroAddedSkills$", () => {
     await setupPage({ context, path: "/", withoutRender: true });
 
     const skills = await context.store.get(zeroAddedSkills$);
-    expect(skills).toStrictEqual([]);
+    expect(skills).toStrictEqual([...SEED_SKILLS]);
   });
 
   it("should seed skills from sub-agent compose when chat agent is set", async () => {
@@ -119,7 +121,8 @@ describe("zeroAddedSkills$", () => {
     });
 
     const skills = await context.store.get(zeroAddedSkills$);
-    expect(skills).toStrictEqual(["github"]);
+    // Seed skills + compose-specific "github" (not in seed)
+    expect(skills).toStrictEqual([...SEED_SKILLS, "github"]);
   });
 });
 

--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-skills.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-skills.test.ts
@@ -60,7 +60,7 @@ describe("zeroAddedSkills$", () => {
     await setupPage({ context, path: "/", withoutRender: true });
 
     const skills = await context.store.get(zeroAddedSkills$);
-    // Seed skills are always included, plus compose-specific skills
+    // SEED_SKILLS are always included, plus compose-specific skills
     expect(skills).toStrictEqual([...SEED_SKILLS, "slack", "github"]);
   });
 
@@ -121,7 +121,7 @@ describe("zeroAddedSkills$", () => {
     });
 
     const skills = await context.store.get(zeroAddedSkills$);
-    // Seed skills + compose-specific "github" (not in seed)
+    // SEED_SKILLS are always included, plus sub-agent compose skills
     expect(skills).toStrictEqual([...SEED_SKILLS, "github"]);
   });
 });

--- a/turbo/apps/platform/src/signals/zero-page/zero-job-detail.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-job-detail.ts
@@ -7,6 +7,7 @@ import type { AgentDetail, AgentInstructions } from "./agent-types.ts";
 import { triggerAndPollComposeJob } from "./compose-job.ts";
 import { getInstructionsFilename } from "@vm0/core";
 import { skillValueToUrl, skillUrlToValue } from "../../data/skills.ts";
+import { SEED_SKILLS } from "../../data/the-seed.ts";
 import {
   buildCronExpression,
   buildAtTime,
@@ -313,15 +314,15 @@ const internalAddedSkills$ = state<string[] | null>(null);
 
 const seededSkills$ = computed((get) => {
   const detail = get(zeroJobDetail$);
-  if (!detail?.content) {
-    return [];
+  const fromContent: string[] = [];
+  if (detail?.content) {
+    const agentKey = Object.keys(detail.content.agents)[0];
+    if (agentKey) {
+      const agent = detail.content.agents[agentKey];
+      fromContent.push(...(agent?.skills ?? []).map(skillUrlToValue));
+    }
   }
-  const agentKey = Object.keys(detail.content.agents)[0];
-  if (!agentKey) {
-    return [];
-  }
-  const agent = detail.content.agents[agentKey];
-  return (agent?.skills ?? []).map(skillUrlToValue);
+  return [...new Set([...SEED_SKILLS, ...fromContent])];
 });
 
 export const zeroJobAddedSkills$ = computed((get) => {

--- a/turbo/apps/platform/src/signals/zero-page/zero-skills.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-skills.ts
@@ -11,6 +11,7 @@ import { throwIfAbort } from "../utils.ts";
 import { logger } from "../log.ts";
 import { getInstructionsFilename } from "@vm0/core";
 import { skillValueToUrl, skillUrlToValue } from "../../data/skills.ts";
+import { SEED_SKILLS } from "../../data/the-seed.ts";
 import { zeroChatAgentId$ } from "./zero-nav.ts";
 
 const L = logger("ZeroSkills");
@@ -93,18 +94,18 @@ const internalSaving$ = state(false);
 // null = not initialized (fallback to seeded), string[] = user's local draft
 const internalAddedSkills$ = state<string[] | null>(null);
 
-/** Skills seeded from compose content. */
+/** Skills seeded from compose content, always includes default seed skills. */
 const seededSkills$ = computed(async (get) => {
   const compose = await get(zeroCompose$);
-  if (!compose?.content) {
-    return [];
+  const fromContent: string[] = [];
+  if (compose?.content) {
+    const agentKey = Object.keys(compose.content.agents)[0];
+    if (agentKey) {
+      const agent = compose.content.agents[agentKey];
+      fromContent.push(...(agent?.skills ?? []).map(skillUrlToValue));
+    }
   }
-  const agentKey = Object.keys(compose.content.agents)[0];
-  if (!agentKey) {
-    return [];
-  }
-  const agent = compose.content.agents[agentKey];
-  return (agent?.skills ?? []).map(skillUrlToValue);
+  return [...new Set([...SEED_SKILLS, ...fromContent])];
 });
 
 /** Added skills: local draft takes precedence, otherwise seeded from compose. */

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-page.tsx
@@ -738,6 +738,8 @@ interface ZeroChatPageProps {
   zeroAvatarSrc?: string;
   /** Override agent name when chatting with a sub-agent. */
   chatAgentName?: string;
+  /** Navigate to agent team detail page when avatar is clicked. */
+  onAvatarClick?: () => void;
 }
 
 export function ZeroChatPage({
@@ -748,6 +750,7 @@ export function ZeroChatPage({
   onSendMessage,
   zeroAvatarSrc = zeroAvatarImg,
   chatAgentName,
+  onAvatarClick,
 }: ZeroChatPageProps) {
   const agentNameLoadable = useLoadable(agentDisplayName$);
   const defaultAgentName =
@@ -876,14 +879,18 @@ export function ZeroChatPage({
             >
               <IconArrowLeft size={20} stroke={1.5} />
             </Button>
-            <div className="h-8 w-8 shrink-0 overflow-hidden rounded-xl">
+            <button
+              type="button"
+              className="h-8 w-8 shrink-0 flex items-center justify-center overflow-hidden rounded-xl transition-colors duration-150 hover:bg-muted/50 cursor-pointer"
+              onClick={onAvatarClick}
+            >
               <img
                 src={zeroAvatarSrc}
                 alt=""
                 role="presentation"
                 className="h-8 w-8 rounded-full object-cover object-top"
               />
-            </div>
+            </button>
             <span className="font-semibold text-foreground">{agentName}</span>
           </div>
           <div className="flex items-center gap-0.5">
@@ -1046,14 +1053,18 @@ export function ZeroChatPage({
       <main className="flex flex-1 flex-col justify-center overflow-auto px-4 sm:px-6 py-12">
         <div className="mx-auto w-full max-w-[900px] flex flex-col items-stretch gap-8 -mt-24">
           <div className="flex items-center gap-4 w-full">
-            <div className="h-14 w-14 shrink-0 sm:h-16 sm:w-16 overflow-hidden rounded-xl">
+            <button
+              type="button"
+              className="h-14 w-14 shrink-0 sm:h-16 sm:w-16 flex items-center justify-center overflow-hidden rounded-xl transition-colors duration-150 hover:bg-muted/50 cursor-pointer"
+              onClick={onAvatarClick}
+            >
               <img
                 src={zeroAvatarSrc}
                 alt=""
                 role="presentation"
                 className="h-14 w-14 rounded-full object-cover object-top sm:h-16 sm:w-16"
               />
-            </div>
+            </button>
             <div className="flex-1 min-w-0 flex flex-col justify-center">
               <h2 className="text-2xl sm:text-3xl font-semibold tracking-tight text-foreground">
                 <TypewriterText text={tagline} />

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-page.tsx
@@ -881,6 +881,7 @@ export function ZeroChatPage({
             </Button>
             <button
               type="button"
+              aria-label="View agent profile"
               className="h-8 w-8 shrink-0 flex items-center justify-center overflow-hidden rounded-xl transition-colors duration-150 hover:bg-muted/50 cursor-pointer"
               onClick={onAvatarClick}
             >
@@ -1055,6 +1056,7 @@ export function ZeroChatPage({
           <div className="flex items-center gap-4 w-full">
             <button
               type="button"
+              aria-label="View agent profile"
               className="h-14 w-14 shrink-0 sm:h-16 sm:w-16 flex items-center justify-center overflow-hidden rounded-xl transition-colors duration-150 hover:bg-muted/50 cursor-pointer"
               onClick={onAvatarClick}
             >

--- a/turbo/apps/platform/src/views/zero-page/zero-content.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-content.tsx
@@ -86,6 +86,7 @@ export function ZeroContent({
         onNavigateToMeet={onNavigateToMeet}
         zeroAvatarSrc={chatAvatarSrc ?? zeroAvatarSrc}
         chatAgentName={chatAgentName}
+        onAvatarClick={onChatAvatarClick}
       />
     );
   }


### PR DESCRIPTION
## Summary
- **Seed skills fix**: Ensure `SEED_SKILLS` are always included in `seededSkills$` in both `zero-job-detail.ts` and `zero-skills.ts`, preventing default skills from being lost when adding connectors via the team detail page
- **Chat avatar navigation**: Add click-to-team-detail on chat page avatars (both landing and conversation header) with hover background effect
- **Dev tooling**: Persist dev server task ID to `.dev-task-id` file so `/dev-logs` works across conversation sessions

## Test plan
- [ ] Navigate to a team detail page, add a connector, save — verify default skills are preserved in the compose job
- [ ] On the chat page, click the agent avatar — verify it navigates to team detail
- [ ] Verify avatar hover shows background color transition

🤖 Generated with [Claude Code](https://claude.com/claude-code)