### PR TITLE
fix: intercept all outbound tcp in mitmproxy, not just port 80/443

### DIFF
--- a/crates/sandbox-fc/src/network/pool.rs
+++ b/crates/sandbox-fc/src/network/pool.rs
@@ -367,10 +367,11 @@ async fn setup_host_iptables(
     Ok(())
 }
 
-/// Add proxy REDIRECT rules for HTTP/HTTPS traffic in PREROUTING chain.
+/// Add proxy REDIRECT rule for all outbound TCP traffic in PREROUTING chain.
 ///
-/// These rules redirect outbound port 80/443 traffic from the namespace's
-/// veth peer IP to the specified proxy port on the host.
+/// This rule redirects all outbound TCP traffic from the namespace's
+/// veth peer IP to the specified proxy port on the host. mitmproxy in
+/// transparent mode handles both HTTP/HTTPS and non-HTTP (raw TCP passthrough).
 async fn add_proxy_redirect_rules(name: &str, peer_ip: &str, proxy_port: u16) -> Result<()> {
     let src = format!("{peer_ip}/30");
     let port_str = proxy_port.to_string();
@@ -383,29 +384,6 @@ async fn add_proxy_redirect_rules(name: &str, peer_ip: &str, proxy_port: u16) ->
         &src,
         "-p",
         "tcp",
-        "--dport",
-        "80",
-        "-j",
-        "REDIRECT",
-        "--to-port",
-        &port_str,
-        "-m",
-        "comment",
-        "--comment",
-        name,
-    ])
-    .await?;
-    sudo_iptables(&[
-        "-t",
-        "nat",
-        "-A",
-        "PREROUTING",
-        "-s",
-        &src,
-        "-p",
-        "tcp",
-        "--dport",
-        "443",
         "-j",
         "REDIRECT",
         "--to-port",

--- a/crates/sandbox-fc/src/network/pool.rs
+++ b/crates/sandbox-fc/src/network/pool.rs
@@ -372,7 +372,7 @@ async fn setup_host_iptables(
 /// This rule redirects all outbound TCP traffic from the namespace's
 /// veth peer IP to the specified proxy port on the host. mitmproxy in
 /// transparent mode handles both HTTP/HTTPS and non-HTTP (raw TCP passthrough).
-async fn add_proxy_redirect_rules(name: &str, peer_ip: &str, proxy_port: u16) -> Result<()> {
+async fn add_proxy_redirect_rule(name: &str, peer_ip: &str, proxy_port: u16) -> Result<()> {
     let src = format!("{peer_ip}/30");
     let port_str = proxy_port.to_string();
     sudo_iptables(&[
@@ -956,7 +956,7 @@ async fn create_single_namespace(
     match result {
         Ok(()) => {
             if let Some(port) = proxy_port
-                && let Err(e) = add_proxy_redirect_rules(&ns_name, &peer_ip, port).await
+                && let Err(e) = add_proxy_redirect_rule(&ns_name, &peer_ip, port).await
             {
                 error!(name = %ns_name, error = %e, "failed to add proxy rules, cleaning up");
                 delete_namespace_resources(&ns_name, &host_device).await;

--- a/e2e/tests/03-experimental-runner/t45-vm0-tcp-passthrough.bats
+++ b/e2e/tests/03-experimental-runner/t45-vm0-tcp-passthrough.bats
@@ -3,7 +3,7 @@
 # Test that non-HTTP TCP traffic passes through mitmproxy correctly.
 # All outbound TCP from sandbox VMs is redirected through mitmproxy.
 # mitmproxy transparent mode handles non-HTTP as raw TCP passthrough.
-# This test verifies that a raw TCP connection (SSH) works end-to-end.
+# This test verifies raw TCP connections (SSH) work end-to-end.
 
 load '../../helpers/setup'
 
@@ -17,7 +17,7 @@ teardown() {
     [ -n "$TEST_DIR" ] && [ -d "$TEST_DIR" ] && rm -rf "$TEST_DIR"
 }
 
-@test "non-http tcp passes through mitmproxy (ssh banner)" {
+@test "non-http tcp passes through mitmproxy" {
     cat > "$TEST_DIR/vm0.yaml" <<EOF
 version: "1.0"
 
@@ -36,44 +36,15 @@ EOF
     run $CLI_COMMAND artifact push
     assert_success
 
-    # Connect to GitHub's SSH port and read the banner.
-    # This is a raw TCP connection — not HTTP — so it exercises
-    # mitmproxy's TCP passthrough after the all-TCP redirect.
+    # Two raw TCP connections to read SSH banners:
+    # 1. github.com:22 — SSH on standard port, non-HTTP protocol
+    # 2. ssh.github.com:443 — SSH on port 443 (previously intercepted as HTTPS)
+    # Both must pass through mitmproxy as raw TCP without corruption.
     run $CLI_COMMAND run "$AGENT_NAME" \
         --artifact-name "$ARTIFACT_NAME" \
-        "timeout 5 bash -c 'cat < /dev/tcp/github.com/22 | head -1'"
+        "echo PORT22=\$(timeout 5 bash -c 'head -1 < /dev/tcp/github.com/22') && echo PORT443=\$(timeout 5 bash -c 'head -1 < /dev/tcp/ssh.github.com/443')"
     assert_success
     assert_output --partial "● Bash("
-    assert_output --partial "SSH-2.0"
-}
-
-@test "https on non-standard port works through mitmproxy" {
-    cat > "$TEST_DIR/vm0.yaml" <<EOF
-version: "1.0"
-
-agents:
-  $AGENT_NAME:
-    description: "Test agent for HTTPS non-standard port"
-    framework: claude-code
-EOF
-
-    run $CLI_COMMAND compose "$TEST_DIR/vm0.yaml"
-    assert_success
-
-    mkdir -p "$TEST_DIR/$ARTIFACT_NAME"
-    cd "$TEST_DIR/$ARTIFACT_NAME"
-    $CLI_COMMAND artifact init --name "$ARTIFACT_NAME" >/dev/null
-    run $CLI_COMMAND artifact push
-    assert_success
-
-    # GitHub SSH service also listens on port 443 (ssh.github.com:443).
-    # This is a non-standard port for SSH — previously would have been
-    # intercepted as HTTPS and broken. With all-TCP redirect, mitmproxy
-    # detects it's not HTTP and passes through as raw TCP.
-    run $CLI_COMMAND run "$AGENT_NAME" \
-        --artifact-name "$ARTIFACT_NAME" \
-        "timeout 5 bash -c 'cat < /dev/tcp/ssh.github.com/443 | head -1'"
-    assert_success
-    assert_output --partial "● Bash("
-    assert_output --partial "SSH-2.0"
+    assert_output --partial "PORT22=SSH-2.0"
+    assert_output --partial "PORT443=SSH-2.0"
 }

--- a/e2e/tests/03-experimental-runner/t45-vm0-tcp-passthrough.bats
+++ b/e2e/tests/03-experimental-runner/t45-vm0-tcp-passthrough.bats
@@ -43,5 +43,37 @@ EOF
         --artifact-name "$ARTIFACT_NAME" \
         "timeout 5 bash -c 'cat < /dev/tcp/github.com/22 | head -1'"
     assert_success
-    assert_output --partial "SSH"
+    assert_output --partial "● Bash("
+    assert_output --partial "SSH-2.0"
+}
+
+@test "https on non-standard port works through mitmproxy" {
+    cat > "$TEST_DIR/vm0.yaml" <<EOF
+version: "1.0"
+
+agents:
+  $AGENT_NAME:
+    description: "Test agent for HTTPS non-standard port"
+    framework: claude-code
+EOF
+
+    run $CLI_COMMAND compose "$TEST_DIR/vm0.yaml"
+    assert_success
+
+    mkdir -p "$TEST_DIR/$ARTIFACT_NAME"
+    cd "$TEST_DIR/$ARTIFACT_NAME"
+    $CLI_COMMAND artifact init --name "$ARTIFACT_NAME" >/dev/null
+    run $CLI_COMMAND artifact push
+    assert_success
+
+    # GitHub SSH service also listens on port 443 (ssh.github.com:443).
+    # This is a non-standard port for SSH — previously would have been
+    # intercepted as HTTPS and broken. With all-TCP redirect, mitmproxy
+    # detects it's not HTTP and passes through as raw TCP.
+    run $CLI_COMMAND run "$AGENT_NAME" \
+        --artifact-name "$ARTIFACT_NAME" \
+        "timeout 5 bash -c 'cat < /dev/tcp/ssh.github.com/443 | head -1'"
+    assert_success
+    assert_output --partial "● Bash("
+    assert_output --partial "SSH-2.0"
 }

--- a/e2e/tests/03-experimental-runner/t45-vm0-tcp-passthrough.bats
+++ b/e2e/tests/03-experimental-runner/t45-vm0-tcp-passthrough.bats
@@ -1,0 +1,47 @@
+#!/usr/bin/env bats
+
+# Test that non-HTTP TCP traffic passes through mitmproxy correctly.
+# All outbound TCP from sandbox VMs is redirected through mitmproxy.
+# mitmproxy transparent mode handles non-HTTP as raw TCP passthrough.
+# This test verifies that a raw TCP connection (SSH) works end-to-end.
+
+load '../../helpers/setup'
+
+setup() {
+    export TEST_DIR="$(mktemp -d)"
+    export AGENT_NAME="e2e-tcp-$(date +%s%3N)-$RANDOM"
+    export ARTIFACT_NAME="e2e-tcp-art-$(date +%s%3N)-$RANDOM"
+}
+
+teardown() {
+    [ -n "$TEST_DIR" ] && [ -d "$TEST_DIR" ] && rm -rf "$TEST_DIR"
+}
+
+@test "non-http tcp passes through mitmproxy (ssh banner)" {
+    cat > "$TEST_DIR/vm0.yaml" <<EOF
+version: "1.0"
+
+agents:
+  $AGENT_NAME:
+    description: "Test agent for TCP passthrough"
+    framework: claude-code
+EOF
+
+    run $CLI_COMMAND compose "$TEST_DIR/vm0.yaml"
+    assert_success
+
+    mkdir -p "$TEST_DIR/$ARTIFACT_NAME"
+    cd "$TEST_DIR/$ARTIFACT_NAME"
+    $CLI_COMMAND artifact init --name "$ARTIFACT_NAME" >/dev/null
+    run $CLI_COMMAND artifact push
+    assert_success
+
+    # Connect to GitHub's SSH port and read the banner.
+    # This is a raw TCP connection — not HTTP — so it exercises
+    # mitmproxy's TCP passthrough after the all-TCP redirect.
+    run $CLI_COMMAND run "$AGENT_NAME" \
+        --artifact-name "$ARTIFACT_NAME" \
+        "timeout 5 bash -c 'cat < /dev/tcp/github.com/22 | head -1'"
+    assert_success
+    assert_output --partial "SSH"
+}


### PR DESCRIPTION
## Summary
- Replace two port-specific iptables REDIRECT rules (port 80, 443) with a single rule that redirects **all outbound TCP** from sandbox VMs through mitmproxy
- mitmproxy transparent mode handles HTTP/HTTPS normally and passes non-HTTP as raw TCP
- vsock (VM ↔ host) uses Unix Domain Sockets, unaffected by iptables

Closes #5544

## Test plan
- [ ] Deploy runner with this change to dev metal host
- [ ] Verify standard port traffic (80/443) still works as before
- [ ] Verify non-standard port traffic (e.g., 8080) now goes through mitmproxy
- [ ] Verify non-HTTP protocols (e.g., vsock) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)