### PR TITLE
feat(vsock): add real-time stdout streaming from guest to host

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -1616,6 +1616,7 @@ version = "0.6.0"
 dependencies = [
  "async-trait",
  "thiserror 2.0.18",
+ "tokio",
  "uuid",
 ]
 

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -234,24 +234,28 @@ async fn run_in_sandbox(
         .collect();
     info!(run_id = %context.run_id, count = env_refs.len(), "passing env vars via vsock");
 
-    // 5. Spawn agent — append stdout+stderr to system log file
-    //    (guest-agent reads this back via telemetry for incremental upload)
-    let agent_cmd = format!("{} >> {log_file} 2>&1", guest::RUN_AGENT);
+    // 5. Spawn agent — stdout streamed to host via vsock, stderr merged into stdout.
+    //    vsock-guest writes stdout to the guest log file (for telemetry) AND streams
+    //    chunks to the host where we write them to the host log file in real-time.
+    let agent_cmd = format!("{} 2>&1", guest::RUN_AGENT);
     info!(run_id = %context.run_id, "spawning agent");
 
     // JOB_TIMEOUT is used for both spawn_watch (guest-side kill) and wait_exit
     // (host-side watchdog) so neither side outlives the other.
     let t = Instant::now();
     let handle = sandbox
-        .spawn_watch(&ExecRequest {
-            cmd: &agent_cmd,
-            timeout: JOB_TIMEOUT,
-            env: &env_refs,
-            sudo: false,
-        })
+        .spawn_watch(
+            &ExecRequest {
+                cmd: &agent_cmd,
+                timeout: JOB_TIMEOUT,
+                env: &env_refs,
+                sudo: false,
+            },
+            Some(&log_file),
+        )
         .await;
 
-    let handle = match handle {
+    let mut handle = match handle {
         Ok(h) => h,
         Err(e) => {
             telemetry.record("agent_execute", t.elapsed(), false, Some(&e.to_string()));
@@ -259,8 +263,22 @@ async fn run_in_sandbox(
         }
     };
 
+    // Spawn background task to drain stdout chunks and write to host log file.
+    let host_log_path = config.log_paths.system_log(context.run_id);
+    let stream_task = handle
+        .stdout_rx
+        .take()
+        .map(|stdout_rx| tokio::spawn(drain_stdout_to_file(stdout_rx, host_log_path)));
+
     // 6. Wait for exit
     let result = sandbox.wait_exit(handle, JOB_TIMEOUT).await;
+
+    // Wait for streaming to finish (channel closes when process exits).
+    if let Some(task) = stream_task
+        && let Err(e) = task.await
+    {
+        warn!(run_id = %context.run_id, error = %e, "stdout stream task failed");
+    }
     let success = result.as_ref().is_ok_and(|exit| exit.exit_code == 0);
     let err = result.as_ref().err().map(|e| e.to_string());
     telemetry.record("agent_execute", t.elapsed(), success, err.as_deref());
@@ -346,9 +364,37 @@ fn dmesg_indicates_oom(stdout: &str) -> bool {
     lower.contains("out of memory") || lower.contains("oom-kill") || lower.contains("oom_reaper")
 }
 
-/// Copy guest log files to the host log directory.
+/// Drain stdout chunks from the vsock receiver and write them to a host file.
+async fn drain_stdout_to_file(
+    mut rx: tokio::sync::mpsc::UnboundedReceiver<Vec<u8>>,
+    path: std::path::PathBuf,
+) {
+    let file = tokio::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+        .await;
+    let mut file = match file {
+        Ok(f) => f,
+        Err(e) => {
+            warn!(error = %e, path = %path.display(), "failed to open host log file for streaming");
+            return;
+        }
+    };
+    while let Some(chunk) = rx.recv().await {
+        if let Err(e) = tokio::io::AsyncWriteExt::write_all(&mut file, &chunk).await {
+            warn!(error = %e, path = %path.display(), "failed to write stdout chunk to host log");
+            break;
+        }
+    }
+}
+
+/// Copy guest log files to host (best-effort, post-job).
 ///
-/// Best-effort: failures are logged but do not affect job outcome.
+/// The system log is also streamed to the host in real-time via vsock stdout
+/// streaming during the agent phase, but the final copy here overwrites with
+/// the complete file (includes download/restore output written before streaming
+/// started).
 async fn copy_guest_logs(sandbox: &dyn Sandbox, context: &ExecutionContext, log_paths: &LogPaths) {
     let run_id = context.run_id;
     let files = [

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -638,7 +638,11 @@ impl Sandbox for FirecrackerSandbox {
         }
     }
 
-    async fn spawn_watch(&self, request: &ExecRequest<'_>) -> sandbox::Result<SpawnHandle> {
+    async fn spawn_watch(
+        &self,
+        request: &ExecRequest<'_>,
+        stdout_log_path: Option<&str>,
+    ) -> sandbox::Result<SpawnHandle> {
         let guest = self.guest.lock().await.as_ref().cloned().ok_or_else(|| {
             SandboxError::ExecFailed(format!(
                 "sandbox not running (state: {})",
@@ -647,9 +651,9 @@ impl Sandbox for FirecrackerSandbox {
         })?;
 
         tokio::select! {
-            result = guest.spawn_watch(request.cmd, request.timeout_ms(), request.env, request.sudo) => {
-                let pid = result.map_err(|e| SandboxError::ExecFailed(e.to_string()))?;
-                Ok(SpawnHandle { pid })
+            result = guest.spawn_watch(request.cmd, request.timeout_ms(), request.env, request.sudo, stdout_log_path) => {
+                let (pid, stdout_rx) = result.map_err(|e| SandboxError::ExecFailed(e.to_string()))?;
+                Ok(SpawnHandle { pid, stdout_rx: Some(stdout_rx) })
             }
             _ = self.crash_notify.notified() => {
                 Err(SandboxError::ExecFailed("firecracker process crashed".into()))

--- a/crates/sandbox/Cargo.toml
+++ b/crates/sandbox/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 [dependencies]
 async-trait.workspace = true
 thiserror.workspace = true
+tokio = { workspace = true, features = ["sync"] }
 uuid = { workspace = true, features = ["v4"] }
 
 [lints]

--- a/crates/sandbox/src/sandbox.rs
+++ b/crates/sandbox/src/sandbox.rs
@@ -24,6 +24,10 @@ pub trait Sandbox: Send + Sync + Any {
     // -- operations --
     async fn exec(&self, request: &ExecRequest<'_>) -> Result<ExecResult>;
     async fn write_file(&self, path: &str, content: &[u8]) -> Result<()>;
-    async fn spawn_watch(&self, request: &ExecRequest<'_>) -> Result<SpawnHandle>;
+    async fn spawn_watch(
+        &self,
+        request: &ExecRequest<'_>,
+        stdout_log_path: Option<&str>,
+    ) -> Result<SpawnHandle>;
     async fn wait_exit(&self, handle: SpawnHandle, timeout: Duration) -> Result<ProcessExit>;
 }

--- a/crates/sandbox/src/types.rs
+++ b/crates/sandbox/src/types.rs
@@ -22,6 +22,9 @@ pub struct ExecResult {
 
 pub struct SpawnHandle {
     pub pid: u32,
+    /// Receives stdout chunks in real-time when the guest streams them.
+    /// `None` when the backend does not support streaming.
+    pub stdout_rx: Option<tokio::sync::mpsc::UnboundedReceiver<Vec<u8>>>,
 }
 
 pub struct ProcessExit {

--- a/crates/vsock-guest/src/lib.rs
+++ b/crates/vsock-guest/src/lib.rs
@@ -364,6 +364,14 @@ fn handle_shutdown(seq: u32) -> io::Result<Vec<u8>> {
 ///
 /// When `stdout_log_path` is `Some`, stdout is streamed to the host via
 /// `MSG_STDOUT_CHUNK` messages AND teed to the specified file path inside the VM.
+/// Handle spawn_watch: spawn the child, write the response over the wire,
+/// THEN start the background monitor. This ordering is critical — the
+/// streaming monitor thread also writes to the same socket (via the shared
+/// `writer` mutex), and `MSG_STDOUT_CHUNK` messages must not arrive at the
+/// host before the `MSG_SPAWN_WATCH_RESULT` for this pid. If the monitor
+/// thread were spawned first, it could race the main thread for the mutex
+/// and send chunks before the result, causing the host to drop them (the
+/// host only registers the stdout channel when it processes the result).
 fn handle_spawn_watch(
     timeout_ms: u32,
     command: &str,
@@ -372,7 +380,7 @@ fn handle_spawn_watch(
     stdout_log_path: Option<&str>,
     seq: u32,
     writer: Arc<Mutex<UnixStream>>,
-) -> io::Result<Vec<u8>> {
+) -> io::Result<()> {
     log(
         "INFO",
         &format!(
@@ -407,6 +415,18 @@ fn handle_spawn_watch(
             let pid = child.id();
             log("INFO", &format!("spawn_watch: started pid={}", pid));
 
+            // Write the response BEFORE spawning the monitor thread.
+            // The monitor thread contends for the same writer mutex to send
+            // stdout chunks / process_exit. Writing here guarantees the
+            // spawn_watch_result is on the wire first.
+            let payload = vsock_proto::encode_spawn_watch_result(pid);
+            let response =
+                vsock_proto::encode(MSG_SPAWN_WATCH_RESULT, seq, &payload).map_err(to_io_error)?;
+            {
+                let mut w = writer.lock().unwrap_or_else(|e| e.into_inner());
+                w.write_all(&response)?;
+            }
+
             if let Some(log_path) = stdout_log_path {
                 // Streaming mode: tee stdout to log file + vsock chunks.
                 // Take stdout from child so we can read it in a separate thread.
@@ -424,13 +444,14 @@ fn handle_spawn_watch(
                 spawn_buffered_monitor(pid, child, timeout_ms, writer);
             }
 
-            // Return immediate acknowledgment with PID
-            let payload = vsock_proto::encode_spawn_watch_result(pid);
-            vsock_proto::encode(MSG_SPAWN_WATCH_RESULT, seq, &payload).map_err(to_io_error)
+            Ok(())
         }
         Err(e) => {
             let payload = vsock_proto::encode_error(&format!("Failed to spawn: {}", e));
-            vsock_proto::encode(MSG_ERROR, seq, &payload).map_err(to_io_error)
+            let response = vsock_proto::encode(MSG_ERROR, seq, &payload).map_err(to_io_error)?;
+            let mut w = writer.lock().unwrap_or_else(|e| e.into_inner());
+            w.write_all(&response)?;
+            Ok(())
         }
     }
 }
@@ -759,7 +780,10 @@ pub fn handle_connection(stream: UnixStream) -> io::Result<()> {
             // pipe fd) would otherwise stall all subsequent messages.
             if msg.msg_type == MSG_SPAWN_WATCH {
                 let d = vsock_proto::decode_spawn_watch(&msg.payload).map_err(to_io_error)?;
-                let response = handle_spawn_watch(
+                // handle_spawn_watch writes the response itself (before
+                // spawning the streaming thread) to prevent a race where
+                // stdout chunks could arrive at the host before the result.
+                handle_spawn_watch(
                     d.exec.timeout_ms,
                     d.exec.command,
                     &d.exec.env,
@@ -768,8 +792,6 @@ pub fn handle_connection(stream: UnixStream) -> io::Result<()> {
                     msg.seq,
                     Arc::clone(&writer),
                 )?;
-                let mut w = writer.lock().unwrap_or_else(|e| e.into_inner());
-                w.write_all(&response)?;
             } else if msg.msg_type == MSG_EXEC {
                 log(
                     "INFO",

--- a/crates/vsock-guest/src/lib.rs
+++ b/crates/vsock-guest/src/lib.rs
@@ -16,8 +16,8 @@ use std::time::Duration;
 
 use vsock_proto::{
     self, MSG_ERROR, MSG_EXEC, MSG_EXEC_RESULT, MSG_PING, MSG_PONG, MSG_PROCESS_EXIT, MSG_READY,
-    MSG_SHUTDOWN, MSG_SHUTDOWN_ACK, MSG_SPAWN_WATCH, MSG_SPAWN_WATCH_RESULT, MSG_WRITE_FILE,
-    MSG_WRITE_FILE_RESULT, ProtocolError, RawMessage,
+    MSG_SHUTDOWN, MSG_SHUTDOWN_ACK, MSG_SPAWN_WATCH, MSG_SPAWN_WATCH_RESULT, MSG_STDOUT_CHUNK,
+    MSG_WRITE_FILE, MSG_WRITE_FILE_RESULT, ProtocolError, RawMessage,
 };
 
 /// Flag indicating shutdown was received (don't reconnect after shutdown).
@@ -38,6 +38,9 @@ const EXIT_CODE_TIMEOUT: i32 = 124;
 
 /// Maximum length for command preview in logs
 const COMMAND_PREVIEW_MAX_LEN: usize = 100;
+
+/// Buffer size for reading stdout chunks from a spawned process.
+const STDOUT_CHUNK_SIZE: usize = 8 * 1024;
 
 /// Convert a ProtocolError to an io::Error
 fn to_io_error(e: ProtocolError) -> io::Error {
@@ -355,24 +358,30 @@ fn handle_shutdown(seq: u32) -> io::Result<Vec<u8>> {
     vsock_proto::encode(MSG_SHUTDOWN_ACK, seq, &[]).map_err(to_io_error)
 }
 
-/// Handle spawn_watch message - spawn process and monitor in background
-/// Returns immediate acknowledgment with PID, then sends process_exit when done
+/// Handle spawn_watch message - spawn process and monitor in background.
+///
+/// Returns immediate acknowledgment with PID, then sends process_exit when done.
+///
+/// When `stdout_log_path` is `Some`, stdout is streamed to the host via
+/// `MSG_STDOUT_CHUNK` messages AND teed to the specified file path inside the VM.
 fn handle_spawn_watch(
     timeout_ms: u32,
     command: &str,
     env: &[(&str, &str)],
     sudo: bool,
+    stdout_log_path: Option<&str>,
     seq: u32,
     writer: Arc<Mutex<UnixStream>>,
 ) -> io::Result<Vec<u8>> {
     log(
         "INFO",
         &format!(
-            "spawn_watch: {} (timeout={}ms, sudo={}, env_count={})",
+            "spawn_watch: {} (timeout={}ms, sudo={}, env_count={}, stream={})",
             truncate_preview(command),
             timeout_ms,
             sudo,
             env.len(),
+            stdout_log_path.is_some(),
         ),
     );
     let command = prepend_env(command, env);
@@ -394,54 +403,26 @@ fn handle_spawn_watch(
         .spawn();
 
     match child {
-        Ok(child) => {
+        Ok(mut child) => {
             let pid = child.id();
             log("INFO", &format!("spawn_watch: started pid={}", pid));
 
-            // Spawn background thread to monitor process exit
-            thread::spawn(move || {
-                let result = if timeout_ms > 0 {
-                    wait_with_timeout(child, timeout_ms)
-                } else {
-                    // No timeout - wait indefinitely
-                    match child.wait_with_output() {
-                        Ok(output) => (
-                            extract_exit_code(output.status),
-                            output.stdout,
-                            output.stderr,
-                        ),
-                        Err(e) => (1, Vec::new(), format!("Failed to wait: {}", e).into_bytes()),
-                    }
-                };
-
-                log(
-                    "INFO",
-                    &format!(
-                        "spawn_watch: pid={} exited with code={}, stdout_len={}, stderr_len={}",
-                        pid,
-                        result.0,
-                        result.1.len(),
-                        result.2.len()
-                    ),
+            if let Some(log_path) = stdout_log_path {
+                // Streaming mode: tee stdout to log file + vsock chunks.
+                // Take stdout from child so we can read it in a separate thread.
+                let stdout_pipe = child.stdout.take();
+                spawn_streaming_monitor(
+                    pid,
+                    child,
+                    timeout_ms,
+                    stdout_pipe,
+                    log_path.to_owned(),
+                    writer,
                 );
-
-                // Send process_exit notification
-                let payload = vsock_proto::encode_process_exit(pid, result.0, &result.1, &result.2);
-                // seq=0 for unsolicited messages
-                let exit_msg = match vsock_proto::encode(MSG_PROCESS_EXIT, 0, &payload) {
-                    Ok(msg) => msg,
-                    Err(e) => {
-                        log("ERROR", &format!("Failed to encode process_exit: {}", e));
-                        return;
-                    }
-                };
-                // Recover from poisoned mutex: a panicked thread shouldn't prevent
-                // us from sending the exit notification on a best-effort basis.
-                let mut w = writer.lock().unwrap_or_else(|e| e.into_inner());
-                if let Err(e) = w.write_all(&exit_msg) {
-                    log("ERROR", &format!("Failed to send process_exit: {}", e));
-                }
-            });
+            } else {
+                // Buffered mode: no streaming, collect stdout at exit.
+                spawn_buffered_monitor(pid, child, timeout_ms, writer);
+            }
 
             // Return immediate acknowledgment with PID
             let payload = vsock_proto::encode_spawn_watch_result(pid);
@@ -451,6 +432,203 @@ fn handle_spawn_watch(
             let payload = vsock_proto::encode_error(&format!("Failed to spawn: {}", e));
             vsock_proto::encode(MSG_ERROR, seq, &payload).map_err(to_io_error)
         }
+    }
+}
+
+/// Streaming monitor: reads stdout in chunks, tees to file + vsock, then waits for exit.
+///
+/// The timeout killer is spawned BEFORE the stdout read loop so that a process
+/// producing output past the deadline is still killed. When the process is
+/// killed, the stdout pipe returns EOF (broken pipe), the loop exits, and we
+/// proceed to collect the exit status.
+fn spawn_streaming_monitor(
+    pid: u32,
+    mut child: std::process::Child,
+    timeout_ms: u32,
+    stdout_pipe: Option<std::process::ChildStdout>,
+    log_path: String,
+    writer: Arc<Mutex<UnixStream>>,
+) {
+    thread::spawn(move || {
+        // Set up timeout BEFORE the stdout loop — if the process runs past the
+        // deadline it must be killed even while we are still reading output.
+        let child_id = child.id();
+        let killed_by_timeout = Arc::new(AtomicBool::new(false));
+        let timeout_done_tx = if timeout_ms > 0 {
+            let killed_clone = Arc::clone(&killed_by_timeout);
+            let timeout = Duration::from_millis(timeout_ms as u64);
+            let (tx, rx) = std::sync::mpsc::channel::<()>();
+            thread::spawn(move || {
+                if rx.recv_timeout(timeout).is_err() {
+                    killed_clone.store(true, Ordering::SeqCst);
+                    // SAFETY: child_id is a valid PID. Negative pid kills the process group.
+                    unsafe {
+                        libc::kill(-(child_id as i32), libc::SIGKILL);
+                    }
+                }
+            });
+            Some(tx)
+        } else {
+            None
+        };
+
+        // Drain stderr in a background thread BEFORE the stdout loop.
+        // If we waited until after, a child producing >64KB of stderr could
+        // fill the pipe buffer and block — preventing further stdout writes
+        // and causing our stdout read loop to hang (deadlock).
+        let stderr_handle = child.stderr.take().map(|stderr| {
+            thread::spawn(move || {
+                let mut buf = Vec::new();
+                let mut reader = io::BufReader::new(stderr);
+                let _ = reader.read_to_end(&mut buf);
+                buf
+            })
+        });
+
+        // Stream stdout to file + vsock
+        if let Some(mut stdout) = stdout_pipe {
+            let log_file = std::fs::OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(&log_path);
+            let mut log_file = match log_file {
+                Ok(f) => Some(f),
+                Err(e) => {
+                    log(
+                        "WARN",
+                        &format!("spawn_watch: failed to open log file {}: {}", log_path, e),
+                    );
+                    None
+                }
+            };
+
+            let mut buf = [0u8; STDOUT_CHUNK_SIZE];
+            loop {
+                let n = match stdout.read(&mut buf) {
+                    Ok(0) => break, // EOF
+                    Ok(n) => n,
+                    Err(e) => {
+                        log("WARN", &format!("spawn_watch: stdout read error: {}", e));
+                        break;
+                    }
+                };
+                let chunk = match buf.get(..n) {
+                    Some(c) => c,
+                    None => break,
+                };
+
+                // Write to log file (best-effort)
+                if let Some(ref mut f) = log_file {
+                    let _ = f.write_all(chunk);
+                }
+
+                // Send chunk via vsock (best-effort)
+                let payload = vsock_proto::encode_stdout_chunk(pid, chunk);
+                if let Ok(msg) = vsock_proto::encode(MSG_STDOUT_CHUNK, 0, &payload) {
+                    let mut w = writer.lock().unwrap_or_else(|e| e.into_inner());
+                    if let Err(e) = w.write_all(&msg) {
+                        log(
+                            "WARN",
+                            &format!("spawn_watch: failed to send stdout chunk: {}", e),
+                        );
+                        break;
+                    }
+                }
+            }
+        }
+
+        // Wait for process exit (stdout + stderr already being drained)
+        let status = child.wait();
+
+        // Signal timeout thread that process completed.
+        // Must send() not drop — dropping disconnects the channel, which
+        // recv_timeout treats as an error and would fire the killer.
+        if let Some(tx) = timeout_done_tx {
+            let _ = tx.send(());
+        }
+
+        let stderr = stderr_handle
+            .and_then(|h| h.join().ok())
+            .unwrap_or_default();
+
+        let (exit_code, stderr) = if killed_by_timeout.load(Ordering::SeqCst) {
+            (EXIT_CODE_TIMEOUT, b"Timeout".to_vec())
+        } else {
+            match status {
+                Ok(s) => (extract_exit_code(s), stderr),
+                Err(e) => (1, format!("Failed to wait: {}", e).into_bytes()),
+            }
+        };
+
+        log(
+            "INFO",
+            &format!(
+                "spawn_watch: pid={} exited with code={}, stderr_len={} (streamed)",
+                pid,
+                exit_code,
+                stderr.len()
+            ),
+        );
+
+        send_process_exit(pid, exit_code, &[], &stderr, &writer);
+    });
+}
+
+/// Buffered monitor: waits for process exit, collects stdout/stderr at once.
+fn spawn_buffered_monitor(
+    pid: u32,
+    child: std::process::Child,
+    timeout_ms: u32,
+    writer: Arc<Mutex<UnixStream>>,
+) {
+    thread::spawn(move || {
+        let result = if timeout_ms > 0 {
+            wait_with_timeout(child, timeout_ms)
+        } else {
+            match child.wait_with_output() {
+                Ok(output) => (
+                    extract_exit_code(output.status),
+                    output.stdout,
+                    output.stderr,
+                ),
+                Err(e) => (1, Vec::new(), format!("Failed to wait: {}", e).into_bytes()),
+            }
+        };
+
+        log(
+            "INFO",
+            &format!(
+                "spawn_watch: pid={} exited with code={}, stdout_len={}, stderr_len={}",
+                pid,
+                result.0,
+                result.1.len(),
+                result.2.len()
+            ),
+        );
+
+        send_process_exit(pid, result.0, &result.1, &result.2, &writer);
+    });
+}
+
+/// Send a process_exit notification over vsock (best-effort).
+fn send_process_exit(
+    pid: u32,
+    exit_code: i32,
+    stdout: &[u8],
+    stderr: &[u8],
+    writer: &Arc<Mutex<UnixStream>>,
+) {
+    let payload = vsock_proto::encode_process_exit(pid, exit_code, stdout, stderr);
+    let exit_msg = match vsock_proto::encode(MSG_PROCESS_EXIT, 0, &payload) {
+        Ok(msg) => msg,
+        Err(e) => {
+            log("ERROR", &format!("Failed to encode process_exit: {}", e));
+            return;
+        }
+    };
+    let mut w = writer.lock().unwrap_or_else(|e| e.into_inner());
+    if let Err(e) = w.write_all(&exit_msg) {
+        log("ERROR", &format!("Failed to send process_exit: {}", e));
     }
 }
 
@@ -580,12 +758,13 @@ pub fn handle_connection(stream: UnixStream) -> io::Result<()> {
             // blocking the event loop. A blocking child process (e.g. reading a
             // pipe fd) would otherwise stall all subsequent messages.
             if msg.msg_type == MSG_SPAWN_WATCH {
-                let d = vsock_proto::decode_exec(&msg.payload).map_err(to_io_error)?;
+                let d = vsock_proto::decode_spawn_watch(&msg.payload).map_err(to_io_error)?;
                 let response = handle_spawn_watch(
-                    d.timeout_ms,
-                    d.command,
-                    &d.env,
-                    d.sudo,
+                    d.exec.timeout_ms,
+                    d.exec.command,
+                    &d.exec.env,
+                    d.exec.sudo,
+                    d.stdout_log_path,
                     msg.seq,
                     Arc::clone(&writer),
                 )?;

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -32,8 +32,8 @@ use tokio::time::{self, Instant};
 
 use vsock_proto::{
     Decoder, MSG_ERROR, MSG_EXEC, MSG_EXEC_RESULT, MSG_PING, MSG_PONG, MSG_PROCESS_EXIT, MSG_READY,
-    MSG_SHUTDOWN, MSG_SHUTDOWN_ACK, MSG_SPAWN_WATCH, MSG_SPAWN_WATCH_RESULT, MSG_WRITE_FILE,
-    MSG_WRITE_FILE_RESULT, RawMessage,
+    MSG_SHUTDOWN, MSG_SHUTDOWN_ACK, MSG_SPAWN_WATCH, MSG_SPAWN_WATCH_RESULT, MSG_STDOUT_CHUNK,
+    MSG_WRITE_FILE, MSG_WRITE_FILE_RESULT, RawMessage,
 };
 
 const READ_BUF_SIZE: usize = 64 * 1024;
@@ -69,6 +69,9 @@ struct Shared {
     exits: std::sync::Mutex<HashMap<u32, ProcessExitEvent>>,
     /// Notified when a new exit event arrives.
     exit_notify: Notify,
+    /// Stdout chunk senders: pid → channel sender.
+    /// Registered by `spawn_watch`, fed by `reader_loop`.
+    stdout_senders: std::sync::Mutex<HashMap<u32, tokio::sync::mpsc::UnboundedSender<Vec<u8>>>>,
     /// Set to `true` when the reader task exits (before `closed.notify_waiters()`).
     /// Checked by `request` and `wait_for_exit` to detect a close that happened
     /// before their `Notified` futures were created.
@@ -143,10 +146,37 @@ async fn reader_loop(
             Err(_) => break,
         };
         for msg in messages {
-            if msg.msg_type == MSG_PROCESS_EXIT && msg.seq == 0 {
+            if msg.msg_type == MSG_STDOUT_CHUNK && msg.seq == 0 {
+                if let Ok((pid, data)) = vsock_proto::decode_stdout_chunk(&msg.payload) {
+                    let sender = {
+                        shared
+                            .stdout_senders
+                            .lock()
+                            .unwrap_or_else(|e| e.into_inner())
+                            .get(&pid)
+                            .cloned()
+                    };
+                    if let Some(tx) = sender {
+                        // Best-effort: if receiver is dropped, remove sender.
+                        if tx.send(data.to_vec()).is_err() {
+                            shared
+                                .stdout_senders
+                                .lock()
+                                .unwrap_or_else(|e| e.into_inner())
+                                .remove(&pid);
+                        }
+                    }
+                }
+            } else if msg.msg_type == MSG_PROCESS_EXIT && msg.seq == 0 {
                 if let Ok((pid, exit_code, stdout, stderr)) =
                     vsock_proto::decode_process_exit(&msg.payload)
                 {
+                    // Close stdout channel for this pid (if any).
+                    shared
+                        .stdout_senders
+                        .lock()
+                        .unwrap_or_else(|e| e.into_inner())
+                        .remove(&pid);
                     let event = ProcessExitEvent {
                         pid,
                         exit_code,
@@ -173,6 +203,12 @@ async fn reader_loop(
     // Connection lost — drop all pending senders so receivers get RecvError.
     shared
         .pending
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .clear();
+    // Close all stdout channels so consumers see the stream end.
+    shared
+        .stdout_senders
         .lock()
         .unwrap_or_else(|e| e.into_inner())
         .clear();
@@ -238,6 +274,7 @@ impl VsockHost {
             pending: std::sync::Mutex::new(HashMap::new()),
             exits: std::sync::Mutex::new(HashMap::new()),
             exit_notify: Notify::new(),
+            stdout_senders: std::sync::Mutex::new(HashMap::new()),
             is_closed: AtomicBool::new(false),
             closed: Notify::new(),
         });
@@ -456,16 +493,23 @@ impl VsockHost {
 
     /// Spawn a process on the guest and monitor for exit.
     ///
-    /// Returns immediately with the PID. Use [`wait_for_exit`](Self::wait_for_exit)
+    /// Returns immediately with `(pid, stdout_rx)`. Use [`wait_for_exit`](Self::wait_for_exit)
     /// to wait for completion.
+    ///
+    /// When `stdout_log_path` is `Some`, the guest tees stdout to the given
+    /// file path AND streams chunks to the host via `MSG_STDOUT_CHUNK`.
+    /// The `stdout_rx` channel is closed when the process exits or the
+    /// connection drops.
     pub async fn spawn_watch(
         &self,
         command: &str,
         timeout_ms: u32,
         env: &[(&str, &str)],
         sudo: bool,
-    ) -> io::Result<u32> {
-        let payload = vsock_proto::encode_exec(timeout_ms, command, env, sudo);
+        stdout_log_path: Option<&str>,
+    ) -> io::Result<(u32, tokio::sync::mpsc::UnboundedReceiver<Vec<u8>>)> {
+        let payload =
+            vsock_proto::encode_spawn_watch(timeout_ms, command, env, sudo, stdout_log_path);
         let resp = self
             .request(MSG_SPAWN_WATCH, &payload, Duration::from_secs(30))
             .await?;
@@ -483,8 +527,20 @@ impl VsockHost {
             ));
         }
 
-        vsock_proto::decode_spawn_watch_result(&resp.payload)
-            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))
+        let pid = vsock_proto::decode_spawn_watch_result(&resp.payload)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
+
+        // Register stdout channel for this pid.
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+        {
+            self.shared
+                .stdout_senders
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .insert(pid, tx);
+        }
+
+        Ok((pid, rx))
     }
 
     /// Wait for a spawned process to exit.
@@ -725,7 +781,10 @@ mod tests {
         });
 
         let host = host_from_stream(host_stream).await.unwrap();
-        let pid = host.spawn_watch("sleep 1", 0, &[], false).await.unwrap();
+        let (pid, _stdout_rx) = host
+            .spawn_watch("sleep 1", 0, &[], false, None)
+            .await
+            .unwrap();
         assert_eq!(pid, 42);
 
         let event = host
@@ -768,7 +827,10 @@ mod tests {
         });
 
         let host = host_from_stream(host_stream).await.unwrap();
-        let pid = host.spawn_watch("false", 0, &[], false).await.unwrap();
+        let (pid, _stdout_rx) = host
+            .spawn_watch("false", 0, &[], false, None)
+            .await
+            .unwrap();
         assert_eq!(pid, 99);
 
         let event = host
@@ -969,7 +1031,10 @@ mod tests {
         });
 
         let host = host_from_stream(host_stream).await.unwrap();
-        let pid = host.spawn_watch("quick-exit", 0, &[], false).await.unwrap();
+        let (pid, _stdout_rx) = host
+            .spawn_watch("quick-exit", 0, &[], false, None)
+            .await
+            .unwrap();
         assert_eq!(pid, 88);
 
         // The exit event may already be cached OR still in-flight. Either way
@@ -1009,8 +1074,8 @@ mod tests {
         });
 
         let host = host_from_stream(host_stream).await.unwrap();
-        let pid = host
-            .spawn_watch("long-running", 0, &[], false)
+        let (pid, _stdout_rx) = host
+            .spawn_watch("long-running", 0, &[], false, None)
             .await
             .unwrap();
         assert_eq!(pid, 77);
@@ -1066,8 +1131,8 @@ mod tests {
         });
 
         let host = Arc::new(host_from_stream(host_stream).await.unwrap());
-        let pid = host
-            .spawn_watch("long-running", 0, &[], false)
+        let (pid, _stdout_rx) = host
+            .spawn_watch("long-running", 0, &[], false, None)
             .await
             .unwrap();
         assert_eq!(pid, 50);

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -70,8 +70,16 @@ struct Shared {
     /// Notified when a new exit event arrives.
     exit_notify: Notify,
     /// Stdout chunk senders: pid → channel sender.
-    /// Registered by `spawn_watch`, fed by `reader_loop`.
+    /// Populated by `reader_loop` when it processes `spawn_watch_result`,
+    /// fed by `reader_loop` when it processes `stdout_chunk`.
     stdout_senders: std::sync::Mutex<HashMap<u32, tokio::sync::mpsc::UnboundedSender<Vec<u8>>>>,
+    /// Pre-registered stdout senders: request seq → channel sender.
+    /// `spawn_watch` inserts here BEFORE sending the request so that
+    /// `reader_loop` can move the sender to `stdout_senders` atomically
+    /// when it processes the `spawn_watch_result` — before any `stdout_chunk`
+    /// for that pid is processed. This eliminates the race where early
+    /// chunks could be dropped.
+    pending_stdout: std::sync::Mutex<HashMap<u32, tokio::sync::mpsc::UnboundedSender<Vec<u8>>>>,
     /// Set to `true` when the reader task exits (before `closed.notify_waiters()`).
     /// Checked by `request` and `wait_for_exit` to detect a close that happened
     /// before their `Notified` futures were created.
@@ -190,6 +198,26 @@ async fn reader_loop(
                     shared.exit_notify.notify_waiters();
                 }
             } else {
+                // For spawn_watch_result: move the pre-registered stdout sender
+                // from pending_stdout to stdout_senders BEFORE dispatching the
+                // response. This ensures the channel is keyed by pid in
+                // stdout_senders before any subsequent MSG_STDOUT_CHUNK arrives.
+                if msg.msg_type == MSG_SPAWN_WATCH_RESULT
+                    && let Ok(pid) = vsock_proto::decode_spawn_watch_result(&msg.payload)
+                {
+                    let sender = shared
+                        .pending_stdout
+                        .lock()
+                        .unwrap_or_else(|e| e.into_inner())
+                        .remove(&msg.seq);
+                    if let Some(tx) = sender {
+                        shared
+                            .stdout_senders
+                            .lock()
+                            .unwrap_or_else(|e| e.into_inner())
+                            .insert(pid, tx);
+                    }
+                }
                 let sender = {
                     let mut pending = shared.pending.lock().unwrap_or_else(|e| e.into_inner());
                     pending.remove(&msg.seq)
@@ -209,6 +237,11 @@ async fn reader_loop(
     // Close all stdout channels so consumers see the stream end.
     shared
         .stdout_senders
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .clear();
+    shared
+        .pending_stdout
         .lock()
         .unwrap_or_else(|e| e.into_inner())
         .clear();
@@ -275,6 +308,7 @@ impl VsockHost {
             exits: std::sync::Mutex::new(HashMap::new()),
             exit_notify: Notify::new(),
             stdout_senders: std::sync::Mutex::new(HashMap::new()),
+            pending_stdout: std::sync::Mutex::new(HashMap::new()),
             is_closed: AtomicBool::new(false),
             closed: Notify::new(),
         });
@@ -357,6 +391,20 @@ impl VsockHost {
         timeout: Duration,
     ) -> io::Result<RawMessage> {
         let seq = self.shared.next_seq();
+        self.request_raw(msg_type, seq, payload, timeout).await
+    }
+
+    /// Send a request with a pre-allocated sequence number.
+    ///
+    /// Used by [`spawn_watch`](Self::spawn_watch) which needs the seq to
+    /// pre-register the stdout channel before sending the request.
+    async fn request_raw(
+        &self,
+        msg_type: u8,
+        seq: u32,
+        payload: &[u8],
+        timeout: Duration,
+    ) -> io::Result<RawMessage> {
         let data = vsock_proto::encode(msg_type, seq, payload)
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e.to_string()))?;
 
@@ -510,17 +558,54 @@ impl VsockHost {
     ) -> io::Result<(u32, tokio::sync::mpsc::UnboundedReceiver<Vec<u8>>)> {
         let payload =
             vsock_proto::encode_spawn_watch(timeout_ms, command, env, sudo, stdout_log_path);
-        let resp = self
-            .request(MSG_SPAWN_WATCH, &payload, Duration::from_secs(30))
-            .await?;
+
+        // Pre-create the stdout channel and register it by seq number BEFORE
+        // sending the request. reader_loop will atomically move it from
+        // pending_stdout[seq] to stdout_senders[pid] when it processes the
+        // spawn_watch_result — before any stdout_chunk for that pid.
+        let (stdout_tx, stdout_rx) = tokio::sync::mpsc::unbounded_channel();
+        let seq = self.shared.next_seq();
+        {
+            self.shared
+                .pending_stdout
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .insert(seq, stdout_tx);
+        }
+
+        let resp = match self
+            .request_raw(MSG_SPAWN_WATCH, seq, &payload, Duration::from_secs(30))
+            .await
+        {
+            Ok(resp) => resp,
+            Err(e) => {
+                self.shared
+                    .pending_stdout
+                    .lock()
+                    .unwrap_or_else(|e| e.into_inner())
+                    .remove(&seq);
+                return Err(e);
+            }
+        };
 
         if resp.msg_type == MSG_ERROR {
+            // No pid assigned — clean up pending stdout sender.
+            self.shared
+                .pending_stdout
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .remove(&seq);
             let msg = vsock_proto::decode_error(&resp.payload)
                 .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
             return Err(io::Error::other(msg));
         }
 
         if resp.msg_type != MSG_SPAWN_WATCH_RESULT {
+            self.shared
+                .pending_stdout
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .remove(&seq);
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
                 format!("unexpected response type: 0x{:02X}", resp.msg_type),
@@ -530,17 +615,8 @@ impl VsockHost {
         let pid = vsock_proto::decode_spawn_watch_result(&resp.payload)
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
 
-        // Register stdout channel for this pid.
-        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
-        {
-            self.shared
-                .stdout_senders
-                .lock()
-                .unwrap_or_else(|e| e.into_inner())
-                .insert(pid, tx);
-        }
-
-        Ok((pid, rx))
+        // Channel already moved from pending_stdout to stdout_senders by reader_loop.
+        Ok((pid, stdout_rx))
     }
 
     /// Wait for a spawned process to exit.

--- a/crates/vsock-proto/src/lib.rs
+++ b/crates/vsock-proto/src/lib.rs
@@ -22,11 +22,12 @@
 //! | 0x04 | G→H       | exec_result       | `[4B exit_code][4B stdout_len][stdout][4B stderr_len][stderr]` |
 //! | 0x05 | H→G       | write_file        | `[2B path_len][path][1B flags][4B content_len][content]` |
 //! | 0x06 | G→H       | write_file_result | `[1B success][2B error_len][error]` |
-//! | 0x07 | H→G       | spawn_watch       | `[4B timeout_ms][1B flags][4B cmd_len][command]([4B env_count]([4B key_len][key][4B val_len][value])*)` |
+//! | 0x07 | H→G       | spawn_watch       | `[4B timeout_ms][1B flags][4B cmd_len][command]([4B env_count]([4B key_len][key][4B val_len][value])*)([2B log_path_len][log_path])` |
 //! | 0x08 | G→H       | spawn_watch_result| `[4B pid]` |
 //! | 0x09 | G→H       | process_exit      | `[4B pid][4B exit_code][4B stdout_len][stdout][4B stderr_len][stderr]` |
 //! | 0x0A | H→G       | shutdown          | (empty) |
 //! | 0x0B | G→H       | shutdown_ack      | (empty) |
+//! | 0x0C | G→H       | stdout_chunk      | `[4B pid][data]` |
 //! | 0xFF | G→H       | error             | `[2B error_len][error]` |
 
 /// Header size (4-byte length prefix).
@@ -51,6 +52,7 @@ pub const MSG_SPAWN_WATCH_RESULT: u8 = 0x08;
 pub const MSG_PROCESS_EXIT: u8 = 0x09;
 pub const MSG_SHUTDOWN: u8 = 0x0A;
 pub const MSG_SHUTDOWN_ACK: u8 = 0x0B;
+pub const MSG_STDOUT_CHUNK: u8 = 0x0C;
 pub const MSG_ERROR: u8 = 0xFF;
 
 /// Default vsock port for host-guest communication.
@@ -165,6 +167,54 @@ pub fn encode_exec(timeout_ms: u32, command: &str, env: &[(&str, &str)], sudo: b
     p
 }
 
+/// Encode spawn_watch payload: exec fields + optional `[2B log_path_len][log_path]`.
+///
+/// When `stdout_log_path` is `Some`, the guest tees stdout to this file path
+/// AND streams chunks to the host via `MSG_STDOUT_CHUNK`.
+///
+/// Unlike `encode_exec`, this always writes the env section (even when empty)
+/// so `decode_spawn_watch` can unambiguously find the log_path boundary.
+pub fn encode_spawn_watch(
+    timeout_ms: u32,
+    command: &str,
+    env: &[(&str, &str)],
+    sudo: bool,
+    stdout_log_path: Option<&str>,
+) -> Vec<u8> {
+    let cmd = command.as_bytes();
+    let env_size: usize = 4 + env
+        .iter()
+        .map(|(k, v)| 8 + k.len() + v.len())
+        .sum::<usize>();
+    let log_size: usize = match stdout_log_path {
+        Some(p) => 2 + p.len().min(u16::MAX as usize),
+        None => 0,
+    };
+    let mut p = Vec::with_capacity(9 + cmd.len() + env_size + log_size);
+    p.extend_from_slice(&timeout_ms.to_be_bytes());
+    p.push(if sudo { FLAG_SUDO } else { 0 });
+    p.extend_from_slice(&(cmd.len() as u32).to_be_bytes());
+    p.extend_from_slice(cmd);
+    // Always write env_count so the decoder knows where env ends.
+    p.extend_from_slice(&(env.len() as u32).to_be_bytes());
+    for (key, val) in env {
+        let kb = key.as_bytes();
+        let vb = val.as_bytes();
+        p.extend_from_slice(&(kb.len() as u32).to_be_bytes());
+        p.extend_from_slice(kb);
+        p.extend_from_slice(&(vb.len() as u32).to_be_bytes());
+        p.extend_from_slice(vb);
+    }
+    if let Some(path) = stdout_log_path {
+        let path_bytes = path.as_bytes();
+        let path_len = path_bytes.len().min(u16::MAX as usize) as u16;
+        p.extend_from_slice(&path_len.to_be_bytes());
+        // path_len <= path_bytes.len() is guaranteed by .min() above
+        p.extend_from_slice(path_bytes.get(..path_len as usize).unwrap_or(path_bytes));
+    }
+    p
+}
+
 /// Encode exec_result payload: `[4B exit_code][4B stdout_len][stdout][4B stderr_len][stderr]`.
 pub fn encode_exec_result(exit_code: i32, stdout: &[u8], stderr: &[u8]) -> Vec<u8> {
     let mut p = Vec::with_capacity(12 + stdout.len() + stderr.len());
@@ -226,6 +276,14 @@ pub fn encode_process_exit(pid: u32, exit_code: i32, stdout: &[u8], stderr: &[u8
     p
 }
 
+/// Encode stdout_chunk payload: `[4B pid][data]`.
+pub fn encode_stdout_chunk(pid: u32, data: &[u8]) -> Vec<u8> {
+    let mut p = Vec::with_capacity(4 + data.len());
+    p.extend_from_slice(&pid.to_be_bytes());
+    p.extend_from_slice(data);
+    p
+}
+
 /// Encode error payload: `[2B error_len][error]`.
 ///
 /// Error message is truncated to 65535 bytes if longer.
@@ -243,11 +301,11 @@ pub fn encode_error(message: &str) -> Vec<u8> {
 // Decode
 // ---------------------------------------------------------------------------
 
-/// Decode exec payload. Returns `(timeout_ms, command, env, sudo)`.
+/// Decode exec/spawn_watch shared fields. Returns `(decoded, consumed_offset)`.
 ///
 /// The env section is optional: if the payload ends right after the command,
 /// an empty vec is returned (backward-compatible with old encoders).
-pub fn decode_exec(payload: &[u8]) -> Result<DecodedExec<'_>, ProtocolError> {
+fn decode_exec_inner(payload: &[u8]) -> Result<(DecodedExec<'_>, usize), ProtocolError> {
     let timeout_ms =
         read_u32_at(payload, 0).ok_or(ProtocolError::InvalidPayload("exec payload too short"))?;
     let flags =
@@ -264,12 +322,15 @@ pub fn decode_exec(payload: &[u8]) -> Result<DecodedExec<'_>, ProtocolError> {
 
     let env_start = 9 + cmd_len;
     if env_start >= payload.len() {
-        return Ok(DecodedExec {
-            timeout_ms,
-            command,
-            env: Vec::new(),
-            sudo,
-        });
+        return Ok((
+            DecodedExec {
+                timeout_ms,
+                command,
+                env: Vec::new(),
+                sudo,
+            },
+            env_start,
+        ));
     }
 
     let env_count = read_u32_at(payload, env_start)
@@ -305,11 +366,49 @@ pub fn decode_exec(payload: &[u8]) -> Result<DecodedExec<'_>, ProtocolError> {
         env.push((key, val));
     }
 
-    Ok(DecodedExec {
-        timeout_ms,
-        command,
-        env,
-        sudo,
+    Ok((
+        DecodedExec {
+            timeout_ms,
+            command,
+            env,
+            sudo,
+        },
+        offset,
+    ))
+}
+
+/// Decode exec payload. Returns `(timeout_ms, command, env, sudo)`.
+pub fn decode_exec(payload: &[u8]) -> Result<DecodedExec<'_>, ProtocolError> {
+    decode_exec_inner(payload).map(|(d, _)| d)
+}
+
+/// Decode spawn_watch payload. Extends exec fields with an optional `stdout_log_path`.
+///
+/// Wire format: `[exec fields...]([2B log_path_len][log_path])`.
+/// The log_path section is optional — if the payload ends after the exec
+/// fields, `stdout_log_path` is `None` (backward-compatible with old encoders).
+pub fn decode_spawn_watch(payload: &[u8]) -> Result<DecodedSpawnWatch<'_>, ProtocolError> {
+    let (exec, offset) = decode_exec_inner(payload)?;
+    let stdout_log_path = if offset + 2 <= payload.len() {
+        let path_len = read_u16_at(payload, offset).ok_or(ProtocolError::InvalidPayload(
+            "spawn_watch log_path_len truncated",
+        ))? as usize;
+        if path_len == 0 {
+            None
+        } else {
+            Some(
+                std::str::from_utf8(payload.get(offset + 2..offset + 2 + path_len).ok_or(
+                    ProtocolError::InvalidPayload("spawn_watch log_path truncated"),
+                )?)
+                .map_err(|_| ProtocolError::InvalidPayload("invalid UTF-8 in log_path"))?,
+            )
+        }
+    } else {
+        None
+    };
+    Ok(DecodedSpawnWatch {
+        exec,
+        stdout_log_path,
     })
 }
 
@@ -390,6 +489,14 @@ pub struct DecodedExec<'a> {
     pub sudo: bool,
 }
 
+/// Decoded spawn_watch fields: exec fields + optional stdout log path.
+pub struct DecodedSpawnWatch<'a> {
+    pub exec: DecodedExec<'a>,
+    /// Guest-side file path where vsock-guest tees stdout while streaming
+    /// chunks to the host. `None` disables streaming (legacy mode).
+    pub stdout_log_path: Option<&'a str>,
+}
+
 /// Decoded process_exit fields: `(pid, exit_code, stdout, stderr)`.
 pub type ProcessExit<'a> = (u32, i32, &'a [u8], &'a [u8]);
 
@@ -417,6 +524,14 @@ pub fn decode_process_exit(payload: &[u8]) -> Result<ProcessExit<'_>, ProtocolEr
             "process_exit stderr truncated",
         ))?;
     Ok((pid, exit_code, stdout, stderr))
+}
+
+/// Decode stdout_chunk payload. Returns `(pid, data)`.
+pub fn decode_stdout_chunk(payload: &[u8]) -> Result<(u32, &[u8]), ProtocolError> {
+    let pid =
+        read_u32_at(payload, 0).ok_or(ProtocolError::InvalidPayload("stdout_chunk too short"))?;
+    let data = payload.get(4..).unwrap_or_default();
+    Ok((pid, data))
 }
 
 /// Decode error payload. Returns the error message.
@@ -688,6 +803,43 @@ mod tests {
     }
 
     #[test]
+    fn spawn_watch_payload_roundtrip_with_log_path() {
+        let payload = encode_spawn_watch(
+            5000,
+            "echo hello",
+            &[("FOO", "bar")],
+            false,
+            Some("/tmp/vm0-system-123.log"),
+        );
+        let d = decode_spawn_watch(&payload).unwrap();
+        assert_eq!(d.exec.timeout_ms, 5000);
+        assert_eq!(d.exec.command, "echo hello");
+        assert_eq!(d.exec.env, vec![("FOO", "bar")]);
+        assert!(!d.exec.sudo);
+        assert_eq!(d.stdout_log_path.unwrap(), "/tmp/vm0-system-123.log");
+    }
+
+    #[test]
+    fn spawn_watch_payload_roundtrip_no_log_path() {
+        let payload = encode_spawn_watch(3000, "ls", &[], true, None);
+        let d = decode_spawn_watch(&payload).unwrap();
+        assert_eq!(d.exec.timeout_ms, 3000);
+        assert_eq!(d.exec.command, "ls");
+        assert!(d.exec.env.is_empty());
+        assert!(d.exec.sudo);
+        assert!(d.stdout_log_path.is_none());
+    }
+
+    #[test]
+    fn spawn_watch_backward_compat_old_encoder() {
+        // Old-style payload (no log_path) decoded as spawn_watch → log_path is None
+        let payload = encode_exec(1000, "cmd", &[], false);
+        let d = decode_spawn_watch(&payload).unwrap();
+        assert_eq!(d.exec.command, "cmd");
+        assert!(d.stdout_log_path.is_none());
+    }
+
+    #[test]
     fn process_exit_roundtrip() {
         let payload = encode_process_exit(999, 137, b"output", b"killed");
         let (pid, code, stdout, stderr) = decode_process_exit(&payload).unwrap();
@@ -702,6 +854,27 @@ mod tests {
         let payload = encode_error("something went wrong");
         let msg = decode_error(&payload).unwrap();
         assert_eq!(msg, "something went wrong");
+    }
+
+    #[test]
+    fn stdout_chunk_roundtrip() {
+        let payload = encode_stdout_chunk(42, b"hello world");
+        let (pid, data) = decode_stdout_chunk(&payload).unwrap();
+        assert_eq!(pid, 42);
+        assert_eq!(data, b"hello world");
+    }
+
+    #[test]
+    fn stdout_chunk_empty_data() {
+        let payload = encode_stdout_chunk(1, &[]);
+        let (pid, data) = decode_stdout_chunk(&payload).unwrap();
+        assert_eq!(pid, 1);
+        assert!(data.is_empty());
+    }
+
+    #[test]
+    fn decode_stdout_chunk_too_short() {
+        assert!(decode_stdout_chunk(&[0; 3]).is_err());
     }
 
     #[test]

--- a/crates/vsock-test/tests/integration.rs
+++ b/crates/vsock-test/tests/integration.rs
@@ -290,8 +290,8 @@ async fn test_write_file_creates_parent_dirs() {
 async fn test_spawn_watch() {
     let h = Harness::new().await;
 
-    let pid = h
-        .spawn_watch("echo done", 5000, &[], false)
+    let (pid, _stdout_rx) = h
+        .spawn_watch("echo done", 5000, &[], false, None)
         .await
         .expect("spawn_watch failed");
     assert!(pid > 0);
@@ -311,8 +311,8 @@ async fn test_spawn_watch() {
 async fn test_spawn_watch_exit_code() {
     let h = Harness::new().await;
 
-    let pid = h
-        .spawn_watch("exit 42", 5000, &[], false)
+    let (pid, _stdout_rx) = h
+        .spawn_watch("exit 42", 5000, &[], false, None)
         .await
         .expect("spawn_watch failed");
 
@@ -329,8 +329,8 @@ async fn test_spawn_watch_exit_code() {
 async fn test_spawn_watch_stderr() {
     let h = Harness::new().await;
 
-    let pid = h
-        .spawn_watch("echo error >&2 && exit 1", 5000, &[], false)
+    let (pid, _stdout_rx) = h
+        .spawn_watch("echo error >&2 && exit 1", 5000, &[], false, None)
         .await
         .expect("spawn_watch failed");
 
@@ -348,8 +348,8 @@ async fn test_spawn_watch_stderr() {
 async fn test_spawn_watch_both_stdout_stderr() {
     let h = Harness::new().await;
 
-    let pid = h
-        .spawn_watch("echo out && echo err >&2 && exit 2", 5000, &[], false)
+    let (pid, _stdout_rx) = h
+        .spawn_watch("echo out && echo err >&2 && exit 2", 5000, &[], false, None)
         .await
         .expect("spawn_watch failed");
 
@@ -368,8 +368,8 @@ async fn test_spawn_watch_both_stdout_stderr() {
 async fn test_spawn_watch_no_output() {
     let h = Harness::new().await;
 
-    let pid = h
-        .spawn_watch("true", 5000, &[], false)
+    let (pid, _stdout_rx) = h
+        .spawn_watch("true", 5000, &[], false, None)
         .await
         .expect("spawn_watch failed");
 
@@ -389,12 +389,12 @@ async fn test_spawn_watch_concurrent() {
     let h = Harness::new().await;
 
     // Spawn two processes — second finishes first
-    let pid1 = h
-        .spawn_watch("sleep 0.1 && echo first", 5000, &[], false)
+    let (pid1, _rx1) = h
+        .spawn_watch("sleep 0.1 && echo first", 5000, &[], false, None)
         .await
         .expect("spawn_watch 1 failed");
-    let pid2 = h
-        .spawn_watch("echo second", 5000, &[], false)
+    let (pid2, _rx2) = h
+        .spawn_watch("echo second", 5000, &[], false, None)
         .await
         .expect("spawn_watch 2 failed");
 
@@ -428,8 +428,8 @@ async fn test_exec_while_waiting_for_exit() {
 
     // Spawn a long-running process. Use `exec` to replace the shell so the
     // PID we get is the actual sleep process (same pattern as sigterm/sigkill tests).
-    let pid = h
-        .spawn_watch("exec sleep 60", 0, &[], false)
+    let (pid, _stdout_rx) = h
+        .spawn_watch("exec sleep 60", 0, &[], false, None)
         .await
         .expect("spawn_watch failed");
 
@@ -470,8 +470,8 @@ async fn test_exec_while_waiting_for_exit() {
 async fn test_spawn_watch_timeout() {
     let h = Harness::new().await;
 
-    let pid = h
-        .spawn_watch("sleep 10", 100, &[], false)
+    let (pid, _stdout_rx) = h
+        .spawn_watch("sleep 10", 100, &[], false, None)
         .await
         .expect("spawn_watch failed");
 
@@ -489,8 +489,8 @@ async fn test_spawn_watch_timeout() {
 async fn test_spawn_watch_cached_exit() {
     let h = Harness::new().await;
 
-    let pid = h
-        .spawn_watch("echo cached", 5000, &[], false)
+    let (pid, _stdout_rx) = h
+        .spawn_watch("echo cached", 5000, &[], false, None)
         .await
         .expect("spawn_watch failed");
 
@@ -515,8 +515,8 @@ async fn test_spawn_watch_cached_exit() {
 async fn test_spawn_watch_multiline() {
     let h = Harness::new().await;
 
-    let pid = h
-        .spawn_watch("printf 'line1\\nline2\\nline3\\n'", 5000, &[], false)
+    let (pid, _stdout_rx) = h
+        .spawn_watch("printf 'line1\\nline2\\nline3\\n'", 5000, &[], false, None)
         .await
         .expect("spawn_watch failed");
 
@@ -534,12 +534,13 @@ async fn test_spawn_watch_multiline() {
 async fn test_spawn_watch_large_output() {
     let h = Harness::new().await;
 
-    let pid = h
+    let (pid, _stdout_rx) = h
         .spawn_watch(
             "dd if=/dev/zero bs=1024 count=10 2>/dev/null | base64",
             5000,
             &[],
             false,
+            None,
         )
         .await
         .expect("spawn_watch failed");
@@ -558,8 +559,8 @@ async fn test_spawn_watch_large_output() {
 async fn test_spawn_watch_delayed_output() {
     let h = Harness::new().await;
 
-    let pid = h
-        .spawn_watch("sleep 0.2 && echo delayed", 5000, &[], false)
+    let (pid, _stdout_rx) = h
+        .spawn_watch("sleep 0.2 && echo delayed", 5000, &[], false, None)
         .await
         .expect("spawn_watch failed");
 
@@ -578,8 +579,8 @@ async fn test_spawn_watch_sigterm() {
     let h = Harness::new().await;
 
     // Use `exec` to replace shell so the PID we get is the actual sleep process
-    let pid = h
-        .spawn_watch("exec sleep 60", 0, &[], false)
+    let (pid, _stdout_rx) = h
+        .spawn_watch("exec sleep 60", 0, &[], false, None)
         .await
         .expect("spawn_watch failed");
 
@@ -606,8 +607,8 @@ async fn test_spawn_watch_sigterm() {
 async fn test_spawn_watch_sigkill() {
     let h = Harness::new().await;
 
-    let pid = h
-        .spawn_watch("exec sleep 60", 0, &[], false)
+    let (pid, _stdout_rx) = h
+        .spawn_watch("exec sleep 60", 0, &[], false, None)
         .await
         .expect("spawn_watch failed");
 
@@ -635,8 +636,8 @@ async fn test_spawn_watch_rapid_multiple() {
 
     let mut pids = Vec::new();
     for i in 0..5 {
-        let pid = h
-            .spawn_watch(&format!("echo p{i}"), 5000, &[], false)
+        let (pid, _rx) = h
+            .spawn_watch(&format!("echo p{i}"), 5000, &[], false, None)
             .await
             .expect("spawn_watch failed");
         pids.push(pid);
@@ -662,8 +663,8 @@ async fn test_spawn_watch_rapid_multiple() {
 async fn test_spawn_watch_nonexistent_command() {
     let h = Harness::new().await;
 
-    let pid = h
-        .spawn_watch("nonexistent_command_12345 2>&1", 5000, &[], false)
+    let (pid, _stdout_rx) = h
+        .spawn_watch("nonexistent_command_12345 2>&1", 5000, &[], false, None)
         .await
         .expect("spawn_watch failed");
 
@@ -687,12 +688,13 @@ async fn test_spawn_watch_nonexistent_command() {
 async fn test_spawn_watch_unicode() {
     let h = Harness::new().await;
 
-    let pid = h
+    let (pid, _stdout_rx) = h
         .spawn_watch(
             "printf '你好世界\\nこんにちは\\n🎉emoji🚀'",
             5000,
             &[],
             false,
+            None,
         )
         .await
         .expect("spawn_watch failed");
@@ -714,12 +716,13 @@ async fn test_spawn_watch_unicode() {
 async fn test_spawn_watch_interleaved_output() {
     let h = Harness::new().await;
 
-    let pid = h
+    let (pid, _stdout_rx) = h
         .spawn_watch(
             "echo out1 && echo err1 >&2 && echo out2 && echo err2 >&2",
             5000,
             &[],
             false,
+            None,
         )
         .await
         .expect("spawn_watch failed");
@@ -877,12 +880,13 @@ async fn test_exec_with_env_special_chars() {
 async fn test_spawn_watch_with_env() {
     let h = Harness::new().await;
 
-    let pid = h
+    let (pid, _stdout_rx) = h
         .spawn_watch(
             "echo $GREETING",
             5000,
             &[("GREETING", "hi_from_env")],
             false,
+            None,
         )
         .await
         .expect("spawn_watch failed");
@@ -894,5 +898,193 @@ async fn test_spawn_watch_with_env() {
 
     assert_eq!(event.exit_code, 0);
     assert_eq!(event.stdout, b"hi_from_env\n");
+    h.finish();
+}
+
+// ── stdout streaming ─────────────────────────────────────────────────
+
+/// When stdout_log_path is set, stdout is streamed via MSG_STDOUT_CHUNK
+/// and teed to the specified file. process_exit.stdout should be empty.
+#[tokio::test]
+async fn test_spawn_watch_stdout_streaming() {
+    let h = Harness::new().await;
+
+    let log_file = h.dir.join("stream.log");
+    let log_path = log_file.to_string_lossy().to_string();
+
+    let (pid, mut stdout_rx) = h
+        .spawn_watch("echo hello_stream", 5000, &[], false, Some(&log_path))
+        .await
+        .expect("spawn_watch failed");
+
+    // Collect streamed chunks
+    let mut streamed = Vec::new();
+    let event = loop {
+        tokio::select! {
+            biased;
+            chunk = stdout_rx.recv() => {
+                match chunk {
+                    Some(data) => streamed.extend_from_slice(&data),
+                    None => break h.wait_for_exit(pid, Duration::from_secs(5)).await.expect("wait failed"),
+                }
+            }
+            event = h.wait_for_exit(pid, Duration::from_secs(5)) => {
+                // Drain any remaining chunks
+                while let Ok(data) = stdout_rx.try_recv() {
+                    streamed.extend_from_slice(&data);
+                }
+                break event.expect("wait failed");
+            }
+        }
+    };
+
+    assert_eq!(event.exit_code, 0);
+    // In streaming mode, stdout is delivered via chunks, not process_exit.
+    assert!(event.stdout.is_empty());
+
+    // Streamed data should contain the output
+    assert_eq!(String::from_utf8_lossy(&streamed).trim(), "hello_stream");
+
+    // VM-side log file should also have the output
+    let log_content = std::fs::read_to_string(&log_file).expect("read log file");
+    assert_eq!(log_content.trim(), "hello_stream");
+
+    h.finish();
+}
+
+/// Streaming with multiple chunks (large output).
+#[tokio::test]
+async fn test_spawn_watch_stdout_streaming_large() {
+    let h = Harness::new().await;
+
+    let log_file = h.dir.join("stream_large.log");
+    let log_path = log_file.to_string_lossy().to_string();
+
+    // Generate ~20KB of output (well over the 8KB chunk size)
+    let (pid, mut stdout_rx) = h
+        .spawn_watch(
+            "dd if=/dev/zero bs=1024 count=20 2>/dev/null | base64",
+            5000,
+            &[],
+            false,
+            Some(&log_path),
+        )
+        .await
+        .expect("spawn_watch failed");
+
+    let mut streamed = Vec::new();
+    let event = loop {
+        tokio::select! {
+            biased;
+            chunk = stdout_rx.recv() => {
+                match chunk {
+                    Some(data) => streamed.extend_from_slice(&data),
+                    None => break h.wait_for_exit(pid, Duration::from_secs(10)).await.expect("wait failed"),
+                }
+            }
+            event = h.wait_for_exit(pid, Duration::from_secs(10)) => {
+                while let Ok(data) = stdout_rx.try_recv() {
+                    streamed.extend_from_slice(&data);
+                }
+                break event.expect("wait failed");
+            }
+        }
+    };
+
+    assert_eq!(event.exit_code, 0);
+    assert!(event.stdout.is_empty());
+    // base64 of 20KB = ~27KB output, should span multiple chunks
+    assert!(
+        streamed.len() > 10000,
+        "expected >10KB, got {}",
+        streamed.len()
+    );
+
+    // VM-side log should match streamed data
+    let log_content = std::fs::read(&log_file).expect("read log file");
+    assert_eq!(log_content, streamed);
+
+    h.finish();
+}
+
+/// stdout_log_path does not leak into child environment.
+#[tokio::test]
+async fn test_spawn_watch_stdout_log_path_not_in_env() {
+    let h = Harness::new().await;
+
+    let log_file = h.dir.join("no_leak.log");
+    let log_path = log_file.to_string_lossy().to_string();
+
+    // The child prints its own env — stdout_log_path is a protocol parameter,
+    // not an env var, so it should never appear in the child's environment.
+    let (pid, _stdout_rx) = h
+        .spawn_watch("env", 5000, &[], false, Some(&log_path))
+        .await
+        .expect("spawn_watch failed");
+
+    let event = h
+        .wait_for_exit(pid, Duration::from_secs(5))
+        .await
+        .expect("wait failed");
+
+    assert_eq!(event.exit_code, 0);
+    let log_content = std::fs::read_to_string(&log_file).expect("read log file");
+    assert!(
+        !log_content.contains(&log_path),
+        "stdout_log_path should not appear in child env"
+    );
+
+    h.finish();
+}
+
+/// Timeout must fire even while stdout is being streamed.
+/// Without the fix, the timeout killer thread was only spawned after the stdout
+/// loop finished, so a process producing output past the deadline would hang.
+#[tokio::test]
+async fn test_spawn_watch_stdout_streaming_timeout() {
+    let h = Harness::new().await;
+
+    let log_file = h.dir.join("stream_timeout.log");
+    let log_path = log_file.to_string_lossy().to_string();
+
+    // Process that produces output forever — must be killed by the 100ms timeout.
+    let (pid, mut stdout_rx) = h
+        .spawn_watch(
+            "while true; do echo tick; sleep 0.01; done",
+            100,
+            &[],
+            false,
+            Some(&log_path),
+        )
+        .await
+        .expect("spawn_watch failed");
+
+    // Drain streamed chunks until process exits
+    let mut streamed = Vec::new();
+    let event = loop {
+        tokio::select! {
+            biased;
+            chunk = stdout_rx.recv() => {
+                match chunk {
+                    Some(data) => streamed.extend_from_slice(&data),
+                    None => break h.wait_for_exit(pid, Duration::from_secs(5)).await.expect("wait failed"),
+                }
+            }
+            event = h.wait_for_exit(pid, Duration::from_secs(5)) => {
+                while let Ok(data) = stdout_rx.try_recv() {
+                    streamed.extend_from_slice(&data);
+                }
+                break event.expect("wait failed");
+            }
+        }
+    };
+
+    assert_eq!(event.exit_code, 124); // timeout exit code
+    // Should have received some streamed output before the kill
+    assert!(
+        !streamed.is_empty(),
+        "expected some streamed output before timeout"
+    );
+
     h.finish();
 }


### PR DESCRIPTION
## Summary

- Add `MSG_STDOUT_CHUNK` (0x0C) message type to vsock protocol for real-time log streaming during `spawn_watch`
- Guest tees stdout to a log file AND streams 8KB chunks to host via vsock, providing real-time visibility into running jobs
- `stdout_log_path` passed as a protocol parameter (not env var), keeping child environment clean
- Two-path delivery: streaming for real-time visibility, `copy_guest_logs` for final complete file

### Changed files (10 files, +802 −134)

| Crate | Change |
|---|---|
| `vsock-proto` | New `encode/decode_spawn_watch` with `stdout_log_path`, `encode/decode_stdout_chunk`, backward-compatible wire format |
| `vsock-guest` | `spawn_streaming_monitor` (tee stdout to file + vsock chunks), renamed `spawn_buffered_monitor` for legacy path |
| `vsock-host` | Channel-based chunk delivery via `stdout_senders` HashMap, cleanup on process exit and connection close |
| `sandbox` | `SpawnHandle` gains optional `stdout_rx` receiver, `spawn_watch` trait takes `stdout_log_path` |
| `sandbox-fc` | Passes `stdout_log_path` through to VsockHost |
| `runner` | `drain_stdout_to_file` writes streamed chunks to host log, removed env var hack |
| `vsock-test` | 4 new streaming integration tests + updated all spawn_watch calls |

Closes #5439

## Test plan

- [x] All workspace tests pass (`cargo test --workspace`)
- [x] Clippy clean (`cargo clippy --workspace --all-targets`)
- [x] 4 new streaming tests: basic, large output (multi-chunk), env-not-leaked, timeout-while-streaming
- [x] 3 new proto roundtrip tests: with log_path, without, backward compat
- [x] All 41 existing integration tests still pass
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)