### PR TITLE
feat(runner): pass disallowed tools from execution context to claude cli

### DIFF
--- a/crates/guest-agent/src/cli.rs
+++ b/crates/guest-agent/src/cli.rs
@@ -22,7 +22,12 @@ pub fn build_cli_command() -> Result<Vec<String>, AgentError> {
 }
 
 /// Build the argument list from explicit parameters (testable).
-fn build_claude_args(resume_id: &str, append_system_prompt: &str, prompt: &str) -> Vec<String> {
+fn build_claude_args(
+    resume_id: &str,
+    append_system_prompt: &str,
+    disallowed_tools: &str,
+    prompt: &str,
+) -> Vec<String> {
     let mut args = vec![
         "--print".to_string(),
         "--verbose".to_string(),
@@ -44,6 +49,16 @@ fn build_claude_args(resume_id: &str, append_system_prompt: &str, prompt: &str) 
         args.push(append_system_prompt.to_string());
     }
 
+    if !disallowed_tools.is_empty() {
+        args.push("--disallowed-tools".to_string());
+        for tool in disallowed_tools.split(',') {
+            let tool = tool.trim();
+            if !tool.is_empty() {
+                args.push(tool.to_string());
+            }
+        }
+    }
+
     // Prompt must be the last positional argument
     args.push(prompt.to_string());
     args
@@ -53,6 +68,7 @@ fn build_claude_command(use_mock: bool) -> Vec<String> {
     let args = build_claude_args(
         env::resume_session_id(),
         env::append_system_prompt(),
+        env::disallowed_tools(),
         env::prompt(),
     );
 
@@ -320,7 +336,7 @@ mod tests {
 
     #[test]
     fn build_claude_args_basic() {
-        let args = build_claude_args("", "", "hello world");
+        let args = build_claude_args("", "", "", "hello world");
         assert!(args.contains(&"--print".to_string()));
         assert!(args.contains(&"--dangerously-skip-permissions".to_string()));
         assert_eq!(args.last().unwrap(), "hello world");
@@ -330,7 +346,7 @@ mod tests {
 
     #[test]
     fn build_claude_args_with_append_system_prompt() {
-        let args = build_claude_args("", "Your name is Aria.", "analyze this");
+        let args = build_claude_args("", "Your name is Aria.", "", "analyze this");
         let asp_idx = args
             .iter()
             .position(|a| a == "--append-system-prompt")
@@ -344,13 +360,13 @@ mod tests {
 
     #[test]
     fn build_claude_args_empty_append_system_prompt_omitted() {
-        let args = build_claude_args("", "", "test");
+        let args = build_claude_args("", "", "", "test");
         assert!(!args.contains(&"--append-system-prompt".to_string()));
     }
 
     #[test]
     fn build_claude_args_with_resume_and_append() {
-        let args = build_claude_args("sess-123", "Be helpful.", "prompt");
+        let args = build_claude_args("sess-123", "Be helpful.", "", "prompt");
         assert!(args.contains(&"--resume".to_string()));
         assert!(args.contains(&"--append-system-prompt".to_string()));
         assert_eq!(args.last().unwrap(), "prompt");
@@ -366,5 +382,22 @@ mod tests {
     fn build_claude_command_uses_mock_binary() {
         let cmd = build_claude_command(true);
         assert_eq!(cmd[0], "/usr/local/bin/guest-mock-claude");
+    }
+
+    #[test]
+    fn build_claude_args_with_disallowed_tools() {
+        let args = build_claude_args("", "", "CronCreate,CronDelete,CronList", "hello");
+        let dt_idx = args.iter().position(|a| a == "--disallowed-tools").unwrap();
+        assert_eq!(args[dt_idx + 1], "CronCreate");
+        assert_eq!(args[dt_idx + 2], "CronDelete");
+        assert_eq!(args[dt_idx + 3], "CronList");
+        // Prompt must be last
+        assert_eq!(args.last().unwrap(), "hello");
+    }
+
+    #[test]
+    fn build_claude_args_empty_disallowed_tools_omitted() {
+        let args = build_claude_args("", "", "", "test");
+        assert!(!args.contains(&"--disallowed-tools".to_string()));
     }
 }

--- a/crates/guest-agent/src/env.rs
+++ b/crates/guest-agent/src/env.rs
@@ -24,6 +24,7 @@ static RESUME_SESSION_ID: LazyLock<String> =
 static API_START_TIME: LazyLock<String> = LazyLock::new(|| env_or_empty("VM0_API_START_TIME"));
 static WORKING_DIR: LazyLock<String> = LazyLock::new(|| env_or_empty("VM0_WORKING_DIR"));
 static SECRET_VALUES: LazyLock<String> = LazyLock::new(|| env_or_empty("VM0_SECRET_VALUES"));
+static DISALLOWED_TOOLS: LazyLock<String> = LazyLock::new(|| env_or_empty("VM0_DISALLOWED_TOOLS"));
 static USE_MOCK_CLAUDE: LazyLock<bool> = LazyLock::new(|| {
     std::env::var("USE_MOCK_CLAUDE")
         .map(|v| v == "true")
@@ -103,6 +104,9 @@ pub fn working_dir() -> &'static str {
 }
 pub fn secret_values() -> &'static str {
     &SECRET_VALUES
+}
+pub fn disallowed_tools() -> &'static str {
+    &DISALLOWED_TOOLS
 }
 pub fn use_mock_claude() -> bool {
     *USE_MOCK_CLAUDE

--- a/crates/guest-mock-claude/src/main.rs
+++ b/crates/guest-mock-claude/src/main.rs
@@ -45,6 +45,11 @@ fn parse_args(args: &[String]) -> ParsedArgs {
                     i += 1;
                 }
             }
+            "--disallowed-tools" => {
+                // Skip the flag; tool names fall through to remaining
+                // and prompt is extracted as last remaining arg
+                i += 1;
+            }
             "--print" | "--verbose" | "--dangerously-skip-permissions" => {
                 i += 1;
             }
@@ -57,7 +62,7 @@ fn parse_args(args: &[String]) -> ParsedArgs {
         }
     }
 
-    let prompt = remaining.into_iter().next().unwrap_or_default();
+    let prompt = remaining.into_iter().last().unwrap_or_default();
 
     ParsedArgs {
         output_format,
@@ -389,13 +394,13 @@ mod tests {
     }
 
     #[test]
-    fn parse_args_first_remaining_is_prompt() {
+    fn parse_args_last_remaining_is_prompt() {
         let args: Vec<String> = vec!["first", "second", "third"]
             .into_iter()
             .map(String::from)
             .collect();
         let result = parse_args(&args);
-        assert_eq!(result.prompt, "first");
+        assert_eq!(result.prompt, "third");
     }
 
     #[test]
@@ -456,5 +461,20 @@ mod tests {
         std::thread::sleep(std::time::Duration::from_millis(1));
         let id2 = generate_session_id();
         assert_ne!(id1, id2);
+    }
+
+    #[test]
+    fn parse_args_disallowed_tools_skipped() {
+        let args: Vec<String> = vec![
+            "--disallowed-tools",
+            "CronCreate",
+            "CronDelete",
+            "echo hello",
+        ]
+        .into_iter()
+        .map(String::from)
+        .collect();
+        let result = parse_args(&args);
+        assert_eq!(result.prompt, "echo hello");
     }
 }

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -661,6 +661,13 @@ fn build_env_json(context: &ExecutionContext, api_url: &str) -> HashMap<String, 
         env.insert("VM0_SECRET_VALUES".into(), encoded.join(","));
     }
 
+    // Disallowed tools (comma-separated for guest-agent)
+    if let Some(tools) = &context.disallowed_tools
+        && !tools.is_empty()
+    {
+        env.insert("VM0_DISALLOWED_TOOLS".into(), tools.join(","));
+    }
+
     env
 }
 
@@ -700,6 +707,7 @@ mod tests {
             experimental_firewalls: None,
             experimental_capabilities: None,
             experimental_profile: None,
+            disallowed_tools: None,
         }
     }
 
@@ -1180,5 +1188,31 @@ mod tests {
         for id in valid_ids {
             assert!(is_valid_session_id(id), "expected acceptance for: {id:?}");
         }
+    }
+
+    #[test]
+    fn build_env_json_with_disallowed_tools() {
+        let mut ctx = minimal_context();
+        ctx.disallowed_tools = Some(vec!["CronCreate".into(), "CronDelete".into()]);
+        let env = build_env_json(&ctx, "http://localhost");
+        assert_eq!(
+            env.get("VM0_DISALLOWED_TOOLS").unwrap(),
+            "CronCreate,CronDelete"
+        );
+    }
+
+    #[test]
+    fn build_env_json_empty_disallowed_tools_omitted() {
+        let mut ctx = minimal_context();
+        ctx.disallowed_tools = Some(vec![]);
+        let env = build_env_json(&ctx, "http://localhost");
+        assert!(!env.contains_key("VM0_DISALLOWED_TOOLS"));
+    }
+
+    #[test]
+    fn build_env_json_no_disallowed_tools() {
+        let ctx = minimal_context();
+        let env = build_env_json(&ctx, "http://localhost");
+        assert!(!env.contains_key("VM0_DISALLOWED_TOOLS"));
     }
 }

--- a/crates/runner/src/provider/local.rs
+++ b/crates/runner/src/provider/local.rs
@@ -180,6 +180,7 @@ impl JobProvider for LocalProvider {
             experimental_firewalls: None,
             experimental_capabilities: None,
             experimental_profile: req.profile,
+            disallowed_tools: None,
         })
     }
 

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -87,6 +87,8 @@ pub struct ExecutionContext {
     #[allow(dead_code)]
     #[serde(default)]
     pub experimental_profile: Option<String>,
+    #[serde(default)]
+    pub disallowed_tools: Option<Vec<String>>,
 }
 
 /// A single firewall config with its name, ref key, and API entries.


### PR DESCRIPTION
## Summary

- Add `disallowed_tools: Option<Vec<String>>` field to runner's `ExecutionContext` struct
- Set `VM0_DISALLOWED_TOOLS` comma-separated env var in `build_env_json()` when tools are present
- Add env var reader in guest-agent (`env.rs`) and pass `--disallowed-tools` flag to Claude CLI args (`cli.rs`)
- Handle `--disallowed-tools` flag in mock-claude parser; change prompt extraction to use last positional arg
- Add 6 unit tests covering present, empty, and absent cases across runner, guest-agent, and mock-claude

## Test plan

- [x] `cargo test -p runner -- build_env_json` — 31 tests pass (3 new)
- [x] `cargo test -p guest-agent -- build_claude_args` — 6 tests pass (2 new)
- [x] `cargo test -p guest-mock-claude -- parse_args` — 10 tests pass (1 new)
- [x] `cargo test --workspace` — 548 tests pass, 0 failures
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --workspace` — clean

Closes #5564

🤖 Generated with [Claude Code](https://claude.com/claude-code)