### PR TITLE
chore: reduce max tier concurrency limit from 10 to 5

### DIFF
--- a/turbo/apps/cli/src/commands/run/__tests__/queue.test.ts
+++ b/turbo/apps/cli/src/commands/run/__tests__/queue.test.ts
@@ -32,7 +32,7 @@ describe("run queue command", () => {
     server.use(
       http.get("http://localhost:3000/api/agent/runs/queue", () => {
         return HttpResponse.json({
-          concurrency: { tier: "max", limit: 10, active: 8, available: 2 },
+          concurrency: { tier: "max", limit: 5, active: 3, available: 2 },
           queue: [
             {
               position: 1,
@@ -56,7 +56,7 @@ describe("run queue command", () => {
     await queueCommand.parseAsync(["node", "cli"]);
 
     const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
-    expect(logCalls).toContain("8/10 slots used");
+    expect(logCalls).toContain("3/5 slots used");
     expect(logCalls).toContain("max tier");
     expect(logCalls).toContain("2 runs waiting");
     expect(logCalls).toContain("AGENT");
@@ -72,7 +72,7 @@ describe("run queue command", () => {
     server.use(
       http.get("http://localhost:3000/api/agent/runs/queue", () => {
         return HttpResponse.json({
-          concurrency: { tier: "max", limit: 10, active: 8, available: 2 },
+          concurrency: { tier: "max", limit: 5, active: 3, available: 2 },
           queue: [
             {
               position: 1,

--- a/turbo/apps/web/src/lib/run/run-service.ts
+++ b/turbo/apps/web/src/lib/run/run-service.ts
@@ -49,7 +49,7 @@ export const PENDING_RUN_TTL_MS = 15 * 60 * 1000; // 15 minutes
 const TIER_CONCURRENCY_LIMITS: Record<OrgTier, number> = {
   free: 1,
   pro: 2,
-  max: 10,
+  max: 5,
 };
 
 function getConcurrencyLimitForTier(tier: OrgTier): number {


### PR DESCRIPTION
## Summary
- Reduce max tier concurrent run limit from 10 to 5
- Update CLI queue command test mock data to match

## Test plan
- [ ] Verify max tier orgs are limited to 5 concurrent runs
- [ ] Verify existing free (1) and pro (2) tier limits are unchanged
- [ ] Confirm `CONCURRENT_RUN_LIMIT_CAP` env var still acts as global cap

🤖 Generated with [Claude Code](https://claude.com/claude-code)