### PR TITLE
fix(test): prevent race condition in compose idempotency test

### DIFF
--- a/turbo/apps/web/app/api/compose/jobs/__tests__/server-side-compose.test.ts
+++ b/turbo/apps/web/app/api/compose/jobs/__tests__/server-side-compose.test.ts
@@ -205,6 +205,11 @@ describe("Server-side compose", () => {
     });
 
     it("should return existing sandbox job when falling back to sandbox", async () => {
+      // Stall the fire-and-forget sandbox spawn so it cannot race with request 2.
+      // Without this, the .catch() handler in triggerComposeJob can mark the job
+      // as "failed" before request 2 queries, causing a flaky 201 instead of 200.
+      vi.mocked(Sandbox.create).mockReturnValueOnce(new Promise(() => {}));
+
       // Create a sandbox job first (uncached skill triggers sandbox)
       const content = makeContent({
         skills: ["https://github.com/vm0-ai/vm0-skills/tree/main/uncached"],


### PR DESCRIPTION
## Summary

- Fix flaky test `server-side-compose > idempotency > should return existing sandbox job when falling back to sandbox` that intermittently fails in CI merge queue
- Stall the fire-and-forget sandbox spawn by mocking `Sandbox.create` with a never-settling promise, eliminating the race between the `.catch()` error handler and the second request

## Root Cause

`triggerComposeJob()` spawns a sandbox via fire-and-forget with a `.catch()` that marks the job as `"failed"`. Under CI load, `spawnComposeJobSandbox` can fail (DB connection pressure, E2B mock timing), and the `.catch()` completes before the second request queries for active jobs. The second request then misses the job (status is `"failed"`, not `"pending"`/`"running"`) and creates a new one — returning 201 instead of the expected 200.

Two independent PRs (#5505, #5536) hit this identical failure; both passed on retry.

## Test plan

- [x] All 12 tests in `server-side-compose.test.ts` pass
- [x] 5/5 consecutive runs pass
- [x] Reproduced the CI failure by forcing `Sandbox.create` to reject — confirmed the fix prevents it

🤖 Generated with [Claude Code](https://claude.com/claude-code)