### PR TITLE
feat: add email-based feature switch targeting

### DIFF
--- a/turbo/apps/platform/src/__tests__/mock-auth.ts
+++ b/turbo/apps/platform/src/__tests__/mock-auth.ts
@@ -3,6 +3,7 @@ import { vi } from "vitest";
 interface MockedUser {
   id: string;
   fullName: string;
+  primaryEmailAddress: { emailAddress: string } | null;
   organizationMemberships: { id: string }[];
   getOrganizationInvitations: (params?: {
     status?: string;
@@ -16,12 +17,13 @@ let internalMockedInvitations: { id: string }[] = [];
 let internalMockedMemberships: { id: string }[] = [{ id: "org_default" }];
 
 export function mockUser(
-  user: { id: string; fullName: string } | null,
+  user: { id: string; fullName: string; email?: string } | null,
   session: { token: string } | null,
 ) {
   if (user) {
     internalMockedUser = {
       ...user,
+      primaryEmailAddress: user.email ? { emailAddress: user.email } : null,
       get organizationMemberships() {
         return internalMockedMemberships;
       },

--- a/turbo/apps/platform/src/__tests__/page-helper.ts
+++ b/turbo/apps/platform/src/__tests__/page-helper.ts
@@ -20,7 +20,7 @@ import { setDebugLoggerLocalStorage$ } from "../signals/bootstrap/loggers";
 export async function setupPage(options: {
   context: TestContext;
   path: string;
-  user?: { id: string; fullName: string } | null;
+  user?: { id: string; fullName: string; email?: string } | null;
   session?: { token: string } | null;
   debugLoggers?: string[];
   featureSwitches?: Partial<Record<FeatureSwitchKey, boolean>>;

--- a/turbo/apps/platform/src/signals/external/feature-switch.ts
+++ b/turbo/apps/platform/src/signals/external/feature-switch.ts
@@ -17,8 +17,9 @@ export const featureSwitch$ = computed(async (get) => {
 
   const user = await get(user$);
   const userId = user?.id;
+  const email = user?.primaryEmailAddress?.emailAddress;
 
-  const result = await getAllFeatureStates(userId);
+  const result = await getAllFeatureStates(userId, email);
 
   const override = get(get$);
   if (!override) {

--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-connectors.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-connectors.test.ts
@@ -23,7 +23,7 @@ describe("connectors", () => {
     const gmailConnector = connectorTypes.find((c) => c.type === "gmail");
 
     expect(gmailConnector).toBeDefined();
-    expect(gmailConnector!.connected).toBe(false);
+    expect(gmailConnector!.connected).toBeFalsy();
   });
 
   it("should not show gmail connector when feature switch is disabled", async () => {

--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-connectors.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-connectors.test.ts
@@ -23,7 +23,10 @@ describe("connectors", () => {
     const gmailConnector = connectorTypes.find((c) => c.type === "gmail");
 
     expect(gmailConnector).toBeDefined();
-    expect(gmailConnector!.connected).toBeFalsy();
+    if (!gmailConnector) {
+      return;
+    }
+    expect(gmailConnector.connected).toBeFalsy();
   });
 
   it("should not show gmail connector when feature switch is disabled", async () => {

--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-connectors.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-connectors.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import { testContext } from "../../__tests__/test-helpers.ts";
+import { setupPage } from "../../../__tests__/page-helper.ts";
+import { allConnectorTypes$ } from "../settings/connectors.ts";
+
+const context = testContext();
+
+describe("connectors", () => {
+  it("should show gmail connector when feature switch is enabled for user with email", async () => {
+    await setupPage({
+      context,
+      path: "/",
+      user: {
+        id: "test-user-123",
+        fullName: "Test User",
+        email: "testing@vm0.ai",
+      },
+      featureSwitches: { gmailConnector: true },
+      withoutRender: true,
+    });
+
+    const connectorTypes = await context.store.get(allConnectorTypes$);
+    const gmailConnector = connectorTypes.find((c) => c.type === "gmail");
+
+    expect(gmailConnector).toBeDefined();
+    expect(gmailConnector?.label).toContain("Gmail");
+    expect(gmailConnector?.connected).toBe(false);
+  });
+
+  it("should not show gmail connector when feature switch is disabled", async () => {
+    await setupPage({
+      context,
+      path: "/",
+      user: {
+        id: "test-user-123",
+        fullName: "Test User",
+        email: "testing@vm0.ai",
+      },
+      featureSwitches: { gmailConnector: false },
+      withoutRender: true,
+    });
+
+    const connectorTypes = await context.store.get(allConnectorTypes$);
+    const gmailConnector = connectorTypes.find((c) => c.type === "gmail");
+
+    expect(gmailConnector).toBeUndefined();
+  });
+});

--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-connectors.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-connectors.test.ts
@@ -24,7 +24,7 @@ describe("connectors", () => {
 
     expect(gmailConnector).toBeDefined();
     expect(gmailConnector?.label).toContain("Gmail");
-    expect(gmailConnector?.connected).toBe(false);
+    expect(gmailConnector?.connected).toBeFalsy();
   });
 
   it("should not show gmail connector when feature switch is disabled", async () => {

--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-connectors.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-connectors.test.ts
@@ -23,8 +23,7 @@ describe("connectors", () => {
     const gmailConnector = connectorTypes.find((c) => c.type === "gmail");
 
     expect(gmailConnector).toBeDefined();
-    expect(gmailConnector?.label).toContain("Gmail");
-    expect(gmailConnector?.connected).toBeFalsy();
+    expect(gmailConnector!.connected).toBe(false);
   });
 
   it("should not show gmail connector when feature switch is disabled", async () => {

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { FeatureSwitchKey } from "../feature-switch-key";
-import { isFeatureEnabled } from "../feature-switch";
+import { isFeatureEnabled, getAllFeatureStates } from "../feature-switch";
 
 describe("isFeatureEnabled", () => {
   it("should return true for globally enabled switch", async () => {
@@ -23,5 +23,73 @@ describe("isFeatureEnabled", () => {
     await expect(
       isFeatureEnabled(FeatureSwitchKey.Pricing, "some-user"),
     ).resolves.toBe(false);
+  });
+
+  it("should return false for email-gated switch with non-matching email", async () => {
+    await expect(
+      isFeatureEnabled(
+        FeatureSwitchKey.GmailConnector,
+        undefined,
+        "random@example.com",
+      ),
+    ).resolves.toBe(false);
+  });
+
+  it("should return false for email-gated switch without email", async () => {
+    await expect(
+      isFeatureEnabled(FeatureSwitchKey.GmailConnector),
+    ).resolves.toBe(false);
+  });
+
+  it("should return false for switch with enabledEmailHashes when no enabledEmailHashes configured", async () => {
+    // AhrefsConnector has enabledUserHashes but no enabledEmailHashes
+    await expect(
+      isFeatureEnabled(
+        FeatureSwitchKey.AhrefsConnector,
+        undefined,
+        "test@example.com",
+      ),
+    ).resolves.toBe(false);
+  });
+
+  it("should treat email case-insensitively by lowercasing before hashing", async () => {
+    // Both should produce the same result since email is lowercased
+    const resultLower = await isFeatureEnabled(
+      FeatureSwitchKey.GmailConnector,
+      undefined,
+      "test@example.com",
+    );
+    const resultUpper = await isFeatureEnabled(
+      FeatureSwitchKey.GmailConnector,
+      undefined,
+      "TEST@EXAMPLE.COM",
+    );
+    expect(resultLower).toBe(resultUpper);
+  });
+});
+
+describe("getAllFeatureStates", () => {
+  it("should return states for all feature switches", async () => {
+    const states = await getAllFeatureStates();
+    // Globally enabled switches should be true
+    expect(states[FeatureSwitchKey.Dummy]).toBe(true);
+    // Disabled switches without matching user/email should be false
+    expect(states[FeatureSwitchKey.Pricing]).toBe(false);
+    expect(states[FeatureSwitchKey.GmailConnector]).toBe(false);
+  });
+
+  it("should evaluate email hashes when email is provided", async () => {
+    const statesWithoutEmail = await getAllFeatureStates();
+    const statesWithEmail = await getAllFeatureStates(
+      undefined,
+      "nonmatching@example.com",
+    );
+
+    // Both should have same result for non-matching email
+    expect(statesWithoutEmail[FeatureSwitchKey.GmailConnector]).toBe(false);
+    expect(statesWithEmail[FeatureSwitchKey.GmailConnector]).toBe(false);
+
+    // Globally enabled switches unaffected by email
+    expect(statesWithEmail[FeatureSwitchKey.Dummy]).toBe(true);
   });
 });

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -1,6 +1,26 @@
 import { describe, it, expect } from "vitest";
 import { FeatureSwitchKey } from "../feature-switch-key";
-import { isFeatureEnabled, getAllFeatureStates } from "../feature-switch";
+import {
+  isFeatureEnabled,
+  getAllFeatureStates,
+  computeEmailHash,
+} from "../feature-switch";
+
+describe("computeEmailHash", () => {
+  it("should produce a consistent SHA-1 hex hash", async () => {
+    const hash = await computeEmailHash("test@example.com");
+    // SHA-1 produces a 40-character hex string
+    expect(hash).toMatch(/^[0-9a-f]{40}$/);
+  });
+
+  it("should lowercase the email before hashing", async () => {
+    const lower = await computeEmailHash("test@example.com");
+    const upper = await computeEmailHash("TEST@EXAMPLE.COM");
+    const mixed = await computeEmailHash("Test@Example.Com");
+    expect(lower).toBe(upper);
+    expect(lower).toBe(mixed);
+  });
+});
 
 describe("isFeatureEnabled", () => {
   it("should return true for globally enabled switch", async () => {
@@ -25,18 +45,6 @@ describe("isFeatureEnabled", () => {
     ).resolves.toBe(false);
   });
 
-  it("should return true for email-gated switch with matching email", async () => {
-    // testreviewer@example.com has SHA-1 086eee0974906eb383d645ade1d76c806278ded1
-    // which is in GOOGLE_OAUTH_REVIEWER_EMAIL_HASHES
-    await expect(
-      isFeatureEnabled(
-        FeatureSwitchKey.GmailConnector,
-        undefined,
-        "testreviewer@example.com",
-      ),
-    ).resolves.toBe(true);
-  });
-
   it("should return false for email-gated switch with non-matching email", async () => {
     await expect(
       isFeatureEnabled(
@@ -53,7 +61,7 @@ describe("isFeatureEnabled", () => {
     ).resolves.toBe(false);
   });
 
-  it("should return false for switch with enabledEmailHashes when no enabledEmailHashes configured", async () => {
+  it("should return false for switch with enabledUserHashes but no enabledEmailHashes when only email provided", async () => {
     // AhrefsConnector has enabledUserHashes but no enabledEmailHashes
     await expect(
       isFeatureEnabled(
@@ -62,25 +70,6 @@ describe("isFeatureEnabled", () => {
         "test@example.com",
       ),
     ).resolves.toBe(false);
-  });
-
-  it("should treat email case-insensitively by lowercasing before hashing", async () => {
-    // testreviewer@example.com matches a hash in GOOGLE_OAUTH_REVIEWER_EMAIL_HASHES
-    // Both casing variants should return true, proving lowercasing works for matches
-    await expect(
-      isFeatureEnabled(
-        FeatureSwitchKey.GmailConnector,
-        undefined,
-        "testreviewer@example.com",
-      ),
-    ).resolves.toBe(true);
-    await expect(
-      isFeatureEnabled(
-        FeatureSwitchKey.GmailConnector,
-        undefined,
-        "TESTREVIEWER@EXAMPLE.COM",
-      ),
-    ).resolves.toBe(true);
   });
 });
 
@@ -94,25 +83,17 @@ describe("getAllFeatureStates", () => {
     expect(states[FeatureSwitchKey.GmailConnector]).toBe(false);
   });
 
-  it("should evaluate email hashes when email is provided", async () => {
+  it("should return false for email-gated switches with non-matching email", async () => {
     const statesWithoutEmail = await getAllFeatureStates();
     const statesWithNonMatching = await getAllFeatureStates(
       undefined,
       "nonmatching@example.com",
     );
-    const statesWithMatching = await getAllFeatureStates(
-      undefined,
-      "testreviewer@example.com",
-    );
 
-    // Non-matching email should not enable email-gated switches
     expect(statesWithoutEmail[FeatureSwitchKey.GmailConnector]).toBe(false);
     expect(statesWithNonMatching[FeatureSwitchKey.GmailConnector]).toBe(false);
 
-    // Matching email should enable email-gated switches
-    expect(statesWithMatching[FeatureSwitchKey.GmailConnector]).toBe(true);
-
     // Globally enabled switches unaffected by email
-    expect(statesWithMatching[FeatureSwitchKey.Dummy]).toBe(true);
+    expect(statesWithNonMatching[FeatureSwitchKey.Dummy]).toBe(true);
   });
 });

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -25,6 +25,18 @@ describe("isFeatureEnabled", () => {
     ).resolves.toBe(false);
   });
 
+  it("should return true for email-gated switch with matching email", async () => {
+    // testreviewer@example.com has SHA-1 086eee0974906eb383d645ade1d76c806278ded1
+    // which is in GOOGLE_OAUTH_REVIEWER_EMAIL_HASHES
+    await expect(
+      isFeatureEnabled(
+        FeatureSwitchKey.GmailConnector,
+        undefined,
+        "testreviewer@example.com",
+      ),
+    ).resolves.toBe(true);
+  });
+
   it("should return false for email-gated switch with non-matching email", async () => {
     await expect(
       isFeatureEnabled(
@@ -53,18 +65,22 @@ describe("isFeatureEnabled", () => {
   });
 
   it("should treat email case-insensitively by lowercasing before hashing", async () => {
-    // Both should produce the same result since email is lowercased
-    const resultLower = await isFeatureEnabled(
-      FeatureSwitchKey.GmailConnector,
-      undefined,
-      "test@example.com",
-    );
-    const resultUpper = await isFeatureEnabled(
-      FeatureSwitchKey.GmailConnector,
-      undefined,
-      "TEST@EXAMPLE.COM",
-    );
-    expect(resultLower).toBe(resultUpper);
+    // testreviewer@example.com matches a hash in GOOGLE_OAUTH_REVIEWER_EMAIL_HASHES
+    // Both casing variants should return true, proving lowercasing works for matches
+    await expect(
+      isFeatureEnabled(
+        FeatureSwitchKey.GmailConnector,
+        undefined,
+        "testreviewer@example.com",
+      ),
+    ).resolves.toBe(true);
+    await expect(
+      isFeatureEnabled(
+        FeatureSwitchKey.GmailConnector,
+        undefined,
+        "TESTREVIEWER@EXAMPLE.COM",
+      ),
+    ).resolves.toBe(true);
   });
 });
 
@@ -80,16 +96,23 @@ describe("getAllFeatureStates", () => {
 
   it("should evaluate email hashes when email is provided", async () => {
     const statesWithoutEmail = await getAllFeatureStates();
-    const statesWithEmail = await getAllFeatureStates(
+    const statesWithNonMatching = await getAllFeatureStates(
       undefined,
       "nonmatching@example.com",
     );
+    const statesWithMatching = await getAllFeatureStates(
+      undefined,
+      "testreviewer@example.com",
+    );
 
-    // Both should have same result for non-matching email
+    // Non-matching email should not enable email-gated switches
     expect(statesWithoutEmail[FeatureSwitchKey.GmailConnector]).toBe(false);
-    expect(statesWithEmail[FeatureSwitchKey.GmailConnector]).toBe(false);
+    expect(statesWithNonMatching[FeatureSwitchKey.GmailConnector]).toBe(false);
+
+    // Matching email should enable email-gated switches
+    expect(statesWithMatching[FeatureSwitchKey.GmailConnector]).toBe(true);
 
     // Globally enabled switches unaffected by email
-    expect(statesWithEmail[FeatureSwitchKey.Dummy]).toBe(true);
+    expect(statesWithMatching[FeatureSwitchKey.Dummy]).toBe(true);
   });
 });

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -28,6 +28,14 @@ async function sha1(input: string): Promise<string> {
   return hex;
 }
 
+/**
+ * Compute the SHA-1 hash of an email address (lowercased).
+ * Used for email-based feature switch targeting.
+ */
+export async function computeEmailHash(email: string): Promise<string> {
+  return sha1(email.toLowerCase());
+}
+
 const STAFF_USER_HASHES: readonly string[] = [
   "afc25aa601481d794372ed765038148d3a160e2a",
   "1e7de00267c699185653df499f68e8383013ca08",
@@ -39,7 +47,6 @@ const STAFF_USER_HASHES: readonly string[] = [
 
 const GOOGLE_OAUTH_REVIEWER_EMAIL_HASHES: readonly string[] = [
   "da04f6515e16a883d6e8c4b03932f51ccc362c10", // Google OAuth reviewer
-  "086eee0974906eb383d645ade1d76c806278ded1", // testreviewer@example.com — used by integration tests
 ];
 
 /**

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -39,6 +39,7 @@ const STAFF_USER_HASHES: readonly string[] = [
 
 const GOOGLE_OAUTH_REVIEWER_EMAIL_HASHES: readonly string[] = [
   "da04f6515e16a883d6e8c4b03932f51ccc362c10", // Google OAuth reviewer
+  "086eee0974906eb383d645ade1d76c806278ded1", // testreviewer@example.com — used by integration tests
 ];
 
 /**

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -11,6 +11,7 @@ export interface FeatureSwitch {
   readonly maintainer: string;
   readonly enabled: boolean;
   readonly enabledUserHashes?: readonly string[];
+  readonly enabledEmailHashes?: readonly string[];
 }
 
 const sha1Cache = new Map<string, string>();
@@ -34,6 +35,10 @@ const STAFF_USER_HASHES: readonly string[] = [
   "d938bb6e49cb8ccfaa962942d69c9ccd1ee239af",
   "67a65740246389d7fecf7702f8b7d6914ad38dc5",
   "55651a8b2c85b35ff0629fa3d4718b9476069d0f",
+];
+
+const GOOGLE_OAUTH_REVIEWER_EMAIL_HASHES: readonly string[] = [
+  "da04f6515e16a883d6e8c4b03932f51ccc362c10", // Google OAuth reviewer
 ];
 
 /**
@@ -103,26 +108,31 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     maintainer: "ethan@vm0.ai",
     enabled: false,
     enabledUserHashes: STAFF_USER_HASHES,
+    enabledEmailHashes: GOOGLE_OAUTH_REVIEWER_EMAIL_HASHES,
   },
   [FeatureSwitchKey.GoogleSheetsConnector]: {
     maintainer: "ethan@vm0.ai",
     enabled: false,
     enabledUserHashes: STAFF_USER_HASHES,
+    enabledEmailHashes: GOOGLE_OAUTH_REVIEWER_EMAIL_HASHES,
   },
   [FeatureSwitchKey.GoogleDocsConnector]: {
     maintainer: "ethan@vm0.ai",
     enabled: false,
     enabledUserHashes: STAFF_USER_HASHES,
+    enabledEmailHashes: GOOGLE_OAUTH_REVIEWER_EMAIL_HASHES,
   },
   [FeatureSwitchKey.GoogleDriveConnector]: {
     maintainer: "ethan@vm0.ai",
     enabled: false,
     enabledUserHashes: STAFF_USER_HASHES,
+    enabledEmailHashes: GOOGLE_OAUTH_REVIEWER_EMAIL_HASHES,
   },
   [FeatureSwitchKey.GoogleCalendarConnector]: {
     maintainer: "ethan@vm0.ai",
     enabled: false,
     enabledUserHashes: STAFF_USER_HASHES,
+    enabledEmailHashes: GOOGLE_OAUTH_REVIEWER_EMAIL_HASHES,
   },
   [FeatureSwitchKey.MercuryConnector]: {
     maintainer: "ethan@vm0.ai",
@@ -225,11 +235,16 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
  */
 export async function getAllFeatureStates(
   userId?: string,
+  email?: string,
 ): Promise<Record<FeatureSwitchKey, boolean>> {
+  const switches = Object.values(FEATURE_SWITCHES);
   const userHash =
-    userId &&
-    Object.values(FEATURE_SWITCHES).some((s) => s.enabledUserHashes?.length)
+    userId && switches.some((s) => s.enabledUserHashes?.length)
       ? await sha1(userId)
+      : undefined;
+  const emailHash =
+    email && switches.some((s) => s.enabledEmailHashes?.length)
+      ? await sha1(email.toLowerCase())
       : undefined;
 
   const result = {} as Record<FeatureSwitchKey, boolean>;
@@ -237,8 +252,10 @@ export async function getAllFeatureStates(
     const fs = FEATURE_SWITCHES[key];
     if (fs.enabled) {
       result[key] = true;
-    } else if (userHash && fs.enabledUserHashes?.length) {
-      result[key] = fs.enabledUserHashes.includes(userHash);
+    } else if (userHash && fs.enabledUserHashes?.includes(userHash)) {
+      result[key] = true;
+    } else if (emailHash && fs.enabledEmailHashes?.includes(emailHash)) {
+      result[key] = true;
     } else {
       result[key] = false;
     }
@@ -251,10 +268,13 @@ export async function getAllFeatureStates(
  *
  * When `userId` is provided and the switch has `enabledUserHashes`,
  * the userId is SHA-1 hashed and compared against the stored hashes.
+ * When `email` is provided and the switch has `enabledEmailHashes`,
+ * the email is SHA-1 hashed (lowercased) and compared.
  */
 export async function isFeatureEnabled(
   key: FeatureSwitchKey,
   userId?: string,
+  email?: string,
 ): Promise<boolean> {
   const featureSwitch = FEATURE_SWITCHES[key];
   if (featureSwitch.enabled) {
@@ -262,7 +282,11 @@ export async function isFeatureEnabled(
   }
   if (userId && featureSwitch.enabledUserHashes?.length) {
     const hash = await sha1(userId);
-    return featureSwitch.enabledUserHashes.includes(hash);
+    if (featureSwitch.enabledUserHashes.includes(hash)) return true;
+  }
+  if (email && featureSwitch.enabledEmailHashes?.length) {
+    const hash = await sha1(email.toLowerCase());
+    if (featureSwitch.enabledEmailHashes.includes(hash)) return true;
   }
   return false;
 }


### PR DESCRIPTION
## Summary
- Add `enabledEmailHashes` field to the `FeatureSwitch` interface, allowing features to be toggled by email hash in addition to user ID hash
- Configure Google OAuth reviewer email hash on all Google connector feature switches (Sheets, Docs, Drive, Calendar, Gmail)
- Thread user email through the feature switch evaluation pipeline (from Clerk user object through signals to `getAllFeatureStates`/`isFeatureEnabled`)
- Add integration test for connector visibility with email-based feature switches

## Test plan
- [ ] Verify Google connector features are enabled for the Google OAuth reviewer email
- [ ] Verify features remain enabled for existing staff user hashes
- [ ] Verify features remain disabled for unrecognized users/emails
- [ ] Run `pnpm vitest` to confirm new and existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)