### PR TITLE
fix: surface api error message on agent run creation failure

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-chat.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-chat.test.ts
@@ -428,11 +428,59 @@ describe("zero-chat signals", () => {
       expect(messages[1]?.role).toBe("assistant");
     });
 
-    it("should set error on run creation failure", async () => {
+    it("should surface API error message on run creation failure", async () => {
       useChatThreadHandlers();
       server.use(
         http.post("*/api/agent/runs", () => {
-          return new HttpResponse(null, { status: 500 });
+          return HttpResponse.json(
+            { error: { message: "Some API error", code: "BAD_REQUEST" } },
+            { status: 400 },
+          );
+        }),
+      );
+
+      await setup();
+      await context.store.set(sendZeroChatMessage$, "Hello");
+
+      const messages = context.store.get(zeroChatMessages$);
+      const lastMsg = messages[messages.length - 1];
+      expect(lastMsg?.error).toBe("Some API error");
+      expect(context.store.get(zeroChatSending$)).toBeFalsy();
+    });
+
+    it("should surface provider incompatibility error message", async () => {
+      useChatThreadHandlers();
+      server.use(
+        http.post("*/api/agent/runs", () => {
+          return HttpResponse.json(
+            {
+              error: {
+                message:
+                  "Cannot continue session: this session was created with Moonshot (Kimi) and cannot be continued with Anthropic API Key",
+                code: "PROVIDER_INCOMPATIBLE",
+              },
+            },
+            { status: 400 },
+          );
+        }),
+      );
+
+      await setup();
+      await context.store.set(sendZeroChatMessage$, "Hello");
+
+      const messages = context.store.get(zeroChatMessages$);
+      const lastMsg = messages[messages.length - 1];
+      expect(lastMsg?.error).toBe(
+        "Cannot continue session: this session was created with Moonshot (Kimi) and cannot be continued with Anthropic API Key",
+      );
+      expect(context.store.get(zeroChatSending$)).toBeFalsy();
+    });
+
+    it("should fall back to generic message when error body is unparseable", async () => {
+      useChatThreadHandlers();
+      server.use(
+        http.post("*/api/agent/runs", () => {
+          return new HttpResponse("Bad Gateway", { status: 502 });
         }),
       );
 

--- a/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
@@ -133,14 +133,14 @@ function updateQueuePosition(
   }
 }
 
-/** Start an agent run and return the runId, or null on failure. */
+/** Start an agent run and return the runId. Throws on failure with the API error message. */
 async function startAgentRun(
   fetchFn: typeof fetch,
   composeId: string,
   prompt: string,
   sessionId?: string | null,
   modelProvider?: string | null,
-): Promise<string | null> {
+): Promise<string> {
   const body: Record<string, string> = {
     agentComposeId: composeId,
     prompt: prompt.trim(),
@@ -160,7 +160,10 @@ async function startAgentRun(
   });
 
   if (!response.ok) {
-    return null;
+    const errBody = (await response.json().catch(() => null)) as {
+      error?: { message?: string };
+    } | null;
+    throw new Error(errBody?.error?.message ?? "Failed to start agent run");
   }
 
   const data = (await response.json()) as { runId: string };
@@ -934,19 +937,6 @@ export const sendZeroChatMessage$ = command(
         sessionId,
         modelProvider,
       );
-
-      if (!runId) {
-        set(internalMessages$, (prev) => {
-          const updated = [...prev];
-          updated[updated.length - 1] = {
-            ...updated[updated.length - 1],
-            error: "Failed to start agent run",
-          };
-          return updated;
-        });
-        set(internalSending$, false);
-        return;
-      }
 
       // Associate run to thread (must complete before polling so refresh works)
       await addRunToThread(fetchFn, threadId, runId);


### PR DESCRIPTION
## Summary

- Refactor `startAgentRun()` to throw with the API error message instead of returning `null`, so provider incompatibility and other API errors surface to the user
- Remove dead null-check block in caller since errors now propagate via the existing catch block
- Add tests for structured API errors, provider incompatibility, and unparseable response fallback

Closes #5565

## Test plan

- [x] Verify `startAgentRun()` throws with API error message when response is not ok
- [x] Verify provider incompatibility error message is surfaced (17/17 zero-chat tests pass)
- [x] Verify fallback to "Failed to start agent run" when response body can't be parsed
- [x] Verify existing UI rendering tests still pass (provider incompatible amber UI in zero-session-chat-page)

🤖 Generated with [Claude Code](https://claude.com/claude-code)