### PR TITLE
fix(docker): use playwright chromium for arm64 browser support

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -44,7 +44,7 @@
     "source=agent-browser,target=/home/vscode/.local/share/agent-browser"
   ],
   "postCreateCommand": "bash .devcontainer/setup.sh",
-  "postStartCommand": "gh auth setup-git",
+  "postStartCommand": "gh auth setup-git && bash .devcontainer/start-vnc.sh",
   "customizations": {
     "vscode": {
       "extensions": [

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "VM0 Development",
-  "image": "ghcr.io/vm0-ai/vm0-dev:20260310",
+  "image": "ghcr.io/vm0-ai/vm0-dev:20260319",
   "features": {
     "ghcr.io/itsmechlark/features/postgresql:1": {
       "version": "17"

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -77,8 +77,8 @@ echo "🪝 Installing lefthook git hooks..."
 cd "$WORKSPACE_DIR/turbo" && lefthook install
 echo "✓ Lefthook hooks installed"
 
-# Start VNC stack (Xvfb + openbox + x11vnc + websockify) for headed browser automation
-echo "🖥️ Starting VNC stack..."
+# Ensure VNC dependencies are installed (startup moved to start-vnc.sh via postStartCommand)
+echo "🖥️ Checking VNC dependencies..."
 MISSING=()
 command -v x11vnc >/dev/null 2>&1 || MISSING+=(x11vnc)
 command -v Xvfb >/dev/null 2>&1 || MISSING+=(xvfb)
@@ -88,15 +88,6 @@ if [ ${#MISSING[@]} -gt 0 ]; then
   sudo apt-get update -qq
   sudo apt-get install -y -qq "${MISSING[@]}"
 fi
-if ! pgrep -x Xvfb >/dev/null 2>&1; then
-  nohup Xvfb :99 -screen 0 1344x840x24 >/dev/null 2>&1 &
-  sleep 1
-  nohup env DISPLAY=:99 openbox >/dev/null 2>&1 &
-  nohup x11vnc -display :99 -nopw -forever -shared -rfbport 5900 >/dev/null 2>&1 &
-  nohup websockify --web /usr/share/novnc/ 0.0.0.0:6080 localhost:5900 >/dev/null 2>&1 &
-  echo "✓ VNC stack started (noVNC at http://localhost:6080/vnc.html)"
-else
-  echo "✓ VNC stack already running"
-fi
+echo "✓ VNC dependencies ready"
 
 echo "✅ Dev container setup complete!"

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -89,11 +89,11 @@ if [ ${#MISSING[@]} -gt 0 ]; then
   sudo apt-get install -y -qq "${MISSING[@]}"
 fi
 if ! pgrep -x Xvfb >/dev/null 2>&1; then
-  Xvfb :99 -screen 0 1344x840x24 >/dev/null 2>&1 &
+  nohup Xvfb :99 -screen 0 1344x840x24 >/dev/null 2>&1 &
   sleep 1
-  DISPLAY=:99 openbox >/dev/null 2>&1 &
-  x11vnc -display :99 -nopw -forever -shared -rfbport 5900 >/dev/null 2>&1 &
-  websockify --web /usr/share/novnc/ 0.0.0.0:6080 localhost:5900 >/dev/null 2>&1 &
+  nohup env DISPLAY=:99 openbox >/dev/null 2>&1 &
+  nohup x11vnc -display :99 -nopw -forever -shared -rfbport 5900 >/dev/null 2>&1 &
+  nohup websockify --web /usr/share/novnc/ 0.0.0.0:6080 localhost:5900 >/dev/null 2>&1 &
   echo "✓ VNC stack started (noVNC at http://localhost:6080/vnc.html)"
 else
   echo "✓ VNC stack already running"

--- a/.devcontainer/start-vnc.sh
+++ b/.devcontainer/start-vnc.sh
@@ -1,17 +1,80 @@
 #!/bin/bash
 
 # Start VNC stack (Xvfb + openbox + x11vnc + websockify) for headed browser automation
-# Runs via postStartCommand so processes persist beyond the lifecycle shell
+# Installed as /etc/init.d/vnc and managed via `service vnc start`
 
 echo "🖥️ Starting VNC stack..."
 
-if ! pgrep -x Xvfb >/dev/null 2>&1; then
-  setsid Xvfb :99 -screen 0 1344x840x24 >/dev/null 2>&1 &
-  sleep 1
-  setsid env DISPLAY=:99 openbox >/dev/null 2>&1 &
-  setsid x11vnc -display :99 -nopw -forever -shared -rfbport 5900 >/dev/null 2>&1 &
-  setsid websockify --web /usr/share/novnc/ 0.0.0.0:6080 localhost:5900 >/dev/null 2>&1 &
-  echo "✓ VNC stack started (noVNC at http://localhost:6080/vnc.html)"
-else
-  echo "✓ VNC stack already running"
+# Install init.d service if not present
+if [ ! -f /etc/init.d/vnc ]; then
+  sudo tee /etc/init.d/vnc >/dev/null <<'INITEOF'
+#!/bin/sh
+### BEGIN INIT INFO
+# Provides:          vnc
+# Required-Start:    $local_fs
+# Required-Stop:     $local_fs
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: VNC stack for headed browser automation
+### END INIT INFO
+
+VNC_USER="vscode"
+PIDFILE_XVFB="/var/run/vnc-xvfb.pid"
+PIDFILE_OPENBOX="/var/run/vnc-openbox.pid"
+PIDFILE_X11VNC="/var/run/vnc-x11vnc.pid"
+PIDFILE_WEBSOCKIFY="/var/run/vnc-websockify.pid"
+
+start() {
+    if start-stop-daemon --status --pidfile "$PIDFILE_XVFB" 2>/dev/null; then
+        echo "VNC stack already running"
+        return 0
+    fi
+
+    start-stop-daemon --start --background --make-pidfile --pidfile "$PIDFILE_XVFB" \
+        --chuid "$VNC_USER" --exec /usr/bin/Xvfb -- :99 -screen 0 1344x840x24
+    sleep 1
+
+    start-stop-daemon --start --background --make-pidfile --pidfile "$PIDFILE_OPENBOX" \
+        --chuid "$VNC_USER" --exec /usr/bin/env -- DISPLAY=:99 openbox
+
+    start-stop-daemon --start --background --make-pidfile --pidfile "$PIDFILE_X11VNC" \
+        --chuid "$VNC_USER" --exec /usr/bin/x11vnc -- -display :99 -nopw -forever -shared -rfbport 5900
+
+    start-stop-daemon --start --background --make-pidfile --pidfile "$PIDFILE_WEBSOCKIFY" \
+        --chuid "$VNC_USER" --exec /usr/bin/python3 -- /usr/bin/websockify --web /usr/share/novnc/ 0.0.0.0:6080 localhost:5900
+
+    echo "VNC stack started"
+}
+
+stop() {
+    start-stop-daemon --stop --pidfile "$PIDFILE_WEBSOCKIFY" --oknodo
+    start-stop-daemon --stop --pidfile "$PIDFILE_X11VNC" --oknodo
+    start-stop-daemon --stop --pidfile "$PIDFILE_OPENBOX" --oknodo
+    start-stop-daemon --stop --pidfile "$PIDFILE_XVFB" --oknodo
+    rm -f "$PIDFILE_XVFB" "$PIDFILE_OPENBOX" "$PIDFILE_X11VNC" "$PIDFILE_WEBSOCKIFY"
+    echo "VNC stack stopped"
+}
+
+case "$1" in
+    start)   start ;;
+    stop)    stop ;;
+    restart) stop; start ;;
+    status)
+        if start-stop-daemon --status --pidfile "$PIDFILE_XVFB" 2>/dev/null; then
+            echo "VNC stack is running"
+        else
+            echo "VNC stack is not running"
+            exit 1
+        fi
+        ;;
+    *)
+        echo "Usage: $0 {start|stop|restart|status}"
+        exit 1
+        ;;
+esac
+INITEOF
+  sudo chmod +x /etc/init.d/vnc
 fi
+
+sudo service vnc start
+echo "✓ VNC stack started (noVNC at http://localhost:6080/vnc.html)"

--- a/.devcontainer/start-vnc.sh
+++ b/.devcontainer/start-vnc.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Start VNC stack (Xvfb + openbox + x11vnc + websockify) for headed browser automation
+# Runs via postStartCommand so processes persist beyond the lifecycle shell
+
+echo "🖥️ Starting VNC stack..."
+
+if ! pgrep -x Xvfb >/dev/null 2>&1; then
+  setsid Xvfb :99 -screen 0 1344x840x24 >/dev/null 2>&1 &
+  sleep 1
+  setsid env DISPLAY=:99 openbox >/dev/null 2>&1 &
+  setsid x11vnc -display :99 -nopw -forever -shared -rfbport 5900 >/dev/null 2>&1 &
+  setsid websockify --web /usr/share/novnc/ 0.0.0.0:6080 localhost:5900 >/dev/null 2>&1 &
+  echo "✓ VNC stack started (noVNC at http://localhost:6080/vnc.html)"
+else
+  echo "✓ VNC stack already running"
+fi

--- a/docker/toolchain/Dockerfile
+++ b/docker/toolchain/Dockerfile
@@ -93,11 +93,15 @@ RUN curl -fsSL https://downloads.1password.com/linux/keys/1password.asc | gpg --
     && apt-get install -y 1password-cli \
     && rm -rf /var/lib/apt/lists/*
 
-# Install agent-browser for browser automation
-# Use system chromium instead of Chrome for Testing (no ARM64 builds)
-RUN apt-get update && apt-get install -y chromium-browser \
-    && rm -rf /var/lib/apt/lists/* \
-    && npm install -g agent-browser
+# Install Playwright Chromium for browser automation (supports ARM64)
+RUN npx -y playwright install --with-deps chromium \
+    && CHROMIUM_PATH=$(find /root/.cache/ms-playwright -name chrome -path "*/chrome-linux/*" | head -1) \
+    && ln -sf "$CHROMIUM_PATH" /usr/local/bin/playwright-chromium
+
+ENV AGENT_BROWSER_EXECUTABLE_PATH=/usr/local/bin/playwright-chromium
+
+# Install agent-browser CLI
+RUN npm install -g agent-browser@0.21.2
 
 # Install AWS CLI v2
 RUN apt-get update && apt-get install -y unzip \


### PR DESCRIPTION
## Summary
- Replace non-functional `apt-get install chromium-browser` (snap stub on Ubuntu 22.04) with `npx playwright install --with-deps chromium` which provides real ARM64 Chromium builds
- Symlink Playwright's Chromium to `/usr/local/bin/playwright-chromium` and set `AGENT_BROWSER_EXECUTABLE_PATH` env var so agent-browser finds it automatically
- Pin `agent-browser@0.21.2` and split into separate Docker layer so Chromium cache is preserved on version bumps

## Context
PR #5552 attempted to fix ARM64 by switching from `agent-browser install --with-deps` (Chrome for Testing, no ARM64 builds) to `apt-get install chromium-browser`. However, on Ubuntu 22.04 this package is a snap transitional stub with no actual browser binary, so `agent-browser open` fails with "Chrome exited early".

## Test plan
- [ ] Build Docker image on ARM64 and verify `agent-browser open https://example.com` works
- [ ] Verify `AGENT_BROWSER_EXECUTABLE_PATH` points to valid Chromium binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)