### PR TITLE
fix: add clerk lazy migration fallbacks for read paths

### DIFF
--- a/turbo/apps/web/src/__tests__/api-test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers.ts
@@ -2975,6 +2975,19 @@ export async function getOrgDefaultAgent(
 }
 
 /**
+ * Update the default_agent_compose_id for an org in the `org` table.
+ */
+export async function updateOrgDefaultAgent(
+  orgId: string,
+  composeId: string,
+): Promise<void> {
+  await globalThis.services.db
+    .update(org)
+    .set({ defaultAgentComposeId: composeId, updatedAt: new Date() })
+    .where(eq(org.orgId, orgId));
+}
+
+/**
  * Insert an org_members_cache entry for testing cache behavior.
  */
 export async function insertOrgMembersCacheEntry(entry: {
@@ -3589,4 +3602,18 @@ export async function insertTestUser(userId: string): Promise<void> {
     .insert(users)
     .values({ id: userId })
     .onConflictDoNothing();
+}
+
+/**
+ * Find an org_members entry by orgId and userId.
+ * Returns the full row or undefined.
+ */
+export async function findOrgMembersEntry(orgId: string, userId: string) {
+  initServices();
+  const [row] = await globalThis.services.db
+    .select()
+    .from(orgMembers)
+    .where(and(eq(orgMembers.orgId, orgId), eq(orgMembers.userId, userId)))
+    .limit(1);
+  return row;
 }

--- a/turbo/apps/web/src/lib/email/__tests__/unsubscribe-service.test.ts
+++ b/turbo/apps/web/src/lib/email/__tests__/unsubscribe-service.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { clerkClient } from "@clerk/nextjs/server";
 import { testContext, uniqueId } from "../../../__tests__/test-helpers";
 import { insertTestUser } from "../../../__tests__/api-test-helpers";
 import { isUserUnsubscribed, unsubscribeUser } from "../unsubscribe-service";
@@ -20,6 +21,42 @@ describe("unsubscribe-service", () => {
     it("returns false for user with default value", async () => {
       const { userId } = await context.setupUser();
       await insertTestUser(userId);
+      expect(await isUserUnsubscribed(userId)).toBe(false);
+    });
+
+    it("returns true from Clerk fallback when DB has false", async () => {
+      const { userId } = await context.setupUser();
+      await insertTestUser(userId);
+
+      // Override Clerk getUser to return email_unsubscribed: true
+      const client = await clerkClient();
+      vi.mocked(client.users.getUser).mockResolvedValueOnce({
+        publicMetadata: { email_unsubscribed: true },
+      } as unknown as Awaited<ReturnType<typeof client.users.getUser>>);
+
+      expect(await isUserUnsubscribed(userId)).toBe(true);
+
+      // Verify backfill happened (fire-and-forget, wait a tick)
+      await new Promise((r) => setTimeout(r, 50));
+      expect(await isUserUnsubscribed(userId)).toBe(true);
+    });
+
+    it("skips Clerk call when DB already has true", async () => {
+      const { userId } = await context.setupUser();
+      await insertTestUser(userId);
+      await unsubscribeUser(userId);
+
+      const client = await clerkClient();
+
+      expect(await isUserUnsubscribed(userId)).toBe(true);
+      expect(client.users.getUser).not.toHaveBeenCalled();
+    });
+
+    it("returns false when neither DB nor Clerk has true", async () => {
+      const { userId } = await context.setupUser();
+      await insertTestUser(userId);
+
+      // Default Clerk mock returns no publicMetadata, so fallback returns false
       expect(await isUserUnsubscribed(userId)).toBe(false);
     });
   });

--- a/turbo/apps/web/src/lib/email/unsubscribe-service.ts
+++ b/turbo/apps/web/src/lib/email/unsubscribe-service.ts
@@ -1,9 +1,17 @@
 import { eq } from "drizzle-orm";
+import { clerkClient } from "@clerk/nextjs/server";
 import { users } from "../../db/schema/user";
+import { logger } from "../logger";
+
+const log = logger("service:unsubscribe");
 
 /**
  * Check if a user has unsubscribed from system-initiated emails.
  * Reads `email_unsubscribed` from the users table.
+ *
+ * // TODO(#5514): remove this fallback after full backfill
+ * Falls back to Clerk publicMetadata if DB says false/missing,
+ * and lazy-migrates the value to DB on first access.
  */
 export async function isUserUnsubscribed(userId: string): Promise<boolean> {
   const [row] = await globalThis.services.db
@@ -11,7 +19,37 @@ export async function isUserUnsubscribed(userId: string): Promise<boolean> {
     .from(users)
     .where(eq(users.id, userId))
     .limit(1);
-  return row?.emailUnsubscribed ?? false;
+
+  if (row?.emailUnsubscribed) {
+    return true;
+  }
+
+  // TODO(#5514): remove this fallback after full backfill
+  const client = await clerkClient();
+  const clerkUser = await client.users.getUser(userId);
+  const clerkValue =
+    (clerkUser.publicMetadata as Record<string, unknown> | undefined)
+      ?.email_unsubscribed === true;
+
+  if (clerkValue) {
+    log.info("lazy migration: email_unsubscribed from Clerk", { userId });
+    void globalThis.services.db
+      .insert(users)
+      .values({ id: userId, emailUnsubscribed: true })
+      .onConflictDoUpdate({
+        target: users.id,
+        set: { emailUnsubscribed: true, updatedAt: new Date() },
+      })
+      .catch((err: unknown) =>
+        log.warn("lazy migration: email_unsubscribed write failed", {
+          userId,
+          err,
+        }),
+      );
+    return true;
+  }
+
+  return false;
 }
 
 /**

--- a/turbo/apps/web/src/lib/org/__tests__/org-cache-service.test.ts
+++ b/turbo/apps/web/src/lib/org/__tests__/org-cache-service.test.ts
@@ -130,6 +130,75 @@ describe("getOrgData", () => {
     expect(result.tier).toBe("pro");
   });
 
+  it("falls back to Clerk tier on cache miss when DB has free", async () => {
+    const userId = uniqueId("test-user");
+    const slug = uniqueId("org");
+    mockClerk({
+      userId,
+      clerkOrgs: [{ id: `org_mock_${slug}`, slug, name: slug }],
+    });
+    await createTestOrg(slug);
+    const orgId = `org_mock_${slug}`;
+
+    // Ensure org row exists for this orgId (createTestOrg uses org_mock_${userId})
+    await ensureOrgRow(orgId);
+
+    // Delete cache to force Clerk fetch
+    await deleteOrgCacheEntry(orgId);
+
+    // Override getOrganization to return tier in publicMetadata
+    const client = await clerkClient();
+    vi.mocked(client.organizations.getOrganization).mockResolvedValueOnce({
+      id: orgId,
+      slug,
+      name: slug,
+      publicMetadata: { tier: "pro" },
+    } as unknown as Awaited<
+      ReturnType<typeof client.organizations.getOrganization>
+    >);
+
+    const result = await getOrgData(orgId);
+    expect(result.tier).toBe("pro");
+
+    // Verify backfill (fire-and-forget, wait a tick)
+    await new Promise((r) => setTimeout(r, 50));
+
+    // Re-read via getOrgData with fresh cache (just written above)
+    // to confirm the DB was updated
+    const recheck = await getOrgData(orgId);
+    expect(recheck.tier).toBe("pro");
+  });
+
+  it("returns DB tier directly when DB has non-free on cache miss", async () => {
+    const userId = uniqueId("test-user");
+    const slug = uniqueId("org");
+    mockClerk({
+      userId,
+      clerkOrgs: [{ id: `org_mock_${slug}`, slug, name: slug }],
+    });
+    const { id: orgId } = await createTestOrg(slug);
+
+    await updateOrgTier(orgId, "pro");
+
+    const result = await getOrgData(orgId);
+    expect(result.tier).toBe("pro");
+  });
+
+  it("returns free on cache hit when DB has free (no Clerk fallback)", async () => {
+    const userId = uniqueId("test-user");
+    const slug = uniqueId("org");
+    mockClerk({ userId });
+    const { id: orgId } = await createTestOrg(slug);
+
+    // Cache is fresh (from createTestOrg), DB tier is "free"
+    // No Clerk call happens, so no fallback possible
+    const result = await getOrgData(orgId);
+    expect(result.tier).toBe("free");
+
+    const client = await clerkClient();
+    expect(client.organizations.getOrganization).not.toHaveBeenCalled();
+  });
+
   it("throws when Clerk org has no slug", async () => {
     const userId = uniqueId("test-user");
     const slug = uniqueId("org");

--- a/turbo/apps/web/src/lib/org/org-cache-service.ts
+++ b/turbo/apps/web/src/lib/org/org-cache-service.ts
@@ -18,15 +18,47 @@ interface OrgData {
 /**
  * Read tier from the org table (source of truth).
  * Returns "free" if the org row does not exist.
+ *
+ * // TODO(#5514): remove clerkMetadata fallback after full backfill
+ * When clerkMetadata is provided and DB tier is "free", falls back to
+ * Clerk publicMetadata and lazy-migrates the value to DB.
  */
-async function readTier(orgId: string): Promise<string> {
+async function readTier(
+  orgId: string,
+  clerkMetadata?: Record<string, unknown>,
+): Promise<string> {
   const db = globalThis.services.db;
   const [orgRow] = await db
     .select({ tier: org.tier })
     .from(org)
     .where(eq(org.orgId, orgId))
     .limit(1);
-  return orgRow?.tier ?? "free";
+  const dbTier = orgRow?.tier ?? "free";
+
+  if (dbTier !== "free") {
+    return dbTier;
+  }
+
+  // TODO(#5514): remove this fallback after full backfill
+  if (clerkMetadata) {
+    const clerkTier = clerkMetadata.tier;
+    if (typeof clerkTier === "string" && clerkTier !== "free") {
+      log.info("lazy migration: tier from Clerk", { orgId, clerkTier });
+      void db
+        .insert(org)
+        .values({ orgId, tier: clerkTier })
+        .onConflictDoUpdate({
+          target: org.orgId,
+          set: { tier: clerkTier, updatedAt: new Date() },
+        })
+        .catch((err: unknown) =>
+          log.warn("lazy migration: tier write failed", { orgId, err }),
+        );
+      return clerkTier;
+    }
+  }
+
+  return "free";
 }
 
 /**
@@ -38,9 +70,6 @@ async function readTier(orgId: string): Promise<string> {
 export async function getOrgData(orgId: string): Promise<OrgData> {
   const db = globalThis.services.db;
 
-  // Read tier from org table (source of truth)
-  const tier = await readTier(orgId);
-
   // Check slug cache
   const [cached] = await db
     .select()
@@ -49,10 +78,12 @@ export async function getOrgData(orgId: string): Promise<OrgData> {
     .limit(1);
 
   if (cached && Date.now() - cached.cachedAt.getTime() < CACHE_TTL_MS) {
+    // Cache hit — no Clerk metadata available for tier fallback
+    const tier = await readTier(orgId);
     return { orgId, slug: cached.slug, tier };
   }
 
-  // Fetch slug from Clerk (source of truth for slug)
+  // Cache miss — fetch from Clerk (source of truth for slug)
   const client = await clerkClient();
   const clerkOrg = await client.organizations.getOrganization({
     organizationId: orgId,
@@ -62,6 +93,12 @@ export async function getOrgData(orgId: string): Promise<OrgData> {
     throw new Error(`Clerk organization ${orgId} has no slug — cannot cache`);
   }
   const slug = clerkOrg.slug;
+
+  // Read tier with Clerk metadata fallback (lazy migration)
+  const tier = await readTier(
+    orgId,
+    clerkOrg.publicMetadata as Record<string, unknown> | undefined,
+  );
 
   // Upsert slug cache
   const now = new Date();
@@ -107,6 +144,7 @@ export async function getOrgBySlug(slug: string): Promise<OrgData | null> {
     .limit(1);
 
   if (cached && Date.now() - cached.cachedAt.getTime() < CACHE_TTL_MS) {
+    // Cache hit — no Clerk metadata available for tier fallback
     const tier = await readTier(cached.orgId);
     return { orgId: cached.orgId, slug: cached.slug, tier };
   }
@@ -125,7 +163,11 @@ export async function getOrgBySlug(slug: string): Promise<OrgData | null> {
     return null;
   }
 
-  const tier = await readTier(clerkOrg.id);
+  // Read tier with Clerk metadata fallback (lazy migration)
+  const tier = await readTier(
+    clerkOrg.id,
+    clerkOrg.publicMetadata as Record<string, unknown> | undefined,
+  );
 
   // Upsert slug cache
   const now = new Date();

--- a/turbo/apps/web/src/lib/slack-org/handlers/__tests__/shared-resolve.test.ts
+++ b/turbo/apps/web/src/lib/slack-org/handlers/__tests__/shared-resolve.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { clerkClient } from "@clerk/nextjs/server";
+import { testContext, uniqueId } from "../../../../__tests__/test-helpers";
+import { mockClerk } from "../../../../__tests__/clerk-mock";
+import {
+  createTestOrg,
+  getOrgDefaultAgent,
+  updateOrgDefaultAgent,
+  ensureOrgRow,
+} from "../../../../__tests__/api-test-helpers";
+import { resolveDefaultComposeId } from "../shared";
+
+const context = testContext();
+
+describe("resolveDefaultComposeId", () => {
+  beforeEach(() => {
+    context.setupMocks();
+  });
+
+  it("returns DB value without Clerk call", async () => {
+    const userId = uniqueId("test-user");
+    const slug = uniqueId("org");
+    mockClerk({ userId });
+    const { id: orgId } = await createTestOrg(slug);
+
+    // Set default_agent_compose_id in DB
+    const composeId = "00000000-0000-0000-0000-000000000001";
+    await updateOrgDefaultAgent(orgId, composeId);
+
+    const result = await resolveDefaultComposeId(orgId);
+    expect(result).toBe(composeId);
+
+    const client = await clerkClient();
+    expect(client.organizations.getOrganization).not.toHaveBeenCalled();
+  });
+
+  it("falls back to Clerk when DB has null, backfills DB", async () => {
+    const userId = uniqueId("test-user");
+    const slug = uniqueId("org");
+    mockClerk({
+      userId,
+      clerkOrgs: [{ id: `org_mock_${slug}`, slug, name: slug }],
+    });
+    await createTestOrg(slug);
+    const orgId = `org_mock_${slug}`;
+    await ensureOrgRow(orgId);
+
+    const clerkComposeId = "00000000-0000-0000-0000-000000000002";
+
+    // Override getOrganization to return default_agent_compose_id
+    const client = await clerkClient();
+    vi.mocked(client.organizations.getOrganization).mockResolvedValueOnce({
+      id: orgId,
+      slug,
+      name: slug,
+      publicMetadata: { default_agent_compose_id: clerkComposeId },
+    } as unknown as Awaited<
+      ReturnType<typeof client.organizations.getOrganization>
+    >);
+
+    const result = await resolveDefaultComposeId(orgId);
+    expect(result).toBe(clerkComposeId);
+
+    // Verify backfill (fire-and-forget, wait a tick)
+    await new Promise((r) => setTimeout(r, 50));
+    const dbValue = await getOrgDefaultAgent(orgId);
+    expect(dbValue).toBe(clerkComposeId);
+  });
+
+  it("falls through to env var fallback when DB and Clerk are empty", async () => {
+    const userId = uniqueId("test-user");
+    const slug = uniqueId("org");
+    mockClerk({
+      userId,
+      clerkOrgs: [{ id: `org_mock_${slug}`, slug, name: slug }],
+    });
+    await createTestOrg(slug);
+    const orgId = `org_mock_${slug}`;
+    await ensureOrgRow(orgId);
+
+    // Clerk returns empty publicMetadata (default mock behavior)
+    // resolveDefaultAgentComposeId will also return null since VM0_DEFAULT_AGENT is not set
+    const result = await resolveDefaultComposeId(orgId);
+    expect(result).toBeNull();
+  });
+});

--- a/turbo/apps/web/src/lib/slack-org/handlers/shared.ts
+++ b/turbo/apps/web/src/lib/slack-org/handlers/shared.ts
@@ -1,4 +1,5 @@
 import { eq, and } from "drizzle-orm";
+import { clerkClient } from "@clerk/nextjs/server";
 import { slackOrgInstallations } from "../../../db/schema/slack-org-installation";
 import { slackOrgConnections } from "../../../db/schema/slack-org-connection";
 import { slackOrgThreadSessions } from "../../../db/schema/slack-org-thread-session";
@@ -64,7 +65,9 @@ export async function resolveConnectionFromSlackUser(
 
 /**
  * Resolve default agent compose ID from org table.
- * Falls back to VM0_DEFAULT_AGENT env var if not set.
+ * Falls back to Clerk publicMetadata, then VM0_DEFAULT_AGENT env var.
+ *
+ * // TODO(#5514): remove Clerk fallback after full backfill
  */
 export async function resolveDefaultComposeId(
   orgId: string,
@@ -77,6 +80,33 @@ export async function resolveDefaultComposeId(
 
   if (orgRow?.defaultAgentComposeId) {
     return orgRow.defaultAgentComposeId;
+  }
+
+  // TODO(#5514): remove this fallback after full backfill
+  const client = await clerkClient();
+  const clerkOrg = await client.organizations.getOrganization({
+    organizationId: orgId,
+  });
+  const clerkComposeId = (
+    clerkOrg.publicMetadata as Record<string, unknown> | undefined
+  )?.default_agent_compose_id;
+
+  if (typeof clerkComposeId === "string" && clerkComposeId) {
+    log.info("lazy migration: default_agent_compose_id from Clerk", { orgId });
+    void globalThis.services.db
+      .insert(orgTable)
+      .values({ orgId, defaultAgentComposeId: clerkComposeId })
+      .onConflictDoUpdate({
+        target: orgTable.orgId,
+        set: { defaultAgentComposeId: clerkComposeId, updatedAt: new Date() },
+      })
+      .catch((err: unknown) =>
+        log.warn("lazy migration: default_agent_compose_id write failed", {
+          orgId,
+          err,
+        }),
+      );
+    return clerkComposeId;
   }
 
   // Fallback: resolve from VM0_DEFAULT_AGENT env var

--- a/turbo/apps/web/src/lib/user/__tests__/user-preferences-service.test.ts
+++ b/turbo/apps/web/src/lib/user/__tests__/user-preferences-service.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { clerkClient } from "@clerk/nextjs/server";
+import { testContext } from "../../../__tests__/test-helpers";
+import {
+  insertOrgMembersEntry,
+  findOrgMembersEntry,
+} from "../../../__tests__/api-test-helpers";
+import { getUserPreferences } from "../user-preferences-service";
+
+const context = testContext();
+
+describe("getUserPreferences", () => {
+  beforeEach(() => {
+    context.setupMocks();
+  });
+
+  it("returns DB values when row exists, no Clerk call", async () => {
+    const { userId, orgId } = await context.setupUser();
+    await insertOrgMembersEntry({
+      orgId,
+      userId,
+      timezone: "America/New_York",
+      notifyEmail: true,
+      notifySlack: false,
+      pinnedAgentIds: ["agent-1"],
+      sendMode: "cmd-enter",
+    });
+
+    const client = await clerkClient();
+    const result = await getUserPreferences(orgId, userId);
+
+    expect(result).toEqual({
+      timezone: "America/New_York",
+      notifyEmail: true,
+      notifySlack: false,
+      pinnedAgentIds: ["agent-1"],
+      sendMode: "cmd-enter",
+    });
+    expect(
+      client.organizations.getOrganizationMembershipList,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("falls back to Clerk metadata when no DB row, backfills DB", async () => {
+    const { userId, orgId } = await context.setupUser();
+
+    // Override Clerk membership list to return metadata
+    const client = await clerkClient();
+    vi.mocked(
+      client.organizations.getOrganizationMembershipList,
+    ).mockResolvedValueOnce({
+      data: [
+        {
+          publicUserData: { userId },
+          publicMetadata: {
+            timezone: "Europe/London",
+            notify_email: true,
+            notify_slack: false,
+            pinned_agent_ids: ["pinned-1", "pinned-2"],
+            send_mode: "cmd-enter",
+            onboarding_done: true,
+          },
+        },
+      ],
+    } as unknown as Awaited<
+      ReturnType<typeof client.organizations.getOrganizationMembershipList>
+    >);
+
+    const result = await getUserPreferences(orgId, userId);
+
+    expect(result).toEqual({
+      timezone: "Europe/London",
+      notifyEmail: true,
+      notifySlack: false,
+      pinnedAgentIds: ["pinned-1", "pinned-2"],
+      sendMode: "cmd-enter",
+    });
+
+    // Verify backfill happened (fire-and-forget, wait a tick)
+    await new Promise((r) => setTimeout(r, 50));
+    const row = await findOrgMembersEntry(orgId, userId);
+
+    expect(row).toBeDefined();
+    expect(row!.timezone).toBe("Europe/London");
+    expect(row!.notifyEmail).toBe(true);
+    expect(row!.notifySlack).toBe(false);
+    expect(row!.onboardingDone).toBe(true);
+    expect(row!.sendMode).toBe("cmd-enter");
+  });
+
+  it("returns DEFAULTS when no DB row and Clerk has empty metadata", async () => {
+    const { userId, orgId } = await context.setupUser();
+
+    // Default Clerk mock returns empty publicMetadata
+    const result = await getUserPreferences(orgId, userId);
+
+    expect(result).toEqual({
+      timezone: null,
+      notifyEmail: false,
+      notifySlack: true,
+      pinnedAgentIds: [],
+      sendMode: "enter",
+    });
+  });
+
+  it("backfills onboardingDone from Clerk metadata", async () => {
+    const { userId, orgId } = await context.setupUser();
+
+    const client = await clerkClient();
+    vi.mocked(
+      client.organizations.getOrganizationMembershipList,
+    ).mockResolvedValueOnce({
+      data: [
+        {
+          publicUserData: { userId },
+          publicMetadata: {
+            onboarding_done: true,
+          },
+        },
+      ],
+    } as unknown as Awaited<
+      ReturnType<typeof client.organizations.getOrganizationMembershipList>
+    >);
+
+    await getUserPreferences(orgId, userId);
+
+    // Wait for fire-and-forget backfill
+    await new Promise((r) => setTimeout(r, 50));
+    const row = await findOrgMembersEntry(orgId, userId);
+
+    expect(row).toBeDefined();
+    expect(row!.onboardingDone).toBe(true);
+  });
+});

--- a/turbo/apps/web/src/lib/user/user-preferences-service.ts
+++ b/turbo/apps/web/src/lib/user/user-preferences-service.ts
@@ -1,4 +1,5 @@
 import { eq, and } from "drizzle-orm";
+import { clerkClient } from "@clerk/nextjs/server";
 import { orgMembers } from "../../db/schema/org-members";
 import { badRequest } from "../errors";
 import { logger } from "../logger";
@@ -50,6 +51,10 @@ const DEFAULTS: UserPreferences = {
 /**
  * Get user preferences from org_members table.
  * Returns defaults if no row exists (new member).
+ *
+ * // TODO(#5514): remove this fallback after full backfill
+ * Falls back to Clerk membership publicMetadata if no DB row,
+ * and lazy-migrates the value to DB on first access.
  */
 export async function getUserPreferences(
   orgId: string,
@@ -63,17 +68,73 @@ export async function getUserPreferences(
     .where(and(eq(orgMembers.orgId, orgId), eq(orgMembers.userId, userId)))
     .limit(1);
 
-  if (!row) {
-    return { ...DEFAULTS };
+  if (row) {
+    return {
+      timezone: row.timezone,
+      notifyEmail: row.notifyEmail,
+      notifySlack: row.notifySlack,
+      pinnedAgentIds: toStringArray(row.pinnedAgentIds),
+      sendMode: parseSendMode(row.sendMode),
+    };
   }
 
-  return {
-    timezone: row.timezone,
-    notifyEmail: row.notifyEmail,
-    notifySlack: row.notifySlack,
-    pinnedAgentIds: toStringArray(row.pinnedAgentIds),
-    sendMode: parseSendMode(row.sendMode),
-  };
+  // TODO(#5514): remove this fallback after full backfill
+  const client = await clerkClient();
+  const { data: memberships } =
+    await client.organizations.getOrganizationMembershipList({
+      organizationId: orgId,
+    });
+
+  const membership = memberships.find(
+    (m) => m.publicUserData?.userId === userId,
+  );
+  const meta = membership?.publicMetadata as
+    | Record<string, unknown>
+    | undefined;
+
+  if (meta && Object.keys(meta).length > 0) {
+    const prefs: UserPreferences = {
+      timezone: typeof meta.timezone === "string" ? meta.timezone : null,
+      notifyEmail: meta.notify_email === true,
+      notifySlack: meta.notify_slack !== false,
+      pinnedAgentIds: toStringArray(meta.pinned_agent_ids),
+      sendMode: parseSendMode(meta.send_mode),
+    };
+
+    const onboardingDone = meta.onboarding_done === true;
+
+    log.info("lazy migration: org_members preferences from Clerk", {
+      orgId,
+      userId,
+    });
+    const now = new Date();
+    void db
+      .insert(orgMembers)
+      .values({
+        orgId,
+        userId,
+        timezone: prefs.timezone,
+        notifyEmail: prefs.notifyEmail,
+        notifySlack: prefs.notifySlack,
+        pinnedAgentIds: prefs.pinnedAgentIds,
+        sendMode: prefs.sendMode,
+        onboardingDone,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .onConflictDoNothing()
+      .catch((err: unknown) =>
+        log.warn("lazy migration: org_members write failed", {
+          orgId,
+          userId,
+          err,
+        }),
+      );
+
+    return prefs;
+  }
+
+  return { ...DEFAULTS };
 }
 
 /**


### PR DESCRIPTION
## Summary

- Add Clerk fallback on read paths for 4 fields (`email_unsubscribed`, `org_members` preferences, `tier`, `default_agent_compose_id`) to fix incomplete data backfill from PRs #5539, #5532, #5541
- Pattern: DB returns default → check Clerk → if real value found, fire-and-forget write to DB + log → return Clerk value
- All fallbacks are temporary, marked with `// TODO(#5514): remove this fallback after full backfill`

Closes #5591

### Fields covered

| Field | Service | Trigger |
|-------|---------|---------|
| `email_unsubscribed` | `isUserUnsubscribed()` | DB false/missing → Clerk `publicMetadata.email_unsubscribed` |
| `org_members` prefs | `getUserPreferences()` | No DB row → Clerk membership `publicMetadata` (snake_case keys) |
| `tier` | `readTier()` via `getOrgData()`/`getOrgBySlug()` | Cache miss + DB "free" → Clerk org `publicMetadata.tier` |
| `default_agent_compose_id` | `resolveDefaultComposeId()` | DB null → Clerk org `publicMetadata.default_agent_compose_id` |

## Test plan

- [x] `unsubscribe-service.test.ts` — 3 new tests: Clerk fallback returns true + backfills, DB true skips Clerk, neither has true returns false
- [x] `user-preferences-service.test.ts` — 4 new tests: DB row returns values, Clerk fallback + backfill, empty metadata returns defaults, onboardingDone backfill
- [x] `org-cache-service.test.ts` — 3 new tests: cache miss + Clerk tier fallback, DB non-free direct return, cache hit no fallback
- [x] `shared-resolve.test.ts` — 3 new tests: DB value no Clerk call, Clerk fallback + backfill, empty falls to env var
- [x] All 27 affected tests pass
- [x] Lint passes (0 errors)
- [x] Type check passes
- [x] Knip passes (no unused exports)

🤖 Generated with [Claude Code](https://claude.com/claude-code)