### PR TITLE
feat: hide aws-bedrock and azure-foundry from model provider selection

### DIFF
--- a/turbo/apps/cli/src/commands/org/model-provider/setup.ts
+++ b/turbo/apps/cli/src/commands/org/model-provider/setup.ts
@@ -11,6 +11,7 @@ import {
   MODEL_PROVIDER_TYPES,
   hasModelSelection,
   hasAuthMethods,
+  getSelectableProviderTypes,
   type ModelProviderType,
 } from "@vm0/core";
 import { isInteractive } from "../../../lib/utils/prompt-utils";
@@ -37,24 +38,23 @@ async function handleInteractiveMode(): Promise<SetupInput | null> {
   const { modelProviders: configuredProviders } = await listOrgModelProviders();
   const configuredTypes = new Set(configuredProviders.map((p) => p.type));
 
-  // Build provider choices with configuration status
-  const annotatedChoices = Object.entries(MODEL_PROVIDER_TYPES).map(
-    ([type, config]) => {
-      const isConfigured = configuredTypes.has(type as ModelProviderType);
-      const isExperimental = hasAuthMethods(type as ModelProviderType);
-      let title: string = config.label;
-      if (isConfigured) {
-        title = `${title} ✓`;
-      }
-      if (isExperimental) {
-        title = `${title} ${chalk.dim("(experimental)")}`;
-      }
-      return {
-        title,
-        value: type as ModelProviderType,
-      };
-    },
-  );
+  // Build provider choices with configuration status (only selectable providers)
+  const annotatedChoices = getSelectableProviderTypes().map((type) => {
+    const config = MODEL_PROVIDER_TYPES[type];
+    const isConfigured = configuredTypes.has(type);
+    const isExperimental = hasAuthMethods(type);
+    let title: string = config.label;
+    if (isConfigured) {
+      title = `${title} ✓`;
+    }
+    if (isExperimental) {
+      title = `${title} ${chalk.dim("(experimental)")}`;
+    }
+    return {
+      title,
+      value: type,
+    };
+  });
 
   const typeResponse = await prompts(
     {

--- a/turbo/apps/platform/src/views/zero-page/components/settings/org-add-provider-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/org-add-provider-dialog.tsx
@@ -6,8 +6,8 @@ import {
   DialogTitle,
 } from "@vm0/ui/components/ui/dialog";
 import {
-  MODEL_PROVIDER_TYPES,
   isProviderVisible,
+  getSelectableProviderTypes,
   type ModelProviderType,
 } from "@vm0/core";
 import {
@@ -19,7 +19,7 @@ import { getUILabel, getUIDescription } from "./provider-ui-config.ts";
 import { ProviderIcon } from "./provider-icons.tsx";
 
 function getProviderTypes(): ModelProviderType[] {
-  return Object.keys(MODEL_PROVIDER_TYPES) as ModelProviderType[];
+  return getSelectableProviderTypes();
 }
 
 function ProviderCardInDialog({

--- a/turbo/apps/platform/src/views/zero-page/zero-onboarding.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-onboarding.tsx
@@ -20,6 +20,7 @@ import { ProviderIcon } from "./components/settings/provider-icons";
 import {
   MODEL_PROVIDER_TYPES,
   isProviderVisible,
+  getSelectableProviderTypes,
   type ConnectorType,
   type ModelProviderType,
 } from "@vm0/core";
@@ -180,18 +181,8 @@ class WelcomeAnimation extends Component<
   }
 }
 
-const MODEL_PROVIDER_LIST: readonly ModelProviderType[] = [
-  "claude-code-oauth-token",
-  "anthropic-api-key",
-  "openrouter-api-key",
-  "moonshot-api-key",
-  "minimax-api-key",
-  "deepseek-api-key",
-  "zai-api-key",
-  "vercel-ai-gateway",
-  "azure-foundry",
-  "aws-bedrock",
-];
+const MODEL_PROVIDER_LIST: readonly ModelProviderType[] =
+  getSelectableProviderTypes();
 
 function OnboardingSkillCard({
   label,

--- a/turbo/packages/core/src/contracts/index.ts
+++ b/turbo/packages/core/src/contracts/index.ts
@@ -235,6 +235,8 @@ export {
   // Feature-gated provider support
   getProviderFeatureFlag,
   isProviderVisible,
+  // Selectable provider filtering
+  getSelectableProviderTypes,
   // Multi-auth provider support
   hasAuthMethods,
   getAuthMethodsForType,

--- a/turbo/packages/core/src/contracts/model-providers.ts
+++ b/turbo/packages/core/src/contracts/model-providers.ts
@@ -296,6 +296,27 @@ export type ModelProviderType = keyof typeof MODEL_PROVIDER_TYPES;
 export type ModelProviderFramework = "claude-code";
 
 /**
+ * Provider types hidden from user-facing selection UI.
+ * These providers cannot support token replacement (firewall-based secret protection),
+ * so new selection is blocked until a proper solution is implemented.
+ * Existing configurations continue to work at runtime.
+ */
+const HIDDEN_PROVIDER_TYPES: ReadonlySet<ModelProviderType> = new Set([
+  "aws-bedrock",
+  "azure-foundry",
+]);
+
+/**
+ * Get provider types available for user selection.
+ * Excludes providers that are hidden from the UI (e.g., those without token replacement support).
+ */
+export function getSelectableProviderTypes(): ModelProviderType[] {
+  return (Object.keys(MODEL_PROVIDER_TYPES) as ModelProviderType[]).filter(
+    (type) => !HIDDEN_PROVIDER_TYPES.has(type),
+  );
+}
+
+/**
  * Firewall gateway configs for model providers with static base URLs.
  * Used to auto-generate firewall entries that protect API tokens from sandbox exposure.
  * Excluded: aws-bedrock (dynamic region URLs + SigV4), azure-foundry (dynamic resource URLs).


### PR DESCRIPTION
## Summary

- Add `getSelectableProviderTypes()` to core contracts that filters out providers without token replacement support (`aws-bedrock`, `azure-foundry`)
- Update web platform onboarding and settings dialogs to use the new function
- Update CLI interactive provider selection to use the new function
- Type definitions and runtime behavior preserved for existing configurations

Closes #5599

## Test plan

- [x] Existing model provider tests pass (14/14)
- [x] Lint, format, and knip all pass
- [ ] Verify web onboarding dialog no longer shows AWS Bedrock or Azure Foundry
- [ ] Verify org settings "Add provider" dialog no longer shows these providers
- [ ] Verify CLI `vm0 org model-provider setup` interactive mode no longer lists these providers
- [ ] Verify existing aws-bedrock/azure-foundry configurations still work at runtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)