### PR TITLE
fix(docker): use --no-shell flag for playwright chromium install

### DIFF
--- a/docker/toolchain/Dockerfile
+++ b/docker/toolchain/Dockerfile
@@ -94,9 +94,9 @@ RUN curl -fsSL https://downloads.1password.com/linux/keys/1password.asc | gpg --
     && rm -rf /var/lib/apt/lists/*
 
 # Install Playwright Chromium for browser automation (supports ARM64)
-RUN npx -y playwright install --with-deps chromium \
-    && CHROMIUM_PATH=$(find /root/.cache/ms-playwright -name chrome -path "*/chrome-linux/*" | head -1) \
-    && ln -sf "$CHROMIUM_PATH" /usr/local/bin/playwright-chromium
+RUN npx -y playwright install --with-deps --no-shell chromium \
+    && CHROMIUM_PATH=$(find /root/.cache/ms-playwright -type f -name chrome -path "*/chrome-linux/*" | head -1) \
+    && test -n "$CHROMIUM_PATH" && ln -sf "$CHROMIUM_PATH" /usr/local/bin/playwright-chromium
 
 ENV AGENT_BROWSER_EXECUTABLE_PATH=/usr/local/bin/playwright-chromium
 


### PR DESCRIPTION
## Summary
- Fix CI build failure from #5598 where `playwright install chromium` downloaded headless shell instead of full Chromium
- Add `--no-shell` flag to only install full Chromium binary
- Add `test -n` guard to fail early if binary path is empty

## Context
Follow-up to #5598. The Docker build failed because `find` returned empty — Playwright downloaded `chromium-headless-shell` but not the full `chrome-linux/chrome` binary.

## Test plan
- [ ] Docker build succeeds on both amd64 and arm64
- [ ] `playwright-chromium` symlink points to valid binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)