### PR TITLE
feat(platform): add cancel button to queue page

### DIFF
--- a/turbo/apps/platform/src/signals/queue-page/__tests__/queue-signals.test.ts
+++ b/turbo/apps/platform/src/signals/queue-page/__tests__/queue-signals.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../mocks/server.ts";
+import { testContext } from "../../__tests__/test-helpers.ts";
+import { setupPage } from "../../../__tests__/page-helper.ts";
+import { cancelQueueRun$, queueData$ } from "../queue-signals.ts";
+
+const context = testContext();
+
+function mockQueueResponse() {
+  return {
+    concurrency: { tier: "free", limit: 1, active: 1, available: 0 },
+    queue: [],
+    runningTasks: [
+      {
+        runId: "run-1",
+        agentName: "agent-a",
+        agentDisplayName: "Agent A",
+        userEmail: "user@test.com",
+        startedAt: new Date().toISOString(),
+        isOwner: true,
+      },
+    ],
+    estimatedTimePerRun: 30_000,
+  };
+}
+
+describe("cancelQueueRun$", () => {
+  it("should POST to cancel endpoint and refresh queue data", async () => {
+    let cancelCalledWith: string | null = null;
+    let queueFetchCount = 0;
+
+    server.use(
+      http.get("*/api/agent/runs/queue", () => {
+        queueFetchCount++;
+        return HttpResponse.json(mockQueueResponse());
+      }),
+      http.post("*/api/agent/runs/:runId/cancel", ({ params }) => {
+        cancelCalledWith = params.runId as string;
+        return HttpResponse.json({ ok: true });
+      }),
+    );
+
+    await setupPage({ context, path: "/", withoutRender: true });
+
+    // Cancel a run — this also triggers fetchQueueData$ internally
+    await context.store.set(cancelQueueRun$, "run-1");
+
+    // Verify cancel was called with correct run ID
+    expect(cancelCalledWith).toBe("run-1");
+
+    // Verify queue was refreshed after cancel (fetchQueueData$ called)
+    expect(queueFetchCount).toBeGreaterThanOrEqual(1);
+
+    // Verify queueData$ is now populated from the refresh
+    const data = context.store.get(queueData$);
+    expect(data).toBeTruthy();
+  });
+
+  it("should throw on non-ok cancel response", async () => {
+    server.use(
+      http.get("*/api/agent/runs/queue", () => {
+        return HttpResponse.json(mockQueueResponse());
+      }),
+      http.post("*/api/agent/runs/:runId/cancel", () => {
+        return new HttpResponse(null, {
+          status: 403,
+          statusText: "Forbidden",
+        });
+      }),
+    );
+
+    await setupPage({ context, path: "/", withoutRender: true });
+
+    await expect(context.store.set(cancelQueueRun$, "run-1")).rejects.toThrow(
+      "Failed to cancel run",
+    );
+  });
+});

--- a/turbo/apps/platform/src/signals/queue-page/queue-signals.ts
+++ b/turbo/apps/platform/src/signals/queue-page/queue-signals.ts
@@ -54,3 +54,15 @@ const startPolling$ = command(
 );
 
 export const queuePollingRef$ = onRef(startPolling$);
+
+export const cancelQueueRun$ = command(async ({ get, set }, runId: string) => {
+  const fetchFn = get(fetch$);
+  const response = await fetchFn(`/api/agent/runs/${runId}/cancel`, {
+    method: "POST",
+  });
+  if (!response.ok) {
+    throw new Error(`Failed to cancel run: ${response.statusText}`);
+  }
+  // Refresh queue data after cancel
+  await set(fetchQueueData$);
+});

--- a/turbo/apps/platform/src/views/queue-page/__tests__/queue-page.test.tsx
+++ b/turbo/apps/platform/src/views/queue-page/__tests__/queue-page.test.tsx
@@ -1,0 +1,188 @@
+import { describe, expect, it } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../mocks/server.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { setupPage } from "../../../__tests__/page-helper.ts";
+
+const context = testContext();
+
+function queueResponse(overrides?: {
+  runningTasks?: unknown[];
+  queue?: unknown[];
+  estimatedTimePerRun?: number | null;
+}) {
+  return {
+    concurrency: { tier: "free", limit: 2, active: 1, available: 1 },
+    queue: overrides?.queue ?? [],
+    runningTasks: overrides?.runningTasks ?? [],
+    estimatedTimePerRun: overrides?.estimatedTimePerRun ?? null,
+  };
+}
+
+describe("queue page", () => {
+  it("should show cancel button for owner's running tasks", async () => {
+    server.use(
+      http.get("*/api/agent/runs/queue", () => {
+        return HttpResponse.json(
+          queueResponse({
+            runningTasks: [
+              {
+                runId: "run-owner",
+                agentName: "my-agent",
+                agentDisplayName: "My Agent",
+                userEmail: "me@test.com",
+                startedAt: new Date().toISOString(),
+                isOwner: true,
+              },
+            ],
+          }),
+        );
+      }),
+    );
+
+    await setupPage({ context, path: "/queue" });
+
+    await waitFor(() => {
+      expect(screen.getByText("My Agent")).toBeInTheDocument();
+    });
+
+    // Owner should see the Cancel button
+    const cancelButtons = screen.getAllByRole("button", { name: "Cancel" });
+    expect(cancelButtons).toHaveLength(1);
+  });
+
+  it("should not show cancel button for non-owner running tasks", async () => {
+    server.use(
+      http.get("*/api/agent/runs/queue", () => {
+        return HttpResponse.json(
+          queueResponse({
+            runningTasks: [
+              {
+                runId: "run-other",
+                agentName: "other-agent",
+                agentDisplayName: "Other Agent",
+                userEmail: "other@test.com",
+                startedAt: new Date().toISOString(),
+                isOwner: false,
+              },
+            ],
+          }),
+        );
+      }),
+    );
+
+    await setupPage({ context, path: "/queue" });
+
+    await waitFor(() => {
+      expect(screen.getByText("Other Agent")).toBeInTheDocument();
+    });
+
+    // Non-owner should NOT see a Cancel button
+    expect(screen.queryByRole("button", { name: "Cancel" })).toBeNull();
+  });
+
+  it("should show cancel button for owner's queued entries", async () => {
+    server.use(
+      http.get("*/api/agent/runs/queue", () => {
+        return HttpResponse.json(
+          queueResponse({
+            queue: [
+              {
+                position: 1,
+                agentName: "queued-agent",
+                agentDisplayName: "Queued Agent",
+                userEmail: "me@test.com",
+                createdAt: new Date().toISOString(),
+                isOwner: true,
+                runId: "run-queued",
+                prompt: null,
+                triggerSource: null,
+                sessionLink: null,
+              },
+            ],
+          }),
+        );
+      }),
+    );
+
+    await setupPage({ context, path: "/queue" });
+
+    await waitFor(() => {
+      expect(screen.getByText("Queued Agent")).toBeInTheDocument();
+    });
+
+    const cancelButtons = screen.getAllByRole("button", { name: "Cancel" });
+    expect(cancelButtons).toHaveLength(1);
+  });
+
+  it("should not show cancel button when runId is null", async () => {
+    server.use(
+      http.get("*/api/agent/runs/queue", () => {
+        return HttpResponse.json(
+          queueResponse({
+            runningTasks: [
+              {
+                runId: null,
+                agentName: "starting-agent",
+                agentDisplayName: "Starting Agent",
+                userEmail: "me@test.com",
+                startedAt: null,
+                isOwner: true,
+              },
+            ],
+          }),
+        );
+      }),
+    );
+
+    await setupPage({ context, path: "/queue" });
+
+    await waitFor(() => {
+      expect(screen.getByText("Starting Agent")).toBeInTheDocument();
+    });
+
+    // No cancel button when runId is null, even for owner
+    expect(screen.queryByRole("button", { name: "Cancel" })).toBeNull();
+  });
+
+  it("should call cancel endpoint when cancel button is clicked", async () => {
+    let cancelledRunId: string | null = null;
+
+    server.use(
+      http.get("*/api/agent/runs/queue", () => {
+        return HttpResponse.json(
+          queueResponse({
+            runningTasks: [
+              {
+                runId: "run-to-cancel",
+                agentName: "cancel-test-agent",
+                agentDisplayName: "Cancel Test Agent",
+                userEmail: "me@test.com",
+                startedAt: new Date().toISOString(),
+                isOwner: true,
+              },
+            ],
+          }),
+        );
+      }),
+      http.post("*/api/agent/runs/:runId/cancel", ({ params }) => {
+        cancelledRunId = params.runId as string;
+        return HttpResponse.json({ ok: true });
+      }),
+    );
+
+    await setupPage({ context, path: "/queue" });
+
+    await waitFor(() => {
+      expect(screen.getByText("Cancel Test Agent")).toBeInTheDocument();
+    });
+
+    const cancelButton = screen.getByRole("button", { name: "Cancel" });
+    cancelButton.click();
+
+    await waitFor(() => {
+      expect(cancelledRunId).toBe("run-to-cancel");
+    });
+  });
+});

--- a/turbo/apps/platform/src/views/queue-page/queue-running-table.tsx
+++ b/turbo/apps/platform/src/views/queue-page/queue-running-table.tsx
@@ -1,9 +1,11 @@
+import { useSet } from "ccstate-react";
 import { IconLoader2, IconClock } from "@tabler/icons-react";
 import { cn } from "@vm0/ui";
 import type { RunningTask } from "../../signals/queue-page/queue-signals.ts";
+import { cancelQueueRun$ } from "../../signals/queue-page/queue-signals.ts";
 import { SimpleLink } from "../router/link.tsx";
 
-const ROW_GRID = "grid grid-cols-[1fr_1fr_6rem_5rem] gap-x-4 items-center";
+const ROW_GRID = "grid grid-cols-[1fr_1fr_6rem_5rem_4rem] gap-x-6 items-center";
 
 function formatRelativeTime(iso: string): string {
   const diff = Date.now() - new Date(iso).getTime();
@@ -21,6 +23,7 @@ interface QueueRunningTableProps {
 }
 
 export function QueueRunningTable({ tasks }: QueueRunningTableProps) {
+  const cancelRun = useSet(cancelQueueRun$);
   return (
     <div>
       <p className="text-sm font-medium text-muted-foreground mb-2 px-1">
@@ -31,24 +34,25 @@ export function QueueRunningTable({ tasks }: QueueRunningTableProps) {
           No tasks currently running.
         </div>
       ) : (
-        <div className="zero-card overflow-hidden px-6 pb-2">
+        <div className="zero-card overflow-hidden px-4 sm:px-7 pb-3">
           <div
             className={cn(
               ROW_GRID,
-              "sticky top-0 z-10 -mx-4 px-4 py-2.5 text-xs font-medium text-muted-foreground bg-card border-b border-border/40",
+              "sticky top-0 z-10 -mx-4 px-4 py-3 text-sm font-medium text-muted-foreground bg-card border-b border-border/40",
             )}
           >
             <div>Agent</div>
             <div>User</div>
             <div>Started</div>
             <div>Activity logs</div>
+            <div>Cancel</div>
           </div>
           {tasks.map((task, i) => (
             <div
               key={task.runId ?? `running-${i}`}
               className={cn(
                 ROW_GRID,
-                "py-2.5 -mx-4 px-4 border-b border-border/40 last:border-b-0",
+                "py-3 -mx-4 px-4 border-b border-border/40 last:border-b-0",
               )}
             >
               <div className="text-sm font-medium text-foreground truncate">
@@ -84,6 +88,17 @@ export function QueueRunningTable({ tasks }: QueueRunningTableProps) {
                   </SimpleLink>
                 ) : (
                   <span className="text-sm text-muted-foreground">--</span>
+                )}
+              </div>
+              <div>
+                {task.isOwner && task.runId && (
+                  <button
+                    type="button"
+                    className="text-sm text-destructive hover:underline"
+                    onClick={() => cancelRun(task.runId!)}
+                  >
+                    Cancel
+                  </button>
                 )}
               </div>
             </div>

--- a/turbo/apps/platform/src/views/queue-page/queue-running-table.tsx
+++ b/turbo/apps/platform/src/views/queue-page/queue-running-table.tsx
@@ -1,8 +1,10 @@
 import { useSet } from "ccstate-react";
 import { IconLoader2, IconClock } from "@tabler/icons-react";
 import { cn } from "@vm0/ui";
-import type { RunningTask } from "../../signals/queue-page/queue-signals.ts";
-import { cancelQueueRun$ } from "../../signals/queue-page/queue-signals.ts";
+import {
+  cancelQueueRun$,
+  type RunningTask,
+} from "../../signals/queue-page/queue-signals.ts";
 import { SimpleLink } from "../router/link.tsx";
 
 const ROW_GRID = "grid grid-cols-[1fr_1fr_6rem_5rem_4rem] gap-x-6 items-center";
@@ -47,62 +49,65 @@ export function QueueRunningTable({ tasks }: QueueRunningTableProps) {
             <div>Activity logs</div>
             <div>Cancel</div>
           </div>
-          {tasks.map((task, i) => (
-            <div
-              key={task.runId ?? `running-${i}`}
-              className={cn(
-                ROW_GRID,
-                "py-3 -mx-4 px-4 border-b border-border/40 last:border-b-0",
-              )}
-            >
-              <div className="text-sm font-medium text-foreground truncate">
-                {task.agentDisplayName ?? task.agentName}
-              </div>
-              <div className="text-sm text-muted-foreground truncate">
-                {task.userEmail}
-              </div>
-              <div className="text-sm text-muted-foreground">
-                {task.startedAt ? (
-                  <span className="inline-flex items-center gap-1">
-                    <IconClock size={12} stroke={1.5} />
-                    {formatRelativeTime(task.startedAt)}
-                  </span>
-                ) : (
-                  <span className="inline-flex items-center gap-1">
-                    <IconLoader2
-                      size={12}
-                      stroke={1.5}
-                      className="animate-spin"
-                    />
-                    Starting
-                  </span>
+          {tasks.map((task, i) => {
+            const runId = task.runId;
+            return (
+              <div
+                key={runId ?? `running-${i}`}
+                className={cn(
+                  ROW_GRID,
+                  "py-3 -mx-4 px-4 border-b border-border/40 last:border-b-0",
                 )}
+              >
+                <div className="text-sm font-medium text-foreground truncate">
+                  {task.agentDisplayName ?? task.agentName}
+                </div>
+                <div className="text-sm text-muted-foreground truncate">
+                  {task.userEmail}
+                </div>
+                <div className="text-sm text-muted-foreground">
+                  {task.startedAt ? (
+                    <span className="inline-flex items-center gap-1">
+                      <IconClock size={12} stroke={1.5} />
+                      {formatRelativeTime(task.startedAt)}
+                    </span>
+                  ) : (
+                    <span className="inline-flex items-center gap-1">
+                      <IconLoader2
+                        size={12}
+                        stroke={1.5}
+                        className="animate-spin"
+                      />
+                      Starting
+                    </span>
+                  )}
+                </div>
+                <div>
+                  {runId ? (
+                    <SimpleLink
+                      href={`/activity/${runId}`}
+                      className="text-sm text-primary hover:underline"
+                    >
+                      View logs
+                    </SimpleLink>
+                  ) : (
+                    <span className="text-sm text-muted-foreground">--</span>
+                  )}
+                </div>
+                <div>
+                  {task.isOwner && runId && (
+                    <button
+                      type="button"
+                      className="text-sm text-destructive hover:underline"
+                      onClick={() => void cancelRun(runId)}
+                    >
+                      Cancel
+                    </button>
+                  )}
+                </div>
               </div>
-              <div>
-                {task.runId ? (
-                  <SimpleLink
-                    href={`/activity/${task.runId}`}
-                    className="text-sm text-primary hover:underline"
-                  >
-                    View logs
-                  </SimpleLink>
-                ) : (
-                  <span className="text-sm text-muted-foreground">--</span>
-                )}
-              </div>
-              <div>
-                {task.isOwner && task.runId && (
-                  <button
-                    type="button"
-                    className="text-sm text-destructive hover:underline"
-                    onClick={() => cancelRun(task.runId!)}
-                  >
-                    Cancel
-                  </button>
-                )}
-              </div>
-            </div>
-          ))}
+            );
+          })}
         </div>
       )}
     </div>

--- a/turbo/apps/platform/src/views/queue-page/queue-waiting-table.tsx
+++ b/turbo/apps/platform/src/views/queue-page/queue-waiting-table.tsx
@@ -1,9 +1,11 @@
+import { useSet } from "ccstate-react";
 import { cn } from "@vm0/ui";
 import type { QueueEntry } from "../../signals/queue-page/queue-signals.ts";
+import { cancelQueueRun$ } from "../../signals/queue-page/queue-signals.ts";
 import { SimpleLink } from "../router/link.tsx";
 
 const ROW_GRID =
-  "grid grid-cols-[2.5rem_1fr_1fr_5rem_5rem_7rem] gap-x-4 items-center";
+  "grid grid-cols-[2.5rem_1fr_1fr_5rem_5rem_7rem_4rem] gap-x-6 items-center";
 
 function formatDuration(ms: number): string {
   if (ms < 60_000) {
@@ -35,6 +37,7 @@ export function QueueWaitingTable({
   queue,
   estimatedTimePerRun,
 }: QueueWaitingTableProps) {
+  const cancelRun = useSet(cancelQueueRun$);
   return (
     <div>
       <p className="text-sm font-medium text-muted-foreground mb-2 px-1">
@@ -45,11 +48,11 @@ export function QueueWaitingTable({
           No tasks in queue.
         </div>
       ) : (
-        <div className="zero-card overflow-hidden px-6 pb-2">
+        <div className="zero-card overflow-hidden px-4 sm:px-7 pb-3">
           <div
             className={cn(
               ROW_GRID,
-              "sticky top-0 z-10 -mx-4 px-4 py-2.5 text-xs font-medium text-muted-foreground bg-card border-b border-border/40",
+              "sticky top-0 z-10 -mx-4 px-4 py-3 text-sm font-medium text-muted-foreground bg-card border-b border-border/40",
             )}
           >
             <div>#</div>
@@ -58,13 +61,14 @@ export function QueueWaitingTable({
             <div>Queued</div>
             <div>Est. Wait</div>
             <div>Activity logs</div>
+            <div>Cancel</div>
           </div>
           {queue.map((entry) => (
             <div
               key={entry.runId ?? `queue-${entry.position}`}
               className={cn(
                 ROW_GRID,
-                "py-2.5 -mx-4 px-4 border-b border-border/40 last:border-b-0",
+                "py-3 -mx-4 px-4 border-b border-border/40 last:border-b-0",
               )}
             >
               <div className="text-sm font-medium text-muted-foreground tabular-nums">
@@ -94,6 +98,17 @@ export function QueueWaitingTable({
                   </SimpleLink>
                 ) : (
                   <span className="text-sm text-muted-foreground">--</span>
+                )}
+              </div>
+              <div>
+                {entry.isOwner && entry.runId && (
+                  <button
+                    type="button"
+                    className="text-sm text-destructive hover:underline"
+                    onClick={() => cancelRun(entry.runId!)}
+                  >
+                    Cancel
+                  </button>
                 )}
               </div>
             </div>

--- a/turbo/apps/platform/src/views/queue-page/queue-waiting-table.tsx
+++ b/turbo/apps/platform/src/views/queue-page/queue-waiting-table.tsx
@@ -1,7 +1,9 @@
 import { useSet } from "ccstate-react";
 import { cn } from "@vm0/ui";
-import type { QueueEntry } from "../../signals/queue-page/queue-signals.ts";
-import { cancelQueueRun$ } from "../../signals/queue-page/queue-signals.ts";
+import {
+  cancelQueueRun$,
+  type QueueEntry,
+} from "../../signals/queue-page/queue-signals.ts";
 import { SimpleLink } from "../router/link.tsx";
 
 const ROW_GRID =
@@ -63,56 +65,59 @@ export function QueueWaitingTable({
             <div>Activity logs</div>
             <div>Cancel</div>
           </div>
-          {queue.map((entry) => (
-            <div
-              key={entry.runId ?? `queue-${entry.position}`}
-              className={cn(
-                ROW_GRID,
-                "py-3 -mx-4 px-4 border-b border-border/40 last:border-b-0",
-              )}
-            >
-              <div className="text-sm font-medium text-muted-foreground tabular-nums">
-                {entry.position}
-              </div>
-              <div className="text-sm font-medium text-foreground truncate">
-                {entry.agentDisplayName ?? entry.agentName}
-              </div>
-              <div className="text-sm text-muted-foreground truncate">
-                {entry.userEmail}
-              </div>
-              <div className="text-sm text-muted-foreground tabular-nums">
-                {formatRelativeTime(entry.createdAt)}
-              </div>
-              <div className="text-sm text-muted-foreground tabular-nums">
-                {estimatedTimePerRun
-                  ? formatDuration(estimatedTimePerRun * entry.position)
-                  : "--"}
-              </div>
-              <div>
-                {entry.runId ? (
-                  <SimpleLink
-                    href={`/activity/${entry.runId}`}
-                    className="text-sm text-primary hover:underline"
-                  >
-                    View logs
-                  </SimpleLink>
-                ) : (
-                  <span className="text-sm text-muted-foreground">--</span>
+          {queue.map((entry) => {
+            const runId = entry.runId;
+            return (
+              <div
+                key={runId ?? `queue-${entry.position}`}
+                className={cn(
+                  ROW_GRID,
+                  "py-3 -mx-4 px-4 border-b border-border/40 last:border-b-0",
                 )}
+              >
+                <div className="text-sm font-medium text-muted-foreground tabular-nums">
+                  {entry.position}
+                </div>
+                <div className="text-sm font-medium text-foreground truncate">
+                  {entry.agentDisplayName ?? entry.agentName}
+                </div>
+                <div className="text-sm text-muted-foreground truncate">
+                  {entry.userEmail}
+                </div>
+                <div className="text-sm text-muted-foreground tabular-nums">
+                  {formatRelativeTime(entry.createdAt)}
+                </div>
+                <div className="text-sm text-muted-foreground tabular-nums">
+                  {estimatedTimePerRun
+                    ? formatDuration(estimatedTimePerRun * entry.position)
+                    : "--"}
+                </div>
+                <div>
+                  {runId ? (
+                    <SimpleLink
+                      href={`/activity/${runId}`}
+                      className="text-sm text-primary hover:underline"
+                    >
+                      View logs
+                    </SimpleLink>
+                  ) : (
+                    <span className="text-sm text-muted-foreground">--</span>
+                  )}
+                </div>
+                <div>
+                  {entry.isOwner && runId && (
+                    <button
+                      type="button"
+                      className="text-sm text-destructive hover:underline"
+                      onClick={() => void cancelRun(runId)}
+                    >
+                      Cancel
+                    </button>
+                  )}
+                </div>
               </div>
-              <div>
-                {entry.isOwner && entry.runId && (
-                  <button
-                    type="button"
-                    className="text-sm text-destructive hover:underline"
-                    onClick={() => cancelRun(entry.runId!)}
-                  >
-                    Cancel
-                  </button>
-                )}
-              </div>
-            </div>
-          ))}
+            );
+          })}
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- Add cancel button to both Running and Waiting queue tables, visible only to the run owner (`isOwner && runId`)
- Add `cancelQueueRun$` command signal that POSTs to `/api/agent/runs/:id/cancel` and refreshes queue data
- Align queue table styling (gap, padding, header font size) with the activity page for visual consistency

## Test plan
- [ ] Verify cancel button appears only for runs owned by the current user
- [ ] Verify clicking cancel sends POST request and refreshes queue data
- [ ] Verify table styling matches the activity page (font sizes, padding, gaps)

🤖 Generated with [Claude Code](https://claude.com/claude-code)