### PR TITLE
fix(docker): drop --no-shell and use precise glob for chromium path

### DIFF
--- a/docker/toolchain/Dockerfile
+++ b/docker/toolchain/Dockerfile
@@ -94,8 +94,8 @@ RUN curl -fsSL https://downloads.1password.com/linux/keys/1password.asc | gpg --
     && rm -rf /var/lib/apt/lists/*
 
 # Install Playwright Chromium for browser automation (supports ARM64)
-RUN npx -y playwright install --with-deps --no-shell chromium \
-    && CHROMIUM_PATH=$(find /root/.cache/ms-playwright -type f -name chrome -path "*/chrome-linux/*" | head -1) \
+RUN npx -y playwright install --with-deps chromium \
+    && CHROMIUM_PATH=$(find /root/.cache/ms-playwright/chromium-*/chrome-linux -type f -name chrome | head -1) \
     && test -n "$CHROMIUM_PATH" && ln -sf "$CHROMIUM_PATH" /usr/local/bin/playwright-chromium
 
 ENV AGENT_BROWSER_EXECUTABLE_PATH=/usr/local/bin/playwright-chromium


### PR DESCRIPTION
## Summary
- Remove `--no-shell` flag which caused Playwright to skip Chromium entirely on amd64 (only FFmpeg was downloaded)
- Use `chromium-*/chrome-linux` glob to match full Chromium binary, excluding `chromium_headless_shell-*`

## Context
Follow-up to #5603 which failed in CI. The `--no-shell` flag had unintended side effects on amd64 builds.

## Test plan
- [ ] Docker build succeeds on both amd64 and arm64
- [ ] `/usr/local/bin/playwright-chromium` symlink points to valid binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)