### PR TITLE
fix(runner): remove duplicate disallowed_tools field in execution context

### DIFF
--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -708,7 +708,6 @@ mod tests {
             experimental_capabilities: None,
             disallowed_tools: None,
             experimental_profile: None,
-            disallowed_tools: None,
         }
     }
 

--- a/crates/runner/src/provider/local.rs
+++ b/crates/runner/src/provider/local.rs
@@ -181,7 +181,6 @@ impl JobProvider for LocalProvider {
             experimental_capabilities: None,
             disallowed_tools: None,
             experimental_profile: req.profile,
-            disallowed_tools: None,
         })
     }
 

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -90,8 +90,6 @@ pub struct ExecutionContext {
     #[allow(dead_code)]
     #[serde(default)]
     pub experimental_profile: Option<String>,
-    #[serde(default)]
-    pub disallowed_tools: Option<Vec<String>>,
 }
 
 /// A single firewall config with its name, ref key, and API entries.


### PR DESCRIPTION
## Summary
- Remove duplicate `disallowed_tools` field from `ExecutionContext` struct and its initializers
- The field was defined twice in `types.rs` and initialized twice in `executor.rs` and `local.rs`

## Test plan
- [x] `cargo check` passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)