### PR TITLE
fix(api): use upsert for default agent to handle missing org rows

### DIFF
--- a/turbo/apps/web/app/api/orgs/default-agent/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/orgs/default-agent/__tests__/route.test.ts
@@ -4,6 +4,7 @@ import {
   createTestRequest,
   createTestCompose,
   deleteTestCompose,
+  deleteOrgRow,
   getOrgDefaultAgent,
 } from "../../../../../src/__tests__/api-test-helpers";
 import { testContext } from "../../../../../src/__tests__/test-helpers";
@@ -160,5 +161,24 @@ describe("PUT /api/orgs/default-agent", () => {
 
     const data = await response.json();
     expect(data.agentComposeId).toBe(compose.composeId);
+  });
+
+  it("should succeed when org row does not exist in org table", async () => {
+    const { orgId } = await context.setupUser();
+    const compose = await createTestCompose("test-agent");
+
+    // Remove the org row to simulate a free-tier org that never triggered lazy migration
+    await deleteOrgRow(orgId);
+
+    // The upsert should create the org row and set the default agent
+    const response = await putDefaultAgent(undefined, compose.composeId);
+    expect(response.status).toBe(200);
+
+    const data = await response.json();
+    expect(data.agentComposeId).toBe(compose.composeId);
+
+    // Verify the value was persisted to the org table
+    const storedId = await getOrgDefaultAgent(orgId);
+    expect(storedId).toBe(compose.composeId);
   });
 });

--- a/turbo/apps/web/app/api/orgs/default-agent/route.ts
+++ b/turbo/apps/web/app/api/orgs/default-agent/route.ts
@@ -96,9 +96,12 @@ const router = tsr.router(orgDefaultAgentContract, {
     }
 
     await globalThis.services.db
-      .update(orgTable)
-      .set({ defaultAgentComposeId: agentComposeId, updatedAt: new Date() })
-      .where(eq(orgTable.orgId, org.orgId));
+      .insert(orgTable)
+      .values({ orgId: org.orgId, defaultAgentComposeId: agentComposeId })
+      .onConflictDoUpdate({
+        target: orgTable.orgId,
+        set: { defaultAgentComposeId: agentComposeId, updatedAt: new Date() },
+      });
 
     return {
       status: 200 as const,

--- a/turbo/apps/web/src/__tests__/api-test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers.ts
@@ -2948,6 +2948,14 @@ export async function ensureOrgRow(orgId: string): Promise<void> {
 }
 
 /**
+ * Delete an org row from the `org` table.
+ * Useful for testing scenarios where the org row does not exist.
+ */
+export async function deleteOrgRow(orgId: string): Promise<void> {
+  await globalThis.services.db.delete(org).where(eq(org.orgId, orgId));
+}
+
+/**
  * Update the tier for an org in the `org` table.
  */
 export async function updateOrgTier(


### PR DESCRIPTION
## Summary
- Fix silent failure when setting default agent for free-tier orgs that have no row in the `org` table (never triggered lazy migration)
- Changed `UPDATE` to `INSERT ... ON CONFLICT DO UPDATE` (upsert) so the org row is created if missing, matching the pattern in `slack-org/handlers/shared.ts`

## Test plan
- [x] Existing 10 tests in `default-agent/__tests__/route.test.ts` all pass
- [x] Lint, knip, and commitlint checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)