### PR TITLE
docs: rename platform testing to app testing

### DIFF
--- a/.claude/skills/testing/SKILL.md
+++ b/.claude/skills/testing/SKILL.md
@@ -20,7 +20,7 @@ Read the testing guide and relevant reference based on context:
 | CLI (`turbo/apps/cli`) | [docs/testing.md](../../../docs/testing.md) | [cli-testing.md](../../../docs/testing/cli-testing.md) |
 | CLI E2E (`e2e/tests/`) | [docs/testing.md](../../../docs/testing.md) | [cli-e2e-testing.md](../../../docs/testing/cli-e2e-testing.md) |
 | Web (`turbo/apps/web`) | [docs/testing.md](../../../docs/testing.md) | [web-testing.md](../../../docs/testing/web-testing.md) |
-| Platform (`turbo/apps/platform`) | [docs/testing.md](../../../docs/testing.md) | [platform-testing.md](../../../docs/testing/platform-testing.md) |
+| App (`turbo/apps/platform`) | [docs/testing.md](../../../docs/testing.md) | [app-testing.md](../../../docs/testing/app-testing.md) |
 | Rust (`crates/`) | [docs/testing.md](../../../docs/testing.md) | [rust-testing.md](../../../docs/testing/rust-testing.md) |
 | Python addon (`crates/runner/mitm-addon`) | [docs/testing.md](../../../docs/testing.md) | [mitm-addon-testing.md](../../../docs/testing/mitm-addon-testing.md) |
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -258,7 +258,7 @@ Don't render components directly—use `setupPage()` which mirrors `main.ts` sta
 | CLI commands | [cli-testing.md](./testing/cli-testing.md) |
 | CLI E2E (BATS) | [cli-e2e-testing.md](./testing/cli-e2e-testing.md) |
 | Web routes | [web-testing.md](./testing/web-testing.md) |
-| Platform UI | [platform-testing.md](./testing/platform-testing.md) |
+| App UI | [app-testing.md](./testing/app-testing.md) |
 | Rust crates | [rust-testing.md](./testing/rust-testing.md) |
 | Python addon | [mitm-addon-testing.md](./testing/mitm-addon-testing.md) |
 

--- a/docs/testing/app-testing.md
+++ b/docs/testing/app-testing.md
@@ -1,10 +1,10 @@
-# Platform Testing Patterns
+# App Testing Patterns
 
 This document describes the testing patterns for `turbo/apps/platform`.
 
 ## Test Categories
 
-Platform has two main types of tests:
+App has two main types of tests:
 
 | Type | Location | Suffix | Purpose |
 |------|----------|--------|---------|
@@ -192,7 +192,7 @@ export function resetAllMockHandlers(): void {
 
 ## External Network Requests
 
-**Platform tests do not allow any external network requests.** This is enforced through MSW configuration.
+**App tests do not allow any external network requests.** This is enforced through MSW configuration.
 
 ### Default Configuration
 


### PR DESCRIPTION
## Summary
- Rename `platform-testing.md` to `app-testing.md` to reflect the current naming convention
- Update references in `docs/testing.md` and `.claude/skills/testing/SKILL.md`

## Test plan
- [ ] Verify all internal doc links resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)