### PR TITLE
test: add integration tests for schedule page, onboarding, and chat page

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-page.test.tsx
@@ -1,0 +1,138 @@
+import { describe, expect, it } from "vitest";
+import { screen, waitFor, fireEvent } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../mocks/server.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { setupPage } from "../../../__tests__/page-helper.ts";
+
+const context = testContext();
+
+function mockChatAPI() {
+  server.use(
+    http.get("*/api/chat-threads", () => {
+      return HttpResponse.json({ threads: [] });
+    }),
+  );
+}
+
+async function renderChatPage() {
+  mockChatAPI();
+  await setupPage({ context, path: "/" });
+}
+
+describe("zero chat page - suggested prompts", () => {
+  it("should render 3 suggested prompt cards", async () => {
+    await renderChatPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("Auto-organize inbox")).toBeInTheDocument();
+    });
+    expect(screen.getByText("Daily morning brief")).toBeInTheDocument();
+    expect(screen.getByText("Create a sub-agent")).toBeInTheDocument();
+  });
+
+  it("should render descriptions for suggested prompts", async () => {
+    await renderChatPage();
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Smart categorization, reply, and daily email digest"),
+      ).toBeInTheDocument();
+    });
+    expect(
+      screen.getByText(
+        "Trending topics on a schedule, your personalized digest",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Build a specialized agent for a specific workflow"),
+    ).toBeInTheDocument();
+  });
+
+  it("should populate composer input when suggested prompt is clicked", async () => {
+    await renderChatPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("Auto-organize inbox")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText("Auto-organize inbox"));
+
+    await waitFor(() => {
+      const textarea = screen.getByPlaceholderText(
+        "Ask me to automate workflows, manage tasks...",
+      );
+      expect(textarea).toHaveValue(
+        "Set up auto-organization for my inbox with smart categorization, auto-reply rules, and a daily email digest",
+      );
+    });
+  });
+});
+
+describe("zero chat page - composer", () => {
+  it("should render composer textarea", async () => {
+    await renderChatPage();
+
+    await waitFor(() => {
+      expect(
+        screen.getByPlaceholderText(
+          "Ask me to automate workflows, manage tasks...",
+        ),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("should render Send button", async () => {
+    await renderChatPage();
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Send" })).toBeInTheDocument();
+    });
+  });
+
+  it("should render Attach button", async () => {
+    await renderChatPage();
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "Attach" }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("should disable Send button when input is empty", async () => {
+    await renderChatPage();
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Send" })).toBeDisabled();
+    });
+  });
+
+  it("should enable Send button when input has text", async () => {
+    await renderChatPage();
+
+    const textarea = await waitFor(() =>
+      screen.getByPlaceholderText(
+        "Ask me to automate workflows, manage tasks...",
+      ),
+    );
+
+    fireEvent.change(textarea, { target: { value: "Hello" } });
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Send" })).not.toBeDisabled();
+    });
+  });
+});
+
+describe("zero chat page - agent avatar and greeting", () => {
+  it("should render agent avatar on the landing page", async () => {
+    await renderChatPage();
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "View agent profile" }),
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-onboarding.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-onboarding.test.tsx
@@ -1,0 +1,254 @@
+import { describe, expect, it } from "vitest";
+import { screen, waitFor, fireEvent } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../mocks/server.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { setupPage } from "../../../__tests__/page-helper.ts";
+
+const context = testContext();
+
+function mockOnboardingNeeded() {
+  server.use(
+    http.get("*/api/onboarding/status", () => {
+      return HttpResponse.json({
+        needsOnboarding: true,
+        isAdmin: true,
+        hasOrg: true,
+        hasModelProvider: false,
+        hasDefaultAgent: false,
+        defaultAgentName: null,
+        defaultAgentComposeId: null,
+        defaultAgentMetadata: null,
+        defaultAgentSkills: [],
+      });
+    }),
+  );
+}
+
+async function renderOnboardingPage() {
+  await setupPage({ context, path: "/" });
+}
+
+describe("zero onboarding - step 1: welcome", () => {
+  it("should render welcome dialog when onboarding is needed", async () => {
+    mockOnboardingNeeded();
+    await renderOnboardingPage();
+
+    // Step 1 shows the welcome dialog with typewriter text
+    await waitFor(
+      () => {
+        expect(
+          screen.getByText(/Meet Zero, your new teammate/),
+        ).toBeInTheDocument();
+      },
+      { timeout: 5000 },
+    );
+  });
+
+  it("should show Next button in step 1", async () => {
+    mockOnboardingNeeded();
+    await renderOnboardingPage();
+
+    await waitFor(
+      () => {
+        expect(
+          screen.getByRole("button", { name: "Next" }),
+        ).toBeInTheDocument();
+      },
+      { timeout: 5000 },
+    );
+  });
+
+  it("should advance to step 2 (model provider) when Next is clicked", async () => {
+    mockOnboardingNeeded();
+    await renderOnboardingPage();
+
+    await waitFor(
+      () => {
+        expect(
+          screen.getByRole("button", { name: "Next" }),
+        ).toBeInTheDocument();
+      },
+      { timeout: 5000 },
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Next" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Add model provider")).toBeInTheDocument();
+    });
+  });
+});
+
+describe("zero onboarding - step 2: model provider", () => {
+  it("should render provider selection grid in step 2", async () => {
+    mockOnboardingNeeded();
+    await renderOnboardingPage();
+
+    // Advance to step 2
+    await waitFor(
+      () => {
+        expect(
+          screen.getByRole("button", { name: "Next" }),
+        ).toBeInTheDocument();
+      },
+      { timeout: 5000 },
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Next" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Add model provider")).toBeInTheDocument();
+    });
+
+    // Should show provider choices
+    expect(
+      screen.getByText(
+        "Bring your own model. We never charge for chat. Pick a provider below to get started.",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("should show Back button in step 2", async () => {
+    mockOnboardingNeeded();
+    await renderOnboardingPage();
+
+    await waitFor(
+      () => {
+        expect(
+          screen.getByRole("button", { name: "Next" }),
+        ).toBeInTheDocument();
+      },
+      { timeout: 5000 },
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Next" }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Back" })).toBeInTheDocument();
+    });
+  });
+
+  it("should go back to step 1 when Back is clicked in step 2", async () => {
+    mockOnboardingNeeded();
+    await renderOnboardingPage();
+
+    await waitFor(
+      () => {
+        expect(
+          screen.getByRole("button", { name: "Next" }),
+        ).toBeInTheDocument();
+      },
+      { timeout: 5000 },
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Next" }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Back" })).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Back" }));
+
+    await waitFor(
+      () => {
+        expect(
+          screen.getByText(/Meet Zero, your new teammate/),
+        ).toBeInTheDocument();
+      },
+      { timeout: 5000 },
+    );
+  });
+});
+
+describe("zero onboarding - skip model provider when already set", () => {
+  it("should skip step 2 and go directly to step 3 if model provider exists", async () => {
+    server.use(
+      http.get("*/api/onboarding/status", () => {
+        return HttpResponse.json({
+          needsOnboarding: true,
+          isAdmin: true,
+          hasOrg: true,
+          hasModelProvider: true,
+          hasDefaultAgent: false,
+          defaultAgentName: null,
+          defaultAgentComposeId: null,
+          defaultAgentMetadata: null,
+          defaultAgentSkills: [],
+        });
+      }),
+    );
+
+    await renderOnboardingPage();
+
+    await waitFor(
+      () => {
+        expect(
+          screen.getByRole("button", { name: "Next" }),
+        ).toBeInTheDocument();
+      },
+      { timeout: 5000 },
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Next" }));
+
+    // Should go to step 3 (Add connector), not step 2
+    await waitFor(() => {
+      expect(screen.getByText("Add connector")).toBeInTheDocument();
+    });
+  });
+});
+
+describe("zero onboarding - step 3: connectors", () => {
+  it("should show connector step with skip instruction", async () => {
+    mockOnboardingNeeded();
+
+    // Mock model provider existing so we can navigate through step 2
+    server.use(
+      http.get("*/api/onboarding/status", () => {
+        return HttpResponse.json({
+          needsOnboarding: true,
+          isAdmin: true,
+          hasOrg: true,
+          hasModelProvider: true,
+          hasDefaultAgent: false,
+          defaultAgentName: null,
+          defaultAgentComposeId: null,
+          defaultAgentMetadata: null,
+          defaultAgentSkills: [],
+        });
+      }),
+    );
+
+    await renderOnboardingPage();
+
+    // Step 1 -> Next
+    await waitFor(
+      () => {
+        expect(
+          screen.getByRole("button", { name: "Next" }),
+        ).toBeInTheDocument();
+      },
+      { timeout: 5000 },
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Next" }));
+
+    // Should reach step 3 (connectors)
+    await waitFor(() => {
+      expect(screen.getByText("Add connector")).toBeInTheDocument();
+    });
+    expect(
+      screen.getByText(/You can skip and add more later/),
+    ).toBeInTheDocument();
+  });
+});
+
+describe("zero onboarding - does not render when not needed", () => {
+  it("should not show onboarding dialog when needsOnboarding is false", async () => {
+    // Default mock handler already returns needsOnboarding: false
+    await renderOnboardingPage();
+
+    // Wait for page to load and verify onboarding dialog is NOT shown
+    await waitFor(() => {
+      // The chat page tagline should be visible instead
+      expect(
+        screen.queryByText(/Meet Zero, your new teammate/),
+      ).not.toBeInTheDocument();
+    });
+  });
+});

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-schedule-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-schedule-page.test.tsx
@@ -1,0 +1,303 @@
+import { describe, expect, it } from "vitest";
+import { screen, waitFor, fireEvent } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../mocks/server.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { setupPage } from "../../../__tests__/page-helper.ts";
+
+const context = testContext();
+
+function createMockSchedules() {
+  return [
+    {
+      id: "sched-1",
+      composeId: "mock-compose-id",
+      composeName: "zero",
+      orgSlug: "test",
+      name: "morning-briefing",
+      triggerType: "cron",
+      cronExpression: "0 9 * * 1-5",
+      atTime: null,
+      intervalSeconds: null,
+      timezone: "UTC",
+      prompt: "Summarize yesterday's threads",
+      enabled: true,
+      notifyEmail: false,
+      notifySlack: false,
+      nextRunAt: null,
+      lastRunAt: null,
+      createdAt: "2026-03-01T00:00:00Z",
+      updatedAt: "2026-03-01T00:00:00Z",
+    },
+    {
+      id: "sched-2",
+      composeId: "mock-compose-id",
+      composeName: "zero",
+      orgSlug: "test",
+      name: "check-inbox",
+      triggerType: "loop",
+      cronExpression: null,
+      atTime: null,
+      intervalSeconds: 900,
+      timezone: "UTC",
+      prompt: "Check inbox for urgent items",
+      enabled: true,
+      notifyEmail: false,
+      notifySlack: false,
+      nextRunAt: null,
+      lastRunAt: null,
+      createdAt: "2026-03-02T00:00:00Z",
+      updatedAt: "2026-03-02T00:00:00Z",
+    },
+    {
+      id: "sched-disabled",
+      composeId: "mock-compose-id",
+      composeName: "zero",
+      orgSlug: "test",
+      name: "disabled-schedule",
+      triggerType: "cron",
+      cronExpression: "0 12 * * *",
+      atTime: null,
+      intervalSeconds: null,
+      timezone: "UTC",
+      prompt: "Disabled daily task",
+      enabled: false,
+      notifyEmail: false,
+      notifySlack: false,
+      nextRunAt: null,
+      lastRunAt: null,
+      createdAt: "2026-02-28T00:00:00Z",
+      updatedAt: "2026-02-28T00:00:00Z",
+    },
+  ];
+}
+
+function mockScheduleAPI(schedules = createMockSchedules()) {
+  server.use(
+    http.get("*/api/agent/schedules", () => {
+      return HttpResponse.json({ schedules });
+    }),
+    http.get("*/api/chat-threads", () => {
+      return HttpResponse.json({ threads: [] });
+    }),
+  );
+}
+
+async function renderSchedulePage() {
+  await setupPage({ context, path: "/schedule" });
+}
+
+describe("zero schedule page - list view", () => {
+  it("should render schedule entries with time and prompt", async () => {
+    mockScheduleAPI();
+    await renderSchedulePage();
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Summarize yesterday's threads"),
+      ).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByText("Check inbox for urgent items"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Every weekday at 9:00 AM")).toBeInTheDocument();
+    expect(screen.getByText("Every 15 minutes")).toBeInTheDocument();
+  });
+
+  it("should render page title and subtitle", async () => {
+    mockScheduleAPI();
+    await renderSchedulePage();
+
+    await waitFor(() => {
+      expect(screen.getByText("Scheduled tasks")).toBeInTheDocument();
+    });
+    expect(
+      screen.getByText(
+        "Automated tasks scheduled across all agents in your workspace.",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("should show empty state when no schedules exist", async () => {
+    mockScheduleAPI([]);
+    await renderSchedulePage();
+
+    await waitFor(() => {
+      expect(screen.getByText("Nothing on the calendar")).toBeInTheDocument();
+    });
+    expect(
+      screen.getByText(
+        "Set up a schedule and your agents will handle the rest.",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("should have Add schedule button in header", async () => {
+    mockScheduleAPI();
+    await renderSchedulePage();
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /Add schedule/i }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("should show edit buttons for each schedule entry", async () => {
+    mockScheduleAPI();
+    await renderSchedulePage();
+
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText("Edit Every weekday at 9:00 AM"),
+      ).toBeInTheDocument();
+    });
+    expect(screen.getByLabelText("Edit Every 15 minutes")).toBeInTheDocument();
+  });
+
+  it("should show delete buttons for named schedule entries", async () => {
+    mockScheduleAPI();
+    await renderSchedulePage();
+
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText("Delete Every weekday at 9:00 AM"),
+      ).toBeInTheDocument();
+    });
+  });
+});
+
+describe("zero schedule page - create dialog", () => {
+  it("should open create dialog when Add schedule is clicked", async () => {
+    mockScheduleAPI();
+    await renderSchedulePage();
+
+    // Wait for the schedule list to render (non-empty so only one Add schedule in header)
+    await waitFor(() => {
+      expect(
+        screen.getByText("Summarize yesterday's threads"),
+      ).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /Add schedule/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("New schedule")).toBeInTheDocument();
+    });
+    expect(screen.getByLabelText("Prompt")).toBeInTheDocument();
+  });
+
+  it("should save a new schedule via API", async () => {
+    let capturedBody: Record<string, unknown> | null = null;
+
+    server.use(
+      http.get("*/api/agent/schedules", () => {
+        return HttpResponse.json({ schedules: createMockSchedules() });
+      }),
+      http.post("*/api/agent/schedules", async ({ request }) => {
+        capturedBody = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json({ success: true });
+      }),
+      http.get("*/api/chat-threads", () => {
+        return HttpResponse.json({ threads: [] });
+      }),
+    );
+
+    await renderSchedulePage();
+
+    // Wait for schedules to render
+    await waitFor(() => {
+      expect(
+        screen.getByText("Summarize yesterday's threads"),
+      ).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /Add schedule/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("New schedule")).toBeInTheDocument();
+    });
+
+    // Fill in prompt
+    const promptInput = screen.getByLabelText("Prompt");
+    fireEvent.change(promptInput, {
+      target: { value: "Daily standup summary" },
+    });
+
+    // Click Create
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+
+    await waitFor(() => {
+      expect(capturedBody).toBeTruthy();
+    });
+    expect(capturedBody).toHaveProperty("prompt", "Daily standup summary");
+  });
+});
+
+describe("zero schedule page - toggle enabled", () => {
+  it("should send PATCH request when toggling schedule enabled state", async () => {
+    let capturedAction: string | null = null;
+
+    server.use(
+      http.get("*/api/agent/schedules", () => {
+        return HttpResponse.json({ schedules: createMockSchedules() });
+      }),
+      http.post("*/api/agent/schedules/:name/:action", ({ params }) => {
+        capturedAction = params["action"] as string;
+        return HttpResponse.json({ success: true });
+      }),
+      http.get("*/api/chat-threads", () => {
+        return HttpResponse.json({ threads: [] });
+      }),
+    );
+
+    await renderSchedulePage();
+
+    // Wait for the schedule list to render
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText("Disable Every weekday at 9:00 AM"),
+      ).toBeInTheDocument();
+    });
+
+    // Toggle the first schedule's enabled switch
+    const toggleSwitch = screen.getByLabelText(
+      "Disable Every weekday at 9:00 AM",
+    );
+    fireEvent.click(toggleSwitch);
+
+    await waitFor(() => {
+      expect(capturedAction).toBe("disable");
+    });
+  });
+});
+
+describe("zero schedule page - view modes", () => {
+  it("should render list and calendar view tabs", async () => {
+    mockScheduleAPI();
+    await renderSchedulePage();
+
+    await waitFor(() => {
+      expect(screen.getByRole("tab", { name: /List/i })).toBeInTheDocument();
+    });
+    expect(screen.getByRole("tab", { name: /Calendar/i })).toBeInTheDocument();
+  });
+
+  it("should switch to calendar view when Calendar tab is clicked", async () => {
+    mockScheduleAPI();
+    await renderSchedulePage();
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("tab", { name: /Calendar/i }),
+      ).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("tab", { name: /Calendar/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Week view")).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add 11 integration tests for the schedule page (list view, create dialog, toggle enabled, view modes)
- Add 9 integration tests for the onboarding flow (welcome step, model provider, back navigation, step skipping, connectors)
- Add 9 integration tests for the chat page (suggested prompts, composer, send/attach buttons, avatar)

All tests use `setupPage()` with MSW for HTTP mocking, following the project's integration-only testing guidelines.

Closes #5611

## Test plan
- [x] All 29 new tests pass locally
- [x] All 19 existing zero-page tests still pass
- [x] Lint passes
- [x] Type check passes
- [x] Knip passes (no unused exports)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)