### PR TITLE
fix(e2e): use click+type instead of fill for clerk sign-in inputs

### DIFF
--- a/e2e/cli-auth-automation.sh
+++ b/e2e/cli-auth-automation.sh
@@ -286,8 +286,10 @@ else
   CONTINUE_REF=$(extract_ref "$(echo "$SNAP_I" | grep -i '"Continue"' || true)")
 
   echo "📧 Entering email: $EMAIL"
-  agent-browser fill "$EMAIL_REF" "$EMAIL"
+  agent-browser click "$EMAIL_REF"
   agent-browser wait 300
+  agent-browser type "$EMAIL_REF" "$EMAIL"
+  agent-browser wait 500
   agent-browser click "$CONTINUE_REF"
   agent-browser wait 5000
   step_screenshot "after-email-continue"
@@ -328,10 +330,14 @@ else
     PASS_REF=$(extract_ref "$(echo "$SNAP_I" | grep -i 'textbox "Password"' || true)")
     CONTINUE_REF=$(extract_ref "$(echo "$SNAP_I" | grep -i '"Continue"' || true)")
 
-    agent-browser fill "$EMAIL_REF" "$EMAIL"
+    agent-browser click "$EMAIL_REF"
     agent-browser wait 300
-    agent-browser fill "$PASS_REF" "$SIGNUP_PASSWORD"
+    agent-browser type "$EMAIL_REF" "$EMAIL"
+    agent-browser wait 500
+    agent-browser click "$PASS_REF"
     agent-browser wait 300
+    agent-browser type "$PASS_REF" "$SIGNUP_PASSWORD"
+    agent-browser wait 500
     agent-browser click "$CONTINUE_REF"
     agent-browser wait 5000
     step_screenshot "after-sign-up-continue"


### PR DESCRIPTION
## Summary
- `agent-browser fill` does not trigger React synthetic events on Clerk's controlled input components, leaving the email field empty
- Browser native validation ("Please fill out this field") blocks sign-in, causing e2e-auth to fail
- Replace `fill` with `click` + `type` to fire proper keyboard events that React/Clerk can handle
- Fix applied to both sign-in and sign-up flows

## Test plan
- [ ] Run e2e-auth CI job and verify email is correctly entered into Clerk sign-in form
- [ ] Verify sign-in completes successfully through OTP flow
- [ ] Verify sign-up flow also works if account doesn't exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)