### PR TITLE
refactor: move disallowed_tools from vm0.yaml to run-time parameter

### DIFF
--- a/turbo/apps/cli/src/commands/run/__tests__/continue.test.ts
+++ b/turbo/apps/cli/src/commands/run/__tests__/continue.test.ts
@@ -199,6 +199,36 @@ describe("run continue command", () => {
       );
     });
 
+    it("should pass disallowed-tools option to API", async () => {
+      let capturedBody: Record<string, unknown> | undefined;
+
+      server.use(
+        http.post(
+          "http://localhost:3000/api/agent/runs",
+          async ({ request }) => {
+            capturedBody = (await request.json()) as Record<string, unknown>;
+            return HttpResponse.json(defaultRunResponse, { status: 201 });
+          },
+        ),
+      );
+
+      await continueCommand.parseAsync([
+        "node",
+        "cli",
+        testSessionId,
+        "test prompt",
+        "--disallowed-tools",
+        "CronCreate",
+        "WebSearch",
+      ]);
+
+      expect(capturedBody).toEqual(
+        expect.objectContaining({
+          disallowedTools: ["CronCreate", "WebSearch"],
+        }),
+      );
+    });
+
     it("should pass model provider option to API", async () => {
       let capturedBody: Record<string, unknown> | undefined;
 

--- a/turbo/apps/cli/src/commands/run/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/run/__tests__/index.test.ts
@@ -819,6 +819,38 @@ describe("run command", () => {
     });
   });
 
+  describe("--disallowed-tools flag", () => {
+    it("should pass disallowed-tools to API", async () => {
+      let capturedBody: Record<string, unknown> | undefined;
+
+      server.use(
+        http.post(
+          "http://localhost:3000/api/agent/runs",
+          async ({ request }) => {
+            capturedBody = (await request.json()) as Record<string, unknown>;
+            return HttpResponse.json(defaultRunResponse, { status: 201 });
+          },
+        ),
+      );
+
+      await runCommand.parseAsync([
+        "node",
+        "cli",
+        testUuid,
+        "test prompt",
+        "--disallowed-tools",
+        "CronCreate",
+        "WebSearch",
+      ]);
+
+      expect(capturedBody).toEqual(
+        expect.objectContaining({
+          disallowedTools: ["CronCreate", "WebSearch"],
+        }),
+      );
+    });
+  });
+
   describe("error handling", () => {
     it("should handle authentication errors", async () => {
       server.use(

--- a/turbo/apps/cli/src/commands/run/__tests__/resume.test.ts
+++ b/turbo/apps/cli/src/commands/run/__tests__/resume.test.ts
@@ -206,6 +206,36 @@ describe("run resume command", () => {
       );
     });
 
+    it("should pass disallowed-tools option to API", async () => {
+      let capturedBody: Record<string, unknown> | undefined;
+
+      server.use(
+        http.post(
+          "http://localhost:3000/api/agent/runs",
+          async ({ request }) => {
+            capturedBody = (await request.json()) as Record<string, unknown>;
+            return HttpResponse.json(defaultRunResponse, { status: 201 });
+          },
+        ),
+      );
+
+      await resumeCommand.parseAsync([
+        "node",
+        "cli",
+        testCheckpointId,
+        "test prompt",
+        "--disallowed-tools",
+        "CronCreate",
+        "WebSearch",
+      ]);
+
+      expect(capturedBody).toEqual(
+        expect.objectContaining({
+          disallowedTools: ["CronCreate", "WebSearch"],
+        }),
+      );
+    });
+
     it("should pass model provider option to API", async () => {
       let capturedBody: Record<string, unknown> | undefined;
 

--- a/turbo/apps/cli/src/commands/run/continue.ts
+++ b/turbo/apps/cli/src/commands/run/continue.ts
@@ -41,6 +41,10 @@ export const continueCommand = new Command()
     "--append-system-prompt <text>",
     "Append text to the agent's system prompt",
   )
+  .option(
+    "--disallowed-tools <tools...>",
+    "Tools to disable in Claude CLI (e.g., CronCreate WebSearch)",
+  )
   .option("--verbose", "Show full tool inputs and outputs")
   .option("--check-env", "Validate secrets and vars before running")
   .addOption(new Option("--debug-no-mock-claude").hideHelp())
@@ -55,6 +59,7 @@ export const continueCommand = new Command()
           secrets: Record<string, string>;
           modelProvider?: string;
           appendSystemPrompt?: string;
+          disallowedTools?: string[];
           verbose?: boolean;
           checkEnv?: boolean;
           debugNoMockClaude?: boolean;
@@ -69,6 +74,7 @@ export const continueCommand = new Command()
           secrets: Record<string, string>;
           modelProvider?: string;
           appendSystemPrompt?: string;
+          disallowedTools?: string[];
           verbose?: boolean;
           checkEnv?: boolean;
           debugNoMockClaude?: boolean;
@@ -105,6 +111,7 @@ export const continueCommand = new Command()
           modelProvider: options.modelProvider || allOpts.modelProvider,
           appendSystemPrompt:
             options.appendSystemPrompt || allOpts.appendSystemPrompt,
+          disallowedTools: options.disallowedTools || allOpts.disallowedTools,
           checkEnv: options.checkEnv || allOpts.checkEnv || undefined,
           debugNoMockClaude:
             options.debugNoMockClaude || allOpts.debugNoMockClaude || undefined,

--- a/turbo/apps/cli/src/commands/run/resume.ts
+++ b/turbo/apps/cli/src/commands/run/resume.ts
@@ -46,6 +46,10 @@ export const resumeCommand = new Command()
     "--append-system-prompt <text>",
     "Append text to the agent's system prompt",
   )
+  .option(
+    "--disallowed-tools <tools...>",
+    "Tools to disable in Claude CLI (e.g., CronCreate WebSearch)",
+  )
   .option("--verbose", "Show full tool inputs and outputs")
   .option("--check-env", "Validate secrets and vars before running")
   .addOption(new Option("--debug-no-mock-claude").hideHelp())
@@ -60,6 +64,7 @@ export const resumeCommand = new Command()
           secrets: Record<string, string>;
           modelProvider?: string;
           appendSystemPrompt?: string;
+          disallowedTools?: string[];
           verbose?: boolean;
           checkEnv?: boolean;
           debugNoMockClaude?: boolean;
@@ -75,6 +80,7 @@ export const resumeCommand = new Command()
           volumeVersion: Record<string, string>;
           modelProvider?: string;
           appendSystemPrompt?: string;
+          disallowedTools?: string[];
           verbose?: boolean;
           checkEnv?: boolean;
           debugNoMockClaude?: boolean;
@@ -115,6 +121,7 @@ export const resumeCommand = new Command()
           modelProvider: options.modelProvider || allOpts.modelProvider,
           appendSystemPrompt:
             options.appendSystemPrompt || allOpts.appendSystemPrompt,
+          disallowedTools: options.disallowedTools || allOpts.disallowedTools,
           checkEnv: options.checkEnv || allOpts.checkEnv || undefined,
           debugNoMockClaude:
             options.debugNoMockClaude || allOpts.debugNoMockClaude || undefined,

--- a/turbo/apps/cli/src/commands/run/run.ts
+++ b/turbo/apps/cli/src/commands/run/run.ts
@@ -73,6 +73,10 @@ export const mainRunCommand = new Command()
     "--append-system-prompt <text>",
     "Append text to the agent's system prompt",
   )
+  .option(
+    "--disallowed-tools <tools...>",
+    "Tools to disable in Claude CLI (e.g., CronCreate WebSearch)",
+  )
   .option("--verbose", "Show full tool inputs and outputs")
   .option("--check-env", "Validate secrets and vars before running")
   .addOption(new Option("--debug-no-mock-claude").hideHelp())
@@ -93,6 +97,7 @@ export const mainRunCommand = new Command()
           conversation?: string;
           modelProvider?: string;
           appendSystemPrompt?: string;
+          disallowedTools?: string[];
           verbose?: boolean;
           checkEnv?: boolean;
           debugNoMockClaude?: boolean;
@@ -177,6 +182,7 @@ export const mainRunCommand = new Command()
           conversationId: options.conversation,
           modelProvider: options.modelProvider,
           appendSystemPrompt: options.appendSystemPrompt,
+          disallowedTools: options.disallowedTools,
           checkEnv: options.checkEnv || undefined,
           debugNoMockClaude: options.debugNoMockClaude || undefined,
         });

--- a/turbo/apps/cli/src/lib/api/domains/runs.ts
+++ b/turbo/apps/cli/src/lib/api/domains/runs.ts
@@ -38,6 +38,8 @@ export async function createRun(body: {
   checkEnv?: boolean;
   // Append text to the agent's system prompt
   appendSystemPrompt?: string;
+  // Tools to disable in Claude CLI (passed as --disallowed-tools)
+  disallowedTools?: string[];
   // Required
   prompt: string;
 }): Promise<CreateRunResponse> {

--- a/turbo/apps/docs/content/docs/reference/configuration/vm0-yaml.mdx
+++ b/turbo/apps/docs/content/docs/reference/configuration/vm0-yaml.mdx
@@ -36,10 +36,6 @@ agents:
     experimental_capabilities:
       - artifact:read
       - artifact:write
-    disallowed_tools:
-      - CronCreate
-      - CronDelete
-      - CronList
     environment:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
       MY_VAR: ${{ vars.MY_VAR }}
@@ -79,7 +75,6 @@ Each agent key must be a valid agent name: 3-64 characters, starting and ending 
 | `volumes`                | array  | No       | `[]`           | Volume mounts in format `name:path`. See [Volume](/docs/core-concept/volume)                      |
 | `environment`            | object | No       | `{}`           | Environment variables. See [Environment Variables](/docs/core-concept/environment-variable)       |
 | `experimental_capabilities` | array  | No       | `[]`           | Sandbox API access permissions. See [Capabilities](/docs/core-concept/capabilities)                       |
-| `disallowed_tools`       | array  | No       | `[]`           | List of Claude Code tool names to disable (e.g., `CronCreate`, `WebSearch`). These are passed as `--disallowed-tools` to the Claude CLI |
 | `experimental_runner`    | object | No       | -              | Self-hosted runner configuration. Object with `group` field in `org/name` format (e.g., `acme/production`) |
 
 ## Volume Fields

--- a/turbo/apps/web/app/api/agent/runs/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/route.ts
@@ -231,6 +231,7 @@ const router = tsr.router(runsMainContract, {
         userId,
         prompt: body.prompt,
         appendSystemPrompt: body.appendSystemPrompt,
+        disallowedTools: body.disallowedTools,
         composeId: body.agentComposeId,
         agentComposeVersionId: body.agentComposeVersionId,
         checkpointId: body.checkpointId,

--- a/turbo/apps/web/src/lib/run/build-context.ts
+++ b/turbo/apps/web/src/lib/run/build-context.ts
@@ -541,6 +541,7 @@ interface BuildContextParams {
   // Required
   prompt: string;
   appendSystemPrompt?: string;
+  disallowedTools?: string[];
   runId: string;
   sandboxToken: string;
   userId: string;
@@ -862,21 +863,6 @@ function buildExperimentalCapabilities(
 }
 
 /**
- * Extract disallowed_tools from the first agent in compose.
- * Returns undefined if not present or empty.
- */
-function extractDisallowedTools(agentCompose: unknown): string[] | undefined {
-  const compose = agentCompose as AgentComposeYaml | undefined;
-  if (!compose?.agents) return undefined;
-
-  const firstAgent = Object.values(compose.agents)[0];
-  const disallowedTools = firstAgent?.disallowed_tools;
-  if (!disallowedTools || disallowedTools.length === 0) return undefined;
-
-  return disallowedTools;
-}
-
-/**
  * Build unified execution context from various parameter sources.
  * Supports: new run, checkpoint resume, session continue.
  *
@@ -1021,8 +1007,8 @@ export async function buildExecutionContext(
   // Build experimental capabilities list from compose
   const experimentalCapabilities = buildExperimentalCapabilities(agentCompose);
 
-  // Build disallowed tools list from compose
-  const disallowedTools = extractDisallowedTools(agentCompose);
+  // Disallowed tools from run-time params (not compose)
+  const disallowedTools = params.disallowedTools;
 
   // Build final execution context
   return {

--- a/turbo/apps/web/src/lib/run/run-service.ts
+++ b/turbo/apps/web/src/lib/run/run-service.ts
@@ -289,6 +289,7 @@ export interface CreateRunParams {
   agentComposeVersionId: string;
   prompt: string;
   appendSystemPrompt?: string;
+  disallowedTools?: string[];
 
   // Optional — caller-resolved compose ID
   // When provided, createRun() uses this to load the compose instead of
@@ -348,6 +349,7 @@ export interface StartRunParams {
 
   // --- Optional params (forwarded to createRun) ---
   appendSystemPrompt?: string;
+  disallowedTools?: string[];
   conversationId?: string;
   vars?: Record<string, string>;
   secrets?: Record<string, string>;
@@ -586,7 +588,13 @@ async function buildAndDispatchRun(opts: {
     authorizeTime,
     transactionTime,
   } = opts;
-  const { userId, agentComposeVersionId, prompt, appendSystemPrompt } = params;
+  const {
+    userId,
+    agentComposeVersionId,
+    prompt,
+    appendSystemPrompt,
+    disallowedTools,
+  } = params;
 
   try {
     // Extract capabilities from compose content for sandbox token
@@ -623,6 +631,7 @@ async function buildAndDispatchRun(opts: {
       agentCompose: composeContent,
       prompt,
       appendSystemPrompt,
+      disallowedTools,
       runId,
       sandboxToken,
       userId,
@@ -903,6 +912,7 @@ export async function startRun(
     agentComposeVersionId: resolved.agentComposeVersionId,
     prompt: params.prompt,
     appendSystemPrompt,
+    disallowedTools: params.disallowedTools,
     composeId: resolved.composeId,
     checkpointId: params.checkpointId,
     sessionId: params.sessionId,

--- a/turbo/apps/web/src/types/agent-compose.ts
+++ b/turbo/apps/web/src/types/agent-compose.ts
@@ -59,11 +59,6 @@ interface AgentDefinition {
    * Validated at compose time against VALID_CAPABILITIES.
    */
   experimental_capabilities?: (typeof VALID_CAPABILITIES)[number][];
-  /**
-   * Tools that Claude Code cannot use.
-   * Each entry is a tool name (e.g., "CronCreate", "WebSearch").
-   */
-  disallowed_tools?: string[];
 }
 
 export interface AgentComposeYaml {

--- a/turbo/packages/core/src/contracts/composes.ts
+++ b/turbo/packages/core/src/contracts/composes.ts
@@ -174,12 +174,6 @@ const agentDefinitionSchema = z.object({
       message: "Duplicate capabilities are not allowed",
     })
     .optional(),
-  /**
-   * Tools that Claude Code cannot use.
-   * Each entry is a tool name (e.g., "CronCreate", "WebSearch").
-   * These are passed as --disallowed-tools to the Claude CLI.
-   */
-  disallowed_tools: z.array(z.string()).optional(),
 });
 
 /**

--- a/turbo/packages/core/src/contracts/runs.ts
+++ b/turbo/packages/core/src/contracts/runs.ts
@@ -56,6 +56,9 @@ const unifiedRunRequestSchema = z.object({
 
   // Optional system prompt to append to the agent's system prompt
   appendSystemPrompt: z.string().optional(),
+
+  // Optional list of tools to disable in Claude CLI (passed as --disallowed-tools)
+  disallowedTools: z.array(z.string()).optional(),
 });
 
 /**


### PR DESCRIPTION
## Summary

- Remove `disallowed_tools` from compose/agent definition schema (vm0.yaml)
- Add `disallowedTools` as a run-time parameter following the `appendSystemPrompt` pattern
- Add `--disallowed-tools` CLI option to `run`, `continue`, and `resume` commands
- Downstream pipeline (ExecutionContext → Rust → guest-agent) unchanged — already supports the field

## Changes

**Remove from compose:**
- `composes.ts` — remove from `agentDefinitionSchema`
- `agent-compose.ts` — remove from `AgentDefinition` type
- `build-context.ts` — remove `extractDisallowedTools()`, accept via params
- `vm0-yaml.mdx` — remove field from docs

**Add to run params:**
- `runs.ts` — add `disallowedTools` to `unifiedRunRequestSchema`
- `run-service.ts` — add to `CreateRunParams`, `StartRunParams`, forward through pipeline
- `route.ts` — forward from request body
- `run.ts`, `continue.ts`, `resume.ts` — add CLI option
- `runs.ts` (CLI API client) — add to body type

## Test plan

- [x] CLI `run` command: `--disallowed-tools` passes through to API request body
- [x] CLI `continue` command: `--disallowed-tools` passes through to API request body
- [x] CLI `resume` command: `--disallowed-tools` passes through to API request body
- [x] All 943 CLI tests pass
- [x] All 280 core package tests pass
- [x] Lint passes (0 warnings, 0 errors)
- [x] Knip passes (no unused code)
- [x] Type check passes (cli, web, core — platform has pre-existing tiptap errors)

Closes #5614

🤖 Generated with [Claude Code](https://claude.com/claude-code)