### PR TITLE
chore: bump devcontainer image to a63ed4e

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "VM0 Development",
-  "image": "ghcr.io/vm0-ai/vm0-dev:20260319",
+  "image": "ghcr.io/vm0-ai/vm0-dev:a63ed4e",
   "features": {
     "ghcr.io/itsmechlark/features/postgresql:1": {
       "version": "17"

--- a/docker/toolchain/Dockerfile
+++ b/docker/toolchain/Dockerfile
@@ -103,7 +103,7 @@ RUN npx -y playwright@1.58.2 install-deps chromium \
     && npx -y playwright@1.58.2 install chrome-for-testing
 
 # Symlink Chromium binary to a stable path for agent-browser
-RUN CHROMIUM_PATH=$(find /root/.cache/ms-playwright/chromium-*/chrome-linux -type f -name chrome 2>/dev/null | head -1) \
+RUN CHROMIUM_PATH=$(find /root/.cache/ms-playwright/chromium-*/chrome-linux* -type f -name chrome 2>/dev/null | head -1) \
     && test -n "$CHROMIUM_PATH" || { echo "ERROR: Chromium not found"; ls -laR /root/.cache/ms-playwright/; exit 1; } \
     && ln -sf "$CHROMIUM_PATH" /usr/local/bin/playwright-chromium
 

--- a/docker/toolchain/Dockerfile
+++ b/docker/toolchain/Dockerfile
@@ -93,15 +93,21 @@ RUN curl -fsSL https://downloads.1password.com/linux/keys/1password.asc | gpg --
     && apt-get install -y 1password-cli \
     && rm -rf /var/lib/apt/lists/*
 
-# Install Playwright Chromium for browser automation (supports ARM64)
-RUN npx -y playwright install --with-deps chromium \
-    && CHROMIUM_PATH=$(find /root/.cache/ms-playwright/chromium-*/chrome-linux -type f -name chrome | head -1) \
-    && test -n "$CHROMIUM_PATH" && ln -sf "$CHROMIUM_PATH" /usr/local/bin/playwright-chromium
+# Install agent-browser for browser automation
+RUN npm install -g agent-browser@0.21.2
+
+# Install Chromium via Playwright (supports both amd64 and arm64)
+# Use chrome-for-testing to ensure full browser (not just headless shell)
+# is downloaded, needed for headed mode (AGENT_BROWSER_HEADED=1)
+RUN npx -y playwright@1.58.2 install-deps chromium \
+    && npx -y playwright@1.58.2 install chrome-for-testing
+
+# Symlink Chromium binary to a stable path for agent-browser
+RUN CHROMIUM_PATH=$(find /root/.cache/ms-playwright/chromium-*/chrome-linux -type f -name chrome 2>/dev/null | head -1) \
+    && test -n "$CHROMIUM_PATH" || { echo "ERROR: Chromium not found"; ls -laR /root/.cache/ms-playwright/; exit 1; } \
+    && ln -sf "$CHROMIUM_PATH" /usr/local/bin/playwright-chromium
 
 ENV AGENT_BROWSER_EXECUTABLE_PATH=/usr/local/bin/playwright-chromium
-
-# Install agent-browser CLI
-RUN npm install -g agent-browser@0.21.2
 
 # Install AWS CLI v2
 RUN apt-get update && apt-get install -y unzip \


### PR DESCRIPTION
## Summary
- Update devcontainer image to `a63ed4e` which includes chrome-for-testing fix for ARM64 browser support (#5615)

## Test plan
- [ ] Devcontainer rebuilds with new image
- [ ] `agent-browser open` works in devcontainer

🤖 Generated with [Claude Code](https://claude.com/claude-code)