### PR TITLE
fix(runner): add user-agent to mitmproxy firewall auth requests

### DIFF
--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -271,6 +271,7 @@ def fetch_firewall_headers(encrypted_secrets: str, auth_headers: dict, sandbox_t
     req = urllib.request.Request(url, data=data, headers={
         "Authorization": f"Bearer {sandbox_token}",
         "Content-Type": "application/json",
+        "User-Agent": "vm0-mitm-addon/1.0",
     })
     if VERCEL_BYPASS:
         req.add_header("x-vercel-protection-bypass", VERCEL_BYPASS)


### PR DESCRIPTION
## Summary
- Add `User-Agent: vm0-mitm-addon/1.0` header to `fetch_firewall_headers()` in the mitmproxy addon
- Cloudflare Bot Management (error 1010) blocks the default `Python-urllib/3.x` User-Agent, causing all firewall auth resolution to fail with HTTP 403

Closes #5630

## Test plan
- [x] Verified from metal host: `urllib` with custom User-Agent returns 401 (expected) instead of 403
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)