### PR TITLE
perf(mitm-addon): use asyncio.to_thread for blocking firewall auth requests

### DIFF
--- a/crates/runner/mitm-addon/pyproject.toml
+++ b/crates/runner/mitm-addon/pyproject.toml
@@ -10,9 +10,11 @@ requires-python = ">=3.10"
 [project.optional-dependencies]
 test = [
     "pytest>=7.0",
+    "pytest-asyncio>=0.23",
     "mitmproxy>=10.0",
 ]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 pythonpath = ["src"]
+asyncio_mode = "auto"

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -8,6 +8,7 @@ This addon runs on the runner HOST (not inside VMs) and:
 3. Injects auth headers for configured firewall rules (proxy-side token replacement)
 4. Logs network activity per-run to JSONL files
 """
+import asyncio
 import os
 import json
 import time
@@ -255,13 +256,9 @@ def match_firewall_request(url: str, method: str, vm_firewalls: list | None) -> 
     return None
 
 
-def fetch_firewall_headers(encrypted_secrets: str, auth_headers: dict, sandbox_token: str,
-                          secret_connector_map: dict | None = None) -> dict:
-    """Resolve auth headers via server-side decryption.
-
-    When secret_connector_map is provided, the auth endpoint can refresh
-    expired OAuth tokens and returns an expiresAt timestamp for TTL caching.
-    """
+def _fetch_firewall_headers_sync(encrypted_secrets: str, auth_headers: dict, sandbox_token: str,
+                                 secret_connector_map: dict | None = None) -> dict:
+    """Synchronous helper — runs in a thread to avoid blocking the event loop."""
     api_url = get_api_url()
     url = f"{api_url}/api/webhooks/agent/firewall/auth"
     body: dict = {"encryptedSecrets": encrypted_secrets, "authHeaders": auth_headers}
@@ -279,8 +276,22 @@ def fetch_firewall_headers(encrypted_secrets: str, auth_headers: dict, sandbox_t
     return json.loads(resp.read())
 
 
-def get_firewall_headers(run_id: str, api_id: str, encrypted_secrets: str, auth_headers: dict,
-                        sandbox_token: str, secret_connector_map: dict | None = None) -> dict:
+async def fetch_firewall_headers(encrypted_secrets: str, auth_headers: dict, sandbox_token: str,
+                                 secret_connector_map: dict | None = None) -> dict:
+    """Resolve auth headers via server-side decryption.
+
+    When secret_connector_map is provided, the auth endpoint can refresh
+    expired OAuth tokens and returns an expiresAt timestamp for TTL caching.
+
+    Uses asyncio.to_thread to avoid blocking mitmproxy's event loop.
+    """
+    return await asyncio.to_thread(
+        _fetch_firewall_headers_sync, encrypted_secrets, auth_headers, sandbox_token, secret_connector_map
+    )
+
+
+async def get_firewall_headers(run_id: str, api_id: str, encrypted_secrets: str, auth_headers: dict,
+                              sandbox_token: str, secret_connector_map: dict | None = None) -> dict:
     """Get firewall auth headers with TTL-based caching.
 
     Cache is evicted when:
@@ -296,13 +307,13 @@ def get_firewall_headers(run_id: str, api_id: str, encrypted_secrets: str, auth_
             return cached["headers"]
         # Token expired — evict and re-fetch
 
-    result = fetch_firewall_headers(encrypted_secrets, auth_headers, sandbox_token, secret_connector_map)
+    result = await fetch_firewall_headers(encrypted_secrets, auth_headers, sandbox_token, secret_connector_map)
     headers = result["headers"]
     _firewall_header_cache[cache_key] = {"headers": headers, "expiresAt": result.get("expiresAt")}
     return headers
 
 
-def handle_firewall_request(flow: http.HTTPFlow, api_entry: dict, vm_info: dict, match_info: dict) -> None:
+async def handle_firewall_request(flow: http.HTTPFlow, api_entry: dict, vm_info: dict, match_info: dict) -> None:
     """Handle a firewall-matched request: fetch resolved headers, inject into request."""
     client_ip = flow.client_conn.peername[0]
     firewall_base = api_entry["base"]
@@ -332,7 +343,7 @@ def handle_firewall_request(flow: http.HTTPFlow, api_entry: dict, vm_info: dict,
         return
 
     try:
-        headers = get_firewall_headers(run_id, api_id, encrypted_secrets, auth_headers, sandbox_token, secret_connector_map)
+        headers = await get_firewall_headers(run_id, api_id, encrypted_secrets, auth_headers, sandbox_token, secret_connector_map)
     except Exception as e:
         ctx.log.error(f"[{run_id}] Firewall header fetch failed: {e}")
         flow.metadata["firewall_action"] = "DENY"
@@ -401,7 +412,7 @@ def tls_clienthello(data: tls.ClientHelloData) -> None:
 # HTTP Request Handler (MITM mode)
 # ============================================================================
 
-def request(flow: http.HTTPFlow) -> None:
+async def request(flow: http.HTTPFlow) -> None:
     """
     Intercept request: inject firewall auth headers for configured firewall rules.
 
@@ -477,7 +488,7 @@ def request(flow: http.HTTPFlow) -> None:
             )
             return
         if isinstance(result, FirewallAllow):
-            handle_firewall_request(flow, result.api_entry, vm_info, result.match_info)
+            await handle_firewall_request(flow, result.api_entry, vm_info, result.match_info)
             return
 
     # No firewall match — pass through directly

--- a/crates/runner/mitm-addon/tests/test_connectors.py
+++ b/crates/runner/mitm-addon/tests/test_connectors.py
@@ -1,7 +1,7 @@
 """Tests for firewall subsystem: matching, caching, header injection, and HTTP fetching."""
 import json
 import time
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import mitm_addon
 from mitm_addon import FirewallAllow, FirewallBlock
@@ -381,14 +381,15 @@ class TestGetFirewallHeaders:
     def setup_method(self):
         mitm_addon._firewall_header_cache.clear()
 
-    def test_cache_miss_fetches_and_caches(self):
+    async def test_cache_miss_fetches_and_caches(self):
         mock_headers = {"Authorization": "Bearer fresh-token"}
         mock_result = {"headers": mock_headers}
         encrypted = "iv:tag:data"
         auth_templates = {"Authorization": "Bearer ${{ secrets.TOKEN }}"}
 
-        with patch.object(mitm_addon, "fetch_firewall_headers", return_value=mock_result) as mock_fetch:
-            headers = mitm_addon.get_firewall_headers("run-1", "https://api.github.com", encrypted, auth_templates, "tok-xyz")
+        mock_fetch = AsyncMock(return_value=mock_result)
+        with patch.object(mitm_addon, "fetch_firewall_headers", mock_fetch):
+            headers = await mitm_addon.get_firewall_headers("run-1", "https://api.github.com", encrypted, auth_templates, "tok-xyz")
 
         assert headers == mock_headers
         mock_fetch.assert_called_once_with(encrypted, auth_templates, "tok-xyz", None)
@@ -398,20 +399,21 @@ class TestGetFirewallHeaders:
         assert cache_key in mitm_addon._firewall_header_cache
         assert mitm_addon._firewall_header_cache[cache_key]["headers"] == mock_headers
 
-    def test_cache_hit_returns_cached(self):
+    async def test_cache_hit_returns_cached(self):
         cache_key = ("run-1", "https://api.github.com")
         cached_headers = {"Authorization": "Bearer cached-token"}
         mitm_addon._firewall_header_cache[cache_key] = {
             "headers": cached_headers,
         }
 
-        with patch.object(mitm_addon, "fetch_firewall_headers") as mock_fetch:
-            headers = mitm_addon.get_firewall_headers("run-1", "https://api.github.com", "iv:tag:data", {}, "tok-xyz")
+        mock_fetch = AsyncMock()
+        with patch.object(mitm_addon, "fetch_firewall_headers", mock_fetch):
+            headers = await mitm_addon.get_firewall_headers("run-1", "https://api.github.com", "iv:tag:data", {}, "tok-xyz")
 
         assert headers == cached_headers
         mock_fetch.assert_not_called()
 
-    def test_cache_hit_with_valid_ttl_returns_cached(self):
+    async def test_cache_hit_with_valid_ttl_returns_cached(self):
         """Cached entry with expiresAt in the future should be returned without fetching."""
         cache_key = ("run-1", "api-1")
         cached_headers = {"Authorization": "Bearer valid-token"}
@@ -420,13 +422,14 @@ class TestGetFirewallHeaders:
             "expiresAt": time.time() + 3600,  # 1 hour from now
         }
 
-        with patch.object(mitm_addon, "fetch_firewall_headers") as mock_fetch:
-            headers = mitm_addon.get_firewall_headers("run-1", "api-1", "iv:tag:data", {}, "tok-xyz")
+        mock_fetch = AsyncMock()
+        with patch.object(mitm_addon, "fetch_firewall_headers", mock_fetch):
+            headers = await mitm_addon.get_firewall_headers("run-1", "api-1", "iv:tag:data", {}, "tok-xyz")
 
         assert headers == cached_headers
         mock_fetch.assert_not_called()
 
-    def test_cache_evicted_when_ttl_expired(self):
+    async def test_cache_evicted_when_ttl_expired(self):
         """Cached entry with expiresAt in the past should trigger a re-fetch."""
         cache_key = ("run-1", "api-1")
         mitm_addon._firewall_header_cache[cache_key] = {
@@ -437,15 +440,16 @@ class TestGetFirewallHeaders:
         fresh_headers = {"Authorization": "Bearer fresh-token"}
         mock_result = {"headers": fresh_headers, "expiresAt": time.time() + 3600}
 
-        with patch.object(mitm_addon, "fetch_firewall_headers", return_value=mock_result) as mock_fetch:
-            headers = mitm_addon.get_firewall_headers("run-1", "api-1", "iv:tag:data", {}, "tok-xyz")
+        mock_fetch = AsyncMock(return_value=mock_result)
+        with patch.object(mitm_addon, "fetch_firewall_headers", mock_fetch):
+            headers = await mitm_addon.get_firewall_headers("run-1", "api-1", "iv:tag:data", {}, "tok-xyz")
 
         assert headers == fresh_headers
         mock_fetch.assert_called_once()
         # Verify cache was updated with new entry
         assert mitm_addon._firewall_header_cache[cache_key]["headers"] == fresh_headers
 
-    def test_cache_with_null_expires_at_never_evicts(self):
+    async def test_cache_with_null_expires_at_never_evicts(self):
         """Cached entry with expiresAt=None (non-expiring) should never be evicted by TTL."""
         cache_key = ("run-1", "api-1")
         cached_headers = {"Authorization": "Bearer permanent-token"}
@@ -454,8 +458,9 @@ class TestGetFirewallHeaders:
             "expiresAt": None,
         }
 
-        with patch.object(mitm_addon, "fetch_firewall_headers") as mock_fetch:
-            headers = mitm_addon.get_firewall_headers("run-1", "api-1", "iv:tag:data", {}, "tok-xyz")
+        mock_fetch = AsyncMock()
+        with patch.object(mitm_addon, "fetch_firewall_headers", mock_fetch):
+            headers = await mitm_addon.get_firewall_headers("run-1", "api-1", "iv:tag:data", {}, "tok-xyz")
 
         assert headers == cached_headers
         mock_fetch.assert_not_called()
@@ -470,7 +475,7 @@ class TestHandleFirewallRequest:
     def setup_method(self):
         mitm_addon._firewall_header_cache.clear()
 
-    def test_success_injects_headers_and_audit_metadata(self):
+    async def test_success_injects_headers_and_audit_metadata(self):
         flow = _make_http_flow()
         api_entry = {"id": "run-1:0", "base": "https://api.github.com", "auth": {"headers": {"Authorization": "Bearer ${{ secrets.GITHUB_TOKEN }}"}}}
         vm_info = {
@@ -483,10 +488,10 @@ class TestHandleFirewallRequest:
         resolved_headers = {"Authorization": "Bearer real-token", "X-Custom": "value"}
 
         with (
-            patch.object(mitm_addon, "get_firewall_headers", return_value=resolved_headers),
+            patch.object(mitm_addon, "get_firewall_headers", AsyncMock(return_value=resolved_headers)),
             patch.object(mitm_addon.ctx, "log", MagicMock(), create=True),
         ):
-            mitm_addon.handle_firewall_request(flow, api_entry, vm_info, match_info)
+            await mitm_addon.handle_firewall_request(flow, api_entry, vm_info, match_info)
 
         # Headers injected
         assert flow.request.headers["Authorization"] == "Bearer real-token"
@@ -506,7 +511,7 @@ class TestHandleFirewallRequest:
         assert flow.metadata["firewall_rule_match"] == "GET /repos/{owner}/{repo}"
         assert flow.metadata["firewall_params"] == {"owner": "octocat", "repo": "hello"}
 
-    def test_failure_returns_502(self):
+    async def test_failure_returns_502(self):
         flow = _make_http_flow()
         api_entry = {"base": "https://api.github.com", "auth": {"headers": {}}}
         vm_info = {
@@ -520,12 +525,12 @@ class TestHandleFirewallRequest:
         with (
             patch.object(
                 mitm_addon, "get_firewall_headers",
-                side_effect=Exception("API unreachable"),
+                AsyncMock(side_effect=Exception("API unreachable")),
             ),
             patch.object(mitm_addon.ctx, "log", MagicMock(), create=True),
             patch.object(mitm_addon, "get_api_url", return_value="https://api.vm0.ai"),
         ):
-            mitm_addon.handle_firewall_request(flow, api_entry, vm_info, match_info)
+            await mitm_addon.handle_firewall_request(flow, api_entry, vm_info, match_info)
 
         assert flow.response is not None
         assert flow.response.status_code == 502
@@ -536,7 +541,7 @@ class TestHandleFirewallRequest:
         assert "API unreachable" in body["message"]
         assert body["firewall"] == "github"
 
-    def test_no_response_set_on_success(self):
+    async def test_no_response_set_on_success(self):
         """On success, flow.response should remain None (request continues to origin)."""
         flow = _make_http_flow()
         api_entry = {"base": "https://api.github.com", "auth": {"headers": {}}}
@@ -544,14 +549,14 @@ class TestHandleFirewallRequest:
         match_info = {"name": "github", "ref": "github"}
 
         with (
-            patch.object(mitm_addon, "get_firewall_headers", return_value={"Auth": "tok"}),
+            patch.object(mitm_addon, "get_firewall_headers", AsyncMock(return_value={"Auth": "tok"})),
             patch.object(mitm_addon.ctx, "log", MagicMock(), create=True),
         ):
-            mitm_addon.handle_firewall_request(flow, api_entry, vm_info, match_info)
+            await mitm_addon.handle_firewall_request(flow, api_entry, vm_info, match_info)
 
         assert flow.response is None
 
-    def test_missing_encrypted_secrets_returns_502(self):
+    async def test_missing_encrypted_secrets_returns_502(self):
         """When encryptedSecrets is missing from vm_info, return 502."""
         flow = _make_http_flow()
         api_entry = {"base": "https://api.github.com", "auth": {"headers": {}}}
@@ -559,7 +564,7 @@ class TestHandleFirewallRequest:
         match_info = {"name": "github", "ref": "github"}
 
         with patch.object(mitm_addon.ctx, "log", MagicMock(), create=True):
-            mitm_addon.handle_firewall_request(flow, api_entry, vm_info, match_info)
+            await mitm_addon.handle_firewall_request(flow, api_entry, vm_info, match_info)
 
         assert flow.response is not None
         assert flow.response.status_code == 502
@@ -585,7 +590,7 @@ class TestFetchFirewallHeaders:
             patch("mitm_addon.urllib.request.urlopen", return_value=mock_resp),
             patch.object(mitm_addon, "VERCEL_BYPASS", ""),
         ):
-            result = mitm_addon.fetch_firewall_headers("iv:tag:data", {"Authorization": "Bearer ${{ secrets.TOKEN }}"}, "tok-xyz")
+            result = mitm_addon._fetch_firewall_headers_sync("iv:tag:data", {"Authorization": "Bearer ${{ secrets.TOKEN }}"}, "tok-xyz")
 
         assert result == {"headers": {"Authorization": "Bearer tok"}}
 
@@ -613,7 +618,7 @@ class TestFetchFirewallHeaders:
             patch("mitm_addon.urllib.request.urlopen", return_value=mock_resp),
             patch.object(mitm_addon, "VERCEL_BYPASS", "secret-bypass-value"),
         ):
-            mitm_addon.fetch_firewall_headers("iv:tag:data", {}, "tok-xyz")
+            mitm_addon._fetch_firewall_headers_sync("iv:tag:data", {}, "tok-xyz")
 
         mock_req_instance.add_header.assert_called_once_with("x-vercel-protection-bypass", "secret-bypass-value")
 
@@ -629,6 +634,6 @@ class TestFetchFirewallHeaders:
             patch("mitm_addon.urllib.request.urlopen", return_value=mock_resp),
             patch.object(mitm_addon, "VERCEL_BYPASS", ""),
         ):
-            mitm_addon.fetch_firewall_headers("iv:tag:data", {}, "tok-xyz")
+            mitm_addon._fetch_firewall_headers_sync("iv:tag:data", {}, "tok-xyz")
 
         mock_req_instance.add_header.assert_not_called()

--- a/crates/runner/mitm-addon/tests/test_handlers.py
+++ b/crates/runner/mitm-addon/tests/test_handlers.py
@@ -2,7 +2,7 @@
 import json
 import time
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import mitm_addon
 
@@ -44,7 +44,7 @@ class TestRequestHandler:
     def setup_method(self):
         _reset()
 
-    def test_allowed_domain_passes_through(self, registry_file):
+    async def test_allowed_domain_passes_through(self, registry_file):
         flow = _make_http_flow(host="api.anthropic.com")
 
         with (
@@ -52,11 +52,11 @@ class TestRequestHandler:
             patch.object(mitm_addon, "get_api_url", return_value="https://api.vm0.ai"),
             patch.object(mitm_addon.ctx, "log", MagicMock(), create=True),
         ):
-            mitm_addon.request(flow)
+            await mitm_addon.request(flow)
 
         assert flow.metadata["firewall_action"] == "ALLOW"
 
-    def test_vm0_api_auto_allowed(self, registry_file):
+    async def test_vm0_api_auto_allowed(self, registry_file):
         flow = _make_http_flow(host="api.vm0.ai")
 
         with (
@@ -64,12 +64,12 @@ class TestRequestHandler:
             patch.object(mitm_addon, "get_api_url", return_value="https://api.vm0.ai"),
             patch.object(mitm_addon.ctx, "log", MagicMock(), create=True),
         ):
-            mitm_addon.request(flow)
+            await mitm_addon.request(flow)
 
         assert flow.metadata["firewall_action"] == "ALLOW"
         assert flow.metadata["firewall_rule"] == "vm0-api"
 
-    def test_tracks_start_time(self, registry_file):
+    async def test_tracks_start_time(self, registry_file):
         flow = _make_http_flow(host="api.anthropic.com")
 
         with (
@@ -77,11 +77,11 @@ class TestRequestHandler:
             patch.object(mitm_addon, "get_api_url", return_value="https://api.vm0.ai"),
             patch.object(mitm_addon.ctx, "log", MagicMock(), create=True),
         ):
-            mitm_addon.request(flow)
+            await mitm_addon.request(flow)
 
         assert flow.id in mitm_addon._request_start_times
 
-    def test_unregistered_vm_passes_through(self, registry_file):
+    async def test_unregistered_vm_passes_through(self, registry_file):
         flow = _make_http_flow(client_ip="192.168.99.99", host="anything.com")
 
         with (
@@ -89,13 +89,13 @@ class TestRequestHandler:
             patch.object(mitm_addon, "get_api_url", return_value="https://api.vm0.ai"),
             patch.object(mitm_addon.ctx, "log", MagicMock(), create=True),
         ):
-            mitm_addon.request(flow)
+            await mitm_addon.request(flow)
 
         # No 403, no metadata set
         assert flow.response is None
         assert "firewall_action" not in flow.metadata
 
-    def test_mitm_allowed_passes_through(self, registry_file):
+    async def test_mitm_allowed_passes_through(self, registry_file):
         """Allowed request passes through without rewrite."""
         flow = _make_http_flow(host="api.anthropic.com", path="/v1/messages")
 
@@ -104,14 +104,14 @@ class TestRequestHandler:
             patch.object(mitm_addon, "get_api_url", return_value="https://api.vm0.ai"),
             patch.object(mitm_addon.ctx, "log", MagicMock(), create=True),
         ):
-            mitm_addon.request(flow)
+            await mitm_addon.request(flow)
 
         # Request should pass through without rewrite
         assert flow.response is None
         assert flow.metadata["firewall_action"] == "ALLOW"
         assert flow.metadata.get("original_url") == "https://api.anthropic.com/v1/messages"
 
-    def test_firewall_match_calls_handler(self, tmp_path):
+    async def test_firewall_match_calls_handler(self, tmp_path):
         """When URL matches a firewall rule, handle_firewall_request is called."""
         registry = {
             "vms": {
@@ -139,13 +139,14 @@ class TestRequestHandler:
             client_ip="10.200.0.5", host="api.github.com", path="/repos"
         )
 
+        mock_handler = AsyncMock()
         with (
             patch.object(mitm_addon, "get_registry_path", return_value=str(reg_path)),
             patch.object(mitm_addon, "get_api_url", return_value="https://api.vm0.ai"),
             patch.object(mitm_addon.ctx, "log", MagicMock(), create=True),
-            patch.object(mitm_addon, "handle_firewall_request") as mock_handler,
+            patch.object(mitm_addon, "handle_firewall_request", mock_handler),
         ):
-            mitm_addon.request(flow)
+            await mitm_addon.request(flow)
 
         mock_handler.assert_called_once()
         call_args = mock_handler.call_args
@@ -156,7 +157,7 @@ class TestRequestHandler:
         assert match_info["ref"] == "github"
         assert match_info["permission"] == "full-access"
 
-    def test_firewall_permission_blocks_unmatched(self, tmp_path):
+    async def test_firewall_permission_blocks_unmatched(self, tmp_path):
         """Firewall with permissions but no matching rule returns 403."""
         registry = {
             "vms": {
@@ -186,13 +187,14 @@ class TestRequestHandler:
             client_ip="10.200.0.5", host="api.github.com", path="/orgs"
         )
 
+        mock_handler = AsyncMock()
         with (
             patch.object(mitm_addon, "get_registry_path", return_value=str(reg_path)),
             patch.object(mitm_addon, "get_api_url", return_value="https://api.vm0.ai"),
             patch.object(mitm_addon.ctx, "log", MagicMock(), create=True),
-            patch.object(mitm_addon, "handle_firewall_request") as mock_handler,
+            patch.object(mitm_addon, "handle_firewall_request", mock_handler),
         ):
-            mitm_addon.request(flow)
+            await mitm_addon.request(flow)
 
         mock_handler.assert_not_called()
         assert flow.response is not None
@@ -207,7 +209,7 @@ class TestRequestHandler:
         assert body["base"] == "https://api.github.com"
         assert "hint" in body
 
-    def test_firewall_permission_allows_matched(self, tmp_path):
+    async def test_firewall_permission_allows_matched(self, tmp_path):
         """Firewall with permissions and matching rule calls handler with match_info."""
         registry = {
             "vms": {
@@ -237,13 +239,14 @@ class TestRequestHandler:
             client_ip="10.200.0.5", host="api.github.com", path="/repos/octocat/hello"
         )
 
+        mock_handler = AsyncMock()
         with (
             patch.object(mitm_addon, "get_registry_path", return_value=str(reg_path)),
             patch.object(mitm_addon, "get_api_url", return_value="https://api.vm0.ai"),
             patch.object(mitm_addon.ctx, "log", MagicMock(), create=True),
-            patch.object(mitm_addon, "handle_firewall_request") as mock_handler,
+            patch.object(mitm_addon, "handle_firewall_request", mock_handler),
         ):
-            mitm_addon.request(flow)
+            await mitm_addon.request(flow)
 
         mock_handler.assert_called_once()
         call_args = mock_handler.call_args
@@ -256,7 +259,7 @@ class TestRequestHandler:
         assert match_info["rule"] == "GET /repos/{owner}/{repo}"
         assert match_info["params"] == {"owner": "octocat", "repo": "hello"}
 
-    def test_firewall_no_base_match_passes_through(self, tmp_path):
+    async def test_firewall_no_base_match_passes_through(self, tmp_path):
         """URL not matching any firewall base → pass-through (not block)."""
         registry = {
             "vms": {
@@ -285,13 +288,14 @@ class TestRequestHandler:
             client_ip="10.200.0.5", host="api.example.com", path="/data"
         )
 
+        mock_handler = AsyncMock()
         with (
             patch.object(mitm_addon, "get_registry_path", return_value=str(reg_path)),
             patch.object(mitm_addon, "get_api_url", return_value="https://api.vm0.ai"),
             patch.object(mitm_addon.ctx, "log", MagicMock(), create=True),
-            patch.object(mitm_addon, "handle_firewall_request") as mock_handler,
+            patch.object(mitm_addon, "handle_firewall_request", mock_handler),
         ):
-            mitm_addon.request(flow)
+            await mitm_addon.request(flow)
 
         # No firewall match → pass-through, not blocked
         mock_handler.assert_not_called()


### PR DESCRIPTION
## Summary

- Move blocking `urllib.request.urlopen` call in `fetch_firewall_headers` to a thread via `asyncio.to_thread()`, preventing the mitmproxy event loop from stalling during firewall auth resolution
- Make `request`, `handle_firewall_request`, `get_firewall_headers`, and `fetch_firewall_headers` async (mitmproxy natively supports async hooks)
- Update all related tests to use `async def` + `await` with `AsyncMock`, add `pytest-asyncio` dependency

## Test plan

- [x] All 87 mitm-addon tests pass locally
- [ ] CI passes

Closes #5635

🤖 Generated with [Claude Code](https://claude.com/claude-code)