### PR TITLE
ci: skip crates check and mitm-addon-test when no crates changed

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -25,6 +25,7 @@ jobs:
     container:
       image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260310
     outputs:
+      any-changed: ${{ steps.detect.outputs.any-changed }}
       ci-changed: ${{ steps.detect.outputs.ci-changed }}
       ably-subscriber-changed: ${{ steps.detect.outputs.ably-subscriber-changed }}
       runner-changed: ${{ steps.detect.outputs.runner-changed }}
@@ -69,11 +70,19 @@ jobs:
           check_crate guest-agent
           check_crate guest-mock-claude
 
+          # Aggregate: true if any crate or CI config changed
+          if grep -q "=true" "$GITHUB_OUTPUT"; then
+            echo "any-changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "any-changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
   check:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260310
     needs: [detect]
+    if: needs.detect.outputs.any-changed == 'true'
     steps:
       - uses: actions/checkout@v6
 
@@ -110,6 +119,8 @@ jobs:
 
   mitm-addon-test:
     runs-on: ubuntu-latest
+    needs: [detect]
+    if: needs.detect.outputs.any-changed == 'true'
     steps:
       - uses: actions/checkout@v6
 
@@ -740,10 +751,10 @@ jobs:
 
           # Must-succeed: only 'success' is acceptable
           check_result "detect" "${{ needs.detect.result }}" ""
-          check_result "check" "${{ needs.check.result }}" ""
-          check_result "mitm-addon-test" "${{ needs.mitm-addon-test.result }}" ""
 
-          # May-skip: runner jobs only run when relevant crates change
+          # May-skip: only run when relevant crates change
+          check_result "check" "${{ needs.check.result }}" "true"
+          check_result "mitm-addon-test" "${{ needs.mitm-addon-test.result }}" "true"
           check_result "runner-build" "${{ needs.runner-build.result }}" "true"
           check_result "runner-benchmark" "${{ needs.runner-benchmark.result }}" "true"
           check_result "runner-exec" "${{ needs.runner-exec.result }}" "true"


### PR DESCRIPTION
## Summary

- Add `any-changed` aggregate output to `detect` job in `crates.yml`
- Gate `check` (cargo fmt/clippy/test) and `mitm-addon-test` (pytest) on `any-changed == 'true'`
- Update ci-gate to allow skip for these jobs

This avoids ~3 min of unnecessary cargo/pytest work on merge queue entries that don't touch crates code. GitHub's `merge_group` event doesn't support paths filter, so the workflow always triggers — this change adds job-level gating instead.

## Test plan

- [ ] CI passes on this PR (crates changed → `check` and `mitm-addon-test` run as usual)
- [ ] Verify on a non-crates PR in merge queue that these jobs are skipped
- [ ] ci-gate correctly handles skipped status

Closes #5640

🤖 Generated with [Claude Code](https://claude.com/claude-code)