### PR TITLE
ci: add branches-ignore for release-please branches

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -3,6 +3,8 @@ name: Cleanup Resources
 on:
   pull_request_target:
     types: [closed]
+    branches-ignore:
+      - 'release-please--branches--**'
 
 concurrency:
   group: ${{ github.head_ref || github.ref }}

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -3,8 +3,6 @@ name: Cleanup Resources
 on:
   pull_request_target:
     types: [closed]
-    branches-ignore:
-      - 'release-please--branches--**'
 
 concurrency:
   group: ${{ github.head_ref || github.ref }}
@@ -12,6 +10,8 @@ concurrency:
 
 jobs:
   cleanup-runner:
+    # Skip for release-please PRs (only version bumps and changelogs)
+    if: "!startsWith(github.head_ref || '', 'release-please--branches--')"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -76,6 +76,8 @@ jobs:
           fi
 
   cleanup-database:
+    # Skip for release-please PRs (only version bumps and changelogs)
+    if: "!startsWith(github.head_ref || '', 'release-please--branches--')"
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/vm0-ai/vm0-toolchain:20260310
@@ -91,6 +93,8 @@ jobs:
           action: "cleanup"
 
   cleanup-deployments:
+    # Skip for release-please PRs (only version bumps and changelogs)
+    if: "!startsWith(github.head_ref || '', 'release-please--branches--')"
     runs-on: ubuntu-latest
     permissions:
       deployments: write

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -2,8 +2,6 @@ name: Crates
 
 on:
   pull_request:
-    branches-ignore:
-      - 'release-please--branches--**'
     paths:
       - 'crates/**'
       - 'ansible/**'
@@ -23,6 +21,8 @@ concurrency:
 
 jobs:
   detect:
+    # Skip for release-please PRs (only version bumps and changelogs)
+    if: "!startsWith(github.head_ref || '', 'release-please--branches--')"
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260310
@@ -111,6 +111,8 @@ jobs:
           cargo run -p ably-subscriber --example smoke_test
 
   mitm-addon-test:
+    # Skip for release-please PRs (only version bumps and changelogs)
+    if: "!startsWith(github.head_ref || '', 'release-please--branches--')"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -712,9 +714,10 @@ jobs:
       - runner-balloon
       - runner-upgrade-local
     # Always run so the gate reports an explicit result (not "skipped").
-    # Skip on release-please commits — GitHub treats "skipped" as passing.
+    # Skip on release-please PRs and commits — GitHub treats "skipped" as passing.
     if: >-
       always() &&
+      !startsWith(github.head_ref || '', 'release-please--branches--') &&
       (github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore: release'))
     steps:
       - name: Validate CI results

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -2,6 +2,8 @@ name: Crates
 
 on:
   pull_request:
+    branches-ignore:
+      - 'release-please--branches--**'
     paths:
       - 'crates/**'
       - 'ansible/**'

--- a/.github/workflows/docker-toolchain.yml
+++ b/.github/workflows/docker-toolchain.yml
@@ -2,6 +2,8 @@ name: Docker Toolchain Build
 
 on:
   pull_request:
+    branches-ignore:
+      - 'release-please--branches--**'
     paths:
       - 'docker/toolchain/**'
       - '.github/workflows/docker-toolchain.yml'

--- a/.github/workflows/docker-toolchain.yml
+++ b/.github/workflows/docker-toolchain.yml
@@ -2,8 +2,6 @@ name: Docker Toolchain Build
 
 on:
   pull_request:
-    branches-ignore:
-      - 'release-please--branches--**'
     paths:
       - 'docker/toolchain/**'
       - '.github/workflows/docker-toolchain.yml'
@@ -17,6 +15,8 @@ permissions:
 
 jobs:
   toolchain:
+    # Skip for release-please PRs (only version bumps and changelogs)
+    if: "!startsWith(github.head_ref || '', 'release-please--branches--')"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -2,8 +2,6 @@ name: Security Scanning
 
 on:
   pull_request:
-    branches-ignore:
-      - 'release-please--branches--**'
   push:
     branches:
       - main
@@ -15,6 +13,8 @@ permissions:
 jobs:
   semgrep:
     name: Semgrep SAST
+    # Skip for release-please PRs (only version bumps and changelogs)
+    if: "!startsWith(github.head_ref || '', 'release-please--branches--')"
     runs-on: ubuntu-latest
     container:
       image: semgrep/semgrep
@@ -73,6 +73,8 @@ jobs:
 
   codeql:
     name: CodeQL SAST
+    # Skip for release-please PRs (only version bumps and changelogs)
+    if: "!startsWith(github.head_ref || '', 'release-please--branches--')"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -89,6 +91,8 @@ jobs:
 
   pnpm-audit:
     name: pnpm audit (SCA)
+    # Skip for release-please PRs (only version bumps and changelogs)
+    if: "!startsWith(github.head_ref || '', 'release-please--branches--')"
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -115,6 +119,8 @@ jobs:
 
   gitleaks:
     name: Gitleaks Secrets Detection
+    # Skip for release-please PRs (only version bumps and changelogs)
+    if: "!startsWith(github.head_ref || '', 'release-please--branches--')"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -2,6 +2,8 @@ name: Security Scanning
 
 on:
   pull_request:
+    branches-ignore:
+      - 'release-please--branches--**'
   push:
     branches:
       - main

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -2,8 +2,6 @@ name: Turbo
 
 on:
   pull_request:
-    branches-ignore:
-      - 'release-please--branches--**'
   push:
     branches:
       - main
@@ -16,6 +14,8 @@ concurrency:
 jobs:
   # Prepare: detect changes and set job-ref identifier
   prepare:
+    # Skip for release-please PRs (only version bumps and changelogs)
+    if: "!startsWith(github.head_ref || '', 'release-please--branches--')"
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/vm0-ai/vm0-toolchain:20260310
@@ -174,8 +174,8 @@ jobs:
 
   file-size-check:
     runs-on: ubuntu-latest
-    # Skip for release-please commits (only version bumps and changelogs)
-    if: "${{ github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore: release') }}"
+    # Skip for release-please PRs and release-please commits
+    if: "${{ !startsWith(github.head_ref || '', 'release-please--branches--') && (github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore: release')) }}"
     steps:
       - uses: actions/checkout@v6
         with:
@@ -212,8 +212,8 @@ jobs:
   # Lint jobs - split into 4 parallel jobs for faster CI
   lint-eslint:
     runs-on: ubuntu-latest
-    # Skip for release-please commits (only version bumps and changelogs)
-    if: "${{ github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore: release') }}"
+    # Skip for release-please PRs and release-please commits
+    if: "${{ !startsWith(github.head_ref || '', 'release-please--branches--') && (github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore: release')) }}"
     container:
       image: ghcr.io/vm0-ai/vm0-toolchain:20260310
     steps:
@@ -225,8 +225,8 @@ jobs:
 
   lint-types:
     runs-on: ubuntu-latest
-    # Skip for release-please commits (only version bumps and changelogs)
-    if: "${{ github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore: release') }}"
+    # Skip for release-please PRs and release-please commits
+    if: "${{ !startsWith(github.head_ref || '', 'release-please--branches--') && (github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore: release')) }}"
     container:
       image: ghcr.io/vm0-ai/vm0-toolchain:20260310
     steps:
@@ -238,8 +238,8 @@ jobs:
 
   lint-format:
     runs-on: ubuntu-latest
-    # Skip for release-please commits (only version bumps and changelogs)
-    if: "${{ github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore: release') }}"
+    # Skip for release-please PRs and release-please commits
+    if: "${{ !startsWith(github.head_ref || '', 'release-please--branches--') && (github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore: release')) }}"
     container:
       image: ghcr.io/vm0-ai/vm0-toolchain:20260310
     steps:
@@ -251,8 +251,8 @@ jobs:
 
   lint-knip:
     runs-on: ubuntu-latest
-    # Skip for release-please commits (only version bumps and changelogs)
-    if: "${{ github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore: release') }}"
+    # Skip for release-please PRs and release-please commits
+    if: "${{ !startsWith(github.head_ref || '', 'release-please--branches--') && (github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore: release')) }}"
     container:
       image: ghcr.io/vm0-ai/vm0-toolchain:20260310
     steps:
@@ -266,8 +266,8 @@ jobs:
   test-web:
     needs: prepare
     runs-on: ubuntu-latest
-    # Skip for release-please commits (only version bumps and changelogs)
-    if: "${{ github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore: release') }}"
+    # Skip for release-please PRs and release-please commits
+    if: "${{ !startsWith(github.head_ref || '', 'release-please--branches--') && (github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore: release')) }}"
     strategy:
       matrix:
         shard: [1, 2, 3, 4]
@@ -339,6 +339,8 @@ jobs:
         run: pnpm tsx scripts/test-migration-consistency-schema.ts
 
   test-cli:
+    # Skip for release-please PRs (only version bumps and changelogs)
+    if: "!startsWith(github.head_ref || '', 'release-please--branches--')"
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/vm0-ai/vm0-toolchain:20260310
@@ -365,6 +367,8 @@ jobs:
           report_type: test_results
 
   test-app:
+    # Skip for release-please PRs (only version bumps and changelogs)
+    if: "!startsWith(github.head_ref || '', 'release-please--branches--')"
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/vm0-ai/vm0-toolchain:20260310
@@ -391,6 +395,8 @@ jobs:
           report_type: test_results
 
   test-other:
+    # Skip for release-please PRs (only version bumps and changelogs)
+    if: "!startsWith(github.head_ref || '', 'release-please--branches--')"
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260310
@@ -1723,9 +1729,10 @@ jobs:
       - lighthouse-web
       - lighthouse-app
     # Always run so the gate reports an explicit result (not "skipped").
-    # Skip on release-please commits — GitHub treats "skipped" as passing.
+    # Skip on release-please PRs and commits — GitHub treats "skipped" as passing.
     if: >-
       always() &&
+      !startsWith(github.head_ref || '', 'release-please--branches--') &&
       (github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore: release'))
     steps:
       - name: Validate CI results

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -2,6 +2,8 @@ name: Turbo
 
 on:
   pull_request:
+    branches-ignore:
+      - 'release-please--branches--**'
   push:
     branches:
       - main


### PR DESCRIPTION
## Summary
- Add `branches-ignore` for `release-please--branches--**` pattern to all CI workflows (cleanup, crates, docker-toolchain, security, turbo)
- Prevents unnecessary CI runs on release-please auto-generated PRs

## Test plan
- [ ] Create a test branch starting with `release-please--branches--` and verify CI workflows do not trigger
- [ ] Verify normal PRs still trigger CI workflows as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)