### PR TITLE
chore: bump devcontainer image to d645321

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "VM0 Development",
-  "image": "ghcr.io/vm0-ai/vm0-dev:a63ed4e",
+  "image": "ghcr.io/vm0-ai/vm0-dev:d645321",
   "features": {
     "ghcr.io/itsmechlark/features/postgresql:1": {
       "version": "17"


### PR DESCRIPTION
## Summary
- Bump devcontainer image from `a63ed4e` to `d645321` which includes chromium cross-arch fixes and non-root access permissions

## Test plan
- [ ] Verify devcontainer builds and starts correctly with the new image

🤖 Generated with [Claude Code](https://claude.com/claude-code)