### PR TITLE
refactor: extract workspace cleanup into reusable service function

### DIFF
--- a/turbo/apps/web/app/api/integrations/slack/org/route.ts
+++ b/turbo/apps/web/app/api/integrations/slack/org/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { eq, and, inArray } from "drizzle-orm";
+import { eq, and } from "drizzle-orm";
 import {
   extractAndGroupVariables,
   getConnectorProvidedSecretNames,
@@ -10,7 +10,6 @@ import { getAuthContext } from "../../../../../src/lib/auth/get-auth-context";
 import { resolveOrg } from "../../../../../src/lib/org/resolve-org";
 import { slackOrgInstallations } from "../../../../../src/db/schema/slack-org-installation";
 import { slackOrgConnections } from "../../../../../src/db/schema/slack-org-connection";
-import { slackOrgPendingQuestions } from "../../../../../src/db/schema/slack-org-pending-question";
 import {
   resolveDefaultComposeId,
   getWorkspaceAgent,
@@ -31,6 +30,7 @@ import { publishAppHome } from "../../../../../src/lib/slack/client";
 import { buildAppHomeView } from "../../../../../src/lib/slack/blocks";
 import { decryptSecretValue } from "../../../../../src/lib/crypto/secrets-encryption";
 import { refreshOrgAppHome } from "../../../../../src/lib/slack-org/handlers/app-home";
+import { cleanupWorkspaceInstallation } from "../../../../../src/lib/slack-org/connect-service";
 import type { AgentComposeYaml } from "../../../../../src/types/agent-compose";
 import { logger } from "../../../../../src/lib/logger";
 
@@ -189,10 +189,7 @@ async function handleUninstall(
 
   // Refresh App Home for all connected users before deleting (best-effort)
   const connections = await db
-    .select({
-      id: slackOrgConnections.id,
-      slackUserId: slackOrgConnections.slackUserId,
-    })
+    .select({ slackUserId: slackOrgConnections.slackUserId })
     .from(slackOrgConnections)
     .where(
       eq(slackOrgConnections.slackWorkspaceId, installation.slackWorkspaceId),
@@ -216,27 +213,10 @@ async function handleUninstall(
         ),
       ),
     );
-
-    // Delete pending questions
-    const connectionIds = connections.map((c) => c.id);
-    await db
-      .delete(slackOrgPendingQuestions)
-      .where(inArray(slackOrgPendingQuestions.connectionId, connectionIds));
   }
 
-  // Delete all connections (cascades to thread sessions)
-  await db
-    .delete(slackOrgConnections)
-    .where(
-      eq(slackOrgConnections.slackWorkspaceId, installation.slackWorkspaceId),
-    );
-
-  // Delete the installation
-  await db
-    .delete(slackOrgInstallations)
-    .where(
-      eq(slackOrgInstallations.slackWorkspaceId, installation.slackWorkspaceId),
-    );
+  // Clean up installation and all related data
+  await cleanupWorkspaceInstallation(installation.slackWorkspaceId);
 
   log.info("Slack workspace uninstalled", {
     workspaceId: installation.slackWorkspaceId,

--- a/turbo/apps/web/app/api/slack/org/events/route.ts
+++ b/turbo/apps/web/app/api/slack/org/events/route.ts
@@ -84,6 +84,96 @@ interface SlackEventCallback {
 
 type SlackEvent = SlackUrlVerificationEvent | SlackEventCallback;
 
+function handleEventCallback(payload: SlackEventCallback) {
+  const event = payload.event;
+
+  if (event.type === "app_mention") {
+    initServices();
+    after(
+      handleOrgMention({
+        workspaceId: payload.team_id,
+        channelId: event.channel,
+        userId: event.user,
+        messageText: event.text,
+        messageTs: event.ts,
+        threadTs: event.thread_ts,
+        files: event.files,
+      }).catch((error) => {
+        log.error("Error handling org app_mention", { error });
+      }),
+    );
+  }
+
+  if (
+    event.type === "message" &&
+    event.channel_type === "im" &&
+    (!event.subtype || event.subtype === "file_share") &&
+    !event.bot_id
+  ) {
+    initServices();
+    after(
+      handleOrgDirectMessage({
+        workspaceId: payload.team_id,
+        channelId: event.channel,
+        userId: event.user,
+        messageText: event.text,
+        files: event.files,
+        messageTs: event.ts,
+        threadTs: event.thread_ts,
+      }).catch((error) => {
+        log.error("Error handling org direct_message", { error });
+      }),
+    );
+  }
+
+  if (event.type === "app_home_opened" && event.tab === "home") {
+    initServices();
+    after(
+      handleOrgAppHomeOpened({
+        workspaceId: payload.team_id,
+        userId: event.user,
+      }).catch((error) => {
+        log.error("Error handling org app_home_opened", { error });
+      }),
+    );
+  }
+
+  if (event.type === "app_home_opened" && event.tab === "messages") {
+    initServices();
+    after(
+      handleOrgMessagesTabOpened({
+        workspaceId: payload.team_id,
+        userId: event.user,
+        channelId: event.channel,
+      }).catch((error) => {
+        log.error("Error handling org messages_tab_opened", { error });
+      }),
+    );
+  }
+
+  if (event.type === "app_uninstalled") {
+    initServices();
+    after(
+      cleanupWorkspaceInstallation(payload.team_id).catch((error) => {
+        log.error("Error handling app_uninstalled", { error });
+      }),
+    );
+  }
+
+  if (
+    event.type === "tokens_revoked" &&
+    event.tokens.bot &&
+    event.tokens.bot.length > 0
+  ) {
+    initServices();
+    after(
+      cleanupWorkspaceInstallation(payload.team_id).catch((error) => {
+        log.error("Error handling tokens_revoked", { error });
+      }),
+    );
+  }
+}
+
 /**
  * POST /api/slack/org/events
  *
@@ -135,94 +225,7 @@ export async function POST(request: Request) {
   }
 
   if (payload.type === "event_callback") {
-    const event = payload.event;
-
-    if (event.type === "app_mention") {
-      initServices();
-      after(
-        handleOrgMention({
-          workspaceId: payload.team_id,
-          channelId: event.channel,
-          userId: event.user,
-          messageText: event.text,
-          messageTs: event.ts,
-          threadTs: event.thread_ts,
-          files: event.files,
-        }).catch((error) => {
-          log.error("Error handling org app_mention", { error });
-        }),
-      );
-    }
-
-    if (
-      event.type === "message" &&
-      event.channel_type === "im" &&
-      (!event.subtype || event.subtype === "file_share") &&
-      !event.bot_id
-    ) {
-      initServices();
-      after(
-        handleOrgDirectMessage({
-          workspaceId: payload.team_id,
-          channelId: event.channel,
-          userId: event.user,
-          messageText: event.text,
-          files: event.files,
-          messageTs: event.ts,
-          threadTs: event.thread_ts,
-        }).catch((error) => {
-          log.error("Error handling org direct_message", { error });
-        }),
-      );
-    }
-
-    if (event.type === "app_home_opened" && event.tab === "home") {
-      initServices();
-      after(
-        handleOrgAppHomeOpened({
-          workspaceId: payload.team_id,
-          userId: event.user,
-        }).catch((error) => {
-          log.error("Error handling org app_home_opened", { error });
-        }),
-      );
-    }
-
-    if (event.type === "app_home_opened" && event.tab === "messages") {
-      initServices();
-      after(
-        handleOrgMessagesTabOpened({
-          workspaceId: payload.team_id,
-          userId: event.user,
-          channelId: event.channel,
-        }).catch((error) => {
-          log.error("Error handling org messages_tab_opened", { error });
-        }),
-      );
-    }
-
-    if (event.type === "app_uninstalled") {
-      initServices();
-      after(
-        cleanupWorkspaceInstallation(payload.team_id).catch((error) => {
-          log.error("Error handling app_uninstalled", { error });
-        }),
-      );
-    }
-
-    if (
-      event.type === "tokens_revoked" &&
-      event.tokens.bot &&
-      event.tokens.bot.length > 0
-    ) {
-      initServices();
-      after(
-        cleanupWorkspaceInstallation(payload.team_id).catch((error) => {
-          log.error("Error handling tokens_revoked", { error });
-        }),
-      );
-    }
-
+    handleEventCallback(payload);
     return new Response("OK", { status: 200 });
   }
 

--- a/turbo/apps/web/app/api/slack/org/events/route.ts
+++ b/turbo/apps/web/app/api/slack/org/events/route.ts
@@ -11,6 +11,7 @@ import {
   handleOrgAppHomeOpened,
   handleOrgMessagesTabOpened,
 } from "../../../../../src/lib/slack-org/handlers/app-home";
+import { cleanupWorkspaceInstallation } from "../../../../../src/lib/slack-org/connect-service";
 import type { SlackFile } from "../../../../../src/lib/slack/context";
 import { logger } from "../../../../../src/lib/logger";
 
@@ -54,6 +55,18 @@ interface SlackAppHomeOpenedEvent {
   channel: string;
 }
 
+interface SlackAppUninstalledEvent {
+  type: "app_uninstalled";
+}
+
+interface SlackTokensRevokedEvent {
+  type: "tokens_revoked";
+  tokens: {
+    oauth?: string[];
+    bot?: string[];
+  };
+}
+
 interface SlackEventCallback {
   type: "event_callback";
   token: string;
@@ -62,7 +75,9 @@ interface SlackEventCallback {
   event:
     | SlackAppMentionEvent
     | SlackDirectMessageEvent
-    | SlackAppHomeOpenedEvent;
+    | SlackAppHomeOpenedEvent
+    | SlackAppUninstalledEvent
+    | SlackTokensRevokedEvent;
   event_id: string;
   event_time: number;
 }
@@ -182,6 +197,28 @@ export async function POST(request: Request) {
           channelId: event.channel,
         }).catch((error) => {
           log.error("Error handling org messages_tab_opened", { error });
+        }),
+      );
+    }
+
+    if (event.type === "app_uninstalled") {
+      initServices();
+      after(
+        cleanupWorkspaceInstallation(payload.team_id).catch((error) => {
+          log.error("Error handling app_uninstalled", { error });
+        }),
+      );
+    }
+
+    if (
+      event.type === "tokens_revoked" &&
+      event.tokens.bot &&
+      event.tokens.bot.length > 0
+    ) {
+      initServices();
+      after(
+        cleanupWorkspaceInstallation(payload.team_id).catch((error) => {
+          log.error("Error handling tokens_revoked", { error });
         }),
       );
     }

--- a/turbo/apps/web/src/__tests__/api-test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers.ts
@@ -25,6 +25,7 @@ import { skills } from "../db/schema/skill";
 import { usageDaily } from "../db/schema/usage-daily";
 import { slackOrgInstallations } from "../db/schema/slack-org-installation";
 import { slackOrgConnections } from "../db/schema/slack-org-connection";
+import { slackOrgPendingQuestions } from "../db/schema/slack-org-pending-question";
 import { githubInstallations } from "../db/schema/github-installation";
 import { githubUserLinks } from "../db/schema/github-user-link";
 import { githubIssueSessions } from "../db/schema/github-issue-session";
@@ -3584,4 +3585,130 @@ export async function insertVm0ApiKeys(
  */
 export async function getTestVm0ApiKey(vendor: string) {
   return getVm0ApiKey(vendor);
+}
+
+/**
+ * Seed a Slack org connection directly for testing cleanup scenarios.
+ *
+ * Unlike createTestSlackOrgConnection, this does not require the
+ * installation to have an orgId.
+ */
+export async function seedTestSlackOrgConnection(opts: {
+  slackUserId: string;
+  slackWorkspaceId: string;
+  vm0UserId: string;
+}): Promise<{ connectionId: string }> {
+  initServices();
+  const [row] = await globalThis.services.db
+    .insert(slackOrgConnections)
+    .values({
+      slackUserId: opts.slackUserId,
+      slackWorkspaceId: opts.slackWorkspaceId,
+      vm0UserId: opts.vm0UserId,
+    })
+    .returning({ id: slackOrgConnections.id });
+  if (!row) {
+    throw new Error("Failed to seed Slack org connection");
+  }
+  return { connectionId: row.id };
+}
+
+/**
+ * Seed an agent compose record for testing.
+ */
+export async function seedTestCompose(opts: {
+  userId: string;
+  name: string;
+  orgId: string;
+}): Promise<{ composeId: string }> {
+  initServices();
+  const [row] = await globalThis.services.db
+    .insert(agentComposes)
+    .values({
+      userId: opts.userId,
+      name: opts.name,
+      orgId: opts.orgId,
+    })
+    .returning({ id: agentComposes.id });
+  if (!row) {
+    throw new Error("Failed to seed agent compose");
+  }
+  return { composeId: row.id };
+}
+
+/**
+ * Seed a Slack org pending question for testing.
+ */
+export async function seedTestSlackOrgPendingQuestion(opts: {
+  runId: string;
+  slackWorkspaceId: string;
+  slackChannelId: string;
+  slackThreadTs: string;
+  connectionId: string;
+  composeId: string;
+  agentName: string;
+  questions: unknown;
+  expiresAt: Date;
+}): Promise<{ pendingQuestionId: string }> {
+  initServices();
+  const [row] = await globalThis.services.db
+    .insert(slackOrgPendingQuestions)
+    .values({
+      runId: opts.runId,
+      slackWorkspaceId: opts.slackWorkspaceId,
+      slackChannelId: opts.slackChannelId,
+      slackThreadTs: opts.slackThreadTs,
+      connectionId: opts.connectionId,
+      composeId: opts.composeId,
+      agentName: opts.agentName,
+      questions: opts.questions,
+      expiresAt: opts.expiresAt,
+    })
+    .returning({ id: slackOrgPendingQuestions.id });
+  if (!row) {
+    throw new Error("Failed to seed pending question");
+  }
+  return { pendingQuestionId: row.id };
+}
+
+/**
+ * Count Slack org installations for a workspace.
+ */
+export async function countSlackOrgInstallations(
+  workspaceId: string,
+): Promise<number> {
+  initServices();
+  const rows = await globalThis.services.db
+    .select({ id: slackOrgInstallations.slackWorkspaceId })
+    .from(slackOrgInstallations)
+    .where(eq(slackOrgInstallations.slackWorkspaceId, workspaceId));
+  return rows.length;
+}
+
+/**
+ * Count Slack org connections for a workspace.
+ */
+export async function countSlackOrgConnections(
+  workspaceId: string,
+): Promise<number> {
+  initServices();
+  const rows = await globalThis.services.db
+    .select({ id: slackOrgConnections.id })
+    .from(slackOrgConnections)
+    .where(eq(slackOrgConnections.slackWorkspaceId, workspaceId));
+  return rows.length;
+}
+
+/**
+ * Count Slack org pending questions for a connection.
+ */
+export async function countSlackOrgPendingQuestions(
+  connectionId: string,
+): Promise<number> {
+  initServices();
+  const rows = await globalThis.services.db
+    .select({ id: slackOrgPendingQuestions.id })
+    .from(slackOrgPendingQuestions)
+    .where(eq(slackOrgPendingQuestions.connectionId, connectionId));
+  return rows.length;
 }

--- a/turbo/apps/web/src/lib/slack-org/__tests__/connect-service.test.ts
+++ b/turbo/apps/web/src/lib/slack-org/__tests__/connect-service.test.ts
@@ -1,59 +1,90 @@
-import { describe, it, expect, beforeAll } from "vitest";
-import { eq } from "drizzle-orm";
+import { describe, it, expect } from "vitest";
 import { uniqueId } from "../../../__tests__/test-helpers";
-import { initServices } from "../../init-services";
-import { slackOrgInstallations } from "../../../db/schema/slack-org-installation";
-import { slackOrgConnections } from "../../../db/schema/slack-org-connection";
+import {
+  createTestSlackOrgInstallation,
+  seedTestSlackOrgConnection,
+  seedTestCompose,
+  seedTestSlackOrgPendingQuestion,
+  countSlackOrgInstallations,
+  countSlackOrgConnections,
+  countSlackOrgPendingQuestions,
+} from "../../../__tests__/api-test-helpers";
 import { cleanupWorkspaceInstallation } from "../connect-service";
-
-beforeAll(() => {
-  initServices();
-});
 
 describe("cleanupWorkspaceInstallation", () => {
   it("should delete installation and all connections for a workspace", async () => {
-    const db = globalThis.services.db;
     const workspaceId = uniqueId("T-ws");
 
-    // Seed installation
-    await db.insert(slackOrgInstallations).values({
-      slackWorkspaceId: workspaceId,
-      encryptedBotToken: "encrypted-token",
-      botUserId: "B001",
+    await createTestSlackOrgInstallation({
+      workspaceId,
       orgId: uniqueId("org"),
     });
 
-    // Seed connections
-    await db.insert(slackOrgConnections).values([
-      {
-        slackUserId: "U001",
-        slackWorkspaceId: workspaceId,
-        vm0UserId: uniqueId("user"),
-      },
-      {
-        slackUserId: "U002",
-        slackWorkspaceId: workspaceId,
-        vm0UserId: uniqueId("user"),
-      },
-    ]);
+    await seedTestSlackOrgConnection({
+      slackUserId: "U001",
+      slackWorkspaceId: workspaceId,
+      vm0UserId: uniqueId("user"),
+    });
+    await seedTestSlackOrgConnection({
+      slackUserId: "U002",
+      slackWorkspaceId: workspaceId,
+      vm0UserId: uniqueId("user"),
+    });
 
     const result = await cleanupWorkspaceInstallation(workspaceId);
 
     expect(result).toBe(true);
+    expect(await countSlackOrgInstallations(workspaceId)).toBe(0);
+    expect(await countSlackOrgConnections(workspaceId)).toBe(0);
+  });
 
-    // Verify installation deleted
-    const installations = await db
-      .select()
-      .from(slackOrgInstallations)
-      .where(eq(slackOrgInstallations.slackWorkspaceId, workspaceId));
-    expect(installations).toHaveLength(0);
+  it("should delete pending questions before connections", async () => {
+    const workspaceId = uniqueId("T-ws");
+    const orgId = uniqueId("org");
 
-    // Verify connections deleted
-    const connections = await db
-      .select()
-      .from(slackOrgConnections)
-      .where(eq(slackOrgConnections.slackWorkspaceId, workspaceId));
-    expect(connections).toHaveLength(0);
+    await createTestSlackOrgInstallation({ workspaceId, orgId });
+
+    const { connectionId } = await seedTestSlackOrgConnection({
+      slackUserId: "U001",
+      slackWorkspaceId: workspaceId,
+      vm0UserId: uniqueId("user"),
+    });
+
+    const { composeId } = await seedTestCompose({
+      userId: uniqueId("user"),
+      name: uniqueId("compose"),
+      orgId,
+    });
+
+    await seedTestSlackOrgPendingQuestion({
+      runId: uniqueId("run"),
+      slackWorkspaceId: workspaceId,
+      slackChannelId: "C001",
+      slackThreadTs: "1234567890.000001",
+      connectionId,
+      composeId,
+      agentName: "test-agent",
+      questions: [{ type: "text", question: "test?" }],
+      expiresAt: new Date(Date.now() + 3600000),
+    });
+    await seedTestSlackOrgPendingQuestion({
+      runId: uniqueId("run"),
+      slackWorkspaceId: workspaceId,
+      slackChannelId: "C002",
+      slackThreadTs: "1234567890.000002",
+      connectionId,
+      composeId,
+      agentName: "test-agent",
+      questions: [{ type: "text", question: "another?" }],
+      expiresAt: new Date(Date.now() + 3600000),
+    });
+
+    const result = await cleanupWorkspaceInstallation(workspaceId);
+
+    expect(result).toBe(true);
+    expect(await countSlackOrgPendingQuestions(connectionId)).toBe(0);
+    expect(await countSlackOrgConnections(workspaceId)).toBe(0);
+    expect(await countSlackOrgInstallations(workspaceId)).toBe(0);
   });
 
   it("should return false when workspace does not exist", async () => {
@@ -63,23 +94,13 @@ describe("cleanupWorkspaceInstallation", () => {
   });
 
   it("should handle workspace with no connections", async () => {
-    const db = globalThis.services.db;
     const workspaceId = uniqueId("T-ws");
 
-    await db.insert(slackOrgInstallations).values({
-      slackWorkspaceId: workspaceId,
-      encryptedBotToken: "encrypted-token",
-      botUserId: "B001",
-    });
+    await createTestSlackOrgInstallation({ workspaceId, orgId: null });
 
     const result = await cleanupWorkspaceInstallation(workspaceId);
 
     expect(result).toBe(true);
-
-    const installations = await db
-      .select()
-      .from(slackOrgInstallations)
-      .where(eq(slackOrgInstallations.slackWorkspaceId, workspaceId));
-    expect(installations).toHaveLength(0);
+    expect(await countSlackOrgInstallations(workspaceId)).toBe(0);
   });
 });

--- a/turbo/apps/web/src/lib/slack-org/__tests__/connect-service.test.ts
+++ b/turbo/apps/web/src/lib/slack-org/__tests__/connect-service.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { eq } from "drizzle-orm";
+import { uniqueId } from "../../../__tests__/test-helpers";
+import { initServices } from "../../init-services";
+import { slackOrgInstallations } from "../../../db/schema/slack-org-installation";
+import { slackOrgConnections } from "../../../db/schema/slack-org-connection";
+import { cleanupWorkspaceInstallation } from "../connect-service";
+
+beforeAll(() => {
+  initServices();
+});
+
+describe("cleanupWorkspaceInstallation", () => {
+  it("should delete installation and all connections for a workspace", async () => {
+    const db = globalThis.services.db;
+    const workspaceId = uniqueId("T-ws");
+
+    // Seed installation
+    await db.insert(slackOrgInstallations).values({
+      slackWorkspaceId: workspaceId,
+      encryptedBotToken: "encrypted-token",
+      botUserId: "B001",
+      orgId: uniqueId("org"),
+    });
+
+    // Seed connections
+    await db.insert(slackOrgConnections).values([
+      {
+        slackUserId: "U001",
+        slackWorkspaceId: workspaceId,
+        vm0UserId: uniqueId("user"),
+      },
+      {
+        slackUserId: "U002",
+        slackWorkspaceId: workspaceId,
+        vm0UserId: uniqueId("user"),
+      },
+    ]);
+
+    const result = await cleanupWorkspaceInstallation(workspaceId);
+
+    expect(result).toBe(true);
+
+    // Verify installation deleted
+    const installations = await db
+      .select()
+      .from(slackOrgInstallations)
+      .where(eq(slackOrgInstallations.slackWorkspaceId, workspaceId));
+    expect(installations).toHaveLength(0);
+
+    // Verify connections deleted
+    const connections = await db
+      .select()
+      .from(slackOrgConnections)
+      .where(eq(slackOrgConnections.slackWorkspaceId, workspaceId));
+    expect(connections).toHaveLength(0);
+  });
+
+  it("should return false when workspace does not exist", async () => {
+    const result = await cleanupWorkspaceInstallation("T-nonexistent");
+
+    expect(result).toBe(false);
+  });
+
+  it("should handle workspace with no connections", async () => {
+    const db = globalThis.services.db;
+    const workspaceId = uniqueId("T-ws");
+
+    await db.insert(slackOrgInstallations).values({
+      slackWorkspaceId: workspaceId,
+      encryptedBotToken: "encrypted-token",
+      botUserId: "B001",
+    });
+
+    const result = await cleanupWorkspaceInstallation(workspaceId);
+
+    expect(result).toBe(true);
+
+    const installations = await db
+      .select()
+      .from(slackOrgInstallations)
+      .where(eq(slackOrgInstallations.slackWorkspaceId, workspaceId));
+    expect(installations).toHaveLength(0);
+  });
+});

--- a/turbo/apps/web/src/lib/slack-org/connect-service.ts
+++ b/turbo/apps/web/src/lib/slack-org/connect-service.ts
@@ -1,6 +1,7 @@
-import { eq, and, isNull } from "drizzle-orm";
+import { eq, and, isNull, inArray } from "drizzle-orm";
 import { slackOrgInstallations } from "../../db/schema/slack-org-installation";
 import { slackOrgConnections } from "../../db/schema/slack-org-connection";
+import { slackOrgPendingQuestions } from "../../db/schema/slack-org-pending-question";
 import {
   ensureOrgArtifact,
   resolveDefaultComposeId,
@@ -211,6 +212,56 @@ export async function disconnect(params: {
     .where(eq(slackOrgConnections.id, connectionId));
 
   log.info("User disconnected from Slack", params);
+}
+
+/**
+ * Remove a workspace installation and all associated data.
+ *
+ * Deletes: pending questions → connections (cascades thread sessions) → installation.
+ * Skips Slack API calls — the caller decides whether to refresh App Homes first.
+ *
+ * Returns true if an installation was deleted, false if none existed.
+ */
+export async function cleanupWorkspaceInstallation(
+  workspaceId: string,
+): Promise<boolean> {
+  const db = globalThis.services.db;
+
+  const [installation] = await db
+    .select({ slackWorkspaceId: slackOrgInstallations.slackWorkspaceId })
+    .from(slackOrgInstallations)
+    .where(eq(slackOrgInstallations.slackWorkspaceId, workspaceId))
+    .limit(1);
+
+  if (!installation) {
+    return false;
+  }
+
+  // Delete pending questions for all connections in this workspace
+  const connections = await db
+    .select({ id: slackOrgConnections.id })
+    .from(slackOrgConnections)
+    .where(eq(slackOrgConnections.slackWorkspaceId, workspaceId));
+
+  if (connections.length > 0) {
+    const connectionIds = connections.map((c) => c.id);
+    await db
+      .delete(slackOrgPendingQuestions)
+      .where(inArray(slackOrgPendingQuestions.connectionId, connectionIds));
+  }
+
+  // Delete all connections (cascades to thread sessions)
+  await db
+    .delete(slackOrgConnections)
+    .where(eq(slackOrgConnections.slackWorkspaceId, workspaceId));
+
+  // Delete the installation
+  await db
+    .delete(slackOrgInstallations)
+    .where(eq(slackOrgInstallations.slackWorkspaceId, workspaceId));
+
+  log.info("Cleaned up workspace installation", { workspaceId });
+  return true;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Extract workspace installation cleanup logic (delete pending questions, connections, installation) from the uninstall API route into a shared `cleanupWorkspaceInstallation` function in `connect-service.ts`
- Add `app_uninstalled` and `tokens_revoked` Slack event handlers that reuse the same cleanup logic, ensuring workspace data is properly removed when Slack revokes access
- Include integration tests for the new `cleanupWorkspaceInstallation` function

## Test plan
- [ ] Verify `cleanupWorkspaceInstallation` deletes installation and all connections
- [ ] Verify it returns false for non-existent workspaces
- [ ] Verify it handles workspaces with no connections
- [ ] Verify `app_uninstalled` event triggers cleanup
- [ ] Verify `tokens_revoked` event with bot tokens triggers cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)