### PR TITLE
chore: add ruff linting and formatting for mitm-addon python code

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -128,6 +128,13 @@ jobs:
         with:
           python-version: '3.12'
 
+      - name: Lint and format check
+        run: |
+          cd crates/runner/mitm-addon
+          pip install ".[dev]"
+          ruff check .
+          ruff format --check .
+
       - name: Run mitm-addon tests
         run: |
           cd crates/runner/mitm-addon

--- a/crates/runner/mitm-addon/pyproject.toml
+++ b/crates/runner/mitm-addon/pyproject.toml
@@ -8,11 +8,21 @@ version = "0.1.0"
 requires-python = ">=3.10"
 
 [project.optional-dependencies]
+dev = [
+    "ruff>=0.8",
+]
 test = [
     "pytest>=7.0",
     "pytest-asyncio>=0.23",
     "mitmproxy>=10.0",
 ]
+
+[tool.ruff]
+line-length = 100
+target-version = "py310"
+
+[tool.ruff.lint]
+select = ["E", "F", "I"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -8,16 +8,17 @@ This addon runs on the runner HOST (not inside VMs) and:
 3. Injects auth headers for configured firewall rules (proxy-side token replacement)
 4. Logs network activity per-run to JSONL files
 """
+
 import asyncio
-import os
 import json
+import os
 import time
 import urllib.parse
 import urllib.request
 from typing import NamedTuple
-from mitmproxy import http, ctx, tls
-from mitmproxy.addonmanager import Loader
 
+from mitmproxy import ctx, http, tls
+from mitmproxy.addonmanager import Loader
 
 # Vercel bypass secret (still from environment as it's a secret)
 VERCEL_BYPASS = os.environ.get("VERCEL_AUTOMATION_BYPASS_SECRET", "")
@@ -127,6 +128,7 @@ def get_original_url(flow: http.HTTPFlow) -> str:
 # Firewall Header Resolution
 # ============================================================================
 
+
 def match_path(path: str, pattern: str) -> dict | None:
     """Match a URL path against a rule pattern. Returns extracted params or None.
 
@@ -174,19 +176,23 @@ def match_path(path: str, pattern: str) -> dict | None:
 
 class FirewallAllow(NamedTuple):
     """Permission matched — inject auth headers."""
+
     api_entry: dict
     match_info: dict
 
 
 class FirewallBlock(NamedTuple):
     """Base URL matched but no permission granted — return 403."""
+
     base: str
     firewall_ref: str
     method: str
     path: str
 
 
-def match_firewall_request(url: str, method: str, vm_firewalls: list | None) -> FirewallAllow | FirewallBlock | None:
+def match_firewall_request(
+    url: str, method: str, vm_firewalls: list | None
+) -> FirewallAllow | FirewallBlock | None:
     """Match request against firewall permissions.
 
     Returns:
@@ -212,7 +218,7 @@ def match_firewall_request(url: str, method: str, vm_firewalls: list | None) -> 
             base = api_entry.get("base", "").rstrip("/")
             if not base or not url.startswith(base):
                 continue
-            rest = url[len(base):]
+            rest = url[len(base) :]
             if rest and rest[0] not in ("/", "?", "#"):
                 continue
 
@@ -240,24 +246,31 @@ def match_firewall_request(url: str, method: str, vm_firewalls: list | None) -> 
                         continue
                     params = match_path(rel_path, rule_pattern)
                     if params is not None:
-                        return FirewallAllow(api_entry, {
-                            "name": fw_name,
-                            "ref": fw_ref,
-                            "permission": perm_name,
-                            "params": params,
-                            "rule": rule_str,
-                        })
+                        return FirewallAllow(
+                            api_entry,
+                            {
+                                "name": fw_name,
+                                "ref": fw_ref,
+                                "permission": perm_name,
+                                "params": params,
+                                "rule": rule_str,
+                            },
+                        )
 
     if blocked_base is not None:
         # Extract relative path for the error message
-        rest = url[len(blocked_base):]
+        rest = url[len(blocked_base) :]
         rel_path = rest.split("?")[0].split("#")[0] or "/"
         return FirewallBlock(blocked_base, blocked_ref, upper_method, rel_path)
     return None
 
 
-def _fetch_firewall_headers_sync(encrypted_secrets: str, auth_headers: dict, sandbox_token: str,
-                                 secret_connector_map: dict | None = None) -> dict:
+def _fetch_firewall_headers_sync(
+    encrypted_secrets: str,
+    auth_headers: dict,
+    sandbox_token: str,
+    secret_connector_map: dict | None = None,
+) -> dict:
     """Synchronous helper — runs in a thread to avoid blocking the event loop."""
     api_url = get_api_url()
     url = f"{api_url}/api/webhooks/agent/firewall/auth"
@@ -265,19 +278,27 @@ def _fetch_firewall_headers_sync(encrypted_secrets: str, auth_headers: dict, san
     if secret_connector_map:
         body["secretConnectorMap"] = secret_connector_map
     data = json.dumps(body).encode()
-    req = urllib.request.Request(url, data=data, headers={
-        "Authorization": f"Bearer {sandbox_token}",
-        "Content-Type": "application/json",
-        "User-Agent": "vm0-mitm-addon/1.0",
-    })
+    req = urllib.request.Request(
+        url,
+        data=data,
+        headers={
+            "Authorization": f"Bearer {sandbox_token}",
+            "Content-Type": "application/json",
+            "User-Agent": "vm0-mitm-addon/1.0",
+        },
+    )
     if VERCEL_BYPASS:
         req.add_header("x-vercel-protection-bypass", VERCEL_BYPASS)
     resp = urllib.request.urlopen(req, timeout=10)
     return json.loads(resp.read())
 
 
-async def fetch_firewall_headers(encrypted_secrets: str, auth_headers: dict, sandbox_token: str,
-                                 secret_connector_map: dict | None = None) -> dict:
+async def fetch_firewall_headers(
+    encrypted_secrets: str,
+    auth_headers: dict,
+    sandbox_token: str,
+    secret_connector_map: dict | None = None,
+) -> dict:
     """Resolve auth headers via server-side decryption.
 
     When secret_connector_map is provided, the auth endpoint can refresh
@@ -286,12 +307,22 @@ async def fetch_firewall_headers(encrypted_secrets: str, auth_headers: dict, san
     Uses asyncio.to_thread to avoid blocking mitmproxy's event loop.
     """
     return await asyncio.to_thread(
-        _fetch_firewall_headers_sync, encrypted_secrets, auth_headers, sandbox_token, secret_connector_map
+        _fetch_firewall_headers_sync,
+        encrypted_secrets,
+        auth_headers,
+        sandbox_token,
+        secret_connector_map,
     )
 
 
-async def get_firewall_headers(run_id: str, api_id: str, encrypted_secrets: str, auth_headers: dict,
-                              sandbox_token: str, secret_connector_map: dict | None = None) -> dict:
+async def get_firewall_headers(
+    run_id: str,
+    api_id: str,
+    encrypted_secrets: str,
+    auth_headers: dict,
+    sandbox_token: str,
+    secret_connector_map: dict | None = None,
+) -> dict:
     """Get firewall auth headers with TTL-based caching.
 
     Cache is evicted when:
@@ -307,13 +338,17 @@ async def get_firewall_headers(run_id: str, api_id: str, encrypted_secrets: str,
             return cached["headers"]
         # Token expired — evict and re-fetch
 
-    result = await fetch_firewall_headers(encrypted_secrets, auth_headers, sandbox_token, secret_connector_map)
+    result = await fetch_firewall_headers(
+        encrypted_secrets, auth_headers, sandbox_token, secret_connector_map
+    )
     headers = result["headers"]
     _firewall_header_cache[cache_key] = {"headers": headers, "expiresAt": result.get("expiresAt")}
     return headers
 
 
-async def handle_firewall_request(flow: http.HTTPFlow, api_entry: dict, vm_info: dict, match_info: dict) -> None:
+async def handle_firewall_request(
+    flow: http.HTTPFlow, api_entry: dict, vm_info: dict, match_info: dict
+) -> None:
     """Handle a firewall-matched request: fetch resolved headers, inject into request."""
     client_ip = flow.client_conn.peername[0]
     firewall_base = api_entry["base"]
@@ -329,12 +364,14 @@ async def handle_firewall_request(flow: http.HTTPFlow, api_entry: dict, vm_info:
         flow.metadata["firewall_action"] = "DENY"
         flow.metadata["firewall_rule"] = f"firewall:{firewall_base}"
         flow.metadata["original_url"] = get_original_url(flow)
-        error_body = json.dumps({
-            "error": "firewall_auth_unavailable",
-            "message": "Firewall auth secrets not configured",
-            "firewall": match_info.get("ref", ""),
-            "base": firewall_base,
-        })
+        error_body = json.dumps(
+            {
+                "error": "firewall_auth_unavailable",
+                "message": "Firewall auth secrets not configured",
+                "firewall": match_info.get("ref", ""),
+                "base": firewall_base,
+            }
+        )
         flow.response = http.Response.make(
             502,
             error_body.encode(),
@@ -343,18 +380,22 @@ async def handle_firewall_request(flow: http.HTTPFlow, api_entry: dict, vm_info:
         return
 
     try:
-        headers = await get_firewall_headers(run_id, api_id, encrypted_secrets, auth_headers, sandbox_token, secret_connector_map)
+        headers = await get_firewall_headers(
+            run_id, api_id, encrypted_secrets, auth_headers, sandbox_token, secret_connector_map
+        )
     except Exception as e:
         ctx.log.error(f"[{run_id}] Firewall header fetch failed: {e}")
         flow.metadata["firewall_action"] = "DENY"
         flow.metadata["firewall_rule"] = f"firewall:{firewall_base}"
         flow.metadata["original_url"] = get_original_url(flow)
-        error_body = json.dumps({
-            "error": "firewall_auth_failed",
-            "message": f"Failed to resolve firewall auth headers: {e}",
-            "firewall": match_info.get("ref", ""),
-            "base": firewall_base,
-        })
+        error_body = json.dumps(
+            {
+                "error": "firewall_auth_failed",
+                "message": f"Failed to resolve firewall auth headers: {e}",
+                "firewall": match_info.get("ref", ""),
+                "base": firewall_base,
+            }
+        )
         flow.response = http.Response.make(
             502,
             error_body.encode(),
@@ -388,6 +429,7 @@ async def handle_firewall_request(flow: http.HTTPFlow, api_entry: dict, vm_info:
 # TLS ClientHello Handler
 # ============================================================================
 
+
 def tls_clienthello(data: tls.ClientHelloData) -> None:
     """
     Handle TLS ClientHello — decide whether to MITM intercept.
@@ -411,6 +453,7 @@ def tls_clienthello(data: tls.ClientHelloData) -> None:
 # ============================================================================
 # HTTP Request Handler (MITM mode)
 # ============================================================================
+
 
 async def request(flow: http.HTTPFlow) -> None:
     """
@@ -468,19 +511,27 @@ async def request(flow: http.HTTPFlow) -> None:
         original_url = get_original_url(flow)
         result = match_firewall_request(original_url, flow.request.method, vm_firewalls)
         if isinstance(result, FirewallBlock):
-            ctx.log.warn(f"[{run_id}] Firewall {result.firewall_ref}: no matching permission for {result.method} {result.path}")
+            ctx.log.warn(
+                f"[{run_id}] Firewall {result.firewall_ref}: "
+                f"no matching permission for {result.method} {result.path}"
+            )
             flow.metadata["firewall_action"] = "DENY"
             flow.metadata["firewall_rule"] = f"firewall:{result.base}"
             flow.metadata["original_url"] = original_url
-            error_body = json.dumps({
-                "error": "firewall_permission_denied",
-                "message": "Request blocked: no matching permission rule",
-                "method": result.method,
-                "path": result.path,
-                "firewall": result.firewall_ref,
-                "base": result.base,
-                "hint": f"Add a permission rule for '{result.method} {result.path}' to the {result.firewall_ref} firewall in vm0.yaml",
-            })
+            error_body = json.dumps(
+                {
+                    "error": "firewall_permission_denied",
+                    "message": "Request blocked: no matching permission rule",
+                    "method": result.method,
+                    "path": result.path,
+                    "firewall": result.firewall_ref,
+                    "base": result.base,
+                    "hint": (
+                        f"Add a permission rule for '{result.method} {result.path}'"
+                        f" to the {result.firewall_ref} firewall in vm0.yaml"
+                    ),
+                }
+            )
             flow.response = http.Response.make(
                 403,
                 error_body.encode(),
@@ -589,9 +640,7 @@ def response(flow: http.HTTPFlow) -> None:
 
     # Log errors to mitmproxy console
     if flow.response and flow.response.status_code >= 400:
-        ctx.log.warn(
-            f"[{run_id}] Response {flow.response.status_code}: {original_url}"
-        )
+        ctx.log.warn(f"[{run_id}] Response {flow.response.status_code}: {original_url}")
 
 
 def error(flow: http.HTTPFlow) -> None:

--- a/crates/runner/mitm-addon/tests/conftest.py
+++ b/crates/runner/mitm-addon/tests/conftest.py
@@ -1,4 +1,5 @@
 import json
+
 import pytest
 
 

--- a/crates/runner/mitm-addon/tests/test_connectors.py
+++ b/crates/runner/mitm-addon/tests/test_connectors.py
@@ -1,4 +1,5 @@
 """Tests for firewall subsystem: matching, caching, header injection, and HTTP fetching."""
+
 import json
 import time
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -50,7 +51,9 @@ class TestMatchPath:
         assert result == {"owner": "octocat", "repo": "hello-world"}
 
     def test_mixed_literal_and_param(self):
-        result = mitm_addon.match_path("/repos/octocat/hello-world/issues", "/repos/{owner}/{repo}/issues")
+        result = mitm_addon.match_path(
+            "/repos/octocat/hello-world/issues", "/repos/{owner}/{repo}/issues"
+        )
         assert result == {"owner": "octocat", "repo": "hello-world"}
 
     def test_greedy_param_matches_rest(self):
@@ -115,10 +118,16 @@ class TestMatchFirewallRequest:
 
     def test_no_permissions_blocks(self):
         """Missing permissions field → block (fail-closed)."""
-        fw_configs = _wrap_firewalls([
-            {"base": "https://api.github.com", "auth": {"headers": {}}},
-        ], name="github", ref="github")
-        result = mitm_addon.match_firewall_request("https://api.github.com/repos", "GET", fw_configs)
+        fw_configs = _wrap_firewalls(
+            [
+                {"base": "https://api.github.com", "auth": {"headers": {}}},
+            ],
+            name="github",
+            ref="github",
+        )
+        result = mitm_addon.match_firewall_request(
+            "https://api.github.com/repos", "GET", fw_configs
+        )
         assert isinstance(result, FirewallBlock)
         assert result.base == "https://api.github.com"
         assert result.firewall_ref == "github"
@@ -126,12 +135,20 @@ class TestMatchFirewallRequest:
         assert result.path == "/repos"
 
     def test_permission_match_allows(self):
-        fw_configs = _wrap_firewalls([{
-            "base": "https://api.github.com",
-            "auth": {"headers": {}},
-            "permissions": [{"name": "repo-read", "rules": ["GET /repos/{owner}/{repo}"]}],
-        }], name="github", ref="github")
-        result = mitm_addon.match_firewall_request("https://api.github.com/repos/octocat/hello", "GET", fw_configs)
+        fw_configs = _wrap_firewalls(
+            [
+                {
+                    "base": "https://api.github.com",
+                    "auth": {"headers": {}},
+                    "permissions": [{"name": "repo-read", "rules": ["GET /repos/{owner}/{repo}"]}],
+                }
+            ],
+            name="github",
+            ref="github",
+        )
+        result = mitm_addon.match_firewall_request(
+            "https://api.github.com/repos/octocat/hello", "GET", fw_configs
+        )
         assert isinstance(result, FirewallAllow)
         assert result.match_info["name"] == "github"
         assert result.match_info["permission"] == "repo-read"
@@ -139,49 +156,79 @@ class TestMatchFirewallRequest:
         assert result.match_info["rule"] == "GET /repos/{owner}/{repo}"
 
     def test_any_method_matches(self):
-        fw_configs = _wrap_firewalls([{
-            "base": "https://api.github.com",
-            "auth": {"headers": {}},
-            "permissions": [{"name": "full-access", "rules": ["ANY /{path+}"]}],
-        }])
-        result = mitm_addon.match_firewall_request("https://api.github.com/anything", "DELETE", fw_configs)
+        fw_configs = _wrap_firewalls(
+            [
+                {
+                    "base": "https://api.github.com",
+                    "auth": {"headers": {}},
+                    "permissions": [{"name": "full-access", "rules": ["ANY /{path+}"]}],
+                }
+            ]
+        )
+        result = mitm_addon.match_firewall_request(
+            "https://api.github.com/anything", "DELETE", fw_configs
+        )
         assert isinstance(result, FirewallAllow)
         assert result.match_info["permission"] == "full-access"
 
     def test_method_case_insensitive(self):
-        fw_configs = _wrap_firewalls([{
-            "base": "https://api.github.com",
-            "auth": {"headers": {}},
-            "permissions": [{"name": "p", "rules": ["post /repos"]}],
-        }])
-        result = mitm_addon.match_firewall_request("https://api.github.com/repos", "POST", fw_configs)
+        fw_configs = _wrap_firewalls(
+            [
+                {
+                    "base": "https://api.github.com",
+                    "auth": {"headers": {}},
+                    "permissions": [{"name": "p", "rules": ["post /repos"]}],
+                }
+            ]
+        )
+        result = mitm_addon.match_firewall_request(
+            "https://api.github.com/repos", "POST", fw_configs
+        )
         assert isinstance(result, FirewallAllow)
 
     def test_wrong_method_blocks(self):
-        fw_configs = _wrap_firewalls([{
-            "base": "https://api.github.com",
-            "auth": {"headers": {}},
-            "permissions": [{"name": "read-only", "rules": ["GET /repos/{owner}/{repo}"]}],
-        }])
-        result = mitm_addon.match_firewall_request("https://api.github.com/repos/a/b", "POST", fw_configs)
+        fw_configs = _wrap_firewalls(
+            [
+                {
+                    "base": "https://api.github.com",
+                    "auth": {"headers": {}},
+                    "permissions": [{"name": "read-only", "rules": ["GET /repos/{owner}/{repo}"]}],
+                }
+            ]
+        )
+        result = mitm_addon.match_firewall_request(
+            "https://api.github.com/repos/a/b", "POST", fw_configs
+        )
         assert isinstance(result, FirewallBlock)
 
     def test_wrong_path_blocks(self):
-        fw_configs = _wrap_firewalls([{
-            "base": "https://api.github.com",
-            "auth": {"headers": {}},
-            "permissions": [{"name": "repo-read", "rules": ["GET /repos/{owner}/{repo}"]}],
-        }])
-        result = mitm_addon.match_firewall_request("https://api.github.com/users/octocat", "GET", fw_configs)
+        fw_configs = _wrap_firewalls(
+            [
+                {
+                    "base": "https://api.github.com",
+                    "auth": {"headers": {}},
+                    "permissions": [{"name": "repo-read", "rules": ["GET /repos/{owner}/{repo}"]}],
+                }
+            ]
+        )
+        result = mitm_addon.match_firewall_request(
+            "https://api.github.com/users/octocat", "GET", fw_configs
+        )
         assert isinstance(result, FirewallBlock)
 
     def test_no_base_match_returns_none(self):
-        fw_configs = _wrap_firewalls([{
-            "base": "https://api.github.com",
-            "auth": {"headers": {}},
-            "permissions": [{"name": "p", "rules": ["GET /{path+}"]}],
-        }])
-        result = mitm_addon.match_firewall_request("https://api.gitlab.com/repos", "GET", fw_configs)
+        fw_configs = _wrap_firewalls(
+            [
+                {
+                    "base": "https://api.github.com",
+                    "auth": {"headers": {}},
+                    "permissions": [{"name": "p", "rules": ["GET /{path+}"]}],
+                }
+            ]
+        )
+        result = mitm_addon.match_firewall_request(
+            "https://api.gitlab.com/repos", "GET", fw_configs
+        )
         assert result is None
 
     def test_no_firewall_returns_none(self):
@@ -192,181 +239,273 @@ class TestMatchFirewallRequest:
 
     def test_exact_base_no_path(self):
         """URL equals base exactly (rest='') → rel_path='/' → matches root rule."""
-        fw_configs = _wrap_firewalls([{
-            "base": "https://api.github.com",
-            "auth": {"headers": {}},
-            "permissions": [{"name": "root", "rules": ["GET /"]}],
-        }])
+        fw_configs = _wrap_firewalls(
+            [
+                {
+                    "base": "https://api.github.com",
+                    "auth": {"headers": {}},
+                    "permissions": [{"name": "root", "rules": ["GET /"]}],
+                }
+            ]
+        )
         result = mitm_addon.match_firewall_request("https://api.github.com", "GET", fw_configs)
         assert isinstance(result, FirewallAllow)
         assert result.match_info["permission"] == "root"
 
     def test_trailing_slash_on_url(self):
         """URL trailing slash doesn't affect matching (split filters empty segments)."""
-        fw_configs = _wrap_firewalls([{
-            "base": "https://api.github.com",
-            "auth": {"headers": {}},
-            "permissions": [{"name": "p", "rules": ["GET /repos"]}],
-        }])
-        result = mitm_addon.match_firewall_request("https://api.github.com/repos/", "GET", fw_configs)
+        fw_configs = _wrap_firewalls(
+            [
+                {
+                    "base": "https://api.github.com",
+                    "auth": {"headers": {}},
+                    "permissions": [{"name": "p", "rules": ["GET /repos"]}],
+                }
+            ]
+        )
+        result = mitm_addon.match_firewall_request(
+            "https://api.github.com/repos/", "GET", fw_configs
+        )
         assert isinstance(result, FirewallAllow)
 
     def test_trailing_slash_on_base_config(self):
         """Base URL with trailing slash still matches (rstrip strips it)."""
-        fw_configs = _wrap_firewalls([{
-            "base": "https://api.github.com/",
-            "auth": {"headers": {}},
-            "permissions": [{"name": "p", "rules": ["GET /repos"]}],
-        }])
-        result = mitm_addon.match_firewall_request("https://api.github.com/repos", "GET", fw_configs)
+        fw_configs = _wrap_firewalls(
+            [
+                {
+                    "base": "https://api.github.com/",
+                    "auth": {"headers": {}},
+                    "permissions": [{"name": "p", "rules": ["GET /repos"]}],
+                }
+            ]
+        )
+        result = mitm_addon.match_firewall_request(
+            "https://api.github.com/repos", "GET", fw_configs
+        )
         assert isinstance(result, FirewallAllow)
 
     def test_port_boundary_rejected(self):
         """Port in URL (rest starts with ':') is not a valid path boundary."""
-        fw_configs = _wrap_firewalls([{
-            "base": "https://api.github.com",
-            "auth": {"headers": {}},
-            "permissions": [{"name": "p", "rules": ["ANY /{path+}"]}],
-        }])
-        result = mitm_addon.match_firewall_request("https://api.github.com:8443/repos", "GET", fw_configs)
+        fw_configs = _wrap_firewalls(
+            [
+                {
+                    "base": "https://api.github.com",
+                    "auth": {"headers": {}},
+                    "permissions": [{"name": "p", "rules": ["ANY /{path+}"]}],
+                }
+            ]
+        )
+        result = mitm_addon.match_firewall_request(
+            "https://api.github.com:8443/repos", "GET", fw_configs
+        )
         assert result is None
 
     def test_evil_domain_not_matched(self):
-        fw_configs = _wrap_firewalls([{
-            "base": "https://api.github.com",
-            "auth": {"headers": {}},
-            "permissions": [{"name": "p", "rules": ["ANY /{path+}"]}],
-        }])
-        result = mitm_addon.match_firewall_request("https://api.github.com.evil.com/steal", "GET", fw_configs)
+        fw_configs = _wrap_firewalls(
+            [
+                {
+                    "base": "https://api.github.com",
+                    "auth": {"headers": {}},
+                    "permissions": [{"name": "p", "rules": ["ANY /{path+}"]}],
+                }
+            ]
+        )
+        result = mitm_addon.match_firewall_request(
+            "https://api.github.com.evil.com/steal", "GET", fw_configs
+        )
         assert result is None
 
     def test_multiple_permissions_first_match_wins(self):
-        fw_configs = _wrap_firewalls([{
-            "base": "https://slack.com/api",
-            "auth": {"headers": {}},
-            "permissions": [
-                {"name": "messages-read", "rules": ["POST /conversations.history"]},
-                {"name": "messages-send", "rules": ["POST /chat.postMessage"]},
-            ],
-        }])
-        result = mitm_addon.match_firewall_request("https://slack.com/api/chat.postMessage", "POST", fw_configs)
+        fw_configs = _wrap_firewalls(
+            [
+                {
+                    "base": "https://slack.com/api",
+                    "auth": {"headers": {}},
+                    "permissions": [
+                        {"name": "messages-read", "rules": ["POST /conversations.history"]},
+                        {"name": "messages-send", "rules": ["POST /chat.postMessage"]},
+                    ],
+                }
+            ]
+        )
+        result = mitm_addon.match_firewall_request(
+            "https://slack.com/api/chat.postMessage", "POST", fw_configs
+        )
         assert isinstance(result, FirewallAllow)
         assert result.match_info["permission"] == "messages-send"
 
     def test_malformed_rules_skipped(self):
         """Rules without 'METHOD /path' format are silently skipped, not crash or false-allow."""
-        fw_configs = _wrap_firewalls([{
-            "base": "https://api.github.com",
-            "auth": {"headers": {}},
-            "permissions": [{"name": "bad", "rules": ["GET", "", "INVALID", "  ", "GET /repos"]}],
-        }])
+        fw_configs = _wrap_firewalls(
+            [
+                {
+                    "base": "https://api.github.com",
+                    "auth": {"headers": {}},
+                    "permissions": [
+                        {"name": "bad", "rules": ["GET", "", "INVALID", "  ", "GET /repos"]}
+                    ],
+                }
+            ]
+        )
         # Only "GET /repos" is valid — the rest are skipped
-        result = mitm_addon.match_firewall_request("https://api.github.com/repos", "GET", fw_configs)
+        result = mitm_addon.match_firewall_request(
+            "https://api.github.com/repos", "GET", fw_configs
+        )
         assert isinstance(result, FirewallAllow)
         # Non-matching path still blocks (malformed rules don't accidentally allow)
-        result2 = mitm_addon.match_firewall_request("https://api.github.com/users", "GET", fw_configs)
+        result2 = mitm_addon.match_firewall_request(
+            "https://api.github.com/users", "GET", fw_configs
+        )
         assert isinstance(result2, FirewallBlock)
 
     def test_path_case_sensitive(self):
         """URL paths are case-sensitive — /REPOS must not match /repos."""
-        fw_configs = _wrap_firewalls([{
-            "base": "https://api.github.com",
-            "auth": {"headers": {}},
-            "permissions": [{"name": "p", "rules": ["GET /repos/{owner}"]}],
-        }])
-        result = mitm_addon.match_firewall_request("https://api.github.com/REPOS/octocat", "GET", fw_configs)
+        fw_configs = _wrap_firewalls(
+            [
+                {
+                    "base": "https://api.github.com",
+                    "auth": {"headers": {}},
+                    "permissions": [{"name": "p", "rules": ["GET /repos/{owner}"]}],
+                }
+            ]
+        )
+        result = mitm_addon.match_firewall_request(
+            "https://api.github.com/REPOS/octocat", "GET", fw_configs
+        )
         assert isinstance(result, FirewallBlock)
 
     def test_multiple_services_match_across(self):
         fw_configs = [
-            {"name": "github", "ref": "github", "apis": [{
-                "base": "https://api.github.com",
-                "auth": {"headers": {}},
-                "permissions": [{"name": "full-access", "rules": ["ANY /{path+}"]}],
-            }]},
-            {"name": "slack", "ref": "slack", "apis": [{
-                "base": "https://slack.com/api",
-                "auth": {"headers": {}},
-                "permissions": [{"name": "full-access", "rules": ["ANY /{path+}"]}],
-            }]},
+            {
+                "name": "github",
+                "ref": "github",
+                "apis": [
+                    {
+                        "base": "https://api.github.com",
+                        "auth": {"headers": {}},
+                        "permissions": [{"name": "full-access", "rules": ["ANY /{path+}"]}],
+                    }
+                ],
+            },
+            {
+                "name": "slack",
+                "ref": "slack",
+                "apis": [
+                    {
+                        "base": "https://slack.com/api",
+                        "auth": {"headers": {}},
+                        "permissions": [{"name": "full-access", "rules": ["ANY /{path+}"]}],
+                    }
+                ],
+            },
         ]
         gh = mitm_addon.match_firewall_request("https://api.github.com/repos", "GET", fw_configs)
         assert isinstance(gh, FirewallAllow)
         assert gh.match_info["name"] == "github"
 
-        sl = mitm_addon.match_firewall_request("https://slack.com/api/chat.postMessage", "POST", fw_configs)
+        sl = mitm_addon.match_firewall_request(
+            "https://slack.com/api/chat.postMessage", "POST", fw_configs
+        )
         assert isinstance(sl, FirewallAllow)
         assert sl.match_info["name"] == "slack"
 
     def test_query_string_stripped_for_matching(self):
-        fw_configs = _wrap_firewalls([{
-            "base": "https://api.github.com",
-            "auth": {"headers": {}},
-            "permissions": [{"name": "p", "rules": ["GET /repos"]}],
-        }])
-        result = mitm_addon.match_firewall_request("https://api.github.com/repos?page=1", "GET", fw_configs)
+        fw_configs = _wrap_firewalls(
+            [
+                {
+                    "base": "https://api.github.com",
+                    "auth": {"headers": {}},
+                    "permissions": [{"name": "p", "rules": ["GET /repos"]}],
+                }
+            ]
+        )
+        result = mitm_addon.match_firewall_request(
+            "https://api.github.com/repos?page=1", "GET", fw_configs
+        )
         assert isinstance(result, FirewallAllow)
 
     def test_fragment_stripped_for_matching(self):
-        fw_configs = _wrap_firewalls([{
-            "base": "https://api.github.com",
-            "auth": {"headers": {}},
-            "permissions": [{"name": "p", "rules": ["GET /repos"]}],
-        }])
-        result = mitm_addon.match_firewall_request("https://api.github.com/repos#section", "GET", fw_configs)
+        fw_configs = _wrap_firewalls(
+            [
+                {
+                    "base": "https://api.github.com",
+                    "auth": {"headers": {}},
+                    "permissions": [{"name": "p", "rules": ["GET /repos"]}],
+                }
+            ]
+        )
+        result = mitm_addon.match_firewall_request(
+            "https://api.github.com/repos#section", "GET", fw_configs
+        )
         assert isinstance(result, FirewallAllow)
 
     def test_empty_permissions_list_blocks(self):
         """If permissions is present but empty, no rules can match → block."""
-        fw_configs = _wrap_firewalls([{
-            "base": "https://api.github.com",
-            "auth": {"headers": {}},
-            "permissions": [],
-        }])
-        result = mitm_addon.match_firewall_request("https://api.github.com/repos", "GET", fw_configs)
+        fw_configs = _wrap_firewalls(
+            [
+                {
+                    "base": "https://api.github.com",
+                    "auth": {"headers": {}},
+                    "permissions": [],
+                }
+            ]
+        )
+        result = mitm_addon.match_firewall_request(
+            "https://api.github.com/repos", "GET", fw_configs
+        )
         assert isinstance(result, FirewallBlock)
 
     def test_different_bases_same_permission_name(self):
         """Same permission name across different api_entries — each matches its own base."""
-        fw_configs = _wrap_firewalls([
-            {
-                "base": "https://slack.com/api",
-                "auth": {"headers": {"Authorization": "Bearer api-token"}},
-                "permissions": [{"name": "full-access", "rules": ["ANY /{path+}"]}],
-            },
-            {
-                "base": "https://files.slack.com",
-                "auth": {"headers": {"Authorization": "Bearer files-token"}},
-                "permissions": [{"name": "full-access", "rules": ["ANY /{path+}"]}],
-            },
-        ])
+        fw_configs = _wrap_firewalls(
+            [
+                {
+                    "base": "https://slack.com/api",
+                    "auth": {"headers": {"Authorization": "Bearer api-token"}},
+                    "permissions": [{"name": "full-access", "rules": ["ANY /{path+}"]}],
+                },
+                {
+                    "base": "https://files.slack.com",
+                    "auth": {"headers": {"Authorization": "Bearer files-token"}},
+                    "permissions": [{"name": "full-access", "rules": ["ANY /{path+}"]}],
+                },
+            ]
+        )
         # Request to first base
-        result = mitm_addon.match_firewall_request("https://slack.com/api/conversations.history", "POST", fw_configs)
+        result = mitm_addon.match_firewall_request(
+            "https://slack.com/api/conversations.history", "POST", fw_configs
+        )
         assert isinstance(result, FirewallAllow)
         assert result.api_entry["auth"]["headers"]["Authorization"] == "Bearer api-token"
         assert result.match_info["permission"] == "full-access"
 
         # Request to second base
-        result = mitm_addon.match_firewall_request("https://files.slack.com/files-pri/T1/download", "GET", fw_configs)
+        result = mitm_addon.match_firewall_request(
+            "https://files.slack.com/files-pri/T1/download", "GET", fw_configs
+        )
         assert isinstance(result, FirewallAllow)
         assert result.api_entry["auth"]["headers"]["Authorization"] == "Bearer files-token"
         assert result.match_info["permission"] == "full-access"
 
     def test_same_base_different_permissions(self):
         """Same base URL with different permissions/auth — second api_entry can match."""
-        fw_configs = _wrap_firewalls([
-            {
-                "base": "https://slack.com/api",
-                "auth": {"headers": {"Authorization": "Bearer bot"}},
-                "permissions": [{"name": "read", "rules": ["POST /conversations.history"]}],
-            },
-            {
-                "base": "https://slack.com/api",
-                "auth": {"headers": {"Authorization": "Bearer user"}},
-                "permissions": [{"name": "send", "rules": ["POST /chat.postMessage"]}],
-            },
-        ])
-        result = mitm_addon.match_firewall_request("https://slack.com/api/chat.postMessage", "POST", fw_configs)
+        fw_configs = _wrap_firewalls(
+            [
+                {
+                    "base": "https://slack.com/api",
+                    "auth": {"headers": {"Authorization": "Bearer bot"}},
+                    "permissions": [{"name": "read", "rules": ["POST /conversations.history"]}],
+                },
+                {
+                    "base": "https://slack.com/api",
+                    "auth": {"headers": {"Authorization": "Bearer user"}},
+                    "permissions": [{"name": "send", "rules": ["POST /chat.postMessage"]}],
+                },
+            ]
+        )
+        result = mitm_addon.match_firewall_request(
+            "https://slack.com/api/chat.postMessage", "POST", fw_configs
+        )
         assert isinstance(result, FirewallAllow)
         assert result.api_entry["auth"]["headers"]["Authorization"] == "Bearer user"
         assert result.match_info["permission"] == "send"
@@ -389,7 +528,9 @@ class TestGetFirewallHeaders:
 
         mock_fetch = AsyncMock(return_value=mock_result)
         with patch.object(mitm_addon, "fetch_firewall_headers", mock_fetch):
-            headers = await mitm_addon.get_firewall_headers("run-1", "https://api.github.com", encrypted, auth_templates, "tok-xyz")
+            headers = await mitm_addon.get_firewall_headers(
+                "run-1", "https://api.github.com", encrypted, auth_templates, "tok-xyz"
+            )
 
         assert headers == mock_headers
         mock_fetch.assert_called_once_with(encrypted, auth_templates, "tok-xyz", None)
@@ -408,7 +549,9 @@ class TestGetFirewallHeaders:
 
         mock_fetch = AsyncMock()
         with patch.object(mitm_addon, "fetch_firewall_headers", mock_fetch):
-            headers = await mitm_addon.get_firewall_headers("run-1", "https://api.github.com", "iv:tag:data", {}, "tok-xyz")
+            headers = await mitm_addon.get_firewall_headers(
+                "run-1", "https://api.github.com", "iv:tag:data", {}, "tok-xyz"
+            )
 
         assert headers == cached_headers
         mock_fetch.assert_not_called()
@@ -424,7 +567,9 @@ class TestGetFirewallHeaders:
 
         mock_fetch = AsyncMock()
         with patch.object(mitm_addon, "fetch_firewall_headers", mock_fetch):
-            headers = await mitm_addon.get_firewall_headers("run-1", "api-1", "iv:tag:data", {}, "tok-xyz")
+            headers = await mitm_addon.get_firewall_headers(
+                "run-1", "api-1", "iv:tag:data", {}, "tok-xyz"
+            )
 
         assert headers == cached_headers
         mock_fetch.assert_not_called()
@@ -442,7 +587,9 @@ class TestGetFirewallHeaders:
 
         mock_fetch = AsyncMock(return_value=mock_result)
         with patch.object(mitm_addon, "fetch_firewall_headers", mock_fetch):
-            headers = await mitm_addon.get_firewall_headers("run-1", "api-1", "iv:tag:data", {}, "tok-xyz")
+            headers = await mitm_addon.get_firewall_headers(
+                "run-1", "api-1", "iv:tag:data", {}, "tok-xyz"
+            )
 
         assert headers == fresh_headers
         mock_fetch.assert_called_once()
@@ -460,7 +607,9 @@ class TestGetFirewallHeaders:
 
         mock_fetch = AsyncMock()
         with patch.object(mitm_addon, "fetch_firewall_headers", mock_fetch):
-            headers = await mitm_addon.get_firewall_headers("run-1", "api-1", "iv:tag:data", {}, "tok-xyz")
+            headers = await mitm_addon.get_firewall_headers(
+                "run-1", "api-1", "iv:tag:data", {}, "tok-xyz"
+            )
 
         assert headers == cached_headers
         mock_fetch.assert_not_called()
@@ -477,18 +626,30 @@ class TestHandleFirewallRequest:
 
     async def test_success_injects_headers_and_audit_metadata(self):
         flow = _make_http_flow()
-        api_entry = {"id": "run-1:0", "base": "https://api.github.com", "auth": {"headers": {"Authorization": "Bearer ${{ secrets.GITHUB_TOKEN }}"}}}
+        api_entry = {
+            "id": "run-1:0",
+            "base": "https://api.github.com",
+            "auth": {"headers": {"Authorization": "Bearer ${{ secrets.GITHUB_TOKEN }}"}},
+        }
         vm_info = {
             "runId": "run-1",
             "sandboxToken": "tok-xyz",
             "encryptedSecrets": "iv:tag:data",
             "networkLogPath": "/tmp/net.jsonl",
         }
-        match_info = {"name": "github", "ref": "github", "permission": "repo-read", "rule": "GET /repos/{owner}/{repo}", "params": {"owner": "octocat", "repo": "hello"}}
+        match_info = {
+            "name": "github",
+            "ref": "github",
+            "permission": "repo-read",
+            "rule": "GET /repos/{owner}/{repo}",
+            "params": {"owner": "octocat", "repo": "hello"},
+        }
         resolved_headers = {"Authorization": "Bearer real-token", "X-Custom": "value"}
 
         with (
-            patch.object(mitm_addon, "get_firewall_headers", AsyncMock(return_value=resolved_headers)),
+            patch.object(
+                mitm_addon, "get_firewall_headers", AsyncMock(return_value=resolved_headers)
+            ),
             patch.object(mitm_addon.ctx, "log", MagicMock(), create=True),
         ):
             await mitm_addon.handle_firewall_request(flow, api_entry, vm_info, match_info)
@@ -524,7 +685,8 @@ class TestHandleFirewallRequest:
 
         with (
             patch.object(
-                mitm_addon, "get_firewall_headers",
+                mitm_addon,
+                "get_firewall_headers",
                 AsyncMock(side_effect=Exception("API unreachable")),
             ),
             patch.object(mitm_addon.ctx, "log", MagicMock(), create=True),
@@ -545,11 +707,18 @@ class TestHandleFirewallRequest:
         """On success, flow.response should remain None (request continues to origin)."""
         flow = _make_http_flow()
         api_entry = {"base": "https://api.github.com", "auth": {"headers": {}}}
-        vm_info = {"runId": "run-1", "sandboxToken": "tok-xyz", "encryptedSecrets": "iv:tag:data", "networkLogPath": ""}
+        vm_info = {
+            "runId": "run-1",
+            "sandboxToken": "tok-xyz",
+            "encryptedSecrets": "iv:tag:data",
+            "networkLogPath": "",
+        }
         match_info = {"name": "github", "ref": "github"}
 
         with (
-            patch.object(mitm_addon, "get_firewall_headers", AsyncMock(return_value={"Auth": "tok"})),
+            patch.object(
+                mitm_addon, "get_firewall_headers", AsyncMock(return_value={"Auth": "tok"})
+            ),
             patch.object(mitm_addon.ctx, "log", MagicMock(), create=True),
         ):
             await mitm_addon.handle_firewall_request(flow, api_entry, vm_info, match_info)
@@ -582,7 +751,9 @@ class TestHandleFirewallRequest:
 class TestFetchFirewallHeaders:
     def test_builds_correct_request(self):
         mock_resp = MagicMock()
-        mock_resp.read.return_value = json.dumps({"headers": {"Authorization": "Bearer tok"}}).encode()
+        mock_resp.read.return_value = json.dumps(
+            {"headers": {"Authorization": "Bearer tok"}}
+        ).encode()
 
         with (
             patch.object(mitm_addon, "get_api_url", return_value="https://api.vm0.ai"),
@@ -590,7 +761,9 @@ class TestFetchFirewallHeaders:
             patch("mitm_addon.urllib.request.urlopen", return_value=mock_resp),
             patch.object(mitm_addon, "VERCEL_BYPASS", ""),
         ):
-            result = mitm_addon._fetch_firewall_headers_sync("iv:tag:data", {"Authorization": "Bearer ${{ secrets.TOKEN }}"}, "tok-xyz")
+            result = mitm_addon._fetch_firewall_headers_sync(
+                "iv:tag:data", {"Authorization": "Bearer ${{ secrets.TOKEN }}"}, "tok-xyz"
+            )
 
         assert result == {"headers": {"Authorization": "Bearer tok"}}
 
@@ -620,7 +793,9 @@ class TestFetchFirewallHeaders:
         ):
             mitm_addon._fetch_firewall_headers_sync("iv:tag:data", {}, "tok-xyz")
 
-        mock_req_instance.add_header.assert_called_once_with("x-vercel-protection-bypass", "secret-bypass-value")
+        mock_req_instance.add_header.assert_called_once_with(
+            "x-vercel-protection-bypass", "secret-bypass-value"
+        )
 
     def test_no_vercel_bypass_when_empty(self):
         mock_resp = MagicMock()

--- a/crates/runner/mitm-addon/tests/test_handlers.py
+++ b/crates/runner/mitm-addon/tests/test_handlers.py
@@ -1,6 +1,6 @@
 """Tests for HTTP/TLS handlers."""
+
 import json
-import time
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -120,13 +120,23 @@ class TestRequestHandler:
                     "sandboxToken": "tok-conn",
                     "networkLogPath": str(tmp_path / "net.jsonl"),
                     "firewalls": [
-                        {"name": "github", "ref": "github", "apis": [
-                            {
-                                "base": "https://api.github.com",
-                                "auth": {"headers": {"Authorization": "Bearer ${{ secrets.GITHUB_TOKEN }}"}},
-                                "permissions": [{"name": "full-access", "rules": ["ANY /{path+}"]}],
-                            },
-                        ]},
+                        {
+                            "name": "github",
+                            "ref": "github",
+                            "apis": [
+                                {
+                                    "base": "https://api.github.com",
+                                    "auth": {
+                                        "headers": {
+                                            "Authorization": "Bearer ${{ secrets.GITHUB_TOKEN }}"
+                                        }
+                                    },
+                                    "permissions": [
+                                        {"name": "full-access", "rules": ["ANY /{path+}"]}
+                                    ],
+                                },
+                            ],
+                        },
                     ],
                     "encryptedSecrets": "iv:tag:data",
                 }
@@ -135,9 +145,7 @@ class TestRequestHandler:
         reg_path = tmp_path / "registry.json"
         reg_path.write_text(json.dumps(registry))
 
-        flow = _make_http_flow(
-            client_ip="10.200.0.5", host="api.github.com", path="/repos"
-        )
+        flow = _make_http_flow(client_ip="10.200.0.5", host="api.github.com", path="/repos")
 
         mock_handler = AsyncMock()
         with (
@@ -166,15 +174,26 @@ class TestRequestHandler:
                     "sandboxToken": "tok-conn",
                     "networkLogPath": str(tmp_path / "net.jsonl"),
                     "firewalls": [
-                        {"name": "github", "ref": "github", "apis": [
-                            {
-                                "base": "https://api.github.com",
-                                "auth": {"headers": {"Authorization": "Bearer ${{ secrets.GITHUB_TOKEN }}"}},
-                                "permissions": [
-                                    {"name": "read-repos", "rules": ["GET /repos/{owner}/{repo}"]},
-                                ],
-                            },
-                        ]},
+                        {
+                            "name": "github",
+                            "ref": "github",
+                            "apis": [
+                                {
+                                    "base": "https://api.github.com",
+                                    "auth": {
+                                        "headers": {
+                                            "Authorization": "Bearer ${{ secrets.GITHUB_TOKEN }}"
+                                        }
+                                    },
+                                    "permissions": [
+                                        {
+                                            "name": "read-repos",
+                                            "rules": ["GET /repos/{owner}/{repo}"],
+                                        },
+                                    ],
+                                },
+                            ],
+                        },
                     ],
                     "encryptedSecrets": "iv:tag:data",
                 }
@@ -183,9 +202,7 @@ class TestRequestHandler:
         reg_path = tmp_path / "registry.json"
         reg_path.write_text(json.dumps(registry))
 
-        flow = _make_http_flow(
-            client_ip="10.200.0.5", host="api.github.com", path="/orgs"
-        )
+        flow = _make_http_flow(client_ip="10.200.0.5", host="api.github.com", path="/orgs")
 
         mock_handler = AsyncMock()
         with (
@@ -218,15 +235,26 @@ class TestRequestHandler:
                     "sandboxToken": "tok-conn",
                     "networkLogPath": str(tmp_path / "net.jsonl"),
                     "firewalls": [
-                        {"name": "github", "ref": "github", "apis": [
-                            {
-                                "base": "https://api.github.com",
-                                "auth": {"headers": {"Authorization": "Bearer ${{ secrets.GITHUB_TOKEN }}"}},
-                                "permissions": [
-                                    {"name": "read-repos", "rules": ["GET /repos/{owner}/{repo}"]},
-                                ],
-                            },
-                        ]},
+                        {
+                            "name": "github",
+                            "ref": "github",
+                            "apis": [
+                                {
+                                    "base": "https://api.github.com",
+                                    "auth": {
+                                        "headers": {
+                                            "Authorization": "Bearer ${{ secrets.GITHUB_TOKEN }}"
+                                        }
+                                    },
+                                    "permissions": [
+                                        {
+                                            "name": "read-repos",
+                                            "rules": ["GET /repos/{owner}/{repo}"],
+                                        },
+                                    ],
+                                },
+                            ],
+                        },
                     ],
                     "encryptedSecrets": "iv:tag:data",
                 }
@@ -268,13 +296,19 @@ class TestRequestHandler:
                     "sandboxToken": "tok-conn",
                     "networkLogPath": str(tmp_path / "net.jsonl"),
                     "firewalls": [
-                        {"name": "github", "ref": "github", "apis": [
-                            {
-                                "base": "https://api.github.com",
-                                "auth": {"headers": {}},
-                                "permissions": [{"name": "full-access", "rules": ["ANY /{path+}"]}],
-                            },
-                        ]},
+                        {
+                            "name": "github",
+                            "ref": "github",
+                            "apis": [
+                                {
+                                    "base": "https://api.github.com",
+                                    "auth": {"headers": {}},
+                                    "permissions": [
+                                        {"name": "full-access", "rules": ["ANY /{path+}"]}
+                                    ],
+                                },
+                            ],
+                        },
                     ],
                     "encryptedSecrets": "iv:tag:data",
                 }
@@ -284,9 +318,7 @@ class TestRequestHandler:
         reg_path.write_text(json.dumps(registry))
 
         # Request to example.com — not a firewall match, passes through
-        flow = _make_http_flow(
-            client_ip="10.200.0.5", host="api.example.com", path="/data"
-        )
+        flow = _make_http_flow(client_ip="10.200.0.5", host="api.example.com", path="/data")
 
         mock_handler = AsyncMock()
         with (

--- a/crates/runner/mitm-addon/tests/test_registry.py
+++ b/crates/runner/mitm-addon/tests/test_registry.py
@@ -1,7 +1,8 @@
 """Tests for registry loading, caching, and network logging."""
+
 import json
 from pathlib import Path
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
 
 import mitm_addon
 

--- a/crates/runner/mitm-addon/tests/test_utils.py
+++ b/crates/runner/mitm-addon/tests/test_utils.py
@@ -1,5 +1,7 @@
 """Tests for URL utility functions."""
+
 from unittest.mock import MagicMock
+
 from mitm_addon import get_original_url
 
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -37,6 +37,16 @@ pre-commit:
             run: cargo clippy --all-targets --all-features
             root: crates/
             glob: "crates/**/*.{rs,toml}"
+          - name: ruff-fmt
+            run: ruff format .
+            root: crates/runner/mitm-addon/
+            glob: "crates/runner/mitm-addon/**/*.py"
+            stage_fixed: true
+          - name: ruff-check
+            run: ruff check --fix .
+            root: crates/runner/mitm-addon/
+            glob: "crates/runner/mitm-addon/**/*.py"
+            stage_fixed: true
     - name: check-file-size
       run: ./scripts/check-file-size.sh {staged_files}
       glob: "**/*"


### PR DESCRIPTION
## Summary
- Add ruff as linter/formatter for `crates/runner/mitm-addon/` Python code
- Configure in `pyproject.toml` (line-length=100, E/F/I rules, dev optional-dep)
- Add `ruff check` + `ruff format --check` to `crates.yml` CI
- Add `ruff-fmt` and `ruff-check` pre-commit hooks in `lefthook.yml`
- Fix all existing violations (import sorting, unused imports, line length, formatting)

Closes #5651

## Test plan
- [ ] CI `mitm-addon-test` job passes (lint + format + tests)
- [ ] Pre-commit hooks trigger on `.py` file changes in mitm-addon

🤖 Generated with [Claude Code](https://claude.com/claude-code)