### PR TITLE
feat: add no-secret provider shape for vm0 managed provider

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-onboarding.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-onboarding.test.ts
@@ -5,9 +5,13 @@ import { testContext } from "../../__tests__/test-helpers.ts";
 import { setupPage } from "../../../__tests__/page-helper.ts";
 import {
   completeZeroOnboarding$,
+  saveZeroModelProvider$,
   setZeroAgentName$,
+  setZeroProviderType$,
   setZeroStep$,
   toggleZeroSkill$,
+  zeroCanSave$,
+  zeroFormValues$,
   zeroOnboardingStep$,
   zeroOnboardingError$,
   zeroSaving$,
@@ -270,5 +274,75 @@ describe("completeZeroOnboarding$", () => {
 
     expect(context.store.get(zeroOnboardingError$)).toBeNull();
     expect(context.store.get(zeroOnboardingStep$)).toBe("done");
+  });
+});
+
+describe("zero-onboarding vm0 no-secret provider", () => {
+  it("should allow saving without a secret for vm0 provider", async () => {
+    await setupPage({ context, path: "/", withoutRender: true });
+
+    // Switch to vm0 provider type
+    context.store.set(setZeroProviderType$, "vm0");
+
+    // zeroCanSave$ should return true without entering any secret
+    const canSave = context.store.get(zeroCanSave$);
+    expect(canSave).toBeTruthy();
+  });
+
+  it("should initialize useDefaultModel to false when provider has a default model", async () => {
+    await setupPage({ context, path: "/", withoutRender: true });
+
+    // Switch to vm0 provider — vm0 has a default model (claude-sonnet-4.6)
+    context.store.set(setZeroProviderType$, "vm0");
+
+    const formValues = context.store.get(zeroFormValues$);
+    expect(formValues.useDefaultModel).toBeFalsy();
+    expect(formValues.selectedModel).toBe("claude-sonnet-4.6");
+  });
+
+  it("should not include secret in request when saving vm0 provider", async () => {
+    let capturedBody: Record<string, unknown> | null = null;
+
+    server.use(
+      http.put("*/api/org/model-providers", async ({ request }) => {
+        capturedBody = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json(
+          {
+            provider: {
+              id: "test-id",
+              type: "vm0",
+              framework: "claude-code",
+              secretName: null,
+              authMethod: null,
+              secretNames: null,
+              isDefault: true,
+              selectedModel: (capturedBody.selectedModel as string) ?? null,
+              createdAt: new Date().toISOString(),
+              updatedAt: new Date().toISOString(),
+            },
+            created: true,
+          },
+          { status: 201 },
+        );
+      }),
+    );
+
+    await setupPage({ context, path: "/", withoutRender: true });
+
+    // Switch to vm0 provider type
+    context.store.set(setZeroProviderType$, "vm0");
+
+    // Save the model provider
+    await context.store.set(saveZeroModelProvider$, context.signal);
+
+    // Should have sent the request
+    expect(capturedBody).not.toBeNull();
+    expect(capturedBody!.type).toBe("vm0");
+
+    // Should NOT include a secret field
+    expect(capturedBody).not.toHaveProperty("secret");
+
+    // Should include the pre-selected model
+    expect(capturedBody!.selectedModel).toBe("claude-sonnet-4.6");
   });
 });

--- a/turbo/apps/platform/src/signals/zero-page/settings/__tests__/org-model-providers.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/__tests__/org-model-providers.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../../mocks/server.ts";
+import { testContext } from "../../../__tests__/test-helpers.ts";
+import {
+  orgOpenAddDialog$,
+  orgSubmitDialog$,
+  orgDialogFormValues$,
+  orgFormErrors$,
+  orgUpdateFormModel$,
+} from "../org-model-providers.ts";
+import { getProviderShape } from "../../../../views/zero-page/components/settings/provider-ui-config.ts";
+
+const context = testContext();
+
+describe("org-model-providers vm0 provider", () => {
+  it("should treat vm0 as a no-secret provider shape, not api-key", () => {
+    const shape = getProviderShape("vm0");
+    expect(shape).not.toBe("api-key");
+    expect(shape).toBe("no-secret");
+  });
+
+  it("should not require an API key when submitting a vm0 provider", async () => {
+    const { store, signal } = context;
+    let capturedBody: Record<string, unknown> | null = null;
+
+    server.use(
+      http.put("*/api/org/model-providers", async ({ request }) => {
+        capturedBody = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json(
+          {
+            provider: {
+              id: "test-id",
+              type: "vm0",
+              framework: "claude-code",
+              secretName: null,
+              authMethod: null,
+              secretNames: null,
+              isDefault: true,
+              selectedModel: (capturedBody.selectedModel as string) ?? null,
+              createdAt: new Date().toISOString(),
+              updatedAt: new Date().toISOString(),
+            },
+            created: true,
+          },
+          { status: 201 },
+        );
+      }),
+    );
+
+    // Open the add dialog for vm0
+    store.set(orgOpenAddDialog$, "vm0");
+
+    // Submit without providing any secret (vm0 should not need one)
+    await store.set(orgSubmitDialog$, signal);
+
+    // Should not have validation errors
+    const errors = store.get(orgFormErrors$);
+    expect(errors).toStrictEqual({});
+
+    // Should have sent the request
+    expect(capturedBody).not.toBeNull();
+    expect(capturedBody!.type).toBe("vm0");
+  });
+
+  it("should include selectedModel when user accepts the pre-selected default without changing it", async () => {
+    const { store, signal } = context;
+    let capturedBody: Record<string, unknown> | null = null;
+
+    server.use(
+      http.put("*/api/org/model-providers", async ({ request }) => {
+        capturedBody = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json(
+          {
+            provider: {
+              id: "test-id",
+              type: "vm0",
+              framework: "claude-code",
+              secretName: null,
+              authMethod: null,
+              secretNames: null,
+              isDefault: true,
+              selectedModel: (capturedBody.selectedModel as string) ?? null,
+              createdAt: new Date().toISOString(),
+              updatedAt: new Date().toISOString(),
+            },
+            created: true,
+          },
+          { status: 201 },
+        );
+      }),
+    );
+
+    // Open the add dialog for vm0 — the default model is pre-selected
+    store.set(orgOpenAddDialog$, "vm0");
+
+    // Verify the form has a pre-selected model
+    const formValues = store.get(orgDialogFormValues$);
+    expect(formValues.selectedModel).toBe("claude-sonnet-4.6");
+
+    // Submit WITHOUT changing the model selector (user accepted the default)
+    await store.set(orgSubmitDialog$, signal);
+
+    // The selectedModel should be included in the request
+    expect(capturedBody).not.toBeNull();
+    expect(capturedBody!.selectedModel).toBe("claude-sonnet-4.6");
+  });
+
+  it("should include selectedModel when user explicitly changes the model", async () => {
+    const { store, signal } = context;
+    let capturedBody: Record<string, unknown> | null = null;
+
+    server.use(
+      http.put("*/api/org/model-providers", async ({ request }) => {
+        capturedBody = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json(
+          {
+            provider: {
+              id: "test-id",
+              type: "vm0",
+              framework: "claude-code",
+              secretName: null,
+              authMethod: null,
+              secretNames: null,
+              isDefault: true,
+              selectedModel: (capturedBody.selectedModel as string) ?? null,
+              createdAt: new Date().toISOString(),
+              updatedAt: new Date().toISOString(),
+            },
+            created: true,
+          },
+          { status: 201 },
+        );
+      }),
+    );
+
+    // Open the add dialog for vm0
+    store.set(orgOpenAddDialog$, "vm0");
+
+    // User explicitly selects a different model
+    store.set(orgUpdateFormModel$, "claude-opus-4");
+
+    // Submit
+    await store.set(orgSubmitDialog$, signal);
+
+    // The selectedModel should be included in the request
+    expect(capturedBody).not.toBeNull();
+    expect(capturedBody!.selectedModel).toBe("claude-opus-4");
+  });
+});

--- a/turbo/apps/platform/src/signals/zero-page/settings/org-model-providers.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/org-model-providers.ts
@@ -4,6 +4,7 @@ import {
   MODEL_PROVIDER_TYPES,
   getDefaultAuthMethod,
   getDefaultModel,
+  getSecretNameForType,
   getSecretsForAuthMethod,
   hasAuthMethods,
   hasModelSelection,
@@ -143,7 +144,7 @@ export const orgOpenAddDialog$ = command(
       selectedModel: defaultModel,
       authMethod: defaultAuth,
       secrets: {},
-      useDefaultModel: true,
+      useDefaultModel: !defaultModel,
     });
     set(internalOrgFormErrors$, {});
     set(internalOrgDialogState$, {
@@ -273,7 +274,10 @@ export const orgSubmitDialog$ = command(
           }
         }
       }
-    } else if (dialogState.mode === "add") {
+    } else if (
+      dialogState.mode === "add" &&
+      getSecretNameForType(providerType)
+    ) {
       if (!formValues.secret.trim()) {
         errors["secret"] =
           providerType === "claude-code-oauth-token"

--- a/turbo/apps/platform/src/signals/zero-page/zero-onboarding.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-onboarding.ts
@@ -152,6 +152,10 @@ export const zeroCanSave$ = computed((get) => {
     return true;
   }
 
+  if (shape === "no-secret") {
+    return true;
+  }
+
   return formValues.secret.trim().length > 0;
 });
 
@@ -183,7 +187,7 @@ export const setZeroProviderType$ = command(
       selectedModel: defaultModel,
       authMethod: defaultAuth,
       secrets: {},
-      useDefaultModel: true,
+      useDefaultModel: !defaultModel,
     });
   },
 );
@@ -274,7 +278,7 @@ export const saveZeroModelProvider$ = command(
       if (shape === "multi-auth") {
         request.authMethod = formValues.authMethod;
         request.secrets = formValues.secrets;
-      } else {
+      } else if (shape !== "no-secret") {
         request.secret = formValues.secret.trim();
       }
 

--- a/turbo/apps/platform/src/views/zero-page/components/settings/org-provider-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/org-provider-dialog.tsx
@@ -29,6 +29,7 @@ import {
   OAuthFields,
   ApiKeyFields,
   MultiAuthFields,
+  NoSecretFields,
 } from "./provider-dialog-fields.tsx";
 
 export function OrgProviderDialog() {
@@ -139,6 +140,16 @@ export function OrgProviderDialog() {
               onUseDefaultModelChange={setUseDefaultModel}
               errors={errors}
               isLoading={isLoading}
+            />
+          )}
+
+          {shape === "no-secret" && (
+            <NoSecretFields
+              providerType={providerType}
+              selectedModel={formValues.selectedModel}
+              useDefaultModel={formValues.useDefaultModel}
+              onModelChange={setModel}
+              onUseDefaultModelChange={setUseDefaultModel}
             />
           )}
         </div>

--- a/turbo/apps/platform/src/views/zero-page/components/settings/provider-dialog-fields.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/provider-dialog-fields.tsx
@@ -231,6 +231,10 @@ export function NoSecretFields({
   onModelChange: (value: string) => void;
   onUseDefaultModelChange: (value: boolean) => void;
 }) {
+  if (!hasModelSelection(providerType)) {
+    return null;
+  }
+
   return (
     <ModelSelector
       providerType={providerType}

--- a/turbo/apps/platform/src/views/zero-page/components/settings/provider-dialog-fields.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/provider-dialog-fields.tsx
@@ -16,6 +16,7 @@ import {
   hasModelSelection,
   allowsCustomModel,
   getCustomModelPlaceholder,
+  type ModelProviderType,
 } from "@vm0/core";
 import {
   getUIDefaultModel,
@@ -210,6 +211,34 @@ export function MultiAuthFields({
         onUseDefaultModelChange={onUseDefaultModelChange}
       />
     </>
+  );
+}
+
+/**
+ * Fields for providers that require no secret (e.g. vm0 managed provider).
+ * Only renders the model selector if the provider supports model selection.
+ */
+export function NoSecretFields({
+  providerType,
+  selectedModel,
+  useDefaultModel,
+  onModelChange,
+  onUseDefaultModelChange,
+}: {
+  providerType: ModelProviderType;
+  selectedModel: string;
+  useDefaultModel: boolean;
+  onModelChange: (value: string) => void;
+  onUseDefaultModelChange: (value: boolean) => void;
+}) {
+  return (
+    <ModelSelector
+      providerType={providerType}
+      selectedModel={selectedModel}
+      useDefaultModel={useDefaultModel}
+      onModelChange={onModelChange}
+      onUseDefaultModelChange={onUseDefaultModelChange}
+    />
   );
 }
 

--- a/turbo/apps/platform/src/views/zero-page/components/settings/provider-form-fields.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/provider-form-fields.tsx
@@ -132,6 +132,16 @@ export function ProviderFormFields({
           isLoading={isLoading}
         />
       )}
+
+      {shape === "no-secret" && hasModelSelection(providerType) && (
+        <ModelSelector
+          providerType={providerType}
+          selectedModel={formValues.selectedModel}
+          useDefaultModel={formValues.useDefaultModel}
+          onModelChange={onModelChange}
+          onUseDefaultModelChange={onUseDefaultModelChange}
+        />
+      )}
     </>
   );
 }

--- a/turbo/apps/platform/src/views/zero-page/components/settings/provider-ui-config.ts
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/provider-ui-config.ts
@@ -1,5 +1,6 @@
 import {
   MODEL_PROVIDER_TYPES,
+  getSecretNameForType,
   hasAuthMethods,
   type ModelProviderType,
   type SecretFieldConfig,
@@ -7,8 +8,13 @@ import {
 
 /**
  * Provider dialog shape: determines which dialog UI to render
+ *
+ * - "oauth": OAuth token flow (e.g. claude-code-oauth-token)
+ * - "multi-auth": Multiple auth methods with secret fields (e.g. aws-bedrock)
+ * - "no-secret": No credentials needed (e.g. vm0 managed provider)
+ * - "api-key": Single API key input (default for legacy providers)
  */
-type ProviderShape = "oauth" | "api-key" | "multi-auth";
+type ProviderShape = "oauth" | "api-key" | "multi-auth" | "no-secret";
 
 export function getProviderShape(type: ModelProviderType): ProviderShape {
   if (type === "claude-code-oauth-token") {
@@ -16,6 +22,9 @@ export function getProviderShape(type: ModelProviderType): ProviderShape {
   }
   if (hasAuthMethods(type)) {
     return "multi-auth";
+  }
+  if (!getSecretNameForType(type)) {
+    return "no-secret";
   }
   return "api-key";
 }


### PR DESCRIPTION
## Summary
- Adds a new `no-secret` provider shape for providers that don't require API keys or secrets (e.g. the vm0 managed provider)
- Updates the provider dialog UI (both org settings and zero-onboarding) to render a model-only selector for no-secret providers
- Fixes `useDefaultModel` initialization to be `false` when a default model exists, so the pre-selected model is correctly sent in requests
- Adds integration tests verifying vm0 provider submission works without secrets and includes selected model

## Test plan
- [ ] Verify vm0 provider can be added from org settings without entering any secret
- [ ] Verify vm0 provider can be added from zero-onboarding without entering any secret
- [ ] Verify model selection works correctly for vm0 provider
- [ ] Run `pnpm vitest` to confirm all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)