### PR TITLE
fix: default artifactName to "artifact" in startRun()

### DIFF
--- a/turbo/apps/web/src/lib/run/run-service.ts
+++ b/turbo/apps/web/src/lib/run/run-service.ts
@@ -921,7 +921,7 @@ export async function startRun(
     conversationId: params.conversationId,
     vars: params.vars,
     secrets: params.secrets,
-    artifactName: params.artifactName,
+    artifactName: params.artifactName ?? "artifact",
     artifactVersion: params.artifactVersion,
     memoryName: params.memoryName,
     volumeVersions: params.volumeVersions,


### PR DESCRIPTION
## Summary

- Default `artifactName` to `"artifact"` inside `startRun()` when the caller does not provide one
- Callers can still override by explicitly passing `artifactName`

## Change

```ts
// Before
artifactName: params.artifactName,

// After
artifactName: params.artifactName ?? "artifact",
```

One line in `run-service.ts:924`. No interface changes, no caller changes needed.

Closes #5661