### PR TITLE
feat: add files:write scope to Slack connector

### DIFF
--- a/turbo/packages/core/src/contracts/connectors.ts
+++ b/turbo/packages/core/src/contracts/connectors.ts
@@ -584,13 +584,46 @@ const CONNECTOR_TYPES_DEF = {
       authorizationUrl: "https://slack.com/oauth/v2/authorize",
       tokenUrl: "https://slack.com/api/oauth.v2.access",
       scopes: [
+        // Channels
         "channels:read",
         "channels:history",
+        // Messaging
         "chat:write",
+        // Users
         "users:read",
         "users:read.email",
+        // Files
         "files:read",
         "files:write",
+        // Direct messages (high priority)
+        "im:history",
+        "im:write",
+        // Reactions (high priority)
+        "reactions:read",
+        "reactions:write",
+        // Search (high priority)
+        "search:read",
+        // Private channels (high priority)
+        "groups:read",
+        "groups:history",
+        // Reminders (medium priority)
+        "reminders:read",
+        "reminders:write",
+        // Pins (medium priority)
+        "pins:read",
+        "pins:write",
+        // User groups (medium priority)
+        "usergroups:read",
+        // Multi-person DMs (medium priority)
+        "mpim:history",
+        // Do Not Disturb (low priority)
+        "dnd:read",
+        // Bookmarks (low priority)
+        "bookmarks:read",
+        // Team info (low priority)
+        "team:read",
+        // Custom emoji (low priority)
+        "emoji:read",
       ],
       environmentMapping: {
         SLACK_TOKEN: "$secrets.SLACK_ACCESS_TOKEN",

--- a/turbo/packages/core/src/contracts/connectors.ts
+++ b/turbo/packages/core/src/contracts/connectors.ts
@@ -590,6 +590,7 @@ const CONNECTOR_TYPES_DEF = {
         "users:read",
         "users:read.email",
         "files:read",
+        "files:write",
       ],
       environmentMapping: {
         SLACK_TOKEN: "$secrets.SLACK_ACCESS_TOKEN",


### PR DESCRIPTION
## Summary

Expands the Slack OAuth connector scopes to cover the full range of capabilities needed for Zero as an office assistant.

**High priority (core assistant capabilities)**
- \`im:history\` + \`im:write\` — Read and send direct messages
- \`reactions:read\` + \`reactions:write\` — Emoji reactions for lightweight acknowledgment (👍 read, ✅ done)
- \`search:read\` — Search messages and files across the workspace
- \`groups:read\` + \`groups:history\` — Access private channels (without this, assistant is blind in private channels)

**Medium priority (workflow improvement)**
- \`reminders:read\` + \`reminders:write\` — Create and manage reminders / follow-ups
- \`pins:read\` + \`pins:write\` — Read and pin important messages
- \`usergroups:read\` — Support @team level operations
- \`mpim:history\` — Read group DM history

**Low priority (quality of life)**
- \`dnd:read\` — Check do-not-disturb status before pinging users
- \`bookmarks:read\` — Read channel bookmarks
- \`team:read\` — Read workspace info
- \`emoji:read\` — List custom emoji

## Test plan

- [ ] Reconnect Slack connector after deployment
- [ ] Verify DM read/write works
- [ ] Verify file upload works (files:write)
- [ ] Verify search returns results (search:read)
- [ ] Verify reactions can be added to messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)