### PR TITLE
fix: persist trigger source when enqueueing runs

### DIFF
--- a/turbo/apps/web/src/lib/run/__tests__/run-queue-service.test.ts
+++ b/turbo/apps/web/src/lib/run/__tests__/run-queue-service.test.ts
@@ -71,6 +71,22 @@ describe("run-queue-service", () => {
       expect(queueEntry!.expiresAt).toBeInstanceOf(Date);
     });
 
+    it("should persist triggerSource on the queued run record", async () => {
+      const result = await enqueueRun(
+        baseParams({ prompt: "Web run", triggerSource: "web" }),
+      );
+
+      const run = await findTestRunRecord(result.runId);
+      expect(run!.triggerSource).toBe("web");
+    });
+
+    it("should default triggerSource to cli when not provided", async () => {
+      const result = await enqueueRun(baseParams({ prompt: "No source" }));
+
+      const run = await findTestRunRecord(result.runId);
+      expect(run!.triggerSource).toBe("cli");
+    });
+
     it("should store encrypted params that can be decrypted", async () => {
       const secrets = { API_KEY: "sk-secret-123" };
       const result = await enqueueRun(

--- a/turbo/apps/web/src/lib/run/run-queue-service.ts
+++ b/turbo/apps/web/src/lib/run/run-queue-service.ts
@@ -71,6 +71,7 @@ export async function enqueueRun(
         continuedFromSessionId: params.sessionId ?? null,
         scheduleId: params.scheduleId ?? null,
         modelProvider: params.modelProvider ?? null,
+        triggerSource: params.triggerSource ?? "cli",
         lastHeartbeatAt: new Date(),
       })
       .returning();


### PR DESCRIPTION
## Summary

- `enqueueRun()` was missing the `triggerSource` field in its DB insert, causing queued runs to have `NULL` `trigger_source`
- `inferTriggerSource()` falls back to `"cli"` for NULL values, so runs triggered from the web UI but queued due to concurrency limits incorrectly showed as "cli" source
- Added `triggerSource: params.triggerSource ?? "cli"` to match the same pattern used in `createRun()`

## Test plan

- [x] Added test: `should persist triggerSource on the queued run record` — verifies explicit `"web"` source is stored
- [x] Added test: `should default triggerSource to cli when not provided` — verifies fallback behavior
- [x] All 17 existing run-queue-service tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)