### PR TITLE
feat: add rust test coverage reporting to codecov

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -110,10 +110,10 @@ jobs:
       - name: Run tests with coverage
         run: |
           cd crates
-          cargo llvm-cov --all-targets --lcov --output-path lcov.info
+          cargo llvm-cov --all-targets --all-features --lcov --output-path lcov.info
 
       - name: Upload coverage to Codecov
-        if: always()
+        if: success() || failure()
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -104,10 +104,21 @@ jobs:
           cd crates
           cargo clippy --all-targets --all-features
 
-      - name: Run tests
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+
+      - name: Run tests with coverage
         run: |
           cd crates
-          cargo test --all-targets
+          cargo llvm-cov --all-targets --lcov --output-path lcov.info
+
+      - name: Upload coverage to Codecov
+        if: always()
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: crates/lcov.info
+          flags: rust
 
       - name: Run ably-subscriber smoke test
         if: |


### PR DESCRIPTION
## Summary

- Install `cargo-llvm-cov` via `taiki-e/install-action` in the `check` job
- Replace `cargo test --all-targets` with `cargo llvm-cov --all-targets --lcov` to generate coverage reports
- Upload lcov report to Codecov with `rust` flag for independent tracking

Closes #5637

## Test plan

- [ ] CI `check` job passes with `cargo llvm-cov` instead of `cargo test`
- [ ] Codecov receives the Rust coverage upload (check Codecov dashboard after merge)
- [ ] Coverage flag `rust` appears in Codecov UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)