### PR TITLE
fix: deduplicate slack error messages on run dispatch failure

### DIFF
--- a/turbo/apps/web/src/lib/slack-org/__tests__/mention-error-dedup.test.ts
+++ b/turbo/apps/web/src/lib/slack-org/__tests__/mention-error-dedup.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  testContext,
+  uniqueId,
+  type UserContext,
+} from "../../../__tests__/test-helpers";
+import {
+  createTestCompose,
+  createTestSlackOrgInstallation,
+  seedTestSlackOrgConnection,
+  seedTestCompose,
+  updateOrgDefaultAgent,
+} from "../../../__tests__/api-test-helpers";
+import { handleOrgMention } from "../handlers/mention";
+import { handleOrgDirectMessage } from "../handlers/direct-message";
+
+/**
+ * Mock @slack/web-api (external dependency).
+ * vi.hoisted() ensures the mock fns are available when vi.mock is hoisted.
+ */
+const { mockPostMessage, mockPostEphemeral, mockSetStatus, MockWebClient } =
+  vi.hoisted(() => {
+    const mockPostMessage = vi.fn().mockResolvedValue({ ok: true, ts: "1.1" });
+    const mockPostEphemeral = vi.fn().mockResolvedValue({ ok: true });
+    const mockSetStatus = vi.fn().mockResolvedValue({ ok: true });
+    const mockUsersInfo = vi.fn().mockResolvedValue({
+      ok: true,
+      user: { id: "U-test", profile: { display_name: "Test" }, tz: "UTC" },
+    });
+    const mockConversationsReplies = vi.fn().mockResolvedValue({
+      ok: true,
+      messages: [],
+    });
+    const mockConversationsHistory = vi.fn().mockResolvedValue({
+      ok: true,
+      messages: [],
+    });
+
+    class MockWebClient {
+      chat = {
+        postMessage: mockPostMessage,
+        postEphemeral: mockPostEphemeral,
+      };
+      assistant = {
+        threads: { setStatus: mockSetStatus },
+      };
+      users = { info: mockUsersInfo };
+      conversations = {
+        replies: mockConversationsReplies,
+        history: mockConversationsHistory,
+      };
+    }
+
+    return {
+      mockPostMessage,
+      mockPostEphemeral,
+      mockSetStatus,
+      MockWebClient,
+    };
+  });
+
+vi.mock("@slack/web-api", () => ({
+  WebClient: MockWebClient,
+}));
+
+const context = testContext();
+
+describe("Slack org error message deduplication", () => {
+  let user: UserContext;
+
+  beforeEach(async () => {
+    context.setupMocks();
+    user = await context.setupUser();
+    mockPostMessage.mockClear();
+    mockPostEphemeral.mockClear();
+    mockSetStatus.mockClear();
+  });
+
+  /**
+   * Set up workspace installation + connection for the test user.
+   */
+  async function setupWorkspace(
+    orgId: string,
+    opts?: { slackUserId?: string },
+  ): Promise<{ workspaceId: string; slackUserId: string }> {
+    const workspaceId = uniqueId("T-ws");
+    const slackUserId = opts?.slackUserId ?? uniqueId("U-slack");
+
+    await createTestSlackOrgInstallation({ workspaceId, orgId });
+    await seedTestSlackOrgConnection({
+      slackUserId,
+      slackWorkspaceId: workspaceId,
+      vm0UserId: user.userId,
+    });
+
+    return { workspaceId, slackUserId };
+  }
+
+  /** Filter postMessage calls that contain the generic error text. */
+  function errorMessageCalls(): unknown[][] {
+    return mockPostMessage.mock.calls.filter((call: unknown[]) => {
+      const arg = call[0] as Record<string, unknown>;
+      return (
+        typeof arg.text === "string" &&
+        arg.text.includes("Something went wrong")
+      );
+    });
+  }
+
+  describe("handleOrgMention", () => {
+    it("should not post error when run was created (callback handles it)", async () => {
+      // Set up a valid compose so the run IS created before dispatch fails
+      const compose = await createTestCompose(uniqueId("agent"));
+      await updateOrgDefaultAgent(user.orgId, compose.composeId);
+      const { workspaceId, slackUserId } = await setupWorkspace(user.orgId);
+
+      await handleOrgMention({
+        workspaceId,
+        channelId: "C-test",
+        userId: slackUserId,
+        messageText: "Hello agent",
+        messageTs: "1000.001",
+      });
+
+      // The run was created but dispatch failed → runId exists.
+      // Handler should NOT post an error (callback will handle it).
+      expect(errorMessageCalls()).toHaveLength(0);
+    });
+
+    it("should post error when run was not created (no callback)", async () => {
+      // Set up a compose WITHOUT a version → startRun fails before creating the run
+      const { composeId } = await seedTestCompose({
+        userId: user.userId,
+        name: uniqueId("agent"),
+        orgId: user.orgId,
+      });
+      await updateOrgDefaultAgent(user.orgId, composeId);
+      const { workspaceId, slackUserId } = await setupWorkspace(user.orgId);
+
+      await handleOrgMention({
+        workspaceId,
+        channelId: "C-test",
+        userId: slackUserId,
+        messageText: "Hello agent",
+        messageTs: "1000.002",
+      });
+
+      // startRun failed before creating a run → no runId → no callback.
+      // Handler should post the error message.
+      expect(errorMessageCalls()).toHaveLength(1);
+    });
+  });
+
+  describe("handleOrgDirectMessage", () => {
+    it("should not post error when run was created (callback handles it)", async () => {
+      const compose = await createTestCompose(uniqueId("agent"));
+      await updateOrgDefaultAgent(user.orgId, compose.composeId);
+      const { workspaceId, slackUserId } = await setupWorkspace(user.orgId);
+
+      await handleOrgDirectMessage({
+        workspaceId,
+        channelId: "D-test",
+        userId: slackUserId,
+        messageText: "Hello agent",
+        messageTs: "2000.001",
+      });
+
+      expect(errorMessageCalls()).toHaveLength(0);
+    });
+
+    it("should post error when run was not created (no callback)", async () => {
+      const { composeId } = await seedTestCompose({
+        userId: user.userId,
+        name: uniqueId("agent"),
+        orgId: user.orgId,
+      });
+      await updateOrgDefaultAgent(user.orgId, composeId);
+      const { workspaceId, slackUserId } = await setupWorkspace(user.orgId);
+
+      await handleOrgDirectMessage({
+        workspaceId,
+        channelId: "D-test",
+        userId: slackUserId,
+        messageText: "Hello agent",
+        messageTs: "2000.002",
+      });
+
+      expect(errorMessageCalls()).toHaveLength(1);
+    });
+  });
+});

--- a/turbo/apps/web/src/lib/slack-org/__tests__/mention-error-dedup.test.ts
+++ b/turbo/apps/web/src/lib/slack-org/__tests__/mention-error-dedup.test.ts
@@ -18,49 +18,55 @@ import { handleOrgDirectMessage } from "../handlers/direct-message";
  * Mock @slack/web-api (external dependency).
  * vi.hoisted() ensures the mock fns are available when vi.mock is hoisted.
  */
-const { mockPostMessage, mockPostEphemeral, mockSetStatus, MockWebClient } =
-  vi.hoisted(() => {
-    const mockPostMessage = vi.fn().mockResolvedValue({ ok: true, ts: "1.1" });
-    const mockPostEphemeral = vi.fn().mockResolvedValue({ ok: true });
-    const mockSetStatus = vi.fn().mockResolvedValue({ ok: true });
-    const mockUsersInfo = vi.fn().mockResolvedValue({
-      ok: true,
-      user: { id: "U-test", profile: { display_name: "Test" }, tz: "UTC" },
-    });
-    const mockConversationsReplies = vi.fn().mockResolvedValue({
-      ok: true,
-      messages: [],
-    });
-    const mockConversationsHistory = vi.fn().mockResolvedValue({
-      ok: true,
-      messages: [],
-    });
-
-    class MockWebClient {
-      chat = {
-        postMessage: mockPostMessage,
-        postEphemeral: mockPostEphemeral,
-      };
-      assistant = {
-        threads: { setStatus: mockSetStatus },
-      };
-      users = { info: mockUsersInfo };
-      conversations = {
-        replies: mockConversationsReplies,
-        history: mockConversationsHistory,
-      };
-    }
-
-    return {
-      mockPostMessage,
-      mockPostEphemeral,
-      mockSetStatus,
-      MockWebClient,
-    };
+const {
+  mockPostMessage,
+  mockPostEphemeral,
+  mockSetStatus,
+  createMockWebClient,
+} = vi.hoisted(() => {
+  const mockPostMessage = vi.fn().mockResolvedValue({ ok: true, ts: "1.1" });
+  const mockPostEphemeral = vi.fn().mockResolvedValue({ ok: true });
+  const mockSetStatus = vi.fn().mockResolvedValue({ ok: true });
+  const mockUsersInfo = vi.fn().mockResolvedValue({
+    ok: true,
+    user: { id: "U-test", profile: { display_name: "Test" }, tz: "UTC" },
+  });
+  const mockConversationsReplies = vi.fn().mockResolvedValue({
+    ok: true,
+    messages: [],
+  });
+  const mockConversationsHistory = vi.fn().mockResolvedValue({
+    ok: true,
+    messages: [],
   });
 
+  function createMockWebClient() {
+    return {
+      chat: {
+        postMessage: mockPostMessage,
+        postEphemeral: mockPostEphemeral,
+      },
+      assistant: {
+        threads: { setStatus: mockSetStatus },
+      },
+      users: { info: mockUsersInfo },
+      conversations: {
+        replies: mockConversationsReplies,
+        history: mockConversationsHistory,
+      },
+    };
+  }
+
+  return {
+    mockPostMessage,
+    mockPostEphemeral,
+    mockSetStatus,
+    createMockWebClient,
+  };
+});
+
 vi.mock("@slack/web-api", () => ({
-  WebClient: MockWebClient,
+  WebClient: createMockWebClient,
 }));
 
 const context = testContext();
@@ -96,17 +102,6 @@ describe("Slack org error message deduplication", () => {
     return { workspaceId, slackUserId };
   }
 
-  /** Filter postMessage calls that contain the generic error text. */
-  function errorMessageCalls(): unknown[][] {
-    return mockPostMessage.mock.calls.filter((call: unknown[]) => {
-      const arg = call[0] as Record<string, unknown>;
-      return (
-        typeof arg.text === "string" &&
-        arg.text.includes("Something went wrong")
-      );
-    });
-  }
-
   describe("handleOrgMention", () => {
     it("should not post error when run was created (callback handles it)", async () => {
       // Set up a valid compose so the run IS created before dispatch fails
@@ -124,7 +119,7 @@ describe("Slack org error message deduplication", () => {
 
       // The run was created but dispatch failed → runId exists.
       // Handler should NOT post an error (callback will handle it).
-      expect(errorMessageCalls()).toHaveLength(0);
+      expect(mockPostMessage).not.toHaveBeenCalled();
     });
 
     it("should post error when run was not created (no callback)", async () => {
@@ -147,7 +142,7 @@ describe("Slack org error message deduplication", () => {
 
       // startRun failed before creating a run → no runId → no callback.
       // Handler should post the error message.
-      expect(errorMessageCalls()).toHaveLength(1);
+      expect(mockPostMessage).toHaveBeenCalledOnce();
     });
   });
 
@@ -165,7 +160,7 @@ describe("Slack org error message deduplication", () => {
         messageTs: "2000.001",
       });
 
-      expect(errorMessageCalls()).toHaveLength(0);
+      expect(mockPostMessage).not.toHaveBeenCalled();
     });
 
     it("should post error when run was not created (no callback)", async () => {
@@ -185,7 +180,7 @@ describe("Slack org error message deduplication", () => {
         messageTs: "2000.002",
       });
 
-      expect(errorMessageCalls()).toHaveLength(1);
+      expect(mockPostMessage).toHaveBeenCalledOnce();
     });
   });
 });

--- a/turbo/apps/web/src/lib/slack-org/handlers/direct-message.ts
+++ b/turbo/apps/web/src/lib/slack-org/handlers/direct-message.ts
@@ -21,7 +21,6 @@ import {
   enrichMessageContent,
   fetchConversationContexts,
   buildOrgConnectUrl,
-  buildLogsUrl,
   buildAgentLogsUrl,
   getWorkspaceAgent,
   resolveSessionCompose,
@@ -214,13 +213,21 @@ export async function handleOrgDirectMessage(
       ],
     });
   } else if (status === "failed") {
-    const errorText = response ?? "Sorry, an error occurred. Please try again.";
-    const logsUrl = runId ? buildLogsUrl(runId) : buildAgentLogsUrl();
-    const deepLinks = detectDeepLinks(errorText, getAppUrl(), agentName);
-    await postMessage(client, context.channelId, errorText, {
-      threadTs,
-      blocks: buildAgentResponseMessage(errorText, logsUrl, deepLinks),
-    });
+    log.error("Failed to dispatch agent run", { response, runId });
+
+    // When the run was created (runId exists), the completion callback
+    // will post the error to Slack — skip here to avoid duplicate messages.
+    if (!runId) {
+      const errorText =
+        response ?? "Sorry, an error occurred. Please try again.";
+      const logsUrl = buildAgentLogsUrl();
+      const deepLinks = detectDeepLinks(errorText, getAppUrl(), agentName);
+      await postMessage(client, context.channelId, errorText, {
+        threadTs,
+        blocks: buildAgentResponseMessage(errorText, logsUrl, deepLinks),
+      });
+    }
+
     await setThreadStatus(client, context.channelId, threadTs, "").catch(
       (err) => log.warn("Failed to clear thread status", { error: err }),
     );

--- a/turbo/apps/web/src/lib/slack-org/handlers/mention.ts
+++ b/turbo/apps/web/src/lib/slack-org/handlers/mention.ts
@@ -17,7 +17,6 @@ import {
   enrichMessageContent,
   fetchConversationContexts,
   buildOrgConnectUrl,
-  buildLogsUrl,
   buildAgentLogsUrl,
   getWorkspaceAgent,
   resolveSessionCompose,
@@ -212,16 +211,23 @@ export async function handleOrgMention(
       ],
     });
   } else if (status === "failed") {
-    log.error("Failed to dispatch agent run", { response });
-    const errorText = response ?? "Sorry, an error occurred. Please try again.";
-    const logsUrl = runId ? buildLogsUrl(runId) : buildAgentLogsUrl();
-    const deepLinks = detectDeepLinks(errorText, getAppUrl(), agentName);
-    await client.chat.postMessage({
-      channel: context.channelId,
-      thread_ts: threadTs,
-      text: errorText,
-      blocks: buildAgentResponseMessage(errorText, logsUrl, deepLinks),
-    });
+    log.error("Failed to dispatch agent run", { response, runId });
+
+    // When the run was created (runId exists), the completion callback
+    // will post the error to Slack — skip here to avoid duplicate messages.
+    if (!runId) {
+      const errorText =
+        response ?? "Sorry, an error occurred. Please try again.";
+      const logsUrl = buildAgentLogsUrl();
+      const deepLinks = detectDeepLinks(errorText, getAppUrl(), agentName);
+      await client.chat.postMessage({
+        channel: context.channelId,
+        thread_ts: threadTs,
+        text: errorText,
+        blocks: buildAgentResponseMessage(errorText, logsUrl, deepLinks),
+      });
+    }
+
     await setThreadStatus(client, context.channelId, threadTs, "").catch(
       (err) => log.warn("Failed to clear thread status", { error: err }),
     );


### PR DESCRIPTION
## Summary

- When a Slack-triggered run fails **after** the run record is created, both the mention/DM handler and the completion callback were posting error messages to Slack, resulting in duplicate messages
- Skip the handler-side error message when `runId` exists — the completion callback will post the actual error with more detail
- Only post from the handler when no run was created (no callback will fire)
- Applies to both `handleOrgMention` and `handleOrgDirectMessage`

## Test plan

- [x] Added integration tests for mention and DM handlers covering both cases:
  - Run created (dispatch fails after DB insert) → no handler error posted
  - Run not created (fails before DB insert) → handler posts error
- [x] Existing slack-org tests pass
- [x] Knip, lint, format all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)