### PR TITLE
ci: remove duplicate if condition in mitm-addon-test job

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -120,8 +120,6 @@ jobs:
           cargo run -p ably-subscriber --example smoke_test
 
   mitm-addon-test:
-    # Skip for release-please PRs (only version bumps and changelogs)
-    if: "!startsWith(github.head_ref || '', 'release-please--branches--')"
     runs-on: ubuntu-latest
     needs: [detect]
     if: needs.detect.outputs.any-changed == 'true'


### PR DESCRIPTION
## Summary
- `mitm-addon-test` job had two `if:` keys at the same YAML level — the second silently overwrites the first
- Removed the ineffective release-please skip condition since the `detect` job already gates on changed files

## Test plan
- [ ] CI workflow syntax is valid (GitHub Actions will validate on PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)