### PR TITLE
refactor: api layer separation phase 1 — foundation (infra-client + platform ts-rest)

### DIFF
--- a/turbo/apps/platform/package.json
+++ b/turbo/apps/platform/package.json
@@ -26,6 +26,7 @@
     "@tiptap/react": "^3.20.4",
     "@tiptap/starter-kit": "^3.20.4",
     "@uiw/react-markdown-preview": "^5.1.5",
+    "@ts-rest/core": "3.53.0-rc.1",
     "@vm0/core": "workspace:*",
     "@vm0/ui": "workspace:*",
     "canvas-confetti": "^1.9.4",

--- a/turbo/apps/platform/src/signals/api-client.ts
+++ b/turbo/apps/platform/src/signals/api-client.ts
@@ -1,0 +1,48 @@
+/**
+ * Type-safe ts-rest API client for platform → zero API calls.
+ *
+ * Replaces raw fetch$ usage with typed ts-rest clients that provide
+ * compile-time type checking for request/response shapes.
+ */
+import { computed } from "ccstate";
+import { initClient, tsRestFetchApi, type AppRouter } from "@ts-rest/core";
+import { clerk$ } from "./auth.ts";
+import { apiBase$ } from "./fetch.ts";
+
+/**
+ * Factory signal for creating typed ts-rest clients.
+ *
+ * Returns a function that accepts any ts-rest contract and returns
+ * a fully configured client with auth token injection and base URL
+ * resolution.
+ *
+ * @example
+ * ```ts
+ * const createClient = get(zeroClient$);
+ * const client = createClient(zeroAgentsByNameContract);
+ * const result = await client.get({ params: { name: "my-agent" } });
+ * if (result.status === 200) {
+ *   console.log(result.body.displayName);
+ * }
+ * ```
+ */
+export const zeroClient$ = computed((get) => {
+  return <T extends AppRouter>(contract: T) => {
+    const apiBase = get(apiBase$);
+
+    return initClient(contract, {
+      baseUrl: apiBase,
+      jsonQuery: false,
+      api: async (args: Parameters<typeof tsRestFetchApi>[0]) => {
+        const clerk = await get(clerk$);
+        const token = await clerk.session?.getToken();
+
+        const headers = token
+          ? { ...args.headers, Authorization: `Bearer ${token}` }
+          : args.headers;
+
+        return tsRestFetchApi({ ...args, headers });
+      },
+    });
+  };
+});

--- a/turbo/apps/platform/src/signals/fetch.ts
+++ b/turbo/apps/platform/src/signals/fetch.ts
@@ -51,7 +51,7 @@ function resolveApiBase(): string {
   return CONFIGURED_API_URL;
 }
 
-const apiBase$ = computed(() => {
+export const apiBase$ = computed(() => {
   return resolveApiBase();
 });
 

--- a/turbo/apps/web/src/lib/infra-client.ts
+++ b/turbo/apps/web/src/lib/infra-client.ts
@@ -15,7 +15,9 @@ import { env } from "../env";
  * Priority:
  * 1. VM0_API_URL if explicitly set (e.g. tunnel URL in dev)
  * 2. Vercel deployment URL in production/preview
- * 3. localhost:3000 fallback for local development
+ * 3. localhost:3000 fallback for local development only
+ *
+ * Throws in non-development environments if neither URL is configured.
  */
 function getInfraBaseUrl(): string {
   const e = env();
@@ -24,7 +26,9 @@ function getInfraBaseUrl(): string {
 
   if (e.VERCEL_URL) return `https://${e.VERCEL_URL}`;
 
-  return "http://localhost:3000";
+  if (e.NODE_ENV === "development") return "http://localhost:3000";
+
+  throw new Error("VM0_API_URL or VERCEL_URL must be configured in production");
 }
 
 /**

--- a/turbo/apps/web/src/lib/infra-client.ts
+++ b/turbo/apps/web/src/lib/infra-client.ts
@@ -1,0 +1,54 @@
+/**
+ * Internal HTTP client for zero routes to call infra (agent) endpoints.
+ *
+ * Zero routes (application layer) use this client to call agent routes
+ * (infra layer) with full ts-rest type safety. In local dev the calls
+ * go through localhost; in production they go through the deployment URL.
+ */
+import "server-only";
+import { initClient, type AppRouter } from "@ts-rest/core";
+import { env } from "../env";
+
+/**
+ * Resolve the base URL for internal infra calls.
+ *
+ * Priority:
+ * 1. VM0_API_URL if explicitly set (e.g. tunnel URL in dev)
+ * 2. Vercel deployment URL in production/preview
+ * 3. localhost:3000 fallback for local development
+ */
+function getInfraBaseUrl(): string {
+  const e = env();
+
+  if (e.VM0_API_URL) return e.VM0_API_URL;
+
+  if (e.VERCEL_URL) return `https://${e.VERCEL_URL}`;
+
+  return "http://localhost:3000";
+}
+
+/**
+ * Create a typed ts-rest client for an infra (agent) contract.
+ *
+ * @param contract - The ts-rest contract to create a client for
+ * @param authToken - The Authorization header value to forward (e.g. "Bearer xxx")
+ *
+ * @example
+ * ```ts
+ * const client = createInfraClient(runsMainContract, headers.authorization);
+ * const result = await client.create({ body: runRequest });
+ * if (result.status === 200) {
+ *   return { status: 200, body: result.body };
+ * }
+ * ```
+ */
+export function createInfraClient<T extends AppRouter>(
+  contract: T,
+  authToken?: string,
+) {
+  return initClient(contract, {
+    baseUrl: getInfraBaseUrl(),
+    baseHeaders: authToken ? { Authorization: authToken } : {},
+    jsonQuery: false,
+  });
+}

--- a/turbo/knip.json
+++ b/turbo/knip.json
@@ -43,7 +43,11 @@
       "ignoreDependencies": ["@vm0/typescript-config", "tailwindcss"]
     },
     "apps/platform": {
-      "entry": ["src/main.ts", "**/*.{test,spec}.ts?(x)"],
+      "entry": [
+        "src/main.ts",
+        "src/signals/api-client.ts",
+        "**/*.{test,spec}.ts?(x)"
+      ],
       "project": ["**/*.{ts,tsx}"],
       "ignore": ["custom-eslint/**"],
       "ignoreDependencies": [
@@ -104,6 +108,7 @@
     "apps/cli/src/lib/utils/paginate.ts",
     "apps/cli/src/commands/cook/cook.ts",
     "apps/web/src/lib/auth/sandbox-token.ts",
+    "apps/web/src/lib/infra-client.ts",
     "scripts/rebuild-snapshots.ts",
     "scripts/rebuild-snapshots-from-db.ts"
   ],

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -55,7 +55,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@24.3.0)(@vitest/ui@4.1.0)(happy-dom@20.1.0)(msw@2.12.7(@types/node@24.3.0)(typescript@5.9.3))(vite@7.3.1(@types/node@24.3.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1))
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@24.3.0)(@vitest/ui@4.1.0)(happy-dom@20.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(msw@2.12.7(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.1)
 
   apps/cli:
     dependencies:
@@ -131,7 +131,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@24.3.0)(@vitest/ui@4.1.0)(happy-dom@20.1.0)(msw@2.12.7(@types/node@24.3.0)(typescript@5.9.3))(vite@7.3.1(@types/node@24.3.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1))
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@24.3.0)(@vitest/ui@4.1.0)(happy-dom@20.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(msw@2.12.7(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.1)
 
   apps/docs:
     dependencies:
@@ -235,6 +235,9 @@ importers:
       '@tiptap/starter-kit':
         specifier: ^3.20.4
         version: 3.20.4
+      '@ts-rest/core':
+        specifier: 3.53.0-rc.1
+        version: 3.53.0-rc.1(@types/node@24.3.0)
       '@uiw/react-markdown-preview':
         specifier: ^5.1.5
         version: 5.1.5(@types/react@19.1.12)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
@@ -343,7 +346,7 @@ importers:
         version: 7.3.1(@types/node@24.3.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1)
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@24.3.0)(@vitest/ui@4.1.0)(happy-dom@20.1.0)(msw@2.12.7(@types/node@24.3.0)(typescript@5.9.3))(vite@7.3.1(@types/node@24.3.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1))
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@24.3.0)(@vitest/ui@4.1.0)(happy-dom@20.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(msw@2.12.7(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.1)
 
   apps/web:
     dependencies:
@@ -530,7 +533,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@24.3.0)(@vitest/ui@4.1.0)(happy-dom@20.1.0)(msw@2.12.7(@types/node@24.3.0)(typescript@5.9.3))(vite@7.3.1(@types/node@24.3.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1))
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@24.3.0)(@vitest/ui@4.1.0)(happy-dom@20.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(msw@2.12.7(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.1)
 
   packages/core:
     dependencies:
@@ -561,7 +564,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@24.3.0)(@vitest/ui@4.1.0)(happy-dom@20.1.0)(msw@2.12.7(@types/node@24.3.0)(typescript@5.9.3))(vite@7.3.1(@types/node@24.3.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1))
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@24.3.0)(@vitest/ui@4.1.0)(happy-dom@20.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(msw@2.12.7(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.1)
 
   packages/eslint-config:
     devDependencies:
@@ -698,7 +701,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@24.3.0)(@vitest/ui@4.1.0)(happy-dom@20.1.0)(msw@2.12.7(@types/node@24.3.0)(typescript@5.9.3))(vite@7.3.1(@types/node@24.3.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1))
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@24.3.0)(@vitest/ui@4.1.0)(happy-dom@20.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(msw@2.12.7(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.1)
 
 packages:
 
@@ -8949,7 +8952,6 @@ packages:
       '@vitest/ui': 4.1.0
       happy-dom: '*'
       jsdom: '*'
-      vite: ^6.0.0 || ^7.0.0 || ^8.0.0-0
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true
@@ -13699,7 +13701,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.0.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@24.3.0)(@vitest/ui@4.1.0)(happy-dom@20.1.0)(msw@2.12.7(@types/node@24.3.0)(typescript@5.9.3))(vite@7.3.1(@types/node@24.3.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1))
+      vitest: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@24.3.0)(@vitest/ui@4.1.0)(happy-dom@20.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(msw@2.12.7(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.1)
 
   '@vitest/expect@4.1.0':
     dependencies:
@@ -13746,7 +13748,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vitest: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@24.3.0)(@vitest/ui@4.1.0)(happy-dom@20.1.0)(msw@2.12.7(@types/node@24.3.0)(typescript@5.9.3))(vite@7.3.1(@types/node@24.3.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1))
+      vitest: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@24.3.0)(@vitest/ui@4.1.0)(happy-dom@20.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(msw@2.12.7(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.1)
 
   '@vitest/utils@4.1.0':
     dependencies:
@@ -18625,7 +18627,7 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.8.1
 
-  vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@24.3.0)(@vitest/ui@4.1.0)(happy-dom@20.1.0)(msw@2.12.7(@types/node@24.3.0)(typescript@5.9.3))(vite@7.3.1(@types/node@24.3.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1)):
+  vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@24.3.0)(@vitest/ui@4.1.0)(happy-dom@20.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(msw@2.12.7(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.1):
     dependencies:
       '@vitest/expect': 4.1.0
       '@vitest/mocker': 4.1.0(msw@2.12.7(@types/node@24.3.0)(typescript@5.9.3))(vite@7.3.1(@types/node@24.3.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1))
@@ -18653,7 +18655,17 @@ snapshots:
       '@vitest/ui': 4.1.0(vitest@4.1.0)
       happy-dom: 20.1.0
     transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
       - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - yaml
 
   vscode-jsonrpc@8.2.0: {}
 


### PR DESCRIPTION
## Summary

Closes #5671 (Phase 1 of #5670 API layer separation)

- **`createInfraClient(contract, authToken)`** in `apps/web/src/lib/infra-client.ts` — typed ts-rest client for zero routes to call infra (agent) endpoints internally. Resolves base URL from `VM0_API_URL` / `VERCEL_URL` / localhost fallback and forwards auth token transparently.
- **`zeroClient$`** computed signal in `apps/platform/src/signals/api-client.ts` — factory for creating typed ts-rest clients on the platform side. Injects auth via Clerk and resolves base URL from `apiBase$`.
- Exports `apiBase$` from `fetch.ts` for reuse
- Adds `@ts-rest/core` dependency to platform

These are foundation utilities with no consumers yet — Phases 2–5 will add route migrations that use them.

## Test plan

- [x] `pnpm check-types` — all pass
- [x] `pnpm turbo run lint` — all pass
- [x] `pnpm knip` — clean (infra-client in knip ignore, api-client as platform entry point)
- [x] `pnpm vitest run` — 316/317 pass (1 pre-existing failure unrelated to this PR)
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)