### PR TITLE
ci: run e2e tests on merge queue with isolated resources

### DIFF
--- a/.github/workflows/cleanup-stale.yml
+++ b/.github/workflows/cleanup-stale.yml
@@ -46,9 +46,9 @@ jobs:
               continue
             fi
 
-            # Extract PR number from preview/pr-{number}
-            if [[ "$branch" =~ ^preview/pr-([0-9]+)$ ]]; then
-              PR_NUMBER="${BASH_REMATCH[1]}"
+            # Extract PR number from preview/pr-{number} or preview/pr-{number}-merge-queue
+            PR_NUMBER=$(echo "$branch" | grep -oE 'pr-[0-9]+' | head -1 | sed 's/pr-//')
+            if [ -n "$PR_NUMBER" ]; then
 
               # Check PR state via GitHub API
               PR_STATE=$(curl -sf -H "Authorization: token $GH_TOKEN" \
@@ -161,8 +161,8 @@ jobs:
               let shouldDelete = false;
               let reason = '';
 
-              // Check if it's a PR-based deployment (pr-123 format)
-              const prMatch = identifier.match(/^pr-(\d+)$/);
+              // Check if it's a PR-based deployment (pr-123 or pr-123-merge-queue format)
+              const prMatch = identifier.match(/^pr-(\d+)(-merge-queue)?$/);
               if (prMatch) {
                 const prNumber = parseInt(prMatch[1]);
                 if (!openPRNumbers.has(prNumber)) {
@@ -277,34 +277,40 @@ jobs:
 
             if [ "$DRY_RUN" = "true" ]; then
               echo "[DRY-RUN] Would cleanup turbo runner pr-${PR_NUMBER}"
+              echo "[DRY-RUN] Would cleanup turbo runner pr-${PR_NUMBER}-merge-queue"
               echo "[DRY-RUN] Would cleanup crates runner pr-${PR_NUMBER}-test"
+              echo "[DRY-RUN] Would cleanup crates runner pr-${PR_NUMBER}-merge-queue-test"
               CLEANED=$((CLEANED + 1))
               continue
             fi
 
             PR_FAILED=0
 
-            # Cleanup turbo runner
-            if ! ansible-playbook \
-              -i "${METAL_HOSTS}," \
-              playbooks/cleanup-turbo-runner.yml \
-              -e "ansible_user=${METAL_USER}" \
-              -e "job_ref=pr-${PR_NUMBER}" \
-              -v; then
-              echo "::warning::Turbo runner cleanup failed for PR #${PR_NUMBER}"
-              PR_FAILED=1
-            fi
+            # Cleanup turbo runners (PR and merge-queue)
+            for JOB_REF in "pr-${PR_NUMBER}" "pr-${PR_NUMBER}-merge-queue"; do
+              if ! ansible-playbook \
+                -i "${METAL_HOSTS}," \
+                playbooks/cleanup-turbo-runner.yml \
+                -e "ansible_user=${METAL_USER}" \
+                -e "job_ref=${JOB_REF}" \
+                -v; then
+                echo "::warning::Turbo runner cleanup failed for ${JOB_REF}"
+                PR_FAILED=1
+              fi
+            done
 
-            # Cleanup crates runner
-            if ! ansible-playbook \
-              -i "${METAL_HOSTS}," \
-              playbooks/cleanup-crates-runner.yml \
-              -e "ansible_user=${METAL_USER}" \
-              -e "job_ref=pr-${PR_NUMBER}-test" \
-              -v; then
-              echo "::warning::Crates runner cleanup failed for PR #${PR_NUMBER}"
-              PR_FAILED=1
-            fi
+            # Cleanup crates runners (PR and merge-queue)
+            for JOB_REF in "pr-${PR_NUMBER}-test" "pr-${PR_NUMBER}-merge-queue-test"; do
+              if ! ansible-playbook \
+                -i "${METAL_HOSTS}," \
+                playbooks/cleanup-crates-runner.yml \
+                -e "ansible_user=${METAL_USER}" \
+                -e "job_ref=${JOB_REF}" \
+                -v; then
+                echo "::warning::Crates runner cleanup failed for ${JOB_REF}"
+                PR_FAILED=1
+              fi
+            done
 
             if [ "$PR_FAILED" -eq 1 ]; then
               FAILED=$((FAILED + 1))

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -49,14 +49,16 @@ jobs:
           METAL_HOSTS: ${{ secrets.AWS_METAL_RUNNER_HOSTS }}
         run: |
           cd ansible
-          if ! ansible-playbook \
-            -i "${METAL_HOSTS}," \
-            playbooks/cleanup-turbo-runner.yml \
-            -e "ansible_user=${METAL_USER}" \
-            -e "job_ref=pr-${PR_NUMBER}" \
-            -v; then
-            echo "::warning::Turbo runner cleanup failed for PR #${PR_NUMBER} — stale services may remain on metal hosts"
-          fi
+          for JOB_REF in "pr-${PR_NUMBER}" "pr-${PR_NUMBER}-merge-queue"; do
+            if ! ansible-playbook \
+              -i "${METAL_HOSTS}," \
+              playbooks/cleanup-turbo-runner.yml \
+              -e "ansible_user=${METAL_USER}" \
+              -e "job_ref=${JOB_REF}" \
+              -v; then
+              echo "::warning::Turbo runner cleanup failed for ${JOB_REF} — stale services may remain on metal hosts"
+            fi
+          done
 
       - name: Cleanup crates runner on all metal hosts
         if: steps.check.outputs.should-cleanup == 'true'
@@ -66,14 +68,16 @@ jobs:
           METAL_HOSTS: ${{ secrets.AWS_METAL_RUNNER_HOSTS }}
         run: |
           cd ansible
-          if ! ansible-playbook \
-            -i "${METAL_HOSTS}," \
-            playbooks/cleanup-crates-runner.yml \
-            -e "ansible_user=${METAL_USER}" \
-            -e "job_ref=pr-${PR_NUMBER}-test" \
-            -v; then
-            echo "::warning::Crates runner cleanup failed for PR #${PR_NUMBER} — stale services may remain on metal hosts"
-          fi
+          for JOB_REF in "pr-${PR_NUMBER}-test" "pr-${PR_NUMBER}-merge-queue-test"; do
+            if ! ansible-playbook \
+              -i "${METAL_HOSTS}," \
+              playbooks/cleanup-crates-runner.yml \
+              -e "ansible_user=${METAL_USER}" \
+              -e "job_ref=${JOB_REF}" \
+              -v; then
+              echo "::warning::Crates runner cleanup failed for ${JOB_REF} — stale services may remain on metal hosts"
+            fi
+          done
 
   cleanup-database:
     # Skip for release-please PRs (only version bumps and changelogs)
@@ -92,6 +96,14 @@ jobs:
           branch-name: "${{ github.event.pull_request.head.ref }}"
           action: "cleanup"
 
+      - name: Delete Neon Branch (merge-queue)
+        uses: ./.github/actions/neon-branch
+        with:
+          neon-api-key: ${{ secrets.NEON_API_KEY }}
+          neon-project-id: ${{ vars.NEON_PROJECT_ID }}
+          branch-name: "pr-${{ github.event.pull_request.number }}-merge-queue"
+          action: "cleanup"
+
   cleanup-deployments:
     # Skip for release-please PRs (only version bumps and changelogs)
     if: "!startsWith(github.head_ref || '', 'release-please--branches--')"
@@ -105,8 +117,10 @@ jobs:
           script: |
             const branchName = context.payload.pull_request.head.ref;
             const sha = context.payload.pull_request.head.sha;
+            const prNumber = context.payload.pull_request.number;
+            const mergeQueueJobRef = `pr-${prNumber}-merge-queue`;
 
-            console.log(`Cleaning up deployments for branch: ${branchName}, sha: ${sha}`);
+            console.log(`Cleaning up deployments for branch: ${branchName}, sha: ${sha}, merge-queue: ${mergeQueueJobRef}`);
 
             // Get all deployments and filter by branch name
             const allDeployments = await github.rest.repos.listDeployments({
@@ -115,13 +129,14 @@ jobs:
               per_page: 100
             });
 
-            // Filter deployments that belong to this branch
+            // Filter deployments that belong to this branch or its merge-queue run
             const branchDeployments = allDeployments.data.filter(deployment => {
               // Match by ref or environment name containing branch
               return deployment.ref === branchName ||
                      deployment.ref === `refs/heads/${branchName}` ||
                      deployment.ref === sha ||
-                     deployment.environment?.includes(`preview/${branchName}`);
+                     deployment.environment?.includes(`preview/${branchName}`) ||
+                     deployment.environment?.includes(`preview/${mergeQueueJobRef}`);
             });
 
             console.log(`Found ${branchDeployments.length} deployments to delete`);

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -234,7 +234,7 @@ jobs:
               exit 1
             fi
           else
-            JOB_REF="main-test"
+            JOB_REF="staging-test"
           fi
 
           HOSTS=$(echo "$METAL_HOSTS" | tr ',' '\n' | grep .)

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -219,8 +219,24 @@ jobs:
         id: host
         env:
           METAL_HOSTS: ${{ secrets.AWS_METAL_RUNNER_HOSTS }}
-          JOB_REF: ${{ github.event_name == 'pull_request' && format('pr-{0}-test', github.event.pull_request.number) || 'main-test' }}
+          EVENT_NAME: ${{ github.event_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          MQ_HEAD_REF: ${{ github.event.merge_group.head_ref }}
         run: |
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            JOB_REF="pr-${PR_NUMBER}-test"
+          elif [ "$EVENT_NAME" = "merge_group" ]; then
+            MQ_PR_NUM=$(echo "$MQ_HEAD_REF" | grep -oE 'pr-[0-9]+' | head -1 | sed 's/pr-//')
+            if [ -n "$MQ_PR_NUM" ]; then
+              JOB_REF="pr-${MQ_PR_NUM}-merge-queue-test"
+            else
+              echo "::error::Failed to extract PR number from merge_group head_ref: $MQ_HEAD_REF"
+              exit 1
+            fi
+          else
+            JOB_REF="main-test"
+          fi
+
           HOSTS=$(echo "$METAL_HOSTS" | tr ',' '\n' | grep .)
           NUM_HOSTS=$(echo "$HOSTS" | grep -c .)
           if [ "$NUM_HOSTS" -lt 1 ]; then
@@ -232,7 +248,7 @@ jobs:
           HOST=$(echo "$HOSTS" | sed -n "$((HOST_INDEX + 1))p")
           echo "host=${HOST}" >> "$GITHUB_OUTPUT"
           echo "job-ref=${JOB_REF}" >> "$GITHUB_OUTPUT"
-          echo "Selected metal host: ${HOST} (index ${HOST_INDEX}/${NUM_HOSTS})"
+          echo "Selected metal host: ${HOST} (index ${HOST_INDEX}/${NUM_HOSTS}, job-ref: ${JOB_REF})"
 
       - name: Deploy and build on metal host
         id: build

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -149,8 +149,15 @@ jobs:
             echo "job-ref=pr-${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
             echo "Job ref set to: pr-${{ github.event.pull_request.number }}"
           elif [ "${{ github.event_name }}" = "merge_group" ]; then
-            echo "job-ref=" >> $GITHUB_OUTPUT
-            echo "Job ref set to: (empty - merge_group will skip deployments)"
+            MQ_REF="${{ github.event.merge_group.head_ref }}"
+            PR_NUM=$(echo "$MQ_REF" | grep -oE 'pr-[0-9]+' | head -1 | sed 's/pr-//')
+            if [ -n "$PR_NUM" ]; then
+              echo "job-ref=pr-${PR_NUM}-merge-queue" >> $GITHUB_OUTPUT
+              echo "Job ref set to: pr-${PR_NUM}-merge-queue"
+            else
+              echo "::error::Failed to extract PR number from merge_group head_ref: $MQ_REF"
+              exit 1
+            fi
           else
             echo "job-ref=staging" >> $GITHUB_OUTPUT
             echo "Job ref set to: staging"


### PR DESCRIPTION
## Summary

- Merge queue events now get a real `job-ref` (`pr-{N}-merge-queue` for turbo, `pr-{N}-merge-queue-test` for crates) instead of empty, activating the full deploy + e2e pipeline
- Resources are fully isolated from the PR's own CI run — no conflicts between PR CI and merge queue CI
- Cleanup covers both variants in two layers: immediate (PR close) and daily stale sweep

## Changes

| File | Change |
|---|---|
| `turbo.yml` | Extract PR number from `merge_group.head_ref`, set `job-ref=pr-{N}-merge-queue` |
| `crates.yml` | Same pattern, set `job-ref=pr-{N}-merge-queue-test` |
| `cleanup.yml` | Clean both `pr-{N}` and `pr-{N}-merge-queue` for turbo runner, crates runner, Neon branch, and deployments |
| `cleanup-stale.yml` | Update regex and runner loops to match merge-queue naming patterns |

## Test plan

- [ ] Create a test PR with web/cli changes, add to merge queue, verify deploy-web and e2e jobs run
- [ ] Verify Neon branch `preview/pr-{N}-merge-queue` is created
- [ ] Verify runner deploys with `pr-{N}-merge-queue-{host}` naming
- [ ] Close the PR, verify cleanup.yml removes merge-queue resources
- [ ] Run cleanup-stale.yml in dry-run mode, verify it recognizes merge-queue patterns

Closes #5645

🤖 Generated with [Claude Code](https://claude.com/claude-code)