### PR TITLE
refactor: api layer separation phase 2 — simple proxy domains (connectors, org)

### DIFF
--- a/turbo/apps/platform/src/mocks/handlers/api-connectors.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-connectors.ts
@@ -1,7 +1,7 @@
 /**
  * Connectors API Handlers
  *
- * Mock handlers for /api/connectors endpoint.
+ * Mock handlers for /api/zero/connectors endpoint (connectors via zero layer).
  */
 
 import { http, HttpResponse } from "msw";
@@ -21,8 +21,8 @@ export function resetMockConnectors(): void {
 }
 
 export const apiConnectorsHandlers = [
-  // GET /api/connectors - List all connectors
-  http.get("/api/connectors", () => {
+  // GET /api/zero/connectors - List all connectors (zero proxy)
+  http.get("*/api/zero/connectors", () => {
     const response: ConnectorListResponse = {
       connectors: mockConnectors,
       configuredTypes: ALL_CONNECTOR_TYPES,
@@ -31,8 +31,8 @@ export const apiConnectorsHandlers = [
     return HttpResponse.json(response);
   }),
 
-  // DELETE /api/connectors/:type - Disconnect a connector
-  http.delete("/api/connectors/:type", ({ params }) => {
+  // DELETE /api/zero/connectors/:type - Disconnect a connector (zero proxy)
+  http.delete("*/api/zero/connectors/:type", ({ params }) => {
     const type = params.type as string;
     const existing = mockConnectors.find((c) => c.type === type);
 

--- a/turbo/apps/platform/src/mocks/handlers/api-org.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-org.ts
@@ -1,7 +1,7 @@
 /**
  * Org API Handlers
  *
- * Mock handlers for /api/org endpoint (org API).
+ * Mock handlers for /api/zero/org endpoint (org API via zero layer).
  * Default behavior: user always has an org (for tests that need auth to work).
  */
 
@@ -12,14 +12,12 @@ import type { Org } from "../../signals/org.ts";
 const mockOrg: Org = {
   id: "org_1",
   slug: "user-12345678",
-  createdAt: "2024-01-01T00:00:00Z",
-  updatedAt: "2024-01-01T00:00:00Z",
   role: "admin",
 };
 
 export const apiOrgHandlers = [
-  // GET /api/org - Get current user's default org
-  http.get("/api/org", () => {
+  // GET /api/zero/org - Get current user's default org (zero proxy)
+  http.get("*/api/zero/org", () => {
     return HttpResponse.json(mockOrg);
   }),
 ];

--- a/turbo/apps/platform/src/signals/external/connectors.ts
+++ b/turbo/apps/platform/src/signals/external/connectors.ts
@@ -1,6 +1,11 @@
 import { command, computed, state } from "ccstate";
-import { fetch$ } from "../fetch";
-import type { ConnectorListResponse } from "@vm0/core";
+import {
+  zeroConnectorsMainContract,
+  zeroConnectorsByTypeContract,
+  type ConnectorListResponse,
+  type ConnectorType,
+} from "@vm0/core";
+import { zeroClient$ } from "../api-client";
 
 /**
  * Reload trigger for connector signals.
@@ -13,9 +18,15 @@ const internalReloadConnectors$ = state(0);
  */
 export const connectors$ = computed(async (get) => {
   get(internalReloadConnectors$);
-  const fetchFn = get(fetch$);
-  const resp = await fetchFn("/api/connectors");
-  return (await resp.json()) as ConnectorListResponse;
+  const createClient = get(zeroClient$);
+  const client = createClient(zeroConnectorsMainContract);
+  const result = await client.list();
+
+  if (result.status === 200) {
+    return result.body as ConnectorListResponse;
+  }
+
+  throw new Error(`Failed to fetch connectors: ${result.status}`);
 });
 
 /**
@@ -28,15 +39,16 @@ export const reloadConnectors$ = command(({ set }) => {
 /**
  * Delete a connector by type.
  */
-export const deleteConnector$ = command(async ({ get, set }, type: string) => {
-  const fetchFn = get(fetch$);
-  const response = await fetchFn(`/api/connectors/${type}`, {
-    method: "DELETE",
-  });
+export const deleteConnector$ = command(
+  async ({ get, set }, type: ConnectorType) => {
+    const createClient = get(zeroClient$);
+    const client = createClient(zeroConnectorsByTypeContract);
+    const result = await client.delete({ params: { type } });
 
-  if (!response.ok) {
-    throw new Error(`Failed to delete connector: ${response.status}`);
-  }
+    if (result.status !== 204) {
+      throw new Error(`Failed to delete connector: ${result.status}`);
+    }
 
-  set(internalReloadConnectors$, (x) => x + 1);
-});
+    set(internalReloadConnectors$, (x) => x + 1);
+  },
+);

--- a/turbo/apps/platform/src/signals/org.ts
+++ b/turbo/apps/platform/src/signals/org.ts
@@ -1,20 +1,15 @@
 import { computed } from "ccstate";
+import { zeroOrgContract, type OrgResponse } from "@vm0/core";
 import { user$ } from "./auth.ts";
-import { fetch$ } from "./fetch.ts";
+import { zeroClient$ } from "./api-client.ts";
 import { logger } from "./log.ts";
 
 const L = logger("Org");
 
 /**
- * Org response type from API
+ * Re-export for backward compatibility with mocks and consumers.
  */
-export interface Org {
-  id: string;
-  slug: string;
-  createdAt: string;
-  updatedAt: string;
-  role?: "admin" | "member";
-}
+export type Org = OrgResponse;
 
 /**
  * Current user's default org.
@@ -26,19 +21,21 @@ export const org$ = computed(async (get) => {
     return undefined;
   }
 
-  const fetchFn = get(fetch$);
-  const response = await fetchFn("/api/org");
+  const createClient = get(zeroClient$);
+  const client = createClient(zeroOrgContract);
+  const result = await client.get();
 
-  L.debug(`Fetched /api/org with status ${response.status}`);
-  if (response.status === 404) {
+  L.debug(`Fetched /api/zero/org with status ${result.status}`);
+
+  if (result.status === 404) {
     return undefined;
   }
 
-  if (!response.ok) {
-    throw new Error(`Failed to fetch org: ${response.status}`);
+  if (result.status === 200) {
+    return result.body;
   }
 
-  return (await response.json()) as Org;
+  throw new Error(`Failed to fetch org: ${result.status}`);
 });
 
 /**

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-skill-card.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-skill-card.test.tsx
@@ -33,7 +33,7 @@ function makeConnector(
 
 function mockConnectors(connectors: ConnectorResponse[]) {
   server.use(
-    http.get("*/api/connectors", () => {
+    http.get("*/api/zero/connectors", () => {
       return HttpResponse.json({
         connectors,
         configuredTypes: Object.keys(CONNECTOR_TYPES),
@@ -257,7 +257,7 @@ describe("zero skill card scope review modal", () => {
     ]);
 
     server.use(
-      http.get("*/api/connectors/github/scope-diff", () => {
+      http.get("*/api/zero/connectors/github/scope-diff", () => {
         return HttpResponse.json({
           addedScopes: ["project"],
           removedScopes: [],
@@ -295,7 +295,7 @@ describe("zero skill card scope review modal", () => {
     ]);
 
     server.use(
-      http.get("*/api/connectors/github/scope-diff", () => {
+      http.get("*/api/zero/connectors/github/scope-diff", () => {
         return HttpResponse.json({
           addedScopes: ["project"],
           removedScopes: [],

--- a/turbo/apps/platform/src/views/zero-page/components/settings/scope-review-modal.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/scope-review-modal.tsx
@@ -6,9 +6,14 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@vm0/ui/components/ui/dialog";
-import { CONNECTOR_TYPES, type ConnectorType, type ScopeDiff } from "@vm0/core";
+import {
+  CONNECTOR_TYPES,
+  zeroConnectorScopeDiffContract,
+  type ConnectorType,
+  type ScopeDiff,
+} from "@vm0/core";
 import { ConnectorIcon } from "./connector-icons.tsx";
-import { fetch$ } from "../../../../signals/fetch.ts";
+import { zeroClient$ } from "../../../../signals/api-client.ts";
 
 interface ScopeReviewModalProps {
   connectorType: ConnectorType | null;
@@ -21,7 +26,7 @@ export function ScopeReviewModal({
   onClose,
   onReconnect,
 }: ScopeReviewModalProps) {
-  const fetchFn = useGet(fetch$);
+  const createClient = useGet(zeroClient$);
   const scopeDiff$ = useCCState<ScopeDiff | null>(null);
   const loading$ = useCCState(false);
   const scopeDiff = useGet(scopeDiff$);
@@ -36,10 +41,13 @@ export function ScopeReviewModal({
         return;
       }
       set(loading$, true);
-      fetchFn(`/api/connectors/${connectorType}/scope-diff`)
-        .then((resp) => resp.json())
-        .then((data: ScopeDiff) => {
-          setScopeDiff(data);
+      const client = createClient(zeroConnectorScopeDiffContract);
+      client
+        .getScopeDiff({ params: { type: connectorType } })
+        .then((result) => {
+          if (result.status === 200) {
+            setScopeDiff(result.body);
+          }
           setLoading(false);
         })
         .catch(() => {

--- a/turbo/apps/platform/src/views/zero-page/components/settings/scope-review-modal.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/scope-review-modal.tsx
@@ -14,6 +14,9 @@ import {
 } from "@vm0/core";
 import { ConnectorIcon } from "./connector-icons.tsx";
 import { zeroClient$ } from "../../../../signals/api-client.ts";
+import { logger } from "../../../../signals/log.ts";
+
+const L = logger("ScopeReviewModal");
 
 interface ScopeReviewModalProps {
   connectorType: ConnectorType | null;
@@ -47,10 +50,16 @@ export function ScopeReviewModal({
         .then((result) => {
           if (result.status === 200) {
             setScopeDiff(result.body);
+          } else {
+            L.error(
+              `Failed to fetch scope diff: ${result.status}`,
+              result.body,
+            );
           }
           setLoading(false);
         })
-        .catch(() => {
+        .catch((error: unknown) => {
+          L.error("Failed to fetch scope diff:", error);
           setLoading(false);
         });
     }),

--- a/turbo/apps/web/app/api/zero/connectors/[type]/route.ts
+++ b/turbo/apps/web/app/api/zero/connectors/[type]/route.ts
@@ -1,0 +1,47 @@
+import {
+  createHandler,
+  createSafeErrorHandler,
+  tsr,
+} from "../../../../../src/lib/ts-rest-handler";
+import {
+  zeroConnectorsByTypeContract,
+  connectorsByTypeContract,
+  type ApiErrorResponse,
+} from "@vm0/core";
+import { initServices } from "../../../../../src/lib/init-services";
+import { createInfraClient } from "../../../../../src/lib/infra-client";
+
+const router = tsr.router(zeroConnectorsByTypeContract, {
+  delete: async ({ params, headers }, { request }) => {
+    initServices();
+
+    const orgSlug = new URL(request.url).searchParams.get("org");
+    const client = createInfraClient(
+      connectorsByTypeContract,
+      headers.authorization,
+      orgSlug ? { query: { org: orgSlug } } : undefined,
+    );
+
+    const result = await client.delete({ params: { type: params.type } });
+
+    if (result.status === 204) {
+      return { status: 204 as const, body: undefined };
+    }
+    if (result.status === 401) {
+      return {
+        status: 401 as const,
+        body: result.body as ApiErrorResponse,
+      };
+    }
+    return {
+      status: 404 as const,
+      body: result.body as ApiErrorResponse,
+    };
+  },
+});
+
+const handler = createHandler(zeroConnectorsByTypeContract, router, {
+  errorHandler: createSafeErrorHandler("zero-connectors:type"),
+});
+
+export { handler as DELETE };

--- a/turbo/apps/web/app/api/zero/connectors/[type]/scope-diff/route.ts
+++ b/turbo/apps/web/app/api/zero/connectors/[type]/scope-diff/route.ts
@@ -1,0 +1,43 @@
+import {
+  createHandler,
+  createSafeErrorHandler,
+  tsr,
+} from "../../../../../../src/lib/ts-rest-handler";
+import {
+  zeroConnectorScopeDiffContract,
+  createErrorResponse,
+  getScopeDiff,
+} from "@vm0/core";
+import { initServices } from "../../../../../../src/lib/init-services";
+import { getAuthContext } from "../../../../../../src/lib/auth/get-auth-context";
+import { resolveOrg } from "../../../../../../src/lib/org/resolve-org";
+import { getConnector } from "../../../../../../src/lib/connector/connector-service";
+
+const router = tsr.router(zeroConnectorScopeDiffContract, {
+  getScopeDiff: async ({ params, headers }, { request }) => {
+    initServices();
+
+    const authCtx = await getAuthContext(headers.authorization);
+    if (!authCtx) {
+      return createErrorResponse("UNAUTHORIZED", "Not authenticated");
+    }
+    const { userId } = authCtx;
+
+    const orgSlug = new URL(request.url).searchParams.get("org");
+    const { org } = await resolveOrg(authCtx, orgSlug);
+    const connector = await getConnector(org.orgId, userId, params.type);
+
+    if (!connector) {
+      return createErrorResponse("NOT_FOUND", "Connector not found");
+    }
+
+    const diff = getScopeDiff(params.type, connector.oauthScopes);
+    return { status: 200 as const, body: diff };
+  },
+});
+
+const handler = createHandler(zeroConnectorScopeDiffContract, router, {
+  errorHandler: createSafeErrorHandler("zero-connectors:scope-diff"),
+});
+
+export { handler as GET };

--- a/turbo/apps/web/app/api/zero/connectors/route.ts
+++ b/turbo/apps/web/app/api/zero/connectors/route.ts
@@ -1,0 +1,47 @@
+import {
+  createHandler,
+  createSafeErrorHandler,
+  tsr,
+} from "../../../../src/lib/ts-rest-handler";
+import {
+  zeroConnectorsMainContract,
+  connectorsMainContract,
+  type ApiErrorResponse,
+} from "@vm0/core";
+import { initServices } from "../../../../src/lib/init-services";
+import { createInfraClient } from "../../../../src/lib/infra-client";
+
+const router = tsr.router(zeroConnectorsMainContract, {
+  list: async ({ headers }, { request }) => {
+    initServices();
+
+    const orgSlug = new URL(request.url).searchParams.get("org");
+    const client = createInfraClient(
+      connectorsMainContract,
+      headers.authorization,
+      orgSlug ? { query: { org: orgSlug } } : undefined,
+    );
+
+    const result = await client.list();
+
+    if (result.status === 200) {
+      return { status: 200 as const, body: result.body };
+    }
+    if (result.status === 401) {
+      return {
+        status: 401 as const,
+        body: result.body as ApiErrorResponse,
+      };
+    }
+    return {
+      status: 500 as const,
+      body: result.body as ApiErrorResponse,
+    };
+  },
+});
+
+const handler = createHandler(zeroConnectorsMainContract, router, {
+  errorHandler: createSafeErrorHandler("zero-connectors"),
+});
+
+export { handler as GET };

--- a/turbo/apps/web/app/api/zero/org/route.ts
+++ b/turbo/apps/web/app/api/zero/org/route.ts
@@ -1,0 +1,43 @@
+import {
+  createHandler,
+  createSafeErrorHandler,
+  tsr,
+} from "../../../../src/lib/ts-rest-handler";
+import { zeroOrgContract, orgContract, type ApiErrorResponse } from "@vm0/core";
+import { initServices } from "../../../../src/lib/init-services";
+import { createInfraClient } from "../../../../src/lib/infra-client";
+
+const router = tsr.router(zeroOrgContract, {
+  get: async ({ headers }, { request }) => {
+    initServices();
+
+    const orgSlug = new URL(request.url).searchParams.get("org");
+    const client = createInfraClient(
+      orgContract,
+      headers.authorization,
+      orgSlug ? { query: { org: orgSlug } } : undefined,
+    );
+
+    const result = await client.get();
+
+    if (result.status === 200) {
+      return { status: 200 as const, body: result.body };
+    }
+    if (result.status === 401) {
+      return {
+        status: 401 as const,
+        body: result.body as ApiErrorResponse,
+      };
+    }
+    return {
+      status: 404 as const,
+      body: result.body as ApiErrorResponse,
+    };
+  },
+});
+
+const handler = createHandler(zeroOrgContract, router, {
+  errorHandler: createSafeErrorHandler("zero-org"),
+});
+
+export { handler as GET };

--- a/turbo/apps/web/src/lib/infra-client.ts
+++ b/turbo/apps/web/src/lib/infra-client.ts
@@ -6,7 +6,7 @@
  * go through localhost; in production they go through the deployment URL.
  */
 import "server-only";
-import { initClient, type AppRouter } from "@ts-rest/core";
+import { initClient, tsRestFetchApi, type AppRouter } from "@ts-rest/core";
 import { env } from "../env";
 
 /**
@@ -31,28 +31,49 @@ function getInfraBaseUrl(): string {
   throw new Error("VM0_API_URL or VERCEL_URL must be configured in production");
 }
 
+interface InfraClientOptions {
+  /** Query parameters to forward to the infra endpoint (e.g. { org: "my-org" }) */
+  query?: Record<string, string>;
+}
+
 /**
  * Create a typed ts-rest client for an infra (agent) contract.
  *
  * @param contract - The ts-rest contract to create a client for
  * @param authToken - The Authorization header value to forward (e.g. "Bearer xxx")
+ * @param options - Additional options (e.g. query params to forward)
  *
  * @example
  * ```ts
+ * // Simple call
  * const client = createInfraClient(runsMainContract, headers.authorization);
  * const result = await client.create({ body: runRequest });
- * if (result.status === 200) {
- *   return { status: 200, body: result.body };
- * }
+ *
+ * // With org query param forwarding (for proxy routes)
+ * const client = createInfraClient(connectorsMainContract, headers.authorization, {
+ *   query: { org: orgSlug },
+ * });
+ * const result = await client.list();
  * ```
  */
 export function createInfraClient<T extends AppRouter>(
   contract: T,
   authToken?: string,
+  options?: InfraClientOptions,
 ) {
   return initClient(contract, {
     baseUrl: getInfraBaseUrl(),
     baseHeaders: authToken ? { Authorization: authToken } : {},
     jsonQuery: false,
+    api: options?.query
+      ? async (args: Parameters<typeof tsRestFetchApi>[0]) => {
+          const params = new URLSearchParams(options.query);
+          const separator = args.path.includes("?") ? "&" : "?";
+          return tsRestFetchApi({
+            ...args,
+            path: `${args.path}${separator}${params.toString()}`,
+          });
+        }
+      : undefined,
   });
 }

--- a/turbo/packages/core/src/contracts/index.ts
+++ b/turbo/packages/core/src/contracts/index.ts
@@ -542,3 +542,12 @@ export {
   type ZeroAgentInstructionsResponse,
   type ZeroAgentInstructionsRequest,
 } from "./zero-agents";
+export {
+  zeroConnectorsMainContract,
+  zeroConnectorsByTypeContract,
+  zeroConnectorScopeDiffContract,
+  type ZeroConnectorsMainContract,
+  type ZeroConnectorsByTypeContract,
+  type ZeroConnectorScopeDiffContract,
+} from "./zero-connectors";
+export { zeroOrgContract, type ZeroOrgContract } from "./zero-org";

--- a/turbo/packages/core/src/contracts/zero-connectors.ts
+++ b/turbo/packages/core/src/contracts/zero-connectors.ts
@@ -1,0 +1,71 @@
+import { z } from "zod";
+import { authHeadersSchema, initContract } from "./base";
+import { apiErrorSchema } from "./errors";
+import {
+  connectorListResponseSchema,
+  connectorTypeSchema,
+  scopeDiffResponseSchema,
+} from "./connectors";
+
+const c = initContract();
+
+/**
+ * Zero contract for GET /api/zero/connectors
+ * Proxies to GET /api/connectors
+ */
+export const zeroConnectorsMainContract = c.router({
+  list: {
+    method: "GET",
+    path: "/api/zero/connectors",
+    headers: authHeadersSchema,
+    responses: {
+      200: connectorListResponseSchema,
+      401: apiErrorSchema,
+      500: apiErrorSchema,
+    },
+    summary: "List all connectors (zero proxy)",
+  },
+});
+
+/**
+ * Zero contract for DELETE /api/zero/connectors/:type
+ * Proxies to DELETE /api/connectors/:type
+ */
+export const zeroConnectorsByTypeContract = c.router({
+  delete: {
+    method: "DELETE",
+    path: "/api/zero/connectors/:type",
+    headers: authHeadersSchema,
+    pathParams: z.object({ type: connectorTypeSchema }),
+    responses: {
+      204: c.noBody(),
+      401: apiErrorSchema,
+      404: apiErrorSchema,
+    },
+    summary: "Disconnect a connector (zero proxy)",
+  },
+});
+
+/**
+ * Zero contract for GET /api/zero/connectors/:type/scope-diff
+ * App-layer endpoint (direct service call, no proxy)
+ */
+export const zeroConnectorScopeDiffContract = c.router({
+  getScopeDiff: {
+    method: "GET",
+    path: "/api/zero/connectors/:type/scope-diff",
+    headers: authHeadersSchema,
+    pathParams: z.object({ type: connectorTypeSchema }),
+    responses: {
+      200: scopeDiffResponseSchema,
+      401: apiErrorSchema,
+      404: apiErrorSchema,
+    },
+    summary: "Get scope diff for a connector",
+  },
+});
+
+export type ZeroConnectorsMainContract = typeof zeroConnectorsMainContract;
+export type ZeroConnectorsByTypeContract = typeof zeroConnectorsByTypeContract;
+export type ZeroConnectorScopeDiffContract =
+  typeof zeroConnectorScopeDiffContract;

--- a/turbo/packages/core/src/contracts/zero-org.ts
+++ b/turbo/packages/core/src/contracts/zero-org.ts
@@ -1,0 +1,25 @@
+import { authHeadersSchema, initContract } from "./base";
+import { apiErrorSchema } from "./errors";
+import { orgResponseSchema } from "./orgs";
+
+const c = initContract();
+
+/**
+ * Zero contract for GET /api/zero/org
+ * Proxies to GET /api/org
+ */
+export const zeroOrgContract = c.router({
+  get: {
+    method: "GET",
+    path: "/api/zero/org",
+    headers: authHeadersSchema,
+    responses: {
+      200: orgResponseSchema,
+      401: apiErrorSchema,
+      404: apiErrorSchema,
+    },
+    summary: "Get current org (zero proxy)",
+  },
+});
+
+export type ZeroOrgContract = typeof zeroOrgContract;


### PR DESCRIPTION
## Summary

Closes #5672 (Phase 2 of #5670 API layer separation)

Migrates connectors and org platform API calls behind `/api/zero/` proxy layer:

### New contracts & routes
- **`/api/zero/connectors`** (GET) — proxies to `GET /api/connectors` via `createInfraClient`
- **`/api/zero/connectors/:type`** (DELETE) — proxies to `DELETE /api/connectors/:type`
- **`/api/zero/connectors/:type/scope-diff`** (GET) — app-layer endpoint (direct service call, no proxy)
- **`/api/zero/org`** (GET) — proxies to `GET /api/org`

### Platform migration
- `connectors.ts` signal: `fetch$` → `zeroClient$` with `zeroConnectorsMainContract` / `zeroConnectorsByTypeContract`
- `org.ts` signal: `fetch$` → `zeroClient$` with `zeroOrgContract`, replaced local `Org` type with `OrgResponse` from core
- `scope-review-modal.tsx`: `fetch$` → `zeroClient$` with `zeroConnectorScopeDiffContract`

### Infrastructure
- Enhanced `createInfraClient` with query param forwarding support (for `?org=` passthrough)
- Updated MSW mock handlers and test URLs for `/api/zero/*` paths

## Test plan

- [x] `pnpm check-types` — all pass
- [x] `pnpm turbo run lint` — all pass
- [x] `pnpm knip` — clean
- [x] Platform tests: 308/308 pass (including updated zero-skill-card tests)
- [x] Web tests: all pass (1 pre-existing failure unrelated)
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)