### PR TITLE
ci: add actionlint workflow validation step

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -126,7 +126,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Run actionlint
-        uses: rhysd/actionlint@v1
+        uses: rhysd/actionlint@v1.7.11
 
   gitleaks:
     name: Gitleaks Secrets Detection

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -117,6 +117,20 @@ jobs:
           cat audit-output.txt >> "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"
 
+  actionlint:
+    name: Workflow Lint
+    # Skip for release-please PRs (only version bumps and changelogs)
+    if: "!startsWith(github.head_ref || '', 'release-please--branches--')"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install actionlint
+        run: bash <(curl -s https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+
+      - name: Run actionlint
+        run: ./actionlint
+
   gitleaks:
     name: Gitleaks Secrets Detection
     # Skip for release-please PRs (only version bumps and changelogs)

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -125,8 +125,11 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Install actionlint
+        run: bash <(curl -s https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+
       - name: Run actionlint
-        uses: rhysd/actionlint@v1.7.11
+        run: ./actionlint
 
   gitleaks:
     name: Gitleaks Secrets Detection

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -129,7 +129,7 @@ jobs:
         run: bash <(curl -s https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
 
       - name: Run actionlint
-        run: ./actionlint
+        run: ./actionlint -shellcheck=
 
   gitleaks:
     name: Gitleaks Secrets Detection

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -125,11 +125,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Install actionlint
-        run: bash <(curl -s https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
-
       - name: Run actionlint
-        run: ./actionlint
+        uses: rhysd/actionlint@v1
 
   gitleaks:
     name: Gitleaks Secrets Detection


### PR DESCRIPTION
## Summary
- Adds `actionlint` job to `security.yml` to lint all GitHub Actions workflow files on every PR
- Catches YAML syntax errors and invalid workflow configuration before merge
- Prevents silent workflow parse failures from concurrent PR merges

Closes #5677

## Test plan
- [ ] `actionlint` job runs and passes in CI
- [ ] Validates all existing workflow files have no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)