### PR TITLE
fix: handle ime composition events to prevent accidental submit

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -471,7 +471,11 @@ export function ZeroChatComposer({
     onSend(trimmed, buildModelOpts(selectedModel));
   };
 
-  const handleKeyDown = useSendKeyHandler(handleSend);
+  const {
+    onKeyDown: handleKeyDown,
+    onCompositionStart,
+    onCompositionEnd,
+  } = useSendKeyHandler(handleSend);
 
   const handleFileSelect = () => {
     fileInputEl?.click();
@@ -523,6 +527,8 @@ export function ZeroChatComposer({
               value={input}
               onChange={(e) => onInputChange(e.target.value)}
               onKeyDown={handleKeyDown}
+              onCompositionStart={onCompositionStart}
+              onCompositionEnd={onCompositionEnd}
               onPaste={handlePaste}
               disabled={sending}
             />

--- a/turbo/apps/platform/src/views/zero-page/zero-send-key.ts
+++ b/turbo/apps/platform/src/views/zero-page/zero-send-key.ts
@@ -1,5 +1,6 @@
-import { useRef, type KeyboardEvent } from "react";
-import { useLastLoadable } from "ccstate-react";
+import type { KeyboardEvent } from "react";
+import { useGet, useSet, useLastLoadable } from "ccstate-react";
+import { useCCState } from "ccstate-react/experimental";
 import { sendMode$ } from "../../signals/send-mode.ts";
 import type { SendMode } from "@vm0/core";
 
@@ -10,29 +11,30 @@ import type { SendMode } from "@vm0/core";
  * - "enter": Enter sends, Shift+Enter inserts newline
  * - "cmd-enter": Cmd/Ctrl+Enter sends, Enter inserts newline
  *
- * Uses a manual composition ref because on Chrome macOS the `compositionend`
- * event fires *before* the confirming `keydown`, making
- * `KeyboardEvent.isComposing` unreliable at that point.
+ * Uses component-scoped composition state because on Chrome macOS the
+ * `compositionend` event fires *before* the confirming `keydown`, making
+ * `KeyboardEvent.isComposing` unreliable at that point.  With reactive
+ * state the `composing` value captured in the render closure stays `true`
+ * until the next render, so the keydown that follows compositionend in the
+ * same tick is still correctly blocked.
  */
 export function useSendKeyHandler(onSend: () => void) {
   const loadable = useLastLoadable(sendMode$);
   const mode: SendMode = loadable.state === "hasData" ? loadable.data : "enter";
-  const composingRef = useRef(false);
+  const composing$ = useCCState(false);
+  const composing = useGet(composing$);
+  const setComposing = useSet(composing$);
 
   const onCompositionStart = () => {
-    composingRef.current = true;
+    setComposing(true);
   };
 
   const onCompositionEnd = () => {
-    // Delay clearing so the Enter keydown that immediately follows
-    // compositionend still sees the composing flag.
-    requestAnimationFrame(() => {
-      composingRef.current = false;
-    });
+    setComposing(false);
   };
 
   const onKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
-    if (composingRef.current || e.nativeEvent.isComposing) {
+    if (composing || e.nativeEvent.isComposing) {
       return;
     }
     if (e.key !== "Enter") {

--- a/turbo/apps/platform/src/views/zero-page/zero-send-key.ts
+++ b/turbo/apps/platform/src/views/zero-page/zero-send-key.ts
@@ -1,21 +1,38 @@
-import type { KeyboardEvent } from "react";
+import { useRef, type KeyboardEvent } from "react";
 import { useLastLoadable } from "ccstate-react";
 import { sendMode$ } from "../../signals/send-mode.ts";
 import type { SendMode } from "@vm0/core";
 
 /**
- * Returns a keydown handler for the chat textarea that respects the
- * user's send-mode preference.
+ * Returns keyboard and composition event handlers for the chat textarea
+ * that respect the user's send-mode preference and IME composition state.
  *
  * - "enter": Enter sends, Shift+Enter inserts newline
  * - "cmd-enter": Cmd/Ctrl+Enter sends, Enter inserts newline
+ *
+ * Uses a manual composition ref because on Chrome macOS the `compositionend`
+ * event fires *before* the confirming `keydown`, making
+ * `KeyboardEvent.isComposing` unreliable at that point.
  */
 export function useSendKeyHandler(onSend: () => void) {
   const loadable = useLastLoadable(sendMode$);
   const mode: SendMode = loadable.state === "hasData" ? loadable.data : "enter";
+  const composingRef = useRef(false);
 
-  return (e: KeyboardEvent<HTMLTextAreaElement>) => {
-    if (e.nativeEvent.isComposing) {
+  const onCompositionStart = () => {
+    composingRef.current = true;
+  };
+
+  const onCompositionEnd = () => {
+    // Delay clearing so the Enter keydown that immediately follows
+    // compositionend still sees the composing flag.
+    requestAnimationFrame(() => {
+      composingRef.current = false;
+    });
+  };
+
+  const onKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (composingRef.current || e.nativeEvent.isComposing) {
       return;
     }
     if (e.key !== "Enter") {
@@ -30,4 +47,6 @@ export function useSendKeyHandler(onSend: () => void) {
       onSend();
     }
   };
+
+  return { onKeyDown, onCompositionStart, onCompositionEnd };
 }


### PR DESCRIPTION
## Summary
- Track IME composition state via a manual ref instead of relying solely on `KeyboardEvent.isComposing`, which is unreliable on Chrome macOS where `compositionend` fires before the confirming `keydown`
- Delay clearing the composition flag with `requestAnimationFrame` so the Enter key that confirms an IME candidate is not mistaken for a message send
- Add `onCompositionStart`/`onCompositionEnd` handlers to the chat textarea

Closes #5684

## Test plan
- [ ] Open chat, switch to Chinese (Pinyin) input method
- [ ] Type characters to trigger IME candidate selection
- [ ] Press Enter to confirm candidate — should insert text, not submit
- [ ] After confirming, press Enter again — should submit the message
- [ ] Verify Shift+Enter still inserts newline
- [ ] Verify cmd-enter mode still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)