### PR TITLE
refactor: api layer separation phase 3 — core domain proxies

### DIFF
--- a/turbo/apps/platform/src/mocks/handlers/api-agents.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-agents.ts
@@ -24,8 +24,8 @@ export const apiAgentsHandlers = [
     });
   }),
 
-  // GET /api/agent/composes/list
-  http.get("/api/agent/composes/list", () => {
+  // GET /api/zero/composes/list
+  http.get("/api/zero/composes/list", () => {
     return HttpResponse.json({
       composes: [
         {
@@ -39,8 +39,8 @@ export const apiAgentsHandlers = [
     });
   }),
 
-  // GET /api/agent/composes/:id
-  http.get("/api/agent/composes/:id", ({ params }) => {
+  // GET /api/zero/composes/:id
+  http.get("/api/zero/composes/:id", ({ params }) => {
     // Skip if it matches a sub-route like "list"
     if (params.id === "list") {
       return;
@@ -67,8 +67,8 @@ export const apiAgentsHandlers = [
     });
   }),
 
-  // GET /api/agent/schedules
-  http.get("/api/agent/schedules", () => {
+  // GET /api/zero/schedules
+  http.get("/api/zero/schedules", () => {
     return HttpResponse.json({ schedules: [] });
   }),
 

--- a/turbo/apps/platform/src/signals/queue-page/__tests__/queue-signals.test.ts
+++ b/turbo/apps/platform/src/signals/queue-page/__tests__/queue-signals.test.ts
@@ -31,11 +31,11 @@ describe("cancelQueueRun$", () => {
     let queueFetchCount = 0;
 
     server.use(
-      http.get("*/api/agent/runs/queue", () => {
+      http.get("*/api/zero/runs/queue", () => {
         queueFetchCount++;
         return HttpResponse.json(mockQueueResponse());
       }),
-      http.post("*/api/agent/runs/:runId/cancel", ({ params }) => {
+      http.post("*/api/zero/runs/:runId/cancel", ({ params }) => {
         cancelCalledWith = params.runId as string;
         return HttpResponse.json({ ok: true });
       }),
@@ -59,10 +59,10 @@ describe("cancelQueueRun$", () => {
 
   it("should throw on non-ok cancel response", async () => {
     server.use(
-      http.get("*/api/agent/runs/queue", () => {
+      http.get("*/api/zero/runs/queue", () => {
         return HttpResponse.json(mockQueueResponse());
       }),
-      http.post("*/api/agent/runs/:runId/cancel", () => {
+      http.post("*/api/zero/runs/:runId/cancel", () => {
         return new HttpResponse(null, {
           status: 403,
           statusText: "Forbidden",

--- a/turbo/apps/platform/src/signals/queue-page/queue-signals.ts
+++ b/turbo/apps/platform/src/signals/queue-page/queue-signals.ts
@@ -20,7 +20,7 @@ export const queueData$ = computed((get) => get(internalQueueData$));
 
 const fetchQueueData$ = command(async ({ get, set }) => {
   const fetchFn = get(fetch$);
-  const response = await fetchFn("/api/agent/runs/queue");
+  const response = await fetchFn("/api/zero/runs/queue");
   if (!response.ok) {
     throw new Error(`Failed to fetch queue: ${response.statusText}`);
   }
@@ -57,7 +57,7 @@ export const queuePollingRef$ = onRef(startPolling$);
 
 export const cancelQueueRun$ = command(async ({ get, set }, runId: string) => {
   const fetchFn = get(fetch$);
-  const response = await fetchFn(`/api/agent/runs/${runId}/cancel`, {
+  const response = await fetchFn(`/api/zero/runs/${runId}/cancel`, {
     method: "POST",
   });
   if (!response.ok) {

--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-activity.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-activity.test.ts
@@ -183,7 +183,7 @@ describe("zero-activity signals", () => {
           return new HttpResponse(null, { status: 404 });
         }),
         http.get(
-          "http://localhost:3000/api/agent/runs/:runId/telemetry/agent",
+          "http://localhost:3000/api/zero/runs/:runId/telemetry/agent",
           () => {
             return HttpResponse.json({
               events: [],

--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-chat.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-chat.test.ts
@@ -205,10 +205,10 @@ describe("zero-chat signals", () => {
     it("should abort in-flight polling when switching threads", async () => {
       let pollCount = 0;
       server.use(
-        http.post("*/api/agent/runs", () => {
+        http.post("*/api/zero/runs", () => {
           return HttpResponse.json({ runId: "run-old" });
         }),
-        http.get("*/api/agent/runs/:runId/telemetry/agent", () => {
+        http.get("*/api/zero/runs/:runId/telemetry/agent", () => {
           return HttpResponse.json({
             events: [],
             hasMore: false,
@@ -311,10 +311,10 @@ describe("zero-chat signals", () => {
     it("should abort in-flight polling when starting a new session", async () => {
       let pollCount = 0;
       server.use(
-        http.post("*/api/agent/runs", () => {
+        http.post("*/api/zero/runs", () => {
           return HttpResponse.json({ runId: "run-poll" });
         }),
-        http.get("*/api/agent/runs/:runId/telemetry/agent", () => {
+        http.get("*/api/zero/runs/:runId/telemetry/agent", () => {
           return HttpResponse.json({
             events: [],
             hasMore: false,
@@ -378,11 +378,11 @@ describe("zero-chat signals", () => {
         http.get("*/api/chat-threads", () => {
           return HttpResponse.json({ threads: [] });
         }),
-        http.post("*/api/agent/runs", async ({ request }) => {
+        http.post("*/api/zero/runs", async ({ request }) => {
           capturedRunBody = (await request.json()) as Record<string, string>;
           return HttpResponse.json({ runId: "run-123" });
         }),
-        http.get("*/api/agent/runs/:runId/telemetry/agent", () => {
+        http.get("*/api/zero/runs/:runId/telemetry/agent", () => {
           return HttpResponse.json({
             events: [],
             hasMore: false,
@@ -400,7 +400,7 @@ describe("zero-chat signals", () => {
             completedAt: "2026-03-10T00:00:02Z",
           });
         }),
-        http.get("*/api/agent/runs/:runId", () => {
+        http.get("*/api/zero/runs/:runId", () => {
           return HttpResponse.json({
             result: { agentSessionId: "new-session-id" },
           });
@@ -431,7 +431,7 @@ describe("zero-chat signals", () => {
     it("should surface API error message on run creation failure", async () => {
       useChatThreadHandlers();
       server.use(
-        http.post("*/api/agent/runs", () => {
+        http.post("*/api/zero/runs", () => {
           return HttpResponse.json(
             { error: { message: "Some API error", code: "BAD_REQUEST" } },
             { status: 400 },
@@ -451,7 +451,7 @@ describe("zero-chat signals", () => {
     it("should surface provider incompatibility error message", async () => {
       useChatThreadHandlers();
       server.use(
-        http.post("*/api/agent/runs", () => {
+        http.post("*/api/zero/runs", () => {
           return HttpResponse.json(
             {
               error: {
@@ -479,7 +479,7 @@ describe("zero-chat signals", () => {
     it("should fall back to generic message when error body is unparseable", async () => {
       useChatThreadHandlers();
       server.use(
-        http.post("*/api/agent/runs", () => {
+        http.post("*/api/zero/runs", () => {
           return new HttpResponse("Bad Gateway", { status: 502 });
         }),
       );
@@ -512,7 +512,7 @@ describe("zero-chat signals", () => {
     it("should not send empty messages", async () => {
       let runCalled = false;
       server.use(
-        http.post("*/api/agent/runs", () => {
+        http.post("*/api/zero/runs", () => {
           runCalled = true;
           return HttpResponse.json({ runId: "run-123" });
         }),
@@ -553,11 +553,11 @@ describe("zero-chat signals", () => {
         http.get("*/api/chat-threads", () => {
           return HttpResponse.json({ threads: [] });
         }),
-        http.post("*/api/agent/runs", async ({ request }) => {
+        http.post("*/api/zero/runs", async ({ request }) => {
           capturedRunBody = (await request.json()) as Record<string, string>;
           return HttpResponse.json({ runId: "run-456" });
         }),
-        http.get("*/api/agent/runs/:runId/telemetry/agent", () => {
+        http.get("*/api/zero/runs/:runId/telemetry/agent", () => {
           return HttpResponse.json({
             events: [],
             hasMore: false,
@@ -575,7 +575,7 @@ describe("zero-chat signals", () => {
             completedAt: "2026-03-10T00:00:02Z",
           });
         }),
-        http.get("*/api/agent/runs/:runId", () => {
+        http.get("*/api/zero/runs/:runId", () => {
           return HttpResponse.json({
             result: { agentSessionId: "existing-session" },
           });

--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-job-detail.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-job-detail.test.ts
@@ -104,7 +104,7 @@ describe("zero-job-detail signals", () => {
     it("should fetch detail, instructions, and schedules successfully", async () => {
       const agentResponse = mockAgentResponse();
       server.use(
-        http.get("http://localhost:3000/api/agent/composes", () => {
+        http.get("http://localhost:3000/api/zero/composes", () => {
           return HttpResponse.json(agentResponse);
         }),
         http.get(
@@ -113,7 +113,7 @@ describe("zero-job-detail signals", () => {
             return HttpResponse.json(mockInstructions());
           },
         ),
-        http.get("http://localhost:3000/api/agent/schedules", () => {
+        http.get("http://localhost:3000/api/zero/schedules", () => {
           return HttpResponse.json(mockSchedules());
         }),
       );
@@ -150,7 +150,7 @@ describe("zero-job-detail signals", () => {
 
     it("should set error state when detail API fails", async () => {
       server.use(
-        http.get("http://localhost:3000/api/agent/composes", () => {
+        http.get("http://localhost:3000/api/zero/composes", () => {
           return HttpResponse.json(
             { error: "Not Found" },
             { status: 404, statusText: "Not Found" },
@@ -172,7 +172,7 @@ describe("zero-job-detail signals", () => {
 
     it("should set instructions error when instructions API fails", async () => {
       server.use(
-        http.get("http://localhost:3000/api/agent/composes", () => {
+        http.get("http://localhost:3000/api/zero/composes", () => {
           return HttpResponse.json(mockAgentResponse());
         }),
         http.get(
@@ -184,7 +184,7 @@ describe("zero-job-detail signals", () => {
             );
           },
         ),
-        http.get("http://localhost:3000/api/agent/schedules", () => {
+        http.get("http://localhost:3000/api/zero/schedules", () => {
           return HttpResponse.json(mockSchedules());
         }),
       );
@@ -206,7 +206,7 @@ describe("zero-job-detail signals", () => {
 
     it("should set schedule error when schedules API fails", async () => {
       server.use(
-        http.get("http://localhost:3000/api/agent/composes", () => {
+        http.get("http://localhost:3000/api/zero/composes", () => {
           return HttpResponse.json(mockAgentResponse());
         }),
         http.get(
@@ -215,7 +215,7 @@ describe("zero-job-detail signals", () => {
             return HttpResponse.json(mockInstructions());
           },
         ),
-        http.get("http://localhost:3000/api/agent/schedules", () => {
+        http.get("http://localhost:3000/api/zero/schedules", () => {
           return HttpResponse.json(
             { error: "Forbidden" },
             { status: 403, statusText: "Forbidden" },
@@ -239,7 +239,7 @@ describe("zero-job-detail signals", () => {
 
     it("should pass agent name directly to API", async () => {
       server.use(
-        http.get("http://localhost:3000/api/agent/composes", ({ request }) => {
+        http.get("http://localhost:3000/api/zero/composes", ({ request }) => {
           const url = new URL(request.url);
           const name = url.searchParams.get("name");
 
@@ -256,7 +256,7 @@ describe("zero-job-detail signals", () => {
             return HttpResponse.json(mockInstructions());
           },
         ),
-        http.get("http://localhost:3000/api/agent/schedules", () => {
+        http.get("http://localhost:3000/api/zero/schedules", () => {
           return HttpResponse.json({ schedules: [] });
         }),
       );
@@ -272,7 +272,7 @@ describe("zero-job-detail signals", () => {
   describe("saveZeroJobSchedule$", () => {
     async function setupWithAgent() {
       server.use(
-        http.get("http://localhost:3000/api/agent/composes", () => {
+        http.get("http://localhost:3000/api/zero/composes", () => {
           return HttpResponse.json(mockAgentResponse());
         }),
         http.get(
@@ -281,7 +281,7 @@ describe("zero-job-detail signals", () => {
             return HttpResponse.json(mockInstructions());
           },
         ),
-        http.get("http://localhost:3000/api/agent/schedules", () => {
+        http.get("http://localhost:3000/api/zero/schedules", () => {
           return HttpResponse.json({ schedules: [] });
         }),
       );
@@ -297,13 +297,13 @@ describe("zero-job-detail signals", () => {
 
       server.use(
         http.post(
-          "http://localhost:3000/api/agent/schedules",
+          "http://localhost:3000/api/zero/schedules",
           async ({ request }) => {
             capturedBody = (await request.json()) as Record<string, unknown>;
             return HttpResponse.json({ id: "new-sched" });
           },
         ),
-        http.get("http://localhost:3000/api/agent/schedules", () => {
+        http.get("http://localhost:3000/api/zero/schedules", () => {
           return HttpResponse.json({ schedules: [] });
         }),
       );
@@ -336,13 +336,13 @@ describe("zero-job-detail signals", () => {
 
       server.use(
         http.post(
-          "http://localhost:3000/api/agent/schedules",
+          "http://localhost:3000/api/zero/schedules",
           async ({ request }) => {
             capturedBody = (await request.json()) as Record<string, unknown>;
             return HttpResponse.json({ id: "new-sched" });
           },
         ),
-        http.get("http://localhost:3000/api/agent/schedules", () => {
+        http.get("http://localhost:3000/api/zero/schedules", () => {
           return HttpResponse.json({ schedules: [] });
         }),
       );
@@ -372,7 +372,7 @@ describe("zero-job-detail signals", () => {
       await setupWithAgent();
 
       server.use(
-        http.post("http://localhost:3000/api/agent/schedules", () => {
+        http.post("http://localhost:3000/api/zero/schedules", () => {
           return HttpResponse.json(
             { error: { message: "Quota exceeded" } },
             { status: 429, statusText: "Too Many Requests" },
@@ -401,7 +401,7 @@ describe("zero-job-detail signals", () => {
       let capturedUrl = "";
 
       server.use(
-        http.get("http://localhost:3000/api/agent/composes", () => {
+        http.get("http://localhost:3000/api/zero/composes", () => {
           return HttpResponse.json(mockAgentResponse());
         }),
         http.get(
@@ -410,7 +410,7 @@ describe("zero-job-detail signals", () => {
             return HttpResponse.json(mockInstructions());
           },
         ),
-        http.get("http://localhost:3000/api/agent/schedules", () => {
+        http.get("http://localhost:3000/api/zero/schedules", () => {
           return HttpResponse.json(mockSchedules());
         }),
       );
@@ -420,20 +420,20 @@ describe("zero-job-detail signals", () => {
 
       server.use(
         http.delete(
-          "http://localhost:3000/api/agent/schedules/:name",
+          "http://localhost:3000/api/zero/schedules/:name",
           ({ request }) => {
             capturedUrl = request.url;
             return new HttpResponse(null, { status: 204 });
           },
         ),
-        http.get("http://localhost:3000/api/agent/schedules", () => {
+        http.get("http://localhost:3000/api/zero/schedules", () => {
           return HttpResponse.json({ schedules: [] });
         }),
       );
 
       await context.store.set(deleteZeroJobSchedule$, "daily-run");
 
-      expect(capturedUrl).toContain("/api/agent/schedules/daily-run");
+      expect(capturedUrl).toContain("/api/zero/schedules/daily-run");
       expect(capturedUrl).toContain("composeId=compose-1");
 
       const entries = await context.store.get(zeroJobScheduleEntries$);
@@ -442,7 +442,7 @@ describe("zero-job-detail signals", () => {
 
     it("should throw when delete API returns error", async () => {
       server.use(
-        http.get("http://localhost:3000/api/agent/composes", () => {
+        http.get("http://localhost:3000/api/zero/composes", () => {
           return HttpResponse.json(mockAgentResponse());
         }),
         http.get(
@@ -451,7 +451,7 @@ describe("zero-job-detail signals", () => {
             return HttpResponse.json(mockInstructions());
           },
         ),
-        http.get("http://localhost:3000/api/agent/schedules", () => {
+        http.get("http://localhost:3000/api/zero/schedules", () => {
           return HttpResponse.json(mockSchedules());
         }),
       );
@@ -460,7 +460,7 @@ describe("zero-job-detail signals", () => {
       await context.store.set(fetchZeroJobData$, "my-agent");
 
       server.use(
-        http.delete("http://localhost:3000/api/agent/schedules/:name", () => {
+        http.delete("http://localhost:3000/api/zero/schedules/:name", () => {
           return HttpResponse.json(
             { error: { message: "Not found" } },
             { status: 404, statusText: "Not Found" },
@@ -479,7 +479,7 @@ describe("zero-job-detail signals", () => {
       let capturedUrl = "";
 
       server.use(
-        http.get("http://localhost:3000/api/agent/composes", () => {
+        http.get("http://localhost:3000/api/zero/composes", () => {
           return HttpResponse.json(mockAgentResponse());
         }),
         http.get(
@@ -488,7 +488,7 @@ describe("zero-job-detail signals", () => {
             return HttpResponse.json(mockInstructions());
           },
         ),
-        http.get("http://localhost:3000/api/agent/schedules", () => {
+        http.get("http://localhost:3000/api/zero/schedules", () => {
           return HttpResponse.json(mockSchedules());
         }),
       );
@@ -498,13 +498,13 @@ describe("zero-job-detail signals", () => {
 
       server.use(
         http.post(
-          "http://localhost:3000/api/agent/schedules/:name/:action",
+          "http://localhost:3000/api/zero/schedules/:name/:action",
           ({ request }) => {
             capturedUrl = request.url;
             return HttpResponse.json({ ok: true });
           },
         ),
-        http.get("http://localhost:3000/api/agent/schedules", () => {
+        http.get("http://localhost:3000/api/zero/schedules", () => {
           return HttpResponse.json(mockSchedules());
         }),
       );
@@ -514,14 +514,14 @@ describe("zero-job-detail signals", () => {
         enabled: true,
       });
 
-      expect(capturedUrl).toContain("/api/agent/schedules/daily-run/enable");
+      expect(capturedUrl).toContain("/api/zero/schedules/daily-run/enable");
     });
 
     it("should send disable request for a schedule", async () => {
       let capturedUrl = "";
 
       server.use(
-        http.get("http://localhost:3000/api/agent/composes", () => {
+        http.get("http://localhost:3000/api/zero/composes", () => {
           return HttpResponse.json(mockAgentResponse());
         }),
         http.get(
@@ -530,7 +530,7 @@ describe("zero-job-detail signals", () => {
             return HttpResponse.json(mockInstructions());
           },
         ),
-        http.get("http://localhost:3000/api/agent/schedules", () => {
+        http.get("http://localhost:3000/api/zero/schedules", () => {
           return HttpResponse.json(mockSchedules());
         }),
       );
@@ -540,13 +540,13 @@ describe("zero-job-detail signals", () => {
 
       server.use(
         http.post(
-          "http://localhost:3000/api/agent/schedules/:name/:action",
+          "http://localhost:3000/api/zero/schedules/:name/:action",
           ({ request }) => {
             capturedUrl = request.url;
             return HttpResponse.json({ ok: true });
           },
         ),
-        http.get("http://localhost:3000/api/agent/schedules", () => {
+        http.get("http://localhost:3000/api/zero/schedules", () => {
           return HttpResponse.json(mockSchedules());
         }),
       );
@@ -556,12 +556,12 @@ describe("zero-job-detail signals", () => {
         enabled: false,
       });
 
-      expect(capturedUrl).toContain("/api/agent/schedules/daily-run/disable");
+      expect(capturedUrl).toContain("/api/zero/schedules/daily-run/disable");
     });
 
     it("should show toast error when toggle API fails", async () => {
       server.use(
-        http.get("http://localhost:3000/api/agent/composes", () => {
+        http.get("http://localhost:3000/api/zero/composes", () => {
           return HttpResponse.json(mockAgentResponse());
         }),
         http.get(
@@ -570,7 +570,7 @@ describe("zero-job-detail signals", () => {
             return HttpResponse.json(mockInstructions());
           },
         ),
-        http.get("http://localhost:3000/api/agent/schedules", () => {
+        http.get("http://localhost:3000/api/zero/schedules", () => {
           return HttpResponse.json(mockSchedules());
         }),
       );
@@ -580,7 +580,7 @@ describe("zero-job-detail signals", () => {
 
       server.use(
         http.post(
-          "http://localhost:3000/api/agent/schedules/:name/:action",
+          "http://localhost:3000/api/zero/schedules/:name/:action",
           () => {
             return HttpResponse.json(
               { error: { message: "Server error" } },
@@ -602,7 +602,7 @@ describe("zero-job-detail signals", () => {
   describe("instructions editing", () => {
     async function setupWithAgent() {
       server.use(
-        http.get("http://localhost:3000/api/agent/composes", () => {
+        http.get("http://localhost:3000/api/zero/composes", () => {
           return HttpResponse.json(mockAgentResponse());
         }),
         http.get(
@@ -611,7 +611,7 @@ describe("zero-job-detail signals", () => {
             return HttpResponse.json(mockInstructions());
           },
         ),
-        http.get("http://localhost:3000/api/agent/schedules", () => {
+        http.get("http://localhost:3000/api/zero/schedules", () => {
           return HttpResponse.json({ schedules: [] });
         }),
       );
@@ -664,7 +664,7 @@ describe("zero-job-detail signals", () => {
             });
           },
         ),
-        http.get("http://localhost:3000/api/agent/composes", () => {
+        http.get("http://localhost:3000/api/zero/composes", () => {
           return HttpResponse.json(mockAgentResponse());
         }),
       );
@@ -748,7 +748,7 @@ describe("zero-job-detail signals", () => {
   describe("zeroJobUpdateSettings$", () => {
     async function setupWithAgent() {
       server.use(
-        http.get("http://localhost:3000/api/agent/composes", () => {
+        http.get("http://localhost:3000/api/zero/composes", () => {
           return HttpResponse.json(mockAgentResponse());
         }),
         http.get(
@@ -757,7 +757,7 @@ describe("zero-job-detail signals", () => {
             return HttpResponse.json(mockInstructions());
           },
         ),
-        http.get("http://localhost:3000/api/agent/schedules", () => {
+        http.get("http://localhost:3000/api/zero/schedules", () => {
           return HttpResponse.json({ schedules: [] });
         }),
       );
@@ -773,13 +773,13 @@ describe("zero-job-detail signals", () => {
 
       server.use(
         http.patch(
-          "http://localhost:3000/api/agent/composes/compose-1/metadata",
+          "http://localhost:3000/api/zero/composes/compose-1/metadata",
           async ({ request }) => {
             capturedBody = (await request.json()) as Record<string, unknown>;
             return new HttpResponse(null, { status: 204 });
           },
         ),
-        http.get("http://localhost:3000/api/agent/composes", () => {
+        http.get("http://localhost:3000/api/zero/composes", () => {
           return HttpResponse.json(mockAgentResponse());
         }),
       );
@@ -804,13 +804,13 @@ describe("zero-job-detail signals", () => {
 
       server.use(
         http.patch(
-          "http://localhost:3000/api/agent/composes/compose-1/metadata",
+          "http://localhost:3000/api/zero/composes/compose-1/metadata",
           () => {
             patchCalled = true;
             return new HttpResponse(null, { status: 204 });
           },
         ),
-        http.get("http://localhost:3000/api/agent/composes", () => {
+        http.get("http://localhost:3000/api/zero/composes", () => {
           return HttpResponse.json(mockAgentResponse());
         }),
       );
@@ -827,7 +827,7 @@ describe("zero-job-detail signals", () => {
 
       server.use(
         http.patch(
-          "http://localhost:3000/api/agent/composes/compose-1/metadata",
+          "http://localhost:3000/api/zero/composes/compose-1/metadata",
           () => {
             return new HttpResponse("Internal error", { status: 500 });
           },
@@ -846,7 +846,7 @@ describe("zero-job-detail signals", () => {
   describe("skills management", () => {
     async function setupWithAgent() {
       server.use(
-        http.get("http://localhost:3000/api/agent/composes", () => {
+        http.get("http://localhost:3000/api/zero/composes", () => {
           return HttpResponse.json(mockAgentResponse());
         }),
         http.get(
@@ -855,7 +855,7 @@ describe("zero-job-detail signals", () => {
             return HttpResponse.json(mockInstructions());
           },
         ),
-        http.get("http://localhost:3000/api/agent/schedules", () => {
+        http.get("http://localhost:3000/api/zero/schedules", () => {
           return HttpResponse.json({ schedules: [] });
         }),
       );
@@ -929,7 +929,7 @@ describe("zero-job-detail signals", () => {
             });
           },
         ),
-        http.get("http://localhost:3000/api/agent/composes", () => {
+        http.get("http://localhost:3000/api/zero/composes", () => {
           return HttpResponse.json(mockAgentResponse());
         }),
       );

--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-schedule.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-schedule.test.ts
@@ -84,7 +84,7 @@ describe("zero-schedule signals", () => {
   describe("fetchZeroSchedules$", () => {
     it("should fetch and filter schedules for the default agent", async () => {
       server.use(
-        http.get("http://localhost:3000/api/agent/schedules", () => {
+        http.get("http://localhost:3000/api/zero/schedules", () => {
           return HttpResponse.json({ schedules: createMockSchedules() });
         }),
       );
@@ -100,7 +100,7 @@ describe("zero-schedule signals", () => {
 
     it("should convert cron schedule to display string", async () => {
       server.use(
-        http.get("http://localhost:3000/api/agent/schedules", () => {
+        http.get("http://localhost:3000/api/zero/schedules", () => {
           return HttpResponse.json({ schedules: createMockSchedules() });
         }),
       );
@@ -114,7 +114,7 @@ describe("zero-schedule signals", () => {
 
     it("should convert loop schedule to display string", async () => {
       server.use(
-        http.get("http://localhost:3000/api/agent/schedules", () => {
+        http.get("http://localhost:3000/api/zero/schedules", () => {
           return HttpResponse.json({ schedules: createMockSchedules() });
         }),
       );
@@ -128,7 +128,7 @@ describe("zero-schedule signals", () => {
 
     it("should handle empty response", async () => {
       server.use(
-        http.get("http://localhost:3000/api/agent/schedules", () => {
+        http.get("http://localhost:3000/api/zero/schedules", () => {
           return HttpResponse.json({ schedules: [] });
         }),
       );
@@ -142,7 +142,7 @@ describe("zero-schedule signals", () => {
 
     it("should handle API error gracefully", async () => {
       server.use(
-        http.get("http://localhost:3000/api/agent/schedules", () => {
+        http.get("http://localhost:3000/api/zero/schedules", () => {
           return new HttpResponse(null, { status: 500 });
         }),
       );
@@ -161,13 +161,13 @@ describe("zero-schedule signals", () => {
 
       server.use(
         http.post(
-          "http://localhost:3000/api/agent/schedules",
+          "http://localhost:3000/api/zero/schedules",
           async ({ request }) => {
             captured.body = (await request.json()) as Record<string, unknown>;
             return HttpResponse.json({ success: true });
           },
         ),
-        http.get("http://localhost:3000/api/agent/schedules", () => {
+        http.get("http://localhost:3000/api/zero/schedules", () => {
           return HttpResponse.json({ schedules: [] });
         }),
       );
@@ -196,13 +196,13 @@ describe("zero-schedule signals", () => {
 
       server.use(
         http.post(
-          "http://localhost:3000/api/agent/schedules",
+          "http://localhost:3000/api/zero/schedules",
           async ({ request }) => {
             captured.body = (await request.json()) as Record<string, unknown>;
             return HttpResponse.json({ success: true });
           },
         ),
-        http.get("http://localhost:3000/api/agent/schedules", () => {
+        http.get("http://localhost:3000/api/zero/schedules", () => {
           return HttpResponse.json({ schedules: [] });
         }),
       );
@@ -227,13 +227,13 @@ describe("zero-schedule signals", () => {
 
       server.use(
         http.post(
-          "http://localhost:3000/api/agent/schedules",
+          "http://localhost:3000/api/zero/schedules",
           async ({ request }) => {
             captured.body = (await request.json()) as Record<string, unknown>;
             return HttpResponse.json({ success: true });
           },
         ),
-        http.get("http://localhost:3000/api/agent/schedules", () => {
+        http.get("http://localhost:3000/api/zero/schedules", () => {
           return HttpResponse.json({ schedules: [] });
         }),
       );
@@ -264,14 +264,14 @@ describe("zero-schedule signals", () => {
 
       server.use(
         http.post(
-          "http://localhost:3000/api/agent/schedules/:name/:action",
+          "http://localhost:3000/api/zero/schedules/:name/:action",
           async ({ params, request }) => {
             captured.action = params["action"] as string;
             captured.body = (await request.json()) as Record<string, unknown>;
             return HttpResponse.json({ success: true });
           },
         ),
-        http.get("http://localhost:3000/api/agent/schedules", () => {
+        http.get("http://localhost:3000/api/zero/schedules", () => {
           return HttpResponse.json({ schedules: [] });
         }),
       );
@@ -291,13 +291,13 @@ describe("zero-schedule signals", () => {
 
       server.use(
         http.post(
-          "http://localhost:3000/api/agent/schedules/:name/:action",
+          "http://localhost:3000/api/zero/schedules/:name/:action",
           ({ params }) => {
             captured.action = params["action"] as string;
             return HttpResponse.json({ success: true });
           },
         ),
-        http.get("http://localhost:3000/api/agent/schedules", () => {
+        http.get("http://localhost:3000/api/zero/schedules", () => {
           return HttpResponse.json({ schedules: [] });
         }),
       );
@@ -314,7 +314,7 @@ describe("zero-schedule signals", () => {
     it("should throw and show toast on API error", async () => {
       server.use(
         http.post(
-          "http://localhost:3000/api/agent/schedules/:name/:action",
+          "http://localhost:3000/api/zero/schedules/:name/:action",
           () => {
             return HttpResponse.json(
               { error: { message: "Schedule not found" } },
@@ -341,7 +341,7 @@ describe("zero-schedule signals", () => {
 
       server.use(
         http.delete(
-          "http://localhost:3000/api/agent/schedules/:name",
+          "http://localhost:3000/api/zero/schedules/:name",
           ({ params, request }) => {
             deletedName = params["name"] as string;
             const url = new URL(request.url);
@@ -349,7 +349,7 @@ describe("zero-schedule signals", () => {
             return new HttpResponse(null, { status: 204 });
           },
         ),
-        http.get("http://localhost:3000/api/agent/schedules", () => {
+        http.get("http://localhost:3000/api/zero/schedules", () => {
           return HttpResponse.json({ schedules: [] });
         }),
       );

--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-skills.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-skills.test.ts
@@ -23,7 +23,7 @@ function mockComposeApi(content: {
   >;
 }) {
   server.use(
-    http.get("*/api/agent/composes/mock-compose-id", () => {
+    http.get("*/api/zero/composes/mock-compose-id", () => {
       return HttpResponse.json({
         id: "mock-compose-id",
         name: "test-compose",
@@ -81,7 +81,7 @@ describe("zeroAddedSkills$", () => {
 
     // Sub-agent has github only
     server.use(
-      http.get(`*/api/agent/composes/${subAgentComposeId}`, () => {
+      http.get(`*/api/zero/composes/${subAgentComposeId}`, () => {
         return HttpResponse.json({
           id: subAgentComposeId,
           name: "cycling-coach",

--- a/turbo/apps/platform/src/signals/zero-page/agents-list.ts
+++ b/turbo/apps/platform/src/signals/zero-page/agents-list.ts
@@ -53,7 +53,7 @@ export const fetchAgentsList$ = command(async ({ get, set }) => {
     // Fetch schedules (optional - don't fail if schedules API is unavailable)
     let schedules: Schedule[] = [];
     try {
-      const schedulesResponse = await fetchFn("/api/agent/schedules");
+      const schedulesResponse = await fetchFn("/api/zero/schedules");
       if (schedulesResponse.ok) {
         const schedulesData = (await schedulesResponse.json()) as {
           schedules: Schedule[];

--- a/turbo/apps/platform/src/signals/zero-page/log-types.ts
+++ b/turbo/apps/platform/src/signals/zero-page/log-types.ts
@@ -71,7 +71,7 @@ export interface AgentEvent {
   createdAt: string;
 }
 
-// Agent events response from /api/agent/runs/[id]/telemetry/agent
+// Agent events response from /api/zero/runs/[id]/telemetry/agent
 export interface AgentEventsResponse {
   events: AgentEvent[];
   hasMore: boolean;

--- a/turbo/apps/platform/src/signals/zero-page/polling.ts
+++ b/turbo/apps/platform/src/signals/zero-page/polling.ts
@@ -49,7 +49,7 @@ function createEventPageComputed(
       params.set("since", String(new Date(since).getTime()));
     }
     const response = await fetchFn(
-      `/api/agent/runs/${runId}/telemetry/agent?${params.toString()}`,
+      `/api/zero/runs/${runId}/telemetry/agent?${params.toString()}`,
     );
     if (!response.ok) {
       throw new Error(`Failed to fetch agent events: ${response.statusText}`);

--- a/turbo/apps/platform/src/signals/zero-page/zero-activity.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-activity.ts
@@ -49,7 +49,7 @@ export const zeroActivityOrgAgents$ = computed((get) =>
 
 const fetchOrgAgents$ = command(async ({ get, set }) => {
   const fetchFn = get(fetch$);
-  const resp = await fetchFn("/api/agent/composes/list");
+  const resp = await fetchFn("/api/zero/composes/list");
   if (!resp.ok) {
     throw new Error(`Failed to fetch org agents: ${resp.statusText}`);
   }
@@ -281,7 +281,7 @@ function createEventPageComputed(
       params.set("since", String(new Date(since).getTime()));
     }
     const response = await fetchFn(
-      `/api/agent/runs/${runId}/telemetry/agent?${params.toString()}`,
+      `/api/zero/runs/${runId}/telemetry/agent?${params.toString()}`,
     );
     if (!response.ok) {
       throw new Error(`Failed to fetch agent events: ${response.statusText}`);

--- a/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
@@ -154,7 +154,7 @@ async function startAgentRun(
     body.modelProvider = modelProvider;
   }
 
-  const response = await fetchFn("/api/agent/runs", {
+  const response = await fetchFn("/api/zero/runs", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(body),
@@ -284,7 +284,7 @@ export const cancelActiveRun$ = command(async ({ get, set }) => {
   set(internalRunStatus$, null);
 
   const fetchFn = get(fetch$);
-  await fetchFn(`/api/agent/runs/${runId}/cancel`, { method: "POST" });
+  await fetchFn(`/api/zero/runs/${runId}/cancel`, { method: "POST" });
 });
 
 /** Queue position for the active run (0 = not queued). */
@@ -1057,7 +1057,7 @@ const onZeroRunComplete$ = command(async ({ get, set }, runId: string) => {
 
   try {
     const fetchFn = get(fetch$);
-    const res = await fetchFn(`/api/agent/runs/${runId}`);
+    const res = await fetchFn(`/api/zero/runs/${runId}`);
     if (res.ok) {
       const data = (await res.json()) as {
         result?: { output?: string; agentSessionId?: string };

--- a/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
@@ -145,7 +145,6 @@ async function startAgentRun(
     agentComposeId: composeId,
     prompt: prompt.trim(),
     memoryName: "memory",
-    triggerSource: "web",
   };
   if (sessionId) {
     body.sessionId = sessionId;

--- a/turbo/apps/platform/src/signals/zero-page/zero-job-detail.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-job-detail.ts
@@ -62,7 +62,7 @@ const fetchZeroJobDetail$ = command(async ({ get, set }) => {
     const fetchFn = get(fetch$);
     const params = new URLSearchParams({ name });
 
-    const response = await fetchFn(`/api/agent/composes?${params.toString()}`);
+    const response = await fetchFn(`/api/zero/composes?${params.toString()}`);
     if (!response.ok) {
       const status = response.status;
       const text = response.statusText || `HTTP ${status}`;
@@ -251,7 +251,7 @@ export const zeroJobUpdateSettings$ = command(
     try {
       const fetchFn = get(fetch$);
       const response = await fetchFn(
-        `/api/agent/composes/${detail.id}/metadata`,
+        `/api/zero/composes/${detail.id}/metadata`,
         {
           method: "PATCH",
           headers: { "Content-Type": "application/json" },
@@ -507,7 +507,7 @@ const fetchZeroJobSchedule$ = command(async ({ get, set }) => {
 
   try {
     const fetchFn = get(fetch$);
-    const response = await fetchFn("/api/agent/schedules");
+    const response = await fetchFn("/api/zero/schedules");
     if (!response.ok) {
       throw new Error(`Failed to fetch schedules: ${response.statusText}`);
     }
@@ -600,7 +600,7 @@ export const saveZeroJobSchedule$ = command(
       body = { ...base, cronExpression };
     }
 
-    const response = await fetchFn("/api/agent/schedules", {
+    const response = await fetchFn("/api/zero/schedules", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(body),
@@ -630,7 +630,7 @@ export const toggleZeroJobScheduleEnabled$ = command(
     const fetchFn = get(fetch$);
     const action = params.enabled ? "enable" : "disable";
     const response = await fetchFn(
-      `/api/agent/schedules/${encodeURIComponent(params.name)}/${action}`,
+      `/api/zero/schedules/${encodeURIComponent(params.name)}/${action}`,
       {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -662,7 +662,7 @@ export const deleteZeroJobSchedule$ = command(
 
     const fetchFn = get(fetch$);
     const response = await fetchFn(
-      `/api/agent/schedules/${encodeURIComponent(scheduleName)}?composeId=${encodeURIComponent(detail.id)}`,
+      `/api/zero/schedules/${encodeURIComponent(scheduleName)}?composeId=${encodeURIComponent(detail.id)}`,
       { method: "DELETE" },
     );
 
@@ -691,7 +691,7 @@ export const deleteZeroJobAgent$ = command(async ({ get, set }) => {
   }
 
   const fetchFn = get(fetch$);
-  const response = await fetchFn(`/api/agent/composes/${detail.id}`, {
+  const response = await fetchFn(`/api/zero/composes/${detail.id}`, {
     method: "DELETE",
   });
 

--- a/turbo/apps/platform/src/signals/zero-page/zero-schedule.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-schedule.ts
@@ -164,7 +164,7 @@ export const fetchZeroSchedules$ = command(async ({ get, set }) => {
 
   try {
     const fetchFn = get(fetch$);
-    const response = await fetchFn("/api/agent/schedules");
+    const response = await fetchFn("/api/zero/schedules");
 
     if (!response.ok) {
       set(internalSchedules$, []);
@@ -273,7 +273,7 @@ export const saveZeroSchedule$ = command(
       body = { ...base, cronExpression };
     }
 
-    const response = await fetchFn("/api/agent/schedules", {
+    const response = await fetchFn("/api/zero/schedules", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(body),
@@ -308,7 +308,7 @@ export const toggleZeroScheduleEnabled$ = command(
     const fetchFn = get(fetch$);
     const action = params.enabled ? "enable" : "disable";
     const response = await fetchFn(
-      `/api/agent/schedules/${encodeURIComponent(params.name)}/${action}`,
+      `/api/zero/schedules/${encodeURIComponent(params.name)}/${action}`,
       {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -345,7 +345,7 @@ export const deleteZeroSchedule$ = command(
 
     const fetchFn = get(fetch$);
     const response = await fetchFn(
-      `/api/agent/schedules/${encodeURIComponent(scheduleName)}?composeId=${encodeURIComponent(composeId)}`,
+      `/api/zero/schedules/${encodeURIComponent(scheduleName)}?composeId=${encodeURIComponent(composeId)}`,
       { method: "DELETE" },
     );
 
@@ -423,7 +423,7 @@ export const refreshScheduleIfActive$ = command(({ get, set }) => {
 const fetchAllOrgSchedules$ = command(async ({ get, set }) => {
   const fetchFn = get(fetch$);
   try {
-    const response = await fetchFn("/api/agent/schedules");
+    const response = await fetchFn("/api/zero/schedules");
     if (!response.ok) {
       set(internalAllSchedules$, []);
       return;
@@ -502,7 +502,7 @@ export const saveOrgSchedule$ = command(
       body = { ...base, cronExpression };
     }
 
-    const response = await fetchFn("/api/agent/schedules", {
+    const response = await fetchFn("/api/zero/schedules", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(body),
@@ -530,7 +530,7 @@ export const toggleOrgScheduleEnabled$ = command(
     const fetchFn = get(fetch$);
     const action = params.enabled ? "enable" : "disable";
     const response = await fetchFn(
-      `/api/agent/schedules/${encodeURIComponent(params.name)}/${action}`,
+      `/api/zero/schedules/${encodeURIComponent(params.name)}/${action}`,
       {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -557,7 +557,7 @@ export const deleteOrgSchedule$ = command(
   async ({ get, set }, params: { name: string; composeId: string }) => {
     const fetchFn = get(fetch$);
     const response = await fetchFn(
-      `/api/agent/schedules/${encodeURIComponent(params.name)}?composeId=${encodeURIComponent(params.composeId)}`,
+      `/api/zero/schedules/${encodeURIComponent(params.name)}?composeId=${encodeURIComponent(params.composeId)}`,
       { method: "DELETE" },
     );
 

--- a/turbo/apps/platform/src/signals/zero-page/zero-skills.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-skills.ts
@@ -59,7 +59,7 @@ const zeroCompose$ = computed(async (get) => {
   }
 
   const fetchFn = get(fetch$);
-  const resp = await fetchFn(`/api/agent/composes/${composeId}`);
+  const resp = await fetchFn(`/api/zero/composes/${composeId}`);
   if (!resp.ok) {
     throw new Error(`Failed to fetch compose: ${resp.statusText}`);
   }

--- a/turbo/apps/platform/src/views/queue-page/__tests__/queue-page.test.tsx
+++ b/turbo/apps/platform/src/views/queue-page/__tests__/queue-page.test.tsx
@@ -23,7 +23,7 @@ function queueResponse(overrides?: {
 describe("queue page", () => {
   it("should show cancel button for owner's running tasks", async () => {
     server.use(
-      http.get("*/api/agent/runs/queue", () => {
+      http.get("*/api/zero/runs/queue", () => {
         return HttpResponse.json(
           queueResponse({
             runningTasks: [
@@ -54,7 +54,7 @@ describe("queue page", () => {
 
   it("should not show cancel button for non-owner running tasks", async () => {
     server.use(
-      http.get("*/api/agent/runs/queue", () => {
+      http.get("*/api/zero/runs/queue", () => {
         return HttpResponse.json(
           queueResponse({
             runningTasks: [
@@ -84,7 +84,7 @@ describe("queue page", () => {
 
   it("should show cancel button for owner's queued entries", async () => {
     server.use(
-      http.get("*/api/agent/runs/queue", () => {
+      http.get("*/api/zero/runs/queue", () => {
         return HttpResponse.json(
           queueResponse({
             queue: [
@@ -118,7 +118,7 @@ describe("queue page", () => {
 
   it("should not show cancel button when runId is null", async () => {
     server.use(
-      http.get("*/api/agent/runs/queue", () => {
+      http.get("*/api/zero/runs/queue", () => {
         return HttpResponse.json(
           queueResponse({
             runningTasks: [
@@ -150,7 +150,7 @@ describe("queue page", () => {
     let cancelledRunId: string | null = null;
 
     server.use(
-      http.get("*/api/agent/runs/queue", () => {
+      http.get("*/api/zero/runs/queue", () => {
         return HttpResponse.json(
           queueResponse({
             runningTasks: [
@@ -166,7 +166,7 @@ describe("queue page", () => {
           }),
         );
       }),
-      http.post("*/api/agent/runs/:runId/cancel", ({ params }) => {
+      http.post("*/api/zero/runs/:runId/cancel", ({ params }) => {
         cancelledRunId = params.runId as string;
         return HttpResponse.json({ ok: true });
       }),

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-schedule-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-schedule-page.test.tsx
@@ -74,7 +74,7 @@ function createMockSchedules() {
 
 function mockScheduleAPI(schedules = createMockSchedules()) {
   server.use(
-    http.get("*/api/agent/schedules", () => {
+    http.get("*/api/zero/schedules", () => {
       return HttpResponse.json({ schedules });
     }),
     http.get("*/api/chat-threads", () => {
@@ -192,10 +192,10 @@ describe("zero schedule page - create dialog", () => {
     let capturedBody: Record<string, unknown> | null = null;
 
     server.use(
-      http.get("*/api/agent/schedules", () => {
+      http.get("*/api/zero/schedules", () => {
         return HttpResponse.json({ schedules: createMockSchedules() });
       }),
-      http.post("*/api/agent/schedules", async ({ request }) => {
+      http.post("*/api/zero/schedules", async ({ request }) => {
         capturedBody = (await request.json()) as Record<string, unknown>;
         return HttpResponse.json({ success: true });
       }),
@@ -240,10 +240,10 @@ describe("zero schedule page - toggle enabled", () => {
     let capturedAction: string | null = null;
 
     server.use(
-      http.get("*/api/agent/schedules", () => {
+      http.get("*/api/zero/schedules", () => {
         return HttpResponse.json({ schedules: createMockSchedules() });
       }),
-      http.post("*/api/agent/schedules/:name/:action", ({ params }) => {
+      http.post("*/api/zero/schedules/:name/:action", ({ params }) => {
         capturedAction = params["action"] as string;
         return HttpResponse.json({ success: true });
       }),

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-skill-card.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-skill-card.test.tsx
@@ -50,7 +50,7 @@ function mockConnectors(connectors: ConnectorResponse[]) {
 async function renderTeamPage(skills: string[]) {
   // Mock the agent compose lookup (fetched by name query param)
   server.use(
-    http.get("*/api/agent/composes", () => {
+    http.get("*/api/zero/composes", () => {
       return HttpResponse.json({
         id: "compose-1",
         name: "zero",

--- a/turbo/apps/web/app/api/zero/composes/[id]/metadata/route.ts
+++ b/turbo/apps/web/app/api/zero/composes/[id]/metadata/route.ts
@@ -1,0 +1,13 @@
+/**
+ * PATCH /api/zero/composes/:id/metadata
+ * Proxies to /api/agent/composes/:id/metadata
+ */
+import { proxyToInfra } from "../../../../../../src/lib/infra-client";
+
+export async function PATCH(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  return proxyToInfra(`/api/agent/composes/${id}/metadata`, request);
+}

--- a/turbo/apps/web/app/api/zero/composes/[id]/route.ts
+++ b/turbo/apps/web/app/api/zero/composes/[id]/route.ts
@@ -26,7 +26,7 @@ const router = tsr.router(zeroComposesByIdContract, {
       composesByIdContract,
       headers.authorization,
     );
-    const result = await client.delete({ params, body: null });
+    const result = await client.delete({ params });
     return forwardInfra(result);
   },
 });

--- a/turbo/apps/web/app/api/zero/composes/[id]/route.ts
+++ b/turbo/apps/web/app/api/zero/composes/[id]/route.ts
@@ -1,0 +1,35 @@
+import {
+  createHandler,
+  createSafeErrorHandler,
+  tsr,
+} from "../../../../../src/lib/ts-rest-handler";
+import { zeroComposesByIdContract, composesByIdContract } from "@vm0/core";
+import { initServices } from "../../../../../src/lib/init-services";
+import { createInfraClient } from "../../../../../src/lib/infra-client";
+
+const router = tsr.router(zeroComposesByIdContract, {
+  getById: async ({ params, headers }) => {
+    initServices();
+    const client = createInfraClient(
+      composesByIdContract,
+      headers.authorization,
+    );
+    const result = await client.getById({ params });
+    return { status: result.status, body: result.body };
+  },
+  delete: async ({ params, headers }) => {
+    initServices();
+    const client = createInfraClient(
+      composesByIdContract,
+      headers.authorization,
+    );
+    const result = await client.delete({ params, body: null });
+    return { status: result.status, body: result.body };
+  },
+});
+
+const handler = createHandler(zeroComposesByIdContract, router, {
+  errorHandler: createSafeErrorHandler("zero-composes:id"),
+});
+
+export { handler as GET, handler as DELETE };

--- a/turbo/apps/web/app/api/zero/composes/[id]/route.ts
+++ b/turbo/apps/web/app/api/zero/composes/[id]/route.ts
@@ -5,7 +5,10 @@ import {
 } from "../../../../../src/lib/ts-rest-handler";
 import { zeroComposesByIdContract, composesByIdContract } from "@vm0/core";
 import { initServices } from "../../../../../src/lib/init-services";
-import { createInfraClient } from "../../../../../src/lib/infra-client";
+import {
+  createInfraClient,
+  forwardInfra,
+} from "../../../../../src/lib/infra-client";
 
 const router = tsr.router(zeroComposesByIdContract, {
   getById: async ({ params, headers }) => {
@@ -15,7 +18,7 @@ const router = tsr.router(zeroComposesByIdContract, {
       headers.authorization,
     );
     const result = await client.getById({ params });
-    return { status: result.status, body: result.body };
+    return forwardInfra(result);
   },
   delete: async ({ params, headers }) => {
     initServices();
@@ -24,7 +27,7 @@ const router = tsr.router(zeroComposesByIdContract, {
       headers.authorization,
     );
     const result = await client.delete({ params, body: null });
-    return { status: result.status, body: result.body };
+    return forwardInfra(result);
   },
 });
 

--- a/turbo/apps/web/app/api/zero/composes/list/route.ts
+++ b/turbo/apps/web/app/api/zero/composes/list/route.ts
@@ -5,7 +5,10 @@ import {
 } from "../../../../../src/lib/ts-rest-handler";
 import { zeroComposesListContract, composesListContract } from "@vm0/core";
 import { initServices } from "../../../../../src/lib/init-services";
-import { createInfraClient } from "../../../../../src/lib/infra-client";
+import {
+  createInfraClient,
+  forwardInfra,
+} from "../../../../../src/lib/infra-client";
 
 const router = tsr.router(zeroComposesListContract, {
   list: async ({ query, headers }) => {
@@ -15,7 +18,7 @@ const router = tsr.router(zeroComposesListContract, {
       headers.authorization,
     );
     const result = await client.list({ query });
-    return { status: result.status, body: result.body };
+    return forwardInfra(result);
   },
 });
 

--- a/turbo/apps/web/app/api/zero/composes/list/route.ts
+++ b/turbo/apps/web/app/api/zero/composes/list/route.ts
@@ -1,0 +1,26 @@
+import {
+  createHandler,
+  createSafeErrorHandler,
+  tsr,
+} from "../../../../../src/lib/ts-rest-handler";
+import { zeroComposesListContract, composesListContract } from "@vm0/core";
+import { initServices } from "../../../../../src/lib/init-services";
+import { createInfraClient } from "../../../../../src/lib/infra-client";
+
+const router = tsr.router(zeroComposesListContract, {
+  list: async ({ query, headers }) => {
+    initServices();
+    const client = createInfraClient(
+      composesListContract,
+      headers.authorization,
+    );
+    const result = await client.list({ query });
+    return { status: result.status, body: result.body };
+  },
+});
+
+const handler = createHandler(zeroComposesListContract, router, {
+  errorHandler: createSafeErrorHandler("zero-composes:list"),
+});
+
+export { handler as GET };

--- a/turbo/apps/web/app/api/zero/composes/route.ts
+++ b/turbo/apps/web/app/api/zero/composes/route.ts
@@ -5,7 +5,10 @@ import {
 } from "../../../../src/lib/ts-rest-handler";
 import { zeroComposesMainContract, composesMainContract } from "@vm0/core";
 import { initServices } from "../../../../src/lib/init-services";
-import { createInfraClient } from "../../../../src/lib/infra-client";
+import {
+  createInfraClient,
+  forwardInfra,
+} from "../../../../src/lib/infra-client";
 
 const router = tsr.router(zeroComposesMainContract, {
   getByName: async ({ query, headers }) => {
@@ -15,7 +18,7 @@ const router = tsr.router(zeroComposesMainContract, {
       headers.authorization,
     );
     const result = await client.getByName({ query });
-    return { status: result.status, body: result.body };
+    return forwardInfra(result);
   },
 });
 

--- a/turbo/apps/web/app/api/zero/composes/route.ts
+++ b/turbo/apps/web/app/api/zero/composes/route.ts
@@ -1,0 +1,26 @@
+import {
+  createHandler,
+  createSafeErrorHandler,
+  tsr,
+} from "../../../../src/lib/ts-rest-handler";
+import { zeroComposesMainContract, composesMainContract } from "@vm0/core";
+import { initServices } from "../../../../src/lib/init-services";
+import { createInfraClient } from "../../../../src/lib/infra-client";
+
+const router = tsr.router(zeroComposesMainContract, {
+  getByName: async ({ query, headers }) => {
+    initServices();
+    const client = createInfraClient(
+      composesMainContract,
+      headers.authorization,
+    );
+    const result = await client.getByName({ query });
+    return { status: result.status, body: result.body };
+  },
+});
+
+const handler = createHandler(zeroComposesMainContract, router, {
+  errorHandler: createSafeErrorHandler("zero-composes"),
+});
+
+export { handler as GET };

--- a/turbo/apps/web/app/api/zero/connectors/route.ts
+++ b/turbo/apps/web/app/api/zero/connectors/route.ts
@@ -3,13 +3,12 @@ import {
   createSafeErrorHandler,
   tsr,
 } from "../../../../src/lib/ts-rest-handler";
-import {
-  zeroConnectorsMainContract,
-  connectorsMainContract,
-  type ApiErrorResponse,
-} from "@vm0/core";
+import { zeroConnectorsMainContract, connectorsMainContract } from "@vm0/core";
 import { initServices } from "../../../../src/lib/init-services";
-import { createInfraClient } from "../../../../src/lib/infra-client";
+import {
+  createInfraClient,
+  forwardInfra,
+} from "../../../../src/lib/infra-client";
 
 const router = tsr.router(zeroConnectorsMainContract, {
   list: async ({ headers }, { request }) => {
@@ -22,21 +21,8 @@ const router = tsr.router(zeroConnectorsMainContract, {
       orgSlug ? { query: { org: orgSlug } } : undefined,
     );
 
-    const result = await client.list();
-
-    if (result.status === 200) {
-      return { status: 200 as const, body: result.body };
-    }
-    if (result.status === 401) {
-      return {
-        status: 401 as const,
-        body: result.body as ApiErrorResponse,
-      };
-    }
-    return {
-      status: 500 as const,
-      body: result.body as ApiErrorResponse,
-    };
+    const result = await client.list({ headers: {} });
+    return forwardInfra(result);
   },
 });
 

--- a/turbo/apps/web/app/api/zero/org/route.ts
+++ b/turbo/apps/web/app/api/zero/org/route.ts
@@ -3,9 +3,12 @@ import {
   createSafeErrorHandler,
   tsr,
 } from "../../../../src/lib/ts-rest-handler";
-import { zeroOrgContract, orgContract, type ApiErrorResponse } from "@vm0/core";
+import { zeroOrgContract, orgContract } from "@vm0/core";
 import { initServices } from "../../../../src/lib/init-services";
-import { createInfraClient } from "../../../../src/lib/infra-client";
+import {
+  createInfraClient,
+  forwardInfra,
+} from "../../../../src/lib/infra-client";
 
 const router = tsr.router(zeroOrgContract, {
   get: async ({ headers }, { request }) => {
@@ -18,21 +21,8 @@ const router = tsr.router(zeroOrgContract, {
       orgSlug ? { query: { org: orgSlug } } : undefined,
     );
 
-    const result = await client.get();
-
-    if (result.status === 200) {
-      return { status: 200 as const, body: result.body };
-    }
-    if (result.status === 401) {
-      return {
-        status: 401 as const,
-        body: result.body as ApiErrorResponse,
-      };
-    }
-    return {
-      status: 404 as const,
-      body: result.body as ApiErrorResponse,
-    };
+    const result = await client.get({ headers: {} });
+    return forwardInfra(result);
   },
 });
 

--- a/turbo/apps/web/app/api/zero/runs/[id]/cancel/route.ts
+++ b/turbo/apps/web/app/api/zero/runs/[id]/cancel/route.ts
@@ -1,0 +1,23 @@
+import {
+  createHandler,
+  createSafeErrorHandler,
+  tsr,
+} from "../../../../../../src/lib/ts-rest-handler";
+import { zeroRunsCancelContract, runsCancelContract } from "@vm0/core";
+import { initServices } from "../../../../../../src/lib/init-services";
+import { createInfraClient } from "../../../../../../src/lib/infra-client";
+
+const router = tsr.router(zeroRunsCancelContract, {
+  cancel: async ({ params, headers }) => {
+    initServices();
+    const client = createInfraClient(runsCancelContract, headers.authorization);
+    const result = await client.cancel({ params, body: undefined });
+    return { status: result.status, body: result.body };
+  },
+});
+
+const handler = createHandler(zeroRunsCancelContract, router, {
+  errorHandler: createSafeErrorHandler("zero-runs:cancel"),
+});
+
+export { handler as POST };

--- a/turbo/apps/web/app/api/zero/runs/[id]/cancel/route.ts
+++ b/turbo/apps/web/app/api/zero/runs/[id]/cancel/route.ts
@@ -5,14 +5,17 @@ import {
 } from "../../../../../../src/lib/ts-rest-handler";
 import { zeroRunsCancelContract, runsCancelContract } from "@vm0/core";
 import { initServices } from "../../../../../../src/lib/init-services";
-import { createInfraClient } from "../../../../../../src/lib/infra-client";
+import {
+  createInfraClient,
+  forwardInfra,
+} from "../../../../../../src/lib/infra-client";
 
 const router = tsr.router(zeroRunsCancelContract, {
   cancel: async ({ params, headers }) => {
     initServices();
     const client = createInfraClient(runsCancelContract, headers.authorization);
-    const result = await client.cancel({ params, body: undefined });
-    return { status: result.status, body: result.body };
+    const result = await client.cancel({ params });
+    return forwardInfra(result);
   },
 });
 

--- a/turbo/apps/web/app/api/zero/runs/[id]/route.ts
+++ b/turbo/apps/web/app/api/zero/runs/[id]/route.ts
@@ -1,0 +1,23 @@
+import {
+  createHandler,
+  createSafeErrorHandler,
+  tsr,
+} from "../../../../../src/lib/ts-rest-handler";
+import { zeroRunsByIdContract, runsByIdContract } from "@vm0/core";
+import { initServices } from "../../../../../src/lib/init-services";
+import { createInfraClient } from "../../../../../src/lib/infra-client";
+
+const router = tsr.router(zeroRunsByIdContract, {
+  getById: async ({ params, headers }) => {
+    initServices();
+    const client = createInfraClient(runsByIdContract, headers.authorization);
+    const result = await client.getById({ params });
+    return { status: result.status, body: result.body };
+  },
+});
+
+const handler = createHandler(zeroRunsByIdContract, router, {
+  errorHandler: createSafeErrorHandler("zero-runs:id"),
+});
+
+export { handler as GET };

--- a/turbo/apps/web/app/api/zero/runs/[id]/route.ts
+++ b/turbo/apps/web/app/api/zero/runs/[id]/route.ts
@@ -5,14 +5,17 @@ import {
 } from "../../../../../src/lib/ts-rest-handler";
 import { zeroRunsByIdContract, runsByIdContract } from "@vm0/core";
 import { initServices } from "../../../../../src/lib/init-services";
-import { createInfraClient } from "../../../../../src/lib/infra-client";
+import {
+  createInfraClient,
+  forwardInfra,
+} from "../../../../../src/lib/infra-client";
 
 const router = tsr.router(zeroRunsByIdContract, {
   getById: async ({ params, headers }) => {
     initServices();
     const client = createInfraClient(runsByIdContract, headers.authorization);
     const result = await client.getById({ params });
-    return { status: result.status, body: result.body };
+    return forwardInfra(result);
   },
 });
 

--- a/turbo/apps/web/app/api/zero/runs/[id]/telemetry/agent/route.ts
+++ b/turbo/apps/web/app/api/zero/runs/[id]/telemetry/agent/route.ts
@@ -5,7 +5,10 @@ import {
 } from "../../../../../../../src/lib/ts-rest-handler";
 import { zeroRunAgentEventsContract, runAgentEventsContract } from "@vm0/core";
 import { initServices } from "../../../../../../../src/lib/init-services";
-import { createInfraClient } from "../../../../../../../src/lib/infra-client";
+import {
+  createInfraClient,
+  forwardInfra,
+} from "../../../../../../../src/lib/infra-client";
 
 const router = tsr.router(zeroRunAgentEventsContract, {
   getAgentEvents: async ({ params, query, headers }) => {
@@ -15,7 +18,7 @@ const router = tsr.router(zeroRunAgentEventsContract, {
       headers.authorization,
     );
     const result = await client.getAgentEvents({ params, query });
-    return { status: result.status, body: result.body };
+    return forwardInfra(result);
   },
 });
 

--- a/turbo/apps/web/app/api/zero/runs/[id]/telemetry/agent/route.ts
+++ b/turbo/apps/web/app/api/zero/runs/[id]/telemetry/agent/route.ts
@@ -1,0 +1,26 @@
+import {
+  createHandler,
+  createSafeErrorHandler,
+  tsr,
+} from "../../../../../../../src/lib/ts-rest-handler";
+import { zeroRunAgentEventsContract, runAgentEventsContract } from "@vm0/core";
+import { initServices } from "../../../../../../../src/lib/init-services";
+import { createInfraClient } from "../../../../../../../src/lib/infra-client";
+
+const router = tsr.router(zeroRunAgentEventsContract, {
+  getAgentEvents: async ({ params, query, headers }) => {
+    initServices();
+    const client = createInfraClient(
+      runAgentEventsContract,
+      headers.authorization,
+    );
+    const result = await client.getAgentEvents({ params, query });
+    return { status: result.status, body: result.body };
+  },
+});
+
+const handler = createHandler(zeroRunAgentEventsContract, router, {
+  errorHandler: createSafeErrorHandler("zero-runs:telemetry:agent"),
+});
+
+export { handler as GET };

--- a/turbo/apps/web/app/api/zero/runs/queue/route.ts
+++ b/turbo/apps/web/app/api/zero/runs/queue/route.ts
@@ -5,20 +5,17 @@ import {
 } from "../../../../../src/lib/ts-rest-handler";
 import { zeroRunsQueueContract, runsQueueContract } from "@vm0/core";
 import { initServices } from "../../../../../src/lib/init-services";
-import { createInfraClient } from "../../../../../src/lib/infra-client";
+import {
+  createInfraClient,
+  forwardInfra,
+} from "../../../../../src/lib/infra-client";
 
 const router = tsr.router(zeroRunsQueueContract, {
   getQueue: async ({ headers }) => {
     initServices();
     const client = createInfraClient(runsQueueContract, headers.authorization);
     const result = await client.getQueue({ headers: {} });
-    if (result.status === 200)
-      return { status: 200 as const, body: result.body };
-    if (result.status === 401)
-      return { status: 401 as const, body: result.body };
-    if (result.status === 403)
-      return { status: 403 as const, body: result.body };
-    return { status: result.status, body: result.body };
+    return forwardInfra(result);
   },
 });
 

--- a/turbo/apps/web/app/api/zero/runs/queue/route.ts
+++ b/turbo/apps/web/app/api/zero/runs/queue/route.ts
@@ -1,0 +1,29 @@
+import {
+  createHandler,
+  createSafeErrorHandler,
+  tsr,
+} from "../../../../../src/lib/ts-rest-handler";
+import { zeroRunsQueueContract, runsQueueContract } from "@vm0/core";
+import { initServices } from "../../../../../src/lib/init-services";
+import { createInfraClient } from "../../../../../src/lib/infra-client";
+
+const router = tsr.router(zeroRunsQueueContract, {
+  getQueue: async ({ headers }) => {
+    initServices();
+    const client = createInfraClient(runsQueueContract, headers.authorization);
+    const result = await client.getQueue({ headers: {} });
+    if (result.status === 200)
+      return { status: 200 as const, body: result.body };
+    if (result.status === 401)
+      return { status: 401 as const, body: result.body };
+    if (result.status === 403)
+      return { status: 403 as const, body: result.body };
+    return { status: result.status, body: result.body };
+  },
+});
+
+const handler = createHandler(zeroRunsQueueContract, router, {
+  errorHandler: createSafeErrorHandler("zero-runs:queue"),
+});
+
+export { handler as GET };

--- a/turbo/apps/web/app/api/zero/runs/route.ts
+++ b/turbo/apps/web/app/api/zero/runs/route.ts
@@ -5,14 +5,17 @@ import {
 } from "../../../../src/lib/ts-rest-handler";
 import { zeroRunsMainContract, runsMainContract } from "@vm0/core";
 import { initServices } from "../../../../src/lib/init-services";
-import { createInfraClient } from "../../../../src/lib/infra-client";
+import {
+  createInfraClient,
+  forwardInfra,
+} from "../../../../src/lib/infra-client";
 
 const router = tsr.router(zeroRunsMainContract, {
   create: async ({ body, headers }) => {
     initServices();
     const client = createInfraClient(runsMainContract, headers.authorization);
     const result = await client.create({ body });
-    return { status: result.status, body: result.body };
+    return forwardInfra(result);
   },
 });
 

--- a/turbo/apps/web/app/api/zero/runs/route.ts
+++ b/turbo/apps/web/app/api/zero/runs/route.ts
@@ -1,0 +1,23 @@
+import {
+  createHandler,
+  createSafeErrorHandler,
+  tsr,
+} from "../../../../src/lib/ts-rest-handler";
+import { zeroRunsMainContract, runsMainContract } from "@vm0/core";
+import { initServices } from "../../../../src/lib/init-services";
+import { createInfraClient } from "../../../../src/lib/infra-client";
+
+const router = tsr.router(zeroRunsMainContract, {
+  create: async ({ body, headers }) => {
+    initServices();
+    const client = createInfraClient(runsMainContract, headers.authorization);
+    const result = await client.create({ body });
+    return { status: result.status, body: result.body };
+  },
+});
+
+const handler = createHandler(zeroRunsMainContract, router, {
+  errorHandler: createSafeErrorHandler("zero-runs"),
+});
+
+export { handler as POST };

--- a/turbo/apps/web/app/api/zero/runs/route.ts
+++ b/turbo/apps/web/app/api/zero/runs/route.ts
@@ -14,7 +14,9 @@ const router = tsr.router(zeroRunsMainContract, {
   create: async ({ body, headers }) => {
     initServices();
     const client = createInfraClient(runsMainContract, headers.authorization);
-    const result = await client.create({ body });
+    const result = await client.create({
+      body: { ...body, triggerSource: "web" },
+    });
     return forwardInfra(result);
   },
 });

--- a/turbo/apps/web/app/api/zero/schedules/[name]/disable/route.ts
+++ b/turbo/apps/web/app/api/zero/schedules/[name]/disable/route.ts
@@ -1,0 +1,16 @@
+/**
+ * POST /api/zero/schedules/:name/disable
+ * Proxies to /api/agent/schedules/:name/disable
+ */
+import { proxyToInfra } from "../../../../../../src/lib/infra-client";
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ name: string }> },
+) {
+  const { name } = await params;
+  return proxyToInfra(
+    `/api/agent/schedules/${encodeURIComponent(name)}/disable`,
+    request,
+  );
+}

--- a/turbo/apps/web/app/api/zero/schedules/[name]/enable/route.ts
+++ b/turbo/apps/web/app/api/zero/schedules/[name]/enable/route.ts
@@ -1,0 +1,16 @@
+/**
+ * POST /api/zero/schedules/:name/enable
+ * Proxies to /api/agent/schedules/:name/enable
+ */
+import { proxyToInfra } from "../../../../../../src/lib/infra-client";
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ name: string }> },
+) {
+  const { name } = await params;
+  return proxyToInfra(
+    `/api/agent/schedules/${encodeURIComponent(name)}/enable`,
+    request,
+  );
+}

--- a/turbo/apps/web/app/api/zero/schedules/[name]/route.ts
+++ b/turbo/apps/web/app/api/zero/schedules/[name]/route.ts
@@ -8,7 +8,10 @@ import {
   schedulesByNameContract,
 } from "@vm0/core";
 import { initServices } from "../../../../../src/lib/init-services";
-import { createInfraClient } from "../../../../../src/lib/infra-client";
+import {
+  createInfraClient,
+  forwardInfra,
+} from "../../../../../src/lib/infra-client";
 
 const router = tsr.router(zeroSchedulesByNameContract, {
   delete: async ({ params, query, headers }) => {
@@ -18,7 +21,7 @@ const router = tsr.router(zeroSchedulesByNameContract, {
       headers.authorization,
     );
     const result = await client.delete({ params, query });
-    return { status: result.status, body: result.body };
+    return forwardInfra(result);
   },
 });
 

--- a/turbo/apps/web/app/api/zero/schedules/[name]/route.ts
+++ b/turbo/apps/web/app/api/zero/schedules/[name]/route.ts
@@ -1,0 +1,29 @@
+import {
+  createHandler,
+  createSafeErrorHandler,
+  tsr,
+} from "../../../../../src/lib/ts-rest-handler";
+import {
+  zeroSchedulesByNameContract,
+  schedulesByNameContract,
+} from "@vm0/core";
+import { initServices } from "../../../../../src/lib/init-services";
+import { createInfraClient } from "../../../../../src/lib/infra-client";
+
+const router = tsr.router(zeroSchedulesByNameContract, {
+  delete: async ({ params, query, headers }) => {
+    initServices();
+    const client = createInfraClient(
+      schedulesByNameContract,
+      headers.authorization,
+    );
+    const result = await client.delete({ params, query });
+    return { status: result.status, body: result.body };
+  },
+});
+
+const handler = createHandler(zeroSchedulesByNameContract, router, {
+  errorHandler: createSafeErrorHandler("zero-schedules:name"),
+});
+
+export { handler as DELETE };

--- a/turbo/apps/web/app/api/zero/schedules/route.ts
+++ b/turbo/apps/web/app/api/zero/schedules/route.ts
@@ -1,0 +1,41 @@
+import {
+  createHandler,
+  createSafeErrorHandler,
+  tsr,
+} from "../../../../src/lib/ts-rest-handler";
+import { zeroSchedulesMainContract, schedulesMainContract } from "@vm0/core";
+import { initServices } from "../../../../src/lib/init-services";
+import { createInfraClient } from "../../../../src/lib/infra-client";
+
+const router = tsr.router(zeroSchedulesMainContract, {
+  deploy: async ({ body, headers }) => {
+    initServices();
+    const client = createInfraClient(
+      schedulesMainContract,
+      headers.authorization,
+    );
+    const result = await client.deploy({ body });
+    return { status: result.status, body: result.body };
+  },
+  list: async ({ headers }) => {
+    initServices();
+    const client = createInfraClient(
+      schedulesMainContract,
+      headers.authorization,
+    );
+    const result = await client.list({ headers: {} });
+    if (result.status === 200)
+      return { status: 200 as const, body: result.body };
+    if (result.status === 401)
+      return { status: 401 as const, body: result.body };
+    if (result.status === 403)
+      return { status: 403 as const, body: result.body };
+    return { status: result.status, body: result.body };
+  },
+});
+
+const handler = createHandler(zeroSchedulesMainContract, router, {
+  errorHandler: createSafeErrorHandler("zero-schedules"),
+});
+
+export { handler as GET, handler as POST };

--- a/turbo/apps/web/app/api/zero/schedules/route.ts
+++ b/turbo/apps/web/app/api/zero/schedules/route.ts
@@ -5,7 +5,10 @@ import {
 } from "../../../../src/lib/ts-rest-handler";
 import { zeroSchedulesMainContract, schedulesMainContract } from "@vm0/core";
 import { initServices } from "../../../../src/lib/init-services";
-import { createInfraClient } from "../../../../src/lib/infra-client";
+import {
+  createInfraClient,
+  forwardInfra,
+} from "../../../../src/lib/infra-client";
 
 const router = tsr.router(zeroSchedulesMainContract, {
   deploy: async ({ body, headers }) => {
@@ -15,7 +18,7 @@ const router = tsr.router(zeroSchedulesMainContract, {
       headers.authorization,
     );
     const result = await client.deploy({ body });
-    return { status: result.status, body: result.body };
+    return forwardInfra(result);
   },
   list: async ({ headers }) => {
     initServices();
@@ -24,13 +27,7 @@ const router = tsr.router(zeroSchedulesMainContract, {
       headers.authorization,
     );
     const result = await client.list({ headers: {} });
-    if (result.status === 200)
-      return { status: 200 as const, body: result.body };
-    if (result.status === 401)
-      return { status: 401 as const, body: result.body };
-    if (result.status === 403)
-      return { status: 403 as const, body: result.body };
-    return { status: result.status, body: result.body };
+    return forwardInfra(result);
   },
 });
 

--- a/turbo/apps/web/src/lib/infra-client.ts
+++ b/turbo/apps/web/src/lib/infra-client.ts
@@ -79,6 +79,28 @@ export function createInfraClient<T extends AppRouter>(
 }
 
 /**
+ * Distribute a union status into a discriminated union of response objects.
+ * { status: A | B | C; body: X } → { status: A; body: X } | { status: B; body: X } | …
+ */
+type DistributeResponse<S extends number, B> = S extends S
+  ? { status: S; body: B }
+  : never;
+
+/**
+ * Forward an infra client result to a zero route handler.
+ *
+ * ts-rest initClient returns { status: HTTPStatusCode; body: unknown } but
+ * tsr.router handlers expect a discriminated union of response types.
+ * This helper distributes the broad status union into discriminated form.
+ */
+export function forwardInfra<S extends number, B>(result: {
+  status: S;
+  body: B;
+}): DistributeResponse<S, B> {
+  return result as DistributeResponse<S, B>;
+}
+
+/**
  * Proxy a raw HTTP request to an infra endpoint.
  *
  * Used for infra endpoints that don't have ts-rest contracts

--- a/turbo/apps/web/src/lib/infra-client.ts
+++ b/turbo/apps/web/src/lib/infra-client.ts
@@ -77,3 +77,41 @@ export function createInfraClient<T extends AppRouter>(
       : undefined,
   });
 }
+
+/**
+ * Proxy a raw HTTP request to an infra endpoint.
+ *
+ * Used for infra endpoints that don't have ts-rest contracts
+ * (e.g. metadata PATCH, schedule enable/disable).
+ */
+export async function proxyToInfra(
+  infraPath: string,
+  request: Request,
+): Promise<Response> {
+  const baseUrl = getInfraBaseUrl();
+  const incomingUrl = new URL(request.url);
+  const targetUrl = new URL(infraPath, baseUrl);
+
+  // Forward query parameters
+  incomingUrl.searchParams.forEach((value, key) => {
+    targetUrl.searchParams.set(key, value);
+  });
+
+  const headers: Record<string, string> = {};
+  const contentType = request.headers.get("content-type");
+  if (contentType) {
+    headers["Content-Type"] = contentType;
+  }
+  const auth = request.headers.get("authorization");
+  if (auth) {
+    headers["Authorization"] = auth;
+  }
+
+  const hasBody = request.method !== "GET" && request.method !== "HEAD";
+
+  return fetch(targetUrl, {
+    method: request.method,
+    headers,
+    body: hasBody ? await request.text() : undefined,
+  });
+}

--- a/turbo/apps/web/src/lib/infra-client.ts
+++ b/turbo/apps/web/src/lib/infra-client.ts
@@ -80,24 +80,27 @@ export function createInfraClient<T extends AppRouter>(
 
 /**
  * Distribute a union status into a discriminated union of response objects.
- * { status: A | B | C; body: X } → { status: A; body: X } | { status: B; body: X } | …
+ * Uses `never` for body so the result is assignable to any expected body type
+ * (never is the bottom type — assignable to everything).
  */
-type DistributeResponse<S extends number, B> = S extends S
-  ? { status: S; body: B }
+type DistributeResponse<S extends number> = S extends S
+  ? { status: S; body: never }
   : never;
 
 /**
  * Forward an infra client result to a zero route handler.
  *
  * ts-rest initClient returns { status: HTTPStatusCode; body: unknown } but
- * tsr.router handlers expect a discriminated union of response types.
- * This helper distributes the broad status union into discriminated form.
+ * tsr.router handlers expect a discriminated union with specific body types.
+ * This helper distributes the status union and erases the body type so the
+ * result is assignable to the handler's expected return type.
+ * Safe for proxy routes where infra and zero contracts share response shapes.
  */
-export function forwardInfra<S extends number, B>(result: {
+export function forwardInfra<S extends number>(result: {
   status: S;
-  body: B;
-}): DistributeResponse<S, B> {
-  return result as DistributeResponse<S, B>;
+  body: unknown;
+}): DistributeResponse<S> {
+  return result as DistributeResponse<S>;
 }
 
 /**

--- a/turbo/packages/core/src/contracts/index.ts
+++ b/turbo/packages/core/src/contracts/index.ts
@@ -551,3 +551,31 @@ export {
   type ZeroConnectorScopeDiffContract,
 } from "./zero-connectors";
 export { zeroOrgContract, type ZeroOrgContract } from "./zero-org";
+export {
+  zeroComposesMainContract,
+  zeroComposesByIdContract,
+  zeroComposesListContract,
+  type ZeroComposesMainContract,
+  type ZeroComposesByIdContract,
+  type ZeroComposesListContract,
+} from "./zero-composes";
+export {
+  zeroRunsMainContract,
+  zeroRunsByIdContract,
+  zeroRunsCancelContract,
+  zeroRunsQueueContract,
+  zeroRunAgentEventsContract,
+  type ZeroRunsMainContract,
+  type ZeroRunsByIdContract,
+  type ZeroRunsCancelContract,
+  type ZeroRunsQueueContract,
+  type ZeroRunAgentEventsContract,
+} from "./zero-runs";
+export {
+  zeroSchedulesMainContract,
+  zeroSchedulesByNameContract,
+  zeroSchedulesEnableContract,
+  type ZeroSchedulesMainContract,
+  type ZeroSchedulesByNameContract,
+  type ZeroSchedulesEnableContract,
+} from "./zero-schedules";

--- a/turbo/packages/core/src/contracts/zero-composes.ts
+++ b/turbo/packages/core/src/contracts/zero-composes.ts
@@ -1,0 +1,97 @@
+import { z } from "zod";
+import { authHeadersSchema, initContract } from "./base";
+import { apiErrorSchema } from "./errors";
+import { composeResponseSchema, composeListItemSchema } from "./composes";
+
+const c = initContract();
+
+/**
+ * Zero composes main contract (GET /api/zero/composes)
+ * Proxies to composesMainContract.getByName
+ */
+export const zeroComposesMainContract = c.router({
+  getByName: {
+    method: "GET",
+    path: "/api/zero/composes",
+    headers: authHeadersSchema,
+    query: z.object({
+      name: z.string().min(1, "Missing name query parameter"),
+      org: z.string().optional(),
+    }),
+    responses: {
+      200: composeResponseSchema,
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+    },
+    summary: "Get agent compose by name (zero proxy)",
+  },
+});
+
+/**
+ * Zero composes by ID contract (GET/DELETE /api/zero/composes/:id)
+ * Proxies to composesByIdContract
+ */
+export const zeroComposesByIdContract = c.router({
+  getById: {
+    method: "GET",
+    path: "/api/zero/composes/:id",
+    headers: authHeadersSchema,
+    pathParams: z.object({
+      id: z.string().min(1, "Compose ID is required"),
+    }),
+    responses: {
+      200: composeResponseSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      404: apiErrorSchema,
+    },
+    summary: "Get agent compose by ID (zero proxy)",
+  },
+  delete: {
+    method: "DELETE",
+    path: "/api/zero/composes/:id",
+    headers: authHeadersSchema,
+    pathParams: z.object({
+      id: z.string().uuid("Compose ID is required"),
+    }),
+    body: c.noBody(),
+    responses: {
+      204: c.noBody(),
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      404: apiErrorSchema,
+      409: apiErrorSchema,
+    },
+    summary: "Delete agent compose (zero proxy)",
+  },
+});
+
+/**
+ * Zero composes list contract (GET /api/zero/composes/list)
+ * Proxies to composesListContract
+ */
+export const zeroComposesListContract = c.router({
+  list: {
+    method: "GET",
+    path: "/api/zero/composes/list",
+    headers: authHeadersSchema,
+    query: z.object({
+      org: z.string().optional(),
+    }),
+    responses: {
+      200: z.object({
+        composes: z.array(composeListItemSchema),
+      }),
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+    },
+    summary: "List all agent composes (zero proxy)",
+  },
+});
+
+// Type exports
+export type ZeroComposesMainContract = typeof zeroComposesMainContract;
+export type ZeroComposesByIdContract = typeof zeroComposesByIdContract;
+export type ZeroComposesListContract = typeof zeroComposesListContract;

--- a/turbo/packages/core/src/contracts/zero-runs.ts
+++ b/turbo/packages/core/src/contracts/zero-runs.ts
@@ -10,6 +10,14 @@ import {
   unifiedRunRequestSchema,
 } from "./runs";
 
+/**
+ * Zero run request schema — same as unified but without triggerSource
+ * (the proxy injects triggerSource: "web" automatically).
+ */
+const zeroRunRequestSchema = unifiedRunRequestSchema.omit({
+  triggerSource: true,
+});
+
 const c = initContract();
 
 /**
@@ -21,7 +29,7 @@ export const zeroRunsMainContract = c.router({
     method: "POST",
     path: "/api/zero/runs",
     headers: authHeadersSchema,
-    body: unifiedRunRequestSchema,
+    body: zeroRunRequestSchema,
     responses: {
       201: createRunResponseSchema,
       400: apiErrorSchema,

--- a/turbo/packages/core/src/contracts/zero-runs.ts
+++ b/turbo/packages/core/src/contracts/zero-runs.ts
@@ -1,0 +1,131 @@
+import { z } from "zod";
+import { authHeadersSchema, initContract } from "./base";
+import { apiErrorSchema } from "./errors";
+import {
+  createRunResponseSchema,
+  getRunResponseSchema,
+  cancelRunResponseSchema,
+  agentEventsResponseSchema,
+  queueResponseSchema,
+  unifiedRunRequestSchema,
+} from "./runs";
+
+const c = initContract();
+
+/**
+ * Zero runs main contract (POST /api/zero/runs)
+ * Proxies to runsMainContract.create
+ */
+export const zeroRunsMainContract = c.router({
+  create: {
+    method: "POST",
+    path: "/api/zero/runs",
+    headers: authHeadersSchema,
+    body: unifiedRunRequestSchema,
+    responses: {
+      201: createRunResponseSchema,
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      404: apiErrorSchema,
+    },
+    summary: "Create and execute agent run (zero proxy)",
+  },
+});
+
+/**
+ * Zero runs by ID contract (GET /api/zero/runs/:id)
+ * Proxies to runsByIdContract
+ */
+export const zeroRunsByIdContract = c.router({
+  getById: {
+    method: "GET",
+    path: "/api/zero/runs/:id",
+    headers: authHeadersSchema,
+    pathParams: z.object({
+      id: z.string().min(1, "Run ID is required"),
+    }),
+    responses: {
+      200: getRunResponseSchema,
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      404: apiErrorSchema,
+    },
+    summary: "Get agent run by ID (zero proxy)",
+  },
+});
+
+/**
+ * Zero runs cancel contract (POST /api/zero/runs/:id/cancel)
+ * Proxies to runsCancelContract
+ */
+export const zeroRunsCancelContract = c.router({
+  cancel: {
+    method: "POST",
+    path: "/api/zero/runs/:id/cancel",
+    headers: authHeadersSchema,
+    pathParams: z.object({
+      id: z.string().min(1, "Run ID is required"),
+    }),
+    body: z.undefined(),
+    responses: {
+      200: cancelRunResponseSchema,
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      404: apiErrorSchema,
+    },
+    summary: "Cancel a pending or running run (zero proxy)",
+  },
+});
+
+/**
+ * Zero runs queue contract (GET /api/zero/runs/queue)
+ * Proxies to runsQueueContract
+ */
+export const zeroRunsQueueContract = c.router({
+  getQueue: {
+    method: "GET",
+    path: "/api/zero/runs/queue",
+    headers: authHeadersSchema,
+    responses: {
+      200: queueResponseSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+    },
+    summary: "Get org run queue status (zero proxy)",
+  },
+});
+
+/**
+ * Zero run agent events contract (GET /api/zero/runs/:id/telemetry/agent)
+ * Proxies to runAgentEventsContract
+ */
+export const zeroRunAgentEventsContract = c.router({
+  getAgentEvents: {
+    method: "GET",
+    path: "/api/zero/runs/:id/telemetry/agent",
+    headers: authHeadersSchema,
+    pathParams: z.object({
+      id: z.string().min(1, "Run ID is required"),
+    }),
+    query: z.object({
+      since: z.coerce.number().optional(),
+      limit: z.coerce.number().min(1).max(100).default(5),
+      order: z.enum(["asc", "desc"]).default("desc"),
+    }),
+    responses: {
+      200: agentEventsResponseSchema,
+      401: apiErrorSchema,
+      404: apiErrorSchema,
+    },
+    summary: "Get agent events with pagination (zero proxy)",
+  },
+});
+
+// Type exports
+export type ZeroRunsMainContract = typeof zeroRunsMainContract;
+export type ZeroRunsByIdContract = typeof zeroRunsByIdContract;
+export type ZeroRunsCancelContract = typeof zeroRunsCancelContract;
+export type ZeroRunsQueueContract = typeof zeroRunsQueueContract;
+export type ZeroRunAgentEventsContract = typeof zeroRunAgentEventsContract;

--- a/turbo/packages/core/src/contracts/zero-schedules.ts
+++ b/turbo/packages/core/src/contracts/zero-schedules.ts
@@ -1,0 +1,119 @@
+import { z } from "zod";
+import { authHeadersSchema, initContract } from "./base";
+import { apiErrorSchema } from "./errors";
+import {
+  deployScheduleRequestSchema,
+  scheduleListResponseSchema,
+  deployScheduleResponseSchema,
+  scheduleResponseSchema,
+} from "./schedules";
+
+const c = initContract();
+
+/**
+ * Zero schedules main contract (GET/POST /api/zero/schedules)
+ * Proxies to schedulesMainContract
+ */
+export const zeroSchedulesMainContract = c.router({
+  deploy: {
+    method: "POST",
+    path: "/api/zero/schedules",
+    headers: authHeadersSchema,
+    body: deployScheduleRequestSchema,
+    responses: {
+      200: deployScheduleResponseSchema,
+      201: deployScheduleResponseSchema,
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      404: apiErrorSchema,
+    },
+    summary: "Deploy schedule (zero proxy)",
+  },
+  list: {
+    method: "GET",
+    path: "/api/zero/schedules",
+    headers: authHeadersSchema,
+    responses: {
+      200: scheduleListResponseSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+    },
+    summary: "List all schedules (zero proxy)",
+  },
+});
+
+/**
+ * Zero schedules by name contract (DELETE /api/zero/schedules/:name)
+ * Proxies to schedulesByNameContract.delete
+ */
+export const zeroSchedulesByNameContract = c.router({
+  delete: {
+    method: "DELETE",
+    path: "/api/zero/schedules/:name",
+    headers: authHeadersSchema,
+    pathParams: z.object({
+      name: z.string().min(1, "Schedule name required"),
+    }),
+    query: z.object({
+      composeId: z.string().uuid("Compose ID required"),
+    }),
+    responses: {
+      204: c.noBody(),
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      404: apiErrorSchema,
+    },
+    summary: "Delete schedule (zero proxy)",
+  },
+});
+
+/**
+ * Zero schedules enable/disable contract
+ * Proxies to schedulesEnableContract
+ */
+export const zeroSchedulesEnableContract = c.router({
+  enable: {
+    method: "POST",
+    path: "/api/zero/schedules/:name/enable",
+    headers: authHeadersSchema,
+    pathParams: z.object({
+      name: z.string().min(1, "Schedule name required"),
+    }),
+    body: z.object({
+      composeId: z.string().uuid("Compose ID required"),
+    }),
+    responses: {
+      200: scheduleResponseSchema,
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      404: apiErrorSchema,
+    },
+    summary: "Enable schedule (zero proxy)",
+  },
+  disable: {
+    method: "POST",
+    path: "/api/zero/schedules/:name/disable",
+    headers: authHeadersSchema,
+    pathParams: z.object({
+      name: z.string().min(1, "Schedule name required"),
+    }),
+    body: z.object({
+      composeId: z.string().uuid("Compose ID required"),
+    }),
+    responses: {
+      200: scheduleResponseSchema,
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      404: apiErrorSchema,
+    },
+    summary: "Disable schedule (zero proxy)",
+  },
+});
+
+// Type exports
+export type ZeroSchedulesMainContract = typeof zeroSchedulesMainContract;
+export type ZeroSchedulesByNameContract = typeof zeroSchedulesByNameContract;
+export type ZeroSchedulesEnableContract = typeof zeroSchedulesEnableContract;


### PR DESCRIPTION
## Summary

- Create zero proxy routes for **composes**, **runs**, and **schedules** domains that forward requests from `/api/zero/` to `/api/agent/` infra endpoints using ts-rest typed clients
- Add `proxyToInfra` raw HTTP proxy helper for infra endpoints without ts-rest contracts (metadata PATCH, schedule enable/disable)
- Migrate all platform signal files from `/api/agent/` to `/api/zero/` paths, keeping `/api/agent/composes/:id/instructions` unchanged (out of scope)

Part of #5670 (API layer separation). Depends on Phase 1 (#5681, merged).

Closes #5673

## What changed

### Contracts (`@vm0/core`)
- `zero-composes.ts` — contracts for getByName, getById, delete, list
- `zero-runs.ts` — contracts for create, getById, cancel, queue, agent events
- `zero-schedules.ts` — contracts for deploy, list, delete, enable/disable

### Proxy routes (`apps/web`)
- **ts-rest proxy routes** (13 handlers): typed infra client forwarding via `createInfraClient`
- **Raw proxy routes** (3 handlers): metadata PATCH, schedule enable/disable via `proxyToInfra`

### Platform signals (`apps/platform`)
- Updated 9 signal files + 9 test files + 1 shared mock handler to use `/api/zero/` paths

## Test plan

- [x] `pnpm check-types` passes (0 errors)
- [x] `pnpm turbo run lint` passes (0 warnings)
- [x] `pnpm format` — no changes needed
- [x] `pnpm knip` — no unused exports/deps
- [x] `pnpm vitest run` — 318/319 pass (1 pre-existing failure on main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)