### PR TITLE
feat: add cargo-llvm-cov to toolchain docker image

### DIFF
--- a/docker/toolchain/Dockerfile
+++ b/docker/toolchain/Dockerfile
@@ -167,5 +167,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python3-pip \
     && rm -rf /var/lib/apt/lists/*
 
+# Install cargo-llvm-cov for Rust test coverage
+RUN cargo install cargo-llvm-cov --locked \
+    && rustup component add llvm-tools-preview
+
 # Default command
 CMD ["/usr/bin/zsh"]


### PR DESCRIPTION
## Summary

- Bake `cargo-llvm-cov` and `llvm-tools-preview` into the toolchain Docker image
- Phase 2 of #5637: eliminates the need for `taiki-e/install-action` in CI per run

## Test plan

- [ ] Verify toolchain image builds successfully with the new layer
- [ ] After image is published, update `crates.yml` to remove `taiki-e/install-action` step

🤖 Generated with [Claude Code](https://claude.com/claude-code)