### PR TITLE
fix: preserve agent metadata when updating only connectors

### DIFF
--- a/turbo/apps/web/app/api/zero/agents/[name]/route.ts
+++ b/turbo/apps/web/app/api/zero/agents/[name]/route.ts
@@ -151,7 +151,14 @@ const router = tsr.router(zeroAgentsByNameContract, {
       };
     }
 
-    // Write metadata to zero_agents
+    // Write metadata to zero_agents — only overwrite fields explicitly provided
+    const metadataSet: Record<string, unknown> = { updatedAt: new Date() };
+    if (body.displayName !== undefined)
+      metadataSet.displayName = body.displayName;
+    if (body.description !== undefined)
+      metadataSet.description = body.description;
+    if (body.sound !== undefined) metadataSet.sound = body.sound;
+
     await globalThis.services.db
       .insert(zeroAgents)
       .values({
@@ -163,12 +170,7 @@ const router = tsr.router(zeroAgentsByNameContract, {
       })
       .onConflictDoUpdate({
         target: [zeroAgents.orgId, zeroAgents.name],
-        set: {
-          displayName: body.displayName ?? null,
-          description: body.description ?? null,
-          sound: body.sound ?? null,
-          updatedAt: new Date(),
-        },
+        set: metadataSet,
       });
 
     log.info(`Updated zero agent: ${result.composeName}`);

--- a/turbo/apps/web/app/api/zero/agents/[name]/route.ts
+++ b/turbo/apps/web/app/api/zero/agents/[name]/route.ts
@@ -152,13 +152,7 @@ const router = tsr.router(zeroAgentsByNameContract, {
     }
 
     // Write metadata to zero_agents — only overwrite fields explicitly provided
-    const metadataSet: Record<string, unknown> = { updatedAt: new Date() };
-    if (body.displayName !== undefined)
-      metadataSet.displayName = body.displayName;
-    if (body.description !== undefined)
-      metadataSet.description = body.description;
-    if (body.sound !== undefined) metadataSet.sound = body.sound;
-
+    const now = new Date();
     await globalThis.services.db
       .insert(zeroAgents)
       .values({
@@ -170,19 +164,40 @@ const router = tsr.router(zeroAgentsByNameContract, {
       })
       .onConflictDoUpdate({
         target: [zeroAgents.orgId, zeroAgents.name],
-        set: metadataSet,
+        set: {
+          updatedAt: now,
+          ...(body.displayName !== undefined && {
+            displayName: body.displayName,
+          }),
+          ...(body.description !== undefined && {
+            description: body.description,
+          }),
+          ...(body.sound !== undefined && { sound: body.sound }),
+        },
       });
 
     log.info(`Updated zero agent: ${result.composeName}`);
+
+    // Re-query to return actual persisted state
+    const [agent] = await globalThis.services.db
+      .select()
+      .from(zeroAgents)
+      .where(
+        and(
+          eq(zeroAgents.orgId, org.orgId),
+          eq(zeroAgents.name, result.composeName),
+        ),
+      )
+      .limit(1);
 
     return {
       status: 200 as const,
       body: {
         name: result.composeName,
         agentComposeId: result.composeId,
-        description: body.description ?? null,
-        displayName: body.displayName ?? null,
-        sound: body.sound ?? null,
+        description: agent?.description ?? null,
+        displayName: agent?.displayName ?? null,
+        sound: agent?.sound ?? null,
         connectors: extractConnectors(content),
       },
     };

--- a/turbo/apps/web/app/api/zero/agents/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/agents/__tests__/route.test.ts
@@ -273,6 +273,38 @@ describe("Zero Agents API", () => {
       expect(data.sound).toBe("casual");
     });
 
+    it("should preserve metadata when only connectors are updated", async () => {
+      // Create agent with metadata
+      const createResponse = await postAgent(
+        {
+          connectors: [],
+          displayName: "My Agent",
+          description: "A helpful agent",
+          sound: "professional",
+        },
+        testCliToken,
+        testOrgSlug,
+      );
+      const created = await createResponse.json();
+
+      // Update only connectors — no metadata fields
+      const updateResponse = await putAgent(
+        created.name,
+        { connectors: [] },
+        testCliToken,
+        testOrgSlug,
+      );
+      expect(updateResponse.status).toBe(200);
+
+      // Verify metadata is preserved
+      const getRes = await getAgent(created.name, testCliToken, testOrgSlug);
+      expect(getRes.status).toBe(200);
+      const fetched = await getRes.json();
+      expect(fetched.displayName).toBe("My Agent");
+      expect(fetched.description).toBe("A helpful agent");
+      expect(fetched.sound).toBe("professional");
+    });
+
     it("should return 404 for unknown agent", async () => {
       const response = await putAgent(
         "nonexistent-agent",


### PR DESCRIPTION
## Summary
- `PUT /api/zero/agents/:name` unconditionally overwrote `displayName`, `description`, and `sound` with `body.field ?? null` in the `onConflictDoUpdate` clause
- When callers (e.g. `syncSkillsToCompose$`, `zero-job-detail.ts`) updated only connectors without passing metadata fields, `undefined ?? null` = `null` silently erased existing metadata
- Fix: only include metadata fields in the `onConflictDoUpdate` set when they are explicitly provided (`!== undefined`)

## Test plan
- [x] Added integration test: create agent with metadata → update with only connectors → verify metadata preserved via GET
- [x] All 17 existing zero agents tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)