### PR TITLE
refactor: simplify agent-api-connector skill to implementation-only

### DIFF
--- a/.claude/skills/agent-api-connector/SKILL.md
+++ b/.claude/skills/agent-api-connector/SKILL.md
@@ -1,149 +1,43 @@
 ---
 name: agent-api-connector
-description: Process api-token connector issues end-to-end — merge existing PRs first, then implement one new connector
+description: Implement an api-token connector from a GitHub issue — research, code, and create PR
 context: fork
 ---
 
-# Process API-Token Connector
+# Implement API-Token Connector
 
-You are an api-token connector lifecycle specialist. Each invocation does TWO phases:
-1. **Phase A:** Check and merge existing connector PRs (resolve conflicts, wait for CI, merge when ready)
-2. **Phase B:** Implement one new connector (only if no open connector PR exists)
+You are an api-token connector implementation specialist. Given an issue, you research the connector, implement it across the required files, and create a PR.
 
-This single-agent design avoids the N! merge conflict problem caused by parallel agents.
+For PR lifecycle management (merge conflicts, CI monitoring, merging), use `/coding-loop api-token connector` instead.
 
----
+## Arguments
 
-## Phase A: Check and Merge Existing PRs
+Your args are: `$ARGUMENTS`
 
-Process existing open connector PRs **one at a time, sequentially**.
-
-### Step A0: Sync Main
-
-```bash
-rm -f .claude/scheduled_tasks.lock
-git checkout main
-git stash 2>/dev/null; git pull; git stash pop 2>/dev/null; true
-```
-
-### Step A1: List Connector PRs
-
-```bash
-gh pr list --state open --json number,title,mergeable,headRefName \
-  --jq '.[] | select(.title | test("connector|api.?key|api.?token"; "i")) | {number, title, mergeable}'
-```
-
-If no open connector PRs, skip to **Phase B**.
-
-### Step A2: Process Each PR Sequentially
-
-For each PR (one at a time, never parallel):
-
-#### Check Merge Conflict Status
-
-```bash
-gh pr view <PR> --json mergeable --jq '.mergeable'
-```
-
-#### Case 1: Merge Conflict
-
-1. **Disable auto-merge first** (prevent stale auto-merge from triggering after push):
-   ```bash
-   gh pr merge --disable-auto <PR>
-   ```
-
-2. **Checkout, resolve conflict, push:**
-   ```bash
-   git checkout <branch>
-   git fetch origin main
-   git merge origin/main
-   # Resolve conflicts in the shared files (connectors.ts, services.ts, provider-registry.ts, connector-icons.tsx, connectorTypeSchema)
-   # These are always additive — keep ALL entries from both sides, maintain alphabetical order
-   git add <resolved files>
-   git commit -m "chore: resolve merge conflict with main"
-   git push
-   ```
-
-3. **Return to main:**
-   ```bash
-   rm -f .claude/scheduled_tasks.lock
-   git checkout main
-   git stash 2>/dev/null; git pull; git stash pop 2>/dev/null; true
-   ```
-
-4. **DO NOT merge this PR in this round.** Move to next PR. The pushed conflict resolution needs a fresh CI run.
-
-#### Case 2: No Conflict, CI Failing
-
-1. Check CI status:
-   ```bash
-   gh pr checks <PR> --json name,state,conclusion
-   ```
-
-2. **If runner/e2e failures:** Post to Slack channel (channelId: `C0ALXC1SHHN`) with the failed job URL. Do NOT mention or @ any users. Then retry:
-   ```bash
-   gh pr checks <PR> --json name,state,conclusion --jq '.[] | select(.conclusion == "failure")'
-   # Retry failed workflows
-   ```
-
-3. **If other failures (lint, type, build):** Checkout the branch, fix the code, push. **Do NOT merge this round** — wait for next CI run.
-
-4. Return to main after fixing.
-
-#### Case 3: No Conflict, CI Passing (15+ SUCCESS), No Push This Round → MERGE
-
-1. **Verify CI completion** — at least 15 checks must show SUCCESS. Do not merge if checks are still in_progress:
-   ```bash
-   gh pr checks <PR> --json name,state,conclusion \
-     --jq '[.[] | select(.conclusion == "success")] | length'
-   ```
-
-2. **Merge:**
-   ```bash
-   gh pr merge <PR> --merge --delete-branch
-   ```
-
-3. **Pull main** to get the merge:
-   ```bash
-   rm -f .claude/scheduled_tasks.lock
-   git checkout main
-   git stash 2>/dev/null; git pull; git stash pop 2>/dev/null; true
-   ```
-
-4. Proceed to next PR.
-
-### Step A3: Summary
-
-After processing all PRs, report:
-- How many PRs were merged
-- How many had conflicts resolved (pending next CI)
-- How many had CI failures fixed (pending next CI)
-- How many are still waiting for CI
+Parse the args to get the issue number. If no issue number is provided, find the next available issue automatically (see Step 1).
 
 ---
 
-## Phase B: Implement New Connector
+## Step 1: Find the Issue
 
-**Skip Phase B entirely if any open connector PR exists after Phase A.** Only proceed when there are zero open connector PRs.
+If an issue number was provided, use it directly. Otherwise, find the next unlinked issue:
 
-### Step B1: Find Next Issue
+```bash
+gh issue list --repo vm0-ai/vm0 --label "api-token connector" --state open \
+  --json number,title,closedByPullRequestsReferences --limit 50
+```
 
-1. List open issues with the `api-token connector` label that have no linked PR:
-   ```bash
-   gh issue list --repo vm0-ai/vm0 --label "api-token connector" --state open \
-     --json number,title,closedByPullRequestsReferences --limit 50
-   ```
+Filter to issues where `closedByPullRequestsReferences` is empty. Pick the lowest issue number.
 
-2. Filter to issues where `closedByPullRequestsReferences` is empty. Pick the lowest issue number.
+Verify no existing open PR exists for this connector:
 
-3. Also check there is no existing open PR for this connector:
-   ```bash
-   gh api "repos/vm0-ai/vm0/pulls?state=open&per_page=100" --jq '.[].title' | grep -i <connector-name>
-   ```
+```bash
+gh api "repos/vm0-ai/vm0/pulls?state=open&per_page=100" --jq '.[].title' | grep -i <connector-name>
+```
 
-4. If no unlinked issues remain, end.
+If no unlinked issues remain, end.
 
-### Step B2: Research the Connector
+## Step 2: Research the Connector
 
 In parallel:
 
@@ -156,30 +50,31 @@ In parallel:
 
 2. **Find a real SVG logo** from the internet (simpleicons.org, svgrepo.com, worldvectorlogo.com, brandfetch.com, or the service's official website/GitHub repo). **Never fabricate a logo.**
 
-### Step B3: Create Feature Branch
+## Step 3: Create Feature Branch
 
 ```bash
+git checkout main && git pull
 git checkout -b feat/add-<name>-connector
 ```
 
-### Step B4: Implement the Connector
+## Step 4: Implement the Connector
 
 Edit these files (use existing connectors like `twenty`, `qiita`, `zeptomail` as templates):
 
-#### 4a. `turbo/packages/core/src/contracts/connectors.ts` (2 spots)
+### 4a. `turbo/packages/core/src/contracts/connectors.ts` (2 spots)
 
 1. **CONNECTOR_TYPES_DEF** — Add connector config with label, helpText, authMethods (api-token), defaultAuthMethod. Insert alphabetically.
 
 2. **connectorTypeSchema z.enum** — Add the connector type string
 
-#### 4a2. `turbo/packages/core/src/contracts/services.ts` (1 spot)
+### 4b. `turbo/packages/core/src/contracts/services.ts` (1 spot)
 
 - **SERVICE_CONFIGS** — Add service configuration if the API uses header-based auth:
   - Bearer auth: `api("https://api.example.com", bearerAuth("XXX_TOKEN"))`
   - Custom header: `api("https://api.example.com", { headers: { "x-api-key": "${{ secrets.XXX_TOKEN }}" } })`
   - **Skip** if auth is query-param-based or requires base64 encoding (Basic auth)
 
-#### 4b. `turbo/apps/web/src/lib/connector/providers/<name>-handler.ts` (new file)
+### 4c. `turbo/apps/web/src/lib/connector/providers/<name>-handler.ts` (new file)
 
 ```typescript
 import { type ProviderHandler } from "../provider-types";
@@ -197,21 +92,21 @@ export const <name>Handler: ProviderHandler = {
 };
 ```
 
-#### 4c. `turbo/apps/web/src/lib/connector/provider-registry.ts` (2 spots)
+### 4d. `turbo/apps/web/src/lib/connector/provider-registry.ts` (2 spots)
 
 1. Add import for the handler
 2. Add entry to `PROVIDER_HANDLERS` record
 
-#### 4d. `turbo/apps/platform/src/views/settings-page/icons/<name>.svg` (new file)
+### 4e. `turbo/apps/platform/src/views/settings-page/icons/<name>.svg` (new file)
 
-The real SVG logo found in Step B2.
+The real SVG logo found in Step 2.
 
-#### 4e. `turbo/apps/platform/src/views/settings-page/connector-icons.tsx` (2 spots)
+### 4f. `turbo/apps/platform/src/views/settings-page/connector-icons.tsx` (2 spots)
 
 1. Add import for the SVG icon
 2. Add entry to `CONNECTOR_ICONS` record
 
-### Step B5: Update vm0-skills Secret Name (if needed)
+## Step 5: Update vm0-skills Secret Name (if needed)
 
 If the skill's `vm0_secrets` doesn't follow `XXX_TOKEN` convention, rename it:
 
@@ -224,7 +119,7 @@ gh api --method PUT "repos/vm0-ai/vm0-skills/contents/<name>/SKILL.md" \
   -f message="chore: rename OLD_SECRET to NEW_SECRET" -f content="$CONTENT" -f sha="$SHA"
 ```
 
-### Step B6: Commit and Push
+## Step 6: Commit and Push
 
 ```bash
 git add <all changed files>
@@ -234,7 +129,7 @@ git push -u origin feat/add-<name>-connector
 
 **Important:** Do NOT run `check-types` locally — it gets stuck. The lefthook pre-commit hook runs prettier + knip which is sufficient.
 
-### Step B7: Create PR
+## Step 7: Create PR
 
 ```bash
 gh pr create --title "feat: add <name> api-token connector" --body "$(cat <<'EOF'
@@ -250,27 +145,12 @@ EOF
 )"
 ```
 
-### Step B8: Return to Main
-
-```bash
-rm -f .claude/scheduled_tasks.lock
-git checkout main
-git stash 2>/dev/null; git pull; git stash pop 2>/dev/null; true
-```
-
 ---
 
 ## Key Rules
 
-- **One open connector PR at a time** — do not create a new connector PR while another is still open. Merge existing PRs first in Phase A
-- **One PR per issue, one issue at a time**
-- **Sequential PR processing** — never process multiple PRs in parallel
-- **Never merge a PR you pushed to in the same round** — always wait for fresh CI
-- **Disable auto-merge before pushing conflict fixes** — prevents stale auto-merge
-- **15+ SUCCESS checks required before merging** — in_progress is not sufficient
 - **Secret naming:** Always `XXX_TOKEN` — never `_API_KEY`, `_SECRET_KEY`, `_ACCESS_TOKEN`
 - **Logo:** Must be from a real internet source — never self-created
 - **Service config:** Only for header-based auth (Bearer, custom headers) in `services.ts`. Skip for query param auth or Basic auth requiring base64
 - **No `check-types` locally** — it gets stuck. Rely on CI
-- **Always pull after returning to main**
-- **Conflict resolution for shared files:** These connectors only add new entries to shared files. Conflicts are always additive — keep ALL entries from both sides, maintain alphabetical order
+- **Alphabetical ordering** — Insert new entries alphabetically in all shared files (connectors.ts, services.ts, provider-registry.ts, connector-icons.tsx)


### PR DESCRIPTION
## Summary
- Remove Phase A (PR lifecycle management) from agent-api-connector skill — this logic is already handled by the generic `coding-loop` skill
- Focus the skill purely on implementing a connector from a GitHub issue (research, code, create PR)
- Reduce skill definition from 277 lines to 156 lines (~44% smaller)

## Test plan
- [ ] Verify `/agent-api-connector` skill description updated in skill list
- [ ] Verify skill can be invoked with an issue number argument
- [ ] Verify `coding-loop api-token connector` still handles the PR lifecycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)