### PR TITLE
fix(ci): resolve shellcheck issues and enable shellcheck in actionlint

### DIFF
--- a/.github/workflows/cleanup-stale.yml
+++ b/.github/workflows/cleanup-stale.yml
@@ -220,9 +220,9 @@ jobs:
         run: |
           if [ -z "$SSH_KEY" ] || [ -z "$METAL_HOSTS" ]; then
             echo "Metal secrets not available, skipping runner cleanup"
-            echo "should-cleanup=false" >> $GITHUB_OUTPUT
+            echo "should-cleanup=false" >> "$GITHUB_OUTPUT"
           else
-            echo "should-cleanup=true" >> $GITHUB_OUTPUT
+            echo "should-cleanup=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Find recently closed PRs

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -24,9 +24,9 @@ jobs:
         run: |
           if [ -z "$SSH_KEY" ] || [ -z "$METAL_HOSTS" ]; then
             echo "Metal secrets not available, skipping runner cleanup"
-            echo "should-cleanup=false" >> $GITHUB_OUTPUT
+            echo "should-cleanup=false" >> "$GITHUB_OUTPUT"
           else
-            echo "should-cleanup=true" >> $GITHUB_OUTPUT
+            echo "should-cleanup=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Install Ansible

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -61,9 +61,15 @@ jobs:
 
           # scripts/crate-changed.sh: exit 0=changed, 1=not changed, 2+=error
           check_crate() {
-            ./scripts/crate-changed.sh "$1" "$BASE_REF" && echo "$1-changed=true" >> "$GITHUB_OUTPUT" || {
-              rc=$?; [ $rc -eq 1 ] && echo "$1-changed=false" >> "$GITHUB_OUTPUT" || exit $rc
-            }
+            local rc=0
+            ./scripts/crate-changed.sh "$1" "$BASE_REF" && rc=0 || rc=$?
+            if [ $rc -eq 0 ]; then
+              echo "$1-changed=true" >> "$GITHUB_OUTPUT"
+            elif [ $rc -eq 1 ]; then
+              echo "$1-changed=false" >> "$GITHUB_OUTPUT"
+            else
+              exit $rc
+            fi
           }
           check_crate ably-subscriber
           check_crate runner
@@ -198,17 +204,17 @@ jobs:
       - name: Cross-compile guest binaries for ARM64
         run: |
           cd crates
-          cargo build --profile $CARGO_PROFILE --target $TARGET_TRIPLE \
+          cargo build --profile "$CARGO_PROFILE" --target "$TARGET_TRIPLE" \
             -p guest-agent -p guest-download -p guest-init -p guest-mock-claude
 
       - name: Cross-compile runner with embedded guests for ARM64
         run: |
           cd crates
-          GUEST_AGENT_PATH=target/$TARGET_TRIPLE/$CARGO_PROFILE/guest-agent \
-          GUEST_DOWNLOAD_PATH=target/$TARGET_TRIPLE/$CARGO_PROFILE/guest-download \
-          GUEST_INIT_PATH=target/$TARGET_TRIPLE/$CARGO_PROFILE/guest-init \
-          GUEST_MOCK_CLAUDE_PATH=target/$TARGET_TRIPLE/$CARGO_PROFILE/guest-mock-claude \
-          cargo build --profile $CARGO_PROFILE --target $TARGET_TRIPLE -p runner
+          GUEST_AGENT_PATH="target/$TARGET_TRIPLE/$CARGO_PROFILE/guest-agent" \
+          GUEST_DOWNLOAD_PATH="target/$TARGET_TRIPLE/$CARGO_PROFILE/guest-download" \
+          GUEST_INIT_PATH="target/$TARGET_TRIPLE/$CARGO_PROFILE/guest-init" \
+          GUEST_MOCK_CLAUDE_PATH="target/$TARGET_TRIPLE/$CARGO_PROFILE/guest-mock-claude" \
+          cargo build --profile "$CARGO_PROFILE" --target "$TARGET_TRIPLE" -p runner
 
       - name: Setup SSH via Cloudflare Tunnel
         uses: ./.github/actions/setup-ssh-tunnel
@@ -269,26 +275,31 @@ jobs:
           JOB_REF: ${{ steps.host.outputs.job-ref }}
         run: |
           REMOTE="${METAL_USER}@${HOST}"
+          # shellcheck disable=SC2088
           BIN_DIR="~/.vm0-runner/bin/${JOB_REF}"
           TARGET_DIR="crates/target/${TARGET_TRIPLE}/${CARGO_PROFILE}"
 
           # Clean previous run artifacts and upload runner (guests are embedded)
           echo "=== Deploying runner to ${HOST}:${BIN_DIR} ==="
-          ssh $REMOTE "rm -rf ${BIN_DIR} ~/.vm0-runner/runners/${JOB_REF}-bench ~/.vm0-runner/runners/${JOB_REF}-local && mkdir -p ${BIN_DIR}"
+          # shellcheck disable=SC2029
+          ssh "$REMOTE" "rm -rf ${BIN_DIR} ~/.vm0-runner/runners/${JOB_REF}-bench ~/.vm0-runner/runners/${JOB_REF}-local && mkdir -p ${BIN_DIR}"
           scp "${TARGET_DIR}/runner" "${REMOTE}:${BIN_DIR}/"
 
           # Clean up old rootfs/snapshots, keep the 3 most recent deploys
-          ssh $REMOTE "${BIN_DIR}/runner gc --keep-latest 3"
+          # shellcheck disable=SC2029
+          ssh "$REMOTE" "${BIN_DIR}/runner gc --keep-latest 3"
 
           # Run setup (downloads firecracker/kernel/mitmdump, cached + idempotent)
           echo "=== Running setup ==="
-          ssh $REMOTE "${BIN_DIR}/runner setup"
+          # shellcheck disable=SC2029
+          ssh "$REMOTE" "${BIN_DIR}/runner setup"
 
           # Run build (rootfs via Docker + snapshot via Firecracker)
           # Use tee to stream output in real-time while capturing for hash extraction
           echo "=== Building vm0/default ==="
           BUILD_LOG_DEFAULT=$(mktemp)
-          ssh $REMOTE "${BIN_DIR}/runner build --profile vm0/default" | tee "$BUILD_LOG_DEFAULT"
+          # shellcheck disable=SC2029
+          ssh "$REMOTE" "${BIN_DIR}/runner build --profile vm0/default" | tee "$BUILD_LOG_DEFAULT"
           DEFAULT_ROOTFS_HASH=$(grep '^rootfs_hash=' "$BUILD_LOG_DEFAULT" | cut -d= -f2)
           DEFAULT_SNAPSHOT_HASH=$(grep '^snapshot_hash=' "$BUILD_LOG_DEFAULT" | cut -d= -f2)
           rm -f "$BUILD_LOG_DEFAULT"
@@ -324,11 +335,14 @@ jobs:
           DEFAULT_SNAPSHOT_HASH: ${{ needs.runner-build.outputs.default-snapshot-hash }}
         run: |
           REMOTE="${METAL_USER}@${HOST}"
+          # shellcheck disable=SC2088
           BIN_DIR="~/.vm0-runner/bin/${JOB_REF}"
+          # shellcheck disable=SC2088
           RUNNER_DIR="~/.vm0-runner/runners/${JOB_REF}-bench"
 
           echo "=== Generating config ==="
-          ssh $REMOTE "${BIN_DIR}/runner config \
+          # shellcheck disable=SC2029
+          ssh "$REMOTE" "${BIN_DIR}/runner config \
             --profile vm0/default \
             --rootfs-hash ${DEFAULT_ROOTFS_HASH} \
             --snapshot-hash ${DEFAULT_SNAPSHOT_HASH} \
@@ -339,13 +353,15 @@ jobs:
             --token vm0_official_${OFFICIAL_RUNNER_SECRET}"
 
           echo "=== Running benchmark (default) ==="
-          ssh $REMOTE "${BIN_DIR}/runner benchmark \
+          # shellcheck disable=SC2029
+          ssh "$REMOTE" "${BIN_DIR}/runner benchmark \
             --config ${RUNNER_DIR}/runner.yaml \
             --profile vm0/default \
             'curl -sf --max-time 10 https://httpbin.org/get'"
 
           echo "=== Running benchmark (browser automation) ==="
-          ssh $REMOTE "${BIN_DIR}/runner benchmark \
+          # shellcheck disable=SC2029
+          ssh "$REMOTE" "${BIN_DIR}/runner benchmark \
             --config ${RUNNER_DIR}/runner.yaml \
             --profile vm0/default \
             'agent-browser open https://github.com/ && agent-browser get title && agent-browser close'"
@@ -374,10 +390,12 @@ jobs:
           DEFAULT_SNAPSHOT_HASH: ${{ needs.runner-build.outputs.default-snapshot-hash }}
         run: |
           REMOTE="${METAL_USER}@${HOST}"
+          # shellcheck disable=SC2088
           BIN_DIR="~/.vm0-runner/bin/${JOB_REF}"
 
           echo "=== Generating config ==="
-          ssh $REMOTE "${BIN_DIR}/runner config \
+          # shellcheck disable=SC2029
+          ssh "$REMOTE" "${BIN_DIR}/runner config \
             --profile vm0/default \
             --rootfs-hash ${DEFAULT_ROOTFS_HASH} \
             --snapshot-hash ${DEFAULT_SNAPSHOT_HASH} \
@@ -389,7 +407,7 @@ jobs:
             --token vm0_official_${OFFICIAL_RUNNER_SECRET}"
 
           echo "=== Running exec test ==="
-          ssh $REMOTE bash -s -- "${BIN_DIR}" "${JOB_REF}" <<'REMOTE_SCRIPT'
+          ssh "$REMOTE" bash -s -- "${BIN_DIR}" "${JOB_REF}" <<'REMOTE_SCRIPT'
           BIN_DIR=$1; JOB_REF=$2
           RUNNER_DIR="$HOME/.vm0-runner/runners/${JOB_REF}-exec"
           SVC="${JOB_REF}-exec"
@@ -475,10 +493,12 @@ jobs:
           DEFAULT_SNAPSHOT_HASH: ${{ needs.runner-build.outputs.default-snapshot-hash }}
         run: |
           REMOTE="${METAL_USER}@${HOST}"
+          # shellcheck disable=SC2088
           BIN_DIR="~/.vm0-runner/bin/${JOB_REF}"
 
           echo "=== Generating config ==="
-          ssh $REMOTE "${BIN_DIR}/runner config \
+          # shellcheck disable=SC2029
+          ssh "$REMOTE" "${BIN_DIR}/runner config \
             --profile vm0/default \
             --rootfs-hash ${DEFAULT_ROOTFS_HASH} \
             --snapshot-hash ${DEFAULT_SNAPSHOT_HASH} \
@@ -490,7 +510,7 @@ jobs:
             --token vm0_official_${OFFICIAL_RUNNER_SECRET}"
 
           echo "=== Running balloon test ==="
-          ssh $REMOTE bash -s -- "${BIN_DIR}" "${JOB_REF}" <<'REMOTE_SCRIPT'
+          ssh "$REMOTE" bash -s -- "${BIN_DIR}" "${JOB_REF}" <<'REMOTE_SCRIPT'
           BIN_DIR=$1; JOB_REF=$2
           RUNNER_DIR="$HOME/.vm0-runner/runners/${JOB_REF}-balloon"
           SVC="${JOB_REF}-balloon"
@@ -653,12 +673,14 @@ jobs:
           DEFAULT_SNAPSHOT_HASH: ${{ needs.runner-build.outputs.default-snapshot-hash }}
         run: |
           REMOTE="${METAL_USER}@${HOST}"
+          # shellcheck disable=SC2088
           BIN_DIR="~/.vm0-runner/bin/${JOB_REF}"
           GROUP="vm0/upgrade-${JOB_REF}"
 
           echo "=== Generating configs for runner A and B ==="
           for SUFFIX in upgrade-a upgrade-b; do
-            ssh $REMOTE "${BIN_DIR}/runner config \
+            # shellcheck disable=SC2029
+            ssh "$REMOTE" "${BIN_DIR}/runner config \
               --profile vm0/default \
               --rootfs-hash ${DEFAULT_ROOTFS_HASH} \
               --snapshot-hash ${DEFAULT_SNAPSHOT_HASH} \
@@ -671,7 +693,7 @@ jobs:
           done
 
           echo "=== Running upgrade test ==="
-          ssh $REMOTE bash -s -- "${BIN_DIR}" "${JOB_REF}" "${GROUP}" <<'REMOTE_SCRIPT'
+          ssh "$REMOTE" bash -s -- "${BIN_DIR}" "${JOB_REF}" "${GROUP}" <<'REMOTE_SCRIPT'
           BIN_DIR=$1; JOB_REF=$2; GROUP=$3
           RUNNER_DIR_A="$HOME/.vm0-runner/runners/${JOB_REF}-upgrade-a"
           RUNNER_DIR_B="$HOME/.vm0-runner/runners/${JOB_REF}-upgrade-b"

--- a/.github/workflows/docker-toolchain-publish.yml
+++ b/.github/workflows/docker-toolchain-publish.yml
@@ -42,8 +42,8 @@ jobs:
       - name: Extract metadata
         id: meta
         run: |
-          echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
-          echo "date=$(date +'%Y%m%d')" >> $GITHUB_OUTPUT
+          echo "sha_short=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+          echo "date=$(date +'%Y%m%d')" >> "$GITHUB_OUTPUT"
 
       - name: Build and push toolchain image
         uses: docker/build-push-action@v7

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -76,14 +76,14 @@ jobs:
 
       - name: Record start time
         id: timer
-        run: echo "start=$(date +%s)" >> $GITHUB_OUTPUT
+        run: echo "start=$(date +%s)" >> "$GITHUB_OUTPUT"
 
       - name: Get Production Database URL
         id: get-db-url
         run: |
           # Get the main branch database URL (production)
           DATABASE_URL=$(neonctl connection-string production --project-id ${{ vars.NEON_PROJECT_ID }} --database-name neondb --pooled)
-          echo "database-url=$DATABASE_URL" >> $GITHUB_OUTPUT
+          echo "database-url=$DATABASE_URL" >> "$GITHUB_OUTPUT"
         env:
           NEON_API_KEY: ${{ secrets.NEON_API_KEY }}
 
@@ -104,7 +104,7 @@ jobs:
           if [ $h -gt 0 ]; then text="${h}h ${m}m ${s}s"
           elif [ $m -gt 0 ]; then text="${m}m ${s}s"
           else text="${s}s"; fi
-          echo "text=$text" >> $GITHUB_OUTPUT
+          echo "text=$text" >> "$GITHUB_OUTPUT"
 
       - name: Notify Slack - Success
         if: ${{ success() && steps.slack-start.outputs.ts }}
@@ -174,14 +174,14 @@ jobs:
 
       - name: Record start time
         id: timer
-        run: echo "start=$(date +%s)" >> $GITHUB_OUTPUT
+        run: echo "start=$(date +%s)" >> "$GITHUB_OUTPUT"
 
       - name: Get Production Database URL
         id: get-db-url
         run: |
           # Get the main branch database URL (production)
           DATABASE_URL=$(neonctl connection-string production --project-id ${{ vars.NEON_PROJECT_ID }} --database-name neondb --pooled)
-          echo "database-url=$DATABASE_URL" >> $GITHUB_OUTPUT
+          echo "database-url=$DATABASE_URL" >> "$GITHUB_OUTPUT"
         env:
           NEON_API_KEY: ${{ secrets.NEON_API_KEY }}
 
@@ -308,7 +308,7 @@ jobs:
           if [ $h -gt 0 ]; then text="${h}h ${m}m ${s}s"
           elif [ $m -gt 0 ]; then text="${m}m ${s}s"
           else text="${s}s"; fi
-          echo "text=$text" >> $GITHUB_OUTPUT
+          echo "text=$text" >> "$GITHUB_OUTPUT"
 
       - name: Notify Slack - Success
         if: ${{ success() && steps.slack-start.outputs.ts }}
@@ -375,7 +375,7 @@ jobs:
 
       - name: Record start time
         id: timer
-        run: echo "start=$(date +%s)" >> $GITHUB_OUTPUT
+        run: echo "start=$(date +%s)" >> "$GITHUB_OUTPUT"
 
       - name: Deploy Docs to Vercel Production
         id: deploy
@@ -396,7 +396,7 @@ jobs:
           if [ $h -gt 0 ]; then text="${h}h ${m}m ${s}s"
           elif [ $m -gt 0 ]; then text="${m}m ${s}s"
           else text="${s}s"; fi
-          echo "text=$text" >> $GITHUB_OUTPUT
+          echo "text=$text" >> "$GITHUB_OUTPUT"
 
       - name: Notify Slack - Success
         if: ${{ success() && steps.slack-start.outputs.ts }}
@@ -463,7 +463,7 @@ jobs:
 
       - name: Record start time
         id: timer
-        run: echo "start=$(date +%s)" >> $GITHUB_OUTPUT
+        run: echo "start=$(date +%s)" >> "$GITHUB_OUTPUT"
 
       - name: Deploy App to Vercel Production
         id: deploy
@@ -491,7 +491,7 @@ jobs:
           if [ $h -gt 0 ]; then text="${h}h ${m}m ${s}s"
           elif [ $m -gt 0 ]; then text="${m}m ${s}s"
           else text="${s}s"; fi
-          echo "text=$text" >> $GITHUB_OUTPUT
+          echo "text=$text" >> "$GITHUB_OUTPUT"
 
       - name: Notify Slack - Success
         if: ${{ success() && steps.slack-start.outputs.ts }}
@@ -554,7 +554,7 @@ jobs:
 
       - name: Record start time
         id: timer
-        run: echo "start=$(date +%s)" >> $GITHUB_OUTPUT
+        run: echo "start=$(date +%s)" >> "$GITHUB_OUTPUT"
 
       - uses: actions/setup-node@v6
         with:
@@ -587,7 +587,7 @@ jobs:
           if [ $h -gt 0 ]; then text="${h}h ${m}m ${s}s"
           elif [ $m -gt 0 ]; then text="${m}m ${s}s"
           else text="${s}s"; fi
-          echo "text=$text" >> $GITHUB_OUTPUT
+          echo "text=$text" >> "$GITHUB_OUTPUT"
 
       - name: Notify Slack - Success
         if: ${{ success() && steps.slack-start.outputs.ts }}
@@ -658,7 +658,7 @@ jobs:
 
       - name: Record start time
         id: timer
-        run: echo "start=$(date +%s)" >> $GITHUB_OUTPUT
+        run: echo "start=$(date +%s)" >> "$GITHUB_OUTPUT"
 
       # Cross-compile Rust binaries for ARM64 (metal runners are ARM64)
       - name: Cross-compile guest binaries for ARM64
@@ -763,7 +763,7 @@ jobs:
           if [ $h -gt 0 ]; then text="${h}h ${m}m ${s}s"
           elif [ $m -gt 0 ]; then text="${m}m ${s}s"
           else text="${s}s"; fi
-          echo "text=$text" >> $GITHUB_OUTPUT
+          echo "text=$text" >> "$GITHUB_OUTPUT"
 
       - name: Notify Slack - Success
         if: ${{ success() && steps.slack-start.outputs.ts }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -113,9 +113,11 @@ jobs:
           set -o pipefail
           echo "## pnpm audit results" >> "$GITHUB_STEP_SUMMARY"
           pnpm audit --prod 2>&1 | tee audit-output.txt
-          echo '```' >> "$GITHUB_STEP_SUMMARY"
-          cat audit-output.txt >> "$GITHUB_STEP_SUMMARY"
-          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo '```'
+            cat audit-output.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
 
   actionlint:
     name: Workflow Lint
@@ -129,7 +131,7 @@ jobs:
         run: bash <(curl -s https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
 
       - name: Run actionlint
-        run: ./actionlint -shellcheck=
+        run: ./actionlint
 
   gitleaks:
     name: Gitleaks Secrets Detection

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -57,13 +57,14 @@ jobs:
             echo "Main push mode: comparing against HEAD^"
           fi
 
-          echo "base-ref=$BASE_REF" >> $GITHUB_OUTPUT
+          echo "base-ref=$BASE_REF" >> "$GITHUB_OUTPUT"
 
           # Run changed.sh to get all package changes in one go
-          CHANGES_JSON=$(./scripts/changed.sh $BASE_REF)
+          CHANGES_JSON=$(./scripts/changed.sh "$BASE_REF")
 
           # Parse JSON and set outputs for each app
-          for app in $(ls turbo/apps); do
+          for app_dir in turbo/apps/*/; do
+            app=$(basename "$app_dir")
             # Get the package name from package.json
             if [ -f "turbo/apps/$app/package.json" ]; then
               PKG_NAME=$(jq -r '.name' "turbo/apps/$app/package.json")
@@ -71,14 +72,14 @@ jobs:
 
               if [ "$CHANGED" = "true" ]; then
                 echo "Changes detected in $app ($PKG_NAME)"
-                echo "${app}-changed=true" >> $GITHUB_OUTPUT
+                echo "${app}-changed=true" >> "$GITHUB_OUTPUT"
               else
                 echo "No changes in $app ($PKG_NAME)"
-                echo "${app}-changed=false" >> $GITHUB_OUTPUT
+                echo "${app}-changed=false" >> "$GITHUB_OUTPUT"
               fi
             else
               echo "No package.json for $app, skipping"
-              echo "${app}-changed=false" >> $GITHUB_OUTPUT
+              echo "${app}-changed=false" >> "$GITHUB_OUTPUT"
             fi
           done
 
@@ -88,10 +89,10 @@ jobs:
           BASE_REF="${{ steps.detect.outputs.base-ref }}"
           if git diff --name-only "$BASE_REF" HEAD | grep -q "^turbo/scripts/e2b/"; then
             echo "E2B template changes detected"
-            echo "e2b-changed=true" >> $GITHUB_OUTPUT
+            echo "e2b-changed=true" >> "$GITHUB_OUTPUT"
           else
             echo "No E2B template changes"
-            echo "e2b-changed=false" >> $GITHUB_OUTPUT
+            echo "e2b-changed=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Detect migration/schema changes
@@ -100,10 +101,10 @@ jobs:
           BASE_REF="${{ steps.detect.outputs.base-ref }}"
           if git diff --name-only "$BASE_REF" HEAD | grep -qE "^turbo/apps/web/src/db/(migrations|schema)/"; then
             echo "Migration or schema changes detected"
-            echo "migration-changed=true" >> $GITHUB_OUTPUT
+            echo "migration-changed=true" >> "$GITHUB_OUTPUT"
           else
             echo "No migration or schema changes"
-            echo "migration-changed=false" >> $GITHUB_OUTPUT
+            echo "migration-changed=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Detect crates changes
@@ -112,10 +113,10 @@ jobs:
           BASE_REF="${{ steps.detect.outputs.base-ref }}"
           if git diff --name-only "$BASE_REF" HEAD | grep -q "^crates/"; then
             echo "Crates changes detected"
-            echo "crates-changed=true" >> $GITHUB_OUTPUT
+            echo "crates-changed=true" >> "$GITHUB_OUTPUT"
           else
             echo "No crates changes"
-            echo "crates-changed=false" >> $GITHUB_OUTPUT
+            echo "crates-changed=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Detect CI workflow changes
@@ -124,10 +125,10 @@ jobs:
           BASE_REF="${{ steps.detect.outputs.base-ref }}"
           if git diff --name-only "$BASE_REF" HEAD | grep -qE "^\.github/workflows/turbo\.yml$|^ansible/"; then
             echo "CI workflow changes detected"
-            echo "ci-changed=true" >> $GITHUB_OUTPUT
+            echo "ci-changed=true" >> "$GITHUB_OUTPUT"
           else
             echo "No CI workflow changes"
-            echo "ci-changed=false" >> $GITHUB_OUTPUT
+            echo "ci-changed=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Detect E2E test changes
@@ -136,30 +137,30 @@ jobs:
           BASE_REF="${{ steps.detect.outputs.base-ref }}"
           if git diff --name-only "$BASE_REF" HEAD | grep -q "^e2e/"; then
             echo "E2E test changes detected"
-            echo "e2e-changed=true" >> $GITHUB_OUTPUT
+            echo "e2e-changed=true" >> "$GITHUB_OUTPUT"
           else
             echo "No E2E test changes"
-            echo "e2e-changed=false" >> $GITHUB_OUTPUT
+            echo "e2e-changed=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Set job-ref
         id: set-job-ref
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            echo "job-ref=pr-${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
+            echo "job-ref=pr-${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
             echo "Job ref set to: pr-${{ github.event.pull_request.number }}"
           elif [ "${{ github.event_name }}" = "merge_group" ]; then
             MQ_REF="${{ github.event.merge_group.head_ref }}"
             PR_NUM=$(echo "$MQ_REF" | grep -oE 'pr-[0-9]+' | head -1 | sed 's/pr-//')
             if [ -n "$PR_NUM" ]; then
-              echo "job-ref=pr-${PR_NUM}-merge-queue" >> $GITHUB_OUTPUT
+              echo "job-ref=pr-${PR_NUM}-merge-queue" >> "$GITHUB_OUTPUT"
               echo "Job ref set to: pr-${PR_NUM}-merge-queue"
             else
               echo "::error::Failed to extract PR number from merge_group head_ref: $MQ_REF"
               exit 1
             fi
           else
-            echo "job-ref=staging" >> $GITHUB_OUTPUT
+            echo "job-ref=staging" >> "$GITHUB_OUTPUT"
             echo "Job ref set to: staging"
           fi
 
@@ -170,12 +171,12 @@ jobs:
           PREVIEW_DOMAIN="${{ vars.PREVIEW_DOMAIN }}"
 
           if [ -n "$PREVIEW_DOMAIN" ] && [ -n "$JOB_REF" ]; then
-            echo "web-url=https://${JOB_REF}-www.${PREVIEW_DOMAIN}" >> $GITHUB_OUTPUT
-            echo "app-url=https://${JOB_REF}-app.${PREVIEW_DOMAIN}" >> $GITHUB_OUTPUT
+            echo "web-url=https://${JOB_REF}-www.${PREVIEW_DOMAIN}" >> "$GITHUB_OUTPUT"
+            echo "app-url=https://${JOB_REF}-app.${PREVIEW_DOMAIN}" >> "$GITHUB_OUTPUT"
             echo "Preview URL set to: https://${JOB_REF}-www.${PREVIEW_DOMAIN}"
           else
-            echo "web-url=" >> $GITHUB_OUTPUT
-            echo "app-url=" >> $GITHUB_OUTPUT
+            echo "web-url=" >> "$GITHUB_OUTPUT"
+            echo "app-url=" >> "$GITHUB_OUTPUT"
             echo "Preview URL not set (PREVIEW_DOMAIN or job-ref is empty)"
           fi
 
@@ -192,7 +193,7 @@ jobs:
         run: |
           # Get changed files in PR
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            BASE_SHA=${{ github.event.pull_request.base.sha }}
+            BASE_SHA="${{ github.event.pull_request.base.sha }}"
           else
             BASE_SHA="HEAD^"
           fi
@@ -213,7 +214,8 @@ jobs:
             exit 0
           fi
 
-          # Check file sizes
+          # Check file sizes (word splitting is intentional to pass multiple files)
+          # shellcheck disable=SC2086
           ./scripts/check-file-size.sh $FILTERED_FILES
 
   # Lint jobs - split into 4 parallel jobs for faster CI
@@ -935,7 +937,8 @@ jobs:
       - name: Verify device flow authentication
         run: |
           echo "Verifying device flow with ${{ needs.deploy-web.outputs.preview-url }}"
-          cd e2e && bash cli-auth-automation.sh ${{ needs.deploy-web.outputs.preview-url }} || true
+          cd e2e
+          bash cli-auth-automation.sh "${{ needs.deploy-web.outputs.preview-url }}" || true
         env:
           VM0_API_URL: ${{ needs.deploy-web.outputs.preview-url }}
       - name: Upload auth screenshots
@@ -1032,7 +1035,7 @@ jobs:
         run: |
           chmod +x ./e2e/scripts/cron-simulator.sh
           ./e2e/scripts/cron-simulator.sh "$VM0_API_URL" 60 &
-          echo "CRON_SIMULATOR_PID=$!" >> $GITHUB_ENV
+          echo "CRON_SIMULATOR_PID=$!" >> "$GITHUB_ENV"
         env:
           VM0_API_URL: ${{ needs.deploy-web.outputs.preview-url }}
           CRON_SECRET: ${{ secrets.CRON_SECRET }}
@@ -1117,17 +1120,17 @@ jobs:
       - name: Cross-compile guest binaries for ARM64
         run: |
           cd crates
-          cargo build --profile $CARGO_PROFILE --target $TARGET_TRIPLE \
+          cargo build --profile "$CARGO_PROFILE" --target "$TARGET_TRIPLE" \
             -p guest-agent -p guest-download -p guest-init -p guest-mock-claude
 
       - name: Cross-compile runner with embedded guests for ARM64
         run: |
           cd crates
-          GUEST_AGENT_PATH=target/$TARGET_TRIPLE/$CARGO_PROFILE/guest-agent \
-          GUEST_DOWNLOAD_PATH=target/$TARGET_TRIPLE/$CARGO_PROFILE/guest-download \
-          GUEST_INIT_PATH=target/$TARGET_TRIPLE/$CARGO_PROFILE/guest-init \
-          GUEST_MOCK_CLAUDE_PATH=target/$TARGET_TRIPLE/$CARGO_PROFILE/guest-mock-claude \
-          cargo build --profile $CARGO_PROFILE --target $TARGET_TRIPLE -p runner
+          GUEST_AGENT_PATH="target/$TARGET_TRIPLE/$CARGO_PROFILE/guest-agent" \
+          GUEST_DOWNLOAD_PATH="target/$TARGET_TRIPLE/$CARGO_PROFILE/guest-download" \
+          GUEST_INIT_PATH="target/$TARGET_TRIPLE/$CARGO_PROFILE/guest-init" \
+          GUEST_MOCK_CLAUDE_PATH="target/$TARGET_TRIPLE/$CARGO_PROFILE/guest-mock-claude" \
+          cargo build --profile "$CARGO_PROFILE" --target "$TARGET_TRIPLE" -p runner
 
       - name: Setup SSH via Cloudflare Tunnel
         uses: ./.github/actions/setup-ssh-tunnel
@@ -1195,18 +1198,18 @@ jobs:
               [ "${CHUNK_WEIGHTS[$i]}" -lt "${CHUNK_WEIGHTS[$min_idx]}" ] && min_idx=$i
             done
             CHUNK_FILES[$min_idx]="${CHUNK_FILES[$min_idx]:+${CHUNK_FILES[$min_idx]} }$f"
-            CHUNK_WEIGHTS[$min_idx]=$(( CHUNK_WEIGHTS[$min_idx] + WEIGHTS[$f] ))
+            CHUNK_WEIGHTS[$min_idx]=$(( CHUNK_WEIGHTS[min_idx] + WEIGHTS[$f] ))
           done
 
           CHUNKS="["
           for ((i=0; i<NUM_CHUNKS; i++)); do
-            [ $i -gt 0 ] && CHUNKS="$CHUNKS,"
-            file_count=$(echo ${CHUNK_FILES[$i]} | wc -w)
+            [ "$i" -gt 0 ] && CHUNKS="$CHUNKS,"
+            file_count=$(echo "${CHUNK_FILES[$i]}" | wc -w)
             CHUNKS="$CHUNKS{\"index\":$((i+1)),\"files\":\"${CHUNK_FILES[$i]}\"}"
             echo "Chunk $((i+1)): ${file_count} files, weight ${CHUNK_WEIGHTS[$i]}"
           done
-          echo "matrix=${CHUNKS}]" >> $GITHUB_OUTPUT
-          echo "chunk-count=${NUM_CHUNKS}" >> $GITHUB_OUTPUT
+          echo "matrix=${CHUNKS}]" >> "$GITHUB_OUTPUT"
+          echo "chunk-count=${NUM_CHUNKS}" >> "$GITHUB_OUTPUT"
 
       - name: Deploy binaries and build rootfs/snapshot on all metal hosts
         id: deploy
@@ -1229,17 +1232,21 @@ jobs:
             echo "=== Deploying to ${HOST} (runner: ${RUNNER_NAME}) ==="
 
             # Clean previous run artifacts and upload runner (guests are embedded)
-            ssh $REMOTE "rm -rf ${BIN_DIR} ${RUNNER_DIR} && mkdir -p ${BIN_DIR}"
+            # shellcheck disable=SC2029
+            ssh "$REMOTE" "rm -rf ${BIN_DIR} ${RUNNER_DIR} && mkdir -p ${BIN_DIR}"
             scp "${TARGET_DIR}/runner" "${REMOTE}:${BIN_DIR}/"
 
             # Clean up old rootfs/snapshots, keep the 6 most recent (3 deploys × 2 profiles)
-            ssh $REMOTE "${BIN_DIR}/runner gc --keep-latest 6"
+            # shellcheck disable=SC2029
+            ssh "$REMOTE" "${BIN_DIR}/runner gc --keep-latest 6"
 
             # Run setup (downloads firecracker/kernel/mitmdump, cached + idempotent)
-            ssh $REMOTE "${BIN_DIR}/runner setup"
+            # shellcheck disable=SC2029
+            ssh "$REMOTE" "${BIN_DIR}/runner setup"
 
             # Run build to create rootfs + snapshot (outputs hashes to stdout)
-            ssh $REMOTE "${BIN_DIR}/runner build --profile vm0/default"
+            # shellcheck disable=SC2029
+            ssh "$REMOTE" "${BIN_DIR}/runner build --profile vm0/default"
             echo "=== Done deploying to ${HOST} ==="
           }
 
@@ -1269,7 +1276,7 @@ jobs:
           fi
 
           # Extract build hashes from any host's log (all hosts produce identical hashes).
-          FIRST_LOG=$(ls ${LOG_DIR}/*.log | head -1)
+          FIRST_LOG=$(find "$LOG_DIR" -name '*.log' | head -1)
           DEFAULT_ROOTFS_HASH=$(grep '^rootfs_hash=' "$FIRST_LOG" | cut -d= -f2)
           DEFAULT_SNAPSHOT_HASH=$(grep '^snapshot_hash=' "$FIRST_LOG" | cut -d= -f2)
           rm -rf "$LOG_DIR"
@@ -1330,13 +1337,15 @@ jobs:
             echo "=== Starting runner ${RUNNER_NAME} on ${HOST} ==="
 
             # Guard: ensure binary exists (fails fast on "Re-run failed jobs" without prepare)
+            # shellcheck disable=SC2029
             if ! ssh "$REMOTE" "test -x ${BIN_DIR}/runner"; then
               echo "::error::Runner binary not found on ${HOST}. Use 'Re-run all jobs' to redeploy the runner first."
               return 1
             fi
 
             # Generate runner.yaml with real preview URL (no build needed, uses cached hashes)
-            ssh $REMOTE "${BIN_DIR}/runner config \
+            # shellcheck disable=SC2029
+            ssh "$REMOTE" "${BIN_DIR}/runner config \
               --profile vm0/default \
               --rootfs-hash ${DEFAULT_ROOTFS_HASH} \
               --snapshot-hash ${DEFAULT_SNAPSHOT_HASH} \
@@ -1349,10 +1358,12 @@ jobs:
 
             # Stop any existing service from a previous run (e.g., re-run after test failure).
             # Ignore errors if not running.
-            ssh $REMOTE "${BIN_DIR}/runner service stop --name ${RUNNER_NAME}" 2>/dev/null || true
+            # shellcheck disable=SC2029
+            ssh "$REMOTE" "${BIN_DIR}/runner service stop --name ${RUNNER_NAME}" 2>/dev/null || true
 
             # Start as systemd transient service
-            ssh $REMOTE "${BIN_DIR}/runner service start \
+            # shellcheck disable=SC2029
+            ssh "$REMOTE" "${BIN_DIR}/runner service start \
               --name ${RUNNER_NAME} \
               --config ${RUNNER_DIR}/runner.yaml \
               --env VERCEL_AUTOMATION_BYPASS_SECRET=${VERCEL_BYPASS} \
@@ -1360,7 +1371,8 @@ jobs:
 
             # Health check — wait for runner startup, then verify
             sleep 5
-            ssh $REMOTE "${BIN_DIR}/runner doctor --name ${RUNNER_NAME}"
+            # shellcheck disable=SC2029
+            ssh "$REMOTE" "${BIN_DIR}/runner doctor --name ${RUNNER_NAME}"
             echo "=== Runner started on ${HOST} ==="
           }
 
@@ -1392,6 +1404,7 @@ jobs:
           # Sum auto-detected max_concurrent from all hosts' status.json
           TOTAL=0
           for HOST in $(echo "$METAL_HOSTS" | tr ',' ' '); do
+            # shellcheck disable=SC2029
             MC=$(ssh "${METAL_USER}@${HOST}" "grep -o '\"max_concurrent\": [0-9]*' ${RUNNER_DIR}/status.json | grep -o '[0-9]*'") || true
             if [ -z "$MC" ] || ! [[ "$MC" =~ ^[0-9]+$ ]]; then
               echo "::error::Failed to read max_concurrent from ${HOST}"
@@ -1498,7 +1511,7 @@ jobs:
         run: |
           chmod +x ./e2e/scripts/cron-simulator.sh
           ./e2e/scripts/cron-simulator.sh "$VM0_API_URL" 60 &
-          echo "CRON_SIMULATOR_PID=$!" >> $GITHUB_ENV
+          echo "CRON_SIMULATOR_PID=$!" >> "$GITHUB_ENV"
         env:
           VM0_API_URL: ${{ needs.deploy-web.outputs.preview-url }}
           CRON_SECRET: ${{ secrets.CRON_SECRET }}

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1190,15 +1190,15 @@ jobs:
 
           # Greedy bin-packing: assign each file to the chunk with lowest total weight
           declare -a CHUNK_FILES CHUNK_WEIGHTS
-          for ((i=0; i<NUM_CHUNKS; i++)); do CHUNK_FILES[$i]=""; CHUNK_WEIGHTS[$i]=0; done
+          for ((i=0; i<NUM_CHUNKS; i++)); do CHUNK_FILES[i]=""; CHUNK_WEIGHTS[i]=0; done
           for f in "${FILES[@]}"; do
             # Find lightest chunk
             min_idx=0
             for ((i=1; i<NUM_CHUNKS; i++)); do
-              [ "${CHUNK_WEIGHTS[$i]}" -lt "${CHUNK_WEIGHTS[$min_idx]}" ] && min_idx=$i
+              [ "${CHUNK_WEIGHTS[i]}" -lt "${CHUNK_WEIGHTS[min_idx]}" ] && min_idx=$i
             done
-            CHUNK_FILES[$min_idx]="${CHUNK_FILES[$min_idx]:+${CHUNK_FILES[$min_idx]} }$f"
-            CHUNK_WEIGHTS[$min_idx]=$(( CHUNK_WEIGHTS[min_idx] + WEIGHTS[$f] ))
+            CHUNK_FILES[min_idx]="${CHUNK_FILES[min_idx]:+${CHUNK_FILES[min_idx]} }$f"
+            CHUNK_WEIGHTS[min_idx]=$(( CHUNK_WEIGHTS[min_idx] + WEIGHTS[$f] ))
           done
 
           CHUNKS="["
@@ -1753,12 +1753,14 @@ jobs:
     if: always()
     steps:
       - name: Validate CI results
+        env:
+          HEAD_REF: ${{ github.head_ref || '' }}
+          COMMIT_MSG: ${{ github.event.head_commit.message || '' }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
           # Auto-pass for release-please PRs (only version bumps and changelogs)
-          HEAD_REF="${{ github.head_ref || '' }}"
-          COMMIT_MSG="${{ github.event.head_commit.message || '' }}"
           if [[ "$HEAD_REF" == release-please--branches--* ]] || \
-             { [[ "${{ github.event_name }}" == "push" ]] && [[ "$COMMIT_MSG" == chore:\ release* ]]; }; then
+             { [[ "$EVENT_NAME" == "push" ]] && [[ "$COMMIT_MSG" == chore:\ release* ]]; }; then
             echo "✅ Release-please PR — skipping CI gate"
             exit 0
           fi


### PR DESCRIPTION
## Summary
- Remove `-shellcheck=` flag from actionlint to enable full shellcheck integration
- Fix all 110 shellcheck findings across 7 workflow files
- All fixes verified with actionlint passing cleanly (exit 0)

### Changes by category
| Fix | Count | Files |
|-----|-------|-------|
| Quote `$GITHUB_OUTPUT`/`$GITHUB_ENV` (SC2086) | 78 | all 7 files |
| Add `# shellcheck disable=SC2029` for intentional SSH client-side expansion | 20 | crates.yml, turbo.yml |
| Add `# shellcheck disable=SC2088` for intentional tilde in SSH paths | 6 | crates.yml |
| Rewrite `A && B \|\| C` to `if/elif/else` (SC2015) | 2 | crates.yml, turbo.yml |
| Replace `ls` iteration with glob (SC2045) | 1 | turbo.yml |
| Replace `ls` pipe with `find` (SC2012) | 1 | turbo.yml |
| Remove unnecessary `$` in arithmetic (SC2004) | 1 | turbo.yml |
| Group repeated redirections (SC2129) | 1 | security.yml |

## Test plan
- [ ] actionlint CI job passes without `-shellcheck=` flag
- [ ] All other CI jobs pass (no behavioral changes to scripts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)