### PR TITLE
chore: update toolchain image tags to 20260320

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "VM0 Development",
-  "image": "ghcr.io/vm0-ai/vm0-dev:d645321",
+  "image": "ghcr.io/vm0-ai/vm0-dev:20260320",
   "features": {
     "ghcr.io/itsmechlark/features/postgresql:1": {
       "version": "17"

--- a/.github/workflows/cleanup-stale.yml
+++ b/.github/workflows/cleanup-stale.yml
@@ -17,7 +17,7 @@ jobs:
   cleanup-neon-branches:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260310
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260320
     steps:
       - name: Install neonctl
         run: npm install -g neonctl@2.15.0

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -84,7 +84,7 @@ jobs:
     if: "!startsWith(github.head_ref || '', 'release-please--branches--')"
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260310
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260320
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -25,7 +25,7 @@ jobs:
     if: "!startsWith(github.head_ref || '', 'release-please--branches--')"
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260310
+      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260320
     outputs:
       any-changed: ${{ steps.detect.outputs.any-changed }}
       ci-changed: ${{ steps.detect.outputs.ci-changed }}
@@ -88,7 +88,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260310
+      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260320
     needs: [detect]
     if: needs.detect.outputs.any-changed == 'true'
     steps:
@@ -163,7 +163,7 @@ jobs:
   runner-build:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260310
+      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260320
     needs: [detect]
     if: |
       needs.detect.outputs.ci-changed == 'true' ||

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -47,7 +47,7 @@ jobs:
     if: ${{ needs.release-please.outputs.web_release_created == 'true' }}
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260310
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260320
     permissions:
       contents: read
     environment: production
@@ -144,7 +144,7 @@ jobs:
     if: ${{ needs.release-please.outputs.web_release_created == 'true' }}
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260310
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260320
     permissions:
       contents: read
       deployments: write
@@ -348,7 +348,7 @@ jobs:
     if: ${{ needs.release-please.outputs.docs_release_created == 'true' }}
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260310
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260320
     permissions:
       contents: read
       deployments: write
@@ -436,7 +436,7 @@ jobs:
     if: ${{ needs.release-please.outputs.app_release_created == 'true' }}
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260310
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260320
     permissions:
       contents: read
       deployments: write
@@ -627,7 +627,7 @@ jobs:
     if: ${{ needs.release-please.outputs.runner_rs_release_created == 'true' }}
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260310
+      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260320
     permissions:
       contents: write
     environment: production
@@ -805,7 +805,7 @@ jobs:
     if: ${{ needs.release-please.outputs.releases_created == 'true' }}
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260310
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260320
     permissions:
       contents: read
     environment: production
@@ -829,7 +829,7 @@ jobs:
     if: ${{ needs.release-please.outputs.releases_created == 'true' }}
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260310
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260320
     permissions:
       contents: read
     steps:

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -18,7 +18,7 @@ jobs:
     if: "!startsWith(github.head_ref || '', 'release-please--branches--')"
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260310
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260320
     outputs:
       job-ref: ${{ steps.set-job-ref.outputs.job-ref }}
       web-preview-url: ${{ steps.preview-urls.outputs.web-url }}
@@ -224,7 +224,7 @@ jobs:
     # Skip for release-please PRs and release-please commits
     if: "${{ !startsWith(github.head_ref || '', 'release-please--branches--') && (github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore: release')) }}"
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260310
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260320
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/toolchain-init
@@ -237,7 +237,7 @@ jobs:
     # Skip for release-please PRs and release-please commits
     if: "${{ !startsWith(github.head_ref || '', 'release-please--branches--') && (github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore: release')) }}"
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260310
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260320
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/toolchain-init
@@ -250,7 +250,7 @@ jobs:
     # Skip for release-please PRs and release-please commits
     if: "${{ !startsWith(github.head_ref || '', 'release-please--branches--') && (github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore: release')) }}"
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260310
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260320
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/toolchain-init
@@ -263,7 +263,7 @@ jobs:
     # Skip for release-please PRs and release-please commits
     if: "${{ !startsWith(github.head_ref || '', 'release-please--branches--') && (github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore: release')) }}"
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260310
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260320
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/toolchain-init
@@ -281,7 +281,7 @@ jobs:
       matrix:
         shard: [1, 2, 3, 4]
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260310
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260320
     services:
       postgres:
         image: postgres:17-alpine
@@ -327,7 +327,7 @@ jobs:
     # Only run when migration or schema files changed
     if: needs.prepare.outputs.migration-changed == 'true'
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260310
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260320
     services:
       postgres:
         image: postgres:17-alpine
@@ -352,7 +352,7 @@ jobs:
     if: "!startsWith(github.head_ref || '', 'release-please--branches--')"
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260310
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260320
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/toolchain-init
@@ -380,7 +380,7 @@ jobs:
     if: "!startsWith(github.head_ref || '', 'release-please--branches--')"
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260310
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260320
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/toolchain-init
@@ -408,7 +408,7 @@ jobs:
     if: "!startsWith(github.head_ref || '', 'release-please--branches--')"
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260310
+      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260320
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/toolchain-init
@@ -435,7 +435,7 @@ jobs:
   deploy-web:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260310
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260320
     needs: [prepare]
     # Deploy if job-ref is set (PR or main), not a release-please commit, and web, CLI, runner, or platform changed
     if: |
@@ -820,7 +820,7 @@ jobs:
   deploy-docs:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260310
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260320
     needs: [prepare]
     # Deploy if job-ref is set (PR or main), not a release-please commit, and docs changed
     if: "${{ (github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore: release')) && needs.prepare.outputs.job-ref != '' && needs.prepare.outputs.docs-changed == 'true' }}"
@@ -862,7 +862,7 @@ jobs:
   deploy-app:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260310
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260320
     needs: [prepare]
     # Deploy if job-ref is set (PR or main), not a release-please commit, and platform changed
     if: "${{ (github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore: release')) && needs.prepare.outputs.job-ref != '' && needs.prepare.outputs.platform-changed == 'true' }}"
@@ -954,7 +954,7 @@ jobs:
   build-cli:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260310
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260320
     needs: [prepare]
     if: |
       (github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore: release')) &&
@@ -1075,7 +1075,7 @@ jobs:
   deploy-runner-prepare:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260310
+      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260320
     needs: [prepare]
     timeout-minutes: 10
     env:
@@ -1562,7 +1562,7 @@ jobs:
   build-e2b-template:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260310
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260320
     needs: [prepare]
     # Build on PR or main push when E2B templates changed, skip release-please commits
     if: |


### PR DESCRIPTION
## Summary

- Update all `ghcr.io/vm0-ai/vm0-toolchain*` and `vm0-dev` image tags from `20260310`/`d645321` to `20260320`
- New toolchain-rust image includes `cargo-llvm-cov` (from #5699)

## Test plan

- [ ] CI passes with updated image tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)