### PR TITLE
ci: upload bats junit xml as github actions artifact

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1061,6 +1061,14 @@ jobs:
           files: e2e/results/*.xml
           report_type: test_results
 
+      - name: Upload JUnit XML artifact
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-serial-junit-xml
+          path: e2e/results/
+          retention-days: 7
+
       - name: Stop Cron Simulator
         if: always()
         run: |
@@ -1548,6 +1556,14 @@ jobs:
           flags: e2e-runner
           files: e2e/results/*.xml
           report_type: test_results
+
+      - name: Upload JUnit XML artifact
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-runner-junit-xml-${{ matrix.index }}
+          path: e2e/results/
+          retention-days: 7
 
       - name: Stop Cron Simulator
         if: always()


### PR DESCRIPTION
## Summary

- Add `actions/upload-artifact@v4` steps to `cli-e2e-01-serial` and `cli-e2e-03-runner` jobs
- Serial job uploads as `e2e-serial-junit-xml`, runner job uploads as `e2e-runner-junit-xml-{index}` (unique per matrix chunk)
- Artifacts have 7-day retention and upload even on test failure (`if: !cancelled()`)

Closes #5720

## Test plan

- [ ] Verify `cli-e2e-01-serial` job shows `e2e-serial-junit-xml` artifact on Actions run summary
- [ ] Verify each `cli-e2e-03-runner` matrix chunk shows `e2e-runner-junit-xml-{index}` artifact
- [ ] Verify artifacts are downloadable and contain JUnit XML files
- [ ] Verify existing Codecov upload steps are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)