### PR TITLE
feat: add v0 api-token connector

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/components/settings/connector-icons.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/connector-icons.tsx
@@ -46,6 +46,7 @@ const MONOCHROME_ICONS: Readonly<Record<string, true>> = Object.freeze({
   openai: true,
   pdforge: true,
   wix: true,
+  v0: true,
   x: true,
 });
 

--- a/turbo/apps/platform/src/views/zero-page/components/settings/icons/v0.svg
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/icons/v0.svg
@@ -1,0 +1,1 @@
+<svg viewBox="0 0 80 40" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M4 8l16 24L36 8" stroke="#000" stroke-width="5" stroke-linecap="round" stroke-linejoin="round" fill="none"/><ellipse cx="58" cy="20" rx="14" ry="14" stroke="#000" stroke-width="5" fill="none"/></svg>

--- a/turbo/apps/web/src/lib/connector/provider-registry.ts
+++ b/turbo/apps/web/src/lib/connector/provider-registry.ts
@@ -119,6 +119,7 @@ import { wrikeHandler } from "./providers/wrike-handler";
 import { xeroHandler } from "./providers/xero-handler";
 import { pdforgeHandler } from "./providers/pdforge-handler";
 import { slackWebhookHandler } from "./providers/slack-webhook-handler";
+import { v0Handler } from "./providers/v0-handler";
 import { wixHandler } from "./providers/wix-handler";
 import { zeptomailHandler } from "./providers/zeptomail-handler";
 
@@ -243,6 +244,7 @@ export const PROVIDER_HANDLERS: Record<
   zendesk: zendeskHandler,
   pdforge: pdforgeHandler,
   "slack-webhook": slackWebhookHandler,
+  v0: v0Handler,
   wix: wixHandler,
 };
 

--- a/turbo/apps/web/src/lib/connector/providers/v0-handler.ts
+++ b/turbo/apps/web/src/lib/connector/providers/v0-handler.ts
@@ -1,0 +1,13 @@
+import { type ProviderHandler } from "../provider-types";
+
+export const v0Handler: ProviderHandler = {
+  buildAuthUrl() {
+    throw new Error("v0 does not support OAuth — use API token auth");
+  },
+  exchangeCode() {
+    throw new Error("v0 does not support OAuth — use API token auth");
+  },
+  getClientId: () => undefined,
+  getClientSecret: () => undefined,
+  getSecretName: () => "V0_TOKEN",
+};

--- a/turbo/packages/core/src/contracts/connectors.ts
+++ b/turbo/packages/core/src/contracts/connectors.ts
@@ -3065,6 +3065,24 @@ const CONNECTOR_TYPES_DEF = {
     } as Record<string, ConnectorAuthMethodConfig>,
     defaultAuthMethod: "api-token",
   },
+  v0: {
+    label: "v0",
+    helpText:
+      "Connect your v0 account to generate and iterate on React and Next.js UI components with AI",
+    authMethods: {
+      "api-token": {
+        label: "API Token",
+        secrets: {
+          V0_TOKEN: {
+            label: "API Token",
+            required: true,
+            placeholder: "v0-...",
+          },
+        },
+      },
+    } as Record<string, ConnectorAuthMethodConfig>,
+    defaultAuthMethod: "api-token",
+  },
 } satisfies Record<string, ConnectorConfig>;
 
 export type ConnectorType = keyof typeof CONNECTOR_TYPES_DEF;
@@ -3189,6 +3207,7 @@ export const connectorTypeSchema = z.enum([
   "pdforge",
   "slack-webhook",
   "wix",
+  "v0",
 ]);
 
 /**


### PR DESCRIPTION
## Summary

- Add v0 (Vercel AI app builder) as an api-token connector with Bearer token authentication
- Includes connector type definition, provider handler, registry entry, and SVG icon
- Uses `V0_TOKEN` secret following existing `XXX_TOKEN` convention

Closes #5710

## Test plan

- [ ] Verify TypeScript compilation passes
- [ ] Verify connector appears in the connectors list
- [ ] Verify v0 icon renders correctly
- [ ] Verify API token authentication flow works with v0

🤖 Generated with [Claude Code](https://claude.com/claude-code)