### PR TITLE
feat: improve v0 connector description and auth setup instructions

### DIFF
--- a/turbo/packages/core/src/contracts/connectors.ts
+++ b/turbo/packages/core/src/contracts/connectors.ts
@@ -3192,10 +3192,12 @@ const CONNECTOR_TYPES_DEF = {
   v0: {
     label: "v0",
     helpText:
-      "Connect your v0 account to generate and iterate on React and Next.js UI components with AI",
+      "Connect your v0 account to generate UI components, chat completions, and iterate on React and Next.js code with the v0 Platform API",
     authMethods: {
       "api-token": {
         label: "API Token",
+        helpText:
+          "1. Log in to [v0](https://v0.dev)\n2. Go to **Settings** → **Keys** ([direct link](https://v0.dev/chat/settings/keys))\n3. Create a new API key\n4. Copy the generated token",
         secrets: {
           V0_TOKEN: {
             label: "API Token",


### PR DESCRIPTION
## Summary
- Updated the v0 connector top-level `helpText` to more accurately describe Platform API capabilities (generate UI components, chat completions, iterate on React/Next.js code)
- Added step-by-step `helpText` to the api-token auth method with a direct link to the v0 API key settings page at v0.dev/chat/settings/keys
- Kept the `v0-...` token placeholder format (matches actual v0 API token format)

Closes #5741

## Test plan
- [x] TypeScript type checking passes for `@vm0/core`
- [x] All 280 existing tests pass (including connector tests)
- [x] Lint passes with 0 warnings
- [x] Code formatted with prettier (no changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)