### PR TITLE
feat: add sandbox token capability enforcement to /api/zero/agents endpoints

### DIFF
--- a/turbo/apps/web/app/api/zero/agents/[name]/instructions/route.ts
+++ b/turbo/apps/web/app/api/zero/agents/[name]/instructions/route.ts
@@ -43,7 +43,9 @@ const router = tsr.router(zeroAgentInstructionsContract, {
   get: async ({ params, headers }, { request }) => {
     initServices();
 
-    const authCtx = await requireAuth(headers.authorization);
+    const authCtx = await requireAuth(headers.authorization, {
+      requiredCapability: "agent:read",
+    });
     if (isAuthError(authCtx)) return authCtx;
 
     const orgSlug = new URL(request.url).searchParams.get("org");
@@ -181,7 +183,9 @@ const router = tsr.router(zeroAgentInstructionsContract, {
   update: async ({ params, body, headers }, { request }) => {
     initServices();
 
-    const authCtx = await requireAuth(headers.authorization);
+    const authCtx = await requireAuth(headers.authorization, {
+      requiredCapability: "agent:write",
+    });
     if (isAuthError(authCtx)) return authCtx;
     const { userId } = authCtx;
 

--- a/turbo/apps/web/app/api/zero/agents/[name]/route.ts
+++ b/turbo/apps/web/app/api/zero/agents/[name]/route.ts
@@ -29,7 +29,9 @@ const router = tsr.router(zeroAgentsByNameContract, {
   get: async ({ params, headers }, { request }) => {
     initServices();
 
-    const authCtx = await requireAuth(headers.authorization);
+    const authCtx = await requireAuth(headers.authorization, {
+      requiredCapability: "agent:read",
+    });
     if (isAuthError(authCtx)) return authCtx;
 
     const orgSlug = new URL(request.url).searchParams.get("org");
@@ -96,7 +98,9 @@ const router = tsr.router(zeroAgentsByNameContract, {
   update: async ({ params, body, headers }, { request }) => {
     initServices();
 
-    const authCtx = await requireAuth(headers.authorization);
+    const authCtx = await requireAuth(headers.authorization, {
+      requiredCapability: "agent:write",
+    });
     if (isAuthError(authCtx)) return authCtx;
     const { userId } = authCtx;
 

--- a/turbo/apps/web/app/api/zero/agents/__tests__/sandbox-capability.test.ts
+++ b/turbo/apps/web/app/api/zero/agents/__tests__/sandbox-capability.test.ts
@@ -1,0 +1,373 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { POST } from "../route";
+import { GET, PUT } from "../[name]/route";
+import {
+  GET as getInstructions,
+  PUT as putInstructions,
+} from "../[name]/instructions/route";
+import {
+  createTestRequest,
+  insertOrgMembersCacheEntry,
+} from "../../../../../src/__tests__/api-test-helpers";
+import {
+  testContext,
+  type UserContext,
+} from "../../../../../src/__tests__/test-helpers";
+import { mockClerk } from "../../../../../src/__tests__/clerk-mock";
+import { generateSandboxToken } from "../../../../../src/lib/auth/sandbox-token";
+
+const context = testContext();
+
+describe("Sandbox capability enforcement on zero agent routes", () => {
+  let user: UserContext;
+  let orgSlug: string;
+
+  beforeEach(async () => {
+    context.setupMocks();
+    user = await context.setupUser();
+    orgSlug = `org-${user.userId.slice(-8)}`;
+  });
+
+  describe("POST /api/zero/agents (create)", () => {
+    it("sandbox token with agent:write can create agent", async () => {
+      await insertOrgMembersCacheEntry({
+        userId: user.userId,
+        orgId: user.orgId,
+        role: "admin",
+      });
+
+      mockClerk({ userId: null, orgId: user.orgId });
+      const token = await generateSandboxToken(user.userId, "run-123", [
+        "agent:write",
+      ]);
+
+      const request = createTestRequest(
+        `http://localhost:3000/api/zero/agents?org=${orgSlug}`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({ connectors: [] }),
+        },
+      );
+
+      const response = await POST(request);
+      expect(response.status).toBe(201);
+    });
+
+    it("sandbox token without agent:write gets 403", async () => {
+      mockClerk({ userId: null });
+      const token = await generateSandboxToken(user.userId, "run-123", [
+        "agent:read",
+      ]);
+
+      const request = createTestRequest(
+        `http://localhost:3000/api/zero/agents?org=${orgSlug}`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({ connectors: [] }),
+        },
+      );
+
+      const response = await POST(request);
+      expect(response.status).toBe(403);
+    });
+  });
+
+  describe("GET /api/zero/agents/:name", () => {
+    it("sandbox token with agent:read can get agent", async () => {
+      // First create an agent with a regular CLI token
+      const cliUser = await context.setupUser();
+      const { createTestCliToken } = await import(
+        "../../../../../src/__tests__/api-test-helpers"
+      );
+      const cliToken = await createTestCliToken(cliUser.userId);
+      const cliOrgSlug = `org-${cliUser.userId.slice(-8)}`;
+
+      const createResponse = await POST(
+        createTestRequest(
+          `http://localhost:3000/api/zero/agents?org=${cliOrgSlug}`,
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              Authorization: `Bearer ${cliToken}`,
+            },
+            body: JSON.stringify({ connectors: [] }),
+          },
+        ),
+      );
+      expect(createResponse.status).toBe(201);
+      const created = await createResponse.json();
+
+      // Now access with sandbox token
+      await insertOrgMembersCacheEntry({
+        userId: cliUser.userId,
+        orgId: cliUser.orgId,
+        role: "admin",
+      });
+
+      mockClerk({ userId: null, orgId: cliUser.orgId });
+      const token = await generateSandboxToken(cliUser.userId, "run-123", [
+        "agent:read",
+      ]);
+
+      const request = createTestRequest(
+        `http://localhost:3000/api/zero/agents/${created.name}?org=${cliOrgSlug}`,
+        {
+          headers: { Authorization: `Bearer ${token}` },
+        },
+      );
+
+      const response = await GET(request);
+      expect(response.status).toBe(200);
+    });
+
+    it("sandbox token without agent:read gets 403", async () => {
+      mockClerk({ userId: null });
+      const token = await generateSandboxToken(user.userId, "run-123", [
+        "artifact:read",
+      ]);
+
+      const request = createTestRequest(
+        `http://localhost:3000/api/zero/agents/some-agent?org=${orgSlug}`,
+        {
+          headers: { Authorization: `Bearer ${token}` },
+        },
+      );
+
+      const response = await GET(request);
+      expect(response.status).toBe(403);
+    });
+  });
+
+  describe("PUT /api/zero/agents/:name", () => {
+    it("sandbox token with agent:write can update agent", async () => {
+      // First create an agent with a regular CLI token
+      const cliUser = await context.setupUser();
+      const { createTestCliToken } = await import(
+        "../../../../../src/__tests__/api-test-helpers"
+      );
+      const cliToken = await createTestCliToken(cliUser.userId);
+      const cliOrgSlug = `org-${cliUser.userId.slice(-8)}`;
+
+      const createResponse = await POST(
+        createTestRequest(
+          `http://localhost:3000/api/zero/agents?org=${cliOrgSlug}`,
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              Authorization: `Bearer ${cliToken}`,
+            },
+            body: JSON.stringify({ connectors: [] }),
+          },
+        ),
+      );
+      expect(createResponse.status).toBe(201);
+      const created = await createResponse.json();
+
+      // Now update with sandbox token
+      await insertOrgMembersCacheEntry({
+        userId: cliUser.userId,
+        orgId: cliUser.orgId,
+        role: "admin",
+      });
+
+      mockClerk({ userId: null, orgId: cliUser.orgId });
+      const token = await generateSandboxToken(cliUser.userId, "run-123", [
+        "agent:write",
+      ]);
+
+      const request = createTestRequest(
+        `http://localhost:3000/api/zero/agents/${created.name}?org=${cliOrgSlug}`,
+        {
+          method: "PUT",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({
+            connectors: [],
+            displayName: "Updated via sandbox",
+          }),
+        },
+      );
+
+      const response = await PUT(request);
+      expect(response.status).toBe(200);
+    });
+
+    it("sandbox token without agent:write gets 403", async () => {
+      mockClerk({ userId: null });
+      const token = await generateSandboxToken(user.userId, "run-123", [
+        "agent:read",
+      ]);
+
+      const request = createTestRequest(
+        `http://localhost:3000/api/zero/agents/some-agent?org=${orgSlug}`,
+        {
+          method: "PUT",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({ connectors: [] }),
+        },
+      );
+
+      const response = await PUT(request);
+      expect(response.status).toBe(403);
+    });
+  });
+
+  describe("GET /api/zero/agents/:name/instructions", () => {
+    it("sandbox token with agent:read can get instructions", async () => {
+      // First create an agent with a regular CLI token
+      const cliUser = await context.setupUser();
+      const { createTestCliToken } = await import(
+        "../../../../../src/__tests__/api-test-helpers"
+      );
+      const cliToken = await createTestCliToken(cliUser.userId);
+      const cliOrgSlug = `org-${cliUser.userId.slice(-8)}`;
+
+      const createResponse = await POST(
+        createTestRequest(
+          `http://localhost:3000/api/zero/agents?org=${cliOrgSlug}`,
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              Authorization: `Bearer ${cliToken}`,
+            },
+            body: JSON.stringify({ connectors: [] }),
+          },
+        ),
+      );
+      expect(createResponse.status).toBe(201);
+      const created = await createResponse.json();
+
+      // Now access instructions with sandbox token
+      await insertOrgMembersCacheEntry({
+        userId: cliUser.userId,
+        orgId: cliUser.orgId,
+        role: "admin",
+      });
+
+      mockClerk({ userId: null, orgId: cliUser.orgId });
+      const token = await generateSandboxToken(cliUser.userId, "run-123", [
+        "agent:read",
+      ]);
+
+      const request = createTestRequest(
+        `http://localhost:3000/api/zero/agents/${created.name}/instructions?org=${cliOrgSlug}`,
+        {
+          headers: { Authorization: `Bearer ${token}` },
+        },
+      );
+
+      const response = await getInstructions(request);
+      expect(response.status).toBe(200);
+    });
+
+    it("sandbox token without agent:read gets 403", async () => {
+      mockClerk({ userId: null });
+      const token = await generateSandboxToken(user.userId, "run-123", [
+        "artifact:read",
+      ]);
+
+      const request = createTestRequest(
+        `http://localhost:3000/api/zero/agents/some-agent/instructions?org=${orgSlug}`,
+        {
+          headers: { Authorization: `Bearer ${token}` },
+        },
+      );
+
+      const response = await getInstructions(request);
+      expect(response.status).toBe(403);
+    });
+  });
+
+  describe("PUT /api/zero/agents/:name/instructions", () => {
+    it("sandbox token with agent:write can update instructions", async () => {
+      // First create an agent with a regular CLI token
+      const cliUser = await context.setupUser();
+      const { createTestCliToken } = await import(
+        "../../../../../src/__tests__/api-test-helpers"
+      );
+      const cliToken = await createTestCliToken(cliUser.userId);
+      const cliOrgSlug = `org-${cliUser.userId.slice(-8)}`;
+
+      const createResponse = await POST(
+        createTestRequest(
+          `http://localhost:3000/api/zero/agents?org=${cliOrgSlug}`,
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              Authorization: `Bearer ${cliToken}`,
+            },
+            body: JSON.stringify({ connectors: [] }),
+          },
+        ),
+      );
+      expect(createResponse.status).toBe(201);
+      const created = await createResponse.json();
+
+      // Now update instructions with sandbox token
+      await insertOrgMembersCacheEntry({
+        userId: cliUser.userId,
+        orgId: cliUser.orgId,
+        role: "admin",
+      });
+
+      mockClerk({ userId: null, orgId: cliUser.orgId });
+      const token = await generateSandboxToken(cliUser.userId, "run-123", [
+        "agent:write",
+      ]);
+
+      const request = createTestRequest(
+        `http://localhost:3000/api/zero/agents/${created.name}/instructions?org=${cliOrgSlug}`,
+        {
+          method: "PUT",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({ content: "# Updated Instructions" }),
+        },
+      );
+
+      const response = await putInstructions(request);
+      expect(response.status).toBe(200);
+    });
+
+    it("sandbox token without agent:write gets 403", async () => {
+      mockClerk({ userId: null });
+      const token = await generateSandboxToken(user.userId, "run-123", [
+        "agent:read",
+      ]);
+
+      const request = createTestRequest(
+        `http://localhost:3000/api/zero/agents/some-agent/instructions?org=${orgSlug}`,
+        {
+          method: "PUT",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({ content: "# Instructions" }),
+        },
+      );
+
+      const response = await putInstructions(request);
+      expect(response.status).toBe(403);
+    });
+  });
+});

--- a/turbo/apps/web/app/api/zero/agents/__tests__/sandbox-capability.test.ts
+++ b/turbo/apps/web/app/api/zero/agents/__tests__/sandbox-capability.test.ts
@@ -6,6 +6,7 @@ import {
   PUT as putInstructions,
 } from "../[name]/instructions/route";
 import {
+  createTestCliToken,
   createTestRequest,
   insertOrgMembersCacheEntry,
 } from "../../../../../src/__tests__/api-test-helpers";
@@ -84,9 +85,7 @@ describe("Sandbox capability enforcement on zero agent routes", () => {
     it("sandbox token with agent:read can get agent", async () => {
       // First create an agent with a regular CLI token
       const cliUser = await context.setupUser();
-      const { createTestCliToken } = await import(
-        "../../../../../src/__tests__/api-test-helpers"
-      );
+
       const cliToken = await createTestCliToken(cliUser.userId);
       const cliOrgSlug = `org-${cliUser.userId.slice(-8)}`;
 
@@ -151,9 +150,7 @@ describe("Sandbox capability enforcement on zero agent routes", () => {
     it("sandbox token with agent:write can update agent", async () => {
       // First create an agent with a regular CLI token
       const cliUser = await context.setupUser();
-      const { createTestCliToken } = await import(
-        "../../../../../src/__tests__/api-test-helpers"
-      );
+
       const cliToken = await createTestCliToken(cliUser.userId);
       const cliOrgSlug = `org-${cliUser.userId.slice(-8)}`;
 
@@ -231,9 +228,7 @@ describe("Sandbox capability enforcement on zero agent routes", () => {
     it("sandbox token with agent:read can get instructions", async () => {
       // First create an agent with a regular CLI token
       const cliUser = await context.setupUser();
-      const { createTestCliToken } = await import(
-        "../../../../../src/__tests__/api-test-helpers"
-      );
+
       const cliToken = await createTestCliToken(cliUser.userId);
       const cliOrgSlug = `org-${cliUser.userId.slice(-8)}`;
 
@@ -298,9 +293,7 @@ describe("Sandbox capability enforcement on zero agent routes", () => {
     it("sandbox token with agent:write can update instructions", async () => {
       // First create an agent with a regular CLI token
       const cliUser = await context.setupUser();
-      const { createTestCliToken } = await import(
-        "../../../../../src/__tests__/api-test-helpers"
-      );
+
       const cliToken = await createTestCliToken(cliUser.userId);
       const cliOrgSlug = `org-${cliUser.userId.slice(-8)}`;
 

--- a/turbo/apps/web/app/api/zero/agents/route.ts
+++ b/turbo/apps/web/app/api/zero/agents/route.ts
@@ -24,7 +24,9 @@ const router = tsr.router(zeroAgentsMainContract, {
   create: async ({ body, headers }, { request }) => {
     initServices();
 
-    const authCtx = await requireAuth(headers.authorization);
+    const authCtx = await requireAuth(headers.authorization, {
+      requiredCapability: "agent:write",
+    });
     if (isAuthError(authCtx)) return authCtx;
     const { userId } = authCtx;
 


### PR DESCRIPTION
## Summary

- Add `requiredCapability` to all 5 `requireAuth()` calls in `/api/zero/agents` endpoints so sandbox tokens with `agent:read`/`agent:write` capabilities are accepted
- GET endpoints require `agent:read`, POST/PUT endpoints require `agent:write`
- Add 10 integration tests covering both positive (correct capability) and negative (wrong capability -> 403) cases for all endpoints

Closes #5732

## Test plan

- [x] All 10 new sandbox capability tests pass
- [x] All 17 existing zero agents route tests pass
- [x] Type check passes for web package
- [x] Lint passes for web package
- [x] Knip passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)