### PR TITLE
fix: keep markdown text readable in dark mode

### DIFF
--- a/turbo/apps/platform/src/views/components/markdown.tsx
+++ b/turbo/apps/platform/src/views/components/markdown.tsx
@@ -162,6 +162,7 @@ export function Markdown({ className, style, ...rest }: MarkdownPreviewProps) {
       className={`!bg-transparent !text-foreground text-sm ${className ?? ""}`}
       style={{
         backgroundColor: "transparent",
+        color: "hsl(var(--foreground))",
         fontSize: "0.875rem",
         lineHeight: "1.5",
         fontFamily: "var(--font-family-sans)",


### PR DESCRIPTION
## Bug
https://github.com/vm0-ai/vm0/issues/5704 — markdown-rendered text is hard to read in dark mode due to insufficient foreground contrast.

## Fix
Explicitly set markdown preview text color to the theme foreground token in the shared markdown component.

- Updated `Markdown` component inline style to include:
  - `color: "hsl(var(--foreground))"`

This keeps markdown content readable in dark mode while preserving the existing theme tokens/styling pipeline.

## Testing
- Verified the markdown wrapper now always receives a foreground text color derived from active theme tokens.
- Change is isolated to markdown rendering and does not alter parsing logic.

Happy to refine further if you'd like additional dark-mode typography adjustments.

Greetings, saschabuehrle
