### PR TITLE
refactor: separate auth error from firewall action in network logs

### DIFF
--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -371,7 +371,8 @@ async def handle_firewall_request(
 
     if not encrypted_secrets:
         ctx.log.error(f"[{run_id}] No encryptedSecrets for firewall rule {firewall_base}")
-        flow.metadata["firewall_action"] = "ERROR"
+        flow.metadata["firewall_action"] = "ALLOW"
+        flow.metadata["firewall_error"] = "auth_unavailable"
         flow.response = http.Response.make(
             502,
             json.dumps(
@@ -392,7 +393,8 @@ async def handle_firewall_request(
         )
     except Exception as e:
         ctx.log.error(f"[{run_id}] Firewall header fetch failed: {e}")
-        flow.metadata["firewall_action"] = "ERROR"
+        flow.metadata["firewall_action"] = "ALLOW"
+        flow.metadata["firewall_error"] = "auth_failed"
         flow.response = http.Response.make(
             502,
             json.dumps(
@@ -609,6 +611,9 @@ def response(flow: http.HTTPFlow) -> None:
             params = flow.metadata.get("firewall_params")
             if params:
                 log_entry["firewall_params"] = params
+            error = flow.metadata.get("firewall_error")
+            if error:
+                log_entry["firewall_error"] = error
 
         log_network_entry(network_log_path, log_entry)
 

--- a/crates/runner/mitm-addon/tests/test_connectors.py
+++ b/crates/runner/mitm-addon/tests/test_connectors.py
@@ -694,7 +694,8 @@ class TestHandleFirewallRequest:
 
         assert flow.response is not None
         assert flow.response.status_code == 502
-        assert flow.metadata["firewall_action"] == "ERROR"
+        assert flow.metadata["firewall_action"] == "ALLOW"
+        assert flow.metadata["firewall_error"] == "auth_failed"
         body = json.loads(flow.response.content)
         assert body["error"] == "firewall_auth_failed"
         assert "API unreachable" in body["message"]
@@ -734,7 +735,8 @@ class TestHandleFirewallRequest:
 
         assert flow.response is not None
         assert flow.response.status_code == 502
-        assert flow.metadata["firewall_action"] == "ERROR"
+        assert flow.metadata["firewall_action"] == "ALLOW"
+        assert flow.metadata["firewall_error"] == "auth_unavailable"
         body = json.loads(flow.response.content)
         assert body["error"] == "firewall_auth_unavailable"
         assert body["firewall"] == "github"

--- a/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
@@ -775,7 +775,7 @@ describe("logs command", () => {
               networkLogs: [
                 {
                   timestamp: "2024-01-15T10:30:00Z",
-                  action: "ERROR",
+                  action: "ALLOW",
                   method: "GET",
                   status: 502,
                   latency_ms: 5,
@@ -783,6 +783,7 @@ describe("logs command", () => {
                   response_size: 100,
                   url: "https://api.stripe.com/v1/users",
                   firewall_name: "stripe",
+                  firewall_error: "auth_failed",
                 },
               ],
               hasMore: false,
@@ -797,7 +798,7 @@ describe("logs command", () => {
       expect(logCalls).toContain("502");
       expect(logCalls).toContain("5ms");
       expect(logCalls).toContain("[stripe]");
-      expect(logCalls).toContain("auth failed");
+      expect(logCalls).toContain("auth_failed");
     });
 
     it("should handle empty network logs", async () => {

--- a/turbo/apps/cli/src/commands/logs/index.ts
+++ b/turbo/apps/cli/src/commands/logs/index.ts
@@ -107,7 +107,9 @@ function formatNetworkRequest(entry: NetworkLogEntry): string {
   const firewall = entry.firewall_name
     ? ` ${chalk.cyan(`[${entry.firewall_name}]`)}`
     : "";
-  const error = entry.action === "ERROR" ? ` ${chalk.red("auth failed")}` : "";
+  const error = entry.firewall_error
+    ? ` ${chalk.red(entry.firewall_error)}`
+    : "";
 
   return `[${entry.timestamp}] ${method.padEnd(6)} ${statusColor(status)} ${latencyColor(latencyMs + "ms")} ${formatBytes(requestSize)}/${formatBytes(responseSize)} ${chalk.dim(url)}${firewall}${error}`;
 }

--- a/turbo/apps/web/app/api/agent/runs/[id]/telemetry/network/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/telemetry/network/route.ts
@@ -21,7 +21,7 @@ interface AxiomNetworkEvent {
   _time: string;
   runId: string;
   userId: string;
-  action?: "ALLOW" | "DENY" | "ERROR";
+  action?: "ALLOW" | "DENY";
   host?: string;
   port?: number;
   method?: string;
@@ -36,6 +36,7 @@ interface AxiomNetworkEvent {
   firewall_permission?: string;
   firewall_rule_match?: string;
   firewall_params?: Record<string, string>;
+  firewall_error?: string;
 }
 
 const router = tsr.router(runNetworkLogsContract, {
@@ -117,6 +118,7 @@ ${sinceFilter}
       firewall_permission: e.firewall_permission,
       firewall_rule_match: e.firewall_rule_match,
       firewall_params: e.firewall_params,
+      firewall_error: e.firewall_error,
     }));
 
     return {

--- a/turbo/packages/core/src/contracts/runs.ts
+++ b/turbo/packages/core/src/contracts/runs.ts
@@ -346,7 +346,7 @@ const agentEventsResponseSchema = z.object({
  */
 const networkLogEntrySchema = z.object({
   timestamp: z.string(),
-  action: z.enum(["ALLOW", "DENY", "ERROR"]).optional(),
+  action: z.enum(["ALLOW", "DENY"]).optional(),
   host: z.string().optional(),
   port: z.number().optional(),
   method: z.string().optional(),
@@ -361,6 +361,7 @@ const networkLogEntrySchema = z.object({
   firewall_permission: z.string().optional(),
   firewall_rule_match: z.string().optional(),
   firewall_params: z.record(z.string(), z.string()).optional(),
+  firewall_error: z.string().optional(),
 });
 
 /**


### PR DESCRIPTION
## Summary

- Move auth failure indication from `action` enum to a dedicated `firewall_error` field
- `action` now only has two values: `ALLOW` (permitted) and `DENY` (blocked by permission)
- `firewall_error` captures auth resolution failures: `auth_unavailable` (secrets not configured) and `auth_failed` (auth API call failed)
- CLI displays `firewall_error` value in red after the request line

Closes #5754

## Test plan

- [x] Python tests pass (87 passed)
- [x] CLI tests pass (43 passed)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)