### PR TITLE
ci: add stripe billing environment variables to ci workflows

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -310,6 +310,10 @@ jobs:
             POSTHOG_OAUTH_CLIENT_SECRET=${{ secrets.POSTHOG_OAUTH_CLIENT_SECRET }}
             STRIPE_OAUTH_CLIENT_ID=${{ vars.STRIPE_OAUTH_CLIENT_ID }}
             STRIPE_OAUTH_CLIENT_SECRET=${{ secrets.STRIPE_OAUTH_CLIENT_SECRET }}
+            STRIPE_SECRET_KEY=${{ secrets.STRIPE_SECRET_KEY }}
+            STRIPE_WEBHOOK_SECRET=${{ secrets.STRIPE_WEBHOOK_SECRET }}
+            ZERO_PRO_PLAN_PRICE_ID=${{ secrets.ZERO_PRO_PLAN_PRICE_ID }}
+            ZERO_MAX_PLAN_PRICE_ID=${{ secrets.ZERO_MAX_PLAN_PRICE_ID }}
             NGROK_API_KEY=${{ secrets.NGROK_API_KEY }}
             NGROK_COMPUTER_CONNECTOR_DOMAIN=${{ vars.NGROK_COMPUTER_CONNECTOR_DOMAIN }}
             APP_URL=https://app.vm0.ai

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -564,6 +564,10 @@ jobs:
           POSTHOG_OAUTH_CLIENT_SECRET: ${{ secrets.POSTHOG_OAUTH_CLIENT_SECRET }}
           STRIPE_OAUTH_CLIENT_ID: ${{ vars.STRIPE_OAUTH_CLIENT_ID }}
           STRIPE_OAUTH_CLIENT_SECRET: ${{ secrets.STRIPE_OAUTH_CLIENT_SECRET }}
+          STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
+          STRIPE_WEBHOOK_SECRET: ${{ secrets.STRIPE_WEBHOOK_SECRET }}
+          ZERO_PRO_PLAN_PRICE_ID: ${{ secrets.ZERO_PRO_PLAN_PRICE_ID }}
+          ZERO_MAX_PLAN_PRICE_ID: ${{ secrets.ZERO_MAX_PLAN_PRICE_ID }}
           NGROK_API_KEY: ${{ secrets.NGROK_API_KEY }}
           NGROK_COMPUTER_CONNECTOR_DOMAIN: ${{ vars.NGROK_COMPUTER_CONNECTOR_DOMAIN }}
           APP_URL: ${{ needs.prepare.outputs.app-preview-url }}
@@ -755,6 +759,10 @@ jobs:
             ASANA_OAUTH_CLIENT_SECRET=${{ secrets.ASANA_OAUTH_CLIENT_SECRET }}
             STRIPE_OAUTH_CLIENT_ID=${{ vars.STRIPE_OAUTH_CLIENT_ID }}
             STRIPE_OAUTH_CLIENT_SECRET=${{ secrets.STRIPE_OAUTH_CLIENT_SECRET }}
+            STRIPE_SECRET_KEY=${{ secrets.STRIPE_SECRET_KEY }}
+            STRIPE_WEBHOOK_SECRET=${{ secrets.STRIPE_WEBHOOK_SECRET }}
+            ZERO_PRO_PLAN_PRICE_ID=${{ secrets.ZERO_PRO_PLAN_PRICE_ID }}
+            ZERO_MAX_PLAN_PRICE_ID=${{ secrets.ZERO_MAX_PLAN_PRICE_ID }}
             NGROK_API_KEY=${{ secrets.NGROK_API_KEY }}
             NGROK_COMPUTER_CONNECTOR_DOMAIN=${{ vars.NGROK_COMPUTER_CONNECTOR_DOMAIN }}
             APP_URL=${{ needs.prepare.outputs.app-preview-url }}

--- a/turbo/apps/web/.env.local.tpl
+++ b/turbo/apps/web/.env.local.tpl
@@ -134,6 +134,12 @@ STRIPE_OAUTH_CLIENT_SECRET=op://Development/stripe/STRIPE_OAUTH_CLIENT_SECRET
 # Optional: Stripe Billing (Vercel AI Gateway metering)
 STRIPE_VERCEL_GATEWAY_REPORT_ACCESS_KEY=op://Development/stripe/STRIPE_VERCEL_GATEWAY_REPORT_ACCESS_KEY
 
+# Optional: Stripe Billing (subscription + credits)
+STRIPE_SECRET_KEY=op://Development/stripe/STRIPE_SECRET_KEY
+STRIPE_WEBHOOK_SECRET=op://Development/stripe/STRIPE_WEBHOOK_SECRET
+ZERO_PRO_PLAN_PRICE_ID=op://Development/stripe/ZERO_PRO_PLAN_PRICE_ID
+ZERO_MAX_PLAN_PRICE_ID=op://Development/stripe/ZERO_MAX_PLAN_PRICE_ID
+
 # Optional: ngrok (Computer Connector)
 NGROK_API_KEY=op://Development/ngrok/NGROK_API_KEY
 NGROK_COMPUTER_CONNECTOR_DOMAIN=computer.vm7.io


### PR DESCRIPTION
## Summary
- Add `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`, `ZERO_PRO_PLAN_PRICE_ID`, and `ZERO_MAX_PLAN_PRICE_ID` to CI workflow secrets in `turbo.yml` and `release-please.yml`
- Add the same variables to the `.env.local.tpl` template with 1Password references for local development

## Test plan
- [ ] Verify CI workflows pass with the new environment variables
- [ ] Confirm `.env.local.tpl` syncs correctly via `script/sync-env.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)