### PR TITLE
chore: add no-use-ccstate-in-views eslint rule

### DIFF
--- a/turbo/apps/platform/custom-eslint/__tests__/no-use-ccstate-in-views.test.ts
+++ b/turbo/apps/platform/custom-eslint/__tests__/no-use-ccstate-in-views.test.ts
@@ -1,0 +1,42 @@
+import { RuleTester } from "@typescript-eslint/rule-tester";
+import { describe, it, afterAll } from "vitest";
+import rule from "../rules/no-use-ccstate-in-views.ts";
+
+RuleTester.afterAll = afterAll;
+RuleTester.describe = describe;
+RuleTester.it = it;
+
+const ruleTester = new RuleTester();
+
+ruleTester.run("no-use-ccstate-in-views", rule, {
+  valid: [
+    {
+      code: 'const input$ = useCCState("")',
+      filename: "/project/src/signals/zero-page/zero-chat.ts",
+    },
+    {
+      code: "const value = useGet(someSignal$)",
+      filename: "/project/src/views/zero-page/zero-chat-page.tsx",
+    },
+    {
+      code: 'const [value, setValue] = useState("")',
+      filename: "/project/src/views/zero-page/zero-chat-page.tsx",
+    },
+    {
+      code: 'const input$ = useCCState("")',
+      filename: "/project/src/__tests__/test.tsx",
+    },
+  ],
+  invalid: [
+    {
+      code: 'const input$ = useCCState("")',
+      filename: "/project/src/views/zero-page/zero-chat-page.tsx",
+      errors: [{ messageId: "noUseCCStateInViews" }],
+    },
+    {
+      code: "const flag$ = useCCState(false)",
+      filename: "/project/src/views/zero-page/zero-sidebar.tsx",
+      errors: [{ messageId: "noUseCCStateInViews" }],
+    },
+  ],
+});

--- a/turbo/apps/platform/custom-eslint/index.ts
+++ b/turbo/apps/platform/custom-eslint/index.ts
@@ -13,6 +13,7 @@
  * - computed-const-args-package-scope: Enforce package scope for constant functions
  * - no-store-in-params: Prevent Store type in function params
  * - no-side-effect-in-render: Prevent side-effect calls (set, detach) directly in render
+ * - no-use-ccstate-in-views: Disallow useCCState() in views/ — signals must be in signals/
  */
 
 import signalDollarSuffix from "./rules/signal-dollar-suffix.ts";
@@ -27,6 +28,7 @@ import computedConstArgsPackageScope from "./rules/computed-const-args-package-s
 import noStoreInParams from "./rules/no-store-in-params.ts";
 import setupPageRender from "./rules/setup-page-render.ts";
 import noSideEffectInRender from "./rules/no-side-effect-in-render.ts";
+import noUseCCStateInViews from "./rules/no-use-ccstate-in-views.ts";
 
 const plugin = {
   meta: {
@@ -46,6 +48,7 @@ const plugin = {
     "no-store-in-params": noStoreInParams,
     "setup-page-render": setupPageRender,
     "no-side-effect-in-render": noSideEffectInRender,
+    "no-use-ccstate-in-views": noUseCCStateInViews,
   },
 };
 

--- a/turbo/apps/platform/custom-eslint/rules/no-use-ccstate-in-views.ts
+++ b/turbo/apps/platform/custom-eslint/rules/no-use-ccstate-in-views.ts
@@ -1,0 +1,58 @@
+/**
+ * ESLint rule: no-use-ccstate-in-views
+ *
+ * Disallows useCCState() calls in views/ files.
+ * Signals should only be declared in signals/ files, not inline in components.
+ *
+ * Good: const [value, setValue] = useState("") // React local state
+ * Good: const value = useGet(someSignal$)      // consume signal from signals/
+ * Bad:  const input$ = useCCState("")           // declaring signal in a view
+ */
+
+import { ESLintUtils } from "@typescript-eslint/utils";
+
+const createRule = ESLintUtils.RuleCreator(
+  (name) =>
+    `https://github.com/anthropics/vm0/blob/main/docs/eslint/${name}.md`,
+);
+
+type MessageIds = "noUseCCStateInViews";
+
+export default createRule<[], MessageIds>({
+  name: "no-use-ccstate-in-views",
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow useCCState() in views/ — signals must be declared in signals/ files",
+    },
+    schema: [],
+    messages: {
+      noUseCCStateInViews:
+        "useCCState() is not allowed in views/. For shared state, declare state()/computed()/command() in signals/ and consume with useGet()/useSet(). For component-local state, use React useState().",
+    },
+  },
+  defaultOptions: [],
+  create(context) {
+    const filename = context.filename.replace(/\\/g, "/");
+
+    const isInViews = /\/src\/views\//.test(filename);
+    if (!isInViews) {
+      return {};
+    }
+
+    return {
+      CallExpression(node) {
+        if (
+          node.callee.type === "Identifier" &&
+          node.callee.name === "useCCState"
+        ) {
+          context.report({
+            node,
+            messageId: "noUseCCStateInViews",
+          });
+        }
+      },
+    };
+  },
+});

--- a/turbo/apps/platform/eslint.config.js
+++ b/turbo/apps/platform/eslint.config.js
@@ -26,6 +26,7 @@ export default [
       "ccstate/test-context-in-hooks": "error",
       "ccstate/setup-page-render": "error",
       "ccstate/no-side-effect-in-render": "error",
+      "ccstate/no-use-ccstate-in-views": "error",
     },
   },
   // Type-aware rules (only for TypeScript files)

--- a/turbo/apps/platform/src/views/zero-page/components/settings/add-connection-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/add-connection-dialog.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable ccstate/no-use-ccstate-in-views */
 import { useLastResolved, useGet, useSet } from "ccstate-react";
 import { useCCState } from "ccstate-react/experimental";
 import { IconSearch, IconPlus } from "@tabler/icons-react";

--- a/turbo/apps/platform/src/views/zero-page/components/settings/notification-settings.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/notification-settings.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable ccstate/no-use-ccstate-in-views */
 import { useCCState } from "ccstate-react/experimental";
 import { useGet, useLastResolved, useSet } from "ccstate-react";
 import { Skeleton } from "@vm0/ui/components/ui/skeleton";

--- a/turbo/apps/platform/src/views/zero-page/components/settings/scope-review-modal.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/scope-review-modal.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable ccstate/no-use-ccstate-in-views */
 import { useGet, useSet } from "ccstate-react";
 import { useCCState, useCommand } from "ccstate-react/experimental";
 import {

--- a/turbo/apps/platform/src/views/zero-page/components/settings/timezone-settings.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/timezone-settings.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable ccstate/no-use-ccstate-in-views */
 import { useCCState } from "ccstate-react/experimental";
 import { useGet, useLastResolved, useSet } from "ccstate-react";
 import {

--- a/turbo/apps/platform/src/views/zero-page/use-file-upload-handlers.ts
+++ b/turbo/apps/platform/src/views/zero-page/use-file-upload-handlers.ts
@@ -1,3 +1,4 @@
+/* eslint-disable ccstate/no-use-ccstate-in-views */
 import type { ClipboardEvent, DragEvent } from "react";
 import { useCCState } from "ccstate-react/experimental";
 import { useGet, useSet } from "ccstate-react";

--- a/turbo/apps/platform/src/views/zero-page/zero-account-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-account-page.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable ccstate/no-use-ccstate-in-views */
 import { useCCState } from "ccstate-react/experimental";
 import { useGet, useSet, useLoadable } from "ccstate-react";
 import {

--- a/turbo/apps/platform/src/views/zero-page/zero-activity-detail-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-activity-detail-page.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable ccstate/no-use-ccstate-in-views */
 import { useCCState } from "ccstate-react/experimental";
 import {
   useGet,

--- a/turbo/apps/platform/src/views/zero-page/zero-app-shell.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-app-shell.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable ccstate/no-use-ccstate-in-views */
 import { useCCState, useCommand } from "ccstate-react/experimental";
 import { useGet, useSet, useLoadable, useLastLoadable } from "ccstate-react";
 import {

--- a/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable ccstate/no-use-ccstate-in-views */
 import type { MouseEvent } from "react";
 import { useCCState, useCommand } from "ccstate-react/experimental";
 import { useGet, useSet } from "ccstate-react";

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable ccstate/no-use-ccstate-in-views */
 import type { ChangeEvent } from "react";
 import { useCCState } from "ccstate-react/experimental";
 import { useGet, useSet, useLastLoadable } from "ccstate-react";

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-page.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable ccstate/no-use-ccstate-in-views */
 import { Component } from "react";
 import { useCCState, useCommand } from "ccstate-react/experimental";
 import { useGet, useSet, useLoadable } from "ccstate-react";

--- a/turbo/apps/platform/src/views/zero-page/zero-job-detail-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-job-detail-page.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable ccstate/no-use-ccstate-in-views */
 import { useGet, useSet, useLoadable, useLastLoadable } from "ccstate-react";
 import { useCCState } from "ccstate-react/experimental";
 import {

--- a/turbo/apps/platform/src/views/zero-page/zero-model-preference.ts
+++ b/turbo/apps/platform/src/views/zero-page/zero-model-preference.ts
@@ -1,3 +1,4 @@
+/* eslint-disable ccstate/no-use-ccstate-in-views */
 import { useGet, useSet, useLastLoadable } from "ccstate-react";
 import { useCCState } from "ccstate-react/experimental";
 import { MODEL_PROVIDER_TYPES } from "@vm0/core";

--- a/turbo/apps/platform/src/views/zero-page/zero-onboarding.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-onboarding.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable ccstate/no-use-ccstate-in-views */
 import { Component } from "react";
 import { useCCState } from "ccstate-react/experimental";
 import {

--- a/turbo/apps/platform/src/views/zero-page/zero-schedule-card.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-schedule-card.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable ccstate/no-use-ccstate-in-views */
 "use client";
 
 import { useCCState } from "ccstate-react/experimental";

--- a/turbo/apps/platform/src/views/zero-page/zero-schedule-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-schedule-page.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable ccstate/no-use-ccstate-in-views */
 import { useCCState } from "ccstate-react/experimental";
 import { useGet, useSet, useLoadable, useLastLoadable } from "ccstate-react";
 import {

--- a/turbo/apps/platform/src/views/zero-page/zero-schedule-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-schedule-tab.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable ccstate/no-use-ccstate-in-views */
 import { useCCState } from "ccstate-react/experimental";
 import { useGet, useSet, useLoadable } from "ccstate-react";
 import { Card, CardContent } from "@vm0/ui";

--- a/turbo/apps/platform/src/views/zero-page/zero-send-key.ts
+++ b/turbo/apps/platform/src/views/zero-page/zero-send-key.ts
@@ -1,3 +1,4 @@
+/* eslint-disable ccstate/no-use-ccstate-in-views */
 import type { KeyboardEvent } from "react";
 import { useGet, useSet, useLastLoadable } from "ccstate-react";
 import { useCCState } from "ccstate-react/experimental";

--- a/turbo/apps/platform/src/views/zero-page/zero-session-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-session-chat-page.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable ccstate/no-use-ccstate-in-views */
 import { useCCState, useCommand } from "ccstate-react/experimental";
 import { useGet, useSet, useLoadable, useLastLoadable } from "ccstate-react";
 import {

--- a/turbo/apps/platform/src/views/zero-page/zero-settings-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-settings-tab.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable ccstate/no-use-ccstate-in-views */
 import { useCCState, useCommand } from "ccstate-react/experimental";
 import { useGet, useSet } from "ccstate-react";
 import {

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable ccstate/no-use-ccstate-in-views */
 import type { ReactNode } from "react";
 import {
   useLoadable,

--- a/turbo/apps/platform/src/views/zero-page/zero-skills-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-skills-tab.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable ccstate/no-use-ccstate-in-views */
 import { useGet, useSet, useLastLoadable } from "ccstate-react";
 import { useCCState } from "ccstate-react/experimental";
 import { IconPlus } from "@tabler/icons-react";

--- a/turbo/apps/platform/src/views/zero-page/zero-slack-connect-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-slack-connect-page.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable ccstate/no-use-ccstate-in-views */
 import { useCCState, useCommand } from "ccstate-react/experimental";
 import { useGet, useSet } from "ccstate-react";
 import {

--- a/turbo/apps/platform/src/views/zero-page/zero-works-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-works-page.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable ccstate/no-use-ccstate-in-views */
 import { useCCState, useCommand } from "ccstate-react/experimental";
 import { useGet, useSet, useLoadable } from "ccstate-react";
 import {


### PR DESCRIPTION
## Summary
- Add custom ESLint rule `no-use-ccstate-in-views` that disallows `useCCState()` calls in `views/` files
- Enforces that signals are declared in `signals/` files, not inline in view components
- Existing violations in 24 view files are suppressed with `eslint-disable` comments for incremental migration
- Includes test coverage for valid and invalid cases

## Test plan
- [ ] Verify the new ESLint rule catches `useCCState()` in views/ files
- [ ] Verify `useCCState()` is still allowed in signals/ and test files
- [ ] Verify `useGet()` and `useState()` remain allowed in views/
- [ ] Confirm existing view files pass lint with the eslint-disable comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)