### PR TITLE
fix(slack): remove disallowed-tools param to unblock agent runs

### DIFF
--- a/turbo/apps/web/src/lib/integration-context.ts
+++ b/turbo/apps/web/src/lib/integration-context.ts
@@ -19,15 +19,6 @@ export function buildIntegrationContext(
 }
 
 /**
- * Cron tools to disallow when schedule guidance is active.
- */
-export const DISALLOWED_CRON_TOOLS = [
-  "CronCreate",
-  "CronList",
-  "CronDelete",
-] as const;
-
-/**
  * Build schedule guidance prompt that redirects agents from ephemeral cron
  * tools to vm0's persistent schedule system.
  */

--- a/turbo/apps/web/src/lib/slack-org/handlers/run-agent.ts
+++ b/turbo/apps/web/src/lib/slack-org/handlers/run-agent.ts
@@ -2,7 +2,6 @@ import { startRun, isRunDispatchError } from "../../run";
 import {
   buildIntegrationContext,
   buildScheduleGuidance,
-  DISALLOWED_CRON_TOOLS,
 } from "../../integration-context";
 import { isConcurrentRunLimit } from "../../errors";
 import { generateCallbackSecret, getApiUrl } from "../../callback";
@@ -88,7 +87,6 @@ export async function runAgentForSlackOrg(
       composeId,
       prompt,
       appendSystemPrompt,
-      disallowedTools: [...DISALLOWED_CRON_TOOLS],
       sessionId,
       triggerSource: "slack",
       callbacks: [


### PR DESCRIPTION
## Summary
- Remove `disallowedTools` parameter from Slack-triggered runs to fix "Agent exited with code 1" failures
- Remove unused `DISALLOWED_CRON_TOOLS` constant (caught by knip)
- Keep schedule guidance system prompt in place — agents are still instructed not to use cron tools

## Context
After deploying #5779, all Slack-triggered runs fail with exit code 1 while web UI runs work fine. The only difference is the new `--disallowed-tools CronCreate CronList CronDelete` flag passed to the CLI. Root cause is likely a sandbox image version mismatch (guest-agent v0.19.0 not yet deployed to sandbox images).

## Test plan
- [ ] Deploy and verify Slack agent runs complete successfully
- [ ] Verify web UI runs still work
- [ ] Re-enable disallowedTools after sandbox images are updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)