### PR TITLE
feat: enable pricing feature switch for staff users

### DIFF
--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -56,6 +56,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
   [FeatureSwitchKey.Pricing]: {
     maintainer: "ethan@vm0.ai",
     enabled: false,
+    enabledUserHashes: STAFF_USER_HASHES,
   },
   [FeatureSwitchKey.Dummy]: {
     maintainer: "ethan@vm0.ai",


### PR DESCRIPTION
## Summary
- Enable the Pricing feature switch for staff users by adding `enabledUserHashes: STAFF_USER_HASHES` to the Pricing feature switch configuration
- This allows staff to access pricing features while keeping them disabled for general users

## Test plan
- [ ] Verify staff users can see pricing features
- [ ] Verify non-staff users still cannot see pricing features

🤖 Generated with [Claude Code](https://claude.com/claude-code)