### PR TITLE
feat: add tcp connection logging and network log type field

### DIFF
--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -17,7 +17,7 @@ import urllib.parse
 import urllib.request
 from typing import NamedTuple
 
-from mitmproxy import ctx, http, tls
+from mitmproxy import ctx, http, tcp, tls
 from mitmproxy.addonmanager import Loader
 
 # Vercel bypass secret (still from environment as it's a secret)
@@ -590,6 +590,7 @@ def response(flow: http.HTTPFlow) -> None:
     if run_id and network_log_path:
         log_entry = {
             "timestamp": time.strftime("%Y-%m-%dT%H:%M:%S", time.gmtime()),
+            "type": "http",
             "action": firewall_action,
             "host": host,
             "port": port,
@@ -639,5 +640,76 @@ def error(flow: http.HTTPFlow) -> None:
     _request_start_times.pop(flow.id, None)
 
 
+# ============================================================================
+# TCP Connection Handlers
+# ============================================================================
+
+
+def tcp_start(flow: tcp.TCPFlow) -> None:
+    """Track TCP connection start time and look up VM info."""
+    client_ip = flow.client_conn.peername[0] if flow.client_conn.peername else None
+    if not client_ip:
+        return
+
+    vm_info = get_vm_info(client_ip)
+    if not vm_info:
+        return
+
+    flow.metadata["vm_run_id"] = vm_info.get("runId", "")
+    flow.metadata["vm_network_log_path"] = vm_info.get("networkLogPath", "")
+    flow.metadata["tcp_start_time"] = time.time()
+
+
+def tcp_end(flow: tcp.TCPFlow) -> None:
+    """Log TCP connection details when it closes."""
+    _log_tcp(flow)
+
+
+def tcp_error(flow: tcp.TCPFlow) -> None:
+    """Log TCP connection errors."""
+    _log_tcp(flow)
+
+
+def _log_tcp(flow: tcp.TCPFlow) -> None:
+    run_id = flow.metadata.get("vm_run_id", "")
+    network_log_path = flow.metadata.get("vm_network_log_path", "")
+    if not run_id or not network_log_path:
+        return
+
+    start_time = flow.metadata.get("tcp_start_time")
+    latency_ms = int((time.time() - start_time) * 1000) if start_time else 0
+
+    request_size = sum(len(m.content) for m in flow.messages if m.from_client)
+    response_size = sum(len(m.content) for m in flow.messages if not m.from_client)
+
+    server_addr = flow.server_conn.address if flow.server_conn else None
+    host = server_addr[0] if server_addr else "unknown"
+    port = server_addr[1] if server_addr else 0
+
+    log_entry = {
+        "timestamp": time.strftime("%Y-%m-%dT%H:%M:%S", time.gmtime()),
+        "type": "tcp",
+        "host": host,
+        "port": port,
+        "latency_ms": latency_ms,
+        "request_size": request_size,
+        "response_size": response_size,
+    }
+
+    if flow.error:
+        log_entry["error"] = flow.error.msg
+
+    log_network_entry(network_log_path, log_entry)
+
+
 # mitmproxy addon registration
-addons = [tls_clienthello, request, responseheaders, response, error]
+addons = [
+    tls_clienthello,
+    request,
+    responseheaders,
+    response,
+    error,
+    tcp_start,
+    tcp_end,
+    tcp_error,
+]

--- a/crates/runner/mitm-addon/tests/test_handlers.py
+++ b/crates/runner/mitm-addon/tests/test_handlers.py
@@ -1,6 +1,7 @@
-"""Tests for HTTP/TLS handlers."""
+"""Tests for HTTP/TLS/TCP handlers."""
 
 import json
+import time
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -516,3 +517,142 @@ class TestTlsClienthello:
 
         # All registered VMs use MITM — should NOT set ignore_connection
         assert data.ignore_connection is False
+
+
+def _make_tcp_flow(client_ip="10.200.0.1"):
+    """Create a mock TCP flow."""
+    flow = MagicMock()
+    flow.client_conn.peername = (client_ip, 12345)
+    flow.server_conn.address = ("140.82.116.3", 22)
+    flow.metadata = {}
+    flow.error = None
+    # Two messages: one from client, one from server
+    client_msg = MagicMock()
+    client_msg.content = b"hello"
+    client_msg.from_client = True
+    server_msg = MagicMock()
+    server_msg.content = b"SSH-2.0-babeld"
+    server_msg.from_client = False
+    flow.messages = [client_msg, server_msg]
+    return flow
+
+
+class TestTcpStart:
+    def setup_method(self):
+        _reset()
+
+    def test_sets_metadata_for_registered_vm(self, registry_file):
+        flow = _make_tcp_flow(client_ip="10.200.0.1")
+
+        with (
+            patch.object(mitm_addon, "get_registry_path", return_value=str(registry_file)),
+            patch.object(mitm_addon.ctx, "log", MagicMock(), create=True),
+        ):
+            mitm_addon.tcp_start(flow)
+
+        assert flow.metadata["vm_run_id"] == "run-abc-123"
+        assert "vm_network_log_path" in flow.metadata
+        assert "tcp_start_time" in flow.metadata
+
+    def test_skips_when_no_client_ip(self, registry_file):
+        flow = _make_tcp_flow()
+        flow.client_conn.peername = None
+
+        with (
+            patch.object(mitm_addon, "get_registry_path", return_value=str(registry_file)),
+            patch.object(mitm_addon.ctx, "log", MagicMock(), create=True),
+        ):
+            mitm_addon.tcp_start(flow)
+
+        assert "vm_run_id" not in flow.metadata
+
+    def test_skips_when_vm_not_registered(self, registry_file):
+        flow = _make_tcp_flow(client_ip="192.168.99.99")
+
+        with (
+            patch.object(mitm_addon, "get_registry_path", return_value=str(registry_file)),
+            patch.object(mitm_addon.ctx, "log", MagicMock(), create=True),
+        ):
+            mitm_addon.tcp_start(flow)
+
+        assert "vm_run_id" not in flow.metadata
+
+
+class TestTcpLog:
+    def setup_method(self):
+        _reset()
+
+    def test_logs_tcp_connection(self, registry_file, tmp_path):
+        flow = _make_tcp_flow(client_ip="10.200.0.1")
+        log_path = str(tmp_path / "network.jsonl")
+        flow.metadata["vm_run_id"] = "run-abc-123"
+        flow.metadata["vm_network_log_path"] = log_path
+        flow.metadata["tcp_start_time"] = time.time() - 0.05
+
+        with patch.object(mitm_addon.ctx, "log", MagicMock(), create=True):
+            mitm_addon.tcp_end(flow)
+
+        lines = Path(log_path).read_text().splitlines()
+        assert len(lines) == 1
+        entry = json.loads(lines[0])
+        assert entry["type"] == "tcp"
+        assert entry["host"] == "140.82.116.3"
+        assert entry["port"] == 22
+        assert entry["latency_ms"] > 0
+        assert entry["request_size"] == 5  # b"hello"
+        assert entry["response_size"] == 14  # b"SSH-2.0-babeld"
+        assert "error" not in entry
+
+    def test_logs_tcp_error(self, registry_file, tmp_path):
+        flow = _make_tcp_flow(client_ip="10.200.0.1")
+        log_path = str(tmp_path / "network.jsonl")
+        flow.metadata["vm_run_id"] = "run-abc-123"
+        flow.metadata["vm_network_log_path"] = log_path
+        flow.metadata["tcp_start_time"] = time.time()
+        flow.error = MagicMock()
+        flow.error.msg = "connection reset by peer"
+
+        with patch.object(mitm_addon.ctx, "log", MagicMock(), create=True):
+            mitm_addon.tcp_error(flow)
+
+        lines = Path(log_path).read_text().splitlines()
+        entry = json.loads(lines[0])
+        assert entry["type"] == "tcp"
+        assert entry["error"] == "connection reset by peer"
+
+    def test_skips_when_no_run_id(self, tmp_path):
+        flow = _make_tcp_flow()
+        log_path = str(tmp_path / "network.jsonl")
+        flow.metadata["vm_network_log_path"] = log_path
+
+        with patch.object(mitm_addon.ctx, "log", MagicMock(), create=True):
+            mitm_addon.tcp_end(flow)
+
+        assert not Path(log_path).exists()
+
+    def test_handles_missing_server_addr(self, tmp_path):
+        flow = _make_tcp_flow()
+        log_path = str(tmp_path / "network.jsonl")
+        flow.metadata["vm_run_id"] = "run-abc-123"
+        flow.metadata["vm_network_log_path"] = log_path
+        flow.metadata["tcp_start_time"] = time.time()
+        flow.server_conn = None
+
+        with patch.object(mitm_addon.ctx, "log", MagicMock(), create=True):
+            mitm_addon.tcp_end(flow)
+
+        entry = json.loads(Path(log_path).read_text().strip())
+        assert entry["host"] == "unknown"
+        assert entry["port"] == 0
+
+    def test_handles_missing_start_time(self, tmp_path):
+        flow = _make_tcp_flow()
+        log_path = str(tmp_path / "network.jsonl")
+        flow.metadata["vm_run_id"] = "run-abc-123"
+        flow.metadata["vm_network_log_path"] = log_path
+
+        with patch.object(mitm_addon.ctx, "log", MagicMock(), create=True):
+            mitm_addon.tcp_end(flow)
+
+        entry = json.loads(Path(log_path).read_text().strip())
+        assert entry["latency_ms"] == 0

--- a/e2e/tests/03-experimental-runner/t45-vm0-tcp-passthrough.bats
+++ b/e2e/tests/03-experimental-runner/t45-vm0-tcp-passthrough.bats
@@ -47,4 +47,18 @@ EOF
     assert_output --partial "● Bash("
     assert_output --partial "PORT22=SSH-2.0"
     assert_output --partial "PORT443=SSH-2.0"
+
+    # Verify TCP connections appear in network logs
+    RUN_ID=$(echo "$output" | grep -oP 'Run ID:\s+\K[a-f0-9-]{36}' | head -1)
+    [ -n "$RUN_ID" ] || {
+        echo "# Failed to extract Run ID"
+        return 1
+    }
+
+    run $CLI_COMMAND logs "$RUN_ID" --network --tail 100
+    assert_success
+    # TCP connections show as IP:port (DNS resolved before TCP layer)
+    assert_output --partial "TCP"
+    assert_output --partial ":22"
+    assert_output --partial ":443"
 }

--- a/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
@@ -801,6 +801,69 @@ describe("logs command", () => {
       expect(logCalls).toContain("auth_failed");
     });
 
+    it("should display TCP connection logs", async () => {
+      server.use(
+        http.get(
+          "http://localhost:3000/api/agent/runs/:id/telemetry/network",
+          () => {
+            return HttpResponse.json({
+              networkLogs: [
+                {
+                  timestamp: "2024-01-15T10:30:00Z",
+                  type: "tcp",
+                  host: "redis.example.com",
+                  port: 6379,
+                  latency_ms: 5000,
+                  request_size: 1024,
+                  response_size: 2048,
+                },
+              ],
+              hasMore: false,
+            });
+          },
+        ),
+      );
+
+      await logsCommand.parseAsync(["node", "cli", "run-123", "--network"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("TCP");
+      expect(logCalls).toContain("redis.example.com:6379");
+      expect(logCalls).toContain("5000ms");
+    });
+
+    it("should display TCP error logs", async () => {
+      server.use(
+        http.get(
+          "http://localhost:3000/api/agent/runs/:id/telemetry/network",
+          () => {
+            return HttpResponse.json({
+              networkLogs: [
+                {
+                  timestamp: "2024-01-15T10:30:00Z",
+                  type: "tcp",
+                  host: "db.example.com",
+                  port: 5432,
+                  latency_ms: 3000,
+                  request_size: 0,
+                  response_size: 0,
+                  error: "connection reset by peer",
+                },
+              ],
+              hasMore: false,
+            });
+          },
+        ),
+      );
+
+      await logsCommand.parseAsync(["node", "cli", "run-123", "--network"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("TCP");
+      expect(logCalls).toContain("db.example.com:5432");
+      expect(logCalls).toContain("connection reset by peer");
+    });
+
     it("should handle empty network logs", async () => {
       server.use(
         http.get(

--- a/turbo/apps/cli/src/commands/logs/index.ts
+++ b/turbo/apps/cli/src/commands/logs/index.ts
@@ -115,9 +115,24 @@ function formatNetworkRequest(entry: NetworkLogEntry): string {
 }
 
 /**
+ * Format a TCP connection log entry
+ */
+function formatNetworkTcp(entry: NetworkLogEntry): string {
+  const host = entry.host || "unknown";
+  const port = entry.port || 0;
+  const requestSize = entry.request_size || 0;
+  const responseSize = entry.response_size || 0;
+  const latencyMs = entry.latency_ms || 0;
+  const error = entry.error ? ` ${chalk.red(entry.error)}` : "";
+
+  return `[${entry.timestamp}] ${chalk.blue("TCP")}   ${latencyMs}ms ${formatBytes(requestSize)}/${formatBytes(responseSize)} ${chalk.dim(`${host}:${port}`)}${error}`;
+}
+
+/**
  * Format a network log entry
  */
 function formatNetworkLog(entry: NetworkLogEntry): string {
+  if (entry.type === "tcp") return formatNetworkTcp(entry);
   if (entry.action === "DENY") return formatNetworkDeny(entry);
   return formatNetworkRequest(entry);
 }


### PR DESCRIPTION
## Summary

- Add `--tcp-hosts .*` to mitmproxy args so TCP flows trigger hooks
- Add `tcp_start`/`tcp_end`/`tcp_error` hooks to log TCP connections with host, port, bytes, duration
- Add `type` field (`http`/`tcp`) to network log entries to distinguish connection types
- Add `error` field for TCP connection errors (from `flow.error.msg`)
- HTTP logs now include `"type": "http"`; TCP logs have no `action` field (no firewall decision)
- CLI displays TCP entries as `TCP  host:port size duration` with error in red if present
- E2E: t42 verifies HTTP network logs (ALLOW/DENY with firewall tags), t45 verifies TCP logs

Closes #5592

## Test plan

- [x] Python tests pass (87 passed)
- [x] CLI tests pass (45 passed, includes TCP + TCP error cases)
- [ ] CI green
- [ ] E2E: t42 firewall test validates HTTP network logs (ALLOW 200 + DENY)
- [ ] E2E: t45 TCP passthrough test validates TCP entries in network logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)