### PR TITLE
fix: activity detail page stuck on skeleton when accessed directly

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-activity-detail-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-activity-detail-page.test.tsx
@@ -59,7 +59,7 @@ function mockActivityDetailAPI() {
   );
 }
 
-describe("ZeroActivityDetailPage", () => {
+describe("zeroActivityDetailPage", () => {
   it("should load detail when navigating directly to /activity/:runId", async () => {
     mockActivityDetailAPI();
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-activity-detail-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-activity-detail-page.test.tsx
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../mocks/server.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { setupPage } from "../../../__tests__/page-helper.ts";
+import type {
+  LogDetail,
+  AgentEventsResponse,
+} from "../../../signals/zero-page/log-types.ts";
+
+const context = testContext();
+
+function mockActivityDetailAPI() {
+  const logDetail: LogDetail = {
+    id: "run_1",
+    sessionId: "session_1",
+    agentName: "Test Agent",
+    displayName: "Test Agent",
+    framework: "claude-code",
+    modelProvider: null,
+    triggerSource: "web",
+    status: "completed",
+    prompt: "Hello, what can you do?",
+    appendSystemPrompt: null,
+    error: null,
+    createdAt: "2026-03-10T14:56:00Z",
+    startedAt: "2026-03-10T14:56:01Z",
+    completedAt: "2026-03-10T14:56:10Z",
+    artifact: { name: null, version: null },
+  };
+
+  const eventsResponse: AgentEventsResponse = {
+    events: [
+      {
+        sequenceNumber: 0,
+        eventType: "assistant",
+        eventData: { message: { content: [{ type: "text", text: "Hi!" }] } },
+        createdAt: "2026-03-10T14:56:02Z",
+      },
+    ],
+    hasMore: false,
+    framework: "claude-code",
+  };
+
+  server.use(
+    http.get("*/api/zero/logs/:id", ({ params }) => {
+      if (params["id"] === "run_1") {
+        return HttpResponse.json(logDetail);
+      }
+      return new HttpResponse(null, { status: 404 });
+    }),
+    http.get("*/api/zero/runs/:runId/telemetry/agent", () => {
+      return HttpResponse.json(eventsResponse);
+    }),
+    http.get("*/api/zero/chat-threads", () => {
+      return HttpResponse.json({ threads: [] });
+    }),
+  );
+}
+
+describe("ZeroActivityDetailPage", () => {
+  it("should load detail when navigating directly to /activity/:runId", async () => {
+    mockActivityDetailAPI();
+
+    await setupPage({
+      context,
+      path: "/activity/run_1",
+    });
+
+    // The page should show the detail header card (not skeleton)
+    await waitFor(
+      () => {
+        expect(
+          screen.getByRole("heading", { name: "Test Agent" }),
+        ).toBeInTheDocument();
+      },
+      { timeout: 3000 },
+    );
+
+    // Verify the header card rendered with run details
+    expect(screen.getByText("9.0s")).toBeInTheDocument();
+  }, 10_000);
+});

--- a/turbo/apps/platform/src/views/zero-page/zero-activity-detail-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-activity-detail-page.tsx
@@ -1,4 +1,5 @@
 /* eslint-disable ccstate/no-use-ccstate-in-views */
+import { forwardRef } from "react";
 import { useCCState } from "ccstate-react/experimental";
 import {
   useGet,
@@ -216,115 +217,127 @@ function ActivityHeaderCard({
   );
 }
 
-export function ZeroActivityDetailPage() {
-  const detailLoadable = useLastLoadable(zeroActivityDetail$);
-  const eventsLoadable = useLastLoadable(zeroActivityEvents$);
-  // Resolve agent display name from the detail response
-  const detail =
-    detailLoadable.state === "hasData" ? detailLoadable.data : null;
-  const agentName = detail ? (detail.displayName ?? detail.agentName) : "Agent";
+export const ZeroActivityDetailPage = forwardRef<HTMLDivElement>(
+  function ZeroActivityDetailPage(_props, ref) {
+    const detailLoadable = useLastLoadable(zeroActivityDetail$);
+    const eventsLoadable = useLastLoadable(zeroActivityEvents$);
+    // Resolve agent display name from the detail response
+    const detail =
+      detailLoadable.state === "hasData" ? detailLoadable.data : null;
+    const agentName = detail
+      ? (detail.displayName ?? detail.agentName)
+      : "Agent";
 
-  const stepSearch$ = useCCState("");
-  const stepSearch = useGet(stepSearch$);
-  const setStepSearch = useSet(stepSearch$);
-  const features = useLastResolved(featureSwitch$);
+    const stepSearch$ = useCCState("");
+    const stepSearch = useGet(stepSearch$);
+    const setStepSearch = useSet(stepSearch$);
+    const features = useLastResolved(featureSwitch$);
 
-  // Skeleton until both detail and initial events are loaded
-  const eventsReady = eventsLoadable.state === "hasData";
-  if (!detail || !eventsReady) {
-    if (detailLoadable.state === "hasError") {
-      return <ActivityNotFound />;
+    // Skeleton until both detail and initial events are loaded
+    const eventsReady = eventsLoadable.state === "hasData";
+    if (!detail || !eventsReady) {
+      if (detailLoadable.state === "hasError") {
+        return (
+          <div ref={ref}>
+            <ActivityNotFound />
+          </div>
+        );
+      }
+      return (
+        <div ref={ref}>
+          <ActivitySkeleton />
+        </div>
+      );
     }
-    return <ActivitySkeleton />;
-  }
 
-  const events: AgentEvent[] = eventsLoadable.data;
+    const events: AgentEvent[] = eventsLoadable.data;
 
-  const allMessages = groupEventsIntoMessages(events);
+    const allMessages = groupEventsIntoMessages(events);
 
-  // Filter out text-only assistant messages right before result (redundant)
-  const visibleMessages = allMessages.filter((message, index) =>
-    isVisibleMessage(message, allMessages[index + 1]),
-  );
+    // Filter out text-only assistant messages right before result (redundant)
+    const visibleMessages = allMessages.filter((message, index) =>
+      isVisibleMessage(message, allMessages[index + 1]),
+    );
 
-  const messages = visibleMessages.filter((m) =>
-    groupedMessageMatchesSearch(m, stepSearch.trim()),
-  );
+    const messages = visibleMessages.filter((m) =>
+      groupedMessageMatchesSearch(m, stepSearch.trim()),
+    );
 
-  const showSystemPrompt =
-    features?.[FeatureSwitchKey.ShowSystemPrompt] ?? false;
+    const showSystemPrompt =
+      features?.[FeatureSwitchKey.ShowSystemPrompt] ?? false;
 
-  const prompt = detail.prompt ?? "";
-  const appendSystemPrompt = detail.appendSystemPrompt ?? "";
-  const hasSystemPrompt =
-    showSystemPrompt && appendSystemPrompt.trim().length > 0;
-  const status: LogStatus = detail.status;
-  const time = formatLogTime(detail.createdAt);
-  const duration = formatDuration(detail.startedAt, detail.completedAt);
-  return (
-    <div className="h-full flex flex-col min-h-0 overflow-hidden">
-      <div className="flex-1 flex flex-col min-h-0 overflow-auto">
-        <nav className="shrink-0 flex items-center gap-1 px-4 pt-4 text-sm text-muted-foreground">
-          <ActivityBreadcrumbLink />
-          <span className="text-muted-foreground/40 select-none">/</span>
-          <span className="rounded-md px-1.5 py-0.5 text-foreground font-medium truncate">
-            {agentName}
-          </span>
-        </nav>
-        <div className="mx-auto w-full max-w-[900px] px-4 sm:px-6 pt-4 pb-8">
-          <ActivityHeaderCard
-            agentName={agentName}
-            status={status}
-            triggerSource={detail.triggerSource ?? null}
-            detail={detail}
-            duration={duration}
-            time={time}
-            events={events}
-          />
+    const prompt = detail.prompt ?? "";
+    const appendSystemPrompt = detail.appendSystemPrompt ?? "";
+    const hasSystemPrompt =
+      showSystemPrompt && appendSystemPrompt.trim().length > 0;
+    const status: LogStatus = detail.status;
+    const time = formatLogTime(detail.createdAt);
+    const duration = formatDuration(detail.startedAt, detail.completedAt);
+    return (
+      <div ref={ref} className="h-full flex flex-col min-h-0 overflow-hidden">
+        <div className="flex-1 flex flex-col min-h-0 overflow-auto">
+          <nav className="shrink-0 flex items-center gap-1 px-4 pt-4 text-sm text-muted-foreground">
+            <ActivityBreadcrumbLink />
+            <span className="text-muted-foreground/40 select-none">/</span>
+            <span className="rounded-md px-1.5 py-0.5 text-foreground font-medium truncate">
+              {agentName}
+            </span>
+          </nav>
+          <div className="mx-auto w-full max-w-[900px] px-4 sm:px-6 pt-4 pb-8">
+            <ActivityHeaderCard
+              agentName={agentName}
+              status={status}
+              triggerSource={detail.triggerSource ?? null}
+              detail={detail}
+              duration={duration}
+              time={time}
+              events={events}
+            />
 
-          {/* Steps section */}
-          <div className="flex flex-col gap-4 flex-1 min-h-0 min-w-0 mt-6">
-            <div className="flex flex-col gap-4 pb-8 min-w-0">
-              <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
-                <div className="flex items-center gap-3">
-                  <span className="text-base font-medium text-foreground whitespace-nowrap">
-                    Steps
-                  </span>
-                  <span className="text-sm text-muted-foreground whitespace-nowrap">
-                    {stepSearch.trim()
-                      ? `(${messages.length}/${visibleMessages.length} matched)`
-                      : `${visibleMessages.length} total`}
-                  </span>
-                </div>
-                <div className="flex items-center gap-2 sm:gap-3">
-                  <div className="zero-search-input relative flex h-9 flex-1 sm:flex-none items-center rounded-lg border transition-colors focus-within:border-primary focus-within:ring-[3px] focus-within:ring-primary/10">
-                    <div className="pl-2">
-                      <IconSearch className="h-4 w-4 text-muted-foreground" />
+            {/* Steps section */}
+            <div className="flex flex-col gap-4 flex-1 min-h-0 min-w-0 mt-6">
+              <div className="flex flex-col gap-4 pb-8 min-w-0">
+                <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+                  <div className="flex items-center gap-3">
+                    <span className="text-base font-medium text-foreground whitespace-nowrap">
+                      Steps
+                    </span>
+                    <span className="text-sm text-muted-foreground whitespace-nowrap">
+                      {stepSearch.trim()
+                        ? `(${messages.length}/${visibleMessages.length} matched)`
+                        : `${visibleMessages.length} total`}
+                    </span>
+                  </div>
+                  <div className="flex items-center gap-2 sm:gap-3">
+                    <div className="zero-search-input relative flex h-9 flex-1 sm:flex-none items-center rounded-lg border transition-colors focus-within:border-primary focus-within:ring-[3px] focus-within:ring-primary/10">
+                      <div className="pl-2">
+                        <IconSearch className="h-4 w-4 text-muted-foreground" />
+                      </div>
+                      <Input
+                        placeholder="Search steps"
+                        value={stepSearch}
+                        onChange={(e) => setStepSearch(e.target.value)}
+                        className="h-full w-full sm:w-44 border-0 text-sm focus:border-0 focus:ring-0 pl-2 pr-3 bg-transparent"
+                      />
                     </div>
-                    <Input
-                      placeholder="Search steps"
-                      value={stepSearch}
-                      onChange={(e) => setStepSearch(e.target.value)}
-                      className="h-full w-full sm:w-44 border-0 text-sm focus:border-0 focus:ring-0 pl-2 pr-3 bg-transparent"
-                    />
                   </div>
                 </div>
-              </div>
 
-              <StepsList
-                prompt={prompt}
-                appendSystemPrompt={hasSystemPrompt ? appendSystemPrompt : ""}
-                messages={messages}
-                stepSearch={stepSearch}
-                isLoading={false}
-              />
+                <StepsList
+                  prompt={prompt}
+                  appendSystemPrompt={hasSystemPrompt ? appendSystemPrompt : ""}
+                  messages={messages}
+                  stepSearch={stepSearch}
+                  isLoading={false}
+                />
+              </div>
             </div>
           </div>
         </div>
       </div>
-    </div>
-  );
-}
+    );
+  },
+);
 
 function ActivitySkeleton() {
   return (

--- a/turbo/apps/platform/src/views/zero-page/zero-activity-detail-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-activity-detail-page.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable ccstate/no-use-ccstate-in-views */
-import { forwardRef } from "react";
+import type { Ref } from "react";
 import { useCCState } from "ccstate-react/experimental";
 import {
   useGet,
@@ -217,127 +217,123 @@ function ActivityHeaderCard({
   );
 }
 
-export const ZeroActivityDetailPage = forwardRef<HTMLDivElement>(
-  function ZeroActivityDetailPage(_props, ref) {
-    const detailLoadable = useLastLoadable(zeroActivityDetail$);
-    const eventsLoadable = useLastLoadable(zeroActivityEvents$);
-    // Resolve agent display name from the detail response
-    const detail =
-      detailLoadable.state === "hasData" ? detailLoadable.data : null;
-    const agentName = detail
-      ? (detail.displayName ?? detail.agentName)
-      : "Agent";
+export function ZeroActivityDetailPage({ ref }: { ref?: Ref<HTMLDivElement> }) {
+  const detailLoadable = useLastLoadable(zeroActivityDetail$);
+  const eventsLoadable = useLastLoadable(zeroActivityEvents$);
+  // Resolve agent display name from the detail response
+  const detail =
+    detailLoadable.state === "hasData" ? detailLoadable.data : null;
+  const agentName = detail ? (detail.displayName ?? detail.agentName) : "Agent";
 
-    const stepSearch$ = useCCState("");
-    const stepSearch = useGet(stepSearch$);
-    const setStepSearch = useSet(stepSearch$);
-    const features = useLastResolved(featureSwitch$);
+  const stepSearch$ = useCCState("");
+  const stepSearch = useGet(stepSearch$);
+  const setStepSearch = useSet(stepSearch$);
+  const features = useLastResolved(featureSwitch$);
 
-    // Skeleton until both detail and initial events are loaded
-    const eventsReady = eventsLoadable.state === "hasData";
-    if (!detail || !eventsReady) {
-      if (detailLoadable.state === "hasError") {
-        return (
-          <div ref={ref}>
-            <ActivityNotFound />
-          </div>
-        );
-      }
+  // Skeleton until both detail and initial events are loaded
+  const eventsReady = eventsLoadable.state === "hasData";
+  if (!detail || !eventsReady) {
+    if (detailLoadable.state === "hasError") {
       return (
         <div ref={ref}>
-          <ActivitySkeleton />
+          <ActivityNotFound />
         </div>
       );
     }
-
-    const events: AgentEvent[] = eventsLoadable.data;
-
-    const allMessages = groupEventsIntoMessages(events);
-
-    // Filter out text-only assistant messages right before result (redundant)
-    const visibleMessages = allMessages.filter((message, index) =>
-      isVisibleMessage(message, allMessages[index + 1]),
-    );
-
-    const messages = visibleMessages.filter((m) =>
-      groupedMessageMatchesSearch(m, stepSearch.trim()),
-    );
-
-    const showSystemPrompt =
-      features?.[FeatureSwitchKey.ShowSystemPrompt] ?? false;
-
-    const prompt = detail.prompt ?? "";
-    const appendSystemPrompt = detail.appendSystemPrompt ?? "";
-    const hasSystemPrompt =
-      showSystemPrompt && appendSystemPrompt.trim().length > 0;
-    const status: LogStatus = detail.status;
-    const time = formatLogTime(detail.createdAt);
-    const duration = formatDuration(detail.startedAt, detail.completedAt);
     return (
-      <div ref={ref} className="h-full flex flex-col min-h-0 overflow-hidden">
-        <div className="flex-1 flex flex-col min-h-0 overflow-auto">
-          <nav className="shrink-0 flex items-center gap-1 px-4 pt-4 text-sm text-muted-foreground">
-            <ActivityBreadcrumbLink />
-            <span className="text-muted-foreground/40 select-none">/</span>
-            <span className="rounded-md px-1.5 py-0.5 text-foreground font-medium truncate">
-              {agentName}
-            </span>
-          </nav>
-          <div className="mx-auto w-full max-w-[900px] px-4 sm:px-6 pt-4 pb-8">
-            <ActivityHeaderCard
-              agentName={agentName}
-              status={status}
-              triggerSource={detail.triggerSource ?? null}
-              detail={detail}
-              duration={duration}
-              time={time}
-              events={events}
-            />
+      <div ref={ref}>
+        <ActivitySkeleton />
+      </div>
+    );
+  }
 
-            {/* Steps section */}
-            <div className="flex flex-col gap-4 flex-1 min-h-0 min-w-0 mt-6">
-              <div className="flex flex-col gap-4 pb-8 min-w-0">
-                <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
-                  <div className="flex items-center gap-3">
-                    <span className="text-base font-medium text-foreground whitespace-nowrap">
-                      Steps
-                    </span>
-                    <span className="text-sm text-muted-foreground whitespace-nowrap">
-                      {stepSearch.trim()
-                        ? `(${messages.length}/${visibleMessages.length} matched)`
-                        : `${visibleMessages.length} total`}
-                    </span>
-                  </div>
-                  <div className="flex items-center gap-2 sm:gap-3">
-                    <div className="zero-search-input relative flex h-9 flex-1 sm:flex-none items-center rounded-lg border transition-colors focus-within:border-primary focus-within:ring-[3px] focus-within:ring-primary/10">
-                      <div className="pl-2">
-                        <IconSearch className="h-4 w-4 text-muted-foreground" />
-                      </div>
-                      <Input
-                        placeholder="Search steps"
-                        value={stepSearch}
-                        onChange={(e) => setStepSearch(e.target.value)}
-                        className="h-full w-full sm:w-44 border-0 text-sm focus:border-0 focus:ring-0 pl-2 pr-3 bg-transparent"
-                      />
+  const events: AgentEvent[] = eventsLoadable.data;
+
+  const allMessages = groupEventsIntoMessages(events);
+
+  // Filter out text-only assistant messages right before result (redundant)
+  const visibleMessages = allMessages.filter((message, index) =>
+    isVisibleMessage(message, allMessages[index + 1]),
+  );
+
+  const messages = visibleMessages.filter((m) =>
+    groupedMessageMatchesSearch(m, stepSearch.trim()),
+  );
+
+  const showSystemPrompt =
+    features?.[FeatureSwitchKey.ShowSystemPrompt] ?? false;
+
+  const prompt = detail.prompt ?? "";
+  const appendSystemPrompt = detail.appendSystemPrompt ?? "";
+  const hasSystemPrompt =
+    showSystemPrompt && appendSystemPrompt.trim().length > 0;
+  const status: LogStatus = detail.status;
+  const time = formatLogTime(detail.createdAt);
+  const duration = formatDuration(detail.startedAt, detail.completedAt);
+  return (
+    <div ref={ref} className="h-full flex flex-col min-h-0 overflow-hidden">
+      <div className="flex-1 flex flex-col min-h-0 overflow-auto">
+        <nav className="shrink-0 flex items-center gap-1 px-4 pt-4 text-sm text-muted-foreground">
+          <ActivityBreadcrumbLink />
+          <span className="text-muted-foreground/40 select-none">/</span>
+          <span className="rounded-md px-1.5 py-0.5 text-foreground font-medium truncate">
+            {agentName}
+          </span>
+        </nav>
+        <div className="mx-auto w-full max-w-[900px] px-4 sm:px-6 pt-4 pb-8">
+          <ActivityHeaderCard
+            agentName={agentName}
+            status={status}
+            triggerSource={detail.triggerSource ?? null}
+            detail={detail}
+            duration={duration}
+            time={time}
+            events={events}
+          />
+
+          {/* Steps section */}
+          <div className="flex flex-col gap-4 flex-1 min-h-0 min-w-0 mt-6">
+            <div className="flex flex-col gap-4 pb-8 min-w-0">
+              <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+                <div className="flex items-center gap-3">
+                  <span className="text-base font-medium text-foreground whitespace-nowrap">
+                    Steps
+                  </span>
+                  <span className="text-sm text-muted-foreground whitespace-nowrap">
+                    {stepSearch.trim()
+                      ? `(${messages.length}/${visibleMessages.length} matched)`
+                      : `${visibleMessages.length} total`}
+                  </span>
+                </div>
+                <div className="flex items-center gap-2 sm:gap-3">
+                  <div className="zero-search-input relative flex h-9 flex-1 sm:flex-none items-center rounded-lg border transition-colors focus-within:border-primary focus-within:ring-[3px] focus-within:ring-primary/10">
+                    <div className="pl-2">
+                      <IconSearch className="h-4 w-4 text-muted-foreground" />
                     </div>
+                    <Input
+                      placeholder="Search steps"
+                      value={stepSearch}
+                      onChange={(e) => setStepSearch(e.target.value)}
+                      className="h-full w-full sm:w-44 border-0 text-sm focus:border-0 focus:ring-0 pl-2 pr-3 bg-transparent"
+                    />
                   </div>
                 </div>
-
-                <StepsList
-                  prompt={prompt}
-                  appendSystemPrompt={hasSystemPrompt ? appendSystemPrompt : ""}
-                  messages={messages}
-                  stepSearch={stepSearch}
-                  isLoading={false}
-                />
               </div>
+
+              <StepsList
+                prompt={prompt}
+                appendSystemPrompt={hasSystemPrompt ? appendSystemPrompt : ""}
+                messages={messages}
+                stepSearch={stepSearch}
+                isLoading={false}
+              />
             </div>
           </div>
         </div>
       </div>
-    );
-  },
-);
+    </div>
+  );
+}
 
 function ActivitySkeleton() {
   return (

--- a/turbo/apps/platform/src/views/zero-page/zero-activity-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-activity-page.tsx
@@ -154,7 +154,7 @@ export function ZeroActivityPage() {
 
   // Detail view when sub-route is present
   if (sub) {
-    return <ZeroActivityDetailPage />;
+    return <ZeroActivityDetailPage ref={initPageRef} />;
   }
 
   return (


### PR DESCRIPTION
## Summary

- Fix activity detail page (`/activity/:runId`) being permanently stuck on skeleton loading when accessed directly via URL (e.g., page refresh, external link)
- The root cause was that `syncZeroActivitySub$` (which initializes data fetching) was only triggered via a `ref` callback on a DOM element that never rendered when the detail sub-route was active
- Forward `initPageRef` to `ZeroActivityDetailPage` via `forwardRef` so the sync triggers regardless of entry path
- Add integration test that reproduces the bug: navigates directly to `/activity/run_1` and verifies the detail page renders

## Test plan

- [x] Test fails without fix (skeleton never resolves, times out after 3s)
- [x] Test passes with fix (detail page renders in ~130ms)
- [ ] Verify in browser: direct navigation to `/activity/:runId` loads content
- [ ] Verify in browser: navigating from activity list to detail still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)