### PR TITLE
refactor: broaden eslint rule to ban all ccstate-react/experimental imports

### DIFF
--- a/turbo/apps/platform/custom-eslint/__tests__/no-use-ccstate-in-views.test.ts
+++ b/turbo/apps/platform/custom-eslint/__tests__/no-use-ccstate-in-views.test.ts
@@ -10,33 +10,45 @@ const ruleTester = new RuleTester();
 
 ruleTester.run("no-use-ccstate-in-views", rule, {
   valid: [
+    // OK: experimental import in signals/ (not views/)
     {
-      code: 'const input$ = useCCState("")',
+      code: 'import { useCCState } from "ccstate-react/experimental"',
       filename: "/project/src/signals/zero-page/zero-chat.ts",
     },
+    // OK: non-experimental import in views/
     {
-      code: "const value = useGet(someSignal$)",
+      code: 'import { useGet } from "ccstate-react"',
       filename: "/project/src/views/zero-page/zero-chat-page.tsx",
     },
+    // OK: React useState in views/
     {
-      code: 'const [value, setValue] = useState("")',
+      code: 'import { useState } from "react"',
       filename: "/project/src/views/zero-page/zero-chat-page.tsx",
     },
+    // OK: experimental import in tests/
     {
-      code: 'const input$ = useCCState("")',
+      code: 'import { useCCState } from "ccstate-react/experimental"',
       filename: "/project/src/__tests__/test.tsx",
     },
   ],
   invalid: [
+    // Bad: useCCState from experimental in views/
     {
-      code: 'const input$ = useCCState("")',
+      code: 'import { useCCState } from "ccstate-react/experimental"',
       filename: "/project/src/views/zero-page/zero-chat-page.tsx",
-      errors: [{ messageId: "noUseCCStateInViews" }],
+      errors: [{ messageId: "noExperimentalImport" }],
     },
+    // Bad: useCommand from experimental in views/
     {
-      code: "const flag$ = useCCState(false)",
+      code: 'import { useCommand } from "ccstate-react/experimental"',
+      filename: "/project/src/views/zero-page/zero-activity-page.tsx",
+      errors: [{ messageId: "noExperimentalImport" }],
+    },
+    // Bad: multiple imports from experimental in views/
+    {
+      code: 'import { useCCState, useCommand } from "ccstate-react/experimental"',
       filename: "/project/src/views/zero-page/zero-sidebar.tsx",
-      errors: [{ messageId: "noUseCCStateInViews" }],
+      errors: [{ messageId: "noExperimentalImport" }],
     },
   ],
 });

--- a/turbo/apps/platform/custom-eslint/rules/no-use-ccstate-in-views.ts
+++ b/turbo/apps/platform/custom-eslint/rules/no-use-ccstate-in-views.ts
@@ -1,12 +1,14 @@
 /**
  * ESLint rule: no-use-ccstate-in-views
  *
- * Disallows useCCState() calls in views/ files.
- * Signals should only be declared in signals/ files, not inline in components.
+ * Disallows importing from "ccstate-react/experimental" in views/ files.
+ * The experimental module contains hooks like useCCState, useCommand, useCompute
+ * that should not be used in view components.
  *
- * Good: const [value, setValue] = useState("") // React local state
  * Good: const value = useGet(someSignal$)      // consume signal from signals/
- * Bad:  const input$ = useCCState("")           // declaring signal in a view
+ * Good: const [value, setValue] = useState("")  // React local state
+ * Bad:  import { useCCState } from "ccstate-react/experimental"
+ * Bad:  import { useCommand } from "ccstate-react/experimental"
  */
 
 import { ESLintUtils } from "@typescript-eslint/utils";
@@ -16,7 +18,7 @@ const createRule = ESLintUtils.RuleCreator(
     `https://github.com/anthropics/vm0/blob/main/docs/eslint/${name}.md`,
 );
 
-type MessageIds = "noUseCCStateInViews";
+type MessageIds = "noExperimentalImport";
 
 export default createRule<[], MessageIds>({
   name: "no-use-ccstate-in-views",
@@ -24,12 +26,12 @@ export default createRule<[], MessageIds>({
     type: "problem",
     docs: {
       description:
-        "Disallow useCCState() in views/ — signals must be declared in signals/ files",
+        "Disallow importing from ccstate-react/experimental in views/ — signals must be declared in signals/ files",
     },
     schema: [],
     messages: {
-      noUseCCStateInViews:
-        "useCCState() is not allowed in views/. For shared state, declare state()/computed()/command() in signals/ and consume with useGet()/useSet(). For component-local state, use React useState().",
+      noExperimentalImport:
+        'Importing from "ccstate-react/experimental" is not allowed in views/. For shared state, declare state()/computed()/command() in signals/ and consume with useGet()/useSet(). For component-local state, use React useState().',
     },
   },
   defaultOptions: [],
@@ -42,14 +44,11 @@ export default createRule<[], MessageIds>({
     }
 
     return {
-      CallExpression(node) {
-        if (
-          node.callee.type === "Identifier" &&
-          node.callee.name === "useCCState"
-        ) {
+      ImportDeclaration(node) {
+        if (node.source.value === "ccstate-react/experimental") {
           context.report({
             node,
-            messageId: "noUseCCStateInViews",
+            messageId: "noExperimentalImport",
           });
         }
       },

--- a/turbo/apps/platform/src/views/zero-page/zero-activity-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-activity-page.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable ccstate/no-use-ccstate-in-views */
 import { useGet, useSet, useLoadable } from "ccstate-react";
 import { useCommand } from "ccstate-react/experimental";
 import {


### PR DESCRIPTION
## Summary

- Broadened `ccstate/no-use-ccstate-in-views` ESLint rule from checking `useCCState()` calls to checking `import` declarations from `"ccstate-react/experimental"`
- This catches `useCommand` and `useCompute` in addition to `useCCState` — the entire experimental module should not be used in views
- Updated rule tests to cover import-level detection

Currently 25 files in `views/` have `eslint-disable` comments suppressing this rule. These should be migrated incrementally.

## Test plan

- [x] ESLint rule unit tests pass (7 cases: 4 valid, 3 invalid)
- [x] Verified rule catches all 25 violating files when disable comments are removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)