### PR TITLE
chore: run runner in parallel with dev server

### DIFF
--- a/.claude/skills/dev-server/SKILL.md
+++ b/.claude/skills/dev-server/SKILL.md
@@ -41,32 +41,41 @@ cd "$PROJECT_ROOT/turbo" && pnpm dev:status
 
 If all three services show `running`, the dev server is already up — display the output and stop. Otherwise, proceed to start the server.
 
-### Step 2: Start Dev Server in Background
+### Step 2: Start Dev Server and Runner in Background
 
-Start the server using Bash tool with `run_in_background: true` parameter.
+Start **both** the dev server and the runner in parallel, each using Bash tool with `run_in_background: true` parameter (two separate Bash calls in the same message).
 
-**If `--tunnel-hostname=<fqdn>` was provided in args**, pass it as `TUNNEL_HOSTNAME` env var:
+**Dev server** — if `--tunnel-hostname=<fqdn>` was provided in args, pass it as `TUNNEL_HOSTNAME` env var:
 
 ```bash
 PROJECT_ROOT=$(git rev-parse --show-toplevel)
 cd "$PROJECT_ROOT/turbo" && TUNNEL_HOSTNAME=<fqdn> pnpm dev
 ```
 
-**Otherwise** (default):
+Otherwise (default):
 
 ```bash
 PROJECT_ROOT=$(git rev-parse --show-toplevel)
 cd "$PROJECT_ROOT/turbo" && pnpm dev
 ```
 
-This will return a task_id for monitoring.
-
-**Save the task_id** to a local file so `/dev-logs` can find it across conversation sessions:
+**Runner** — start in parallel with the dev server:
 
 ```bash
 PROJECT_ROOT=$(git rev-parse --show-toplevel)
-echo "<task_id>" > "$PROJECT_ROOT/turbo/.dev-task-id"
+cd "$PROJECT_ROOT/turbo" && pnpm runner
 ```
+
+Both return a task_id for monitoring.
+
+**Save the dev server task_id** to a local file so `/dev-logs` can find it across conversation sessions:
+
+```bash
+PROJECT_ROOT=$(git rev-parse --show-toplevel)
+echo "<dev-task_id>" > "$PROJECT_ROOT/turbo/.dev-task-id"
+```
+
+**Note on runner**: The runner takes several minutes to initialize (cross-compile, upload, build rootfs/snapshots). The app works without it — only chat/agent interaction features require the runner. You will be notified when the runner background task completes.
 
 ### Step 3: Display Results
 
@@ -74,15 +83,17 @@ Once the server is confirmed running, display the URLs:
 
 ```
 ✅ Dev server started in background
+🔧 Runner deployment started in background (takes several minutes)
 
 - Web:      https://www.vm7.ai:8443
 - App:      https://app.vm7.ai:8443
 - Docs:     https://docs.vm7.ai:8443
 
+The app is usable now. Chat/agent features will become available once the runner finishes initializing.
+
 Next steps:
 - Use `/dev-logs` to view server output
 - Use `/dev-logs [pattern]` to filter logs (e.g., `/dev-logs error`)
-- Use `/dev-runner` to deploy a runner (needed for running agents)
 - Use `/dev-stop` to stop the server
 ```
 
@@ -301,16 +312,23 @@ PROJECT_ROOT=$(git rev-parse --show-toplevel)
 cd "$PROJECT_ROOT/turbo" && pnpm build
 ```
 
-### Step 3: Start Dev Server
+### Step 3: Start Dev Server and Runner
 
-Use Bash tool with `run_in_background: true`:
+Use Bash tool with `run_in_background: true` for **both** commands in parallel (two separate Bash calls in the same message):
 
+**Dev server:**
 ```bash
 PROJECT_ROOT=$(git rev-parse --show-toplevel)
 cd "$PROJECT_ROOT/turbo" && pnpm dev
 ```
 
-This will return a task_id for monitoring. The web app will automatically start a Cloudflare tunnel.
+**Runner:**
+```bash
+PROJECT_ROOT=$(git rev-parse --show-toplevel)
+cd "$PROJECT_ROOT/turbo" && pnpm runner
+```
+
+Both return a task_id for monitoring. The web app will automatically start a Cloudflare tunnel. The runner takes several minutes to initialize but doesn't block the app — only chat/agent features need it.
 
 ### Step 4: Wait for Tunnel URL
 
@@ -374,6 +392,7 @@ cat ~/.vm0/config.json
 
 ```
 ✅ Dev server with tunnel started!
+🔧 Runner deployment started in background (takes several minutes)
 
 Local:   http://localhost:3000
 Tunnel:  <tunnel-url>
@@ -383,11 +402,7 @@ VM0_API_URL exported to: <tunnel-url>
 ✅ CLI authentication successful!
 Auth token saved to: ~/.vm0/config.json
 
-You can now test webhooks locally:
-  vm0 run <agent-name> "<prompt>"
-
-Note: To run agents (CLI, frontend sessions, etc.), you need a runner.
-Use `/dev-runner` to deploy one (takes several minutes).
+The app is usable now. Chat/agent features will become available once the runner finishes initializing.
 
 Use `/dev-stop` to stop the server.
 ```


### PR DESCRIPTION
## Summary
- Updated dev-server skill to start `pnpm runner` alongside `pnpm dev` as parallel background tasks
- Runner initialization takes several minutes but doesn't block the app — only chat/agent interaction features require it
- Updated both `start` and `tunnel` operations with parallel runner launch and revised status messages

## Test plan
- [ ] Run `/dev-start` and verify both dev server and runner start as parallel background tasks
- [ ] Verify app is accessible before runner finishes initializing
- [ ] Run `/dev-tunnel` and verify runner starts alongside dev server + tunnel

🤖 Generated with [Claude Code](https://claude.com/claude-code)