### PR TITLE
ci: skip sarif uploads during merge group events

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Upload Semgrep SARIF
         uses: github/codeql-action/upload-sarif@v4
-        if: always()
+        if: always() && github.event_name != 'merge_group'
         with:
           sarif_file: semgrep-results.sarif
           category: semgrep
@@ -89,6 +89,7 @@ jobs:
         uses: github/codeql-action/analyze@v4
         with:
           category: codeql
+          upload: ${{ github.event_name != 'merge_group' }}
 
   pnpm-audit:
     name: pnpm audit (SCA)


### PR DESCRIPTION
## Summary
- Skip Semgrep SARIF upload step when running in `merge_group` event (temporary branch ref gets deleted before upload completes)
- Set CodeQL `upload: false` in `merge_group` event to prevent the same ref-not-found error
- Analysis still runs in both cases; only the SARIF upload to GitHub Code Scanning is skipped

Fixes consistent `ref not found` failures in merge queue for security workflow:
```
ref 'refs/heads/gh-readonly-queue/main/pr-XXXX-...' not found in this repository
```

## Test plan
- [ ] Verify security workflow passes on this PR
- [ ] Verify security workflow passes in merge queue

🤖 Generated with [Claude Code](https://claude.com/claude-code)