### PR TITLE
refactor: remove ccstate-react/experimental from activity views

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/zero-activity.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-activity.ts
@@ -132,13 +132,14 @@ export const {
 /**
  * Refresh activity data if the current tab is "activity".
  * Called from `setupZeroPage$` on every route entry so that each visit
- * to the activity tab triggers a fresh fetch.
+ * to the activity tab triggers a fresh fetch and syncs detail polling.
  */
 export const refreshZeroActivityIfActive$ = command(({ get, set }) => {
   const activeTab = get(zeroActiveId$);
   if (activeTab !== "activity") {
     return;
   }
+  set(syncZeroActivitySub$);
   detach(set(refreshZeroActivity$), Reason.Entrance);
 });
 
@@ -173,16 +174,35 @@ export const setZeroActivityFilter$ = command(
 const internalPollingAbort$ = state<AbortController | null>(null);
 const lastSyncedLogId$ = state<string | null>(null);
 
+// ---------------------------------------------------------------------------
+// Detail step search — component-local filter for the detail view
+// ---------------------------------------------------------------------------
+
+const internalStepSearch$ = state("");
+
+/** Current step search filter for the activity detail view. */
+export const zeroActivityStepSearch$ = computed((get) =>
+  get(internalStepSearch$),
+);
+
+/** Update the step search filter. */
+export const setZeroActivityStepSearch$ = command(({ set }, value: string) => {
+  set(internalStepSearch$, value);
+});
+
 /**
  * Sync the URL sub-route to the detail polling lifecycle.
  * Idempotent: only restarts polling when the log ID actually changes.
  */
-export const syncZeroActivitySub$ = command(({ get, set }) => {
+const syncZeroActivitySub$ = command(({ get, set }) => {
   const sub = get(zeroTabSub$);
   const prev = get(lastSyncedLogId$);
   if (sub === prev) {
     return;
   }
+
+  // Reset step search when switching log entries
+  set(internalStepSearch$, "");
 
   // Abort previous polling
   const prevAbort = get(internalPollingAbort$);

--- a/turbo/apps/platform/src/views/zero-page/zero-activity-detail-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-activity-detail-page.tsx
@@ -1,6 +1,3 @@
-/* eslint-disable ccstate/no-use-ccstate-in-views */
-import type { Ref } from "react";
-import { useCCState } from "ccstate-react/experimental";
 import {
   useGet,
   useSet,
@@ -32,6 +29,8 @@ import { StatusBadge } from "./components/logs/status-badge.tsx";
 import {
   zeroActivityDetail$,
   zeroActivityEvents$,
+  zeroActivityStepSearch$,
+  setZeroActivityStepSearch$,
   formatLogTime,
   formatDuration,
 } from "../../signals/zero-page/zero-activity.ts";
@@ -217,7 +216,7 @@ function ActivityHeaderCard({
   );
 }
 
-export function ZeroActivityDetailPage({ ref }: { ref?: Ref<HTMLDivElement> }) {
+export function ZeroActivityDetailPage() {
   const detailLoadable = useLastLoadable(zeroActivityDetail$);
   const eventsLoadable = useLastLoadable(zeroActivityEvents$);
   // Resolve agent display name from the detail response
@@ -225,26 +224,17 @@ export function ZeroActivityDetailPage({ ref }: { ref?: Ref<HTMLDivElement> }) {
     detailLoadable.state === "hasData" ? detailLoadable.data : null;
   const agentName = detail ? (detail.displayName ?? detail.agentName) : "Agent";
 
-  const stepSearch$ = useCCState("");
-  const stepSearch = useGet(stepSearch$);
-  const setStepSearch = useSet(stepSearch$);
+  const stepSearch = useGet(zeroActivityStepSearch$);
+  const setStepSearch = useSet(setZeroActivityStepSearch$);
   const features = useLastResolved(featureSwitch$);
 
   // Skeleton until both detail and initial events are loaded
   const eventsReady = eventsLoadable.state === "hasData";
   if (!detail || !eventsReady) {
     if (detailLoadable.state === "hasError") {
-      return (
-        <div ref={ref}>
-          <ActivityNotFound />
-        </div>
-      );
+      return <ActivityNotFound />;
     }
-    return (
-      <div ref={ref}>
-        <ActivitySkeleton />
-      </div>
-    );
+    return <ActivitySkeleton />;
   }
 
   const events: AgentEvent[] = eventsLoadable.data;
@@ -271,7 +261,7 @@ export function ZeroActivityDetailPage({ ref }: { ref?: Ref<HTMLDivElement> }) {
   const time = formatLogTime(detail.createdAt);
   const duration = formatDuration(detail.startedAt, detail.completedAt);
   return (
-    <div ref={ref} className="h-full flex flex-col min-h-0 overflow-hidden">
+    <div className="h-full flex flex-col min-h-0 overflow-hidden">
       <div className="flex-1 flex flex-col min-h-0 overflow-auto">
         <nav className="shrink-0 flex items-center gap-1 px-4 pt-4 text-sm text-muted-foreground">
           <ActivityBreadcrumbLink />

--- a/turbo/apps/platform/src/views/zero-page/zero-activity-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-activity-page.tsx
@@ -1,6 +1,4 @@
-/* eslint-disable ccstate/no-use-ccstate-in-views */
 import { useGet, useSet, useLoadable } from "ccstate-react";
-import { useCommand } from "ccstate-react/experimental";
 import {
   IconClock,
   IconChevronRight,
@@ -32,7 +30,6 @@ import {
   zeroActivityLimit$,
   zeroActivityHasPrev$,
   zeroActivityCurrentPage$,
-  syncZeroActivitySub$,
   goToNextZeroActivityPage$,
   goToPrevZeroActivityPage$,
   goForwardTwoZeroActivityPages$,
@@ -43,7 +40,7 @@ import {
 } from "../../signals/zero-page/zero-activity.ts";
 import { zeroTabSub$ } from "../../signals/zero-page/zero-nav.ts";
 import { SimpleLink } from "../router/link.tsx";
-import { Reason, detach, onRef } from "../../signals/utils.ts";
+import { Reason, detach } from "../../signals/utils.ts";
 import emptyActivityImg from "./assets/empty-activity.png";
 
 const STATUS_OPTIONS: readonly Readonly<{ value: string; label: string }>[] = [
@@ -124,11 +121,6 @@ export function ZeroActivityPage() {
   const goForwardTwo = useSet(goForwardTwoZeroActivityPages$);
   const goBackTwo = useSet(goBackTwoZeroActivityPages$);
   const setRowsPerPage = useSet(setZeroActivityRowsPerPage$);
-  const initPage$ = useCommand(({ set }) => {
-    set(syncZeroActivitySub$);
-  });
-  const initPageRef$ = onRef(initPage$);
-  const initPageRef = useSet(initPageRef$);
 
   // URL-driven detail: /activity/:logId
   const sub = useGet(zeroTabSub$);
@@ -155,11 +147,11 @@ export function ZeroActivityPage() {
 
   // Detail view when sub-route is present
   if (sub) {
-    return <ZeroActivityDetailPage ref={initPageRef} />;
+    return <ZeroActivityDetailPage />;
   }
 
   return (
-    <div ref={initPageRef} className="flex flex-1 flex-col min-h-0">
+    <div className="flex flex-1 flex-col min-h-0">
       {/* Fixed header: title + filters */}
       <header className="shrink-0 bg-transparent px-4 sm:px-6 pt-10 pb-3">
         <div className="mx-auto max-w-[900px]">


### PR DESCRIPTION
## Summary

- Move `syncZeroActivitySub$` trigger from view-layer `useCommand` + `onRef` into `refreshZeroActivityIfActive$` in the signals layer, eliminating unnecessary DOM lifecycle coupling
- Replace `useCCState("")` with `state("")` / `computed()` / `command()` in `zero-activity.ts` for the step search filter
- Remove `ref` prop from `ZeroActivityDetailPage` (was only forwarding an init ref it didn't consume)
- Remove all `eslint-disable ccstate/no-use-ccstate-in-views` comments and `ccstate-react/experimental` imports from both activity view files

## Test plan

- [x] Lint passes (`pnpm turbo run lint`)
- [x] Type check passes (no new errors vs main)
- [x] Knip passes (no unused exports)
- [x] All activity-related tests pass
- [ ] Manual: navigate to activity list, verify data loads
- [ ] Manual: navigate to activity detail (`/activity/:id`), verify events load and step search works
- [ ] Manual: switch between log entries, verify search resets

Closes #5805

🤖 Generated with [Claude Code](https://claude.com/claude-code)