### PR TITLE
feat: enable novnc remote resizing and auto-reconnect

### DIFF
--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -84,6 +84,7 @@ command -v x11vnc >/dev/null 2>&1 || MISSING+=(x11vnc)
 command -v Xvfb >/dev/null 2>&1 || MISSING+=(xvfb)
 command -v openbox >/dev/null 2>&1 || MISSING+=(openbox)
 command -v websockify >/dev/null 2>&1 || MISSING+=(novnc)
+command -v xrandr >/dev/null 2>&1 || MISSING+=(x11-xserver-utils)
 if [ ${#MISSING[@]} -gt 0 ]; then
   sudo apt-get update -qq
   sudo apt-get install -y -qq "${MISSING[@]}"

--- a/.devcontainer/start-vnc.sh
+++ b/.devcontainer/start-vnc.sh
@@ -23,6 +23,8 @@ PIDFILE_XVFB="/var/run/vnc-xvfb.pid"
 PIDFILE_OPENBOX="/var/run/vnc-openbox.pid"
 PIDFILE_X11VNC="/var/run/vnc-x11vnc.pid"
 PIDFILE_WEBSOCKIFY="/var/run/vnc-websockify.pid"
+PIDFILE_RESIZE="/var/run/vnc-resize.pid"
+X11VNC_LOG="/tmp/x11vnc-debug.log"
 
 start() {
     if start-stop-daemon --status --pidfile "$PIDFILE_XVFB" 2>/dev/null; then
@@ -31,27 +33,44 @@ start() {
     fi
 
     start-stop-daemon --start --background --make-pidfile --pidfile "$PIDFILE_XVFB" \
-        --chuid "$VNC_USER" --exec /usr/bin/Xvfb -- :99 -screen 0 1344x840x24
+        --chuid "$VNC_USER" --exec /usr/bin/Xvfb -- :99 -screen 0 3840x2160x24
     sleep 1
+
+    # Add common display modes and set initial resolution
+    if command -v xrandr >/dev/null 2>&1; then
+        DISPLAY=:99 xrandr --newmode "1344x840" 0 1344 1344 1344 1344 840 840 840 840 2>/dev/null || true
+        DISPLAY=:99 xrandr --addmode screen "1344x840" 2>/dev/null || true
+        DISPLAY=:99 xrandr -s 1344x840 2>/dev/null || true
+    fi
 
     start-stop-daemon --start --background --make-pidfile --pidfile "$PIDFILE_OPENBOX" \
         --chuid "$VNC_USER" --exec /usr/bin/env -- DISPLAY=:99 openbox
 
+    : > "$X11VNC_LOG"
     start-stop-daemon --start --background --make-pidfile --pidfile "$PIDFILE_X11VNC" \
-        --chuid "$VNC_USER" --exec /usr/bin/x11vnc -- -display :99 -nopw -forever -shared -rfbport 5900
+        --chuid "$VNC_USER" --exec /usr/bin/x11vnc -- -display :99 -nopw -forever -shared -rfbport 5900 -xrandr resize -v -o "$X11VNC_LOG"
 
     start-stop-daemon --start --background --make-pidfile --pidfile "$PIDFILE_WEBSOCKIFY" \
         --chuid "$VNC_USER" --exec /usr/bin/python3 -- /usr/bin/websockify --web /usr/share/novnc/ 0.0.0.0:6080 localhost:5900
+
+    # Resize helper: watches x11vnc log for client resize requests and applies them via xrandr
+    SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+    RESIZE_SCRIPT="${SCRIPT_DIR}/../.devcontainer/vnc-resize-helper.sh"
+    if [ -x "$RESIZE_SCRIPT" ]; then
+        start-stop-daemon --start --background --make-pidfile --pidfile "$PIDFILE_RESIZE" \
+            --chuid "$VNC_USER" --exec /bin/bash -- "$RESIZE_SCRIPT" "$X11VNC_LOG"
+    fi
 
     echo "VNC stack started"
 }
 
 stop() {
+    start-stop-daemon --stop --pidfile "$PIDFILE_RESIZE" --oknodo
     start-stop-daemon --stop --pidfile "$PIDFILE_WEBSOCKIFY" --oknodo
     start-stop-daemon --stop --pidfile "$PIDFILE_X11VNC" --oknodo
     start-stop-daemon --stop --pidfile "$PIDFILE_OPENBOX" --oknodo
     start-stop-daemon --stop --pidfile "$PIDFILE_XVFB" --oknodo
-    rm -f "$PIDFILE_XVFB" "$PIDFILE_OPENBOX" "$PIDFILE_X11VNC" "$PIDFILE_WEBSOCKIFY"
+    rm -f "$PIDFILE_XVFB" "$PIDFILE_OPENBOX" "$PIDFILE_X11VNC" "$PIDFILE_WEBSOCKIFY" "$PIDFILE_RESIZE"
     echo "VNC stack stopped"
 }
 

--- a/.devcontainer/vnc-resize-helper.sh
+++ b/.devcontainer/vnc-resize-helper.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# vnc-resize-helper.sh — Watch x11vnc log for client resize requests and apply them via xrandr
+#
+# x11vnc logs "Client requested resolution change to (WxH)" but cannot
+# call xrandr itself. This helper watches the log and does it instead.
+
+set -eu
+
+LOG_FILE="${1:-/tmp/x11vnc-debug.log}"
+DISPLAY="${DISPLAY:-:99}"
+export DISPLAY
+
+LAST_APPLIED=""
+
+tail -n 0 -F "$LOG_FILE" 2>/dev/null | while read -r line; do
+  if [[ "$line" =~ "Client requested resolution change to ("([0-9]+)x([0-9]+)")" ]]; then
+    W="${BASH_REMATCH[1]}"
+    H="${BASH_REMATCH[2]}"
+    MODE="${W}x${H}"
+
+    # Skip if we just applied this
+    [[ "$MODE" == "$LAST_APPLIED" ]] && continue
+
+    # Create mode if it doesn't exist
+    if ! xrandr | grep -q "^   ${MODE} "; then
+      xrandr --newmode "$MODE" 0 "$W" "$W" "$W" "$W" "$H" "$H" "$H" "$H" 2>/dev/null || true
+      xrandr --addmode screen "$MODE" 2>/dev/null || true
+    fi
+
+    # Switch to it
+    if xrandr -s "$MODE" 2>/dev/null; then
+      LAST_APPLIED="$MODE"
+      echo "[vnc-resize] Applied ${MODE}"
+    else
+      echo "[vnc-resize] Failed to apply ${MODE}" >&2
+    fi
+  fi
+done

--- a/docker/toolchain/Dockerfile
+++ b/docker/toolchain/Dockerfile
@@ -160,7 +160,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     x11vnc \
     openbox \
     novnc \
-    && rm -rf /var/lib/apt/lists/*
+    x11-xserver-utils \
+    && rm -rf /var/lib/apt/lists/* \
+    && sed -i "s/UI.initSetting('resize', 'off')/UI.initSetting('resize', 'remote')/" /usr/share/novnc/app/ui.js \
+    && sed -i "s/UI.initSetting('reconnect', false)/UI.initSetting('reconnect', true)/" /usr/share/novnc/app/ui.js
 
 # Install pip for Python testing
 RUN apt-get update && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
## Summary
- Enable noVNC remote resizing so the VNC display dynamically adapts to the browser window size
- Add a resize helper daemon that watches x11vnc logs for client `SetDesktopSize` requests and creates/applies xrandr modes on the fly
- Set noVNC defaults: `resize=remote`, `reconnect=true`
- Increase Xvfb virtual screen to 3840x2160 to provide resize headroom
- Install `x11-xserver-utils` (xrandr) in toolchain Dockerfile

## Test plan
- [ ] Open noVNC at `http://localhost:6080/vnc.html`
- [ ] Verify Scaling Mode defaults to "Remote Resizing" (no manual toggle needed)
- [ ] Resize the browser window and confirm the VNC display resolution changes accordingly
- [ ] Restart VNC stack (`service vnc restart`) and verify noVNC auto-reconnects
- [ ] Verify agent-browser still works normally after the changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)