### PR TITLE
refactor: remove ccstate-react/experimental from zero-app-shell.tsx

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-chat.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-chat.test.ts
@@ -20,6 +20,8 @@ import {
   switchZeroSession$,
   startNewZeroSession$,
   sendZeroChatMessage$,
+  sendFromZeroDemo$,
+  syncUrlSession$,
 } from "../zero-chat.ts";
 
 const context = testContext();
@@ -593,6 +595,152 @@ describe("zero-chat signals", () => {
       expect(threadCreateCalled).toBeFalsy();
       expect(capturedRunBody).toBeTruthy();
       expect(capturedRunBody!.sessionId).toBe("existing-session");
+    });
+  });
+
+  describe("sendFromZeroDemo$", () => {
+    it("should reset session and start sending the message", async () => {
+      let runCreated = false;
+      server.use(
+        http.post("*/api/zero/chat-threads", () => {
+          return HttpResponse.json(
+            { id: "thread-demo", createdAt: "2026-03-10T00:00:00Z" },
+            { status: 201 },
+          );
+        }),
+        http.post("*/api/zero/chat-threads/:id/runs", () => {
+          return new HttpResponse(null, { status: 204 });
+        }),
+        http.get("*/api/zero/chat-threads", () => {
+          return HttpResponse.json({ threads: [] });
+        }),
+        http.post("*/api/zero/runs", () => {
+          runCreated = true;
+          return HttpResponse.json({ runId: "run-demo" });
+        }),
+        http.get("*/api/zero/runs/:runId/telemetry/agent", () => {
+          return HttpResponse.json({
+            events: [],
+            hasMore: false,
+            framework: "claude-code",
+          });
+        }),
+        http.get("*/api/zero/logs/:runId", () => {
+          return HttpResponse.json({
+            id: "run-demo",
+            status: "completed",
+            error: null,
+            prompt: "Hello from demo",
+            createdAt: "2026-03-10T00:00:00Z",
+            startedAt: "2026-03-10T00:00:01Z",
+            completedAt: "2026-03-10T00:00:02Z",
+          });
+        }),
+        http.get("*/api/zero/runs/:runId", () => {
+          return HttpResponse.json({
+            result: { agentSessionId: "demo-session" },
+          });
+        }),
+      );
+
+      await setup();
+
+      // Set up some existing state that should get reset
+      context.store.set(setZeroChatInput$, "old input");
+
+      context.store.set(sendFromZeroDemo$, "Hello from demo");
+
+      // Wait for the detached send to complete
+      await delay(100);
+
+      expect(runCreated).toBeTruthy();
+      // Session was reset before sending
+      expect(context.store.get(zeroChatInput$)).toBe("");
+    });
+  });
+
+  describe("syncUrlSession$", () => {
+    it("should switch to the URL session when it differs from current", async () => {
+      server.use(
+        http.get("*/api/zero/chat-threads/:id", () => {
+          return HttpResponse.json({
+            id: "url-thread",
+            title: null,
+            agentComposeId: "mock-compose-id",
+            chatMessages: [
+              {
+                role: "user",
+                content: "From URL",
+                createdAt: "2026-03-10T00:00:00Z",
+              },
+            ],
+            latestSessionId: "url-session",
+            createdAt: "2026-03-10T00:00:00Z",
+            updatedAt: "2026-03-10T00:00:00Z",
+          });
+        }),
+      );
+
+      // Set up with the chat session path so zeroSessionId$ returns "url-thread"
+      await setupPage({
+        context,
+        path: "/chat/url-thread",
+        withoutRender: true,
+      });
+
+      await context.store.set(syncUrlSession$);
+
+      expect(context.store.get(zeroChatThreadId$)).toBe("url-thread");
+      expect(context.store.get(zeroCurrentSessionId$)).toBe("url-session");
+      const messages = context.store.get(zeroChatMessages$);
+      expect(messages).toHaveLength(1);
+      expect(messages[0]?.content).toBe("From URL");
+    });
+
+    it("should skip when no session ID in URL", async () => {
+      // Set up with /chat path (no session ID)
+      await setupPage({
+        context,
+        path: "/chat",
+        withoutRender: true,
+      });
+
+      await context.store.set(syncUrlSession$);
+
+      expect(context.store.get(zeroChatThreadId$)).toBeNull();
+    });
+
+    it("should skip when URL session already matches current thread", async () => {
+      let switchCount = 0;
+      server.use(
+        http.get("*/api/zero/chat-threads/:id", () => {
+          switchCount++;
+          return HttpResponse.json({
+            id: "already-loaded",
+            title: null,
+            agentComposeId: "mock-compose-id",
+            chatMessages: [],
+            latestSessionId: null,
+            createdAt: "2026-03-10T00:00:00Z",
+            updatedAt: "2026-03-10T00:00:00Z",
+          });
+        }),
+      );
+
+      // Set up with the chat session path
+      await setupPage({
+        context,
+        path: "/chat/already-loaded",
+        withoutRender: true,
+      });
+
+      // First sync should switch
+      await context.store.set(syncUrlSession$);
+      expect(switchCount).toBe(1);
+
+      // Second sync with same URL should skip
+      await context.store.set(syncUrlSession$);
+      expect(switchCount).toBe(1);
     });
   });
 });

--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-nav.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-nav.test.ts
@@ -1,5 +1,5 @@
 import { command } from "ccstate";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { mockLocation } from "../../location.ts";
 import { testContext } from "../../__tests__/test-helpers.ts";
 import { createPushStateMock } from "../../../__tests__/page-helper.ts";
@@ -9,6 +9,15 @@ import {
   zeroChatAgentName$,
   zeroChatAgentId$,
   setZeroChatAgent$,
+  zeroAvatarIndex$,
+  cycleZeroAvatar$,
+  zeroShowAboutPage$,
+  setZeroShowAboutPage$,
+  zeroSidebarCollapsed$,
+  setZeroSidebarCollapsed$,
+  initSidebarCollapsed$,
+  handleZeroNavSelect$,
+  handleZeroAccountAction$,
 } from "../zero-nav.ts";
 import { setRootSignal$ } from "../../root-signal.ts";
 import { initRoutes$ } from "../../route.ts";
@@ -155,6 +164,139 @@ describe("zero-nav", () => {
       });
       context.store.set(setZeroChatAgent$, null);
       expect(context.store.get(zeroChatAgentId$)).toBeNull();
+    });
+  });
+
+  describe("zeroAvatarIndex$ and cycleZeroAvatar$", () => {
+    it("should default to 0", () => {
+      expect(context.store.get(zeroAvatarIndex$)).toBe(0);
+    });
+
+    it("should advance to the next index", () => {
+      context.store.set(cycleZeroAvatar$, 5);
+      expect(context.store.get(zeroAvatarIndex$)).toBe(1);
+    });
+
+    it("should wrap around when reaching the end", () => {
+      context.store.set(cycleZeroAvatar$, 3);
+      context.store.set(cycleZeroAvatar$, 3);
+      context.store.set(cycleZeroAvatar$, 3);
+      expect(context.store.get(zeroAvatarIndex$)).toBe(0);
+    });
+  });
+
+  describe("zeroShowAboutPage$ and setZeroShowAboutPage$", () => {
+    it("should default to false", () => {
+      expect(context.store.get(zeroShowAboutPage$)).toBeFalsy();
+    });
+
+    it("should set to true", () => {
+      context.store.set(setZeroShowAboutPage$, true);
+      expect(context.store.get(zeroShowAboutPage$)).toBeTruthy();
+    });
+
+    it("should set back to false", () => {
+      context.store.set(setZeroShowAboutPage$, true);
+      context.store.set(setZeroShowAboutPage$, false);
+      expect(context.store.get(zeroShowAboutPage$)).toBeFalsy();
+    });
+  });
+
+  describe("zeroSidebarCollapsed$", () => {
+    it("should default to false", () => {
+      expect(context.store.get(zeroSidebarCollapsed$)).toBeFalsy();
+    });
+
+    it("should toggle via setZeroSidebarCollapsed$", () => {
+      context.store.set(setZeroSidebarCollapsed$, true);
+      expect(context.store.get(zeroSidebarCollapsed$)).toBeTruthy();
+
+      context.store.set(setZeroSidebarCollapsed$, false);
+      expect(context.store.get(zeroSidebarCollapsed$)).toBeFalsy();
+    });
+
+    it("should initialize as collapsed on mobile viewport", () => {
+      vi.spyOn(window, "innerWidth", "get").mockReturnValue(500);
+
+      context.store.set(initSidebarCollapsed$);
+      expect(context.store.get(zeroSidebarCollapsed$)).toBeTruthy();
+
+      vi.restoreAllMocks();
+    });
+
+    it("should initialize as expanded on desktop viewport", () => {
+      vi.spyOn(window, "innerWidth", "get").mockReturnValue(1024);
+
+      context.store.set(initSidebarCollapsed$);
+      expect(context.store.get(zeroSidebarCollapsed$)).toBeFalsy();
+
+      vi.restoreAllMocks();
+    });
+  });
+
+  describe("handleZeroNavSelect$", () => {
+    it("should navigate to the selected tab and close about page", async () => {
+      const pushStateMock = await setupNav();
+
+      context.store.set(setZeroShowAboutPage$, true);
+      context.store.set(handleZeroNavSelect$, "schedule");
+
+      expect(pushStateMock).toHaveBeenCalledWith({}, "", "/schedule");
+      expect(context.store.get(zeroActiveId$)).toBe("schedule");
+      expect(context.store.get(zeroShowAboutPage$)).toBeFalsy();
+    });
+
+    async function setupNav() {
+      context.store.set(setRootSignal$, context.signal);
+      const pushStateMock = createPushStateMock(context.signal);
+      mockLocation({ pathname: "/", search: "" }, context.signal);
+      const noop$ = command(() => void 0);
+      await context.store.set(
+        initRoutes$,
+        [
+          { path: "/", setup: noop$ },
+          { path: "/:tab", setup: noop$ },
+        ],
+        context.signal,
+      );
+      return pushStateMock;
+    }
+  });
+
+  describe("handleZeroAccountAction$", () => {
+    it("should navigate to preferences for 'preferences' action", async () => {
+      context.store.set(setRootSignal$, context.signal);
+      createPushStateMock(context.signal);
+      mockLocation({ pathname: "/", search: "" }, context.signal);
+      const noop$ = command(() => void 0);
+      await context.store.set(
+        initRoutes$,
+        [
+          { path: "/", setup: noop$ },
+          { path: "/:tab", setup: noop$ },
+        ],
+        context.signal,
+      );
+
+      context.store.set(handleZeroAccountAction$, "preferences");
+
+      expect(context.store.get(zeroActiveId$)).toBe("preferences");
+    });
+
+    it("should do nothing for 'signout' action", () => {
+      mockLocation({ pathname: "/schedule", search: "" }, context.signal);
+
+      context.store.set(handleZeroAccountAction$, "signout");
+
+      expect(context.store.get(zeroActiveId$)).toBe("schedule");
+    });
+
+    it("should do nothing for 'manage' action", () => {
+      mockLocation({ pathname: "/schedule", search: "" }, context.signal);
+
+      context.store.set(handleZeroAccountAction$, "manage");
+
+      expect(context.store.get(zeroActiveId$)).toBe("schedule");
     });
   });
 });

--- a/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
@@ -10,7 +10,9 @@ import {
   zeroChatAgentId$,
   setZeroChatAgent$,
   zeroInChat$,
+  zeroSessionId$,
 } from "./zero-nav.ts";
+import { updatePathname$ } from "../route.ts";
 import { agentsList$ } from "./agents-list.ts";
 import type { ChatThreadListItem } from "@vm0/core";
 
@@ -1105,4 +1107,33 @@ const onZeroRunComplete$ = command(async ({ get, set }, runId: string) => {
     throwIfAbort(error);
     L.error("Failed to extract run result:", error);
   }
+});
+
+// ---------------------------------------------------------------------------
+// Composite shell commands
+// ---------------------------------------------------------------------------
+
+/** Send a message from the demo/home page: navigate to chat, reset session, fire message. */
+export const sendFromZeroDemo$ = command(
+  ({ set }, message: string, options?: { modelProvider?: string }) => {
+    set(updatePathname$, "/chat");
+    set(startNewZeroSession$);
+    detach(set(sendZeroChatMessage$, message, options), Reason.DomCallback);
+  },
+);
+
+/**
+ * Sync URL session ID to the chat signal.
+ * Called from setupZeroPage$ on each route entry for /chat/:sessionId routes.
+ */
+export const syncUrlSession$ = command(async ({ get, set }) => {
+  const urlSessionId = get(zeroSessionId$);
+  if (!urlSessionId) {
+    return;
+  }
+  const currentThreadId = get(zeroChatThreadId$);
+  if (urlSessionId === currentThreadId) {
+    return;
+  }
+  await set(switchZeroSession$, urlSessionId);
 });

--- a/turbo/apps/platform/src/signals/zero-page/zero-nav.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-nav.ts
@@ -1,6 +1,9 @@
 import { command, computed, state } from "ccstate";
 import { pathname$, updatePathname$, navigateInReact$ } from "../route.ts";
-import type { ZeroNavId } from "../../views/zero-page/zero-sidebar.tsx";
+import type {
+  ZeroNavId,
+  ZeroAccountAction,
+} from "../../views/zero-page/zero-sidebar.tsx";
 
 function isValidTab(tab: string): tab is ZeroNavId {
   return (
@@ -126,3 +129,72 @@ export const navigateToZeroSession$ = command(({ set }, sessionId: string) => {
 export const navigateFromZeroSession$ = command(() => {
   window.history.back();
 });
+
+// ---------------------------------------------------------------------------
+// Shell UI state — avatar, about page, sidebar
+// ---------------------------------------------------------------------------
+
+const internalAvatarIndex$ = state(0);
+
+/** Current avatar index for the Zero agent avatar cycle. */
+export const zeroAvatarIndex$ = computed((get) => get(internalAvatarIndex$));
+
+/** Advance the avatar to the next image in the cycle. */
+export const cycleZeroAvatar$ = command(({ get, set }, avatarCount: number) => {
+  const current = get(internalAvatarIndex$);
+  set(internalAvatarIndex$, (current + 1) % avatarCount);
+});
+
+const internalShowAboutPage$ = state(false);
+
+/** Whether the About VM0 page is shown. */
+export const zeroShowAboutPage$ = computed((get) =>
+  get(internalShowAboutPage$),
+);
+
+/** Show or hide the About VM0 page. */
+export const setZeroShowAboutPage$ = command(({ set }, show: boolean) => {
+  set(internalShowAboutPage$, show);
+});
+
+const internalSidebarCollapsed$ = state(false);
+
+/** Whether the sidebar is collapsed. */
+export const zeroSidebarCollapsed$ = computed((get) =>
+  get(internalSidebarCollapsed$),
+);
+
+/** Set sidebar collapsed state. */
+export const setZeroSidebarCollapsed$ = command(
+  ({ set }, collapsed: boolean) => {
+    set(internalSidebarCollapsed$, collapsed);
+  },
+);
+
+/** Initialize sidebar collapsed state from viewport width. */
+export const initSidebarCollapsed$ = command(({ set }) => {
+  const isMobile = typeof window !== "undefined" && window.innerWidth < 768;
+  set(internalSidebarCollapsed$, isMobile);
+});
+
+// ---------------------------------------------------------------------------
+// Shell commands — nav select, account action, send from demo
+// ---------------------------------------------------------------------------
+
+/** Handle nav tab selection: navigate to tab and close about page. */
+export const handleZeroNavSelect$ = command(({ set }, id: ZeroNavId) => {
+  set(setZeroActiveId$, id);
+  set(internalShowAboutPage$, false);
+});
+
+/** Handle account menu action. */
+export const handleZeroAccountAction$ = command(
+  ({ set }, action: ZeroAccountAction) => {
+    if (action === "signout" || action === "manage") {
+      return;
+    }
+    if (action === "preferences") {
+      set(setZeroActiveId$, "preferences");
+    }
+  },
+);

--- a/turbo/apps/platform/src/signals/zero-page/zero-page.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-page.ts
@@ -11,8 +11,12 @@ import {
 } from "./zero-activity.ts";
 import { refreshScheduleIfActive$ } from "./zero-schedule.ts";
 import { initSlackOrg$ } from "./zero-slack.ts";
-import { zeroChatAgentName$, zeroInChat$ } from "./zero-nav.ts";
-import { switchActiveAgent$ } from "./zero-chat.ts";
+import {
+  zeroChatAgentName$,
+  zeroInChat$,
+  initSidebarCollapsed$,
+} from "./zero-nav.ts";
+import { switchActiveAgent$, syncUrlSession$ } from "./zero-chat.ts";
 import {
   pinnedAgentIds$,
   updatePinnedAgentIds$,
@@ -30,7 +34,7 @@ const initialDataLoaded$ = state(false);
  * Resolve the active agent from the URL and switch to it.
  *
  * - `/talk/:name` → find agent by name, switch to it
- * - `/chat/:threadId` → skip (switchZeroSession$ handles it)
+ * - `/chat/:threadId` → sync session via syncUrlSession$
  * - `/` → redirect to `/talk/:defaultAgent`
  * - other `/*` → switch to default agent
  *
@@ -43,10 +47,11 @@ async function resolveAndSwitchAgent(
 ) {
   const currentPath = get(pathname$);
 
-  // On /chat/:threadId, switchZeroSession$ resolves the agent from
-  // the thread's agentComposeId. Don't interfere here.
+  // On /chat/:threadId, syncUrlSession$ switches to the correct session.
+  // Don't resolve agent here — switchZeroSession$ handles that internally.
   if (get(zeroInChat$)) {
-    L.info("on chat URL, deferring to switchZeroSession$");
+    L.info("on chat URL, syncing session");
+    await set(syncUrlSession$);
     return;
   }
   L.info("resolveAgent path:", currentPath);
@@ -117,6 +122,7 @@ export const setupZeroPage$ = command(
       ]);
       signal.throwIfAborted();
       set(initialDataLoaded$, true);
+      set(initSidebarCollapsed$);
       detach(set(initZeroActivity$), Reason.Daemon);
     }
 

--- a/turbo/apps/platform/src/views/zero-page/zero-app-shell.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-app-shell.tsx
@@ -1,11 +1,7 @@
-/* eslint-disable ccstate/no-use-ccstate-in-views */
-import { useCCState, useCommand } from "ccstate-react/experimental";
 import { useGet, useSet, useLoadable, useLastLoadable } from "ccstate-react";
 import {
   ZeroSidebar,
   useAgentAvatar,
-  type ZeroNavId,
-  type ZeroAccountAction,
   type SubagentInfo,
 } from "./zero-sidebar.tsx";
 import { Button } from "@vm0/ui";
@@ -22,7 +18,6 @@ import {
   defaultAgentName$,
 } from "../../signals/zero-page/zero-agent-name.ts";
 import { zeroSubagents$ } from "../../signals/zero-page/zero-agents.ts";
-import { detach, Reason } from "../../signals/utils.ts";
 import {
   zeroActiveId$,
   zeroInChat$,
@@ -30,19 +25,24 @@ import {
   zeroChatAgentId$,
   zeroChatAgentName$,
   zeroTalkAgentResolved$,
-  setZeroActiveId$,
   navigateToZeroSession$,
   navigateFromZeroSession$,
+  zeroAvatarIndex$,
+  cycleZeroAvatar$,
+  zeroShowAboutPage$,
+  setZeroShowAboutPage$,
+  zeroSidebarCollapsed$,
+  setZeroSidebarCollapsed$,
+  handleZeroNavSelect$,
+  handleZeroAccountAction$,
 } from "../../signals/zero-page/zero-nav.ts";
-import { updatePathname$, navigateInReact$ } from "../../signals/route.ts";
+import { navigateInReact$ } from "../../signals/route.ts";
 import {
   zeroSessionList$,
   zeroSessionListLoading$,
   zeroSessionListError$,
-  zeroChatThreadId$,
-  switchZeroSession$,
   startNewZeroSession$,
-  sendZeroChatMessage$,
+  sendFromZeroDemo$,
 } from "../../signals/zero-page/zero-chat.ts";
 
 import zeroAvatarImg from "./assets/zero-avatar.png";
@@ -164,31 +164,6 @@ function useSessionLifecycle() {
   return { recentSessions, recentSessionsLoading, recentSessionsError };
 }
 
-/**
- * Sync URL session ID to the chat signal, avoiding redundant switches.
- */
-function useUrlSessionSync(
-  urlSessionId: string | null,
-  currentSessionId: string | null,
-  switchSession: (id: string) => Promise<void>,
-) {
-  const lastDispatched$ = useCCState<string | null>(null);
-  const lastDispatched = useGet(lastDispatched$);
-  const setLastDispatched = useSet(lastDispatched$);
-  if (
-    urlSessionId &&
-    urlSessionId !== lastDispatched &&
-    urlSessionId !== currentSessionId
-  ) {
-    setLastDispatched(urlSessionId);
-    queueMicrotask(() => {
-      detach(switchSession(urlSessionId), Reason.DomCallback);
-    });
-  } else if (!urlSessionId) {
-    setLastDispatched(null);
-  }
-}
-
 function GuestNavBar({ onAbout }: { onAbout: () => void }) {
   return (
     <nav
@@ -222,7 +197,6 @@ function GuestNavBar({ onAbout }: { onAbout: () => void }) {
 }
 
 function useContentNavigation(resolvedAgentName: string | null) {
-  const navigate = useSet(updatePathname$);
   const navigateInReact = useSet(navigateInReact$);
 
   const handleNavigateToSchedule = () => {
@@ -253,7 +227,6 @@ function useContentNavigation(resolvedAgentName: string | null) {
   };
 
   return {
-    navigate,
     navigateInReact,
     handleNavigateToSchedule,
     handleNavigateToMeet,
@@ -324,15 +297,11 @@ export function ZeroAppShell({ initialJobAgent }: ZeroAppShellProps) {
   const currentChatAgentId = useGet(zeroChatAgentId$);
 
   const activeId = useGet(zeroActiveId$);
-  const avatarIndex$ = useCCState(0);
-  const avatarIndex = useGet(avatarIndex$);
-  const setAvatarIndex = useSet(avatarIndex$);
-  const showAboutPage$ = useCCState(false);
-  const showAboutPage = useGet(showAboutPage$);
-  const setShowAboutPage = useSet(showAboutPage$);
+  const avatarIndex = useGet(zeroAvatarIndex$);
+  const cycleAvatar = useSet(cycleZeroAvatar$);
+  const showAboutPage = useGet(zeroShowAboutPage$);
+  const setShowAboutPage = useSet(setZeroShowAboutPage$);
   const zeroAvatarSrc = ZERO_AVATARS[avatarIndex] ?? ZERO_AVATARS[0];
-  const cycleZeroAvatar = () =>
-    setAvatarIndex((avatarIndex + 1) % ZERO_AVATARS.length);
 
   // Resolve the effective agent name/avatar for the chat page
   const selectedSubagent = currentChatAgentId
@@ -346,10 +315,8 @@ export function ZeroAppShell({ initialJobAgent }: ZeroAppShellProps) {
   const inChat = useGet(zeroInChat$);
   const urlSessionId = useGet(zeroSessionId$);
   const inSession = inChat;
-  const currentThreadId = useGet(zeroChatThreadId$);
-  const switchSession = useSet(switchZeroSession$);
   const startNewSession = useSet(startNewZeroSession$);
-  const sendMessage = useSet(sendZeroChatMessage$);
+  const handleSendFromDemo = useSet(sendFromZeroDemo$);
 
   // When visiting /talk/:name, wait for the agent to be resolved
   const talkAgentName = useGet(zeroChatAgentName$);
@@ -359,9 +326,6 @@ export function ZeroAppShell({ initialJobAgent }: ZeroAppShellProps) {
   const { recentSessions, recentSessionsLoading, recentSessionsError } =
     useSessionLifecycle();
 
-  // Sync URL thread ID to chat signal (skip if signal already matches)
-  useUrlSessionSync(urlSessionId, currentThreadId, switchSession);
-
   const resolvedAgentName = selectedSubagent?.name ?? defaultRawName;
   const {
     navigateInReact,
@@ -370,10 +334,10 @@ export function ZeroAppShell({ initialJobAgent }: ZeroAppShellProps) {
     handleChatAvatarClick,
   } = useContentNavigation(resolvedAgentName);
 
-  const handleRecentSelect$ = useCommand(({ set }, sessionId: string) => {
-    set(navigateToZeroSession$, sessionId);
-  });
-  const handleRecentSelect = useSet(handleRecentSelect$);
+  const navigateToSession = useSet(navigateToZeroSession$);
+  const navigateBack = useSet(navigateFromZeroSession$);
+  const handleNavSelect = useSet(handleZeroNavSelect$);
+  const handleAccountAction = useSet(handleZeroAccountAction$);
 
   const handleNewChat = (agent: { id: string; name: string } | null) => {
     startNewSession();
@@ -388,42 +352,8 @@ export function ZeroAppShell({ initialJobAgent }: ZeroAppShellProps) {
     }
   };
 
-  const handleSendFromDemo$ = useCommand(
-    ({ set }, message: string, options?: { modelProvider?: string }) => {
-      set(updatePathname$, "/chat");
-      startNewSession();
-      detach(sendMessage(message, options), Reason.DomCallback);
-    },
-  );
-  const handleSendFromDemo = useSet(handleSendFromDemo$);
-
-  const handleBackFromSession$ = useCommand(({ set }) => {
-    set(navigateFromZeroSession$);
-  });
-  const handleBackFromSession = useSet(handleBackFromSession$);
-
-  const handleNavSelect$ = useCommand(({ set }, id: ZeroNavId) => {
-    set(setZeroActiveId$, id);
-    set(showAboutPage$, false);
-  });
-  const handleNavSelect = useSet(handleNavSelect$);
-
-  const handleAccountAction$ = useCommand(
-    ({ set }, action: ZeroAccountAction) => {
-      if (action === "signout" || action === "manage") {
-        return;
-      }
-      if (action === "preferences") {
-        set(setZeroActiveId$, "preferences");
-      }
-    },
-  );
-  const handleAccountAction = useSet(handleAccountAction$);
-
-  const isMobile = typeof window !== "undefined" && window.innerWidth < 768;
-  const sidebarCollapsed$ = useCCState(isMobile);
-  const sidebarCollapsed = useGet(sidebarCollapsed$);
-  const setSidebarCollapsed = useSet(sidebarCollapsed$);
+  const sidebarCollapsed = useGet(zeroSidebarCollapsed$);
+  const setSidebarCollapsed = useSet(setZeroSidebarCollapsed$);
 
   const dataReady =
     isLoggedIn && onboardingReady && agentNameReady && talkAgentReady;
@@ -449,7 +379,7 @@ export function ZeroAppShell({ initialJobAgent }: ZeroAppShellProps) {
         collapsed={sidebarCollapsed}
         onCollapse={() => setSidebarCollapsed(!sidebarCollapsed)}
         onSelect={handleNavSelect}
-        onRecentSelect={handleRecentSelect}
+        onRecentSelect={navigateToSession}
         selectedRecentId={urlSessionId}
         onAccountAction={handleAccountAction}
         recentSessions={recentSessions}
@@ -477,12 +407,12 @@ export function ZeroAppShell({ initialJobAgent }: ZeroAppShellProps) {
             selectedAgentName={initialJobAgent}
             onNavigateToSchedule={handleNavigateToSchedule}
             onNavigateToMeet={handleNavigateToMeet}
-            onBackFromSession={handleBackFromSession}
+            onBackFromSession={navigateBack}
             zeroAvatarSrc={zeroAvatarSrc}
             chatAgentName={chatAgentName}
             chatAvatarSrc={chatAvatarSrc}
             onChatAvatarClick={handleChatAvatarClick}
-            onCycleZeroAvatar={cycleZeroAvatar}
+            onCycleZeroAvatar={() => cycleAvatar(ZERO_AVATARS.length)}
           />
         )}
       </div>


### PR DESCRIPTION
## Summary

- Move 3 `useCCState` atoms (`avatarIndex`, `showAboutPage`, `sidebarCollapsed`) to `state()`/`computed()`/`command()` in `zero-nav.ts`
- Extract 2 composite `useCommand` hooks to signal commands in `zero-nav.ts` and `zero-chat.ts`
- Replace 3 simple `useCommand` delegations with direct signal calls (per user preference for simplicity)
- **Eliminate render-time side effect**: move URL-to-session sync from `useUrlSessionSync` (render-phase `queueMicrotask` hack) to `syncUrlSession$` command called from `setupZeroPage$`
- Remove `eslint-disable` comment and `ccstate-react/experimental` import

Closes #5798

## Test plan

- [x] `pnpm check-types` — no new errors (pre-existing errors unchanged)
- [x] `pnpm turbo run lint` — passes
- [x] `pnpm format` — no changes needed
- [x] `pnpm knip` — no unused exports
- [x] `zero-chat.test.ts` — all 17 tests pass
- [ ] CI pipeline passes
- [ ] Manual: navigate between chat sessions via URL, verify session switching still works
- [ ] Manual: verify sidebar collapse, avatar cycling, about page toggle

🤖 Generated with [Claude Code](https://claude.com/claude-code)