### PR TITLE
chore: bump dev docker image to 20260321

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "VM0 Development",
-  "image": "ghcr.io/vm0-ai/vm0-dev:20260320",
+  "image": "ghcr.io/vm0-ai/vm0-dev:20260321",
   "features": {
     "ghcr.io/itsmechlark/features/postgresql:1": {
       "version": "17"


### PR DESCRIPTION
## Summary
- Bump `ghcr.io/vm0-ai/vm0-dev` from `20260320` to `20260321`
- New image includes noVNC remote resizing, auto-reconnect, and xrandr support from #5825

## Test plan
- [ ] Verify devcontainer rebuilds successfully with new image

🤖 Generated with [Claude Code](https://claude.com/claude-code)