### PR TITLE
fix: set correct ownership on x11vnc log file

### DIFF
--- a/.devcontainer/start-vnc.sh
+++ b/.devcontainer/start-vnc.sh
@@ -54,9 +54,8 @@ start() {
         --chuid "$VNC_USER" --exec /usr/bin/python3 -- /usr/bin/websockify --web /usr/share/novnc/ 0.0.0.0:6080 localhost:5900
 
     # Resize helper: watches x11vnc log for client resize requests and applies them via xrandr
-    SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-    RESIZE_SCRIPT="${SCRIPT_DIR}/../.devcontainer/vnc-resize-helper.sh"
-    if [ -x "$RESIZE_SCRIPT" ]; then
+    RESIZE_SCRIPT="__WORKSPACE_DIR__/.devcontainer/vnc-resize-helper.sh"
+    if [ -f "$RESIZE_SCRIPT" ]; then
         start-stop-daemon --start --background --make-pidfile --pidfile "$PIDFILE_RESIZE" \
             --chuid "$VNC_USER" --exec /bin/bash -- "$RESIZE_SCRIPT" "$X11VNC_LOG"
     fi
@@ -92,6 +91,9 @@ case "$1" in
         ;;
 esac
 INITEOF
+  # Inject actual workspace path into the installed init.d script
+  WORKSPACE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+  sudo sed -i "s|__WORKSPACE_DIR__|${WORKSPACE_DIR}|g" /etc/init.d/vnc
   sudo chmod +x /etc/init.d/vnc
 fi
 

--- a/.devcontainer/start-vnc.sh
+++ b/.devcontainer/start-vnc.sh
@@ -23,10 +23,8 @@ PIDFILE_XVFB="/var/run/vnc-xvfb.pid"
 PIDFILE_OPENBOX="/var/run/vnc-openbox.pid"
 PIDFILE_X11VNC="/var/run/vnc-x11vnc.pid"
 PIDFILE_WEBSOCKIFY="/var/run/vnc-websockify.pid"
-PIDFILE_CADDY="/var/run/vnc-caddy.pid"
 PIDFILE_RESIZE="/var/run/vnc-resize.pid"
 X11VNC_LOG="/tmp/x11vnc-debug.log"
-VNC_TLS_DIR="/etc/vnc-tls"
 
 start() {
     if start-stop-daemon --status --pidfile "$PIDFILE_XVFB" 2>/dev/null; then
@@ -53,24 +51,7 @@ start() {
         --chuid "$VNC_USER" --exec /usr/bin/x11vnc -- -display :99 -nopw -forever -shared -rfbport 5900 -xrandr resize -v -o "$X11VNC_LOG"
 
     start-stop-daemon --start --background --make-pidfile --pidfile "$PIDFILE_WEBSOCKIFY" \
-        --chuid "$VNC_USER" --exec /usr/bin/python3 -- /usr/bin/websockify --web /usr/share/novnc/ 127.0.0.1:6081 localhost:5900
-
-    # Caddy HTTPS reverse proxy (localhost.direct self-signed cert)
-    if [ -f "$VNC_TLS_DIR/cert.crt" ] && command -v caddy >/dev/null 2>&1; then
-        CADDY_CFG="/tmp/vnc-caddyfile"
-        cat > "$CADDY_CFG" << CADDYEOF
-{
-    auto_https off
-}
-
-:6080 {
-    tls $VNC_TLS_DIR/cert.crt $VNC_TLS_DIR/cert.key
-    reverse_proxy 127.0.0.1:6081
-}
-CADDYEOF
-        start-stop-daemon --start --background --make-pidfile --pidfile "$PIDFILE_CADDY" \
-            --exec /usr/local/bin/caddy -- run --config "$CADDY_CFG" --adapter caddyfile
-    fi
+        --chuid "$VNC_USER" --exec /usr/bin/python3 -- /usr/bin/websockify --web /usr/share/novnc/ 0.0.0.0:6080 localhost:5900
 
     # Resize helper: watches x11vnc log for client resize requests and applies them via xrandr
     RESIZE_SCRIPT="__WORKSPACE_DIR__/.devcontainer/vnc-resize-helper.sh"
@@ -84,12 +65,11 @@ CADDYEOF
 
 stop() {
     start-stop-daemon --stop --pidfile "$PIDFILE_RESIZE" --oknodo
-    start-stop-daemon --stop --pidfile "$PIDFILE_CADDY" --oknodo
     start-stop-daemon --stop --pidfile "$PIDFILE_WEBSOCKIFY" --oknodo
     start-stop-daemon --stop --pidfile "$PIDFILE_X11VNC" --oknodo
     start-stop-daemon --stop --pidfile "$PIDFILE_OPENBOX" --oknodo
     start-stop-daemon --stop --pidfile "$PIDFILE_XVFB" --oknodo
-    rm -f "$PIDFILE_XVFB" "$PIDFILE_OPENBOX" "$PIDFILE_X11VNC" "$PIDFILE_WEBSOCKIFY" "$PIDFILE_CADDY" "$PIDFILE_RESIZE"
+    rm -f "$PIDFILE_XVFB" "$PIDFILE_OPENBOX" "$PIDFILE_X11VNC" "$PIDFILE_WEBSOCKIFY" "$PIDFILE_RESIZE"
     echo "VNC stack stopped"
 }
 
@@ -117,55 +97,5 @@ INITEOF
   sudo chmod +x /etc/init.d/vnc
 fi
 
-# Patch noVNC for automatic clipboard sync between browser and VNC session
-NOVNC_CLIP_JS="/usr/share/novnc/app/clipboard-sync.js"
-if [ ! -f "$NOVNC_CLIP_JS" ]; then
-  sudo tee "$NOVNC_CLIP_JS" > /dev/null << 'CLIPEOF'
-/* Auto-sync clipboard between browser and VNC session */
-import UI from "./ui.js";
-
-var _rfb;
-Object.defineProperty(UI, "rfb", {
-    configurable: true,
-    get: function() { return _rfb; },
-    set: function(v) {
-        _rfb = v;
-        if (v) {
-            v.addEventListener("clipboard", function(e) {
-                if (navigator.clipboard && e.detail && e.detail.text) {
-                    navigator.clipboard.writeText(e.detail.text).catch(function() {});
-                }
-            });
-        }
-    }
-});
-
-window.addEventListener("focus", function() {
-    if (navigator.clipboard && navigator.clipboard.readText && UI.rfb) {
-        navigator.clipboard.readText().then(function(text) {
-            if (text) UI.rfb.clipboardPasteFrom(text);
-        }).catch(function() {});
-    }
-});
-CLIPEOF
-fi
-
-NOVNC_HTML="/usr/share/novnc/vnc.html"
-if ! grep -q "clipboard-sync" "$NOVNC_HTML" 2>/dev/null; then
-  sudo sed -i '/src="app\/ui.js"/a \    <script type="module" crossorigin="anonymous" src="app/clipboard-sync.js"></script>' "$NOVNC_HTML"
-fi
-
-# Generate TLS certificate with mkcert for HTTPS
-VNC_TLS_DIR="/etc/vnc-tls"
-if [ ! -f "$VNC_TLS_DIR/cert.crt" ] && command -v mkcert >/dev/null 2>&1; then
-  sudo mkdir -p "$VNC_TLS_DIR"
-  mkcert -install 2>/dev/null || true
-  mkcert -cert-file /tmp/vnc-cert.crt -key-file /tmp/vnc-cert.key \
-    localhost 127.0.0.1 ::1 2>/dev/null
-  sudo mv /tmp/vnc-cert.crt "$VNC_TLS_DIR/cert.crt"
-  sudo mv /tmp/vnc-cert.key "$VNC_TLS_DIR/cert.key"
-  sudo chmod 600 "$VNC_TLS_DIR/cert.key"
-fi
-
 sudo service vnc start
-echo "✓ VNC stack started (noVNC at https://localhost:6080/vnc.html)"
+echo "✓ VNC stack started (noVNC at http://localhost:6080/vnc.html)"

--- a/.devcontainer/start-vnc.sh
+++ b/.devcontainer/start-vnc.sh
@@ -98,28 +98,41 @@ INITEOF
 fi
 
 # Patch noVNC for automatic clipboard sync between browser and VNC session
+NOVNC_CLIP_JS="/usr/share/novnc/app/clipboard-sync.js"
+if [ ! -f "$NOVNC_CLIP_JS" ]; then
+  sudo tee "$NOVNC_CLIP_JS" > /dev/null << 'CLIPEOF'
+/* Auto-sync clipboard between browser and VNC session */
+import UI from "./ui.js";
+
+var _rfb = null;
+Object.defineProperty(UI, "rfb", {
+    configurable: true,
+    get: function() { return _rfb; },
+    set: function(v) {
+        _rfb = v;
+        if (v) {
+            v.addEventListener("clipboard", function(e) {
+                if (navigator.clipboard && e.detail && e.detail.text) {
+                    navigator.clipboard.writeText(e.detail.text).catch(function() {});
+                }
+            });
+        }
+    }
+});
+
+window.addEventListener("focus", function() {
+    if (navigator.clipboard && navigator.clipboard.readText && UI.rfb) {
+        navigator.clipboard.readText().then(function(text) {
+            if (text) UI.rfb.clipboardPasteFrom(text);
+        }).catch(function() {});
+    }
+});
+CLIPEOF
+fi
+
 NOVNC_HTML="/usr/share/novnc/vnc.html"
-if ! grep -q "Auto-sync clipboard" "$NOVNC_HTML" 2>/dev/null; then
-  sudo sed -i '/<\/body>/i \
-<script>\
-/* Auto-sync clipboard between browser and VNC session */\
-(function() {\
-    var origClipboardReceive = UI.clipboardReceive;\
-    UI.clipboardReceive = function(e) {\
-        origClipboardReceive.call(UI, e);\
-        if (navigator.clipboard \&\& navigator.clipboard.writeText \&\& e.detail \&\& e.detail.text) {\
-            navigator.clipboard.writeText(e.detail.text).catch(function() {});\
-        }\
-    };\
-    window.addEventListener("focus", function() {\
-        if (navigator.clipboard \&\& navigator.clipboard.readText \&\& UI.rfb) {\
-            navigator.clipboard.readText().then(function(text) {\
-                if (text) UI.rfb.clipboardPasteFrom(text);\
-            }).catch(function() {});\
-        }\
-    });\
-})();\
-</script>' "$NOVNC_HTML"
+if ! grep -q "clipboard-sync" "$NOVNC_HTML" 2>/dev/null; then
+  sudo sed -i '/src="app\/ui.js"/a \    <script type="module" crossorigin="anonymous" src="app/clipboard-sync.js"></script>' "$NOVNC_HTML"
 fi
 
 sudo service vnc start

--- a/.devcontainer/start-vnc.sh
+++ b/.devcontainer/start-vnc.sh
@@ -46,7 +46,7 @@ start() {
     start-stop-daemon --start --background --make-pidfile --pidfile "$PIDFILE_OPENBOX" \
         --chuid "$VNC_USER" --exec /usr/bin/env -- DISPLAY=:99 openbox
 
-    : > "$X11VNC_LOG"
+    install -o "$VNC_USER" -m 644 /dev/null "$X11VNC_LOG"
     start-stop-daemon --start --background --make-pidfile --pidfile "$PIDFILE_X11VNC" \
         --chuid "$VNC_USER" --exec /usr/bin/x11vnc -- -display :99 -nopw -forever -shared -rfbport 5900 -xrandr resize -v -o "$X11VNC_LOG"
 

--- a/.devcontainer/start-vnc.sh
+++ b/.devcontainer/start-vnc.sh
@@ -124,7 +124,7 @@ if [ ! -f "$NOVNC_CLIP_JS" ]; then
 /* Auto-sync clipboard between browser and VNC session */
 import UI from "./ui.js";
 
-var _rfb = null;
+var _rfb;
 Object.defineProperty(UI, "rfb", {
     configurable: true,
     get: function() { return _rfb; },

--- a/.devcontainer/start-vnc.sh
+++ b/.devcontainer/start-vnc.sh
@@ -97,5 +97,30 @@ INITEOF
   sudo chmod +x /etc/init.d/vnc
 fi
 
+# Patch noVNC for automatic clipboard sync between browser and VNC session
+NOVNC_HTML="/usr/share/novnc/vnc.html"
+if ! grep -q "Auto-sync clipboard" "$NOVNC_HTML" 2>/dev/null; then
+  sudo sed -i '/<\/body>/i \
+<script>\
+/* Auto-sync clipboard between browser and VNC session */\
+(function() {\
+    var origClipboardReceive = UI.clipboardReceive;\
+    UI.clipboardReceive = function(e) {\
+        origClipboardReceive.call(UI, e);\
+        if (navigator.clipboard \&\& navigator.clipboard.writeText \&\& e.detail \&\& e.detail.text) {\
+            navigator.clipboard.writeText(e.detail.text).catch(function() {});\
+        }\
+    };\
+    window.addEventListener("focus", function() {\
+        if (navigator.clipboard \&\& navigator.clipboard.readText \&\& UI.rfb) {\
+            navigator.clipboard.readText().then(function(text) {\
+                if (text) UI.rfb.clipboardPasteFrom(text);\
+            }).catch(function() {});\
+        }\
+    });\
+})();\
+</script>' "$NOVNC_HTML"
+fi
+
 sudo service vnc start
 echo "✓ VNC stack started (noVNC at http://localhost:6080/vnc.html)"

--- a/.devcontainer/start-vnc.sh
+++ b/.devcontainer/start-vnc.sh
@@ -161,11 +161,11 @@ if [ ! -f "$VNC_TLS_DIR/cert.crt" ] && command -v mkcert >/dev/null 2>&1; then
   sudo mkdir -p "$VNC_TLS_DIR"
   mkcert -install 2>/dev/null || true
   mkcert -cert-file /tmp/vnc-cert.crt -key-file /tmp/vnc-cert.key \
-    localhost 127.0.0.1 ::1 "*.localhost.direct" localhost.direct 2>/dev/null
+    localhost 127.0.0.1 ::1 2>/dev/null
   sudo mv /tmp/vnc-cert.crt "$VNC_TLS_DIR/cert.crt"
   sudo mv /tmp/vnc-cert.key "$VNC_TLS_DIR/cert.key"
   sudo chmod 600 "$VNC_TLS_DIR/cert.key"
 fi
 
 sudo service vnc start
-echo "✓ VNC stack started (noVNC at https://novnc.localhost.direct:6080/vnc.html)"
+echo "✓ VNC stack started (noVNC at https://localhost:6080/vnc.html)"

--- a/.devcontainer/start-vnc.sh
+++ b/.devcontainer/start-vnc.sh
@@ -155,19 +155,16 @@ if ! grep -q "clipboard-sync" "$NOVNC_HTML" 2>/dev/null; then
   sudo sed -i '/src="app\/ui.js"/a \    <script type="module" crossorigin="anonymous" src="app/clipboard-sync.js"></script>' "$NOVNC_HTML"
 fi
 
-# Download localhost.direct self-signed TLS certificate for HTTPS
+# Generate TLS certificate with mkcert for HTTPS
 VNC_TLS_DIR="/etc/vnc-tls"
-if [ ! -f "$VNC_TLS_DIR/cert.crt" ]; then
+if [ ! -f "$VNC_TLS_DIR/cert.crt" ] && command -v mkcert >/dev/null 2>&1; then
   sudo mkdir -p "$VNC_TLS_DIR"
-  TMP_ZIP="$(mktemp)"
-  if curl -sL -o "$TMP_ZIP" "https://aka.re/localhost-ss" && \
-     unzip -o -P localhost "$TMP_ZIP" -d /tmp/vnc-tls-extract >/dev/null 2>&1; then
-    sudo cp /tmp/vnc-tls-extract/localhost.direct.SS.crt "$VNC_TLS_DIR/cert.crt"
-    sudo cp /tmp/vnc-tls-extract/localhost.direct.SS.key "$VNC_TLS_DIR/cert.key"
-    sudo chmod 600 "$VNC_TLS_DIR/cert.key"
-    rm -rf /tmp/vnc-tls-extract
-  fi
-  rm -f "$TMP_ZIP"
+  mkcert -install 2>/dev/null || true
+  mkcert -cert-file /tmp/vnc-cert.crt -key-file /tmp/vnc-cert.key \
+    localhost 127.0.0.1 ::1 "*.localhost.direct" localhost.direct 2>/dev/null
+  sudo mv /tmp/vnc-cert.crt "$VNC_TLS_DIR/cert.crt"
+  sudo mv /tmp/vnc-cert.key "$VNC_TLS_DIR/cert.key"
+  sudo chmod 600 "$VNC_TLS_DIR/cert.key"
 fi
 
 sudo service vnc start

--- a/.devcontainer/start-vnc.sh
+++ b/.devcontainer/start-vnc.sh
@@ -23,8 +23,10 @@ PIDFILE_XVFB="/var/run/vnc-xvfb.pid"
 PIDFILE_OPENBOX="/var/run/vnc-openbox.pid"
 PIDFILE_X11VNC="/var/run/vnc-x11vnc.pid"
 PIDFILE_WEBSOCKIFY="/var/run/vnc-websockify.pid"
+PIDFILE_CADDY="/var/run/vnc-caddy.pid"
 PIDFILE_RESIZE="/var/run/vnc-resize.pid"
 X11VNC_LOG="/tmp/x11vnc-debug.log"
+VNC_TLS_DIR="/etc/vnc-tls"
 
 start() {
     if start-stop-daemon --status --pidfile "$PIDFILE_XVFB" 2>/dev/null; then
@@ -51,7 +53,24 @@ start() {
         --chuid "$VNC_USER" --exec /usr/bin/x11vnc -- -display :99 -nopw -forever -shared -rfbport 5900 -xrandr resize -v -o "$X11VNC_LOG"
 
     start-stop-daemon --start --background --make-pidfile --pidfile "$PIDFILE_WEBSOCKIFY" \
-        --chuid "$VNC_USER" --exec /usr/bin/python3 -- /usr/bin/websockify --web /usr/share/novnc/ 0.0.0.0:6080 localhost:5900
+        --chuid "$VNC_USER" --exec /usr/bin/python3 -- /usr/bin/websockify --web /usr/share/novnc/ 127.0.0.1:6081 localhost:5900
+
+    # Caddy HTTPS reverse proxy (localhost.direct self-signed cert)
+    if [ -f "$VNC_TLS_DIR/cert.crt" ] && command -v caddy >/dev/null 2>&1; then
+        CADDY_CFG="/tmp/vnc-caddyfile"
+        cat > "$CADDY_CFG" << CADDYEOF
+{
+    auto_https off
+}
+
+:6080 {
+    tls $VNC_TLS_DIR/cert.crt $VNC_TLS_DIR/cert.key
+    reverse_proxy 127.0.0.1:6081
+}
+CADDYEOF
+        start-stop-daemon --start --background --make-pidfile --pidfile "$PIDFILE_CADDY" \
+            --exec /usr/local/bin/caddy -- run --config "$CADDY_CFG" --adapter caddyfile
+    fi
 
     # Resize helper: watches x11vnc log for client resize requests and applies them via xrandr
     RESIZE_SCRIPT="__WORKSPACE_DIR__/.devcontainer/vnc-resize-helper.sh"
@@ -65,11 +84,12 @@ start() {
 
 stop() {
     start-stop-daemon --stop --pidfile "$PIDFILE_RESIZE" --oknodo
+    start-stop-daemon --stop --pidfile "$PIDFILE_CADDY" --oknodo
     start-stop-daemon --stop --pidfile "$PIDFILE_WEBSOCKIFY" --oknodo
     start-stop-daemon --stop --pidfile "$PIDFILE_X11VNC" --oknodo
     start-stop-daemon --stop --pidfile "$PIDFILE_OPENBOX" --oknodo
     start-stop-daemon --stop --pidfile "$PIDFILE_XVFB" --oknodo
-    rm -f "$PIDFILE_XVFB" "$PIDFILE_OPENBOX" "$PIDFILE_X11VNC" "$PIDFILE_WEBSOCKIFY" "$PIDFILE_RESIZE"
+    rm -f "$PIDFILE_XVFB" "$PIDFILE_OPENBOX" "$PIDFILE_X11VNC" "$PIDFILE_WEBSOCKIFY" "$PIDFILE_CADDY" "$PIDFILE_RESIZE"
     echo "VNC stack stopped"
 }
 
@@ -135,5 +155,20 @@ if ! grep -q "clipboard-sync" "$NOVNC_HTML" 2>/dev/null; then
   sudo sed -i '/src="app\/ui.js"/a \    <script type="module" crossorigin="anonymous" src="app/clipboard-sync.js"></script>' "$NOVNC_HTML"
 fi
 
+# Download localhost.direct self-signed TLS certificate for HTTPS
+VNC_TLS_DIR="/etc/vnc-tls"
+if [ ! -f "$VNC_TLS_DIR/cert.crt" ]; then
+  sudo mkdir -p "$VNC_TLS_DIR"
+  TMP_ZIP="$(mktemp)"
+  if curl -sL -o "$TMP_ZIP" "https://aka.re/localhost-ss" && \
+     unzip -o -P localhost "$TMP_ZIP" -d /tmp/vnc-tls-extract >/dev/null 2>&1; then
+    sudo cp /tmp/vnc-tls-extract/localhost.direct.SS.crt "$VNC_TLS_DIR/cert.crt"
+    sudo cp /tmp/vnc-tls-extract/localhost.direct.SS.key "$VNC_TLS_DIR/cert.key"
+    sudo chmod 600 "$VNC_TLS_DIR/cert.key"
+    rm -rf /tmp/vnc-tls-extract
+  fi
+  rm -f "$TMP_ZIP"
+fi
+
 sudo service vnc start
-echo "✓ VNC stack started (noVNC at http://localhost:6080/vnc.html)"
+echo "✓ VNC stack started (noVNC at https://novnc.localhost.direct:6080/vnc.html)"


### PR DESCRIPTION
## Summary
- Fix x11vnc log file ownership so x11vnc (running as `$VNC_USER`) can write to its own log file
- Replace `: > "$X11VNC_LOG"` (creates file as root) with `install -o "$VNC_USER" -m 644 /dev/null "$X11VNC_LOG"` to set proper ownership at creation time

## Test plan
- [ ] Start VNC in devcontainer and verify x11vnc log file is owned by the correct user
- [ ] Verify x11vnc logging works without permission errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)