### PR TITLE
feat: add pay-as-you-go auto-recharge for org credits

### DIFF
--- a/turbo/apps/platform/src/mocks/handlers/api-billing.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-billing.ts
@@ -13,6 +13,7 @@ let mockBillingStatus: BillingStatus = {
   subscriptionStatus: null,
   currentPeriodEnd: null,
   hasSubscription: false,
+  autoRecharge: { enabled: false, threshold: null, amount: null },
 };
 
 export function setMockBillingStatus(status: Partial<BillingStatus>): void {
@@ -26,6 +27,7 @@ export function resetMockBilling(): void {
     subscriptionStatus: null,
     currentPeriodEnd: null,
     hasSubscription: false,
+    autoRecharge: { enabled: false, threshold: null, amount: null },
   };
 }
 
@@ -49,5 +51,23 @@ export const apiBillingHandlers = [
     return HttpResponse.json({
       url: "https://billing.stripe.com/test-portal",
     });
+  }),
+
+  http.get("*/api/billing/auto-recharge", () => {
+    return HttpResponse.json(mockBillingStatus.autoRecharge);
+  }),
+
+  http.put("*/api/billing/auto-recharge", async ({ request }) => {
+    const body = (await request.json()) as {
+      enabled: boolean;
+      threshold?: number;
+      amount?: number;
+    };
+    mockBillingStatus.autoRecharge = {
+      enabled: body.enabled,
+      threshold: body.enabled ? (body.threshold ?? null) : null,
+      amount: body.enabled ? (body.amount ?? null) : null,
+    };
+    return HttpResponse.json(mockBillingStatus.autoRecharge);
   }),
 ];

--- a/turbo/apps/platform/src/signals/zero-page/billing-dialog-state.ts
+++ b/turbo/apps/platform/src/signals/zero-page/billing-dialog-state.ts
@@ -8,3 +8,50 @@ export const selectedPlanTier$ = computed((get) => get(internalSelectedTier$));
 export const setSelectedPlanTier$ = command(({ set }, tier: BillingTier) => {
   set(internalSelectedTier$, tier);
 });
+
+// ---------------------------------------------------------------------------
+// Auto-recharge form state
+// ---------------------------------------------------------------------------
+
+const internalAutoRechargeEnabled$ = state(false);
+const internalAutoRechargeThreshold$ = state("");
+const internalAutoRechargeAmount$ = state("");
+
+export const autoRechargeEnabled$ = computed((get) =>
+  get(internalAutoRechargeEnabled$),
+);
+export const autoRechargeThreshold$ = computed((get) =>
+  get(internalAutoRechargeThreshold$),
+);
+export const autoRechargeAmount$ = computed((get) =>
+  get(internalAutoRechargeAmount$),
+);
+
+export const setAutoRechargeEnabled$ = command(({ set }, enabled: boolean) => {
+  set(internalAutoRechargeEnabled$, enabled);
+});
+
+export const setAutoRechargeThreshold$ = command(
+  ({ set }, threshold: string) => {
+    set(internalAutoRechargeThreshold$, threshold);
+  },
+);
+
+export const setAutoRechargeAmount$ = command(({ set }, amount: string) => {
+  set(internalAutoRechargeAmount$, amount);
+});
+
+export const syncAutoRechargeForm$ = command(
+  (
+    { set },
+    config: {
+      enabled: boolean;
+      threshold: number | null;
+      amount: number | null;
+    },
+  ) => {
+    set(internalAutoRechargeEnabled$, config.enabled);
+    set(internalAutoRechargeThreshold$, config.threshold?.toString() ?? "");
+    set(internalAutoRechargeAmount$, config.amount?.toString() ?? "");
+  },
+);

--- a/turbo/apps/platform/src/signals/zero-page/billing.ts
+++ b/turbo/apps/platform/src/signals/zero-page/billing.ts
@@ -11,12 +11,19 @@ const log = logger("billing");
 
 export type BillingTier = "free" | "pro" | "max";
 
+interface AutoRechargeConfig {
+  enabled: boolean;
+  threshold: number | null;
+  amount: number | null;
+}
+
 export interface BillingStatus {
   tier: BillingTier;
   credits: number;
   subscriptionStatus: string | null;
   currentPeriodEnd: string | null;
   hasSubscription: boolean;
+  autoRecharge: AutoRechargeConfig;
 }
 
 // ---------------------------------------------------------------------------
@@ -123,3 +130,37 @@ export const startDowngrade$ = command(async ({ get, set }) => {
     set(internalDialogLoading$, false);
   }
 });
+
+// ---------------------------------------------------------------------------
+// Auto-recharge
+// ---------------------------------------------------------------------------
+
+export const saveAutoRecharge$ = command(
+  async (
+    { get, set },
+    config: { enabled: boolean; threshold?: number; amount?: number },
+  ) => {
+    set(internalDialogLoading$, true);
+
+    const fetchFn = get(fetch$);
+    const response = await fetchFn("/api/billing/auto-recharge", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(config),
+    });
+
+    const data = (await response.json()) as {
+      enabled?: boolean;
+      error?: string;
+    };
+
+    set(internalDialogLoading$, false);
+
+    if (!response.ok) {
+      log.error("Auto-recharge save failed", data.error);
+      return { ok: false, error: data.error };
+    }
+
+    return { ok: true };
+  },
+);

--- a/turbo/apps/platform/src/signals/zero-page/billing.ts
+++ b/turbo/apps/platform/src/signals/zero-page/billing.ts
@@ -1,7 +1,10 @@
 import { command, computed, state } from "ccstate";
 import { fetch$ } from "../fetch.ts";
 import { logger } from "../log.ts";
-import { setSelectedPlanTier$ } from "./billing-dialog-state.ts";
+import {
+  setSelectedPlanTier$,
+  syncAutoRechargeForm$,
+} from "./billing-dialog-state.ts";
 
 const log = logger("billing");
 
@@ -67,6 +70,14 @@ export const openBillingDialog$ = command(async ({ get, set }) => {
   const status = await get(billingStatusAsync$);
   const currentTier = (status?.tier as BillingTier) ?? "free";
   set(setSelectedPlanTier$, currentTier);
+  set(
+    syncAutoRechargeForm$,
+    status?.autoRecharge ?? {
+      enabled: false,
+      threshold: null,
+      amount: null,
+    },
+  );
   set(internalDialogOpen$, true);
 });
 

--- a/turbo/apps/platform/src/signals/zero-page/billing.ts
+++ b/turbo/apps/platform/src/signals/zero-page/billing.ts
@@ -32,6 +32,7 @@ export interface BillingStatus {
 
 const internalDialogOpen$ = state(false);
 const internalDialogLoading$ = state(false);
+const billingReload$ = state(0);
 
 // ---------------------------------------------------------------------------
 // Selectors
@@ -47,6 +48,7 @@ export const billingDialogLoading$ = computed((get) =>
  * Use with useLastLoadable() in views for automatic loading.
  */
 export const billingStatusAsync$ = computed(async (get) => {
+  get(billingReload$);
   const fetchFn = await get(fetch$);
   const response = await fetchFn("/api/billing/status");
   if (!response.ok) {
@@ -160,6 +162,9 @@ export const saveAutoRecharge$ = command(
       log.error("Auto-recharge save failed", data.error);
       return { ok: false, error: data.error };
     }
+
+    // Invalidate billing status cache so the dialog shows fresh data on re-open
+    set(billingReload$, (x) => x + 1);
 
     return { ok: true };
   },

--- a/turbo/apps/platform/src/views/zero-page/__tests__/billing-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/billing-dialog.test.tsx
@@ -237,3 +237,110 @@ describe("billing in sidebar", () => {
     ).resolves.toBeInTheDocument();
   });
 });
+
+describe("auto-recharge in billing dialog", () => {
+  async function openBillingDialog(tier: "free" | "pro" | "max") {
+    await setupPage({
+      context,
+      path: "/works",
+      featureSwitches: { [FeatureSwitchKey.Pricing]: true },
+    });
+
+    const billingButton = await screen.findByText(tier, {}, { timeout: 3000 });
+    await act(() => {
+      fireEvent.click(billingButton);
+    });
+
+    await screen.findByText("Choose your plan");
+  }
+
+  it("should not show auto-recharge section for free tier", async () => {
+    setMockBillingStatus({
+      tier: "free",
+      credits: 2000,
+      autoRecharge: { enabled: false, threshold: null, amount: null },
+    });
+
+    await openBillingDialog("free");
+
+    expect(screen.queryByText("Auto-recharge")).not.toBeInTheDocument();
+  });
+
+  it("should show auto-recharge section for pro tier", async () => {
+    setMockBillingStatus({
+      tier: "pro",
+      credits: 20_000,
+      subscriptionStatus: "active",
+      hasSubscription: true,
+      autoRecharge: { enabled: false, threshold: null, amount: null },
+    });
+
+    await openBillingDialog("pro");
+
+    expect(screen.getByText("Auto-recharge")).toBeInTheDocument();
+  });
+
+  it("should show auto-recharge section for max tier", async () => {
+    setMockBillingStatus({
+      tier: "max",
+      credits: 80_000,
+      subscriptionStatus: "active",
+      hasSubscription: true,
+      autoRecharge: { enabled: false, threshold: null, amount: null },
+    });
+
+    await openBillingDialog("max");
+
+    expect(screen.getByText("Auto-recharge")).toBeInTheDocument();
+  });
+
+  it("should show threshold and amount inputs when auto-recharge is toggled on", async () => {
+    setMockBillingStatus({
+      tier: "pro",
+      credits: 20_000,
+      subscriptionStatus: "active",
+      hasSubscription: true,
+      autoRecharge: { enabled: false, threshold: null, amount: null },
+    });
+
+    await openBillingDialog("pro");
+
+    // Toggle auto-recharge on
+    const toggle = screen.getByRole("switch");
+    await act(() => {
+      fireEvent.click(toggle);
+    });
+
+    expect(screen.getByText("When credits drop below")).toBeInTheDocument();
+    expect(screen.getByText("Recharge amount")).toBeInTheDocument();
+  });
+
+  it("should display dollar amount preview for recharge input", async () => {
+    setMockBillingStatus({
+      tier: "pro",
+      credits: 20_000,
+      subscriptionStatus: "active",
+      hasSubscription: true,
+      autoRecharge: { enabled: true, threshold: 1000, amount: 10000 },
+    });
+
+    await openBillingDialog("pro");
+
+    // $10.00 for 10,000 credits ($1 = 1,000 credits)
+    expect(screen.getByText("= $10.00")).toBeInTheDocument();
+  });
+
+  it("should show Save button that calls the auto-recharge API", async () => {
+    setMockBillingStatus({
+      tier: "pro",
+      credits: 20_000,
+      subscriptionStatus: "active",
+      hasSubscription: true,
+      autoRecharge: { enabled: false, threshold: null, amount: null },
+    });
+
+    await openBillingDialog("pro");
+
+    expect(screen.getByText("Save")).toBeInTheDocument();
+  });
+});

--- a/turbo/apps/platform/src/views/zero-page/__tests__/billing-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/billing-dialog.test.tsx
@@ -1,5 +1,7 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { screen, fireEvent, act } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers";
 import { setupPage } from "../../../__tests__/page-helper";
 import { setMockBillingStatus } from "../../../mocks/handlers/api-billing";
@@ -330,7 +332,19 @@ describe("auto-recharge in billing dialog", () => {
     expect(screen.getByText("= $10.00")).toBeInTheDocument();
   });
 
-  it("should show Save button that calls the auto-recharge API", async () => {
+  it("should send correct PUT body when enabling auto-recharge via Save", async () => {
+    const requestBody = vi.fn();
+    server.use(
+      http.put("*/api/billing/auto-recharge", async ({ request }) => {
+        requestBody(await request.json());
+        return HttpResponse.json({
+          enabled: true,
+          threshold: 2000,
+          amount: 5000,
+        });
+      }),
+    );
+
     setMockBillingStatus({
       tier: "pro",
       credits: 20_000,
@@ -341,6 +355,71 @@ describe("auto-recharge in billing dialog", () => {
 
     await openBillingDialog("pro");
 
-    expect(screen.getByText("Save")).toBeInTheDocument();
+    // Toggle on
+    const toggle = screen.getByRole("switch");
+    await act(() => {
+      fireEvent.click(toggle);
+    });
+
+    // Fill in threshold and amount
+    const inputs = screen.getAllByRole("spinbutton");
+    await act(() => {
+      fireEvent.change(inputs[0]!, { target: { value: "2000" } });
+      fireEvent.change(inputs[1]!, { target: { value: "5000" } });
+    });
+
+    // Click Save
+    await act(() => {
+      fireEvent.click(screen.getByText("Save"));
+    });
+
+    // Verify PUT request was sent with correct body
+    await vi.waitFor(() => {
+      expect(requestBody).toHaveBeenCalledWith({
+        enabled: true,
+        threshold: 2000,
+        amount: 5000,
+      });
+    });
+  });
+
+  it("should send enabled:false when disabling auto-recharge via Save", async () => {
+    const requestBody = vi.fn();
+    server.use(
+      http.put("*/api/billing/auto-recharge", async ({ request }) => {
+        requestBody(await request.json());
+        return HttpResponse.json({
+          enabled: false,
+          threshold: null,
+          amount: null,
+        });
+      }),
+    );
+
+    setMockBillingStatus({
+      tier: "pro",
+      credits: 20_000,
+      subscriptionStatus: "active",
+      hasSubscription: true,
+      autoRecharge: { enabled: true, threshold: 1000, amount: 5000 },
+    });
+
+    await openBillingDialog("pro");
+
+    // Toggle off
+    const toggle = screen.getByRole("switch");
+    expect(toggle).toHaveAttribute("aria-checked", "true");
+    await act(() => {
+      fireEvent.click(toggle);
+    });
+
+    // Click Save
+    await act(() => {
+      fireEvent.click(screen.getByText("Save"));
+    });
+
+    await vi.waitFor(() => {
+      expect(requestBody).toHaveBeenCalledWith({ enabled: false });
+    });
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/billing-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/billing-dialog.test.tsx
@@ -323,7 +323,7 @@ describe("auto-recharge in billing dialog", () => {
       credits: 20_000,
       subscriptionStatus: "active",
       hasSubscription: true,
-      autoRecharge: { enabled: true, threshold: 1000, amount: 10000 },
+      autoRecharge: { enabled: true, threshold: 1000, amount: 10_000 },
     });
 
     await openBillingDialog("pro");

--- a/turbo/apps/platform/src/views/zero-page/billing-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/billing-dialog.tsx
@@ -1,4 +1,3 @@
-import { useState, useEffect } from "react";
 import { useGet, useSet, useLastLoadable } from "ccstate-react";
 import { detach, Reason } from "../../signals/utils.ts";
 import {
@@ -23,6 +22,12 @@ import {
 import {
   selectedPlanTier$,
   setSelectedPlanTier$,
+  autoRechargeEnabled$,
+  autoRechargeThreshold$,
+  autoRechargeAmount$,
+  setAutoRechargeEnabled$,
+  setAutoRechargeThreshold$,
+  setAutoRechargeAmount$,
 } from "../../signals/zero-page/billing-dialog-state.ts";
 
 const PLANS = [
@@ -111,32 +116,22 @@ const CREDITS_PER_DOLLAR = 1000;
 
 function AutoRechargeSection({
   currentTier,
-  autoRecharge,
   loading,
 }: {
   currentTier: BillingTier;
-  autoRecharge: {
-    enabled: boolean;
-    threshold: number | null;
-    amount: number | null;
-  };
   loading: boolean;
 }) {
   const save = useSet(saveAutoRecharge$);
-  const [enabled, setEnabled] = useState(autoRecharge.enabled);
-  const [threshold, setThreshold] = useState(
-    autoRecharge.threshold?.toString() ?? "",
-  );
-  const [amount, setAmount] = useState(autoRecharge.amount?.toString() ?? "");
+  const enabled = useGet(autoRechargeEnabled$);
+  const threshold = useGet(autoRechargeThreshold$);
+  const amount = useGet(autoRechargeAmount$);
+  const setEnabled = useSet(setAutoRechargeEnabled$);
+  const setThreshold = useSet(setAutoRechargeThreshold$);
+  const setAmount = useSet(setAutoRechargeAmount$);
 
-  // Sync local state when dialog data changes
-  useEffect(() => {
-    setEnabled(autoRecharge.enabled);
-    setThreshold(autoRecharge.threshold?.toString() ?? "");
-    setAmount(autoRecharge.amount?.toString() ?? "");
-  }, [autoRecharge.enabled, autoRecharge.threshold, autoRecharge.amount]);
-
-  if (currentTier === "free") return null;
+  if (currentTier === "free") {
+    return null;
+  }
 
   const amountNum = Number(amount);
   const dollarAmount =
@@ -299,17 +294,7 @@ export function BillingDialog() {
         )}
 
         {status && (
-          <AutoRechargeSection
-            currentTier={currentTier}
-            autoRecharge={
-              status.autoRecharge ?? {
-                enabled: false,
-                threshold: null,
-                amount: null,
-              }
-            }
-            loading={loading}
-          />
+          <AutoRechargeSection currentTier={currentTier} loading={loading} />
         )}
       </DialogContent>
     </Dialog>

--- a/turbo/apps/platform/src/views/zero-page/billing-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/billing-dialog.tsx
@@ -1,3 +1,4 @@
+import { useState, useEffect } from "react";
 import { useGet, useSet, useLastLoadable } from "ccstate-react";
 import { detach, Reason } from "../../signals/utils.ts";
 import {
@@ -17,6 +18,7 @@ import {
   closeBillingDialog$,
   startCheckout$,
   startDowngrade$,
+  saveAutoRecharge$,
 } from "../../signals/zero-page/billing.ts";
 import {
   selectedPlanTier$,
@@ -105,6 +107,130 @@ function PlanCard({
   );
 }
 
+const CREDITS_PER_DOLLAR = 1000;
+
+function AutoRechargeSection({
+  currentTier,
+  autoRecharge,
+  loading,
+}: {
+  currentTier: BillingTier;
+  autoRecharge: {
+    enabled: boolean;
+    threshold: number | null;
+    amount: number | null;
+  };
+  loading: boolean;
+}) {
+  const save = useSet(saveAutoRecharge$);
+  const [enabled, setEnabled] = useState(autoRecharge.enabled);
+  const [threshold, setThreshold] = useState(
+    autoRecharge.threshold?.toString() ?? "",
+  );
+  const [amount, setAmount] = useState(autoRecharge.amount?.toString() ?? "");
+
+  // Sync local state when dialog data changes
+  useEffect(() => {
+    setEnabled(autoRecharge.enabled);
+    setThreshold(autoRecharge.threshold?.toString() ?? "");
+    setAmount(autoRecharge.amount?.toString() ?? "");
+  }, [autoRecharge.enabled, autoRecharge.threshold, autoRecharge.amount]);
+
+  if (currentTier === "free") return null;
+
+  const amountNum = Number(amount);
+  const dollarAmount =
+    amountNum > 0 ? (amountNum / CREDITS_PER_DOLLAR).toFixed(2) : "0.00";
+
+  const canSave =
+    !loading &&
+    (!enabled || (Number(threshold) > 0 && amountNum >= CREDITS_PER_DOLLAR));
+
+  const handleSave = () => {
+    detach(
+      save({
+        enabled,
+        ...(enabled ? { threshold: Number(threshold), amount: amountNum } : {}),
+      }),
+      Reason.DomCallback,
+    );
+  };
+
+  return (
+    <div className="border-t border-border pt-4 mt-4">
+      <div className="flex items-center justify-between mb-3">
+        <span className="text-sm font-semibold text-foreground">
+          Auto-recharge
+        </span>
+        <button
+          type="button"
+          role="switch"
+          aria-checked={enabled}
+          onClick={() => setEnabled(!enabled)}
+          className={`relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors ${
+            enabled ? "bg-primary" : "bg-muted"
+          }`}
+        >
+          <span
+            className={`pointer-events-none inline-block h-4 w-4 rounded-full bg-background shadow-sm transition-transform ${
+              enabled ? "translate-x-4" : "translate-x-0"
+            }`}
+          />
+        </button>
+      </div>
+
+      {enabled && (
+        <div className="flex flex-col gap-3">
+          <label className="flex flex-col gap-1">
+            <span className="text-xs text-muted-foreground">
+              When credits drop below
+            </span>
+            <input
+              type="number"
+              min={1}
+              value={threshold}
+              onChange={(e) => setThreshold(e.target.value)}
+              placeholder="e.g. 1000"
+              className="rounded-md border border-border bg-background px-3 py-1.5 text-sm text-foreground"
+            />
+          </label>
+
+          <label className="flex flex-col gap-1">
+            <span className="text-xs text-muted-foreground">
+              Recharge amount
+            </span>
+            <div className="flex items-center gap-2">
+              <input
+                type="number"
+                min={CREDITS_PER_DOLLAR}
+                step={CREDITS_PER_DOLLAR}
+                value={amount}
+                onChange={(e) => setAmount(e.target.value)}
+                placeholder="e.g. 10000"
+                className="rounded-md border border-border bg-background px-3 py-1.5 text-sm text-foreground flex-1"
+              />
+              <span className="text-xs text-muted-foreground whitespace-nowrap">
+                = ${dollarAmount}
+              </span>
+            </div>
+          </label>
+        </div>
+      )}
+
+      <div className="flex justify-end mt-3">
+        <Button
+          size="sm"
+          variant="outline"
+          disabled={!canSave}
+          onClick={handleSave}
+        >
+          {loading ? "Saving..." : "Save"}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
 export function BillingDialog() {
   const open = useGet(billingDialogOpen$);
   const loading = useGet(billingDialogLoading$);
@@ -170,6 +296,20 @@ export function BillingDialog() {
                   : "Manage subscription"}
             </Button>
           </div>
+        )}
+
+        {status && (
+          <AutoRechargeSection
+            currentTier={currentTier}
+            autoRecharge={
+              status.autoRecharge ?? {
+                enabled: false,
+                threshold: null,
+                amount: null,
+              }
+            }
+            loading={loading}
+          />
         )}
       </DialogContent>
     </Dialog>

--- a/turbo/apps/web/app/api/billing/auto-recharge/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/billing/auto-recharge/__tests__/route.test.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  createTestRequest,
+  updateOrgTier,
+  updateOrgAutoRecharge,
+  getOrgAutoRechargeFields,
+} from "../../../../../src/__tests__/api-test-helpers";
+import {
+  testContext,
+  type UserContext,
+} from "../../../../../src/__tests__/test-helpers";
+import { mockClerk } from "../../../../../src/__tests__/clerk-mock";
+import { reloadEnv } from "../../../../../src/env";
+
+// Stripe mock (needed because billing-service imports it)
+vi.mock("stripe", () => ({
+  default: function MockStripe() {
+    return {
+      invoices: {
+        create: vi.fn(),
+        finalizeInvoice: vi.fn(),
+        pay: vi.fn(),
+      },
+      invoiceItems: { create: vi.fn() },
+      subscriptions: { retrieve: vi.fn() },
+      customers: { create: vi.fn() },
+      checkout: { sessions: { create: vi.fn() } },
+      billingPortal: { sessions: { create: vi.fn() } },
+      webhooks: { constructEvent: vi.fn() },
+    };
+  },
+}));
+
+import { GET, PUT } from "../route";
+
+const context = testContext();
+
+const BASE_URL = "http://localhost:3000/api/billing/auto-recharge";
+
+describe("/api/billing/auto-recharge", () => {
+  let user: UserContext;
+
+  beforeEach(async () => {
+    context.setupMocks();
+    user = await context.setupUser();
+
+    vi.stubEnv("STRIPE_SECRET_KEY", "sk_test_fake");
+    reloadEnv();
+  });
+
+  describe("GET", () => {
+    it("returns default config for new org", async () => {
+      const request = createTestRequest(BASE_URL);
+      const response = await GET(request);
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data).toEqual({
+        enabled: false,
+        threshold: null,
+        amount: null,
+      });
+    });
+
+    it("returns configured auto-recharge settings", async () => {
+      await updateOrgAutoRecharge(user.orgId, {
+        autoRechargeEnabled: true,
+        autoRechargeThreshold: 2000,
+        autoRechargeAmount: 10000,
+      });
+
+      const request = createTestRequest(BASE_URL);
+      const response = await GET(request);
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data).toEqual({
+        enabled: true,
+        threshold: 2000,
+        amount: 10000,
+      });
+    });
+  });
+
+  describe("PUT", () => {
+    it("enables auto-recharge for pro tier org", async () => {
+      await updateOrgTier(user.orgId, "pro");
+
+      const request = createTestRequest(BASE_URL, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          enabled: true,
+          threshold: 1000,
+          amount: 5000,
+        }),
+      });
+
+      const response = await PUT(request);
+      expect(response.status).toBe(200);
+
+      const data = await response.json();
+      expect(data).toEqual({
+        enabled: true,
+        threshold: 1000,
+        amount: 5000,
+      });
+
+      const fields = await getOrgAutoRechargeFields(user.orgId);
+      expect(fields?.autoRechargeEnabled).toBe(true);
+      expect(fields?.autoRechargeThreshold).toBe(1000);
+      expect(fields?.autoRechargeAmount).toBe(5000);
+    });
+
+    it("disables auto-recharge and clears pending state", async () => {
+      await updateOrgTier(user.orgId, "pro");
+      await updateOrgAutoRecharge(user.orgId, {
+        autoRechargeEnabled: true,
+        autoRechargeThreshold: 1000,
+        autoRechargeAmount: 5000,
+        autoRechargePendingAt: new Date(),
+      });
+
+      const request = createTestRequest(BASE_URL, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ enabled: false }),
+      });
+
+      const response = await PUT(request);
+      expect(response.status).toBe(200);
+
+      const fields = await getOrgAutoRechargeFields(user.orgId);
+      expect(fields?.autoRechargeEnabled).toBe(false);
+      expect(fields?.autoRechargePendingAt).toBeNull();
+    });
+
+    it("returns 400 when enabling on free tier", async () => {
+      // Org is free by default
+
+      const request = createTestRequest(BASE_URL, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          enabled: true,
+          threshold: 1000,
+          amount: 5000,
+        }),
+      });
+
+      const response = await PUT(request);
+      expect(response.status).toBe(400);
+
+      const data = await response.json();
+      expect(data.error).toContain("paid plans");
+    });
+
+    it("returns 400 when enabling without threshold and amount", async () => {
+      await updateOrgTier(user.orgId, "pro");
+
+      const request = createTestRequest(BASE_URL, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ enabled: true }),
+      });
+
+      const response = await PUT(request);
+      expect(response.status).toBe(400);
+
+      const data = await response.json();
+      expect(data.error).toContain("required");
+    });
+
+    it("returns 400 when amount is below minimum", async () => {
+      await updateOrgTier(user.orgId, "pro");
+
+      const request = createTestRequest(BASE_URL, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          enabled: true,
+          threshold: 1000,
+          amount: 500, // below CREDITS_PER_DOLLAR (1000)
+        }),
+      });
+
+      const response = await PUT(request);
+      expect(response.status).toBe(400);
+    });
+
+    it("returns 403 for non-admin member", async () => {
+      // Re-mock clerk with member role
+      mockClerk({
+        userId: user.userId,
+        orgId: user.orgId,
+        orgRole: "org:member",
+      });
+
+      await updateOrgTier(user.orgId, "pro");
+
+      const request = createTestRequest(BASE_URL, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          enabled: true,
+          threshold: 1000,
+          amount: 5000,
+        }),
+      });
+
+      const response = await PUT(request);
+      expect(response.status).toBe(403);
+
+      const data = await response.json();
+      expect(data.error).toContain("admin");
+    });
+  });
+});

--- a/turbo/apps/web/app/api/billing/auto-recharge/route.ts
+++ b/turbo/apps/web/app/api/billing/auto-recharge/route.ts
@@ -1,0 +1,133 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { eq } from "drizzle-orm";
+import { initServices } from "../../../../src/lib/init-services";
+import {
+  requireAuth,
+  isAuthError,
+} from "../../../../src/lib/auth/require-auth";
+import { resolveOrg } from "../../../../src/lib/org/resolve-org";
+import { orgMetadata } from "../../../../src/db/schema/org-metadata";
+import { CREDITS_PER_DOLLAR } from "../../../../src/lib/billing/auto-recharge-service";
+
+const updateBodySchema = z.object({
+  enabled: z.boolean(),
+  threshold: z.number().int().positive().optional(),
+  amount: z.number().int().min(CREDITS_PER_DOLLAR).optional(),
+});
+
+/**
+ * GET /api/billing/auto-recharge?org={slug}
+ *
+ * Get auto-recharge configuration for the current org.
+ * Any org member can read.
+ */
+export async function GET(request: Request) {
+  initServices();
+
+  const authResult = await requireAuth(
+    request.headers.get("authorization") ?? undefined,
+  );
+  if (isAuthError(authResult)) {
+    return NextResponse.json(authResult.body, { status: authResult.status });
+  }
+
+  const orgSlug = new URL(request.url).searchParams.get("org");
+  const { org } = await resolveOrg(authResult, orgSlug);
+
+  const db = globalThis.services.db;
+  const [row] = await db
+    .select({
+      autoRechargeEnabled: orgMetadata.autoRechargeEnabled,
+      autoRechargeThreshold: orgMetadata.autoRechargeThreshold,
+      autoRechargeAmount: orgMetadata.autoRechargeAmount,
+    })
+    .from(orgMetadata)
+    .where(eq(orgMetadata.orgId, org.orgId))
+    .limit(1);
+
+  return NextResponse.json({
+    enabled: row?.autoRechargeEnabled ?? false,
+    threshold: row?.autoRechargeThreshold ?? null,
+    amount: row?.autoRechargeAmount ?? null,
+  });
+}
+
+/**
+ * PUT /api/billing/auto-recharge?org={slug}
+ *
+ * Update auto-recharge configuration.
+ * Only org admins can update.
+ */
+export async function PUT(request: Request) {
+  initServices();
+
+  const authResult = await requireAuth(
+    request.headers.get("authorization") ?? undefined,
+  );
+  if (isAuthError(authResult)) {
+    return NextResponse.json(authResult.body, { status: authResult.status });
+  }
+
+  const orgSlug = new URL(request.url).searchParams.get("org");
+  const { org, member } = await resolveOrg(authResult, orgSlug);
+
+  // Only admins can update auto-recharge settings
+  if (member.role !== "admin") {
+    return NextResponse.json(
+      { error: "Only org admins can update auto-recharge settings" },
+      { status: 403 },
+    );
+  }
+
+  const parsed = updateBodySchema.safeParse(await request.json());
+  if (!parsed.success) {
+    return NextResponse.json(
+      {
+        error: `Invalid body — ${parsed.error.issues.map((i) => i.message).join(", ")}`,
+      },
+      { status: 400 },
+    );
+  }
+
+  const { enabled, threshold, amount } = parsed.data;
+
+  // When enabling, threshold and amount are required, and org must be on a paid tier
+  if (enabled) {
+    if (org.tier === "free") {
+      return NextResponse.json(
+        { error: "Auto-recharge is only available for paid plans (Pro/Max)" },
+        { status: 400 },
+      );
+    }
+
+    if (threshold === undefined || amount === undefined) {
+      return NextResponse.json(
+        {
+          error:
+            "threshold and amount are required when enabling auto-recharge",
+        },
+        { status: 400 },
+      );
+    }
+  }
+
+  const db = globalThis.services.db;
+  await db
+    .update(orgMetadata)
+    .set({
+      autoRechargeEnabled: enabled,
+      autoRechargeThreshold: enabled ? threshold : null,
+      autoRechargeAmount: enabled ? amount : null,
+      // Clear pending state when disabling
+      ...(!enabled ? { autoRechargePendingAt: null } : {}),
+      updatedAt: new Date(),
+    })
+    .where(eq(orgMetadata.orgId, org.orgId));
+
+  return NextResponse.json({
+    enabled,
+    threshold: enabled ? threshold : null,
+    amount: enabled ? amount : null,
+  });
+}

--- a/turbo/apps/web/app/api/webhooks/stripe/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/stripe/__tests__/route.test.ts
@@ -9,6 +9,8 @@ import {
   updateOrgStripeFields,
   getOrgBillingFields,
   grantCreditsToOrg,
+  updateOrgAutoRecharge,
+  getOrgAutoRechargeFields,
 } from "../../../../../src/__tests__/api-test-helpers";
 import type { StripeMockFns } from "../../../../../src/__tests__/stripe-mock";
 import { reloadEnv } from "../../../../../src/env";
@@ -332,6 +334,40 @@ describe("POST /api/webhooks/stripe", () => {
       });
 
       expect(response.status).toBe(200);
+    });
+
+    it("grants credits for auto-recharge invoice via metadata", async () => {
+      const cusId = uniqueId("cus-auto");
+
+      await updateOrgStripeFields(user.orgId, {
+        stripeCustomerId: cusId,
+      });
+      await updateOrgAutoRecharge(user.orgId, {
+        autoRechargePendingAt: new Date(),
+      });
+
+      const creditsBefore = await getOrgCredits(user.orgId);
+
+      const response = await sendWebhookEvent("invoice.paid", {
+        id: uniqueId("inv-auto"),
+        customer: cusId,
+        metadata: {
+          type: "auto_recharge",
+          orgId: user.orgId,
+          creditsAmount: "5000",
+        },
+        parent: null,
+      });
+
+      expect(response.status).toBe(200);
+
+      // Credits should be granted
+      const creditsAfter = await getOrgCredits(user.orgId);
+      expect(creditsAfter! - creditsBefore!).toBe(5000);
+
+      // Pending flag should be cleared
+      const autoRecharge = await getOrgAutoRechargeFields(user.orgId);
+      expect(autoRecharge?.autoRechargePendingAt).toBeNull();
     });
   });
 

--- a/turbo/apps/web/src/__tests__/api-test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers.ts
@@ -3771,3 +3771,42 @@ export async function getOrgBillingFields(orgId: string) {
     .limit(1);
   return row ?? null;
 }
+
+// ---------------------------------------------------------------------------
+// Auto-recharge helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Configure auto-recharge settings on an org.
+ */
+export async function updateOrgAutoRecharge(
+  orgId: string,
+  fields: {
+    autoRechargeEnabled?: boolean;
+    autoRechargeThreshold?: number | null;
+    autoRechargeAmount?: number | null;
+    autoRechargePendingAt?: Date | null;
+  },
+): Promise<void> {
+  await globalThis.services.db
+    .update(orgMetadata)
+    .set({ ...fields, updatedAt: new Date() })
+    .where(eq(orgMetadata.orgId, orgId));
+}
+
+/**
+ * Read auto-recharge fields from an org.
+ */
+export async function getOrgAutoRechargeFields(orgId: string) {
+  const [row] = await globalThis.services.db
+    .select({
+      autoRechargeEnabled: orgMetadata.autoRechargeEnabled,
+      autoRechargeThreshold: orgMetadata.autoRechargeThreshold,
+      autoRechargeAmount: orgMetadata.autoRechargeAmount,
+      autoRechargePendingAt: orgMetadata.autoRechargePendingAt,
+    })
+    .from(orgMetadata)
+    .where(eq(orgMetadata.orgId, orgId))
+    .limit(1);
+  return row ?? null;
+}

--- a/turbo/apps/web/src/db/migrations/0176_add_auto_recharge.sql
+++ b/turbo/apps/web/src/db/migrations/0176_add_auto_recharge.sql
@@ -1,4 +1,0 @@
-ALTER TABLE org_metadata ADD COLUMN auto_recharge_enabled boolean NOT NULL DEFAULT false;
-ALTER TABLE org_metadata ADD COLUMN auto_recharge_threshold bigint;
-ALTER TABLE org_metadata ADD COLUMN auto_recharge_amount bigint;
-ALTER TABLE org_metadata ADD COLUMN auto_recharge_pending_at timestamptz;

--- a/turbo/apps/web/src/db/migrations/0176_add_auto_recharge.sql
+++ b/turbo/apps/web/src/db/migrations/0176_add_auto_recharge.sql
@@ -1,0 +1,4 @@
+ALTER TABLE org_metadata ADD COLUMN auto_recharge_enabled boolean NOT NULL DEFAULT false;
+ALTER TABLE org_metadata ADD COLUMN auto_recharge_threshold bigint;
+ALTER TABLE org_metadata ADD COLUMN auto_recharge_amount bigint;
+ALTER TABLE org_metadata ADD COLUMN auto_recharge_pending_at timestamptz;

--- a/turbo/apps/web/src/db/migrations/0176_wealthy_mystique.sql
+++ b/turbo/apps/web/src/db/migrations/0176_wealthy_mystique.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "org_metadata" ADD COLUMN "auto_recharge_enabled" boolean DEFAULT false NOT NULL;--> statement-breakpoint
+ALTER TABLE "org_metadata" ADD COLUMN "auto_recharge_threshold" bigint;--> statement-breakpoint
+ALTER TABLE "org_metadata" ADD COLUMN "auto_recharge_amount" bigint;--> statement-breakpoint
+ALTER TABLE "org_metadata" ADD COLUMN "auto_recharge_pending_at" timestamp;

--- a/turbo/apps/web/src/db/migrations/meta/0176_snapshot.json
+++ b/turbo/apps/web/src/db/migrations/meta/0176_snapshot.json
@@ -1,0 +1,5928 @@
+{
+  "id": "c5b45abf-1b64-4335-8acc-74be839f2680",
+  "prevId": "38b180ae-9951-44d9-b3aa-137e892c67eb",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.agent_compose_versions": {
+      "name": "agent_compose_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "compose_id": {
+          "name": "compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_compose_versions_compose_id": {
+          "name": "idx_agent_compose_versions_compose_id",
+          "columns": [
+            {
+              "expression": "compose_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_compose_versions_compose_id_agent_composes_id_fk": {
+          "name": "agent_compose_versions_compose_id_agent_composes_id_fk",
+          "tableFrom": "agent_compose_versions",
+          "tableTo": "agent_composes",
+          "columnsFrom": ["compose_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_composes": {
+      "name": "agent_composes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "head_version_id": {
+          "name": "head_version_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_composes_org": {
+          "name": "idx_agent_composes_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_composes_org_name": {
+          "name": "idx_agent_composes_org_name",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_run_callbacks": {
+      "name": "agent_run_callbacks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_secret": {
+          "name": "encrypted_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_attempt_at": {
+          "name": "last_attempt_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_run_callbacks_run_id": {
+          "name": "idx_agent_run_callbacks_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_run_callbacks_pending": {
+          "name": "idx_agent_run_callbacks_pending",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "status = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_run_callbacks_run_id_agent_runs_id_fk": {
+          "name": "agent_run_callbacks_run_id_agent_runs_id_fk",
+          "tableFrom": "agent_run_callbacks",
+          "tableTo": "agent_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_run_events": {
+      "name": "agent_run_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence_number": {
+          "name": "sequence_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_data": {
+          "name": "event_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_run_events_run_id_agent_runs_id_fk": {
+          "name": "agent_run_events_run_id_agent_runs_id_fk",
+          "tableFrom": "agent_run_events",
+          "tableTo": "agent_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_run_queue": {
+      "name": "agent_run_queue",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_params": {
+          "name": "encrypted_params",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "agent_run_queue_user_created_idx": {
+          "name": "agent_run_queue_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_run_queue_org_created_idx": {
+          "name": "agent_run_queue_org_created_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_run_queue_expires_at_idx": {
+          "name": "agent_run_queue_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_run_queue_run_id_agent_runs_id_fk": {
+          "name": "agent_run_queue_run_id_agent_runs_id_fk",
+          "tableFrom": "agent_run_queue",
+          "tableTo": "agent_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_runs": {
+      "name": "agent_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_compose_version_id": {
+          "name": "agent_compose_version_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resumed_from_checkpoint_id": {
+          "name": "resumed_from_checkpoint_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "continued_from_session_id": {
+          "name": "continued_from_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "append_system_prompt": {
+          "name": "append_system_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vars": {
+          "name": "vars",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "secret_names": {
+          "name": "secret_names",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_provider": {
+          "name": "model_provider",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected_model": {
+          "name": "selected_model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_source": {
+          "name": "trigger_source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_heartbeat_at": {
+          "name": "last_heartbeat_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_agent_runs_user_created": {
+          "name": "idx_agent_runs_user_created",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_runs_org": {
+          "name": "idx_agent_runs_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_runs_status_heartbeat": {
+          "name": "idx_agent_runs_status_heartbeat",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_heartbeat_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_runs_running_heartbeat": {
+          "name": "idx_agent_runs_running_heartbeat",
+          "columns": [
+            {
+              "expression": "last_heartbeat_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "status = 'running'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_runs_schedule_created": {
+          "name": "idx_agent_runs_schedule_created",
+          "columns": [
+            {
+              "expression": "schedule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "schedule_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_runs_agent_compose_version_id_agent_compose_versions_id_fk": {
+          "name": "agent_runs_agent_compose_version_id_agent_compose_versions_id_fk",
+          "tableFrom": "agent_runs",
+          "tableTo": "agent_compose_versions",
+          "columnsFrom": ["agent_compose_version_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "agent_runs_schedule_id_agent_schedules_id_fk": {
+          "name": "agent_runs_schedule_id_agent_schedules_id_fk",
+          "tableFrom": "agent_runs",
+          "tableTo": "agent_schedules",
+          "columnsFrom": ["schedule_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_schedules": {
+      "name": "agent_schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "compose_id": {
+          "name": "compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_type": {
+          "name": "trigger_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'cron'"
+        },
+        "cron_expression": {
+          "name": "cron_expression",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "at_time": {
+          "name": "at_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "interval_seconds": {
+          "name": "interval_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "append_system_prompt": {
+          "name": "append_system_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vars": {
+          "name": "vars",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_secrets": {
+          "name": "encrypted_secrets",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artifact_name": {
+          "name": "artifact_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artifact_version": {
+          "name": "artifact_version",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "volume_versions": {
+          "name": "volume_versions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notify_email": {
+          "name": "notify_email",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "notify_slack": {
+          "name": "notify_slack",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_run_id": {
+          "name": "last_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retry_started_at": {
+          "name": "retry_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consecutive_failures": {
+          "name": "consecutive_failures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_schedules_compose": {
+          "name": "idx_agent_schedules_compose",
+          "columns": [
+            {
+              "expression": "compose_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_schedules_org": {
+          "name": "idx_agent_schedules_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_schedules_compose_name_org_user": {
+          "name": "idx_agent_schedules_compose_name_org_user",
+          "columns": [
+            {
+              "expression": "compose_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_schedules_next_run": {
+          "name": "idx_agent_schedules_next_run",
+          "columns": [
+            {
+              "expression": "next_run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "enabled = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_schedules_compose_id_agent_composes_id_fk": {
+          "name": "agent_schedules_compose_id_agent_composes_id_fk",
+          "tableFrom": "agent_schedules",
+          "tableTo": "agent_composes",
+          "columnsFrom": ["compose_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_schedules_last_run_id_agent_runs_id_fk": {
+          "name": "agent_schedules_last_run_id_agent_runs_id_fk",
+          "tableFrom": "agent_schedules",
+          "tableTo": "agent_runs",
+          "columnsFrom": ["last_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_sessions": {
+      "name": "agent_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_compose_id": {
+          "name": "agent_compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artifact_name": {
+          "name": "artifact_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_name": {
+          "name": "memory_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chat_messages": {
+          "name": "chat_messages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_sessions_user_compose_artifact": {
+          "name": "idx_agent_sessions_user_compose_artifact",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_compose_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "artifact_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_sessions_org": {
+          "name": "idx_agent_sessions_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_sessions_agent_compose_id_agent_composes_id_fk": {
+          "name": "agent_sessions_agent_compose_id_agent_composes_id_fk",
+          "tableFrom": "agent_sessions",
+          "tableTo": "agent_composes",
+          "columnsFrom": ["agent_compose_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_sessions_conversation_id_conversations_id_fk": {
+          "name": "agent_sessions_conversation_id_conversations_id_fk",
+          "tableFrom": "agent_sessions",
+          "tableTo": "conversations",
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blobs": {
+      "name": "blobs",
+      "schema": "",
+      "columns": {
+        "hash": {
+          "name": "hash",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref_count": {
+          "name": "ref_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_blobs_ref_count": {
+          "name": "idx_blobs_ref_count",
+          "columns": [
+            {
+              "expression": "ref_count",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_thread_runs": {
+      "name": "chat_thread_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chat_thread_id": {
+          "name": "chat_thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_chat_thread_runs_unique": {
+          "name": "idx_chat_thread_runs_unique",
+          "columns": [
+            {
+              "expression": "chat_thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_chat_thread_runs_thread": {
+          "name": "idx_chat_thread_runs_thread",
+          "columns": [
+            {
+              "expression": "chat_thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_thread_runs_chat_thread_id_chat_threads_id_fk": {
+          "name": "chat_thread_runs_chat_thread_id_chat_threads_id_fk",
+          "tableFrom": "chat_thread_runs",
+          "tableTo": "chat_threads",
+          "columnsFrom": ["chat_thread_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "chat_thread_runs_run_id_agent_runs_id_fk": {
+          "name": "chat_thread_runs_run_id_agent_runs_id_fk",
+          "tableFrom": "chat_thread_runs",
+          "tableTo": "agent_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_threads": {
+      "name": "chat_threads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_compose_id": {
+          "name": "agent_compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_chat_threads_user_compose_updated": {
+          "name": "idx_chat_threads_user_compose_updated",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_compose_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_threads_agent_compose_id_agent_composes_id_fk": {
+          "name": "chat_threads_agent_compose_id_agent_composes_id_fk",
+          "tableFrom": "chat_threads",
+          "tableTo": "agent_composes",
+          "columnsFrom": ["agent_compose_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.checkpoints": {
+      "name": "checkpoints",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_compose_snapshot": {
+          "name": "agent_compose_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_snapshot": {
+          "name": "artifact_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_snapshot": {
+          "name": "memory_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "volume_versions_snapshot": {
+          "name": "volume_versions_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "checkpoints_run_id_agent_runs_id_fk": {
+          "name": "checkpoints_run_id_agent_runs_id_fk",
+          "tableFrom": "checkpoints",
+          "tableTo": "agent_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "checkpoints_conversation_id_conversations_id_fk": {
+          "name": "checkpoints_conversation_id_conversations_id_fk",
+          "tableFrom": "checkpoints",
+          "tableTo": "conversations",
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "checkpoints_run_id_unique": {
+          "name": "checkpoints_run_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["run_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cli_tokens": {
+      "name": "cli_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cli_tokens_token_unique": {
+          "name": "cli_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.compose_jobs": {
+      "name": "compose_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_url": {
+          "name": "github_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "overwrite": {
+          "name": "overwrite",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'github'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_compose_jobs_user_status": {
+          "name": "idx_compose_jobs_user_status",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_compose_jobs_created": {
+          "name": "idx_compose_jobs_created",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_compose_jobs_user_active": {
+          "name": "idx_compose_jobs_user_active",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status IN ('pending', 'running')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.connector_sessions": {
+      "name": "connector_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(9)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "connector_session_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_connector_sessions_code": {
+          "name": "idx_connector_sessions_code",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_connector_sessions_user_status": {
+          "name": "idx_connector_sessions_user_status",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.connectors": {
+      "name": "connectors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_method": {
+          "name": "auth_method",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_username": {
+          "name": "external_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_email": {
+          "name": "external_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_scopes": {
+          "name": "oauth_scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "needs_reconnect": {
+          "name": "needs_reconnect",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_connectors_org": {
+          "name": "idx_connectors_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_connectors_org_user_type": {
+          "name": "idx_connectors_org_user_type",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversations": {
+      "name": "conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cli_agent_type": {
+          "name": "cli_agent_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cli_agent_session_id": {
+          "name": "cli_agent_session_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cli_agent_session_history": {
+          "name": "cli_agent_session_history",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cli_agent_session_history_hash": {
+          "name": "cli_agent_session_history_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "conversations_run_id_agent_runs_id_fk": {
+          "name": "conversations_run_id_agent_runs_id_fk",
+          "tableFrom": "conversations",
+          "tableTo": "agent_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "conversations_run_id_unique": {
+          "name": "conversations_run_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["run_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.credit_pricing": {
+      "name": "credit_pricing",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_provider": {
+          "name": "model_provider",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "input_token_price": {
+          "name": "input_token_price",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_token_price": {
+          "name": "output_token_price",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cache_read_token_price": {
+          "name": "cache_read_token_price",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_creation_token_price": {
+          "name": "cache_creation_token_price",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_credit_pricing_model_provider": {
+          "name": "uq_credit_pricing_model_provider",
+          "columns": [
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model_provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.credit_usage": {
+      "name": "credit_usage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result_uuid": {
+          "name": "result_uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_provider": {
+          "name": "model_provider",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_read_input_tokens": {
+          "name": "cache_read_input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_creation_input_tokens": {
+          "name": "cache_creation_input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "web_search_requests": {
+          "name": "web_search_requests",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "numeric(12, 8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credits_charged": {
+          "name": "credits_charged",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "uq_credit_usage_run_result": {
+          "name": "uq_credit_usage_run_result",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "result_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_credit_usage_run_id": {
+          "name": "idx_credit_usage_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_credit_usage_org_status": {
+          "name": "idx_credit_usage_org_status",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_credit_usage_org_created": {
+          "name": "idx_credit_usage_org_created",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "credit_usage_run_id_agent_runs_id_fk": {
+          "name": "credit_usage_run_id_agent_runs_id_fk",
+          "tableFrom": "credit_usage",
+          "tableTo": "agent_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.device_codes": {
+      "name": "device_codes",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "varchar(9)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "device_code_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_slug": {
+          "name": "org_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_outbox": {
+      "name": "email_outbox",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "from_address": {
+          "name": "from_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_addresses": {
+          "name": "to_addresses",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cc_addresses": {
+          "name": "cc_addresses",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reply_to": {
+          "name": "reply_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headers": {
+          "name": "headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "template": {
+          "name": "template",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_send_action": {
+          "name": "post_send_action",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_retry_at": {
+          "name": "next_retry_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resend_id": {
+          "name": "resend_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_outbox_drain_idx": {
+          "name": "email_outbox_drain_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_retry_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_outbox_created_at_idx": {
+          "name": "email_outbox_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_reply_requests": {
+      "name": "email_reply_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_thread_session_id": {
+          "name": "email_thread_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inbound_email_id": {
+          "name": "inbound_email_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inbound_message_id": {
+          "name": "inbound_message_id",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_email_reply_requests_run": {
+          "name": "idx_email_reply_requests_run",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_reply_requests_run_id_agent_runs_id_fk": {
+          "name": "email_reply_requests_run_id_agent_runs_id_fk",
+          "tableFrom": "email_reply_requests",
+          "tableTo": "agent_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "email_reply_requests_email_thread_session_id_email_thread_sessions_id_fk": {
+          "name": "email_reply_requests_email_thread_session_id_email_thread_sessions_id_fk",
+          "tableFrom": "email_reply_requests",
+          "tableTo": "email_thread_sessions",
+          "columnsFrom": ["email_thread_session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_suppressions": {
+      "name": "email_suppressions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email_address": {
+          "name": "email_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resend_email_id": {
+          "name": "resend_email_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_suppressions_email_lower_idx": {
+          "name": "email_suppressions_email_lower_idx",
+          "columns": [
+            {
+              "expression": "lower(\"email_address\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_thread_sessions": {
+      "name": "email_thread_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "compose_id": {
+          "name": "compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_session_id": {
+          "name": "agent_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_email_message_id": {
+          "name": "last_email_message_id",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_to_token": {
+          "name": "reply_to_token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_email_thread_sessions_reply_token": {
+          "name": "idx_email_thread_sessions_reply_token",
+          "columns": [
+            {
+              "expression": "reply_to_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_email_thread_sessions_user": {
+          "name": "idx_email_thread_sessions_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_thread_sessions_compose_id_agent_composes_id_fk": {
+          "name": "email_thread_sessions_compose_id_agent_composes_id_fk",
+          "tableFrom": "email_thread_sessions",
+          "tableTo": "agent_composes",
+          "columnsFrom": ["compose_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "email_thread_sessions_agent_session_id_agent_sessions_id_fk": {
+          "name": "email_thread_sessions_agent_session_id_agent_sessions_id_fk",
+          "tableFrom": "email_thread_sessions",
+          "tableTo": "agent_sessions",
+          "columnsFrom": ["agent_session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.export_jobs": {
+      "name": "export_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artifact_urls": {
+          "name": "artifact_urls",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_export_jobs_user_status": {
+          "name": "idx_export_jobs_user_status",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_export_jobs_created": {
+          "name": "idx_export_jobs_created",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_export_jobs_user_active": {
+          "name": "idx_export_jobs_user_active",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status IN ('pending', 'running')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_installations": {
+      "name": "github_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_access_token": {
+          "name": "encrypted_access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_name": {
+          "name": "target_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "admin_github_user_id": {
+          "name": "admin_github_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_compose_id": {
+          "name": "default_compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_configs": {
+          "name": "repo_configs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "github_installations_installation_id_unique": {
+          "name": "github_installations_installation_id_unique",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "installation_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_installations_default_compose_id_agent_composes_id_fk": {
+          "name": "github_installations_default_compose_id_agent_composes_id_fk",
+          "tableFrom": "github_installations",
+          "tableTo": "agent_composes",
+          "columnsFrom": ["default_compose_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_issue_sessions": {
+      "name": "github_issue_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo": {
+          "name": "repo",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_number": {
+          "name": "issue_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_session_id": {
+          "name": "agent_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_comment_id": {
+          "name": "last_comment_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_github_issue_sessions_installation_repo_issue": {
+          "name": "idx_github_issue_sessions_installation_repo_issue",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "repo",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "issue_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_github_issue_sessions_installation": {
+          "name": "idx_github_issue_sessions_installation",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_issue_sessions_installation_id_github_installations_id_fk": {
+          "name": "github_issue_sessions_installation_id_github_installations_id_fk",
+          "tableFrom": "github_issue_sessions",
+          "tableTo": "github_installations",
+          "columnsFrom": ["installation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_issue_sessions_agent_session_id_agent_sessions_id_fk": {
+          "name": "github_issue_sessions_agent_session_id_agent_sessions_id_fk",
+          "tableFrom": "github_issue_sessions",
+          "tableTo": "agent_sessions",
+          "columnsFrom": ["agent_session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_user_links": {
+      "name": "github_user_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "github_user_id": {
+          "name": "github_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vm0_user_id": {
+          "name": "vm0_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_github_user_links_user_installation": {
+          "name": "idx_github_user_links_user_installation",
+          "columns": [
+            {
+              "expression": "github_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_user_links_installation_id_github_installations_id_fk": {
+          "name": "github_user_links_installation_id_github_installations_id_fk",
+          "tableFrom": "github_user_links",
+          "tableTo": "github_installations",
+          "columnsFrom": ["installation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_providers": {
+      "name": "model_providers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_id": {
+          "name": "secret_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_method": {
+          "name": "auth_method",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "selected_model": {
+          "name": "selected_model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_model_providers_secret": {
+          "name": "idx_model_providers_secret",
+          "columns": [
+            {
+              "expression": "secret_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_model_providers_org": {
+          "name": "idx_model_providers_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_model_providers_org_user_type": {
+          "name": "idx_model_providers_org_user_type",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "model_providers_secret_id_secrets_id_fk": {
+          "name": "model_providers_secret_id_secrets_id_fk",
+          "tableFrom": "model_providers",
+          "tableTo": "secrets",
+          "columnsFrom": ["secret_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_cache": {
+      "name": "org_cache",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cached_at": {
+          "name": "cached_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_org_cache_slug": {
+          "name": "idx_org_cache_slug",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_members_cache": {
+      "name": "org_members_cache",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "cached_at": {
+          "name": "cached_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "org_members_cache_org_id_user_id_pk": {
+          "name": "org_members_cache_org_id_user_id_pk",
+          "columns": ["org_id", "user_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_members_metadata": {
+      "name": "org_members_metadata",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notify_email": {
+          "name": "notify_email",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "notify_slack": {
+          "name": "notify_slack",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "pinned_agent_ids": {
+          "name": "pinned_agent_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "send_mode": {
+          "name": "send_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'enter'"
+        },
+        "onboarding_done": {
+          "name": "onboarding_done",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "org_members_metadata_org_id_user_id_pk": {
+          "name": "org_members_metadata_org_id_user_id_pk",
+          "columns": ["org_id", "user_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_metadata": {
+      "name": "org_metadata",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "credits": {
+          "name": "credits",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 2000
+        },
+        "tier": {
+          "name": "tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "default_agent_compose_id": {
+          "name": "default_agent_compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscription_status": {
+          "name": "subscription_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_processed_invoice_id": {
+          "name": "last_processed_invoice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_recharge_enabled": {
+          "name": "auto_recharge_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auto_recharge_threshold": {
+          "name": "auto_recharge_threshold",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_recharge_amount": {
+          "name": "auto_recharge_amount",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_recharge_pending_at": {
+          "name": "auto_recharge_pending_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_org_stripe_customer": {
+          "name": "uq_org_stripe_customer",
+          "columns": [
+            {
+              "expression": "stripe_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runner_job_queue": {
+      "name": "runner_job_queue",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "runner_group": {
+          "name": "runner_group",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile": {
+          "name": "profile",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'vm0/default'"
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_context": {
+          "name": "execution_context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "runner_job_queue_group_profile_unclaimed_idx": {
+          "name": "runner_job_queue_group_profile_unclaimed_idx",
+          "columns": [
+            {
+              "expression": "runner_group",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "profile",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "claimed_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runner_job_queue_expires_at_idx": {
+          "name": "runner_job_queue_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "runner_job_queue_run_id_agent_runs_id_fk": {
+          "name": "runner_job_queue_run_id_agent_runs_id_fk",
+          "tableFrom": "runner_job_queue",
+          "tableTo": "agent_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sandbox_telemetry": {
+      "name": "sandbox_telemetry",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_sandbox_telemetry_run_id": {
+          "name": "idx_sandbox_telemetry_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sandbox_telemetry_run_id_agent_runs_id_fk": {
+          "name": "sandbox_telemetry_run_id_agent_runs_id_fk",
+          "tableFrom": "sandbox_telemetry",
+          "tableTo": "agent_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.secrets": {
+      "name": "secrets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_value": {
+          "name": "encrypted_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_secrets_type": {
+          "name": "idx_secrets_type",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_secrets_org": {
+          "name": "idx_secrets_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_secrets_org_user_name_type": {
+          "name": "idx_secrets_org_user_name_type",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.skills": {
+      "name": "skills",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "full_path": {
+          "name": "full_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_id": {
+          "name": "storage_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_hash": {
+          "name": "version_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "frontmatter": {
+          "name": "frontmatter",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "file_count": {
+          "name": "file_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_skills_name": {
+          "name": "idx_skills_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_skills_storage_id": {
+          "name": "idx_skills_storage_id",
+          "columns": [
+            {
+              "expression": "storage_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "skills_storage_id_storages_id_fk": {
+          "name": "skills_storage_id_storages_id_fk",
+          "tableFrom": "skills",
+          "tableTo": "storages",
+          "columnsFrom": ["storage_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "skills_url_unique": {
+          "name": "skills_url_unique",
+          "nullsNotDistinct": false,
+          "columns": ["url"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_org_connections": {
+      "name": "slack_org_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slack_user_id": {
+          "name": "slack_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_workspace_id": {
+          "name": "slack_workspace_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vm0_user_id": {
+          "name": "vm0_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dm_welcome_sent": {
+          "name": "dm_welcome_sent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_slack_org_connections_user_workspace": {
+          "name": "idx_slack_org_connections_user_workspace",
+          "columns": [
+            {
+              "expression": "slack_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slack_workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_slack_org_connections_workspace": {
+          "name": "idx_slack_org_connections_workspace",
+          "columns": [
+            {
+              "expression": "slack_workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_slack_org_connections_vm0_user_workspace": {
+          "name": "idx_slack_org_connections_vm0_user_workspace",
+          "columns": [
+            {
+              "expression": "vm0_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slack_workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "slack_org_connections_slack_workspace_id_slack_org_installations_slack_workspace_id_fk": {
+          "name": "slack_org_connections_slack_workspace_id_slack_org_installations_slack_workspace_id_fk",
+          "tableFrom": "slack_org_connections",
+          "tableTo": "slack_org_installations",
+          "columnsFrom": ["slack_workspace_id"],
+          "columnsTo": ["slack_workspace_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_org_installations": {
+      "name": "slack_org_installations",
+      "schema": "",
+      "columns": {
+        "slack_workspace_id": {
+          "name": "slack_workspace_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slack_workspace_name": {
+          "name": "slack_workspace_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_bot_token": {
+          "name": "encrypted_bot_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bot_user_id": {
+          "name": "bot_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installed_by_user_id": {
+          "name": "installed_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_slack_org_installations_org": {
+          "name": "idx_slack_org_installations_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_slack_org_installations_org_unique": {
+          "name": "idx_slack_org_installations_org_unique",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "org_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_org_pending_questions": {
+      "name": "slack_org_pending_questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_workspace_id": {
+          "name": "slack_workspace_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_channel_id": {
+          "name": "slack_channel_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_thread_ts": {
+          "name": "slack_thread_ts",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_message_ts": {
+          "name": "slack_message_ts",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "compose_id": {
+          "name": "compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "questions": {
+          "name": "questions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "answered_at": {
+          "name": "answered_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_slack_org_pending_questions_run_id": {
+          "name": "idx_slack_org_pending_questions_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "slack_org_pending_questions_connection_id_slack_org_connections_id_fk": {
+          "name": "slack_org_pending_questions_connection_id_slack_org_connections_id_fk",
+          "tableFrom": "slack_org_pending_questions",
+          "tableTo": "slack_org_connections",
+          "columnsFrom": ["connection_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "slack_org_pending_questions_compose_id_agent_composes_id_fk": {
+          "name": "slack_org_pending_questions_compose_id_agent_composes_id_fk",
+          "tableFrom": "slack_org_pending_questions",
+          "tableTo": "agent_composes",
+          "columnsFrom": ["compose_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "slack_org_pending_questions_session_id_agent_sessions_id_fk": {
+          "name": "slack_org_pending_questions_session_id_agent_sessions_id_fk",
+          "tableFrom": "slack_org_pending_questions",
+          "tableTo": "agent_sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_org_thread_sessions": {
+      "name": "slack_org_thread_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_channel_id": {
+          "name": "slack_channel_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_thread_ts": {
+          "name": "slack_thread_ts",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_session_id": {
+          "name": "agent_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_processed_message_ts": {
+          "name": "last_processed_message_ts",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_slack_org_thread_sessions_conn_channel_thread": {
+          "name": "idx_slack_org_thread_sessions_conn_channel_thread",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slack_channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slack_thread_ts",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_slack_org_thread_sessions_connection": {
+          "name": "idx_slack_org_thread_sessions_connection",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "slack_org_thread_sessions_connection_id_slack_org_connections_id_fk": {
+          "name": "slack_org_thread_sessions_connection_id_slack_org_connections_id_fk",
+          "tableFrom": "slack_org_thread_sessions",
+          "tableTo": "slack_org_connections",
+          "columnsFrom": ["connection_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "slack_org_thread_sessions_agent_session_id_agent_sessions_id_fk": {
+          "name": "slack_org_thread_sessions_agent_session_id_agent_sessions_id_fk",
+          "tableFrom": "slack_org_thread_sessions",
+          "tableTo": "agent_sessions",
+          "columnsFrom": ["agent_session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.storage_version_lineage": {
+      "name": "storage_version_lineage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "storage_id": {
+          "name": "storage_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_id": {
+          "name": "version_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_version_id": {
+          "name": "parent_version_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_type": {
+          "name": "storage_type",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_storage_version_lineage_storage_version": {
+          "name": "idx_storage_version_lineage_storage_version",
+          "columns": [
+            {
+              "expression": "storage_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_storage_version_lineage_storage_parent": {
+          "name": "idx_storage_version_lineage_storage_parent",
+          "columns": [
+            {
+              "expression": "storage_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parent_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_storage_version_lineage_run": {
+          "name": "idx_storage_version_lineage_run",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "storage_version_lineage_storage_id_storages_id_fk": {
+          "name": "storage_version_lineage_storage_id_storages_id_fk",
+          "tableFrom": "storage_version_lineage",
+          "tableTo": "storages",
+          "columnsFrom": ["storage_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "storage_version_lineage_run_id_agent_runs_id_fk": {
+          "name": "storage_version_lineage_run_id_agent_runs_id_fk",
+          "tableFrom": "storage_version_lineage",
+          "tableTo": "agent_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.storage_versions": {
+      "name": "storage_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "storage_id": {
+          "name": "storage_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "file_count": {
+          "name": "file_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "storage_versions_storage_id_storages_id_fk": {
+          "name": "storage_versions_storage_id_storages_id_fk",
+          "tableFrom": "storage_versions",
+          "tableTo": "storages",
+          "columnsFrom": ["storage_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.storages": {
+      "name": "storages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'volume'"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "s3_prefix": {
+          "name": "s3_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "file_count": {
+          "name": "file_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "head_version_id": {
+          "name": "head_version_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_storages_org": {
+          "name": "idx_storages_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_storages_org_user_name_type": {
+          "name": "idx_storages_org_user_name_type",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "storages_head_version_id_storage_versions_id_fk": {
+          "name": "storages_head_version_id_storage_versions_id_fk",
+          "tableFrom": "storages",
+          "tableTo": "storage_versions",
+          "columnsFrom": ["head_version_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_installations": {
+      "name": "telegram_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "telegram_bot_id": {
+          "name": "telegram_bot_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bot_username": {
+          "name": "bot_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_bot_token": {
+          "name": "encrypted_bot_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhook_secret": {
+          "name": "webhook_secret",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_compose_id": {
+          "name": "default_compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "admin_user_id": {
+          "name": "admin_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "telegram_installations_default_compose_id_agent_composes_id_fk": {
+          "name": "telegram_installations_default_compose_id_agent_composes_id_fk",
+          "tableFrom": "telegram_installations",
+          "tableTo": "agent_composes",
+          "columnsFrom": ["default_compose_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "telegram_installations_telegram_bot_id_unique": {
+          "name": "telegram_installations_telegram_bot_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["telegram_bot_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_messages": {
+      "name": "telegram_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_user_id": {
+          "name": "from_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_username": {
+          "name": "from_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_bot": {
+          "name": "is_bot",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_telegram_messages_unique": {
+          "name": "idx_telegram_messages_unique",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_telegram_messages_chat": {
+          "name": "idx_telegram_messages_chat",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_telegram_messages_created_at": {
+          "name": "idx_telegram_messages_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "telegram_messages_installation_id_telegram_installations_id_fk": {
+          "name": "telegram_messages_installation_id_telegram_installations_id_fk",
+          "tableFrom": "telegram_messages",
+          "tableTo": "telegram_installations",
+          "columnsFrom": ["installation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_thread_sessions": {
+      "name": "telegram_thread_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "telegram_user_link_id": {
+          "name": "telegram_user_link_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "root_message_id": {
+          "name": "root_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_session_id": {
+          "name": "agent_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_processed_message_id": {
+          "name": "last_processed_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_telegram_thread_sessions_chat_user_link": {
+          "name": "idx_telegram_thread_sessions_chat_user_link",
+          "columns": [
+            {
+              "expression": "telegram_user_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "root_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_telegram_thread_sessions_user_link": {
+          "name": "idx_telegram_thread_sessions_user_link",
+          "columns": [
+            {
+              "expression": "telegram_user_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "telegram_thread_sessions_telegram_user_link_id_telegram_user_links_id_fk": {
+          "name": "telegram_thread_sessions_telegram_user_link_id_telegram_user_links_id_fk",
+          "tableFrom": "telegram_thread_sessions",
+          "tableTo": "telegram_user_links",
+          "columnsFrom": ["telegram_user_link_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "telegram_thread_sessions_agent_session_id_agent_sessions_id_fk": {
+          "name": "telegram_thread_sessions_agent_session_id_agent_sessions_id_fk",
+          "tableFrom": "telegram_thread_sessions",
+          "tableTo": "agent_sessions",
+          "columnsFrom": ["agent_session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_user_links": {
+      "name": "telegram_user_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "telegram_user_id": {
+          "name": "telegram_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vm0_user_id": {
+          "name": "vm0_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dm_welcome_sent": {
+          "name": "dm_welcome_sent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_telegram_user_links_user_installation": {
+          "name": "idx_telegram_user_links_user_installation",
+          "columns": [
+            {
+              "expression": "telegram_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "telegram_user_links_installation_id_telegram_installations_id_fk": {
+          "name": "telegram_user_links_installation_id_telegram_installations_id_fk",
+          "tableFrom": "telegram_user_links",
+          "tableTo": "telegram_installations",
+          "columnsFrom": ["installation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.usage_daily": {
+      "name": "usage_daily",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_count": {
+          "name": "run_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "run_time_ms": {
+          "name": "run_time_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_usage_daily_user_org_date": {
+          "name": "uq_usage_daily_user_org_date",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_cache": {
+      "name": "user_cache",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_list_cached_at": {
+          "name": "org_list_cached_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cached_at": {
+          "name": "cached_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email_unsubscribed": {
+          "name": "email_unsubscribed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.variables": {
+      "name": "variables",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_variables_org": {
+          "name": "idx_variables_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_variables_org_user_name": {
+          "name": "idx_variables_org_user_name",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vm0_api_keys": {
+      "name": "vm0_api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "vendor": {
+          "name": "vendor",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_vm0_api_keys_vendor": {
+          "name": "idx_vm0_api_keys_vendor",
+          "columns": [
+            {
+              "expression": "vendor",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.zero_agents": {
+      "name": "zero_agents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sound": {
+          "name": "sound",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_zero_agents_org_name": {
+          "name": "idx_zero_agents_org_name",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_zero_agents_org": {
+          "name": "idx_zero_agents_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.connector_session_status": {
+      "name": "connector_session_status",
+      "schema": "public",
+      "values": ["pending", "complete", "expired", "error"]
+    },
+    "public.device_code_status": {
+      "name": "device_code_status",
+      "schema": "public",
+      "values": ["pending", "authenticated", "expired", "denied"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/turbo/apps/web/src/db/migrations/meta/0176_snapshot.json
+++ b/turbo/apps/web/src/db/migrations/meta/0176_snapshot.json
@@ -1,5 +1,5 @@
 {
-  "id": "c5b45abf-1b64-4335-8acc-74be839f2680",
+  "id": "0b13b38f-b139-4700-9d76-ea5ede50c23b",
   "prevId": "38b180ae-9951-44d9-b3aa-137e892c67eb",
   "version": "7",
   "dialect": "postgresql",

--- a/turbo/apps/web/src/db/migrations/meta/_journal.json
+++ b/turbo/apps/web/src/db/migrations/meta/_journal.json
@@ -1237,8 +1237,8 @@
     {
       "idx": 176,
       "version": "7",
-      "when": 1774051200020,
-      "tag": "0176_add_auto_recharge",
+      "when": 1774071909702,
+      "tag": "0176_wealthy_mystique",
       "breakpoints": true
     }
   ]

--- a/turbo/apps/web/src/db/migrations/meta/_journal.json
+++ b/turbo/apps/web/src/db/migrations/meta/_journal.json
@@ -1233,6 +1233,13 @@
       "when": 1774051200019,
       "tag": "0175_sudden_baron_zemo",
       "breakpoints": true
+    },
+    {
+      "idx": 176,
+      "version": "7",
+      "when": 1774051200020,
+      "tag": "0176_add_auto_recharge",
+      "breakpoints": true
     }
   ]
 }

--- a/turbo/apps/web/src/db/schema/org-metadata.ts
+++ b/turbo/apps/web/src/db/schema/org-metadata.ts
@@ -1,5 +1,6 @@
 import {
   bigint,
+  boolean,
   pgTable,
   text,
   timestamp,
@@ -28,6 +29,15 @@ export const orgMetadata = pgTable(
     subscriptionStatus: varchar("subscription_status", { length: 20 }),
     currentPeriodEnd: timestamp("current_period_end"),
     lastProcessedInvoiceId: text("last_processed_invoice_id"),
+    // Auto-recharge configuration
+    autoRechargeEnabled: boolean("auto_recharge_enabled")
+      .notNull()
+      .default(false),
+    autoRechargeThreshold: bigint("auto_recharge_threshold", {
+      mode: "number",
+    }),
+    autoRechargeAmount: bigint("auto_recharge_amount", { mode: "number" }),
+    autoRechargePendingAt: timestamp("auto_recharge_pending_at"),
     createdAt: timestamp("created_at").defaultNow().notNull(),
     updatedAt: timestamp("updated_at").defaultNow().notNull(),
   },

--- a/turbo/apps/web/src/lib/billing/__tests__/auto-recharge-service.test.ts
+++ b/turbo/apps/web/src/lib/billing/__tests__/auto-recharge-service.test.ts
@@ -19,6 +19,7 @@ const stripeMocks = vi.hoisted(() => ({
   invoicesFinalize: vi.fn(),
   invoicesPay: vi.fn(),
   customersRetrieve: vi.fn(),
+  subscriptionsRetrieve: vi.fn(),
 }));
 
 vi.mock("stripe", () => ({
@@ -30,8 +31,7 @@ vi.mock("stripe", () => ({
         pay: stripeMocks.invoicesPay,
       },
       invoiceItems: { create: stripeMocks.invoiceItemsCreate },
-      // Stubs for other services that may be initialized
-      subscriptions: { retrieve: vi.fn() },
+      subscriptions: { retrieve: stripeMocks.subscriptionsRetrieve },
       customers: {
         create: stripeMocks.customersRetrieve,
         retrieve: stripeMocks.customersRetrieve,
@@ -66,12 +66,16 @@ describe("auto-recharge-service", () => {
     stripeMocks.invoicesFinalize.mockReset();
     stripeMocks.invoicesPay.mockReset();
     stripeMocks.customersRetrieve.mockReset();
+    stripeMocks.subscriptionsRetrieve.mockReset();
 
     // Default: Stripe calls succeed
     stripeMocks.customersRetrieve.mockResolvedValue({
       id: "cus_test",
       deleted: false,
       invoice_settings: { default_payment_method: "pm_test_default" },
+    });
+    stripeMocks.subscriptionsRetrieve.mockResolvedValue({
+      default_payment_method: "pm_sub_default",
     });
     stripeMocks.invoicesCreate.mockResolvedValue({ id: "inv_auto_test" });
     stripeMocks.invoiceItemsCreate.mockResolvedValue({});

--- a/turbo/apps/web/src/lib/billing/__tests__/auto-recharge-service.test.ts
+++ b/turbo/apps/web/src/lib/billing/__tests__/auto-recharge-service.test.ts
@@ -255,6 +255,93 @@ describe("auto-recharge-service", () => {
       // Only one should have created an invoice
       expect(stripeMocks.invoicesCreate).toHaveBeenCalledTimes(1);
     });
+
+    it("skips when Stripe customer is deleted", async () => {
+      const cusId = uniqueId("cus");
+      await updateOrgTier(user.orgId, "pro");
+      await updateOrgStripeFields(user.orgId, {
+        stripeCustomerId: cusId,
+      });
+      await updateOrgAutoRecharge(user.orgId, {
+        autoRechargeEnabled: true,
+        autoRechargeThreshold: 3000,
+        autoRechargeAmount: 5000,
+      });
+
+      stripeMocks.customersRetrieve.mockResolvedValue({ deleted: true });
+
+      await triggerAutoRecharge(user.orgId);
+
+      // No invoice should be created
+      expect(stripeMocks.invoicesCreate).not.toHaveBeenCalled();
+      // Pending flag should be cleared
+      const fields = await getOrgAutoRechargeFields(user.orgId);
+      expect(fields?.autoRechargePendingAt).toBeNull();
+    });
+
+    it("skips when no payment method on customer or subscription", async () => {
+      const cusId = uniqueId("cus");
+      const subId = uniqueId("sub");
+      await updateOrgTier(user.orgId, "pro");
+      await updateOrgStripeFields(user.orgId, {
+        stripeCustomerId: cusId,
+        stripeSubscriptionId: subId,
+      });
+      await updateOrgAutoRecharge(user.orgId, {
+        autoRechargeEnabled: true,
+        autoRechargeThreshold: 3000,
+        autoRechargeAmount: 5000,
+      });
+
+      // Customer has no default payment method
+      stripeMocks.customersRetrieve.mockResolvedValue({
+        id: cusId,
+        deleted: false,
+        invoice_settings: { default_payment_method: null },
+      });
+      // Subscription also has no payment method
+      stripeMocks.subscriptionsRetrieve.mockResolvedValue({
+        default_payment_method: null,
+      });
+
+      await triggerAutoRecharge(user.orgId);
+
+      expect(stripeMocks.invoicesCreate).not.toHaveBeenCalled();
+      const fields = await getOrgAutoRechargeFields(user.orgId);
+      expect(fields?.autoRechargePendingAt).toBeNull();
+    });
+
+    it("uses subscription payment method when customer has none", async () => {
+      const cusId = uniqueId("cus");
+      const subId = uniqueId("sub");
+      await updateOrgTier(user.orgId, "pro");
+      await updateOrgStripeFields(user.orgId, {
+        stripeCustomerId: cusId,
+        stripeSubscriptionId: subId,
+      });
+      await updateOrgAutoRecharge(user.orgId, {
+        autoRechargeEnabled: true,
+        autoRechargeThreshold: 3000,
+        autoRechargeAmount: 5000,
+      });
+
+      // Customer has no default payment method
+      stripeMocks.customersRetrieve.mockResolvedValue({
+        id: cusId,
+        deleted: false,
+        invoice_settings: { default_payment_method: null },
+      });
+      // Subscription has a payment method
+      stripeMocks.subscriptionsRetrieve.mockResolvedValue({
+        default_payment_method: "pm_from_subscription",
+      });
+
+      await triggerAutoRecharge(user.orgId);
+
+      // Invoice should be created with subscription's payment method
+      const invoiceCall = stripeMocks.invoicesCreate.mock.calls[0]?.[0];
+      expect(invoiceCall?.default_payment_method).toBe("pm_from_subscription");
+    });
   });
 
   describe("handleAutoRechargeInvoicePaid", () => {

--- a/turbo/apps/web/src/lib/billing/__tests__/auto-recharge-service.test.ts
+++ b/turbo/apps/web/src/lib/billing/__tests__/auto-recharge-service.test.ts
@@ -1,0 +1,297 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  testContext,
+  uniqueId,
+  type UserContext,
+} from "../../../__tests__/test-helpers";
+import {
+  getOrgCredits,
+  updateOrgTier,
+  updateOrgStripeFields,
+  updateOrgAutoRecharge,
+  getOrgAutoRechargeFields,
+} from "../../../__tests__/api-test-helpers";
+
+// Stripe mock — must be defined before importing the service
+const stripeMocks = vi.hoisted(() => ({
+  invoicesCreate: vi.fn(),
+  invoiceItemsCreate: vi.fn(),
+  invoicesFinalize: vi.fn(),
+  invoicesPay: vi.fn(),
+}));
+
+vi.mock("stripe", () => ({
+  default: function MockStripe() {
+    return {
+      invoices: {
+        create: stripeMocks.invoicesCreate,
+        finalizeInvoice: stripeMocks.invoicesFinalize,
+        pay: stripeMocks.invoicesPay,
+      },
+      invoiceItems: { create: stripeMocks.invoiceItemsCreate },
+      // Stubs for other services that may be initialized
+      subscriptions: { retrieve: vi.fn() },
+      customers: { create: vi.fn() },
+      checkout: { sessions: { create: vi.fn() } },
+      billingPortal: { sessions: { create: vi.fn() } },
+      webhooks: { constructEvent: vi.fn() },
+    };
+  },
+}));
+
+import { reloadEnv } from "../../../env";
+import {
+  triggerAutoRecharge,
+  handleAutoRechargeInvoicePaid,
+  CREDITS_PER_DOLLAR,
+} from "../auto-recharge-service";
+
+const context = testContext();
+
+describe("auto-recharge-service", () => {
+  let user: UserContext;
+
+  beforeEach(async () => {
+    context.setupMocks();
+    user = await context.setupUser();
+
+    vi.stubEnv("STRIPE_SECRET_KEY", "sk_test_fake");
+    reloadEnv();
+
+    stripeMocks.invoicesCreate.mockReset();
+    stripeMocks.invoiceItemsCreate.mockReset();
+    stripeMocks.invoicesFinalize.mockReset();
+    stripeMocks.invoicesPay.mockReset();
+
+    // Default: Stripe calls succeed
+    stripeMocks.invoicesCreate.mockResolvedValue({ id: "inv_auto_test" });
+    stripeMocks.invoiceItemsCreate.mockResolvedValue({});
+    stripeMocks.invoicesFinalize.mockResolvedValue({});
+    stripeMocks.invoicesPay.mockResolvedValue({});
+  });
+
+  describe("triggerAutoRecharge", () => {
+    it("skips when auto-recharge is disabled", async () => {
+      await updateOrgTier(user.orgId, "pro");
+      await updateOrgStripeFields(user.orgId, {
+        stripeCustomerId: uniqueId("cus"),
+      });
+      // auto-recharge is disabled by default
+
+      await triggerAutoRecharge(user.orgId);
+
+      expect(stripeMocks.invoicesCreate).not.toHaveBeenCalled();
+    });
+
+    it("skips when tier is free", async () => {
+      await updateOrgStripeFields(user.orgId, {
+        stripeCustomerId: uniqueId("cus"),
+      });
+      await updateOrgAutoRecharge(user.orgId, {
+        autoRechargeEnabled: true,
+        autoRechargeThreshold: 500,
+        autoRechargeAmount: 5000,
+      });
+
+      await triggerAutoRecharge(user.orgId);
+
+      expect(stripeMocks.invoicesCreate).not.toHaveBeenCalled();
+    });
+
+    it("skips when balance is above threshold", async () => {
+      await updateOrgTier(user.orgId, "pro");
+      await updateOrgStripeFields(user.orgId, {
+        stripeCustomerId: uniqueId("cus"),
+      });
+      await updateOrgAutoRecharge(user.orgId, {
+        autoRechargeEnabled: true,
+        autoRechargeThreshold: 500,
+        autoRechargeAmount: 5000,
+      });
+      // Default credits = 2000, threshold = 500 → above threshold
+
+      await triggerAutoRecharge(user.orgId);
+
+      expect(stripeMocks.invoicesCreate).not.toHaveBeenCalled();
+    });
+
+    it("skips when a recent pending recharge exists", async () => {
+      const cusId = uniqueId("cus");
+      await updateOrgTier(user.orgId, "pro");
+      await updateOrgStripeFields(user.orgId, {
+        stripeCustomerId: cusId,
+      });
+      await updateOrgAutoRecharge(user.orgId, {
+        autoRechargeEnabled: true,
+        autoRechargeThreshold: 3000,
+        autoRechargeAmount: 5000,
+        autoRechargePendingAt: new Date(), // just set now
+      });
+
+      await triggerAutoRecharge(user.orgId);
+
+      expect(stripeMocks.invoicesCreate).not.toHaveBeenCalled();
+    });
+
+    it("creates Stripe invoice with correct amount when threshold is breached", async () => {
+      const cusId = uniqueId("cus");
+      await updateOrgTier(user.orgId, "pro");
+      await updateOrgStripeFields(user.orgId, {
+        stripeCustomerId: cusId,
+      });
+      await updateOrgAutoRecharge(user.orgId, {
+        autoRechargeEnabled: true,
+        autoRechargeThreshold: 3000, // balance (2000) is below this
+        autoRechargeAmount: 10000,
+      });
+
+      await triggerAutoRecharge(user.orgId);
+
+      expect(stripeMocks.invoicesCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          customer: cusId,
+          metadata: {
+            type: "auto_recharge",
+            orgId: user.orgId,
+            creditsAmount: "10000",
+          },
+        }),
+      );
+
+      // 10000 credits / 1000 credits per dollar = $10 = 1000 cents
+      expect(stripeMocks.invoiceItemsCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          invoice: "inv_auto_test",
+          customer: cusId,
+          price_data: expect.objectContaining({
+            unit_amount: 1000,
+            currency: "usd",
+          }),
+        }),
+      );
+
+      expect(stripeMocks.invoicesFinalize).toHaveBeenCalledWith(
+        "inv_auto_test",
+      );
+      expect(stripeMocks.invoicesPay).toHaveBeenCalledWith("inv_auto_test");
+
+      // pending_at should be set
+      const fields = await getOrgAutoRechargeFields(user.orgId);
+      expect(fields?.autoRechargePendingAt).toBeInstanceOf(Date);
+    });
+
+    it("clears pending flag on Stripe failure", async () => {
+      const cusId = uniqueId("cus");
+      await updateOrgTier(user.orgId, "pro");
+      await updateOrgStripeFields(user.orgId, {
+        stripeCustomerId: cusId,
+      });
+      await updateOrgAutoRecharge(user.orgId, {
+        autoRechargeEnabled: true,
+        autoRechargeThreshold: 3000,
+        autoRechargeAmount: 5000,
+      });
+
+      stripeMocks.invoicesCreate.mockRejectedValue(new Error("Card declined"));
+
+      await triggerAutoRecharge(user.orgId);
+
+      // pending_at should be cleared after failure
+      const fields = await getOrgAutoRechargeFields(user.orgId);
+      expect(fields?.autoRechargePendingAt).toBeNull();
+    });
+
+    it("retries when pending recharge is stale (>10 min)", async () => {
+      const cusId = uniqueId("cus");
+      await updateOrgTier(user.orgId, "pro");
+      await updateOrgStripeFields(user.orgId, {
+        stripeCustomerId: cusId,
+      });
+
+      // Set pending_at to 15 minutes ago (stale)
+      const staleTime = new Date(Date.now() - 15 * 60 * 1000);
+      await updateOrgAutoRecharge(user.orgId, {
+        autoRechargeEnabled: true,
+        autoRechargeThreshold: 3000,
+        autoRechargeAmount: 5000,
+        autoRechargePendingAt: staleTime,
+      });
+
+      await triggerAutoRecharge(user.orgId);
+
+      // Should have created a new invoice (retry after stale)
+      expect(stripeMocks.invoicesCreate).toHaveBeenCalled();
+    });
+
+    it("concurrent triggers — only one succeeds", async () => {
+      const cusId = uniqueId("cus");
+      await updateOrgTier(user.orgId, "pro");
+      await updateOrgStripeFields(user.orgId, {
+        stripeCustomerId: cusId,
+      });
+      await updateOrgAutoRecharge(user.orgId, {
+        autoRechargeEnabled: true,
+        autoRechargeThreshold: 3000,
+        autoRechargeAmount: 5000,
+      });
+
+      // Run two concurrent triggers
+      await Promise.all([
+        triggerAutoRecharge(user.orgId),
+        triggerAutoRecharge(user.orgId),
+      ]);
+
+      // Only one should have created an invoice
+      expect(stripeMocks.invoicesCreate).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("handleAutoRechargeInvoicePaid", () => {
+    it("returns false for non-auto-recharge invoices", async () => {
+      const result = await handleAutoRechargeInvoicePaid({
+        id: "inv_sub",
+        metadata: null,
+      });
+      expect(result).toBe(false);
+    });
+
+    it("returns false for invoices with different metadata type", async () => {
+      const result = await handleAutoRechargeInvoicePaid({
+        id: "inv_other",
+        metadata: { type: "subscription" },
+      });
+      expect(result).toBe(false);
+    });
+
+    it("grants credits and clears pending flag", async () => {
+      await updateOrgAutoRecharge(user.orgId, {
+        autoRechargePendingAt: new Date(),
+      });
+
+      const creditsBefore = await getOrgCredits(user.orgId);
+
+      const result = await handleAutoRechargeInvoicePaid({
+        id: "inv_auto",
+        metadata: {
+          type: "auto_recharge",
+          orgId: user.orgId,
+          creditsAmount: "5000",
+        },
+      });
+
+      expect(result).toBe(true);
+
+      const creditsAfter = await getOrgCredits(user.orgId);
+      expect(creditsAfter! - creditsBefore!).toBe(5000);
+
+      const fields = await getOrgAutoRechargeFields(user.orgId);
+      expect(fields?.autoRechargePendingAt).toBeNull();
+    });
+  });
+
+  describe("CREDITS_PER_DOLLAR", () => {
+    it("is 1000", () => {
+      expect(CREDITS_PER_DOLLAR).toBe(1000);
+    });
+  });
+});

--- a/turbo/apps/web/src/lib/billing/__tests__/auto-recharge-service.test.ts
+++ b/turbo/apps/web/src/lib/billing/__tests__/auto-recharge-service.test.ts
@@ -43,7 +43,6 @@ import { reloadEnv } from "../../../env";
 import {
   triggerAutoRecharge,
   handleAutoRechargeInvoicePaid,
-  CREDITS_PER_DOLLAR,
 } from "../auto-recharge-service";
 
 const context = testContext();
@@ -286,12 +285,6 @@ describe("auto-recharge-service", () => {
 
       const fields = await getOrgAutoRechargeFields(user.orgId);
       expect(fields?.autoRechargePendingAt).toBeNull();
-    });
-  });
-
-  describe("CREDITS_PER_DOLLAR", () => {
-    it("is 1000", () => {
-      expect(CREDITS_PER_DOLLAR).toBe(1000);
     });
   });
 });

--- a/turbo/apps/web/src/lib/billing/__tests__/auto-recharge-service.test.ts
+++ b/turbo/apps/web/src/lib/billing/__tests__/auto-recharge-service.test.ts
@@ -162,10 +162,8 @@ describe("auto-recharge-service", () => {
         expect.objectContaining({
           invoice: "inv_auto_test",
           customer: cusId,
-          price_data: expect.objectContaining({
-            unit_amount: 1000,
-            currency: "usd",
-          }),
+          amount: 1000,
+          currency: "usd",
         }),
       );
 

--- a/turbo/apps/web/src/lib/billing/__tests__/auto-recharge-service.test.ts
+++ b/turbo/apps/web/src/lib/billing/__tests__/auto-recharge-service.test.ts
@@ -18,6 +18,7 @@ const stripeMocks = vi.hoisted(() => ({
   invoiceItemsCreate: vi.fn(),
   invoicesFinalize: vi.fn(),
   invoicesPay: vi.fn(),
+  customersRetrieve: vi.fn(),
 }));
 
 vi.mock("stripe", () => ({
@@ -31,7 +32,10 @@ vi.mock("stripe", () => ({
       invoiceItems: { create: stripeMocks.invoiceItemsCreate },
       // Stubs for other services that may be initialized
       subscriptions: { retrieve: vi.fn() },
-      customers: { create: vi.fn() },
+      customers: {
+        create: stripeMocks.customersRetrieve,
+        retrieve: stripeMocks.customersRetrieve,
+      },
       checkout: { sessions: { create: vi.fn() } },
       billingPortal: { sessions: { create: vi.fn() } },
       webhooks: { constructEvent: vi.fn() },
@@ -61,8 +65,14 @@ describe("auto-recharge-service", () => {
     stripeMocks.invoiceItemsCreate.mockReset();
     stripeMocks.invoicesFinalize.mockReset();
     stripeMocks.invoicesPay.mockReset();
+    stripeMocks.customersRetrieve.mockReset();
 
     // Default: Stripe calls succeed
+    stripeMocks.customersRetrieve.mockResolvedValue({
+      id: "cus_test",
+      deleted: false,
+      invoice_settings: { default_payment_method: "pm_test_default" },
+    });
     stripeMocks.invoicesCreate.mockResolvedValue({ id: "inv_auto_test" });
     stripeMocks.invoiceItemsCreate.mockResolvedValue({});
     stripeMocks.invoicesFinalize.mockResolvedValue({});

--- a/turbo/apps/web/src/lib/billing/auto-recharge-service.ts
+++ b/turbo/apps/web/src/lib/billing/auto-recharge-service.ts
@@ -78,10 +78,42 @@ export async function triggerAutoRecharge(orgId: string): Promise<void> {
   const stripe = getStripe();
 
   try {
+    // Resolve the payment method from the customer's subscription or default
+    const customer = await stripe.customers.retrieve(org.stripeCustomerId);
+    if (customer.deleted) {
+      log.warn("Stripe customer is deleted, skipping auto-recharge", { orgId });
+      await db
+        .update(orgMetadata)
+        .set({ autoRechargePendingAt: null, updatedAt: new Date() })
+        .where(eq(orgMetadata.orgId, orgId));
+      return;
+    }
+
+    const paymentMethodId =
+      (typeof customer.invoice_settings?.default_payment_method === "string"
+        ? customer.invoice_settings.default_payment_method
+        : customer.invoice_settings?.default_payment_method?.id) ?? null;
+
+    if (!paymentMethodId) {
+      log.warn(
+        "No default payment method on customer, skipping auto-recharge",
+        {
+          orgId,
+          customerId: org.stripeCustomerId,
+        },
+      );
+      await db
+        .update(orgMetadata)
+        .set({ autoRechargePendingAt: null, updatedAt: new Date() })
+        .where(eq(orgMetadata.orgId, orgId));
+      return;
+    }
+
     // Create a one-time invoice with metadata for webhook identification
     const invoice = await stripe.invoices.create({
       customer: org.stripeCustomerId,
       auto_advance: false,
+      default_payment_method: paymentMethodId,
       metadata: {
         type: "auto_recharge",
         orgId,

--- a/turbo/apps/web/src/lib/billing/auto-recharge-service.ts
+++ b/turbo/apps/web/src/lib/billing/auto-recharge-service.ts
@@ -1,0 +1,171 @@
+import { eq, sql } from "drizzle-orm";
+import { orgMetadata } from "../../db/schema/org-metadata";
+import { grantOrgCredits } from "../org/org-service";
+import { getStripe } from "../stripe";
+import { logger } from "../logger";
+
+const log = logger("billing:auto-recharge");
+
+/** $1 = 1,000 credits */
+export const CREDITS_PER_DOLLAR = 1000;
+
+/** Pending recharge older than this is considered stale and can be retried. */
+const STALE_THRESHOLD_MINUTES = 10;
+
+/**
+ * Check if auto-recharge should trigger for an org and, if so,
+ * create a Stripe one-time invoice to purchase credits.
+ *
+ * Called after processOrgCredits commits its transaction.
+ * Errors are caught internally — callers should fire-and-forget.
+ */
+export async function triggerAutoRecharge(orgId: string): Promise<void> {
+  const db = globalThis.services.db;
+
+  // Read org state
+  const [org] = await db
+    .select({
+      credits: orgMetadata.credits,
+      tier: orgMetadata.tier,
+      stripeCustomerId: orgMetadata.stripeCustomerId,
+      autoRechargeEnabled: orgMetadata.autoRechargeEnabled,
+      autoRechargeThreshold: orgMetadata.autoRechargeThreshold,
+      autoRechargeAmount: orgMetadata.autoRechargeAmount,
+      autoRechargePendingAt: orgMetadata.autoRechargePendingAt,
+    })
+    .from(orgMetadata)
+    .where(eq(orgMetadata.orgId, orgId))
+    .limit(1);
+
+  if (!org) return;
+
+  // Guard: feature must be enabled
+  if (!org.autoRechargeEnabled) return;
+
+  // Guard: only paid tiers
+  if (org.tier === "free") return;
+
+  // Guard: must have Stripe customer
+  if (!org.stripeCustomerId) return;
+
+  // Guard: must have valid config
+  if (!org.autoRechargeThreshold || !org.autoRechargeAmount) return;
+
+  // Guard: balance must be at or below threshold
+  if (org.credits > org.autoRechargeThreshold) return;
+
+  // Atomically claim the recharge slot — only one writer wins.
+  // Allows retry if the previous pending is stale (> 10 min).
+  const claimed = await db
+    .update(orgMetadata)
+    .set({ autoRechargePendingAt: new Date(), updatedAt: new Date() })
+    .where(
+      sql`${orgMetadata.orgId} = ${orgId}
+          AND ${orgMetadata.autoRechargeEnabled} = true
+          AND (${orgMetadata.autoRechargePendingAt} IS NULL
+               OR ${orgMetadata.autoRechargePendingAt} < now() - interval '${sql.raw(String(STALE_THRESHOLD_MINUTES))} minutes')`,
+    )
+    .returning({ orgId: orgMetadata.orgId });
+
+  if (claimed.length === 0) {
+    log.debug("Auto-recharge already pending, skipping", { orgId });
+    return;
+  }
+
+  const creditsAmount = org.autoRechargeAmount;
+  const amountCents = Math.ceil(creditsAmount / CREDITS_PER_DOLLAR) * 100;
+
+  const stripe = getStripe();
+
+  try {
+    // Create a one-time invoice with metadata for webhook identification
+    const invoice = await stripe.invoices.create({
+      customer: org.stripeCustomerId,
+      auto_advance: false,
+      metadata: {
+        type: "auto_recharge",
+        orgId,
+        creditsAmount: String(creditsAmount),
+      },
+    });
+
+    // Add the line item with dynamic pricing
+    await stripe.invoiceItems.create({
+      invoice: invoice.id,
+      customer: org.stripeCustomerId,
+      price_data: {
+        currency: "usd",
+        unit_amount: amountCents,
+        product_data: { name: "Credit top-up" },
+      },
+      quantity: 1,
+    });
+
+    // Finalize and pay immediately
+    await stripe.invoices.finalizeInvoice(invoice.id);
+    await stripe.invoices.pay(invoice.id);
+
+    log.info("Auto-recharge invoice created and paid", {
+      orgId,
+      creditsAmount,
+      amountCents,
+      invoiceId: invoice.id,
+    });
+  } catch (err) {
+    // Payment failed — clear pending flag so next deduction cycle can retry
+    log.warn("Auto-recharge Stripe call failed, clearing pending flag", {
+      orgId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+
+    await db
+      .update(orgMetadata)
+      .set({ autoRechargePendingAt: null, updatedAt: new Date() })
+      .where(eq(orgMetadata.orgId, orgId));
+  }
+}
+
+/**
+ * Handle an auto-recharge invoice.paid webhook event.
+ * Grants credits to the org and clears the pending flag.
+ *
+ * @returns true if the invoice was an auto-recharge invoice and was handled
+ */
+export async function handleAutoRechargeInvoicePaid(invoice: {
+  id: string;
+  metadata: Record<string, string> | null;
+}): Promise<boolean> {
+  const metadata = invoice.metadata;
+  if (!metadata || metadata.type !== "auto_recharge") {
+    return false;
+  }
+
+  const orgId = metadata.orgId;
+  const creditsAmount = Number(metadata.creditsAmount);
+
+  if (!orgId || !creditsAmount || isNaN(creditsAmount)) {
+    log.warn("Auto-recharge invoice has invalid metadata", {
+      invoiceId: invoice.id,
+      metadata,
+    });
+    return false;
+  }
+
+  const db = globalThis.services.db;
+
+  await db.transaction(async (tx) => {
+    await grantOrgCredits(tx, orgId, creditsAmount);
+    await tx
+      .update(orgMetadata)
+      .set({ autoRechargePendingAt: null, updatedAt: new Date() })
+      .where(eq(orgMetadata.orgId, orgId));
+  });
+
+  log.info("Auto-recharge credits granted", {
+    orgId,
+    creditsAmount,
+    invoiceId: invoice.id,
+  });
+
+  return true;
+}

--- a/turbo/apps/web/src/lib/billing/auto-recharge-service.ts
+++ b/turbo/apps/web/src/lib/billing/auto-recharge-service.ts
@@ -1,4 +1,5 @@
 import { eq, sql } from "drizzle-orm";
+import type Stripe from "stripe";
 import { orgMetadata } from "../../db/schema/org-metadata";
 import { grantOrgCredits } from "../org/org-service";
 import { getStripe } from "../stripe";
@@ -11,6 +12,82 @@ export const CREDITS_PER_DOLLAR = 1000;
 
 /** Pending recharge older than this is considered stale and can be retried. */
 const STALE_THRESHOLD_MINUTES = 10;
+
+interface OrgRechargeState {
+  credits: number;
+  tier: string;
+  stripeCustomerId: string | null;
+  stripeSubscriptionId: string | null;
+  autoRechargeEnabled: boolean;
+  autoRechargeThreshold: number | null;
+  autoRechargeAmount: number | null;
+  autoRechargePendingAt: Date | null;
+}
+
+function isEligibleForRecharge(
+  org: OrgRechargeState,
+): org is OrgRechargeState & {
+  stripeCustomerId: string;
+  autoRechargeThreshold: number;
+  autoRechargeAmount: number;
+} {
+  return (
+    org.autoRechargeEnabled &&
+    org.tier !== "free" &&
+    org.stripeCustomerId !== null &&
+    org.autoRechargeThreshold !== null &&
+    org.autoRechargeAmount !== null &&
+    org.credits <= org.autoRechargeThreshold
+  );
+}
+
+async function clearPendingFlag(orgId: string): Promise<void> {
+  const db = globalThis.services.db;
+  await db
+    .update(orgMetadata)
+    .set({ autoRechargePendingAt: null, updatedAt: new Date() })
+    .where(eq(orgMetadata.orgId, orgId));
+}
+
+function resolvePaymentMethodId(
+  pm: string | Stripe.PaymentMethod | null | undefined,
+): string | null {
+  if (typeof pm === "string") return pm;
+  return pm?.id ?? null;
+}
+
+async function resolvePaymentMethod(
+  stripe: Stripe,
+  org: { stripeCustomerId: string; stripeSubscriptionId: string | null },
+  orgId: string,
+): Promise<string | null> {
+  const customer = await stripe.customers.retrieve(org.stripeCustomerId);
+  if (customer.deleted) {
+    log.warn("Stripe customer is deleted, skipping auto-recharge", { orgId });
+    await clearPendingFlag(orgId);
+    return null;
+  }
+
+  const customerPm = resolvePaymentMethodId(
+    customer.invoice_settings?.default_payment_method,
+  );
+  if (customerPm) return customerPm;
+
+  if (org.stripeSubscriptionId) {
+    const subscription = await stripe.subscriptions.retrieve(
+      org.stripeSubscriptionId,
+    );
+    const subPm = resolvePaymentMethodId(subscription.default_payment_method);
+    if (subPm) return subPm;
+  }
+
+  log.warn(
+    "No payment method found on customer or subscription, skipping auto-recharge",
+    { orgId, customerId: org.stripeCustomerId },
+  );
+  await clearPendingFlag(orgId);
+  return null;
+}
 
 /**
  * Check if auto-recharge should trigger for an org and, if so,
@@ -38,22 +115,7 @@ export async function triggerAutoRecharge(orgId: string): Promise<void> {
     .where(eq(orgMetadata.orgId, orgId))
     .limit(1);
 
-  if (!org) return;
-
-  // Guard: feature must be enabled
-  if (!org.autoRechargeEnabled) return;
-
-  // Guard: only paid tiers
-  if (org.tier === "free") return;
-
-  // Guard: must have Stripe customer
-  if (!org.stripeCustomerId) return;
-
-  // Guard: must have valid config
-  if (!org.autoRechargeThreshold || !org.autoRechargeAmount) return;
-
-  // Guard: balance must be at or below threshold
-  if (org.credits > org.autoRechargeThreshold) return;
+  if (!org || !isEligibleForRecharge(org)) return;
 
   // Atomically claim the recharge slot — only one writer wins.
   // Allows retry if the previous pending is stale (> 10 min).
@@ -79,48 +141,8 @@ export async function triggerAutoRecharge(orgId: string): Promise<void> {
   const stripe = getStripe();
 
   try {
-    // Resolve the payment method from the customer's subscription or default
-    const customer = await stripe.customers.retrieve(org.stripeCustomerId);
-    if (customer.deleted) {
-      log.warn("Stripe customer is deleted, skipping auto-recharge", { orgId });
-      await db
-        .update(orgMetadata)
-        .set({ autoRechargePendingAt: null, updatedAt: new Date() })
-        .where(eq(orgMetadata.orgId, orgId));
-      return;
-    }
-
-    // Try customer default, then fall back to subscription's payment method
-    const customerPm =
-      typeof customer.invoice_settings?.default_payment_method === "string"
-        ? customer.invoice_settings.default_payment_method
-        : customer.invoice_settings?.default_payment_method?.id;
-
-    let paymentMethodId = customerPm ?? null;
-
-    // Fallback: retrieve payment method from the active subscription
-    if (!paymentMethodId && org.stripeSubscriptionId) {
-      const subscription = await stripe.subscriptions.retrieve(
-        org.stripeSubscriptionId,
-      );
-      const subPm =
-        typeof subscription.default_payment_method === "string"
-          ? subscription.default_payment_method
-          : subscription.default_payment_method?.id;
-      paymentMethodId = subPm ?? null;
-    }
-
-    if (!paymentMethodId) {
-      log.warn(
-        "No payment method found on customer or subscription, skipping auto-recharge",
-        { orgId, customerId: org.stripeCustomerId },
-      );
-      await db
-        .update(orgMetadata)
-        .set({ autoRechargePendingAt: null, updatedAt: new Date() })
-        .where(eq(orgMetadata.orgId, orgId));
-      return;
-    }
+    const paymentMethodId = await resolvePaymentMethod(stripe, org, orgId);
+    if (!paymentMethodId) return;
 
     // Create a one-time invoice with metadata for webhook identification
     const invoice = await stripe.invoices.create({
@@ -160,10 +182,7 @@ export async function triggerAutoRecharge(orgId: string): Promise<void> {
       error: err instanceof Error ? err.message : String(err),
     });
 
-    await db
-      .update(orgMetadata)
-      .set({ autoRechargePendingAt: null, updatedAt: new Date() })
-      .where(eq(orgMetadata.orgId, orgId));
+    await clearPendingFlag(orgId);
   }
 }
 

--- a/turbo/apps/web/src/lib/billing/auto-recharge-service.ts
+++ b/turbo/apps/web/src/lib/billing/auto-recharge-service.ts
@@ -89,16 +89,13 @@ export async function triggerAutoRecharge(orgId: string): Promise<void> {
       },
     });
 
-    // Add the line item with dynamic pricing
+    // Add the line item
     await stripe.invoiceItems.create({
       invoice: invoice.id,
       customer: org.stripeCustomerId,
-      price_data: {
-        currency: "usd",
-        unit_amount: amountCents,
-        product_data: { name: "Credit top-up" },
-      },
-      quantity: 1,
+      amount: amountCents,
+      currency: "usd",
+      description: `Credit top-up: ${creditsAmount.toLocaleString()} credits`,
     });
 
     // Finalize and pay immediately

--- a/turbo/apps/web/src/lib/billing/auto-recharge-service.ts
+++ b/turbo/apps/web/src/lib/billing/auto-recharge-service.ts
@@ -28,6 +28,7 @@ export async function triggerAutoRecharge(orgId: string): Promise<void> {
       credits: orgMetadata.credits,
       tier: orgMetadata.tier,
       stripeCustomerId: orgMetadata.stripeCustomerId,
+      stripeSubscriptionId: orgMetadata.stripeSubscriptionId,
       autoRechargeEnabled: orgMetadata.autoRechargeEnabled,
       autoRechargeThreshold: orgMetadata.autoRechargeThreshold,
       autoRechargeAmount: orgMetadata.autoRechargeAmount,
@@ -89,18 +90,30 @@ export async function triggerAutoRecharge(orgId: string): Promise<void> {
       return;
     }
 
-    const paymentMethodId =
-      (typeof customer.invoice_settings?.default_payment_method === "string"
+    // Try customer default, then fall back to subscription's payment method
+    const customerPm =
+      typeof customer.invoice_settings?.default_payment_method === "string"
         ? customer.invoice_settings.default_payment_method
-        : customer.invoice_settings?.default_payment_method?.id) ?? null;
+        : customer.invoice_settings?.default_payment_method?.id;
+
+    let paymentMethodId = customerPm ?? null;
+
+    // Fallback: retrieve payment method from the active subscription
+    if (!paymentMethodId && org.stripeSubscriptionId) {
+      const subscription = await stripe.subscriptions.retrieve(
+        org.stripeSubscriptionId,
+      );
+      const subPm =
+        typeof subscription.default_payment_method === "string"
+          ? subscription.default_payment_method
+          : subscription.default_payment_method?.id;
+      paymentMethodId = subPm ?? null;
+    }
 
     if (!paymentMethodId) {
       log.warn(
-        "No default payment method on customer, skipping auto-recharge",
-        {
-          orgId,
-          customerId: org.stripeCustomerId,
-        },
+        "No payment method found on customer or subscription, skipping auto-recharge",
+        { orgId, customerId: org.stripeCustomerId },
       );
       await db
         .update(orgMetadata)

--- a/turbo/apps/web/src/lib/billing/billing-service.ts
+++ b/turbo/apps/web/src/lib/billing/billing-service.ts
@@ -4,6 +4,7 @@ import { getStripe } from "../stripe";
 import { env } from "../../env";
 import { orgMetadata } from "../../db/schema/org-metadata";
 import { grantOrgCredits } from "../org/org-service";
+import { handleAutoRechargeInvoicePaid } from "./auto-recharge-service";
 import { logger } from "../logger";
 
 const log = logger("billing");
@@ -24,6 +25,7 @@ interface CheckoutSessionInput {
 interface InvoiceInput {
   id: string;
   customer: string | { id: string } | null;
+  metadata: Record<string, string> | null;
   parent: {
     subscription_details: {
       subscription: string | { id: string };
@@ -217,6 +219,10 @@ export async function handleCheckoutCompleted(
  * Idempotent: checks last_processed_invoice_id.
  */
 export async function handleInvoicePaid(invoice: InvoiceInput): Promise<void> {
+  // Handle auto-recharge invoices (identified by metadata) before subscription logic
+  const handled = await handleAutoRechargeInvoicePaid(invoice);
+  if (handled) return;
+
   // In Stripe v2025 API, subscription is under parent.subscription_details
   const subDetails = invoice.parent?.subscription_details;
   const subscriptionId = subDetails
@@ -404,6 +410,11 @@ export async function getBillingStatus(orgId: string): Promise<{
   subscriptionStatus: string | null;
   currentPeriodEnd: Date | null;
   hasSubscription: boolean;
+  autoRecharge: {
+    enabled: boolean;
+    threshold: number | null;
+    amount: number | null;
+  };
 }> {
   const db = globalThis.services.db;
   const [org] = await db
@@ -413,6 +424,9 @@ export async function getBillingStatus(orgId: string): Promise<{
       subscriptionStatus: orgMetadata.subscriptionStatus,
       currentPeriodEnd: orgMetadata.currentPeriodEnd,
       stripeSubscriptionId: orgMetadata.stripeSubscriptionId,
+      autoRechargeEnabled: orgMetadata.autoRechargeEnabled,
+      autoRechargeThreshold: orgMetadata.autoRechargeThreshold,
+      autoRechargeAmount: orgMetadata.autoRechargeAmount,
     })
     .from(orgMetadata)
     .where(eq(orgMetadata.orgId, orgId))
@@ -424,5 +438,10 @@ export async function getBillingStatus(orgId: string): Promise<{
     subscriptionStatus: org?.subscriptionStatus ?? null,
     currentPeriodEnd: org?.currentPeriodEnd ?? null,
     hasSubscription: !!org?.stripeSubscriptionId,
+    autoRecharge: {
+      enabled: org?.autoRechargeEnabled ?? false,
+      threshold: org?.autoRechargeThreshold ?? null,
+      amount: org?.autoRechargeAmount ?? null,
+    },
   };
 }

--- a/turbo/apps/web/src/lib/credit/credit-service.ts
+++ b/turbo/apps/web/src/lib/credit/credit-service.ts
@@ -2,6 +2,7 @@ import { eq, and, sql } from "drizzle-orm";
 import { creditUsage } from "../../db/schema/credit-usage";
 import { creditPricing } from "../../db/schema/credit-pricing";
 import { deductOrgCredits } from "../org/org-service";
+import { triggerAutoRecharge } from "../billing/auto-recharge-service";
 import { logger } from "../logger";
 
 const log = logger("service:credit");
@@ -118,6 +119,17 @@ export async function processOrgCredits(orgId: string): Promise<void> {
     processedCount: result.processedCount,
     totalCredits: result.totalCredits,
   });
+
+  // After deduction, check if auto-recharge should trigger.
+  // Fire-and-forget: errors are logged internally, never propagated.
+  if (result.totalCredits > 0) {
+    triggerAutoRecharge(orgId).catch((err) => {
+      log.warn("Auto-recharge trigger failed", {
+        orgId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    });
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary

- Add threshold-triggered auto-recharge: when org credits drop below a configured threshold after deduction, automatically purchase credits via Stripe one-time invoice ($1 = 1,000 credits)
- New `GET/PUT /api/billing/auto-recharge` API with admin-only write, free tier blocked
- Auto-recharge section in billing dialog UI for pro/max tiers with dollar amount preview
- Race condition prevention via atomic `auto_recharge_pending_at` timestamp (10 min staleness)

## Changes

| Area | Files |
|------|-------|
| DB | Migration 0176 adds 4 columns to `org_metadata` |
| Service | `auto-recharge-service.ts` — trigger logic, webhook handler |
| Pipeline | `credit-service.ts` — fire-and-forget after deduction |
| Webhook | `billing-service.ts` — detect auto-recharge invoices in `invoice.paid` |
| API | `GET/PUT /api/billing/auto-recharge` — config CRUD |
| Status | `getBillingStatus` returns `autoRecharge` field |
| UI | Billing dialog auto-recharge section (toggle, inputs, $ preview) |
| Tests | 20 new integration tests, all 42 related tests pass |

## Test plan

- [x] Auto-recharge service: guard conditions (disabled, free tier, above threshold, pending)
- [x] Stripe invoice creation with correct amount and metadata
- [x] Race condition: concurrent triggers, stale pending retry
- [x] Stripe failure: pending flag cleared for retry
- [x] Webhook: auto-recharge invoice grants credits, clears pending
- [x] API: admin-only write, free tier blocked, validation
- [x] All existing billing/credit tests pass

Closes #5833

🤖 Generated with [Claude Code](https://claude.com/claude-code)