### PR TITLE
refactor: replace openbox with i3 tiling window manager

### DIFF
--- a/.devcontainer/i3-config
+++ b/.devcontainer/i3-config
@@ -1,0 +1,119 @@
+# i3 config for VNC devcontainer
+# Uses Alt (Mod1) as modifier to avoid conflicts with host OS keybindings
+
+set $mod Mod1
+
+font pango:monospace 8
+
+# Use Mouse+$mod to drag floating windows
+floating_modifier $mod
+
+# Terminal
+bindsym $mod+Return exec i3-sensible-terminal
+
+# Kill focused window
+bindsym $mod+Shift+q kill
+
+# Application launcher
+bindsym $mod+d exec --no-startup-id dmenu_run
+
+# Change focus
+bindsym $mod+j focus left
+bindsym $mod+k focus down
+bindsym $mod+l focus up
+bindsym $mod+semicolon focus right
+bindsym $mod+Left focus left
+bindsym $mod+Down focus down
+bindsym $mod+Up focus up
+bindsym $mod+Right focus right
+
+# Move focused window
+bindsym $mod+Shift+j move left
+bindsym $mod+Shift+k move down
+bindsym $mod+Shift+l move up
+bindsym $mod+Shift+semicolon move right
+bindsym $mod+Shift+Left move left
+bindsym $mod+Shift+Down move down
+bindsym $mod+Shift+Up move up
+bindsym $mod+Shift+Right move right
+
+# Split orientation
+bindsym $mod+h split h
+bindsym $mod+v split v
+
+# Fullscreen
+bindsym $mod+f fullscreen toggle
+
+# Layout
+bindsym $mod+s layout stacking
+bindsym $mod+w layout tabbed
+bindsym $mod+e layout toggle split
+
+# Floating
+bindsym $mod+Shift+space floating toggle
+bindsym $mod+space focus mode_toggle
+
+# Parent/child focus
+bindsym $mod+a focus parent
+
+# Workspaces
+set $ws1 "1"
+set $ws2 "2"
+set $ws3 "3"
+set $ws4 "4"
+set $ws5 "5"
+set $ws6 "6"
+set $ws7 "7"
+set $ws8 "8"
+set $ws9 "9"
+set $ws10 "10"
+
+bindsym $mod+1 workspace number $ws1
+bindsym $mod+2 workspace number $ws2
+bindsym $mod+3 workspace number $ws3
+bindsym $mod+4 workspace number $ws4
+bindsym $mod+5 workspace number $ws5
+bindsym $mod+6 workspace number $ws6
+bindsym $mod+7 workspace number $ws7
+bindsym $mod+8 workspace number $ws8
+bindsym $mod+9 workspace number $ws9
+bindsym $mod+0 workspace number $ws10
+
+bindsym $mod+Shift+1 move container to workspace number $ws1
+bindsym $mod+Shift+2 move container to workspace number $ws2
+bindsym $mod+Shift+3 move container to workspace number $ws3
+bindsym $mod+Shift+4 move container to workspace number $ws4
+bindsym $mod+Shift+5 move container to workspace number $ws5
+bindsym $mod+Shift+6 move container to workspace number $ws6
+bindsym $mod+Shift+7 move container to workspace number $ws7
+bindsym $mod+Shift+8 move container to workspace number $ws8
+bindsym $mod+Shift+9 move container to workspace number $ws9
+bindsym $mod+Shift+0 move container to workspace number $ws10
+
+# Reload/restart
+bindsym $mod+Shift+c reload
+bindsym $mod+Shift+r restart
+
+# Resize mode
+mode "resize" {
+        bindsym j resize shrink width 10 px or 10 ppt
+        bindsym k resize grow height 10 px or 10 ppt
+        bindsym l resize shrink height 10 px or 10 ppt
+        bindsym semicolon resize grow width 10 px or 10 ppt
+
+        bindsym Left resize shrink width 10 px or 10 ppt
+        bindsym Down resize grow height 10 px or 10 ppt
+        bindsym Up resize shrink height 10 px or 10 ppt
+        bindsym Right resize grow width 10 px or 10 ppt
+
+        bindsym Return mode "default"
+        bindsym Escape mode "default"
+        bindsym $mod+r mode "default"
+}
+
+bindsym $mod+r mode "resize"
+
+# Status bar
+bar {
+        status_command i3status
+}

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -82,7 +82,7 @@ echo "🖥️ Checking VNC dependencies..."
 MISSING=()
 command -v x11vnc >/dev/null 2>&1 || MISSING+=(x11vnc)
 command -v Xvfb >/dev/null 2>&1 || MISSING+=(xvfb)
-command -v openbox >/dev/null 2>&1 || MISSING+=(openbox)
+command -v i3 >/dev/null 2>&1 || MISSING+=(i3)
 command -v websockify >/dev/null 2>&1 || MISSING+=(novnc)
 command -v xrandr >/dev/null 2>&1 || MISSING+=(x11-xserver-utils)
 if [ ${#MISSING[@]} -gt 0 ]; then

--- a/.devcontainer/start-vnc.sh
+++ b/.devcontainer/start-vnc.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Start VNC stack (Xvfb + openbox + x11vnc + websockify) for headed browser automation
+# Start VNC stack (Xvfb + i3 + x11vnc + websockify) for headed browser automation
 # Installed as /etc/init.d/vnc and managed via `service vnc start`
 
 echo "🖥️ Starting VNC stack..."
@@ -15,12 +15,12 @@ if [ ! -f /etc/init.d/vnc ]; then
 # Required-Stop:     $local_fs
 # Default-Start:     2 3 4 5
 # Default-Stop:      0 1 6
-# Short-Description: VNC stack for headed browser automation
+# Short-Description: VNC stack (i3 + x11vnc) for headed browser automation
 ### END INIT INFO
 
 VNC_USER="vscode"
 PIDFILE_XVFB="/var/run/vnc-xvfb.pid"
-PIDFILE_OPENBOX="/var/run/vnc-openbox.pid"
+PIDFILE_I3="/var/run/vnc-i3.pid"
 PIDFILE_X11VNC="/var/run/vnc-x11vnc.pid"
 PIDFILE_WEBSOCKIFY="/var/run/vnc-websockify.pid"
 PIDFILE_RESIZE="/var/run/vnc-resize.pid"
@@ -43,8 +43,17 @@ start() {
         DISPLAY=:99 xrandr -s 1344x840 2>/dev/null || true
     fi
 
-    start-stop-daemon --start --background --make-pidfile --pidfile "$PIDFILE_OPENBOX" \
-        --chuid "$VNC_USER" --exec /usr/bin/env -- DISPLAY=:99 openbox
+    # Install i3 config to suppress first-run wizard
+    I3_CONFIG_DIR="/home/$VNC_USER/.config/i3"
+    I3_CONFIG_SRC="__WORKSPACE_DIR__/.devcontainer/i3-config"
+    if [ ! -f "$I3_CONFIG_DIR/config" ] && [ -f "$I3_CONFIG_SRC" ]; then
+        mkdir -p "$I3_CONFIG_DIR"
+        cp "$I3_CONFIG_SRC" "$I3_CONFIG_DIR/config"
+        chown -R "$VNC_USER:$VNC_USER" "$I3_CONFIG_DIR"
+    fi
+
+    start-stop-daemon --start --background --make-pidfile --pidfile "$PIDFILE_I3" \
+        --chuid "$VNC_USER" --exec /usr/bin/env -- DISPLAY=:99 i3
 
     : > "$X11VNC_LOG"
     start-stop-daemon --start --background --make-pidfile --pidfile "$PIDFILE_X11VNC" \
@@ -68,9 +77,9 @@ stop() {
     start-stop-daemon --stop --pidfile "$PIDFILE_RESIZE" --oknodo
     start-stop-daemon --stop --pidfile "$PIDFILE_WEBSOCKIFY" --oknodo
     start-stop-daemon --stop --pidfile "$PIDFILE_X11VNC" --oknodo
-    start-stop-daemon --stop --pidfile "$PIDFILE_OPENBOX" --oknodo
+    start-stop-daemon --stop --pidfile "$PIDFILE_I3" --oknodo
     start-stop-daemon --stop --pidfile "$PIDFILE_XVFB" --oknodo
-    rm -f "$PIDFILE_XVFB" "$PIDFILE_OPENBOX" "$PIDFILE_X11VNC" "$PIDFILE_WEBSOCKIFY" "$PIDFILE_RESIZE"
+    rm -f "$PIDFILE_XVFB" "$PIDFILE_I3" "$PIDFILE_X11VNC" "$PIDFILE_WEBSOCKIFY" "$PIDFILE_RESIZE"
     echo "VNC stack stopped"
 }
 

--- a/docker/toolchain/Dockerfile
+++ b/docker/toolchain/Dockerfile
@@ -158,7 +158,7 @@ RUN mkdir -p /usr/share/keyrings \
 RUN apt-get update && apt-get install -y --no-install-recommends \
     xvfb \
     x11vnc \
-    openbox \
+    i3 \
     novnc \
     x11-xserver-utils \
     && rm -rf /var/lib/apt/lists/* \


### PR DESCRIPTION
## Summary
- Replace openbox (stacking WM) with i3 (tiling WM) in the VNC devcontainer stack
- Windows automatically tile side-by-side instead of overlapping, improving headed browser automation
- Ship default i3 config using Alt as modifier key to avoid VNC key conflicts
- Auto-deploy config on VNC startup to suppress the first-run wizard

## Test plan
- [x] Verified i3 starts without config wizard prompt
- [x] Verified all VNC stack processes (Xvfb, i3, x11vnc, websockify) run correctly
- [x] Verified browser opens and tiles properly via agent-browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)