### PR TITLE
refactor: migrate /activity route to dedicated setup function

### DIFF
--- a/turbo/apps/platform/src/signals/bootstrap.ts
+++ b/turbo/apps/platform/src/signals/bootstrap.ts
@@ -9,6 +9,7 @@ import { setupZeroJobDetailRoute$ } from "./zero-page/zero-job-detail-route.ts";
 import { setupSelectOrgPage$ } from "./select-org/select-org-page.ts";
 import { setupSlackConnectPage$ } from "./zero-page/slack-connect-page.ts";
 import { setupQueuePage$ } from "./queue-page/queue-page-setup.ts";
+import { setupActivityPage$ } from "./zero-page/activity-page-setup.ts";
 const ROUTE_CONFIG = [
   {
     path: "/select-org",
@@ -33,6 +34,10 @@ const ROUTE_CONFIG = [
   {
     path: "/queue",
     setup: setupAuthPageWrapper(setupQueuePage$),
+  },
+  {
+    path: "/activity",
+    setup: setupAuthPageWrapper(setupActivityPage$),
   },
   {
     path: "/:tab/:sub",

--- a/turbo/apps/platform/src/signals/zero-page/activity-page-setup.ts
+++ b/turbo/apps/platform/src/signals/zero-page/activity-page-setup.ts
@@ -1,0 +1,19 @@
+import { command } from "ccstate";
+import { createElement } from "react";
+import { ZeroActivityPageWrapper } from "../../views/zero-page/zero-activity-page-wrapper.tsx";
+import { updatePage$ } from "../react-router.ts";
+import { fetchAgentsList$ } from "./zero-agents.ts";
+import { initZeroOnboarding$ } from "./zero-onboarding.ts";
+import { switchActiveAgent$ } from "./zero-chat.ts";
+
+export const setupActivityPage$ = command(
+  async ({ set }, signal: AbortSignal) => {
+    set(updatePage$, createElement(ZeroActivityPageWrapper));
+    await Promise.all([
+      set(fetchAgentsList$),
+      set(initZeroOnboarding$, signal),
+    ]);
+    signal.throwIfAborted();
+    set(switchActiveAgent$, null);
+  },
+);

--- a/turbo/apps/platform/src/views/zero-page/zero-activity-page-wrapper.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-activity-page-wrapper.tsx
@@ -1,0 +1,10 @@
+import { SidebarLayout } from "./sidebar-layout.tsx";
+import { ZeroActivityPage } from "./zero-activity-page.tsx";
+
+export function ZeroActivityPageWrapper() {
+  return (
+    <SidebarLayout>
+      <ZeroActivityPage />
+    </SidebarLayout>
+  );
+}


### PR DESCRIPTION
## Summary

- Create `activity-page-setup.ts` with `setupActivityPage$` command following the `/queue` pattern
- Create `zero-activity-page-wrapper.tsx` with `SidebarLayout`
- Add explicit `/activity` route to `bootstrap.ts`

This is part of the migration effort to move all routes from the centralized `setupZeroPage$` to dedicated setup functions.

## Test plan

- [ ] Navigate to `/activity` directly
- [ ] Navigate to `/activity` via sidebar
- [ ] Refresh page on `/activity` route
- [ ] Verify sidebar highlighting works

Closes #5846

🤖 Generated with [Claude Code](https://claude.com/claude-code)