### PR TITLE
feat: add dev seed script for credit pricing and api keys

### DIFF
--- a/.claude/skills/dev-server/SKILL.md
+++ b/.claude/skills/dev-server/SKILL.md
@@ -41,11 +41,33 @@ cd "$PROJECT_ROOT/turbo" && pnpm dev:status
 
 If all three services show `running`, the dev server is already up — display the output and stop. Otherwise, proceed to start the server.
 
-### Step 2: Start Dev Server and Runner in Background
+### Step 2: Start Runner in Background
 
-Start **both** the dev server and the runner in parallel, each using Bash tool with `run_in_background: true` parameter (two separate Bash calls in the same message).
+Start the runner first using Bash tool with `run_in_background: true` parameter. The runner takes several minutes to initialize, so we start it early to overlap with the prepare step.
 
-**Dev server** — if `--tunnel-hostname=<fqdn>` was provided in args, pass it as `TUNNEL_HOSTNAME` env var:
+```bash
+PROJECT_ROOT=$(git rev-parse --show-toplevel)
+cd "$PROJECT_ROOT/turbo" && pnpm runner
+```
+
+This returns a task_id for monitoring.
+
+**Note on runner**: The runner takes several minutes to initialize (cross-compile, upload, build rootfs/snapshots). The app works without it — only chat/agent interaction features require the runner. You will be notified when the runner background task completes.
+
+### Step 3: Run prepare.sh
+
+While the runner is initializing in the background, run `prepare.sh` to set up the environment (sync .env.local, install dependencies, run database migrations). This may take a few minutes — wait for it to complete:
+
+```bash
+PROJECT_ROOT=$(git rev-parse --show-toplevel)
+cd "$PROJECT_ROOT" && bash scripts/prepare.sh
+```
+
+### Step 4: Start Dev Server in Background
+
+After `prepare.sh` completes successfully, start the dev server using Bash tool with `run_in_background: true` parameter.
+
+If `--tunnel-hostname=<fqdn>` was provided in args, pass it as `TUNNEL_HOSTNAME` env var:
 
 ```bash
 PROJECT_ROOT=$(git rev-parse --show-toplevel)
@@ -59,15 +81,6 @@ PROJECT_ROOT=$(git rev-parse --show-toplevel)
 cd "$PROJECT_ROOT/turbo" && pnpm dev
 ```
 
-**Runner** — start in parallel with the dev server:
-
-```bash
-PROJECT_ROOT=$(git rev-parse --show-toplevel)
-cd "$PROJECT_ROOT/turbo" && pnpm runner
-```
-
-Both return a task_id for monitoring.
-
 **Save the dev server task_id** to a local file so `/dev-logs` can find it across conversation sessions:
 
 ```bash
@@ -75,9 +88,7 @@ PROJECT_ROOT=$(git rev-parse --show-toplevel)
 echo "<dev-task_id>" > "$PROJECT_ROOT/turbo/.dev-task-id"
 ```
 
-**Note on runner**: The runner takes several minutes to initialize (cross-compile, upload, build rootfs/snapshots). The app works without it — only chat/agent interaction features require the runner. You will be notified when the runner background task completes.
-
-### Step 3: Display Results
+### Step 5: Display Results
 
 Once the server is confirmed running, display the URLs:
 
@@ -95,18 +106,6 @@ Next steps:
 - Use `/dev-logs` to view server output
 - Use `/dev-logs [pattern]` to filter logs (e.g., `/dev-logs error`)
 - Use `/dev-stop` to stop the server
-```
-
-If the script fails with error:
-- a database error (e.g., missing `org_cache` table)
-- missing environment variables
-- missing npm modules
-
-Then the user likely needs to set up their environment. run prepare.sh, this will setup .env.local, set up the database, run migrations, and install npm dependencies. it may cost minutes to run, wait for it to complete:
-
-```bash
-PROJECT_ROOT=$(git rev-parse --show-toplevel)
-cd "$PROJECT_ROOT" && bash scripts/prepare.sh
 ```
 
 ## Notes

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -582,6 +582,10 @@ jobs:
           GITHUB_APP_CLIENT_SECRET: ${{ secrets.VM0_GITHUB_APP_CLIENT_SECRET }}
           GITHUB_APP_WEBHOOK_SECRET: ${{ secrets.VM0_GITHUB_APP_WEBHOOK_SECRET }}
           GITHUB_APP_PRIVATE_KEY: ${{ secrets.VM0_GITHUB_APP_PRIVATE_KEY }}
+          DEV_MODEL_ANTHROPIC_KEY: fake-key
+          DEV_MODEL_MINIMAX_KEY: fake-key
+          DEV_MODEL_MOONSHOT_KEY: fake-key
+          DEV_MODEL_ZAI_KEY: fake-key
         run: |
           # --- Start Neon branch creation in background ---
           (
@@ -616,6 +620,7 @@ jobs:
             echo "$DATABASE_URL" > /tmp/neon-database-url
 
             cd turbo && DATABASE_URL="$DATABASE_URL" pnpm -F web db:migrate
+            cd turbo && DATABASE_URL="$DATABASE_URL" pnpm -F web db:dev-seed
             echo "Neon branch ready"
           ) > /tmp/neon-log 2>&1 &
           NEON_PID=$!

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["github.vscode-github-actions"]
+}

--- a/scripts/prepare.sh
+++ b/scripts/prepare.sh
@@ -155,6 +155,18 @@ else
 fi
 
 # -----------------------------------------------------------------------------
+# 9. Seed development data
+# -----------------------------------------------------------------------------
+echo "9. Seeding development data..."
+cd "$TURBO_DIR"
+if pnpm --filter web db:dev-seed; then
+  echo -e "${GREEN}   Development seed complete${NC}"
+else
+  echo -e "${RED}   Error: Development seed failed${NC}"
+  FAILED=1
+fi
+
+# -----------------------------------------------------------------------------
 # Summary
 # -----------------------------------------------------------------------------
 echo ""

--- a/turbo/apps/web/.env.local.tpl
+++ b/turbo/apps/web/.env.local.tpl
@@ -168,6 +168,12 @@ GITHUB_APP_PRIVATE_KEY=op://Development/github/GITHUB_APP_PRIVATE_KEY
 GITHUB_APP_SLUG=op://Development/github/GITHUB_APP_SLUG
 GITHUB_APP_WEBHOOK_SECRET=op://Development/github/GITHUB_APP_WEBHOOK_SECRET
 
+# Optional: VM0 Managed Model Provider API Keys
+DEV_MODEL_ANTHROPIC_KEY=op://Development/anthropic/DEV_MODEL_ANTHROPIC_KEY
+DEV_MODEL_MOONSHOT_KEY=op://Development/moonshot/DEV_MODEL_MOONSHOT_KEY
+DEV_MODEL_ZAI_KEY=op://Development/z.ai/DEV_MODEL_ZAI_KEY
+DEV_MODEL_MINIMAX_KEY=op://Development/minimax/DEV_MODEL_MINIMAX_KEY
+
 # Optional: Self-hosted Runner (for local development with runner on dev-1)
 # RUNNER_DEFAULT_GROUP is auto-configured by sync-env.sh — do not add here
 OFFICIAL_RUNNER_SECRET=0000000000000000000000000000000000000000000000000000000000000000

--- a/turbo/apps/web/package.json
+++ b/turbo/apps/web/package.json
@@ -14,6 +14,7 @@
     "db:migrate": "tsx scripts/migrate.ts",
     "db:generate": "drizzle-kit generate",
     "db:seed": "tsx scripts/seed.ts",
+    "db:dev-seed": "dotenv -e .env.local -- tsx scripts/dev-seed.ts",
     "db:studio": "drizzle-kit studio",
     "db:reset": "tsx scripts/reset-db.ts"
   },

--- a/turbo/apps/web/scripts/dev-seed.ts
+++ b/turbo/apps/web/scripts/dev-seed.ts
@@ -1,0 +1,211 @@
+#!/usr/bin/env tsx
+
+import postgres from "postgres";
+
+/**
+ * Dev seed: populate credit_pricing and vm0_api_keys tables.
+ *
+ * Pricing convention: 1 USD = 1000 credits.
+ * Prices are per 1M tokens, stored as integer credits per 1M tokens.
+ *
+ * API keys are read from environment variables:
+ *   DEV_MODEL_ANTHROPIC_KEY, DEV_MODEL_MOONSHOT_KEY,
+ *   DEV_MODEL_ZAI_KEY, DEV_MODEL_MINIMAX_KEY
+ */
+
+interface ModelPricing {
+  model: string;
+  modelProvider: string;
+  inputTokenPrice: number;
+  outputTokenPrice: number;
+  cacheReadTokenPrice: number;
+  cacheCreationTokenPrice: number;
+}
+
+interface Vm0ApiKey {
+  vendor: string;
+  model: string;
+  apiKey: string;
+  label: string;
+}
+
+/** 1 USD = 1000 credits */
+const USD_TO_CREDITS = 1000;
+
+function usd(amount: number): number {
+  return Math.round(amount * USD_TO_CREDITS);
+}
+
+const MODEL_PRICING: ModelPricing[] = [
+  // Anthropic
+  {
+    model: "claude-sonnet-4.6",
+    modelProvider: "vm0",
+    inputTokenPrice: usd(3),
+    outputTokenPrice: usd(15),
+    cacheReadTokenPrice: usd(0.3),
+    cacheCreationTokenPrice: usd(3.75),
+  },
+  {
+    model: "claude-opus-4.6",
+    modelProvider: "vm0",
+    inputTokenPrice: usd(15),
+    outputTokenPrice: usd(75),
+    cacheReadTokenPrice: usd(1.5),
+    cacheCreationTokenPrice: usd(18.75),
+  },
+  // Moonshot
+  {
+    model: "kimi-k2.5",
+    modelProvider: "vm0",
+    inputTokenPrice: usd(0.5),
+    outputTokenPrice: usd(2),
+    cacheReadTokenPrice: 0,
+    cacheCreationTokenPrice: 0,
+  },
+  {
+    model: "kimi-k2-thinking-turbo",
+    modelProvider: "vm0",
+    inputTokenPrice: usd(0.5),
+    outputTokenPrice: usd(2),
+    cacheReadTokenPrice: 0,
+    cacheCreationTokenPrice: 0,
+  },
+  {
+    model: "kimi-k2-thinking",
+    modelProvider: "vm0",
+    inputTokenPrice: usd(1),
+    outputTokenPrice: usd(4),
+    cacheReadTokenPrice: 0,
+    cacheCreationTokenPrice: 0,
+  },
+  // Z.AI (GLM)
+  {
+    model: "glm-5",
+    modelProvider: "vm0",
+    inputTokenPrice: usd(1),
+    outputTokenPrice: usd(4),
+    cacheReadTokenPrice: 0,
+    cacheCreationTokenPrice: 0,
+  },
+  {
+    model: "glm-4.7",
+    modelProvider: "vm0",
+    inputTokenPrice: usd(0.5),
+    outputTokenPrice: usd(2),
+    cacheReadTokenPrice: 0,
+    cacheCreationTokenPrice: 0,
+  },
+  {
+    model: "glm-4.5-air",
+    modelProvider: "vm0",
+    inputTokenPrice: usd(0.2),
+    outputTokenPrice: usd(0.8),
+    cacheReadTokenPrice: 0,
+    cacheCreationTokenPrice: 0,
+  },
+  // MiniMax
+  {
+    model: "MiniMax-M2.1",
+    modelProvider: "vm0",
+    inputTokenPrice: usd(1),
+    outputTokenPrice: usd(4),
+    cacheReadTokenPrice: 0,
+    cacheCreationTokenPrice: 0,
+  },
+];
+
+/**
+ * Build vm0_api_keys entries from environment variables.
+ * Each vendor key is shared across all models of that vendor.
+ */
+function buildVm0ApiKeys(): Vm0ApiKey[] {
+  const vendorEnvMap: Record<string, { envVar: string; models: string[] }> = {
+    anthropic: {
+      envVar: "DEV_MODEL_ANTHROPIC_KEY",
+      models: ["claude-sonnet-4.6", "claude-opus-4.6"],
+    },
+    moonshot: {
+      envVar: "DEV_MODEL_MOONSHOT_KEY",
+      models: ["kimi-k2.5", "kimi-k2-thinking-turbo", "kimi-k2-thinking"],
+    },
+    zai: {
+      envVar: "DEV_MODEL_ZAI_KEY",
+      models: ["glm-5", "glm-4.7", "glm-4.5-air"],
+    },
+    minimax: {
+      envVar: "DEV_MODEL_MINIMAX_KEY",
+      models: ["MiniMax-M2.1"],
+    },
+  };
+
+  const keys: Vm0ApiKey[] = [];
+  for (const [vendor, config] of Object.entries(vendorEnvMap)) {
+    const apiKey = process.env[config.envVar];
+    if (!apiKey) {
+      console.log(`  ⚠ ${config.envVar} not set, skipping ${vendor}`);
+      continue;
+    }
+    for (const model of config.models) {
+      keys.push({ vendor, model, apiKey, label: "dev-seed" });
+    }
+  }
+  return keys;
+}
+
+async function devSeed() {
+  if (!process.env.DATABASE_URL) {
+    throw new Error("DATABASE_URL environment variable is not set");
+  }
+
+  const sql = postgres(process.env.DATABASE_URL, { max: 1 });
+
+  try {
+    // --- credit_pricing ---
+    console.log("Seeding credit_pricing...");
+    for (const p of MODEL_PRICING) {
+      await sql`
+        INSERT INTO credit_pricing (
+          model, model_provider,
+          input_token_price, output_token_price,
+          cache_read_token_price, cache_creation_token_price,
+          updated_at
+        ) VALUES (
+          ${p.model}, ${p.modelProvider},
+          ${p.inputTokenPrice}, ${p.outputTokenPrice},
+          ${p.cacheReadTokenPrice}, ${p.cacheCreationTokenPrice},
+          NOW()
+        )
+        ON CONFLICT (model, model_provider)
+        DO UPDATE SET
+          input_token_price = EXCLUDED.input_token_price,
+          output_token_price = EXCLUDED.output_token_price,
+          cache_read_token_price = EXCLUDED.cache_read_token_price,
+          cache_creation_token_price = EXCLUDED.cache_creation_token_price,
+          updated_at = NOW()
+      `;
+      console.log(
+        `  ${p.modelProvider}/${p.model}: input=${p.inputTokenPrice} output=${p.outputTokenPrice}`,
+      );
+    }
+    console.log(`✅ Seeded ${MODEL_PRICING.length} credit pricing entries`);
+
+    // --- vm0_api_keys ---
+    console.log("Seeding vm0_api_keys...");
+    const apiKeys = buildVm0ApiKeys();
+    // Replace all dev-seed keys with fresh set
+    await sql`DELETE FROM vm0_api_keys WHERE label = 'dev-seed'`;
+    for (const k of apiKeys) {
+      await sql`
+        INSERT INTO vm0_api_keys (vendor, model, api_key, label, updated_at)
+        VALUES (${k.vendor}, ${k.model}, ${k.apiKey}, ${k.label}, NOW())
+      `;
+      console.log(`  ${k.vendor}/${k.model}`);
+    }
+    console.log(`✅ Seeded ${apiKeys.length} vm0 API key entries`);
+  } finally {
+    await sql.end();
+  }
+}
+
+await devSeed();


### PR DESCRIPTION
## Summary
- Add `db:dev-seed` script that seeds `credit_pricing` (model pricing at 1 USD = 1000 credits) and `vm0_api_keys` (from `DEV_MODEL_*` env vars) tables
- Integrate into `prepare.sh` (step 9, after db:migrate) and deploy-web CI job (fake-key for CI)
- Add `DEV_MODEL_ANTHROPIC_KEY` / `MOONSHOT` / `ZAI` / `MINIMAX` env vars to `.env.local.tpl` (1Password backed)
- Refactor dev-server skill: run `prepare.sh` between runner start and dev server start

## Test plan
- [x] `pnpm --filter web db:dev-seed` runs successfully locally
- [x] `credit_pricing` table populated with 9 model pricing entries
- [x] `vm0_api_keys` table populated with 9 keys (label=dev-seed)
- [ ] CI deploy-web job passes with fake-key env vars

🤖 Generated with [Claude Code](https://claude.com/claude-code)