### PR TITLE
chore: bump devcontainer image to c456944 (i3)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "VM0 Development",
-  "image": "ghcr.io/vm0-ai/vm0-dev:20260321",
+  "image": "ghcr.io/vm0-ai/vm0-dev:c456944",
   "features": {
     "ghcr.io/itsmechlark/features/postgresql:1": {
       "version": "17"


### PR DESCRIPTION
## Summary
- Bump devcontainer toolchain image from `20260321` to `c456944`
- New image includes i3 tiling window manager (from #5838), replacing openbox

## Test plan
- [ ] Rebuild devcontainer and verify i3 starts correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)