### PR TITLE
docs: update rust toolchain comment in dockerfile

### DIFF
--- a/docker/toolchain/Dockerfile
+++ b/docker/toolchain/Dockerfile
@@ -30,7 +30,7 @@ RUN npm install -g pnpm@10.15.0 lefthook@1.12.3
 FROM toolchain AS toolchain-rust
 
 # Install Rust toolchain with ARM64 cross-compilation support
-# Used for building guest-init for Firecracker VMs (ARM64 metal runners)
+# Used for building runner and guest binaries for Firecracker VMs (ARM64 metal runners)
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH


### PR DESCRIPTION
## Summary
- Update comment in `docker/toolchain/Dockerfile` to reflect that the Rust toolchain is used for building the entire runner binary, not just guest-init

## Test plan
- [ ] No functional changes — comment-only update

🤖 Generated with [Claude Code](https://claude.com/claude-code)