### PR TITLE
chore: move rustls features from workspace to reqeast

### DIFF
--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -60,7 +60,7 @@ sentry = { version = "0.47", default-features = false }
 which = "8"
 ureq = "3"
 reqwest = { version = "0.13", default-features = false }
-rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12"] }
+rustls = { version = "0.23", default-features = false }
 hmac = "0.12"
 sha2 = "0.10"
 tokio-util = "0.7"

--- a/crates/reqeast/Cargo.toml
+++ b/crates/reqeast/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 
 [dependencies]
 reqwest = { workspace = true, features = ["json", "rustls-no-provider"] }
-rustls = { workspace = true }
+rustls = { workspace = true, features = ["ring", "std", "tls12"] }
 
 [lints]
 workspace = true


### PR DESCRIPTION
## Summary
- Move `rustls` feature flags (`ring`, `std`, `tls12`) from workspace `Cargo.toml` to `reqeast/Cargo.toml` where they're actually used

## Test plan
- [x] `cargo check -p reqeast` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)