### PR TITLE
fix(ci): wait for neon branch ready after create

### DIFF
--- a/.github/actions/neon-branch/action.yml
+++ b/.github/actions/neon-branch/action.yml
@@ -71,25 +71,25 @@ runs:
           echo "Branch $BRANCH_NAME already exists"
           echo "Resetting branch to sync with parent (main)..."
           neonctl branches reset "$BRANCH_NAME" --project-id "$NEON_PROJECT_ID" --parent
-
-          # Wait for reset to complete (branch state changes to "ready")
-          echo "Waiting for branch reset to complete..."
-          for i in {1..30}; do
-            CURRENT_STATE=$(neonctl branches list --project-id "$NEON_PROJECT_ID" --output json | jq -r ".[] | select(.name == \"$BRANCH_NAME\") | .current_state")
-            if [ "$CURRENT_STATE" = "ready" ]; then
-              echo "Branch reset complete (state: $CURRENT_STATE)"
-              break
-            fi
-            echo "Branch state: $CURRENT_STATE (attempt $i/30)"
-            sleep 2
-          done
-
-          if [ "$CURRENT_STATE" != "ready" ]; then
-            echo "Warning: Branch may not be ready after 60 seconds (state: $CURRENT_STATE)"
-          fi
         else
           echo "Creating branch $BRANCH_NAME"
           neonctl branches create --name "$BRANCH_NAME" --project-id "$NEON_PROJECT_ID"
+        fi
+
+        echo "Waiting for branch to become ready..."
+        for i in {1..30}; do
+          CURRENT_STATE=$(neonctl branches list --project-id "$NEON_PROJECT_ID" --output json | jq -r ".[] | select(.name == \"$BRANCH_NAME\") | .current_state")
+          if [ "$CURRENT_STATE" = "ready" ]; then
+            echo "Branch ready (state: $CURRENT_STATE)"
+            break
+          fi
+          echo "Branch state: $CURRENT_STATE (attempt $i/30)"
+          sleep 2
+        done
+
+        if [ "$CURRENT_STATE" != "ready" ]; then
+          echo "::error::Neon branch not ready after 60 seconds (state: $CURRENT_STATE)"
+          exit 1
         fi
 
         DATABASE_URL=$(neonctl connection-string "$BRANCH_NAME" --project-id "$NEON_PROJECT_ID" --database-name "$INPUT_DATABASE_NAME" --pooled)


### PR DESCRIPTION
## Summary
- Fix merge queue `deploy-web` failures caused by running migrations before Neon branch is ready
- New branch creation returns with `current_state: "init"` — migrations hit a disconnected socket
- Move the wait-for-ready loop (already existed for `reset`) to run after both `create` and `reset`
- Fail fast with `exit 1` if branch not ready after 60s (was only a warning before)

## Root cause
`neonctl branches create` returns immediately while the branch is still initializing. The script proceeded to `db:migrate` against a not-yet-ready database, causing `TypeError: Cannot read properties of null (reading 'write')` in the postgres driver.

## Test plan
- [x] Verified from CI logs: branch state was `init` at migration time
- [ ] Merge queue run should pass `deploy-web` with this fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)