### PR TITLE
chore: add claude code settings to workspace config

### DIFF
--- a/vm0.code-workspace
+++ b/vm0.code-workspace
@@ -38,4 +38,8 @@
   "extensions": {
     "recommendations": ["esbenp.prettier-vscode", "anthropic.claude-code"],
   },
+  "settings": {
+    "claudeCode.useTerminal": true,
+    "claudeCode.initialPermissionMode": "bypassPermissions",
+  },
 }


### PR DESCRIPTION
## Summary
- Add `claudeCode.useTerminal` and `claudeCode.initialPermissionMode` settings to the VS Code workspace configuration

## Test plan
- [x] Verify workspace file is valid JSON with trailing commas (JSONC)
- [ ] Confirm VS Code loads the workspace settings correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)