### PR TITLE
docs: update skills (dev-browser, pr-handoff, ui-bug-reproduce)

### DIFF
--- a/.claude/skills/dev-browser/SKILL.md
+++ b/.claude/skills/dev-browser/SKILL.md
@@ -153,4 +153,7 @@ Video:
 - **Verify page state with snapshot** — use `agent-browser snapshot -i` after navigation instead of `wait --load networkidle` (which frequently times out)
 - **Scroll within modals** — use `agent-browser scroll down 500 --selector "<modal-selector>"` for content inside modals, not plain `scroll down`
 - **Handle modals/dialogs** — check snapshot output for unexpected modals and close them before proceeding
-- **Onboarding model provider API key** — if the onboarding flow asks for a model provider API key, enter any random string to skip past it
+- **Model provider API key** — if the onboarding or chat flow asks for a model provider API key, use the Moonshot API key from `turbo/apps/web/.env.local` (the `MOONSHOT_API_KEY` value) and select the **Kimi K2.5** model as the model provider. Extract the key with:
+  ```bash
+  grep MOONSHOT_API_KEY "$(git rev-parse --show-toplevel)/turbo/apps/web/.env.local" | cut -d= -f2
+  ```

--- a/.claude/skills/pr-handoff/SKILL.md
+++ b/.claude/skills/pr-handoff/SKILL.md
@@ -63,6 +63,8 @@ If no PR exists for this branch, delegate to the `pull-request create` skill to 
 Skill({ skill: "pull-request", args: "create" })
 ```
 
+**IMPORTANT:** Only create the PR — do NOT run `/pr-check` or any CI monitoring after creation. The assigned worker will run `/pr-check` itself. The goal here is to get the PR created and handed off as fast as possible.
+
 After `/pr-create` completes, capture the PR number and proceed to Phase 2.
 
 ### Step 2b: Existing PR → Push Any Pending Changes


### PR DESCRIPTION
## Summary
- **dev-browser**: Use Moonshot API key from `.env.local` with Kimi K2.5 model instead of random string for model provider setup
- **pr-handoff**: Clarify that `/pr-check` is skipped when called from handoff — workers run it themselves
- **ui-bug-reproduce**: New skill for automated UI bug triage — find unassigned bugs, reproduce with failing tests, handoff to workers

## Test plan
- [x] Skills are markdown-only, no code changes
- [x] All commits pass pre-commit hooks

🤖 Generated with [Claude Code](https://claude.com/claude-code)