### PR TITLE
fix(platform): show 404 page for unknown routes instead of chat dashboard

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-nav.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-nav.test.ts
@@ -36,9 +36,9 @@ describe("zero-nav", () => {
       expect(context.store.get(zeroActiveId$)).toBe("chat");
     });
 
-    it("should resolve unknown tab /meet to default 'chat'", () => {
+    it("should resolve unknown tab /meet to 'not-found'", () => {
       mockLocation({ pathname: "/meet", search: "" }, context.signal);
-      expect(context.store.get(zeroActiveId$)).toBe("chat");
+      expect(context.store.get(zeroActiveId$)).toBe("not-found");
     });
 
     it("should resolve /schedule to 'schedule'", () => {
@@ -66,9 +66,21 @@ describe("zero-nav", () => {
       expect(context.store.get(zeroActiveId$)).toBe("preferences");
     });
 
-    it("should fall back to 'chat' for invalid tab", () => {
+    it("should resolve to 'not-found' for invalid tab", () => {
       mockLocation({ pathname: "/invalid", search: "" }, context.signal);
-      expect(context.store.get(zeroActiveId$)).toBe("chat");
+      expect(context.store.get(zeroActiveId$)).toBe("not-found");
+    });
+
+    it("should not resolve unknown path /scheduled to chat (bug #5869)", () => {
+      mockLocation({ pathname: "/scheduled", search: "" }, context.signal);
+      expect(context.store.get(zeroActiveId$)).not.toBe("chat");
+      expect(context.store.get(zeroActiveId$)).toBe("not-found");
+    });
+
+    it("should not resolve unknown path /foo to chat (bug #5869)", () => {
+      mockLocation({ pathname: "/foo", search: "" }, context.signal);
+      expect(context.store.get(zeroActiveId$)).not.toBe("chat");
+      expect(context.store.get(zeroActiveId$)).toBe("not-found");
     });
 
     it("should resolve /settings to 'settings'", () => {

--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-nav.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-nav.test.ts
@@ -73,13 +73,11 @@ describe("zero-nav", () => {
 
     it("should not resolve unknown path /scheduled to chat (bug #5869)", () => {
       mockLocation({ pathname: "/scheduled", search: "" }, context.signal);
-      expect(context.store.get(zeroActiveId$)).not.toBe("chat");
       expect(context.store.get(zeroActiveId$)).toBe("not-found");
     });
 
     it("should not resolve unknown path /foo to chat (bug #5869)", () => {
       mockLocation({ pathname: "/foo", search: "" }, context.signal);
-      expect(context.store.get(zeroActiveId$)).not.toBe("chat");
       expect(context.store.get(zeroActiveId$)).toBe("not-found");
     });
 

--- a/turbo/apps/platform/src/signals/zero-page/zero-nav.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-nav.ts
@@ -2,10 +2,11 @@ import { command, computed, state } from "ccstate";
 import { pathname$, updatePathname$, navigateInReact$ } from "../route.ts";
 import type {
   ZeroNavId,
+  ZeroNavTab,
   ZeroAccountAction,
 } from "../../views/zero-page/zero-sidebar.tsx";
 
-function isValidTab(tab: string): tab is ZeroNavId {
+function isValidTab(tab: string): tab is ZeroNavTab {
   return (
     tab === "chat" ||
     tab === "schedule" ||
@@ -82,7 +83,7 @@ export const zeroChatAgentId$ = computed((get): string | null => {
  * Navigate to a zero tab — updates the URL path to `/:tab`.
  * "chat" maps to `/` (the default, no suffix needed).
  */
-export const setZeroActiveId$ = command(({ set }, id: ZeroNavId) => {
+export const setZeroActiveId$ = command(({ set }, id: ZeroNavTab) => {
   if (id === "chat") {
     set(navigateInReact$, "/");
   } else {
@@ -186,7 +187,7 @@ export const initSidebarCollapsed$ = command(({ set }) => {
 // ---------------------------------------------------------------------------
 
 /** Handle nav tab selection: navigate to tab and close about page. */
-export const handleZeroNavSelect$ = command(({ set }, id: ZeroNavId) => {
+export const handleZeroNavSelect$ = command(({ set }, id: ZeroNavTab) => {
   set(setZeroActiveId$, id);
   set(internalShowAboutPage$, false);
 });

--- a/turbo/apps/platform/src/signals/zero-page/zero-nav.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-nav.ts
@@ -22,14 +22,18 @@ function isValidTab(tab: string): tab is ZeroNavId {
  * Active zero nav id, derived from the URL path `/:tab`.
  * `/`, `/chat`, `/chat/:sessionId`, and `/talk/:name`
  * all resolve to "chat".
+ * Unknown paths resolve to "not-found".
  */
 export const zeroActiveId$ = computed((get): ZeroNavId => {
   const path = get(pathname$);
   const segment = path.split("/")[1] ?? "";
-  if (segment && isValidTab(segment)) {
+  if (segment === "" || segment === "talk") {
+    return "chat";
+  }
+  if (isValidTab(segment)) {
     return segment;
   }
-  return "chat";
+  return "not-found";
 });
 
 /**

--- a/turbo/apps/platform/src/views/zero-page/zero-content.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-content.tsx
@@ -47,6 +47,7 @@ function getSectionTitles(
     settings: "Settings",
     preferences: "Preferences",
     queue: "Queue",
+    "not-found": "Page not found",
   };
 }
 
@@ -116,6 +117,22 @@ export function ZeroContent({
   }
   if (sectionId === "preferences") {
     return <ZeroPreferencesPage />;
+  }
+  if (sectionId === "not-found") {
+    return (
+      <div className="flex flex-1 flex-col items-center justify-center min-h-0 px-4">
+        <h1 className="text-4xl font-bold text-foreground">404</h1>
+        <p className="mt-2 text-base text-muted-foreground">
+          The page you are looking for does not exist.
+        </p>
+        <a
+          href="/"
+          className="mt-6 text-sm font-medium text-primary hover:underline"
+        >
+          Go to home
+        </a>
+      </div>
+    );
   }
 
   const title = getSectionTitles(agentName)[sectionId];

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -165,7 +165,8 @@ export type ZeroNavId =
   | "works"
   | "settings"
   | "preferences"
-  | "queue";
+  | "queue"
+  | "not-found";
 
 type NavIcon = (props: { size?: number; className?: string }) => ReactNode;
 const MANAGE_NAV = [

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -157,7 +157,8 @@ export interface SubagentInfo {
   displayName?: string | null;
 }
 
-export type ZeroNavId =
+/** Valid navigable tab IDs — used in write paths (navigation commands). */
+export type ZeroNavTab =
   | "chat"
   | "schedule"
   | "team"
@@ -165,8 +166,10 @@ export type ZeroNavId =
   | "works"
   | "settings"
   | "preferences"
-  | "queue"
-  | "not-found";
+  | "queue";
+
+/** Active ID derived from the URL — includes valid tabs plus "not-found" for unknown routes. */
+export type ZeroNavId = ZeroNavTab | "not-found";
 
 type NavIcon = (props: { size?: number; className?: string }) => ReactNode;
 const MANAGE_NAV = [
@@ -177,13 +180,13 @@ const MANAGE_NAV = [
 
 const FOOTER_NAV = [
   {
-    id: "works" as const satisfies ZeroNavId,
+    id: "works" as const satisfies ZeroNavTab,
     label: "Where Zero works",
     icon: IconLayoutGrid as NavIcon,
     iconImg: slackIcon,
   },
   {
-    id: "settings" as const satisfies ZeroNavId,
+    id: "settings" as const satisfies ZeroNavTab,
     label: "Settings",
     icon: IconSettings as NavIcon,
     iconImg: undefined,


### PR DESCRIPTION
## Summary

- Unknown routes (e.g., `/scheduled`, `/foo`) now show a 404 page instead of silently falling back to the chat dashboard
- `zeroActiveId$` returns `"not-found"` for unrecognized path segments instead of defaulting to `"chat"`
- `ZeroContent` renders a proper 404 page with navigation back to home when the active tab is `"not-found"`

Closes #5869

## Test plan

- [x] Existing tests updated: invalid tab paths now expect `"not-found"` instead of `"chat"`
- [x] New tests added for `/scheduled` and `/foo` per the issue reproduction steps
- [x] Valid routes (`/`, `/chat`, `/schedule`, `/team`, `/activity`, `/works`, `/settings`, `/preferences`, `/talk/agent-name`) still resolve correctly
- [x] All 35 zero-nav tests pass
- [x] Type checking passes
- [x] Lint passes with 0 warnings
- [x] Knip finds no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)