### PR TITLE
fix(platform): show 404 page for unknown routes instead of chat fallback

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-nav.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-nav.test.ts
@@ -36,9 +36,9 @@ describe("zero-nav", () => {
       expect(context.store.get(zeroActiveId$)).toBe("chat");
     });
 
-    it("should resolve unknown tab /meet to default 'chat'", () => {
+    it("should resolve unknown tab /meet to 'not-found'", () => {
       mockLocation({ pathname: "/meet", search: "" }, context.signal);
-      expect(context.store.get(zeroActiveId$)).toBe("chat");
+      expect(context.store.get(zeroActiveId$)).toBe("not-found");
     });
 
     it("should resolve /schedule to 'schedule'", () => {
@@ -66,9 +66,21 @@ describe("zero-nav", () => {
       expect(context.store.get(zeroActiveId$)).toBe("preferences");
     });
 
-    it("should fall back to 'chat' for invalid tab", () => {
+    it("should resolve unknown path to 'not-found'", () => {
       mockLocation({ pathname: "/invalid", search: "" }, context.signal);
-      expect(context.store.get(zeroActiveId$)).toBe("chat");
+      expect(context.store.get(zeroActiveId$)).toBe("not-found");
+    });
+
+    it("should not resolve unknown path /scheduled to chat (bug #5869)", () => {
+      mockLocation({ pathname: "/scheduled", search: "" }, context.signal);
+      expect(context.store.get(zeroActiveId$)).not.toBe("chat");
+      expect(context.store.get(zeroActiveId$)).toBe("not-found");
+    });
+
+    it("should not resolve unknown path /foo to chat (bug #5869)", () => {
+      mockLocation({ pathname: "/foo", search: "" }, context.signal);
+      expect(context.store.get(zeroActiveId$)).not.toBe("chat");
+      expect(context.store.get(zeroActiveId$)).toBe("not-found");
     });
 
     it("should resolve /settings to 'settings'", () => {

--- a/turbo/apps/platform/src/signals/zero-page/zero-nav.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-nav.ts
@@ -22,14 +22,18 @@ function isValidTab(tab: string): tab is ZeroNavId {
  * Active zero nav id, derived from the URL path `/:tab`.
  * `/`, `/chat`, `/chat/:sessionId`, and `/talk/:name`
  * all resolve to "chat".
+ * Unknown paths resolve to "not-found".
  */
 export const zeroActiveId$ = computed((get): ZeroNavId => {
   const path = get(pathname$);
   const segment = path.split("/")[1] ?? "";
-  if (segment && isValidTab(segment)) {
+  if (!segment || segment === "talk") {
+    return "chat";
+  }
+  if (isValidTab(segment)) {
     return segment;
   }
-  return "chat";
+  return "not-found";
 });
 
 /**

--- a/turbo/apps/platform/src/views/zero-page/zero-content.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-content.tsx
@@ -1,4 +1,3 @@
-import { useLoadable } from "ccstate-react";
 import type { ZeroNavId } from "./zero-sidebar.tsx";
 import { ZeroChatPage } from "./zero-chat-page.tsx";
 import { ZeroSessionChatPage } from "./zero-session-chat-page.tsx";
@@ -9,7 +8,6 @@ import { ZeroWorksPage } from "./zero-works-page.tsx";
 import { QueuePage } from "../queue-page/queue-page.tsx";
 import { ZeroSchedulePage } from "./zero-schedule-page.tsx";
 import { ZeroSettingsPage } from "./zero-settings-page.tsx";
-import { agentDisplayName$ } from "../../signals/zero-page/zero-agent-name.ts";
 import zeroAvatarImg from "./assets/zero-avatar.png";
 
 interface ZeroContentProps {
@@ -35,21 +33,6 @@ interface ZeroContentProps {
   onCycleZeroAvatar?: () => void;
 }
 
-function getSectionTitles(
-  agentName: string,
-): Readonly<Record<ZeroNavId, string>> {
-  return {
-    chat: `Chat with ${agentName}`,
-    schedule: "Scheduled",
-    team: `${agentName}'s team`,
-    activity: "Activities",
-    works: `Where ${agentName} works`,
-    settings: "Settings",
-    preferences: "Preferences",
-    queue: "Queue",
-  };
-}
-
 export function ZeroContent({
   sectionId,
   inSession = false,
@@ -64,9 +47,6 @@ export function ZeroContent({
   onChatAvatarClick,
   onCycleZeroAvatar,
 }: ZeroContentProps) {
-  const agentNameLoadable = useLoadable(agentDisplayName$);
-  const agentName =
-    agentNameLoadable.state === "hasData" ? agentNameLoadable.data : "Zero";
   if (sectionId === "chat") {
     if (inSession) {
       return (
@@ -118,27 +98,19 @@ export function ZeroContent({
     return <ZeroPreferencesPage />;
   }
 
-  const title = getSectionTitles(agentName)[sectionId];
+  return <ZeroNotFoundPage />;
+}
 
+function ZeroNotFoundPage() {
   return (
-    <div className="flex flex-1 flex-col min-h-0">
-      <header className="shrink-0 border-b border-divider bg-transparent px-4 sm:px-6 pt-6 sm:pt-6 pb-4 sm:pb-5">
-        <h1 className="text-lg font-semibold tracking-tight text-foreground">
-          {title}
-        </h1>
-        <p className="mt-0.5 text-sm text-muted-foreground">
-          {agentName} — your AI assistant
-        </p>
-      </header>
-      <main className="flex-1 overflow-auto px-4 sm:px-6 pb-8">
-        <div className="mx-auto max-w-[900px]">
-          <div className="zero-card p-6">
-            <p className="text-sm text-muted-foreground">
-              Content for &quot;{title}&quot; will appear here.
-            </p>
-          </div>
-        </div>
-      </main>
+    <div className="flex flex-1 flex-col items-center justify-center min-h-0 px-4">
+      <h1 className="text-6xl font-bold text-muted-foreground/50">404</h1>
+      <p className="mt-4 text-lg text-muted-foreground">
+        The page you are looking for does not exist.
+      </p>
+      <a href="/" className="mt-6 text-sm text-primary hover:underline">
+        Go to home
+      </a>
     </div>
   );
 }

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -165,7 +165,8 @@ export type ZeroNavId =
   | "works"
   | "settings"
   | "preferences"
-  | "queue";
+  | "queue"
+  | "not-found";
 
 type NavIcon = (props: { size?: number; className?: string }) => ReactNode;
 const MANAGE_NAV = [


### PR DESCRIPTION
## Summary

- Unknown routes (e.g. `/scheduled`, `/foo`, `/bar`) now show a 404 page instead of silently rendering the chat dashboard
- `zeroActiveId$` returns `"not-found"` for unrecognized path segments (previously fell back to `"chat"`)
- `/talk/*` paths continue to correctly resolve to `"chat"`
- Added `ZeroNotFoundPage` component with 404 message and home link

Closes #5869

## Test plan

- [x] Existing tests updated: invalid tab test now expects `"not-found"` instead of `"chat"`
- [x] New tests added for `/scheduled` and `/foo` confirming they resolve to `"not-found"` (bug reproduction tests from issue)
- [x] `/talk/agent-name` still resolves to `"chat"` (verified by existing test)
- [x] All 321 platform tests pass
- [x] Lint, type-check, knip all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)