### PR TITLE
fix(www): hide blog nav link when blog feature is disabled

### DIFF
--- a/turbo/apps/web/app/components/Navbar.tsx
+++ b/turbo/apps/web/app/components/Navbar.tsx
@@ -11,6 +11,7 @@ import ThemeToggle from "./ThemeToggle";
 import LanguageSwitcher from "./LanguageSwitcher";
 import { useUser, useClerk } from "@clerk/nextjs";
 import { getAppUrl } from "../../src/lib/url";
+import { isBlogEnabled } from "../../src/env";
 export default function Navbar() {
   const { theme } = useTheme();
   const t = useTranslations("nav");
@@ -74,9 +75,11 @@ export default function Navbar() {
             <Link href="/security" className="nav-link">
               Security
             </Link>
-            <Link href="/blog" className="nav-link">
-              {t("blog")}
-            </Link>
+            {isBlogEnabled() && (
+              <Link href="/blog" className="nav-link">
+                {t("blog")}
+              </Link>
+            )}
             <a
               href="https://github.com/vm0-ai/vm0"
               target="_blank"
@@ -159,13 +162,15 @@ export default function Navbar() {
             >
               Security
             </Link>
-            <Link
-              href="/blog"
-              className="mobile-menu-link"
-              onClick={() => setMobileMenuOpen(false)}
-            >
-              {t("blog")}
-            </Link>
+            {isBlogEnabled() && (
+              <Link
+                href="/blog"
+                className="mobile-menu-link"
+                onClick={() => setMobileMenuOpen(false)}
+              >
+                {t("blog")}
+              </Link>
+            )}
             <a
               href="https://github.com/vm0-ai/vm0"
               target="_blank"

--- a/turbo/apps/web/app/components/__tests__/navbar-blog.test.tsx
+++ b/turbo/apps/web/app/components/__tests__/navbar-blog.test.tsx
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { ThemeProvider } from "../ThemeProvider";
+import Navbar from "../Navbar";
+
+// External: next-intl/navigation (used by navigation.ts -> Link, usePathname, useRouter)
+vi.mock("next-intl/navigation", () => ({
+  createNavigation: vi.fn(() => ({
+    Link: ({
+      href,
+      children,
+      className,
+    }: {
+      href: string;
+      children: React.ReactNode;
+      className?: string;
+    }) => (
+      <a href={href} className={className}>
+        {children}
+      </a>
+    ),
+    redirect: vi.fn(),
+    usePathname: vi.fn(() => "/"),
+    useRouter: vi.fn(() => ({ push: vi.fn() })),
+  })),
+}));
+
+// External: next-intl (used by Navbar, LanguageSwitcher)
+vi.mock("next-intl", () => ({
+  useTranslations: vi.fn(() => (key: string) => key),
+  useLocale: vi.fn(() => "en"),
+}));
+
+// External: @clerk/nextjs (used by Navbar)
+vi.mock("@clerk/nextjs", () => ({
+  useUser: vi.fn(() => ({ isSignedIn: false, user: null, isLoaded: true })),
+  useClerk: vi.fn(() => ({ signOut: vi.fn() })),
+}));
+
+// External: next/link (used by Navbar)
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    className,
+  }: {
+    href: string;
+    children: React.ReactNode;
+    className?: string;
+  }) => (
+    <a href={href} className={className}>
+      {children}
+    </a>
+  ),
+}));
+
+// External: next/image (used by Navbar)
+vi.mock("next/image", () => ({
+  default: ({ alt, src }: { alt: string; src: string }) => (
+    <span data-alt={alt} data-src={src} />
+  ),
+}));
+
+// External: @tabler/icons-react (used by Navbar)
+vi.mock("@tabler/icons-react", () => ({
+  IconArrowRight: () => <span />,
+}));
+
+function renderNavbar() {
+  return renderToStaticMarkup(
+    <ThemeProvider>
+      <Navbar />
+    </ThemeProvider>,
+  );
+}
+
+describe("Navbar blog link visibility", () => {
+  it("does not render blog link when blog feature is disabled", () => {
+    // NEXT_PUBLIC_STRAPI_URL is not stubbed in global test setup,
+    // so isBlogEnabled() returns false by default
+    const html = renderNavbar();
+
+    expect(html).not.toContain('href="/blog"');
+  });
+
+  it("renders blog link when blog feature is enabled", () => {
+    vi.stubEnv("NEXT_PUBLIC_STRAPI_URL", "https://strapi.example.com");
+
+    const html = renderNavbar();
+
+    expect(html).toContain('href="/blog"');
+  });
+});


### PR DESCRIPTION
## Summary
- Hide the Blog navigation link (desktop and mobile) when `isBlogEnabled()` returns false (i.e., `NEXT_PUBLIC_STRAPI_URL` is not set)
- Add integration test verifying the blog link is conditionally rendered based on feature flag

## Test plan
- [x] New test `navbar-blog.test.tsx` verifies blog link absent when disabled and present when enabled
- [x] Existing blog page tests still pass
- [x] Lint, type check, format, and knip all pass

Closes #5870

🤖 Generated with [Claude Code](https://claude.com/claude-code)