### PR TITLE
fix(platform): add accessible name to connectors button

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-page.test.tsx
@@ -100,6 +100,15 @@ describe("zero chat page - composer", () => {
     });
   });
 
+  it("should have accessible name on connectors button", async () => {
+    await renderChatPage();
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "Connectors" }),
+      ).toBeInTheDocument();
+    });
+  });
+
   it("should disable Send button when input is empty", async () => {
     await renderChatPage();
 

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -267,6 +267,7 @@ function ConnectorsPopoverButton({
               <button
                 type="button"
                 className="inline-flex shrink-0 items-center justify-center rounded-lg h-9 min-w-9 px-1.5 hover:bg-accent transition-colors"
+                aria-label="Connectors"
               >
                 <ConnectorTriggerIcons connectors={agentConnectors} />
               </button>


### PR DESCRIPTION
## Summary

- Add `aria-label="Connectors"` to the ConnectorsPopoverButton in the chat composer toolbar, fixing a WCAG 2.1 SC 4.1.2 violation where the button had no accessible name for screen readers
- Add integration test verifying the button has an accessible name

Closes #5873

## Test plan

- [x] Existing tests pass (10/10 in zero-chat-page.test.tsx)
- [x] New test `should have accessible name on connectors button` passes
- [x] Lint, type check, and knip all pass
- [ ] CI passes on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)