### PR TITLE
fix(www): conditionally render blog link in navbar

### DIFF
--- a/turbo/apps/web/app/[locale]/blog/__tests__/page.test.ts
+++ b/turbo/apps/web/app/[locale]/blog/__tests__/page.test.ts
@@ -34,15 +34,35 @@ vi.mock("@clerk/nextjs", () => ({
   useClerk: vi.fn(() => ({ signOut: vi.fn() })),
 }));
 
+// Sentinel to simulate Next.js notFound() control flow interruption
+const NOT_FOUND_SENTINEL = "NEXT_NOT_FOUND";
+
 // External: next/navigation (used by BlogContent)
 vi.mock("next/navigation", () => ({
-  notFound: vi.fn(),
+  notFound: vi.fn(() => {
+    throw new Error(NOT_FOUND_SENTINEL);
+  }),
   useSearchParams: vi.fn(() => new URLSearchParams()),
   useParams: vi.fn(() => ({})),
   useRouter: vi.fn(() => ({})),
 }));
 
-import { generateMetadata } from "../page";
+import { notFound } from "next/navigation";
+import BlogPage, { generateMetadata } from "../page";
+
+describe("blog page", () => {
+  it("calls notFound when blog feature is disabled", async () => {
+    // Default test setup does not stub NEXT_PUBLIC_STRAPI_URL,
+    // so isBlogEnabled() returns false. Override the beforeEach stub.
+    vi.stubEnv("NEXT_PUBLIC_STRAPI_URL", "");
+    reloadEnv();
+
+    await expect(
+      BlogPage({ params: Promise.resolve({ locale: "en" }) }),
+    ).rejects.toThrow(NOT_FOUND_SENTINEL);
+    expect(notFound).toHaveBeenCalled();
+  });
+});
 
 describe("blog list page metadata", () => {
   it("includes canonical URL with locale", async () => {

--- a/turbo/apps/web/app/components/Navbar.tsx
+++ b/turbo/apps/web/app/components/Navbar.tsx
@@ -11,6 +11,7 @@ import ThemeToggle from "./ThemeToggle";
 import LanguageSwitcher from "./LanguageSwitcher";
 import { useUser, useClerk } from "@clerk/nextjs";
 import { getAppUrl } from "../../src/lib/url";
+import { isBlogEnabled } from "../../src/env";
 export default function Navbar() {
   const { theme } = useTheme();
   const t = useTranslations("nav");
@@ -74,9 +75,11 @@ export default function Navbar() {
             <Link href="/security" className="nav-link">
               Security
             </Link>
-            <Link href="/blog" className="nav-link">
-              {t("blog")}
-            </Link>
+            {isBlogEnabled() && (
+              <Link href="/blog" className="nav-link">
+                {t("blog")}
+              </Link>
+            )}
             <a
               href="https://github.com/vm0-ai/vm0"
               target="_blank"
@@ -159,13 +162,15 @@ export default function Navbar() {
             >
               Security
             </Link>
-            <Link
-              href="/blog"
-              className="mobile-menu-link"
-              onClick={() => setMobileMenuOpen(false)}
-            >
-              {t("blog")}
-            </Link>
+            {isBlogEnabled() && (
+              <Link
+                href="/blog"
+                className="mobile-menu-link"
+                onClick={() => setMobileMenuOpen(false)}
+              >
+                {t("blog")}
+              </Link>
+            )}
             <a
               href="https://github.com/vm0-ai/vm0"
               target="_blank"


### PR DESCRIPTION
## Summary

- Conditionally render the blog navigation link in both desktop and mobile Navbar menus using `isBlogEnabled()` from `src/env.ts`
- Add integration test verifying the blog page calls `notFound()` when the blog feature is disabled (`NEXT_PUBLIC_STRAPI_URL` is not set)
- Previously, the blog link was always visible but led to a 404 when Strapi was not configured

Closes #5870

## Test plan

- [x] Existing blog page metadata tests continue to pass
- [x] New test verifies `notFound()` is called when blog is disabled
- [x] All 3860 tests pass across 333 test files
- [x] Lint, format, knip, and commitlint all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)