### PR TITLE
fix: resolve eslint set-state-in-effect error in theme provider

### DIFF
--- a/turbo/apps/web/app/components/ThemeProvider.tsx
+++ b/turbo/apps/web/app/components/ThemeProvider.tsx
@@ -5,7 +5,7 @@ import {
   useCallback,
   useContext,
   useEffect,
-  useState,
+  useSyncExternalStore,
   type ReactNode,
 } from "react";
 
@@ -37,6 +37,20 @@ function resolveClientTheme(): Theme {
     : "light";
 }
 
+function subscribeToThemeChanges(callback: () => void): () => void {
+  const mql = window.matchMedia("(prefers-color-scheme: dark)");
+  window.addEventListener("storage", callback);
+  mql.addEventListener("change", callback);
+  return () => {
+    window.removeEventListener("storage", callback);
+    mql.removeEventListener("change", callback);
+  };
+}
+
+function getServerThemeSnapshot(): Theme {
+  return "dark";
+}
+
 function applyTheme(newTheme: Theme) {
   localStorage.setItem("theme", newTheme);
   document.documentElement.setAttribute("data-theme", newTheme);
@@ -50,49 +64,30 @@ interface ThemeProviderProps {
 }
 
 export function ThemeProvider({ children }: ThemeProviderProps) {
-  // Start with "dark" to match the server render and the HTML default data-theme="dark".
-  // The inline script in layout.tsx prevents FOUC by setting the correct data-theme
-  // before paint. After hydration, useEffect reads the real client theme.
-  const [theme, setThemeState] = useState<Theme>("dark");
-
-  // After mount, sync state with the actual client theme
-  useEffect(() => {
-    setThemeState(resolveClientTheme());
-  }, []);
+  // useSyncExternalStore reads the theme from localStorage/matchMedia on the
+  // client, and returns "dark" on the server to match the HTML default.
+  // React handles the server-to-client transition internally, avoiding the
+  // need for a useState + useEffect mount pattern that violates
+  // react-hooks/set-state-in-effect.
+  const theme = useSyncExternalStore(
+    subscribeToThemeChanges,
+    resolveClientTheme,
+    getServerThemeSnapshot,
+  );
 
   // Apply data-theme attribute whenever theme changes
   useEffect(() => {
     document.documentElement.setAttribute("data-theme", theme);
   }, [theme]);
 
-  // Subscribe to external theme changes (storage events, OS preference changes)
-  useEffect(() => {
-    const onStorage = () => {
-      setThemeState(resolveClientTheme());
-    };
-    const mql = window.matchMedia("(prefers-color-scheme: dark)");
-    const onMediaChange = () => {
-      setThemeState(resolveClientTheme());
-    };
-    window.addEventListener("storage", onStorage);
-    mql.addEventListener("change", onMediaChange);
-    return () => {
-      window.removeEventListener("storage", onStorage);
-      mql.removeEventListener("change", onMediaChange);
-    };
-  }, []);
-
   const setTheme = useCallback((newTheme: Theme) => {
     applyTheme(newTheme);
-    setThemeState(newTheme);
   }, []);
 
   const toggleTheme = useCallback(() => {
-    setThemeState((current) => {
-      const newTheme = current === "dark" ? "light" : "dark";
-      applyTheme(newTheme);
-      return newTheme;
-    });
+    const current = resolveClientTheme();
+    const newTheme = current === "dark" ? "light" : "dark";
+    applyTheme(newTheme);
   }, []);
 
   return (


### PR DESCRIPTION
## Summary

- Replace `useState` + `useEffect` mount pattern with `useSyncExternalStore` in `ThemeProvider.tsx` to fix the `react-hooks/set-state-in-effect` ESLint violation introduced by PR #5892
- `useSyncExternalStore` reads theme from localStorage/matchMedia on the client and returns "dark" on the server, eliminating the need for a synchronous `setState` call inside `useEffect`
- All existing theme toggle tests pass, dark mode toggle functionality preserved

Closes #5896

## Test plan

- [x] `pnpm turbo run lint` passes with zero errors (previously failed on `react-hooks/set-state-in-effect`)
- [x] Theme toggle integration tests pass (3/3)
- [ ] Manual: verify dark mode toggle works on landing page (no hydration mismatch, no FOUC)

Generated with [Claude Code](https://claude.com/claude-code)