### PR TITLE
refactor: extract activity list and detail pages into dedicated routes

### DIFF
--- a/turbo/apps/platform/src/signals/activity-page/activity-detail-page-setup.ts
+++ b/turbo/apps/platform/src/signals/activity-page/activity-detail-page-setup.ts
@@ -1,0 +1,31 @@
+import { command } from "ccstate";
+import { createElement } from "react";
+import { ZeroActivityDetailPageWrapper } from "../../views/activity-page/zero-activity-detail-page-wrapper.tsx";
+import { updatePage$ } from "../react-router.ts";
+import { fetchAgentsList$ } from "../zero-page/zero-agents.ts";
+import { initZeroOnboarding$ } from "../zero-page/zero-onboarding.ts";
+import { switchActiveAgent$ } from "../zero-page/zero-chat.ts";
+import { pathParams$ } from "../route.ts";
+import { setZeroActivitySelectedLogId$ } from "./activity-signals.ts";
+
+export const setupActivityDetailPage$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    set(updatePage$, createElement(ZeroActivityDetailPageWrapper));
+    await Promise.all([
+      set(fetchAgentsList$),
+      set(initZeroOnboarding$, signal),
+    ]);
+    signal.throwIfAborted();
+
+    const params = get(pathParams$);
+    const logId =
+      params && typeof params === "object" && "logId" in params
+        ? String(params.logId)
+        : null;
+
+    if (logId) {
+      set(setZeroActivitySelectedLogId$, logId);
+    }
+    set(switchActiveAgent$, null);
+  },
+);

--- a/turbo/apps/platform/src/signals/activity-page/activity-page-setup.ts
+++ b/turbo/apps/platform/src/signals/activity-page/activity-page-setup.ts
@@ -1,0 +1,21 @@
+import { command } from "ccstate";
+import { createElement } from "react";
+import { ZeroActivityPageWrapper } from "../../views/activity-page/zero-activity-page-wrapper.tsx";
+import { updatePage$ } from "../react-router.ts";
+import { fetchAgentsList$ } from "../zero-page/zero-agents.ts";
+import { initZeroOnboarding$ } from "../zero-page/zero-onboarding.ts";
+import { switchActiveAgent$ } from "../zero-page/zero-chat.ts";
+import { initZeroActivity$ } from "./activity-signals.ts";
+
+export const setupActivityPage$ = command(
+  async ({ set }, signal: AbortSignal) => {
+    set(updatePage$, createElement(ZeroActivityPageWrapper));
+    await Promise.all([
+      set(fetchAgentsList$),
+      set(initZeroOnboarding$, signal),
+      set(initZeroActivity$),
+    ]);
+    signal.throwIfAborted();
+    set(switchActiveAgent$, null);
+  },
+);

--- a/turbo/apps/platform/src/signals/activity-page/activity-signals.ts
+++ b/turbo/apps/platform/src/signals/activity-page/activity-signals.ts
@@ -4,14 +4,13 @@ import type {
   AgentEvent,
   AgentEventsResponse,
   LogStatus,
-} from "./log-types.ts";
+} from "../zero-page/log-types.ts";
 import type { ComposeListItem } from "@vm0/core";
 import { fetch$ } from "../fetch.ts";
 import { searchParams$, updateSearchParams$ } from "../route.ts";
 import { createCursorPagination } from "../cursor-pagination.ts";
 import { throwIfAbort, detach, Reason } from "../utils.ts";
-import { zeroOnboardingStatus$ } from "./zero-onboarding.ts";
-import { zeroActiveId$, zeroTabSub$ } from "./zero-nav.ts";
+import { zeroOnboardingStatus$ } from "../zero-page/zero-onboarding.ts";
 import { delay } from "signal-timers";
 
 const EVENTS_PAGE_LIMIT = 30;
@@ -84,7 +83,6 @@ export const initZeroActivity$ = command(async ({ set }) => {
 export const {
   limit$: zeroActivityLimit$,
   data$: zeroActivityData$,
-  refresh$: refreshZeroActivity$,
   seedCursorHistory$: seedZeroActivityCursorHistory$,
   hasPrev$: zeroActivityHasPrev$,
   currentPage$: zeroActivityCurrentPage$,
@@ -127,20 +125,6 @@ export const {
     }
     return result;
   },
-});
-
-/**
- * Refresh activity data if the current tab is "activity".
- * Called from `setupZeroPage$` on every route entry so that each visit
- * to the activity tab triggers a fresh fetch and syncs detail polling.
- */
-export const refreshZeroActivityIfActive$ = command(({ get, set }) => {
-  const activeTab = get(zeroActiveId$);
-  if (activeTab !== "activity") {
-    return;
-  }
-  set(syncZeroActivitySub$);
-  detach(set(refreshZeroActivity$), Reason.Entrance);
 });
 
 /** Update a filter — resets pagination and writes to URL. */
@@ -191,40 +175,7 @@ export const setZeroActivityStepSearch$ = command(({ set }, value: string) => {
 });
 
 /**
- * Sync the URL sub-route to the detail polling lifecycle.
- * Idempotent: only restarts polling when the log ID actually changes.
- */
-const syncZeroActivitySub$ = command(({ get, set }) => {
-  const sub = get(zeroTabSub$);
-  const prev = get(lastSyncedLogId$);
-  if (sub === prev) {
-    return;
-  }
-
-  // Reset step search when switching log entries
-  set(internalStepSearch$, "");
-
-  // Abort previous polling
-  const prevAbort = get(internalPollingAbort$);
-  if (prevAbort) {
-    prevAbort.abort();
-  }
-  set(internalPollingAbort$, null);
-  set(pagedEvents$, []);
-  set(lastSyncedLogId$, sub);
-
-  if (sub) {
-    const controller = new AbortController();
-    set(internalPollingAbort$, controller);
-    detach(
-      set(setupZeroActivityEventPolling$, controller.signal),
-      Reason.Daemon,
-    );
-  }
-});
-
-/**
- * Set selected log ID directly (used by tests).
+ * Set selected log ID directly — triggers detail fetch + event polling.
  */
 export const setZeroActivitySelectedLogId$ = command(
   ({ get, set }, logId: string | null) => {

--- a/turbo/apps/platform/src/signals/bootstrap.ts
+++ b/turbo/apps/platform/src/signals/bootstrap.ts
@@ -9,6 +9,8 @@ import { setupZeroJobDetailRoute$ } from "./zero-page/zero-job-detail-route.ts";
 import { setupSelectOrgPage$ } from "./select-org/select-org-page.ts";
 import { setupSlackConnectPage$ } from "./zero-page/slack-connect-page.ts";
 import { setupQueuePage$ } from "./queue-page/queue-page-setup.ts";
+import { setupActivityPage$ } from "./activity-page/activity-page-setup.ts";
+import { setupActivityDetailPage$ } from "./activity-page/activity-detail-page-setup.ts";
 const ROUTE_CONFIG = [
   {
     path: "/select-org",
@@ -33,6 +35,14 @@ const ROUTE_CONFIG = [
   {
     path: "/queue",
     setup: setupAuthPageWrapper(setupQueuePage$),
+  },
+  {
+    path: "/activity/:logId",
+    setup: setupAuthPageWrapper(setupActivityDetailPage$),
+  },
+  {
+    path: "/activity",
+    setup: setupAuthPageWrapper(setupActivityPage$),
   },
   {
     path: "/:tab/:sub",

--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-activity.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-activity.test.ts
@@ -12,7 +12,7 @@ import {
   zeroActivityDetail$,
   formatLogTime,
   formatDuration,
-} from "../zero-activity.ts";
+} from "../../activity-page/activity-signals.ts";
 
 const context = testContext();
 

--- a/turbo/apps/platform/src/signals/zero-page/zero-nav.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-nav.ts
@@ -111,16 +111,6 @@ export const setZeroChatAgent$ = command(
 );
 
 /**
- * Sub-path segment under the current tab, e.g. `/activity/:sub`.
- * Returns null when there is no sub-segment.
- */
-export const zeroTabSub$ = computed((get): string | null => {
-  const path = get(pathname$);
-  const parts = path.split("/");
-  return parts[2] || null;
-});
-
-/**
  * Navigate to a specific chat session — `/chat/:sessionId`.
  */
 export const navigateToZeroSession$ = command(({ set }, sessionId: string) => {

--- a/turbo/apps/platform/src/signals/zero-page/zero-page.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-page.ts
@@ -5,10 +5,6 @@ import { updatePage$ } from "../react-router.ts";
 import { fetchAgentsList$, zeroSubagents$ } from "./zero-agents.ts";
 import { defaultAgentName$ } from "./zero-agent-name.ts";
 import { initZeroOnboarding$ } from "./zero-onboarding.ts";
-import {
-  initZeroActivity$,
-  refreshZeroActivityIfActive$,
-} from "./zero-activity.ts";
 import { refreshScheduleIfActive$ } from "./zero-schedule.ts";
 import { initSlackOrg$ } from "./zero-slack.ts";
 import {
@@ -123,11 +119,9 @@ export const setupZeroPage$ = command(
       signal.throwIfAborted();
       set(initialDataLoaded$, true);
       set(initSidebarCollapsed$);
-      detach(set(initZeroActivity$), Reason.Daemon);
     }
 
     // Refresh tab-specific data on each route entry
-    set(refreshZeroActivityIfActive$);
     set(refreshScheduleIfActive$);
 
     await resolveAndSwitchAgent(get, set, signal);

--- a/turbo/apps/platform/src/types/route.ts
+++ b/turbo/apps/platform/src/types/route.ts
@@ -2,6 +2,8 @@ export type RoutePath =
   | "/"
   | "/select-org"
   | "/:tab"
+  | "/activity"
+  | "/activity/:logId"
   | "/chat/:sessionId"
   | "/team/:name"
   | "/talk/:name"

--- a/turbo/apps/platform/src/views/activity-page/__tests__/activity-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/activity-page/__tests__/activity-navigation.test.tsx
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+import { screen, waitFor, fireEvent } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../mocks/server.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { setupPage } from "../../../__tests__/page-helper.ts";
+import type {
+  LogDetail,
+  AgentEventsResponse,
+} from "../../../signals/zero-page/log-types.ts";
+
+const context = testContext();
+
+function mockActivityAPIs() {
+  const listData = [
+    {
+      id: "run_1",
+      sessionId: "session_1",
+      agentName: "test-agent",
+      displayName: "Test Agent",
+      orgSlug: "test",
+      framework: "claude-code",
+      status: "completed",
+      triggerSource: "web",
+      createdAt: "2026-03-10T14:56:00Z",
+      startedAt: "2026-03-10T14:56:01Z",
+      completedAt: "2026-03-10T14:56:10Z",
+    },
+  ];
+
+  const logDetail: LogDetail = {
+    id: "run_1",
+    sessionId: "session_1",
+    agentName: "test-agent",
+    displayName: "Test Agent",
+    framework: "claude-code",
+    modelProvider: null,
+    triggerSource: "web",
+    status: "completed",
+    prompt: "Hello, what can you do?",
+    appendSystemPrompt: null,
+    error: null,
+    createdAt: "2026-03-10T14:56:00Z",
+    startedAt: "2026-03-10T14:56:01Z",
+    completedAt: "2026-03-10T14:56:10Z",
+    artifact: { name: null, version: null },
+  };
+
+  const eventsResponse: AgentEventsResponse = {
+    events: [
+      {
+        sequenceNumber: 0,
+        eventType: "assistant",
+        eventData: { message: { content: [{ type: "text", text: "Hi!" }] } },
+        createdAt: "2026-03-10T14:56:02Z",
+      },
+    ],
+    hasMore: false,
+    framework: "claude-code",
+  };
+
+  server.use(
+    http.get("*/api/zero/logs", () => {
+      return HttpResponse.json({
+        data: listData,
+        pagination: { hasMore: false, nextCursor: null, totalPages: 1 },
+      });
+    }),
+    http.get("*/api/zero/composes/list", () => {
+      return HttpResponse.json({ composes: [] });
+    }),
+    http.get("*/api/zero/logs/:id", ({ params }) => {
+      if (params["id"] === "run_1") {
+        return HttpResponse.json(logDetail);
+      }
+      return new HttpResponse(null, { status: 404 });
+    }),
+    http.get("*/api/zero/runs/:runId/telemetry/agent", () => {
+      return HttpResponse.json(eventsResponse);
+    }),
+    http.get("*/api/zero/chat-threads", () => {
+      return HttpResponse.json({ threads: [] });
+    }),
+  );
+}
+
+describe("activity navigation", () => {
+  it("should load detail page when clicking an activity row from the list", async () => {
+    mockActivityAPIs();
+
+    await setupPage({
+      context,
+      path: "/activity",
+    });
+
+    // Wait for the list to render with the activity row
+    await waitFor(
+      () => {
+        expect(screen.getByText("Test Agent")).toBeInTheDocument();
+      },
+      { timeout: 3000 },
+    );
+
+    // Click the activity row to navigate to detail
+    fireEvent.click(screen.getByText("Test Agent"));
+
+    // The detail page should render with the agent name as heading
+    await waitFor(
+      () => {
+        expect(
+          screen.getByRole("heading", { name: "Test Agent" }),
+        ).toBeInTheDocument();
+      },
+      { timeout: 3000 },
+    );
+
+    // Verify the detail content is visible (duration)
+    expect(screen.getByText("9.0s")).toBeInTheDocument();
+  }, 15_000);
+});

--- a/turbo/apps/platform/src/views/activity-page/zero-activity-detail-page-wrapper.tsx
+++ b/turbo/apps/platform/src/views/activity-page/zero-activity-detail-page-wrapper.tsx
@@ -1,0 +1,10 @@
+import { SidebarLayout } from "../zero-page/sidebar-layout.tsx";
+import { ZeroActivityDetailPage } from "../zero-page/zero-activity-detail-page.tsx";
+
+export function ZeroActivityDetailPageWrapper() {
+  return (
+    <SidebarLayout>
+      <ZeroActivityDetailPage />
+    </SidebarLayout>
+  );
+}

--- a/turbo/apps/platform/src/views/activity-page/zero-activity-page-wrapper.tsx
+++ b/turbo/apps/platform/src/views/activity-page/zero-activity-page-wrapper.tsx
@@ -1,0 +1,10 @@
+import { SidebarLayout } from "../zero-page/sidebar-layout.tsx";
+import { ZeroActivityPage } from "../zero-page/zero-activity-page.tsx";
+
+export function ZeroActivityPageWrapper() {
+  return (
+    <SidebarLayout>
+      <ZeroActivityPage />
+    </SidebarLayout>
+  );
+}

--- a/turbo/apps/platform/src/views/zero-page/zero-activity-detail-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-activity-detail-page.tsx
@@ -18,7 +18,7 @@ import {
   type ModelProviderType,
 } from "@vm0/core";
 import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
-import { SimpleLink } from "../router/link.tsx";
+import { Link } from "../router/link.tsx";
 import {
   TRIGGER_SOURCE_LABELS,
   type LogStatus,
@@ -33,7 +33,7 @@ import {
   setZeroActivityStepSearch$,
   formatLogTime,
   formatDuration,
-} from "../../signals/zero-page/zero-activity.ts";
+} from "../../signals/activity-page/activity-signals.ts";
 import {
   groupEventsIntoMessages,
   groupedMessageMatchesSearch,
@@ -64,17 +64,15 @@ function isVisibleMessage(
   return (message.toolOperations?.length ?? 0) > 0;
 }
 
-const ACTIVITY_HREF = "/activity";
-
 function ActivityBreadcrumbLink() {
   return (
-    <SimpleLink
-      href={ACTIVITY_HREF}
+    <Link
+      pathname="/activity"
       className="inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 hover:bg-muted hover:text-foreground transition-colors no-underline text-inherit"
     >
       <IconChartLine size={14} stroke={1.5} className="shrink-0" />
       Activity
-    </SimpleLink>
+    </Link>
   );
 }
 
@@ -97,12 +95,12 @@ function ActivityNotFound() {
           This log doesn&apos;t exist or you don&apos;t have permission to view
           it in the current organization.
         </p>
-        <SimpleLink
-          href={ACTIVITY_HREF}
+        <Link
+          pathname="/activity"
           className="zero-btn-morandi mt-2 inline-flex items-center justify-center rounded-md border px-3 py-1.5 text-sm font-medium no-underline text-inherit hover:bg-accent"
         >
           Back to activity
-        </SimpleLink>
+        </Link>
       </div>
     </div>
   );

--- a/turbo/apps/platform/src/views/zero-page/zero-activity-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-activity-page.tsx
@@ -20,7 +20,6 @@ import {
 } from "../../signals/zero-page/log-types.ts";
 import { StatusBadge } from "./components/logs/status-badge.tsx";
 import { Pagination } from "../components/pagination.tsx";
-import { ZeroActivityDetailPage } from "./zero-activity-detail-page.tsx";
 import {
   zeroActivityAgentFilter$,
   zeroActivityStatusFilter$,
@@ -37,9 +36,8 @@ import {
   setZeroActivityRowsPerPage$,
   formatLogTime,
   formatDuration,
-} from "../../signals/zero-page/zero-activity.ts";
-import { zeroTabSub$ } from "../../signals/zero-page/zero-nav.ts";
-import { SimpleLink } from "../router/link.tsx";
+} from "../../signals/activity-page/activity-signals.ts";
+import { Link } from "../router/link.tsx";
 import { Reason, detach } from "../../signals/utils.ts";
 import emptyActivityImg from "./assets/empty-activity.png";
 
@@ -57,17 +55,18 @@ const ROW_GRID =
 
 function ActivityRow({
   entry,
-  href,
+  logId,
   agentName = "Zero",
 }: {
   entry: LogEntry;
-  href: string;
+  logId: string;
   agentName?: string;
 }) {
   const time = formatLogTime(entry.createdAt);
   return (
-    <SimpleLink
-      href={href}
+    <Link
+      pathname="/activity/:logId"
+      options={{ pathParams: { logId } }}
       className="block py-3 -mx-4 px-4 transition-colors hover:bg-muted/50 cursor-pointer border-b border-border/40 last:border-b-0 no-underline text-inherit"
     >
       <div className={cn(ROW_GRID)}>
@@ -107,7 +106,7 @@ function ActivityRow({
           </span>
         </div>
       </div>
-    </SimpleLink>
+    </Link>
   );
 }
 
@@ -121,9 +120,6 @@ export function ZeroActivityPage() {
   const goForwardTwo = useSet(goForwardTwoZeroActivityPages$);
   const goBackTwo = useSet(goBackTwoZeroActivityPages$);
   const setRowsPerPage = useSet(setZeroActivityRowsPerPage$);
-
-  // URL-driven detail: /activity/:logId
-  const sub = useGet(zeroTabSub$);
 
   const agentFilter = useGet(zeroActivityAgentFilter$);
   const statusFilter = useGet(zeroActivityStatusFilter$);
@@ -144,11 +140,6 @@ export function ZeroActivityPage() {
     { value: "all", label: "All agents" },
     ...orgAgents.map((a) => ({ value: a.name, label: a.displayName })),
   ];
-
-  // Detail view when sub-route is present
-  if (sub) {
-    return <ZeroActivityDetailPage />;
-  }
 
   return (
     <div className="flex flex-1 flex-col min-h-0">
@@ -256,7 +247,7 @@ export function ZeroActivityPage() {
                     <ActivityRow
                       key={entry.id}
                       entry={entry}
-                      href={`/activity/${entry.id}`}
+                      logId={entry.id}
                       agentName={entry.displayName ?? entry.agentName}
                     />
                   ))

--- a/turbo/apps/platform/src/views/zero-page/zero-content.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-content.tsx
@@ -3,7 +3,6 @@ import { ZeroChatPage } from "./zero-chat-page.tsx";
 import { ZeroSessionChatPage } from "./zero-session-chat-page.tsx";
 import { ZeroPreferencesPage } from "./zero-account-page.tsx";
 import { ZeroJobsPage } from "./zero-jobs-page.tsx";
-import { ZeroActivityPage } from "./zero-activity-page.tsx";
 import { ZeroWorksPage } from "./zero-works-page.tsx";
 import { QueuePage } from "../queue-page/queue-page.tsx";
 import { ZeroSchedulePage } from "./zero-schedule-page.tsx";
@@ -81,9 +80,6 @@ export function ZeroContent({
         onCycleZeroAvatar={onCycleZeroAvatar}
       />
     );
-  }
-  if (sectionId === "activity") {
-    return <ZeroActivityPage />;
   }
   if (sectionId === "works") {
     return <ZeroWorksPage />;


### PR DESCRIPTION
## Summary

- Extract `/activity` and `/activity/:logId` from the monolithic `ZeroPage` into dedicated routes with their own setup functions, following the queue page pattern
- Fix activity detail page permanently stuck on skeleton loading when navigating from list via click (#5857) — `SimpleLink` didn't trigger route setup, so `lastSyncedLogId$` was never set
- Add regression test covering list-to-detail click navigation

## Changes

### New files
- `signals/activity-page/activity-page-setup.ts` — `setupActivityPage$` for `/activity` list
- `signals/activity-page/activity-detail-page-setup.ts` — `setupActivityDetailPage$` for `/activity/:logId`
- `views/activity-page/zero-activity-page-wrapper.tsx` — SidebarLayout + ZeroActivityPage
- `views/activity-page/zero-activity-detail-page-wrapper.tsx` — SidebarLayout + ZeroActivityDetailPage
- `views/activity-page/__tests__/activity-navigation.test.tsx` — regression test

### Moved files
- `signals/zero-page/zero-activity.ts` → `signals/activity-page/activity-signals.ts`

### Modified files
- `bootstrap.ts` — register `/activity/:logId` and `/activity` routes before `/:tab/:sub`
- `zero-page.ts` — remove `initZeroActivity$` and `refreshZeroActivityIfActive$`
- `zero-content.tsx` — remove activity case (now handled by dedicated route)
- `zero-activity-page.tsx` — remove sub-route detection, replace `SimpleLink` with `Link`
- `zero-activity-detail-page.tsx` — replace `SimpleLink` with `Link` for breadcrumb
- `zero-nav.ts` — remove unused `zeroTabSub$`
- `route.ts` — add `/activity` and `/activity/:logId` to `RoutePath`

Closes #5895
Closes #5857
Closes #5847

## Test plan

- [x] Regression test: click activity row from list → detail page loads with agent name and duration
- [x] Existing test: direct navigation to `/activity/:runId` continues to work
- [x] Existing signal tests: all 8 zero-activity signal tests pass
- [x] Nav tests: all 35 zero-nav tests pass
- [x] Pre-commit checks: lint, format, knip all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)