### PR TITLE
test: add integration tests for linear connector token injection

### DIFF
--- a/turbo/apps/web/src/__tests__/api-test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers.ts
@@ -1619,6 +1619,7 @@ const OAUTH_PROVIDER_MOCKS: Record<
   {
     tokenUrl: string;
     userUrl: string;
+    userMethod?: "get" | "post";
     envVars: Record<string, string>;
     buildTokenResponse: (accessToken: string) => Record<string, unknown>;
     buildUserResponse: (opts: {
@@ -1686,6 +1687,31 @@ const OAUTH_PROVIDER_MOCKS: Record<
       handle: opts.username ?? "testuser",
     }),
   },
+  linear: {
+    tokenUrl: "https://api.linear.app/oauth/token",
+    userUrl: "https://api.linear.app/graphql",
+    userMethod: "post",
+    envVars: {
+      LINEAR_OAUTH_CLIENT_ID: "linear-test-client-id",
+      LINEAR_OAUTH_CLIENT_SECRET: "linear-test-client-secret",
+    },
+    buildTokenResponse: (accessToken) => ({
+      access_token: accessToken,
+      refresh_token: "linear-refresh-token",
+      expires_in: 86399,
+      token_type: "Bearer",
+      scope: "read,write",
+    }),
+    buildUserResponse: (opts) => ({
+      data: {
+        viewer: {
+          id: opts.userId?.toString() ?? "linear-user-123",
+          name: opts.username ?? "Linear User",
+          email: opts.email ?? "user@linear.app",
+        },
+      },
+    }),
+  },
 };
 
 /**
@@ -1717,7 +1743,7 @@ async function createTestOAuthConnector(options?: {
     mswHttp.post(providerMock.tokenUrl, () =>
       HttpResponse.json(providerMock.buildTokenResponse(accessToken)),
     ),
-    mswHttp.get(providerMock.userUrl, () =>
+    mswHttp[providerMock.userMethod ?? "get"](providerMock.userUrl, () =>
       HttpResponse.json(
         providerMock.buildUserResponse({
           username: options?.externalUsername ?? "testuser",

--- a/turbo/apps/web/src/lib/run/__tests__/create-run.test.ts
+++ b/turbo/apps/web/src/lib/run/__tests__/create-run.test.ts
@@ -1124,5 +1124,68 @@ describe("createRun()", () => {
         GH_TOKEN: "ghp_oauth_test_456",
       });
     });
+
+    it("should inject Linear OAuth connector secret into sandbox environment", async () => {
+      const compose = await createTestCompose(uniqueId("linear-oauth-agent"), {
+        overrides: {
+          environment: {
+            ANTHROPIC_API_KEY: "test-api-key",
+            LINEAR_TOKEN: "${{ secrets.LINEAR_TOKEN }}",
+          },
+        },
+      });
+
+      await createTestConnector({
+        type: "linear",
+        authMethod: "oauth",
+        accessToken: "lin_oauth_test_789",
+      });
+
+      const result = await createRun(
+        baseParams({ agentComposeVersionId: compose.versionId }),
+      );
+
+      expect(result.runId).toBeDefined();
+      expect(result.status).toBe("pending");
+
+      const job = await findTestRunnerJobEntry(result.runId);
+      expect(job).toBeDefined();
+      expect(job!.executionContext.environment).toMatchObject({
+        LINEAR_TOKEN: "lin_oauth_test_789",
+      });
+      // Ensure template placeholder was fully resolved
+      expect(job!.executionContext.environment!.LINEAR_TOKEN).not.toContain(
+        "${{",
+      );
+    });
+
+    it("should leave Linear token template unresolved when connector not connected", async () => {
+      const compose = await createTestCompose(
+        uniqueId("linear-no-connector-agent"),
+        {
+          overrides: {
+            environment: {
+              ANTHROPIC_API_KEY: "test-api-key",
+              LINEAR_TOKEN: "${{ secrets.LINEAR_TOKEN }}",
+            },
+          },
+        },
+      );
+
+      // Do NOT create a Linear connector
+
+      const result = await createRun(
+        baseParams({ agentComposeVersionId: compose.versionId }),
+      );
+
+      expect(result.runId).toBeDefined();
+      expect(result.status).toBe("pending");
+
+      const job = await findTestRunnerJobEntry(result.runId);
+      expect(job).toBeDefined();
+      expect(job!.executionContext.environment!.LINEAR_TOKEN).toBe(
+        "${{ secrets.LINEAR_TOKEN }}",
+      );
+    });
   });
 });


### PR DESCRIPTION
## Summary

- Add `linear` entry to `OAUTH_PROVIDER_MOCKS` in test helpers with POST-based GraphQL user info endpoint support
- Add `userMethod` field to mock config type so `createTestOAuthConnector` uses `mswHttp.post` vs `mswHttp.get` based on provider
- Add two integration tests in "Connector Secret Injection" block: happy path (LINEAR_TOKEN resolves via OAuth) and failure case (template leaks when connector not connected)

Closes #5904

## Test plan

- [x] `pnpm vitest run src/lib/run/__tests__/create-run.test.ts -t "Linear"` — both new tests pass
- [x] `pnpm vitest run src/lib/run/__tests__/create-run.test.ts` — all 51 tests pass (no regressions)
- [x] Lint passes
- [x] No new type errors introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)