### PR TITLE
test: add integration tests for linear connector token injection

### DIFF
--- a/turbo/apps/web/src/__tests__/api-test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers.ts
@@ -1619,6 +1619,7 @@ const OAUTH_PROVIDER_MOCKS: Record<
   {
     tokenUrl: string;
     userUrl: string;
+    userMethod?: "get" | "post";
     envVars: Record<string, string>;
     buildTokenResponse: (accessToken: string) => Record<string, unknown>;
     buildUserResponse: (opts: {
@@ -1686,6 +1687,30 @@ const OAUTH_PROVIDER_MOCKS: Record<
       handle: opts.username ?? "testuser",
     }),
   },
+  linear: {
+    tokenUrl: "https://api.linear.app/oauth/token",
+    userUrl: "https://api.linear.app/graphql",
+    userMethod: "post",
+    envVars: {
+      LINEAR_OAUTH_CLIENT_ID: "linear-test-client-id",
+      LINEAR_OAUTH_CLIENT_SECRET: "linear-test-client-secret",
+    },
+    buildTokenResponse: (accessToken) => ({
+      access_token: accessToken,
+      refresh_token: "linear-refresh-token",
+      expires_in: 86399,
+      scope: "read,write,issues:create,comments:create,timeSchedule:write",
+    }),
+    buildUserResponse: (opts) => ({
+      data: {
+        viewer: {
+          id: opts.userId?.toString() ?? "linear-user-12345",
+          name: opts.username ?? "testuser",
+          email: opts.email ?? "test@example.com",
+        },
+      },
+    }),
+  },
 };
 
 /**
@@ -1713,11 +1738,13 @@ async function createTestOAuthConnector(options?: {
   reloadEnv();
 
   // Set up MSW handlers for token exchange + user info
+  const userHandler =
+    providerMock.userMethod === "post" ? mswHttp.post : mswHttp.get;
   server.use(
     mswHttp.post(providerMock.tokenUrl, () =>
       HttpResponse.json(providerMock.buildTokenResponse(accessToken)),
     ),
-    mswHttp.get(providerMock.userUrl, () =>
+    userHandler(providerMock.userUrl, () =>
       HttpResponse.json(
         providerMock.buildUserResponse({
           username: options?.externalUsername ?? "testuser",

--- a/turbo/apps/web/src/lib/run/__tests__/create-run.test.ts
+++ b/turbo/apps/web/src/lib/run/__tests__/create-run.test.ts
@@ -1124,5 +1124,72 @@ describe("createRun()", () => {
         GH_TOKEN: "ghp_oauth_test_456",
       });
     });
+
+    it("should inject Linear OAuth connector secret via environmentMapping into sandbox environment", async () => {
+      // Create a compose that references the mapped secret name
+      const compose = await createTestCompose(uniqueId("linear-oauth-agent"), {
+        overrides: {
+          environment: {
+            ANTHROPIC_API_KEY: "test-api-key",
+            LINEAR_TOKEN: "${{ secrets.LINEAR_TOKEN }}",
+          },
+        },
+      });
+
+      // Create a Linear connector with OAuth auth via callback route
+      // Linear uses GraphQL (POST) for user info — this validates the userMethod support
+      await createTestConnector({
+        type: "linear",
+        authMethod: "oauth",
+        accessToken: "lin_oauth_test_789",
+      });
+
+      const result = await createRun(
+        baseParams({ agentComposeVersionId: compose.versionId }),
+      );
+
+      expect(result.runId).toBeDefined();
+      expect(result.status).toBe("pending");
+
+      // Verify the runner job queue entry contains the injected secret
+      const job = await findTestRunnerJobEntry(result.runId);
+      expect(job).toBeDefined();
+      expect(job!.executionContext.environment).toMatchObject({
+        LINEAR_TOKEN: "lin_oauth_test_789",
+      });
+      // Verify the template placeholder was fully resolved
+      const env = job!.executionContext.environment;
+      expect(env).not.toBeNull();
+      expect(env!.LINEAR_TOKEN).not.toContain("${{");
+    });
+
+    it("should leave Linear token as raw template when connector is not connected", async () => {
+      // Create a compose that references LINEAR_TOKEN but do NOT create a connector
+      const compose = await createTestCompose(
+        uniqueId("linear-no-connector-agent"),
+        {
+          overrides: {
+            environment: {
+              ANTHROPIC_API_KEY: "test-api-key",
+              LINEAR_TOKEN: "${{ secrets.LINEAR_TOKEN }}",
+            },
+          },
+        },
+      );
+
+      const result = await createRun(
+        baseParams({ agentComposeVersionId: compose.versionId }),
+      );
+
+      expect(result.runId).toBeDefined();
+      expect(result.status).toBe("pending");
+
+      // Verify the template is left as-is when no connector is connected
+      const job = await findTestRunnerJobEntry(result.runId);
+      expect(job).toBeDefined();
+      const env = job!.executionContext.environment;
+      expect(env).not.toBeNull();
+      expect(env!.LINEAR_TOKEN).toBe("${{ secrets.LINEAR_TOKEN }}");
+    });
   });
 });


### PR DESCRIPTION
## Summary

- Add Linear OAuth mock to `OAUTH_PROVIDER_MOCKS` with GraphQL user info endpoint support (`userMethod: "post"`)
- Update `createTestOAuthConnector()` to use configurable HTTP method for user info requests (GET vs POST)
- Add two integration tests for Linear connector secret injection in `create-run.test.ts`

Closes #5904

## Test plan

- [x] `pnpm vitest run src/lib/run/__tests__/create-run.test.ts -t "Linear"` — both new tests pass
- [x] `pnpm vitest run src/lib/run/__tests__/create-run.test.ts` — all 51 tests pass (no regressions)
- [x] Lint passes
- [x] Type check passes (pre-existing unrelated issue in theme-toggle.test.tsx)
- [x] Knip passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)