### PR TITLE
ci: rename ci-gate jobs to unique names per workflow

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -767,7 +767,7 @@ jobs:
           echo "=== Upgrade test passed ==="
           REMOTE_SCRIPT
 
-  ci-gate:
+  ci-gate-crates:
     runs-on: ubuntu-latest
     needs:
       - detect

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -42,12 +42,12 @@ jobs:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
-      # Create ci-gate check run on release PR head commit.
-      # GITHUB_TOKEN pushes don't trigger pull_request events, so turbo.yml
-      # never runs on the new commit. The Checks API with GITHUB_TOKEN produces
-      # a check run with integration_id 15368 (GitHub Actions), satisfying the
-      # required_status_checks ruleset.
-      - name: Pass ci-gate for release PR
+      # Create ci-gate check runs on release PR head commit.
+      # GITHUB_TOKEN pushes don't trigger pull_request events, so the CI
+      # workflows never run on the new commit. The Checks API with GITHUB_TOKEN
+      # produces check runs with integration_id 15368 (GitHub Actions),
+      # satisfying the required_status_checks ruleset.
+      - name: Pass ci-gate checks for release PR
         if: ${{ steps.release.outputs.releases_created != 'true' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -57,14 +57,16 @@ jobs:
             echo "No release PR found, skipping"
             exit 0
           fi
-          gh api repos/${{ github.repository }}/check-runs -X POST \
-            -f name="ci-gate" \
-            -f head_sha="$PR_HEAD" \
-            -f status="completed" \
-            -f conclusion="success" \
-            -f "output[title]=Release PR — CI skipped" \
-            -f "output[summary]=Release-please PRs only contain version bumps and changelogs."
-          echo "✅ Created ci-gate check run on $PR_HEAD"
+          for gate in ci-gate-turbo ci-gate-crates ci-gate-security; do
+            gh api repos/${{ github.repository }}/check-runs -X POST \
+              -f name="$gate" \
+              -f head_sha="$PR_HEAD" \
+              -f status="completed" \
+              -f conclusion="success" \
+              -f "output[title]=Release PR — CI skipped" \
+              -f "output[summary]=Release-please PRs only contain version bumps and changelogs."
+            echo "✅ Created $gate check run on $PR_HEAD"
+          done
 
   # Run database migrations in production
   migrate-production:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -158,7 +158,7 @@ jobs:
             gitleaks detect --source . --log-opts="HEAD~1..HEAD" --verbose --redact
           fi
 
-  ci-gate:
+  ci-gate-security:
     runs-on: ubuntu-latest
     needs:
       - semgrep

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1749,7 +1749,7 @@ jobs:
   # Aggregates all job results — must ALWAYS run to report explicit success/failure.
   # Using !failure() or !cancelled() would cause the gate to be skipped when
   # dependencies fail, and GitHub treats "skipped" as passing — defeating the purpose.
-  ci-gate:
+  ci-gate-turbo:
     runs-on: ubuntu-latest
     # Runner cleanup is handled by cleanup.yml (pull_request_target:closed).
     needs:


### PR DESCRIPTION
## Summary
- Rename `ci-gate` job to `ci-gate-turbo` in turbo.yml, `ci-gate-crates` in crates.yml, and `ci-gate-security` in security.yml so branch protection can require each independently
- Update release-please.yml to create check runs for all three gate names on release PRs

## Test plan
- [ ] Verify CI workflows trigger and the renamed gate jobs complete successfully
- [ ] Verify branch protection rules are updated to reference the new job names
- [ ] Verify release-please creates all three check runs on release PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)