### PR TITLE
fix: resolve activity page overflow and add internal connector logos page

### DIFF
--- a/turbo/apps/platform/src/signals/bootstrap.ts
+++ b/turbo/apps/platform/src/signals/bootstrap.ts
@@ -12,6 +12,7 @@ import { setupActivityPage$ } from "./activity-page/activity-page-setup.ts";
 import { setupActivityDetailPage$ } from "./activity-page/activity-detail-page-setup.ts";
 import { setupTeamPage$ } from "./team-page/team-page-setup.ts";
 import { setupTeamDetailPage$ } from "./team-page/team-detail-page-setup.ts";
+import { setupInternalConnectorLogos$ } from "./internal-connector-logos-setup.ts";
 const ROUTE_CONFIG = [
   {
     path: "/select-org",
@@ -48,6 +49,10 @@ const ROUTE_CONFIG = [
   {
     path: "/activity",
     setup: setupAuthPageWrapper(setupActivityPage$),
+  },
+  {
+    path: "/__internal-connector-logos",
+    setup: setupInternalConnectorLogos$,
   },
   {
     path: "/:tab/:sub",

--- a/turbo/apps/platform/src/signals/internal-connector-logos-setup.ts
+++ b/turbo/apps/platform/src/signals/internal-connector-logos-setup.ts
@@ -1,6 +1,5 @@
 import { command, state, computed } from "ccstate";
 import { createElement } from "react";
-import { InternalConnectorLogos } from "../views/internal-connector-logos.tsx";
 import { updatePage$ } from "./react-router.ts";
 
 const ICON_SIZES = [16, 32, 48, 96, 128, 256] as const;
@@ -16,6 +15,9 @@ export const setIconSize$ = command(({ set }, size: IconSize) => {
   set(internalIconSize$, size);
 });
 
-export const setupInternalConnectorLogos$ = command(({ set }) => {
+export const setupInternalConnectorLogos$ = command(async ({ set }) => {
+  const { InternalConnectorLogos } = await import(
+    "../views/internal-connector-logos.tsx"
+  );
   set(updatePage$, createElement(InternalConnectorLogos));
 });

--- a/turbo/apps/platform/src/signals/internal-connector-logos-setup.ts
+++ b/turbo/apps/platform/src/signals/internal-connector-logos-setup.ts
@@ -1,0 +1,21 @@
+import { command, state, computed } from "ccstate";
+import { createElement } from "react";
+import { InternalConnectorLogos } from "../views/internal-connector-logos.tsx";
+import { updatePage$ } from "./react-router.ts";
+
+const ICON_SIZES = [16, 32, 48, 96, 128, 256] as const;
+export type IconSize = (typeof ICON_SIZES)[number];
+
+const internalIconSize$ = state<IconSize>(128);
+
+export const iconSize$ = computed((get) => get(internalIconSize$));
+
+export const iconSizes$ = computed(() => ICON_SIZES);
+
+export const setIconSize$ = command(({ set }, size: IconSize) => {
+  set(internalIconSize$, size);
+});
+
+export const setupInternalConnectorLogos$ = command(({ set }) => {
+  set(updatePage$, createElement(InternalConnectorLogos));
+});

--- a/turbo/apps/platform/src/types/route.ts
+++ b/turbo/apps/platform/src/types/route.ts
@@ -12,5 +12,5 @@ export type RoutePath =
   | "/queue"
   | "/activity"
   | "/activity/:logId"
-  | `/__internal-connector-logos`
+  | "/__internal-connector-logos"
   | `/projects/${string}`;

--- a/turbo/apps/platform/src/types/route.ts
+++ b/turbo/apps/platform/src/types/route.ts
@@ -12,4 +12,5 @@ export type RoutePath =
   | "/queue"
   | "/activity"
   | "/activity/:logId"
+  | `/__internal-connector-logos`
   | `/projects/${string}`;

--- a/turbo/apps/platform/src/views/internal-connector-logos.tsx
+++ b/turbo/apps/platform/src/views/internal-connector-logos.tsx
@@ -1,5 +1,4 @@
 import { CONNECTOR_TYPES, type ConnectorType } from "@vm0/core";
-import { Fragment } from "react";
 import { useGet, useSet } from "ccstate-react";
 import { CONNECTOR_ICONS } from "./zero-page/components/settings/connector-icons.tsx";
 import {
@@ -10,11 +9,21 @@ import {
 } from "../signals/internal-connector-logos-setup.ts";
 
 function getIconType(url: string): string {
-  if (url.startsWith("data:image/svg+xml")) return "SVG (inline)";
-  if (url.endsWith(".svg")) return "SVG";
-  if (url.endsWith(".png")) return "PNG";
-  if (url.endsWith(".jpg") || url.endsWith(".jpeg")) return "JPEG";
-  if (url.endsWith(".webp")) return "WebP";
+  if (url.startsWith("data:image/svg+xml")) {
+    return "SVG (inline)";
+  }
+  if (url.endsWith(".svg")) {
+    return "SVG";
+  }
+  if (url.endsWith(".png")) {
+    return "PNG";
+  }
+  if (url.endsWith(".jpg") || url.endsWith(".jpeg")) {
+    return "JPEG";
+  }
+  if (url.endsWith(".webp")) {
+    return "WebP";
+  }
   return "unknown";
 }
 
@@ -139,7 +148,7 @@ export function InternalConnectorLogos() {
           const iconUrl = CONNECTOR_ICONS[type];
           const iconType = getIconType(iconUrl);
           return (
-            <Fragment key={type}>
+            <div key={type} style={{ display: "contents" }}>
               <IconBox src={iconUrl} size={size} shape="square" bg="#fff" />
               <IconBox src={iconUrl} size={size} shape="square" bg="#7c3aed" />
               <IconBox src={iconUrl} size={size} shape="circle" bg="#fff" />
@@ -151,7 +160,7 @@ export function InternalConnectorLogos() {
                 <span style={{ fontSize: 12, color: "#999" }}>{type}</span>
                 <span style={{ fontSize: 12, color: "#666" }}>{iconType}</span>
               </div>
-            </Fragment>
+            </div>
           );
         })}
       </div>

--- a/turbo/apps/platform/src/views/internal-connector-logos.tsx
+++ b/turbo/apps/platform/src/views/internal-connector-logos.tsx
@@ -1,4 +1,5 @@
 import { CONNECTOR_TYPES, type ConnectorType } from "@vm0/core";
+import { Fragment } from "react";
 import { useGet, useSet } from "ccstate-react";
 import { CONNECTOR_ICONS } from "./zero-page/components/settings/connector-icons.tsx";
 import {
@@ -138,7 +139,7 @@ export function InternalConnectorLogos() {
           const iconUrl = CONNECTOR_ICONS[type];
           const iconType = getIconType(iconUrl);
           return (
-            <>
+            <Fragment key={type}>
               <IconBox src={iconUrl} size={size} shape="square" bg="#fff" />
               <IconBox src={iconUrl} size={size} shape="square" bg="#7c3aed" />
               <IconBox src={iconUrl} size={size} shape="circle" bg="#fff" />
@@ -150,7 +151,7 @@ export function InternalConnectorLogos() {
                 <span style={{ fontSize: 12, color: "#999" }}>{type}</span>
                 <span style={{ fontSize: 12, color: "#666" }}>{iconType}</span>
               </div>
-            </>
+            </Fragment>
           );
         })}
       </div>

--- a/turbo/apps/platform/src/views/internal-connector-logos.tsx
+++ b/turbo/apps/platform/src/views/internal-connector-logos.tsx
@@ -1,0 +1,159 @@
+import { CONNECTOR_TYPES, type ConnectorType } from "@vm0/core";
+import { useGet, useSet } from "ccstate-react";
+import { CONNECTOR_ICONS } from "./zero-page/components/settings/connector-icons.tsx";
+import {
+  iconSize$,
+  iconSizes$,
+  setIconSize$,
+  type IconSize,
+} from "../signals/internal-connector-logos-setup.ts";
+
+function getIconType(url: string): string {
+  if (url.startsWith("data:image/svg+xml")) return "SVG (inline)";
+  if (url.endsWith(".svg")) return "SVG";
+  if (url.endsWith(".png")) return "PNG";
+  if (url.endsWith(".jpg") || url.endsWith(".jpeg")) return "JPEG";
+  if (url.endsWith(".webp")) return "WebP";
+  return "unknown";
+}
+
+function IconBox({
+  src,
+  size,
+  shape,
+  bg,
+}: {
+  src: string;
+  size: number;
+  shape: "square" | "circle";
+  bg: string;
+}) {
+  return (
+    <div
+      style={{
+        width: size,
+        height: size,
+        border: bg === "#fff" ? "1px solid red" : undefined,
+        borderRadius: shape === "circle" ? "50%" : 0,
+        background: bg,
+        flexShrink: 0,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        overflow: "hidden",
+      }}
+    >
+      <img
+        src={src}
+        alt=""
+        style={{
+          // Circle: inscribed square = diameter / √2 ≈ 70.7%
+          width:
+            shape === "circle" ? `${(100 / Math.SQRT2).toFixed(2)}%` : "100%",
+          height:
+            shape === "circle" ? `${(100 / Math.SQRT2).toFixed(2)}%` : "100%",
+          objectFit: "contain",
+        }}
+      />
+    </div>
+  );
+}
+
+export function InternalConnectorLogos() {
+  const size = useGet(iconSize$);
+  const sizes = useGet(iconSizes$);
+  const setSize = useSet(setIconSize$);
+  const connectorTypes = Object.keys(CONNECTOR_TYPES) as ConnectorType[];
+
+  return (
+    <div style={{ padding: 32, fontFamily: "monospace", background: "#fff" }}>
+      <div
+        style={{
+          marginBottom: 24,
+          display: "flex",
+          alignItems: "center",
+          gap: 16,
+          position: "sticky",
+          top: 0,
+          background: "#fff",
+          padding: "12px 0",
+          borderBottom: "1px solid #eee",
+          zIndex: 10,
+        }}
+      >
+        <h1 style={{ fontSize: 20, margin: 0 }}>
+          Connector Logos ({connectorTypes.length})
+        </h1>
+        <div style={{ display: "flex", gap: 4 }}>
+          {sizes.map((s) => (
+            <button
+              key={s}
+              onClick={() => setSize(s as IconSize)}
+              style={{
+                padding: "4px 12px",
+                fontSize: 14,
+                border: s === size ? "2px solid #111" : "1px solid #ccc",
+                borderRadius: 4,
+                background: s === size ? "#111" : "#fff",
+                color: s === size ? "#fff" : "#333",
+                cursor: "pointer",
+                fontFamily: "monospace",
+              }}
+            >
+              {s}
+            </button>
+          ))}
+        </div>
+        <span style={{ fontSize: 13, color: "#999" }}>
+          {size}x{size}px
+        </span>
+      </div>
+
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "auto auto auto auto 1fr",
+          gap: "12px 16px",
+          alignItems: "center",
+        }}
+      >
+        {/* Header */}
+        <span style={{ fontSize: 12, color: "#999", fontWeight: 600 }}>
+          Square / white
+        </span>
+        <span style={{ fontSize: 12, color: "#999", fontWeight: 600 }}>
+          Square / purple
+        </span>
+        <span style={{ fontSize: 12, color: "#999", fontWeight: 600 }}>
+          Circle / white
+        </span>
+        <span style={{ fontSize: 12, color: "#999", fontWeight: 600 }}>
+          Circle / purple
+        </span>
+        <span style={{ fontSize: 12, color: "#999", fontWeight: 600 }}>
+          Info
+        </span>
+
+        {connectorTypes.map((type) => {
+          const iconUrl = CONNECTOR_ICONS[type];
+          const iconType = getIconType(iconUrl);
+          return (
+            <>
+              <IconBox src={iconUrl} size={size} shape="square" bg="#fff" />
+              <IconBox src={iconUrl} size={size} shape="square" bg="#7c3aed" />
+              <IconBox src={iconUrl} size={size} shape="circle" bg="#fff" />
+              <IconBox src={iconUrl} size={size} shape="circle" bg="#7c3aed" />
+              <div style={{ display: "flex", flexDirection: "column", gap: 2 }}>
+                <span style={{ fontSize: 14, color: "#111", fontWeight: 600 }}>
+                  {CONNECTOR_TYPES[type].label}
+                </span>
+                <span style={{ fontSize: 12, color: "#999" }}>{type}</span>
+                <span style={{ fontSize: 12, color: "#666" }}>{iconType}</span>
+              </div>
+            </>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/turbo/apps/platform/src/views/zero-page/components/settings/connector-icons.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/connector-icons.tsx
@@ -1,35 +1,36 @@
 import { CONNECTOR_TYPES, type ConnectorType } from "@vm0/core";
 import { cn } from "@vm0/ui";
 
-const CONNECTOR_ICONS: Readonly<Record<ConnectorType, string>> = Object.freeze(
-  (() => {
-    const allIcons = Object.fromEntries(
-      Object.entries(
-        import.meta.glob<string>("./icons/*.svg", {
-          eager: true,
-          import: "default",
-        }),
-      ).map(([path, url]) => [
-        path.replace("./icons/", "").replace(".svg", ""),
-        url,
-      ]),
-    );
+export const CONNECTOR_ICONS: Readonly<Record<ConnectorType, string>> =
+  Object.freeze(
+    (() => {
+      const allIcons = Object.fromEntries(
+        Object.entries(
+          import.meta.glob<string>("./icons/*.svg", {
+            eager: true,
+            import: "default",
+          }),
+        ).map(([path, url]) => [
+          path.replace("./icons/", "").replace(".svg", ""),
+          url,
+        ]),
+      );
 
-    const connectorKeys = Object.keys(CONNECTOR_TYPES) as ConnectorType[];
-    const filtered: Record<string, string> = {};
-    for (const key of connectorKeys) {
-      const icon = allIcons[key];
-      if (typeof icon !== "string") {
-        throw new Error(
-          `Missing SVG icon for connector type "${key}". Add icons/${key}.svg.`,
-        );
+      const connectorKeys = Object.keys(CONNECTOR_TYPES) as ConnectorType[];
+      const filtered: Record<string, string> = {};
+      for (const key of connectorKeys) {
+        const icon = allIcons[key];
+        if (typeof icon !== "string") {
+          throw new Error(
+            `Missing SVG icon for connector type "${key}". Add icons/${key}.svg.`,
+          );
+        }
+        filtered[key] = icon;
       }
-      filtered[key] = icon;
-    }
 
-    return filtered as Record<ConnectorType, string>;
-  })(),
-);
+      return filtered as Record<ConnectorType, string>;
+    })(),
+  );
 
 const MONOCHROME_ICONS: Readonly<Record<string, true>> = Object.freeze({
   agentmail: true,

--- a/turbo/apps/platform/src/views/zero-page/zero-activity-detail-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-activity-detail-page.tsx
@@ -138,7 +138,7 @@ function ActivityHeaderCard({
           className="w-px h-3.5 shrink-0 bg-border self-center"
           aria-hidden
         />
-        <div className="flex items-center gap-x-0 text-sm min-w-0 overflow-x-auto">
+        <div className="flex items-center gap-x-0 text-sm min-w-0 overflow-hidden">
           <div className="flex items-center gap-1.5 pl-3 pr-3">
             <span className="text-muted-foreground shrink-0">Status</span>
             <StatusBadge status={status} zeroStyle />

--- a/turbo/apps/platform/src/views/zero-page/zero-activity-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-activity-page.tsx
@@ -67,7 +67,7 @@ function ActivityRow({
     <Link
       pathname="/activity/:logId"
       options={{ pathParams: { logId } }}
-      className="block py-3 -mx-4 px-4 transition-colors hover:bg-muted/50 cursor-pointer border-b border-border/40 last:border-b-0 no-underline text-inherit"
+      className="block py-3 transition-colors hover:bg-muted/50 cursor-pointer border-b border-border/40 last:border-b-0 no-underline text-inherit"
     >
       <div className={cn(ROW_GRID)}>
         <div className="min-w-0 truncate text-left text-sm font-medium text-foreground">
@@ -203,7 +203,7 @@ export function ZeroActivityPage() {
                   <div
                     className={cn(
                       ROW_GRID,
-                      "sticky top-0 z-10 -mx-4 px-4 py-3 text-sm font-medium text-muted-foreground bg-card border-b border-border/40",
+                      "sticky top-0 z-10 py-3 text-sm font-medium text-muted-foreground bg-card border-b border-border/40",
                     )}
                   >
                     <div className="text-left">Agent</div>


### PR DESCRIPTION
## Summary
- Fix activity page overflow and negative margin layout issues
- Add internal connector logos page for developer inspection of connector icons

## Changes
1. **Activity page fix**: Resolve overflow and negative margin issues in the activity page layout
2. **Internal connector logos**: Add `/__internal-connector-logos` dev tool page for visually inspecting connector logos at different sizes and shapes
3. **Code review fixes**: Add missing React `key` prop on Fragment, fix template literal consistency in route types