### PR TITLE
feat: add pre-flight credit check for vm0 model provider runs

### DIFF
--- a/turbo/apps/cli/src/instrument.ts
+++ b/turbo/apps/cli/src/instrument.ts
@@ -33,6 +33,7 @@ const OPERATIONAL_ERROR_PATTERNS = [
   // Rate limiting (expected operational condition)
   /rate limit/i,
   /concurrent run limit/i,
+  /insufficient.*credit/i,
   // Network issues (transient, not bugs)
   /network error/i,
   /network issue/i,

--- a/turbo/apps/cli/src/lib/command/with-error-handler.ts
+++ b/turbo/apps/cli/src/lib/command/with-error-handler.ts
@@ -19,6 +19,13 @@ export function withErrorHandler<T extends unknown[]>(
         if (error.code === "UNAUTHORIZED") {
           console.error(chalk.red("✗ Not authenticated"));
           console.error(chalk.dim("  Run: vm0 auth login"));
+        } else if (error.code === "INSUFFICIENT_CREDITS") {
+          console.error(chalk.red("✗ Credits depleted"));
+          console.error(
+            chalk.dim(
+              "  Add credits at your billing page or configure your own API key.",
+            ),
+          );
         } else {
           console.error(chalk.red(`✗ ${error.status}: ${error.message}`));
         }

--- a/turbo/apps/web/app/api/agent/runs/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/route.ts
@@ -23,6 +23,7 @@ import {
   isNotFound,
   isUnauthorized,
   isProviderIncompatible,
+  isInsufficientCredits,
 } from "../../../../src/lib/errors";
 import { resolveOrg } from "../../../../src/lib/org/resolve-org";
 
@@ -41,6 +42,15 @@ function handleCreateRunError(error: unknown) {
       status: 400 as const,
       body: {
         error: { message: error.message, code: "PROVIDER_INCOMPATIBLE" },
+      },
+    };
+  }
+
+  if (isInsufficientCredits(error)) {
+    return {
+      status: 402 as const,
+      body: {
+        error: { message: error.message, code: "INSUFFICIENT_CREDITS" },
       },
     };
   }

--- a/turbo/apps/web/src/__tests__/api-test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers.ts
@@ -39,6 +39,8 @@ import { telegramInstallations } from "../db/schema/telegram-installation";
 import { telegramMessages } from "../db/schema/telegram-message";
 import { telegramUserLinks } from "../db/schema/telegram-user-link";
 import { orgMetadata } from "../db/schema/org-metadata";
+import { modelProviders } from "../db/schema/model-provider";
+import { ORG_SENTINEL_USER_ID } from "../lib/org/org-sentinel";
 import { orgCache } from "../db/schema/org-cache";
 import { orgMembersCache } from "../db/schema/org-members-cache";
 import { orgMembersMetadata } from "../db/schema/org-members-metadata";
@@ -2910,6 +2912,41 @@ export async function getOrgCredits(orgId: string): Promise<number | null> {
     .where(eq(orgMetadata.orgId, orgId))
     .limit(1);
   return row?.credits ?? null;
+}
+
+/**
+ * Set the credit balance for an org in the `org` table.
+ * Ensures the org row exists first.
+ */
+export async function setOrgCredits(
+  orgId: string,
+  credits: number,
+): Promise<void> {
+  await globalThis.services.db
+    .insert(orgMetadata)
+    .values({ orgId, credits })
+    .onConflictDoUpdate({
+      target: orgMetadata.orgId,
+      set: { credits, updatedAt: new Date() },
+    });
+}
+
+/**
+ * Insert an org-level default model provider directly in the database.
+ * Useful for testing credit check behavior with different provider types.
+ */
+export async function insertOrgDefaultModelProvider(
+  orgId: string,
+  type: string,
+  selectedModel?: string,
+): Promise<void> {
+  await globalThis.services.db.insert(modelProviders).values({
+    type,
+    userId: ORG_SENTINEL_USER_ID,
+    orgId,
+    isDefault: true,
+    selectedModel: selectedModel ?? null,
+  });
 }
 
 /**

--- a/turbo/apps/web/src/lib/errors.ts
+++ b/turbo/apps/web/src/lib/errors.ts
@@ -53,6 +53,12 @@ interface ConcurrentRunLimitError extends ApiErrorBase {
   readonly code: "TOO_MANY_REQUESTS";
 }
 
+interface InsufficientCreditsError extends ApiErrorBase {
+  readonly name: "InsufficientCreditsError";
+  readonly statusCode: 402;
+  readonly code: "INSUFFICIENT_CREDITS";
+}
+
 interface ProviderIncompatibleError extends ApiErrorBase {
   readonly name: "ProviderIncompatibleError";
   readonly statusCode: 400;
@@ -123,6 +129,15 @@ export function concurrentRunLimit(
   return error;
 }
 
+export function insufficientCredits(credits: number): InsufficientCreditsError {
+  const message = `Insufficient credits (balance: ${credits}). Your VM0 credits are depleted. Add credits or configure your own API key to continue.`;
+  const error = new Error(message) as InsufficientCreditsError;
+  (error as { name: string }).name = "InsufficientCreditsError";
+  (error as { statusCode: number }).statusCode = 402;
+  (error as { code: string }).code = "INSUFFICIENT_CREDITS";
+  return error;
+}
+
 export function providerIncompatible(
   message: string,
 ): ProviderIncompatibleError {
@@ -163,6 +178,12 @@ export function isSchedulePast(e: unknown): e is SchedulePastError {
 
 export function isConcurrentRunLimit(e: unknown): e is ConcurrentRunLimitError {
   return e instanceof Error && e.name === "ConcurrentRunLimitError";
+}
+
+export function isInsufficientCredits(
+  e: unknown,
+): e is InsufficientCreditsError {
+  return e instanceof Error && e.name === "InsufficientCreditsError";
 }
 
 export function isProviderIncompatible(

--- a/turbo/apps/web/src/lib/run/__tests__/credit-check.test.ts
+++ b/turbo/apps/web/src/lib/run/__tests__/credit-check.test.ts
@@ -1,0 +1,215 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  testContext,
+  uniqueId,
+  type UserContext,
+} from "../../../__tests__/test-helpers";
+import {
+  createTestCompose,
+  findTestRunRecord,
+  findTestQueueEntry,
+  markRunningRunsAsCompleted,
+  setOrgCredits,
+  deleteOrgRow,
+  insertOrgDefaultModelProvider,
+} from "../../../__tests__/api-test-helpers";
+import { reloadEnv } from "../../../env";
+import {
+  createRun,
+  dispatchQueuedRun,
+  type CreateRunParams,
+} from "../run-service";
+import { drainOrgQueue, enqueueRun } from "../run-queue-service";
+import { isInsufficientCredits } from "../../errors";
+
+const context = testContext();
+
+describe("credit check", () => {
+  let user: UserContext;
+  let versionId: string;
+
+  beforeEach(async () => {
+    context.setupMocks();
+    user = await context.setupUser();
+    const compose = await createTestCompose(uniqueId("agent"));
+    versionId = compose.versionId;
+  });
+
+  function baseParams(overrides?: Partial<CreateRunParams>): CreateRunParams {
+    return {
+      userId: user.userId,
+      agentComposeVersionId: versionId,
+      prompt: "Credit check test",
+      orgId: user.orgId,
+      ...overrides,
+    };
+  }
+
+  describe("createRun() path", () => {
+    it("should allow VM0 run when credits > 0", async () => {
+      await setOrgCredits(user.orgId, 100);
+
+      const result = await createRun(baseParams({ modelProvider: "vm0" }));
+
+      expect(result.status).toBe("pending");
+      expect(result.runId).toBeDefined();
+    });
+
+    it("should reject VM0 run when credits = 0", async () => {
+      await setOrgCredits(user.orgId, 0);
+
+      await expect(
+        createRun(baseParams({ modelProvider: "vm0" })),
+      ).rejects.toSatisfy(isInsufficientCredits);
+    });
+
+    it("should reject VM0 run when credits are negative", async () => {
+      await setOrgCredits(user.orgId, -500);
+
+      await expect(
+        createRun(baseParams({ modelProvider: "vm0" })),
+      ).rejects.toSatisfy(isInsufficientCredits);
+    });
+
+    it("should allow non-VM0 run when credits = 0", async () => {
+      await setOrgCredits(user.orgId, 0);
+
+      const result = await createRun(
+        baseParams({ modelProvider: "anthropic" }),
+      );
+
+      expect(result.status).toBe("pending");
+    });
+
+    it("should reject when org default is VM0 and credits = 0", async () => {
+      await setOrgCredits(user.orgId, 0);
+      await insertOrgDefaultModelProvider(user.orgId, "vm0");
+
+      await expect(createRun(baseParams())).rejects.toSatisfy(
+        isInsufficientCredits,
+      );
+    });
+
+    it("should allow when org default is non-VM0 and credits = 0", async () => {
+      await setOrgCredits(user.orgId, 0);
+      await insertOrgDefaultModelProvider(user.orgId, "anthropic-api-key");
+
+      const result = await createRun(baseParams());
+
+      expect(result.status).toBe("pending");
+    });
+
+    it("should allow when no org default provider and credits = 0", async () => {
+      await setOrgCredits(user.orgId, 0);
+
+      const result = await createRun(baseParams());
+
+      expect(result.status).toBe("pending");
+    });
+
+    it("should allow when org_metadata row is missing", async () => {
+      await deleteOrgRow(user.orgId);
+
+      const result = await createRun(baseParams({ modelProvider: "vm0" }));
+
+      expect(result.status).toBe("pending");
+    });
+
+    it("should not enqueue a rejected VM0 run", async () => {
+      await setOrgCredits(user.orgId, 0);
+
+      await expect(
+        createRun(baseParams({ modelProvider: "vm0" })),
+      ).rejects.toSatisfy(isInsufficientCredits);
+    });
+  });
+
+  describe("dequeueNextAtomic() path", () => {
+    it("should fail queued VM0 run when credits depleted at drain time", async () => {
+      vi.stubEnv("CONCURRENT_RUN_LIMIT_CAP", "1");
+      reloadEnv();
+
+      // Create a running run + a queued VM0 run
+      await createRun(baseParams({ prompt: "Running" }));
+      const queued = await enqueueRun(
+        baseParams({ prompt: "Queued VM0", modelProvider: "vm0" }),
+      );
+
+      // Deplete credits
+      await setOrgCredits(user.orgId, 0);
+
+      // Mark running run as completed to free slot
+      await markRunningRunsAsCompleted(user.userId);
+
+      // Drain queue
+      await drainOrgQueue(user.orgId, dispatchQueuedRun);
+
+      // Queued run should be marked as failed
+      const run = await findTestRunRecord(queued.runId);
+      expect(run!.status).toBe("failed");
+      expect(run!.error).toContain("Insufficient credits");
+
+      // Queue entry should be deleted
+      const queueEntry = await findTestQueueEntry(queued.runId);
+      expect(queueEntry).toBeUndefined();
+    });
+
+    it("should dequeue non-VM0 run when credits depleted", async () => {
+      vi.stubEnv("CONCURRENT_RUN_LIMIT_CAP", "1");
+      reloadEnv();
+
+      // Create a running run + a queued non-VM0 run
+      await createRun(baseParams({ prompt: "Running" }));
+      const queued = await enqueueRun(
+        baseParams({ prompt: "Queued Anthropic", modelProvider: "anthropic" }),
+      );
+
+      // Deplete credits
+      await setOrgCredits(user.orgId, 0);
+
+      // Mark running run as completed
+      await markRunningRunsAsCompleted(user.userId);
+
+      // Drain queue
+      await drainOrgQueue(user.orgId, dispatchQueuedRun);
+
+      // Non-VM0 run should be dequeued normally
+      const run = await findTestRunRecord(queued.runId);
+      expect(run!.status).toBe("pending");
+    });
+
+    it("should skip failed VM0 run and dequeue next non-VM0 run", async () => {
+      vi.stubEnv("CONCURRENT_RUN_LIMIT_CAP", "1");
+      reloadEnv();
+
+      // Create a running run
+      await createRun(baseParams({ prompt: "Running" }));
+
+      // Enqueue two runs: first VM0, then non-VM0
+      const vm0Run = await enqueueRun(
+        baseParams({ prompt: "VM0 run", modelProvider: "vm0" }),
+      );
+      const nonVm0Run = await enqueueRun(
+        baseParams({ prompt: "Anthropic run", modelProvider: "anthropic" }),
+      );
+
+      // Deplete credits
+      await setOrgCredits(user.orgId, 0);
+
+      // Mark running run as completed
+      await markRunningRunsAsCompleted(user.userId);
+
+      // Drain queue
+      await drainOrgQueue(user.orgId, dispatchQueuedRun);
+
+      // VM0 run should be failed
+      const vm0 = await findTestRunRecord(vm0Run.runId);
+      expect(vm0!.status).toBe("failed");
+      expect(vm0!.error).toContain("Insufficient credits");
+
+      // Non-VM0 run should be dequeued
+      const nonVm0 = await findTestRunRecord(nonVm0Run.runId);
+      expect(nonVm0!.status).toBe("pending");
+    });
+  });
+});

--- a/turbo/apps/web/src/lib/run/__tests__/credit-check.test.ts
+++ b/turbo/apps/web/src/lib/run/__tests__/credit-check.test.ts
@@ -7,6 +7,7 @@ import {
 import {
   createTestCompose,
   findTestRunRecord,
+  findTestRunsByUserAndPrompt,
   findTestQueueEntry,
   markRunningRunsAsCompleted,
   setOrgCredits,
@@ -118,9 +119,14 @@ describe("credit check", () => {
     it("should not enqueue a rejected VM0 run", async () => {
       await setOrgCredits(user.orgId, 0);
 
+      const prompt = "Rejected VM0 run - no enqueue";
       await expect(
-        createRun(baseParams({ modelProvider: "vm0" })),
+        createRun(baseParams({ modelProvider: "vm0", prompt })),
       ).rejects.toSatisfy(isInsufficientCredits);
+
+      // Verify no run record was created (credit check rejects before INSERT)
+      const runs = await findTestRunsByUserAndPrompt(user.userId, prompt);
+      expect(runs).toHaveLength(0);
     });
   });
 

--- a/turbo/apps/web/src/lib/run/run-queue-service.ts
+++ b/turbo/apps/web/src/lib/run/run-queue-service.ts
@@ -5,8 +5,9 @@ import { agentRunQueue } from "../../db/schema/agent-run-queue";
 import { orgMetadata } from "../../db/schema/org-metadata";
 import { env } from "../../env";
 import { logger } from "../logger";
-import { isConcurrentRunLimit } from "../errors";
-import { getOrgDefaultModelProvider } from "../model-provider/model-provider-service";
+import { isConcurrentRunLimit, insufficientCredits } from "../errors";
+import { modelProviders } from "../../db/schema/model-provider";
+import { ORG_SENTINEL_USER_ID } from "../org/org-sentinel";
 import {
   encryptSecretsMap,
   decryptSecretsMap,
@@ -233,13 +234,17 @@ async function dequeueNextAtomic(
 
         // Check credits for VM0 provider runs
         if (orgCredits !== null && orgCredits <= 0) {
-          const isVm0 = await resolveIsVm0Provider(row.model_provider, orgId);
+          const isVm0 = await resolveIsVm0Provider(
+            row.model_provider,
+            orgId,
+            tx,
+          );
           if (isVm0) {
             await transitionRunStatus(
               row.run_id,
               {
                 status: "failed",
-                error: `Insufficient credits (balance: ${orgCredits}). Your VM0 credits are depleted. Add credits or configure your own API key to continue.`,
+                error: insufficientCredits(orgCredits).message,
                 completedAt: new Date(),
               },
               ["queued"],
@@ -286,19 +291,28 @@ async function dequeueNextAtomic(
 
 /**
  * Resolve whether the effective model provider is VM0.
- * Only calls getOrgDefaultModelProvider() when modelProvider is null.
+ * Queries the model_providers table within the provided transaction
+ * to maintain advisory lock guarantees.
  */
 async function resolveIsVm0Provider(
   modelProvider: string | null,
   orgId: string,
+  db: typeof globalThis.services.db,
 ): Promise<boolean> {
   if (modelProvider === "vm0") return true;
   if (modelProvider && modelProvider !== "vm0") return false;
-  // null → check org default
-  const defaultProvider = await getOrgDefaultModelProvider(
-    orgId,
-    "claude-code",
-  );
+  // null → check org default within the transaction
+  const [defaultProvider] = await db
+    .select({ type: modelProviders.type })
+    .from(modelProviders)
+    .where(
+      and(
+        eq(modelProviders.orgId, orgId),
+        eq(modelProviders.userId, ORG_SENTINEL_USER_ID),
+        eq(modelProviders.isDefault, true),
+      ),
+    )
+    .limit(1);
   return defaultProvider?.type === "vm0";
 }
 

--- a/turbo/apps/web/src/lib/run/run-queue-service.ts
+++ b/turbo/apps/web/src/lib/run/run-queue-service.ts
@@ -6,6 +6,7 @@ import { orgMetadata } from "../../db/schema/org-metadata";
 import { env } from "../../env";
 import { logger } from "../logger";
 import { isConcurrentRunLimit } from "../errors";
+import { getOrgDefaultModelProvider } from "../model-provider/model-provider-service";
 import {
   encryptSecretsMap,
   decryptSecretsMap,
@@ -195,14 +196,15 @@ async function dequeueNextAtomic(
       // Serialize all queue operations for this org
       await tx.execute(sql`SELECT pg_advisory_xact_lock(hashtext(${orgId}))`);
 
-      // Look up org tier from org table (source of truth).
+      // Look up org tier and credits from org table (source of truth).
       // Falls back to "free" (most conservative limit) if row is missing.
       const [orgRow] = await tx
-        .select({ tier: orgMetadata.tier })
+        .select({ tier: orgMetadata.tier, credits: orgMetadata.credits })
         .from(orgMetadata)
         .where(eq(orgMetadata.orgId, orgId))
         .limit(1);
       const orgTier = parseOrgTier(orgRow?.tier);
+      const orgCredits = orgRow?.credits ?? null;
 
       // Check concurrency FIRST — don't dequeue if no slot available
       await checkRunConcurrencyLimit(orgId, orgTier, tx);
@@ -210,14 +212,17 @@ async function dequeueNextAtomic(
       // Fetch all queue entries for this org (ordered FIFO).
       // Typically 0-2 entries; iterating in-transaction to skip
       // already-processed runs without releasing the advisory lock.
+      // JOIN agentRuns to read modelProvider for credit check.
       const rows = await tx.execute<{
         run_id: string;
         encrypted_params: string | null;
+        model_provider: string | null;
       }>(
-        sql`SELECT run_id, encrypted_params
-         FROM agent_run_queue
-         WHERE org_id = ${orgId}
-         ORDER BY created_at ASC`,
+        sql`SELECT q.run_id, q.encrypted_params, r.model_provider
+         FROM agent_run_queue q
+         JOIN agent_runs r ON r.id = q.run_id
+         WHERE q.org_id = ${orgId}
+         ORDER BY q.created_at ASC`,
       );
 
       for (const row of rows.rows) {
@@ -225,6 +230,25 @@ async function dequeueNextAtomic(
         await tx
           .delete(agentRunQueue)
           .where(eq(agentRunQueue.runId, row.run_id));
+
+        // Check credits for VM0 provider runs
+        if (orgCredits !== null && orgCredits <= 0) {
+          const isVm0 = await resolveIsVm0Provider(row.model_provider, orgId);
+          if (isVm0) {
+            await transitionRunStatus(
+              row.run_id,
+              {
+                status: "failed",
+                error: `Insufficient credits (balance: ${orgCredits}). Your VM0 credits are depleted. Add credits or configure your own API key to continue.`,
+                completedAt: new Date(),
+              },
+              ["queued"],
+              tx,
+            );
+            log.debug(`Run ${row.run_id} failed credit check, skipping`);
+            continue;
+          }
+        }
 
         // Update run status — fails silently if run was already cancelled/failed
         const [updated] = await tx
@@ -258,6 +282,24 @@ async function dequeueNextAtomic(
     }
     throw error;
   }
+}
+
+/**
+ * Resolve whether the effective model provider is VM0.
+ * Only calls getOrgDefaultModelProvider() when modelProvider is null.
+ */
+async function resolveIsVm0Provider(
+  modelProvider: string | null,
+  orgId: string,
+): Promise<boolean> {
+  if (modelProvider === "vm0") return true;
+  if (modelProvider && modelProvider !== "vm0") return false;
+  // null → check org default
+  const defaultProvider = await getOrgDefaultModelProvider(
+    orgId,
+    "claude-code",
+  );
+  return defaultProvider?.type === "vm0";
 }
 
 /**

--- a/turbo/apps/web/src/lib/run/run-service.ts
+++ b/turbo/apps/web/src/lib/run/run-service.ts
@@ -15,7 +15,10 @@ import {
   forbidden,
   concurrentRunLimit,
   isConcurrentRunLimit,
+  insufficientCredits,
 } from "../errors";
+import { orgMetadata } from "../../db/schema/org-metadata";
+import { getOrgDefaultModelProvider } from "../model-provider/model-provider-service";
 import { enqueueRun, drainOrgQueue } from "./run-queue-service";
 import { buildAgentIdentityPrompt } from "../agent-identity";
 import { logger } from "../logger";
@@ -119,6 +122,59 @@ export async function checkRunConcurrencyLimit(
     );
     throw concurrentRunLimit();
   }
+}
+
+/**
+ * Check if the org has sufficient credits for a VM0 provider run.
+ *
+ * Only blocks runs using the VM0 managed provider (where the platform
+ * bears API costs). Runs using the org's own API key are not affected.
+ *
+ * Uses lazy resolution: getOrgDefaultModelProvider() is only called
+ * when modelProvider is null AND credits are already depleted.
+ */
+async function checkOrgCredits(
+  orgId: string,
+  modelProvider: string | null | undefined,
+  db: Database,
+): Promise<void> {
+  // Explicit non-VM0 provider — skip check entirely
+  if (modelProvider && modelProvider !== "vm0") {
+    return;
+  }
+
+  // Read credits from org_metadata
+  const [orgRow] = await db
+    .select({ credits: orgMetadata.credits })
+    .from(orgMetadata)
+    .where(eq(orgMetadata.orgId, orgId))
+    .limit(1);
+
+  // No org row → treat as sufficient (new org, default 2000 credits)
+  if (!orgRow) {
+    return;
+  }
+
+  // Credits > 0 → sufficient for any provider
+  if (orgRow.credits > 0) {
+    return;
+  }
+
+  // Credits <= 0 — resolve effective provider if needed
+  if (modelProvider === "vm0") {
+    throw insufficientCredits(orgRow.credits);
+  }
+
+  // modelProvider is null/undefined — check org default
+  const defaultProvider = await getOrgDefaultModelProvider(
+    orgId,
+    "claude-code",
+  );
+  if (defaultProvider?.type === "vm0") {
+    throw insufficientCredits(orgRow.credits);
+  }
+
+  // Effective provider is not VM0 — skip check
 }
 
 /**
@@ -1021,6 +1077,9 @@ export async function createRun(
 
       // Check concurrent run limit within the serialized transaction
       await checkRunConcurrencyLimit(orgId, params.orgTier ?? "free", tx);
+
+      // Check credit balance for VM0 provider runs
+      await checkOrgCredits(orgId, params.modelProvider, tx);
 
       // INSERT within the same transaction
       const [newRun] = await tx

--- a/turbo/apps/web/src/lib/run/run-service.ts
+++ b/turbo/apps/web/src/lib/run/run-service.ts
@@ -18,8 +18,9 @@ import {
   insufficientCredits,
 } from "../errors";
 import { orgMetadata } from "../../db/schema/org-metadata";
-import { getOrgDefaultModelProvider } from "../model-provider/model-provider-service";
+import { modelProviders } from "../../db/schema/model-provider";
 import { enqueueRun, drainOrgQueue } from "./run-queue-service";
+import { ORG_SENTINEL_USER_ID } from "../org/org-sentinel";
 import { buildAgentIdentityPrompt } from "../agent-identity";
 import { logger } from "../logger";
 import type { Database } from "../../types/global";
@@ -36,7 +37,6 @@ import { extractTemplateVars } from "../config-validator";
 import { canAccessCompose } from "../agent/compose-access";
 
 import { getVariableValues } from "../variable/variable-service";
-import { ORG_SENTINEL_USER_ID } from "../org/org-sentinel";
 import { encryptSecretValue } from "../crypto/secrets-encryption";
 import { type OrgTier, type TriggerSource, orgTierSchema } from "@vm0/core";
 import { getOrgData } from "../org/org-cache-service";
@@ -130,8 +130,10 @@ export async function checkRunConcurrencyLimit(
  * Only blocks runs using the VM0 managed provider (where the platform
  * bears API costs). Runs using the org's own API key are not affected.
  *
- * Uses lazy resolution: getOrgDefaultModelProvider() is only called
+ * Uses lazy resolution: the org default provider is only queried
  * when modelProvider is null AND credits are already depleted.
+ * The query runs within the caller's transaction to preserve
+ * advisory lock guarantees.
  */
 async function checkOrgCredits(
   orgId: string,
@@ -165,11 +167,18 @@ async function checkOrgCredits(
     throw insufficientCredits(orgRow.credits);
   }
 
-  // modelProvider is null/undefined — check org default
-  const defaultProvider = await getOrgDefaultModelProvider(
-    orgId,
-    "claude-code",
-  );
+  // modelProvider is null/undefined — check org default within the transaction
+  const [defaultProvider] = await db
+    .select({ type: modelProviders.type })
+    .from(modelProviders)
+    .where(
+      and(
+        eq(modelProviders.orgId, orgId),
+        eq(modelProviders.userId, ORG_SENTINEL_USER_ID),
+        eq(modelProviders.isDefault, true),
+      ),
+    )
+    .limit(1);
   if (defaultProvider?.type === "vm0") {
     throw insufficientCredits(orgRow.credits);
   }

--- a/turbo/apps/web/src/lib/slack-org/handlers/run-agent.ts
+++ b/turbo/apps/web/src/lib/slack-org/handlers/run-agent.ts
@@ -4,7 +4,7 @@ import {
   buildScheduleGuidance,
   DISALLOWED_CRON_TOOLS,
 } from "../../integration-context";
-import { isConcurrentRunLimit } from "../../errors";
+import { isConcurrentRunLimit, isInsufficientCredits } from "../../errors";
 import { generateCallbackSecret, getApiUrl } from "../../callback";
 import { logger } from "../../logger";
 
@@ -115,6 +115,15 @@ export async function runAgentForSlackOrg(
         status: "failed",
         response:
           "You have too many concurrent runs. Please wait for existing runs to complete.",
+        runId: undefined,
+      };
+    }
+    if (isInsufficientCredits(error)) {
+      log.warn("Insufficient credits", { composeId, agentName, userId });
+      return {
+        status: "failed",
+        response:
+          "Your VM0 credits are depleted. Add credits at your billing page or configure your own API key.",
         runId: undefined,
       };
     }

--- a/turbo/apps/web/src/lib/telegram/handlers/run-agent.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/run-agent.ts
@@ -1,6 +1,6 @@
 import { startRun, isRunDispatchError } from "../../run";
 import { buildIntegrationContext } from "../../integration-context";
-import { isConcurrentRunLimit } from "../../errors";
+import { isConcurrentRunLimit, isInsufficientCredits } from "../../errors";
 import { logger } from "../../logger";
 import { generateCallbackSecret, getApiUrl } from "../../callback";
 
@@ -99,6 +99,15 @@ export async function runAgentForTelegram(
         status: "failed",
         response:
           "You have too many concurrent runs. Please wait for existing runs to complete.",
+        runId: undefined,
+      };
+    }
+    if (isInsufficientCredits(error)) {
+      log.warn("Insufficient credits", { composeId, agentName, userId });
+      return {
+        status: "failed",
+        response:
+          "Your VM0 credits are depleted. Add credits at your billing page or configure your own API key.",
         runId: undefined,
       };
     }

--- a/turbo/packages/core/src/contracts/errors.ts
+++ b/turbo/packages/core/src/contracts/errors.ts
@@ -10,6 +10,10 @@ export const ApiError = {
   FORBIDDEN: { status: 403 as const, code: "FORBIDDEN" },
   NOT_FOUND: { status: 404 as const, code: "NOT_FOUND" },
   CONFLICT: { status: 409 as const, code: "CONFLICT" },
+  INSUFFICIENT_CREDITS: {
+    status: 402 as const,
+    code: "INSUFFICIENT_CREDITS",
+  },
   PAYLOAD_TOO_LARGE: { status: 413 as const, code: "PAYLOAD_TOO_LARGE" },
   TOO_MANY_REQUESTS: { status: 429 as const, code: "TOO_MANY_REQUESTS" },
   INTERNAL_SERVER_ERROR: {

--- a/turbo/packages/core/src/contracts/runs.ts
+++ b/turbo/packages/core/src/contracts/runs.ts
@@ -214,6 +214,7 @@ export const runsMainContract = c.router({
       201: createRunResponseSchema,
       400: apiErrorSchema,
       401: apiErrorSchema,
+      402: apiErrorSchema,
       403: apiErrorSchema,
       404: apiErrorSchema,
     },


### PR DESCRIPTION
## Summary

- Add `checkOrgCredits()` that rejects runs when `org_metadata.credits <= 0` and the effective model provider is VM0
- Credit check runs inside the existing advisory-locked transactions in both `createRun()` and `dequeueNextAtomic()` to prevent TOCTOU races
- New `InsufficientCreditsError` (HTTP 402, `INSUFFICIENT_CREDITS` code) surfaced across API route, CLI, Slack, Telegram, and Sentry filter
- In `createRun()`: hard reject — run is neither created nor queued (credits won't increase while queued)
- In `dequeueNextAtomic()`: per-entry credit check — failed VM0 runs are marked failed, non-VM0 runs proceed normally
- Lazy provider resolution: `getOrgDefaultModelProvider()` only called when `modelProvider` is null AND credits are depleted

## Test plan

- [x] 12 integration tests covering both `createRun()` and `dequeueNextAtomic()` paths
- [x] VM0 explicit + credits > 0 → run created
- [x] VM0 explicit + credits = 0 → InsufficientCreditsError
- [x] Non-VM0 + credits = 0 → run created (not affected)
- [x] VM0 org default + credits = 0 → InsufficientCreditsError
- [x] Non-VM0 org default + credits = 0 → run created
- [x] Missing org_metadata row → run created (treat as sufficient)
- [x] Queued VM0 run + credits depleted at drain → run marked failed
- [x] Queued non-VM0 run + credits depleted → dequeued normally
- [x] Multiple queued: VM0 fails, next non-VM0 dequeued
- [x] All existing run service tests pass (68 tests)
- [x] Lint, type-check, format, knip all clean

Closes #5836

🤖 Generated with [Claude Code](https://claude.com/claude-code)