### PR TITLE
ci: remove path filters from crates workflow to fix missing ci-gate-crates

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -2,17 +2,9 @@ name: Crates
 
 on:
   pull_request:
-    paths:
-      - 'crates/**'
-      - 'ansible/**'
-      - '.github/workflows/crates.yml'
   push:
     branches:
       - main
-    paths:
-      - 'crates/**'
-      - 'ansible/**'
-      - '.github/workflows/crates.yml'
   merge_group:
 
 concurrency:


### PR DESCRIPTION
## Summary
- Remove `paths:` filters from `crates.yml` so the workflow triggers on all PRs
- Fixes PRs being blocked because `ci-gate-crates` was never reported when no crate files changed
- The existing `detect` job already gates expensive downstream work via per-crate change detection — no other changes needed

Unblocks #5912 and all other non-Rust PRs.

## Test plan
- [ ] Verify `ci-gate-crates` reports SUCCESS on this PR (no crate files changed)
- [ ] Verify PR #5912 is unblocked after rebase onto main

🤖 Generated with [Claude Code](https://claude.com/claude-code)