### PR TITLE
refactor: cleanup stale references after activity/team route migration

### DIFF
--- a/turbo/apps/platform/src/types/route.ts
+++ b/turbo/apps/platform/src/types/route.ts
@@ -10,7 +10,5 @@ export type RoutePath =
   | "/talk/:name"
   | "/slack/connect"
   | "/queue"
-  | "/activity"
-  | "/activity/:logId"
   | "/__internal-connector-logos"
   | `/projects/${string}`;

--- a/turbo/apps/platform/src/views/zero-page/zero-content.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-content.tsx
@@ -2,10 +2,7 @@ import type { ZeroNavId } from "./zero-sidebar.tsx";
 import { ZeroChatPage } from "./zero-chat-page.tsx";
 import { ZeroSessionChatPage } from "./zero-session-chat-page.tsx";
 import { ZeroPreferencesPage } from "./zero-account-page.tsx";
-import { ZeroActivityPage } from "./zero-activity-page.tsx";
-import { ZeroJobsPage } from "./zero-jobs-page.tsx";
 import { ZeroWorksPage } from "./zero-works-page.tsx";
-import { QueuePage } from "../queue-page/queue-page.tsx";
 import { ZeroSchedulePage } from "./zero-schedule-page.tsx";
 import { ZeroSettingsPage } from "./zero-settings-page.tsx";
 import zeroAvatarImg from "./assets/zero-avatar.png";
@@ -68,17 +65,8 @@ export function ZeroContent({
   if (sectionId === "schedule") {
     return <ZeroSchedulePage />;
   }
-  if (sectionId === "activity") {
-    return <ZeroActivityPage />;
-  }
-  if (sectionId === "team") {
-    return <ZeroJobsPage />;
-  }
   if (sectionId === "works") {
     return <ZeroWorksPage />;
-  }
-  if (sectionId === "queue") {
-    return <QueuePage />;
   }
   if (sectionId === "settings") {
     return <ZeroSettingsPage />;


### PR DESCRIPTION
## Summary
- Remove duplicate `/activity` and `/activity/:logId` entries from the `RoutePath` type union
- Remove dead `ZeroContent` branches for `activity`, `team`, and `queue` routes that now have dedicated setup functions (`activity-page-setup.ts`, `team-page-setup.ts`, `queue-page-setup.ts`)
- Remove unused imports (`ZeroActivityPage`, `ZeroJobsPage`, `QueuePage`) from `zero-content.tsx`

Closes #5921

## Test plan
- [x] Lint passes
- [x] Type check passes (platform app)
- [x] Knip passes (no unused exports/imports)
- [x] Pre-commit hooks pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)