### PR TITLE
refactor: remove ccstate-react/experimental from use-file-upload-handlers

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
@@ -522,6 +522,12 @@ export const zeroChatAttachments$ = computed((get) =>
   get(internalAttachments$),
 );
 
+const internalDragOver$ = state(false);
+export const zeroDragOver$ = computed((get) => get(internalDragOver$));
+export const setZeroDragOver$ = command(({ set }, value: boolean) => {
+  set(internalDragOver$, value);
+});
+
 export const uploadZeroAttachment$ = command(
   async ({ get, set }, file: File) => {
     const id = crypto.randomUUID();

--- a/turbo/apps/platform/src/views/zero-page/use-file-upload-handlers.ts
+++ b/turbo/apps/platform/src/views/zero-page/use-file-upload-handlers.ts
@@ -1,9 +1,11 @@
-/* eslint-disable ccstate/no-use-ccstate-in-views */
 import type { ClipboardEvent, DragEvent } from "react";
-import { useCCState } from "ccstate-react/experimental";
 import { useGet, useSet } from "ccstate-react";
 import { detach, Reason } from "../../signals/utils.ts";
-import { uploadZeroAttachment$ } from "../../signals/zero-page/zero-chat.ts";
+import {
+  uploadZeroAttachment$,
+  zeroDragOver$,
+  setZeroDragOver$,
+} from "../../signals/zero-page/zero-chat.ts";
 
 interface FileUploadHandlers {
   dragOver: boolean;
@@ -15,9 +17,8 @@ interface FileUploadHandlers {
 
 export function useFileUploadHandlers(): FileUploadHandlers {
   const uploadAttachment = useSet(uploadZeroAttachment$);
-  const dragOver$ = useCCState(false);
-  const dragOver = useGet(dragOver$);
-  const setDragOver = useSet(dragOver$);
+  const dragOver = useGet(zeroDragOver$);
+  const setDragOver = useSet(setZeroDragOver$);
 
   const handlePaste = (e: ClipboardEvent<HTMLTextAreaElement>) => {
     const items = e.clipboardData?.items;


### PR DESCRIPTION
## Summary

- Move `dragOver` boolean state from `useCCState` (ccstate-react/experimental) to proper signal pattern (`state` + `computed` + `command`) in `zero-chat.ts` signals
- Remove `eslint-disable ccstate/no-use-ccstate-in-views` comment
- Remove `ccstate-react/experimental` import

Closes #5818

## Test plan

- [x] All existing zero-chat tests pass (21 tests)
- [x] Lint passes with no violations
- [x] Type check passes
- [x] Knip reports no unused exports
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)