### PR TITLE
refactor: remove ccstate-react/experimental from zero-onboarding.tsx

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/zero-onboarding.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-onboarding.ts
@@ -71,6 +71,24 @@ export const completeMemberOnboarding$ = command(async ({ get, set }) => {
 });
 
 // ---------------------------------------------------------------------------
+// Member welcome step state
+// ---------------------------------------------------------------------------
+
+type MemberWelcomeStep = "welcome" | "connectors" | "where";
+
+const internalMemberWelcomeStep$ = state<MemberWelcomeStep>("welcome");
+
+export const memberWelcomeStep$ = computed((get) =>
+  get(internalMemberWelcomeStep$),
+);
+
+export const setMemberWelcomeStep$ = command(
+  ({ set }, step: MemberWelcomeStep) => {
+    set(internalMemberWelcomeStep$, step);
+  },
+);
+
+// ---------------------------------------------------------------------------
 // Onboarding form state
 // ---------------------------------------------------------------------------
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-onboarding.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-onboarding.test.tsx
@@ -120,3 +120,125 @@ describe("zero onboarding - does not render when not needed", () => {
     });
   });
 });
+
+// ---------------------------------------------------------------------------
+// Member Welcome (non-admin onboarding)
+// ---------------------------------------------------------------------------
+
+function mockMemberOnboardingNeeded() {
+  server.use(
+    http.get("*/api/zero/onboarding/status", () => {
+      return HttpResponse.json({
+        needsOnboarding: true,
+        isAdmin: false,
+        hasOrg: true,
+        hasModelProvider: true,
+        hasDefaultAgent: true,
+        defaultAgentName: "zero",
+        defaultAgentComposeId: "mock-compose-id",
+        defaultAgentMetadata: null,
+        defaultAgentSkills: [],
+      });
+    }),
+  );
+}
+
+describe("member welcome - step navigation", () => {
+  it("should render welcome dialog for non-admin member needing onboarding", async () => {
+    mockMemberOnboardingNeeded();
+    await renderOnboardingPage();
+
+    await waitFor(
+      () => {
+        expect(
+          screen.getByText(/Meet .+, your new teammate/),
+        ).toBeInTheDocument();
+      },
+      { timeout: 5000 },
+    );
+  });
+
+  it("should advance from welcome to where-to-work step when no connectors", async () => {
+    mockMemberOnboardingNeeded();
+    await renderOnboardingPage();
+
+    await waitFor(
+      () => {
+        expect(
+          screen.getByRole("button", { name: "Next" }),
+        ).toBeInTheDocument();
+      },
+      { timeout: 5000 },
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Next" }));
+
+    // With no defaultAgentSkills, it should skip connectors and go to "where"
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Where would you like to work with/),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("should show Slack and web options in where-to-work step", async () => {
+    mockMemberOnboardingNeeded();
+    await renderOnboardingPage();
+
+    await waitFor(
+      () => {
+        expect(
+          screen.getByRole("button", { name: "Next" }),
+        ).toBeInTheDocument();
+      },
+      { timeout: 5000 },
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Next" }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "Go to Slack" }),
+      ).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByRole("button", { name: /Chat with/ }),
+    ).toBeInTheDocument();
+  });
+
+  it("should navigate back from where-to-work to welcome", async () => {
+    mockMemberOnboardingNeeded();
+    await renderOnboardingPage();
+
+    // Advance to "where" step
+    await waitFor(
+      () => {
+        expect(
+          screen.getByRole("button", { name: "Next" }),
+        ).toBeInTheDocument();
+      },
+      { timeout: 5000 },
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Next" }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Where would you like to work with/),
+      ).toBeInTheDocument();
+    });
+
+    // Click Back
+    fireEvent.click(screen.getByRole("button", { name: "Back" }));
+
+    // Should be back at welcome
+    await waitFor(
+      () => {
+        expect(
+          screen.getByText(/Meet .+, your new teammate/),
+        ).toBeInTheDocument();
+      },
+      { timeout: 5000 },
+    );
+  });
+});

--- a/turbo/apps/platform/src/views/zero-page/zero-onboarding.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-onboarding.tsx
@@ -1,6 +1,4 @@
-/* eslint-disable ccstate/no-use-ccstate-in-views */
 import { Component } from "react";
-import { useCCState } from "ccstate-react/experimental";
 import {
   useGet,
   useSet,
@@ -30,6 +28,8 @@ import {
   clearZeroOnboardingError$,
   completeMemberOnboarding$,
   zeroOnboardingStatus$,
+  memberWelcomeStep$,
+  setMemberWelcomeStep$,
 } from "../../signals/zero-page/zero-onboarding.ts";
 import {
   sendZeroChatMessage$,
@@ -546,9 +546,8 @@ export function MemberWelcome({
   agentName?: string;
   zeroAvatarSrc?: string;
 }) {
-  const step$ = useCCState<"welcome" | "connectors" | "where">("welcome");
-  const step = useGet(step$);
-  const setStep = useSet(step$);
+  const step = useGet(memberWelcomeStep$);
+  const setStep = useSet(setMemberWelcomeStep$);
   const completeMember = useSet(completeMemberOnboarding$);
   const navigate = useSet(updatePathname$);
   const startNewSession = useSet(startNewZeroSession$);


### PR DESCRIPTION
## Summary
- Replace `useCCState()` in `MemberWelcome` component with proper signal pattern (`memberWelcomeStep$`/`setMemberWelcomeStep$` in signals file)
- Remove the `eslint-disable ccstate/no-use-ccstate-in-views` comment and `ccstate-react/experimental` import
- Add integration tests for `MemberWelcome` step navigation (welcome, connectors skip, where-to-work, back navigation)

Closes #5808

## Test plan
- [x] All 9 existing zero-onboarding tests pass
- [x] 4 new MemberWelcome navigation tests pass
- [x] Lint passes (no eslint-disable, no restricted imports)
- [x] Knip passes (no unused exports)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)