### PR TITLE
refactor: extract lane, pipeline, and pr status queries into reusable shell scripts

### DIFF
--- a/.claude/skills/coding-assign/SKILL.md
+++ b/.claude/skills/coding-assign/SKILL.md
@@ -51,19 +51,19 @@ ME=$(gh api user --jq '.login')
 
 ### Step 3: Count Issues and PRs Per Worker
 
-For each worker label (`vm01` through `vm0N`), count **both** open issues and open PRs assigned to the current user:
+Fetch all lane data in a single parallel call:
 
 ```bash
-for i in $(seq 1 $MAX_WORKERS); do
-  LABEL=$(printf "vm%02d" "$i")
-  ISSUE_COUNT=$(gh issue list --repo vm0-ai/vm0 --label "$LABEL" --assignee "$ME" --state open --json number --jq 'length')
-  PR_COUNT=$(gh pr list --repo vm0-ai/vm0 --label "$LABEL" --author "$ME" --state open --json number --jq 'length')
-  TOTAL=$((ISSUE_COUNT + PR_COUNT))
-  echo "$LABEL: $TOTAL (issues: $ISSUE_COUNT, PRs: $PR_COUNT)"
-done
+FIRST_LANE=$(printf "vm%02d" 1)
+LAST_LANE=$(printf "vm%02d" $MAX_WORKERS)
+LANES=$(scripts/lane-status.sh "${FIRST_LANE}-${LAST_LANE}" --user "$ME")
 ```
 
-**Label format**: Always use `printf "vm%02d"` to generate labels — this produces `vm01`..`vm09` for single digits and `vm10`..`vm99` for double digits. Never use `seq -w` combined with string concatenation, as it produces wrong formats like `vm001` when workers > 9.
+This queries all lanes **in parallel** and returns issue/PR counts per lane. Extract the load per lane:
+
+```bash
+echo "$LANES" | jq '.[] | {lane, issue_count, pr_count, total}'
+```
 
 ### Step 4: Select Least-Loaded Worker
 

--- a/.claude/skills/coding-dashboard/SKILL.md
+++ b/.claude/skills/coding-dashboard/SKILL.md
@@ -45,195 +45,68 @@ ME=$(gh api user --jq '.login')
 
 Generate lane labels: `vm01`, `vm02`, ..., `vm0N` using `printf "vm%02d" $i`.
 
-### Step 2: Check Main CI Pipeline
+### Step 2: Get Pipeline Status (CI + Merge Queue + Release)
 
-Query the last 10 workflow runs on `main`:
+Fetch all pipeline data in a single call:
 
 ```bash
-gh run list --workflow turbo.yml --branch main --limit 10 \
-  --json databaseId,conclusion,url,name,headBranch,createdAt \
-  --jq '.[] | {id: .databaseId, conclusion, url, createdAt}'
+PIPELINE=$(scripts/pipeline-status.sh)
+```
+
+This runs CI pipeline check, merge queue GraphQL query, and release PR check **in parallel** and returns unified JSON with `ci_runs`, `merge_queue`, and `release` sections.
+
+#### CI Pipeline Display
+
+Extract CI runs and display status line:
+```bash
+echo "$PIPELINE" | jq '.ci_runs'
 ```
 
 Display a status line showing all 10 runs in order (most recent first), using ✅ for success and 🔴 for failure.
 
 - If **all runs** have `conclusion == "success"`, report: "全部通过，无失败"
 - If **any run** has `conclusion == "failure"`:
-  1. Identify the **most recent failed run** among the 10 results. Track its position (1-indexed, where 1 is the most recent run).
-  2. Get the failed job names for that run:
-     ```bash
-     gh run view <RUN_ID> --json jobs --jq '[.jobs[] | select(.conclusion == "failure") | .name]'
-     ```
-  3. Calculate **success count since last failure** — the number of consecutive successful runs that occurred after (more recent than) the failed run. This equals `position - 1`.
-  4. Calculate **time elapsed since the failure** — compute a human-readable duration from the failed run's `createdAt` to now (e.g., "2 小时 15 分钟", "1 天 3 小时"). Use hours and minutes for durations under 24 hours, days and hours for longer durations.
-  5. Report the failure details in the dashboard output (see output format below).
-  6. Post to Slack using the Slack MCP tool (`slack_send_message` with `channelId: C0ALXC1SHHN`). Do NOT mention or @ any users in the message. Use Slack mrkdwn link syntax `<url|display text>` for all URLs so they render as clickable links. Example message format:
-     ```
-     🔴 main CI failure
-     Failed jobs: lint, test
-     Run: <https://github.com/vm0-ai/vm0/actions/runs/12345|#12345>
-     ```
+  1. Identify the **most recent failed run**. Track its position (1-indexed).
+  2. Get the failed job names: `gh run view <RUN_ID> --json jobs --jq '[.jobs[] | select(.conclusion == "failure") | .name]'`
+  3. Calculate **success count since last failure** (position - 1).
+  4. Calculate **time elapsed since the failure** (human-readable duration).
+  5. Post to Slack using the Slack MCP tool (`slack_send_message` with `channelId: C0ALXC1SHHN`). Do NOT mention or @ any users. Use Slack mrkdwn link syntax `<url|display text>`.
 
-#### Pipeline Output Format
+#### Merge Queue Display
 
-When failures exist:
-```
-📊 主分支 CI 流水线（最近 10 次）
-✅✅✅🔴✅✅✅✅✅✅
-
-最近一次失败: 第 4/10 次
-  Run: https://github.com/vm0-ai/vm0/actions/runs/123456
-  失败 Jobs: deploy, cli-e2e
-  此后连续成功: 3 次
-  距今: 2 小时 15 分钟
+Extract merge queue entries:
+```bash
+echo "$PIPELINE" | jq '.merge_queue'
 ```
 
-When all green:
-```
-📊 主分支 CI 流水线（最近 10 次）
-✅✅✅✅✅✅✅✅✅✅
-全部通过，无失败
+For each entry, map `ci_state` to emoji: `SUCCESS` → ✅, `FAILURE`/`ERROR` → 🔴, `PENDING`/`EXPECTED`/missing → ⏳
+
+#### Release Status Display
+
+Extract release info:
+```bash
+echo "$PIPELINE" | jq '.release'
 ```
 
-### Step 3: Check Merge Queue Status
+- If `release` is not null and has `open_pr`, show PR number and change list
+- If `release.in_progress_run` is not null, show changes being deployed
+- If `release` is null, skip this section entirely
 
-Query the merge queue for the `main` branch using the GitHub GraphQL API:
+### Step 5: Get Lane Status (Issues + PRs per Lane)
+
+Fetch all lane data in a single call with parallel queries:
 
 ```bash
-gh api graphql -f query='
-{
-  repository(owner: "vm0-ai", name: "vm0") {
-    mergeQueue(branch: "main") {
-      entries(first: 20) {
-        nodes {
-          pullRequest {
-            number
-            title
-            author {
-              login
-            }
-            commits(last: 1) {
-              nodes {
-                commit {
-                  statusCheckRollup {
-                    state
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-}'
+FIRST_LANE=$(printf "vm%02d" 1)
+LAST_LANE=$(printf "vm%02d" $MAX_WORKERS)
+LANES=$(scripts/lane-status.sh "${FIRST_LANE}-${LAST_LANE}" --user "$ME")
 ```
 
-For each entry in the merge queue, determine the CI status:
-- **All checks passed** → ✅
-- **Any check failed** → 🔴
-- **Checks still running or pending** → ⏳
+This queries all lanes **in parallel** (issues assigned + authored, PRs authored) and returns unified JSON with deduplication already handled.
 
-Use `statusCheckRollup.state`:
-- `SUCCESS` → ✅
-- `FAILURE` or `ERROR` → 🔴
-- `PENDING` or `EXPECTED` or missing → ⏳
+For each lane in the output, display issues and PRs. Mark items with `pending: true` as `[Pending]`. Empty lanes show `-- idle`.
 
-#### Merge Queue Output Format
-
-When merge queue has entries:
-```
-🚦 Merge Queue
-
-- ✅ #5680 — feat: add files:write scope to Slack connector (e7h4n)
-- ⏳ #5685 — fix: persist trigger source when enqueueing runs (e7h4n)
-```
-
-When merge queue is empty:
-```
-🚦 Merge Queue
-无排队 PR
-```
-
-### Step 4: Check Release Status
-
-Query release-related information to show pending and in-progress releases.
-
-#### Step 4a: Check Open Release PR
-
-Find the open release PR created by the github-actions bot (title: "chore: release main") and extract its changelog:
-
-```bash
-# Find release PR (authored by github-actions bot with title "chore: release main")
-gh pr list --repo vm0-ai/vm0 --author "app/github-actions" --state open \
-  --json number,title,body --limit 1 \
-  --jq '.[0] | select(.title == "chore: release main") | {number, title, body}'
-```
-
-If a release PR exists, parse the PR body to extract change titles. The release PR body contains changelog entries inside `<details>` blocks in markdown format (`* <title>` lines). Filter out dependency-only lines and deduplicate:
-
-```bash
-# Extract change titles from PR body, excluding dependency update noise and deduplicating
-gh pr view <PR_NUMBER> --repo vm0-ai/vm0 --json body \
-  --jq '.body' | grep -E '^\* ' | grep -v 'The following workspace dependencies were updated' | sort -u | sed 's/^\* /- /'
-```
-
-#### Step 4b: Check In-Progress Release Deployment
-
-Check if the `release-please.yml` workflow has an in-progress run, and if so, extract the changes being deployed:
-
-```bash
-# Check for in-progress release-please workflow run
-RELEASE_RUN=$(gh run list --repo vm0-ai/vm0 --workflow release-please.yml --status in_progress --limit 1 \
-  --json databaseId,headSha --jq '.[0] | {id: .databaseId, sha: .headSha} // empty')
-```
-
-If an in-progress run exists, get the release commit's changes. The release commit created by release-please aggregates multiple changes. Extract the change titles from the commit message or the associated release PR body:
-
-```bash
-# Get the commit message which contains the changelog
-gh api repos/vm0-ai/vm0/git/commits/<HEAD_SHA> --jq '.message' | grep -E '^\* ' | sed 's/^\* /- /'
-```
-
-#### Step 4c: Output
-
-- If an open release PR exists, show its number and list of change titles
-- If a release-please workflow is in-progress, show the changes being deployed
-- If neither exists, skip this section entirely (do not show "Release Status" header)
-
-### Step 5: Check Open Issues per Lane
-
-For each lane `vm01` through `vm0N`:
-
-```bash
-gh issue list --repo vm0-ai/vm0 --label "$LANE" --assignee "$ME" --state open \
-  --json number,title,labels --limit 50 \
-  --jq '.[] | {number, title, pending: ([.labels[].name] | any(. == "pending"))}'
-```
-
-Also check issues where the current user is the author:
-
-```bash
-gh issue list --repo vm0-ai/vm0 --label "$LANE" --author "$ME" --state open \
-  --json number,title,labels --limit 50 \
-  --jq '.[] | {number, title, pending: ([.labels[].name] | any(. == "pending"))}'
-```
-
-Deduplicate by issue number. Mark items with `pending` label as `[Pending]`.
-
-### Step 6: Check Open PRs per Lane
-
-For each lane `vm01` through `vm0N`:
-
-```bash
-gh pr list --repo vm0-ai/vm0 --label "$LANE" --author "$ME" --state open \
-  --json number,title,labels --limit 50 \
-  --jq '.[] | {number, title, pending: ([.labels[].name] | any(. == "pending"))}'
-```
-
-Mark items with `pending` label as `[Pending]`.
-
-### Step 7: List Recently Merged PRs
+### Step 6: List Recently Merged PRs
 
 Query the last 20 merged PRs across all lanes:
 

--- a/.claude/skills/coding-loop/SKILL.md
+++ b/.claude/skills/coding-loop/SKILL.md
@@ -89,9 +89,9 @@ If the skip flag exists, delete it and **skip directly to Phase B**. This allows
 ### Step A1: List PRs with Label (excluding pending)
 
 ```bash
-gh pr list --state open --label "$LABEL" --author "@me" \
-  --json number,title,mergeable,headRefName,headRefOid,labels \
-  --jq '[.[] | select(([.labels[].name] | any(. == "pending")) | not)] | .[] | {number, title, mergeable, head: .headRefOid[:7]}'
+LANE_DATA=$(scripts/lane-status.sh "$LABEL")
+# Extract non-pending PRs from the output
+echo "$LANE_DATA" | jq '.[0].prs | [.[] | select(.pending | not)]'
 ```
 
 If no non-pending open PRs with this label, skip to **Phase B**.
@@ -100,13 +100,22 @@ If no non-pending open PRs with this label, skip to **Phase B**.
 
 For each non-pending PR (one at a time, never parallel):
 
-#### Step A2.1: Check Merge Conflict Status
+#### Step A2.1: Get PR Status
+
+Run the status check script to get conflict/CI/review status in one call:
 
 ```bash
-gh pr view <PR> --json mergeable --jq '.mergeable'
+PR_STATUS=$(scripts/pr-status.sh <PR_NUMBER>)
+STATUS=$(echo "$PR_STATUS" | jq -r '.status')
 ```
 
-**If merge conflict:** Resolve and **END this round**.
+The `status` field classifies the PR into one of: `conflict`, `ci_failing`, `ci_running_no_review`, `ci_running_reviewed`, `ci_passed`.
+
+#### Step A2.2: Handle Based on Status
+
+---
+
+**If `status == "conflict"`:** Resolve and **END this round**.
 
 1. Disable auto-merge:
    ```bash
@@ -133,21 +142,13 @@ gh pr view <PR> --json mergeable --jq '.mergeable'
 
 The pushed conflict resolution needs a fresh CI run. End this round.
 
-#### Step A2.2: Check CI Status
-
-```bash
-gh pr checks <PR> --json name,state,conclusion
-```
-
-Classify into one of these cases:
-
 ---
 
-**Case A: CI has failures**
+**If `status == "ci_failing"`:**
 
+Check the failed jobs from `PR_STATUS`:
 ```bash
-gh pr checks <PR> --json name,state,conclusion \
-  --jq '.[] | select(.conclusion == "failure")'
+echo "$PR_STATUS" | jq '.ci.failed_jobs'
 ```
 
 - **If runner/e2e failures:** Post to Slack channel (channelId: `C0ALXC1SHHN`) with the failed job URL. Do NOT mention or @ any users.
@@ -159,25 +160,11 @@ gh pr checks <PR> --json name,state,conclusion \
 
 ---
 
-**Case B: CI still running (no failures yet), code review NOT done for latest commit**
-
-Check if a code review comment exists for the latest commit:
-
-```bash
-# Get latest commit SHA
-HEAD_SHA=$(gh pr view <PR> --json headRefOid --jq '.headRefOid[:7]')
-
-# Check if a review comment exists that references this commit
-gh api "repos/vm0-ai/vm0/issues/<PR>/comments" \
-  --jq "[.[] | select(.body | test(\"## Code Review\")) | select(.body | test(\"$HEAD_SHA\"))] | length"
-```
-
-If no review for the latest commit:
+**If `status == "ci_running_no_review"`:**
 
 1. **Delete old review comments** (from previous commits):
    ```bash
-   gh api "repos/vm0-ai/vm0/issues/<PR>/comments" \
-     --jq '.[] | select(.body | test("## Code Review")) | .id' | \
+   echo "$PR_STATUS" | jq -r '.review.review_comment_ids[]' | \
      while read id; do gh api -X DELETE "repos/vm0-ai/vm0/issues/comments/$id"; done
    ```
 
@@ -193,7 +180,7 @@ If no review for the latest commit:
 
 ---
 
-**Case C: CI still running (no failures yet), code review already done for latest commit**
+**If `status == "ci_running_reviewed"`:**
 
 Nothing to do for this PR. Write the skip flag so the **next round skips Phase A and goes directly to Phase B**:
 
@@ -205,9 +192,9 @@ touch "/tmp/coding-loop-skip-phase-a-${LABEL}"
 
 ---
 
-**Case D: CI all passing, no P0/P1 issues**
+**If `status == "ci_passed"`:**
 
-The PR should already have auto-merge enabled from Case B. It will enter the merge queue automatically. **END** this round.
+The PR should already have auto-merge enabled. It will enter the merge queue automatically. **END** this round.
 
 If auto-merge is somehow not enabled, enable it:
 ```bash
@@ -245,22 +232,13 @@ After processing all PRs, report:
 
 ### Step B1: Find Next Issue
 
-1. List open issues with the label, assigned to current user, excluding `pending`:
-   ```bash
-   # Get current GitHub username
-   ME=$(gh api user --jq '.login')
+```bash
+NEXT_ISSUE=$(scripts/next-issue.sh "$LABEL")
+```
 
-   gh issue list --repo vm0-ai/vm0 --label "$LABEL" --assignee "$ME" --state open \
-     --json number,title,labels,closedByPullRequestsReferences --limit 50 \
-     --jq '[.[] | select(([.labels[].name] | any(. == "pending")) | not) | select(.closedByPullRequestsReferences | length == 0)] | sort_by(.number) | .[0]'
-   ```
+This script finds the first non-pending, non-PR-linked issue assigned to the current user for this label, and verifies no open PR already covers it.
 
-2. If no unlinked, non-pending issues remain, end.
-
-3. Verify no existing open PR exists for this issue:
-   ```bash
-   gh api "repos/vm0-ai/vm0/pulls?state=open&per_page=100" --jq '.[].title'
-   ```
+If no output (empty), no actionable issues remain — end.
 
 ### Step B2: Read Issue Content (with Security Filtering)
 

--- a/.claude/skills/pr-handoff/SKILL.md
+++ b/.claude/skills/pr-handoff/SKILL.md
@@ -49,10 +49,11 @@ This skill runs in two phases: **Create/Update PR** then **Assign Worker**.
 
 ## Phase 1: Create or Update PR
 
-### Step 1: Check if PR Already Exists
+### Step 1: Check Current State
 
 ```bash
 existing_pr=$(gh pr view --json number,url,labels 2>/dev/null)
+has_uncommitted=$(git status --porcelain)
 ```
 
 ### Step 2a: No Existing PR → Use `/pr-create`
@@ -64,6 +65,8 @@ Skill({ skill: "pull-request", args: "create" })
 ```
 
 **IMPORTANT:** Only create the PR — do NOT run `/pr-check` or any CI monitoring after creation. The assigned worker will run `/pr-check` itself. The goal here is to get the PR created and handed off as fast as possible.
+
+This also applies when **there are uncommitted changes but no PR yet** — `/pr-create` will handle staging, committing, branch creation, and PR opening all in one step. Skip `/pr-check` as the worker handles it.
 
 After `/pr-create` completes, capture the PR number and proceed to Phase 2.
 
@@ -122,18 +125,14 @@ Only runs if PR has no existing worker label.
 
 ```bash
 ME=$(gh api user --jq '.login')
-
 MAX_WORKERS=<from args or 4>
-for i in $(seq 1 $MAX_WORKERS); do
-  LABEL=$(printf "vm%02d" "$i")
-  ISSUE_COUNT=$(gh issue list --repo vm0-ai/vm0 --label "$LABEL" --assignee "$ME" --state open --json number --jq 'length')
-  PR_COUNT=$(gh pr list --repo vm0-ai/vm0 --label "$LABEL" --author "$ME" --state open --json number --jq 'length')
-  TOTAL=$((ISSUE_COUNT + PR_COUNT))
-  echo "$LABEL: $TOTAL (issues: $ISSUE_COUNT, PRs: $PR_COUNT)"
-done
-```
 
-**Label format**: Always use `printf "vm%02d"` to generate labels — this produces `vm01`..`vm09` for single digits and `vm10`..`vm99` for double digits.
+FIRST_LANE=$(printf "vm%02d" 1)
+LAST_LANE=$(printf "vm%02d" $MAX_WORKERS)
+LANES=$(scripts/lane-status.sh "${FIRST_LANE}-${LAST_LANE}" --user "$ME")
+
+echo "$LANES" | jq '.[] | {lane, issue_count, pr_count, total}'
+```
 
 ### Step 5: Apply Worker Label
 

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Shared constants for vm0 scripts
+
+REPO="vm0-ai/vm0"

--- a/scripts/lane-status.sh
+++ b/scripts/lane-status.sh
@@ -9,7 +9,9 @@
 
 set -euo pipefail
 
-REPO="vm0-ai/vm0"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=_common.sh
+source "$SCRIPT_DIR/_common.sh"
 
 usage() {
   echo "Usage: $0 <label|range> [--user LOGIN]" >&2
@@ -48,28 +50,28 @@ else
   LANES+=("$LABEL_ARG")
 fi
 
-TMPDIR=$(mktemp -d)
-trap 'rm -rf "$TMPDIR"' EXIT
+WORK_DIR=$(mktemp -d)
+trap 'rm -rf "$WORK_DIR"' EXIT
 
 query_lane() {
   local lane="$1"
-  local dir="$TMPDIR/$lane"
+  local dir="$WORK_DIR/$lane"
   mkdir -p "$dir"
 
   # Issues assigned to user
   gh issue list --repo "$REPO" --label "$lane" --assignee "$USER" --state open \
     --json number,title,labels,closedByPullRequestsReferences --limit 50 \
-    > "$dir/issues_assignee.json" 2>/dev/null &
+    > "$dir/issues_assignee.json" &
 
   # Issues authored by user (for dashboard dedup)
   gh issue list --repo "$REPO" --label "$lane" --author "$USER" --state open \
     --json number,title,labels,closedByPullRequestsReferences --limit 50 \
-    > "$dir/issues_author.json" 2>/dev/null &
+    > "$dir/issues_author.json" &
 
   # PRs authored by user
   gh pr list --repo "$REPO" --label "$lane" --author "$USER" --state open \
     --json number,title,labels,mergeable,headRefOid,headRefName --limit 50 \
-    > "$dir/prs.json" 2>/dev/null &
+    > "$dir/prs.json" &
 
   wait
 }
@@ -85,7 +87,7 @@ build_output() {
   echo "["
   local first=true
   for lane in "${LANES[@]}"; do
-    local dir="$TMPDIR/$lane"
+    local dir="$WORK_DIR/$lane"
     $first && first=false || echo ","
 
     # Deduplicate issues (assignee + author), transform

--- a/scripts/lane-status.sh
+++ b/scripts/lane-status.sh
@@ -1,0 +1,142 @@
+#!/bin/bash
+# Lane Status — parallel query of issues + PRs per worker lane
+# Usage:
+#   scripts/lane-status.sh <label>              # single lane
+#   scripts/lane-status.sh <label1-labelN>      # range (e.g., vm01-vm04)
+#   scripts/lane-status.sh <label> --user LOGIN  # explicit user
+#
+# Output: JSON array of lane objects with issues, prs, counts
+
+set -euo pipefail
+
+REPO="vm0-ai/vm0"
+
+usage() {
+  echo "Usage: $0 <label|range> [--user LOGIN]" >&2
+  exit 1
+}
+
+[[ $# -lt 1 ]] && usage
+
+LABEL_ARG="$1"
+shift
+USER=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --user) USER="$2"; shift 2 ;;
+    *) usage ;;
+  esac
+done
+
+if [[ -z "$USER" ]]; then
+  USER=$(gh api user --jq '.login')
+fi
+
+# Parse label arg into array of lanes
+LANES=()
+if [[ "$LABEL_ARG" =~ ^([a-zA-Z]+)([0-9]+)-([a-zA-Z]+)([0-9]+)$ ]] && [[ "${BASH_REMATCH[1]}" == "${BASH_REMATCH[3]}" ]]; then
+  PREFIX="${BASH_REMATCH[1]}"
+  START="${BASH_REMATCH[2]}"
+  END="${BASH_REMATCH[4]}"
+  START=$((10#$START))
+  END=$((10#$END))
+  for ((i=START; i<=END; i++)); do
+    LANES+=("$(printf "%s%02d" "$PREFIX" "$i")")
+  done
+else
+  LANES+=("$LABEL_ARG")
+fi
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+query_lane() {
+  local lane="$1"
+  local dir="$TMPDIR/$lane"
+  mkdir -p "$dir"
+
+  # Issues assigned to user
+  gh issue list --repo "$REPO" --label "$lane" --assignee "$USER" --state open \
+    --json number,title,labels,closedByPullRequestsReferences --limit 50 \
+    > "$dir/issues_assignee.json" 2>/dev/null &
+
+  # Issues authored by user (for dashboard dedup)
+  gh issue list --repo "$REPO" --label "$lane" --author "$USER" --state open \
+    --json number,title,labels,closedByPullRequestsReferences --limit 50 \
+    > "$dir/issues_author.json" 2>/dev/null &
+
+  # PRs authored by user
+  gh pr list --repo "$REPO" --label "$lane" --author "$USER" --state open \
+    --json number,title,labels,mergeable,headRefOid,headRefName --limit 50 \
+    > "$dir/prs.json" 2>/dev/null &
+
+  wait
+}
+
+# Launch all lane queries in parallel
+for lane in "${LANES[@]}"; do
+  query_lane "$lane" &
+done
+wait
+
+# Merge results into JSON
+build_output() {
+  echo "["
+  local first=true
+  for lane in "${LANES[@]}"; do
+    local dir="$TMPDIR/$lane"
+    $first && first=false || echo ","
+
+    # Deduplicate issues (assignee + author), transform
+    local issues
+    issues=$(jq -s '
+      [.[0][], .[1][]]
+      | group_by(.number)
+      | map(.[0])
+      | map({
+          number,
+          title,
+          pending: ([.labels[].name] | any(. == "pending")),
+          linked_prs: (.closedByPullRequestsReferences | length)
+        })
+      | sort_by(.number)
+    ' "$dir/issues_assignee.json" "$dir/issues_author.json")
+
+    # Transform PRs
+    local prs
+    prs=$(jq '
+      map({
+        number,
+        title,
+        pending: ([.labels[].name] | any(. == "pending")),
+        mergeable,
+        head: (.headRefOid[:7]),
+        branch: .headRefName
+      })
+      | sort_by(.number)
+    ' "$dir/prs.json")
+
+    local issue_count pr_count
+    issue_count=$(echo "$issues" | jq 'length')
+    pr_count=$(echo "$prs" | jq 'length')
+
+    jq -n \
+      --arg lane "$lane" \
+      --argjson issues "$issues" \
+      --argjson prs "$prs" \
+      --argjson issue_count "$issue_count" \
+      --argjson pr_count "$pr_count" \
+      '{
+        lane: $lane,
+        issues: $issues,
+        prs: $prs,
+        issue_count: $issue_count,
+        pr_count: $pr_count,
+        total: ($issue_count + $pr_count)
+      }'
+  done
+  echo "]"
+}
+
+build_output

--- a/scripts/next-issue.sh
+++ b/scripts/next-issue.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Next Issue — find the next actionable issue for a label
+# Usage:
+#   scripts/next-issue.sh <label>
+#
+# Output: JSON object of the next issue, or empty if none found
+# Filters: excludes pending, excludes PR-linked, picks lowest number
+
+set -euo pipefail
+
+REPO="vm0-ai/vm0"
+
+[[ $# -lt 1 ]] && { echo "Usage: $0 <label>" >&2; exit 1; }
+
+LABEL="$1"
+ME=$(gh api user --jq '.login')
+
+# Find first actionable issue: not pending, not linked to PR, sorted by number
+ISSUE=$(gh issue list --repo "$REPO" --label "$LABEL" --assignee "$ME" --state open \
+  --json number,title,labels,closedByPullRequestsReferences --limit 50 \
+  --jq '
+    [.[]
+      | select(([.labels[].name] | any(. == "pending")) | not)
+      | select(.closedByPullRequestsReferences | length == 0)
+    ]
+    | sort_by(.number)
+    | .[0]
+    // empty
+  ')
+
+[[ -z "$ISSUE" ]] && exit 0
+
+ISSUE_NUMBER=$(echo "$ISSUE" | jq -r '.number')
+
+# Verify no open PR already covers this issue
+OPEN_PR=$(gh pr list --repo "$REPO" --state open --json number,title --limit 100 \
+  --jq "[.[] | select(.title | test(\"#${ISSUE_NUMBER}\\\\b\"; \"x\"))] | length")
+
+if [[ "$OPEN_PR" -gt 0 ]]; then
+  exit 0
+fi
+
+# Output the issue with cleaned-up labels
+echo "$ISSUE" | jq '{number, title, labels: [.labels[].name]}'

--- a/scripts/next-issue.sh
+++ b/scripts/next-issue.sh
@@ -8,7 +8,9 @@
 
 set -euo pipefail
 
-REPO="vm0-ai/vm0"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=_common.sh
+source "$SCRIPT_DIR/_common.sh"
 
 [[ $# -lt 1 ]] && { echo "Usage: $0 <label>" >&2; exit 1; }
 
@@ -34,7 +36,7 @@ ISSUE_NUMBER=$(echo "$ISSUE" | jq -r '.number')
 
 # Verify no open PR already covers this issue
 OPEN_PR=$(gh pr list --repo "$REPO" --state open --json number,title --limit 100 \
-  --jq "[.[] | select(.title | test(\"#${ISSUE_NUMBER}\\\\b\"; \"x\"))] | length")
+  --jq --arg num "#${ISSUE_NUMBER}" '[.[] | select(.title | contains($num))] | length')
 
 if [[ "$OPEN_PR" -gt 0 ]]; then
   exit 0

--- a/scripts/pipeline-status.sh
+++ b/scripts/pipeline-status.sh
@@ -7,16 +7,19 @@
 
 set -euo pipefail
 
-REPO="vm0-ai/vm0"
-TMPDIR=$(mktemp -d)
-trap 'rm -rf "$TMPDIR"' EXIT
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=_common.sh
+source "$SCRIPT_DIR/_common.sh"
+
+WORK_DIR=$(mktemp -d)
+trap 'rm -rf "$WORK_DIR"' EXIT
 
 # Run 3 queries in parallel
 
 # 1. CI pipeline (last 10 runs on main)
 gh run list --repo "$REPO" --workflow turbo.yml --branch main --limit 10 \
   --json databaseId,conclusion,url,createdAt \
-  > "$TMPDIR/ci_runs.json" 2>/dev/null &
+  > "$WORK_DIR/ci_runs.json" &
 
 # 2. Merge queue
 gh api graphql -f query='
@@ -41,21 +44,21 @@ gh api graphql -f query='
       }
     }
   }
-}' > "$TMPDIR/merge_queue.json" 2>/dev/null &
+}' > "$WORK_DIR/merge_queue.json" &
 
 # 3. Release PR
 gh pr list --repo "$REPO" --author "app/github-actions" --state open \
   --json number,title,body --limit 5 \
-  > "$TMPDIR/release_prs.json" 2>/dev/null &
+  > "$WORK_DIR/release_prs.json" &
 
 wait
 
 # Process CI runs
-CI_RUNS=$(jq '[.[] | {id: .databaseId, conclusion, url, created_at: .createdAt}]' "$TMPDIR/ci_runs.json")
+CI_RUNS=$(jq '[.[] | {id: .databaseId, conclusion, url, created_at: .createdAt}]' "$WORK_DIR/ci_runs.json")
 
 # Process merge queue
 MERGE_QUEUE=$(jq '
-  [.data.repository.mergeQueue.entries.nodes[]
+  [(.data.repository.mergeQueue.entries.nodes // [])[]
     | .pullRequest
     | {
         number,
@@ -64,12 +67,12 @@ MERGE_QUEUE=$(jq '
         ci_state: (.commits.nodes[0].commit.statusCheckRollup.state // "PENDING")
       }
   ]
-' "$TMPDIR/merge_queue.json" 2>/dev/null || echo '[]')
+' "$WORK_DIR/merge_queue.json")
 
 # Process release
 RELEASE_PR=$(jq '
   [.[] | select(.title == "chore: release main")] | .[0] // empty
-' "$TMPDIR/release_prs.json")
+' "$WORK_DIR/release_prs.json")
 
 RELEASE="null"
 if [[ -n "$RELEASE_PR" && "$RELEASE_PR" != "null" ]]; then
@@ -81,7 +84,7 @@ if [[ -n "$RELEASE_PR" && "$RELEASE_PR" != "null" ]]; then
 
   # Check for in-progress release-please run
   IN_PROGRESS_RUN=$(gh run list --repo "$REPO" --workflow release-please.yml --status in_progress --limit 1 \
-    --json databaseId,headSha --jq '.[0] // empty' 2>/dev/null || echo "")
+    --json databaseId,headSha --jq '.[0] // empty')
 
   if [[ -n "$IN_PROGRESS_RUN" ]]; then
     RELEASE=$(jq -n \

--- a/scripts/pipeline-status.sh
+++ b/scripts/pipeline-status.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+# Pipeline Status — parallel query of CI pipeline + merge queue + release status
+# Usage:
+#   scripts/pipeline-status.sh
+#
+# Output: JSON with ci_runs, merge_queue, and release sections
+
+set -euo pipefail
+
+REPO="vm0-ai/vm0"
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+# Run 3 queries in parallel
+
+# 1. CI pipeline (last 10 runs on main)
+gh run list --repo "$REPO" --workflow turbo.yml --branch main --limit 10 \
+  --json databaseId,conclusion,url,createdAt \
+  > "$TMPDIR/ci_runs.json" 2>/dev/null &
+
+# 2. Merge queue
+gh api graphql -f query='
+{
+  repository(owner: "vm0-ai", name: "vm0") {
+    mergeQueue(branch: "main") {
+      entries(first: 20) {
+        nodes {
+          pullRequest {
+            number
+            title
+            author { login }
+            commits(last: 1) {
+              nodes {
+                commit {
+                  statusCheckRollup { state }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}' > "$TMPDIR/merge_queue.json" 2>/dev/null &
+
+# 3. Release PR
+gh pr list --repo "$REPO" --author "app/github-actions" --state open \
+  --json number,title,body --limit 5 \
+  > "$TMPDIR/release_prs.json" 2>/dev/null &
+
+wait
+
+# Process CI runs
+CI_RUNS=$(jq '[.[] | {id: .databaseId, conclusion, url, created_at: .createdAt}]' "$TMPDIR/ci_runs.json")
+
+# Process merge queue
+MERGE_QUEUE=$(jq '
+  [.data.repository.mergeQueue.entries.nodes[]
+    | .pullRequest
+    | {
+        number,
+        title,
+        author: .author.login,
+        ci_state: (.commits.nodes[0].commit.statusCheckRollup.state // "PENDING")
+      }
+  ]
+' "$TMPDIR/merge_queue.json" 2>/dev/null || echo '[]')
+
+# Process release
+RELEASE_PR=$(jq '
+  [.[] | select(.title == "chore: release main")] | .[0] // empty
+' "$TMPDIR/release_prs.json")
+
+RELEASE="null"
+if [[ -n "$RELEASE_PR" && "$RELEASE_PR" != "null" ]]; then
+  RELEASE_NUMBER=$(echo "$RELEASE_PR" | jq '.number')
+  RELEASE_CHANGES=$(echo "$RELEASE_PR" | jq '
+    [.body | split("\n")[] | select(test("^\\* ")) | select(test("workspace dependencies") | not) | ltrimstr("* ")]
+    | unique
+  ')
+
+  # Check for in-progress release-please run
+  IN_PROGRESS_RUN=$(gh run list --repo "$REPO" --workflow release-please.yml --status in_progress --limit 1 \
+    --json databaseId,headSha --jq '.[0] // empty' 2>/dev/null || echo "")
+
+  if [[ -n "$IN_PROGRESS_RUN" ]]; then
+    RELEASE=$(jq -n \
+      --argjson number "$RELEASE_NUMBER" \
+      --argjson changes "$RELEASE_CHANGES" \
+      --argjson run "$IN_PROGRESS_RUN" \
+      '{open_pr: {number: $number, changes: $changes}, in_progress_run: {id: $run.databaseId, sha: $run.headSha}}')
+  else
+    RELEASE=$(jq -n \
+      --argjson number "$RELEASE_NUMBER" \
+      --argjson changes "$RELEASE_CHANGES" \
+      '{open_pr: {number: $number, changes: $changes}, in_progress_run: null}')
+  fi
+fi
+
+jq -n \
+  --argjson ci_runs "$CI_RUNS" \
+  --argjson merge_queue "$MERGE_QUEUE" \
+  --argjson release "$RELEASE" \
+  '{ci_runs: $ci_runs, merge_queue: $merge_queue, release: $release}'

--- a/scripts/pr-status.sh
+++ b/scripts/pr-status.sh
@@ -8,42 +8,44 @@
 
 set -euo pipefail
 
-REPO="vm0-ai/vm0"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=_common.sh
+source "$SCRIPT_DIR/_common.sh"
 
 [[ $# -lt 1 ]] && { echo "Usage: $0 <pr-number>" >&2; exit 1; }
 
 PR="$1"
-TMPDIR=$(mktemp -d)
-trap 'rm -rf "$TMPDIR"' EXIT
+WORK_DIR=$(mktemp -d)
+trap 'rm -rf "$WORK_DIR"' EXIT
 
 # Run 3 queries in parallel
 gh pr view "$PR" --repo "$REPO" --json mergeable,headRefOid \
-  > "$TMPDIR/pr_view.json" 2>/dev/null &
+  > "$WORK_DIR/pr_view.json" &
 
 gh pr checks "$PR" --repo "$REPO" --json name,state,bucket \
-  > "$TMPDIR/pr_checks.json" 2>/dev/null &
+  > "$WORK_DIR/pr_checks.json" &
 
 gh api "repos/$REPO/issues/$PR/comments" \
   --jq '[.[] | select(.body | test("## Code Review"))]' \
-  > "$TMPDIR/reviews.json" 2>/dev/null &
+  > "$WORK_DIR/reviews.json" &
 
 wait
 
 # Parse results
-MERGEABLE=$(jq -r '.mergeable' "$TMPDIR/pr_view.json")
-HEAD_SHA=$(jq -r '.headRefOid' "$TMPDIR/pr_view.json")
+MERGEABLE=$(jq -r '.mergeable' "$WORK_DIR/pr_view.json")
+HEAD_SHA=$(jq -r '.headRefOid' "$WORK_DIR/pr_view.json")
 HEAD_SHORT="${HEAD_SHA:0:7}"
 
 # CI analysis — use state field (SUCCESS/FAILURE/IN_PROGRESS/SKIPPED) and bucket (pass/fail/pending/skipping)
-HAS_FAILURE=$(jq '[.[] | select(.state == "FAILURE")] | length > 0' "$TMPDIR/pr_checks.json")
-FAILED_JOBS=$(jq '[.[] | select(.state == "FAILURE") | .name]' "$TMPDIR/pr_checks.json")
-PENDING_JOBS=$(jq '[.[] | select(.bucket == "pending") | .name]' "$TMPDIR/pr_checks.json")
-ALL_PASSED=$(jq '[.[] | select(.state != "SUCCESS" and .state != "SKIPPED")] | length == 0' "$TMPDIR/pr_checks.json")
+HAS_FAILURE=$(jq '[.[] | select(.state == "FAILURE")] | length > 0' "$WORK_DIR/pr_checks.json")
+FAILED_JOBS=$(jq '[.[] | select(.state == "FAILURE") | .name]' "$WORK_DIR/pr_checks.json")
+PENDING_JOBS=$(jq '[.[] | select(.bucket == "pending") | .name]' "$WORK_DIR/pr_checks.json")
+ALL_PASSED=$(jq '[.[] | select(.state != "SUCCESS" and .state != "SKIPPED")] | length == 0' "$WORK_DIR/pr_checks.json")
 
 # Review analysis — check if review exists for current HEAD
 HAS_REVIEW=$(jq --arg sha "$HEAD_SHORT" \
-  '[.[] | select(.body | test($sha))] | length > 0' "$TMPDIR/reviews.json")
-REVIEW_IDS=$(jq '[.[].id]' "$TMPDIR/reviews.json")
+  '[.[] | select(.body | test($sha))] | length > 0' "$WORK_DIR/reviews.json")
+REVIEW_IDS=$(jq '[.[].id]' "$WORK_DIR/reviews.json")
 
 # Classify status
 if [[ "$MERGEABLE" == "CONFLICTING" ]]; then

--- a/scripts/pr-status.sh
+++ b/scripts/pr-status.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+# PR Status — check PR conflict/CI/review status in parallel
+# Usage:
+#   scripts/pr-status.sh <pr-number>
+#
+# Output: JSON with classified status:
+#   "conflict" | "ci_failing" | "ci_running_no_review" | "ci_running_reviewed" | "ci_passed"
+
+set -euo pipefail
+
+REPO="vm0-ai/vm0"
+
+[[ $# -lt 1 ]] && { echo "Usage: $0 <pr-number>" >&2; exit 1; }
+
+PR="$1"
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+# Run 3 queries in parallel
+gh pr view "$PR" --repo "$REPO" --json mergeable,headRefOid \
+  > "$TMPDIR/pr_view.json" 2>/dev/null &
+
+gh pr checks "$PR" --repo "$REPO" --json name,state,bucket \
+  > "$TMPDIR/pr_checks.json" 2>/dev/null &
+
+gh api "repos/$REPO/issues/$PR/comments" \
+  --jq '[.[] | select(.body | test("## Code Review"))]' \
+  > "$TMPDIR/reviews.json" 2>/dev/null &
+
+wait
+
+# Parse results
+MERGEABLE=$(jq -r '.mergeable' "$TMPDIR/pr_view.json")
+HEAD_SHA=$(jq -r '.headRefOid' "$TMPDIR/pr_view.json")
+HEAD_SHORT="${HEAD_SHA:0:7}"
+
+# CI analysis — use state field (SUCCESS/FAILURE/IN_PROGRESS/SKIPPED) and bucket (pass/fail/pending/skipping)
+HAS_FAILURE=$(jq '[.[] | select(.state == "FAILURE")] | length > 0' "$TMPDIR/pr_checks.json")
+FAILED_JOBS=$(jq '[.[] | select(.state == "FAILURE") | .name]' "$TMPDIR/pr_checks.json")
+PENDING_JOBS=$(jq '[.[] | select(.bucket == "pending") | .name]' "$TMPDIR/pr_checks.json")
+ALL_PASSED=$(jq '[.[] | select(.state != "SUCCESS" and .state != "SKIPPED")] | length == 0' "$TMPDIR/pr_checks.json")
+
+# Review analysis — check if review exists for current HEAD
+HAS_REVIEW=$(jq --arg sha "$HEAD_SHORT" \
+  '[.[] | select(.body | test($sha))] | length > 0' "$TMPDIR/reviews.json")
+REVIEW_IDS=$(jq '[.[].id]' "$TMPDIR/reviews.json")
+
+# Classify status
+if [[ "$MERGEABLE" == "CONFLICTING" ]]; then
+  STATUS="conflict"
+elif [[ "$HAS_FAILURE" == "true" ]]; then
+  STATUS="ci_failing"
+elif [[ "$ALL_PASSED" == "true" ]]; then
+  STATUS="ci_passed"
+elif [[ "$HAS_REVIEW" == "true" ]]; then
+  STATUS="ci_running_reviewed"
+else
+  STATUS="ci_running_no_review"
+fi
+
+jq -n \
+  --argjson number "$PR" \
+  --arg status "$STATUS" \
+  --arg mergeable "$MERGEABLE" \
+  --arg head_sha "$HEAD_SHORT" \
+  --argjson has_failure "$HAS_FAILURE" \
+  --argjson failed_jobs "$FAILED_JOBS" \
+  --argjson pending_jobs "$PENDING_JOBS" \
+  --argjson all_passed "$ALL_PASSED" \
+  --argjson has_review "$HAS_REVIEW" \
+  --argjson review_ids "$REVIEW_IDS" \
+  '{
+    number: $number,
+    status: $status,
+    mergeable: $mergeable,
+    head_sha: $head_sha,
+    ci: {
+      has_failure: $has_failure,
+      failed_jobs: $failed_jobs,
+      pending_jobs: $pending_jobs,
+      all_passed: $all_passed
+    },
+    review: {
+      has_review_for_head: $has_review,
+      review_comment_ids: $review_ids
+    }
+  }'


### PR DESCRIPTION
## Summary
- Extract repetitive GitHub API queries (lane status, pipeline status, PR status, next issue) into 4 reusable shell scripts under `scripts/`
- Update skill docs (coding-assign, coding-dashboard, coding-loop, pr-handoff) to use the new scripts instead of inline `gh` commands
- Scripts run queries in parallel for better performance and return structured JSON output

## Test plan
- [ ] Verify `scripts/lane-status.sh` returns correct JSON for single lane and range queries
- [ ] Verify `scripts/pipeline-status.sh` returns CI, merge queue, and release data
- [ ] Verify `scripts/pr-status.sh` correctly classifies PR status
- [ ] Verify `scripts/next-issue.sh` finds actionable issues
- [ ] Run coding-dashboard and coding-loop skills to confirm they work with the new scripts

🤖 Generated with [Claude Code](https://claude.com/claude-code)