### PR TITLE
refactor: remove ccstate-react/experimental from zero-chat-composer.tsx

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
@@ -1137,3 +1137,33 @@ export const syncUrlSession$ = command(async ({ get, set }) => {
   }
   await set(switchZeroSession$, urlSessionId);
 });
+
+// ---------------------------------------------------------------------------
+// Composer local UI state
+// ---------------------------------------------------------------------------
+
+const internalComposerFileInput$ = state<HTMLElement | null>(null);
+
+/** The file input element used by the composer attach button. */
+export const composerFileInput$ = computed((get) =>
+  get(internalComposerFileInput$),
+);
+
+/** Store a reference to the composer file input element. */
+export const setComposerFileInput$ = command(
+  ({ set }, el: HTMLElement | null) => {
+    set(internalComposerFileInput$, el);
+  },
+);
+
+const internalComposerAddDialogOpen$ = state(false);
+
+/** Whether the "Add connector" dialog in the composer is open. */
+export const composerAddDialogOpen$ = computed((get) =>
+  get(internalComposerAddDialogOpen$),
+);
+
+/** Toggle the "Add connector" dialog open state. */
+export const setComposerAddDialogOpen$ = command(({ set }, open: boolean) => {
+  set(internalComposerAddDialogOpen$, open);
+});

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-page.test.tsx
@@ -143,10 +143,12 @@ describe("zero chat page - file input ref", () => {
     );
 
     // The hidden file input should exist in the DOM
-    const fileInput = document.querySelector(
-      'input[type="file"]',
-    ) as HTMLInputElement;
+    const fileInput =
+      document.querySelector<HTMLInputElement>('input[type="file"]');
     expect(fileInput).toBeInTheDocument();
+    if (!fileInput) {
+      throw new Error("file input not found");
+    }
 
     // Mock the click method to verify it gets called
     const clickSpy = vi.fn();

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-page.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { screen, waitFor, fireEvent } from "@testing-library/react";
 import { http, HttpResponse } from "msw";
 import { server } from "../../../mocks/server.ts";
@@ -130,6 +130,52 @@ describe("zero chat page - composer", () => {
 
     await waitFor(() => {
       expect(screen.getByRole("button", { name: "Send" })).not.toBeDisabled();
+    });
+  });
+});
+
+describe("zero chat page - file input ref", () => {
+  it("should open file picker when Attach button is clicked", async () => {
+    await renderChatPage();
+
+    const attachButton = await waitFor(() =>
+      screen.getByRole("button", { name: "Attach" }),
+    );
+
+    // The hidden file input should exist in the DOM
+    const fileInput = document.querySelector(
+      'input[type="file"]',
+    ) as HTMLInputElement;
+    expect(fileInput).toBeInTheDocument();
+
+    // Mock the click method to verify it gets called
+    const clickSpy = vi.fn();
+    fileInput.click = clickSpy;
+
+    fireEvent.click(attachButton);
+
+    expect(clickSpy).toHaveBeenCalledOnce();
+  });
+});
+
+describe("zero chat page - add connector dialog", () => {
+  it("should open add connector dialog when clicking Add connector in popover", async () => {
+    await renderChatPage();
+
+    const connectorsButton = await waitFor(() =>
+      screen.getByRole("button", { name: "Connectors" }),
+    );
+
+    fireEvent.click(connectorsButton);
+
+    const addConnectorButton = await waitFor(() =>
+      screen.getByText("Add connector"),
+    );
+
+    fireEvent.click(addConnectorButton);
+
+    await waitFor(() => {
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
     });
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -1,6 +1,4 @@
-/* eslint-disable ccstate/no-use-ccstate-in-views */
 import type { ChangeEvent } from "react";
-import { useCCState } from "ccstate-react/experimental";
 import { useGet, useSet, useLastLoadable } from "ccstate-react";
 import {
   IconSend,
@@ -33,6 +31,10 @@ import {
   zeroChatAttachments$,
   uploadZeroAttachment$,
   removeZeroAttachment$,
+  composerFileInput$,
+  setComposerFileInput$,
+  composerAddDialogOpen$,
+  setComposerAddDialogOpen$,
 } from "../../signals/zero-page/zero-chat.ts";
 import { AttachmentChips } from "./zero-attachment-chips.tsx";
 import { useFileUploadHandlers } from "./use-file-upload-handlers.ts";
@@ -370,9 +372,8 @@ export function ZeroChatComposer({
   const removeAttachment = useSet(removeZeroAttachment$);
 
   // File picker
-  const fileInputEl$ = useCCState<HTMLInputElement | null>(null);
-  const fileInputEl = useGet(fileInputEl$);
-  const setFileInputEl = useSet(fileInputEl$);
+  const fileInputEl = useGet(composerFileInput$);
+  const setFileInputEl = useSet(setComposerFileInput$);
 
   // File upload (paste / drag-drop)
   const { dragOver, handlePaste, handleDrop, handleDragOver, handleDragLeave } =
@@ -398,9 +399,8 @@ export function ZeroChatComposer({
   const saveSkills = useSet(saveZeroSkills$);
   const optimisticConnected = useGet(justConnectedTypes$);
   const clearOptimistic = useSet(clearJustConnectedTypes$);
-  const addDialogOpen$ = useCCState(false);
-  const addDialogOpen = useGet(addDialogOpen$);
-  const setAddDialogOpen = useSet(addDialogOpen$);
+  const addDialogOpen = useGet(composerAddDialogOpen$);
+  const setAddDialogOpen = useSet(setComposerAddDialogOpen$);
 
   const allConnectors =
     allTypesLoadable.state === "hasData" ? allTypesLoadable.data : [];


### PR DESCRIPTION
## Summary

- Move `fileInputEl` and `addDialogOpen` component-local state from `useCCState` (ccstate-react/experimental) to proper `state()`/`computed()`/`command()` declarations in `signals/zero-page/zero-chat.ts`
- Remove the `eslint-disable ccstate/no-use-ccstate-in-views` comment and `ccstate-react/experimental` import from `zero-chat-composer.tsx`
- Add integration tests for file picker ref callback and add-connector dialog open behavior

## Test plan

- [x] New integration tests pass for file picker (Attach button click triggers file input click) and add-connector dialog (popover Add connector button opens dialog)
- [x] All existing tests pass
- [x] Lint passes (oxlint + eslint)
- [x] Type check passes
- [x] Knip finds no unused exports

Closes #5807

🤖 Generated with [Claude Code](https://claude.com/claude-code)