### PR TITLE
refactor: extract lightbox state from view components into shared signal

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/zero-attachment-chips.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-attachment-chips.ts
@@ -1,0 +1,35 @@
+import { command, computed, state } from "ccstate";
+import { onRef } from "../utils.ts";
+
+// ---------------------------------------------------------------------------
+// Lightbox state — tracks which image URL is open in the lightbox
+// ---------------------------------------------------------------------------
+
+const internalLightboxUrl$ = state<string | null>(null);
+
+export const lightboxUrl$ = computed((get) => get(internalLightboxUrl$));
+
+export const setLightboxUrl$ = command(({ set }, value: string | null) => {
+  set(internalLightboxUrl$, value);
+});
+
+// ---------------------------------------------------------------------------
+// Escape-key handler for ImageLightbox — closes lightbox on Escape
+// ---------------------------------------------------------------------------
+
+const closeLightboxOnEscape$ = command(
+  ({ set }, el: HTMLDivElement, signal: AbortSignal) => {
+    document.addEventListener(
+      "keydown",
+      (e: KeyboardEvent) => {
+        if (e.key === "Escape") {
+          set(internalLightboxUrl$, null);
+        }
+      },
+      { signal },
+    );
+    el.focus();
+  },
+);
+
+export const lightboxDialogRef$ = onRef(closeLightboxOnEscape$);

--- a/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
@@ -1,10 +1,12 @@
-/* eslint-disable ccstate/no-use-ccstate-in-views */
 import type { MouseEvent } from "react";
-import { useCCState, useCommand } from "ccstate-react/experimental";
 import { useGet, useSet } from "ccstate-react";
 import { IconFile, IconPhoto, IconLoader2, IconX } from "@tabler/icons-react";
 import type { ZeroChatAttachment } from "../../signals/zero-page/zero-chat.ts";
-import { onRef } from "../../signals/utils.ts";
+import {
+  lightboxUrl$,
+  setLightboxUrl$,
+  lightboxDialogRef$,
+} from "../../signals/zero-page/zero-attachment-chips.ts";
 import docPdfIcon from "./assets/doc-pdf.svg";
 import docDocIcon from "./assets/doc-doc.svg";
 import docCsvIcon from "./assets/doc-csv.svg";
@@ -39,33 +41,13 @@ function getFileTypeIcon(filename: string): string | null {
 // ImageLightbox — full-screen image viewer
 // ---------------------------------------------------------------------------
 
-export function ImageLightbox({
-  url,
-  onClose,
-}: {
-  url: string;
-  onClose: () => void;
-}) {
-  const escapeKeydown$ = useCommand(
-    (_, el: HTMLDivElement, signal: AbortSignal) => {
-      document.addEventListener(
-        "keydown",
-        (e: KeyboardEvent) => {
-          if (e.key === "Escape") {
-            onClose();
-          }
-        },
-        { signal },
-      );
-      el.focus();
-    },
-  );
-  const dialogRef$ = onRef(escapeKeydown$);
-  const dialogRef = useSet(dialogRef$);
+export function ImageLightbox({ url }: { url: string }) {
+  const dialogRef = useSet(lightboxDialogRef$);
+  const closeLightbox = useSet(setLightboxUrl$);
 
   const handleBackdropClick = (e: MouseEvent<HTMLDivElement>) => {
     if (e.target === e.currentTarget) {
-      onClose();
+      closeLightbox(null);
     }
   };
 
@@ -80,7 +62,7 @@ export function ImageLightbox({
     >
       <button
         type="button"
-        onClick={onClose}
+        onClick={() => closeLightbox(null)}
         className="absolute top-4 right-4 p-2 rounded-full bg-black/50 text-white hover:bg-black/70 transition-colors"
         aria-label="Close"
       >
@@ -139,9 +121,8 @@ function AttachmentChip({
   attachment: ZeroChatAttachment;
   onRemove: () => void;
 }) {
-  const lightboxUrl$ = useCCState<string | null>(null);
   const lightboxUrl = useGet(lightboxUrl$);
-  const setLightboxUrl = useSet(lightboxUrl$);
+  const setLightboxUrlFn = useSet(setLightboxUrl$);
   const isImage = attachment.contentType.startsWith("image/");
   const iconSrc = isImage ? null : getFileTypeIcon(attachment.filename);
   return (
@@ -153,7 +134,7 @@ function AttachmentChip({
         {isImage ? (
           <button
             type="button"
-            onClick={() => attachment.url && setLightboxUrl(attachment.url)}
+            onClick={() => attachment.url && setLightboxUrlFn(attachment.url)}
             disabled={!attachment.url}
             className="group relative h-9 w-9 rounded-lg overflow-hidden border border-foreground/10 hover:border-foreground/25 transition-colors"
           >
@@ -207,9 +188,7 @@ function AttachmentChip({
           </button>
         )}
       </div>
-      {lightboxUrl && (
-        <ImageLightbox url={lightboxUrl} onClose={() => setLightboxUrl(null)} />
-      )}
+      {lightboxUrl && <ImageLightbox url={lightboxUrl} />}
     </>
   );
 }

--- a/turbo/apps/platform/src/views/zero-page/zero-session-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-session-chat-page.tsx
@@ -26,6 +26,10 @@ import {
 import { Markdown } from "../components/markdown.tsx";
 import { detach, onRef, Reason } from "../../signals/utils.ts";
 import { FileAttachmentChip, ImageLightbox } from "./zero-attachment-chips.tsx";
+import {
+  lightboxUrl$ as attachmentLightboxUrl$,
+  setLightboxUrl$ as setAttachmentLightboxUrl$,
+} from "../../signals/zero-page/zero-attachment-chips.ts";
 import { agentDisplayName$ } from "../../signals/zero-page/zero-agent-name.ts";
 import {
   zeroChatMessages$,
@@ -274,9 +278,8 @@ function UserMessage({ message }: { message: ZeroChatMessage }) {
   // Preserve user-entered line breaks: CommonMark collapses single newlines
   // into spaces, so convert each \n to a hard line break (two trailing spaces + \n).
   const displayContent = cleanContent.replace(/\n/g, "  \n");
-  const lightboxUrl$ = useCCState<string | null>(null);
-  const lightboxUrl = useGet(lightboxUrl$);
-  const setLightboxUrl = useSet(lightboxUrl$);
+  const lightboxUrl = useGet(attachmentLightboxUrl$);
+  const setLightboxUrl = useSet(setAttachmentLightboxUrl$);
 
   // Merge explicit attachments with those parsed from content
   const allAttachments = [
@@ -341,9 +344,7 @@ function UserMessage({ message }: { message: ZeroChatMessage }) {
           </div>
         </div>
       </div>
-      {lightboxUrl && (
-        <ImageLightbox url={lightboxUrl} onClose={() => setLightboxUrl(null)} />
-      )}
+      {lightboxUrl && <ImageLightbox url={lightboxUrl} />}
     </>
   );
 }


### PR DESCRIPTION
## Summary
- Extract lightbox state (`lightboxUrl$`, `setLightboxUrl$`, `lightboxDialogRef$`) from inline `useCCState`/`useCommand` in view components into a dedicated signal module at `signals/zero-page/zero-attachment-chips.ts`
- Remove `eslint-disable ccstate/no-use-ccstate-in-views` comment from `zero-attachment-chips.tsx`
- Share lightbox state between `AttachmentChip` and `UserMessage` components via the new signal instead of duplicating local state

## Test plan
- [ ] Verify image lightbox opens when clicking an image attachment chip
- [ ] Verify lightbox closes on backdrop click, close button, and Escape key
- [ ] Verify lightbox works in both attachment chips and user message contexts

🤖 Generated with [Claude Code](https://claude.com/claude-code)