### PR TITLE
refactor: remove ccstate-react/experimental from zero-works-page.tsx

### DIFF
--- a/scripts/next-issue.sh
+++ b/scripts/next-issue.sh
@@ -36,7 +36,7 @@ ISSUE_NUMBER=$(echo "$ISSUE" | jq -r '.number')
 
 # Verify no open PR already covers this issue
 OPEN_PR=$(gh pr list --repo "$REPO" --state open --json number,title --limit 100 \
-  --jq --arg num "#${ISSUE_NUMBER}" '[.[] | select(.title | contains($num))] | length')
+  --jq "[.[] | select(.title | contains(\"#${ISSUE_NUMBER}\"))] | length")
 
 if [[ "$OPEN_PR" -gt 0 ]]; then
   exit 0

--- a/turbo/apps/platform/src/signals/zero-page/zero-slack.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-slack.ts
@@ -2,6 +2,7 @@ import { command, computed, state } from "ccstate";
 import { toast } from "@vm0/ui/components/ui/sonner";
 import { delay } from "signal-timers";
 import { fetch$ } from "../fetch.ts";
+import { detach, onRef, Reason } from "../utils.ts";
 
 interface SlackOrgData {
   isConnected: boolean;
@@ -33,6 +34,22 @@ const slackOrgState$ = state<SlackOrgState>({
 });
 
 export const slackOrgData$ = computed((get) => get(slackOrgState$).data);
+
+// ---------------------------------------------------------------------------
+// Uninstall dialog visibility — view-local state managed in signals layer
+// ---------------------------------------------------------------------------
+
+const showUninstallDialogState$ = state(false);
+
+/** Whether the uninstall confirmation dialog is visible. */
+export const showUninstallDialog$ = computed((get) =>
+  get(showUninstallDialogState$),
+);
+
+/** Show or hide the uninstall confirmation dialog. */
+export const setShowUninstallDialog$ = command(({ set }, show: boolean) => {
+  set(showUninstallDialogState$, show);
+});
 
 const fetchSlackOrg$ = command(async ({ get, set }) => {
   set(slackOrgState$, (prev) => ({
@@ -103,7 +120,7 @@ const POLL_INTERVAL_MS = 3000;
  * Used on the works page so that after the user completes OAuth in another tab
  * the UI updates automatically without a manual refresh.
  */
-export const pollSlackConnection$ = command(
+const pollSlackConnection$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     // Already connected — nothing to poll.
     const current = get(slackOrgState$).data;
@@ -130,6 +147,20 @@ export const pollSlackConnection$ = command(
     }
   },
 );
+
+// ---------------------------------------------------------------------------
+// Polling trigger — extracted from the view's useCommand + onRef pattern.
+// The command uses the AbortSignal from onRef so polling stops on unmount.
+// ---------------------------------------------------------------------------
+
+const startSlackPolling$ = command(
+  ({ set }, _el: HTMLElement, signal: AbortSignal) => {
+    detach(set(pollSlackConnection$, signal), Reason.DomCallback);
+  },
+);
+
+/** Ref callback that starts Slack connection polling when the element mounts. */
+export const slackPollingRef$ = onRef(startSlackPolling$);
 
 export const initSlackOrg$ = command(async ({ set }) => {
   await set(fetchSlackOrg$);

--- a/turbo/apps/platform/src/views/zero-page/zero-works-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-works-page.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable ccstate/no-use-ccstate-in-views */
-import { useCCState, useCommand } from "ccstate-react/experimental";
 import { useGet, useSet, useLoadable } from "ccstate-react";
 import {
   IconCircleCheck,
@@ -25,9 +23,11 @@ import {
   slackOrgData$,
   disconnectSlackOrg$,
   uninstallSlackOrg$,
-  pollSlackConnection$,
+  showUninstallDialog$,
+  setShowUninstallDialog$,
+  slackPollingRef$,
 } from "../../signals/zero-page/zero-slack.ts";
-import { detach, onRef, Reason } from "../../signals/utils.ts";
+import { detach, Reason } from "../../signals/utils.ts";
 import slackIconImg from "./assets/slack-icon.svg";
 
 /** Append a cache-busting timestamp so the browser never reuses a cached OAuth redirect. */
@@ -128,23 +128,14 @@ function SlackCard({ agentName }: { agentName: string }) {
   const disconnect = useSet(disconnectSlackOrg$);
   const uninstall = useSet(uninstallSlackOrg$);
 
-  const showUninstallDialog$ = useCCState(false);
   const showUninstallDialog = useGet(showUninstallDialog$);
-  const setShowUninstallDialog = useSet(showUninstallDialog$);
+  const setShowUninstallDialog = useSet(setShowUninstallDialog$);
 
   const isConnected = slackData?.isConnected ?? false;
   const isInstalled = slackData?.isInstalled ?? isConnected;
   const isAdmin = slackData?.isAdmin ?? false;
 
-  // Poll for Slack connection while not connected — auto-detects when the
-  // user completes OAuth in another tab.
-  const startPolling$ = useCommand(
-    ({ set }, _el: HTMLElement, signal: AbortSignal) => {
-      detach(set(pollSlackConnection$, signal), Reason.DomCallback);
-    },
-  );
-  const pollingRef$ = onRef(startPolling$);
-  const pollingRef = useSet(pollingRef$);
+  const pollingRef = useSet(slackPollingRef$);
 
   return (
     <>


### PR DESCRIPTION
## Summary
- Extract uninstall dialog visibility state (`state`/`computed`/`command`) from the view into `zero-slack.ts` signals layer
- Extract `useCommand` + `onRef` polling logic into `zero-slack.ts` as `startSlackPolling$` + `slackPollingRef$`, preserving the `onRef` pattern since it uses the AbortSignal
- Remove `ccstate-react/experimental` import and `eslint-disable` comment from `zero-works-page.tsx`
- Make `pollSlackConnection$` internal (no longer exported, only used by the extracted command)
- Fix `scripts/next-issue.sh` to use shell interpolation instead of unsupported `jq --arg` with `gh`

Closes #5801

## Test plan
- [x] All 21 existing tests in `zero-works-page.test.tsx` pass
- [x] Lint passes cleanly
- [x] Knip passes cleanly
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)