### PR TITLE
refactor: remove ccstate-react/experimental from zero-attachment-chips.tsx

### DIFF
--- a/scripts/next-issue.sh
+++ b/scripts/next-issue.sh
@@ -36,7 +36,7 @@ ISSUE_NUMBER=$(echo "$ISSUE" | jq -r '.number')
 
 # Verify no open PR already covers this issue
 OPEN_PR=$(gh pr list --repo "$REPO" --state open --json number,title --limit 100 \
-  --jq --arg num "#${ISSUE_NUMBER}" '[.[] | select(.title | contains($num))] | length')
+  --jq "[.[] | select(.title | contains(\"#${ISSUE_NUMBER}\"))] | length")
 
 if [[ "$OPEN_PR" -gt 0 ]]; then
   exit 0

--- a/turbo/apps/platform/src/signals/zero-page/zero-attachment-lightbox.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-attachment-lightbox.ts
@@ -1,0 +1,41 @@
+import { command, computed, state } from "ccstate";
+import { onRef } from "../utils.ts";
+
+// ---------------------------------------------------------------------------
+// Attachment lightbox state (shared across AttachmentChips)
+// ---------------------------------------------------------------------------
+
+const internalLightboxUrl$ = state<string | null>(null);
+
+export const attachmentLightboxUrl$ = computed((get) =>
+  get(internalLightboxUrl$),
+);
+
+export const openAttachmentLightbox$ = command(({ set }, url: string) => {
+  set(internalLightboxUrl$, url);
+});
+
+export const closeAttachmentLightbox$ = command(({ set }) => {
+  set(internalLightboxUrl$, null);
+});
+
+// ---------------------------------------------------------------------------
+// Escape key dismiss ref — closes the attachment lightbox on Escape
+// ---------------------------------------------------------------------------
+
+const escapeKeydown$ = command(
+  ({ set }, el: HTMLDivElement, signal: AbortSignal) => {
+    document.addEventListener(
+      "keydown",
+      (e: KeyboardEvent) => {
+        if (e.key === "Escape") {
+          set(internalLightboxUrl$, null);
+        }
+      },
+      { signal },
+    );
+    el.focus();
+  },
+);
+
+export const attachmentLightboxRef$ = onRef(escapeKeydown$);

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
@@ -1,0 +1,313 @@
+import { createElement } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { screen, fireEvent, act, render } from "@testing-library/react";
+import { StoreProvider } from "ccstate-react";
+import {
+  AttachmentChips,
+  FileAttachmentChip,
+  ImageLightbox,
+} from "../zero-attachment-chips.tsx";
+import type { ZeroChatAttachment } from "../../../signals/zero-page/zero-chat.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+
+const context = testContext();
+
+function renderWithStore(element: React.ReactElement) {
+  return render(
+    createElement(StoreProvider, { value: context.store }, element),
+  );
+}
+
+function makeAttachment(
+  overrides: Partial<ZeroChatAttachment> & { id: string },
+): ZeroChatAttachment {
+  return {
+    filename: "photo.png",
+    contentType: "image/png",
+    size: 1024,
+    url: "https://example.com/photo.png",
+    uploading: false,
+    ...overrides,
+  };
+}
+
+describe("attachment chips", () => {
+  it("should render image attachment with thumbnail", () => {
+    const onRemove = vi.fn();
+    renderWithStore(
+      createElement(AttachmentChips, {
+        attachments: [
+          makeAttachment({
+            id: "img-1",
+            filename: "screenshot.png",
+            contentType: "image/png",
+            url: "https://example.com/screenshot.png",
+          }),
+        ],
+        onRemove,
+      }),
+    );
+
+    const chip = screen.getByTitle("screenshot.png");
+    const img = chip.querySelector("img");
+    expect(img).toHaveAttribute("src", "https://example.com/screenshot.png");
+  });
+
+  it("should render file attachment with file icon for known type", () => {
+    const onRemove = vi.fn();
+    renderWithStore(
+      createElement(AttachmentChips, {
+        attachments: [
+          makeAttachment({
+            id: "file-1",
+            filename: "report.pdf",
+            contentType: "application/pdf",
+            url: "https://example.com/report.pdf",
+          }),
+        ],
+        onRemove,
+      }),
+    );
+
+    expect(screen.getByTitle("report.pdf")).toBeInTheDocument();
+  });
+
+  it("should call onRemove when remove button is clicked", async () => {
+    const onRemove = vi.fn();
+    renderWithStore(
+      createElement(AttachmentChips, {
+        attachments: [
+          makeAttachment({
+            id: "file-1",
+            filename: "report.pdf",
+            contentType: "application/pdf",
+            url: "https://example.com/report.pdf",
+          }),
+        ],
+        onRemove,
+      }),
+    );
+
+    const removeButton = screen.getByLabelText("Remove report.pdf");
+    await act(() => {
+      fireEvent.click(removeButton);
+    });
+
+    expect(onRemove).toHaveBeenCalledWith("file-1");
+  });
+
+  it("should show uploading spinner instead of remove button", () => {
+    const onRemove = vi.fn();
+    renderWithStore(
+      createElement(AttachmentChips, {
+        attachments: [
+          makeAttachment({
+            id: "uploading-1",
+            filename: "photo.png",
+            contentType: "image/png",
+            url: "",
+            uploading: true,
+          }),
+        ],
+        onRemove,
+      }),
+    );
+
+    expect(screen.queryByLabelText("Remove photo.png")).not.toBeInTheDocument();
+  });
+
+  it("should open lightbox when clicking image attachment", async () => {
+    const onRemove = vi.fn();
+    renderWithStore(
+      createElement(AttachmentChips, {
+        attachments: [
+          makeAttachment({
+            id: "img-1",
+            contentType: "image/png",
+            url: "https://example.com/photo.png",
+          }),
+        ],
+        onRemove,
+      }),
+    );
+
+    const imageButton = screen.getByRole("button", { name: "" });
+    await act(() => {
+      fireEvent.click(imageButton);
+    });
+
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+  });
+
+  it("should close lightbox when Escape key is pressed", async () => {
+    const onRemove = vi.fn();
+    renderWithStore(
+      createElement(AttachmentChips, {
+        attachments: [
+          makeAttachment({
+            id: "img-1",
+            contentType: "image/png",
+            url: "https://example.com/photo.png",
+          }),
+        ],
+        onRemove,
+      }),
+    );
+
+    // Open the lightbox
+    const imageButton = screen.getByRole("button", { name: "" });
+    await act(() => {
+      fireEvent.click(imageButton);
+    });
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+
+    // Press Escape to close
+    await act(() => {
+      fireEvent.keyDown(document, { key: "Escape" });
+    });
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("should close lightbox when clicking the backdrop", async () => {
+    const onRemove = vi.fn();
+    renderWithStore(
+      createElement(AttachmentChips, {
+        attachments: [
+          makeAttachment({
+            id: "img-1",
+            contentType: "image/png",
+            url: "https://example.com/photo.png",
+          }),
+        ],
+        onRemove,
+      }),
+    );
+
+    // Open the lightbox
+    const imageButton = screen.getByRole("button", { name: "" });
+    await act(() => {
+      fireEvent.click(imageButton);
+    });
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+
+    // Click the backdrop to close
+    const backdrop = screen.getByRole("dialog");
+    await act(() => {
+      fireEvent.click(backdrop);
+    });
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("should close lightbox when clicking the close button", async () => {
+    const onRemove = vi.fn();
+    renderWithStore(
+      createElement(AttachmentChips, {
+        attachments: [
+          makeAttachment({
+            id: "img-1",
+            contentType: "image/png",
+            url: "https://example.com/photo.png",
+          }),
+        ],
+        onRemove,
+      }),
+    );
+
+    // Open the lightbox
+    const imageButton = screen.getByRole("button", { name: "" });
+    await act(() => {
+      fireEvent.click(imageButton);
+    });
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+
+    // Click the close button
+    const closeButton = screen.getByLabelText("Close");
+    await act(() => {
+      fireEvent.click(closeButton);
+    });
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+});
+
+describe("image lightbox", () => {
+  it("should render with the image url", () => {
+    const onClose = vi.fn();
+    renderWithStore(
+      createElement(ImageLightbox, {
+        url: "https://example.com/full.png",
+        onClose,
+      }),
+    );
+
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).toBeInTheDocument();
+
+    const images = dialog.querySelectorAll("img");
+    expect(images).toHaveLength(1);
+    expect(images[0]).toHaveAttribute("src", "https://example.com/full.png");
+  });
+
+  it("should call onClose when clicking the backdrop", async () => {
+    const onClose = vi.fn();
+    renderWithStore(
+      createElement(ImageLightbox, {
+        url: "https://example.com/full.png",
+        onClose,
+      }),
+    );
+
+    const backdrop = screen.getByRole("dialog");
+    await act(() => {
+      fireEvent.click(backdrop);
+    });
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("should call onClose when clicking the close button", async () => {
+    const onClose = vi.fn();
+    renderWithStore(
+      createElement(ImageLightbox, {
+        url: "https://example.com/full.png",
+        onClose,
+      }),
+    );
+
+    const closeButton = screen.getByLabelText("Close");
+    await act(() => {
+      fireEvent.click(closeButton);
+    });
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("file attachment chip", () => {
+  it("should render download link for PDF file", () => {
+    renderWithStore(
+      createElement(FileAttachmentChip, {
+        filename: "document.pdf",
+        url: "https://example.com/document.pdf",
+      }),
+    );
+
+    const link = screen.getByTitle("document.pdf");
+    expect(link).toHaveAttribute("href", "https://example.com/document.pdf");
+    expect(link).toHaveAttribute("download", "document.pdf");
+  });
+
+  it("should render generic file icon for unknown extension", () => {
+    renderWithStore(
+      createElement(FileAttachmentChip, {
+        filename: "data.xyz",
+        url: "https://example.com/data.xyz",
+      }),
+    );
+
+    const link = screen.getByTitle("data.xyz");
+    expect(link).toBeInTheDocument();
+  });
+});

--- a/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
@@ -1,10 +1,13 @@
-/* eslint-disable ccstate/no-use-ccstate-in-views */
-import type { MouseEvent } from "react";
-import { useCCState, useCommand } from "ccstate-react/experimental";
+import type { MouseEvent, Ref } from "react";
 import { useGet, useSet } from "ccstate-react";
 import { IconFile, IconPhoto, IconLoader2, IconX } from "@tabler/icons-react";
 import type { ZeroChatAttachment } from "../../signals/zero-page/zero-chat.ts";
-import { onRef } from "../../signals/utils.ts";
+import {
+  attachmentLightboxRef$,
+  attachmentLightboxUrl$,
+  closeAttachmentLightbox$,
+  openAttachmentLightbox$,
+} from "../../signals/zero-page/zero-attachment-lightbox.ts";
 import docPdfIcon from "./assets/doc-pdf.svg";
 import docDocIcon from "./assets/doc-doc.svg";
 import docCsvIcon from "./assets/doc-csv.svg";
@@ -42,27 +45,12 @@ function getFileTypeIcon(filename: string): string | null {
 export function ImageLightbox({
   url,
   onClose,
+  dialogRef,
 }: {
   url: string;
   onClose: () => void;
+  dialogRef?: Ref<HTMLDivElement>;
 }) {
-  const escapeKeydown$ = useCommand(
-    (_, el: HTMLDivElement, signal: AbortSignal) => {
-      document.addEventListener(
-        "keydown",
-        (e: KeyboardEvent) => {
-          if (e.key === "Escape") {
-            onClose();
-          }
-        },
-        { signal },
-      );
-      el.focus();
-    },
-  );
-  const dialogRef$ = onRef(escapeKeydown$);
-  const dialogRef = useSet(dialogRef$);
-
   const handleBackdropClick = (e: MouseEvent<HTMLDivElement>) => {
     if (e.target === e.currentTarget) {
       onClose();
@@ -139,78 +127,71 @@ function AttachmentChip({
   attachment: ZeroChatAttachment;
   onRemove: () => void;
 }) {
-  const lightboxUrl$ = useCCState<string | null>(null);
-  const lightboxUrl = useGet(lightboxUrl$);
-  const setLightboxUrl = useSet(lightboxUrl$);
+  const openLightbox = useSet(openAttachmentLightbox$);
   const isImage = attachment.contentType.startsWith("image/");
   const iconSrc = isImage ? null : getFileTypeIcon(attachment.filename);
   return (
-    <>
-      <div
-        className="relative inline-flex items-center justify-center"
-        title={attachment.filename}
-      >
-        {isImage ? (
-          <button
-            type="button"
-            onClick={() => attachment.url && setLightboxUrl(attachment.url)}
-            disabled={!attachment.url}
-            className="group relative h-9 w-9 rounded-lg overflow-hidden border border-foreground/10 hover:border-foreground/25 transition-colors"
-          >
-            {attachment.url ? (
-              <>
-                <img
-                  src={attachment.url}
-                  alt=""
-                  className="h-full w-full object-cover"
-                />
-                <span className="absolute inset-0 flex items-center justify-center bg-black/0 group-hover:bg-black/30 transition-colors">
-                  <IconPhoto
-                    size={18}
-                    className="text-white opacity-0 group-hover:opacity-100 transition-opacity drop-shadow"
-                  />
-                </span>
-              </>
-            ) : (
-              <IconPhoto
-                size={20}
-                stroke={1.5}
-                className="text-muted-foreground m-auto h-full"
+    <div
+      className="relative inline-flex items-center justify-center"
+      title={attachment.filename}
+    >
+      {isImage ? (
+        <button
+          type="button"
+          onClick={() => attachment.url && openLightbox(attachment.url)}
+          disabled={!attachment.url}
+          className="group relative h-9 w-9 rounded-lg overflow-hidden border border-foreground/10 hover:border-foreground/25 transition-colors"
+        >
+          {attachment.url ? (
+            <>
+              <img
+                src={attachment.url}
+                alt=""
+                className="h-full w-full object-cover"
               />
-            )}
-          </button>
-        ) : iconSrc ? (
-          <img
-            alt=""
-            className="h-9 w-9 object-contain opacity-80"
-            aria-hidden="true"
-            src={iconSrc}
-          />
-        ) : (
-          <IconFile size={28} stroke={1.5} className="text-muted-foreground" />
-        )}
-        {attachment.uploading ? (
-          <span className="absolute -top-1 -right-1 flex h-3.5 w-3.5 items-center justify-center rounded-full bg-background">
-            <IconLoader2
-              size={10}
-              className="animate-spin text-muted-foreground"
+              <span className="absolute inset-0 flex items-center justify-center bg-black/0 group-hover:bg-black/30 transition-colors">
+                <IconPhoto
+                  size={18}
+                  className="text-white opacity-0 group-hover:opacity-100 transition-opacity drop-shadow"
+                />
+              </span>
+            </>
+          ) : (
+            <IconPhoto
+              size={20}
+              stroke={1.5}
+              className="text-muted-foreground m-auto h-full"
             />
-          </span>
-        ) : (
-          <button
-            type="button"
-            onClick={onRemove}
-            className="absolute -top-1 -right-1 flex h-3.5 w-3.5 items-center justify-center rounded-full bg-muted hover:bg-destructive hover:text-destructive-foreground transition-colors"
-            aria-label={`Remove ${attachment.filename}`}
-          >
-            <IconX size={9} stroke={2.5} />
-          </button>
-        )}
-      </div>
-      {lightboxUrl && (
-        <ImageLightbox url={lightboxUrl} onClose={() => setLightboxUrl(null)} />
+          )}
+        </button>
+      ) : iconSrc ? (
+        <img
+          alt=""
+          className="h-9 w-9 object-contain opacity-80"
+          aria-hidden="true"
+          src={iconSrc}
+        />
+      ) : (
+        <IconFile size={28} stroke={1.5} className="text-muted-foreground" />
       )}
-    </>
+      {attachment.uploading ? (
+        <span className="absolute -top-1 -right-1 flex h-3.5 w-3.5 items-center justify-center rounded-full bg-background">
+          <IconLoader2
+            size={10}
+            className="animate-spin text-muted-foreground"
+          />
+        </span>
+      ) : (
+        <button
+          type="button"
+          onClick={onRemove}
+          className="absolute -top-1 -right-1 flex h-3.5 w-3.5 items-center justify-center rounded-full bg-muted hover:bg-destructive hover:text-destructive-foreground transition-colors"
+          aria-label={`Remove ${attachment.filename}`}
+        >
+          <IconX size={9} stroke={2.5} />
+        </button>
+      )}
+    </div>
   );
 }
 
@@ -225,6 +206,10 @@ export function AttachmentChips({
   attachments: ZeroChatAttachment[];
   onRemove: (id: string) => void;
 }) {
+  const lightboxUrl = useGet(attachmentLightboxUrl$);
+  const closeLightbox = useSet(closeAttachmentLightbox$);
+  const lightboxRef = useSet(attachmentLightboxRef$);
+
   return (
     <div className="flex flex-wrap gap-2 px-4 pt-3">
       {attachments.map((a) => (
@@ -234,6 +219,13 @@ export function AttachmentChips({
           onRemove={() => onRemove(a.id)}
         />
       ))}
+      {lightboxUrl && (
+        <ImageLightbox
+          url={lightboxUrl}
+          onClose={closeLightbox}
+          dialogRef={lightboxRef}
+        />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Extract `useCCState` (lightbox URL) to a shared `state()`/`computed()`/`command()` pattern in `signals/zero-page/zero-attachment-lightbox.ts`, lifting lightbox state from per-chip to the `AttachmentChips` wrapper level
- Extract `useCommand` + `onRef` (escape key dismiss) to a static `command()` + `onRef()` in the signals file
- Add `dialogRef` prop to `ImageLightbox` for external ref binding (backward-compatible optional prop)
- Remove `eslint-disable ccstate/no-use-ccstate-in-views` comment
- Remove `ccstate-react/experimental` import
- Add 13 integration tests covering attachment chip rendering, lightbox open/close, escape key dismiss, backdrop click, close button, file chip download links
- Fix `scripts/next-issue.sh` jq `--arg` quoting issue with `gh pr list`

Closes #5802

## Test plan

- [x] All 13 new integration tests pass
- [x] All 436 existing platform app tests pass
- [x] Lint passes (0 errors)
- [x] Type check passes
- [x] Knip finds no unused exports
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)