### PR TITLE
refactor: remove ccstate-react/experimental from zero-account-page

### DIFF
--- a/scripts/next-issue.sh
+++ b/scripts/next-issue.sh
@@ -36,7 +36,7 @@ ISSUE_NUMBER=$(echo "$ISSUE" | jq -r '.number')
 
 # Verify no open PR already covers this issue
 OPEN_PR=$(gh pr list --repo "$REPO" --state open --json number,title --limit 100 \
-  --jq --arg num "#${ISSUE_NUMBER}" '[.[] | select(.title | contains($num))] | length')
+  --jq "[.[] | select(.title | contains(\"#${ISSUE_NUMBER}\"))] | length")
 
 if [[ "$OPEN_PR" -gt 0 ]]; then
   exit 0

--- a/turbo/apps/platform/src/signals/zero-page/settings/preferences-page.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/preferences-page.ts
@@ -1,0 +1,26 @@
+import { command, computed, state } from "ccstate";
+import type { SendMode } from "@vm0/core";
+
+// ---------------------------------------------------------------------------
+// Preferences tab state
+// ---------------------------------------------------------------------------
+
+const internalPreferencesTab$ = state("appearance");
+
+export const preferencesTab$ = computed((get) => get(internalPreferencesTab$));
+
+export const setPreferencesTab$ = command(({ set }, value: string) => {
+  set(internalPreferencesTab$, value);
+});
+
+// ---------------------------------------------------------------------------
+// Send mode saving state
+// ---------------------------------------------------------------------------
+
+const internalSendModeSaving$ = state<SendMode | null>(null);
+
+export const sendModeSaving$ = computed((get) => get(internalSendModeSaving$));
+
+export const setSendModeSaving$ = command(({ set }, value: SendMode | null) => {
+  set(internalSendModeSaving$, value);
+});

--- a/turbo/apps/platform/src/views/zero-page/zero-account-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-account-page.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable ccstate/no-use-ccstate-in-views */
-import { useCCState } from "ccstate-react/experimental";
 import { useGet, useSet, useLoadable } from "ccstate-react";
 import {
   IconSun,
@@ -22,6 +20,12 @@ import { sendMode$ } from "../../signals/send-mode.ts";
 import { detach, Reason } from "../../signals/utils.ts";
 import type { SendMode } from "@vm0/core";
 import { updateNotificationPreference$ } from "../../signals/zero-page/settings/notification-settings.ts";
+import {
+  preferencesTab$,
+  setPreferencesTab$,
+  sendModeSaving$,
+  setSendModeSaving$,
+} from "../../signals/zero-page/settings/preferences-page.ts";
 import { toast } from "@vm0/ui/components/ui/sonner";
 
 function AppearanceSettings() {
@@ -96,9 +100,8 @@ function SendModeSettings() {
   const current: SendMode =
     prefsLoadable.state === "hasData" ? prefsLoadable.data : "enter";
   const updatePref = useSet(updateNotificationPreference$);
-  const saving$ = useCCState<SendMode | null>(null);
-  const saving = useGet(saving$);
-  const setSaving = useSet(saving$);
+  const saving = useGet(sendModeSaving$);
+  const setSaving = useSet(setSendModeSaving$);
 
   const handleChange = (value: SendMode) => {
     setSaving(value);
@@ -171,9 +174,8 @@ function SendModeSettings() {
 }
 
 export function ZeroPreferencesPage() {
-  const tab$ = useCCState("appearance");
-  const tab = useGet(tab$);
-  const setTab = useSet(tab$);
+  const tab = useGet(preferencesTab$);
+  const setTab = useSet(setPreferencesTab$);
 
   return (
     <div className="flex flex-1 flex-col min-h-0 overflow-auto [scrollbar-gutter:stable]">


### PR DESCRIPTION
## Summary
- Replace `useCCState()` calls in `zero-account-page.tsx` with proper ccstate `state()`/`computed()`/`command()` pattern in a new `preferences-page.ts` signals file
- Remove `eslint-disable ccstate/no-use-ccstate-in-views` comment and `ccstate-react/experimental` import
- Fix `jq --arg` quoting bug in `scripts/next-issue.sh`

Closes #5814

## Test plan
- [x] Existing integration tests pass (6/6 in `zero-preferences-page.test.tsx`)
- [x] Lint passes (`pnpm turbo run lint`)
- [x] Type check passes (`pnpm check-types`)
- [x] Knip passes (no unused exports)
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)