### PR TITLE
refactor: remove ccstate-react/experimental from zero-schedule-tab.tsx

### DIFF
--- a/scripts/next-issue.sh
+++ b/scripts/next-issue.sh
@@ -36,7 +36,7 @@ ISSUE_NUMBER=$(echo "$ISSUE" | jq -r '.number')
 
 # Verify no open PR already covers this issue
 OPEN_PR=$(gh pr list --repo "$REPO" --state open --json number,title --limit 100 \
-  --jq --arg num "#${ISSUE_NUMBER}" '[.[] | select(.title | contains($num))] | length')
+  --jq "[.[] | select(.title | contains(\"#${ISSUE_NUMBER}\"))] | length")
 
 if [[ "$OPEN_PR" -gt 0 ]]; then
   exit 0

--- a/turbo/apps/platform/src/signals/zero-page/zero-schedule.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-schedule.ts
@@ -46,6 +46,17 @@ interface ScheduleResponse {
 
 const internalSchedules$ = state<ScheduleResponse[]>([]);
 
+// Schedule tab saving state (used by ZeroScheduleTab to show loading during save)
+const internalScheduleTabSaving$ = state(false);
+
+export const scheduleTabSaving$ = computed((get) =>
+  get(internalScheduleTabSaving$),
+);
+
+export const setScheduleTabSaving$ = command(({ set }, value: boolean) => {
+  set(internalScheduleTabSaving$, value);
+});
+
 // ---------------------------------------------------------------------------
 // Convert ScheduleResponse to display time string
 // ---------------------------------------------------------------------------

--- a/turbo/apps/platform/src/views/zero-page/zero-schedule-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-schedule-tab.tsx
@@ -1,9 +1,11 @@
-/* eslint-disable ccstate/no-use-ccstate-in-views */
-import { useCCState } from "ccstate-react/experimental";
 import { useGet, useSet, useLoadable } from "ccstate-react";
 import { Card, CardContent } from "@vm0/ui";
 import { ZeroScheduleCard, type ScheduleEntry } from "./zero-schedule-card.tsx";
 import { notificationPreferences$ } from "../../signals/zero-page/settings/notification-settings.ts";
+import {
+  scheduleTabSaving$,
+  setScheduleTabSaving$,
+} from "../../signals/zero-page/zero-schedule.ts";
 
 interface ZeroScheduleSaveParams {
   prompt: string;
@@ -41,9 +43,8 @@ export function ZeroScheduleTab({
   const prefsLoadable = useLoadable(notificationPreferences$);
   const userTimezone =
     prefsLoadable.state === "hasData" ? prefsLoadable.data.timezone : null;
-  const saving$ = useCCState(false);
-  const saving = useGet(saving$);
-  const setSaving = useSet(saving$);
+  const saving = useGet(scheduleTabSaving$);
+  const setSaving = useSet(setScheduleTabSaving$);
 
   if (scheduleError) {
     return (


### PR DESCRIPTION
## Summary

- Move the `saving` boolean state from inline `useCCState` (ccstate-react/experimental) to the signals layer using `state()`/`computed()`/`command()` pattern in `zero-schedule.ts`
- Remove `eslint-disable ccstate/no-use-ccstate-in-views` comment and `ccstate-react/experimental` import
- Fix `next-issue.sh` script where `--arg` flag was incompatible with `gh pr list --jq`

## Test plan

- [x] All 23 existing tests pass (12 signal tests + 11 page tests)
- [x] Lint passes with 0 warnings/errors
- [x] Knip finds no unused exports
- [x] Type check passes for changed files (pre-existing errors in unrelated files)

Closes #5811

🤖 Generated with [Claude Code](https://claude.com/claude-code)