### PR TITLE
refactor: remove ccstate-react/experimental from zero-slack-connect-page

### DIFF
--- a/turbo/apps/platform/src/mocks/handlers/api-integrations-slack-connect.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-integrations-slack-connect.ts
@@ -1,0 +1,49 @@
+/**
+ * Slack Connect API Handlers
+ *
+ * Mock handlers for /api/zero/integrations/slack/connect endpoint.
+ * Default behavior: user is not yet connected.
+ */
+
+import { http, HttpResponse } from "msw";
+
+interface MockSlackConnectData {
+  isConnected: boolean;
+  postError: string | null;
+}
+
+let mockData: MockSlackConnectData = {
+  isConnected: false,
+  postError: null,
+};
+
+export function setMockSlackConnectData(
+  data: Partial<MockSlackConnectData>,
+): void {
+  mockData = { ...mockData, ...data };
+}
+
+export function resetMockSlackConnect(): void {
+  mockData = {
+    isConnected: false,
+    postError: null,
+  };
+}
+
+export const apiIntegrationsSlackConnectHandlers = [
+  // GET /api/zero/integrations/slack/connect — check connection status
+  http.get("*/api/zero/integrations/slack/connect", () => {
+    return HttpResponse.json({ isConnected: mockData.isConnected });
+  }),
+
+  // POST /api/zero/integrations/slack/connect — connect account
+  http.post("*/api/zero/integrations/slack/connect", () => {
+    if (mockData.postError) {
+      return HttpResponse.json(
+        { error: { message: mockData.postError } },
+        { status: 400 },
+      );
+    }
+    return HttpResponse.json({ ok: true });
+  }),
+];

--- a/turbo/apps/platform/src/mocks/handlers/index.ts
+++ b/turbo/apps/platform/src/mocks/handlers/index.ts
@@ -33,6 +33,10 @@ import {
 } from "./api-user-preferences.ts";
 import { apiOnboardingHandlers } from "./api-onboarding.ts";
 import { apiBillingHandlers, resetMockBilling } from "./api-billing.ts";
+import {
+  apiIntegrationsSlackConnectHandlers,
+  resetMockSlackConnect,
+} from "./api-integrations-slack-connect.ts";
 
 export const handlers = [
   ...apiConnectorsHandlers,
@@ -48,6 +52,7 @@ export const handlers = [
   ...apiUserPreferencesHandlers,
   ...apiOnboardingHandlers,
   ...apiBillingHandlers,
+  ...apiIntegrationsSlackConnectHandlers,
 ];
 
 export function resetAllMockHandlers(): void {
@@ -59,4 +64,5 @@ export function resetAllMockHandlers(): void {
   resetMockUserPreferences();
   resetMockOrgModelProviders();
   resetMockBilling();
+  resetMockSlackConnect();
 }

--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-slack-connect.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-slack-connect.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { delay } from "signal-timers";
+import { testContext } from "../../__tests__/test-helpers.ts";
+import { setupPage } from "../../../__tests__/page-helper.ts";
+import {
+  slackConnectStatus$,
+  effectiveStatus$,
+  effectiveError$,
+  connectSlackAccount$,
+} from "../slack-connect-signals.ts";
+import { updateSearchParams$ } from "../../route.ts";
+import { setMockSlackConnectData } from "../../../mocks/handlers/api-integrations-slack-connect.ts";
+
+const context = testContext();
+
+// The signal code sets window.location.href = "slack://open" on success,
+// which changes happy-dom's location and corrupts subsequent tests.
+// Reset the href after each test to prevent location pollution.
+afterEach(() => {
+  if (!window.location.href.startsWith("http://localhost")) {
+    window.location.href = "http://localhost/slack/connect";
+  }
+});
+
+async function setup(path: string) {
+  await setupPage({
+    context,
+    path,
+    withoutRender: true,
+  });
+  // Allow the async init command (detached via Reason.Entrance) to complete
+  await delay(50);
+}
+
+describe("slack-connect-page signals", () => {
+  describe("init: check connection status on mount", () => {
+    it("should set status to success when already connected", async () => {
+      setMockSlackConnectData({ isConnected: true });
+      await setup("/slack/connect?w=ws1&u=user1");
+
+      expect(context.store.get(slackConnectStatus$)).toBe("success");
+    });
+
+    it("should stay idle when not connected", async () => {
+      setMockSlackConnectData({ isConnected: false });
+      await setup("/slack/connect?w=ws1&u=user1");
+
+      expect(context.store.get(slackConnectStatus$)).toBe("idle");
+    });
+
+    it("should skip connection check when no workspace param", async () => {
+      await setup("/slack/connect");
+
+      expect(context.store.get(slackConnectStatus$)).toBe("idle");
+    });
+  });
+
+  describe("effective status from URL params", () => {
+    it("should return success when status=connected in URL", async () => {
+      await setup("/slack/connect?status=connected");
+
+      expect(context.store.get(effectiveStatus$)).toBe("success");
+    });
+
+    it("should return error when error param in URL", async () => {
+      await setup("/slack/connect?error=Something+went+wrong");
+
+      expect(context.store.get(effectiveStatus$)).toBe("error");
+      expect(context.store.get(effectiveError$)).toBe("Something went wrong");
+    });
+
+    it("should return idle when no special URL params", async () => {
+      await setup("/slack/connect");
+
+      expect(context.store.get(effectiveStatus$)).toBe("idle");
+    });
+  });
+
+  describe("connectSlackAccount$", () => {
+    it("should set status to success on successful connect", async () => {
+      setMockSlackConnectData({ isConnected: false });
+      // Setup without w param to avoid init fetch, then add params for connect
+      await setup("/slack/connect");
+      context.store.set(
+        updateSearchParams$,
+        new URLSearchParams("w=ws1&u=user1"),
+      );
+
+      await context.store.set(connectSlackAccount$);
+
+      expect(context.store.get(slackConnectStatus$)).toBe("success");
+    });
+
+    it("should set status to error on failed connect", async () => {
+      setMockSlackConnectData({ postError: "Account already linked" });
+      // Setup without w param to avoid init fetch, then add params for connect
+      await setup("/slack/connect");
+      context.store.set(
+        updateSearchParams$,
+        new URLSearchParams("w=ws1&u=user1"),
+      );
+
+      await context.store.set(connectSlackAccount$);
+
+      expect(context.store.get(slackConnectStatus$)).toBe("error");
+      expect(context.store.get(effectiveError$)).toBe("Account already linked");
+    });
+
+    it("should not connect without workspace and user params", async () => {
+      await setup("/slack/connect");
+
+      await context.store.set(connectSlackAccount$);
+
+      expect(context.store.get(slackConnectStatus$)).toBe("idle");
+    });
+  });
+});

--- a/turbo/apps/platform/src/signals/zero-page/slack-connect-page.ts
+++ b/turbo/apps/platform/src/signals/zero-page/slack-connect-page.ts
@@ -2,7 +2,14 @@ import { command } from "ccstate";
 import { createElement } from "react";
 import { updatePage$ } from "../react-router.ts";
 import { ZeroSlackConnectPage } from "../../views/zero-page/zero-slack-connect-page.tsx";
+import { detach, Reason } from "../utils.ts";
+import {
+  resetSlackConnectState$,
+  initSlackConnectPage$,
+} from "./slack-connect-signals.ts";
 
 export const setupSlackConnectPage$ = command(({ set }) => {
+  set(resetSlackConnectState$);
   set(updatePage$, createElement(ZeroSlackConnectPage));
+  detach(set(initSlackConnectPage$), Reason.Entrance);
 });

--- a/turbo/apps/platform/src/signals/zero-page/slack-connect-signals.ts
+++ b/turbo/apps/platform/src/signals/zero-page/slack-connect-signals.ts
@@ -1,0 +1,101 @@
+import { command, computed, state } from "ccstate";
+import { searchParams$ } from "../route.ts";
+import { fetch$ } from "../fetch.ts";
+
+// Internal state
+const internalStatus$ = state<
+  "idle" | "checking" | "connecting" | "success" | "error"
+>("idle");
+const internalErrorMsg$ = state("");
+
+// Exported reads
+export const slackConnectStatus$ = computed((get) => get(internalStatus$));
+
+// Derived state combining URL params and signals
+export const effectiveStatus$ = computed((get) => {
+  const params = get(searchParams$);
+  const initialStatus = params.get("status");
+  const initialError = params.get("error");
+  const status = get(internalStatus$);
+  return initialStatus === "connected"
+    ? "success"
+    : initialError
+      ? "error"
+      : status;
+});
+
+export const effectiveError$ = computed((get) => {
+  const params = get(searchParams$);
+  return params.get("error") ?? get(internalErrorMsg$);
+});
+
+// Reset state (called from setupSlackConnectPage$)
+export const resetSlackConnectState$ = command(({ set }) => {
+  set(internalStatus$, "idle");
+  set(internalErrorMsg$, "");
+});
+
+// Init: check connection on page load
+export const initSlackConnectPage$ = command(async ({ get, set }) => {
+  const params = get(searchParams$);
+  const workspaceId = params.get("w");
+  const initialStatus = params.get("status");
+  const initialError = params.get("error");
+
+  if (!initialStatus && !initialError && workspaceId) {
+    set(internalStatus$, "checking");
+    const fetchFn = await get(fetch$);
+    const res = await fetchFn("/api/zero/integrations/slack/connect");
+    if (res.ok) {
+      const data = (await res.json()) as { isConnected?: boolean };
+      if (data.isConnected) {
+        set(internalStatus$, "success");
+        return;
+      }
+    }
+    set(internalStatus$, "idle");
+  }
+
+  if (initialStatus === "connected") {
+    window.location.href = "slack://open";
+  }
+});
+
+// Connect account
+export const connectSlackAccount$ = command(async ({ get, set }) => {
+  const params = get(searchParams$);
+  const workspaceId = params.get("w");
+  const slackUserId = params.get("u");
+  if (!workspaceId || !slackUserId) {
+    return;
+  }
+
+  set(internalStatus$, "connecting");
+  const fetchFn = await get(fetch$);
+  const channelId = params.get("c");
+  const threadTs = params.get("t");
+  const res = await fetchFn("/api/zero/integrations/slack/connect", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      workspaceId,
+      slackUserId,
+      ...(channelId ? { channelId } : {}),
+      ...(threadTs ? { threadTs } : {}),
+    }),
+  });
+
+  if (res.ok) {
+    set(internalStatus$, "success");
+    window.location.href = "slack://open";
+  } else {
+    const body = (await res.json().catch(() => ({}))) as {
+      error?: { message?: string };
+    };
+    set(
+      internalErrorMsg$,
+      body.error?.message ?? "Failed to connect. Please try again.",
+    );
+    set(internalStatus$, "error");
+  }
+});

--- a/turbo/apps/platform/src/views/zero-page/zero-slack-connect-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-slack-connect-page.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable ccstate/no-use-ccstate-in-views */
-import { useCCState, useCommand } from "ccstate-react/experimental";
 import { useGet, useSet } from "ccstate-react";
 import {
   IconBrandSlack,
@@ -9,9 +7,15 @@ import {
   IconArrowLeft,
 } from "@tabler/icons-react";
 import { Button } from "@vm0/ui";
-import { fetch$ } from "../../signals/fetch.ts";
-import { detach, onRef, Reason } from "../../signals/utils.ts";
+import { detach, Reason } from "../../signals/utils.ts";
 import { Link } from "../router/link.tsx";
+import { searchParams$ } from "../../signals/route.ts";
+import {
+  slackConnectStatus$,
+  effectiveStatus$,
+  effectiveError$,
+  connectSlackAccount$,
+} from "../../signals/zero-page/slack-connect-signals.ts";
 
 function BackLink() {
   return (
@@ -36,102 +40,27 @@ function BackLink() {
  * - error: error message to display
  */
 export function ZeroSlackConnectPage() {
-  const fetchFn = useGet(fetch$);
-  const status$ = useCCState<
-    "idle" | "checking" | "connecting" | "success" | "error"
-  >("idle");
-  const status = useGet(status$);
-  const setStatus = useSet(status$);
-  const errorMsg$ = useCCState("");
-  const errorMsg = useGet(errorMsg$);
-  const setErrorMsg = useSet(errorMsg$);
-
-  const params = new URLSearchParams(window.location.search);
+  const params = useGet(searchParams$);
   const workspaceId = params.get("w");
   const slackUserId = params.get("u");
-  const initialStatus = params.get("status");
-  const initialError = params.get("error");
   const workspaceName = params.get("workspace");
 
-  // Check connection on mount + auto-redirect on initial success
-  const initPage$ = useCommand(({ set }) => {
-    if (!initialStatus && !initialError && workspaceId) {
-      set(status$, "checking");
-      detach(
-        (async () => {
-          const res = await fetchFn("/api/zero/integrations/slack/connect");
-          if (res.ok) {
-            const data = (await res.json()) as { isConnected?: boolean };
-            if (data.isConnected) {
-              set(status$, "success");
-              return;
-            }
-          }
-          set(status$, "idle");
-        })(),
-        Reason.DomCallback,
-      );
-    }
-    // Auto-open Slack when arriving with status=connected (post-install redirect)
-    if (initialStatus === "connected") {
-      window.location.href = "slack://open";
-    }
-  });
-  const initRef$ = onRef(initPage$);
-  const initRef = useSet(initRef$);
+  const status = useGet(slackConnectStatus$);
+  const eStatus = useGet(effectiveStatus$);
+  const eError = useGet(effectiveError$);
 
-  const effectiveStatus =
-    initialStatus === "connected" ? "success" : initialError ? "error" : status;
-  const effectiveError = initialError ?? errorMsg;
-
+  const connect = useSet(connectSlackAccount$);
   const handleConnect = () => {
-    if (!workspaceId || !slackUserId) {
-      return;
-    }
-    setStatus("connecting");
-
-    detach(
-      (async () => {
-        const channelId = params.get("c");
-        const threadTs = params.get("t");
-        const res = await fetchFn("/api/zero/integrations/slack/connect", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            workspaceId,
-            slackUserId,
-            ...(channelId ? { channelId } : {}),
-            ...(threadTs ? { threadTs } : {}),
-          }),
-        });
-
-        if (res.ok) {
-          setStatus("success");
-          window.location.href = "slack://open";
-        } else {
-          const body = (await res.json().catch(() => ({}))) as {
-            error?: { message?: string };
-          };
-          setErrorMsg(
-            body.error?.message ?? "Failed to connect. Please try again.",
-          );
-          setStatus("error");
-        }
-      })(),
-      Reason.DomCallback,
-    );
+    detach(connect(), Reason.DomCallback);
   };
 
   return (
-    <div
-      ref={initRef}
-      className="zero-app flex h-dvh w-full bg-background zero-workspace-bg"
-    >
+    <div className="zero-app flex h-dvh w-full bg-background zero-workspace-bg">
       <div className="flex flex-1 items-center justify-center p-4">
         <div className="zero-card w-full max-w-sm rounded-xl border border-border bg-card p-5 sm:p-8 flex flex-col items-center gap-6">
           <PageContent
-            effectiveStatus={effectiveStatus}
-            effectiveError={effectiveError}
+            effectiveStatus={eStatus}
+            effectiveError={eError}
             workspaceName={workspaceName}
             workspaceId={workspaceId}
             slackUserId={slackUserId}


### PR DESCRIPTION
## Summary
- Extract inline `useCCState` and `useCommand` from the Slack connect page view into a dedicated signals file (`slack-connect-signals.ts`)
- Move `onRef`-based init logic to `setupSlackConnectPage$` in the route setup layer, eliminating unnecessary ref forwarding
- Remove `eslint-disable ccstate/no-use-ccstate-in-views` comment and `ccstate-react/experimental` import
- Add MSW handler for `/api/zero/integrations/slack/connect` and 9 integration tests covering init, effective status derivation, and connect flows

Closes #5803

## Test plan
- [x] 9 new integration tests for slack connect page signals
- [x] All existing tests pass (3904 tests across the suite)
- [x] Lint passes (oxlint + eslint)
- [x] Type check passes
- [x] Knip passes (no unused exports/dependencies)

🤖 Generated with [Claude Code](https://claude.com/claude-code)