### PR TITLE
refactor: remove ccstate-react/experimental from zero-send-key.ts

### DIFF
--- a/turbo/apps/platform/src/signals/send-mode.ts
+++ b/turbo/apps/platform/src/signals/send-mode.ts
@@ -1,4 +1,4 @@
-import { computed } from "ccstate";
+import { computed, state, command } from "ccstate";
 import type { SendMode } from "@vm0/core";
 import { notificationPreferences$ } from "./zero-page/settings/notification-settings.ts";
 
@@ -6,4 +6,18 @@ import { notificationPreferences$ } from "./zero-page/settings/notification-sett
 export const sendMode$ = computed(async (get): Promise<SendMode> => {
   const prefs = await get(notificationPreferences$);
   return prefs.sendMode ?? "enter";
+});
+
+/** Whether an IME composition session is active in the chat composer. */
+const internalComposing$ = state(false);
+export const composing$ = computed((get) => get(internalComposing$));
+
+/** Mark IME composition as started. */
+export const compositionStart$ = command(({ set }) => {
+  set(internalComposing$, true);
+});
+
+/** Mark IME composition as ended. */
+export const compositionEnd$ = command(({ set }) => {
+  set(internalComposing$, false);
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-send-key.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-send-key.test.tsx
@@ -1,0 +1,161 @@
+import { describe, expect, it, vi } from "vitest";
+import { screen, waitFor, fireEvent, act } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../mocks/server.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { setupPage } from "../../../__tests__/page-helper.ts";
+
+const context = testContext();
+
+const PLACEHOLDER = "Ask me to automate workflows, manage tasks...";
+
+function mockChatAPI() {
+  server.use(
+    http.get("*/api/zero/chat-threads", () => {
+      return HttpResponse.json({ threads: [] });
+    }),
+  );
+}
+
+function mockSendMode(mode: "enter" | "cmd-enter") {
+  server.use(
+    http.get("*/api/zero/user-preferences", () => {
+      return HttpResponse.json({
+        timezone: null,
+        notifyEmail: false,
+        notifySlack: false,
+        pinnedAgentIds: [],
+        sendMode: mode,
+      });
+    }),
+  );
+}
+
+async function renderChatPage(sendMode: "enter" | "cmd-enter" = "enter") {
+  mockChatAPI();
+  mockSendMode(sendMode);
+  await setupPage({ context, path: "/" });
+}
+
+async function getTextarea(): Promise<HTMLTextAreaElement> {
+  return waitFor(
+    () => screen.getByPlaceholderText(PLACEHOLDER) as HTMLTextAreaElement,
+  );
+}
+
+describe("send-key behavior — enter mode", () => {
+  it("should send when Enter is pressed", async () => {
+    await renderChatPage("enter");
+
+    const textarea = await getTextarea();
+    fireEvent.change(textarea, { target: { value: "Hello" } });
+
+    const preventDefault = vi.fn();
+    await act(async () => {
+      textarea.dispatchEvent(
+        Object.assign(
+          new KeyboardEvent("keydown", { key: "Enter", bubbles: true }),
+          {
+            preventDefault,
+          },
+        ),
+      );
+    });
+
+    expect(preventDefault).toHaveBeenCalled();
+  });
+
+  it("should not send when Shift+Enter is pressed", async () => {
+    await renderChatPage("enter");
+
+    const textarea = await getTextarea();
+    fireEvent.change(textarea, { target: { value: "Hello" } });
+
+    const preventDefault = vi.fn();
+    await act(async () => {
+      textarea.dispatchEvent(
+        Object.assign(
+          new KeyboardEvent("keydown", {
+            key: "Enter",
+            shiftKey: true,
+            bubbles: true,
+          }),
+          { preventDefault },
+        ),
+      );
+    });
+
+    expect(preventDefault).not.toHaveBeenCalled();
+  });
+});
+
+describe("send-key behavior — cmd-enter mode", () => {
+  it("should send when Cmd+Enter is pressed", async () => {
+    await renderChatPage("cmd-enter");
+
+    const textarea = await getTextarea();
+    fireEvent.change(textarea, { target: { value: "Hello" } });
+
+    const preventDefault = vi.fn();
+    await act(async () => {
+      textarea.dispatchEvent(
+        Object.assign(
+          new KeyboardEvent("keydown", {
+            key: "Enter",
+            metaKey: true,
+            bubbles: true,
+          }),
+          { preventDefault },
+        ),
+      );
+    });
+
+    expect(preventDefault).toHaveBeenCalled();
+  });
+
+  it("should not send when plain Enter is pressed", async () => {
+    await renderChatPage("cmd-enter");
+
+    const textarea = await getTextarea();
+    fireEvent.change(textarea, { target: { value: "Hello" } });
+
+    const preventDefault = vi.fn();
+    await act(async () => {
+      textarea.dispatchEvent(
+        Object.assign(
+          new KeyboardEvent("keydown", { key: "Enter", bubbles: true }),
+          { preventDefault },
+        ),
+      );
+    });
+
+    expect(preventDefault).not.toHaveBeenCalled();
+  });
+});
+
+describe("send-key behavior — IME composition", () => {
+  it("should not send during IME composition even when Enter is pressed", async () => {
+    await renderChatPage("enter");
+
+    const textarea = await getTextarea();
+    fireEvent.change(textarea, { target: { value: "Hello" } });
+
+    // Start IME composition
+    fireEvent.compositionStart(textarea);
+
+    const preventDefault = vi.fn();
+    await act(async () => {
+      textarea.dispatchEvent(
+        Object.assign(
+          new KeyboardEvent("keydown", { key: "Enter", bubbles: true }),
+          { preventDefault },
+        ),
+      );
+    });
+
+    expect(preventDefault).not.toHaveBeenCalled();
+
+    // End IME composition
+    fireEvent.compositionEnd(textarea);
+  });
+});

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-send-key.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-send-key.test.tsx
@@ -37,7 +37,7 @@ async function renderChatPage(sendMode: "enter" | "cmd-enter" = "enter") {
   await setupPage({ context, path: "/" });
 }
 
-async function getTextarea(): Promise<HTMLTextAreaElement> {
+function getTextarea(): Promise<HTMLTextAreaElement> {
   return waitFor(
     () => screen.getByPlaceholderText(PLACEHOLDER) as HTMLTextAreaElement,
   );
@@ -51,7 +51,7 @@ describe("send-key behavior — enter mode", () => {
     fireEvent.change(textarea, { target: { value: "Hello" } });
 
     const preventDefault = vi.fn();
-    await act(async () => {
+    act(() => {
       textarea.dispatchEvent(
         Object.assign(
           new KeyboardEvent("keydown", { key: "Enter", bubbles: true }),
@@ -62,7 +62,7 @@ describe("send-key behavior — enter mode", () => {
       );
     });
 
-    expect(preventDefault).toHaveBeenCalled();
+    expect(preventDefault).toHaveBeenCalledWith();
   });
 
   it("should not send when Shift+Enter is pressed", async () => {
@@ -72,7 +72,7 @@ describe("send-key behavior — enter mode", () => {
     fireEvent.change(textarea, { target: { value: "Hello" } });
 
     const preventDefault = vi.fn();
-    await act(async () => {
+    act(() => {
       textarea.dispatchEvent(
         Object.assign(
           new KeyboardEvent("keydown", {
@@ -97,7 +97,7 @@ describe("send-key behavior — cmd-enter mode", () => {
     fireEvent.change(textarea, { target: { value: "Hello" } });
 
     const preventDefault = vi.fn();
-    await act(async () => {
+    act(() => {
       textarea.dispatchEvent(
         Object.assign(
           new KeyboardEvent("keydown", {
@@ -110,7 +110,7 @@ describe("send-key behavior — cmd-enter mode", () => {
       );
     });
 
-    expect(preventDefault).toHaveBeenCalled();
+    expect(preventDefault).toHaveBeenCalledWith();
   });
 
   it("should not send when plain Enter is pressed", async () => {
@@ -120,7 +120,7 @@ describe("send-key behavior — cmd-enter mode", () => {
     fireEvent.change(textarea, { target: { value: "Hello" } });
 
     const preventDefault = vi.fn();
-    await act(async () => {
+    act(() => {
       textarea.dispatchEvent(
         Object.assign(
           new KeyboardEvent("keydown", { key: "Enter", bubbles: true }),
@@ -144,7 +144,7 @@ describe("send-key behavior — IME composition", () => {
     fireEvent.compositionStart(textarea);
 
     const preventDefault = vi.fn();
-    await act(async () => {
+    act(() => {
       textarea.dispatchEvent(
         Object.assign(
           new KeyboardEvent("keydown", { key: "Enter", bubbles: true }),

--- a/turbo/apps/platform/src/views/zero-page/zero-send-key.ts
+++ b/turbo/apps/platform/src/views/zero-page/zero-send-key.ts
@@ -1,8 +1,11 @@
-/* eslint-disable ccstate/no-use-ccstate-in-views */
 import type { KeyboardEvent } from "react";
 import { useGet, useSet, useLastLoadable } from "ccstate-react";
-import { useCCState } from "ccstate-react/experimental";
-import { sendMode$ } from "../../signals/send-mode.ts";
+import {
+  sendMode$,
+  composing$,
+  compositionStart$,
+  compositionEnd$,
+} from "../../signals/send-mode.ts";
 import type { SendMode } from "@vm0/core";
 
 /**
@@ -22,17 +25,9 @@ import type { SendMode } from "@vm0/core";
 export function useSendKeyHandler(onSend: () => void) {
   const loadable = useLastLoadable(sendMode$);
   const mode: SendMode = loadable.state === "hasData" ? loadable.data : "enter";
-  const composing$ = useCCState(false);
   const composing = useGet(composing$);
-  const setComposing = useSet(composing$);
-
-  const onCompositionStart = () => {
-    setComposing(true);
-  };
-
-  const onCompositionEnd = () => {
-    setComposing(false);
-  };
+  const onCompositionStart = useSet(compositionStart$);
+  const onCompositionEnd = useSet(compositionEnd$);
 
   const onKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
     if (composing || e.nativeEvent.isComposing) {


### PR DESCRIPTION
## Summary

- Move IME composing state from `ccstate-react/experimental` `useCCState` to a standard `state`/`computed`/`command` pattern in `send-mode.ts`
- Remove the `eslint-disable ccstate/no-use-ccstate-in-views` comment from `zero-send-key.ts`
- Add integration tests for send-key behavior covering Enter/Shift+Enter/Cmd+Enter modes and IME composition blocking

## Test plan

- [x] All 5 new send-key integration tests pass
- [x] Lint passes (`pnpm turbo run lint`)
- [x] Type check passes (`pnpm check-types`)
- [x] Knip passes (no unused exports)
- [x] Format passes (`pnpm format`)

Closes #5817

🤖 Generated with [Claude Code](https://claude.com/claude-code)