### PR TITLE
refactor: remove ccstate-react/experimental from zero-sidebar.tsx

### DIFF
--- a/scripts/next-issue.sh
+++ b/scripts/next-issue.sh
@@ -35,8 +35,8 @@ ISSUE=$(gh issue list --repo "$REPO" --label "$LABEL" --assignee "$ME" --state o
 ISSUE_NUMBER=$(echo "$ISSUE" | jq -r '.number')
 
 # Verify no open PR already covers this issue
-OPEN_PR=$(gh pr list --repo "$REPO" --state open --json number,title --limit 100 \
-  --jq --arg num "#${ISSUE_NUMBER}" '[.[] | select(.title | contains($num))] | length')
+OPEN_PR=$(gh pr list --repo "$REPO" --state open --json number,title --limit 100 | \
+  jq --arg num "#${ISSUE_NUMBER}" '[.[] | select(.title | contains($num))] | length')
 
 if [[ "$OPEN_PR" -gt 0 ]]; then
   exit 0

--- a/turbo/apps/platform/src/signals/zero-page/zero-sidebar-state.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-sidebar-state.ts
@@ -1,0 +1,41 @@
+import { command, computed, state } from "ccstate";
+
+// ---------------------------------------------------------------------------
+// Sidebar search state
+// ---------------------------------------------------------------------------
+const internalSearchOpen$ = state(false);
+export const sidebarSearchOpen$ = computed((get) => get(internalSearchOpen$));
+
+const internalSearchTerm$ = state("");
+export const sidebarSearchTerm$ = computed((get) => get(internalSearchTerm$));
+
+export const setSidebarSearchOpen$ = command(({ set }, open: boolean) => {
+  set(internalSearchOpen$, open);
+  if (!open) {
+    set(internalSearchTerm$, "");
+  }
+});
+
+export const setSidebarSearchTerm$ = command(({ set }, term: string) => {
+  set(internalSearchTerm$, term);
+});
+
+// ---------------------------------------------------------------------------
+// Manage pinned agents dialog state
+// ---------------------------------------------------------------------------
+const internalManagePinnedOpen$ = state(false);
+export const managePinnedDialogOpen$ = computed((get) =>
+  get(internalManagePinnedOpen$),
+);
+export const setManagePinnedDialogOpen$ = command(({ set }, open: boolean) => {
+  set(internalManagePinnedOpen$, open);
+});
+
+// ---------------------------------------------------------------------------
+// Draft pinned IDs (for dialog editing before save)
+// ---------------------------------------------------------------------------
+const internalDraftPinnedIds$ = state<string[]>([]);
+export const draftPinnedIds$ = computed((get) => get(internalDraftPinnedIds$));
+export const setDraftPinnedIds$ = command(({ set }, ids: string[]) => {
+  set(internalDraftPinnedIds$, ids);
+});

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
@@ -1,11 +1,61 @@
 import { describe, expect, it } from "vitest";
 import { testContext } from "../../../signals/__tests__/test-helpers";
 import { setupPage } from "../../../__tests__/page-helper";
-import { screen } from "@testing-library/react";
+import { act, screen, waitFor, fireEvent } from "@testing-library/react";
 import { featureSwitch$ } from "../../../signals/external/feature-switch";
 import { FeatureSwitchKey } from "@vm0/core";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../mocks/server.ts";
 
 const context = testContext();
+
+function mockAPIs({
+  threads = [
+    {
+      id: "thread-1",
+      title: "First chat",
+      preview: "Hello world",
+      createdAt: "2026-03-10T00:00:00Z",
+      updatedAt: "2026-03-10T00:00:00Z",
+    },
+    {
+      id: "thread-2",
+      title: "Second chat",
+      preview: "Goodbye moon",
+      createdAt: "2026-03-09T00:00:00Z",
+      updatedAt: "2026-03-09T00:00:00Z",
+    },
+  ],
+}: {
+  threads?: {
+    id: string;
+    title: string;
+    preview: string;
+    createdAt: string;
+    updatedAt: string;
+  }[];
+} = {}) {
+  server.use(
+    http.get("*/api/zero/team", () => {
+      return HttpResponse.json({
+        composes: [
+          {
+            id: "mock-compose-id",
+            name: "zero",
+            displayName: null,
+            description: null,
+            headVersionId: "version_1",
+            updatedAt: "2024-01-01T00:00:00Z",
+            isOwner: true,
+          },
+        ],
+      });
+    }),
+    http.get("*/api/zero/chat-threads", () => {
+      return HttpResponse.json({ threads });
+    }),
+  );
+}
 
 describe("zero sidebar", () => {
   it("should render clerk org switcher", async () => {
@@ -37,5 +87,68 @@ describe("zero sidebar", () => {
 
     const features = await context.store.get(featureSwitch$);
     expect(features[FeatureSwitchKey.DataExport]).toBeFalsy();
+  });
+
+  it("should filter chat sessions when searching", async () => {
+    mockAPIs();
+    await setupPage({ context, path: "/" });
+
+    // Wait for chat threads to render
+    await waitFor(() => {
+      expect(screen.getByText("Hello world")).toBeInTheDocument();
+    });
+    expect(screen.getByText("Goodbye moon")).toBeInTheDocument();
+
+    // Click search button
+    const searchButton = screen.getByRole("button", { name: "Search chats" });
+    await act(() => {
+      searchButton.click();
+    });
+
+    // Type search query
+    const searchInput = screen.getByPlaceholderText("Search chats...");
+    await act(() => {
+      fireEvent.change(searchInput, { target: { value: "Hello" } });
+    });
+
+    // Only matching thread should be visible
+    expect(screen.getByText("Hello world")).toBeInTheDocument();
+    expect(screen.queryByText("Goodbye moon")).not.toBeInTheDocument();
+  });
+
+  it("should close search and reset filter", async () => {
+    mockAPIs();
+    await setupPage({ context, path: "/" });
+
+    // Wait for chat threads to render
+    await waitFor(() => {
+      expect(screen.getByText("Hello world")).toBeInTheDocument();
+    });
+
+    // Open search
+    const searchButton = screen.getByRole("button", { name: "Search chats" });
+    await act(() => {
+      searchButton.click();
+    });
+
+    // Type search query that filters out one thread
+    const searchInput = screen.getByPlaceholderText("Search chats...");
+    await act(() => {
+      fireEvent.change(searchInput, { target: { value: "Hello" } });
+    });
+
+    expect(screen.queryByText("Goodbye moon")).not.toBeInTheDocument();
+
+    // Close search
+    const closeButton = screen.getByRole("button", { name: "Close search" });
+    await act(() => {
+      closeButton.click();
+    });
+
+    // Both threads should be visible again (search term was reset)
+    await waitFor(() => {
+      expect(screen.getByText("Hello world")).toBeInTheDocument();
+    });
+    expect(screen.getByText("Goodbye moon")).toBeInTheDocument();
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable ccstate/no-use-ccstate-in-views */
 import type { ReactNode } from "react";
 import {
   useLoadable,
@@ -7,7 +6,6 @@ import {
   useGet,
   useSet,
 } from "ccstate-react";
-import { useCCState } from "ccstate-react/experimental";
 import {
   IconChartLine,
   IconLayoutGrid,
@@ -102,6 +100,16 @@ import {
   savingPinnedAgents$,
   updatePinnedAgentIds$,
 } from "../../signals/zero-page/zero-pinned-agents.ts";
+import {
+  sidebarSearchOpen$,
+  sidebarSearchTerm$,
+  setSidebarSearchOpen$,
+  setSidebarSearchTerm$,
+  managePinnedDialogOpen$,
+  setManagePinnedDialogOpen$,
+  draftPinnedIds$,
+  setDraftPinnedIds$,
+} from "../../signals/zero-page/zero-sidebar-state.ts";
 import { VM0ClerkProvider } from "../clerk/clerk-provider.tsx";
 import { ClerkOrgSwitcher } from "./clerk-org-switcher.tsx";
 import { agentAvatarOverrides$ } from "../../signals/zero-page/zero-agent-avatars.ts";
@@ -509,12 +517,10 @@ function RecentChatSection({
   selectedRecentId: string | null;
   onRecentSelect?: (id: string) => void;
 }) {
-  const searchOpen$ = useCCState(false);
-  const searchOpen = useGet(searchOpen$);
-  const setSearchOpen = useSet(searchOpen$);
-  const searchTerm$ = useCCState("");
-  const searchTerm = useGet(searchTerm$);
-  const setSearchTerm = useSet(searchTerm$);
+  const searchOpen = useGet(sidebarSearchOpen$);
+  const setSearchOpen = useSet(setSidebarSearchOpen$);
+  const searchTerm = useGet(sidebarSearchTerm$);
+  const setSearchTerm = useSet(setSidebarSearchTerm$);
 
   const trimmedTerm = searchTerm.trim().toLowerCase();
   const filteredSessions = trimmedTerm
@@ -532,7 +538,6 @@ function RecentChatSection({
           onBlur={(e) => {
             if (!e.currentTarget.contains(e.relatedTarget)) {
               setSearchOpen(false);
-              setSearchTerm("");
             }
           }}
         >
@@ -553,7 +558,6 @@ function RecentChatSection({
             type="button"
             onClick={() => {
               setSearchOpen(false);
-              setSearchTerm("");
             }}
             className="shrink-0 flex items-center justify-center h-5 w-5 rounded text-sidebar-foreground/50 hover:text-sidebar-foreground hover:bg-sidebar-accent transition-colors"
             aria-label="Close search"
@@ -681,7 +685,6 @@ function ManagePinnedAgentsDialog({
   zeroAvatarSrc,
   displayName,
   subagents,
-  pinnedIds,
   onPinnedIdsChange,
   saving = false,
 }: {
@@ -691,12 +694,10 @@ function ManagePinnedAgentsDialog({
   zeroAvatarSrc: string;
   displayName: string;
   subagents: SubagentInfo[];
-  pinnedIds: string[];
   onPinnedIdsChange: (ids: string[]) => void;
 }) {
-  const draftIds$ = useCCState(pinnedIds);
-  const draftIds = useGet(draftIds$);
-  const setDraftIds = useSet(draftIds$);
+  const draftIds = useGet(draftPinnedIds$);
+  const setDraftIds = useSet(setDraftPinnedIds$);
 
   const orderedPinned = draftIds
     .map((id) => subagents.find((a) => a.id === id))
@@ -1031,9 +1032,9 @@ export function ZeroSidebar() {
   const setPinnedIds = (ids: string[]) => {
     detach(savePinnedIds(ids), Reason.DomCallback);
   };
-  const managePinnedOpen$ = useCCState(false);
-  const managePinnedOpen = useGet(managePinnedOpen$);
-  const setManagePinnedOpen = useSet(managePinnedOpen$);
+  const managePinnedOpen = useGet(managePinnedDialogOpen$);
+  const setManagePinnedOpen = useSet(setManagePinnedDialogOpen$);
+  const initDraftPinnedIds = useSet(setDraftPinnedIds$);
 
   // Billing
   const features = useLastResolved(featureSwitch$);
@@ -1202,7 +1203,10 @@ export function ZeroSidebar() {
             defaultAgentRawName={defaultAgentRawName}
             zeroAvatarSrc={zeroAvatarSrc}
             pinnedAgents={pinnedAgents}
-            onManagePinned={() => setManagePinnedOpen(true)}
+            onManagePinned={() => {
+              initDraftPinnedIds(pinnedIds);
+              setManagePinnedOpen(true);
+            }}
           />
 
           {/* Recent chat sessions */}
@@ -1260,13 +1264,11 @@ export function ZeroSidebar() {
 
       {/* Manage pinned agents dialog */}
       <ManagePinnedAgentsDialog
-        key={managePinnedOpen ? "open" : "closed"}
         open={managePinnedOpen}
         onOpenChange={setManagePinnedOpen}
         zeroAvatarSrc={zeroAvatarSrc}
         displayName={displayName}
         subagents={subagents}
-        pinnedIds={pinnedIds}
         onPinnedIdsChange={setPinnedIds}
         saving={savingPinned}
       />


### PR DESCRIPTION
## Summary

Closes #5806

- Move 4 `useCCState` calls from `zero-sidebar.tsx` to proper `state()`/`computed()`/`command()` patterns in a new `zero-sidebar-state.ts` signals file
- Remove `eslint-disable ccstate/no-use-ccstate-in-views` comment and `ccstate-react/experimental` import
- Add integration tests for sidebar search filtering (open search, type query, verify filtering, close search and verify reset)
- Fix `scripts/next-issue.sh` jq arg passing bug

## Test plan

- [x] Existing sidebar tests pass (org switcher, feature switch, chat navigation)
- [x] New search filter test: opens search, types query, verifies only matching threads shown
- [x] New search close test: closes search, verifies all threads visible again (term reset)
- [x] Lint passes with no warnings
- [x] Type check passes
- [x] Knip finds no unused exports

🤖 Generated with [Claude Code](https://claude.com/claude-code)