### PR TITLE
refactor: remove ccstate-react/experimental from zero-skills-tab

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -144,6 +144,20 @@ export const setSelectedConnectorType$ = command(
 );
 
 // ---------------------------------------------------------------------------
+// Scope review modal state
+// ---------------------------------------------------------------------------
+
+const internalScopeReviewType$ = state<ConnectorType | null>(null);
+export const scopeReviewType$ = computed((get) =>
+  get(internalScopeReviewType$),
+);
+export const setScopeReviewType$ = command(
+  ({ set }, type: ConnectorType | null) => {
+    set(internalScopeReviewType$, type);
+  },
+);
+
+// ---------------------------------------------------------------------------
 // Token form state (used by add-connection dialog)
 // ---------------------------------------------------------------------------
 

--- a/turbo/apps/platform/src/views/zero-page/zero-skills-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-skills-tab.tsx
@@ -1,6 +1,4 @@
-/* eslint-disable ccstate/no-use-ccstate-in-views */
 import { useGet, useSet, useLastLoadable } from "ccstate-react";
-import { useCCState } from "ccstate-react/experimental";
 import { IconPlus } from "@tabler/icons-react";
 import type { ConnectorType } from "@vm0/core";
 import { skills$ } from "../../data/skills.ts";
@@ -14,6 +12,8 @@ import {
   setSelectedConnectorType$,
   pollingConnectorType$,
   justConnectedTypes$,
+  scopeReviewType$,
+  setScopeReviewType$,
 } from "../../signals/zero-page/settings/connectors.ts";
 import { deleteConnector$ } from "../../signals/external/connectors.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
@@ -59,9 +59,8 @@ export function ZeroSkillsTab({
   const selectedType = useGet(selectedConnectorType$);
   const setSelected = useSet(setSelectedConnectorType$);
 
-  const scopeReviewType$ = useCCState<ConnectorType | null>(null);
   const scopeReviewType = useGet(scopeReviewType$);
-  const setScopeReviewType = useSet(scopeReviewType$);
+  const setScopeReviewType = useSet(setScopeReviewType$);
 
   const allSkills = useGet(skills$);
 


### PR DESCRIPTION
## Summary
- Moves `scopeReviewType` state from inline `useCCState` (ccstate-react/experimental) to `state()` + `computed()` + `command()` in `signals/zero-page/settings/connectors.ts`
- Removes the `eslint-disable ccstate/no-use-ccstate-in-views` comment and `ccstate-react/experimental` import from `zero-skills-tab.tsx`
- Follows the project's strict signal-view separation pattern

## Test plan
- [x] All 16 existing tests pass (zero-skill-card.test.tsx + zero-skills.test.ts)
- [x] Lint passes with zero warnings
- [x] Knip reports no unused exports
- [x] Pre-commit hooks pass

Closes #5815

🤖 Generated with [Claude Code](https://claude.com/claude-code)