### PR TITLE
refactor: remove ccstate-react/experimental from zero-model-preference

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-model-preference.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-model-preference.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import { mockLocation, setPathname } from "../../location.ts";
+import { testContext } from "../../__tests__/test-helpers.ts";
+import { updatePathname$ } from "../../route.ts";
+import {
+  selectedModel$,
+  setSelectedModel$,
+  syncModelPreference$,
+  persistModelPreference$,
+} from "../zero-model-preference.ts";
+
+const context = testContext();
+
+describe("zero-model-preference signals", () => {
+  it("should default selectedModel to 'default'", () => {
+    expect(context.store.get(selectedModel$)).toBe("default");
+  });
+
+  it("should update selectedModel via setSelectedModel$", () => {
+    context.store.set(setSelectedModel$, "openai");
+    expect(context.store.get(selectedModel$)).toBe("openai");
+  });
+
+  it("should sync model preference from localStorage for current agent", () => {
+    mockLocation({ pathname: "/talk/my-agent", search: "" }, context.signal);
+    localStorage.setItem("zero.modelProvider.my-agent", "anthropic");
+
+    context.store.set(syncModelPreference$);
+
+    expect(context.store.get(selectedModel$)).toBe("anthropic");
+  });
+
+  it("should sync to 'default' when no localStorage entry exists", () => {
+    mockLocation({ pathname: "/talk/new-agent", search: "" }, context.signal);
+    // Set to something first
+    context.store.set(setSelectedModel$, "openai");
+
+    context.store.set(syncModelPreference$);
+
+    expect(context.store.get(selectedModel$)).toBe("default");
+  });
+
+  it("should use 'default' key when zeroChatAgentName is null", () => {
+    mockLocation({ pathname: "/", search: "" }, context.signal);
+    localStorage.setItem("zero.modelProvider.default", "anthropic");
+
+    context.store.set(syncModelPreference$);
+
+    expect(context.store.get(selectedModel$)).toBe("anthropic");
+  });
+
+  it("should persist model preference to localStorage", () => {
+    mockLocation({ pathname: "/talk/my-agent", search: "" }, context.signal);
+    context.store.set(setSelectedModel$, "openai");
+
+    context.store.set(persistModelPreference$);
+
+    expect(localStorage.getItem("zero.modelProvider.my-agent")).toBe("openai");
+  });
+
+  it("should remove localStorage entry when persisting 'default'", () => {
+    mockLocation({ pathname: "/talk/my-agent", search: "" }, context.signal);
+    localStorage.setItem("zero.modelProvider.my-agent", "openai");
+    context.store.set(setSelectedModel$, "default");
+
+    context.store.set(persistModelPreference$);
+
+    expect(localStorage.getItem("zero.modelProvider.my-agent")).toBeNull();
+  });
+
+  it("should reset model selection when agent changes via sync", () => {
+    // Agent-a has a saved preference; agent-b does not.
+    // Each sync should read localStorage for the current agent.
+    localStorage.setItem("zero.modelProvider.agent-a", "anthropic");
+
+    // Start on agent-a
+    mockLocation({ pathname: "/talk/agent-a", search: "" }, context.signal);
+    context.store.set(syncModelPreference$);
+    expect(context.store.get(selectedModel$)).toBe("anthropic");
+
+    // Navigate to agent-b — use setPathname + updatePathname$ to
+    // both update the override and trigger pathname$ recomputation.
+    setPathname("/talk/agent-b");
+    context.store.set(updatePathname$, "/talk/agent-b");
+
+    context.store.set(syncModelPreference$);
+    expect(context.store.get(selectedModel$)).toBe("default");
+  });
+});

--- a/turbo/apps/platform/src/signals/zero-page/zero-model-preference.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-model-preference.ts
@@ -1,0 +1,57 @@
+import { command, computed, state } from "ccstate";
+import { zeroChatAgentName$ } from "./zero-nav.ts";
+
+function readModelPreference(key: string): string {
+  if (typeof window === "undefined") {
+    return "default";
+  }
+  return localStorage.getItem(key) ?? "default";
+}
+
+function writeModelPreference(key: string, value: string) {
+  if (value === "default") {
+    localStorage.removeItem(key);
+  } else {
+    localStorage.setItem(key, value);
+  }
+}
+
+function modelStorageKey(agentName: string | null): string {
+  return `zero.modelProvider.${agentName ?? "default"}`;
+}
+
+// ---------------------------------------------------------------------------
+// State
+// ---------------------------------------------------------------------------
+
+const internalSelectedModel$ = state("default");
+
+/** Currently selected model provider for the active agent. */
+export const selectedModel$ = computed((get) => get(internalSelectedModel$));
+
+/** Set the selected model provider. */
+export const setSelectedModel$ = command(({ set }, value: string) => {
+  set(internalSelectedModel$, value);
+});
+
+/**
+ * Sync model preference from localStorage for the current agent.
+ * Called from setupZeroPage$ on each navigation — eliminates the
+ * prevAgentName + queueMicrotask pattern entirely.
+ */
+export const syncModelPreference$ = command(({ get, set }) => {
+  const agentName = get(zeroChatAgentName$);
+  const key = modelStorageKey(agentName);
+  set(internalSelectedModel$, readModelPreference(key));
+});
+
+/**
+ * Persist the current model selection to localStorage.
+ * Called before sending a message.
+ */
+export const persistModelPreference$ = command(({ get }) => {
+  const agentName = get(zeroChatAgentName$);
+  const key = modelStorageKey(agentName);
+  const value = get(internalSelectedModel$);
+  writeModelPreference(key, value);
+});

--- a/turbo/apps/platform/src/signals/zero-page/zero-page.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-page.ts
@@ -17,6 +17,7 @@ import {
   pinnedAgentIds$,
   updatePinnedAgentIds$,
 } from "./zero-pinned-agents.ts";
+import { syncModelPreference$ } from "./zero-model-preference.ts";
 import { logger } from "../log.ts";
 import { pathname$ } from "../route.ts";
 import { Reason, detach } from "../utils.ts";
@@ -125,5 +126,8 @@ export const setupZeroPage$ = command(
     set(refreshScheduleIfActive$);
 
     await resolveAndSwitchAgent(get, set, signal);
+
+    // Reset model selection for the (possibly new) active agent
+    set(syncModelPreference$);
   },
 );

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -381,7 +381,7 @@ export function ZeroChatComposer({
 
   // Model selection
   const { modelOptions, selectedModel, setSelectedModel, persistSelection } =
-    useModelSelection(agentName);
+    useModelSelection();
 
   // Connectors
   const allTypesLoadable = useLastLoadable(allConnectorTypes$);

--- a/turbo/apps/platform/src/views/zero-page/zero-model-preference.ts
+++ b/turbo/apps/platform/src/views/zero-page/zero-model-preference.ts
@@ -1,29 +1,18 @@
-/* eslint-disable ccstate/no-use-ccstate-in-views */
 import { useGet, useSet, useLastLoadable } from "ccstate-react";
-import { useCCState } from "ccstate-react/experimental";
 import { MODEL_PROVIDER_TYPES } from "@vm0/core";
 import { orgModelProviders$ } from "../../signals/external/org-model-providers.ts";
-
-function readModelPreference(key: string): string {
-  if (typeof window === "undefined") {
-    return "default";
-  }
-  return localStorage.getItem(key) ?? "default";
-}
-
-function writeModelPreference(key: string, value: string) {
-  if (value === "default") {
-    localStorage.removeItem(key);
-  } else {
-    localStorage.setItem(key, value);
-  }
-}
+import {
+  selectedModel$,
+  setSelectedModel$,
+  persistModelPreference$,
+} from "../../signals/zero-page/zero-model-preference.ts";
 
 /**
- * Hook for managing model selection state with agent-change reset.
- * Returns the current selected model, a setter, and a handler to persist on send.
+ * Hook for managing model selection state.
+ * State lives in the signals layer; the view only reads/writes.
+ * Agent-change reset is handled by syncModelPreference$ in setupZeroPage$.
  */
-export function useModelSelection(agentName: string) {
+export function useModelSelection() {
   const modelProvidersLoadable = useLastLoadable(orgModelProviders$);
   const configuredProviders =
     modelProvidersLoadable.state === "hasData"
@@ -37,25 +26,9 @@ export function useModelSelection(agentName: string) {
     })),
   ];
 
-  const modelStorageKey = `zero.modelProvider.${agentName}`;
-  const selectedModel$ = useCCState(readModelPreference(modelStorageKey));
   const selectedModel = useGet(selectedModel$);
-  const setSelectedModel = useSet(selectedModel$);
-
-  // Reset model selection when agent changes
-  const prevAgentName$ = useCCState(agentName);
-  const prevAgentName = useGet(prevAgentName$);
-  const setPrevAgentName = useSet(prevAgentName$);
-  if (agentName !== prevAgentName) {
-    queueMicrotask(() => {
-      setPrevAgentName(agentName);
-      setSelectedModel(readModelPreference(`zero.modelProvider.${agentName}`));
-    });
-  }
-
-  const persistSelection = () => {
-    writeModelPreference(modelStorageKey, selectedModel);
-  };
+  const setSelectedModel = useSet(setSelectedModel$);
+  const persistSelection = useSet(persistModelPreference$);
 
   return {
     modelOptions,


### PR DESCRIPTION
## Summary

- Moves model selection state from view-local `useCCState` to the signals layer (`signals/zero-page/zero-model-preference.ts`) using `state()` / `computed()` / `command()`
- Eliminates the `prevAgentName` + `queueMicrotask` render-phase side effect by calling `syncModelPreference$` from `setupZeroPage$` on each navigation
- Removes `ccstate-react/experimental` import and `eslint-disable` comment from the view file
- The `useModelSelection` hook no longer needs an `agentName` parameter — the signals layer reads `zeroChatAgentName$` directly

Closes #5816

## Test plan

- [x] Added 8 signal-level integration tests covering sync, persist, reset on agent change
- [x] All 442 existing platform tests pass
- [x] Lint, type check, knip all pass
- [ ] Verify model dropdown renders and resets correctly when switching agents in the browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)