### PR TITLE
refactor: remove ccstate-react/experimental from add-connection-dialog

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -130,6 +130,33 @@ export const setAddConnectionDialogTab$ = command(
 );
 
 // ---------------------------------------------------------------------------
+// Zero variant: add connection dialog search & tab state
+// ---------------------------------------------------------------------------
+
+const internalZeroDialogSearch$ = state("");
+export const zeroDialogSearch$ = computed((get) =>
+  get(internalZeroDialogSearch$),
+);
+export const setZeroDialogSearch$ = command(({ set }, search: string) => {
+  set(internalZeroDialogSearch$, search);
+});
+
+const internalZeroDialogTab$ = state<"not-connected" | "connected">(
+  "not-connected",
+);
+export const zeroDialogTab$ = computed((get) => get(internalZeroDialogTab$));
+export const setZeroDialogTab$ = command(
+  ({ set }, tab: "not-connected" | "connected") => {
+    set(internalZeroDialogTab$, tab);
+  },
+);
+
+export const resetZeroDialogState$ = command(({ set }) => {
+  set(internalZeroDialogSearch$, "");
+  set(internalZeroDialogTab$, "not-connected");
+});
+
+// ---------------------------------------------------------------------------
 // Selected connector for connect modal
 // ---------------------------------------------------------------------------
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-add-connection-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-add-connection-dialog.test.tsx
@@ -1,0 +1,169 @@
+import { describe, expect, it } from "vitest";
+import { screen, waitFor, fireEvent } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../mocks/server.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { setupPage } from "../../../__tests__/page-helper.ts";
+import {
+  CONNECTOR_TYPES,
+  type ConnectorResponse,
+  type ConnectorType,
+} from "@vm0/core";
+
+const context = testContext();
+
+function makeConnector(
+  overrides: Partial<ConnectorResponse> & { type: ConnectorType },
+): ConnectorResponse {
+  return {
+    id: `conn-${overrides.type}`,
+    authMethod: "oauth",
+    externalId: null,
+    externalUsername: null,
+    externalEmail: null,
+    oauthScopes: null,
+    needsReconnect: false,
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function mockConnectors(connectors: ConnectorResponse[]) {
+  server.use(
+    http.get("*/api/zero/connectors", () => {
+      return HttpResponse.json({
+        connectors,
+        configuredTypes: Object.keys(CONNECTOR_TYPES),
+        connectorProvidedSecretNames: [],
+      });
+    }),
+  );
+}
+
+async function renderTeamPage(skills: string[]) {
+  server.use(
+    http.get("*/api/zero/composes", () => {
+      return HttpResponse.json({
+        id: "compose-1",
+        name: "zero",
+        headVersionId: "version_1",
+        content: {
+          version: "1",
+          agents: { zero: { framework: "claude-code", skills } },
+        },
+        createdAt: "2024-01-01T00:00:00Z",
+        updatedAt: "2024-01-01T00:00:00Z",
+      });
+    }),
+  );
+
+  await setupPage({ context, path: "/team/zero" });
+}
+
+async function openAddConnectorDialog() {
+  const addButton = await waitFor(() =>
+    screen.getByRole("button", { name: /Add connector/i }),
+  );
+  fireEvent.click(addButton);
+  await waitFor(() => {
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+  });
+}
+
+describe("zero add connection dialog", () => {
+  it("opens dialog when Add connector is clicked", async () => {
+    mockConnectors([]);
+    await renderTeamPage([]);
+
+    await openAddConnectorDialog();
+
+    expect(screen.getByText(/Add connector to/)).toBeInTheDocument();
+  });
+
+  it("filters connectors by search text", async () => {
+    mockConnectors([]);
+    await renderTeamPage([]);
+
+    await openAddConnectorDialog();
+
+    // Wait for connector cards to load
+    await waitFor(() => {
+      expect(screen.getByText("GitHub")).toBeInTheDocument();
+    });
+
+    // Type in search box to filter
+    const searchInput = screen.getByPlaceholderText("Search...");
+    fireEvent.change(searchInput, { target: { value: "github" } });
+
+    // GitHub should still be visible
+    await waitFor(() => {
+      expect(screen.getByText("GitHub")).toBeInTheDocument();
+    });
+
+    // Axiom should not be visible (filtered out)
+    expect(screen.queryByText("Axiom")).not.toBeInTheDocument();
+  });
+
+  it("switches between Not connected and Connected tabs", async () => {
+    // Slack is connected but NOT in addedSkills, so it appears in the dialog
+    mockConnectors([
+      makeConnector({
+        type: "slack",
+        authMethod: "oauth",
+        oauthScopes: ["channels:read"],
+      }),
+    ]);
+    await renderTeamPage([]);
+
+    await openAddConnectorDialog();
+
+    // Wait for connector list to load on the default "Not connected" tab
+    await waitFor(() => {
+      expect(screen.getByText("GitHub")).toBeInTheDocument();
+    });
+
+    // Slack is connected, so it should NOT appear on the "Not connected" tab
+    expect(screen.queryByText("Slack")).not.toBeInTheDocument();
+
+    // Click Connected tab
+    fireEvent.click(screen.getByRole("tab", { name: /^Connected/ }));
+
+    // Slack should appear on Connected tab
+    await waitFor(() => {
+      expect(screen.getByText("Slack")).toBeInTheDocument();
+    });
+
+    // GitHub should not appear on Connected tab (not connected)
+    expect(screen.queryByText("GitHub")).not.toBeInTheDocument();
+  });
+
+  it("resets search when dialog is closed and reopened", async () => {
+    mockConnectors([]);
+    await renderTeamPage([]);
+
+    await openAddConnectorDialog();
+
+    await waitFor(() => {
+      expect(screen.getByText("GitHub")).toBeInTheDocument();
+    });
+
+    // Type search text
+    const searchInput = screen.getByPlaceholderText("Search...");
+    fireEvent.change(searchInput, { target: { value: "github" } });
+
+    // Close dialog by pressing Escape
+    fireEvent.keyDown(screen.getByRole("dialog"), { key: "Escape" });
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+
+    // Reopen dialog
+    await openAddConnectorDialog();
+
+    // Search should be cleared
+    const newSearchInput = screen.getByPlaceholderText("Search...");
+    expect(newSearchInput).toHaveValue("");
+  });
+});

--- a/turbo/apps/platform/src/views/zero-page/components/settings/add-connection-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/add-connection-dialog.tsx
@@ -1,6 +1,4 @@
-/* eslint-disable ccstate/no-use-ccstate-in-views */
 import { useLastResolved, useGet, useSet } from "ccstate-react";
-import { useCCState } from "ccstate-react/experimental";
 import { IconSearch, IconPlus } from "@tabler/icons-react";
 import {
   Dialog,
@@ -24,6 +22,11 @@ import {
   setTokenFormSubmitting$,
   selectedConnectorType$,
   setSelectedConnectorType$,
+  zeroDialogSearch$,
+  setZeroDialogSearch$,
+  zeroDialogTab$,
+  setZeroDialogTab$,
+  resetZeroDialogState$,
   type ConnectorTypeWithStatus,
 } from "../../../../signals/zero-page/settings/connectors.ts";
 import { openAddSecretDialog$ } from "../../../../signals/zero-page/settings/secrets.ts";
@@ -626,12 +629,11 @@ function ZeroAddConnectionDialog({
   agentName?: string;
 }) {
   const connectorTypes = useLastResolved(allConnectorTypes$);
-  const search$ = useCCState("");
-  const search = useGet(search$);
-  const setSearch = useSet(search$);
-  const tab$ = useCCState<"not-connected" | "connected">("not-connected");
-  const tab = useGet(tab$);
-  const setTab = useSet(tab$);
+  const search = useGet(zeroDialogSearch$);
+  const setSearch = useSet(setZeroDialogSearch$);
+  const tab = useGet(zeroDialogTab$);
+  const setTab = useSet(setZeroDialogTab$);
+  const resetState = useSet(resetZeroDialogState$);
   const types = Object.keys(CONNECTOR_TYPES) as ConnectorType[];
 
   const baseFiltered = connectorTypes
@@ -666,8 +668,7 @@ function ZeroAddConnectionDialog({
       open={open}
       onOpenChange={(v) => {
         if (!v) {
-          setSearch("");
-          setTab("not-connected");
+          resetState();
         }
         onOpenChange(v);
       }}


### PR DESCRIPTION
## Summary
- Move `ZeroAddConnectionDialog` search and tab state from `useCCState` (ccstate-react/experimental) to proper signals in the connectors signal layer
- Remove the `eslint-disable ccstate/no-use-ccstate-in-views` comment and the `ccstate-react/experimental` import
- Add integration tests for search filtering, tab switching, and dialog state reset

Closes #5821

## Test plan
- [x] New integration tests cover dialog open, search filtering, tab switching, and state reset on close
- [x] Existing `zero-skill-card` tests continue to pass (12 tests)
- [x] Lint, type checks, format, and knip all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)