### PR TITLE
refactor: remove ccstate-react/experimental from zero-job-detail-page

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/zero-job-detail.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-job-detail.ts
@@ -3,6 +3,7 @@ import { toast } from "@vm0/ui/components/ui/sonner";
 import { fetch$ } from "../fetch.ts";
 import { throwIfAbort } from "../utils.ts";
 import { logger } from "../log.ts";
+import { search } from "../location.ts";
 import type { AgentDetail, AgentInstructions } from "./agent-types.ts";
 import { skillUrlToValue } from "../../data/skills.ts";
 import { SEED_SKILLS } from "../../data/the-seed.ts";
@@ -26,6 +27,40 @@ const L = logger("ZeroJobDetail");
 const internalAgentName$ = state<string | null>(null);
 const setZeroJobAgentName$ = command(({ set }, name: string | null) => {
   set(internalAgentName$, name);
+});
+
+// ---------------------------------------------------------------------------
+// Active tab
+// ---------------------------------------------------------------------------
+
+function isValidTab(tab: string): boolean {
+  return (
+    tab === "connectors" ||
+    tab === "schedule" ||
+    tab === "profile" ||
+    tab === "instructions"
+  );
+}
+
+function getInitialTab(): string {
+  const params = new URLSearchParams(search());
+  const tab = params.get("tab") ?? "";
+  return isValidTab(tab) ? tab : "connectors";
+}
+
+const internalActiveTab$ = state("connectors");
+
+export const zeroJobActiveTab$ = computed((get) => get(internalActiveTab$));
+
+export const setZeroJobActiveTab$ = command(({ set }, tab: string) => {
+  set(internalActiveTab$, tab);
+  const url = new URL(location.href);
+  if (tab === "connectors") {
+    url.searchParams.delete("tab");
+  } else {
+    url.searchParams.set("tab", tab);
+  }
+  history.replaceState(null, "", url.toString());
 });
 
 // ---------------------------------------------------------------------------
@@ -730,6 +765,7 @@ export const fetchZeroJobData$ = command(async ({ set }, agentName: string) => {
   set(internalBuildError$, null);
   set(jobBuilding$, false);
   set(internalSaving$, false);
+  set(internalActiveTab$, getInitialTab());
 
   set(setZeroJobAgentName$, agentName);
   await set(fetchZeroJobDetail$);

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-job-detail-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-job-detail-page.test.tsx
@@ -1,0 +1,153 @@
+import { describe, expect, it } from "vitest";
+import { screen, waitFor, act, fireEvent } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../mocks/server.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { setupPage } from "../../../__tests__/page-helper.ts";
+
+const context = testContext();
+
+function mockAPIs() {
+  server.use(
+    http.get("*/api/zero/team", () => {
+      return HttpResponse.json({
+        composes: [
+          {
+            id: "mock-compose-id",
+            name: "zero",
+            displayName: null,
+            description: null,
+            headVersionId: "version_1",
+            updatedAt: "2024-01-01T00:00:00Z",
+            isOwner: true,
+          },
+          {
+            id: "agent-detail-id",
+            name: "my-agent",
+            displayName: "My Agent",
+            description: "A helpful agent",
+            headVersionId: "version_2",
+            updatedAt: "2024-01-02T00:00:00Z",
+            isOwner: false,
+          },
+        ],
+      });
+    }),
+    http.get("*/api/zero/chat-threads", () => {
+      return HttpResponse.json({ threads: [] });
+    }),
+    http.get("*/api/zero/composes", () => {
+      return HttpResponse.json({
+        id: "agent-detail-id",
+        name: "my-agent",
+        content: {
+          agents: {
+            "my-agent": {
+              description: "A helpful agent",
+              framework: null,
+            },
+          },
+        },
+      });
+    }),
+    http.get("*/api/zero/agents/:name/instructions", () => {
+      return HttpResponse.json({ instructions: null });
+    }),
+    http.get("*/api/zero/schedules", () => {
+      return HttpResponse.json({ schedules: [] });
+    }),
+  );
+}
+
+describe("zero job detail page", () => {
+  it("should render agent detail with header and tabs", async () => {
+    mockAPIs();
+    await setupPage({ context, path: "/team/my-agent" });
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "My Agent" }),
+      ).toBeInTheDocument();
+    });
+    expect(screen.getByText("A helpful agent")).toBeInTheDocument();
+
+    // All tabs should be visible
+    expect(
+      screen.getByRole("tab", { name: /Connectors/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: /Scheduled/i })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: /Profile/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("tab", { name: /Instructions/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("should switch to profile tab and show settings form", async () => {
+    mockAPIs();
+    await setupPage({ context, path: "/team/my-agent" });
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "My Agent" }),
+      ).toBeInTheDocument();
+    });
+
+    // Click Profile tab
+    await act(() => {
+      fireEvent.click(screen.getByRole("tab", { name: /Profile/i }));
+    });
+
+    // Profile tab should show settings form with agent name input
+    await waitFor(() => {
+      expect(screen.getByLabelText(/name/i)).toBeInTheDocument();
+    });
+  });
+
+  it("should show not-found error for unknown agent", async () => {
+    server.use(
+      http.get("*/api/zero/team", () => {
+        return HttpResponse.json({
+          composes: [
+            {
+              id: "mock-compose-id",
+              name: "zero",
+              displayName: null,
+              description: null,
+              headVersionId: "version_1",
+              updatedAt: "2024-01-01T00:00:00Z",
+              isOwner: true,
+            },
+          ],
+        });
+      }),
+      http.get("*/api/zero/chat-threads", () => {
+        return HttpResponse.json({ threads: [] });
+      }),
+      http.get("*/api/zero/composes", () => {
+        return HttpResponse.json({ error: "Not found" }, { status: 404 });
+      }),
+    );
+
+    await setupPage({ context, path: "/team/nonexistent" });
+
+    await waitFor(() => {
+      expect(screen.getByText("Agent not found")).toBeInTheDocument();
+    });
+  });
+
+  it("should initialize tab from URL query parameter", async () => {
+    mockAPIs();
+    await setupPage({ context, path: "/team/my-agent?tab=profile" });
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "My Agent" }),
+      ).toBeInTheDocument();
+    });
+
+    // Profile tab content should be visible (settings form with agent name input)
+    await waitFor(() => {
+      expect(screen.getByLabelText(/name/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/turbo/apps/platform/src/views/zero-page/zero-job-detail-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-job-detail-page.tsx
@@ -1,6 +1,4 @@
-/* eslint-disable ccstate/no-use-ccstate-in-views */
 import { useGet, useSet, useLoadable, useLastLoadable } from "ccstate-react";
-import { useCCState } from "ccstate-react/experimental";
 import {
   IconFileText,
   IconUserCircle,
@@ -56,6 +54,8 @@ import {
   removeZeroJobSkill$,
   saveZeroJobSkills$,
   discardZeroJobSkills$,
+  zeroJobActiveTab$,
+  setZeroJobActiveTab$,
 } from "../../signals/zero-page/zero-job-detail.ts";
 import type { AgentDetail } from "../../signals/zero-page/agent-types.ts";
 import { zeroOnboardingStatus$ } from "../../signals/zero-page/zero-onboarding.ts";
@@ -182,37 +182,6 @@ function DetailError({
 
 const TAB_TRIGGER_CLASS =
   "gap-1.5 text-sm data-[state=active]:bg-background px-3";
-
-function isValidTab(tab: string): boolean {
-  return (
-    tab === "connectors" ||
-    tab === "schedule" ||
-    tab === "profile" ||
-    tab === "instructions"
-  );
-}
-
-function getInitialTab(): string {
-  if (typeof window === "undefined") {
-    return "connectors";
-  }
-  const params = new URLSearchParams(window.location.search);
-  const tab = params.get("tab") ?? "";
-  return isValidTab(tab) ? tab : "connectors";
-}
-
-function syncTabToUrl(tab: string) {
-  if (typeof window === "undefined") {
-    return;
-  }
-  const url = new URL(window.location.href);
-  if (tab === "connectors") {
-    url.searchParams.delete("tab");
-  } else {
-    url.searchParams.set("tab", tab);
-  }
-  window.history.replaceState(null, "", url.toString());
-}
 
 function extractAgentFields(
   detail: AgentDetail | null,
@@ -371,13 +340,8 @@ export function ZeroJobDetailPage({
     nav("/team");
   };
 
-  const activeTab$ = useCCState(getInitialTab());
-  const activeTab = useGet(activeTab$);
-  const rawSetActiveTab = useSet(activeTab$);
-  const setActiveTab = (tab: string) => {
-    rawSetActiveTab(tab);
-    syncTabToUrl(tab);
-  };
+  const activeTab = useGet(zeroJobActiveTab$);
+  const setActiveTab = useSet(setZeroJobActiveTab$);
 
   const agentAvatar = useAgentAvatar(agentName);
   const setAgentAvatarCmd = useSet(setAgentAvatar$);


### PR DESCRIPTION
## Summary

- Moved active tab state from `useCCState()` in the view to `state()`/`computed()`/`command()` in the signals file, following the ccstate pattern
- Removed the `eslint-disable ccstate/no-use-ccstate-in-views` comment and the `ccstate-react/experimental` import
- Removed the now-unnecessary `getInitialTab`/`syncTabToUrl`/`isValidTab` helper functions from the view
- Added integration tests for the job detail page covering header rendering, tab switching, not-found error state, and URL-based tab initialization

Closes #5813

## Test plan

- [x] New integration tests pass (4 tests covering header, tab switching, 404, URL tab init)
- [x] Existing signal tests pass (26 tests in zero-job-detail.test.ts)
- [x] Existing navigation tests pass (3 tests in team-navigation.test.tsx)
- [x] Lint passes (no eslint-disable, no restricted imports)
- [x] Type check passes
- [x] Knip passes (no unused exports)

🤖 Generated with [Claude Code](https://claude.com/claude-code)