### PR TITLE
refactor: remove ccstate-react/experimental from timezone-settings

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/settings/preferences-page.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/preferences-page.ts
@@ -24,3 +24,15 @@ export const sendModeSaving$ = computed((get) => get(internalSendModeSaving$));
 export const setSendModeSaving$ = command(({ set }, value: SendMode | null) => {
   set(internalSendModeSaving$, value);
 });
+
+// ---------------------------------------------------------------------------
+// Timezone saving state
+// ---------------------------------------------------------------------------
+
+const internalTimezoneSaving$ = state(false);
+
+export const timezoneSaving$ = computed((get) => get(internalTimezoneSaving$));
+
+export const setTimezoneSaving$ = command(({ set }, value: boolean) => {
+  set(internalTimezoneSaving$, value);
+});

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-preferences-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-preferences-page.test.tsx
@@ -182,3 +182,64 @@ describe("zero preferences page - send mode interaction", () => {
     expect(capturedBody).toHaveProperty("sendMode", "cmd-enter");
   });
 });
+
+describe("zero preferences page - timezone update", () => {
+  it("should render timezone settings with current value when switching to timezone tab", async () => {
+    mockPreferencesAPI(createMockPreferences({ timezone: "Asia/Tokyo" }));
+    await renderPreferencesPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("Time Zone")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText("Time Zone"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Time zone")).toBeInTheDocument();
+    });
+    expect(screen.getByText("Japan Standard Time (JST)")).toBeInTheDocument();
+  });
+
+  it("should send update request when changing timezone", async () => {
+    let capturedBody: Record<string, unknown> | null = null;
+
+    server.use(
+      http.get("*/api/zero/user-preferences", () => {
+        return HttpResponse.json(createMockPreferences({ timezone: "UTC" }));
+      }),
+      http.post("*/api/zero/user-preferences", async ({ request }) => {
+        capturedBody = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json(
+          createMockPreferences({ timezone: "America/New_York" }),
+        );
+      }),
+    );
+
+    await renderPreferencesPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("Time Zone")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText("Time Zone"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Time zone")).toBeInTheDocument();
+    });
+
+    // Open the select dropdown
+    const selectTrigger = screen.getByRole("combobox");
+    fireEvent.click(selectTrigger);
+
+    // Select a different timezone
+    await waitFor(() => {
+      expect(screen.getByText("Eastern Time (ET)")).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByText("Eastern Time (ET)"));
+
+    await waitFor(() => {
+      expect(capturedBody).toBeTruthy();
+    });
+    expect(capturedBody).toHaveProperty("timezone", "America/New_York");
+  });
+});

--- a/turbo/apps/platform/src/views/zero-page/components/settings/timezone-settings.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/timezone-settings.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable ccstate/no-use-ccstate-in-views */
-import { useCCState } from "ccstate-react/experimental";
 import { useGet, useLastResolved, useSet } from "ccstate-react";
 import {
   Select,
@@ -15,6 +13,10 @@ import {
   notificationPreferences$,
   updateNotificationPreference$,
 } from "../../../../signals/zero-page/settings/notification-settings.ts";
+import {
+  timezoneSaving$,
+  setTimezoneSaving$,
+} from "../../../../signals/zero-page/settings/preferences-page.ts";
 
 function getCommonTimezones() {
   return [
@@ -42,9 +44,8 @@ export function TimezoneSettings() {
   const preferences = useLastResolved(notificationPreferences$);
   const updatePreference = useSet(updateNotificationPreference$);
 
-  const loading$ = useCCState(false);
-  const loading = useGet(loading$);
-  const setLoading = useSet(loading$);
+  const loading = useGet(timezoneSaving$);
+  const setLoading = useSet(setTimezoneSaving$);
 
   const handleChange = (value: string) => {
     setLoading(true);


### PR DESCRIPTION
## Summary
- Replace `useCCState(false)` from `ccstate-react/experimental` with proper `state()`/`computed()`/`command()` pattern in the preferences-page signals file for timezone saving state
- Remove the `eslint-disable ccstate/no-use-ccstate-in-views` comment
- Remove the `ccstate-react/experimental` import
- Add integration tests for timezone settings update behavior (render with current value, send update request on change)

Closes #5820

## Test plan
- [x] New tests verify timezone tab renders with current timezone value
- [x] New tests verify timezone update sends correct API request
- [x] All 8 preferences page tests pass
- [x] Lint passes with no errors
- [x] Type check passes
- [x] Knip reports no unused exports

🤖 Generated with [Claude Code](https://claude.com/claude-code)