### PR TITLE
fix: add works path to route type union

### DIFF
--- a/turbo/apps/platform/src/types/route.ts
+++ b/turbo/apps/platform/src/types/route.ts
@@ -11,5 +11,6 @@ export type RoutePath =
   | "/slack/connect"
   | "/queue"
   | "/preferences"
+  | "/works"
   | "/__internal-connector-logos"
   | `/projects/${string}`;


### PR DESCRIPTION
## Summary
- Adds `"/works"` to the `RoutePath` type union in `route.ts`
- The `/works` route was migrated in #5948 but its path was not included in the type, breaking type safety for `generateRouterPath("/works")`

## Test plan
- [x] Type checking passes (`pnpm check-types`)
- [x] Lint passes
- [x] Knip passes

Fixes P0 review finding from #5948.

🤖 Generated with [Claude Code](https://claude.com/claude-code)