### PR TITLE
refactor: migrate /schedule route to dedicated setup function

### DIFF
--- a/turbo/apps/platform/src/signals/bootstrap.ts
+++ b/turbo/apps/platform/src/signals/bootstrap.ts
@@ -14,6 +14,7 @@ import { setupTeamPage$ } from "./team-page/team-page-setup.ts";
 import { setupTeamDetailPage$ } from "./team-page/team-detail-page-setup.ts";
 import { setupWorksPage$ } from "./works-page/works-page-setup.ts";
 import { setupPreferencesPage$ } from "./preferences-page/preferences-page-setup.ts";
+import { setupSchedulePage$ } from "./schedule-page/schedule-page-setup.ts";
 import { setupInternalConnectorLogos$ } from "./internal-connector-logos-setup.ts";
 const ROUTE_CONFIG = [
   {
@@ -59,6 +60,10 @@ const ROUTE_CONFIG = [
   {
     path: "/preferences",
     setup: setupAuthPageWrapper(setupPreferencesPage$),
+  },
+  {
+    path: "/schedule",
+    setup: setupAuthPageWrapper(setupSchedulePage$),
   },
   {
     path: "/__internal-connector-logos",

--- a/turbo/apps/platform/src/signals/schedule-page/schedule-page-setup.ts
+++ b/turbo/apps/platform/src/signals/schedule-page/schedule-page-setup.ts
@@ -1,0 +1,22 @@
+import { command } from "ccstate";
+import { createElement } from "react";
+import { ZeroSchedulePageWrapper } from "../../views/schedule-page/zero-schedule-page-wrapper.tsx";
+import { updatePage$ } from "../react-router.ts";
+import { fetchAgentsList$ } from "../zero-page/zero-agents.ts";
+import { initZeroOnboarding$ } from "../zero-page/zero-onboarding.ts";
+import { switchActiveAgent$ } from "../zero-page/zero-chat.ts";
+import { fetchAllOrgSchedules$ } from "../zero-page/zero-schedule.ts";
+import { Reason, detach } from "../utils.ts";
+
+export const setupSchedulePage$ = command(
+  async ({ set }, signal: AbortSignal) => {
+    set(updatePage$, createElement(ZeroSchedulePageWrapper));
+    detach(set(fetchAllOrgSchedules$), Reason.Entrance);
+    await Promise.all([
+      set(fetchAgentsList$),
+      set(initZeroOnboarding$, signal),
+    ]);
+    signal.throwIfAborted();
+    set(switchActiveAgent$, null);
+  },
+);

--- a/turbo/apps/platform/src/signals/zero-page/zero-page.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-page.ts
@@ -5,7 +5,6 @@ import { updatePage$ } from "../react-router.ts";
 import { fetchAgentsList$, zeroSubagents$ } from "./zero-agents.ts";
 import { defaultAgentName$ } from "./zero-agent-name.ts";
 import { initZeroOnboarding$ } from "./zero-onboarding.ts";
-import { refreshScheduleIfActive$ } from "./zero-schedule.ts";
 import { initSlackOrg$ } from "./zero-slack.ts";
 import {
   zeroChatAgentName$,
@@ -121,9 +120,6 @@ export const setupZeroPage$ = command(
       set(initialDataLoaded$, true);
       set(initSidebarCollapsed$);
     }
-
-    // Refresh tab-specific data on each route entry
-    set(refreshScheduleIfActive$);
 
     await resolveAndSwitchAgent(get, set, signal);
 

--- a/turbo/apps/platform/src/signals/zero-page/zero-schedule.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-schedule.ts
@@ -1,10 +1,9 @@
 import { command, computed, state } from "ccstate";
 import { toast } from "@vm0/ui/components/ui/sonner";
 import { fetch$ } from "../fetch.ts";
-import { throwIfAbort, detach, Reason } from "../utils.ts";
+import { throwIfAbort } from "../utils.ts";
 import { logger } from "../log.ts";
 import { zeroOnboardingStatus$ } from "./zero-onboarding.ts";
-import { zeroActiveId$ } from "./zero-nav.ts";
 import {
   buildCronExpression,
   buildAtTime,
@@ -419,19 +418,7 @@ export const allOrgScheduleEntries$ = computed((get) => {
     );
 });
 
-/**
- * Refresh schedule data if the current tab is "schedule".
- * Called from `setupZeroPage$` on every route entry.
- */
-export const refreshScheduleIfActive$ = command(({ get, set }) => {
-  const activeTab = get(zeroActiveId$);
-  if (activeTab !== "schedule") {
-    return;
-  }
-  detach(set(fetchAllOrgSchedules$), Reason.Entrance);
-});
-
-const fetchAllOrgSchedules$ = command(async ({ get, set }) => {
+export const fetchAllOrgSchedules$ = command(async ({ get, set }) => {
   const fetchFn = get(fetch$);
   try {
     const response = await fetchFn("/api/zero/schedules");

--- a/turbo/apps/platform/src/types/route.ts
+++ b/turbo/apps/platform/src/types/route.ts
@@ -10,6 +10,7 @@ export type RoutePath =
   | "/talk/:name"
   | "/slack/connect"
   | "/queue"
+  | "/schedule"
   | "/preferences"
   | "/works"
   | "/__internal-connector-logos"

--- a/turbo/apps/platform/src/views/schedule-page/__tests__/schedule-page.test.tsx
+++ b/turbo/apps/platform/src/views/schedule-page/__tests__/schedule-page.test.tsx
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../mocks/server.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { setupPage } from "../../../__tests__/page-helper.ts";
+
+const context = testContext();
+
+describe("schedule page", () => {
+  it("should render the schedule page with empty schedules", async () => {
+    await setupPage({ context, path: "/schedule" });
+
+    await waitFor(() => {
+      expect(screen.getByText("Scheduled tasks")).toBeInTheDocument();
+    });
+
+    // Empty state shows "Nothing on the calendar"
+    expect(screen.getByText("Nothing on the calendar")).toBeInTheDocument();
+  });
+
+  it("should render schedule entries when data is present", async () => {
+    server.use(
+      http.get("*/api/zero/schedules", () => {
+        return HttpResponse.json({
+          schedules: [
+            {
+              id: "sched-1",
+              composeId: "compose-1",
+              composeName: "Test Agent",
+              orgSlug: "test",
+              name: "test-schedule",
+              triggerType: "cron",
+              cronExpression: "0 9 * * *",
+              atTime: null,
+              intervalSeconds: null,
+              timezone: "UTC",
+              prompt: "Daily standup summary",
+              enabled: true,
+              notifyEmail: false,
+              notifySlack: false,
+              nextRunAt: null,
+              lastRunAt: null,
+              createdAt: "2026-03-01T00:00:00Z",
+              updatedAt: "2026-03-01T00:00:00Z",
+            },
+          ],
+        });
+      }),
+    );
+
+    await setupPage({ context, path: "/schedule" });
+
+    await waitFor(() => {
+      expect(screen.getByText("Scheduled tasks")).toBeInTheDocument();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Daily standup summary")).toBeInTheDocument();
+    });
+  });
+
+  it("should show Add schedule button", async () => {
+    await setupPage({ context, path: "/schedule" });
+
+    await waitFor(() => {
+      expect(screen.getByText("Scheduled tasks")).toBeInTheDocument();
+    });
+
+    // The "Add schedule" button appears in the header and in the empty state
+    const addButtons = screen.getAllByRole("button", {
+      name: /Add schedule/,
+    });
+    expect(addButtons.length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/turbo/apps/platform/src/views/schedule-page/zero-schedule-page-wrapper.tsx
+++ b/turbo/apps/platform/src/views/schedule-page/zero-schedule-page-wrapper.tsx
@@ -1,0 +1,10 @@
+import { SidebarLayout } from "../zero-page/sidebar-layout.tsx";
+import { ZeroSchedulePage } from "../zero-page/zero-schedule-page.tsx";
+
+export function ZeroSchedulePageWrapper() {
+  return (
+    <SidebarLayout>
+      <ZeroSchedulePage />
+    </SidebarLayout>
+  );
+}


### PR DESCRIPTION
## Summary

- Extract schedule page from the `setupZeroPage$` god-object into a dedicated `setupSchedulePage$` command, following the established queue/activity/team pattern
- Create `ZeroSchedulePageWrapper` with `SidebarLayout` and register explicit `/schedule` route before the `/:tab` fallback
- Fire-and-forget `fetchAllOrgSchedules$` in setup to ensure schedule data loads (page uses plain computed atoms, not async ones)
- Remove dead `refreshScheduleIfActive$` function and clean up unused imports from `zero-schedule.ts`
- Add integration tests covering empty state, schedule data rendering, and the Add schedule button

Closes #5841

## Test plan

- [x] New schedule page integration tests pass (3 tests)
- [x] All 376 platform tests pass with no regressions
- [x] Type check passes
- [x] Lint passes
- [x] Knip passes (no unused exports)

🤖 Generated with [Claude Code](https://claude.com/claude-code)