### PR TITLE
refactor: migrate /settings route to dedicated setup function

### DIFF
--- a/turbo/apps/platform/src/signals/bootstrap.ts
+++ b/turbo/apps/platform/src/signals/bootstrap.ts
@@ -14,6 +14,7 @@ import { setupTeamPage$ } from "./team-page/team-page-setup.ts";
 import { setupTeamDetailPage$ } from "./team-page/team-detail-page-setup.ts";
 import { setupWorksPage$ } from "./works-page/works-page-setup.ts";
 import { setupPreferencesPage$ } from "./preferences-page/preferences-page-setup.ts";
+import { setupSettingsPage$ } from "./settings-page/settings-page-setup.ts";
 import { setupInternalConnectorLogos$ } from "./internal-connector-logos-setup.ts";
 const ROUTE_CONFIG = [
   {
@@ -59,6 +60,10 @@ const ROUTE_CONFIG = [
   {
     path: "/preferences",
     setup: setupAuthPageWrapper(setupPreferencesPage$),
+  },
+  {
+    path: "/settings",
+    setup: setupAuthPageWrapper(setupSettingsPage$),
   },
   {
     path: "/__internal-connector-logos",

--- a/turbo/apps/platform/src/signals/settings-page/settings-page-setup.ts
+++ b/turbo/apps/platform/src/signals/settings-page/settings-page-setup.ts
@@ -1,0 +1,19 @@
+import { command } from "ccstate";
+import { createElement } from "react";
+import { ZeroSettingsPageWrapper } from "../../views/settings-page/zero-settings-page-wrapper.tsx";
+import { updatePage$ } from "../react-router.ts";
+import { fetchAgentsList$ } from "../zero-page/zero-agents.ts";
+import { initZeroOnboarding$ } from "../zero-page/zero-onboarding.ts";
+import { switchActiveAgent$ } from "../zero-page/zero-chat.ts";
+
+export const setupSettingsPage$ = command(
+  async ({ set }, signal: AbortSignal) => {
+    set(updatePage$, createElement(ZeroSettingsPageWrapper));
+    await Promise.all([
+      set(fetchAgentsList$),
+      set(initZeroOnboarding$, signal),
+    ]);
+    signal.throwIfAborted();
+    set(switchActiveAgent$, null);
+  },
+);

--- a/turbo/apps/platform/src/types/route.ts
+++ b/turbo/apps/platform/src/types/route.ts
@@ -11,6 +11,7 @@ export type RoutePath =
   | "/slack/connect"
   | "/queue"
   | "/preferences"
+  | "/settings"
   | "/works"
   | "/__internal-connector-logos"
   | `/projects/${string}`;

--- a/turbo/apps/platform/src/views/settings-page/__tests__/settings-page.test.tsx
+++ b/turbo/apps/platform/src/views/settings-page/__tests__/settings-page.test.tsx
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../mocks/server.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { setupPage } from "../../../__tests__/page-helper.ts";
+
+const context = testContext();
+
+describe("settings page", () => {
+  it("should render settings page via direct URL", async () => {
+    server.use(
+      http.get("*/api/zero/chat-threads", () => {
+        return HttpResponse.json({ threads: [] });
+      }),
+    );
+
+    await setupPage({ context, path: "/settings" });
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "Settings", level: 1 }),
+      ).toBeInTheDocument();
+    });
+    expect(
+      screen.getByText("Configure model providers for your agents."),
+    ).toBeInTheDocument();
+  });
+
+  it("should show provider cards when providers exist", async () => {
+    server.use(
+      http.get("*/api/zero/model-providers", () => {
+        return HttpResponse.json({
+          modelProviders: [
+            {
+              id: "prov-1",
+              type: "anthropic-api-key",
+              framework: "claude-code",
+              secretName: "ANTHROPIC_API_KEY",
+              authMethod: null,
+              secretNames: null,
+              isDefault: true,
+              selectedModel: null,
+              createdAt: "2026-03-01T00:00:00Z",
+              updatedAt: "2026-03-01T00:00:00Z",
+            },
+          ],
+        });
+      }),
+      http.get("*/api/zero/chat-threads", () => {
+        return HttpResponse.json({ threads: [] });
+      }),
+    );
+
+    await setupPage({ context, path: "/settings" });
+
+    await waitFor(() => {
+      expect(screen.getByText("Configured")).toBeInTheDocument();
+    });
+  });
+
+  it("should render sidebar on settings page", async () => {
+    server.use(
+      http.get("*/api/zero/chat-threads", () => {
+        return HttpResponse.json({ threads: [] });
+      }),
+    );
+
+    await setupPage({ context, path: "/settings" });
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "Settings", level: 1 }),
+      ).toBeInTheDocument();
+    });
+
+    // Sidebar navigation should be present (multiple nav elements exist)
+    const navElements = screen.getAllByRole("navigation");
+    expect(navElements.length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/turbo/apps/platform/src/views/settings-page/zero-settings-page-wrapper.tsx
+++ b/turbo/apps/platform/src/views/settings-page/zero-settings-page-wrapper.tsx
@@ -1,0 +1,10 @@
+import { SidebarLayout } from "../zero-page/sidebar-layout.tsx";
+import { ZeroSettingsPage } from "../zero-page/zero-settings-page.tsx";
+
+export function ZeroSettingsPageWrapper() {
+  return (
+    <SidebarLayout>
+      <ZeroSettingsPage />
+    </SidebarLayout>
+  );
+}


### PR DESCRIPTION
## Summary

- Extracts `/settings` route from the `setupZeroPage$` catch-all into a dedicated `setupSettingsPage$` command
- Follows the established pattern used by `/queue`, `/activity`, and `/team` route migrations
- Adds integration tests for settings page routing (direct URL, provider cards, sidebar)

## Changes

- **New:** `signals/settings-page/settings-page-setup.ts` — dedicated setup command
- **New:** `views/settings-page/zero-settings-page-wrapper.tsx` — wrapper with SidebarLayout
- **New:** `views/settings-page/__tests__/settings-page.test.tsx` — 3 integration tests
- **Modified:** `signals/bootstrap.ts` — register `/settings` route before `/:tab` catch-all
- **Modified:** `types/route.ts` — add `/settings` to RoutePath union type

Closes #5842

## Test plan

- [x] New settings page integration tests pass (3 tests)
- [x] Existing settings page component tests pass (14 tests)
- [x] All platform tests pass (462 tests, 56 files)
- [x] Lint passes
- [x] Type check passes (platform)
- [x] Knip passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)