### PR TITLE
fix(sandbox-fc): prevent orphan firecracker processes during snapshot creation

### DIFF
--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -194,19 +194,19 @@ impl FirecrackerSandbox {
         let username = current_username()?;
         let api_sock = self.sock_paths.api_sock();
 
+        // Use `exec` to replace the bash process with firecracker, keeping all
+        // descendants in the same process group so `kill_process_group` can
+        // reach them (same pattern as start_from_snapshot and snapshot.rs).
+        let inner_cmd =
+            r#"exec ip netns exec "$1" sudo -u "$2" "$3" --config-file "$4" --api-sock "$5""#;
+
         let mut child = tokio::process::Command::new("sudo")
-            .arg("ip")
-            .arg("netns")
-            .arg("exec")
-            .arg(&self.network.name)
-            .arg("sudo")
-            .arg("-u")
-            .arg(&username)
-            .arg(&self.factory_config.binary_path)
-            .arg("--config-file")
-            .arg(self.sandbox_paths.config())
-            .arg("--api-sock")
-            .arg(&api_sock)
+            .args(["bash", "-c", inner_cmd, "_"])
+            .arg(&self.network.name) // $1
+            .arg(&username) // $2
+            .arg(&self.factory_config.binary_path) // $3
+            .arg(self.sandbox_paths.config()) // $4
+            .arg(&api_sock) // $5
             .current_dir(self.sandbox_paths.workspace())
             .stdin(std::process::Stdio::null())
             .stdout(std::process::Stdio::piped())

--- a/crates/sandbox-fc/src/snapshot.rs
+++ b/crates/sandbox-fc/src/snapshot.rs
@@ -174,17 +174,18 @@ async fn run_snapshot_workflow(
         "spawning firecracker"
     );
 
+    // Use `exec` to replace the bash process with firecracker, keeping all
+    // descendants in the same process group so `kill_process_group` can
+    // reach them.  Without `exec`, `sudo` creates a new process group for
+    // the inner `sudo -u` child, which escapes `killpg` and becomes orphan.
+    let inner_cmd = r#"exec ip netns exec "$1" sudo -u "$2" "$3" --api-sock "$4""#;
+
     let mut child = tokio::process::Command::new("sudo")
-        .arg("ip")
-        .arg("netns")
-        .arg("exec")
-        .arg(&network.name)
-        .arg("sudo")
-        .arg("-u")
-        .arg(&username)
-        .arg(&config.binary_path)
-        .arg("--api-sock")
-        .arg(&api_sock)
+        .args(["bash", "-c", inner_cmd, "_"])
+        .arg(&network.name) // $1
+        .arg(&username) // $2
+        .arg(&config.binary_path) // $3
+        .arg(&api_sock) // $4
         .current_dir(paths.workspace())
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::piped())


### PR DESCRIPTION
## Summary

- Use `exec` in the snapshot creation shell command to replace the bash process with firecracker, keeping all descendants in the same process group
- Previously, the direct `sudo ip netns exec <ns> sudo -u <user> firecracker` chain caused `sudo` to create a new process group for the inner `sudo -u` child, which escaped `killpg` cleanup and became an orphan process (found on dev-1 and dev-2, ~700MB each)
- Aligns with the existing sandbox restore pattern in `sandbox.rs` which already uses `exec` correctly

Closes #5961

## Test plan

- [ ] `cargo check -p sandbox-fc` passes
- [ ] CI crates build passes
- [ ] Runner E2E tests pass (snapshot creation + cleanup)
- [ ] Verify no orphan firecracker processes after snapshot creation on dev machines

🤖 Generated with [Claude Code](https://claude.com/claude-code)