### PR TITLE
feat(slack): add system prompt guidance for Slack messaging API

### DIFF
--- a/turbo/apps/web/src/lib/integration-context.ts
+++ b/turbo/apps/web/src/lib/integration-context.ts
@@ -43,3 +43,18 @@ export function buildScheduleGuidance(): string {
     'Choose a short, descriptive schedule name based on the task (e.g., "deploy-check", "daily-report").',
   ].join("\n");
 }
+
+/**
+ * Build system prompt guidance for Slack messaging via the vm0 proxy API.
+ * Injected into Slack-triggered runs so agents know how to send messages.
+ */
+export function buildSlackMessagingGuidance(): string {
+  return `# Sending Slack Messages
+You can send Slack messages directly using the vm0 integration API:
+curl -X POST "$VM0_API_URL/api/agent/integrations/slack/message" \\
+  -H "Authorization: Bearer $VM0_TOKEN" \\
+  -H "Content-Type: application/json" \\
+  -d '{"channel": "<channel-id>", "text": "your message"}'
+Optional fields: threadTs (reply in thread), blocks (Block Kit JSON).
+Messages are sent as the bot user, not as an individual user.`;
+}

--- a/turbo/apps/web/src/lib/slack-org/handlers/run-agent.ts
+++ b/turbo/apps/web/src/lib/slack-org/handlers/run-agent.ts
@@ -2,6 +2,7 @@ import { startRun, isRunDispatchError } from "../../run";
 import {
   buildIntegrationContext,
   buildScheduleGuidance,
+  buildSlackMessagingGuidance,
   DISALLOWED_CRON_TOOLS,
 } from "../../integration-context";
 import { isApiError } from "../../errors";
@@ -76,6 +77,7 @@ export async function runAgentForSlackOrg(
       threadContext,
       userContext,
       buildScheduleGuidance(),
+      buildSlackMessagingGuidance(),
     ].filter(Boolean);
     const appendSystemPrompt =
       contextParts.length > 0 ? contextParts.join("\n\n") : undefined;


### PR DESCRIPTION
## Summary

- Add `buildSlackMessagingGuidance()` to `integration-context.ts` that returns system prompt guidance for the Slack messaging proxy API
- Inject the guidance into Slack-triggered agent runs via `contextParts` in `run-agent.ts`
- Agents will now know how to send Slack messages via `POST $VM0_API_URL/api/agent/integrations/slack/message`

Closes #5966
Parent Epic: #5964

## Test plan

- [x] `grep "buildSlackMessagingGuidance"` confirms injection in run-agent.ts
- [x] `grep "Sending Slack Messages"` confirms guidance content in integration-context.ts
- [x] `grep "VM0_API_URL"` confirms env var reference in guidance
- [x] Type check passes (`pnpm turbo run check-types --filter=web`)
- [x] Lint passes (`pnpm turbo run lint --filter=web`)
- [x] Formatter shows no changes needed
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)