### PR TITLE
feat: add integration-slack:write capability and proxy api endpoint

### DIFF
--- a/turbo/apps/web/app/api/agent/integrations/slack/message/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/integrations/slack/message/__tests__/route.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { WebClient } from "@slack/web-api";
+import { POST } from "../route";
+import {
+  createTestRequest,
+  createTestCompose,
+  createTestRunInDb,
+  createTestSlackOrgInstallation,
+} from "../../../../../../../src/__tests__/api-test-helpers";
+import {
+  testContext,
+  uniqueId,
+  type UserContext,
+} from "../../../../../../../src/__tests__/test-helpers";
+import { mockClerk } from "../../../../../../../src/__tests__/clerk-mock";
+import { generateSandboxToken } from "../../../../../../../src/lib/auth/sandbox-token";
+
+const URL = "http://localhost:3000/api/agent/integrations/slack/message";
+
+const context = testContext();
+
+describe("POST /api/agent/integrations/slack/message", () => {
+  let user: UserContext;
+
+  beforeEach(async () => {
+    context.setupMocks();
+    user = await context.setupUser();
+  });
+
+  /** Helper: create a run and return a sandbox token with given capabilities */
+  async function sandboxTokenWithRun(
+    capabilities: Parameters<typeof generateSandboxToken>[2],
+  ) {
+    const { composeId } = await createTestCompose(uniqueId("agent"));
+    const { runId } = await createTestRunInDb(user.userId, composeId);
+    mockClerk({ userId: null });
+    const token = await generateSandboxToken(user.userId, runId, capabilities);
+    return { token, runId };
+  }
+
+  it("returns 401 when no auth token provided", async () => {
+    // Clear Clerk session so no auth path succeeds
+    mockClerk({ userId: null });
+
+    const request = createTestRequest(URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ channel: "C123", text: "hello" }),
+    });
+
+    const response = await POST(request);
+    expect(response.status).toBe(401);
+  });
+
+  it("returns 403 when sandbox token lacks integration-slack:write", async () => {
+    const { token } = await sandboxTokenWithRun(["agent:read"]);
+
+    const request = createTestRequest(URL, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ channel: "C123", text: "hello" }),
+    });
+
+    const response = await POST(request);
+    expect(response.status).toBe(403);
+
+    const data = await response.json();
+    expect(data.error.message).toContain("integration-slack:write");
+  });
+
+  it("returns 404 when no Slack installation exists for org", async () => {
+    const { token } = await sandboxTokenWithRun(["integration-slack:write"]);
+
+    const request = createTestRequest(URL, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ channel: "C123", text: "hello" }),
+    });
+
+    const response = await POST(request);
+    expect(response.status).toBe(404);
+
+    const data = await response.json();
+    expect(data.error.message).toContain("No Slack installation");
+  });
+
+  it("sends message successfully and returns Slack response", async () => {
+    const { token } = await sandboxTokenWithRun(["integration-slack:write"]);
+
+    // Create Slack installation for the user's org
+    await createTestSlackOrgInstallation({ orgId: user.orgId });
+
+    const request = createTestRequest(URL, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({
+        channel: "C123456",
+        text: "Hello from agent",
+        threadTs: "1234567890.123456",
+      }),
+    });
+
+    const response = await POST(request);
+    expect(response.status).toBe(200);
+
+    const data = await response.json();
+    expect(data.ok).toBe(true);
+    expect(data.ts).toBe("mock.ts");
+
+    // Verify Slack client was called with correct params
+    const mockClient = vi.mocked(new WebClient(""));
+    expect(mockClient.chat.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "C123456",
+        text: "Hello from agent",
+        thread_ts: "1234567890.123456",
+      }),
+    );
+  });
+
+  it("forwards Slack API error with 400 status", async () => {
+    const { token } = await sandboxTokenWithRun(["integration-slack:write"]);
+
+    await createTestSlackOrgInstallation({ orgId: user.orgId });
+
+    // Mock Slack postMessage to throw a Slack API error
+    const mockClient = vi.mocked(new WebClient(""));
+    vi.mocked(mockClient.chat.postMessage).mockRejectedValueOnce(
+      Object.assign(new Error("channel_not_found"), {
+        data: { ok: false, error: "channel_not_found" },
+      }),
+    );
+
+    const request = createTestRequest(URL, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ channel: "C-invalid", text: "hello" }),
+    });
+
+    const response = await POST(request);
+    expect(response.status).toBe(400);
+
+    const data = await response.json();
+    expect(data.error.code).toBe("SLACK_ERROR");
+    expect(data.error.message).toContain("channel_not_found");
+  });
+});

--- a/turbo/apps/web/app/api/agent/integrations/slack/message/route.ts
+++ b/turbo/apps/web/app/api/agent/integrations/slack/message/route.ts
@@ -7,13 +7,29 @@ import {
 } from "../../../../../../src/lib/auth/require-auth";
 import { isSandboxAuth } from "../../../../../../src/lib/auth/capability-check";
 import { resolveOrg } from "../../../../../../src/lib/org/resolve-org";
-import { getOrgData } from "../../../../../../src/lib/org/org-cache-service";
 import { agentRuns } from "../../../../../../src/db/schema/agent-run";
 import { slackOrgInstallations } from "../../../../../../src/db/schema/slack-org-installation";
 import { decryptSecretValue } from "../../../../../../src/lib/crypto/secrets-encryption";
-import { createSlackClient } from "../../../../../../src/lib/slack/client";
+import {
+  createSlackClient,
+  postMessage,
+} from "../../../../../../src/lib/slack/client";
 import type { Block, KnownBlock } from "@slack/web-api";
 import { eq, and } from "drizzle-orm";
+
+/** Type guard for Slack API platform errors that carry a `data.error` string */
+function isSlackPlatformError(
+  err: unknown,
+): err is Error & { data: { error: string } } {
+  if (!(err instanceof Error) || !("data" in err)) return false;
+  const { data } = err as { data: unknown };
+  return (
+    typeof data === "object" &&
+    data !== null &&
+    "error" in data &&
+    typeof (data as { error: unknown }).error === "string"
+  );
+}
 
 const router = tsr.router(integrationsSlackMessageContract, {
   sendMessage: async ({ body, headers }, { request }) => {
@@ -43,7 +59,7 @@ const router = tsr.router(integrationsSlackMessageContract, {
           },
         };
       }
-      orgId = (await getOrgData(sandboxRun.orgId)).orgId;
+      orgId = sandboxRun.orgId;
     } else {
       const orgSlug = new URL(request.url).searchParams.get("org");
       const { org } = await resolveOrg(authCtx, orgSlug);
@@ -78,13 +94,9 @@ const router = tsr.router(integrationsSlackMessageContract, {
     const client = createSlackClient(botToken);
 
     try {
-      const result = await client.chat.postMessage({
-        channel: body.channel,
-        text: body.text ?? "",
-        ...(body.threadTs !== undefined && { thread_ts: body.threadTs }),
-        ...(body.blocks !== undefined && {
-          blocks: body.blocks as (Block | KnownBlock)[],
-        }),
+      const result = await postMessage(client, body.channel, body.text ?? "", {
+        threadTs: body.threadTs,
+        blocks: body.blocks as (Block | KnownBlock)[],
       });
       return {
         status: 200 as const,
@@ -95,13 +107,12 @@ const router = tsr.router(integrationsSlackMessageContract, {
         },
       };
     } catch (error) {
-      const slackError = (error as { data?: { error?: string } }).data?.error;
-      if (slackError) {
+      if (isSlackPlatformError(error)) {
         return {
           status: 400 as const,
           body: {
             error: {
-              message: `Slack API error: ${slackError}`,
+              message: `Slack API error: ${error.data.error}`,
               code: "SLACK_ERROR",
             },
           },

--- a/turbo/apps/web/app/api/agent/integrations/slack/message/route.ts
+++ b/turbo/apps/web/app/api/agent/integrations/slack/message/route.ts
@@ -1,0 +1,117 @@
+import { createHandler, tsr } from "../../../../../../src/lib/ts-rest-handler";
+import { integrationsSlackMessageContract } from "@vm0/core";
+import { initServices } from "../../../../../../src/lib/init-services";
+import {
+  requireAuth,
+  isAuthError,
+} from "../../../../../../src/lib/auth/require-auth";
+import { isSandboxAuth } from "../../../../../../src/lib/auth/capability-check";
+import { resolveOrg } from "../../../../../../src/lib/org/resolve-org";
+import { getOrgData } from "../../../../../../src/lib/org/org-cache-service";
+import { agentRuns } from "../../../../../../src/db/schema/agent-run";
+import { slackOrgInstallations } from "../../../../../../src/db/schema/slack-org-installation";
+import { decryptSecretValue } from "../../../../../../src/lib/crypto/secrets-encryption";
+import { createSlackClient } from "../../../../../../src/lib/slack/client";
+import type { Block, KnownBlock } from "@slack/web-api";
+import { eq, and } from "drizzle-orm";
+
+const router = tsr.router(integrationsSlackMessageContract, {
+  sendMessage: async ({ body, headers }, { request }) => {
+    initServices();
+
+    const authCtx = await requireAuth(headers.authorization, {
+      requiredCapability: "integration-slack:write",
+    });
+    if (isAuthError(authCtx)) return authCtx;
+    const { userId } = authCtx;
+
+    // Resolve orgId — sandbox tokens derive from runId, CLI/session use resolveOrg
+    let orgId: string;
+    if (isSandboxAuth(authCtx)) {
+      const [sandboxRun] = await globalThis.services.db
+        .select({ orgId: agentRuns.orgId })
+        .from(agentRuns)
+        .where(
+          and(eq(agentRuns.id, authCtx.runId), eq(agentRuns.userId, userId)),
+        )
+        .limit(1);
+      if (!sandboxRun) {
+        return {
+          status: 404 as const,
+          body: {
+            error: { message: "Agent run not found", code: "NOT_FOUND" },
+          },
+        };
+      }
+      orgId = (await getOrgData(sandboxRun.orgId)).orgId;
+    } else {
+      const orgSlug = new URL(request.url).searchParams.get("org");
+      const { org } = await resolveOrg(authCtx, orgSlug);
+      orgId = org.orgId;
+    }
+
+    // Look up Slack installation for the org
+    const [installation] = await globalThis.services.db
+      .select()
+      .from(slackOrgInstallations)
+      .where(eq(slackOrgInstallations.orgId, orgId))
+      .limit(1);
+
+    if (!installation) {
+      return {
+        status: 404 as const,
+        body: {
+          error: {
+            message: "No Slack installation found for this organization",
+            code: "NOT_FOUND",
+          },
+        },
+      };
+    }
+
+    // Decrypt bot token and send message
+    const { SECRETS_ENCRYPTION_KEY } = globalThis.services.env;
+    const botToken = decryptSecretValue(
+      installation.encryptedBotToken,
+      SECRETS_ENCRYPTION_KEY,
+    );
+    const client = createSlackClient(botToken);
+
+    try {
+      const result = await client.chat.postMessage({
+        channel: body.channel,
+        text: body.text ?? "",
+        ...(body.threadTs !== undefined && { thread_ts: body.threadTs }),
+        ...(body.blocks !== undefined && {
+          blocks: body.blocks as (Block | KnownBlock)[],
+        }),
+      });
+      return {
+        status: 200 as const,
+        body: {
+          ok: true as const,
+          ts: result.ts,
+          channel: result.channel,
+        },
+      };
+    } catch (error) {
+      const slackError = (error as { data?: { error?: string } }).data?.error;
+      if (slackError) {
+        return {
+          status: 400 as const,
+          body: {
+            error: {
+              message: `Slack API error: ${slackError}`,
+              code: "SLACK_ERROR",
+            },
+          },
+        };
+      }
+      throw error;
+    }
+  },
+});
+
+const handler = createHandler(integrationsSlackMessageContract, router);
+
+export { handler as POST };

--- a/turbo/packages/core/src/contracts/__tests__/composes.test.ts
+++ b/turbo/packages/core/src/contracts/__tests__/composes.test.ts
@@ -21,7 +21,7 @@ function wrapInCompose(agentOverrides: Record<string, unknown>) {
 
 describe("VALID_CAPABILITIES", () => {
   it("contains 8 capabilities", () => {
-    expect(VALID_CAPABILITIES).toHaveLength(8);
+    expect(VALID_CAPABILITIES).toHaveLength(9);
   });
 
   it("all follow resource:action format", () => {

--- a/turbo/packages/core/src/contracts/composes.ts
+++ b/turbo/packages/core/src/contracts/composes.ts
@@ -41,6 +41,7 @@ export const VALID_CAPABILITIES = [
   "agent-run:write",
   "schedule:read",
   "schedule:write",
+  "integration-slack:write",
 ] as const;
 
 /** Inferred union type of all valid capability strings. */
@@ -72,6 +73,10 @@ export const CAPABILITY_META: Record<ValidCapability, CapabilityMeta> = {
   "agent-run:write": { group: "Operations", label: "Create & cancel runs" },
   "schedule:read": { group: "Operations", label: "View schedules" },
   "schedule:write": { group: "Operations", label: "Manage schedules" },
+  "integration-slack:write": {
+    group: "Integrations",
+    label: "Send Slack messages via org bot",
+  },
 };
 
 /**

--- a/turbo/packages/core/src/contracts/index.ts
+++ b/turbo/packages/core/src/contracts/index.ts
@@ -602,3 +602,7 @@ export {
   zeroSessionsByIdContract,
   type ZeroSessionsByIdContract,
 } from "./zero-sessions";
+export {
+  integrationsSlackMessageContract,
+  type IntegrationsSlackMessageContract,
+} from "./integrations";

--- a/turbo/packages/core/src/contracts/integrations.ts
+++ b/turbo/packages/core/src/contracts/integrations.ts
@@ -1,0 +1,41 @@
+import { z } from "zod";
+import { authHeadersSchema, initContract } from "./base";
+import { apiErrorSchema } from "./errors";
+
+const c = initContract();
+
+/**
+ * Integration Slack message contract
+ * POST /api/agent/integrations/slack/message
+ *
+ * Sends a Slack message via the org's installed bot token.
+ * Requires `integration-slack:write` capability.
+ */
+export const integrationsSlackMessageContract = c.router({
+  sendMessage: {
+    method: "POST",
+    path: "/api/agent/integrations/slack/message",
+    headers: authHeadersSchema,
+    body: z.object({
+      channel: z.string().min(1, "Channel ID is required"),
+      text: z.string().optional(),
+      threadTs: z.string().optional(),
+      blocks: z.array(z.unknown()).optional(),
+    }),
+    responses: {
+      200: z.object({
+        ok: z.literal(true),
+        ts: z.string().optional(),
+        channel: z.string().optional(),
+      }),
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      404: apiErrorSchema,
+    },
+    summary: "Send a Slack message via org bot token",
+  },
+});
+
+export type IntegrationsSlackMessageContract =
+  typeof integrationsSlackMessageContract;

--- a/turbo/packages/core/src/contracts/integrations.ts
+++ b/turbo/packages/core/src/contracts/integrations.ts
@@ -20,7 +20,7 @@ export const integrationsSlackMessageContract = c.router({
       channel: z.string().min(1, "Channel ID is required"),
       text: z.string().optional(),
       threadTs: z.string().optional(),
-      blocks: z.array(z.unknown()).optional(),
+      blocks: z.array(z.object({ type: z.string() }).passthrough()).optional(),
     }),
     responses: {
       200: z.object({


### PR DESCRIPTION
## Summary

- Add `integration-slack:write` capability to `VALID_CAPABILITIES` and `CAPABILITY_META`
- Create ts-rest contract (`integrationsSlackMessageContract`) in `@vm0/core`
- Implement `POST /api/agent/integrations/slack/message` endpoint with sandbox token auth and org bot token decryption
- Integration tests covering 401, 403, 404, 200 success, and Slack API error forwarding

## Test plan

- [x] New integration tests pass (5 scenarios)
- [x] Existing capability tests updated (count 8→9)
- [x] Type-check passes
- [x] Lint passes
- [x] Knip passes (no unused exports)
- [ ] CI pipeline passes

Closes #5965

🤖 Generated with [Claude Code](https://claude.com/claude-code)