### PR TITLE
feat: add org s3 data cleanup service for org deletion

### DIFF
--- a/turbo/apps/web/src/__tests__/api-test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers.ts
@@ -3156,6 +3156,32 @@ export async function findTestExportJobById(id: string) {
 }
 
 /**
+ * Insert a test export job for a specific org.
+ *
+ * Direct DB insert is required because export jobs are normally created
+ * via async workflow, and tests need to control the exact state (status, s3Key).
+ */
+export async function insertTestExportJob(
+  orgId: string,
+  options: {
+    userId: string;
+    status: string;
+    s3Key?: string | null;
+  },
+): Promise<{ id: string }> {
+  const [row] = await globalThis.services.db
+    .insert(exportJobs)
+    .values({
+      orgId,
+      userId: options.userId,
+      status: options.status,
+      s3Key: options.s3Key ?? null,
+    })
+    .returning({ id: exportJobs.id });
+  return row!;
+}
+
+/**
  * Insert a test compose with a version for export testing.
  *
  * Direct DB insert is required because the export test needs compose data

--- a/turbo/apps/web/src/lib/org/__tests__/org-s3-cleanup.test.ts
+++ b/turbo/apps/web/src/lib/org/__tests__/org-s3-cleanup.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { testContext, uniqueId } from "../../../__tests__/test-helpers";
+import {
+  createTestVolumeForOrg,
+  insertTestExportJob,
+} from "../../../__tests__/api-test-helpers";
+import { deleteOrgS3Data } from "../org-s3-cleanup";
+
+const context = testContext();
+
+describe("deleteOrgS3Data", () => {
+  let orgId: string;
+
+  beforeEach(async () => {
+    context.setupMocks();
+    const user = await context.setupUser();
+    orgId = user.orgId;
+  });
+
+  it("should complete without error when org has no data", async () => {
+    await deleteOrgS3Data(orgId);
+
+    expect(context.mocks.s3.listS3Objects).not.toHaveBeenCalled();
+    expect(context.mocks.s3.deleteS3Objects).not.toHaveBeenCalled();
+  });
+
+  it("should delete S3 objects for storages", async () => {
+    const name1 = uniqueId("vol");
+    const name2 = uniqueId("vol");
+
+    await createTestVolumeForOrg(orgId, name1);
+    await createTestVolumeForOrg(orgId, name2);
+
+    const prefix1 = `${orgId}/${name1}`;
+    const prefix2 = `${orgId}/${name2}`;
+
+    context.mocks.s3.listS3Objects
+      .mockResolvedValueOnce([
+        { key: `${prefix1}/v1/archive.tar.gz`, size: 1024 },
+        { key: `${prefix1}/v1/manifest.json`, size: 256 },
+      ])
+      .mockResolvedValueOnce([
+        { key: `${prefix2}/v1/archive.tar.gz`, size: 2048 },
+      ]);
+
+    await deleteOrgS3Data(orgId);
+
+    expect(context.mocks.s3.listS3Objects).toHaveBeenCalledTimes(2);
+    expect(context.mocks.s3.deleteS3Objects).toHaveBeenCalledTimes(2);
+    expect(context.mocks.s3.deleteS3Objects).toHaveBeenCalledWith(
+      "test-bucket",
+      [`${prefix1}/v1/archive.tar.gz`, `${prefix1}/v1/manifest.json`],
+    );
+    expect(context.mocks.s3.deleteS3Objects).toHaveBeenCalledWith(
+      "test-bucket",
+      [`${prefix2}/v1/archive.tar.gz`],
+    );
+  });
+
+  it("should delete export job ZIPs with s3Key", async () => {
+    const key1 = `exports/user1/${uniqueId("job")}.zip`;
+    const key2 = `exports/user2/${uniqueId("job")}.zip`;
+
+    await insertTestExportJob(orgId, {
+      userId: uniqueId("user"),
+      status: "completed",
+      s3Key: key1,
+    });
+    await insertTestExportJob(orgId, {
+      userId: uniqueId("user"),
+      status: "completed",
+      s3Key: key2,
+    });
+
+    await deleteOrgS3Data(orgId);
+
+    expect(context.mocks.s3.deleteS3Objects).toHaveBeenCalledWith(
+      "test-bucket",
+      [key1, key2],
+    );
+  });
+
+  it("should skip export jobs with null s3Key", async () => {
+    await insertTestExportJob(orgId, {
+      userId: uniqueId("user"),
+      status: "pending",
+    });
+    await insertTestExportJob(orgId, {
+      userId: uniqueId("user"),
+      status: "failed",
+    });
+
+    await deleteOrgS3Data(orgId);
+
+    expect(context.mocks.s3.deleteS3Objects).not.toHaveBeenCalled();
+  });
+
+  it("should clean up both storages and export jobs", async () => {
+    const volName = uniqueId("vol");
+    await createTestVolumeForOrg(orgId, volName);
+    const prefix = `${orgId}/${volName}`;
+
+    const exportKey = `exports/user/${uniqueId("job")}.zip`;
+    await insertTestExportJob(orgId, {
+      userId: uniqueId("user"),
+      status: "completed",
+      s3Key: exportKey,
+    });
+
+    context.mocks.s3.listS3Objects.mockResolvedValueOnce([
+      { key: `${prefix}/v1/archive.tar.gz`, size: 512 },
+    ]);
+
+    await deleteOrgS3Data(orgId);
+
+    expect(context.mocks.s3.deleteS3Objects).toHaveBeenCalledWith(
+      "test-bucket",
+      [`${prefix}/v1/archive.tar.gz`],
+    );
+    expect(context.mocks.s3.deleteS3Objects).toHaveBeenCalledWith(
+      "test-bucket",
+      [exportKey],
+    );
+  });
+
+  it("should not call deleteS3Objects when storage prefix has no objects", async () => {
+    const volName = uniqueId("vol");
+    await createTestVolumeForOrg(orgId, volName);
+    const prefix = `${orgId}/${volName}`;
+
+    // listS3Objects returns empty array (default mock behavior)
+
+    await deleteOrgS3Data(orgId);
+
+    expect(context.mocks.s3.listS3Objects).toHaveBeenCalledWith(
+      "test-bucket",
+      prefix,
+    );
+    expect(context.mocks.s3.deleteS3Objects).not.toHaveBeenCalled();
+  });
+});

--- a/turbo/apps/web/src/lib/org/org-s3-cleanup.ts
+++ b/turbo/apps/web/src/lib/org/org-s3-cleanup.ts
@@ -1,0 +1,58 @@
+import { eq, and, isNotNull } from "drizzle-orm";
+import { storages } from "../../db/schema/storage";
+import { exportJobs } from "../../db/schema/export-job";
+import { listS3Objects, deleteS3Objects } from "../s3/s3-client";
+import { logger } from "../logger";
+
+const log = logger("service:org-s3-cleanup");
+
+/**
+ * Delete all S3 objects belonging to an org.
+ * Must be called BEFORE database deletion — reads s3Prefix/s3Key from DB.
+ * Idempotent: deleting non-existent S3 objects is a no-op.
+ */
+export async function deleteOrgS3Data(orgId: string): Promise<void> {
+  const db = globalThis.services.db;
+  const bucket = globalThis.services.env.R2_USER_STORAGES_BUCKET_NAME;
+
+  // 1. Delete storage objects (artifacts, memory, volumes)
+  const orgStorages = await db
+    .select({ s3Prefix: storages.s3Prefix })
+    .from(storages)
+    .where(eq(storages.orgId, orgId));
+
+  for (const storage of orgStorages) {
+    const objects = await listS3Objects(bucket, storage.s3Prefix);
+    if (objects.length > 0) {
+      await deleteS3Objects(
+        bucket,
+        objects.map((o) => o.key),
+      );
+      log.debug("deleted storage objects", {
+        prefix: storage.s3Prefix,
+        count: objects.length,
+      });
+    }
+  }
+
+  // 2. Delete export job ZIPs
+  const orgExports = await db
+    .select({ s3Key: exportJobs.s3Key })
+    .from(exportJobs)
+    .where(and(eq(exportJobs.orgId, orgId), isNotNull(exportJobs.s3Key)));
+
+  const exportKeys = orgExports
+    .map((e) => e.s3Key)
+    .filter((k): k is string => k !== null);
+
+  if (exportKeys.length > 0) {
+    await deleteS3Objects(bucket, exportKeys);
+    log.debug("deleted export objects", { count: exportKeys.length });
+  }
+
+  log.info("org S3 data deleted", {
+    orgId,
+    storageCount: orgStorages.length,
+    exportCount: exportKeys.length,
+  });
+}


### PR DESCRIPTION
## Summary

- Add `deleteOrgS3Data(orgId)` standalone function that deletes all S3 objects belonging to an org (storage archives and GDPR export ZIPs)
- Must be called before database deletion as it reads S3 paths from DB
- Add `insertTestExportJob` test helper for export job data setup

## Details

Part of Epic #5969 — org deletion cascade cleanup.

**New files:**
- `turbo/apps/web/src/lib/org/org-s3-cleanup.ts` — S3 cleanup function
- `turbo/apps/web/src/lib/org/__tests__/org-s3-cleanup.test.ts` — 6 integration tests

**Existing pattern:** Follows the same list-prefix + batch-delete pattern used in compose DELETE route.

Closes #5979

## Test plan

- [x] No data — completes without error, no S3 calls
- [x] Storages with objects — lists and deletes correctly per prefix
- [x] Export jobs with s3Key — deletes export ZIPs
- [x] Export jobs with null s3Key (pending/failed) — skipped
- [x] Mixed storages + exports — both cleaned up
- [x] Empty prefix (no S3 objects) — no deleteS3Objects call

🤖 Generated with [Claude Code](https://claude.com/claude-code)