### PR TITLE
feat: add org external service cleanup function

### DIFF
--- a/turbo/apps/web/src/__tests__/api-test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers.ts
@@ -3896,7 +3896,6 @@ export async function updateAgentComposeOrg(
   composeId: string,
   orgId: string,
 ): Promise<void> {
-  const { agentComposes } = await import("../db/schema/agent-compose");
   await globalThis.services.db
     .update(agentComposes)
     .set({ orgId })
@@ -3912,13 +3911,10 @@ export async function createTelegramInstallationForCompose(
   adminUserId: string,
   botToken: string,
 ): Promise<string> {
-  const { encryptSecretValue } = await import(
-    "../lib/crypto/secrets-encryption"
-  );
   const encryptionKey = globalThis.services.env.SECRETS_ENCRYPTION_KEY;
   const encryptedBotToken = encryptSecretValue(botToken, encryptionKey);
 
-  const [inst] = await globalThis.services.db
+  const rows = await globalThis.services.db
     .insert(telegramInstallations)
     .values({
       telegramBotId: `bot-${randomUUID().slice(0, 8)}`,
@@ -3929,7 +3925,8 @@ export async function createTelegramInstallationForCompose(
     })
     .returning();
 
-  return inst!.id;
+  if (!rows[0]) throw new Error("Failed to create telegram installation");
+  return rows[0].id;
 }
 
 /**
@@ -3939,9 +3936,6 @@ export async function createSlackInstallationForOrg(
   orgId: string,
   workspaceId: string,
 ): Promise<void> {
-  const { encryptSecretValue } = await import(
-    "../lib/crypto/secrets-encryption"
-  );
   const encryptionKey = globalThis.services.env.SECRETS_ENCRYPTION_KEY;
 
   await globalThis.services.db

--- a/turbo/apps/web/src/__tests__/api-test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers.ts
@@ -3869,3 +3869,88 @@ export async function getOrgAutoRechargeFields(orgId: string) {
     .limit(1);
   return row ?? null;
 }
+
+/**
+ * Set Stripe subscription fields on org_metadata for testing billing-related flows.
+ */
+export async function updateOrgStripeSubscription(
+  orgId: string,
+  subscriptionId: string,
+  status: string,
+): Promise<void> {
+  await globalThis.services.db
+    .update(orgMetadata)
+    .set({
+      stripeSubscriptionId: subscriptionId,
+      subscriptionStatus: status,
+      updatedAt: new Date(),
+    })
+    .where(eq(orgMetadata.orgId, orgId));
+}
+
+/**
+ * Update agent compose's orgId. Useful when tests need telegram installations
+ * or other compose-linked entities to belong to a specific org.
+ */
+export async function updateAgentComposeOrg(
+  composeId: string,
+  orgId: string,
+): Promise<void> {
+  const { agentComposes } = await import("../db/schema/agent-compose");
+  await globalThis.services.db
+    .update(agentComposes)
+    .set({ orgId })
+    .where(eq(agentComposes.id, composeId));
+}
+
+/**
+ * Create a telegram installation for a specific compose with a known bot token.
+ * Returns the installation ID.
+ */
+export async function createTelegramInstallationForCompose(
+  composeId: string,
+  adminUserId: string,
+  botToken: string,
+): Promise<string> {
+  const { encryptSecretValue } = await import(
+    "../lib/crypto/secrets-encryption"
+  );
+  const encryptionKey = globalThis.services.env.SECRETS_ENCRYPTION_KEY;
+  const encryptedBotToken = encryptSecretValue(botToken, encryptionKey);
+
+  const [inst] = await globalThis.services.db
+    .insert(telegramInstallations)
+    .values({
+      telegramBotId: `bot-${randomUUID().slice(0, 8)}`,
+      encryptedBotToken,
+      webhookSecret: `secret-${randomUUID().slice(0, 8)}`,
+      defaultComposeId: composeId,
+      adminUserId,
+    })
+    .returning();
+
+  return inst!.id;
+}
+
+/**
+ * Create a Slack org installation for a specific org.
+ */
+export async function createSlackInstallationForOrg(
+  orgId: string,
+  workspaceId: string,
+): Promise<void> {
+  const { encryptSecretValue } = await import(
+    "../lib/crypto/secrets-encryption"
+  );
+  const encryptionKey = globalThis.services.env.SECRETS_ENCRYPTION_KEY;
+
+  await globalThis.services.db
+    .insert(slackOrgInstallations)
+    .values({
+      slackWorkspaceId: workspaceId,
+      orgId,
+      encryptedBotToken: encryptSecretValue("xoxb-test-token", encryptionKey),
+      botUserId: `U${randomUUID().slice(0, 8)}`,
+    })
+    .onConflictDoNothing();
+}

--- a/turbo/apps/web/src/lib/connector/connector-service.ts
+++ b/turbo/apps/web/src/lib/connector/connector-service.ts
@@ -336,7 +336,7 @@ export async function upsertOAuthConnector(
  * and calls the handler's revokeToken method if available.
  * Errors are logged and swallowed — revocation must never block disconnect.
  */
-async function revokeConnectorToken(
+export async function revokeConnectorToken(
   orgId: string,
   userId: string,
   type: ConnectorType,

--- a/turbo/apps/web/src/lib/org/__tests__/org-external-cleanup.test.ts
+++ b/turbo/apps/web/src/lib/org/__tests__/org-external-cleanup.test.ts
@@ -1,0 +1,222 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { HttpResponse } from "msw";
+import type { StripeMockFns } from "../../../__tests__/stripe-mock";
+import { testContext, uniqueId } from "../../../__tests__/test-helpers";
+import { http } from "../../../__tests__/msw";
+import { server } from "../../../mocks/server";
+import { reloadEnv } from "../../../env";
+import {
+  updateOrgStripeSubscription,
+  updateAgentComposeOrg,
+  createTelegramInstallationForCompose,
+  createSlackInstallationForOrg,
+  findTestSlackOrgInstallation,
+} from "../../../__tests__/api-test-helpers";
+import { cleanupOrgExternalServices } from "../org-external-cleanup";
+
+// --- Stripe mock (external dependency — allowed) ---
+
+const stripeMocks = vi.hoisted<
+  Pick<StripeMockFns, "subscriptionsRetrieve"> & {
+    subscriptionsCancel: ReturnType<typeof vi.fn>;
+  }
+>(() => ({
+  subscriptionsRetrieve: vi.fn(),
+  subscriptionsCancel: vi.fn(),
+}));
+
+vi.mock("stripe", () => ({
+  default: function MockStripe() {
+    return {
+      subscriptions: {
+        retrieve: stripeMocks.subscriptionsRetrieve,
+        cancel: stripeMocks.subscriptionsCancel,
+      },
+    };
+  },
+}));
+
+// --- Test setup ---
+
+const context = testContext();
+
+describe("cleanupOrgExternalServices", () => {
+  beforeEach(() => {
+    context.setupMocks();
+    vi.stubEnv("STRIPE_SECRET_KEY", "sk_test_fake");
+    reloadEnv();
+    stripeMocks.subscriptionsCancel.mockResolvedValue({ id: "sub_cancelled" });
+  });
+
+  it("completes without error when org has no external services", async () => {
+    const { orgId } = await context.setupUser();
+
+    await cleanupOrgExternalServices(orgId);
+
+    expect(stripeMocks.subscriptionsCancel).not.toHaveBeenCalled();
+  });
+
+  it("cancels active stripe subscription", async () => {
+    const { orgId } = await context.setupUser();
+    const subId = uniqueId("sub");
+    await updateOrgStripeSubscription(orgId, subId, "active");
+
+    await cleanupOrgExternalServices(orgId);
+
+    expect(stripeMocks.subscriptionsCancel).toHaveBeenCalledWith(subId);
+  });
+
+  it("skips stripe cancellation when subscription is already canceled", async () => {
+    const { orgId } = await context.setupUser();
+    await updateOrgStripeSubscription(orgId, uniqueId("sub"), "canceled");
+
+    await cleanupOrgExternalServices(orgId);
+
+    expect(stripeMocks.subscriptionsCancel).not.toHaveBeenCalled();
+  });
+
+  it("skips stripe cancellation when no subscription exists", async () => {
+    const { orgId } = await context.setupUser();
+
+    await cleanupOrgExternalServices(orgId);
+
+    expect(stripeMocks.subscriptionsCancel).not.toHaveBeenCalled();
+  });
+
+  it("deregisters telegram webhook for org installation", async () => {
+    const { userId, orgId } = await context.setupUser();
+    const compose = await context.createAgentCompose(userId);
+    await updateAgentComposeOrg(compose.id, orgId);
+
+    const botToken = "test-bot-token-123";
+    await createTelegramInstallationForCompose(compose.id, userId, botToken);
+
+    const telegramHandler = http.post(
+      `https://api.telegram.org/bot${botToken}/deleteWebhook`,
+      () => HttpResponse.json({ ok: true, result: true }),
+    );
+    server.use(telegramHandler.handler);
+
+    await cleanupOrgExternalServices(orgId);
+
+    expect(telegramHandler.mocked).toHaveBeenCalledTimes(1);
+  });
+
+  it("deregisters multiple telegram webhooks", async () => {
+    const { userId, orgId } = await context.setupUser();
+
+    const compose1 = await context.createAgentCompose(userId, {
+      name: uniqueId("compose"),
+    });
+    const compose2 = await context.createAgentCompose(userId, {
+      name: uniqueId("compose"),
+    });
+    await updateAgentComposeOrg(compose1.id, orgId);
+    await updateAgentComposeOrg(compose2.id, orgId);
+
+    const token1 = "bot-token-one";
+    const token2 = "bot-token-two";
+    await createTelegramInstallationForCompose(compose1.id, userId, token1);
+    await createTelegramInstallationForCompose(compose2.id, userId, token2);
+
+    const handler1 = http.post(
+      `https://api.telegram.org/bot${token1}/deleteWebhook`,
+      () => HttpResponse.json({ ok: true, result: true }),
+    );
+    const handler2 = http.post(
+      `https://api.telegram.org/bot${token2}/deleteWebhook`,
+      () => HttpResponse.json({ ok: true, result: true }),
+    );
+    server.use(handler1.handler, handler2.handler);
+
+    await cleanupOrgExternalServices(orgId);
+
+    expect(handler1.mocked).toHaveBeenCalledTimes(1);
+    expect(handler2.mocked).toHaveBeenCalledTimes(1);
+  });
+
+  it("revokes connector tokens for org connectors", async () => {
+    const { userId, orgId } = await context.setupUser();
+    // revokeConnectorToken will skip gracefully since OAuth credentials
+    // are not configured in the test environment — best-effort by design
+    await context.createConnector(orgId, { userId, type: "github" });
+
+    // Should complete without error even with no OAuth creds configured
+    await cleanupOrgExternalServices(orgId);
+  });
+
+  it("cleans up slack workspace installation", async () => {
+    const { orgId } = await context.setupUser();
+    const workspaceId = uniqueId("W");
+    await createSlackInstallationForOrg(orgId, workspaceId);
+
+    await cleanupOrgExternalServices(orgId);
+
+    // Verify installation was cleaned up
+    const installation = await findTestSlackOrgInstallation(workspaceId);
+    expect(installation).toBeUndefined();
+  });
+
+  it("continues cleanup when stripe cancellation fails", async () => {
+    const { userId, orgId } = await context.setupUser();
+    const subId = uniqueId("sub");
+    await updateOrgStripeSubscription(orgId, subId, "active");
+    await context.createConnector(orgId, { userId, type: "github" });
+
+    stripeMocks.subscriptionsCancel.mockRejectedValue(
+      new Error("Stripe API down"),
+    );
+
+    // Should not throw — all operations are best-effort
+    await cleanupOrgExternalServices(orgId);
+
+    expect(stripeMocks.subscriptionsCancel).toHaveBeenCalledWith(subId);
+  });
+
+  it("continues deregistering other webhooks when one telegram installation fails", async () => {
+    const { userId, orgId } = await context.setupUser();
+
+    const compose1 = await context.createAgentCompose(userId, {
+      name: uniqueId("compose"),
+    });
+    const compose2 = await context.createAgentCompose(userId, {
+      name: uniqueId("compose"),
+    });
+    await updateAgentComposeOrg(compose1.id, orgId);
+    await updateAgentComposeOrg(compose2.id, orgId);
+
+    const tokenFail = "token-fail";
+    const tokenOk = "token-ok";
+    await createTelegramInstallationForCompose(compose1.id, userId, tokenFail);
+    await createTelegramInstallationForCompose(compose2.id, userId, tokenOk);
+
+    const failHandler = http.post(
+      `https://api.telegram.org/bot${tokenFail}/deleteWebhook`,
+      () => HttpResponse.error(),
+    );
+    const okHandler = http.post(
+      `https://api.telegram.org/bot${tokenOk}/deleteWebhook`,
+      () => HttpResponse.json({ ok: true, result: true }),
+    );
+    server.use(failHandler.handler, okHandler.handler);
+
+    await cleanupOrgExternalServices(orgId);
+
+    // Both were attempted despite the first one failing
+    expect(failHandler.mocked).toHaveBeenCalledTimes(1);
+    expect(okHandler.mocked).toHaveBeenCalledTimes(1);
+  });
+
+  it("is idempotent - calling twice produces no errors", async () => {
+    const { orgId } = await context.setupUser();
+    const subId = uniqueId("sub");
+    await updateOrgStripeSubscription(orgId, subId, "active");
+
+    await cleanupOrgExternalServices(orgId);
+    await cleanupOrgExternalServices(orgId);
+
+    // Stripe cancel called twice (once per invocation, since we don't
+    // update subscriptionStatus locally — Stripe webhook would do that)
+    expect(stripeMocks.subscriptionsCancel).toHaveBeenCalledTimes(2);
+  });
+});

--- a/turbo/apps/web/src/lib/org/org-external-cleanup.ts
+++ b/turbo/apps/web/src/lib/org/org-external-cleanup.ts
@@ -1,0 +1,152 @@
+import { eq } from "drizzle-orm";
+import type { ConnectorType } from "@vm0/core";
+import { logger } from "../logger";
+import { getStripe } from "../stripe";
+import { deleteWebhook } from "../telegram/client";
+import { decryptSecretValue } from "../crypto/secrets-encryption";
+import { revokeConnectorToken } from "../connector/connector-service";
+import { cleanupWorkspaceInstallation } from "../slack-org/connect-service";
+import { orgMetadata } from "../../db/schema/org-metadata";
+import { telegramInstallations } from "../../db/schema/telegram-installation";
+import { agentComposes } from "../../db/schema/agent-compose";
+import { connectors } from "../../db/schema/connector";
+import { slackOrgInstallations } from "../../db/schema/slack-org-installation";
+
+const log = logger("service:org-external-cleanup");
+
+/**
+ * Best-effort cleanup of external services for a deleted org.
+ * Must be called BEFORE database deletion — reads tokens/IDs from DB.
+ * All operations are best-effort: failures are logged but do not throw.
+ * Idempotent: safe to call multiple times.
+ */
+export async function cleanupOrgExternalServices(orgId: string): Promise<void> {
+  await cancelStripeSubscription(orgId);
+  await deregisterTelegramWebhooks(orgId);
+  await revokeOrgConnectorTokens(orgId);
+  await cleanupOrgSlackInstallation(orgId);
+}
+
+async function cancelStripeSubscription(orgId: string): Promise<void> {
+  try {
+    const db = globalThis.services.db;
+    const [meta] = await db
+      .select({
+        stripeSubscriptionId: orgMetadata.stripeSubscriptionId,
+        subscriptionStatus: orgMetadata.subscriptionStatus,
+      })
+      .from(orgMetadata)
+      .where(eq(orgMetadata.orgId, orgId))
+      .limit(1);
+
+    if (!meta?.stripeSubscriptionId || meta.subscriptionStatus === "canceled") {
+      return;
+    }
+
+    const stripe = getStripe();
+    await stripe.subscriptions.cancel(meta.stripeSubscriptionId);
+    log.info("stripe subscription cancelled", {
+      orgId,
+      subId: meta.stripeSubscriptionId,
+    });
+  } catch (error) {
+    log.error("failed to cancel stripe subscription (best-effort)", {
+      orgId,
+      error,
+    });
+  }
+}
+
+async function deregisterTelegramWebhooks(orgId: string): Promise<void> {
+  try {
+    const db = globalThis.services.db;
+    const installations = await db
+      .select({
+        id: telegramInstallations.id,
+        encryptedBotToken: telegramInstallations.encryptedBotToken,
+      })
+      .from(telegramInstallations)
+      .innerJoin(
+        agentComposes,
+        eq(telegramInstallations.defaultComposeId, agentComposes.id),
+      )
+      .where(eq(agentComposes.orgId, orgId));
+
+    const encryptionKey = globalThis.services.env.SECRETS_ENCRYPTION_KEY;
+
+    for (const inst of installations) {
+      try {
+        const botToken = decryptSecretValue(
+          inst.encryptedBotToken,
+          encryptionKey,
+        );
+        await deleteWebhook(botToken);
+        log.debug("telegram webhook deregistered", {
+          installationId: inst.id,
+        });
+      } catch (error) {
+        log.error("failed to deregister telegram webhook (best-effort)", {
+          installationId: inst.id,
+          error,
+        });
+      }
+    }
+  } catch (error) {
+    log.error("failed to query telegram installations (best-effort)", {
+      orgId,
+      error,
+    });
+  }
+}
+
+async function revokeOrgConnectorTokens(orgId: string): Promise<void> {
+  try {
+    const db = globalThis.services.db;
+    const orgConnectors = await db
+      .select({ userId: connectors.userId, type: connectors.type })
+      .from(connectors)
+      .where(eq(connectors.orgId, orgId));
+
+    for (const conn of orgConnectors) {
+      try {
+        await revokeConnectorToken(
+          orgId,
+          conn.userId,
+          conn.type as ConnectorType,
+        );
+      } catch (error) {
+        log.error("failed to revoke connector token (best-effort)", {
+          orgId,
+          userId: conn.userId,
+          type: conn.type,
+          error,
+        });
+      }
+    }
+  } catch (error) {
+    log.error("failed to query connectors (best-effort)", { orgId, error });
+  }
+}
+
+async function cleanupOrgSlackInstallation(orgId: string): Promise<void> {
+  try {
+    const db = globalThis.services.db;
+    const [installation] = await db
+      .select({
+        slackWorkspaceId: slackOrgInstallations.slackWorkspaceId,
+      })
+      .from(slackOrgInstallations)
+      .where(eq(slackOrgInstallations.orgId, orgId))
+      .limit(1);
+
+    if (!installation) return;
+
+    await cleanupWorkspaceInstallation(installation.slackWorkspaceId);
+    log.info("slack workspace installation cleaned up", { orgId });
+  } catch (error) {
+    log.error("failed to cleanup slack installation (best-effort)", {
+      orgId,
+      error,
+    });
+  }
+}

--- a/turbo/apps/web/src/lib/org/org-external-cleanup.ts
+++ b/turbo/apps/web/src/lib/org/org-external-cleanup.ts
@@ -1,5 +1,5 @@
 import { eq } from "drizzle-orm";
-import type { ConnectorType } from "@vm0/core";
+import { connectorTypeSchema } from "@vm0/core";
 import { logger } from "../logger";
 import { getStripe } from "../stripe";
 import { deleteWebhook } from "../telegram/client";
@@ -21,132 +21,127 @@ const log = logger("service:org-external-cleanup");
  * Idempotent: safe to call multiple times.
  */
 export async function cleanupOrgExternalServices(orgId: string): Promise<void> {
-  await cancelStripeSubscription(orgId);
-  await deregisterTelegramWebhooks(orgId);
-  await revokeOrgConnectorTokens(orgId);
-  await cleanupOrgSlackInstallation(orgId);
-}
+  const steps = [
+    { name: "stripe subscription", fn: () => cancelStripeSubscription(orgId) },
+    { name: "telegram webhooks", fn: () => deregisterTelegramWebhooks(orgId) },
+    { name: "connector tokens", fn: () => revokeOrgConnectorTokens(orgId) },
+    {
+      name: "slack installation",
+      fn: () => cleanupOrgSlackInstallation(orgId),
+    },
+  ];
 
-async function cancelStripeSubscription(orgId: string): Promise<void> {
-  try {
-    const db = globalThis.services.db;
-    const [meta] = await db
-      .select({
-        stripeSubscriptionId: orgMetadata.stripeSubscriptionId,
-        subscriptionStatus: orgMetadata.subscriptionStatus,
-      })
-      .from(orgMetadata)
-      .where(eq(orgMetadata.orgId, orgId))
-      .limit(1);
-
-    if (!meta?.stripeSubscriptionId || meta.subscriptionStatus === "canceled") {
-      return;
+  for (const step of steps) {
+    try {
+      await step.fn();
+    } catch (error) {
+      log.error(`failed to cleanup ${step.name} (best-effort)`, {
+        orgId,
+        error,
+      });
     }
-
-    const stripe = getStripe();
-    await stripe.subscriptions.cancel(meta.stripeSubscriptionId);
-    log.info("stripe subscription cancelled", {
-      orgId,
-      subId: meta.stripeSubscriptionId,
-    });
-  } catch (error) {
-    log.error("failed to cancel stripe subscription (best-effort)", {
-      orgId,
-      error,
-    });
   }
 }
 
+async function cancelStripeSubscription(orgId: string): Promise<void> {
+  const db = globalThis.services.db;
+  const [meta] = await db
+    .select({
+      stripeSubscriptionId: orgMetadata.stripeSubscriptionId,
+      subscriptionStatus: orgMetadata.subscriptionStatus,
+    })
+    .from(orgMetadata)
+    .where(eq(orgMetadata.orgId, orgId))
+    .limit(1);
+
+  if (!meta?.stripeSubscriptionId || meta.subscriptionStatus === "canceled") {
+    return;
+  }
+
+  const stripe = getStripe();
+  await stripe.subscriptions.cancel(meta.stripeSubscriptionId);
+  log.info("stripe subscription cancelled", {
+    orgId,
+    subId: meta.stripeSubscriptionId,
+  });
+}
+
 async function deregisterTelegramWebhooks(orgId: string): Promise<void> {
-  try {
-    const db = globalThis.services.db;
-    const installations = await db
-      .select({
-        id: telegramInstallations.id,
-        encryptedBotToken: telegramInstallations.encryptedBotToken,
-      })
-      .from(telegramInstallations)
-      .innerJoin(
-        agentComposes,
-        eq(telegramInstallations.defaultComposeId, agentComposes.id),
-      )
-      .where(eq(agentComposes.orgId, orgId));
+  const db = globalThis.services.db;
+  const installations = await db
+    .select({
+      id: telegramInstallations.id,
+      encryptedBotToken: telegramInstallations.encryptedBotToken,
+    })
+    .from(telegramInstallations)
+    .innerJoin(
+      agentComposes,
+      eq(telegramInstallations.defaultComposeId, agentComposes.id),
+    )
+    .where(eq(agentComposes.orgId, orgId));
 
-    const encryptionKey = globalThis.services.env.SECRETS_ENCRYPTION_KEY;
+  const encryptionKey = globalThis.services.env.SECRETS_ENCRYPTION_KEY;
 
-    for (const inst of installations) {
-      try {
-        const botToken = decryptSecretValue(
-          inst.encryptedBotToken,
-          encryptionKey,
-        );
-        await deleteWebhook(botToken);
-        log.debug("telegram webhook deregistered", {
-          installationId: inst.id,
-        });
-      } catch (error) {
-        log.error("failed to deregister telegram webhook (best-effort)", {
-          installationId: inst.id,
-          error,
-        });
-      }
+  for (const inst of installations) {
+    try {
+      const botToken = decryptSecretValue(
+        inst.encryptedBotToken,
+        encryptionKey,
+      );
+      await deleteWebhook(botToken);
+      log.debug("telegram webhook deregistered", {
+        installationId: inst.id,
+      });
+    } catch (error) {
+      log.error("failed to deregister telegram webhook (best-effort)", {
+        installationId: inst.id,
+        error,
+      });
     }
-  } catch (error) {
-    log.error("failed to query telegram installations (best-effort)", {
-      orgId,
-      error,
-    });
   }
 }
 
 async function revokeOrgConnectorTokens(orgId: string): Promise<void> {
-  try {
-    const db = globalThis.services.db;
-    const orgConnectors = await db
-      .select({ userId: connectors.userId, type: connectors.type })
-      .from(connectors)
-      .where(eq(connectors.orgId, orgId));
+  const db = globalThis.services.db;
+  const orgConnectors = await db
+    .select({ userId: connectors.userId, type: connectors.type })
+    .from(connectors)
+    .where(eq(connectors.orgId, orgId));
 
-    for (const conn of orgConnectors) {
-      try {
-        await revokeConnectorToken(
+  for (const conn of orgConnectors) {
+    try {
+      const parsed = connectorTypeSchema.safeParse(conn.type);
+      if (!parsed.success) {
+        log.warn("unknown connector type, skipping revocation", {
           orgId,
-          conn.userId,
-          conn.type as ConnectorType,
-        );
-      } catch (error) {
-        log.error("failed to revoke connector token (best-effort)", {
-          orgId,
-          userId: conn.userId,
           type: conn.type,
-          error,
         });
+        continue;
       }
+      await revokeConnectorToken(orgId, conn.userId, parsed.data);
+    } catch (error) {
+      log.error("failed to revoke connector token (best-effort)", {
+        orgId,
+        userId: conn.userId,
+        type: conn.type,
+        error,
+      });
     }
-  } catch (error) {
-    log.error("failed to query connectors (best-effort)", { orgId, error });
   }
 }
 
 async function cleanupOrgSlackInstallation(orgId: string): Promise<void> {
-  try {
-    const db = globalThis.services.db;
-    const [installation] = await db
-      .select({
-        slackWorkspaceId: slackOrgInstallations.slackWorkspaceId,
-      })
-      .from(slackOrgInstallations)
-      .where(eq(slackOrgInstallations.orgId, orgId))
-      .limit(1);
+  const db = globalThis.services.db;
+  const [installation] = await db
+    .select({
+      slackWorkspaceId: slackOrgInstallations.slackWorkspaceId,
+    })
+    .from(slackOrgInstallations)
+    .where(eq(slackOrgInstallations.orgId, orgId))
+    .limit(1);
 
-    if (!installation) return;
+  if (!installation) return;
 
-    await cleanupWorkspaceInstallation(installation.slackWorkspaceId);
-    log.info("slack workspace installation cleaned up", { orgId });
-  } catch (error) {
-    log.error("failed to cleanup slack installation (best-effort)", {
-      orgId,
-      error,
-    });
-  }
+  await cleanupWorkspaceInstallation(installation.slackWorkspaceId);
+  log.info("slack workspace installation cleaned up", { orgId });
 }


### PR DESCRIPTION
## Summary

- Create `cleanupOrgExternalServices(orgId)` that performs best-effort cleanup of 4 external services before org database deletion
- Cancel Stripe subscriptions, deregister Telegram webhooks, revoke OAuth connector tokens, and clean up Slack workspace installations
- Export `revokeConnectorToken` from connector-service for reuse
- Add test helpers for org stripe subscription, telegram installation, and slack installation setup

## Changes

| File | Action | Description |
|------|--------|-------------|
| `connector-service.ts` | Modified | Export `revokeConnectorToken` |
| `org-external-cleanup.ts` | New | Main cleanup function with 4 service handlers |
| `org-external-cleanup.test.ts` | New | 11 integration tests |
| `api-test-helpers.ts` | Modified | Add 4 test helpers for org cleanup testing |

## Test plan

- [x] No external services — completes without error
- [x] Stripe cancellation — active subscription cancelled
- [x] Stripe already canceled — skipped
- [x] Stripe no subscription — skipped
- [x] Telegram deregistration — webhook deleted via API (MSW)
- [x] Multiple telegram webhooks — all deregistered
- [x] Connector revocation — runs without error (best-effort skip in test env)
- [x] Slack cleanup — installation removed from DB
- [x] Partial failure (Stripe) — other services still execute
- [x] Partial failure (Telegram) — other installations still deregistered
- [x] Idempotent — calling twice produces no errors
- [x] All 2263 existing tests pass

Closes #5980

🤖 Generated with [Claude Code](https://claude.com/claude-code)