### PR TITLE
refactor: delegate coding loop work to subagent instead of self-executing

### DIFF
--- a/.claude/skills/begin-coding-loop/SKILL.md
+++ b/.claude/skills/begin-coding-loop/SKILL.md
@@ -3,5 +3,7 @@ name: begin-coding-loop
 description: Start an adaptive coding loop that dynamically adjusts interval based on activity — short intervals when busy, longer when idle.
 ---
 
-1. Run `scripts/coding-loop.sh ${ARGUMENTS:-$(hostname)}` and follow the stdout after the first line.
-2. The first line is `INTERVAL:N`. Use CronCreate (one-shot) to schedule `/begin-coding-loop $ARGUMENTS` in N minutes.
+1. Run `scripts/coding-loop.sh ${ARGUMENTS:-$(hostname)}` and capture the stdout.
+2. Parse the first line `INTERVAL:N` and save N.
+3. If the remaining output (after the first line) is "idle", use CronCreate (one-shot) to schedule `/begin-coding-loop $ARGUMENTS` in N minutes immediately.
+4. If the remaining output is NOT "idle", launch a **general-purpose Agent** (subagent) with that output as the prompt. Do NOT execute the instructions yourself — always delegate to a subagent. **Wait for the subagent to complete**, then use CronCreate (one-shot) to schedule `/begin-coding-loop $ARGUMENTS` in N minutes.


### PR DESCRIPTION
## Summary
- Refactors the `begin-coding-loop` skill to differentiate between idle and non-idle states
- When idle, immediately schedules the next cron iteration
- When there is work to do, delegates to a general-purpose subagent instead of self-executing, then schedules the next iteration after completion

## Test plan
- [ ] Verify idle state triggers immediate cron scheduling
- [ ] Verify non-idle state delegates work to a subagent and waits for completion before scheduling next iteration

🤖 Generated with [Claude Code](https://claude.com/claude-code)