### PR TITLE
fix: return chat message summaries on page refresh

### DIFF
--- a/turbo/apps/web/app/api/zero/chat-threads/[id]/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/chat-threads/[id]/__tests__/route.test.ts
@@ -1,24 +1,32 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { GET } from "../route";
 import { POST } from "../../route";
+import { POST as POST_RUN } from "../runs/route";
 import {
   createTestRequest,
   createTestCompose,
+  createTestSessionWithConversation,
+  createTestRunInDb,
 } from "../../../../../../src/__tests__/api-test-helpers";
 import {
   testContext,
   uniqueId,
 } from "../../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
+import { appendChatMessages } from "../../../../../../src/lib/agent-session/agent-session-service";
+import { agentRuns } from "../../../../../../src/db/schema/agent-run";
+import { eq } from "drizzle-orm";
 
 const context = testContext();
 
 describe("GET /api/zero/chat-threads/:id - Get Thread Detail", () => {
   let testComposeId: string;
+  let testUserId: string;
 
   beforeEach(async () => {
     context.setupMocks();
-    await context.setupUser();
+    const user = await context.setupUser();
+    testUserId = user.userId;
 
     const { composeId } = await createTestCompose(uniqueId("chat-detail"));
     testComposeId = composeId;
@@ -78,6 +86,83 @@ describe("GET /api/zero/chat-threads/:id - Get Thread Detail", () => {
     expect(data.unsavedRuns).toEqual([]);
     expect(data.createdAt).toBeDefined();
     expect(data.updatedAt).toBeDefined();
+  });
+
+  it("should return chat messages with summaries after run completes", async () => {
+    const userId = testUserId;
+
+    // 1. Create thread
+    const createRes = await POST(
+      createTestRequest("http://localhost:3000/api/zero/chat-threads", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          agentComposeId: testComposeId,
+          title: "Summaries thread",
+        }),
+      }),
+    );
+    const { id: threadId } = await createRes.json();
+
+    // 2. Create a session (linked to a conversation)
+    const session = await createTestSessionWithConversation(
+      userId,
+      testComposeId,
+    );
+
+    // 3. Create a completed run whose result references the session
+    const { runId } = await createTestRunInDb(userId, testComposeId, {
+      status: "completed",
+      prompt: "What files changed?",
+    });
+
+    // Set run.result to reference the session
+    await globalThis.services.db
+      .update(agentRuns)
+      .set({ result: { agentSessionId: session.id } })
+      .where(eq(agentRuns.id, runId));
+
+    // 4. Append chat messages with summaries to the session
+    await appendChatMessages(session.id, userId, [
+      { role: "user", content: "What files changed?" },
+      {
+        role: "assistant",
+        content: "Here are the changed files.",
+        runId,
+        summaries: ["Bash", "Read", "Grep"],
+      },
+    ]);
+
+    // 5. Link run to thread
+    await POST_RUN(
+      createTestRequest(
+        `http://localhost:3000/api/zero/chat-threads/${threadId}/runs`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ runId }),
+        },
+      ),
+    );
+
+    // 6. GET thread detail — summaries should be present
+    const response = await GET(
+      createTestRequest(
+        `http://localhost:3000/api/zero/chat-threads/${threadId}`,
+      ),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.chatMessages).toHaveLength(2);
+
+    const assistantMsg = data.chatMessages.find(
+      (m: { role: string }) => m.role === "assistant",
+    );
+    expect(assistantMsg).toBeDefined();
+    expect(assistantMsg.content).toBe("Here are the changed files.");
+    expect(assistantMsg.runId).toBe(runId);
+    expect(assistantMsg.summaries).toEqual(["Bash", "Read", "Grep"]);
   });
 
   it("should not return thread owned by another user", async () => {

--- a/turbo/apps/web/app/api/zero/chat-threads/[id]/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/chat-threads/[id]/__tests__/route.test.ts
@@ -14,8 +14,6 @@ import {
 } from "../../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
 import { appendChatMessages } from "../../../../../../src/lib/agent-session/agent-session-service";
-import { agentRuns } from "../../../../../../src/db/schema/agent-run";
-import { eq } from "drizzle-orm";
 
 const context = testContext();
 
@@ -114,13 +112,8 @@ describe("GET /api/zero/chat-threads/:id - Get Thread Detail", () => {
     const { runId } = await createTestRunInDb(userId, testComposeId, {
       status: "completed",
       prompt: "What files changed?",
+      result: { agentSessionId: session.id },
     });
-
-    // Set run.result to reference the session
-    await globalThis.services.db
-      .update(agentRuns)
-      .set({ result: { agentSessionId: session.id } })
-      .where(eq(agentRuns.id, runId));
 
     // 4. Append chat messages with summaries to the session
     await appendChatMessages(session.id, userId, [

--- a/turbo/apps/web/src/__tests__/api-test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers.ts
@@ -598,6 +598,7 @@ async function createTestRunDirect(
     createdAt?: Date;
     startedAt?: Date;
     completedAt?: Date;
+    result?: Record<string, unknown>;
   },
 ): Promise<{ id: string }> {
   const [run] = await globalThis.services.db
@@ -614,6 +615,7 @@ async function createTestRunDirect(
       ...(options?.createdAt ? { createdAt: options.createdAt } : {}),
       ...(options?.startedAt ? { startedAt: options.startedAt } : {}),
       ...(options?.completedAt ? { completedAt: options.completedAt } : {}),
+      ...(options?.result ? { result: options.result } : {}),
     })
     .returning({ id: agentRuns.id });
   return run!;
@@ -693,6 +695,7 @@ export async function createTestRunInDb(
     orgId?: string;
     startedAt?: Date;
     completedAt?: Date;
+    result?: Record<string, unknown>;
   },
 ): Promise<{ runId: string }> {
   // Look up orgId from compose
@@ -720,6 +723,7 @@ export async function createTestRunInDb(
       createdAt: options?.createdAt,
       startedAt: options?.startedAt,
       completedAt: options?.completedAt,
+      result: options?.result,
     },
   );
   return { runId: run.id };

--- a/turbo/apps/web/src/lib/chat-thread/chat-thread-service.ts
+++ b/turbo/apps/web/src/lib/chat-thread/chat-thread-service.ts
@@ -161,6 +161,7 @@ export async function getChatThreadMessages(
     content: string;
     runId?: string;
     error?: string;
+    summaries?: string[];
     createdAt: string;
   }>;
   latestSessionId: string | null;
@@ -201,6 +202,7 @@ export async function getChatThreadMessages(
     role: "user" | "assistant";
     content: string;
     runId?: string;
+    summaries?: string[];
     createdAt: string;
   };
   let messages: StoredMessage[] = [];

--- a/turbo/packages/core/src/contracts/chat-threads.ts
+++ b/turbo/packages/core/src/contracts/chat-threads.ts
@@ -17,6 +17,7 @@ const storedChatMessageSchema = z.object({
   content: z.string(),
   runId: z.string().optional(),
   error: z.string().optional(),
+  summaries: z.array(z.string()).optional(),
   createdAt: z.string(),
 });
 


### PR DESCRIPTION
## Summary
- Fix chat process/progress info (tool calls, intermediate steps) being lost after page refresh
- The `summaries` field was correctly stored in `agent_sessions.chatMessages` JSONB but stripped on read because the `StoredMessage` type, `getChatThreadMessages` return type, and ts-rest contract schema all omitted it
- Added the optional `summaries: z.array(z.string()).optional()` field to the contract, service return type, and internal `StoredMessage` type

## Test plan
- [x] Added integration test: creates a thread with a completed run, appends chat messages with summaries, verifies GET returns summaries
- [x] All 17 chat-thread tests pass
- [x] Type check passes
- [x] Lint, format, knip all pass
- [ ] CI pipeline passes

Closes #5767

🤖 Generated with [Claude Code](https://claude.com/claude-code)