### PR TITLE
fix(platform): onboarding chat redirect and disable duplicate clicks

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-onboarding.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-onboarding.test.ts
@@ -166,7 +166,7 @@ describe("completeZeroOnboarding$", () => {
     });
   });
 
-  it("should set step to done and saving to false after completion", async () => {
+  it("should reset saving to false after completion (step remains unchanged)", async () => {
     server.use(
       http.post("*/api/zero/agents", () => {
         return HttpResponse.json({
@@ -197,7 +197,7 @@ describe("completeZeroOnboarding$", () => {
 
     await context.store.set(completeZeroOnboarding$, context.signal);
 
-    expect(context.store.get(zeroOnboardingStep$)).toBe("done");
+    // Step no longer auto-set to "done"; callers use dismissZeroOnboarding$
     expect(context.store.get(zeroSaving$)).toBeFalsy();
   });
 
@@ -273,7 +273,9 @@ describe("completeZeroOnboarding$", () => {
     await context.store.set(completeZeroOnboarding$, context.signal);
 
     expect(context.store.get(zeroOnboardingError$)).toBeNull();
-    expect(context.store.get(zeroOnboardingStep$)).toBe("done");
+    // Step is no longer auto-set to "done" by completeZeroOnboarding$;
+    // callers use dismissZeroOnboarding$ to dismiss the dialog.
+    expect(context.store.get(zeroOnboardingStep$)).toBe("4");
   });
 });
 

--- a/turbo/apps/platform/src/signals/zero-page/zero-onboarding.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-onboarding.ts
@@ -65,9 +65,14 @@ export const zeroNeedsMemberOnboarding$ = computed(async (get) => {
  * so the dialog disappears (server reads Clerk API directly, no JWT needed).
  */
 export const completeMemberOnboarding$ = command(async ({ get, set }) => {
-  const fetchFn = get(fetch$);
-  await fetchFn("/api/zero/onboarding/complete", { method: "POST" });
-  set(internalReload$, (x) => x + 1);
+  set(internalSaving$, true);
+  try {
+    const fetchFn = get(fetch$);
+    await fetchFn("/api/zero/onboarding/complete", { method: "POST" });
+    set(internalReload$, (x) => x + 1);
+  } finally {
+    set(internalSaving$, false);
+  }
 });
 
 // ---------------------------------------------------------------------------
@@ -369,9 +374,8 @@ export const completeZeroOnboarding$ = command(
       await clerk.session?.getToken({ skipCache: true });
       signal.throwIfAborted();
 
-      // Reload status and mark done
+      // Reload status (caller dismisses via dismissZeroOnboarding$)
       set(internalReload$, (x) => x + 1);
-      set(internalStep$, "done");
 
       return agent.agentComposeId;
     } catch (error) {
@@ -386,3 +390,12 @@ export const completeZeroOnboarding$ = command(
     }
   },
 );
+
+/**
+ * Dismiss the admin onboarding dialog.
+ * Separated from completeZeroOnboarding$ so callers can control when the
+ * dialog disappears (e.g. after a chat thread is initiated).
+ */
+export const dismissZeroOnboarding$ = command(({ set }) => {
+  set(internalStep$, "done");
+});

--- a/turbo/apps/platform/src/views/zero-page/zero-onboarding.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-onboarding.tsx
@@ -332,7 +332,10 @@ export function ZeroOnboarding({
     const controller = new AbortController();
     detach(
       (async () => {
-        await completeOnboarding(controller.signal);
+        const result = await completeOnboarding(controller.signal);
+        if (!result) {
+          return;
+        }
         dismissOnboarding();
         // Admin with install URL: open Slack OAuth install flow
         if (slackData?.isAdmin && slackData.installUrl) {
@@ -351,7 +354,10 @@ export function ZeroOnboarding({
     const controller = new AbortController();
     detach(
       (async () => {
-        await completeOnboarding(controller.signal);
+        const result = await completeOnboarding(controller.signal);
+        if (!result) {
+          return;
+        }
         navigate("/chat");
         startNewSession();
         detach(

--- a/turbo/apps/platform/src/views/zero-page/zero-onboarding.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-onboarding.tsx
@@ -22,6 +22,7 @@ import {
   zeroSaving$,
   setZeroStep$,
   completeZeroOnboarding$,
+  dismissZeroOnboarding$,
   zeroSelectedConnectors$,
   toggleZeroConnector$,
   zeroOnboardingError$,
@@ -300,6 +301,7 @@ export function ZeroOnboarding({
   const selectedConnectors = useGet(zeroSelectedConnectors$);
   const toggleConnector = useSet(toggleZeroConnector$);
   const completeOnboarding = useSet(completeZeroOnboarding$);
+  const dismissOnboarding = useSet(dismissZeroOnboarding$);
   const sendMessage = useSet(sendZeroChatMessage$);
   const startNewSession = useSet(startNewZeroSession$);
   const navigate = useSet(updatePathname$);
@@ -331,6 +333,7 @@ export function ZeroOnboarding({
     detach(
       (async () => {
         await completeOnboarding(controller.signal);
+        dismissOnboarding();
         // Admin with install URL: open Slack OAuth install flow
         if (slackData?.isAdmin && slackData.installUrl) {
           const url = new URL(slackData.installUrl, window.location.origin);
@@ -349,12 +352,13 @@ export function ZeroOnboarding({
     detach(
       (async () => {
         await completeOnboarding(controller.signal);
-        navigate("/");
+        navigate("/chat");
         startNewSession();
         detach(
           sendMessage("Who are you and what can you do?"),
           Reason.DomCallback,
         );
+        dismissOnboarding();
       })(),
       Reason.DomCallback,
     );
@@ -552,6 +556,7 @@ export function MemberWelcome({
   const navigate = useSet(updatePathname$);
   const startNewSession = useSet(startNewZeroSession$);
   const sendIntro = useSet(sendZeroChatMessage$);
+  const saving = useGet(zeroSaving$);
   const selectedConnectorType = useGet(selectedConnectorType$);
   const setSelected = useSet(setSelectedConnectorType$);
   const connectConnectorFn = useSet(connectConnector$);
@@ -599,7 +604,7 @@ export function MemberWelcome({
     detach(
       (async () => {
         await completeMember();
-        navigate("/");
+        navigate("/chat");
         startNewSession();
         detach(
           sendIntro("Who are you and what can you do?"),
@@ -784,8 +789,9 @@ export function MemberWelcome({
                   variant="outline"
                   className="w-full rounded-lg zero-btn-morandi"
                   onClick={handleOpenSlack}
+                  disabled={saving}
                 >
-                  Go to Slack
+                  {saving ? "Saving\u2026" : "Go to Slack"}
                 </Button>
               </div>
               <div className="zero-card flex flex-col items-center text-center rounded-xl border border-border p-5">
@@ -809,8 +815,9 @@ export function MemberWelcome({
                   variant="outline"
                   className="w-full rounded-lg zero-btn-morandi"
                   onClick={handleContinueWeb}
+                  disabled={saving}
                 >
-                  Chat with {agentName}
+                  {saving ? "Saving\u2026" : `Chat with ${agentName}`}
                 </Button>
               </div>
             </div>
@@ -826,6 +833,7 @@ export function MemberWelcome({
                   setStep("welcome");
                 }
               }}
+              disabled={saving}
             >
               Back
             </Button>


### PR DESCRIPTION
## Summary
- **Bug 1 fix**: Separated `dismissZeroOnboarding$` from `completeZeroOnboarding$` so the onboarding dialog stays visible during agent setup. The dialog now dismisses only after the agent is created and the initial chat message is fired. Navigates to `/chat` instead of `/` so `sendZeroChatMessage$` auto-navigates to the thread once created.
- **Bug 2 fix**: Added `saving`/`disabled` state to member onboarding buttons (previously had no loading state). Admin buttons already had `disabled={saving}`, and the saving period now covers the full setup flow.

## Test plan
- [x] Unit tests updated and passing (9/9)
- [x] Lint passes (oxlint + eslint)
- [x] Knip passes (no unused exports)
- [ ] Manual: Complete admin onboarding → verify dialog stays until agent is ready, then redirects to chat with initial message
- [ ] Manual: Complete member onboarding → verify buttons disable on click, no duplicate submissions
- [ ] Manual: Click "Add to Slack" → verify dialog dismisses and redirects to /works

Closes #5765

🤖 Generated with [Claude Code](https://claude.com/claude-code)