### PR TITLE
fix: make cmd/ctrl+enter always send message regardless of send mode

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-send-key.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-send-key.test.tsx
@@ -65,6 +65,29 @@ describe("send-key behavior — enter mode", () => {
     expect(preventDefault).toHaveBeenCalledWith();
   });
 
+  it("should send when Cmd+Enter is pressed", async () => {
+    await renderChatPage("enter");
+
+    const textarea = await getTextarea();
+    fireEvent.change(textarea, { target: { value: "Hello" } });
+
+    const preventDefault = vi.fn();
+    act(() => {
+      textarea.dispatchEvent(
+        Object.assign(
+          new KeyboardEvent("keydown", {
+            key: "Enter",
+            metaKey: true,
+            bubbles: true,
+          }),
+          { preventDefault },
+        ),
+      );
+    });
+
+    expect(preventDefault).toHaveBeenCalledWith();
+  });
+
   it("should not send when Shift+Enter is pressed", async () => {
     await renderChatPage("enter");
 

--- a/turbo/apps/platform/src/views/zero-page/zero-send-key.ts
+++ b/turbo/apps/platform/src/views/zero-page/zero-send-key.ts
@@ -14,6 +14,7 @@ import type { SendMode } from "@vm0/core";
  *
  * - "enter": Enter sends, Shift+Enter inserts newline
  * - "cmd-enter": Cmd/Ctrl+Enter sends, Enter inserts newline
+ * - Cmd/Ctrl+Enter always sends regardless of mode
  *
  * Uses component-scoped composition state because on Chrome macOS the
  * `compositionend` event fires *before* the confirming `keydown`, making
@@ -36,10 +37,8 @@ export function useSendKeyHandler(onSend: () => void) {
     if (e.key !== "Enter") {
       return;
     }
-    const shouldSend =
-      mode === "enter"
-        ? !e.shiftKey && !e.metaKey && !e.ctrlKey
-        : e.metaKey || e.ctrlKey;
+    const hasModifier = e.metaKey || e.ctrlKey;
+    const shouldSend = hasModifier || (mode === "enter" && !e.shiftKey);
     if (shouldSend) {
       e.preventDefault();
       onSend();


### PR DESCRIPTION
## Summary
- Cmd/Ctrl+Enter now always sends the message regardless of send-mode preference ("enter" or "cmd-enter")
- Previously in "enter" mode, Cmd+Enter was treated as "don't send" (because metaKey was true), causing the browser's default Enter behavior (newline insertion) to fire instead — this also caused incorrect behavior during async preference loading when mode defaulted to "enter"
- Added test coverage for Cmd+Enter in "enter" mode

Closes #5695

## Test plan
- [x] Existing send-key tests pass (6/6)
- [x] All zero-page tests pass (104/104)
- [ ] Manual: In "enter" mode, verify Cmd+Enter sends immediately without inserting newline
- [ ] Manual: In "cmd-enter" mode, verify Cmd+Enter sends (unchanged behavior)
- [ ] Manual: In "enter" mode, verify plain Enter still sends
- [ ] Manual: In "enter" mode, verify Shift+Enter still inserts newline

🤖 Generated with [Claude Code](https://claude.com/claude-code)