### PR TITLE
refactor: migrate /talk/:name route to dedicated setup function

### DIFF
--- a/turbo/apps/platform/src/signals/bootstrap.ts
+++ b/turbo/apps/platform/src/signals/bootstrap.ts
@@ -16,6 +16,7 @@ import { setupWorksPage$ } from "./works-page/works-page-setup.ts";
 import { setupPreferencesPage$ } from "./preferences-page/preferences-page-setup.ts";
 import { setupSchedulePage$ } from "./schedule-page/schedule-page-setup.ts";
 import { setupSettingsPage$ } from "./settings-page/settings-page-setup.ts";
+import { setupTalkPage$ } from "./zero-page/talk-page-setup.ts";
 import { setupInternalConnectorLogos$ } from "./internal-connector-logos-setup.ts";
 const ROUTE_CONFIG = [
   {
@@ -28,7 +29,7 @@ const ROUTE_CONFIG = [
   },
   {
     path: "/talk/:name",
-    setup: setupAuthPageWrapper(setupZeroPage$),
+    setup: setupAuthPageWrapper(setupTalkPage$),
   },
   {
     path: "/team/:name",

--- a/turbo/apps/platform/src/signals/zero-page/talk-page-setup.ts
+++ b/turbo/apps/platform/src/signals/zero-page/talk-page-setup.ts
@@ -1,0 +1,68 @@
+import { command } from "ccstate";
+import { createElement } from "react";
+import { ZeroTalkPageWrapper } from "../../views/zero-page/zero-talk-page-wrapper.tsx";
+import { updatePage$ } from "../react-router.ts";
+import { pathParams$ } from "../route.ts";
+import { zeroSubagents$ } from "./zero-agents.ts";
+import { defaultAgentName$ } from "./zero-agent-name.ts";
+import { switchActiveAgent$ } from "./zero-chat.ts";
+import {
+  pinnedAgentIds$,
+  updatePinnedAgentIds$,
+} from "./zero-pinned-agents.ts";
+import { syncModelPreference$ } from "./zero-model-preference.ts";
+import { logger } from "../log.ts";
+import { Reason, detach } from "../utils.ts";
+import { loadInitialData$ } from "./zero-page.ts";
+
+const L = logger("TalkPage");
+
+export const setupTalkPage$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    set(updatePage$, createElement(ZeroTalkPageWrapper));
+
+    await set(loadInitialData$, signal);
+
+    // Resolve agent from /talk/:name
+    const params = get(pathParams$) as { name?: string } | undefined;
+    const agentName = params?.name ?? null;
+    L.info("resolveAgent talk:", agentName);
+
+    if (agentName) {
+      const subagents = await get(zeroSubagents$);
+      const rawDefaultName = await get(defaultAgentName$);
+      signal.throwIfAborted();
+
+      if (agentName === rawDefaultName) {
+        set(switchActiveAgent$, null);
+      } else {
+        const agent = subagents.find((a) => a.name === agentName);
+        if (agent) {
+          set(switchActiveAgent$, { id: agent.id, name: agent.name });
+          // Auto-pin agent if not already pinned
+          const pinned = await get(pinnedAgentIds$);
+          if (!pinned.includes(agent.id)) {
+            detach(
+              set(updatePinnedAgentIds$, [...pinned, agent.id]),
+              Reason.DomCallback,
+            );
+          }
+        } else {
+          // Unknown agent → redirect to default
+          set(switchActiveAgent$, null);
+          if (rawDefaultName) {
+            window.history.replaceState(
+              {},
+              "",
+              `/talk/${encodeURIComponent(rawDefaultName)}`,
+            );
+          }
+        }
+      }
+    } else {
+      set(switchActiveAgent$, null);
+    }
+
+    set(syncModelPreference$);
+  },
+);

--- a/turbo/apps/platform/src/signals/zero-page/talk-page-setup.ts
+++ b/turbo/apps/platform/src/signals/zero-page/talk-page-setup.ts
@@ -3,17 +3,9 @@ import { createElement } from "react";
 import { ZeroTalkPageWrapper } from "../../views/zero-page/zero-talk-page-wrapper.tsx";
 import { updatePage$ } from "../react-router.ts";
 import { pathParams$ } from "../route.ts";
-import { zeroSubagents$ } from "./zero-agents.ts";
-import { defaultAgentName$ } from "./zero-agent-name.ts";
-import { switchActiveAgent$ } from "./zero-chat.ts";
-import {
-  pinnedAgentIds$,
-  updatePinnedAgentIds$,
-} from "./zero-pinned-agents.ts";
 import { syncModelPreference$ } from "./zero-model-preference.ts";
 import { logger } from "../log.ts";
-import { Reason, detach } from "../utils.ts";
-import { loadInitialData$ } from "./zero-page.ts";
+import { loadInitialData$, resolveAgentByName } from "./zero-page.ts";
 
 const L = logger("TalkPage");
 
@@ -28,40 +20,7 @@ export const setupTalkPage$ = command(
     const agentName = params?.name ?? null;
     L.info("resolveAgent talk:", agentName);
 
-    if (agentName) {
-      const subagents = await get(zeroSubagents$);
-      const rawDefaultName = await get(defaultAgentName$);
-      signal.throwIfAborted();
-
-      if (agentName === rawDefaultName) {
-        set(switchActiveAgent$, null);
-      } else {
-        const agent = subagents.find((a) => a.name === agentName);
-        if (agent) {
-          set(switchActiveAgent$, { id: agent.id, name: agent.name });
-          // Auto-pin agent if not already pinned
-          const pinned = await get(pinnedAgentIds$);
-          if (!pinned.includes(agent.id)) {
-            detach(
-              set(updatePinnedAgentIds$, [...pinned, agent.id]),
-              Reason.DomCallback,
-            );
-          }
-        } else {
-          // Unknown agent → redirect to default
-          set(switchActiveAgent$, null);
-          if (rawDefaultName) {
-            window.history.replaceState(
-              {},
-              "",
-              `/talk/${encodeURIComponent(rawDefaultName)}`,
-            );
-          }
-        }
-      }
-    } else {
-      set(switchActiveAgent$, null);
-    }
+    await resolveAgentByName(get, set, signal, agentName);
 
     set(syncModelPreference$);
   },

--- a/turbo/apps/platform/src/signals/zero-page/zero-page.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-page.ts
@@ -1,4 +1,4 @@
-import { command, state } from "ccstate";
+import { command, state, type Getter, type Setter } from "ccstate";
 import { createElement } from "react";
 import { ZeroPage } from "../../views/zero-page/zero-page.tsx";
 import { updatePage$ } from "../react-router.ts";
@@ -48,46 +48,22 @@ export const loadInitialData$ = command(
 );
 
 /**
- * Resolve the active agent from the URL and switch to it.
+ * Resolve an agent by name and switch to it, auto-pinning if needed.
  *
- * - `/talk/:name` → find agent by name, switch to it
- * - `/chat/:threadId` → sync session via syncUrlSession$
- * - `/` → redirect to `/talk/:defaultAgent`
- * - other `/*` → switch to default agent
+ * - If agentName matches the default agent, switches to null (default).
+ * - If agentName is found among subagents, switches to it and auto-pins.
+ * - If agentName is unknown, switches to null and redirects to default.
+ * - If agentName is null, switches to null (no agent).
  *
- * switchActiveAgent$ sets the agent AND fetches the session list atomically.
+ * Shared by setupZeroPage$ and setupTalkPage$ to avoid duplicating
+ * the lookup / pin / redirect logic.
  */
-async function resolveAndSwitchAgent(
-  get: Parameters<Parameters<typeof command>[0]>[0]["get"],
-  set: Parameters<Parameters<typeof command>[0]>[0]["set"],
+export async function resolveAgentByName(
+  get: Getter,
+  set: Setter,
   signal: AbortSignal,
-) {
-  const currentPath = get(pathname$);
-
-  // On /chat/:threadId, syncUrlSession$ switches to the correct session.
-  // Don't resolve agent here — switchZeroSession$ handles that internally.
-  if (get(zeroInChat$)) {
-    L.info("on chat URL, syncing session");
-    await set(syncUrlSession$);
-    return;
-  }
-  L.info("resolveAgent path:", currentPath);
-
-  // If on bare /, redirect to /talk/:defaultAgent
-  if (/^\/?$/.test(currentPath)) {
-    const rawName = await get(defaultAgentName$);
-    signal.throwIfAborted();
-    if (rawName) {
-      window.history.replaceState(
-        {},
-        "",
-        `/talk/${encodeURIComponent(rawName)}`,
-      );
-    }
-  }
-
-  // Resolve agent from /talk/:name
-  const agentName = get(zeroChatAgentName$);
+  agentName: string | null,
+): Promise<void> {
   if (agentName) {
     const subagents = await get(zeroSubagents$);
     const rawDefaultName = await get(defaultAgentName$);
@@ -120,9 +96,52 @@ async function resolveAndSwitchAgent(
       }
     }
   } else {
-    // Non-talk, non-chat URL (e.g. /schedule)
     set(switchActiveAgent$, null);
   }
+}
+
+/**
+ * Resolve the active agent from the URL and switch to it.
+ *
+ * - `/talk/:name` → find agent by name, switch to it
+ * - `/chat/:threadId` → sync session via syncUrlSession$
+ * - `/` → redirect to `/talk/:defaultAgent`
+ * - other `/*` → switch to default agent
+ *
+ * switchActiveAgent$ sets the agent AND fetches the session list atomically.
+ */
+async function resolveAndSwitchAgent(
+  get: Getter,
+  set: Setter,
+  signal: AbortSignal,
+) {
+  const currentPath = get(pathname$);
+
+  // On /chat/:threadId, syncUrlSession$ switches to the correct session.
+  // Don't resolve agent here — switchZeroSession$ handles that internally.
+  if (get(zeroInChat$)) {
+    L.info("on chat URL, syncing session");
+    await set(syncUrlSession$);
+    return;
+  }
+  L.info("resolveAgent path:", currentPath);
+
+  // If on bare /, redirect to /talk/:defaultAgent
+  if (/^\/?$/.test(currentPath)) {
+    const rawName = await get(defaultAgentName$);
+    signal.throwIfAborted();
+    if (rawName) {
+      window.history.replaceState(
+        {},
+        "",
+        `/talk/${encodeURIComponent(rawName)}`,
+      );
+    }
+  }
+
+  // Resolve agent from /talk/:name
+  const agentName = get(zeroChatAgentName$);
+  await resolveAgentByName(get, set, signal, agentName);
 }
 
 export const setupZeroPage$ = command(

--- a/turbo/apps/platform/src/signals/zero-page/zero-page.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-page.ts
@@ -27,6 +27,27 @@ const L = logger("ZeroPage");
 const initialDataLoaded$ = state(false);
 
 /**
+ * Load agents, onboarding, and slack data once.
+ * Shared by setupZeroPage$ and setupTalkPage$ so the first route to
+ * execute pays the cost and subsequent navigations skip it.
+ */
+export const loadInitialData$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    if (get(initialDataLoaded$)) {
+      return;
+    }
+    await Promise.all([
+      set(fetchAgentsList$),
+      set(initZeroOnboarding$, signal),
+      set(initSlackOrg$),
+    ]);
+    signal.throwIfAborted();
+    set(initialDataLoaded$, true);
+    set(initSidebarCollapsed$);
+  },
+);
+
+/**
  * Resolve the active agent from the URL and switch to it.
  *
  * - `/talk/:name` → find agent by name, switch to it
@@ -108,18 +129,7 @@ export const setupZeroPage$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     set(updatePage$, createElement(ZeroPage));
 
-    // Only fetch heavy initial data once — skip on subsequent route changes
-    // (e.g. switching between talk agents).
-    if (!get(initialDataLoaded$)) {
-      await Promise.all([
-        set(fetchAgentsList$),
-        set(initZeroOnboarding$, signal),
-        set(initSlackOrg$),
-      ]);
-      signal.throwIfAborted();
-      set(initialDataLoaded$, true);
-      set(initSidebarCollapsed$);
-    }
+    await set(loadInitialData$, signal);
 
     await resolveAndSwitchAgent(get, set, signal);
 

--- a/turbo/apps/platform/src/views/zero-page/zero-talk-page-wrapper.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-talk-page-wrapper.tsx
@@ -1,0 +1,10 @@
+import { ZeroAppShell } from "./zero-app-shell.tsx";
+
+/**
+ * Wrapper for the /talk/:name route.
+ * Renders the same chat UI as the root page — agent resolution
+ * is handled by the dedicated setup function.
+ */
+export function ZeroTalkPageWrapper() {
+  return <ZeroAppShell />;
+}


### PR DESCRIPTION
## Summary

- Extract `/talk/:name` route handling from monolithic `setupZeroPage$` into a dedicated `setupTalkPage$` command
- Share initial data loading (agents, onboarding, slack) via new `loadInitialData$` command so both setup functions reuse the same once-only guard
- Add `ZeroTalkPageWrapper` component for the dedicated route

Closes #5850
Part of #5840

## Test plan

- [x] Type check passes (`@vm0/app`, `@vm0/core`, `@vm0/ui`)
- [x] Lint passes (oxlint)
- [x] Knip finds no unused exports
- [x] zero-nav tests pass (35 tests)
- [x] zero-chat tests pass (21 tests)
- [x] zero-onboarding tests pass (9 tests)
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)