### PR TITLE
fix: prevent stale activity detail from flashing during navigation

### DIFF
--- a/turbo/apps/platform/src/signals/activity-page/activity-detail-page-setup.ts
+++ b/turbo/apps/platform/src/signals/activity-page/activity-detail-page-setup.ts
@@ -11,12 +11,8 @@ import { setZeroActivitySelectedLogId$ } from "./activity-signals.ts";
 export const setupActivityDetailPage$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     set(updatePage$, createElement(ZeroActivityDetailPageWrapper));
-    await Promise.all([
-      set(fetchAgentsList$),
-      set(initZeroOnboarding$, signal),
-    ]);
-    signal.throwIfAborted();
 
+    // Set logId immediately so the component shows skeleton instead of stale data
     const params = get(pathParams$);
     const logId =
       params && typeof params === "object" && "logId" in params
@@ -26,6 +22,13 @@ export const setupActivityDetailPage$ = command(
     if (logId) {
       set(setZeroActivitySelectedLogId$, logId);
     }
+
+    await Promise.all([
+      set(fetchAgentsList$),
+      set(initZeroOnboarding$, signal),
+    ]);
+    signal.throwIfAborted();
+
     set(switchActiveAgent$, null);
   },
 );

--- a/turbo/apps/platform/src/signals/activity-page/activity-signals.ts
+++ b/turbo/apps/platform/src/signals/activity-page/activity-signals.ts
@@ -158,6 +158,11 @@ export const setZeroActivityFilter$ = command(
 const internalPollingAbort$ = state<AbortController | null>(null);
 const lastSyncedLogId$ = state<string | null>(null);
 
+/** Currently selected log ID (readable). */
+export const zeroActivitySelectedLogId$ = computed((get) =>
+  get(lastSyncedLogId$),
+);
+
 // ---------------------------------------------------------------------------
 // Detail step search — component-local filter for the detail view
 // ---------------------------------------------------------------------------

--- a/turbo/apps/platform/src/views/activity-page/__tests__/activity-detail-stale.test.tsx
+++ b/turbo/apps/platform/src/views/activity-page/__tests__/activity-detail-stale.test.tsx
@@ -1,0 +1,185 @@
+import { describe, expect, it } from "vitest";
+import { screen, waitFor, fireEvent } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../mocks/server.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { setupPage } from "../../../__tests__/page-helper.ts";
+import type {
+  LogDetail,
+  AgentEventsResponse,
+} from "../../../signals/zero-page/log-types.ts";
+
+const context = testContext();
+
+function makeLogDetail(overrides: Partial<LogDetail>): LogDetail {
+  return {
+    id: "run_1",
+    sessionId: "session_1",
+    agentName: "agent-1",
+    displayName: "Agent One",
+    framework: "claude-code",
+    modelProvider: null,
+    triggerSource: "web",
+    status: "completed",
+    prompt: "Hello",
+    appendSystemPrompt: null,
+    error: null,
+    createdAt: "2026-03-10T14:56:00Z",
+    startedAt: "2026-03-10T14:56:01Z",
+    completedAt: "2026-03-10T14:56:10Z",
+    artifact: { name: null, version: null },
+    ...overrides,
+  };
+}
+
+function makeEventsResponse(text: string): AgentEventsResponse {
+  return {
+    events: [
+      {
+        sequenceNumber: 0,
+        eventType: "assistant",
+        eventData: { message: { content: [{ type: "text", text }] } },
+        createdAt: "2026-03-10T14:56:02Z",
+      },
+    ],
+    hasMore: false,
+    framework: "claude-code",
+  };
+}
+
+const detail1 = makeLogDetail({
+  id: "run_1",
+  agentName: "agent-1",
+  displayName: "Agent One",
+});
+
+const detail2 = makeLogDetail({
+  id: "run_2",
+  agentName: "agent-2",
+  displayName: "Agent Two",
+});
+
+function mockAPIs() {
+  const listData = [
+    {
+      id: "run_1",
+      sessionId: "session_1",
+      agentName: "agent-1",
+      displayName: "Agent One",
+      orgSlug: "test",
+      framework: "claude-code",
+      status: "completed",
+      triggerSource: "web",
+      createdAt: "2026-03-10T14:56:00Z",
+      startedAt: "2026-03-10T14:56:01Z",
+      completedAt: "2026-03-10T14:56:10Z",
+    },
+    {
+      id: "run_2",
+      sessionId: "session_2",
+      agentName: "agent-2",
+      displayName: "Agent Two",
+      orgSlug: "test",
+      framework: "claude-code",
+      status: "completed",
+      triggerSource: "cli",
+      createdAt: "2026-03-10T15:00:00Z",
+      startedAt: "2026-03-10T15:00:01Z",
+      completedAt: "2026-03-10T15:00:05Z",
+    },
+  ];
+
+  server.use(
+    http.get("*/api/zero/logs", () => {
+      return HttpResponse.json({
+        data: listData,
+        pagination: { hasMore: false, nextCursor: null, totalPages: 1 },
+      });
+    }),
+    http.get("*/api/zero/composes/list", () => {
+      return HttpResponse.json({ composes: [] });
+    }),
+    http.get("*/api/zero/logs/:id", ({ params }) => {
+      if (params["id"] === "run_1") return HttpResponse.json(detail1);
+      if (params["id"] === "run_2") return HttpResponse.json(detail2);
+      return new HttpResponse(null, { status: 404 });
+    }),
+    http.get("*/api/zero/runs/:runId/telemetry/agent", ({ params }) => {
+      const runId = params["runId"] as string;
+      if (runId === "run_1")
+        return HttpResponse.json(makeEventsResponse("Response from agent one"));
+      if (runId === "run_2")
+        return HttpResponse.json(makeEventsResponse("Response from agent two"));
+      return HttpResponse.json({
+        events: [],
+        hasMore: false,
+        framework: "claude-code",
+      });
+    }),
+    http.get("*/api/zero/chat-threads", () => {
+      return HttpResponse.json({ threads: [] });
+    }),
+  );
+}
+
+describe("activity detail stale data", () => {
+  it("should show skeleton instead of previous activity when navigating between details", async () => {
+    mockAPIs();
+
+    // Start on the first activity detail page
+    await setupPage({
+      context,
+      path: "/activity/run_1",
+    });
+
+    // Wait for first detail to load
+    await waitFor(
+      () => {
+        expect(
+          screen.getByRole("heading", { name: "Agent One" }),
+        ).toBeInTheDocument();
+      },
+      { timeout: 5000 },
+    );
+
+    // Navigate back to the list via breadcrumb
+    const breadcrumb = screen.getByText("Activity").closest("a");
+    expect(breadcrumb).not.toBeNull();
+    fireEvent.click(breadcrumb!);
+
+    // Wait for the list to render
+    await waitFor(
+      () => {
+        expect(
+          screen.getByRole("heading", { name: "Activity" }),
+        ).toBeInTheDocument();
+      },
+      { timeout: 3000 },
+    );
+
+    // Navigate to the second activity
+    const row = screen.getByText("Agent Two").closest("a");
+    expect(row).not.toBeNull();
+    fireEvent.click(row!);
+
+    // The old "Agent One" heading must NOT be visible — we should see skeleton or new data
+    await waitFor(
+      () => {
+        // Either skeleton (no heading) or the new agent heading should be shown
+        const oldHeading = screen.queryByRole("heading", { name: "Agent One" });
+        expect(oldHeading).not.toBeInTheDocument();
+      },
+      { timeout: 1000 },
+    );
+
+    // Eventually the new detail should load
+    await waitFor(
+      () => {
+        expect(
+          screen.getByRole("heading", { name: "Agent Two" }),
+        ).toBeInTheDocument();
+      },
+      { timeout: 5000 },
+    );
+  }, 20_000);
+});

--- a/turbo/apps/platform/src/views/activity-page/__tests__/activity-detail-stale.test.tsx
+++ b/turbo/apps/platform/src/views/activity-page/__tests__/activity-detail-stale.test.tsx
@@ -47,19 +47,19 @@ function makeEventsResponse(text: string): AgentEventsResponse {
   };
 }
 
-const detail1 = makeLogDetail({
-  id: "run_1",
-  agentName: "agent-1",
-  displayName: "Agent One",
-});
-
-const detail2 = makeLogDetail({
-  id: "run_2",
-  agentName: "agent-2",
-  displayName: "Agent Two",
-});
-
 function mockAPIs() {
+  const detail1 = makeLogDetail({
+    id: "run_1",
+    agentName: "agent-1",
+    displayName: "Agent One",
+  });
+
+  const detail2 = makeLogDetail({
+    id: "run_2",
+    agentName: "agent-2",
+    displayName: "Agent Two",
+  });
+
   const listData = [
     {
       id: "run_1",
@@ -100,16 +100,22 @@ function mockAPIs() {
       return HttpResponse.json({ composes: [] });
     }),
     http.get("*/api/zero/logs/:id", ({ params }) => {
-      if (params["id"] === "run_1") return HttpResponse.json(detail1);
-      if (params["id"] === "run_2") return HttpResponse.json(detail2);
+      if (params["id"] === "run_1") {
+        return HttpResponse.json(detail1);
+      }
+      if (params["id"] === "run_2") {
+        return HttpResponse.json(detail2);
+      }
       return new HttpResponse(null, { status: 404 });
     }),
     http.get("*/api/zero/runs/:runId/telemetry/agent", ({ params }) => {
       const runId = params["runId"] as string;
-      if (runId === "run_1")
+      if (runId === "run_1") {
         return HttpResponse.json(makeEventsResponse("Response from agent one"));
-      if (runId === "run_2")
+      }
+      if (runId === "run_2") {
         return HttpResponse.json(makeEventsResponse("Response from agent two"));
+      }
       return HttpResponse.json({
         events: [],
         hasMore: false,

--- a/turbo/apps/platform/src/views/zero-page/zero-activity-detail-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-activity-detail-page.tsx
@@ -32,6 +32,7 @@ import {
   zeroActivityEvents$,
   zeroActivityStepSearch$,
   setZeroActivityStepSearch$,
+  zeroActivitySelectedLogId$,
   formatLogTime,
   formatDuration,
 } from "../../signals/activity-page/activity-signals.ts";
@@ -249,12 +250,16 @@ function ActivityHeaderCard({
 }
 
 export function ZeroActivityDetailPage() {
+  const selectedLogId = useGet(zeroActivitySelectedLogId$);
   const detailLoadable = useLastLoadable(zeroActivityDetail$);
   const eventsLoadable = useLastLoadable(zeroActivityEvents$);
   // Resolve agent display name from the detail response
   const detail =
     detailLoadable.state === "hasData" ? detailLoadable.data : null;
-  const agentName = detail ? (detail.displayName ?? detail.agentName) : "Agent";
+  // Detect stale detail from previous navigation (useLastLoadable keeps old data)
+  const isStale = detail != null && detail.id !== selectedLogId;
+  const agentName =
+    detail && !isStale ? (detail.displayName ?? detail.agentName) : "Agent";
 
   const stepSearch = useGet(zeroActivityStepSearch$);
   const setStepSearch = useSet(setZeroActivityStepSearch$);
@@ -262,7 +267,7 @@ export function ZeroActivityDetailPage() {
 
   // Skeleton until both detail and initial events are loaded
   const eventsReady = eventsLoadable.state === "hasData";
-  if (!detail || !eventsReady) {
+  if (!detail || isStale || !eventsReady) {
     if (detailLoadable.state === "hasError") {
       return <ActivityNotFound />;
     }

--- a/turbo/apps/platform/src/views/zero-page/zero-activity-detail-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-activity-detail-page.tsx
@@ -257,7 +257,7 @@ export function ZeroActivityDetailPage() {
   const detail =
     detailLoadable.state === "hasData" ? detailLoadable.data : null;
   // Detect stale detail from previous navigation (useLastLoadable keeps old data)
-  const isStale = detail != null && detail.id !== selectedLogId;
+  const isStale = detail !== null && detail.id !== selectedLogId;
   const agentName =
     detail && !isStale ? (detail.displayName ?? detail.agentName) : "Agent";
 


### PR DESCRIPTION
## Summary
- Set the selected log ID synchronously before awaiting async fetches in `setupActivityDetailPage$`, so the component detects a log ID mismatch immediately and shows a skeleton instead of stale data from the previous navigation.
- Expose a new `zeroActivitySelectedLogId$` computed signal for the detail page to compare against.
- Add `isStale` guard in `ZeroActivityDetailPage` that triggers the skeleton when `useLastLoadable` still holds data from a different log.
- Add an integration test that navigates detail -> list -> detail and verifies the old agent name never appears.

## Test plan
- [ ] New integration test `activity-detail-stale.test.tsx` covers the back-then-forward navigation scenario
- [ ] Manual verification: navigate between two different activity detail pages rapidly; the old detail should never flash

🤖 Generated with [Claude Code](https://claude.com/claude-code)