### PR TITLE
refactor: migrate chat session route to dedicated setup function

### DIFF
--- a/turbo/apps/platform/src/signals/bootstrap.ts
+++ b/turbo/apps/platform/src/signals/bootstrap.ts
@@ -18,6 +18,7 @@ import { setupSchedulePage$ } from "./schedule-page/schedule-page-setup.ts";
 import { setupSettingsPage$ } from "./settings-page/settings-page-setup.ts";
 import { setupTalkPage$ } from "./zero-page/talk-page-setup.ts";
 import { setupUsagePage$ } from "./usage-page/usage-page-setup.ts";
+import { setupChatSessionPage$ } from "./zero-page/chat-session-page-setup.ts";
 import { setupInternalConnectorLogos$ } from "./internal-connector-logos-setup.ts";
 const ROUTE_CONFIG = [
   {
@@ -26,7 +27,7 @@ const ROUTE_CONFIG = [
   },
   {
     path: "/chat/:sessionId",
-    setup: setupAuthPageWrapper(setupZeroPage$),
+    setup: setupAuthPageWrapper(setupChatSessionPage$),
   },
   {
     path: "/talk/:name",

--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-chat.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-chat.test.ts
@@ -309,6 +309,50 @@ describe("zero-chat signals", () => {
       expect(context.store.get(zeroSessionSwitching$)).toBeTruthy();
     });
 
+    it("should clear messages and session error", async () => {
+      useChatThreadHandlers();
+      server.use(
+        http.post("*/api/zero/runs", () => {
+          return HttpResponse.json({ runId: "run-1" });
+        }),
+        http.get("*/api/zero/runs/:runId/telemetry/agent", () => {
+          return HttpResponse.json({
+            events: [],
+            hasMore: false,
+            framework: "claude-code",
+          });
+        }),
+        http.get("*/api/zero/logs/:runId", () => {
+          return HttpResponse.json({
+            id: "run-1",
+            status: "completed",
+            error: null,
+            prompt: "test",
+            createdAt: "2026-03-10T00:00:00Z",
+            startedAt: "2026-03-10T00:00:01Z",
+            completedAt: "2026-03-10T00:00:02Z",
+          });
+        }),
+        http.get("*/api/zero/runs/:runId", () => {
+          return HttpResponse.json({
+            result: { agentSessionId: "s1" },
+          });
+        }),
+      );
+
+      await setup();
+
+      // Send a message to populate messages
+      await context.store.set(sendZeroChatMessage$, "Hello");
+      await delay(50);
+      expect(context.store.get(zeroChatMessages$).length).toBeGreaterThan(0);
+
+      context.store.set(prepareSessionSwitch$);
+
+      expect(context.store.get(zeroChatMessages$)).toHaveLength(0);
+      expect(context.store.get(zeroSessionError$)).toBeNull();
+    });
+
     it("should be cleared after switchZeroSession$ completes", async () => {
       server.use(
         http.get("*/api/zero/chat-threads/:id", () => {
@@ -778,6 +822,46 @@ describe("zero-chat signals", () => {
       // Second sync with same URL should skip
       await context.store.set(syncUrlSession$);
       expect(switchCount).toBe(1);
+    });
+
+    it("should reset sessionSwitching when thread is already loaded", async () => {
+      server.use(
+        http.get("*/api/zero/chat-threads/:id", () => {
+          return HttpResponse.json({
+            id: "already-loaded",
+            title: null,
+            agentComposeId: "mock-compose-id",
+            chatMessages: [
+              {
+                role: "user",
+                content: "Existing",
+                createdAt: "2026-03-10T00:00:00Z",
+              },
+            ],
+            latestSessionId: null,
+            createdAt: "2026-03-10T00:00:00Z",
+            updatedAt: "2026-03-10T00:00:00Z",
+          });
+        }),
+      );
+
+      await setupPage({
+        context,
+        path: "/chat/already-loaded",
+        withoutRender: true,
+      });
+
+      // First sync loads the thread
+      await context.store.set(syncUrlSession$);
+      expect(context.store.get(zeroChatThreadId$)).toBe("already-loaded");
+
+      // Simulate prepareSessionSwitch$ being called (e.g. by route setup)
+      context.store.set(prepareSessionSwitch$);
+      expect(context.store.get(zeroSessionSwitching$)).toBeTruthy();
+
+      // Second sync detects thread matches — must reset switching
+      await context.store.set(syncUrlSession$);
+      expect(context.store.get(zeroSessionSwitching$)).toBeFalsy();
     });
   });
 });

--- a/turbo/apps/platform/src/signals/zero-page/chat-session-page-setup.ts
+++ b/turbo/apps/platform/src/signals/zero-page/chat-session-page-setup.ts
@@ -2,18 +2,29 @@ import { command } from "ccstate";
 import { createElement } from "react";
 import { ZeroChatSessionPageWrapper } from "../../views/zero-page/zero-chat-session-page-wrapper.tsx";
 import { updatePage$ } from "../react-router.ts";
-import { fetchAgentsList$ } from "./zero-agents.ts";
-import { initZeroOnboarding$ } from "./zero-onboarding.ts";
-import { syncUrlSession$ } from "./zero-chat.ts";
+import {
+  syncUrlSession$,
+  prepareSessionSwitch$,
+  zeroChatThreadId$,
+} from "./zero-chat.ts";
+import { zeroSessionId$ } from "./zero-nav.ts";
+import { loadInitialData$ } from "./zero-page.ts";
 import { syncModelPreference$ } from "./zero-model-preference.ts";
 
 export const setupChatSessionPage$ = command(
-  async ({ set }, signal: AbortSignal) => {
+  async ({ get, set }, signal: AbortSignal) => {
     set(updatePage$, createElement(ZeroChatSessionPageWrapper));
-    await Promise.all([
-      set(fetchAgentsList$),
-      set(initZeroOnboarding$, signal),
-    ]);
+
+    // Show skeleton only when the URL points to a different thread than
+    // what's already loaded.  This covers page refresh (threadId is null)
+    // and sidebar navigation (threadId differs).  When arriving from
+    // /talk after sending a message the thread is already set and messages
+    // are in-flight, so we must NOT clear them.
+    if (get(zeroSessionId$) !== get(zeroChatThreadId$)) {
+      set(prepareSessionSwitch$);
+    }
+
+    await set(loadInitialData$, signal);
     signal.throwIfAborted();
 
     await set(syncUrlSession$);

--- a/turbo/apps/platform/src/signals/zero-page/chat-session-page-setup.ts
+++ b/turbo/apps/platform/src/signals/zero-page/chat-session-page-setup.ts
@@ -17,6 +17,7 @@ export const setupChatSessionPage$ = command(
     signal.throwIfAborted();
 
     await set(syncUrlSession$);
+    signal.throwIfAborted();
     set(syncModelPreference$);
   },
 );

--- a/turbo/apps/platform/src/signals/zero-page/chat-session-page-setup.ts
+++ b/turbo/apps/platform/src/signals/zero-page/chat-session-page-setup.ts
@@ -1,0 +1,22 @@
+import { command } from "ccstate";
+import { createElement } from "react";
+import { ZeroChatSessionPageWrapper } from "../../views/zero-page/zero-chat-session-page-wrapper.tsx";
+import { updatePage$ } from "../react-router.ts";
+import { fetchAgentsList$ } from "./zero-agents.ts";
+import { initZeroOnboarding$ } from "./zero-onboarding.ts";
+import { syncUrlSession$ } from "./zero-chat.ts";
+import { syncModelPreference$ } from "./zero-model-preference.ts";
+
+export const setupChatSessionPage$ = command(
+  async ({ set }, signal: AbortSignal) => {
+    set(updatePage$, createElement(ZeroChatSessionPageWrapper));
+    await Promise.all([
+      set(fetchAgentsList$),
+      set(initZeroOnboarding$, signal),
+    ]);
+    signal.throwIfAborted();
+
+    await set(syncUrlSession$);
+    set(syncModelPreference$);
+  },
+);

--- a/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
@@ -507,6 +507,8 @@ export const zeroSessionSwitching$ = computed((get) =>
  */
 export const prepareSessionSwitch$ = command(({ set }) => {
   set(internalSessionSwitching$, true);
+  set(internalMessages$, []);
+  set(internalSessionError$, null);
 });
 
 // Chat input
@@ -1153,6 +1155,7 @@ export const syncUrlSession$ = command(async ({ get, set }) => {
   }
   const currentThreadId = get(zeroChatThreadId$);
   if (urlSessionId === currentThreadId) {
+    set(internalSessionSwitching$, false);
     return;
   }
   await set(switchZeroSession$, urlSessionId);

--- a/turbo/apps/platform/src/signals/zero-page/zero-nav.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-nav.ts
@@ -1,6 +1,5 @@
 import { command, computed, state } from "ccstate";
 import { pathname$, navigateInReact$ } from "../route.ts";
-import { prepareSessionSwitch$, zeroChatThreadId$ } from "./zero-chat.ts";
 import type {
   ZeroNavId,
   ZeroAccountAction,
@@ -123,17 +122,9 @@ export const setZeroChatAgent$ = command(
  * `setupZeroPage$` guards heavy work behind `initialDataLoaded$`, so
  * re-entry from an already-loaded zero page is cheap.
  */
-export const navigateToZeroSession$ = command(
-  ({ get, set }, sessionId: string) => {
-    // Show skeleton immediately when switching to a different thread.
-    // Skip when navigating to the thread we already have loaded (e.g. after
-    // creating a new thread from /talk) to avoid clearing in-flight messages.
-    if (get(zeroChatThreadId$) !== sessionId) {
-      set(prepareSessionSwitch$);
-    }
-    set(navigateInReact$, "/chat/:sessionId", { pathParams: { sessionId } });
-  },
-);
+export const navigateToZeroSession$ = command(({ set }, sessionId: string) => {
+  set(navigateInReact$, "/chat/:sessionId", { pathParams: { sessionId } });
+});
 
 /**
  * Navigate back from a chat session to the previous route in browser history.

--- a/turbo/apps/platform/src/signals/zero-page/zero-nav.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-nav.ts
@@ -1,5 +1,6 @@
 import { command, computed, state } from "ccstate";
 import { pathname$, navigateInReact$ } from "../route.ts";
+import { prepareSessionSwitch$, zeroChatThreadId$ } from "./zero-chat.ts";
 import type {
   ZeroNavId,
   ZeroAccountAction,
@@ -122,9 +123,17 @@ export const setZeroChatAgent$ = command(
  * `setupZeroPage$` guards heavy work behind `initialDataLoaded$`, so
  * re-entry from an already-loaded zero page is cheap.
  */
-export const navigateToZeroSession$ = command(({ set }, sessionId: string) => {
-  set(navigateInReact$, "/chat/:sessionId", { pathParams: { sessionId } });
-});
+export const navigateToZeroSession$ = command(
+  ({ get, set }, sessionId: string) => {
+    // Show skeleton immediately when switching to a different thread.
+    // Skip when navigating to the thread we already have loaded (e.g. after
+    // creating a new thread from /talk) to avoid clearing in-flight messages.
+    if (get(zeroChatThreadId$) !== sessionId) {
+      set(prepareSessionSwitch$);
+    }
+    set(navigateInReact$, "/chat/:sessionId", { pathParams: { sessionId } });
+  },
+);
 
 /**
  * Navigate back from a chat session to the previous route in browser history.

--- a/turbo/apps/platform/src/views/zero-page/zero-avatars.ts
+++ b/turbo/apps/platform/src/views/zero-page/zero-avatars.ts
@@ -1,0 +1,13 @@
+import zeroAvatarImg from "./assets/zero-avatar.png";
+import avatar1Img from "./assets/avatar-1.png";
+import avatar2Img from "./assets/avatar-2.png";
+import avatar3Img from "./assets/avatar-3.png";
+import avatar4Img from "./assets/avatar-4.png";
+
+export const ZERO_AVATARS = [
+  zeroAvatarImg,
+  avatar1Img,
+  avatar2Img,
+  avatar3Img,
+  avatar4Img,
+] as const;

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-session-page-wrapper.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-session-page-wrapper.tsx
@@ -13,20 +13,7 @@ import {
   defaultAgentName$,
 } from "../../signals/zero-page/zero-agent-name.ts";
 import { navigateInReact$ } from "../../signals/route.ts";
-
-import zeroAvatarImg from "./assets/zero-avatar.png";
-import avatar1Img from "./assets/avatar-1.png";
-import avatar2Img from "./assets/avatar-2.png";
-import avatar3Img from "./assets/avatar-3.png";
-import avatar4Img from "./assets/avatar-4.png";
-
-const ZERO_AVATARS = [
-  zeroAvatarImg,
-  avatar1Img,
-  avatar2Img,
-  avatar3Img,
-  avatar4Img,
-] as const;
+import { ZERO_AVATARS } from "./zero-avatars.ts";
 
 export function ZeroChatSessionPageWrapper() {
   const avatarIndex = useGet(zeroAvatarIndex$);

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-session-page-wrapper.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-session-page-wrapper.tsx
@@ -1,0 +1,92 @@
+import { useGet, useSet, useLastLoadable } from "ccstate-react";
+import { SidebarLayout } from "./sidebar-layout.tsx";
+import { ZeroSessionChatPage } from "./zero-session-chat-page.tsx";
+import { useAgentAvatar } from "./zero-sidebar.tsx";
+import {
+  zeroChatAgentId$,
+  zeroAvatarIndex$,
+  navigateFromZeroSession$,
+} from "../../signals/zero-page/zero-nav.ts";
+import { zeroSubagents$ } from "../../signals/zero-page/zero-agents.ts";
+import {
+  agentDisplayName$,
+  defaultAgentName$,
+} from "../../signals/zero-page/zero-agent-name.ts";
+import { navigateInReact$ } from "../../signals/route.ts";
+
+import zeroAvatarImg from "./assets/zero-avatar.png";
+import avatar1Img from "./assets/avatar-1.png";
+import avatar2Img from "./assets/avatar-2.png";
+import avatar3Img from "./assets/avatar-3.png";
+import avatar4Img from "./assets/avatar-4.png";
+
+const ZERO_AVATARS = [
+  zeroAvatarImg,
+  avatar1Img,
+  avatar2Img,
+  avatar3Img,
+  avatar4Img,
+] as const;
+
+export function ZeroChatSessionPageWrapper() {
+  const avatarIndex = useGet(zeroAvatarIndex$);
+  const zeroAvatarSrc = ZERO_AVATARS[avatarIndex] ?? ZERO_AVATARS[0];
+
+  const currentChatAgentId = useGet(zeroChatAgentId$);
+  const subagentsLoadable = useLastLoadable(zeroSubagents$);
+  const subagents =
+    subagentsLoadable.state === "hasData" ? subagentsLoadable.data : [];
+  const selectedSubagent = currentChatAgentId
+    ? subagents.find((a) => a.id === currentChatAgentId)
+    : null;
+  const subagentAvatarSrc = useAgentAvatar(selectedSubagent?.name ?? "");
+  const chatAvatarSrc = selectedSubagent ? subagentAvatarSrc : zeroAvatarSrc;
+
+  const agentDisplayNameLoadable = useLastLoadable(agentDisplayName$);
+  const agentDisplayName =
+    agentDisplayNameLoadable.state === "hasData"
+      ? agentDisplayNameLoadable.data
+      : "Zero";
+  const chatAgentName = selectedSubagent
+    ? (selectedSubagent.displayName ?? selectedSubagent.name)
+    : agentDisplayName;
+
+  const defaultAgentNameLoadable = useLastLoadable(defaultAgentName$);
+  const defaultRawName =
+    defaultAgentNameLoadable.state === "hasData"
+      ? defaultAgentNameLoadable.data
+      : null;
+  const resolvedAgentName = selectedSubagent?.name ?? defaultRawName;
+
+  const navigateInReact = useSet(navigateInReact$);
+  const navigateBack = useSet(navigateFromZeroSession$);
+
+  const handleNavigateToSchedule = () => {
+    if (resolvedAgentName) {
+      navigateInReact("/team/:name", {
+        pathParams: { name: resolvedAgentName },
+        searchParams: new URLSearchParams({ tab: "schedule" }),
+      });
+    }
+  };
+
+  const handleChatAvatarClick = () => {
+    if (resolvedAgentName) {
+      navigateInReact("/team/:name", {
+        pathParams: { name: resolvedAgentName },
+      });
+    }
+  };
+
+  return (
+    <SidebarLayout>
+      <ZeroSessionChatPage
+        zeroAvatarSrc={chatAvatarSrc}
+        chatAgentName={chatAgentName}
+        onBack={navigateBack}
+        onNavigateToSchedule={handleNavigateToSchedule}
+        onAvatarClick={handleChatAvatarClick}
+      />
+    </SidebarLayout>
+  );
+}


### PR DESCRIPTION
## Summary

- Migrate `/chat/:sessionId` route from monolithic `setupZeroPage$` to a dedicated `setupChatSessionPage$` setup function
- Create `ZeroChatSessionPageWrapper` with `SidebarLayout` + `ZeroSessionChatPage`, resolving avatar/agent/navigation props from signals
- Wire the new setup in `bootstrap.ts` route config

Part of #5840, closes #5849

## Test plan

- [ ] Navigate to `/chat/:sessionId` — page renders correctly with sidebar
- [ ] `syncUrlSession$` correctly loads the session from URL
- [ ] Sidebar navigation works from chat session page
- [ ] Direct URL access to `/chat/:sessionId` works
- [ ] Page refresh on `/chat/:sessionId` preserves state
- [ ] Back navigation from chat session works
- [ ] Agent avatar and name display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)