### PR TITLE
feat: improve chat input ux when agent is processing

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-chat.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-chat.test.ts
@@ -1005,8 +1005,13 @@ describe("zero-chat signals", () => {
       completeRun = true;
       await sendPromise;
 
-      // Wait for the detached auto-send to complete
-      await delay(500);
+      // Poll until the detached auto-send completes (runCount reaches 2 and sending is false)
+      for (let i = 0; i < 50; i++) {
+        if (runCount >= 2 && !context.store.get(zeroChatSending$)) {
+          break;
+        }
+        await delay(50);
+      }
 
       expect(context.store.get(zeroChatQueuedMessage$)).toBeNull();
       // The auto-send should have triggered a second run
@@ -1084,8 +1089,13 @@ describe("zero-chat signals", () => {
       await context.store.set(cancelActiveRun$);
       await sendPromise;
 
-      // Give the detached auto-send time to fire and complete
-      await delay(500);
+      // Poll until the detached auto-send completes (runCount reaches 2 and sending is false)
+      for (let i = 0; i < 50; i++) {
+        if (runCount >= 2 && !context.store.get(zeroChatSending$)) {
+          break;
+        }
+        await delay(50);
+      }
 
       expect(context.store.get(zeroChatQueuedMessage$)).toBeNull();
       // The queued message should have triggered a second run

--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-chat.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-chat.test.ts
@@ -24,6 +24,10 @@ import {
   sendFromZeroDemo$,
   syncUrlSession$,
   prepareSessionSwitch$,
+  zeroChatQueuedMessage$,
+  queueZeroChatMessage$,
+  withdrawQueuedMessage$,
+  cancelActiveRun$,
 } from "../zero-chat.ts";
 
 const context = testContext();
@@ -778,6 +782,316 @@ describe("zero-chat signals", () => {
       // Second sync with same URL should skip
       await context.store.set(syncUrlSession$);
       expect(switchCount).toBe(1);
+    });
+  });
+
+  describe("message queueing", () => {
+    it("should queue a message while sending and clear the input", async () => {
+      let pollCount = 0;
+      server.use(
+        http.post("*/api/zero/runs", () => {
+          return HttpResponse.json({ runId: "run-q1" });
+        }),
+        http.get("*/api/zero/runs/:runId/telemetry/agent", () => {
+          return HttpResponse.json({
+            events: [],
+            hasMore: false,
+            framework: "claude-code",
+          });
+        }),
+        http.get("*/api/zero/logs/:runId", () => {
+          pollCount++;
+          return HttpResponse.json({
+            id: "run-q1",
+            status: "running",
+            error: null,
+            prompt: "first",
+            createdAt: "2026-03-10T00:00:00Z",
+            startedAt: "2026-03-10T00:00:01Z",
+            completedAt: null,
+          });
+        }),
+      );
+      useChatThreadHandlers();
+
+      await setup();
+
+      // Start a send — this puts the system into "sending" state
+      const sendPromise = context.store
+        .set(sendZeroChatMessage$, "first message")
+        .catch(() => {});
+
+      await delay(50);
+      expect(pollCount).toBeGreaterThan(0);
+      expect(context.store.get(zeroChatSending$)).toBeTruthy();
+
+      // Set some input text then queue it
+      context.store.set(setZeroChatInput$, "follow-up");
+      context.store.set(queueZeroChatMessage$, "follow-up");
+
+      // Queued message should be stored and input cleared
+      expect(context.store.get(zeroChatQueuedMessage$)).toStrictEqual({
+        text: "follow-up",
+        modelProvider: undefined,
+      });
+      expect(context.store.get(zeroChatInput$)).toBe("");
+
+      // Clean up: abort the send
+      context.store.set(startNewZeroSession$);
+      await sendPromise;
+    });
+
+    it("should not queue when agent is idle", async () => {
+      await setup();
+
+      context.store.set(queueZeroChatMessage$, "should not queue");
+
+      expect(context.store.get(zeroChatQueuedMessage$)).toBeNull();
+    });
+
+    it("should reject a second queued message", async () => {
+      server.use(
+        http.post("*/api/zero/runs", () => {
+          return HttpResponse.json({ runId: "run-q2" });
+        }),
+        http.get("*/api/zero/runs/:runId/telemetry/agent", () => {
+          return HttpResponse.json({
+            events: [],
+            hasMore: false,
+            framework: "claude-code",
+          });
+        }),
+        http.get("*/api/zero/logs/:runId", () => {
+          return HttpResponse.json({
+            id: "run-q2",
+            status: "running",
+            error: null,
+            prompt: "first",
+            createdAt: "2026-03-10T00:00:00Z",
+            startedAt: "2026-03-10T00:00:01Z",
+            completedAt: null,
+          });
+        }),
+      );
+      useChatThreadHandlers();
+
+      await setup();
+
+      const sendPromise = context.store
+        .set(sendZeroChatMessage$, "first")
+        .catch(() => {});
+
+      await delay(50);
+
+      context.store.set(queueZeroChatMessage$, "queued-1");
+      context.store.set(queueZeroChatMessage$, "queued-2");
+
+      // Only the first queued message should be stored
+      expect(context.store.get(zeroChatQueuedMessage$)?.text).toBe("queued-1");
+
+      context.store.set(startNewZeroSession$);
+      await sendPromise;
+    });
+
+    it("should withdraw a queued message back into the input", async () => {
+      server.use(
+        http.post("*/api/zero/runs", () => {
+          return HttpResponse.json({ runId: "run-q3" });
+        }),
+        http.get("*/api/zero/runs/:runId/telemetry/agent", () => {
+          return HttpResponse.json({
+            events: [],
+            hasMore: false,
+            framework: "claude-code",
+          });
+        }),
+        http.get("*/api/zero/logs/:runId", () => {
+          return HttpResponse.json({
+            id: "run-q3",
+            status: "running",
+            error: null,
+            prompt: "first",
+            createdAt: "2026-03-10T00:00:00Z",
+            startedAt: "2026-03-10T00:00:01Z",
+            completedAt: null,
+          });
+        }),
+      );
+      useChatThreadHandlers();
+
+      await setup();
+
+      const sendPromise = context.store
+        .set(sendZeroChatMessage$, "first")
+        .catch(() => {});
+
+      await delay(50);
+
+      context.store.set(queueZeroChatMessage$, "edit me");
+      expect(context.store.get(zeroChatQueuedMessage$)).toBeTruthy();
+
+      // Withdraw the queued message
+      context.store.set(withdrawQueuedMessage$);
+
+      expect(context.store.get(zeroChatQueuedMessage$)).toBeNull();
+      expect(context.store.get(zeroChatInput$)).toBe("edit me");
+
+      context.store.set(startNewZeroSession$);
+      await sendPromise;
+    });
+
+    it("should auto-send queued message when the run completes", async () => {
+      let runCount = 0;
+      let latestPrompt = "";
+      let completeRun = false;
+      server.use(
+        http.post("*/api/zero/runs", async ({ request }) => {
+          runCount++;
+          const body = (await request.json()) as Record<string, string>;
+          latestPrompt = body.prompt;
+          return HttpResponse.json({ runId: `run-auto-${runCount}` });
+        }),
+        http.get("*/api/zero/runs/:runId/telemetry/agent", () => {
+          return HttpResponse.json({
+            events: [],
+            hasMore: false,
+            framework: "claude-code",
+          });
+        }),
+        http.get("*/api/zero/logs/:runId", () => {
+          if (completeRun) {
+            return HttpResponse.json({
+              id: `run-auto-${runCount}`,
+              status: "completed",
+              error: null,
+              prompt: latestPrompt,
+              createdAt: "2026-03-10T00:00:00Z",
+              startedAt: "2026-03-10T00:00:01Z",
+              completedAt: "2026-03-10T00:00:02Z",
+            });
+          }
+          return HttpResponse.json({
+            id: `run-auto-${runCount}`,
+            status: "running",
+            error: null,
+            prompt: latestPrompt,
+            createdAt: "2026-03-10T00:00:00Z",
+            startedAt: "2026-03-10T00:00:01Z",
+            completedAt: null,
+          });
+        }),
+        http.get("*/api/zero/runs/:runId", () => {
+          return HttpResponse.json({
+            result: { agentSessionId: "session-auto" },
+          });
+        }),
+      );
+      useChatThreadHandlers();
+
+      await setup();
+
+      const sendPromise = context.store
+        .set(sendZeroChatMessage$, "first message")
+        .catch(() => {});
+
+      await delay(50);
+      expect(context.store.get(zeroChatSending$)).toBeTruthy();
+
+      // Queue a follow-up while the first run is in progress
+      context.store.set(queueZeroChatMessage$, "auto follow-up");
+      expect(context.store.get(zeroChatQueuedMessage$)).toBeTruthy();
+
+      // Let both the first run and auto-sent second run complete immediately
+      completeRun = true;
+      await sendPromise;
+
+      // Wait for the detached auto-send to complete
+      await delay(500);
+
+      expect(context.store.get(zeroChatQueuedMessage$)).toBeNull();
+      // The auto-send should have triggered a second run
+      expect(runCount).toBe(2);
+      expect(latestPrompt).toBe("auto follow-up");
+      expect(context.store.get(zeroChatSending$)).toBeFalsy();
+    });
+
+    it("should auto-send queued message after run cancellation", async () => {
+      let runCount = 0;
+      let latestPrompt = "";
+      server.use(
+        http.post("*/api/zero/runs", async ({ request }) => {
+          runCount++;
+          const body = (await request.json()) as Record<string, string>;
+          latestPrompt = body.prompt;
+          return HttpResponse.json({ runId: `run-cancel-${runCount}` });
+        }),
+        http.get("*/api/zero/runs/:runId/telemetry/agent", () => {
+          return HttpResponse.json({
+            events: [],
+            hasMore: false,
+            framework: "claude-code",
+          });
+        }),
+        http.get("*/api/zero/logs/:runId", () => {
+          // First run stays "running" until cancelled; second run completes immediately
+          if (runCount >= 2) {
+            return HttpResponse.json({
+              id: `run-cancel-${runCount}`,
+              status: "completed",
+              error: null,
+              prompt: latestPrompt,
+              createdAt: "2026-03-10T00:00:00Z",
+              startedAt: "2026-03-10T00:00:01Z",
+              completedAt: "2026-03-10T00:00:02Z",
+            });
+          }
+          return HttpResponse.json({
+            id: `run-cancel-${runCount}`,
+            status: "running",
+            error: null,
+            prompt: latestPrompt,
+            createdAt: "2026-03-10T00:00:00Z",
+            startedAt: "2026-03-10T00:00:01Z",
+            completedAt: null,
+          });
+        }),
+        http.post("*/api/zero/runs/:runId/cancel", () => {
+          return new HttpResponse(null, { status: 204 });
+        }),
+        http.get("*/api/zero/runs/:runId", () => {
+          return HttpResponse.json({
+            result: { agentSessionId: "session-cancel" },
+          });
+        }),
+      );
+      useChatThreadHandlers();
+
+      await setup();
+
+      const sendPromise = context.store
+        .set(sendZeroChatMessage$, "first message")
+        .catch(() => {});
+
+      await delay(50);
+      expect(context.store.get(zeroChatSending$)).toBeTruthy();
+
+      // Queue a follow-up
+      context.store.set(queueZeroChatMessage$, "after cancel");
+      expect(context.store.get(zeroChatQueuedMessage$)).toBeTruthy();
+
+      // Cancel the active run — this aborts polling, which causes
+      // sendZeroChatMessage$ to hit its finally block and auto-send
+      await context.store.set(cancelActiveRun$);
+      await sendPromise;
+
+      // Give the detached auto-send time to fire and complete
+      await delay(500);
+
+      expect(context.store.get(zeroChatQueuedMessage$)).toBeNull();
+      // The queued message should have triggered a second run
+      expect(runCount).toBe(2);
+      expect(latestPrompt).toBe("after cancel");
+      expect(context.store.get(zeroChatSending$)).toBeFalsy();
     });
   });
 });

--- a/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
@@ -1133,6 +1133,11 @@ const onZeroRunComplete$ = command(async ({ get, set }, runId: string) => {
 
   set(internalActiveRunId$, null);
 
+  // Capture events BEFORE any await — the queued-message auto-send in
+  // sendZeroChatMessage$'s finally block may clear internalRunEvents$
+  // while we're waiting on the network.
+  const pages = get(internalRunEvents$);
+
   try {
     const fetchFn = get(fetch$);
     const res = await fetchFn(`/api/zero/runs/${runId}`);
@@ -1147,7 +1152,6 @@ const onZeroRunComplete$ = command(async ({ get, set }, runId: string) => {
     }
 
     // Extract result content and summaries from telemetry events
-    const pages = get(internalRunEvents$);
     const { result: resultContent, summaries } = await extractResultFromEvents(
       pages,
       get,

--- a/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
@@ -299,6 +299,47 @@ export const zeroChatQueuePosition$ = computed((get) =>
   get(internalQueuePosition$),
 );
 
+// ---------------------------------------------------------------------------
+// Queued message — allows the user to queue a follow-up while agent is busy
+// ---------------------------------------------------------------------------
+
+interface QueuedMessage {
+  text: string;
+  modelProvider?: string;
+}
+
+const internalQueuedMessage$ = state<QueuedMessage | null>(null);
+export const zeroChatQueuedMessage$ = computed((get) =>
+  get(internalQueuedMessage$),
+);
+
+/** Queue a message to be sent automatically once the current run completes. */
+export const queueZeroChatMessage$ = command(
+  ({ get, set }, text: string, options?: { modelProvider?: string }) => {
+    if (!get(internalSending$)) {
+      return;
+    }
+    if (get(internalQueuedMessage$)) {
+      return;
+    }
+    set(internalQueuedMessage$, {
+      text,
+      modelProvider: options?.modelProvider,
+    });
+    set(internalChatInput$, "");
+  },
+);
+
+/** Withdraw the queued message back into the input box for editing. */
+export const withdrawQueuedMessage$ = command(({ get, set }) => {
+  const queued = get(internalQueuedMessage$);
+  if (!queued) {
+    return;
+  }
+  set(internalChatInput$, queued.text);
+  set(internalQueuedMessage$, null);
+});
+
 /** Latest event summaries for the active run (for display while thinking). */
 export const zeroChatRunSummaries$ = computed(async (get) => {
   const pages = get(internalRunEvents$);
@@ -1030,6 +1071,22 @@ export const sendZeroChatMessage$ = command(
       });
     } finally {
       set(internalSending$, false);
+
+      // Auto-send queued message if one was enqueued while the run was active
+      const queued = get(internalQueuedMessage$);
+      if (queued) {
+        set(internalQueuedMessage$, null);
+        detach(
+          set(
+            sendZeroChatMessage$,
+            queued.text,
+            queued.modelProvider
+              ? { modelProvider: queued.modelProvider }
+              : undefined,
+          ),
+          Reason.DomCallback,
+        );
+      }
     }
   },
 );

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -3,10 +3,11 @@ import { useGet, useSet, useLastLoadable } from "ccstate-react";
 import {
   IconSend,
   IconPaperclip,
-  IconLoader2,
   IconPlayerStop,
   IconPlug,
   IconPlus,
+  IconClock,
+  IconArrowBackUp,
 } from "@tabler/icons-react";
 import {
   Button,
@@ -77,6 +78,10 @@ interface ZeroChatComposerProps {
   sending?: boolean;
   /** Cancel the active run. When provided, a stop button replaces the send button while sending. */
   onCancel?: () => void;
+  /** Message queued for delivery after the current run completes. */
+  queuedMessage?: { text: string } | null;
+  /** Withdraw the queued message back into the input for editing. */
+  onWithdraw?: () => void;
   agentName: string;
   /** Navigate to connectors management page. */
   onManageConnectors?: () => void;
@@ -362,6 +367,8 @@ export function ZeroChatComposer({
   onSend,
   sending,
   onCancel,
+  queuedMessage,
+  onWithdraw,
   agentName,
   onManageConnectors,
   className,
@@ -443,10 +450,10 @@ export function ZeroChatComposer({
       pageSignal,
     );
 
-  // Send
+  // Send (or queue if agent is busy — parent decides)
   const handleSend = () => {
     const trimmed = input.trim();
-    if (!trimmed || sending) {
+    if (!trimmed || !!queuedMessage) {
       return;
     }
     persistSelection();
@@ -502,18 +509,46 @@ export function ZeroChatComposer({
                 onRemove={removeAttachment}
               />
             )}
-            <textarea
-              className="w-full resize-none bg-transparent px-5 pt-4 pb-2 text-sm text-foreground placeholder:text-muted-foreground border-0 min-h-[88px] focus:outline-none focus:ring-0"
-              rows={3}
-              placeholder="Ask me to automate workflows, manage tasks..."
-              value={input}
-              onChange={(e) => onInputChange(e.target.value)}
-              onKeyDown={handleKeyDown}
-              onCompositionStart={onCompositionStart}
-              onCompositionEnd={onCompositionEnd}
-              onPaste={handlePaste}
-              disabled={sending}
-            />
+            {queuedMessage ? (
+              <div className="flex items-start gap-3 px-5 pt-4 pb-2 min-h-[88px]">
+                <IconClock
+                  size={16}
+                  className="text-muted-foreground shrink-0 mt-0.5"
+                />
+                <div className="flex-1 min-w-0">
+                  <p className="text-xs text-muted-foreground mb-1">
+                    Will send when the agent finishes
+                  </p>
+                  <p className="text-sm text-foreground line-clamp-3 break-words">
+                    {queuedMessage.text}
+                  </p>
+                </div>
+                <button
+                  type="button"
+                  onClick={onWithdraw}
+                  className="shrink-0 inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
+                >
+                  <IconArrowBackUp size={14} />
+                  Withdraw
+                </button>
+              </div>
+            ) : (
+              <textarea
+                className="w-full resize-none bg-transparent px-5 pt-4 pb-2 text-sm text-foreground placeholder:text-muted-foreground border-0 min-h-[88px] focus:outline-none focus:ring-0"
+                rows={3}
+                placeholder={
+                  sending
+                    ? "Type your next message\u2026"
+                    : "Ask me to automate workflows, manage tasks..."
+                }
+                value={input}
+                onChange={(e) => onInputChange(e.target.value)}
+                onKeyDown={handleKeyDown}
+                onCompositionStart={onCompositionStart}
+                onCompositionEnd={onCompositionEnd}
+                onPaste={handlePaste}
+              />
+            )}
             <div className="flex items-center justify-between gap-2 px-4 py-3">
               <div className="flex items-center gap-1 text-muted-foreground">
                 <button
@@ -549,7 +584,7 @@ export function ZeroChatComposer({
                     ))}
                   </SelectContent>
                 </Select>
-                {sending && onCancel ? (
+                {sending && onCancel && (
                   <Button
                     size="sm"
                     variant="destructive"
@@ -559,19 +594,16 @@ export function ZeroChatComposer({
                   >
                     <IconPlayerStop size={16} />
                   </Button>
-                ) : (
+                )}
+                {!queuedMessage && (
                   <Button
                     size="sm"
                     className="rounded-lg h-9 w-9 p-0 shrink-0"
                     onClick={handleSend}
-                    disabled={!input.trim() || sending}
-                    aria-label="Send"
+                    disabled={!input.trim()}
+                    aria-label={sending ? "Queue message" : "Send"}
                   >
-                    {sending ? (
-                      <IconLoader2 size={16} className="animate-spin" />
-                    ) : (
-                      <IconSend size={16} stroke={2} />
-                    )}
+                    <IconSend size={16} stroke={2} />
                   </Button>
                 )}
               </div>

--- a/turbo/apps/platform/src/views/zero-page/zero-session-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-session-chat-page.tsx
@@ -45,6 +45,9 @@ import {
   zeroChatRunStatus$,
   zeroChatQueuePosition$,
   cancelActiveRun$,
+  zeroChatQueuedMessage$,
+  queueZeroChatMessage$,
+  withdrawQueuedMessage$,
 } from "../../signals/zero-page/zero-chat.ts";
 import { ZeroChatComposer } from "./zero-chat-composer.tsx";
 import { Link, SimpleLink } from "../router/link.tsx";
@@ -83,6 +86,9 @@ export function ZeroSessionChatPage({
   const clearInput = useSet(clearZeroChatInput$);
   const send = useSet(sendZeroChatMessage$);
   const cancelRun = useSet(cancelActiveRun$);
+  const queuedMessage = useGet(zeroChatQueuedMessage$);
+  const queueMessage = useSet(queueZeroChatMessage$);
+  const withdraw = useSet(withdrawQueuedMessage$);
   // Auto-scroll when messages change — ref callback runs at commit time
   const scrollAnchorRef = (el: HTMLDivElement | null) => {
     if (el && messages.length > 0) {
@@ -91,8 +97,12 @@ export function ZeroSessionChatPage({
   };
 
   const handleSend = (text: string, opts?: { modelProvider: string }) => {
-    clearInput();
-    detach(send(text, opts), Reason.DomCallback);
+    if (sending) {
+      queueMessage(text, opts);
+    } else {
+      clearInput();
+      detach(send(text, opts), Reason.DomCallback);
+    }
   };
 
   return (
@@ -189,6 +199,8 @@ export function ZeroSessionChatPage({
               onSend={handleSend}
               sending={sending}
               onCancel={() => void cancelRun()}
+              queuedMessage={queuedMessage}
+              onWithdraw={withdraw}
               agentName={agentName}
             />
           </div>


### PR DESCRIPTION
## Summary

Closes #5692

- **Input stays enabled while agent is busy** — users can type their next message instead of seeing a disabled textarea
- **Message queueing** — submitting while the agent is processing queues the message, which auto-sends when the current run completes
- **Withdraw support** — queued messages can be withdrawn back into the input for editing
- Placeholder text changes to "Type your next message…" during processing
- Stop and send buttons shown side-by-side when agent is busy

Implements Tier 3 (client-side) from the issue spec:

| State | Input behavior |
|-------|----------------|
| Agent idle | Normal input and submission |
| Agent processing | Input accepts text; submission queues the message |
| Message queued | Input disabled; queued message shown with withdraw option |
| Withdrawn | Input re-enabled and refilled with the withdrawn text |

Server-side queue persistence (stretch goal) is deferred to a follow-up.

## Test plan

- [ ] Verify textarea remains focusable and editable while agent is processing
- [ ] Submit a message while agent is busy → should show queued banner with withdraw button
- [ ] Verify queued message auto-sends when agent run completes
- [ ] Click "Withdraw" → queued message returns to textarea for editing
- [ ] Cancel a run with a queued message → queued message should auto-send
- [ ] Verify normal send flow still works when agent is idle

🤖 Generated with [Claude Code](https://claude.com/claude-code)