### PR TITLE
refactor: replace coding-loop git sync with hard reset and clean

### DIFF
--- a/scripts/coding-loop.sh
+++ b/scripts/coding-loop.sh
@@ -167,8 +167,11 @@ download_pr_content() {
 # --- Step 0: Sync main ---
 
 rm -f .claude/scheduled_tasks.lock
-git checkout main >&2 2>&1 || true
-{ git stash >&2 2>&1; git pull >&2 2>&1; git stash pop >&2 2>&1; } || true
+git fetch origin main >&2 2>&1
+git checkout -f main >&2 2>&1
+git reset --hard origin/main >&2 2>&1
+git clean -df >&2 2>&1
+git stash clear >&2 2>&1
 
 # --- Phase A: Check PRs ---
 


### PR DESCRIPTION
## Summary
- Replace fragile `git stash; git pull; git stash pop` pattern in coding-loop.sh Step 0 with `git fetch + checkout -f + reset --hard + clean -df + stash clear`
- Prevents stale stashes from other branches being applied onto main, which caused silent merge conflicts
- Removes `|| true` error swallowing in favor of explicit, predictable commands

Closes #6010

## Test plan
- [ ] Verify coding-loop.sh runs successfully on next autonomous loop execution
- [ ] Confirm working tree is clean after Step 0 sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)