### PR TITLE
fix(ci): prevent merge queue job-ref collision on metal hosts

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -278,7 +278,7 @@ jobs:
           elif [ "$EVENT_NAME" = "merge_group" ]; then
             MQ_PR_NUM=$(echo "$MQ_HEAD_REF" | grep -oE 'pr-[0-9]+' | head -1 | sed 's/pr-//')
             if [ -n "$MQ_PR_NUM" ]; then
-              JOB_REF="pr-${MQ_PR_NUM}-merge-queue-test"
+              JOB_REF="pr-${MQ_PR_NUM}-mq-${GITHUB_RUN_ID: -6}-test"
             else
               echo "::error::Failed to extract PR number from merge_group head_ref: $MQ_HEAD_REF"
               exit 1

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -278,7 +278,7 @@ jobs:
           elif [ "$EVENT_NAME" = "merge_group" ]; then
             MQ_PR_NUM=$(echo "$MQ_HEAD_REF" | grep -oE 'pr-[0-9]+' | head -1 | sed 's/pr-//')
             if [ -n "$MQ_PR_NUM" ]; then
-              JOB_REF="pr-${MQ_PR_NUM}-mq-${GITHUB_RUN_ID: -6}-test"
+              JOB_REF="pr-${MQ_PR_NUM}-mq-$(printf '%s' "$GITHUB_RUN_ID" | tail -c 6)-test"
             else
               echo "::error::Failed to extract PR number from merge_group head_ref: $MQ_HEAD_REF"
               exit 1

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -202,8 +202,8 @@ jobs:
             MQ_REF="${{ github.event.merge_group.head_ref }}"
             PR_NUM=$(echo "$MQ_REF" | grep -oE 'pr-[0-9]+' | head -1 | sed 's/pr-//')
             if [ -n "$PR_NUM" ]; then
-              echo "job-ref=pr-${PR_NUM}-mq-${GITHUB_RUN_ID: -6}" >> "$GITHUB_OUTPUT"
-              echo "Job ref set to: pr-${PR_NUM}-mq-${GITHUB_RUN_ID: -6}"
+              echo "job-ref=pr-${PR_NUM}-mq-$(printf '%s' "$GITHUB_RUN_ID" | tail -c 6)" >> "$GITHUB_OUTPUT"
+              echo "Job ref set to: pr-${PR_NUM}-mq-$(printf '%s' "$GITHUB_RUN_ID" | tail -c 6)"
             else
               echo "::error::Failed to extract PR number from merge_group head_ref: $MQ_REF"
               exit 1

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -202,8 +202,8 @@ jobs:
             MQ_REF="${{ github.event.merge_group.head_ref }}"
             PR_NUM=$(echo "$MQ_REF" | grep -oE 'pr-[0-9]+' | head -1 | sed 's/pr-//')
             if [ -n "$PR_NUM" ]; then
-              echo "job-ref=pr-${PR_NUM}-merge-queue" >> "$GITHUB_OUTPUT"
-              echo "Job ref set to: pr-${PR_NUM}-merge-queue"
+              echo "job-ref=pr-${PR_NUM}-mq-${GITHUB_RUN_ID: -6}" >> "$GITHUB_OUTPUT"
+              echo "Job ref set to: pr-${PR_NUM}-mq-${GITHUB_RUN_ID: -6}"
             else
               echo "::error::Failed to extract PR number from merge_group head_ref: $MQ_REF"
               exit 1


### PR DESCRIPTION
## Summary
- Append `GITHUB_RUN_ID` last 6 digits to merge queue `JOB_REF` in both `crates.yml` and `turbo.yml`
- Prevents concurrent merge queue runs for the same PR from colliding on shared metal host paths
- Root cause: first run's cleanup deletes binary deployed by second run (observed on PR #5990)

Closes #6013

## Test plan
- [x] Verify `GITHUB_RUN_ID` is available as default env var in GitHub Actions
- [ ] Next merge queue run should produce unique paths (e.g. `pr-XXXX-mq-903066-test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)