### PR TITLE
fix: prevent send mode toggle UI flash when switching to cmd+enter

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/settings/preferences-page.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/preferences-page.ts
@@ -1,5 +1,9 @@
 import { command, computed, state } from "ccstate";
 import type { SendMode } from "@vm0/core";
+import { toast } from "@vm0/ui/components/ui/sonner";
+import { updateNotificationPreference$ } from "./notification-settings.ts";
+import { sendMode$ } from "../../send-mode.ts";
+import { throwIfAbort } from "../../utils.ts";
 
 // ---------------------------------------------------------------------------
 // Preferences tab state
@@ -21,9 +25,29 @@ const internalSendModeSaving$ = state<SendMode | null>(null);
 
 export const sendModeSaving$ = computed((get) => get(internalSendModeSaving$));
 
-export const setSendModeSaving$ = command(({ set }, value: SendMode | null) => {
-  set(internalSendModeSaving$, value);
-});
+/**
+ * Update send mode preference and clear saving state once the refetched value
+ * matches. This keeps the optimistic UI in the signals layer instead of relying
+ * on a React useEffect in the view.
+ */
+export const updateSendMode$ = command(
+  async ({ get, set }, value: SendMode) => {
+    set(internalSendModeSaving$, value);
+    try {
+      await set(updateNotificationPreference$, { sendMode: value });
+      // After the command completes the refetch has been triggered.
+      // Await the refetched sendMode so the UI never flashes back to the old value.
+      const fetched = await get(sendMode$);
+      if (fetched === value) {
+        set(internalSendModeSaving$, null);
+      }
+    } catch (error) {
+      throwIfAbort(error);
+      set(internalSendModeSaving$, null);
+      toast.error("Failed to save send mode preference");
+    }
+  },
+);
 
 // ---------------------------------------------------------------------------
 // Timezone saving state

--- a/turbo/apps/platform/src/views/zero-page/zero-account-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-account-page.tsx
@@ -19,14 +19,12 @@ import {
 import { sendMode$ } from "../../signals/send-mode.ts";
 import { detach, Reason } from "../../signals/utils.ts";
 import type { SendMode } from "@vm0/core";
-import { updateNotificationPreference$ } from "../../signals/zero-page/settings/notification-settings.ts";
 import {
   preferencesTab$,
   setPreferencesTab$,
   sendModeSaving$,
-  setSendModeSaving$,
+  updateSendMode$,
 } from "../../signals/zero-page/settings/preferences-page.ts";
-import { toast } from "@vm0/ui/components/ui/sonner";
 
 function AppearanceSettings() {
   const THEME_OPTIONS = [
@@ -99,22 +97,11 @@ function SendModeSettings() {
   const prefsLoadable = useLoadable(sendMode$);
   const current: SendMode =
     prefsLoadable.state === "hasData" ? prefsLoadable.data : "enter";
-  const updatePref = useSet(updateNotificationPreference$);
   const saving = useGet(sendModeSaving$);
-  const setSaving = useSet(setSendModeSaving$);
+  const saveSendMode = useSet(updateSendMode$);
 
   const handleChange = (value: SendMode) => {
-    setSaving(value);
-    detach(
-      (async () => {
-        await updatePref({ sendMode: value });
-        setSaving(null);
-      })().catch(() => {
-        setSaving(null);
-        toast.error("Failed to save send mode preference");
-      }),
-      Reason.DomCallback,
-    );
+    detach(saveSendMode(value), Reason.DomCallback);
   };
 
   return (
@@ -140,7 +127,7 @@ function SendModeSettings() {
             Send message with
           </div>
           <div className="text-sm text-muted-foreground">
-            {current === "enter"
+            {(saving ?? current) === "enter"
               ? "Press Enter to send, Shift+Enter for new line"
               : "Press ⌘/Ctrl+Enter to send, Enter for new line"}
           </div>


### PR DESCRIPTION
## Summary
- Fix UI flash on the preferences page when toggling send mode: button briefly shows "Enter" before jumping to "⌘ Enter"
- Root cause: `setSaving(null)` ran immediately after the API update, but the `sendMode$` signal refetch hadn't completed yet, causing the UI to briefly revert to the old value
- Moved the save-and-clear lifecycle into a new `updateSendMode$` command in the signals layer, which waits for the `sendMode$` refetch to complete before clearing optimistic state
- Description text also uses the optimistic value to prevent the same flash

Closes #5695

## Test plan
- [x] All zero-page tests pass (103/103)
- [x] Lint, type-check, format, knip all pass
- [ ] Manual: Toggle Enter → ⌘ Enter on preferences page — button and description should switch immediately with no flash
- [ ] Manual: Toggle ⌘ Enter → Enter — same, no flash
- [ ] Manual: On network error, toast should appear and state should revert

🤖 Generated with [Claude Code](https://claude.com/claude-code)